### PR TITLE
fix: Either/Option gen when no yield executes, just a plain return

### DIFF
--- a/.changeset/gorgeous-rules-fix.md
+++ b/.changeset/gorgeous-rules-fix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix: Either/Option gen when no yield executes, just a plain return

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -606,7 +606,7 @@ export const gen: Gen.Gen<EitherTypeLambda, Gen.Adapter<EitherTypeLambda>> = (f)
   const iterator = f(adapter)
   let state: IteratorYieldResult<any> | IteratorReturnResult<any> = iterator.next()
   if (state.done) {
-    return right(void 0) as any
+    return right(state.value) as any
   } else {
     let current = state.value.value
     if (isLeft(current)) {

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1287,7 +1287,7 @@ export const gen: Gen.Gen<OptionTypeLambda, Gen.Adapter<OptionTypeLambda>> = (f)
   const iterator = f(adapter)
   let state: IteratorYieldResult<any> | IteratorReturnResult<any> = iterator.next()
   if (state.done) {
-    return some(void 0)
+    return some(state.value)
   } else {
     let current = state.value.value
     if (isNone(current)) {

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -32,7 +32,7 @@ describe.concurrent("Either", () => {
       return yield* $(Either.right(2))
     })
     expect(a).toEqual(Either.right(3))
-    expect(b).toEqual(Either.right(undefined))
+    expect(b).toEqual(Either.right(10))
     expect(c).toEqual(Either.right(undefined))
     expect(d).toEqual(Either.right(2))
     expect(e).toEqual(Either.left("err"))

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -34,7 +34,7 @@ describe.concurrent("Option", () => {
       return yield* $(_.some(2))
     })
     expect(a).toEqual(_.some(3))
-    expect(b).toEqual(_.some(undefined))
+    expect(b).toEqual(_.some(10))
     expect(c).toEqual(_.some(undefined))
     expect(d).toEqual(_.some(2))
     expect(e).toEqual(_.none())


### PR DESCRIPTION
The test case in question was:
```ts
    const b = Either.gen(function*($) {
      // eslint-disable-next-line no-constant-condition
      if (0 > 1) yield* $(Either.left(0))
      return 10
    })
```

which should be the same as the existing test case
```ts
    // eslint-disable-next-line require-yield
    const b = Either.gen(function*() {
      return 10
    })
```
which was documented in the test as returning `undefined`, that seems wrong to me.