### PR TITLE
fix YieldableError.toString crashing on react-native

### DIFF
--- a/.changeset/hot-crabs-boil.md
+++ b/.changeset/hot-crabs-boil.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix YieldableError.toString crashing on react-native

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -2199,13 +2199,13 @@ export const YieldableError: new(message?: string) => Cause.YieldableError = (fu
       return fail(this)
     }
     toString() {
-      return this.stack ?? `${this.name}: ${this.message}`
+      return `${this.name}: ${this.message}`
     }
     toJSON() {
       return { ...this }
     }
     [NodeInspectSymbol](): string {
-      return this.toString()
+      return this.stack ?? this.toString()
     }
   }
   Object.assign(YieldableError.prototype, StructuralCommitPrototype)

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -2199,13 +2199,17 @@ export const YieldableError: new(message?: string) => Cause.YieldableError = (fu
       return fail(this)
     }
     toString() {
-      return `${this.name}: ${this.message}`
+      return this.message ? `${this.name}: ${this.message}` : this.name
     }
     toJSON() {
       return { ...this }
     }
     [NodeInspectSymbol](): string {
-      return this.stack ?? this.toString()
+      const stack = this.stack
+      if (stack) {
+        return `${this.toString()}\n${stack.split("\n").slice(1).join("\n")}`
+      }
+      return this.toString()
     }
   }
   Object.assign(YieldableError.prototype, StructuralCommitPrototype)

--- a/test/Cause.test.ts
+++ b/test/Cause.test.ts
@@ -7,6 +7,7 @@ import * as internal from "effect/internal/cause"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as fc from "fast-check"
+import { inspect } from "node:util"
 import { assert, describe, expect, it } from "vitest"
 
 describe.concurrent("Cause", () => {
@@ -348,7 +349,7 @@ describe.concurrent("Cause", () => {
       const ex = new Cause.InterruptedException("my message")
       expect(ex.toString()).include("InterruptedException: my message")
       if (typeof window === "undefined") {
-        expect(ex.toString()).include("Cause.test.ts:348")
+        expect(inspect(ex)).include("Cause.test.ts:349")
       }
     })
   })

--- a/test/Effect/error.test.ts
+++ b/test/Effect/error.test.ts
@@ -2,7 +2,6 @@ import * as it from "effect-test/utils/extend"
 import * as Cause from "effect/Cause"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
-import * as Inspectable from "effect/Inspectable"
 import { inspect } from "node:util"
 import { assert, describe, expect } from "vitest"
 
@@ -15,7 +14,7 @@ describe.concurrent("Effect", () => {
       const log = Cause.pretty(cause)
       expect(log).includes("TestError")
       if (typeof window === "undefined") {
-        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:14:78")
+        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:13:78")
       }
       expect(log).includes("at A")
     }))
@@ -33,7 +32,7 @@ describe.concurrent("Effect", () => {
       )
       const log = Cause.pretty(cause)
       if (typeof window === "undefined") {
-        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:28")
+        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:27")
       }
       expect(log).includes("at A")
     }))
@@ -56,30 +55,30 @@ describe.concurrent("Effect", () => {
       const log = Cause.pretty(cause)
       expect(log).includes("Failure: some message")
       if (typeof window === "undefined") {
-        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:50")
+        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:49")
       }
       expect(log).includes("at A")
     }))
 
   if (typeof window === "undefined") {
     it.it("inspect", () => {
-      class MessageError extends Data.TaggedError("MessageError")<{}> {
+      class MessageError extends Data.TaggedError("MessageError") {
         get message() {
           return "fail"
         }
       }
       const err = new MessageError()
       expect(inspect(err)).include("MessageError: fail")
-      expect(inspect(err).replaceAll("\\", "/")).include("test/Effect/error.test.ts:71")
+      expect(inspect(err).replaceAll("\\", "/")).include("test/Effect/error.test.ts:70")
     })
 
     it.it("toString", () => {
-      class MessageError extends Data.TaggedError("MessageError")<{}> {
-        [Inspectable.NodeInspectSymbol]() {
+      class MessageError extends Data.TaggedError("MessageError") {
+        toString() {
           return "fail"
         }
       }
-      expect(inspect(new MessageError())).equal("fail")
+      expect(inspect(new MessageError()).startsWith("fail\n")).toBe(true)
       assert.deepStrictEqual(new MessageError().toJSON(), { _tag: "MessageError" })
     })
   }

--- a/test/Effect/error.test.ts
+++ b/test/Effect/error.test.ts
@@ -2,6 +2,7 @@ import * as it from "effect-test/utils/extend"
 import * as Cause from "effect/Cause"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
+import * as Inspectable from "effect/Inspectable"
 import { inspect } from "node:util"
 import { assert, describe, expect } from "vitest"
 
@@ -14,7 +15,7 @@ describe.concurrent("Effect", () => {
       const log = Cause.pretty(cause)
       expect(log).includes("TestError")
       if (typeof window === "undefined") {
-        expect(log).includes("test/Effect/error.test.ts:13:78")
+        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:14:78")
       }
       expect(log).includes("at A")
     }))
@@ -32,7 +33,7 @@ describe.concurrent("Effect", () => {
       )
       const log = Cause.pretty(cause)
       if (typeof window === "undefined") {
-        expect(log).includes("test/Effect/error.test.ts:27")
+        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:28")
       }
       expect(log).includes("at A")
     }))
@@ -55,7 +56,7 @@ describe.concurrent("Effect", () => {
       const log = Cause.pretty(cause)
       expect(log).includes("Failure: some message")
       if (typeof window === "undefined") {
-        expect(log).includes("test/Effect/error.test.ts:49")
+        expect(log.replaceAll("\\", "/")).includes("test/Effect/error.test.ts:50")
       }
       expect(log).includes("at A")
     }))
@@ -69,12 +70,12 @@ describe.concurrent("Effect", () => {
       }
       const err = new MessageError()
       expect(inspect(err)).include("MessageError: fail")
-      expect(inspect(err)).include("test/Effect/error.test.ts:70")
+      expect(inspect(err).replaceAll("\\", "/")).include("test/Effect/error.test.ts:71")
     })
 
     it.it("toString", () => {
       class MessageError extends Data.TaggedError("MessageError")<{}> {
-        toString() {
+        [Inspectable.NodeInspectSymbol]() {
           return "fail"
         }
       }


### PR DESCRIPTION
Apparently, when accessing `Error.stack` on react-native it makes a call to the `toString` method.
So using `stack` on `toString` causes an infinite loop and crashes the application.

Additionally, AFAIK the standard behavior of `Error.toString` is `${name}: ${message}` without stack.

