### PR TITLE
Fix number of retries in retryN

### DIFF
--- a/.changeset/ten-carpets-itch.md
+++ b/.changeset/ten-carpets-itch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix number of retries in retryN

--- a/src/internal/schedule.ts
+++ b/src/internal/schedule.ts
@@ -1918,7 +1918,7 @@ const retryN_EffectLoop = <R, E, A>(
   n: number
 ): Effect.Effect<R, E, A> => {
   return core.catchAll(self, (e) =>
-    n < 0 ?
+    n <= 0 ?
       core.fail(e) :
       core.flatMap(core.yieldNow(), () => retryN_EffectLoop(self, n - 1)))
 }

--- a/test/Schedule.test.ts
+++ b/test/Schedule.test.ts
@@ -435,6 +435,12 @@ describe.concurrent("Schedule", () => {
         )
         assert.strictEqual(result, "Error: 2")
       }))
+    it.effect("retry exactly 'n' times after failure", () =>
+      Effect.gen(function*($) {
+        const ref = yield* $(Ref.make(0))
+        const result = yield* $(alwaysFail(ref), Effect.retryN(3), Effect.flip)
+        assert.strictEqual(result, "Error: 4")
+      }))
     // TODO(Max): after TestRandom
     // it.skip("for a given number of times with random jitter in (0, 1)")
     // Effect.gen(function*(){


### PR DESCRIPTION
It would seem that the current behaviour of `retryN` is to perform `n + 1` retries. This PR corrects it to `n` retries.
