### PR TITLE
fix: `Struct.omit` and `Struct.pick` return types

### DIFF
--- a/.changeset/polite-snakes-rhyme.md
+++ b/.changeset/polite-snakes-rhyme.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Struct.omit` and `Struct.pick` return types.

--- a/docs/modules/Struct.ts.md
+++ b/docs/modules/Struct.ts.md
@@ -125,7 +125,7 @@ Create a new object by omitting properties of an existing object.
 ```ts
 export declare const omit: <S, Keys extends readonly [keyof S, ...(keyof S)[]]>(
   ...keys: Keys
-) => (s: S) => { [K in Exclude<keyof S, Keys[number]>]: S[K] }
+) => (s: S) => Simplify<Omit<S, Keys[number]>>
 ```
 
 **Example**
@@ -148,7 +148,7 @@ Create a new object by picking properties of an existing object.
 ```ts
 export declare const pick: <S, Keys extends readonly [keyof S, ...(keyof S)[]]>(
   ...keys: Keys
-) => (s: S) => { [K in Keys[number]]: S[K] }
+) => (s: S) => Simplify<Pick<S, Keys[number]>>
 ```
 
 **Example**

--- a/src/Struct.ts
+++ b/src/Struct.ts
@@ -7,6 +7,7 @@
 import * as Equivalence from "./Equivalence"
 import { dual } from "./Function"
 import * as order from "./Order"
+import type { Simplify } from "./Types"
 
 /**
  * Create a new object by picking properties of an existing object.
@@ -22,7 +23,7 @@ import * as order from "./Order"
 export const pick = <S, Keys extends readonly [keyof S, ...Array<keyof S>]>(
   ...keys: Keys
 ) =>
-(s: S): { [K in Keys[number]]: S[K] } => {
+(s: S): Simplify<Pick<S, Keys[number]>> => {
   const out: any = {}
   for (const k of keys) {
     out[k] = s[k]
@@ -44,7 +45,7 @@ export const pick = <S, Keys extends readonly [keyof S, ...Array<keyof S>]>(
 export const omit = <S, Keys extends readonly [keyof S, ...Array<keyof S>]>(
   ...keys: Keys
 ) =>
-(s: S): { [K in Exclude<keyof S, Keys[number]>]: S[K] } => {
+(s: S): Simplify<Omit<S, Keys[number]>> => {
   const out: any = { ...s }
   for (const k of keys) {
     delete out[k]


### PR DESCRIPTION
Currently, the return type is broken if the type contains optional fields and `exactOptionalPropertyTypes` is on. Basically, I used the typing from `Schema.pick` and `Schema.omit` which seems to work as expected.