### PR TITLE
Enforce that members passed to TaggedEnum do not have a `_tag` property

### DIFF
--- a/.changeset/sour-toys-search.md
+++ b/.changeset/sour-toys-search.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+enforce that members passed to TaggedEnum do not have a `_tag` property themselves

--- a/dtslint/Data.ts
+++ b/dtslint/Data.ts
@@ -1,0 +1,16 @@
+import * as Data from 'effect/Data'
+
+type HttpError = Data.TaggedEnum<{
+  BadRequest: { status: 400, a: string }
+  NotFound: { status: 404, b: number }
+}>
+// $ExpectType Data<{ readonly a: string; readonly status: 400; readonly _tag: "BadRequest"; }>
+type BadRequest = Extract<HttpError, { _tag: 'BadRequest' }>
+// $ExpectType Data<{ readonly b: number; readonly status: 404; readonly _tag: "NotFound"; }>
+type NotFound = Extract<HttpError, { _tag: 'NotFound' }>
+
+// @ts-expect-error
+type Err = Data.TaggedEnum<{
+  A: { _tag: 'A' },
+  B: { tag: 'B' }
+}>

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -175,7 +175,6 @@ type TaggedEnum<
   : never
   ;
 
-/** @internal */
 interface _phantom<A> {
   _A: A
   keys: (this[`_A`][keyof this[`_A`]]) extends infer T ? T extends T ? keyof T : never : never;

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -164,31 +164,23 @@ export const Structural: new<A>(
  * @since 2.0.0
  * @category models
  */
-type TaggedEnum<
-  A extends Record<string, Record<string, any>> & Untagged<_>,
-  _ extends _phantom<A> = _phantom<A>
->
-  = keyof A extends | infer Tag
-  ? Tag extends keyof A
-  ? Data<{ readonly [K in `_tag` | keyof A[Tag]]: K extends `_tag` ? Tag : A[Tag][K] }>
+export type TaggedEnum<
+  A extends Record<string, Record<string, any>> & _,
+  _ extends ChildrenUntagged<A> = ChildrenUntagged<A>
+> = keyof A extends infer Tag
+  ? Tag extends keyof A ? Data<{ readonly [K in `_tag` | keyof A[Tag]]: K extends `_tag` ? Tag : A[Tag][K] }>
   : never
   : never
-  ;
 
-interface _phantom<A> {
-  _A: A
-  keys: (this[`_A`][keyof this[`_A`]]) extends infer T ? T extends T ? keyof T : never : never;
-  isTagged: `_tag` extends this[`keys`] ? true : false
-}
+type ChildHasDiscriminant<A> = `_tag` extends ChildKeys<A> ? true : false
 
-/** @internal */
-type Untagged<_ extends { isTagged: any }>
-  = [_[`isTagged`]] extends [true]
+type ChildKeys<A> = A[keyof A] extends infer M ? M extends M ? keyof M : never : never
+
+type ChildrenUntagged<_> = [ChildHasDiscriminant<_>] extends [true]
   ? `It looks like you're trying to create a tagged enum, but one or more of its members already has a \`_tag\` property.`
   : unknown
-  ;
 
-/**
+/** ,
  * @since 2.0.0
  */
 export declare namespace TaggedEnum {

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -164,12 +164,30 @@ export const Structural: new<A>(
  * @since 2.0.0
  * @category models
  */
-export type TaggedEnum<A extends Record<string, Record<string, any>>>
-  = keyof A extends | infer Tag 
-  ? Tag extends keyof A 
-  ? Data<{ readonly [K in "_tag" | keyof A[Tag]]: K extends "_tag" ? Tag : A[Tag][K] }>
+type TaggedEnum<
+  A extends Record<string, Record<string, any>> & CheckUntagged<_>,
+  _ extends _phantom<A> = _phantom<A>
+>
+  = keyof A extends | infer Tag
+  ? Tag extends keyof A
+  ? Data<{ readonly [K in `_tag` | keyof A[Tag]]: K extends `_tag` ? Tag : A[Tag][K] }>
   : never
   : never
+  ;
+
+/** @internal */
+interface _phantom<A> {
+  _A: A
+  keys: (this[`_A`][keyof this[`_A`]]) extends infer T ? T extends T ? keyof T : never : never;
+  isTagged: `_tag` extends this[`keys`] ? true : false
+}
+
+/** @internal */
+type CheckUntagged<_ extends { isTagged: any }>
+  = [_[`isTagged`]] extends [true]
+  ? `It looks like you're trying to create a tagged enum, but one or more of its members already have a \`_tag\` property.`
+  : unknown
+  ;
 
 /**
  * @since 2.0.0

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -165,7 +165,7 @@ export const Structural: new<A>(
  * @category models
  */
 type TaggedEnum<
-  A extends Record<string, Record<string, any>> & CheckUntagged<_>,
+  A extends Record<string, Record<string, any>> & Untagged<_>,
   _ extends _phantom<A> = _phantom<A>
 >
   = keyof A extends | infer Tag
@@ -183,9 +183,9 @@ interface _phantom<A> {
 }
 
 /** @internal */
-type CheckUntagged<_ extends { isTagged: any }>
+type Untagged<_ extends { isTagged: any }>
   = [_[`isTagged`]] extends [true]
-  ? `It looks like you're trying to create a tagged enum, but one or more of its members already have a \`_tag\` property.`
+  ? `It looks like you're trying to create a tagged enum, but one or more of its members already has a \`_tag\` property.`
   : unknown
   ;
 

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -180,7 +180,7 @@ type ChildrenUntagged<_> = [ChildHasDiscriminant<_>] extends [true]
   ? `It looks like you're trying to create a tagged enum, but one or more of its members already has a \`_tag\` property.`
   : unknown
 
-/** ,
+/**
  * @since 2.0.0
  */
 export declare namespace TaggedEnum {

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -164,11 +164,12 @@ export const Structural: new<A>(
  * @since 2.0.0
  * @category models
  */
-export type TaggedEnum<A extends Record<string, Record<string, any>>> = {
-  readonly [Tag in keyof A]: Data<
-    Readonly<Types.Simplify<A[Tag] & { _tag: Tag }>>
-  >
-}[keyof A]
+export type TaggedEnum<A extends Record<string, Record<string, any>>>
+  = keyof A extends | infer Tag 
+  ? Tag extends keyof A 
+  ? Data<{ readonly [K in "_tag" | keyof A[Tag]]: K extends "_tag" ? Tag : A[Tag][K] }>
+  : never
+  : never
 
 /**
  * @since 2.0.0

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -166,17 +166,17 @@ export const Structural: new<A>(
  */
 export type TaggedEnum<
   A extends Record<string, Record<string, any>> & _,
-  _ extends ChildrenUntagged<A> = ChildrenUntagged<A>
+  _ extends ChildHasTagCheck<A> = ChildHasTagCheck<A>
 > = keyof A extends infer Tag
   ? Tag extends keyof A ? Data<{ readonly [K in `_tag` | keyof A[Tag]]: K extends `_tag` ? Tag : A[Tag][K] }>
   : never
   : never
 
-type ChildHasDiscriminant<A> = `_tag` extends ChildKeys<A> ? true : false
+type ChildHasTag<A> = `_tag` extends ChildKeys<A> ? true : false
 
 type ChildKeys<A> = A[keyof A] extends infer M ? M extends M ? keyof M : never : never
 
-type ChildrenUntagged<_> = [ChildHasDiscriminant<_>] extends [true]
+type ChildHasTagCheck<_> = [ChildHasTag<_>] extends [true]
   ? `It looks like you're trying to create a tagged enum, but one or more of its members already has a \`_tag\` property.`
   : unknown
 


### PR DESCRIPTION
Closes https://github.com/Effect-TS/effect/issues/1497

Note: I was not intending to work on this issue -- originally I was actually contributing a minor type-level performance improvement to TaggedEnum, and when I went to open the PR, I checked to see if there were any related issues or pull requests, and saw #1497 (and happened to know how to make that work).

Note that:
1. users will see a type error if they try to create a `TaggedEnum` when one their members has a `_tag` property
2. even though they get the type error, the `TaggedEnum` still gets instantiated, and the `_tag` property is overwritten

Not 100% sure if this is the behavior that makes the most sense, but it seemed the most reasonable to me.

[TS v5.2 Playground](https://tsplay.dev/Wk3GjW)
[TS v4.8 Playground](https://tsplay.dev/WvQEYm)

Happy to make any requested adjustments, and I apologize if any of the names aren't clear -- I wrote this rather quickly, and figured better to get feedback before spending too long on it :)