### PR TITLE
Added refinement overloads to some Sink and Stream functions

### DIFF
--- a/.changeset/tricky-items-swim.md
+++ b/.changeset/tricky-items-swim.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-Added refinement overloads to Sink.collectWhile, Stream.partition and Stream.takeWhile. Added dtslint tests for Sink and Stream functions with refinement overloads
+Added refinement overloads to Sink.collectAllWhile, Stream.partition and Stream.takeWhile. Added dtslint tests for Sink and Stream functions with refinement overloads

--- a/.changeset/tricky-items-swim.md
+++ b/.changeset/tricky-items-swim.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Added refinement overloads to Sink.collectWhile, Stream.partition and Stream.takeWhile. Added dtslint tests for Sink and Stream functions with refinement overloads

--- a/docs/modules/Sink.ts.md
+++ b/docs/modules/Sink.ts.md
@@ -262,7 +262,10 @@ Accumulates incoming elements into a chunk as long as they verify predicate
 **Signature**
 
 ```ts
-export declare const collectAllWhile: <In>(predicate: Predicate<In>) => Sink<never, never, In, In, Chunk.Chunk<In>>
+export declare const collectAllWhile: {
+  <In, Out extends In>(refinement: Refinement<In, Out>): Sink<never, never, In, In, Chunk.Chunk<Out>>
+  <In>(predicate: Predicate<In>): Sink<never, never, In, In, Chunk.Chunk<In>>
+}
 ```
 
 Added in v2.0.0

--- a/docs/modules/Stream.ts.md
+++ b/docs/modules/Stream.ts.md
@@ -4691,19 +4691,21 @@ further than the slower one.
 
 ```ts
 export declare const partition: {
-  <C extends A, B extends A, A>(
+  <C extends A, B extends A, A = C>(
     refinement: Refinement<A, B>,
     options?: { bufferSize?: number | undefined }
-  ): <R, E>(self: Stream<R, E, C>) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, C>, Stream<never, E, B>]>
+  ): <R, E>(
+    self: Stream<R, E, C>
+  ) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, Exclude<C, B>>, Stream<never, E, B>]>
   <A>(
     predicate: Predicate<A>,
     options?: { bufferSize?: number | undefined }
   ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, A>]>
-  <R, E, A, B extends A>(
-    self: Stream<R, E, A>,
+  <R, E, C extends A, B extends A, A = C>(
+    self: Stream<R, E, C>,
     refinement: Refinement<A, B>,
     options?: { bufferSize?: number | undefined }
-  ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, B>]>
+  ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, Exclude<C, B>>, Stream<never, E, B>]>
   <R, E, A>(
     self: Stream<R, E, A>,
     predicate: Predicate<A>,

--- a/docs/modules/Stream.ts.md
+++ b/docs/modules/Stream.ts.md
@@ -4691,10 +4691,19 @@ further than the slower one.
 
 ```ts
 export declare const partition: {
+  <C extends A, B extends A, A>(
+    refinement: Refinement<A, B>,
+    options?: { bufferSize?: number | undefined }
+  ): <R, E>(self: Stream<R, E, C>) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, C>, Stream<never, E, B>]>
   <A>(
     predicate: Predicate<A>,
     options?: { bufferSize?: number | undefined }
   ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, A>]>
+  <R, E, A, B extends A>(
+    self: Stream<R, E, A>,
+    refinement: Refinement<A, B>,
+    options?: { bufferSize?: number | undefined }
+  ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, B>]>
   <R, E, A>(
     self: Stream<R, E, A>,
     predicate: Predicate<A>,
@@ -5291,7 +5300,9 @@ evaluates to `true`.
 
 ```ts
 export declare const takeWhile: {
+  <A, B extends A>(refinement: Refinement<A, B>): <R, E>(self: Stream<R, E, A>) => Stream<R, E, B>
   <A>(predicate: Predicate<A>): <R, E>(self: Stream<R, E, A>) => Stream<R, E, A>
+  <R, E, A, B extends A>(self: Stream<R, E, A>, refinement: Refinement<A, B>): Stream<R, E, B>
   <R, E, A>(self: Stream<R, E, A>, predicate: Predicate<A>): Stream<R, E, A>
 }
 ```

--- a/dtslint/Sink.ts
+++ b/dtslint/Sink.ts
@@ -1,0 +1,19 @@
+import { isNumber } from "effect/Number"
+import type { Predicate } from "effect/Predicate"
+import * as Sink from "effect/Sink"
+import { isString } from "effect/String"
+
+declare const predicate: Predicate<number | string>
+
+// -------------------------------------------------------------------------------------
+// collectAllWhile
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Sink<never, never, string | number, string | number, Chunk<string | number>>
+Sink.collectAllWhile(predicate)
+
+// $ExpectType Sink<never, never, unknown, unknown, Chunk<number>>
+Sink.collectAllWhile(isNumber)
+
+// $ExpectType Sink<never, never, unknown, unknown, Chunk<string>>
+Sink.collectAllWhile(isString)

--- a/dtslint/Stream.ts
+++ b/dtslint/Stream.ts
@@ -62,16 +62,16 @@ Stream.partition(stream, predicate)
 // $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string | number>]>
 pipe(stream, Stream.partition(predicate))
 
-// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, number>]>
+// $ExpectType Effect<Scope, never, [Stream<never, never, string>, Stream<never, never, number>]>
 Stream.partition(stream, isNumber)
 
-// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, number>]>
+// $ExpectType Effect<Scope, never, [Stream<never, never, string>, Stream<never, never, number>]>
 pipe(stream, Stream.partition(isNumber))
 
-// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string>]>
+// $ExpectType Effect<Scope, never, [Stream<never, never, number>, Stream<never, never, string>]>
 Stream.partition(stream, isString)
 
-// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string>]>
+// $ExpectType Effect<Scope, never, [Stream<never, never, number>, Stream<never, never, string>]>
 pipe(stream, Stream.partition(isString))
 
 // -------------------------------------------------------------------------------------

--- a/dtslint/Stream.ts
+++ b/dtslint/Stream.ts
@@ -1,0 +1,97 @@
+import { pipe } from "effect/Function"
+import { isNumber } from "effect/Number"
+import type { Predicate } from "effect/Predicate"
+import * as Stream from "effect/Stream"
+import { isString } from "effect/String"
+
+declare const predicate: Predicate<number | string>
+
+declare const stream: Stream.Stream<never, never, number | string>
+
+// -------------------------------------------------------------------------------------
+// filter
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Stream<never, never, string | number>
+Stream.filter(stream, predicate)
+
+// $ExpectType Stream<never, never, string | number>
+pipe(stream, Stream.filter(predicate))
+
+// $ExpectType Stream<never, never, number>
+Stream.filter(stream, isNumber)
+
+// $ExpectType Stream<never, never, number>
+pipe(stream, Stream.filter(isNumber))
+
+// $ExpectType Stream<never, never, string>
+Stream.filter(stream, isString)
+
+// $ExpectType Stream<never, never, string>
+pipe(stream, Stream.filter(isString))
+
+// -------------------------------------------------------------------------------------
+// find
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Stream<never, never, string | number>
+Stream.find(stream, predicate)
+
+// $ExpectType Stream<never, never, string | number>
+pipe(stream, Stream.find(predicate))
+
+// $ExpectType Stream<never, never, number>
+Stream.find(stream, isNumber)
+
+// $ExpectType Stream<never, never, number>
+pipe(stream, Stream.find(isNumber))
+
+// $ExpectType Stream<never, never, string>
+Stream.find(stream, isString)
+
+// $ExpectType Stream<never, never, string>
+pipe(stream, Stream.find(isString))
+
+// -------------------------------------------------------------------------------------
+// partition
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string | number>]>
+Stream.partition(stream, predicate)
+
+// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string | number>]>
+pipe(stream, Stream.partition(predicate))
+
+// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, number>]>
+Stream.partition(stream, isNumber)
+
+// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, number>]>
+pipe(stream, Stream.partition(isNumber))
+
+// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string>]>
+Stream.partition(stream, isString)
+
+// $ExpectType Effect<Scope, never, [Stream<never, never, string | number>, Stream<never, never, string>]>
+pipe(stream, Stream.partition(isString))
+
+// -------------------------------------------------------------------------------------
+// takeWhile
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Stream<never, never, string | number>
+Stream.takeWhile(stream, predicate)
+
+// $ExpectType Stream<never, never, string | number>
+pipe(stream, Stream.takeWhile(predicate))
+
+// $ExpectType Stream<never, never, number>
+Stream.takeWhile(stream, isNumber)
+
+// $ExpectType Stream<never, never, number>
+pipe(stream, Stream.takeWhile(isNumber))
+
+// $ExpectType Stream<never, never, string>
+Stream.takeWhile(stream, isString)
+
+// $ExpectType Stream<never, never, string>
+pipe(stream, Stream.takeWhile(isString))

--- a/src/Sink.ts
+++ b/src/Sink.ts
@@ -215,8 +215,10 @@ export const collectAllUntilEffect: <In, R, E>(
  * @since 2.0.0
  * @category constructors
  */
-export const collectAllWhile: <In>(predicate: Predicate<In>) => Sink<never, never, In, In, Chunk.Chunk<In>> =
-  internal.collectAllWhile
+export const collectAllWhile: {
+  <In, Out extends In>(refinement: Refinement<In, Out>): Sink<never, never, In, In, Chunk.Chunk<Out>>
+  <In>(predicate: Predicate<In>): Sink<never, never, In, In, Chunk.Chunk<In>>
+} = internal.collectAllWhile
 
 /**
  * Accumulates incoming elements into a chunk as long as they verify effectful

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -2472,6 +2472,14 @@ export const paginateEffect: <S, R, E, A>(
  * @category utils
  */
 export const partition: {
+  <C extends A, B extends A, A>(
+    refinement: Refinement<A, B>,
+    options?: {
+      bufferSize?: number | undefined
+    }
+  ): <R, E>(
+    self: Stream<R, E, C>
+  ) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, C>, Stream<never, E, B>]>
   <A>(
     predicate: Predicate<A>,
     options?: {
@@ -2480,6 +2488,13 @@ export const partition: {
   ): <R, E>(
     self: Stream<R, E, A>
   ) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, A>]>
+  <R, E, A, B extends A>(
+    self: Stream<R, E, A>,
+    refinement: Refinement<A, B>,
+    options?: {
+      bufferSize?: number | undefined
+    }
+  ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, B>]>
   <R, E, A>(
     self: Stream<R, E, A>,
     predicate: Predicate<A>,
@@ -3594,7 +3609,9 @@ export const takeUntilEffect: {
  * @category utils
  */
 export const takeWhile: {
+  <A, B extends A>(refinement: Refinement<A, B>): <R, E>(self: Stream<R, E, A>) => Stream<R, E, B>
   <A>(predicate: Predicate<A>): <R, E>(self: Stream<R, E, A>) => Stream<R, E, A>
+  <R, E, A, B extends A>(self: Stream<R, E, A>, refinement: Refinement<A, B>): Stream<R, E, B>
   <R, E, A>(self: Stream<R, E, A>, predicate: Predicate<A>): Stream<R, E, A>
 } = internal.takeWhile
 

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -2502,7 +2502,7 @@ export const partition: {
       bufferSize?: number | undefined
     }
   ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, A>]>
-} = internal.partition as any
+} = internal.partition
 
 /**
  * Split a stream by an effectful predicate. The faster stream may advance by

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -2472,14 +2472,14 @@ export const paginateEffect: <S, R, E, A>(
  * @category utils
  */
 export const partition: {
-  <C extends A, B extends A, A>(
+  <C extends A, B extends A, A = C>(
     refinement: Refinement<A, B>,
     options?: {
       bufferSize?: number | undefined
     }
   ): <R, E>(
     self: Stream<R, E, C>
-  ) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, C>, Stream<never, E, B>]>
+  ) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, Exclude<C, B>>, Stream<never, E, B>]>
   <A>(
     predicate: Predicate<A>,
     options?: {
@@ -2488,13 +2488,13 @@ export const partition: {
   ): <R, E>(
     self: Stream<R, E, A>
   ) => Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, A>]>
-  <R, E, A, B extends A>(
-    self: Stream<R, E, A>,
+  <R, E, C extends A, B extends A, A = C>(
+    self: Stream<R, E, C>,
     refinement: Refinement<A, B>,
     options?: {
       bufferSize?: number | undefined
     }
-  ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, B>]>
+  ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, Exclude<C, B>>, Stream<never, E, B>]>
   <R, E, A>(
     self: Stream<R, E, A>,
     predicate: Predicate<A>,
@@ -2502,7 +2502,7 @@ export const partition: {
       bufferSize?: number | undefined
     }
   ): Effect.Effect<Scope.Scope | R, E, [Stream<never, E, A>, Stream<never, E, A>]>
-} = internal.partition
+} = internal.partition as any
 
 /**
  * Split a stream by an effectful predicate. The faster stream may advance by

--- a/src/internal/stream.ts
+++ b/src/internal/stream.ts
@@ -4370,23 +4370,38 @@ export const peel = dual<
 })
 
 /** @internal */
-export const partition = dual<
+export const partition: {
+  <C extends A, B extends A, A = C>(
+    refinement: Refinement<A, B>,
+    options?: {
+      bufferSize?: number | undefined
+    }
+  ): <R, E>(
+    self: Stream.Stream<R, E, C>
+  ) => Effect.Effect<Scope.Scope | R, E, [Stream.Stream<never, E, Exclude<C, B>>, Stream.Stream<never, E, B>]>
   <A>(
     predicate: Predicate<A>,
     options?: {
       bufferSize?: number | undefined
     }
-  ) => <R, E>(
+  ): <R, E>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, E, [Stream.Stream<never, E, A>, Stream.Stream<never, E, A>]>,
+  ) => Effect.Effect<Scope.Scope | R, E, [Stream.Stream<never, E, A>, Stream.Stream<never, E, A>]>
+  <R, E, C extends A, B extends A, A = C>(
+    self: Stream.Stream<R, E, C>,
+    refinement: Refinement<A, B>,
+    options?: {
+      bufferSize?: number | undefined
+    }
+  ): Effect.Effect<Scope.Scope | R, E, [Stream.Stream<never, E, Exclude<C, B>>, Stream.Stream<never, E, B>]>
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     predicate: Predicate<A>,
     options?: {
       bufferSize?: number | undefined
     }
-  ) => Effect.Effect<Scope.Scope | R, E, [Stream.Stream<never, E, A>, Stream.Stream<never, E, A>]>
->(
+  ): Effect.Effect<Scope.Scope | R, E, [Stream.Stream<never, E, A>, Stream.Stream<never, E, A>]>
+} = dual(
   (args) => typeof args[1] === "function",
   <R, E, A>(
     self: Stream.Stream<R, E, A>,


### PR DESCRIPTION
This PR adds refinement overloads to:
* `Sink.collectAllWhile`
* `Stream.partition`
* `Stream.takeWhile`

I've also added `dtslint` tests for `Sink` and `Stream` functions with refinements.
