### PR TITLE
Add `Console` combinators to `Effect` module

### DIFF
--- a/.changeset/angry-cows-unite.md
+++ b/.changeset/angry-cows-unite.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add `withConsoleScoped` to `Console`/`Effect` modules

--- a/.changeset/wicked-weeks-change.md
+++ b/.changeset/wicked-weeks-change.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+export `Console` combinators from the `Effect` module to match other default services

--- a/docs/modules/Effect.ts.md
+++ b/docs/modules/Effect.ts.md
@@ -60,6 +60,10 @@ Added in v2.0.0
   - [configProviderWith](#configproviderwith)
   - [withConfigProvider](#withconfigprovider)
   - [withConfigProviderScoped](#withconfigproviderscoped)
+- [console](#console)
+  - [console](#console-1)
+  - [consoleWith](#consolewith)
+  - [withConsole](#withconsole)
 - [constructors](#constructors)
   - [async](#async)
   - [asyncEffect](#asynceffect)
@@ -83,6 +87,7 @@ Added in v2.0.0
   - [sync](#sync)
   - [unit](#unit)
   - [withClockScoped](#withclockscoped)
+  - [withConsoleScoped](#withconsolescoped)
   - [yieldNow](#yieldnow)
 - [context](#context)
   - [context](#context-1)
@@ -1269,6 +1274,49 @@ export declare const withConfigProviderScoped: (value: ConfigProvider) => Effect
 
 Added in v2.0.0
 
+# console
+
+## console
+
+Retreives the `Console` service from the context
+
+**Signature**
+
+```ts
+export declare const console: Effect<never, never, Console>
+```
+
+Added in v2.0.0
+
+## consoleWith
+
+Retreives the `Console` service from the context and provides it to the
+specified effectful function.
+
+**Signature**
+
+```ts
+export declare const consoleWith: <R, E, A>(f: (console: Console) => Effect<R, E, A>) => Effect<R, E, A>
+```
+
+Added in v2.0.0
+
+## withConsole
+
+Executes the specified workflow with the specified implementation of the
+console service.
+
+**Signature**
+
+```ts
+export declare const withConsole: {
+  <A extends Console>(console: A): <R, E, A>(effect: Effect<R, E, A>) => Effect<R, E, A>
+  <R, E, A extends Console>(effect: Effect<R, E, A>, console: A): Effect<R, E, A>
+}
+```
+
+Added in v2.0.0
+
 # constructors
 
 ## async
@@ -1576,6 +1624,19 @@ restores it to its original value when the scope is closed.
 
 ```ts
 export declare const withClockScoped: <A extends Clock.Clock>(value: A) => Effect<Scope.Scope, never, void>
+```
+
+Added in v2.0.0
+
+## withConsoleScoped
+
+Sets the implementation of the clock service to the specified value and
+restores it to its original value when the scope is closed.
+
+**Signature**
+
+```ts
+export declare const withConsoleScoped: <A extends Console>(console: A) => Effect<Scope.Scope, never, void>
 ```
 
 Added in v2.0.0

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -7,6 +7,7 @@ import type * as Clock from "./Clock.js"
 import type { Config } from "./Config.js"
 import type { ConfigError } from "./ConfigError.js"
 import type { ConfigProvider } from "./ConfigProvider.js"
+import type { Console } from "./Console.js"
 import type * as Context from "./Context.js"
 import type * as Deferred from "./Deferred.js"
 import type * as Duration from "./Duration.js"
@@ -25,6 +26,7 @@ import { dual, identity } from "./Function.js"
 import type * as HashMap from "./HashMap.js"
 import type * as HashSet from "./HashSet.js"
 import type { TypeLambda } from "./HKT.js"
+import * as _console from "./internal/console.js"
 import * as effect from "./internal/core-effect.js"
 import * as core from "./internal/core.js"
 import * as defaultServices from "./internal/defaultServices.js"
@@ -2827,6 +2829,49 @@ export const withClock: {
   <A extends Clock.Clock>(value: A): <R, E, A>(effect: Effect<R, E, A>) => Effect<R, E, A>
   <R, E, A extends Clock.Clock>(effect: Effect<R, E, A>, value: A): Effect<R, E, A>
 } = defaultServices.withClock
+
+// -------------------------------------------------------------------------------------
+// console
+// -------------------------------------------------------------------------------------
+
+/**
+ * Retreives the `Console` service from the context
+ *
+ * @since 2.0.0
+ * @category console
+ */
+export const console: Effect<never, never, Console> = _console.console
+
+/**
+ * Retreives the `Console` service from the context and provides it to the
+ * specified effectful function.
+ *
+ * @since 2.0.0
+ * @category console
+ */
+export const consoleWith: <R, E, A>(f: (console: Console) => Effect<R, E, A>) => Effect<R, E, A> = _console.consoleWith
+
+/**
+ * Sets the implementation of the clock service to the specified value and
+ * restores it to its original value when the scope is closed.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const withConsoleScoped: <A extends Console>(console: A) => Effect<Scope.Scope, never, void> =
+  _console.withConsoleScoped
+
+/**
+ * Executes the specified workflow with the specified implementation of the
+ * console service.
+ *
+ * @since 2.0.0
+ * @category console
+ */
+export const withConsole: {
+  <A extends Console>(console: A): <R, E, A>(effect: Effect<R, E, A>) => Effect<R, E, A>
+  <R, E, A extends Console>(effect: Effect<R, E, A>, console: A): Effect<R, E, A>
+} = _console.withConsole
 
 // ---------------------------------------------------------------------------------------
 // delays & timeouts

--- a/src/internal/console.ts
+++ b/src/internal/console.ts
@@ -3,6 +3,7 @@ import * as Context from "../Context.js"
 import type * as Effect from "../Effect.js"
 import { dual } from "../Function.js"
 import type * as Layer from "../Layer.js"
+import type * as Scope from "../Scope.js"
 import * as core from "./core.js"
 import * as defaultServices from "./defaultServices.js"
 import * as defaultConsole from "./defaultServices/console.js"
@@ -32,6 +33,13 @@ export const withConsole = dual<
     defaultServices.currentServices,
     Context.add(defaultConsole.consoleTag, value)
   ))
+
+/** @internal */
+export const withConsoleScoped = <A extends Console.Console>(console: A): Effect.Effect<Scope.Scope, never, void> =>
+  fiberRuntime.fiberRefLocallyScopedWith(
+    defaultServices.currentServices,
+    Context.add(defaultConsole.consoleTag, console)
+  )
 
 /** @internal */
 export const setConsole = <A extends Console.Console>(console: A): Layer.Layer<never, never, never> =>


### PR DESCRIPTION
- Exports `Console` combinators from the `Effect` module to match other default services
- Add `Console.withConsoleScoped` to match other default services