### PR TITLE
Fix off-by-one in Random.shuffle

### DIFF
--- a/.changeset/cyan-rice-act.md
+++ b/.changeset/cyan-rice-act.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix off-by-one in Random.shuffle

--- a/src/internal/random.ts
+++ b/src/internal/random.ts
@@ -47,7 +47,7 @@ class RandomImpl implements Random.Random {
   }
 
   shuffle<A>(elements: Iterable<A>): Effect.Effect<never, never, Chunk.Chunk<A>> {
-    return shuffleWith(elements, (n) => this.nextIntBetween(0, n + 1))
+    return shuffleWith(elements, (n) => this.nextIntBetween(0, n))
   }
 }
 

--- a/test/Random.ts
+++ b/test/Random.ts
@@ -1,0 +1,13 @@
+import { Chunk, Effect, Random, ReadonlyArray } from "effect"
+import * as it from "effect-test/utils/extend"
+import { assert, describe } from "vitest"
+
+describe.concurrent("Random", () => {
+  it.effect("shuffle", () =>
+    Effect.gen(function*($) {
+      const start = ReadonlyArray.range(0, 100)
+      const end = yield* $(Random.shuffle(start))
+      assert.isTrue(Chunk.every(end, (n) => n !== undefined))
+      assert.deepStrictEqual(start.sort(), Array.from(end).sort())
+    }).pipe(Effect.repeatN(100)))
+})


### PR DESCRIPTION
WIth the following:

```ts
it.effect.only("zipWithPar - coherence", () =>
    Effect.gen(function*($) {
      const ints = [0, 2, 5, 8, 8, 3, 4, 6]
      const chunk = pipe(
        Chunk.unsafeFromArray(ints),
        Chunk.appendAll(Chunk.of(20)),
        Chunk.appendAll(Chunk.of(40))
      )
      const randoms: Array<Chunk.Chunk<number>> = []
      const result = yield* $(
        zipParLaw(
          Stream.fromIterableEffect(
            Random.shuffle(chunk).pipe(Effect.tap((random) =>
              Effect.sync(() => {
                randoms.push(random)
              })
            ))
          ),
          findSink(20),
          findSink(40)
        )
      )
      if (!result) {
        console.log(randoms.map(Chunk.toReadonlyArray))
      }
      assert.isTrue(result)
    }).pipe(Effect.repeatN(1000)))
```
    
The test fails and logs something like:
    
```
    [
  [
    8, 6, 5, 20, 3,
    0, 2, 4, 40, 8
  ],
  [
    40, 5, 20, 6, 0,
     8, 8,  4, 2, 3
  ],
  [ 0, 6, 4, 5, 8, 8, 2, 3, undefined, 20, 40 ]
]
```

which seems to suggest the imputing problem is in Random.shuffle (spot the "undefined")