### PR TITLE
Config: propagate the path in validation, closes #1667

### DIFF
--- a/.changeset/metal-humans-agree.md
+++ b/.changeset/metal-humans-agree.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Config: propagate the path in validation, closes #1667

--- a/src/internal/configProvider.ts
+++ b/src/internal/configProvider.ts
@@ -218,6 +218,19 @@ const extend = <A, B>(
   return [leftExtension, rightExtension]
 }
 
+const appendConfigPath = (path: ReadonlyArray<string>, config: Config.Config<unknown>): ReadonlyArray<string> => {
+  let op = config as _config.ConfigPrimitive
+  if (op._tag === "Nested") {
+    const out = path.slice()
+    while (op._tag === "Nested") {
+      out.push(op.name)
+      op = op.config as _config.ConfigPrimitive
+    }
+    return out
+  }
+  return path
+}
+
 const fromFlatLoop = <A>(
   flat: ConfigProvider.ConfigProvider.Flat,
   prefix: ReadonlyArray<string>,
@@ -274,7 +287,7 @@ const fromFlatLoop = <A>(
             core.forEachSequential((a) =>
               pipe(
                 op.mapOrFail(a),
-                core.mapError(configError.prefixed(prefix))
+                core.mapError(configError.prefixed(appendConfigPath(prefix, op.original)))
               )
             )
           )


### PR DESCRIPTION
@mikearnaldi It seems that `OpCodes.OP_MAP_OR_FAIL` is losing the path. I spent a couple of hours studying the code, but I'm uncertain if there's a better solution for this bug. Additionally, I've included some tests.