### PR TITLE
Layer: rename `zipWithPar` to `zipWith` (standard)

### DIFF
--- a/.changeset/wet-cooks-approve.md
+++ b/.changeset/wet-cooks-approve.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Layer: rename `zipWithPar` to `zipWith` (standard)

--- a/docs/modules/Layer.ts.md
+++ b/docs/modules/Layer.ts.md
@@ -126,7 +126,7 @@ Added in v2.0.0
   - [unwrapScoped](#unwrapscoped)
 - [zipping](#zipping)
   - [mergeAll](#mergeall)
-  - [zipWithPar](#zipwithpar)
+  - [zipWith](#zipwith)
 
 ---
 
@@ -1353,7 +1353,7 @@ export declare const mergeAll: <Layers extends [Layer<any, any, never>, ...Layer
 
 Added in v2.0.0
 
-## zipWithPar
+## zipWith
 
 Combines this layer the specified layer, producing a new layer that has the
 inputs of both, and the outputs of both combined using the specified
@@ -1362,7 +1362,7 @@ function.
 **Signature**
 
 ```ts
-export declare const zipWithPar: {
+export declare const zipWith: {
   <R2, E2, B, A, C>(
     that: Layer<R2, E2, B>,
     f: (a: Context.Context<A>, b: Context.Context<B>) => Context.Context<C>

--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -788,7 +788,7 @@ export const provideMerge: {
  * @since 2.0.0
  * @category zipping
  */
-export const zipWithPar: {
+export const zipWith: {
   <R2, E2, B, A, C>(
     that: Layer<R2, E2, B>,
     f: (a: Context.Context<A>, b: Context.Context<B>) => Context.Context<C>
@@ -798,7 +798,7 @@ export const zipWithPar: {
     that: Layer<R2, E2, B>,
     f: (a: Context.Context<A>, b: Context.Context<B>) => Context.Context<C>
   ): Layer<R | R2, E | E2, C>
-} = internal.zipWithPar
+} = internal.zipWith
 
 /**
  * @since 2.0.0

--- a/src/internal/opCodes/layer.ts
+++ b/src/internal/opCodes/layer.ts
@@ -35,19 +35,19 @@ export const OP_SUSPEND = "Suspend" as const
 export type OP_SUSPEND = typeof OP_SUSPEND
 
 /** @internal */
-export const OP_PROVIDE_TO = "ProvideTo" as const
+export const OP_PROVIDE = "Provide" as const
 
 /** @internal */
-export type OP_PROVIDE_TO = typeof OP_PROVIDE_TO
+export type OP_PROVIDE = typeof OP_PROVIDE
+
+/** @internal */
+export const OP_PROVIDE_MERGE = "ProvideMerge" as const
+
+/** @internal */
+export type OP_PROVIDE_MERGE = typeof OP_PROVIDE_MERGE
 
 /** @internal */
 export const OP_ZIP_WITH = "ZipWith" as const
 
 /** @internal */
 export type OP_ZIP_WITH = typeof OP_ZIP_WITH
-
-/** @internal */
-export const OP_ZIP_WITH_PAR = "ZipWithPar" as const
-
-/** @internal */
-export type OP_ZIP_WITH_PAR = typeof OP_ZIP_WITH_PAR


### PR DESCRIPTION
(Layer.zipWith**Par** is the only exception in the entire codebase)