### PR TITLE
Fix ReadonlyArray.difference description

### DIFF
--- a/.changeset/quick-comics-nail.md
+++ b/.changeset/quick-comics-nail.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix ReadonlyArray.difference description

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -1749,7 +1749,7 @@ Added in v2.0.0
 
 ## difference
 
-Creates a `Array` of values not included in the other given `Iterable` using the provided `isEquivalent` function.
+Creates a `Array` of values not included in the other given `Iterable`.
 The order and references of result values are determined by the first `Iterable`.
 
 **Signature**

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1481,7 +1481,7 @@ export const differenceWith = <A>(isEquivalent: (self: A, that: A) => boolean): 
 }
 
 /**
- * Creates a `Array` of values not included in the other given `Iterable` using the provided `isEquivalent` function.
+ * Creates a `Array` of values not included in the other given `Iterable`.
  * The order and references of result values are determined by the first `Iterable`.
  *
  * @since 2.0.0


### PR DESCRIPTION
I guess there was a copy/paste error (from `differenceWith`).