### PR TITLE
use vitest imports throughout

### DIFF
--- a/test/BigDecimal.ts
+++ b/test/BigDecimal.ts
@@ -1,7 +1,7 @@
 import { assertFalse, assertTrue, deepStrictEqual } from "effect-test/util"
 import * as BD from "effect/BigDecimal"
 import * as Option from "effect/Option"
-import { describe, it } from "vitest"
+import { assert, describe, it } from "vitest"
 
 const _ = BD.unsafeFromString
 const assertEquals = (a: BD.BigDecimal, b: BD.BigDecimal) => assertTrue(BD.equals(a, b))

--- a/test/BigInt.ts
+++ b/test/BigInt.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual } from "effect-test/util"
 import * as BigInt from "effect/BigInt"
 import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("BigInt", () => {
   it("sign", () => {

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual } from "effect-test/util"
 import * as Boolean from "effect/Boolean"
 import { pipe } from "effect/Function"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Boolean", () => {
   it("isBoolean", () => {

--- a/test/Brand.ts
+++ b/test/Brand.ts
@@ -1,6 +1,7 @@
 import * as Brand from "effect/Brand"
 import * as Either from "effect/Either"
 import * as Option from "effect/Option"
+import { assert, describe, it } from "vitest"
 
 declare const IntTypeId: unique symbol
 type Int = number & Brand.Brand<typeof IntTypeId>

--- a/test/Cause.ts
+++ b/test/Cause.ts
@@ -7,7 +7,7 @@ import * as internal from "effect/internal/cause"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as fc from "fast-check"
-import { assert, describe } from "vitest"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Cause", () => {
   it("[internal] prettyErrorMessage", () => {

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -10,6 +10,7 @@ import type { Predicate } from "effect/Predicate"
 import * as RA from "effect/ReadonlyArray"
 import * as fc from "fast-check"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Chunk", () => {
   it("exports", () => {

--- a/test/Context.ts
+++ b/test/Context.ts
@@ -213,7 +213,7 @@ describe.concurrent("Context", () => {
     } catch (e) {
       assert.match(
         String(e),
-        new RegExp(/Error: Service not found: C \(defined at (.*)Context.ts:19:19\)/)
+        new RegExp(/Error: Service not found: C \(defined at (.*)Context.ts:20:19\)/)
       )
     }
   })

--- a/test/Context.ts
+++ b/test/Context.ts
@@ -2,6 +2,7 @@ import * as Context from "effect/Context"
 import * as Differ from "effect/Differ"
 import { pipe } from "effect/Function"
 import * as O from "effect/Option"
+import { assert, describe, expect, it } from "vitest"
 
 interface A {
   a: number

--- a/test/Data.ts
+++ b/test/Data.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data"
 import * as Equal from "effect/Equal"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Data", () => {
   it("struct", () => {

--- a/test/Differ.ts
+++ b/test/Differ.ts
@@ -5,7 +5,7 @@ import { pipe } from "effect/Function"
 import * as HashMap from "effect/HashMap"
 import * as HashSet from "effect/HashSet"
 import * as RA from "effect/ReadonlyArray"
-import { it as it_ } from "vitest"
+import { assert, describe, it as it_ } from "vitest"
 
 function diffLaws<Value, Patch>(
   differ: Differ.Differ<Value, Patch>,

--- a/test/Duration.ts
+++ b/test/Duration.ts
@@ -4,6 +4,7 @@ import * as Equal from "effect/Equal"
 import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Duration", () => {
   it("exports", () => {

--- a/test/Effect/environment.ts
+++ b/test/Effect/environment.ts
@@ -2,7 +2,7 @@ import * as it from "effect-test/utils/extend"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import { pipe } from "effect/Function"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 interface NumberService {
   readonly n: number

--- a/test/Effect/promise.ts
+++ b/test/Effect/promise.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect"
 import * as timeout from "effect/internal/timeout"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Effect", () => {
   it("promise - success with AbortSignal", async () => {

--- a/test/Effect/query-deadlock.ts
+++ b/test/Effect/query-deadlock.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
+import { describe } from "vitest"
 
 export const userIds: ReadonlyArray<number> = [1, 1]
 

--- a/test/Effect/query-nested.ts
+++ b/test/Effect/query-nested.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
+import { describe, expect } from "vitest"
 
 interface Counter {
   readonly _: unique symbol

--- a/test/Effect/query.ts
+++ b/test/Effect/query.ts
@@ -13,6 +13,7 @@ import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
 import * as TestClock from "effect/TestClock"
 import type { Concurrency } from "effect/Types"
+import { describe, expect } from "vitest"
 
 interface Counter {
   readonly _: unique symbol

--- a/test/Effect/rendezvous.ts
+++ b/test/Effect/rendezvous.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
 import * as Queue from "effect/Queue"
 import * as TestClock from "effect/TestClock"
-import { describe } from "vitest"
+import { assert, describe } from "vitest"
 
 describe.concurrent("Effect", () => {
   it.effect("bounded 0 is rendezvous", () =>

--- a/test/Effect/runtimeFlags.ts
+++ b/test/Effect/runtimeFlags.ts
@@ -2,7 +2,7 @@ import * as it from "effect-test/utils/extend"
 import * as Effect from "effect/Effect"
 import * as Flags from "effect/RuntimeFlags"
 import * as Patch from "effect/RuntimeFlagsPatch"
-import { describe } from "vitest"
+import { assert, describe } from "vitest"
 
 describe.concurrent("Effect", () => {
   it.it("should enable flags in the current fiber", () =>

--- a/test/Effect/scope-ref.ts
+++ b/test/Effect/scope-ref.ts
@@ -5,7 +5,7 @@ import * as FiberRef from "effect/FiberRef"
 import * as Layer from "effect/Layer"
 import * as List from "effect/List"
 import * as Logger from "effect/Logger"
-import { describe } from "vitest"
+import { assert, describe } from "vitest"
 
 const ref = FiberRef.unsafeMake(List.empty<string>())
 const env = Tag<"context", number>()

--- a/test/Effect/structural.ts
+++ b/test/Effect/structural.ts
@@ -3,7 +3,7 @@ import { assertType, satisfies } from "effect-test/utils/types"
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import * as Option from "effect/Option"
-import { describe } from "vitest"
+import { assert, describe } from "vitest"
 
 describe.concurrent("Effect", () => {
   describe("all", () => {

--- a/test/Effect/tryPromise.ts
+++ b/test/Effect/tryPromise.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import * as timeout from "effect/internal/timeout"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Effect", () => {
   it("tryPromise - success, no catch, no AbortSignal", async () => {

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -6,6 +6,7 @@ import * as N from "effect/Number"
 import * as O from "effect/Option"
 import * as S from "effect/String"
 import { inspect } from "node:util"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Either", () => {
   it("gen", () => {

--- a/test/Encoding.ts
+++ b/test/Encoding.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, strictEqual } from "effect-test/util"
 import * as Either from "effect/Either"
 import * as Encoding from "effect/Encoding"
+import { assert, describe, it } from "vitest"
 
 describe.concurrent("Base64", () => {
   const valid: Array<[string, string]> = [

--- a/test/Equivalence.ts
+++ b/test/Equivalence.ts
@@ -1,5 +1,6 @@
 import * as _ from "effect/Equivalence"
 import { pipe } from "effect/Function"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Equivalence", () => {
   it("array", () => {
@@ -11,7 +12,7 @@ describe.concurrent("Equivalence", () => {
     expect(eq([1, 2, 3], [1, 2])).toEqual(false)
   })
 
-  test("strict returns an Equivalence that uses strict equality (===) to compare values", () => {
+  it("strict returns an Equivalence that uses strict equality (===) to compare values", () => {
     const eq = _.strict<{ a: number }>()
     const a = { a: 1 }
     expect(eq(a, a)).toBe(true)

--- a/test/Exit.ts
+++ b/test/Exit.ts
@@ -1,4 +1,5 @@
 import * as Exit from "effect/Exit"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Exit", () => {
   describe.concurrent("toJSON", () => {

--- a/test/FiberRefs.ts
+++ b/test/FiberRefs.ts
@@ -8,7 +8,7 @@ import * as FiberRefs from "effect/FiberRefs"
 import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 describe.concurrent("FiberRefs", () => {
   it.scoped("propagate FiberRef values across fiber boundaries", () =>

--- a/test/Function.ts
+++ b/test/Function.ts
@@ -1,7 +1,7 @@
-import * as assert from "assert"
 import { deepStrictEqual, double } from "effect-test/util"
 import * as Function from "effect/Function"
 import * as String from "effect/String"
+import { assert, describe, expect, it } from "vitest"
 
 const f = (n: number): number => n + 1
 const g = double

--- a/test/GlobalValue.ts
+++ b/test/GlobalValue.ts
@@ -1,4 +1,5 @@
 import * as G from "effect/GlobalValue"
+import { assert, describe, it } from "vitest"
 
 const a = G.globalValue("id", () => ({}))
 const b = G.globalValue("id", () => ({}))

--- a/test/Hash.ts
+++ b/test/Hash.ts
@@ -1,6 +1,7 @@
 import { absurd, identity } from "effect/Function"
 import * as Hash from "effect/Hash"
 import * as HashSet from "effect/HashSet"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Hash", () => {
   it("exports", () => {

--- a/test/HashMap.ts
+++ b/test/HashMap.ts
@@ -5,6 +5,7 @@ import * as Hash from "effect/Hash"
 import * as HM from "effect/HashMap"
 import * as Option from "effect/Option"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 class Key implements Equal.Equal {
   constructor(readonly n: number) {}

--- a/test/HashSet.ts
+++ b/test/HashSet.ts
@@ -4,6 +4,7 @@ import { pipe } from "effect/Function"
 import * as Hash from "effect/Hash"
 import * as HashSet from "effect/HashSet"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 class Value implements Equal.Equal {
   constructor(readonly n: number) {}

--- a/test/Inspectable.ts
+++ b/test/Inspectable.ts
@@ -1,4 +1,5 @@
 import * as Inspectable from "effect/Inspectable"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Inspectable", () => {
   describe.concurrent("toString", () => {

--- a/test/Logger.ts
+++ b/test/Logger.ts
@@ -8,8 +8,7 @@ import { logLevelInfo } from "effect/internal/core"
 import * as List from "effect/List"
 import * as Logger from "effect/Logger"
 import * as LogSpan from "effect/LogSpan"
-
-import { vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 describe("stringLogger", () => {
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe("stringLogger", () => {
     vi.useRealTimers()
   })
 
-  test("keys with special chars", () => {
+  it("keys with special chars", () => {
     const date = new Date()
     vi.setSystemTime(date)
     const spans = List.make(LogSpan.make("imma span=\"", date.getTime() - 7))
@@ -47,7 +46,7 @@ describe("stringLogger", () => {
     )
   })
 
-  test("with linebreaks", () => {
+  it("with linebreaks", () => {
     const date = new Date()
     vi.setSystemTime(date)
     const spans = List.make(LogSpan.make("imma\nspan=\"", date.getTime() - 7))
@@ -85,7 +84,7 @@ describe("logfmtLogger", () => {
     vi.useRealTimers()
   })
 
-  test("keys with special chars", () => {
+  it("keys with special chars", () => {
     const date = new Date()
     vi.setSystemTime(date)
     const spans = List.make(LogSpan.make("imma span=\"", date.getTime() - 7))
@@ -111,7 +110,7 @@ describe("logfmtLogger", () => {
     )
   })
 
-  test("with linebreaks", () => {
+  it("with linebreaks", () => {
     const date = new Date()
     vi.setSystemTime(date)
     const spans = List.make(LogSpan.make("imma\nspan=\"", date.getTime() - 7))
@@ -140,12 +139,12 @@ describe("logfmtLogger", () => {
     )
   })
 
-  test(".pipe", () => {
+  it(".pipe", () => {
     expect(Logger.stringLogger.pipe(identity)).toBe(Logger.stringLogger)
     expect(logLevelInfo.pipe(identity)).toBe(logLevelInfo)
   })
 
-  test("objects", () => {
+  it("objects", () => {
     const date = new Date()
     vi.setSystemTime(date)
 
@@ -165,7 +164,7 @@ describe("logfmtLogger", () => {
     )
   })
 
-  test("circular objects", () => {
+  it("circular objects", () => {
     const date = new Date()
     vi.setSystemTime(date)
 
@@ -188,7 +187,7 @@ describe("logfmtLogger", () => {
     )
   })
 
-  test("symbols", () => {
+  it("symbols", () => {
     const date = new Date()
     vi.setSystemTime(date)
 
@@ -208,7 +207,7 @@ describe("logfmtLogger", () => {
     )
   })
 
-  test("functions", () => {
+  it("functions", () => {
     const date = new Date()
     vi.setSystemTime(date)
 
@@ -228,7 +227,7 @@ describe("logfmtLogger", () => {
     )
   })
 
-  test("annotations", () => {
+  it("annotations", () => {
     const date = new Date()
     vi.setSystemTime(date)
 

--- a/test/Match.ts
+++ b/test/Match.ts
@@ -4,6 +4,7 @@ import { pipe } from "effect/Function"
 import * as M from "effect/Match"
 import * as O from "effect/Option"
 import * as Predicate from "effect/Predicate"
+import { describe, expect, it } from "vitest"
 
 describe("Match", () => {
   it("exhaustive", () => {

--- a/test/Metric.ts
+++ b/test/Metric.ts
@@ -17,6 +17,7 @@ import * as MetricState from "effect/MetricState"
 import * as Option from "effect/Option"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Schedule from "effect/Schedule"
+import { assert, describe, expect } from "vitest"
 
 const labels = Chunk.make(MetricLabel.make("x", "a"), MetricLabel.make("y", "b"))
 

--- a/test/MutableHashMap.ts
+++ b/test/MutableHashMap.ts
@@ -4,6 +4,7 @@ import * as Hash from "effect/Hash"
 import * as HM from "effect/MutableHashMap"
 import * as O from "effect/Option"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 class Key implements Equal.Equal {
   constructor(readonly a: number, readonly b: number) {}

--- a/test/MutableHashSet.ts
+++ b/test/MutableHashSet.ts
@@ -2,6 +2,7 @@ import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import * as MutableHashSet from "effect/MutableHashSet"
 import { inspect } from "node:util"
+import { describe, expect, it } from "vitest"
 
 class Value implements Equal.Equal {
   constructor(readonly a: number, readonly b: number) {}

--- a/test/MutableList.ts
+++ b/test/MutableList.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, strictEqual } from "effect-test/util"
 import { pipe } from "effect/Function"
 import * as MutableList from "effect/MutableList"
 import { inspect } from "node:util"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("MutableList", () => {
   it("toString", () => {

--- a/test/MutableQueue.ts
+++ b/test/MutableQueue.ts
@@ -1,6 +1,7 @@
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "effect-test/util"
 import * as MutableQueue from "effect/MutableQueue"
 import { inspect } from "node:util"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("MutableQueue", () => {
   it("toString", () => {

--- a/test/MutableRef.ts
+++ b/test/MutableRef.ts
@@ -1,6 +1,7 @@
 import * as Chunk from "effect/Chunk"
 import * as MutableRef from "effect/MutableRef"
 import { inspect } from "node:util"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("MutableRef", () => {
   it("toString", () => {

--- a/test/NonEmptyIterable.ts
+++ b/test/NonEmptyIterable.ts
@@ -1,5 +1,6 @@
 import * as Chunk from "effect/Chunk"
 import * as NonEmpty from "effect/NonEmptyIterable"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("NonEmptyIterable", () => {
   it("should get head and rest", () => {

--- a/test/Number.ts
+++ b/test/Number.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual } from "effect-test/util"
 import { pipe } from "effect/Function"
 import * as Number from "effect/Number"
 import * as Option from "effect/Option"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Number", () => {
   it("isNumber", () => {

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -6,6 +6,7 @@ import * as N from "effect/Number"
 import * as _ from "effect/Option"
 import * as S from "effect/String"
 import { inspect } from "node:util"
+import { assert, assertType, describe, expect, it } from "vitest"
 
 const p = (n: number): boolean => n > 2
 

--- a/test/Order.ts
+++ b/test/Order.ts
@@ -1,6 +1,7 @@
 import { pipe } from "effect/Function"
 import * as _ from "effect/Order"
 import { sort } from "effect/ReadonlyArray"
+import { describe, it } from "vitest"
 import * as U from "./util"
 
 describe.concurrent("Order", () => {

--- a/test/Ordering.ts
+++ b/test/Ordering.ts
@@ -1,4 +1,5 @@
 import * as _ from "effect/Ordering"
+import { describe, it } from "vitest"
 import { deepStrictEqual } from "./util"
 
 describe.concurrent("Ordering", () => {

--- a/test/Pipeable.ts
+++ b/test/Pipeable.ts
@@ -1,4 +1,5 @@
 import * as _ from "effect/Option"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Pipeable", () => {
   it("pipeArguments", () => {

--- a/test/Predicate.ts
+++ b/test/Predicate.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual } from "effect-test/util"
 import { constFalse, constTrue, pipe } from "effect/Function"
 import * as _ from "effect/Predicate"
+import { assert, describe, expect, it } from "vitest"
 
 const isPositive: _.Predicate<number> = (n) => n > 0
 const isNegative: _.Predicate<number> = (n) => n < 0

--- a/test/Queue.ts
+++ b/test/Queue.ts
@@ -11,7 +11,7 @@ import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Ref from "effect/Ref"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 export const waitForValue = <A>(ref: Effect.Effect<never, never, A>, value: A): Effect.Effect<never, never, A> => {
   return ref.pipe(Effect.zipLeft(Effect.yieldNow()), Effect.repeatUntil((a) => value === a))

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -1,4 +1,3 @@
-import * as assert from "assert"
 import { deepStrictEqual, double, strictEqual } from "effect-test/util"
 import * as E from "effect/Either"
 import { identity, pipe } from "effect/Function"
@@ -9,6 +8,7 @@ import type { Predicate } from "effect/Predicate"
 import * as RA from "effect/ReadonlyArray"
 import * as String from "effect/String"
 import * as fc from "fast-check"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("ReadonlyArray", () => {
   it("exports", () => {

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -3,6 +3,7 @@ import { pipe } from "effect/Function"
 import * as N from "effect/Number"
 import * as Option from "effect/Option"
 import * as RR from "effect/ReadonlyRecord"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("ReadonlyRecord", () => {
   it("get", () => {

--- a/test/RedBlackTree.ts
+++ b/test/RedBlackTree.ts
@@ -7,6 +7,7 @@ import * as Option from "effect/Option"
 import * as Order from "effect/Order"
 import * as RedBlackTree from "effect/RedBlackTree"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("RedBlackTree", () => {
   it("toString", () => {

--- a/test/Scope.ts
+++ b/test/Scope.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect"
 import { identity, pipe } from "effect/Function"
 import * as Ref from "effect/Ref"
 import * as Scope from "effect/Scope"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 type Action = Acquire | Use | Release
 

--- a/test/ScopedRef.ts
+++ b/test/ScopedRef.ts
@@ -3,7 +3,7 @@ import * as it from "effect-test/utils/extend"
 import * as Effect from "effect/Effect"
 import { identity, pipe } from "effect/Function"
 import * as ScopedRef from "effect/ScopedRef"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 describe.concurrent("ScopedRef", () => {
   it.scoped("single set", () =>

--- a/test/SortedMap.ts
+++ b/test/SortedMap.ts
@@ -5,6 +5,7 @@ import * as N from "effect/Number"
 import * as O from "effect/Option"
 import * as SM from "effect/SortedMap"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 class Key implements Eq.Equal {
   constructor(readonly id: number) {}
@@ -50,7 +51,7 @@ function makeNumericSortedMap(
 }
 
 describe.concurrent("SortedMap", () => {
-  test("toString", () => {
+  it("toString", () => {
     const map = makeNumericSortedMap([0, 10], [1, 20], [2, 30])
 
     expect(String(map)).toEqual(`{
@@ -72,7 +73,7 @@ describe.concurrent("SortedMap", () => {
 }`)
   })
 
-  test("toJSON", () => {
+  it("toJSON", () => {
     const map = makeNumericSortedMap([0, 10], [1, 20], [2, 30])
 
     expect(map.toJSON()).toEqual(
@@ -80,7 +81,7 @@ describe.concurrent("SortedMap", () => {
     )
   })
 
-  test("inspect", () => {
+  it("inspect", () => {
     const map = makeNumericSortedMap([0, 10], [1, 20], [2, 30])
 
     expect(inspect(map)).toEqual(
@@ -88,7 +89,7 @@ describe.concurrent("SortedMap", () => {
     )
   })
 
-  test("entries", () => {
+  it("entries", () => {
     const map = makeSortedMap([0, 10], [1, 20], [2, 30])
 
     const result = Array.from(map)

--- a/test/SortedSet.ts
+++ b/test/SortedSet.ts
@@ -5,6 +5,7 @@ import * as Order from "effect/Order"
 import * as SortedSet from "effect/SortedSet"
 import * as Str from "effect/String"
 import { inspect } from "node:util"
+import { assert, describe, expect, it } from "vitest"
 
 class Member implements Eq.Equal {
   constructor(readonly id: string) {}

--- a/test/Stream/constructors.ts
+++ b/test/Stream/constructors.ts
@@ -14,7 +14,7 @@ import * as Schedule from "effect/Schedule"
 import * as Stream from "effect/Stream"
 import * as TestClock from "effect/TestClock"
 import * as fc from "fast-check"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 const chunkArb = <A>(
   arb: fc.Arbitrary<A>,

--- a/test/Stream/encoding.ts
+++ b/test/Stream/encoding.ts
@@ -2,6 +2,7 @@ import * as it from "effect-test/utils/extend"
 import * as Chunk from "effect/Chunk"
 import * as Effect from "effect/Effect"
 import * as Stream from "effect/Stream"
+import { describe, expect } from "vitest"
 
 describe.concurrent("Stream", () => {
   it.effect("decodeText/encodeText round trip", () =>

--- a/test/Stream/environment.ts
+++ b/test/Stream/environment.ts
@@ -7,7 +7,7 @@ import * as Layer from "effect/Layer"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Stream from "effect/Stream"
 import type * as Tracer from "effect/Tracer"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 interface StringService {
   readonly string: string

--- a/test/Stream/error-handling.ts
+++ b/test/Stream/error-handling.ts
@@ -8,7 +8,7 @@ import { identity, pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Ref from "effect/Ref"
 import * as Stream from "effect/Stream"
-import { assert, describe } from "vitest"
+import { assert, describe, expect } from "vitest"
 
 describe.concurrent("Stream", () => {
   it.effect("absolve - happy path", () =>

--- a/test/Stream/streamable.ts
+++ b/test/Stream/streamable.ts
@@ -2,7 +2,7 @@ import * as it from "effect-test/utils/extend"
 import * as Effect from "effect/Effect"
 import * as Stream from "effect/Stream"
 import * as Streamable from "effect/Streamable"
-import { describe } from "vitest"
+import { describe, expect } from "vitest"
 
 describe("Streamable", () => {
   it.effect(

--- a/test/Struct.ts
+++ b/test/Struct.ts
@@ -2,6 +2,7 @@ import { pipe } from "effect/Function"
 import * as Number from "effect/Number"
 import * as String from "effect/String"
 import * as Struct from "effect/Struct"
+import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Struct", () => {
   it("exports", () => {

--- a/test/Symbol.ts
+++ b/test/Symbol.ts
@@ -1,4 +1,5 @@
 import * as S from "effect/Symbol"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Symbol", () => {
   it("isSymbol", () => {

--- a/test/Tuple.ts
+++ b/test/Tuple.ts
@@ -1,5 +1,6 @@
 import { pipe } from "effect/Function"
 import * as T from "effect/Tuple"
+import { describe, expect, it } from "vitest"
 
 describe.concurrent("Tuple", () => {
   it("exports", () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,4 @@
-import * as assert from "assert"
+import { assert } from "vitest"
 
 export const assertTrue = (self: boolean) => {
   assert.strictEqual(self, true)

--- a/test/utils/cache/WatchableLookup.ts
+++ b/test/utils/cache/WatchableLookup.ts
@@ -9,6 +9,7 @@ import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
 import type * as Scope from "effect/Scope"
 import * as TestServices from "effect/TestServices"
+import { expect } from "vitest"
 
 export interface WatchableLookup<Key, Error, Value> {
   (key: Key): Effect.Effect<Scope.Scope, Error, Value>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,9 @@
       "effect/*": ["./src/*.ts"],
       "effect-test/*": ["./test/*.ts"]
     },
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "node"
+    ],
     "plugins": [{ "name": "@effect/language-service" }]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,8 +10,7 @@ export default defineConfig({
   plugins: [babel({ babel: babelConfig })],
   test: {
     include: ["./test/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    exclude: ["./test/util.ts", "./test/utils/**/*.ts", "./test/**/*.init.ts"],
-    globals: true
+    exclude: ["./test/util.ts", "./test/utils/**/*.ts", "./test/**/*.init.ts"]
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Currently we are using a mixture of vitest globals and vitest imports. Let's unify that.