### PR TITLE
allow hrtime as `Duration` input

### DIFF
--- a/.changeset/mean-shrimps-hammer.md
+++ b/.changeset/mean-shrimps-hammer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow hrtime as `Duration` input

--- a/docs/modules/Duration.ts.md
+++ b/docs/modules/Duration.ts.md
@@ -310,6 +310,7 @@ export type DurationInput =
   | Duration
   | number // millis
   | bigint // nanos
+  | [number, number] // [seconds, nanos]
   | `${number} ${Unit}`
 ```
 

--- a/src/Duration.ts
+++ b/src/Duration.ts
@@ -63,6 +63,7 @@ export type DurationInput =
   | Duration
   | number // millis
   | bigint // nanos
+  | [number, number] // [seconds, nanos]
   | `${number} ${Unit}`
 
 const DURATION_REGEX = /^(-?\d+(?:\.\d+)?)\s+(nanos|micros|millis|seconds|minutes|hours|days|weeks)$/
@@ -77,6 +78,10 @@ export const decode = (input: DurationInput): Duration => {
     return millis(input)
   } else if (isBigInt(input)) {
     return nanos(input)
+  } else if (Array.isArray(input)) {
+    if (input.length === 2 && isNumber(input[0]) && isNumber(input[1])) {
+      return nanos(BigInt(input[0]) * bigint1e9 + BigInt(input[1]))
+    }
   } else {
     DURATION_REGEX.lastIndex = 0 // Reset the lastIndex before each use
     const match = DURATION_REGEX.exec(input)

--- a/test/Duration.test.ts
+++ b/test/Duration.test.ts
@@ -31,6 +31,9 @@ describe.concurrent("Duration", () => {
     expect(Duration.decode("1.5 seconds")).toEqual(Duration.seconds(1.5))
     expect(Duration.decode("-1.5 seconds")).toEqual(Duration.zero)
 
+    expect(Duration.decode([500, 123456789])).toEqual(Duration.nanos(500123456789n))
+    expect(Duration.decode([-500, 123456789])).toEqual(Duration.zero)
+
     expect(() => Duration.decode("1.5 secs" as any)).toThrowError(new Error("Invalid duration input"))
   })
 


### PR DESCRIPTION
Pre-requisite for 

```ts
Schema.Schema<DurationInput, Duration>
```