### PR TITLE
remove value accumulation in histogram implementation

### DIFF
--- a/.changeset/tender-yaks-leave.md
+++ b/.changeset/tender-yaks-leave.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Removed accumulation of values in histogram implementation

--- a/src/internal/metric/hook.ts
+++ b/src/internal/metric/hook.ts
@@ -165,12 +165,8 @@ export const histogram = (key: MetricKey.MetricKey.Histogram): MetricHook.Metric
 
   const getBuckets = (): Chunk.Chunk<readonly [number, number]> => {
     const builder: Array<readonly [number, number]> = Array(size)
-    let cumulated = 0
     for (let i = 0; i < size; i++) {
-      const boundary = boundaries[i]
-      const value = values[i]
-      cumulated = cumulated + value
-      builder[i] = [boundary, cumulated]
+      builder[i] = [boundaries[i], values[i]]
     }
     return Chunk.unsafeFromArray(builder)
   }


### PR DESCRIPTION
The current implementation appears to be wrong. AFAIK, the accumulation shouldn't happen in the producing app: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram