### PR TITLE
Add forEach_ in Async core

### DIFF
--- a/packages/system/src/Async/core.ts
+++ b/packages/system/src/Async/core.ts
@@ -1008,7 +1008,10 @@ export function tuple<Tasks extends Async<any, any, any>[]>(
 }
 
 // like Promise.all + map on steroids
-export function forEach_<R, A, E1, B>(as: Iterable<A>, f: (a: A) => Async<R, E1, B>) {
+export function forEach_<R, A, E1, B>(
+  as: Iterable<A>,
+  f: (a: A) => Async<R, E1, B>
+): Async<R, E1, readonly B[]> {
   return collectAll(Array.from(as).map(f))
 }
 


### PR DESCRIPTION
This PR adds a non-curried version of forEach in `Async/core.ts`. Let me know if anything needs to be changed. 