### PR TITLE
interfaces: add readonly modifiers when missing and remove bivariance by changing methods to props

### DIFF
--- a/.changeset/purple-spoons-itch.md
+++ b/.changeset/purple-spoons-itch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+interfaces: add readonly modifiers when missing and remove bivariance by changing methods to props

--- a/docs/modules/Brand.ts.md
+++ b/docs/modules/Brand.ts.md
@@ -293,17 +293,17 @@ export interface Constructor<in out A extends Brand<any>> {
    * Constructs a branded type from a value of type `A`, returning `Some<A>`
    * if the provided `A` is valid, `None` otherwise.
    */
-  option: (args: Brand.Unbranded<A>) => Option.Option<A>
+  readonly option: (args: Brand.Unbranded<A>) => Option.Option<A>
   /**
    * Constructs a branded type from a value of type `A`, returning `Right<A>`
    * if the provided `A` is valid, `Left<BrandError>` otherwise.
    */
-  either: (args: Brand.Unbranded<A>) => Either.Either<Brand.BrandErrors, A>
+  readonly either: (args: Brand.Unbranded<A>) => Either.Either<Brand.BrandErrors, A>
   /**
    * Attempts to refine the provided value of type `A`, returning `true` if
    * the provided `A` is valid, `false` otherwise.
    */
-  is: Refinement<Brand.Unbranded<A>, Brand.Unbranded<A> & A>
+  readonly is: Refinement<Brand.Unbranded<A>, Brand.Unbranded<A> & A>
 }
 ```
 

--- a/docs/modules/Cache.ts.md
+++ b/docs/modules/Cache.ts.md
@@ -127,14 +127,14 @@ export interface Cache<Key, Error, Value> extends ConsumerCache<Key, Error, Valu
    * Otherwise computes the value with the lookup function, puts it in the
    * cache, and returns it.
    */
-  get(key: Key): Effect.Effect<never, Error, Value>
+  readonly get: (key: Key) => Effect.Effect<never, Error, Value>
 
   /**
    * Retrieves the value associated with the specified key if it exists as a left.
    * Otherwise computes the value with the lookup function, puts it in the
    * cache, and returns it as a right.
    */
-  getEither(key: Key): Effect.Effect<never, Error, Either<Value, Value>>
+  readonly getEither: (key: Key) => Effect.Effect<never, Error, Either<Value, Value>>
 
   /**
    * Computes the value associated with the specified key, with the lookup
@@ -145,12 +145,12 @@ export interface Cache<Key, Error, Value> extends ConsumerCache<Key, Error, Valu
    * by the lookup function. Additionally, `refresh` always triggers the
    * lookup function, disregarding the last `Error`.
    */
-  refresh(key: Key): Effect.Effect<never, Error, void>
+  readonly refresh: (key: Key) => Effect.Effect<never, Error, void>
 
   /**
    * Associates the specified value with the specified key in the cache.
    */
-  set<Key, Error, Value>(this: Cache<Key, Error, Value>, key: Key, value: Value): Effect.Effect<never, never, void>
+  readonly set: (key: Key, value: Value) => Effect.Effect<never, never, void>
 }
 ```
 
@@ -187,64 +187,64 @@ export interface ConsumerCache<Key, Error, Value> extends Cache.Variance<Key, Er
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
    */
-  getOption(key: Key): Effect.Effect<never, Error, Option.Option<Value>>
+  readonly getOption: (key: Key) => Effect.Effect<never, Error, Option.Option<Value>>
 
   /**
    * Retrieves the value associated with the specified key if it exists and the
    * lookup function has completed. Otherwise returns `Option.none`.
    */
-  getOptionComplete(key: Key): Effect.Effect<never, never, Option.Option<Value>>
+  readonly getOptionComplete: (key: Key) => Effect.Effect<never, never, Option.Option<Value>>
 
   /**
    * Returns statistics for this cache.
    */
-  cacheStats(): Effect.Effect<never, never, CacheStats>
+  readonly cacheStats: () => Effect.Effect<never, never, CacheStats>
 
   /**
    * Returns whether a value associated with the specified key exists in the
    * cache.
    */
-  contains(key: Key): Effect.Effect<never, never, boolean>
+  readonly contains: (key: Key) => Effect.Effect<never, never, boolean>
 
   /**
    * Returns statistics for the specified entry.
    */
-  entryStats(key: Key): Effect.Effect<never, never, Option.Option<EntryStats>>
+  readonly entryStats: (key: Key) => Effect.Effect<never, never, Option.Option<EntryStats>>
 
   /**
    * Invalidates the value associated with the specified key.
    */
-  invalidate(key: Key): Effect.Effect<never, never, void>
+  readonly invalidate: (key: Key) => Effect.Effect<never, never, void>
 
   /**
    * Invalidates the value associated with the specified key if the predicate holds.
    */
-  invalidateWhen(key: Key, when: (value: Value) => boolean): Effect.Effect<never, never, void>
+  readonly invalidateWhen: (key: Key, when: (value: Value) => boolean) => Effect.Effect<never, never, void>
 
   /**
    * Invalidates all values in the cache.
    */
-  invalidateAll(): Effect.Effect<never, never, void>
+  readonly invalidateAll: () => Effect.Effect<never, never, void>
 
   /**
    * Returns the approximate number of values in the cache.
    */
-  size(): Effect.Effect<never, never, number>
+  readonly size: () => Effect.Effect<never, never, number>
 
   /**
    * Returns an approximation of the values in the cache.
    */
-  keys<Key, Error, Value>(this: ConsumerCache<Key, Error, Value>): Effect.Effect<never, never, Array<Key>>
+  readonly keys: () => Effect.Effect<never, never, Array<Key>>
 
   /**
    * Returns an approximation of the values in the cache.
    */
-  values(): Effect.Effect<never, never, Array<Value>>
+  readonly values: () => Effect.Effect<never, never, Array<Value>>
 
   /**
    * Returns an approximation of the values in the cache.
    */
-  entries<Key, Error, Value>(this: ConsumerCache<Key, Error, Value>): Effect.Effect<never, never, Array<[Key, Value]>>
+  readonly entries: () => Effect.Effect<never, never, Array<[Key, Value]>>
 }
 ```
 

--- a/docs/modules/Clock.ts.md
+++ b/docs/modules/Clock.ts.md
@@ -120,7 +120,7 @@ export interface Clock {
   /**
    * Unsafely returns the current time in milliseconds.
    */
-  unsafeCurrentTimeMillis(): number
+  readonly unsafeCurrentTimeMillis: () => number
   /**
    * Returns the current time in milliseconds.
    */
@@ -128,7 +128,7 @@ export interface Clock {
   /**
    * Unsafely returns the current time in nanoseconds.
    */
-  unsafeCurrentTimeNanos(): bigint
+  readonly unsafeCurrentTimeNanos: () => bigint
   /**
    * Returns the current time in nanoseconds.
    */
@@ -136,7 +136,7 @@ export interface Clock {
   /**
    * Asynchronously sleeps for the specified duration.
    */
-  sleep(duration: Duration.Duration): Effect.Effect<never, never, void>
+  readonly sleep: (duration: Duration.Duration) => Effect.Effect<never, never, void>
 }
 ```
 

--- a/docs/modules/Config.ts.md
+++ b/docs/modules/Config.ts.md
@@ -369,7 +369,7 @@ Added in v2.0.0
 ```ts
 export interface Primitive<A> extends Config<A> {
   readonly description: string
-  parse(text: string): Either.Either<ConfigError.ConfigError, A>
+  readonly parse: (text: string) => Either.Either<ConfigError.ConfigError, A>
 }
 ```
 

--- a/docs/modules/ConfigError.ts.md
+++ b/docs/modules/ConfigError.ts.md
@@ -212,7 +212,7 @@ Added in v2.0.0
 
 ```ts
 export interface Options {
-  pathDelim: string
+  readonly pathDelim: string
 }
 ```
 

--- a/docs/modules/ConfigProvider.ts.md
+++ b/docs/modules/ConfigProvider.ts.md
@@ -319,13 +319,15 @@ special support for implementing them.
 ```ts
 export interface Flat {
   readonly [FlatConfigProviderTypeId]: FlatConfigProviderTypeId
-  patch: PathPatch.PathPatch
-  load<A>(
+  readonly patch: PathPatch.PathPatch
+  readonly load: <A>(
     path: ReadonlyArray<string>,
     config: Config.Config.Primitive<A>,
     split?: boolean
-  ): Effect.Effect<never, ConfigError.ConfigError, ReadonlyArray<A>>
-  enumerateChildren(path: ReadonlyArray<string>): Effect.Effect<never, ConfigError.ConfigError, HashSet.HashSet<string>>
+  ) => Effect.Effect<never, ConfigError.ConfigError, ReadonlyArray<A>>
+  readonly enumerateChildren: (
+    path: ReadonlyArray<string>
+  ) => Effect.Effect<never, ConfigError.ConfigError, HashSet.HashSet<string>>
 }
 ```
 

--- a/docs/modules/ConfigProvider.ts.md
+++ b/docs/modules/ConfigProvider.ts.md
@@ -249,12 +249,12 @@ export interface ConfigProvider extends ConfigProvider.Proto, Pipeable {
   /**
    * Loads the specified configuration, or fails with a config error.
    */
-  load<A>(config: Config.Config<A>): Effect.Effect<never, ConfigError.ConfigError, A>
+  readonly load: <A>(config: Config.Config<A>) => Effect.Effect<never, ConfigError.ConfigError, A>
   /**
    * Flattens this config provider into a simplified config provider that knows
    * only how to deal with flat (key/value) properties.
    */
-  flattened: ConfigProvider.Flat
+  readonly flattened: ConfigProvider.Flat
 }
 ```
 

--- a/docs/modules/Console.ts.md
+++ b/docs/modules/Console.ts.md
@@ -279,24 +279,24 @@ Added in v2.0.0
 ```ts
 export interface Console {
   readonly [TypeId]: TypeId
-  assert(condition: boolean, ...args: ReadonlyArray<any>): Effect<never, never, void>
+  readonly assert: (condition: boolean, ...args: ReadonlyArray<any>) => Effect<never, never, void>
   readonly clear: Effect<never, never, void>
-  count(label?: string): Effect<never, never, void>
-  countReset(label?: string): Effect<never, never, void>
-  debug(...args: ReadonlyArray<any>): Effect<never, never, void>
-  dir(item: any, options?: any): Effect<never, never, void>
-  dirxml(...args: ReadonlyArray<any>): Effect<never, never, void>
-  error(...args: ReadonlyArray<any>): Effect<never, never, void>
-  group(options?: { readonly label?: string; readonly collapsed?: boolean }): Effect<never, never, void>
+  readonly count: (label?: string) => Effect<never, never, void>
+  readonly countReset: (label?: string) => Effect<never, never, void>
+  readonly debug: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly dir: (item: any, options?: any) => Effect<never, never, void>
+  readonly dirxml: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly error: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly group: (options?: { readonly label?: string; readonly collapsed?: boolean }) => Effect<never, never, void>
   readonly groupEnd: Effect<never, never, void>
-  info(...args: ReadonlyArray<any>): Effect<never, never, void>
-  log(...args: ReadonlyArray<any>): Effect<never, never, void>
-  table(tabularData: any, properties?: ReadonlyArray<string>): Effect<never, never, void>
-  time(label?: string): Effect<never, never, void>
-  timeEnd(label?: string): Effect<never, never, void>
-  timeLog(label?: string, ...args: ReadonlyArray<any>): Effect<never, never, void>
-  trace(...args: ReadonlyArray<any>): Effect<never, never, void>
-  warn(...args: ReadonlyArray<any>): Effect<never, never, void>
+  readonly info: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly log: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly table: (tabularData: any, properties?: ReadonlyArray<string>) => Effect<never, never, void>
+  readonly time: (label?: string) => Effect<never, never, void>
+  readonly timeEnd: (label?: string) => Effect<never, never, void>
+  readonly timeLog: (label?: string, ...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly trace: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly warn: (...args: ReadonlyArray<any>) => Effect<never, never, void>
   readonly unsafe: UnsafeConsole
 }
 ```

--- a/docs/modules/Console.ts.md
+++ b/docs/modules/Console.ts.md
@@ -309,24 +309,24 @@ Added in v2.0.0
 
 ```ts
 export interface UnsafeConsole {
-  assert(condition: boolean, ...args: ReadonlyArray<any>): void
-  clear(): void
-  count(label?: string): void
-  countReset(label?: string): void
-  debug(...args: ReadonlyArray<any>): void
-  dir(item: any, options?: any): void
-  dirxml(...args: ReadonlyArray<any>): void
-  error(...args: ReadonlyArray<any>): void
-  group(options?: { readonly label?: string; readonly collapsed?: boolean }): void
-  groupEnd(): void
-  info(...args: ReadonlyArray<any>): void
-  log(...args: ReadonlyArray<any>): void
-  table(tabularData: any, properties?: ReadonlyArray<string>): void
-  time(label?: string): void
-  timeEnd(label?: string): void
-  timeLog(label?: string, ...args: ReadonlyArray<any>): void
-  trace(...args: ReadonlyArray<any>): void
-  warn(...args: ReadonlyArray<any>): void
+  readonly assert: (condition: boolean, ...args: ReadonlyArray<any>) => void
+  readonly clear: () => void
+  readonly count: (label?: string) => void
+  readonly countReset: (label?: string) => void
+  readonly debug: (...args: ReadonlyArray<any>) => void
+  readonly dir: (item: any, options?: any) => void
+  readonly dirxml: (...args: ReadonlyArray<any>) => void
+  readonly error: (...args: ReadonlyArray<any>) => void
+  readonly group: (options?: { readonly label?: string; readonly collapsed?: boolean }) => void
+  readonly groupEnd: () => void
+  readonly info: (...args: ReadonlyArray<any>) => void
+  readonly log: (...args: ReadonlyArray<any>) => void
+  readonly table: (tabularData: any, properties?: ReadonlyArray<string>) => void
+  readonly time: (label?: string) => void
+  readonly timeEnd: (label?: string) => void
+  readonly timeLog: (label?: string, ...args: ReadonlyArray<any>) => void
+  readonly trace: (...args: ReadonlyArray<any>) => void
+  readonly warn: (...args: ReadonlyArray<any>) => void
 }
 ```
 

--- a/docs/modules/Context.ts.md
+++ b/docs/modules/Context.ts.md
@@ -267,8 +267,8 @@ export interface Tag<Identifier, Service> extends Pipeable, Inspectable {
     readonly _S: (_: Service) => Service
     readonly _I: (_: Identifier) => Identifier
   }
-  of(self: Service): Service
-  context(self: Service): Context<Identifier>
+  readonly of: (self: Service) => Service
+  readonly context: (self: Service) => Context<Identifier>
   readonly stack?: string | undefined
   readonly identifier?: unknown | undefined
   [Unify.typeSymbol]?: unknown

--- a/docs/modules/Equal.ts.md
+++ b/docs/modules/Equal.ts.md
@@ -70,7 +70,7 @@ Added in v2.0.0
 
 ```ts
 export interface Equal extends Hash.Hash {
-  [symbol](that: Equal): boolean
+  readonly [symbol]: (that: Equal) => boolean
 }
 ```
 

--- a/docs/modules/Fiber.ts.md
+++ b/docs/modules/Fiber.ts.md
@@ -674,44 +674,44 @@ export interface RuntimeFiber<E, A> extends Fiber<E, A>, Fiber.RuntimeVariance<E
   /**
    * Reads the current value of a fiber ref
    */
-  getFiberRef<X>(fiberRef: FiberRef<X>): X
+  readonly getFiberRef: <X>(fiberRef: FiberRef<X>) => X
 
   /**
    * The identity of the fiber.
    */
-  id(): FiberId.Runtime
+  readonly id: () => FiberId.Runtime
 
   /**
    * The status of the fiber.
    */
-  status(): Effect.Effect<never, never, FiberStatus.FiberStatus>
+  readonly status: () => Effect.Effect<never, never, FiberStatus.FiberStatus>
 
   /**
    * Returns the current `RuntimeFlags` the fiber is running with.
    */
-  runtimeFlags(): Effect.Effect<never, never, RuntimeFlags.RuntimeFlags>
+  readonly runtimeFlags: () => Effect.Effect<never, never, RuntimeFlags.RuntimeFlags>
 
   /**
    * Adds an observer to the list of observers.
    */
-  addObserver(observer: (exit: Exit.Exit<E, A>) => void): void
+  readonly addObserver: (observer: (exit: Exit.Exit<E, A>) => void) => void
 
   /**
    * Removes the specified observer from the list of observers that will be
    * notified when the fiber exits.
    */
-  removeObserver(observer: (exit: Exit.Exit<E, A>) => void): void
+  readonly removeObserver: (observer: (exit: Exit.Exit<E, A>) => void) => void
 
   /**
    * Retrieves all fiber refs of the fiber.
    */
-  getFiberRefs(): FiberRefs.FiberRefs
+  readonly getFiberRefs: () => FiberRefs.FiberRefs
 
   /**
    * Unsafely observes the fiber, but returns immediately if it is not
    * already done.
    */
-  unsafePoll(): Exit.Exit<E, A> | null
+  readonly unsafePoll: () => Exit.Exit<E, A> | null
 }
 ```
 

--- a/docs/modules/Fiber.ts.md
+++ b/docs/modules/Fiber.ts.md
@@ -621,37 +621,37 @@ export interface Fiber<E, A> extends Fiber.Variance<E, A>, Pipeable {
   /**
    * The identity of the fiber.
    */
-  id(): FiberId.FiberId
+  readonly id: () => FiberId.FiberId
 
   /**
    * Awaits the fiber, which suspends the awaiting fiber until the result of the
    * fiber has been determined.
    */
-  await(): Effect.Effect<never, never, Exit.Exit<E, A>>
+  readonly await: () => Effect.Effect<never, never, Exit.Exit<E, A>>
 
   /**
    * Retrieves the immediate children of the fiber.
    */
-  children(): Effect.Effect<never, never, Array<Fiber.Runtime<any, any>>>
+  readonly children: () => Effect.Effect<never, never, Array<Fiber.Runtime<any, any>>>
 
   /**
    * Inherits values from all `FiberRef` instances into current fiber. This
    * will resume immediately.
    */
-  inheritAll(): Effect.Effect<never, never, void>
+  readonly inheritAll: () => Effect.Effect<never, never, void>
 
   /**
    * Tentatively observes the fiber, but returns immediately if it is not
    * already done.
    */
-  poll(): Effect.Effect<never, never, Option.Option<Exit.Exit<E, A>>>
+  readonly poll: () => Effect.Effect<never, never, Option.Option<Exit.Exit<E, A>>>
 
   /**
    * In the background, interrupts the fiber as if interrupted from the
    * specified fiber. If the fiber has already exited, the returned effect will
    * resume immediately. Otherwise, the effect will resume when the fiber exits.
    */
-  interruptAsFork(fiberId: FiberId.FiberId): Effect.Effect<never, never, void>
+  readonly interruptAsFork: (fiberId: FiberId.FiberId) => Effect.Effect<never, never, void>
 }
 ```
 

--- a/docs/modules/Hash.ts.md
+++ b/docs/modules/Hash.ts.md
@@ -143,7 +143,7 @@ Added in v2.0.0
 
 ```ts
 export interface Hash {
-  [symbol](): number
+  readonly [symbol]: () => number
 }
 ```
 

--- a/docs/modules/HashMap.ts.md
+++ b/docs/modules/HashMap.ts.md
@@ -369,7 +369,7 @@ Added in v2.0.0
 
 ```ts
 export interface HashMap<Key, Value> extends Iterable<[Key, Value]>, Equal, Pipeable, Inspectable {
-  [TypeId]: TypeId
+  readonly [TypeId]: TypeId
 }
 ```
 

--- a/docs/modules/KeyedPool.ts.md
+++ b/docs/modules/KeyedPool.ts.md
@@ -173,14 +173,14 @@ export interface KeyedPool<K, E, A> extends KeyedPool.Variance<K, E, A>, Pipeabl
    * for that same reason. Retrying a failed acquisition attempt will repeat the
    * acquisition attempt.
    */
-  get(key: K): Effect.Effect<Scope.Scope, E, A>
+  readonly get: (key: K) => Effect.Effect<Scope.Scope, E, A>
 
   /**
    * Invalidates the specified item. This will cause the pool to eventually
    * reallocate the item, although this reallocation may occur lazily rather
    * than eagerly.
    */
-  invalidate(item: A): Effect.Effect<never, never, void>
+  readonly invalidate: (item: A) => Effect.Effect<never, never, void>
 }
 ```
 

--- a/docs/modules/MetricRegistry.ts.md
+++ b/docs/modules/MetricRegistry.ts.md
@@ -43,18 +43,20 @@ Added in v2.0.0
 ```ts
 export interface MetricRegistry {
   readonly [MetricRegistryTypeId]: MetricRegistryTypeId
-  snapshot(): HashSet.HashSet<MetricPair.MetricPair.Untyped>
-  get<Type extends MetricKeyType.MetricKeyType<any, any>>(
+  readonly snapshot: () => HashSet.HashSet<MetricPair.MetricPair.Untyped>
+  readonly get: <Type extends MetricKeyType.MetricKeyType<any, any>>(
     key: MetricKey.MetricKey<Type>
-  ): MetricHook.MetricHook<
+  ) => MetricHook.MetricHook<
     MetricKeyType.MetricKeyType.InType<(typeof key)["keyType"]>,
     MetricKeyType.MetricKeyType.OutType<(typeof key)["keyType"]>
   >
-  getCounter<A extends number | bigint>(key: MetricKey.MetricKey.Counter<A>): MetricHook.MetricHook.Counter<A>
-  getFrequency(key: MetricKey.MetricKey.Frequency): MetricHook.MetricHook.Frequency
-  getGauge<A extends number | bigint>(key: MetricKey.MetricKey.Gauge<A>): MetricHook.MetricHook.Gauge<A>
-  getHistogram(key: MetricKey.MetricKey.Histogram): MetricHook.MetricHook.Histogram
-  getSummary(key: MetricKey.MetricKey.Summary): MetricHook.MetricHook.Summary
+  readonly getCounter: <A extends number | bigint>(
+    key: MetricKey.MetricKey.Counter<A>
+  ) => MetricHook.MetricHook.Counter<A>
+  readonly getFrequency: (key: MetricKey.MetricKey.Frequency) => MetricHook.MetricHook.Frequency
+  readonly getGauge: <A extends number | bigint>(key: MetricKey.MetricKey.Gauge<A>) => MetricHook.MetricHook.Gauge<A>
+  readonly getHistogram: (key: MetricKey.MetricKey.Histogram) => MetricHook.MetricHook.Histogram
+  readonly getSummary: (key: MetricKey.MetricKey.Summary) => MetricHook.MetricHook.Summary
 }
 ```
 

--- a/docs/modules/Pipeable.ts.md
+++ b/docs/modules/Pipeable.ts.md
@@ -27,281 +27,276 @@ Added in v2.0.0
 
 ```ts
 export interface Pipeable {
-  pipe<A, B>(this: A, ab: (_: A) => B): B
-  pipe<A, B, C>(this: A, ab: (_: A) => B, bc: (_: B) => C): C
-  pipe<A, B, C, D>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D): D
-  pipe<A, B, C, D, E>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D, de: (_: D) => E): E
-  pipe<A, B, C, D, E, F>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F
-  ): F
-  pipe<A, B, C, D, E, F, G>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G
-  ): G
-  pipe<A, B, C, D, E, F, G, H>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H
-  ): H
-  pipe<A, B, C, D, E, F, G, H, I>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I
-  ): I
-  pipe<A, B, C, D, E, F, G, H, I, J>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J
-  ): J
-  pipe<A, B, C, D, E, F, G, H, I, J, K>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K
-  ): K
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L
-  ): L
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M
-  ): M
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N
-  ): N
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O
-  ): O
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P
-  ): P
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q
-  ): Q
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R
-  ): R
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S
-  ): S
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S,
-    st: (_: S) => T
-  ): T
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S,
-    st: (_: S) => T,
-    tu: (_: T) => U
-  ): U
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S,
-    st: (_: S) => T,
-    tu: (_: T) => U
-  ): U
+  readonly pipe: {
+    <A, B>(this: A, ab: (_: A) => B): B
+    <A, B, C>(this: A, ab: (_: A) => B, bc: (_: B) => C): C
+    <A, B, C, D>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D): D
+    <A, B, C, D, E>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D, de: (_: D) => E): E
+    <A, B, C, D, E, F>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D, de: (_: D) => E, ef: (_: E) => F): F
+    <A, B, C, D, E, F, G>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G
+    ): G
+    <A, B, C, D, E, F, G, H>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H
+    ): H
+    <A, B, C, D, E, F, G, H, I>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I
+    ): I
+    <A, B, C, D, E, F, G, H, I, J>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J
+    ): J
+    <A, B, C, D, E, F, G, H, I, J, K>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K
+    ): K
+    <A, B, C, D, E, F, G, H, I, J, K, L>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L
+    ): L
+    <A, B, C, D, E, F, G, H, I, J, K, L, M>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M
+    ): M
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N
+    ): N
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O
+    ): O
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P
+    ): P
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q
+    ): Q
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R
+    ): R
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S
+    ): S
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S,
+      st: (_: S) => T
+    ): T
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S,
+      st: (_: S) => T,
+      tu: (_: T) => U
+    ): U
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S,
+      st: (_: S) => T,
+      tu: (_: T) => U
+    ): U
+  }
 }
 ```
 

--- a/docs/modules/Pool.ts.md
+++ b/docs/modules/Pool.ts.md
@@ -148,14 +148,14 @@ export interface Pool<E, A> extends Data.Case, Pool.Variance<E, A>, Pipeable {
    * acquisition fails, then the returned effect will fail for that same reason.
    * Retrying a failed acquisition attempt will repeat the acquisition attempt.
    */
-  get(): Effect.Effect<Scope.Scope, E, A>
+  readonly get: () => Effect.Effect<Scope.Scope, E, A>
 
   /**
    * Invalidates the specified item. This will cause the pool to eventually
    * reallocate the item, although this reallocation may occur lazily rather
    * than eagerly.
    */
-  invalidate(item: A): Effect.Effect<never, never, void>
+  readonly invalidate: (item: A) => Effect.Effect<never, never, void>
 }
 ```
 

--- a/docs/modules/PubSub.ts.md
+++ b/docs/modules/PubSub.ts.md
@@ -175,20 +175,20 @@ export interface PubSub<A> extends Queue.Enqueue<A>, Pipeable {
    * Publishes a message to the `PubSub`, returning whether the message was published
    * to the `PubSub`.
    */
-  publish(value: A): Effect.Effect<never, never, boolean>
+  readonly publish: (value: A) => Effect.Effect<never, never, boolean>
 
   /**
    * Publishes all of the specified messages to the `PubSub`, returning whether they
    * were published to the `PubSub`.
    */
-  publishAll(elements: Iterable<A>): Effect.Effect<never, never, boolean>
+  readonly publishAll: (elements: Iterable<A>) => Effect.Effect<never, never, boolean>
 
   /**
    * Subscribes to receive messages from the `PubSub`. The resulting subscription can
    * be evaluated multiple times within the scope to take a message from the `PubSub`
    * each time.
    */
-  subscribe(): Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>>
+  readonly subscribe: () => Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>>
 }
 ```
 

--- a/docs/modules/Queue.ts.md
+++ b/docs/modules/Queue.ts.md
@@ -363,12 +363,12 @@ export interface Enqueue<A> extends Queue.EnqueueVariance<A>, BaseQueue, Pipeabl
   /**
    * Places one value in the queue.
    */
-  offer(value: A): Effect.Effect<never, never, boolean>
+  readonly offer: (value: A) => Effect.Effect<never, never, boolean>
 
   /**
    * Places one value in the queue when possible without needing the fiber runtime.
    */
-  unsafeOffer(value: A): boolean
+  readonly unsafeOffer: (value: A) => boolean
 
   /**
    * For Bounded Queue: uses the `BackPressure` Strategy, places the values in
@@ -385,7 +385,7 @@ export interface Enqueue<A> extends Queue.EnqueueVariance<A>, BaseQueue, Pipeabl
    * For Dropping Queue: uses `Dropping` Strategy, It places the values in the
    * queue but if there is no room it will not enqueue them and return false.
    */
-  offerAll(iterable: Iterable<A>): Effect.Effect<never, never, boolean>
+  readonly offerAll: (iterable: Iterable<A>) => Effect.Effect<never, never, boolean>
 }
 ```
 

--- a/docs/modules/Queue.ts.md
+++ b/docs/modules/Queue.ts.md
@@ -422,37 +422,40 @@ export interface Strategy<A> extends Queue.StrategyVariance<A> {
    * Returns the number of surplus values that were unable to be added to the
    * `Queue`
    */
-  surplusSize(): number
+  readonly surplusSize: () => number
 
   /**
    * Determines how the `Queue.Strategy` should shut down when the `Queue` is
    * shut down.
    */
-  shutdown(): Effect.Effect<never, never, void>
+  readonly shutdown: () => Effect.Effect<never, never, void>
 
   /**
    * Determines the behavior of the `Queue.Strategy` when there are surplus
    * values that could not be added to the `Queue` following an `offer`
    * operation.
    */
-  handleSurplus(
+  readonly handleSurplus: (
     iterable: Iterable<A>,
     queue: BackingQueue<A>,
     takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>,
     isShutdown: MutableRef.MutableRef<boolean>
-  ): Effect.Effect<never, never, boolean>
+  ) => Effect.Effect<never, never, boolean>
 
   /**
    * It is called when the backing queue is empty but there are some
    * takers that can be completed
    */
-  onCompleteTakersWithEmptyQueue(takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>): void
+  readonly onCompleteTakersWithEmptyQueue: (takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>) => void
 
   /**
    * Determines the behavior of the `Queue.Strategy` when the `Queue` has empty
    * slots following a `take` operation.
    */
-  unsafeOnQueueEmptySpace(queue: BackingQueue<A>, takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>): void
+  readonly unsafeOnQueueEmptySpace: (
+    queue: BackingQueue<A>,
+    takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>
+  ) => void
 }
 ```
 

--- a/docs/modules/Queue.ts.md
+++ b/docs/modules/Queue.ts.md
@@ -266,55 +266,55 @@ export interface BaseQueue {
   /**
    * Returns the number of elements the queue can hold.
    */
-  capacity(): number
+  readonly capacity: () => number
 
   /**
    * Returns false if shutdown has been called.
    */
-  isActive(): boolean
+  readonly isActive: () => boolean
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements
    * in the queue. This may be negative if fibers are suspended waiting for
    * elements to be added to the queue.
    */
-  size(): Effect.Effect<never, never, number>
+  readonly size: () => Effect.Effect<never, never, number>
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements
    * in the queue. This may be negative if fibers are suspended waiting for
    * elements to be added to the queue. Returns None if shutdown has been called
    */
-  unsafeSize(): Option.Option<number>
+  readonly unsafeSize: () => Option.Option<number>
 
   /**
    * Returns `true` if the `Queue` contains at least one element, `false`
    * otherwise.
    */
-  isFull(): Effect.Effect<never, never, boolean>
+  readonly isFull: () => Effect.Effect<never, never, boolean>
 
   /**
    * Returns `true` if the `Queue` contains zero elements, `false` otherwise.
    */
-  isEmpty(): Effect.Effect<never, never, boolean>
+  readonly isEmpty: () => Effect.Effect<never, never, boolean>
 
   /**
    * Interrupts any fibers that are suspended on `offer` or `take`. Future calls
    * to `offer*` and `take*` will be interrupted immediately.
    */
-  shutdown(): Effect.Effect<never, never, void>
+  readonly shutdown: () => Effect.Effect<never, never, void>
 
   /**
    * Returns `true` if `shutdown` has been called, otherwise returns `false`.
    */
-  isShutdown(): Effect.Effect<never, never, boolean>
+  readonly isShutdown: () => Effect.Effect<never, never, boolean>
 
   /**
    * Waits until the queue is shutdown. The `Effect` returned by this method will
    * not resume until the queue has been shutdown. If the queue is already
    * shutdown, the `Effect` will resume right away.
    */
-  awaitShutdown(): Effect.Effect<never, never, void>
+  readonly awaitShutdown: () => Effect.Effect<never, never, void>
 }
 ```
 

--- a/docs/modules/Queue.ts.md
+++ b/docs/modules/Queue.ts.md
@@ -222,34 +222,34 @@ export interface BackingQueue<A> {
    * Dequeues an element from the queue.
    * Returns either an element from the queue, or the `def` param.
    */
-  poll<Def>(def: Def): A | Def
+  readonly poll: <Def>(def: Def) => A | Def
   /**
    * Dequeues up to `limit` elements from the queue.
    */
-  pollUpTo(limit: number): Chunk.Chunk<A>
+  readonly pollUpTo: (limit: number) => Chunk.Chunk<A>
   /**
    * Enqueues a collection of values into the queue.
    *
    * Returns a `Chunk` of the values that were **not** able to be enqueued.
    */
-  offerAll(elements: Iterable<A>): Chunk.Chunk<A>
+  readonly offerAll: (elements: Iterable<A>) => Chunk.Chunk<A>
   /**
    * Offers an element to the queue.
    *
    * Returns whether the enqueue was successful or not.
    */
-  offer(element: A): boolean
+  readonly offer: (element: A) => boolean
   /**
    * The **maximum** number of elements that a queue can hold.
    *
    * **Note**: unbounded queues can still implement this interface with
    * `capacity = Infinity`.
    */
-  capacity(): number
+  readonly capacity: () => number
   /**
    * Returns the number of elements currently in the queue
    */
-  length(): number
+  readonly length: () => number
 }
 ```
 

--- a/docs/modules/Queue.ts.md
+++ b/docs/modules/Queue.ts.md
@@ -330,25 +330,25 @@ export interface Dequeue<A> extends Queue.DequeueVariance<A>, BaseQueue, Pipeabl
    * Takes the oldest value in the queue. If the queue is empty, this will return
    * a computation that resumes when an item has been added to the queue.
    */
-  take(): Effect.Effect<never, never, A>
+  readonly take: () => Effect.Effect<never, never, A>
 
   /**
    * Takes all the values in the queue and returns the values. If the queue is
    * empty returns an empty collection.
    */
-  takeAll(): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly takeAll: () => Effect.Effect<never, never, Chunk.Chunk<A>>
 
   /**
    * Takes up to max number of values from the queue.
    */
-  takeUpTo(max: number): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly takeUpTo: (max: number) => Effect.Effect<never, never, Chunk.Chunk<A>>
 
   /**
    * Takes a number of elements from the queue between the specified minimum and
    * maximum. If there are fewer than the minimum number of elements available,
    * suspends until at least the minimum number of elements have been collected.
    */
-  takeBetween(min: number, max: number): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly takeBetween: (min: number, max: number) => Effect.Effect<never, never, Chunk.Chunk<A>>
 }
 ```
 

--- a/docs/modules/Random.ts.md
+++ b/docs/modules/Random.ts.md
@@ -129,29 +129,29 @@ export interface Random {
   /**
    * Returns the next numeric value from the pseudo-random number generator.
    */
-  next(): Effect.Effect<never, never, number>
+  readonly next: () => Effect.Effect<never, never, number>
   /**
    * Returns the next boolean value from the pseudo-random number generator.
    */
-  nextBoolean(): Effect.Effect<never, never, boolean>
+  readonly nextBoolean: () => Effect.Effect<never, never, boolean>
   /**
    * Returns the next integer value from the pseudo-random number generator.
    */
-  nextInt(): Effect.Effect<never, never, number>
+  readonly nextInt: () => Effect.Effect<never, never, number>
   /**
    * Returns the next numeric value in the specified range from the
    * pseudo-random number generator.
    */
-  nextRange(min: number, max: number): Effect.Effect<never, never, number>
+  readonly nextRange: (min: number, max: number) => Effect.Effect<never, never, number>
   /**
    * Returns the next integer value in the specified range from the
    * pseudo-random number generator.
    */
-  nextIntBetween(min: number, max: number): Effect.Effect<never, never, number>
+  readonly nextIntBetween: (min: number, max: number) => Effect.Effect<never, never, number>
   /**
    * Uses the pseudo-random number generator to shuffle the specified iterable.
    */
-  shuffle<A>(elements: Iterable<A>): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly shuffle: <A>(elements: Iterable<A>) => Effect.Effect<never, never, Chunk.Chunk<A>>
 }
 ```
 

--- a/docs/modules/Ref.ts.md
+++ b/docs/modules/Ref.ts.md
@@ -72,7 +72,7 @@ Added in v2.0.0
 
 ```ts
 export interface Ref<A> extends Ref.Variance<A>, Pipeable {
-  modify: <B>(f: (a: A) => readonly [B, A]) => Effect.Effect<never, never, B>
+  readonly modify: <B>(f: (a: A) => readonly [B, A]) => Effect.Effect<never, never, B>
 }
 ```
 

--- a/docs/modules/Reloadable.ts.md
+++ b/docs/modules/Reloadable.ts.md
@@ -167,7 +167,7 @@ export interface Reloadable<A> extends Reloadable.Variance<A> {
   /**
    * @internal
    */
-  reload(): Effect.Effect<never, unknown, void>
+  readonly reload: () => Effect.Effect<never, unknown, void>
 }
 ```
 

--- a/docs/modules/Request.ts.md
+++ b/docs/modules/Request.ts.md
@@ -146,7 +146,7 @@ export interface Entry<R> extends Entry.Variance<R> {
   readonly listeners: Listeners
   readonly ownerId: FiberId
   readonly state: {
-    completed: boolean
+    completed: boolean // TODO: mutable by design?
   }
 }
 ```

--- a/docs/modules/Request.ts.md
+++ b/docs/modules/Request.ts.md
@@ -177,12 +177,12 @@ Added in v2.0.0
 
 ```ts
 export interface Listeners {
-  count: number
-  observers: Set<(count: number) => void>
-  addObserver(f: (count: number) => void): void
-  removeObserver(f: (count: number) => void): void
-  increment(): void
-  decrement(): void
+  readonly count: number
+  readonly observers: Set<(count: number) => void>
+  readonly addObserver: (f: (count: number) => void) => void
+  readonly removeObserver: (f: (count: number) => void) => void
+  readonly increment: () => void
+  readonly decrement: () => void
 }
 ```
 

--- a/docs/modules/RequestResolver.ts.md
+++ b/docs/modules/RequestResolver.ts.md
@@ -360,12 +360,12 @@ export interface RequestResolver<A, R = never> extends Equal.Equal, Pipeable {
    * of requests that must be performed sequentially. The inner `Chunk`
    * represents a batch of requests that can be performed in parallel.
    */
-  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void> // TODO: remove bivariance
+  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void>
 
   /**
    * Identify the data source using the specific identifier
    */
-  identified(...identifiers: Array<unknown>): RequestResolver<A, R> // TODO: remove bivariance
+  identified(...identifiers: Array<unknown>): RequestResolver<A, R>
 }
 ```
 

--- a/docs/modules/RequestResolver.ts.md
+++ b/docs/modules/RequestResolver.ts.md
@@ -360,12 +360,12 @@ export interface RequestResolver<A, R = never> extends Equal.Equal, Pipeable {
    * of requests that must be performed sequentially. The inner `Chunk`
    * represents a batch of requests that can be performed in parallel.
    */
-  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void>
+  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void> // TODO: remove bivariance
 
   /**
    * Identify the data source using the specific identifier
    */
-  identified(...identifiers: Array<unknown>): RequestResolver<A, R>
+  identified(...identifiers: Array<unknown>): RequestResolver<A, R> // TODO: remove bivariance
 }
 ```
 

--- a/docs/modules/Resource.ts.md
+++ b/docs/modules/Resource.ts.md
@@ -96,7 +96,7 @@ export interface Resource<E, A> extends Resource.Variance<E, A> {
   /** @internal */
   readonly scopedRef: ScopedRef.ScopedRef<Exit.Exit<E, A>>
   /** @internal */
-  acquire(): Effect.Effect<Scope.Scope, E, A>
+  readonly acquire: () => Effect.Effect<Scope.Scope, E, A>
 }
 ```
 

--- a/docs/modules/Runtime.ts.md
+++ b/docs/modules/Runtime.ts.md
@@ -271,8 +271,8 @@ Added in v2.0.0
 
 ```ts
 export interface RunForkOptions {
-  scheduler?: Scheduler
-  updateRefs?: (refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) => FiberRefs.FiberRefs
+  readonly scheduler?: Scheduler
+  readonly updateRefs?: (refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) => FiberRefs.FiberRefs
 }
 ```
 

--- a/docs/modules/STM.ts.md
+++ b/docs/modules/STM.ts.md
@@ -1902,7 +1902,7 @@ export interface STMGen<R, E, A> {
   readonly _E: () => E
   readonly _A: () => A
   readonly value: STM<R, E, A>
-  [Symbol.iterator](): Generator<STMGen<R, E, A>, A>
+  readonly [Symbol.iterator]: () => Generator<STMGen<R, E, A>, A>
 }
 ```
 

--- a/docs/modules/Schedule.ts.md
+++ b/docs/modules/Schedule.ts.md
@@ -1040,10 +1040,10 @@ Added in v2.0.0
 
 ```ts
 export interface ScheduleDriver<Env, In, Out> extends Schedule.DriverVariance<Env, In, Out> {
-  state(): Effect.Effect<never, never, unknown>
-  last(): Effect.Effect<never, Cause.NoSuchElementException, Out>
-  reset(): Effect.Effect<never, never, void>
-  next(input: In): Effect.Effect<Env, Option.Option<never>, Out>
+  readonly state: () => Effect.Effect<never, never, unknown>
+  readonly last: () => Effect.Effect<never, Cause.NoSuchElementException, Out>
+  readonly reset: () => Effect.Effect<never, never, void>
+  readonly next: (input: In) => Effect.Effect<Env, Option.Option<never>, Out>
 }
 ```
 

--- a/docs/modules/Scheduler.ts.md
+++ b/docs/modules/Scheduler.ts.md
@@ -312,8 +312,8 @@ Added in v2.0.0
 
 ```ts
 export interface Scheduler {
-  shouldYield(fiber: RuntimeFiber<unknown, unknown>): number | false
-  scheduleTask(task: Task, priority: number): void
+  readonly shouldYield: (fiber: RuntimeFiber<unknown, unknown>) => number | false
+  readonly scheduleTask: (task: Task, priority: number) => void
 }
 ```
 

--- a/docs/modules/ScopedCache.ts.md
+++ b/docs/modules/ScopedCache.ts.md
@@ -90,47 +90,47 @@ export interface ScopedCache<Key, Error, Value> extends ScopedCache.Variance<Key
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
    */
-  getOption(key: Key): Effect.Effect<Scope.Scope, Error, Option.Option<Value>>
+  readonly getOption: (key: Key) => Effect.Effect<Scope.Scope, Error, Option.Option<Value>>
 
   /**
    * Retrieves the value associated with the specified key if it exists and the
    * lookup function has completed. Otherwise returns `Option.none`.
    */
-  getOptionComplete(key: Key): Effect.Effect<Scope.Scope, never, Option.Option<Value>>
+  readonly getOptionComplete: (key: Key) => Effect.Effect<Scope.Scope, never, Option.Option<Value>>
 
   /**
    * Returns statistics for this cache.
    */
-  cacheStats(): Effect.Effect<never, never, Cache.CacheStats>
+  readonly cacheStats: () => Effect.Effect<never, never, Cache.CacheStats>
 
   /**
    * Return whether a resource associated with the specified key exists in the
    * cache. Sometime `contains` can return true if the resource is currently
    * being created but not yet totally created.
    */
-  contains(key: Key): Effect.Effect<never, never, boolean>
+  readonly contains: (key: Key) => Effect.Effect<never, never, boolean>
 
   /**
    * Return statistics for the specified entry.
    */
-  entryStats(key: Key): Effect.Effect<never, never, Option.Option<Cache.EntryStats>>
+  readonly entryStats: (key: Key) => Effect.Effect<never, never, Option.Option<Cache.EntryStats>>
 
   /**
    * Gets the value from the cache if it exists or otherwise computes it, the
    * release action signals to the cache that the value is no longer being used
    * and can potentially be finalized subject to the policies of the cache.
    */
-  get(key: Key): Effect.Effect<Scope.Scope, Error, Value>
+  readonly get: (key: Key) => Effect.Effect<Scope.Scope, Error, Value>
 
   /**
    * Invalidates the resource associated with the specified key.
    */
-  invalidate(key: Key): Effect.Effect<never, never, void>
+  readonly invalidate: (key: Key) => Effect.Effect<never, never, void>
 
   /**
    * Invalidates all values in the cache.
    */
-  invalidateAll(): Effect.Effect<never, never, void>
+  readonly invalidateAll: () => Effect.Effect<never, never, void>
 
   /**
    * Force the reuse of the lookup function to compute the returned scoped
@@ -140,12 +140,12 @@ export interface ScopedCache<Key, Error, Value> extends ScopedCache.Variance<Key
    * computed, concurrent call the .get will use the old resource if this one is
    * not expired.
    */
-  refresh(key: Key): Effect.Effect<never, Error, void>
+  readonly refresh: (key: Key) => Effect.Effect<never, Error, void>
 
   /**
    * Returns the approximate number of values in the cache.
    */
-  size(): Effect.Effect<never, never, number>
+  readonly size: () => Effect.Effect<never, never, number>
 }
 ```
 

--- a/docs/modules/SingleProducerAsyncInput.ts.md
+++ b/docs/modules/SingleProducerAsyncInput.ts.md
@@ -61,10 +61,10 @@ Producer-side view of `SingleProducerAsyncInput` for variance purposes.
 
 ```ts
 export interface AsyncInputProducer<Err, Elem, Done> {
-  awaitRead(): Effect.Effect<never, never, unknown>
-  done(value: Done): Effect.Effect<never, never, unknown>
-  emit(element: Elem): Effect.Effect<never, never, unknown>
-  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown>
+  awaitRead(): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  done(value: Done): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  emit(element: Elem): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown> // TODO: remove bivariance
 }
 ```
 

--- a/docs/modules/SingleProducerAsyncInput.ts.md
+++ b/docs/modules/SingleProducerAsyncInput.ts.md
@@ -61,10 +61,10 @@ Producer-side view of `SingleProducerAsyncInput` for variance purposes.
 
 ```ts
 export interface AsyncInputProducer<Err, Elem, Done> {
-  awaitRead(): Effect.Effect<never, never, unknown> // TODO: remove bivariance
-  done(value: Done): Effect.Effect<never, never, unknown> // TODO: remove bivariance
-  emit(element: Elem): Effect.Effect<never, never, unknown> // TODO: remove bivariance
-  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  awaitRead(): Effect.Effect<never, never, unknown>
+  done(value: Done): Effect.Effect<never, never, unknown>
+  emit(element: Elem): Effect.Effect<never, never, unknown>
+  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown>
 }
 ```
 

--- a/docs/modules/SingleProducerAsyncInput.ts.md
+++ b/docs/modules/SingleProducerAsyncInput.ts.md
@@ -94,8 +94,8 @@ Features the following semantics:
 export interface SingleProducerAsyncInput<Err, Elem, Done>
   extends AsyncInputProducer<Err, Elem, Done>,
     AsyncInputConsumer<Err, Elem, Done> {
-  close(): Effect.Effect<never, never, unknown>
-  take(): Effect.Effect<never, never, Exit.Exit<Either.Either<Err, Done>, Elem>>
+  readonly close: () => Effect.Effect<never, never, unknown>
+  readonly take: () => Effect.Effect<never, never, Exit.Exit<Either.Either<Err, Done>, Elem>>
 }
 ```
 

--- a/docs/modules/Supervisor.ts.md
+++ b/docs/modules/Supervisor.ts.md
@@ -250,50 +250,50 @@ export interface Supervisor<T> extends Supervisor.Variance<T> {
    * supervisor. This value may change over time, reflecting what the supervisor
    * produces as it supervises fibers.
    */
-  value(): Effect.Effect<never, never, T>
+  readonly value: () => Effect.Effect<never, never, T>
 
   /**
    * Supervises the start of a `Fiber`.
    */
-  onStart<R, E, A>(
+  readonly onStart: <R, E, A>(
     context: Context.Context<R>,
     effect: Effect.Effect<R, E, A>,
     parent: Option.Option<Fiber.RuntimeFiber<any, any>>,
     fiber: Fiber.RuntimeFiber<E, A>
-  ): void
+  ) => void
 
   /**
    * Supervises the end of a `Fiber`.
    */
-  onEnd<E, A>(value: Exit.Exit<E, A>, fiber: Fiber.RuntimeFiber<E, A>): void
+  readonly onEnd: <E, A>(value: Exit.Exit<E, A>, fiber: Fiber.RuntimeFiber<E, A>) => void
 
   /**
    * Supervises the execution of an `Effect` by a `Fiber`.
    */
-  onEffect<E, A>(fiber: Fiber.RuntimeFiber<E, A>, effect: Effect.Effect<any, any, any>): void
+  readonly onEffect: <E, A>(fiber: Fiber.RuntimeFiber<E, A>, effect: Effect.Effect<any, any, any>) => void
 
   /**
    * Supervises the suspension of a computation running within a `Fiber`.
    */
-  onSuspend<E, A>(fiber: Fiber.RuntimeFiber<E, A>): void
+  readonly onSuspend: <E, A>(fiber: Fiber.RuntimeFiber<E, A>) => void
 
   /**
    * Supervises the resumption of a computation running within a `Fiber`.
    */
-  onResume<E, A>(fiber: Fiber.RuntimeFiber<E, A>): void
+  readonly onResume: <E, A>(fiber: Fiber.RuntimeFiber<E, A>) => void
 
   /**
    * Maps this supervisor to another one, which has the same effect, but whose
    * value has been transformed by the specified function.
    */
-  map<B>(f: (a: T) => B): Supervisor<B>
+  readonly map: <B>(f: (a: T) => B) => Supervisor<B>
 
   /**
    * Returns a new supervisor that performs the function of this supervisor, and
    * the function of the specified supervisor, producing a tuple of the outputs
    * produced by both supervisors.
    */
-  zip<A>(right: Supervisor<A>): Supervisor<[T, A]>
+  readonly zip: <A>(right: Supervisor<A>) => Supervisor<[T, A]>
 }
 ```
 

--- a/docs/modules/SynchronizedRef.ts.md
+++ b/docs/modules/SynchronizedRef.ts.md
@@ -80,7 +80,7 @@ Added in v2.0.0
 
 ```ts
 export interface SynchronizedRef<A> extends SynchronizedRef.Variance<A>, Ref.Ref<A> {
-  modifyEffect: <R, E, B>(f: (a: A) => Effect.Effect<R, E, readonly [B, A]>) => Effect.Effect<R, E, B>
+  readonly modifyEffect: <R, E, B>(f: (a: A) => Effect.Effect<R, E, readonly [B, A]>) => Effect.Effect<R, E, B>
 }
 ```
 

--- a/docs/modules/TQueue.ts.md
+++ b/docs/modules/TQueue.ts.md
@@ -310,7 +310,7 @@ export interface TDequeue<A> extends TQueue.TDequeueVariance<A>, BaseTQueue {
   /**
    * Takes up to max number of values from the queue.
    */
-  takeUpTo(max: number): STM.STM<never, never, Array<A>>
+  readonly takeUpTo: (max: number) => STM.STM<never, never, Array<A>>
 }
 ```
 

--- a/docs/modules/TQueue.ts.md
+++ b/docs/modules/TQueue.ts.md
@@ -325,7 +325,7 @@ export interface TEnqueue<A> extends TQueue.TEnqueueVariance<A>, BaseTQueue {
   /**
    * Places one value in the queue.
    */
-  offer(value: A): STM.STM<never, never, boolean>
+  readonly offer: (value: A) => STM.STM<never, never, boolean>
 
   /**
    * For Bounded TQueue: uses the `BackPressure` Strategy, places the values in
@@ -342,7 +342,7 @@ export interface TEnqueue<A> extends TQueue.TEnqueueVariance<A>, BaseTQueue {
    * For Dropping TQueue: uses `Dropping` Strategy, It places the values in the
    * queue but if there is no room it will not enqueue them and return false.
    */
-  offerAll(iterable: Iterable<A>): STM.STM<never, never, boolean>
+  readonly offerAll: (iterable: Iterable<A>) => STM.STM<never, never, boolean>
 }
 ```
 

--- a/docs/modules/TQueue.ts.md
+++ b/docs/modules/TQueue.ts.md
@@ -235,7 +235,7 @@ export interface BaseTQueue {
   /**
    * Returns the number of elements the queue can hold.
    */
-  capacity(): number
+  readonly capacity: () => number
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements

--- a/docs/modules/TRandom.ts.md
+++ b/docs/modules/TRandom.ts.md
@@ -81,16 +81,16 @@ export interface TRandom {
    * Returns the next numeric value in the specified range from the
    * pseudo-random number generator.
    */
-  nextRange(min: number, max: number): STM.STM<never, never, number>
+  readonly nextRange: (min: number, max: number) => STM.STM<never, never, number>
   /**
    * Returns the next integer value in the specified range from the
    * pseudo-random number generator.
    */
-  nextIntBetween(min: number, max: number): STM.STM<never, never, number>
+  readonly nextIntBetween: (min: number, max: number) => STM.STM<never, never, number>
   /**
    * Uses the pseudo-random number generator to shuffle the specified iterable.
    */
-  shuffle<A>(elements: Iterable<A>): STM.STM<never, never, Array<A>>
+  readonly shuffle: <A>(elements: Iterable<A>) => STM.STM<never, never, Array<A>>
 }
 ```
 

--- a/docs/modules/TRef.ts.md
+++ b/docs/modules/TRef.ts.md
@@ -69,7 +69,7 @@ export interface TRef<A> extends TRef.Variance<A> {
   /**
    * Note: the method is unbound, exposed only for potential extensions.
    */
-  modify: <B>(f: (a: A) => readonly [B, A]) => STM.STM<never, never, B>
+  readonly modify: <B>(f: (a: A) => readonly [B, A]) => STM.STM<never, never, B>
 }
 ```
 

--- a/docs/modules/TestAnnotations.ts.md
+++ b/docs/modules/TestAnnotations.ts.md
@@ -55,18 +55,22 @@ export interface TestAnnotations {
    * Accesses an `Annotations` instance in the context and retrieves the
    * annotation of the specified type, or its default value if there is none.
    */
-  get<A>(key: TestAnnotation.TestAnnotation<A>): Effect.Effect<never, never, A>
+  readonly get: <A>(key: TestAnnotation.TestAnnotation<A>) => Effect.Effect<never, never, A>
 
   /**
    * Accesses an `Annotations` instance in the context and appends the
    * specified annotation to the annotation map.
    */
-  annotate<A>(key: TestAnnotation.TestAnnotation<A>, value: A): Effect.Effect<never, never, void>
+  readonly annotate: <A>(key: TestAnnotation.TestAnnotation<A>, value: A) => Effect.Effect<never, never, void>
 
   /**
    * Returns the set of all fibers in this test.
    */
-  supervisedFibers(): Effect.Effect<never, never, SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>>
+  readonly supervisedFibers: () => Effect.Effect<
+    never,
+    never,
+    SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>
+  >
 }
 ```
 

--- a/docs/modules/TestClock.ts.md
+++ b/docs/modules/TestClock.ts.md
@@ -98,11 +98,13 @@ expected effects have been performed.
 
 ```ts
 export interface TestClock extends Clock.Clock {
-  adjust(duration: Duration.DurationInput): Effect.Effect<never, never, void>
-  adjustWith(duration: Duration.DurationInput): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
-  save(): Effect.Effect<never, never, Effect.Effect<never, never, void>>
-  setTime(time: number): Effect.Effect<never, never, void>
-  sleeps(): Effect.Effect<never, never, Chunk.Chunk<number>>
+  readonly adjust: (duration: Duration.DurationInput) => Effect.Effect<never, never, void>
+  readonly adjustWith: (
+    duration: Duration.DurationInput
+  ) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
+  readonly save: () => Effect.Effect<never, never, Effect.Effect<never, never, void>>
+  readonly setTime: (time: number) => Effect.Effect<never, never, void>
+  readonly sleeps: () => Effect.Effect<never, never, Chunk.Chunk<number>>
 }
 ```
 

--- a/docs/modules/TestLive.ts.md
+++ b/docs/modules/TestLive.ts.md
@@ -45,7 +45,7 @@ these services.
 ```ts
 export interface TestLive {
   readonly [TestLiveTypeId]: TestLiveTypeId
-  provide<R, E, A>(effect: Effect.Effect<R, E, A>): Effect.Effect<R, E, A>
+  readonly provide: <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
 }
 ```
 

--- a/docs/modules/TestSized.ts.md
+++ b/docs/modules/TestSized.ts.md
@@ -42,8 +42,8 @@ Added in v2.0.0
 export interface TestSized {
   readonly [TestSizedTypeId]: TestSizedTypeId
   readonly fiberRef: FiberRef.FiberRef<number>
-  size(): Effect.Effect<never, never, number>
-  withSize(size: number): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
+  readonly size: () => Effect.Effect<never, never, number>
+  readonly withSize: (size: number) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
 }
 ```
 

--- a/docs/modules/Utils.ts.md
+++ b/docs/modules/Utils.ts.md
@@ -547,7 +547,7 @@ Added in v2.0.0
 export interface GenKind<F extends TypeLambda, R, O, E, A> extends Variance<F, R, O, E> {
   readonly value: Kind<F, R, O, E, A>
 
-  [Symbol.iterator](): Generator<GenKind<F, R, O, E, A>, A>
+  readonly [Symbol.iterator]: () => Generator<GenKind<F, R, O, E, A>, A>
 }
 ```
 

--- a/src/Brand.ts
+++ b/src/Brand.ts
@@ -97,17 +97,17 @@ export declare namespace Brand {
      * Constructs a branded type from a value of type `A`, returning `Some<A>`
      * if the provided `A` is valid, `None` otherwise.
      */
-    option: (args: Brand.Unbranded<A>) => Option.Option<A>
+    readonly option: (args: Brand.Unbranded<A>) => Option.Option<A>
     /**
      * Constructs a branded type from a value of type `A`, returning `Right<A>`
      * if the provided `A` is valid, `Left<BrandError>` otherwise.
      */
-    either: (args: Brand.Unbranded<A>) => Either.Either<Brand.BrandErrors, A>
+    readonly either: (args: Brand.Unbranded<A>) => Either.Either<Brand.BrandErrors, A>
     /**
      * Attempts to refine the provided value of type `A`, returning `true` if
      * the provided `A` is valid, `false` otherwise.
      */
-    is: Refinement<Brand.Unbranded<A>, Brand.Unbranded<A> & A>
+    readonly is: Refinement<Brand.Unbranded<A>, Brand.Unbranded<A> & A>
   }
 
   /**

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -47,14 +47,14 @@ export interface Cache<Key, Error, Value> extends ConsumerCache<Key, Error, Valu
    * Otherwise computes the value with the lookup function, puts it in the
    * cache, and returns it.
    */
-  get(key: Key): Effect.Effect<never, Error, Value>
+  readonly get: (key: Key) => Effect.Effect<never, Error, Value>
 
   /**
    * Retrieves the value associated with the specified key if it exists as a left.
    * Otherwise computes the value with the lookup function, puts it in the
    * cache, and returns it as a right.
    */
-  getEither(key: Key): Effect.Effect<never, Error, Either<Value, Value>>
+  readonly getEither: (key: Key) => Effect.Effect<never, Error, Either<Value, Value>>
 
   /**
    * Computes the value associated with the specified key, with the lookup
@@ -65,12 +65,15 @@ export interface Cache<Key, Error, Value> extends ConsumerCache<Key, Error, Valu
    * by the lookup function. Additionally, `refresh` always triggers the
    * lookup function, disregarding the last `Error`.
    */
-  refresh(key: Key): Effect.Effect<never, Error, void>
+  readonly refresh: (key: Key) => Effect.Effect<never, Error, void>
 
   /**
    * Associates the specified value with the specified key in the cache.
    */
-  set<Key, Error, Value>(this: Cache<Key, Error, Value>, key: Key, value: Value): Effect.Effect<never, never, void>
+  readonly set: (
+    key: Key,
+    value: Value
+  ) => Effect.Effect<never, never, void>
 }
 
 /**

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -89,64 +89,64 @@ export interface ConsumerCache<Key, Error, Value> extends Cache.Variance<Key, Er
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
    */
-  getOption(key: Key): Effect.Effect<never, Error, Option.Option<Value>>
+  readonly getOption: (key: Key) => Effect.Effect<never, Error, Option.Option<Value>>
 
   /**
    * Retrieves the value associated with the specified key if it exists and the
    * lookup function has completed. Otherwise returns `Option.none`.
    */
-  getOptionComplete(key: Key): Effect.Effect<never, never, Option.Option<Value>>
+  readonly getOptionComplete: (key: Key) => Effect.Effect<never, never, Option.Option<Value>>
 
   /**
    * Returns statistics for this cache.
    */
-  cacheStats(): Effect.Effect<never, never, CacheStats>
+  readonly cacheStats: () => Effect.Effect<never, never, CacheStats>
 
   /**
    * Returns whether a value associated with the specified key exists in the
    * cache.
    */
-  contains(key: Key): Effect.Effect<never, never, boolean>
+  readonly contains: (key: Key) => Effect.Effect<never, never, boolean>
 
   /**
    * Returns statistics for the specified entry.
    */
-  entryStats(key: Key): Effect.Effect<never, never, Option.Option<EntryStats>>
+  readonly entryStats: (key: Key) => Effect.Effect<never, never, Option.Option<EntryStats>>
 
   /**
    * Invalidates the value associated with the specified key.
    */
-  invalidate(key: Key): Effect.Effect<never, never, void>
+  readonly invalidate: (key: Key) => Effect.Effect<never, never, void>
 
   /**
    * Invalidates the value associated with the specified key if the predicate holds.
    */
-  invalidateWhen(key: Key, when: (value: Value) => boolean): Effect.Effect<never, never, void>
+  readonly invalidateWhen: (key: Key, when: (value: Value) => boolean) => Effect.Effect<never, never, void>
 
   /**
    * Invalidates all values in the cache.
    */
-  invalidateAll(): Effect.Effect<never, never, void>
+  readonly invalidateAll: () => Effect.Effect<never, never, void>
 
   /**
    * Returns the approximate number of values in the cache.
    */
-  size(): Effect.Effect<never, never, number>
+  readonly size: () => Effect.Effect<never, never, number>
 
   /**
    * Returns an approximation of the values in the cache.
    */
-  keys<Key, Error, Value>(this: ConsumerCache<Key, Error, Value>): Effect.Effect<never, never, Array<Key>>
+  readonly keys: () => Effect.Effect<never, never, Array<Key>>
 
   /**
    * Returns an approximation of the values in the cache.
    */
-  values(): Effect.Effect<never, never, Array<Value>>
+  readonly values: () => Effect.Effect<never, never, Array<Value>>
 
   /**
    * Returns an approximation of the values in the cache.
    */
-  entries<Key, Error, Value>(this: ConsumerCache<Key, Error, Value>): Effect.Effect<never, never, Array<[Key, Value]>>
+  readonly entries: () => Effect.Effect<never, never, Array<[Key, Value]>>
 }
 
 /**

--- a/src/Clock.ts
+++ b/src/Clock.ts
@@ -31,7 +31,7 @@ export interface Clock {
   /**
    * Unsafely returns the current time in milliseconds.
    */
-  unsafeCurrentTimeMillis(): number
+  readonly unsafeCurrentTimeMillis: () => number
   /**
    * Returns the current time in milliseconds.
    */
@@ -39,7 +39,7 @@ export interface Clock {
   /**
    * Unsafely returns the current time in nanoseconds.
    */
-  unsafeCurrentTimeNanos(): bigint
+  readonly unsafeCurrentTimeNanos: () => bigint
   /**
    * Returns the current time in nanoseconds.
    */
@@ -47,7 +47,7 @@ export interface Clock {
   /**
    * Asynchronously sleeps for the specified duration.
    */
-  sleep(duration: Duration.Duration): Effect.Effect<never, never, void>
+  readonly sleep: (duration: Duration.Duration) => Effect.Effect<never, never, void>
 }
 
 /**

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -54,7 +54,7 @@ export declare namespace Config {
    */
   export interface Primitive<A> extends Config<A> {
     readonly description: string
-    parse(text: string): Either.Either<ConfigError.ConfigError, A>
+    readonly parse: (text: string) => Either.Either<ConfigError.ConfigError, A>
   }
 
   /**

--- a/src/ConfigError.ts
+++ b/src/ConfigError.ts
@@ -133,7 +133,7 @@ export interface Unsupported extends ConfigError.Proto {
  * @category models
  */
 export interface Options {
-  pathDelim: string
+  readonly pathDelim: string
 }
 
 /**

--- a/src/ConfigProvider.ts
+++ b/src/ConfigProvider.ts
@@ -46,12 +46,12 @@ export interface ConfigProvider extends ConfigProvider.Proto, Pipeable {
   /**
    * Loads the specified configuration, or fails with a config error.
    */
-  load<A>(config: Config.Config<A>): Effect.Effect<never, ConfigError.ConfigError, A>
+  readonly load: <A>(config: Config.Config<A>) => Effect.Effect<never, ConfigError.ConfigError, A>
   /**
    * Flattens this config provider into a simplified config provider that knows
    * only how to deal with flat (key/value) properties.
    */
-  flattened: ConfigProvider.Flat
+  readonly flattened: ConfigProvider.Flat
 }
 
 /**

--- a/src/ConfigProvider.ts
+++ b/src/ConfigProvider.ts
@@ -76,15 +76,15 @@ export declare namespace ConfigProvider {
    */
   export interface Flat {
     readonly [FlatConfigProviderTypeId]: FlatConfigProviderTypeId
-    patch: PathPatch.PathPatch
-    load<A>(
+    readonly patch: PathPatch.PathPatch
+    readonly load: <A>(
       path: ReadonlyArray<string>,
       config: Config.Config.Primitive<A>,
       split?: boolean
-    ): Effect.Effect<never, ConfigError.ConfigError, ReadonlyArray<A>>
-    enumerateChildren(
+    ) => Effect.Effect<never, ConfigError.ConfigError, ReadonlyArray<A>>
+    readonly enumerateChildren: (
       path: ReadonlyArray<string>
-    ): Effect.Effect<never, ConfigError.ConfigError, HashSet.HashSet<string>>
+    ) => Effect.Effect<never, ConfigError.ConfigError, HashSet.HashSet<string>>
   }
 
   /**

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -54,27 +54,27 @@ export interface Console {
  * @category model
  */
 export interface UnsafeConsole {
-  assert(condition: boolean, ...args: ReadonlyArray<any>): void
-  clear(): void
-  count(label?: string): void
-  countReset(label?: string): void
-  debug(...args: ReadonlyArray<any>): void
-  dir(item: any, options?: any): void
-  dirxml(...args: ReadonlyArray<any>): void
-  error(...args: ReadonlyArray<any>): void
-  group(options?: {
+  readonly assert: (condition: boolean, ...args: ReadonlyArray<any>) => void
+  readonly clear: () => void
+  readonly count: (label?: string) => void
+  readonly countReset: (label?: string) => void
+  readonly debug: (...args: ReadonlyArray<any>) => void
+  readonly dir: (item: any, options?: any) => void
+  readonly dirxml: (...args: ReadonlyArray<any>) => void
+  readonly error: (...args: ReadonlyArray<any>) => void
+  readonly group: (options?: {
     readonly label?: string
     readonly collapsed?: boolean
-  }): void
-  groupEnd(): void
-  info(...args: ReadonlyArray<any>): void
-  log(...args: ReadonlyArray<any>): void
-  table(tabularData: any, properties?: ReadonlyArray<string>): void
-  time(label?: string): void
-  timeEnd(label?: string): void
-  timeLog(label?: string, ...args: ReadonlyArray<any>): void
-  trace(...args: ReadonlyArray<any>): void
-  warn(...args: ReadonlyArray<any>): void
+  }) => void
+  readonly groupEnd: () => void
+  readonly info: (...args: ReadonlyArray<any>) => void
+  readonly log: (...args: ReadonlyArray<any>) => void
+  readonly table: (tabularData: any, properties?: ReadonlyArray<string>) => void
+  readonly time: (label?: string) => void
+  readonly timeEnd: (label?: string) => void
+  readonly timeLog: (label?: string, ...args: ReadonlyArray<any>) => void
+  readonly trace: (...args: ReadonlyArray<any>) => void
+  readonly warn: (...args: ReadonlyArray<any>) => void
 }
 
 /**

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -25,27 +25,27 @@ export type TypeId = typeof TypeId
  */
 export interface Console {
   readonly [TypeId]: TypeId
-  assert(condition: boolean, ...args: ReadonlyArray<any>): Effect<never, never, void>
+  readonly assert: (condition: boolean, ...args: ReadonlyArray<any>) => Effect<never, never, void>
   readonly clear: Effect<never, never, void>
-  count(label?: string): Effect<never, never, void>
-  countReset(label?: string): Effect<never, never, void>
-  debug(...args: ReadonlyArray<any>): Effect<never, never, void>
-  dir(item: any, options?: any): Effect<never, never, void>
-  dirxml(...args: ReadonlyArray<any>): Effect<never, never, void>
-  error(...args: ReadonlyArray<any>): Effect<never, never, void>
-  group(options?: {
+  readonly count: (label?: string) => Effect<never, never, void>
+  readonly countReset: (label?: string) => Effect<never, never, void>
+  readonly debug: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly dir: (item: any, options?: any) => Effect<never, never, void>
+  readonly dirxml: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly error: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly group: (options?: {
     readonly label?: string
     readonly collapsed?: boolean
-  }): Effect<never, never, void>
+  }) => Effect<never, never, void>
   readonly groupEnd: Effect<never, never, void>
-  info(...args: ReadonlyArray<any>): Effect<never, never, void>
-  log(...args: ReadonlyArray<any>): Effect<never, never, void>
-  table(tabularData: any, properties?: ReadonlyArray<string>): Effect<never, never, void>
-  time(label?: string): Effect<never, never, void>
-  timeEnd(label?: string): Effect<never, never, void>
-  timeLog(label?: string, ...args: ReadonlyArray<any>): Effect<never, never, void>
-  trace(...args: ReadonlyArray<any>): Effect<never, never, void>
-  warn(...args: ReadonlyArray<any>): Effect<never, never, void>
+  readonly info: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly log: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly table: (tabularData: any, properties?: ReadonlyArray<string>) => Effect<never, never, void>
+  readonly time: (label?: string) => Effect<never, never, void>
+  readonly timeEnd: (label?: string) => Effect<never, never, void>
+  readonly timeLog: (label?: string, ...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly trace: (...args: ReadonlyArray<any>) => Effect<never, never, void>
+  readonly warn: (...args: ReadonlyArray<any>) => Effect<never, never, void>
   readonly unsafe: UnsafeConsole
 }
 

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -33,8 +33,8 @@ export interface Tag<Identifier, Service> extends Pipeable, Inspectable {
     readonly _S: (_: Service) => Service
     readonly _I: (_: Identifier) => Identifier
   }
-  of(self: Service): Service
-  context(self: Service): Context<Identifier>
+  readonly of: (self: Service) => Service
+  readonly context: (self: Service) => Context<Identifier>
   readonly stack?: string | undefined
   readonly identifier?: unknown | undefined
   [Unify.typeSymbol]?: unknown

--- a/src/Equal.ts
+++ b/src/Equal.ts
@@ -16,7 +16,7 @@ export const symbol: unique symbol = Symbol.for("effect/Equal")
  * @category models
  */
 export interface Equal extends Hash.Hash {
-  [symbol](that: Equal): boolean
+  readonly [symbol]: (that: Equal) => boolean
 }
 
 /**

--- a/src/Fiber.ts
+++ b/src/Fiber.ts
@@ -60,37 +60,37 @@ export interface Fiber<E, A> extends Fiber.Variance<E, A>, Pipeable {
   /**
    * The identity of the fiber.
    */
-  id(): FiberId.FiberId
+  readonly id: () => FiberId.FiberId
 
   /**
    * Awaits the fiber, which suspends the awaiting fiber until the result of the
    * fiber has been determined.
    */
-  await(): Effect.Effect<never, never, Exit.Exit<E, A>>
+  readonly await: () => Effect.Effect<never, never, Exit.Exit<E, A>>
 
   /**
    * Retrieves the immediate children of the fiber.
    */
-  children(): Effect.Effect<never, never, Array<Fiber.Runtime<any, any>>>
+  readonly children: () => Effect.Effect<never, never, Array<Fiber.Runtime<any, any>>>
 
   /**
    * Inherits values from all `FiberRef` instances into current fiber. This
    * will resume immediately.
    */
-  inheritAll(): Effect.Effect<never, never, void>
+  readonly inheritAll: () => Effect.Effect<never, never, void>
 
   /**
    * Tentatively observes the fiber, but returns immediately if it is not
    * already done.
    */
-  poll(): Effect.Effect<never, never, Option.Option<Exit.Exit<E, A>>>
+  readonly poll: () => Effect.Effect<never, never, Option.Option<Exit.Exit<E, A>>>
 
   /**
    * In the background, interrupts the fiber as if interrupted from the
    * specified fiber. If the fiber has already exited, the returned effect will
    * resume immediately. Otherwise, the effect will resume when the fiber exits.
    */
-  interruptAsFork(fiberId: FiberId.FiberId): Effect.Effect<never, never, void>
+  readonly interruptAsFork: (fiberId: FiberId.FiberId) => Effect.Effect<never, never, void>
 }
 
 /**

--- a/src/Fiber.ts
+++ b/src/Fiber.ts
@@ -109,44 +109,44 @@ export interface RuntimeFiber<E, A> extends Fiber<E, A>, Fiber.RuntimeVariance<E
   /**
    * Reads the current value of a fiber ref
    */
-  getFiberRef<X>(fiberRef: FiberRef<X>): X
+  readonly getFiberRef: <X>(fiberRef: FiberRef<X>) => X
 
   /**
    * The identity of the fiber.
    */
-  id(): FiberId.Runtime
+  readonly id: () => FiberId.Runtime
 
   /**
    * The status of the fiber.
    */
-  status(): Effect.Effect<never, never, FiberStatus.FiberStatus>
+  readonly status: () => Effect.Effect<never, never, FiberStatus.FiberStatus>
 
   /**
    * Returns the current `RuntimeFlags` the fiber is running with.
    */
-  runtimeFlags(): Effect.Effect<never, never, RuntimeFlags.RuntimeFlags>
+  readonly runtimeFlags: () => Effect.Effect<never, never, RuntimeFlags.RuntimeFlags>
 
   /**
    * Adds an observer to the list of observers.
    */
-  addObserver(observer: (exit: Exit.Exit<E, A>) => void): void
+  readonly addObserver: (observer: (exit: Exit.Exit<E, A>) => void) => void
 
   /**
    * Removes the specified observer from the list of observers that will be
    * notified when the fiber exits.
    */
-  removeObserver(observer: (exit: Exit.Exit<E, A>) => void): void
+  readonly removeObserver: (observer: (exit: Exit.Exit<E, A>) => void) => void
 
   /**
    * Retrieves all fiber refs of the fiber.
    */
-  getFiberRefs(): FiberRefs.FiberRefs
+  readonly getFiberRefs: () => FiberRefs.FiberRefs
 
   /**
    * Unsafely observes the fiber, but returns immediately if it is not
    * already done.
    */
-  unsafePoll(): Exit.Exit<E, A> | null
+  readonly unsafePoll: () => Exit.Exit<E, A> | null
 }
 
 /**

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -28,7 +28,7 @@ export const symbol: unique symbol = Symbol.for("effect/Hash")
  * @category models
  */
 export interface Hash {
-  [symbol](): number
+  readonly [symbol]: () => number
 }
 
 /**

--- a/src/HashMap.ts
+++ b/src/HashMap.ts
@@ -23,7 +23,7 @@ export type TypeId = typeof TypeId
  * @category models
  */
 export interface HashMap<Key, Value> extends Iterable<[Key, Value]>, Equal, Pipeable, Inspectable {
-  [TypeId]: TypeId
+  readonly [TypeId]: TypeId
 }
 
 /**

--- a/src/KeyedPool.ts
+++ b/src/KeyedPool.ts
@@ -33,14 +33,14 @@ export interface KeyedPool<K, E, A> extends KeyedPool.Variance<K, E, A>, Pipeabl
    * for that same reason. Retrying a failed acquisition attempt will repeat the
    * acquisition attempt.
    */
-  get(key: K): Effect.Effect<Scope.Scope, E, A>
+  readonly get: (key: K) => Effect.Effect<Scope.Scope, E, A>
 
   /**
    * Invalidates the specified item. This will cause the pool to eventually
    * reallocate the item, although this reallocation may occur lazily rather
    * than eagerly.
    */
-  invalidate(item: A): Effect.Effect<never, never, void>
+  readonly invalidate: (item: A) => Effect.Effect<never, never, void>
 }
 
 /**

--- a/src/MetricRegistry.ts
+++ b/src/MetricRegistry.ts
@@ -26,18 +26,20 @@ export type MetricRegistryTypeId = typeof MetricRegistryTypeId
  */
 export interface MetricRegistry {
   readonly [MetricRegistryTypeId]: MetricRegistryTypeId
-  snapshot(): HashSet.HashSet<MetricPair.MetricPair.Untyped>
-  get<Type extends MetricKeyType.MetricKeyType<any, any>>(
+  readonly snapshot: () => HashSet.HashSet<MetricPair.MetricPair.Untyped>
+  readonly get: <Type extends MetricKeyType.MetricKeyType<any, any>>(
     key: MetricKey.MetricKey<Type>
-  ): MetricHook.MetricHook<
+  ) => MetricHook.MetricHook<
     MetricKeyType.MetricKeyType.InType<typeof key["keyType"]>,
     MetricKeyType.MetricKeyType.OutType<typeof key["keyType"]>
   >
-  getCounter<A extends (number | bigint)>(key: MetricKey.MetricKey.Counter<A>): MetricHook.MetricHook.Counter<A>
-  getFrequency(key: MetricKey.MetricKey.Frequency): MetricHook.MetricHook.Frequency
-  getGauge<A extends (number | bigint)>(key: MetricKey.MetricKey.Gauge<A>): MetricHook.MetricHook.Gauge<A>
-  getHistogram(key: MetricKey.MetricKey.Histogram): MetricHook.MetricHook.Histogram
-  getSummary(key: MetricKey.MetricKey.Summary): MetricHook.MetricHook.Summary
+  readonly getCounter: <A extends (number | bigint)>(
+    key: MetricKey.MetricKey.Counter<A>
+  ) => MetricHook.MetricHook.Counter<A>
+  readonly getFrequency: (key: MetricKey.MetricKey.Frequency) => MetricHook.MetricHook.Frequency
+  readonly getGauge: <A extends (number | bigint)>(key: MetricKey.MetricKey.Gauge<A>) => MetricHook.MetricHook.Gauge<A>
+  readonly getHistogram: (key: MetricKey.MetricKey.Histogram) => MetricHook.MetricHook.Histogram
+  readonly getSummary: (key: MetricKey.MetricKey.Summary) => MetricHook.MetricHook.Summary
 }
 
 /**

--- a/src/Pipeable.ts
+++ b/src/Pipeable.ts
@@ -7,281 +7,283 @@
  * @category models
  */
 export interface Pipeable {
-  pipe<A, B>(this: A, ab: (_: A) => B): B
-  pipe<A, B, C>(this: A, ab: (_: A) => B, bc: (_: B) => C): C
-  pipe<A, B, C, D>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D): D
-  pipe<A, B, C, D, E>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D, de: (_: D) => E): E
-  pipe<A, B, C, D, E, F>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F
-  ): F
-  pipe<A, B, C, D, E, F, G>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G
-  ): G
-  pipe<A, B, C, D, E, F, G, H>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H
-  ): H
-  pipe<A, B, C, D, E, F, G, H, I>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I
-  ): I
-  pipe<A, B, C, D, E, F, G, H, I, J>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J
-  ): J
-  pipe<A, B, C, D, E, F, G, H, I, J, K>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K
-  ): K
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L
-  ): L
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M
-  ): M
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N
-  ): N
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O
-  ): O
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P
-  ): P
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q
-  ): Q
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R
-  ): R
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S
-  ): S
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S,
-    st: (_: S) => T
-  ): T
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S,
-    st: (_: S) => T,
-    tu: (_: T) => U
-  ): U
-  pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
-    this: A,
-    ab: (_: A) => B,
-    bc: (_: B) => C,
-    cd: (_: C) => D,
-    de: (_: D) => E,
-    ef: (_: E) => F,
-    fg: (_: F) => G,
-    gh: (_: G) => H,
-    hi: (_: H) => I,
-    ij: (_: I) => J,
-    jk: (_: J) => K,
-    kl: (_: K) => L,
-    lm: (_: L) => M,
-    mn: (_: M) => N,
-    no: (_: N) => O,
-    op: (_: O) => P,
-    pq: (_: P) => Q,
-    qr: (_: Q) => R,
-    rs: (_: R) => S,
-    st: (_: S) => T,
-    tu: (_: T) => U
-  ): U
+  readonly pipe: {
+    <A, B>(this: A, ab: (_: A) => B): B
+    <A, B, C>(this: A, ab: (_: A) => B, bc: (_: B) => C): C
+    <A, B, C, D>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D): D
+    <A, B, C, D, E>(this: A, ab: (_: A) => B, bc: (_: B) => C, cd: (_: C) => D, de: (_: D) => E): E
+    <A, B, C, D, E, F>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F
+    ): F
+    <A, B, C, D, E, F, G>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G
+    ): G
+    <A, B, C, D, E, F, G, H>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H
+    ): H
+    <A, B, C, D, E, F, G, H, I>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I
+    ): I
+    <A, B, C, D, E, F, G, H, I, J>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J
+    ): J
+    <A, B, C, D, E, F, G, H, I, J, K>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K
+    ): K
+    <A, B, C, D, E, F, G, H, I, J, K, L>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L
+    ): L
+    <A, B, C, D, E, F, G, H, I, J, K, L, M>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M
+    ): M
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N
+    ): N
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O
+    ): O
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P
+    ): P
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q
+    ): Q
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R
+    ): R
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S
+    ): S
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S,
+      st: (_: S) => T
+    ): T
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S,
+      st: (_: S) => T,
+      tu: (_: T) => U
+    ): U
+    <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>(
+      this: A,
+      ab: (_: A) => B,
+      bc: (_: B) => C,
+      cd: (_: C) => D,
+      de: (_: D) => E,
+      ef: (_: E) => F,
+      fg: (_: F) => G,
+      gh: (_: G) => H,
+      hi: (_: H) => I,
+      ij: (_: I) => J,
+      jk: (_: J) => K,
+      kl: (_: K) => L,
+      lm: (_: L) => M,
+      mn: (_: M) => N,
+      no: (_: N) => O,
+      op: (_: O) => P,
+      pq: (_: P) => Q,
+      qr: (_: Q) => R,
+      rs: (_: R) => S,
+      st: (_: S) => T,
+      tu: (_: T) => U
+    ): U
+  }
 }
 
 /**

--- a/src/Pool.ts
+++ b/src/Pool.ts
@@ -34,14 +34,14 @@ export interface Pool<E, A> extends Data.Case, Pool.Variance<E, A>, Pipeable {
    * acquisition fails, then the returned effect will fail for that same reason.
    * Retrying a failed acquisition attempt will repeat the acquisition attempt.
    */
-  get(): Effect.Effect<Scope.Scope, E, A>
+  readonly get: () => Effect.Effect<Scope.Scope, E, A>
 
   /**
    * Invalidates the specified item. This will cause the pool to eventually
    * reallocate the item, although this reallocation may occur lazily rather
    * than eagerly.
    */
-  invalidate(item: A): Effect.Effect<never, never, void>
+  readonly invalidate: (item: A) => Effect.Effect<never, never, void>
 }
 
 /**

--- a/src/PubSub.ts
+++ b/src/PubSub.ts
@@ -20,20 +20,20 @@ export interface PubSub<A> extends Queue.Enqueue<A>, Pipeable {
    * Publishes a message to the `PubSub`, returning whether the message was published
    * to the `PubSub`.
    */
-  publish(value: A): Effect.Effect<never, never, boolean>
+  readonly publish: (value: A) => Effect.Effect<never, never, boolean>
 
   /**
    * Publishes all of the specified messages to the `PubSub`, returning whether they
    * were published to the `PubSub`.
    */
-  publishAll(elements: Iterable<A>): Effect.Effect<never, never, boolean>
+  readonly publishAll: (elements: Iterable<A>) => Effect.Effect<never, never, boolean>
 
   /**
    * Subscribes to receive messages from the `PubSub`. The resulting subscription can
    * be evaluated multiple times within the scope to take a message from the `PubSub`
    * each time.
    */
-  subscribe(): Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>>
+  readonly subscribe: () => Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>>
 }
 
 /**

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -71,12 +71,12 @@ export interface Enqueue<A> extends Queue.EnqueueVariance<A>, BaseQueue, Pipeabl
   /**
    * Places one value in the queue.
    */
-  offer(value: A): Effect.Effect<never, never, boolean>
+  readonly offer: (value: A) => Effect.Effect<never, never, boolean>
 
   /**
    * Places one value in the queue when possible without needing the fiber runtime.
    */
-  unsafeOffer(value: A): boolean
+  readonly unsafeOffer: (value: A) => boolean
 
   /**
    * For Bounded Queue: uses the `BackPressure` Strategy, places the values in
@@ -93,7 +93,7 @@ export interface Enqueue<A> extends Queue.EnqueueVariance<A>, BaseQueue, Pipeabl
    * For Dropping Queue: uses `Dropping` Strategy, It places the values in the
    * queue but if there is no room it will not enqueue them and return false.
    */
-  offerAll(iterable: Iterable<A>): Effect.Effect<never, never, boolean>
+  readonly offerAll: (iterable: Iterable<A>) => Effect.Effect<never, never, boolean>
 }
 
 /**

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -243,34 +243,34 @@ export interface BackingQueue<A> {
    * Dequeues an element from the queue.
    * Returns either an element from the queue, or the `def` param.
    */
-  poll<Def>(def: Def): A | Def
+  readonly poll: <Def>(def: Def) => A | Def
   /**
    * Dequeues up to `limit` elements from the queue.
    */
-  pollUpTo(limit: number): Chunk.Chunk<A>
+  readonly pollUpTo: (limit: number) => Chunk.Chunk<A>
   /**
    * Enqueues a collection of values into the queue.
    *
    * Returns a `Chunk` of the values that were **not** able to be enqueued.
    */
-  offerAll(elements: Iterable<A>): Chunk.Chunk<A>
+  readonly offerAll: (elements: Iterable<A>) => Chunk.Chunk<A>
   /**
    * Offers an element to the queue.
    *
    * Returns whether the enqueue was successful or not.
    */
-  offer(element: A): boolean
+  readonly offer: (element: A) => boolean
   /**
    * The **maximum** number of elements that a queue can hold.
    *
    * **Note**: unbounded queues can still implement this interface with
    * `capacity = Infinity`.
    */
-  capacity(): number
+  readonly capacity: () => number
   /**
    * Returns the number of elements currently in the queue
    */
-  length(): number
+  readonly length: () => number
 }
 
 /**

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -136,55 +136,55 @@ export interface BaseQueue {
   /**
    * Returns the number of elements the queue can hold.
    */
-  capacity(): number
+  readonly capacity: () => number
 
   /**
    * Returns false if shutdown has been called.
    */
-  isActive(): boolean
+  readonly isActive: () => boolean
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements
    * in the queue. This may be negative if fibers are suspended waiting for
    * elements to be added to the queue.
    */
-  size(): Effect.Effect<never, never, number>
+  readonly size: () => Effect.Effect<never, never, number>
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements
    * in the queue. This may be negative if fibers are suspended waiting for
    * elements to be added to the queue. Returns None if shutdown has been called
    */
-  unsafeSize(): Option.Option<number>
+  readonly unsafeSize: () => Option.Option<number>
 
   /**
    * Returns `true` if the `Queue` contains at least one element, `false`
    * otherwise.
    */
-  isFull(): Effect.Effect<never, never, boolean>
+  readonly isFull: () => Effect.Effect<never, never, boolean>
 
   /**
    * Returns `true` if the `Queue` contains zero elements, `false` otherwise.
    */
-  isEmpty(): Effect.Effect<never, never, boolean>
+  readonly isEmpty: () => Effect.Effect<never, never, boolean>
 
   /**
    * Interrupts any fibers that are suspended on `offer` or `take`. Future calls
    * to `offer*` and `take*` will be interrupted immediately.
    */
-  shutdown(): Effect.Effect<never, never, void>
+  readonly shutdown: () => Effect.Effect<never, never, void>
 
   /**
    * Returns `true` if `shutdown` has been called, otherwise returns `false`.
    */
-  isShutdown(): Effect.Effect<never, never, boolean>
+  readonly isShutdown: () => Effect.Effect<never, never, boolean>
 
   /**
    * Waits until the queue is shutdown. The `Effect` returned by this method will
    * not resume until the queue has been shutdown. If the queue is already
    * shutdown, the `Effect` will resume right away.
    */
-  awaitShutdown(): Effect.Effect<never, never, void>
+  readonly awaitShutdown: () => Effect.Effect<never, never, void>
 }
 
 /**

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -105,25 +105,25 @@ export interface Dequeue<A> extends Queue.DequeueVariance<A>, BaseQueue, Pipeabl
    * Takes the oldest value in the queue. If the queue is empty, this will return
    * a computation that resumes when an item has been added to the queue.
    */
-  take(): Effect.Effect<never, never, A>
+  readonly take: () => Effect.Effect<never, never, A>
 
   /**
    * Takes all the values in the queue and returns the values. If the queue is
    * empty returns an empty collection.
    */
-  takeAll(): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly takeAll: () => Effect.Effect<never, never, Chunk.Chunk<A>>
 
   /**
    * Takes up to max number of values from the queue.
    */
-  takeUpTo(max: number): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly takeUpTo: (max: number) => Effect.Effect<never, never, Chunk.Chunk<A>>
 
   /**
    * Takes a number of elements from the queue between the specified minimum and
    * maximum. If there are fewer than the minimum number of elements available,
    * suspends until at least the minimum number of elements have been collected.
    */
-  takeBetween(min: number, max: number): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly takeBetween: (min: number, max: number) => Effect.Effect<never, never, Chunk.Chunk<A>>
 }
 
 /**

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -196,42 +196,42 @@ export interface Strategy<A> extends Queue.StrategyVariance<A> {
    * Returns the number of surplus values that were unable to be added to the
    * `Queue`
    */
-  surplusSize(): number
+  readonly surplusSize: () => number
 
   /**
    * Determines how the `Queue.Strategy` should shut down when the `Queue` is
    * shut down.
    */
-  shutdown(): Effect.Effect<never, never, void>
+  readonly shutdown: () => Effect.Effect<never, never, void>
 
   /**
    * Determines the behavior of the `Queue.Strategy` when there are surplus
    * values that could not be added to the `Queue` following an `offer`
    * operation.
    */
-  handleSurplus(
+  readonly handleSurplus: (
     iterable: Iterable<A>,
     queue: BackingQueue<A>,
     takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>,
     isShutdown: MutableRef.MutableRef<boolean>
-  ): Effect.Effect<never, never, boolean>
+  ) => Effect.Effect<never, never, boolean>
 
   /**
    * It is called when the backing queue is empty but there are some
    * takers that can be completed
    */
-  onCompleteTakersWithEmptyQueue(
+  readonly onCompleteTakersWithEmptyQueue: (
     takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>
-  ): void
+  ) => void
 
   /**
    * Determines the behavior of the `Queue.Strategy` when the `Queue` has empty
    * slots following a `take` operation.
    */
-  unsafeOnQueueEmptySpace(
+  readonly unsafeOnQueueEmptySpace: (
     queue: BackingQueue<A>,
     takers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>
-  ): void
+  ) => void
 }
 
 /**

--- a/src/Random.ts
+++ b/src/Random.ts
@@ -27,29 +27,29 @@ export interface Random {
   /**
    * Returns the next numeric value from the pseudo-random number generator.
    */
-  next(): Effect.Effect<never, never, number>
+  readonly next: () => Effect.Effect<never, never, number>
   /**
    * Returns the next boolean value from the pseudo-random number generator.
    */
-  nextBoolean(): Effect.Effect<never, never, boolean>
+  readonly nextBoolean: () => Effect.Effect<never, never, boolean>
   /**
    * Returns the next integer value from the pseudo-random number generator.
    */
-  nextInt(): Effect.Effect<never, never, number>
+  readonly nextInt: () => Effect.Effect<never, never, number>
   /**
    * Returns the next numeric value in the specified range from the
    * pseudo-random number generator.
    */
-  nextRange(min: number, max: number): Effect.Effect<never, never, number>
+  readonly nextRange: (min: number, max: number) => Effect.Effect<never, never, number>
   /**
    * Returns the next integer value in the specified range from the
    * pseudo-random number generator.
    */
-  nextIntBetween(min: number, max: number): Effect.Effect<never, never, number>
+  readonly nextIntBetween: (min: number, max: number) => Effect.Effect<never, never, number>
   /**
    * Uses the pseudo-random number generator to shuffle the specified iterable.
    */
-  shuffle<A>(elements: Iterable<A>): Effect.Effect<never, never, Chunk.Chunk<A>>
+  readonly shuffle: <A>(elements: Iterable<A>) => Effect.Effect<never, never, Chunk.Chunk<A>>
 }
 
 /**

--- a/src/Ref.ts
+++ b/src/Ref.ts
@@ -23,7 +23,7 @@ export type RefTypeId = typeof RefTypeId
  * @category models
  */
 export interface Ref<A> extends Ref.Variance<A>, Pipeable {
-  modify: <B>(f: (a: A) => readonly [B, A]) => Effect.Effect<never, never, B>
+  readonly modify: <B>(f: (a: A) => readonly [B, A]) => Effect.Effect<never, never, B>
 }
 
 /**

--- a/src/Reloadable.ts
+++ b/src/Reloadable.ts
@@ -35,7 +35,7 @@ export interface Reloadable<A> extends Reloadable.Variance<A> {
   /**
    * @internal
    */
-  reload(): Effect.Effect<never, unknown, void>
+  readonly reload: () => Effect.Effect<never, unknown, void>
 }
 
 /**

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -252,7 +252,7 @@ export interface Entry<R> extends Entry.Variance<R> {
   readonly listeners: Listeners
   readonly ownerId: FiberId
   readonly state: {
-    completed: boolean
+    completed: boolean // TODO: mutable by design?
   }
 }
 

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -187,12 +187,12 @@ export const succeed: {
  * @since 2.0.0
  */
 export interface Listeners {
-  count: number
-  observers: Set<(count: number) => void>
-  addObserver(f: (count: number) => void): void
-  removeObserver(f: (count: number) => void): void
-  increment(): void
-  decrement(): void
+  readonly count: number
+  readonly observers: Set<(count: number) => void>
+  readonly addObserver: (f: (count: number) => void) => void
+  readonly removeObserver: (f: (count: number) => void) => void
+  readonly increment: () => void
+  readonly decrement: () => void
 }
 
 /**

--- a/src/RequestResolver.ts
+++ b/src/RequestResolver.ts
@@ -54,12 +54,12 @@ export interface RequestResolver<A, R = never> extends Equal.Equal, Pipeable {
    * of requests that must be performed sequentially. The inner `Chunk`
    * represents a batch of requests that can be performed in parallel.
    */
-  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void>
+  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void> // TODO: remove bivariance
 
   /**
    * Identify the data source using the specific identifier
    */
-  identified(...identifiers: Array<unknown>): RequestResolver<A, R>
+  identified(...identifiers: Array<unknown>): RequestResolver<A, R> // TODO: remove bivariance
 }
 
 /**

--- a/src/RequestResolver.ts
+++ b/src/RequestResolver.ts
@@ -54,12 +54,12 @@ export interface RequestResolver<A, R = never> extends Equal.Equal, Pipeable {
    * of requests that must be performed sequentially. The inner `Chunk`
    * represents a batch of requests that can be performed in parallel.
    */
-  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void> // TODO: remove bivariance
+  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<R, never, void>
 
   /**
    * Identify the data source using the specific identifier
    */
-  identified(...identifiers: Array<unknown>): RequestResolver<A, R> // TODO: remove bivariance
+  identified(...identifiers: Array<unknown>): RequestResolver<A, R>
 }
 
 /**

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -31,7 +31,7 @@ export interface Resource<E, A> extends Resource.Variance<E, A> {
   /** @internal */
   readonly scopedRef: ScopedRef.ScopedRef<Exit.Exit<E, A>>
   /** @internal */
-  acquire(): Effect.Effect<Scope.Scope, E, A>
+  readonly acquire: () => Effect.Effect<Scope.Scope, E, A>
 }
 
 /**

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -55,8 +55,8 @@ export interface Runtime<R> extends Pipeable {
  * @category models
  */
 export interface RunForkOptions {
-  scheduler?: Scheduler
-  updateRefs?: (refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) => FiberRefs.FiberRefs
+  readonly scheduler?: Scheduler
+  readonly updateRefs?: (refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) => FiberRefs.FiberRefs
 }
 
 /**

--- a/src/STM.ts
+++ b/src/STM.ts
@@ -155,7 +155,7 @@ export interface STMGen<R, E, A> {
   readonly _E: () => E
   readonly _A: () => A
   readonly value: STM<R, E, A>
-  [Symbol.iterator](): Generator<STMGen<R, E, A>, A>
+  readonly [Symbol.iterator]: () => Generator<STMGen<R, E, A>, A>
 }
 
 /**

--- a/src/Schedule.ts
+++ b/src/Schedule.ts
@@ -115,10 +115,10 @@ export declare namespace Schedule {
  * @category models
  */
 export interface ScheduleDriver<Env, In, Out> extends Schedule.DriverVariance<Env, In, Out> {
-  state(): Effect.Effect<never, never, unknown>
-  last(): Effect.Effect<never, Cause.NoSuchElementException, Out>
-  reset(): Effect.Effect<never, never, void>
-  next(input: In): Effect.Effect<Env, Option.Option<never>, Out>
+  readonly state: () => Effect.Effect<never, never, unknown>
+  readonly last: () => Effect.Effect<never, Cause.NoSuchElementException, Out>
+  readonly reset: () => Effect.Effect<never, never, void>
+  readonly next: (input: In) => Effect.Effect<Env, Option.Option<never>, Out>
 }
 
 /**

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -21,8 +21,8 @@ export type Task = () => void
  * @category models
  */
 export interface Scheduler {
-  shouldYield(fiber: RuntimeFiber<unknown, unknown>): number | false
-  scheduleTask(task: Task, priority: number): void
+  readonly shouldYield: (fiber: RuntimeFiber<unknown, unknown>) => number | false
+  readonly scheduleTask: (task: Task, priority: number) => void
 }
 
 /**

--- a/src/ScopedCache.ts
+++ b/src/ScopedCache.ts
@@ -31,47 +31,47 @@ export interface ScopedCache<Key, Error, Value> extends ScopedCache.Variance<Key
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
    */
-  getOption(key: Key): Effect.Effect<Scope.Scope, Error, Option.Option<Value>>
+  readonly getOption: (key: Key) => Effect.Effect<Scope.Scope, Error, Option.Option<Value>>
 
   /**
    * Retrieves the value associated with the specified key if it exists and the
    * lookup function has completed. Otherwise returns `Option.none`.
    */
-  getOptionComplete(key: Key): Effect.Effect<Scope.Scope, never, Option.Option<Value>>
+  readonly getOptionComplete: (key: Key) => Effect.Effect<Scope.Scope, never, Option.Option<Value>>
 
   /**
    * Returns statistics for this cache.
    */
-  cacheStats(): Effect.Effect<never, never, Cache.CacheStats>
+  readonly cacheStats: () => Effect.Effect<never, never, Cache.CacheStats>
 
   /**
    * Return whether a resource associated with the specified key exists in the
    * cache. Sometime `contains` can return true if the resource is currently
    * being created but not yet totally created.
    */
-  contains(key: Key): Effect.Effect<never, never, boolean>
+  readonly contains: (key: Key) => Effect.Effect<never, never, boolean>
 
   /**
    * Return statistics for the specified entry.
    */
-  entryStats(key: Key): Effect.Effect<never, never, Option.Option<Cache.EntryStats>>
+  readonly entryStats: (key: Key) => Effect.Effect<never, never, Option.Option<Cache.EntryStats>>
 
   /**
    * Gets the value from the cache if it exists or otherwise computes it, the
    * release action signals to the cache that the value is no longer being used
    * and can potentially be finalized subject to the policies of the cache.
    */
-  get(key: Key): Effect.Effect<Scope.Scope, Error, Value>
+  readonly get: (key: Key) => Effect.Effect<Scope.Scope, Error, Value>
 
   /**
    * Invalidates the resource associated with the specified key.
    */
-  invalidate(key: Key): Effect.Effect<never, never, void>
+  readonly invalidate: (key: Key) => Effect.Effect<never, never, void>
 
   /**
    * Invalidates all values in the cache.
    */
-  invalidateAll(): Effect.Effect<never, never, void>
+  readonly invalidateAll: () => Effect.Effect<never, never, void>
 
   /**
    * Force the reuse of the lookup function to compute the returned scoped
@@ -81,12 +81,12 @@ export interface ScopedCache<Key, Error, Value> extends ScopedCache.Variance<Key
    * computed, concurrent call the .get will use the old resource if this one is
    * not expired.
    */
-  refresh(key: Key): Effect.Effect<never, Error, void>
+  readonly refresh: (key: Key) => Effect.Effect<never, Error, void>
 
   /**
    * Returns the approximate number of values in the cache.
    */
-  size(): Effect.Effect<never, never, number>
+  readonly size: () => Effect.Effect<never, never, number>
 }
 
 /**

--- a/src/SingleProducerAsyncInput.ts
+++ b/src/SingleProducerAsyncInput.ts
@@ -40,10 +40,10 @@ export interface SingleProducerAsyncInput<Err, Elem, Done>
  * @category models
  */
 export interface AsyncInputProducer<Err, Elem, Done> {
-  awaitRead(): Effect.Effect<never, never, unknown>
-  done(value: Done): Effect.Effect<never, never, unknown>
-  emit(element: Elem): Effect.Effect<never, never, unknown>
-  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown>
+  awaitRead(): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  done(value: Done): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  emit(element: Elem): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown> // TODO: remove bivariance
 }
 
 /**

--- a/src/SingleProducerAsyncInput.ts
+++ b/src/SingleProducerAsyncInput.ts
@@ -29,8 +29,8 @@ import * as internal from "./internal/channel/singleProducerAsyncInput.js"
 export interface SingleProducerAsyncInput<Err, Elem, Done>
   extends AsyncInputProducer<Err, Elem, Done>, AsyncInputConsumer<Err, Elem, Done>
 {
-  close(): Effect.Effect<never, never, unknown>
-  take(): Effect.Effect<never, never, Exit.Exit<Either.Either<Err, Done>, Elem>>
+  readonly close: () => Effect.Effect<never, never, unknown>
+  readonly take: () => Effect.Effect<never, never, Exit.Exit<Either.Either<Err, Done>, Elem>>
 }
 
 /**

--- a/src/SingleProducerAsyncInput.ts
+++ b/src/SingleProducerAsyncInput.ts
@@ -40,10 +40,10 @@ export interface SingleProducerAsyncInput<Err, Elem, Done>
  * @category models
  */
 export interface AsyncInputProducer<Err, Elem, Done> {
-  awaitRead(): Effect.Effect<never, never, unknown> // TODO: remove bivariance
-  done(value: Done): Effect.Effect<never, never, unknown> // TODO: remove bivariance
-  emit(element: Elem): Effect.Effect<never, never, unknown> // TODO: remove bivariance
-  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown> // TODO: remove bivariance
+  awaitRead(): Effect.Effect<never, never, unknown>
+  done(value: Done): Effect.Effect<never, never, unknown>
+  emit(element: Elem): Effect.Effect<never, never, unknown>
+  error(cause: Cause.Cause<Err>): Effect.Effect<never, never, unknown>
 }
 
 /**

--- a/src/Supervisor.ts
+++ b/src/Supervisor.ts
@@ -38,50 +38,50 @@ export interface Supervisor<T> extends Supervisor.Variance<T> {
    * supervisor. This value may change over time, reflecting what the supervisor
    * produces as it supervises fibers.
    */
-  value(): Effect.Effect<never, never, T>
+  readonly value: () => Effect.Effect<never, never, T>
 
   /**
    * Supervises the start of a `Fiber`.
    */
-  onStart<R, E, A>(
+  readonly onStart: <R, E, A>(
     context: Context.Context<R>,
     effect: Effect.Effect<R, E, A>,
     parent: Option.Option<Fiber.RuntimeFiber<any, any>>,
     fiber: Fiber.RuntimeFiber<E, A>
-  ): void
+  ) => void
 
   /**
    * Supervises the end of a `Fiber`.
    */
-  onEnd<E, A>(value: Exit.Exit<E, A>, fiber: Fiber.RuntimeFiber<E, A>): void
+  readonly onEnd: <E, A>(value: Exit.Exit<E, A>, fiber: Fiber.RuntimeFiber<E, A>) => void
 
   /**
    * Supervises the execution of an `Effect` by a `Fiber`.
    */
-  onEffect<E, A>(fiber: Fiber.RuntimeFiber<E, A>, effect: Effect.Effect<any, any, any>): void
+  readonly onEffect: <E, A>(fiber: Fiber.RuntimeFiber<E, A>, effect: Effect.Effect<any, any, any>) => void
 
   /**
    * Supervises the suspension of a computation running within a `Fiber`.
    */
-  onSuspend<E, A>(fiber: Fiber.RuntimeFiber<E, A>): void
+  readonly onSuspend: <E, A>(fiber: Fiber.RuntimeFiber<E, A>) => void
 
   /**
    * Supervises the resumption of a computation running within a `Fiber`.
    */
-  onResume<E, A>(fiber: Fiber.RuntimeFiber<E, A>): void
+  readonly onResume: <E, A>(fiber: Fiber.RuntimeFiber<E, A>) => void
 
   /**
    * Maps this supervisor to another one, which has the same effect, but whose
    * value has been transformed by the specified function.
    */
-  map<B>(f: (a: T) => B): Supervisor<B>
+  readonly map: <B>(f: (a: T) => B) => Supervisor<B>
 
   /**
    * Returns a new supervisor that performs the function of this supervisor, and
    * the function of the specified supervisor, producing a tuple of the outputs
    * produced by both supervisors.
    */
-  zip<A>(right: Supervisor<A>): Supervisor<[T, A]>
+  readonly zip: <A>(right: Supervisor<A>) => Supervisor<[T, A]>
 }
 
 /**

--- a/src/SynchronizedRef.ts
+++ b/src/SynchronizedRef.ts
@@ -25,7 +25,7 @@ export type SynchronizedRefTypeId = typeof SynchronizedRefTypeId
  * @category models
  */
 export interface SynchronizedRef<A> extends SynchronizedRef.Variance<A>, Ref.Ref<A> {
-  modifyEffect: <R, E, B>(f: (a: A) => Effect.Effect<R, E, readonly [B, A]>) => Effect.Effect<R, E, B>
+  readonly modifyEffect: <R, E, B>(f: (a: A) => Effect.Effect<R, E, readonly [B, A]>) => Effect.Effect<R, E, B>
 }
 
 /**

--- a/src/TQueue.ts
+++ b/src/TQueue.ts
@@ -96,7 +96,7 @@ export interface TDequeue<A> extends TQueue.TDequeueVariance<A>, BaseTQueue {
   /**
    * Takes up to max number of values from the queue.
    */
-  takeUpTo(max: number): STM.STM<never, never, Array<A>>
+  readonly takeUpTo: (max: number) => STM.STM<never, never, Array<A>>
 }
 
 /**

--- a/src/TQueue.ts
+++ b/src/TQueue.ts
@@ -44,7 +44,7 @@ export interface TEnqueue<A> extends TQueue.TEnqueueVariance<A>, BaseTQueue {
   /**
    * Places one value in the queue.
    */
-  offer(value: A): STM.STM<never, never, boolean>
+  readonly offer: (value: A) => STM.STM<never, never, boolean>
 
   /**
    * For Bounded TQueue: uses the `BackPressure` Strategy, places the values in
@@ -61,7 +61,7 @@ export interface TEnqueue<A> extends TQueue.TEnqueueVariance<A>, BaseTQueue {
    * For Dropping TQueue: uses `Dropping` Strategy, It places the values in the
    * queue but if there is no room it will not enqueue them and return false.
    */
-  offerAll(iterable: Iterable<A>): STM.STM<never, never, boolean>
+  readonly offerAll: (iterable: Iterable<A>) => STM.STM<never, never, boolean>
 }
 
 /**

--- a/src/TQueue.ts
+++ b/src/TQueue.ts
@@ -109,7 +109,7 @@ export interface BaseTQueue {
   /**
    * Returns the number of elements the queue can hold.
    */
-  capacity(): number
+  readonly capacity: () => number
 
   /**
    * Retrieves the size of the queue, which is equal to the number of elements

--- a/src/TRandom.ts
+++ b/src/TRandom.ts
@@ -42,16 +42,16 @@ export interface TRandom {
    * Returns the next numeric value in the specified range from the
    * pseudo-random number generator.
    */
-  nextRange(min: number, max: number): STM.STM<never, never, number>
+  readonly nextRange: (min: number, max: number) => STM.STM<never, never, number>
   /**
    * Returns the next integer value in the specified range from the
    * pseudo-random number generator.
    */
-  nextIntBetween(min: number, max: number): STM.STM<never, never, number>
+  readonly nextIntBetween: (min: number, max: number) => STM.STM<never, never, number>
   /**
    * Uses the pseudo-random number generator to shuffle the specified iterable.
    */
-  shuffle<A>(elements: Iterable<A>): STM.STM<never, never, Array<A>>
+  readonly shuffle: <A>(elements: Iterable<A>) => STM.STM<never, never, Array<A>>
 }
 /**
  * @internal

--- a/src/TRef.ts
+++ b/src/TRef.ts
@@ -37,7 +37,7 @@ export interface TRef<A> extends TRef.Variance<A> {
   /**
    * Note: the method is unbound, exposed only for potential extensions.
    */
-  modify: <B>(f: (a: A) => readonly [B, A]) => STM.STM<never, never, B>
+  readonly modify: <B>(f: (a: A) => readonly [B, A]) => STM.STM<never, never, B>
 }
 /**
  * @internal

--- a/src/TestAnnotations.ts
+++ b/src/TestAnnotations.ts
@@ -46,18 +46,22 @@ export interface TestAnnotations {
    * Accesses an `Annotations` instance in the context and retrieves the
    * annotation of the specified type, or its default value if there is none.
    */
-  get<A>(key: TestAnnotation.TestAnnotation<A>): Effect.Effect<never, never, A>
+  readonly get: <A>(key: TestAnnotation.TestAnnotation<A>) => Effect.Effect<never, never, A>
 
   /**
    * Accesses an `Annotations` instance in the context and appends the
    * specified annotation to the annotation map.
    */
-  annotate<A>(key: TestAnnotation.TestAnnotation<A>, value: A): Effect.Effect<never, never, void>
+  readonly annotate: <A>(key: TestAnnotation.TestAnnotation<A>, value: A) => Effect.Effect<never, never, void>
 
   /**
    * Returns the set of all fibers in this test.
    */
-  supervisedFibers(): Effect.Effect<never, never, SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>>
+  readonly supervisedFibers: () => Effect.Effect<
+    never,
+    never,
+    SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>
+  >
 }
 
 /** @internal */

--- a/src/TestClock.ts
+++ b/src/TestClock.ts
@@ -76,11 +76,13 @@ import * as Live from "./TestLive.js"
  * @since 2.0.0
  */
 export interface TestClock extends Clock.Clock {
-  adjust(duration: Duration.DurationInput): Effect.Effect<never, never, void>
-  adjustWith(duration: Duration.DurationInput): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
-  save(): Effect.Effect<never, never, Effect.Effect<never, never, void>>
-  setTime(time: number): Effect.Effect<never, never, void>
-  sleeps(): Effect.Effect<never, never, Chunk.Chunk<number>>
+  readonly adjust: (duration: Duration.DurationInput) => Effect.Effect<never, never, void>
+  readonly adjustWith: (
+    duration: Duration.DurationInput
+  ) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
+  readonly save: () => Effect.Effect<never, never, Effect.Effect<never, never, void>>
+  readonly setTime: (time: number) => Effect.Effect<never, never, void>
+  readonly sleeps: () => Effect.Effect<never, never, Chunk.Chunk<number>>
 }
 
 /**

--- a/src/TestLive.ts
+++ b/src/TestLive.ts
@@ -27,7 +27,7 @@ export type TestLiveTypeId = typeof TestLiveTypeId
  */
 export interface TestLive {
   readonly [TestLiveTypeId]: TestLiveTypeId
-  provide<R, E, A>(effect: Effect.Effect<R, E, A>): Effect.Effect<R, E, A>
+  readonly provide: <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
 }
 
 /**

--- a/src/TestSized.ts
+++ b/src/TestSized.ts
@@ -22,8 +22,8 @@ export type TestSizedTypeId = typeof TestSizedTypeId
 export interface TestSized {
   readonly [TestSizedTypeId]: TestSizedTypeId
   readonly fiberRef: FiberRef.FiberRef<number>
-  size(): Effect.Effect<never, never, number>
-  withSize(size: number): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
+  readonly size: () => Effect.Effect<never, never, number>
+  readonly withSize: (size: number) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>
 }
 
 /**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -38,7 +38,7 @@ export type GenKindTypeId = typeof GenKindTypeId
 export interface GenKind<F extends TypeLambda, R, O, E, A> extends Variance<F, R, O, E> {
   readonly value: Kind<F, R, O, E, A>
 
-  [Symbol.iterator](): Generator<GenKind<F, R, O, E, A>, A>
+  readonly [Symbol.iterator]: () => Generator<GenKind<F, R, O, E, A>, A>
 }
 
 /**

--- a/src/internal/cache.ts
+++ b/src/internal/cache.ts
@@ -109,7 +109,7 @@ export type MapKeyTypeId = typeof MapKeyTypeId
  */
 export interface MapKey<K> extends Equal.Equal {
   readonly [MapKeyTypeId]: MapKeyTypeId
-  current: K
+  current: K // TODO: mutable by design?
   previous: MapKey<K> | undefined
   next: MapKey<K> | undefined
 }

--- a/src/internal/cache.ts
+++ b/src/internal/cache.ts
@@ -109,9 +109,9 @@ export type MapKeyTypeId = typeof MapKeyTypeId
  */
 export interface MapKey<K> extends Equal.Equal {
   readonly [MapKeyTypeId]: MapKeyTypeId
-  current: K // TODO: mutable by design?
-  previous: MapKey<K> | undefined
-  next: MapKey<K> | undefined
+  readonly current: K
+  previous: MapKey<K> | undefined // mutable by design
+  next: MapKey<K> | undefined // mutable by design
 }
 
 class MapKeyImpl<K> implements MapKey<K> {
@@ -151,16 +151,16 @@ export const isMapKey = (u: unknown): u is MapKey<unknown> => hasProperty(u, Map
  * @internal
  */
 export interface KeySet<K> {
-  head: MapKey<K> | undefined
-  tail: MapKey<K> | undefined
+  head: MapKey<K> | undefined // mutable by design
+  tail: MapKey<K> | undefined // mutable by design
   /**
    * Adds the specified key to the set.
    */
-  add(key: MapKey<K>): void
+  readonly add: (key: MapKey<K>) => void
   /**
    * Removes the lowest priority key from the set.
    */
-  remove(): MapKey<K> | undefined
+  readonly remove: () => MapKey<K> | undefined
 }
 
 class KeySetImpl<K> implements KeySet<K> {
@@ -216,12 +216,12 @@ export const makeKeySet = <K>(): KeySet<K> => new KeySetImpl<K>()
  * @internal
  */
 export interface CacheState<Key, Error, Value> {
-  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Error, Value>>
-  keys: KeySet<Key>
-  accesses: MutableQueue.MutableQueue<MapKey<Key>>
-  updating: MutableRef.MutableRef<boolean>
-  hits: number
-  misses: number
+  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Error, Value>> // mutable by design
+  keys: KeySet<Key> // mutable by design
+  accesses: MutableQueue.MutableQueue<MapKey<Key>> // mutable by design
+  updating: MutableRef.MutableRef<boolean> // mutable by design
+  hits: number // mutable by design
+  misses: number // mutable by design
 }
 
 /**

--- a/src/internal/cache.ts
+++ b/src/internal/cache.ts
@@ -477,11 +477,7 @@ class CacheImpl<Key, Error, Value> implements Cache.Cache<Key, Error, Value> {
     )
   }
 
-  set<Key, Error, Value>(
-    this: CacheImpl<Key, Error, Value>,
-    key: Key,
-    value: Value
-  ): Effect.Effect<never, never, void> {
+  set(key: Key, value: Value): Effect.Effect<never, never, void> {
     return effect.clockWith((clock) =>
       core.sync(() => {
         const now = clock.unsafeCurrentTimeMillis()
@@ -703,10 +699,10 @@ export const makeWith = <Key, Environment, Error, Value>(
 /** @internal */
 export const unsafeMakeWith = <Key, Error, Value>(
   capacity: number,
-  lookup: Cache.Lookup<never, Key, Error, Value>,
+  lookup: Cache.Lookup<Key, never, Error, Value>,
   timeToLive: (exit: Exit.Exit<Error, Value>) => Duration.DurationInput
 ): Cache.Cache<Key, Error, Value> =>
-  new CacheImpl(
+  new CacheImpl<Key, Error, Value>(
     capacity,
     Context.empty() as Context.Context<any>,
     none,

--- a/src/internal/cache.ts
+++ b/src/internal/cache.ts
@@ -516,7 +516,7 @@ class CacheImpl<Key, Error, Value> implements Cache.Cache<Key, Error, Value> {
     })
   }
 
-  entries<Key, Error, Value>(this: CacheImpl<Key, Error, Value>): Effect.Effect<never, never, Array<[Key, Value]>> {
+  entries(): Effect.Effect<never, never, Array<[Key, Value]>> {
     return core.sync(() => {
       const values: Array<[Key, Value]> = []
       for (const entry of this.cacheState.map) {
@@ -528,7 +528,7 @@ class CacheImpl<Key, Error, Value> implements Cache.Cache<Key, Error, Value> {
     })
   }
 
-  keys<Key, Error, Value>(this: CacheImpl<Key, Error, Value>): Effect.Effect<never, never, Array<Key>> {
+  keys(): Effect.Effect<never, never, Array<Key>> {
     return core.sync(() => {
       const keys: Array<Key> = []
       for (const entry of this.cacheState.map) {

--- a/src/internal/channel/subexecutor.ts
+++ b/src/internal/channel/subexecutor.ts
@@ -8,8 +8,8 @@ import type { ErasedChannel, ErasedExecutor } from "./channelExecutor.js"
 
 /** @internal */
 export interface Subexecutor<R> {
-  close(exit: Exit.Exit<unknown, unknown>): Effect.Effect<R, never, unknown> | undefined
-  enqueuePullFromChild(child: PullFromChild<R>): Subexecutor<R>
+  readonly close: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R, never, unknown> | undefined
+  readonly enqueuePullFromChild: (child: PullFromChild<R>) => Subexecutor<R>
 }
 
 /** @internal */

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -60,7 +60,7 @@ export type Op<Tag extends string, Body = {}> = Config.Config<never> & Body & {
 export interface Constant extends
   Op<OpCodes.OP_CONSTANT, {
     readonly value: unknown
-    parse(text: string): Either.Either<ConfigError.ConfigError, unknown>
+    readonly parse: (text: string) => Either.Either<ConfigError.ConfigError, unknown>
   }>
 {}
 
@@ -85,7 +85,7 @@ export interface Fallback extends
 export interface Fail extends
   Op<OpCodes.OP_FAIL, {
     readonly message: string
-    parse(text: string): Either.Either<ConfigError.ConfigError, unknown>
+    readonly parse: (text: string) => Either.Either<ConfigError.ConfigError, unknown>
   }>
 {}
 
@@ -116,7 +116,7 @@ export interface Nested extends
 export interface Primitive extends
   Op<OpCodes.OP_PRIMITIVE, {
     readonly description: string
-    parse(text: string): Either.Either<ConfigError.ConfigError, unknown>
+    readonly parse: (text: string) => Either.Either<ConfigError.ConfigError, unknown>
   }>
 {}
 

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -294,7 +294,7 @@ export interface OpTag extends Op<OpCodes.OP_TAG, {}> {}
 
 export interface Commit extends
   Op<OpCodes.OP_COMMIT, {
-    commit(): Effect.Effect<unknown, unknown, unknown>
+    readonly commit: () => Effect.Effect<unknown, unknown, unknown>
   }>
 {}
 

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -1952,7 +1952,7 @@ export type ReleaseMapState = {
 
 /** @internal */
 export interface ReleaseMap {
-  state: ReleaseMapState
+  state: ReleaseMapState // mutable by design
 }
 
 /* @internal */

--- a/src/internal/fiberScope.ts
+++ b/src/internal/fiberScope.ts
@@ -24,7 +24,7 @@ export type FiberScopeTypeId = typeof FiberScopeTypeId
 export interface FiberScope {
   readonly [FiberScopeTypeId]: FiberScopeTypeId
   get fiberId(): FiberId.FiberId
-  add(runtimeFlags: RuntimeFlags.RuntimeFlags, child: FiberRuntime.FiberRuntime<any, any>): void
+  readonly add: (runtimeFlags: RuntimeFlags.RuntimeFlags, child: FiberRuntime.FiberRuntime<any, any>) => void
 }
 
 /** @internal */

--- a/src/internal/hashMap.ts
+++ b/src/internal/hashMap.ts
@@ -35,10 +35,10 @@ interface VisitResult<K, V, A> {
 
 /** @internal */
 export interface HashMapImpl<K, V> extends HM.HashMap<K, V> {
-  _editable: boolean
-  _edit: number
-  _root: Node.Node<K, V>
-  _size: number
+  _editable: boolean // mutable by design
+  _edit: number // mutable by design
+  _root: Node.Node<K, V> // mutable by design
+  _size: number // mutable by design
 }
 
 const HashMapProto: HM.HashMap<unknown, unknown> = {

--- a/src/internal/hashMap/node.ts
+++ b/src/internal/hashMap/node.ts
@@ -17,7 +17,7 @@ export type Node<K, V> =
 
 /** @internal */
 export interface SizeRef {
-  value: number
+  value: number // mutable by design
 }
 
 /** @internal */

--- a/src/internal/pubsub.ts
+++ b/src/internal/pubsub.ts
@@ -18,22 +18,22 @@ import * as queue from "./queue.js"
 /** @internal */
 export interface AtomicPubSub<A> {
   readonly capacity: number
-  isEmpty(): boolean
-  isFull(): boolean
-  size(): number
-  publish(value: A): boolean
-  publishAll(elements: Iterable<A>): Chunk.Chunk<A>
-  slide(): void
-  subscribe(): Subscription<A>
+  readonly isEmpty: () => boolean
+  readonly isFull: () => boolean
+  readonly size: () => number
+  readonly publish: (value: A) => boolean
+  readonly publishAll: (elements: Iterable<A>) => Chunk.Chunk<A>
+  readonly slide: () => void
+  readonly subscribe: () => Subscription<A>
 }
 
 /** @internal */
 interface Subscription<A> {
-  isEmpty(): boolean
-  size(): number
-  poll<D>(default_: D): A | D
-  pollUpTo(n: number): Chunk.Chunk<A>
-  unsubscribe(): void
+  readonly isEmpty: () => boolean
+  readonly size: () => number
+  readonly poll: <D>(default_: D) => A | D
+  readonly pollUpTo: (n: number) => Chunk.Chunk<A>
+  readonly unsubscribe: () => void
 }
 
 /** @internal */
@@ -1232,48 +1232,48 @@ export interface PubSubStrategy<A> {
   /**
    * Describes any finalization logic associated with this strategy.
    */
-  shutdown(): Effect.Effect<never, never, void>
+  readonly shutdown: () => Effect.Effect<never, never, void>
 
   /**
    * Describes how publishers should signal to subscribers that they are
    * waiting for space to become available in the `PubSub`.
    */
-  handleSurplus(
+  readonly handleSurplus: (
     pubsub: AtomicPubSub<A>,
     subscribers: Subscribers<A>,
     elements: Iterable<A>,
     isShutdown: MutableRef.MutableRef<boolean>
-  ): Effect.Effect<never, never, boolean>
+  ) => Effect.Effect<never, never, boolean>
 
   /**
    * Describes how subscribers should signal to publishers waiting for space
    * to become available in the `PubSub` that space may be available.
    */
-  unsafeOnPubSubEmptySpace(
+  readonly unsafeOnPubSubEmptySpace: (
     pubsub: AtomicPubSub<A>,
     subscribers: Subscribers<A>
-  ): void
+  ) => void
 
   /**
    * Describes how subscribers waiting for additional values from the `PubSub`
    * should take those values and signal to publishers that they are no
    * longer waiting for additional values.
    */
-  unsafeCompletePollers(
+  readonly unsafeCompletePollers: (
     pubsub: AtomicPubSub<A>,
     subscribers: Subscribers<A>,
     subscription: Subscription<A>,
     pollers: MutableQueue.MutableQueue<Deferred.Deferred<never, A>>
-  ): void
+  ) => void
 
   /**
    * Describes how publishers should signal to subscribers waiting for
    * additional values from the `PubSub` that new values are available.
    */
-  unsafeCompleteSubscribers(
+  readonly unsafeCompleteSubscribers: (
     pubsub: AtomicPubSub<A>,
     subscribers: Subscribers<A>
-  ): void
+  ) => void
 }
 
 /**

--- a/src/internal/scopedCache.ts
+++ b/src/internal/scopedCache.ts
@@ -26,12 +26,12 @@ import * as fiberRuntime from "./fiberRuntime.js"
  * @internal
  */
 export interface CacheState<Key, Error, Value> {
-  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Error, Value>>
-  keys: _cache.KeySet<Key>
-  accesses: MutableQueue.MutableQueue<_cache.MapKey<Key>>
-  updating: MutableRef.MutableRef<boolean>
-  hits: number
-  misses: number
+  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Error, Value>> // mutable by design
+  keys: _cache.KeySet<Key> // mutable by design
+  accesses: MutableQueue.MutableQueue<_cache.MapKey<Key>> // mutable by design
+  updating: MutableRef.MutableRef<boolean> // mutable by design
+  hits: number // mutable by design
+  misses: number // mutable by design
 }
 
 /** @internal */

--- a/src/internal/stm/stm/entry.ts
+++ b/src/internal/stm/stm/entry.ts
@@ -5,9 +5,9 @@ import * as Versioned from "./versioned.js"
 export interface Entry {
   readonly ref: TRef.TRef<any>
   readonly expected: Versioned.Versioned<any>
-  isChanged: boolean
+  isChanged: boolean // mutable by design
   readonly isNew: boolean
-  newValue: any
+  newValue: any // mutable by design
 }
 
 /** @internal */

--- a/src/internal/stm/tReentrantLock.ts
+++ b/src/internal/stm/tReentrantLock.ts
@@ -44,11 +44,11 @@ export interface LockState {
   /**
    * Computes the number of read locks held by the specified fiber id.
    */
-  readLocksHeld(fiberId: FiberId.FiberId): number
+  readonly readLocksHeld: (fiberId: FiberId.FiberId) => number
   /**
    * Computes the number of write locks held by the specified fiber id.
    */
-  writeLocksHeld(fiberId: FiberId.FiberId): number
+  readonly writeLocksHeld: (fiberId: FiberId.FiberId) => number
 }
 
 /**


### PR DESCRIPTION
Leftovers (which raise errors):

- RequestResolver > RequestResolver
- SingleProducerAsyncInput > AsyncInputProducer
