### PR TITLE
Consistency between batching and fiber state

### DIFF
--- a/.changeset/honest-readers-double.md
+++ b/.changeset/honest-readers-double.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Improve consistency between request batching and fiber environment.
+
+In prior releases request batching required operators that act on fiber context such as `Effect.locally` to be aware of batching in order to avoid bugs where the effect executed post batching would lose the fiber environment (context, refs, and flags).
+
+This change restructure how batching internally works, inside the fiber we now slice up the stack and restore the exact context that was destroyed, by rewriting the internals of forEach batching is now transparent to any other function that deals with fiber state.

--- a/docs/modules/Effect.ts.md
+++ b/docs/modules/Effect.ts.md
@@ -262,7 +262,6 @@ Added in v2.0.0
 - [requests & batching](#requests--batching)
   - [blocked](#blocked)
   - [cacheRequestResult](#cacherequestresult)
-  - [flatMapStep](#flatmapstep)
   - [request](#request)
   - [runRequestBlock](#runrequestblock)
   - [step](#step)
@@ -4121,10 +4120,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export interface Blocked<out R, out E, out A> extends Effect<R, E, A> {
+export interface Blocked<out E, out A> extends Effect<never, E, A> {
   readonly _op: "Blocked"
-  readonly i0: RequestBlock<R>
-  readonly i1: Effect<R, E, A>
+  readonly i0: RequestBlock
+  readonly i1: Effect<never, E, A>
 }
 ```
 
@@ -4615,10 +4614,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const blocked: <R, E, A>(
-  blockedRequests: RequestBlock<R>,
-  _continue: Effect<R, E, A>
-) => Blocked<R, E, A>
+export declare const blocked: <E, A>(blockedRequests: RequestBlock, _continue: Effect<never, E, A>) => Blocked<E, A>
 ```
 
 Added in v2.0.0
@@ -4632,19 +4628,6 @@ export declare const cacheRequestResult: <A extends Request.Request<any, any>>(
   request: A,
   result: Request.Request.Result<A>
 ) => Effect<never, never, void>
-```
-
-Added in v2.0.0
-
-## flatMapStep
-
-**Signature**
-
-```ts
-export declare const flatMapStep: <R, E, A, R1, E1, B>(
-  self: Effect<R, E, A>,
-  f: (step: Exit.Exit<E, A> | Blocked<R, E, A>) => Effect<R1, E1, B>
-) => Effect<R | R1, E1, B>
 ```
 
 Added in v2.0.0
@@ -4674,7 +4657,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const runRequestBlock: <R>(blockedRequests: RequestBlock<R>) => Blocked<R, never, void>
+export declare const runRequestBlock: <R>(blockedRequests: RequestBlock) => Effect<R, never, void>
 ```
 
 Added in v2.0.0
@@ -4684,7 +4667,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const step: <R, E, A>(self: Effect<R, E, A>) => Effect<R, E, Exit.Exit<E, A> | Blocked<R, E, A>>
+export declare const step: <R, E, A>(self: Effect<R, E, A>) => Effect<R, E, Exit.Exit<E, A> | Blocked<E, A>>
 ```
 
 Added in v2.0.0

--- a/docs/modules/RequestBlock.ts.md
+++ b/docs/modules/RequestBlock.ts.md
@@ -27,9 +27,6 @@ Added in v2.0.0
     - [Reducer (interface)](#reducer-interface)
   - [Seq (interface)](#seq-interface)
   - [Single (interface)](#single-interface)
-- [utils](#utils)
-  - [locally](#locally)
-  - [mapInputContext](#mapinputcontext)
 
 ---
 
@@ -40,7 +37,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const empty: RequestBlock<never>
+export declare const empty: RequestBlock
 ```
 
 Added in v2.0.0
@@ -50,10 +47,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const mapRequestResolvers: <R, A, R2>(
-  self: RequestBlock<R>,
-  f: (dataSource: RequestResolver.RequestResolver<A, R>) => RequestResolver.RequestResolver<A, R2>
-) => RequestBlock<R | R2>
+export declare const mapRequestResolvers: <A>(
+  self: RequestBlock,
+  f: (dataSource: RequestResolver.RequestResolver<A, never>) => RequestResolver.RequestResolver<A, never>
+) => RequestBlock
 ```
 
 Added in v2.0.0
@@ -63,7 +60,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const parallel: <R, R2>(self: RequestBlock<R>, that: RequestBlock<R2>) => RequestBlock<R | R2>
+export declare const parallel: (self: RequestBlock, that: RequestBlock) => RequestBlock
 ```
 
 Added in v2.0.0
@@ -73,7 +70,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const reduce: <R, Z>(self: RequestBlock<R>, reducer: RequestBlock.Reducer<R, Z>) => Z
+export declare const reduce: <Z>(self: RequestBlock, reducer: RequestBlock.Reducer<Z>) => Z
 ```
 
 Added in v2.0.0
@@ -83,7 +80,7 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const sequential: <R, R2>(self: RequestBlock<R>, that: RequestBlock<R2>) => RequestBlock<R | R2>
+export declare const sequential: (self: RequestBlock, that: RequestBlock) => RequestBlock
 ```
 
 Added in v2.0.0
@@ -93,10 +90,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export declare const single: <R, A>(
-  dataSource: RequestResolver.RequestResolver<A, R>,
+export declare const single: <A>(
+  dataSource: RequestResolver.RequestResolver<A, never>,
   blockedRequest: Request.Entry<A>
-) => RequestBlock<R>
+) => RequestBlock
 ```
 
 Added in v2.0.0
@@ -120,10 +117,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export interface Par<out R> {
+export interface Par {
   readonly _tag: "Par"
-  readonly left: RequestBlock<R>
-  readonly right: RequestBlock<R>
+  readonly left: RequestBlock
+  readonly right: RequestBlock
 }
 ```
 
@@ -140,7 +137,7 @@ preserving ordering guarantees.
 **Signature**
 
 ```ts
-export type RequestBlock<R> = Empty | Par<R> | Seq<R> | Single<R>
+export type RequestBlock = Empty | Par | Seq | Single
 ```
 
 Added in v2.0.0
@@ -154,10 +151,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export interface Reducer<in R, in out Z> {
+export interface Reducer<in out Z> {
   emptyCase(): Z
   parCase(left: Z, right: Z): Z
-  singleCase(dataSource: RequestResolver.RequestResolver<unknown, R>, blockedRequest: Request.Entry<unknown>): Z
+  singleCase(dataSource: RequestResolver.RequestResolver<unknown, never>, blockedRequest: Request.Entry<unknown>): Z
   seqCase(left: Z, right: Z): Z
 }
 ```
@@ -169,10 +166,10 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export interface Seq<out R> {
+export interface Seq {
   readonly _tag: "Seq"
-  readonly left: RequestBlock<R>
-  readonly right: RequestBlock<R>
+  readonly left: RequestBlock
+  readonly right: RequestBlock
 }
 ```
 
@@ -183,40 +180,11 @@ Added in v2.0.0
 **Signature**
 
 ```ts
-export interface Single<out R> {
+export interface Single {
   readonly _tag: "Single"
-  readonly dataSource: RequestResolver.RequestResolver<unknown, R>
+  readonly dataSource: RequestResolver.RequestResolver<unknown, never>
   readonly blockedRequest: Request.Entry<unknown>
 }
-```
-
-Added in v2.0.0
-
-# utils
-
-## locally
-
-Provides each data source with a fiber ref value.
-
-**Signature**
-
-```ts
-export declare const locally: <R, A>(self: RequestBlock<R>, ref: FiberRef<A>, value: A) => RequestBlock<R>
-```
-
-Added in v2.0.0
-
-## mapInputContext
-
-Provides each data source with part of its required environment.
-
-**Signature**
-
-```ts
-export declare const mapInputContext: <R0, R>(
-  self: RequestBlock<R>,
-  f: (context: Context.Context<R0>) => Context.Context<R>
-) => RequestBlock<R0>
 ```
 
 Added in v2.0.0

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -137,10 +137,10 @@ export interface EffectTypeLambda extends TypeLambda {
  * @since 2.0.0
  * @category models
  */
-export interface Blocked<out R, out E, out A> extends Effect<R, E, A> {
+export interface Blocked<out E, out A> extends Effect<never, E, A> {
   readonly _op: "Blocked"
-  readonly i0: RequestBlock<R>
-  readonly i1: Effect<R, E, A>
+  readonly i0: RequestBlock
+  readonly i1: Effect<never, E, A>
 }
 
 /**
@@ -4880,29 +4880,20 @@ export const ap: {
  * @category requests & batching
  * @since 2.0.0
  */
-export const blocked: <R, E, A>(blockedRequests: RequestBlock<R>, _continue: Effect<R, E, A>) => Blocked<R, E, A> =
+export const blocked: <E, A>(blockedRequests: RequestBlock, _continue: Effect<never, E, A>) => Blocked<E, A> =
   core.blocked
 
 /**
  * @category requests & batching
  * @since 2.0.0
  */
-export const runRequestBlock: <R>(blockedRequests: RequestBlock<R>) => Blocked<R, never, void> = core.runRequestBlock
+export const runRequestBlock: <R>(blockedRequests: RequestBlock) => Effect<R, never, void> = core.runRequestBlock
 
 /**
  * @category requests & batching
  * @since 2.0.0
  */
-export const step: <R, E, A>(self: Effect<R, E, A>) => Effect<R, E, Exit.Exit<E, A> | Blocked<R, E, A>> = core.step
-
-/**
- * @category requests & batching
- * @since 2.0.0
- */
-export const flatMapStep: <R, E, A, R1, E1, B>(
-  self: Effect<R, E, A>,
-  f: (step: Exit.Exit<E, A> | Blocked<R, E, A>) => Effect<R1, E1, B>
-) => Effect<R | R1, E1, B> = core.flatMapStep
+export const step: <R, E, A>(self: Effect<R, E, A>) => Effect<R, E, Exit.Exit<E, A> | Blocked<E, A>> = core.step
 
 /**
  * @since 2.0.0

--- a/src/RequestBlock.ts
+++ b/src/RequestBlock.ts
@@ -1,11 +1,7 @@
 /**
  * @since 2.0.0
  */
-import type * as Context from "./Context.js"
-import type { FiberRef } from "./FiberRef.js"
 import * as _RequestBlock from "./internal/blockedRequests.js"
-import * as core from "./internal/core.js"
-import * as _dataSource from "./internal/dataSource.js"
 import type * as Request from "./Request.js"
 import type * as RequestResolver from "./RequestResolver.js"
 
@@ -19,7 +15,7 @@ import type * as RequestResolver from "./RequestResolver.js"
  * @since 2.0.0
  * @category models
  */
-export type RequestBlock<R> = Empty | Par<R> | Seq<R> | Single<R>
+export type RequestBlock = Empty | Par | Seq | Single
 
 /**
  * @since 2.0.0
@@ -30,11 +26,11 @@ export declare namespace RequestBlock {
    * @since 2.0.0
    * @category models
    */
-  export interface Reducer<in R, in out Z> {
+  export interface Reducer<in out Z> {
     emptyCase(): Z
     parCase(left: Z, right: Z): Z
     singleCase(
-      dataSource: RequestResolver.RequestResolver<unknown, R>,
+      dataSource: RequestResolver.RequestResolver<unknown, never>,
       blockedRequest: Request.Entry<unknown>
     ): Z
     seqCase(left: Z, right: Z): Z
@@ -53,29 +49,29 @@ export interface Empty {
  * @since 2.0.0
  * @category models
  */
-export interface Par<out R> {
+export interface Par {
   readonly _tag: "Par"
-  readonly left: RequestBlock<R>
-  readonly right: RequestBlock<R>
+  readonly left: RequestBlock
+  readonly right: RequestBlock
 }
 
 /**
  * @since 2.0.0
  * @category models
  */
-export interface Seq<out R> {
+export interface Seq {
   readonly _tag: "Seq"
-  readonly left: RequestBlock<R>
-  readonly right: RequestBlock<R>
+  readonly left: RequestBlock
+  readonly right: RequestBlock
 }
 
 /**
  * @since 2.0.0
  * @category models
  */
-export interface Single<out R> {
+export interface Single {
   readonly _tag: "Single"
-  readonly dataSource: RequestResolver.RequestResolver<unknown, R>
+  readonly dataSource: RequestResolver.RequestResolver<unknown, never>
   readonly blockedRequest: Request.Entry<unknown>
 }
 
@@ -83,75 +79,40 @@ export interface Single<out R> {
  * @since 2.0.0
  * @category constructors
  */
-export const single: <R, A>(
-  dataSource: RequestResolver.RequestResolver<A, R>,
+export const single: <A>(
+  dataSource: RequestResolver.RequestResolver<A, never>,
   blockedRequest: Request.Entry<A>
-) => RequestBlock<R> = _RequestBlock.single
+) => RequestBlock = _RequestBlock.single
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const empty: RequestBlock<never> = _RequestBlock.empty
+export const empty: RequestBlock = _RequestBlock.empty
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const mapRequestResolvers: <R, A, R2>(
-  self: RequestBlock<R>,
-  f: (dataSource: RequestResolver.RequestResolver<A, R>) => RequestResolver.RequestResolver<A, R2>
-) => RequestBlock<R | R2> = _RequestBlock.mapRequestResolvers
+export const mapRequestResolvers: <A>(
+  self: RequestBlock,
+  f: (dataSource: RequestResolver.RequestResolver<A>) => RequestResolver.RequestResolver<A>
+) => RequestBlock = _RequestBlock.mapRequestResolvers
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const parallel: <R, R2>(self: RequestBlock<R>, that: RequestBlock<R2>) => RequestBlock<R | R2> =
-  _RequestBlock.par
+export const parallel: (self: RequestBlock, that: RequestBlock) => RequestBlock = _RequestBlock.par
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const reduce: <R, Z>(self: RequestBlock<R>, reducer: RequestBlock.Reducer<R, Z>) => Z = _RequestBlock.reduce
+export const reduce: <Z>(self: RequestBlock, reducer: RequestBlock.Reducer<Z>) => Z = _RequestBlock.reduce
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const sequential: <R, R2>(self: RequestBlock<R>, that: RequestBlock<R2>) => RequestBlock<R | R2> =
-  _RequestBlock.seq
-
-/**
- * Provides each data source with part of its required environment.
- *
- * @since 2.0.0
- * @category utils
- */
-export const mapInputContext = <R0, R>(
-  self: RequestBlock<R>,
-  f: (context: Context.Context<R0>) => Context.Context<R>
-): RequestBlock<R0> => reduce(self, MapInputContextReducer(f))
-
-const MapInputContextReducer = <R0, R>(
-  f: (context: Context.Context<R0>) => Context.Context<R>
-): RequestBlock.Reducer<R, RequestBlock<R0>> => ({
-  emptyCase: () => empty,
-  parCase: (left, right) => parallel(left, right),
-  seqCase: (left, right) => sequential(left, right),
-  singleCase: (dataSource, blockedRequest) =>
-    single(
-      _dataSource.mapInputContext(dataSource, f),
-      blockedRequest as any
-    )
-})
-
-/**
- * Provides each data source with a fiber ref value.
- *
- * @since 2.0.0
- * @category utils
- */
-export const locally: <R, A>(self: RequestBlock<R>, ref: FiberRef<A>, value: A) => RequestBlock<R> =
-  core.requestBlockLocally
+export const sequential: (self: RequestBlock, that: RequestBlock) => RequestBlock = _RequestBlock.seq

--- a/src/internal/pubsub.ts
+++ b/src/internal/pubsub.ts
@@ -1302,12 +1302,13 @@ class BackPressureStrategy<in out A> implements PubSubStrategy<A> {
       core.flatMap(
         core.sync(() => unsafePollAllQueue(this.publishers)),
         (publishers) =>
-          fiberRuntime.forEachParUnboundedDiscard(
+          fiberRuntime.forEachConcurrentDiscard(
             publishers,
             ([_, deferred, last]) =>
               last ?
                 pipe(core.deferredInterruptWith(deferred, fiberId), core.asUnit) :
                 core.unit,
+            false,
             false
           )
       ))

--- a/src/internal/query.ts
+++ b/src/internal/query.ts
@@ -78,7 +78,7 @@ export const fromRequest = <
                               proxy,
                               (entry) => entry.handle === orNew.left.handle
                             ),
-                            () => fromRequest(proxy, dataSource)
+                            () => fromRequest(proxy, ds)
                           )
                         }
                         return ensuring(

--- a/src/internal/scopedCache.ts
+++ b/src/internal/scopedCache.ts
@@ -327,9 +327,10 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
   }
 
   get invalidateAll(): Effect.Effect<never, never, void> {
-    return fiberRuntime.forEachParUnboundedDiscard(
+    return fiberRuntime.forEachConcurrentDiscard(
       HashSet.fromIterable(Array.from(this.cacheState.map).map(([key]) => key)),
       (key) => this.invalidate(key),
+      false,
       false
     )
   }
@@ -572,9 +573,10 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
   }
 
   ensureMapSizeNotExceeded(key: _cache.MapKey<Key>): Effect.Effect<never, never, void> {
-    return fiberRuntime.forEachParUnboundedDiscard(
+    return fiberRuntime.forEachConcurrentDiscard(
       this.trackAccess(key),
       (cleanedMapValue) => this.cleanMapValue(cleanedMapValue),
+      false,
       false
     )
   }

--- a/test/Effect/traversing.test.ts
+++ b/test/Effect/traversing.test.ts
@@ -474,7 +474,7 @@ describe.concurrent("Effect", () => {
         }),
         Effect.exit
       )
-      assert.deepStrictEqual(result, Exit.failCause(Cause.parallel(Cause.empty, Cause.fail(1))))
+      assert.deepStrictEqual(result, Exit.failCause(Cause.fail(1)))
     }))
   it.effect("partition - collects only successes", () =>
     Effect.gen(function*($) {
@@ -651,7 +651,7 @@ describe.concurrent("Effect", () => {
           Effect.exit
         )
       )
-      assert.deepStrictEqual(result, Exit.failCause(Cause.parallel(Cause.empty, Cause.fail(1))))
+      assert.deepStrictEqual(result, Exit.failCause(Cause.fail(1)))
     }))
   it.effect("reduceEffect/concurrency - return error if it exists in list", () =>
     Effect.gen(function*($) {
@@ -665,7 +665,7 @@ describe.concurrent("Effect", () => {
           Effect.exit
         )
       )
-      assert.deepStrictEqual(result, Exit.failCause(Cause.parallel(Cause.empty, Cause.fail(1))))
+      assert.deepStrictEqual(result, Exit.failCause(Cause.fail(1)))
     }))
   it.effect("takeUntil - happy path", () =>
     Effect.gen(function*($) {

--- a/test/Stream/zipping.test.ts
+++ b/test/Stream/zipping.test.ts
@@ -143,7 +143,7 @@ describe.concurrent("Stream", () => {
       )
       assert.deepStrictEqual(
         result,
-        Exit.failCause(Cause.parallel(Cause.empty, Cause.die(new Cause.RuntimeException("Ouch"))))
+        Exit.failCause(Cause.die(new Cause.RuntimeException("Ouch")))
       )
     }))
 


### PR DESCRIPTION
Improve consistency between request batching and fiber environment.

In prior releases request batching required operators that act on fiber context such as `Effect.locally` to be aware of batching in order to avoid bugs where the effect executed post batching would lose the fiber environment (context, refs, and flags).

This change restructure how batching internally works, inside the fiber we now slice up the stack and restore the exact context that was destroyed, by rewriting the internals of forEach batching is now transparent to any other function that deals with fiber state.