### PR TITLE
remove instances of instanceof

### DIFF
--- a/src/internal/HashMap/node.ts
+++ b/src/internal/HashMap/node.ts
@@ -40,7 +40,7 @@ export class EmptyNode<K, V> {
 
 /** @internal */
 export function isEmptyNode(a: unknown): a is EmptyNode<unknown, unknown> {
-  return a instanceof EmptyNode
+  return typeof a === "object" && a !== null && "_tag" in a && a._tag === "EmptyNode"
 }
 
 /** @internal */

--- a/src/internal/supervisor.ts
+++ b/src/internal/supervisor.ts
@@ -73,6 +73,7 @@ export class ProxySupervisor<T> implements Supervisor.Supervisor<T> {
 
 /** @internal */
 export class Zip<T0, T1> implements Supervisor.Supervisor<readonly [T0, T1]> {
+  readonly _tag = "Zip"
   readonly [SupervisorTypeId] = supervisorVariance
 
   constructor(
@@ -122,6 +123,10 @@ export class Zip<T0, T1> implements Supervisor.Supervisor<readonly [T0, T1]> {
   zip<A>(right: Supervisor.Supervisor<A>): Supervisor.Supervisor<readonly [readonly [T0, T1], A]> {
     return new Zip(this, right)
   }
+}
+
+export const isZip = (self: unknown): self is Zip<any, any> => {
+  return typeof self === "object" && self !== null && SupervisorTypeId in self && "_tag" in self && self._tag === "Zip"
 }
 
 export class Track implements Supervisor.Supervisor<Array<Fiber.RuntimeFiber<any, any>>> {

--- a/src/internal/supervisor/patch.ts
+++ b/src/internal/supervisor/patch.ts
@@ -131,7 +131,7 @@ const removeSupervisor = (
   if (Equal.equals(self, that)) {
     return supervisor.none
   } else {
-    if (self instanceof supervisor.Zip) {
+    if (supervisor.isZip(self)) {
       return removeSupervisor(self.left, that).zip(removeSupervisor(self.right, that))
     } else {
       return self
@@ -144,7 +144,7 @@ const toSet = (self: Supervisor.Supervisor<any>): HashSet.HashSet<Supervisor.Sup
   if (Equal.equals(self, supervisor.none)) {
     return HashSet.empty()
   } else {
-    if (self instanceof supervisor.Zip) {
+    if (supervisor.isZip(self)) {
       return pipe(toSet(self.left), HashSet.union(toSet(self.right)))
     } else {
       return HashSet.make(self)


### PR DESCRIPTION
I felt a strong urge to open this primarily for the pun in the commit name.

Anyways ... Do we need to worry about these now that we seemingly are going back to a simpler dual package set up? And if so, is this the right fix?
