### PR TITLE
feat: add Streamable constructor

### DIFF
--- a/.changeset/mighty-tomatoes-visit.md
+++ b/.changeset/mighty-tomatoes-visit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add Streamable for creating custom Streams

--- a/src/Streamable.ts
+++ b/src/Streamable.ts
@@ -1,0 +1,42 @@
+/**
+ * @since 2.0.0
+ */
+
+import { pipeArguments } from "./Pipeable"
+import * as Stream from "./Stream"
+
+const streamVariance = {
+  _R: (_: never) => _,
+  _E: (_: never) => _,
+  _A: (_: never) => _
+}
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
+export abstract class Streamable<R, E, A> implements Stream.Stream<R, E, A> {
+  /**
+   * @since 2.0.0
+   */
+  readonly [Stream.StreamTypeId] = streamVariance
+
+  /**
+   * @since 2.0.0
+   */
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+
+  /**
+   * @since 2.0.0
+   */
+  abstract toStream(): Stream.Stream<R, E, A>
+
+  /**
+   * @internal
+   */
+  get channel() {
+    return Stream.toChannel(this.toStream())
+  }
+}

--- a/src/internal/stream.ts
+++ b/src/internal/stream.ts
@@ -2837,10 +2837,13 @@ export const fromChannel = <R, E, A>(
 export const toChannel = <R, E, A>(
   stream: Stream.Stream<R, E, A>
 ): Channel.Channel<R, unknown, unknown, unknown, E, Chunk.Chunk<A>, unknown> => {
-  if (Effect.isEffect(stream)) {
+  if ("channel" in stream) {
+    return (stream as StreamImpl<R, E, A>).channel
+  } else if (Effect.isEffect(stream)) {
     return toChannel(fromEffect(stream)) as any
+  } else {
+    throw new TypeError(`Expected a Stream.`)
   }
-  return (stream as StreamImpl<R, E, A>).channel
 }
 
 /** @internal */

--- a/test/Stream/streamable.ts
+++ b/test/Stream/streamable.ts
@@ -1,0 +1,24 @@
+import * as it from "effect-test/utils/extend"
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+import * as Streamable from "effect/Streamable"
+import { describe } from "vitest"
+
+describe("Streamable", () => {
+  it.effect(
+    "allows creating custom Stream types",
+    () =>
+      Effect.gen(function*($) {
+        class MyStream extends Streamable.Streamable<never, never, number> {
+          toStream() {
+            return Stream.fromIterable([1, 2, 3])
+          }
+        }
+        const stream = new MyStream()
+
+        const values = Array.from(yield* $(Stream.runCollect(stream)))
+
+        expect(values).toEqual([1, 2, 3])
+      })
+  )
+})


### PR DESCRIPTION
I figured I'd just open a PR to start some discussion on an equivalent to Effectable for Stream. 

The modification to `toChannel` is to favor choosing the Stream instance for any custom type which might be both a Stream and an Effect. This felt kinda odd, but I wasn't sure what else to do without larger changes to Stream's representation.