### PR TITLE
create snapshot releases on command

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,9 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "snapshot": {
+    "useCalculatedVersion": false,
+    "prereleaseTemplate": "{tag}-{commit}"
+  }
 }

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,122 @@
+name: Snapshot
+on:
+  issue_comment:
+    types:
+      - created
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: Snapshot
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/snapshot ') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Extract snapshot comment
+        uses: actions-ecosystem/action-regex-match@v2
+        id: comment
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '^/snapshot\s(\w{4,16})\s*$'
+
+      - name: Enforce permission requirement
+        uses: prince-chrismc/check-actor-permissions-action@v3
+        with:
+          permission: write
+
+      - name: Add initial reaction
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
+      - name: Validate pull request
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            try {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              })
+
+              if (context.payload.repository.full_name !== pr.data.head.repo.full_name) {
+                const message = 'The `/snapshot` command is not supported on pull requests from forked repositories.'
+                core.setFailed(message)
+              }
+            } catch (error) {
+              core.setFailed(`Request failed with error ${error}`)
+            }
+
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+
+      - name: Checkout pull request branch
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retrieve changeset entries
+        run: |
+          if [[ $(git branch --show-current) == 'changeset-release/main' ]]; then
+            git checkout origin/main -- .changeset
+          fi
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+
+      - name: Exit prerelease
+        run: pnpm changeset pre exit || true
+
+      - name: Version snapshot
+        run: pnpm changeset version --snapshot ${{ steps.comment.outputs.group1 }}
+
+      - name: Build snapshot
+        run: pnpm build
+
+      - name: Create an .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+
+      - name: Publish snapshot
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const execa = require('execa')
+            const result = await execa.command('pnpm changeset publish --no-git-tag').pipeStdout(process.stdout);
+            const tags = Array
+              .from(result.stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
+              .map(([_, tag]) => tag)
+
+            if (tags.length) {
+              const body = (
+                `**Thanks @${context.actor}! Your snapshot has been published.**\n\n` +
+                `Test the snapshot by updating your \`package.json\` with the newly published version:\n\n` +
+                tags.map(tag => `- ${tag}`).join('\n')
+              )
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              })
+            }
+
+      - name: Add final reaction
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: rocket

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Retrieve changeset entries
         if: ${{ steps.branch.outputs.branch == 'changeset-release/main' }}
-        run: git checkout origin/main -- .changeset/*.md
+        run: git checkout origin/main
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,8 +1,7 @@
 name: Snapshot
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,107 +15,101 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Extract snapshot comment
-        uses: actions-ecosystem/action-regex-match@v2
-        id: comment
-        with:
-          text: ${{ github.event.comment.body }}
-          regex: '^/snapshot\s(\w{4,16})\s*$'
+        id: command
+        run: |
+          snapshot=$(echo "${{ github.event.comment.body }}" | grep -oP '^/snapshot\s([a-z-]{4,16})\s*$' | cut -d' ' -f2)
+          if [[ -n $snapshot ]]; then
+            echo "snapshot=$snapshot" >> $GITHUB_OUTPUT
+          else
+            exit 1
+          fi
 
       - name: Enforce permission requirement
         uses: prince-chrismc/check-actor-permissions-action@v3
         with:
           permission: write
 
-      - name: Add initial reaction
+      - name: Initial comment
+        id: comment
         uses: peter-evans/create-or-update-comment@v3
-        with:
-          comment-id: ${{ github.event.comment.id }}
-          reactions: eyes
-
-      - name: Validate pull request
-        uses: actions/github-script@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          script: |
-            try {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-              })
-
-              if (context.payload.repository.full_name !== pr.data.head.repo.full_name) {
-                const message = 'The `/snapshot` command is not supported on pull requests from forked repositories.'
-                core.setFailed(message)
-              }
-            } catch (error) {
-              core.setFailed(`Request failed with error ${error}`)
-            }
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            **Alright @${{ github.actor }}, I'm working on the snapshot!**
+            
+            You can follow the progress [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
       - name: Checkout default branch
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v2
+  
       - name: Checkout pull request branch
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get current branch name
+        id: branch  
+        run: echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+
       - name: Retrieve changeset entries
-        run: |
-          if [[ $(git branch --show-current) == 'changeset-release/main' ]]; then
-            git checkout origin/main -- .changeset
-          fi
+        if: ${{ steps.branch.outputs.branch == 'changeset-release/main' }}
+        run: git checkout origin/main -- .changeset/*.md
 
       - name: Install dependencies
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/install-dependencies
 
-      - name: Exit prerelease
-        run: pnpm changeset pre exit || true
+      - name: Exit pre-release mode
+        if: ${{ hashFiles('.changeset/pre.json') != '' }}
+        run: pnpm changeset pre exit
 
       - name: Version snapshot
-        run: pnpm changeset version --snapshot ${{ steps.comment.outputs.group1 }}
+        run: pnpm changeset version --snapshot ${{ steps.command.outputs.snapshot }} | grep -q "All files have been updated"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build snapshot
         run: pnpm build
-
-      - name: Create an .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
+ 
+      - name: Set registry config
+        run: pnpm config set --location project "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_TOKEN }}"
 
       - name: Publish snapshot
+        id: snapshot
+        run: |
+          # Publish and extract published tags from stdout.
+          output=$(pnpm changeset publish --tag ${{ steps.command.outputs.snapshot }} --no-git-tag)
+          output=$(echo "$output" | awk '/packages published successfully:/{flag=1; next} flag')
+          output=$(echo "$output" | grep -o '@[^ ]*' | awk '{print "\"" $0 "\""}' | paste -sd ',')
+          echo "tags=[$output]" >> $GITHUB_OUTPUT
+
+      - name: Update comment (success)
         uses: actions/github-script@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
-            const execa = require('execa')
-            const result = await execa.command('pnpm changeset publish --no-git-tag').pipeStdout(process.stdout);
-            const tags = Array
-              .from(result.stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
-              .map(([_, tag]) => tag)
+            const commands = ${{ steps.snapshot.outputs.tags }}.map(tag => '```sh\n' + `pnpm add ${tag}` + '\n```')
+            const header = `**Good news @${{ github.actor }}, your snapshot has been published!**`
+            const footer = `You can review the build log [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
 
-            if (tags.length) {
-              const body = (
-                `**Thanks @${context.actor}! Your snapshot has been published.**\n\n` +
-                `Test the snapshot by updating your \`package.json\` with the newly published version:\n\n` +
-                tags.map(tag => `- ${tag}`).join('\n')
-              )
+            await github.rest.issues.updateComment({
+              comment_id: ${{ steps.comment.outputs.comment-id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${header}\n\n${commands.join('\n')}\n\n${footer}`
+            })
 
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              })
-            }
-
-      - name: Add final reaction
-        uses: peter-evans/create-or-update-comment@v2
+      - name: Update comment (failure)
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          comment-id: ${{ github.event.comment.id }}
-          reactions: rocket
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            **Sorry @${{ github.actor }}, I failed to publish the snapshot!**
+            
+            You can review the build log [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,20 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Enforce permission requirement
+        uses: prince-chrismc/check-actor-permissions-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          permission: write
+
       - name: Extract snapshot comment
         id: command
+        env:
+          COMMENT: ${{ github.event.comment.body }}
         run: |
-          snapshot=$(echo "${{ github.event.comment.body }}" | grep -oP '^/snapshot\s([a-z-]{4,16})\s*$' | cut -d' ' -f2)
+          snapshot=$(echo "$COMMENT" | grep -oP '^/snapshot\s([a-z-]{4,16})\s*$' | cut -d' ' -f2)
           if [[ -n $snapshot ]]; then
             echo "snapshot=$snapshot" >> $GITHUB_OUTPUT
           else
             exit 1
           fi
-
-      - name: Enforce permission requirement
-        uses: prince-chrismc/check-actor-permissions-action@v3
-        with:
-          permission: write
 
       - name: Initial comment
         id: comment

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -62,7 +62,7 @@ jobs:
         run: git checkout origin/main
 
       - name: Install dependencies
-        uses: ./.github/actions/install-dependencies
+        uses: ./.github/actions/setup
 
       - name: Exit pre-release mode
         if: ${{ hashFiles('.changeset/pre.json') != '' }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   snapshot:
     name: Snapshot
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/snapshot ') }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/snapshot') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -21,13 +21,13 @@ jobs:
         with:
           permission: write
 
-      - name: Extract snapshot comment
+      - name: Extract snapshot command
         id: command
         env:
           COMMENT: ${{ github.event.comment.body }}
         run: |
-          snapshot=$(echo "$COMMENT" | grep -oP '^/snapshot\s([a-z-]{4,16})\s*$' | cut -d' ' -f2)
-          if [[ -n $snapshot ]]; then
+          if [[ $COMMENT =~ ^/snapshot([[:space:]]([a-z]{3,12}))?$ ]]; then
+            snapshot="${BASH_REMATCH[2]:-snapshot}"
             echo "snapshot=$snapshot" >> $GITHUB_OUTPUT
           else
             exit 1


### PR DESCRIPTION
@mikearnaldi this could be a good alternative.

In order to create a snapshot release from a user's pull request (or the `changeset-release/main` PR), we can just write

```sh
/snapshot <user defined tag>
```

It'll then create releases versioned like so: 

```sh
effect@0.0.0-{{user defined tag}}-{{commit sha}}
```

We could also adds a prefixed tag (e.g. `snapshot-{{ user defined tag }}`) to the npm release if we wanted to ...

We might also want to add another workflow that *always* publishes the `main` branch to npm as a snapshot using a `main` tag. That way, every commit on the `main` branch would always have a snapshot tagged version available on npm.

NOTE: This is currently untested. Will verify that it works as expected in a different repo with a test package first.

EDIT: If we don't want to allow user-provided tag names we can also just use the github commit hash ...

```sh
effect@0.0.0-snapshot-{{commit sha}}
```