### PR TITLE
Use Nix to manage all dependencies in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,11 +15,11 @@ runs:
       id: pnpm-cache
       shell: bash
       run: |
-        echo "::set-output name=pnpm_cache_dir::$(nix develop --command -- pnpm store path)"
+        echo "STORE_PATH=$(nix develop --command -- pnpm store path --silent)" >> $GITHUB_ENV
     - uses: actions/cache@v3
       name: Cache pnpm
       with:
-        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+        path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,9 +1,5 @@
 name: Setup
 description: Perform standard setup and install dependencies using pnpm.
-inputs:
-  cachixAuthToken:
-    description: The cachix auth token
-    required: true
 
 runs:
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,21 +1,28 @@
 name: Setup
 description: Perform standard setup and install dependencies using pnpm.
 inputs:
-  node-version:
-    description: The version of Node.js to install
+  cachixAuthToken:
+    description: The cachix auth token
     required: true
-    default: 20.9.0
 
 runs:
   using: composite
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@v2
-    - name: Install node
-      uses: actions/setup-node@v3
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "::set-output name=pnpm_cache_dir::$(nix develop --command -- pnpm store path)"
+    - uses: actions/cache@v3
+      name: Cache pnpm
       with:
-        cache: pnpm
-        node-version: ${{ inputs.node-version }}
+        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
     - name: Install dependencies
       shell: bash
-      run: pnpm install --ignore-scripts
+      run: nix develop --command -- pnpm install --ignore-scripts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,26 +16,26 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    steps: 
+    steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm build
+      - run: nix develop --command -- pnpm build
       - name: Check source state
-        run: git add src && git diff-index --cached HEAD --exit-code src
-      - run: pnpm circular
-      - run: pnpm docgen
+        run: nix develop --command -- git add src && git diff-index --cached HEAD --exit-code src
+      - run: nix develop --command -- pnpm circular
+      - run: nix develop --command -- pnpm docgen
       - name: Check docs state
-        run: git add docs && git diff-index --cached HEAD --exit-code docs
+        run: nix develop --command -- git add docs && git diff-index --cached HEAD --exit-code docs
       - name: Create Release Pull Request or Publish
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm update-version
-          publish: pnpm changeset publish
+          version: nix develop --command -- pnpm update-version
+          publish: nix develop --command -- pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm check
-      - run: pnpm lint
-      - run: pnpm dtslint
+      - run: nix develop --command -- pnpm check
+      - run: nix develop --command -- pnpm lint
+      - run: nix develop --command -- pnpm dtslint

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -42,48 +42,48 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             **Alright @${{ github.actor }}, I'm working on the snapshot!**
-            
+
             You can follow the progress [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
       - name: Checkout default branch
         uses: actions/checkout@v2
-  
+
       - name: Checkout pull request branch
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get current branch name
-        id: branch  
-        run: echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+        id: branch
+        run: echo "branch=$(nix develop --command -- git branch --show-current)" >> $GITHUB_OUTPUT
 
       - name: Retrieve changeset entries
         if: ${{ steps.branch.outputs.branch == 'changeset-release/main' }}
-        run: git checkout origin/main
+        run: nix develop --command -- git checkout origin/main
 
       - name: Install dependencies
         uses: ./.github/actions/setup
 
       - name: Exit pre-release mode
         if: ${{ hashFiles('.changeset/pre.json') != '' }}
-        run: pnpm changeset pre exit
+        run: nix develop --command -- pnpm changeset pre exit
 
       - name: Version snapshot
-        run: pnpm changeset version --snapshot ${{ steps.command.outputs.snapshot }} | grep -q "All files have been updated"
+        run: nix develop --command -- pnpm changeset version --snapshot ${{ steps.command.outputs.snapshot }} | grep -q "All files have been updated"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build snapshot
-        run: pnpm build
- 
+        run: nix develop --command -- pnpm build
+
       - name: Set registry config
-        run: pnpm config set --location project "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_TOKEN }}"
+        run: nix develop --command -- pnpm config set --location project "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_TOKEN }}"
 
       - name: Publish snapshot
         id: snapshot
         run: |
           # Publish and extract published tags from stdout.
-          output=$(pnpm changeset publish --tag ${{ steps.command.outputs.snapshot }} --no-git-tag)
+          output=$(nix develop --command -- pnpm changeset publish --tag ${{ steps.command.outputs.snapshot }} --no-git-tag)
           output=$(echo "$output" | awk '/packages published successfully:/{flag=1; next} flag')
           output=$(echo "$output" | grep -o '@[^ ]*' | awk '{print "\"" $0 "\""}' | paste -sd ',')
           echo "tags=[$output]" >> $GITHUB_OUTPUT
@@ -94,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
-            const commands = ${{ steps.snapshot.outputs.tags }}.map(tag => '```sh\n' + `pnpm add ${tag}` + '\n```')
+            const commands = ${{ steps.snapshot.outputs.tags }}.map(tag => '```sh\n' + `nix develop --command -- pnpm add ${tag}` + '\n```')
             const header = `**Good news @${{ github.actor }}, your snapshot has been published!**`
             const footer = `You can review the build log [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
 
@@ -115,5 +115,5 @@ jobs:
           edit-mode: replace
           body: |
             **Sorry @${{ github.actor }}, I failed to publish the snapshot!**
-            
+
             You can review the build log [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command -- pnpm exec playwright install && vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
+      - run: nix develop --command -- pnpm exec playwright install && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:
     name: Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command -- playwright install
-      - run: nix develop --command -- playwright install-deps
-      - run: nix develop --command -- pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
+      - run: nix develop --command bash -c 'playwright install && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}'
 
   bun:
     name: Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command bash -c 'playwright install && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}'
+      - run: nix develop --command bash -c 'playwright install && playwright install-deps && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}'
 
   bun:
     name: Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command -- npx playwright install --with-deps ${{ matrix.browser }}
       - run: nix develop --command -- pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command playwright install
       - run: nix develop --command pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
+      - run: nix develop --command -- pnpm exec playwright install
       - run: nix develop --command -- pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command bash -c 'playwright install && playwright install-deps && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}'
+      - run: nix develop --command playwright install
+      - run: nix develop --command pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:
     name: Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command -- pnpm exec playwright install && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
+      - run: nix develop --command 'pnpm exec playwright install && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}'
 
   bun:
     name: Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,26 +16,20 @@ jobs:
     name: Node
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm vitest
+      - run: nix develop --command -- pnpm vitest
 
   edge:
     name: Edge
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm vitest --environment edge-runtime
+      - run: nix develop --command -- pnpm vitest --environment edge-runtime
 
   browser:
     name: Browser ${{ matrix.shard }} (${{ matrix.browser }})
@@ -45,41 +39,29 @@ jobs:
       matrix:
         browser: [chromium]
         shard: [1/3, 2/3, 3/3]
-
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - name: Install dependencies
-        uses: ./.github/actions/setup
-      - run: npx playwright install --with-deps ${{ matrix.browser }}
-      - run: pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
+      - run: nix develop --command -- npx playwright install --with-deps ${{ matrix.browser }}
+      - run: nix develop --command -- pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:
     name: Bun
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
       - name: Install bun
         uses: oven-sh/setup-bun@v1
-      - run: bun vitest
+      - run: nix develop --command -- bun vitest
 
   deno:
     name: Deno
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
-      - run: deno task test
+      - run: nix develop --command -- deno task test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command 'pnpm exec playwright install && pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}'
+      - run: nix develop --command -- playwright install
+      - run: nix develop --command -- playwright install-deps
+      - run: nix develop --command -- pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:
     name: Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: nix develop --command -- pnpm exec playwright install
-      - run: nix develop --command -- pnpm vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
+      - run: nix develop --command -- pnpm exec playwright install && vitest --browser ${{ matrix.browser }} --shard ${{ matrix.shard }}
 
   bun:
     name: Bun

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701401302,
-        "narHash": "sha256-kfCOHzgtmHcgJwH7uagk8B+K1Qz58rN79eTLe55eGqA=",
+        "lastModified": 1701626906,
+        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "69a165d0fd2b08a78dbd2c98f6f860ceb2bbcd40",
+        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698553279,
-        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
+        "lastModified": 1701401302,
+        "narHash": "sha256-kfCOHzgtmHcgJwH7uagk8B+K1Qz58rN79eTLe55eGqA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
+        "rev": "69a165d0fd2b08a78dbd2c98f6f860ceb2bbcd40",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             bun
             deno
             nodejs_20
-            playwright-driver
+            playwright
           ];
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -34,13 +34,12 @@
               nodejs_20
             ];
 
-            nativeBuildInputs = lib.optionals (!pkgs.stdenvNoCC.isDarwin) [
+            nativeBuildInputs = lib.optionals (!stdenvNoCC.isDarwin) [
               playwright-driver.browsers
             ];
-          }
-          // lib.optionalAttrs (!pkgs.stdenvNoCC.isDarwin) {
-            PLAYWRIGHT_BROWSERS_PATH = "${playwright-driver.browsers}";
-            PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+
+            PLAYWRIGHT_BROWSERS_PATH = lib.optionalString (!stdenvNoCC.isDarwin) "${playwright-driver.browsers}";
+            PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = lib.optionalString (!stdenvNoCC.isDarwin) "true";
           };
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,11 @@
       devShells = {
         default = pkgs.mkShell {
           buildInputs = with pkgs; [
+            corepackEnable
             bun
             deno
             nodejs_20
-            corepackEnable
+            playwright-driver
           ];
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -25,14 +25,21 @@
       formatter = pkgs.alejandra;
 
       devShells = {
-        default = pkgs.mkShell {
-          buildInputs = with pkgs; [
+        default = with pkgs; mkShell {
+          buildInputs = [
             corepackEnable
             bun
             deno
             nodejs_20
-            playwright-driver
+            playwright-test
           ];
+
+          PLAYWRIGHT_BROWSERS_PATH="${playwright-driver.browsers}";
+
+          shellHook = ''
+            # Remove playwright from node_modules, so it will be taken from playwright-test
+            rm node_modules/@playwright/ -R
+          '';
         };
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -25,22 +25,22 @@
       formatter = pkgs.alejandra;
 
       devShells = {
-        default = with pkgs; mkShell {
-          buildInputs = [
-            corepackEnable
-            bun
-            deno
-            nodejs_20
-            playwright-test
-          ];
+        default = with pkgs;
+          mkShell {
+            buildInputs = [
+              corepackEnable
+              bun
+              deno
+              nodejs_20
+            ];
 
-          PLAYWRIGHT_BROWSERS_PATH="${playwright-driver.browsers}";
+            nativeBuildInputs = [
+              playwright-driver.browsers
+            ];
 
-          shellHook = ''
-            # Remove playwright from node_modules, so it will be taken from playwright-test
-            rm node_modules/@playwright/ -R
-          '';
-        };
+            PLAYWRIGHT_BROWSERS_PATH = "${playwright-driver.browsers}";
+            PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+          };
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,10 +34,11 @@
               nodejs_20
             ];
 
-            nativeBuildInputs = [
+            nativeBuildInputs = lib.optional (!pkgs.stdenvNoCC.isDarwin) [
               playwright-driver.browsers
             ];
-
+          }
+          // lib.optionalAttrs (!pkgs.stdenvNoCC.isDarwin) {
             PLAYWRIGHT_BROWSERS_PATH = "${playwright-driver.browsers}";
             PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
               nodejs_20
             ];
 
-            nativeBuildInputs = lib.optional (!pkgs.stdenvNoCC.isDarwin) [
+            nativeBuildInputs = lib.optionals (!pkgs.stdenvNoCC.isDarwin) [
               playwright-driver.browsers
             ];
           }

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         default = pkgs.mkShell {
           buildInputs = with pkgs; [
             bun
+            deno
             nodejs_20
             corepackEnable
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             bun
             deno
             nodejs_20
-            playwright
+            playwright-driver
           ];
         };
       };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "effect",
   "version": "2.0.0-next.58",
   "type": "module",
-  "packageManager": "pnpm@8.10.0",
+  "packageManager": "pnpm@8.11.0",
   "publishConfig": {
     "access": "public",
     "directory": "dist"


### PR DESCRIPTION
Converts our CI environment to utilize the Nix devShell environment for running everything.

The only wrinkle that I have locally at the moment is that when I attempt to spin up my devShell, I get:

```
error: builder for '/nix/store/lq7mg8cziypsydsygx3j83ip83kqns9f-playwright-browsers-1.40.0.drv' failed with exit code 1;
       last 10 log lines:
       >     at TLSSocket._finishInit (node:_tls_wrap:1017:8)
       >     at ssl.onhandshakedone (node:_tls_wrap:803:12) {
       >   code: 'SELF_SIGNED_CERT_IN_CHAIN'
       > }
       > Failed to install browsers
       > Error: Failed to download Chromium 120.0.6099.28 (playwright build v1091), caused by
       > Error: Download failure, code=1
       >     at ChildProcess.<anonymous> (/nix/store/awkhn463308xl3vdp6h754ffk67fpmww-playwright-driver-1.40.0/package/lib/server/registry/browserFetcher.js:91:16)
       >     at ChildProcess.emit (node:events:517:28)
       >     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
       For full logs, run 'nix log /nix/store/lq7mg8cziypsydsygx3j83ip83kqns9f-playwright-browsers-1.40.0.drv'.
```

Can one of you folks check and see if you get the same error locally?