### PR TITLE
Remove workaround

### DIFF
--- a/test/Sink/racing.ts
+++ b/test/Sink/racing.ts
@@ -49,7 +49,6 @@ const sinkRaceLaw = <E, A, L>(
   )
 
 describe.concurrent("Sink", () => {
-  // TODO: Research why this test is flaky.
   it.effect("raceBoth", () =>
     Effect.gen(function*($) {
       const ints = yield* $(unfoldEffect(
@@ -75,5 +74,5 @@ describe.concurrent("Sink", () => {
         )
       )
       assert.isTrue(result)
-    }), { retry: 3 })
+    }))
 })


### PR DESCRIPTION
./cc @IMax153 @tim-smart @mikearnaldi Not sure who to best summon here. I'm a bit lost (and too unfamiliar still with vast parts of the the internals) to pinpoint the exact issue here. 

I left some clues in the test code including the (curious?) observation that it stops failing if one adds any (literally any) operation to the raced stream.