### PR TITLE
fix typo: change "Option" to "Either" in Either.ts module documentation

### DIFF
--- a/.changeset/rare-days-decide.md
+++ b/.changeset/rare-days-decide.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+change typo in Either documentation

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -69,11 +69,11 @@ Added in v2.0.0
 
 ## all
 
-Takes a structure of `Option`s and returns an `Option` of values with the same structure.
+Takes a structure of `Either`s and returns an `Either` of values with the same structure.
 
-- If a tuple is supplied, then the returned `Option` will contain a tuple with the same length.
-- If a struct is supplied, then the returned `Option` will contain a struct with the same keys.
-- If an iterable is supplied, then the returned `Option` will contain an array.
+- If a tuple is supplied, then the returned `Either` will contain a tuple with the same length.
+- If a struct is supplied, then the returned `Either` will contain a struct with the same keys.
+- If an iterable is supplied, then the returned `Either` will contain an array.
 
 **Signature**
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -560,13 +560,13 @@ export const ap: {
 )
 
 /**
- * Takes a structure of `Option`s and returns an `Option` of values with the same structure.
+ * Takes a structure of `Either`s and returns an `Either` of values with the same structure.
  *
- * - If a tuple is supplied, then the returned `Option` will contain a tuple with the same length.
- * - If a struct is supplied, then the returned `Option` will contain a struct with the same keys.
- * - If an iterable is supplied, then the returned `Option` will contain an array.
+ * - If a tuple is supplied, then the returned `Either` will contain a tuple with the same length.
+ * - If a struct is supplied, then the returned `Either` will contain a struct with the same keys.
+ * - If an iterable is supplied, then the returned `Either` will contain an array.
  *
- * @param fields - the struct of `Option`s to be sequenced.
+ * @param fields - the struct of `Either`s to be sequenced.
  *
  * @example
  * import * as Either from "effect/Either"


### PR DESCRIPTION
Fix typo in Either public module: "Option" -> "Either"