### PR TITLE
retry flaky `raceBoth` test

### DIFF
--- a/test/Sink/racing.ts
+++ b/test/Sink/racing.ts
@@ -49,6 +49,7 @@ const sinkRaceLaw = <E, A, L>(
   )
 
 describe.concurrent("Sink", () => {
+  // TODO: Research why this test is flaky.
   it.effect("raceBoth", () =>
     Effect.gen(function*($) {
       const ints = yield* $(unfoldEffect(
@@ -74,5 +75,5 @@ describe.concurrent("Sink", () => {
         )
       )
       assert.isTrue(result)
-    }))
+    }), { retry: 3 })
 })

--- a/test/utils/extend.ts
+++ b/test/utils/extend.ts
@@ -20,7 +20,7 @@ export const effect = (() => {
   const f = <E, A>(
     name: string,
     self: () => Effect.Effect<TestServices.TestServices, E, A>,
-    timeout = 5_000
+    timeout: number | V.TestOptions = 5_000
   ) => {
     return it(
       name,


### PR DESCRIPTION
Also surfaces the `TestOptions` from vitest in our `it.effect` api.