### PR TITLE
remove `export` from examples

### DIFF
--- a/docs/modules/Function.ts.md
+++ b/docs/modules/Function.ts.md
@@ -95,7 +95,7 @@ export interface FunctionN<A extends ReadonlyArray<unknown>, B> {
 ```ts
 import { FunctionN } from 'effect/Function'
 
-export const sum: FunctionN<[number, number], number> = (a, b) => a + b
+const sum: FunctionN<[number, number], number> = (a, b) => a + b
 ```
 
 Added in v2.0.0
@@ -117,7 +117,7 @@ export interface LazyArg<A> {
 ```ts
 import { LazyArg, constant } from 'effect/Function'
 
-export const constNull: LazyArg<null> = constant(null)
+const constNull: LazyArg<null> = constant(null)
 ```
 
 Added in v2.0.0
@@ -369,7 +369,7 @@ export declare const dual: {
 import { dual, pipe } from 'effect/Function'
 
 // Exampe using arity to determine data-first or data-last style
-export const sum: {
+const sum: {
   (that: number): (self: number) => number
   (self: number, that: number): number
 } = dual(2, (self: number, that: number): number => self + that)
@@ -378,7 +378,7 @@ assert.deepStrictEqual(sum(2, 3), 5)
 assert.deepStrictEqual(pipe(2, sum(3)), 5)
 
 // Example using a predicate to determine data-first or data-last style
-export const sum2: {
+const sum2: {
   (that: number): (self: number) => number
   (self: number, that: number): number
 } = dual(

--- a/src/Function.ts
+++ b/src/Function.ts
@@ -49,7 +49,7 @@ export const isFunction = (input: unknown): input is Function => typeof input ==
  * import { dual, pipe } from "effect/Function"
  *
  * // Exampe using arity to determine data-first or data-last style
- * export const sum: {
+ * const sum: {
  *   (that: number): (self: number) => number
  *   (self: number, that: number): number
  * } = dual(2, (self: number, that: number): number => self + that)
@@ -58,7 +58,7 @@ export const isFunction = (input: unknown): input is Function => typeof input ==
  * assert.deepStrictEqual(pipe(2, sum(3)), 5)
  *
  * // Example using a predicate to determine data-first or data-last style
- * export const sum2: {
+ * const sum2: {
  *   (that: number): (self: number) => number
  *   (self: number, that: number): number
  * } = dual((args) => args.length === 1, (self: number, that: number): number => self + that)
@@ -177,7 +177,7 @@ export const apply = <A>(a: A) => <B>(self: (a: A) => B): B => self(a)
  * @example
  * import { LazyArg, constant } from "effect/Function"
  *
- * export const constNull: LazyArg<null> = constant(null)
+ * const constNull: LazyArg<null> = constant(null)
  *
  * @since 2.0.0
  */
@@ -189,7 +189,7 @@ export interface LazyArg<A> {
  * @example
  * import { FunctionN } from "effect/Function"
  *
- * export const sum: FunctionN<[number, number], number> = (a, b) => a + b
+ * const sum: FunctionN<[number, number], number> = (a, b) => a + b
  *
  * @since 2.0.0
  */


### PR DESCRIPTION
This is interfering with some doc test utils I'm toying around with atm. and imho isn't really necessary to illustrate the examples here.