### PR TITLE
add bigint metrics

### DIFF
--- a/src/Metric.ts
+++ b/src/Metric.ts
@@ -89,7 +89,23 @@ export declare namespace Metric {
    * @since 2.0.0
    * @category models
    */
+  export interface BigintCounter<In>
+    extends Metric<MetricKeyType.MetricKeyType.BigintCounter, In, MetricState.MetricState.BigintCounter>
+  {}
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
   export interface Gauge<In> extends Metric<MetricKeyType.MetricKeyType.Gauge, In, MetricState.MetricState.Gauge> {}
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  export interface BigintGauge<In>
+    extends Metric<MetricKeyType.MetricKeyType.BigintGauge, In, MetricState.MetricState.BigintGauge>
+  {}
 
   /**
    * @since 2.0.0
@@ -162,6 +178,15 @@ export const mapInput: {
 export const counter: (name: string, description?: string) => Metric.Counter<number> = internal.counter
 
 /**
+ * A bigint counter, which can be incremented by numbers.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintCounter: (name: string, description?: string) => Metric.BigintCounter<bigint> =
+  internal.bigintCounter
+
+/**
  * A string histogram metric, which keeps track of the counts of different
  * strings.
  *
@@ -201,6 +226,14 @@ export const fromMetricKey: <Type extends MetricKeyType.MetricKeyType<any, any>>
 export const gauge: (name: string, description?: string) => Metric.Gauge<number> = internal.gauge
 
 /**
+ * A bigint gauge, which can be set to a value.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintGauge: (name: string, description?: string) => Metric.BigintGauge<bigint> = internal.bigintGauge
+
+/**
  * A numeric histogram metric, which keeps track of the count of numbers that
  * fall in bins with the specified boundaries.
  *
@@ -217,7 +250,10 @@ export const histogram: (
  * @since 2.0.0
  * @category aspects
  */
-export const increment: (self: Metric.Counter<number>) => Effect.Effect<never, never, void> = internal.increment
+export const increment: {
+  (self: Metric.Counter<number>): Effect.Effect<never, never, void>
+  (self: Metric.Counter<bigint>): Effect.Effect<never, never, void>
+} = internal.increment
 
 /**
  * @since 2.0.0
@@ -226,6 +262,8 @@ export const increment: (self: Metric.Counter<number>) => Effect.Effect<never, n
 export const incrementBy: {
   (amount: number): (self: Metric.Counter<number>) => Effect.Effect<never, never, void>
   (self: Metric.Counter<number>, amount: number): Effect.Effect<never, never, void>
+  (amount: bigint): (self: Metric.Counter<bigint>) => Effect.Effect<never, never, void>
+  (self: Metric.Counter<bigint>, amount: bigint): Effect.Effect<never, never, void>
 } = internal.incrementBy
 
 /**

--- a/src/MetricHook.ts
+++ b/src/MetricHook.ts
@@ -54,7 +54,19 @@ export declare namespace MetricHook {
    * @since 2.0.0
    * @category models
    */
+  export type BigintCounter = MetricHook<bigint, MetricState.MetricState.BigintCounter>
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
   export type Gauge = MetricHook<number, MetricState.MetricState.Gauge>
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  export type BigintGauge = MetricHook<bigint, MetricState.MetricState.BigintGauge>
 
   /**
    * @since 2.0.0
@@ -105,6 +117,13 @@ export const counter: (_key: MetricKey.MetricKey.Counter) => MetricHook.Counter 
  * @since 2.0.0
  * @category constructors
  */
+export const bigintCounter: (_key: MetricKey.MetricKey.BigintCounter) => MetricHook.BigintCounter =
+  internal.bigintCounter
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
 export const frequency: (_key: MetricKey.MetricKey.Frequency) => MetricHook.Frequency = internal.frequency
 
 /**
@@ -112,6 +131,13 @@ export const frequency: (_key: MetricKey.MetricKey.Frequency) => MetricHook.Freq
  * @category constructors
  */
 export const gauge: (_key: MetricKey.MetricKey.Gauge, startAt: number) => MetricHook.Gauge = internal.gauge
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintGauge: (_key: MetricKey.MetricKey.BigintGauge, startAt: bigint) => MetricHook.BigintGauge =
+  internal.bigintGauge
 
 /**
  * @since 2.0.0

--- a/src/MetricKey.ts
+++ b/src/MetricKey.ts
@@ -63,7 +63,19 @@ export declare namespace MetricKey {
    * @since 2.0.0
    * @category models
    */
+  export type BigintCounter = MetricKey<MetricKeyType.MetricKeyType.BigintCounter>
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
   export type Gauge = MetricKey<MetricKeyType.MetricKeyType.Gauge>
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  export type BigintGauge = MetricKey<MetricKeyType.MetricKeyType.BigintGauge>
 
   /**
    * @since 2.0.0
@@ -110,6 +122,14 @@ export const isMetricKey: (u: unknown) => u is MetricKey<MetricKeyType.MetricKey
 export const counter: (name: string, description?: string) => MetricKey.Counter = internal.counter
 
 /**
+ * Creates a metric key for a bigint counter, with the specified name.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintCounter: (name: string, description?: string) => MetricKey.BigintCounter = internal.bigintCounter
+
+/**
  * Creates a metric key for a categorical frequency table, with the specified
  * name.
  *
@@ -125,6 +145,14 @@ export const frequency: (name: string, description?: string) => MetricKey.Freque
  * @category constructors
  */
 export const gauge: (name: string, description?: string) => MetricKey.Gauge = internal.gauge
+
+/**
+ * Creates a metric key for a bigint gauge, with the specified name.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintGauge: (name: string, description?: string) => MetricKey.BigintGauge = internal.bigintGauge
 
 /**
  * Creates a metric key for a histogram, with the specified name and boundaries.

--- a/src/MetricKeyType.ts
+++ b/src/MetricKeyType.ts
@@ -37,6 +37,18 @@ export type CounterKeyTypeTypeId = typeof CounterKeyTypeTypeId
  * @since 2.0.0
  * @category symbols
  */
+export const BigintCounterKeyTypeTypeId: unique symbol = internal.BigintCounterKeyTypeTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type BigintCounterKeyTypeTypeId = typeof BigintCounterKeyTypeTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
 export const FrequencyKeyTypeTypeId: unique symbol = internal.FrequencyKeyTypeTypeId
 
 /**
@@ -56,6 +68,18 @@ export const GaugeKeyTypeTypeId: unique symbol = internal.GaugeKeyTypeTypeId
  * @category symbols
  */
 export type GaugeKeyTypeTypeId = typeof GaugeKeyTypeTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export const BigintGaugeKeyTypeTypeId: unique symbol = internal.BigintGaugeKeyTypeTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type BigintGaugeKeyTypeTypeId = typeof BigintGaugeKeyTypeTypeId
 
 /**
  * @since 2.0.0
@@ -109,6 +133,14 @@ export declare namespace MetricKeyType {
    * @since 2.0.0
    * @category models
    */
+  export type BigintCounter = MetricKeyType<bigint, MetricState.MetricState.BigintCounter> & {
+    readonly [BigintCounterKeyTypeTypeId]: BigintCounterKeyTypeTypeId
+  }
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
   export type Frequency = MetricKeyType<string, MetricState.MetricState.Frequency> & {
     readonly [FrequencyKeyTypeTypeId]: FrequencyKeyTypeTypeId
   }
@@ -119,6 +151,14 @@ export declare namespace MetricKeyType {
    */
   export type Gauge = MetricKeyType<number, MetricState.MetricState.Gauge> & {
     readonly [GaugeKeyTypeTypeId]: GaugeKeyTypeTypeId
+  }
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  export type BigintGauge = MetricKeyType<bigint, MetricState.MetricState.BigintGauge> & {
+    readonly [BigintGaugeKeyTypeTypeId]: BigintGaugeKeyTypeTypeId
   }
 
   /**

--- a/src/MetricState.ts
+++ b/src/MetricState.ts
@@ -37,6 +37,18 @@ export type CounterStateTypeId = typeof CounterStateTypeId
  * @since 2.0.0
  * @category symbols
  */
+export const BigintCounterStateTypeId: unique symbol = internal.BigintCounterStateTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type BigintCounterStateTypeId = typeof BigintCounterStateTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
 export const FrequencyStateTypeId: unique symbol = internal.FrequencyStateTypeId
 
 /**
@@ -56,6 +68,18 @@ export const GaugeStateTypeId: unique symbol = internal.GaugeStateTypeId
  * @category symbols
  */
 export type GaugeStateTypeId = typeof GaugeStateTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export const BigintGaugeStateTypeId: unique symbol = internal.BigintGaugeStateTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type BigintGaugeStateTypeId = typeof BigintGaugeStateTypeId
 
 /**
  * @since 2.0.0
@@ -114,6 +138,15 @@ export declare namespace MetricState {
    * @since 2.0.0
    * @category models
    */
+  export interface BigintCounter extends MetricState<MetricKeyType.MetricKeyType.BigintCounter> {
+    readonly [BigintCounterStateTypeId]: BigintCounterStateTypeId
+    readonly count: bigint
+  }
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
   export interface Frequency extends MetricState<MetricKeyType.MetricKeyType.Frequency> {
     readonly [FrequencyStateTypeId]: FrequencyStateTypeId
     readonly occurrences: HashMap.HashMap<string, number>
@@ -126,6 +159,15 @@ export declare namespace MetricState {
   export interface Gauge extends MetricState<MetricKeyType.MetricKeyType.Gauge> {
     readonly [GaugeStateTypeId]: GaugeStateTypeId
     readonly value: number
+  }
+
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  export interface BigintGauge extends MetricState<MetricKeyType.MetricKeyType.BigintGauge> {
+    readonly [BigintGaugeStateTypeId]: BigintGaugeStateTypeId
+    readonly value: bigint
   }
 
   /**
@@ -176,6 +218,12 @@ export const counter: (count: number) => MetricState.Counter = internal.counter
  * @since 2.0.0
  * @category constructors
  */
+export const bigintCounter: (count: bigint) => MetricState.BigintCounter = internal.bigintCounter
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
 export const frequency: (occurrences: HashMap.HashMap<string, number>) => MetricState.Frequency = internal.frequency
 
 /**
@@ -183,6 +231,12 @@ export const frequency: (occurrences: HashMap.HashMap<string, number>) => Metric
  * @category constructors
  */
 export const gauge: (value: number) => MetricState.Gauge = internal.gauge
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintGauge: (value: bigint) => MetricState.BigintGauge = internal.bigintGauge
 
 /**
  * @since 2.0.0
@@ -229,6 +283,12 @@ export const isCounterState: (u: unknown) => u is MetricState.Counter = internal
  * @since 2.0.0
  * @category refinements
  */
+export const isBigintCounterState: (u: unknown) => u is MetricState.BigintCounter = internal.isBigintCounterState
+
+/**
+ * @since 2.0.0
+ * @category refinements
+ */
 export const isFrequencyState: (u: unknown) => u is MetricState.Frequency = internal.isFrequencyState
 
 /**
@@ -236,6 +296,12 @@ export const isFrequencyState: (u: unknown) => u is MetricState.Frequency = inte
  * @category refinements
  */
 export const isGaugeState: (u: unknown) => u is MetricState.Gauge = internal.isGaugeState
+
+/**
+ * @since 2.0.0
+ * @category refinements
+ */
+export const isBigintGaugeState: (u: unknown) => u is MetricState.BigintGauge = internal.isBigintGaugeState
 
 /**
  * @since 2.0.0

--- a/src/internal/metric/hook.ts
+++ b/src/internal/metric/hook.ts
@@ -67,6 +67,17 @@ export const counter = (_key: MetricKey.MetricKey.Counter): MetricHook.MetricHoo
 }
 
 /** @internal */
+export const bigintCounter = (_key: MetricKey.MetricKey.BigintCounter): MetricHook.MetricHook.BigintCounter => {
+  let sum = BigInt(0)
+  return make({
+    get: () => metricState.bigintCounter(sum),
+    update: (value) => {
+      sum = sum + value
+    }
+  })
+}
+
+/** @internal */
 export const frequency = (_key: MetricKey.MetricKey.Frequency): MetricHook.MetricHook.Frequency => {
   let count = 0
   const values = new Map<string, number>()
@@ -87,6 +98,20 @@ export const gauge = (_key: MetricKey.MetricKey.Gauge, startAt: number): MetricH
   let value = startAt
   return make({
     get: () => metricState.gauge(value),
+    update: (v) => {
+      value = v
+    }
+  })
+}
+
+/** @internal */
+export const bigintGauge = (
+  _key: MetricKey.MetricKey.BigintGauge,
+  startAt: bigint
+): MetricHook.MetricHook.BigintGauge => {
+  let value = startAt
+  return make({
+    get: () => metricState.bigintGauge(value),
     update: (v) => {
       value = v
     }

--- a/src/internal/metric/key.ts
+++ b/src/internal/metric/key.ts
@@ -64,12 +64,20 @@ export const counter = (name: string, description?: string): MetricKey.MetricKey
   new MetricKeyImpl(name, metricKeyType.counter, Option.fromNullable(description))
 
 /** @internal */
+export const bigintCounter = (name: string, description?: string): MetricKey.MetricKey.BigintCounter =>
+  new MetricKeyImpl(name, metricKeyType.bigintCounter, Option.fromNullable(description))
+
+/** @internal */
 export const frequency = (name: string, description?: string): MetricKey.MetricKey.Frequency =>
   new MetricKeyImpl(name, metricKeyType.frequency, Option.fromNullable(description))
 
 /** @internal */
 export const gauge = (name: string, description?: string): MetricKey.MetricKey.Gauge =>
   new MetricKeyImpl(name, metricKeyType.gauge, Option.fromNullable(description))
+
+/** @internal */
+export const bigintGauge = (name: string, description?: string): MetricKey.MetricKey.BigintGauge =>
+  new MetricKeyImpl(name, metricKeyType.bigintGauge, Option.fromNullable(description))
 
 /** @internal */
 export const histogram = (

--- a/src/internal/metric/keyType.ts
+++ b/src/internal/metric/keyType.ts
@@ -24,6 +24,14 @@ export const CounterKeyTypeTypeId: MetricKeyType.CounterKeyTypeTypeId = Symbol.f
 ) as MetricKeyType.CounterKeyTypeTypeId
 
 /** @internal */
+const BigintCounterKeyTypeSymbolKey = "effect/MetricKeyType/BigintCounter"
+
+/** @internal */
+export const BigintCounterKeyTypeTypeId: MetricKeyType.BigintCounterKeyTypeTypeId = Symbol.for(
+  BigintCounterKeyTypeSymbolKey
+) as MetricKeyType.BigintCounterKeyTypeTypeId
+
+/** @internal */
 const FrequencyKeyTypeSymbolKey = "effect/MetricKeyType/Frequency"
 
 /** @internal */
@@ -38,6 +46,14 @@ const GaugeKeyTypeSymbolKey = "effect/MetricKeyType/Gauge"
 export const GaugeKeyTypeTypeId: MetricKeyType.GaugeKeyTypeTypeId = Symbol.for(
   GaugeKeyTypeSymbolKey
 ) as MetricKeyType.GaugeKeyTypeTypeId
+
+/** @internal */
+const BigintGaugeKeyTypeSymbolKey = "effect/MetricKeyType/BigintGauge"
+
+/** @internal */
+export const BigintGaugeKeyTypeTypeId: MetricKeyType.BigintGaugeKeyTypeTypeId = Symbol.for(
+  BigintGaugeKeyTypeSymbolKey
+) as MetricKeyType.BigintGaugeKeyTypeTypeId
 
 /** @internal */
 const HistogramKeyTypeSymbolKey = "effect/MetricKeyType/Histogram"
@@ -77,6 +93,21 @@ class CounterKeyType implements MetricKeyType.MetricKeyType.Counter {
 }
 
 /** @internal */
+class BigintCounterKeyType implements MetricKeyType.MetricKeyType.BigintCounter {
+  readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
+  readonly [BigintCounterKeyTypeTypeId]: MetricKeyType.BigintCounterKeyTypeTypeId = BigintCounterKeyTypeTypeId;
+  [Hash.symbol](): number {
+    return Hash.hash(BigintCounterKeyTypeSymbolKey)
+  }
+  [Equal.symbol](that: unknown): boolean {
+    return isBigintCounterKey(that)
+  }
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+/** @internal */
 class FrequencyKeyType implements MetricKeyType.MetricKeyType.Frequency {
   readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
   readonly [FrequencyKeyTypeTypeId]: MetricKeyType.FrequencyKeyTypeTypeId = FrequencyKeyTypeTypeId;
@@ -100,6 +131,21 @@ class GaugeKeyType implements MetricKeyType.MetricKeyType.Gauge {
   }
   [Equal.symbol](that: unknown): boolean {
     return isGaugeKey(that)
+  }
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+/** @internal */
+class BigintGaugeKeyType implements MetricKeyType.MetricKeyType.BigintGauge {
+  readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
+  readonly [BigintGaugeKeyTypeTypeId]: MetricKeyType.BigintGaugeKeyTypeTypeId = BigintGaugeKeyTypeTypeId;
+  [Hash.symbol](): number {
+    return Hash.hash(BigintGaugeKeyTypeSymbolKey)
+  }
+  [Equal.symbol](that: unknown): boolean {
+    return isBigintGaugeKey(that)
   }
   pipe() {
     return pipeArguments(this, arguments)
@@ -169,6 +215,12 @@ export const counter: MetricKeyType.MetricKeyType.Counter = new CounterKeyType()
  * @since 2.0.0
  * @category constructors
  */
+export const bigintCounter: MetricKeyType.MetricKeyType.BigintCounter = new BigintCounterKeyType()
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
 export const frequency: MetricKeyType.MetricKeyType.Frequency = new FrequencyKeyType()
 
 /**
@@ -176,6 +228,12 @@ export const frequency: MetricKeyType.MetricKeyType.Frequency = new FrequencyKey
  * @category constructors
  */
 export const gauge: MetricKeyType.MetricKeyType.Gauge = new GaugeKeyType()
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
+export const bigintGauge: MetricKeyType.MetricKeyType.BigintGauge = new BigintGaugeKeyType()
 
 /**
  * @since 2.0.0
@@ -220,6 +278,14 @@ export const isCounterKey = (u: unknown): u is MetricKeyType.MetricKeyType.Count
  * @since 2.0.0
  * @category refinements
  */
+export const isBigintCounterKey = (u: unknown): u is MetricKeyType.MetricKeyType.BigintCounter => {
+  return typeof u === "object" && u != null && BigintCounterKeyTypeTypeId in u
+}
+
+/**
+ * @since 2.0.0
+ * @category refinements
+ */
 export const isFrequencyKey = (u: unknown): u is MetricKeyType.MetricKeyType.Frequency => {
   return typeof u === "object" && u != null && FrequencyKeyTypeTypeId in u
 }
@@ -230,6 +296,14 @@ export const isFrequencyKey = (u: unknown): u is MetricKeyType.MetricKeyType.Fre
  */
 export const isGaugeKey = (u: unknown): u is MetricKeyType.MetricKeyType.Gauge => {
   return typeof u === "object" && u != null && GaugeKeyTypeTypeId in u
+}
+
+/**
+ * @since 2.0.0
+ * @category refinements
+ */
+export const isBigintGaugeKey = (u: unknown): u is MetricKeyType.MetricKeyType.BigintGauge => {
+  return typeof u === "object" && u != null && BigintGaugeKeyTypeTypeId in u
 }
 
 /**

--- a/src/internal/metric/registry.ts
+++ b/src/internal/metric/registry.ts
@@ -23,7 +23,7 @@ export const MetricRegistryTypeId: MetricRegistry.MetricRegistryTypeId = Symbol.
 class MetricRegistryImpl implements MetricRegistry.MetricRegistry {
   readonly [MetricRegistryTypeId]: MetricRegistry.MetricRegistryTypeId = MetricRegistryTypeId
 
-  private map = MutableHashMap.empty<
+  private readonly map = MutableHashMap.empty<
     MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
     MetricHook.MetricHook.Root
   >()
@@ -51,8 +51,14 @@ class MetricRegistryImpl implements MetricRegistry.MetricRegistry {
       if (metricKeyType.isCounterKey(key.keyType)) {
         return this.getCounter(key as unknown as MetricKey.MetricKey.Counter) as any
       }
+      if (metricKeyType.isBigintCounterKey(key.keyType)) {
+        return this.getBigintCounter(key as unknown as MetricKey.MetricKey.BigintCounter) as any
+      }
       if (metricKeyType.isGaugeKey(key.keyType)) {
         return this.getGauge(key as unknown as MetricKey.MetricKey.Gauge) as any
+      }
+      if (metricKeyType.isBigintGaugeKey(key.keyType)) {
+        return this.getBigintGauge(key as unknown as MetricKey.MetricKey.BigintGauge) as any
       }
       if (metricKeyType.isFrequencyKey(key.keyType)) {
         return this.getFrequency(key as unknown as MetricKey.MetricKey.Frequency) as any
@@ -71,115 +77,44 @@ class MetricRegistryImpl implements MetricRegistry.MetricRegistry {
     }
   }
 
-  getCounter(key: MetricKey.MetricKey.Counter): MetricHook.MetricHook.Counter {
-    let value = pipe(
-      this.map,
-      MutableHashMap.get(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>),
-      Option.getOrUndefined
-    )
-    if (value == null) {
-      const counter = metricHook.counter(key)
-      if (!pipe(this.map, MutableHashMap.has(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>))) {
-        pipe(
-          this.map,
-          MutableHashMap.set(
-            key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
-            counter as MetricHook.MetricHook.Root
-          )
+  getCounter = makeGet(this.map, (_) => metricHook.counter(_))
+  getBigintCounter = makeGet(this.map, (_) => metricHook.bigintCounter(_))
+  getFrequency = makeGet(this.map, (_) => metricHook.frequency(_))
+  getGauge = makeGet(this.map, (_) => metricHook.gauge(_, 0))
+  getBigintGauge = makeGet(this.map, (_) => metricHook.bigintGauge(_, BigInt(0)))
+  getHistogram = makeGet(this.map, (_) => metricHook.histogram(_))
+  getSummary = makeGet(this.map, (_) => metricHook.summary(_))
+}
+
+/** @internal */
+const makeGet = <Hook extends MetricHook.MetricHook<any, any>, Key extends MetricKey.MetricKey<any>>(
+  map: MutableHashMap.MutableHashMap<
+    MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
+    MetricHook.MetricHook.Root
+  >,
+  fn: (key: Key) => Hook
+) =>
+(key: Key): Hook => {
+  let value = pipe(
+    map,
+    MutableHashMap.get(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>),
+    Option.getOrUndefined
+  )
+  if (value == null) {
+    const val = fn(key)
+    if (!pipe(map, MutableHashMap.has(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>))) {
+      pipe(
+        map,
+        MutableHashMap.set(
+          key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
+          val as MetricHook.MetricHook.Root
         )
-      }
-      value = counter
+      )
     }
-    return value as MetricHook.MetricHook.Counter
+    value = val
   }
 
-  getFrequency(key: MetricKey.MetricKey.Frequency): MetricHook.MetricHook.Frequency {
-    let value = pipe(
-      this.map,
-      MutableHashMap.get(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>),
-      Option.getOrUndefined
-    )
-    if (value == null) {
-      const frequency = metricHook.frequency(key)
-      if (!pipe(this.map, MutableHashMap.has(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>))) {
-        pipe(
-          this.map,
-          MutableHashMap.set(
-            key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
-            frequency as MetricHook.MetricHook.Root
-          )
-        )
-      }
-      value = frequency
-    }
-    return value as MetricHook.MetricHook.Frequency
-  }
-
-  getGauge(key: MetricKey.MetricKey.Gauge): MetricHook.MetricHook.Gauge {
-    let value = pipe(
-      this.map,
-      MutableHashMap.get(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>),
-      Option.getOrUndefined
-    )
-    if (value == null) {
-      const gauge = metricHook.gauge(key, 0)
-      if (!pipe(this.map, MutableHashMap.has(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>))) {
-        pipe(
-          this.map,
-          MutableHashMap.set(
-            key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
-            gauge as MetricHook.MetricHook.Root
-          )
-        )
-      }
-      value = gauge
-    }
-    return value as MetricHook.MetricHook.Gauge
-  }
-
-  getHistogram(key: MetricKey.MetricKey.Histogram): MetricHook.MetricHook.Histogram {
-    let value = pipe(
-      this.map,
-      MutableHashMap.get(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>),
-      Option.getOrUndefined
-    )
-    if (value == null) {
-      const histogram = metricHook.histogram(key)
-      if (!pipe(this.map, MutableHashMap.has(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>))) {
-        pipe(
-          this.map,
-          MutableHashMap.set(
-            key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
-            histogram as MetricHook.MetricHook.Root
-          )
-        )
-      }
-      value = histogram
-    }
-    return value as MetricHook.MetricHook.Histogram
-  }
-
-  getSummary(key: MetricKey.MetricKey.Summary): MetricHook.MetricHook.Summary {
-    let value = pipe(
-      this.map,
-      MutableHashMap.get(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>),
-      Option.getOrUndefined
-    )
-    if (value == null) {
-      const summary = metricHook.summary(key)
-      if (!pipe(this.map, MutableHashMap.has(key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>))) {
-        pipe(
-          this.map,
-          MutableHashMap.set(
-            key as MetricKey.MetricKey<MetricKeyType.MetricKeyType.Untyped>,
-            summary as MetricHook.MetricHook.Root
-          )
-        )
-      }
-      value = summary
-    }
-    return value as MetricHook.MetricHook.Summary
-  }
+  return value as Hook
 }
 
 /** @internal */

--- a/src/internal/metric/state.ts
+++ b/src/internal/metric/state.ts
@@ -24,6 +24,14 @@ export const CounterStateTypeId: MetricState.CounterStateTypeId = Symbol.for(
 ) as MetricState.CounterStateTypeId
 
 /** @internal */
+const BigintCounterStateSymbolKey = "effect/MetricState/BigintCounter"
+
+/** @internal */
+export const BigintCounterStateTypeId: MetricState.BigintCounterStateTypeId = Symbol.for(
+  BigintCounterStateSymbolKey
+) as MetricState.BigintCounterStateTypeId
+
+/** @internal */
 const FrequencyStateSymbolKey = "effect/MetricState/Frequency"
 
 /** @internal */
@@ -38,6 +46,14 @@ const GaugeStateSymbolKey = "effect/MetricState/Gauge"
 export const GaugeStateTypeId: MetricState.GaugeStateTypeId = Symbol.for(
   GaugeStateSymbolKey
 ) as MetricState.GaugeStateTypeId
+
+/** @internal */
+const BigintGaugeStateSymbolKey = "effect/MetricState/BigintGauge"
+
+/** @internal */
+export const BigintGaugeStateTypeId: MetricState.BigintGaugeStateTypeId = Symbol.for(
+  BigintGaugeStateSymbolKey
+) as MetricState.BigintGaugeStateTypeId
 
 /** @internal */
 const HistogramStateSymbolKey = "effect/MetricState/Histogram"
@@ -80,6 +96,25 @@ class CounterState implements MetricState.MetricState.Counter {
 }
 
 /** @internal */
+class BigintCounterState implements MetricState.MetricState.BigintCounter {
+  readonly [MetricStateTypeId] = metricStateVariance
+  readonly [BigintCounterStateTypeId]: MetricState.BigintCounterStateTypeId = BigintCounterStateTypeId
+  constructor(readonly count: bigint) {}
+  [Hash.symbol](): number {
+    return pipe(
+      Hash.hash(CounterStateSymbolKey),
+      Hash.combine(Hash.hash(this.count))
+    )
+  }
+  [Equal.symbol](that: unknown): boolean {
+    return isBigintCounterState(that) && this.count === that.count
+  }
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+/** @internal */
 class FrequencyState implements MetricState.MetricState.Frequency {
   readonly [MetricStateTypeId] = metricStateVariance
   readonly [FrequencyStateTypeId]: MetricState.FrequencyStateTypeId = FrequencyStateTypeId
@@ -111,6 +146,25 @@ class GaugeState implements MetricState.MetricState.Gauge {
   }
   [Equal.symbol](u: unknown): boolean {
     return isGaugeState(u) && this.value === u.value
+  }
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+/** @internal */
+class BigintGaugeState implements MetricState.MetricState.BigintGauge {
+  readonly [MetricStateTypeId] = metricStateVariance
+  readonly [BigintGaugeStateTypeId]: MetricState.BigintGaugeStateTypeId = BigintGaugeStateTypeId
+  constructor(readonly value: bigint) {}
+  [Hash.symbol](): number {
+    return pipe(
+      Hash.hash(BigintGaugeStateSymbolKey),
+      Hash.combine(Hash.hash(this.value))
+    )
+  }
+  [Equal.symbol](u: unknown): boolean {
+    return isBigintGaugeState(u) && this.value === u.value
   }
   pipe() {
     return pipeArguments(this, arguments)
@@ -194,6 +248,11 @@ export const counter = (count: number): MetricState.MetricState.Counter => {
 }
 
 /** @internal */
+export const bigintCounter = (count: bigint): MetricState.MetricState.BigintCounter => {
+  return new BigintCounterState(count)
+}
+
+/** @internal */
 export const frequency = (occurrences: HashMap.HashMap<string, number>): MetricState.MetricState.Frequency => {
   return new FrequencyState(occurrences)
 }
@@ -201,6 +260,11 @@ export const frequency = (occurrences: HashMap.HashMap<string, number>): MetricS
 /** @internal */
 export const gauge = (value: number): MetricState.MetricState.Gauge => {
   return new GaugeState(value)
+}
+
+/** @internal */
+export const bigintGauge = (value: bigint): MetricState.MetricState.BigintGauge => {
+  return new BigintGaugeState(value)
 }
 
 /** @internal */
@@ -251,34 +315,32 @@ export const isCounterState = (u: unknown): u is MetricState.MetricState.Counter
   return typeof u === "object" && u != null && CounterStateTypeId in u
 }
 
-/**
- * @since 2.0.0
- * @category refinements
- */
+/** @internal */
+export const isBigintCounterState = (u: unknown): u is MetricState.MetricState.BigintCounter => {
+  return typeof u === "object" && u != null && BigintCounterStateTypeId in u
+}
+
+/** @internal */
 export const isFrequencyState = (u: unknown): u is MetricState.MetricState.Frequency => {
   return typeof u === "object" && u != null && FrequencyStateTypeId in u
 }
 
-/**
- * @since 2.0.0
- * @category refinements
- */
+/** @internal */
 export const isGaugeState = (u: unknown): u is MetricState.MetricState.Gauge => {
   return typeof u === "object" && u != null && GaugeStateTypeId in u
 }
 
-/**
- * @since 2.0.0
- * @category refinements
- */
+/** @internal */
+export const isBigintGaugeState = (u: unknown): u is MetricState.MetricState.BigintGauge => {
+  return typeof u === "object" && u != null && BigintGaugeStateTypeId in u
+}
+
+/** @internal */
 export const isHistogramState = (u: unknown): u is MetricState.MetricState.Histogram => {
   return typeof u === "object" && u != null && HistogramStateTypeId in u
 }
 
-/**
- * @since 2.0.0
- * @category refinements
- */
+/** @internal */
 export const isSummaryState = (u: unknown): u is MetricState.MetricState.Summary => {
   return typeof u === "object" && u != null && SummaryStateTypeId in u
 }


### PR DESCRIPTION
Opening this for comments ... I don't like this approach. I think I'd prefer a more generic internal API by adding value subtypes for counters, gauges, etc. so we do not inflate the public api further by introducing whole bigint-specific metric types. 