### PR TITLE
ReadonlyArray / List / Chunk: merge mapNonEmpty with map

### DIFF
--- a/.changeset/honest-peaches-drop.md
+++ b/.changeset/honest-peaches-drop.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+ReadonlyArray / List / Chunk: merge mapNonEmpty with map

--- a/docs/modules/Chunk.ts.md
+++ b/docs/modules/Chunk.ts.md
@@ -82,7 +82,6 @@ Added in v2.0.0
   - [reduceRight](#reduceright)
 - [mapping](#mapping)
   - [map](#map)
-  - [mapNonEmpty](#mapnonempty)
 - [model](#model)
   - [NonEmptyChunk (interface)](#nonemptychunk-interface)
 - [models](#models)
@@ -103,6 +102,9 @@ Added in v2.0.0
   - [unsafeHead](#unsafehead)
   - [unsafeLast](#unsafelast)
 - [utils](#utils)
+  - [Chunk (namespace)](#chunk-namespace)
+    - [Infer (type alias)](#infer-type-alias)
+    - [With (type alias)](#with-type-alias)
   - [drop](#drop)
   - [dropRight](#dropright)
   - [dropWhile](#dropwhile)
@@ -977,23 +979,8 @@ Returns a chunk with the elements mapped by the specified f function.
 
 ```ts
 export declare const map: {
-  <A, B>(f: (a: A, i: number) => B): (self: Chunk<A>) => Chunk<B>
-  <A, B>(self: Chunk<A>, f: (a: A, i: number) => B): Chunk<B>
-}
-```
-
-Added in v2.0.0
-
-## mapNonEmpty
-
-Returns a non empty chunk with the elements mapped by the specified f function.
-
-**Signature**
-
-```ts
-export declare const mapNonEmpty: {
-  <A, B>(f: (a: A, i: number) => B): (self: NonEmptyChunk<A>) => NonEmptyChunk<B>
-  <A, B>(self: NonEmptyChunk<A>, f: (a: A, i: number) => B): NonEmptyChunk<B>
+  <T extends Chunk<any>, B>(f: (a: Chunk.Infer<T>, i: number) => B): (self: T) => Chunk.With<T, B>
+  <T extends Chunk<any>, B>(self: T, f: (a: Chunk.Infer<T>, i: number) => B): Chunk.With<T, B>
 }
 ```
 
@@ -1177,6 +1164,30 @@ export declare const unsafeLast: <A>(self: Chunk<A>) => A
 Added in v2.0.0
 
 # utils
+
+## Chunk (namespace)
+
+Added in v2.0.0
+
+### Infer (type alias)
+
+**Signature**
+
+```ts
+export type Infer<T extends Chunk<any>> = T extends Chunk<infer A> ? A : never
+```
+
+Added in v2.0.0
+
+### With (type alias)
+
+**Signature**
+
+```ts
+export type With<T extends Chunk<any>, A> = T extends NonEmptyChunk<any> ? NonEmptyChunk<A> : Chunk<A>
+```
+
+Added in v2.0.0
 
 ## drop
 

--- a/docs/modules/List.ts.md
+++ b/docs/modules/List.ts.md
@@ -28,7 +28,6 @@ Added in v2.0.0
   - [filterMap](#filtermap)
   - [forEach](#foreach)
   - [map](#map)
-  - [mapNonEmpty](#mapnonempty)
   - [partition](#partition)
   - [partitionMap](#partitionmap)
   - [splitAt](#splitat)
@@ -84,6 +83,10 @@ Added in v2.0.0
   - [unsafeHead](#unsafehead)
   - [unsafeLast](#unsafelast)
   - [unsafeTail](#unsafetail)
+- [utils](#utils)
+  - [List (namespace)](#list-namespace)
+    - [Infer (type alias)](#infer-type-alias)
+    - [With (type alias)](#with-type-alias)
 
 ---
 
@@ -170,21 +173,8 @@ Applies the specified mapping function to each element of the list.
 
 ```ts
 export declare const map: {
-  <A, B>(f: (a: A) => B): (self: List<A>) => List<B>
-  <A, B>(self: List<A>, f: (a: A) => B): List<B>
-}
-```
-
-Added in v2.0.0
-
-## mapNonEmpty
-
-**Signature**
-
-```ts
-export declare const mapNonEmpty: {
-  <A, B>(f: (a: A) => B): (self: Cons<A>) => Cons<B>
-  <A, B>(self: Cons<A>, f: (a: A) => B): Cons<B>
+  <T extends List<any>, B>(f: (a: List.Infer<T>, i: number) => B): (self: T) => List.With<T, B>
+  <T extends List<any>, B>(self: T, f: (a: List.Infer<T>, i: number) => B): List.With<T, B>
 }
 ```
 
@@ -796,6 +786,32 @@ Unsafely returns the tail of the specified `List`.
 
 ```ts
 export declare const unsafeTail: <A>(self: List<A>) => List<A>
+```
+
+Added in v2.0.0
+
+# utils
+
+## List (namespace)
+
+Added in v2.0.0
+
+### Infer (type alias)
+
+**Signature**
+
+```ts
+export type Infer<T extends List<any>> = T extends List<infer A> ? A : never
+```
+
+Added in v2.0.0
+
+### With (type alias)
+
+**Signature**
+
+```ts
+export type With<T extends List<any>, A> = T extends Cons<any> ? Cons<A> : List<A>
 ```
 
 Added in v2.0.0

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -108,7 +108,6 @@ Added in v2.0.0
   - [liftPredicate](#liftpredicate)
 - [mapping](#mapping)
   - [map](#map)
-  - [mapNonEmpty](#mapnonempty)
 - [models](#models)
   - [NonEmptyArray (type alias)](#nonemptyarray-type-alias)
   - [NonEmptyReadonlyArray (type alias)](#nonemptyreadonlyarray-type-alias)
@@ -131,6 +130,9 @@ Added in v2.0.0
 - [unsafe](#unsafe)
   - [unsafeGet](#unsafeget)
 - [utils](#utils)
+  - [ReadonlyArray (namespace)](#readonlyarray-namespace)
+    - [Infer (type alias)](#infer-type-alias)
+    - [With (type alias)](#with-type-alias)
   - [chop](#chop)
   - [chopNonEmpty](#chopnonempty)
   - [copy](#copy)
@@ -1363,21 +1365,8 @@ Added in v2.0.0
 
 ```ts
 export declare const map: {
-  <A, B>(f: (a: A, i: number) => B): (self: readonly A[]) => B[]
-  <A, B>(self: readonly A[], f: (a: A, i: number) => B): B[]
-}
-```
-
-Added in v2.0.0
-
-## mapNonEmpty
-
-**Signature**
-
-```ts
-export declare const mapNonEmpty: {
-  <A, B>(f: (a: A, i: number) => B): (self: readonly [A, ...A[]]) => [B, ...B[]]
-  <A, B>(self: readonly [A, ...A[]], f: (a: A, i: number) => B): [B, ...B[]]
+  <T extends readonly any[], B>(f: (a: ReadonlyArray.Infer<T>, i: number) => B): (self: T) => ReadonlyArray.With<T, B>
+  <T extends readonly any[], B>(self: T, f: (a: ReadonlyArray.Infer<T>, i: number) => B): ReadonlyArray.With<T, B>
 }
 ```
 
@@ -1600,6 +1589,30 @@ export declare const unsafeGet: {
 Added in v2.0.0
 
 # utils
+
+## ReadonlyArray (namespace)
+
+Added in v2.0.0
+
+### Infer (type alias)
+
+**Signature**
+
+```ts
+export type Infer<T extends ReadonlyArray<any>> = T[number]
+```
+
+Added in v2.0.0
+
+### With (type alias)
+
+**Signature**
+
+```ts
+export type With<T extends ReadonlyArray<any>, A> = T extends NonEmptyReadonlyArray<any> ? NonEmptyArray<A> : Array<A>
+```
+
+Added in v2.0.0
 
 ## chop
 

--- a/dtslint/Chunk.ts
+++ b/dtslint/Chunk.ts
@@ -1,31 +1,34 @@
 import * as Chunk from "effect/Chunk"
+import { pipe } from "effect/Function"
 import * as Predicate from "effect/Predicate"
 
-declare const nss: Chunk.Chunk<number | string>
-declare const nonEmptynss: Chunk.NonEmptyChunk<number | string>
+declare const numbers: Chunk.Chunk<number>
+declare const nonEmptyNumbers: Chunk.NonEmptyChunk<number>
+declare const numbersOrStrings: Chunk.Chunk<number | string>
+declare const nonEmptyNumbersOrStrings: Chunk.NonEmptyChunk<number | string>
 
 // -------------------------------------------------------------------------------------
 // every
 // -------------------------------------------------------------------------------------
 
-if (Chunk.every(nss, Predicate.isString)) {
-  nss // $ExpectType Chunk<string>
+if (Chunk.every(numbersOrStrings, Predicate.isString)) {
+  numbersOrStrings // $ExpectType Chunk<string>
 }
 
-if (Chunk.every(Predicate.isString)(nss)) {
-  nss // $ExpectType Chunk<string>
+if (Chunk.every(Predicate.isString)(numbersOrStrings)) {
+  numbersOrStrings // $ExpectType Chunk<string>
 }
 
 // -------------------------------------------------------------------------------------
 // some
 // -------------------------------------------------------------------------------------
 
-if (Chunk.some(nss, Predicate.isString)) {
-  nss // $ExpectType NonEmptyChunk<string | number>
+if (Chunk.some(numbersOrStrings, Predicate.isString)) {
+  numbersOrStrings // $ExpectType NonEmptyChunk<string | number>
 }
 
-if (Chunk.some(Predicate.isString)(nss)) {
-  nss // $ExpectType NonEmptyChunk<string | number>
+if (Chunk.some(Predicate.isString)(numbersOrStrings)) {
+  numbersOrStrings // $ExpectType NonEmptyChunk<string | number>
 }
 
 // -------------------------------------------------------------------------------------
@@ -33,66 +36,75 @@ if (Chunk.some(Predicate.isString)(nss)) {
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [Chunk<number>, Chunk<string>]
-Chunk.partition(nss, Predicate.isString)
+Chunk.partition(numbersOrStrings, Predicate.isString)
 
 // $ExpectType [Chunk<number>, Chunk<string>]
-nss.pipe(Chunk.partition(Predicate.isString))
+numbersOrStrings.pipe(Chunk.partition(Predicate.isString))
 
 // -------------------------------------------------------------------------------------
 // append
 // -------------------------------------------------------------------------------------
 
 // $ExpectType NonEmptyChunk<string | number | boolean>
-Chunk.append(nss, true)
+Chunk.append(numbersOrStrings, true)
 
 // $ExpectType NonEmptyChunk<string | number | boolean>
-Chunk.append(true)(nss)
-
-// -------------------------------------------------------------------------------------
-// mapNonEmpty
-// -------------------------------------------------------------------------------------
-
-// $ExpectType NonEmptyChunk<string>
-Chunk.mapNonEmpty(nonEmptynss, (s) => `${s}`)
+Chunk.append(true)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // appendAllNonEmpty
 // -------------------------------------------------------------------------------------
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.appendAllNonEmpty(nss, nonEmptynss)
+Chunk.appendAllNonEmpty(numbersOrStrings, nonEmptyNumbersOrStrings)
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.appendAllNonEmpty(nss)(nonEmptynss)
+Chunk.appendAllNonEmpty(numbersOrStrings)(nonEmptyNumbersOrStrings)
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.appendAllNonEmpty(nonEmptynss, nss)
+Chunk.appendAllNonEmpty(nonEmptyNumbersOrStrings, numbersOrStrings)
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.appendAllNonEmpty(nonEmptynss)(nss)
+Chunk.appendAllNonEmpty(nonEmptyNumbersOrStrings)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // prepend
 // -------------------------------------------------------------------------------------
 
 // $ExpectType NonEmptyChunk<string | number | boolean>
-Chunk.prepend(nss, true)
+Chunk.prepend(numbersOrStrings, true)
 
 // $ExpectType NonEmptyChunk<string | number | boolean>
-Chunk.prepend(true)(nss)
+Chunk.prepend(true)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // prependAllNonEmpty
 // -------------------------------------------------------------------------------------
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.prependAllNonEmpty(nss, nonEmptynss)
+Chunk.prependAllNonEmpty(numbersOrStrings, nonEmptyNumbersOrStrings)
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.prependAllNonEmpty(nss)(nonEmptynss)
+Chunk.prependAllNonEmpty(numbersOrStrings)(nonEmptyNumbersOrStrings)
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.prependAllNonEmpty(nonEmptynss, nss)
+Chunk.prependAllNonEmpty(nonEmptyNumbersOrStrings, numbersOrStrings)
 
 // $ExpectType NonEmptyChunk<string | number>
-Chunk.prependAllNonEmpty(nonEmptynss)(nss)
+Chunk.prependAllNonEmpty(nonEmptyNumbersOrStrings)(numbersOrStrings)
+
+// -------------------------------------------------------------------------------------
+// map
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Chunk<number>
+Chunk.map(numbers, (n) => n + 1)
+
+// $ExpectType Chunk<number>
+pipe(numbers, Chunk.map((n) => n + 1))
+
+// $ExpectType NonEmptyChunk<number>
+Chunk.map(nonEmptyNumbers, (n) => n + 1)
+
+// $ExpectType NonEmptyChunk<number>
+pipe(nonEmptyNumbers, Chunk.map((n) => n + 1))

--- a/dtslint/List.ts
+++ b/dtslint/List.ts
@@ -1,31 +1,34 @@
+import { pipe } from "effect/Function"
 import * as List from "effect/List"
 import * as Predicate from "effect/Predicate"
 
-declare const nss: List.List<number | string>
-declare const nonEmptynss: List.Cons<number | string>
+declare const numbers: List.List<number>
+declare const nonEmptyNumbers: List.Cons<number>
+declare const numbersOrStrings: List.List<number | string>
+declare const nonEmptyNumbersOrStrings: List.Cons<number | string>
 
 // -------------------------------------------------------------------------------------
 // every
 // -------------------------------------------------------------------------------------
 
-if (List.every(nss, Predicate.isString)) {
-  nss // $ExpectType List<string>
+if (List.every(numbersOrStrings, Predicate.isString)) {
+  numbersOrStrings // $ExpectType List<string>
 }
 
-if (List.every(Predicate.isString)(nss)) {
-  nss // $ExpectType List<string>
+if (List.every(Predicate.isString)(numbersOrStrings)) {
+  numbersOrStrings // $ExpectType List<string>
 }
 
 // -------------------------------------------------------------------------------------
 // some
 // -------------------------------------------------------------------------------------
 
-if (List.some(nss, Predicate.isString)) {
-  nss // $ExpectType Cons<string | number>
+if (List.some(numbersOrStrings, Predicate.isString)) {
+  numbersOrStrings // $ExpectType Cons<string | number>
 }
 
-if (List.some(Predicate.isString)(nss)) {
-  nss // $ExpectType Cons<string | number>
+if (List.some(Predicate.isString)(numbersOrStrings)) {
+  numbersOrStrings // $ExpectType Cons<string | number>
 }
 
 // -------------------------------------------------------------------------------------
@@ -33,66 +36,75 @@ if (List.some(Predicate.isString)(nss)) {
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [List<number>, List<string>]
-List.partition(nss, Predicate.isString)
+List.partition(numbersOrStrings, Predicate.isString)
 
 // $ExpectType [List<number>, List<string>]
-nss.pipe(List.partition(Predicate.isString))
+numbersOrStrings.pipe(List.partition(Predicate.isString))
 
 // -------------------------------------------------------------------------------------
 // append
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Cons<string | number | boolean>
-List.append(nss, true)
+List.append(numbersOrStrings, true)
 
 // $ExpectType Cons<string | number | boolean>
-List.append(true)(nss)
-
-// -------------------------------------------------------------------------------------
-// mapNonEmpty
-// -------------------------------------------------------------------------------------
-
-// $ExpectType Cons<string>
-List.mapNonEmpty(nonEmptynss, (s) => `${s}`)
+List.append(true)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // appendAllNonEmpty
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Cons<string | number>
-List.appendAllNonEmpty(nss, nonEmptynss)
+List.appendAllNonEmpty(numbersOrStrings, nonEmptyNumbersOrStrings)
 
 // $ExpectType Cons<string | number>
-List.appendAllNonEmpty(nss)(nonEmptynss)
+List.appendAllNonEmpty(numbersOrStrings)(nonEmptyNumbersOrStrings)
 
 // $ExpectType Cons<string | number>
-List.appendAllNonEmpty(nonEmptynss, nss)
+List.appendAllNonEmpty(nonEmptyNumbersOrStrings, numbersOrStrings)
 
 // $ExpectType Cons<string | number>
-List.appendAllNonEmpty(nonEmptynss)(nss)
+List.appendAllNonEmpty(nonEmptyNumbersOrStrings)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // prepend
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Cons<string | number | boolean>
-List.prepend(nss, true)
+List.prepend(numbersOrStrings, true)
 
 // $ExpectType Cons<string | number | boolean>
-List.prepend(true)(nss)
+List.prepend(true)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // prependAllNonEmpty
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Cons<string | number>
-List.prependAllNonEmpty(nss, nonEmptynss)
+List.prependAllNonEmpty(numbersOrStrings, nonEmptyNumbersOrStrings)
 
 // $ExpectType Cons<string | number>
-List.prependAllNonEmpty(nss)(nonEmptynss)
+List.prependAllNonEmpty(numbersOrStrings)(nonEmptyNumbersOrStrings)
 
 // $ExpectType Cons<string | number>
-List.prependAllNonEmpty(nonEmptynss, nss)
+List.prependAllNonEmpty(nonEmptyNumbersOrStrings, numbersOrStrings)
 
 // $ExpectType Cons<string | number>
-List.prependAllNonEmpty(nonEmptynss)(nss)
+List.prependAllNonEmpty(nonEmptyNumbersOrStrings)(numbersOrStrings)
+
+// -------------------------------------------------------------------------------------
+// map
+// -------------------------------------------------------------------------------------
+
+// $ExpectType List<number>
+List.map(numbers, (n) => n + 1)
+
+// $ExpectType List<number>
+pipe(numbers, List.map((n) => n + 1))
+
+// $ExpectType Cons<number>
+List.map(nonEmptyNumbers, (n) => n + 1)
+
+// $ExpectType Cons<number>
+pipe(nonEmptyNumbers, List.map((n) => n + 1))

--- a/dtslint/ReadonlyArray.ts
+++ b/dtslint/ReadonlyArray.ts
@@ -3,20 +3,20 @@ import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as RA from "effect/ReadonlyArray"
 
-declare const nerns: RA.NonEmptyReadonlyArray<number>
-declare const nens: RA.NonEmptyArray<number>
-declare const rns: ReadonlyArray<number>
-declare const ns: Array<number>
-declare const nss: Array<number | string>
-declare const nonEmptynss: RA.NonEmptyReadonlyArray<number | string>
+declare const nonEmptyReadonlyNumbers: RA.NonEmptyReadonlyArray<number>
+declare const nonEmptyNumbers: RA.NonEmptyArray<number>
+declare const readonlyNumbers: ReadonlyArray<number>
+declare const numbers: Array<number>
+declare const numbersOrStrings: Array<number | string>
+declare const nonEmptyReadonlyNumbersOrStrings: RA.NonEmptyReadonlyArray<number | string>
 
 // -------------------------------------------------------------------------------------
 // isEmptyReadonlyArray
 // -------------------------------------------------------------------------------------
 
-if (RA.isEmptyReadonlyArray(rns)) {
+if (RA.isEmptyReadonlyArray(readonlyNumbers)) {
   // $ExpectType readonly []
-  rns
+  readonlyNumbers
 }
 
 // $ExpectType <A>(c: readonly A[]) => Option<readonly []>
@@ -26,9 +26,9 @@ Option.liftPredicate(RA.isEmptyReadonlyArray)
 // isEmptyArray
 // -------------------------------------------------------------------------------------
 
-if (RA.isEmptyArray(ns)) {
+if (RA.isEmptyArray(numbers)) {
   // $ExpectType []
-  ns
+  numbers
 }
 
 // $ExpectType <A>(c: A[]) => Option<[]>
@@ -38,9 +38,9 @@ Option.liftPredicate(RA.isEmptyArray)
 // isNonEmptyReadonlyArray
 // -------------------------------------------------------------------------------------
 
-if (RA.isNonEmptyReadonlyArray(rns)) {
+if (RA.isNonEmptyReadonlyArray(readonlyNumbers)) {
   // $ExpectType readonly [number, ...number[]]
-  rns
+  readonlyNumbers
 }
 
 // $ExpectType <A>(c: readonly A[]) => Option<readonly [A, ...A[]]>
@@ -50,9 +50,9 @@ Option.liftPredicate(RA.isNonEmptyReadonlyArray)
 // isNonEmptyArray
 // -------------------------------------------------------------------------------------
 
-if (RA.isNonEmptyArray(ns)) {
+if (RA.isNonEmptyArray(numbers)) {
   // $ExpectType [number, ...number[]]
-  ns
+  numbers
 }
 
 // $ExpectType <A>(c: A[]) => Option<[A, ...A[]]>
@@ -63,32 +63,28 @@ Option.liftPredicate(RA.isNonEmptyArray)
 // -------------------------------------------------------------------------------------
 
 // $ExpectType number[]
-RA.map(rns, (n) => n + 1)
+RA.map(readonlyNumbers, (n) => n + 1)
 
 // $ExpectType number[]
-pipe(rns, RA.map((n) => n + 1))
+pipe(readonlyNumbers, RA.map((n) => n + 1))
 
 // $ExpectType number[]
-RA.map(ns, (n) => n + 1)
+RA.map(numbers, (n) => n + 1)
 
 // $ExpectType number[]
-pipe(ns, RA.map((n) => n + 1))
-
-// -------------------------------------------------------------------------------------
-// mapNonEmpty
-// -------------------------------------------------------------------------------------
+pipe(numbers, RA.map((n) => n + 1))
 
 // $ExpectType [number, ...number[]]
-RA.mapNonEmpty(nerns, (n) => n + 1)
+RA.map(nonEmptyReadonlyNumbers, (n) => n + 1)
 
 // $ExpectType [number, ...number[]]
-pipe(nerns, RA.mapNonEmpty((n) => n + 1))
+pipe(nonEmptyReadonlyNumbers, RA.map((n) => n + 1))
 
 // $ExpectType [number, ...number[]]
-RA.mapNonEmpty(nens, (n) => n + 1)
+RA.map(nonEmptyNumbers, (n) => n + 1)
 
 // $ExpectType [number, ...number[]]
-pipe(nens, RA.mapNonEmpty((n) => n + 1))
+pipe(nonEmptyNumbers, RA.map((n) => n + 1))
 
 // -------------------------------------------------------------------------------------
 // groupBy
@@ -106,24 +102,24 @@ RA.groupBy([1, 2, 3], (n) => n > 0 ? "positive" as const : "negative" as const)
 // some
 // -------------------------------------------------------------------------------------
 
-if (RA.some(nss, Predicate.isString)) {
-  nss // $ExpectType (string | number)[] & readonly [string | number, ...(string | number)[]]
+if (RA.some(numbersOrStrings, Predicate.isString)) {
+  numbersOrStrings // $ExpectType (string | number)[] & readonly [string | number, ...(string | number)[]]
 }
 
-if (RA.some(Predicate.isString)(nss)) {
-  nss // $ExpectType (string | number)[] & readonly [string | number, ...(string | number)[]]
+if (RA.some(Predicate.isString)(numbersOrStrings)) {
+  numbersOrStrings // $ExpectType (string | number)[] & readonly [string | number, ...(string | number)[]]
 }
 
 // -------------------------------------------------------------------------------------
 // every
 // -------------------------------------------------------------------------------------
 
-if (RA.every(nss, Predicate.isString)) {
-  nss // $ExpectType (string | number)[] & readonly string[]
+if (RA.every(numbersOrStrings, Predicate.isString)) {
+  numbersOrStrings // $ExpectType (string | number)[] & readonly string[]
 }
 
-if (RA.every(Predicate.isString)(nss)) {
-  nss // $ExpectType (string | number)[] & readonly string[]
+if (RA.every(Predicate.isString)(numbersOrStrings)) {
+  numbersOrStrings // $ExpectType (string | number)[] & readonly string[]
 }
 
 // -------------------------------------------------------------------------------------
@@ -131,49 +127,49 @@ if (RA.every(Predicate.isString)(nss)) {
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [string | number | boolean, ...(string | number | boolean)[]]
-RA.append(nss, true)
+RA.append(numbersOrStrings, true)
 
 // $ExpectType [string | number | boolean, ...(string | number | boolean)[]]
-RA.append(true)(nss)
+RA.append(true)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // appendAllNonEmpty
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.appendAllNonEmpty(nss, nonEmptynss)
+RA.appendAllNonEmpty(numbersOrStrings, nonEmptyReadonlyNumbersOrStrings)
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.appendAllNonEmpty(nss)(nonEmptynss)
+RA.appendAllNonEmpty(numbersOrStrings)(nonEmptyReadonlyNumbersOrStrings)
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.appendAllNonEmpty(nonEmptynss, nss)
+RA.appendAllNonEmpty(nonEmptyReadonlyNumbersOrStrings, numbersOrStrings)
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.appendAllNonEmpty(nonEmptynss)(nss)
+RA.appendAllNonEmpty(nonEmptyReadonlyNumbersOrStrings)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // prepend
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [string | number | boolean, ...(string | number | boolean)[]]
-RA.prepend(nss, true)
+RA.prepend(numbersOrStrings, true)
 
 // $ExpectType [string | number | boolean, ...(string | number | boolean)[]]
-RA.prepend(true)(nss)
+RA.prepend(true)(numbersOrStrings)
 
 // -------------------------------------------------------------------------------------
 // prependAllNonEmpty
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.prependAllNonEmpty(nss, nonEmptynss)
+RA.prependAllNonEmpty(numbersOrStrings, nonEmptyReadonlyNumbersOrStrings)
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.prependAllNonEmpty(nss)(nonEmptynss)
+RA.prependAllNonEmpty(numbersOrStrings)(nonEmptyReadonlyNumbersOrStrings)
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.prependAllNonEmpty(nonEmptynss, nss)
+RA.prependAllNonEmpty(nonEmptyReadonlyNumbersOrStrings, numbersOrStrings)
 
 // $ExpectType [string | number, ...(string | number)[]]
-RA.prependAllNonEmpty(nonEmptynss)(nss)
+RA.prependAllNonEmpty(nonEmptyReadonlyNumbersOrStrings)(numbersOrStrings)

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -823,29 +823,33 @@ export const last = <A>(self: Chunk<A>): Option<A> => get(self, self.length - 1)
 export const unsafeLast = <A>(self: Chunk<A>): A => unsafeGet(self, self.length - 1)
 
 /**
+ * @since 2.0.0
+ */
+export declare namespace Chunk {
+  /**
+   * @since 2.0.0
+   */
+  export type Infer<T extends Chunk<any>> = T extends Chunk<infer A> ? A : never
+
+  /**
+   * @since 2.0.0
+   */
+  export type With<T extends Chunk<any>, A> = T extends NonEmptyChunk<any> ? NonEmptyChunk<A> : Chunk<A>
+}
+
+/**
  * Returns a chunk with the elements mapped by the specified f function.
  *
  * @since 2.0.0
  * @category mapping
  */
 export const map: {
-  <A, B>(f: (a: A, i: number) => B): (self: Chunk<A>) => Chunk<B>
-  <A, B>(self: Chunk<A>, f: (a: A, i: number) => B): Chunk<B>
+  <T extends Chunk<any>, B>(f: (a: Chunk.Infer<T>, i: number) => B): (self: T) => Chunk.With<T, B>
+  <T extends Chunk<any>, B>(self: T, f: (a: Chunk.Infer<T>, i: number) => B): Chunk.With<T, B>
 } = dual(2, <A, B>(self: Chunk<A>, f: (a: A, i: number) => B): Chunk<B> =>
   self.backing._tag === "ISingleton" ?
     of(f(self.backing.a, 0)) :
     unsafeFromArray(pipe(toReadonlyArray(self), RA.map((a, i) => f(a, i)))))
-
-/**
- * Returns a non empty chunk with the elements mapped by the specified f function.
- *
- * @since 2.0.0
- * @category mapping
- */
-export const mapNonEmpty: {
-  <A, B>(f: (a: A, i: number) => B): (self: NonEmptyChunk<A>) => NonEmptyChunk<B>
-  <A, B>(self: NonEmptyChunk<A>, f: (a: A, i: number) => B): NonEmptyChunk<B>
-} = map as any
 
 /**
  * Statefully maps over the chunk, producing new elements of type `B`.

--- a/src/List.ts
+++ b/src/List.ts
@@ -711,14 +711,29 @@ export const head = <A>(self: List<A>): Option.Option<A> => isNil(self) ? Option
 export const last = <A>(self: List<A>): Option.Option<A> => isNil(self) ? Option.none() : Option.some(unsafeLast(self)!)
 
 /**
+ * @since 2.0.0
+ */
+export declare namespace List {
+  /**
+   * @since 2.0.0
+   */
+  export type Infer<T extends List<any>> = T extends List<infer A> ? A : never
+
+  /**
+   * @since 2.0.0
+   */
+  export type With<T extends List<any>, A> = T extends Cons<any> ? Cons<A> : List<A>
+}
+
+/**
  * Applies the specified mapping function to each element of the list.
  *
  * @since 2.0.0
  * @category combinators
  */
 export const map: {
-  <A, B>(f: (a: A) => B): (self: List<A>) => List<B>
-  <A, B>(self: List<A>, f: (a: A) => B): List<B>
+  <T extends List<any>, B>(f: (a: List.Infer<T>, i: number) => B): (self: T) => List.With<T, B>
+  <T extends List<any>, B>(self: T, f: (a: List.Infer<T>, i: number) => B): List.With<T, B>
 } = dual(2, <A, B>(self: List<A>, f: (a: A) => B): List<B> => {
   if (isNil(self)) {
     return self as unknown as List<B>
@@ -735,15 +750,6 @@ export const map: {
     return head
   }
 })
-
-/**
- * @since 2.0.0
- * @category combinators
- */
-export const mapNonEmpty: {
-  <A, B>(f: (a: A) => B): (self: Cons<A>) => Cons<B>
-  <A, B>(self: Cons<A>, f: (a: A) => B): Cons<B>
-} = map as any
 
 /**
  * Partition a list into two lists, where the first list contains all elements

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1531,10 +1531,7 @@ export const map: {
   <T extends ReadonlyArray<any>, B>(
     f: (a: ReadonlyArray.Infer<T>, i: number) => B
   ): (self: T) => ReadonlyArray.With<T, B>
-  <T extends ReadonlyArray<any>, B>(
-    self: T,
-    f: (a: ReadonlyArray.Infer<T>, i: number) => B
-  ): ReadonlyArray.With<T, B>
+  <T extends ReadonlyArray<any>, B>(self: T, f: (a: ReadonlyArray.Infer<T>, i: number) => B): ReadonlyArray.With<T, B>
 } = dual(2, <A, B>(self: ReadonlyArray<A>, f: (a: A, i: number) => B): Array<B> => self.map(f))
 
 /**

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1508,22 +1508,34 @@ export const empty: <A = never>() => Array<A> = () => []
 export const of = <A>(a: A): NonEmptyArray<A> => [a]
 
 /**
- * @category mapping
  * @since 2.0.0
  */
-export const map: {
-  <A, B>(f: (a: A, i: number) => B): (self: ReadonlyArray<A>) => Array<B>
-  <A, B>(self: ReadonlyArray<A>, f: (a: A, i: number) => B): Array<B>
-} = dual(2, <A, B>(self: ReadonlyArray<A>, f: (a: A, i: number) => B): Array<B> => self.map(f))
+export declare namespace ReadonlyArray {
+  /**
+   * @since 2.0.0
+   */
+  export type Infer<T extends ReadonlyArray<any>> = T[number]
+
+  /**
+   * @since 2.0.0
+   */
+  export type With<T extends ReadonlyArray<any>, A> = T extends NonEmptyReadonlyArray<any> ? NonEmptyArray<A>
+    : Array<A>
+}
 
 /**
  * @category mapping
  * @since 2.0.0
  */
-export const mapNonEmpty: {
-  <A, B>(f: (a: A, i: number) => B): (self: readonly [A, ...Array<A>]) => [B, ...Array<B>]
-  <A, B>(self: readonly [A, ...Array<A>], f: (a: A, i: number) => B): [B, ...Array<B>]
-} = map as any
+export const map: {
+  <T extends ReadonlyArray<any>, B>(
+    f: (a: ReadonlyArray.Infer<T>, i: number) => B
+  ): (self: T) => ReadonlyArray.With<T, B>
+  <T extends ReadonlyArray<any>, B>(
+    self: T,
+    f: (a: ReadonlyArray.Infer<T>, i: number) => B
+  ): ReadonlyArray.With<T, B>
+} = dual(2, <A, B>(self: ReadonlyArray<A>, f: (a: A, i: number) => B): Array<B> => self.map(f))
 
 /**
  * @category sequencing

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -667,12 +667,6 @@ describe.concurrent("Chunk", () => {
     expect(Chunk.map(Chunk.make(1, 2, 3), (n, i) => n + i)).toEqual(Chunk.make(1, 3, 5))
   })
 
-  it("mapNonEmpty", () => {
-    expect(Chunk.mapNonEmpty(Chunk.of(1), (n) => n + 1)).toEqual(Chunk.of(2))
-    expect(Chunk.mapNonEmpty(Chunk.make(1, 2, 3), (n) => n + 1)).toEqual(Chunk.make(2, 3, 4))
-    expect(Chunk.mapNonEmpty(Chunk.make(1, 2, 3), (n, i) => n + i)).toEqual(Chunk.make(1, 3, 5))
-  })
-
   it("mapAccum", () => {
     expect(Chunk.mapAccum(Chunk.make(1, 2, 3), "-", (s, a) => [s + a, a + 1])).toEqual(["-123", Chunk.make(2, 3, 4)])
   })

--- a/test/List.ts
+++ b/test/List.ts
@@ -111,10 +111,6 @@ describe.concurrent("List", () => {
     expect(List.map(List.make(1, 2, 3, 4), (n) => n + 1)).toEqual(List.make(2, 3, 4, 5))
   })
 
-  it("mapNonEmpty", () => {
-    expect(List.mapNonEmpty(List.make(1, 2, 3, 4), (n) => n + 1)).toEqual(List.make(2, 3, 4, 5))
-  })
-
   it("partition", () => {
     expect(List.partition(List.make(1, 2, 3, 4), (n) => n > 2)).toEqual([
       List.make(1, 2),

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -909,16 +909,6 @@ describe.concurrent("ReadonlyArray", () => {
     expect(RA.flattenNonEmpty(RA.make(RA.make(1, 2), RA.make(3, 4)))).toEqual([1, 2, 3, 4])
   })
 
-  it("mapNonEmpty", () => {
-    deepStrictEqual(
-      pipe(
-        RA.make(1, 2),
-        RA.mapNonEmpty((n) => n * 2)
-      ),
-      [2, 4]
-    )
-  })
-
   it("min", () => {
     deepStrictEqual(RA.min(Number.Order)([2, 1, 3]), 1)
     deepStrictEqual(RA.min(Number.Order)([3]), 3)


### PR DESCRIPTION
@tim-smart there are many other "NonEmpty" functions that can be merged, I wonder if it's better to test the merge technique (`Infer` + `With`) in userland on this limited portion of APIs, or proceed with the merge of all the other APIs, what do you think?