### PR TITLE
Removes unnecessary type parameter from TaggedEnum

### DIFF
--- a/.changeset/short-crabs-beg.md
+++ b/.changeset/short-crabs-beg.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+removes unnecessary type parameter from TaggedEnum

--- a/docs/modules/Chunk.ts.md
+++ b/docs/modules/Chunk.ts.md
@@ -82,6 +82,7 @@ Added in v2.0.0
   - [reduceRight](#reduceright)
 - [mapping](#mapping)
   - [map](#map)
+  - [mapNonEmpty](#mapnonempty)
 - [model](#model)
   - [NonEmptyChunk (interface)](#nonemptychunk-interface)
 - [models](#models)
@@ -970,7 +971,7 @@ Added in v2.0.0
 
 ## map
 
-Returns an effect whose success is mapped by the specified f function.
+Returns a chunk with the elements mapped by the specified f function.
 
 **Signature**
 
@@ -978,6 +979,21 @@ Returns an effect whose success is mapped by the specified f function.
 export declare const map: {
   <A, B>(f: (a: A, i: number) => B): (self: Chunk<A>) => Chunk<B>
   <A, B>(self: Chunk<A>, f: (a: A, i: number) => B): Chunk<B>
+}
+```
+
+Added in v2.0.0
+
+## mapNonEmpty
+
+Returns a non empty chunk with the elements mapped by the specified f function.
+
+**Signature**
+
+```ts
+export declare const mapNonEmpty: {
+  <A, B>(f: (a: A, i: number) => B): (self: NonEmptyChunk<A>) => NonEmptyChunk<B>
+  <A, B>(self: NonEmptyChunk<A>, f: (a: A, i: number) => B): NonEmptyChunk<B>
 }
 ```
 

--- a/docs/modules/Data.ts.md
+++ b/docs/modules/Data.ts.md
@@ -312,9 +312,11 @@ type HttpErrorPlain =
 **Signature**
 
 ```ts
-export type TaggedEnum<A extends Record<string, Record<string, any>>> = {
-  readonly [Tag in keyof A]: Data<Readonly<Types.Simplify<A[Tag] & { _tag: Tag }>>>
-}[keyof A]
+export type TaggedEnum<A extends Record<string, Record<string, any>> & UntaggedChildren<A>> = keyof A extends infer Tag
+  ? Tag extends keyof A
+    ? Data<{ readonly [K in `_tag` | keyof A[Tag]]: K extends `_tag` ? Tag : A[Tag][K] }>
+    : never
+  : never
 ```
 
 Added in v2.0.0

--- a/docs/modules/List.ts.md
+++ b/docs/modules/List.ts.md
@@ -28,6 +28,7 @@ Added in v2.0.0
   - [filterMap](#filtermap)
   - [forEach](#foreach)
   - [map](#map)
+  - [mapNonEmpty](#mapnonempty)
   - [partition](#partition)
   - [partitionMap](#partitionmap)
   - [splitAt](#splitat)
@@ -171,6 +172,19 @@ Applies the specified mapping function to each element of the list.
 export declare const map: {
   <A, B>(f: (a: A) => B): (self: List<A>) => List<B>
   <A, B>(self: List<A>, f: (a: A) => B): List<B>
+}
+```
+
+Added in v2.0.0
+
+## mapNonEmpty
+
+**Signature**
+
+```ts
+export declare const mapNonEmpty: {
+  <A, B>(f: (a: A) => B): (self: Cons<A>) => Cons<B>
+  <A, B>(self: Cons<A>, f: (a: A) => B): Cons<B>
 }
 ```
 

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -165,19 +165,19 @@ export const Structural: new<A>(
  * @category models
  */
 export type TaggedEnum<
-  A extends Record<string, Record<string, any>> & _,
-  _ extends ChildHasTagCheck<A> = ChildHasTagCheck<A>
+  A extends Record<string, Record<string, any>> & UntaggedChildren<A>
 > = keyof A extends infer Tag
   ? Tag extends keyof A ? Data<{ readonly [K in `_tag` | keyof A[Tag]]: K extends `_tag` ? Tag : A[Tag][K] }>
   : never
   : never
 
-type ChildHasTag<A> = `_tag` extends ChildKeys<A> ? true : false
+type ChildrenAreTagged<A> = keyof A extends infer K ? K extends keyof A ? "_tag" extends keyof A[K] ? true
+    : false
+  : never
+  : never
 
-type ChildKeys<A> = A[keyof A] extends infer M ? M extends M ? keyof M : never : never
-
-type ChildHasTagCheck<_> = [ChildHasTag<_>] extends [true]
-  ? `It looks like you're trying to create a tagged enum, but one or more of its members already has a \`_tag\` property.`
+type UntaggedChildren<A> = true extends ChildrenAreTagged<A>
+  ? "It looks like you're trying to create a tagged enum, but one or more of its members already has a `_tag` property."
   : unknown
 
 /**


### PR DESCRIPTION
Per conversation in https://github.com/Effect-TS/effect/pull/1521 (thank you @gcanti, I didn't realize type parameters could be self-referential like that 😮), this PR removes the phantom type introduced in that PR.

I think we should remove it if possible since it introduces the possibility of confusing users. I previously thought that removing it wasn't possible, and that we were making a tradeoff for which behavior we felt was less surprising, but if the type and its constraint can be embedded into one, I'm all for it.