### PR TITLE
improve performance of fiber forking

### DIFF
--- a/.changeset/chilled-hotels-own.md
+++ b/.changeset/chilled-hotels-own.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+prefer Date.now() over new Date().getTime()

--- a/.changeset/dirty-cheetahs-argue.md
+++ b/.changeset/dirty-cheetahs-argue.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+rename FiberRefs.updatedAs to FiberRef.updateAs

--- a/.changeset/gorgeous-knives-lie.md
+++ b/.changeset/gorgeous-knives-lie.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add FiberRefs.updateManyAs

--- a/.changeset/light-badgers-taste.md
+++ b/.changeset/light-badgers-taste.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+short circuit for empty patches

--- a/.changeset/red-flowers-pull.md
+++ b/.changeset/red-flowers-pull.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+use native js data types for Metrics

--- a/.changeset/smart-horses-grow.md
+++ b/.changeset/smart-horses-grow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+replace use of throw in fiber runtime

--- a/.changeset/smooth-plants-obey.md
+++ b/.changeset/smooth-plants-obey.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+optimize FiberRef.update/forkAs

--- a/.changeset/weak-steaks-float.md
+++ b/.changeset/weak-steaks-float.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+optimize MutableHashMap

--- a/examples/fork.ts
+++ b/examples/fork.ts
@@ -1,0 +1,5 @@
+import { Effect } from "effect"
+
+for (let i = 0; i < 200000; i++) {
+  Effect.runFork(Effect.unit)
+}

--- a/src/Differ.ts
+++ b/src/Differ.ts
@@ -200,7 +200,7 @@ export declare namespace Differ {
      */
     export type TypeId = typeof ReadonlyArrayPatchTypeId
     /**
-     * A patch which describes updates to a chunk of values.
+     * A patch which describes updates to a ReadonlyArray of values.
      *
      * @since 2.0.0
      * @category models
@@ -379,7 +379,7 @@ export const orElseEither: {
 } = internal.orElseEither
 
 /**
- * Constructs a differ that knows how to diff a `HashSet` of values.
+ * Constructs a differ that knows how to diff a `ReadonlyArray` of values.
  *
  * @since 2.0.0
  * @category constructors

--- a/src/Differ.ts
+++ b/src/Differ.ts
@@ -14,6 +14,7 @@ import * as ContextPatch from "./internal/differ/contextPatch.js"
 import * as HashMapPatch from "./internal/differ/hashMapPatch.js"
 import * as HashSetPatch from "./internal/differ/hashSetPatch.js"
 import * as OrPatch from "./internal/differ/orPatch.js"
+import * as ReadonlyArrayPatch from "./internal/differ/readonlyArrayPatch.js"
 import type * as Types from "./Types.js"
 
 /**
@@ -63,6 +64,8 @@ const ContextPatchTypeId: unique symbol = ContextPatch.ContextPatchTypeId as Dif
 const HashMapPatchTypeId: unique symbol = HashMapPatch.HashMapPatchTypeId as Differ.HashMap.TypeId
 const HashSetPatchTypeId: unique symbol = HashSetPatch.HashSetPatchTypeId as Differ.HashSet.TypeId
 const OrPatchTypeId: unique symbol = OrPatch.OrPatchTypeId as Differ.Or.TypeId
+const ReadonlyArrayPatchTypeId: unique symbol = ReadonlyArrayPatch
+  .ReadonlyArrayPatchTypeId as Differ.ReadonlyArray.TypeId
 
 /**
  * @since 2.0.0
@@ -183,6 +186,29 @@ export declare namespace Differ {
         readonly _Value2: Types.Invariant<Value2>
         readonly _Patch: Types.Invariant<Patch>
         readonly _Patch2: Types.Invariant<Patch2>
+      }
+    }
+  }
+
+  /**
+   * @since 2.0.0
+   */
+  export namespace ReadonlyArray {
+    /**
+     * @since 2.0.0
+     * @category symbol
+     */
+    export type TypeId = typeof ReadonlyArrayPatchTypeId
+    /**
+     * A patch which describes updates to a chunk of values.
+     *
+     * @since 2.0.0
+     * @category models
+     */
+    export interface Patch<in out Value, in out Patch> extends Equal {
+      readonly [ReadonlyArrayPatchTypeId]: {
+        readonly _Value: Types.Invariant<Value>
+        readonly _Patch: Types.Invariant<Patch>
       }
     }
   }
@@ -351,6 +377,16 @@ export const orElseEither: {
     Differ.Or.Patch<Value, Value2, Patch, Patch2>
   >
 } = internal.orElseEither
+
+/**
+ * Constructs a differ that knows how to diff a `HashSet` of values.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const readonlyArray: <Value, Patch>(
+  differ: Differ<Value, Patch>
+) => Differ<ReadonlyArray<Value>, Differ.ReadonlyArray.Patch<Value, Patch>> = internal.readonlyArray
 
 /**
  * Transforms the type of values that this differ knows how to differ using

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -4590,17 +4590,6 @@ export const labelMetrics: {
 } = effect.labelMetrics
 
 /**
- * Tags each metric in this effect with the specific tag.
- *
- * @since 2.0.0
- * @category metrics
- */
-export const labelMetricsSet: {
-  (labels: HashSet.HashSet<MetricLabel.MetricLabel>): <R, E, A>(self: Effect<R, E, A>) => Effect<R, E, A>
-  <R, E, A>(self: Effect<R, E, A>, labels: HashSet.HashSet<MetricLabel.MetricLabel>): Effect<R, E, A>
-} = effect.labelMetricsSet
-
-/**
  * Tags each metric in a scope with a the specific tag.
  *
  * @since 2.0.0
@@ -4620,22 +4609,12 @@ export const labelMetricsScoped: (
 ) => Effect<Scope.Scope, never, void> = fiberRuntime.labelMetricsScoped
 
 /**
- * Tags each metric in a scope with a the specific tag.
- *
- * @since 2.0.0
- * @category metrics
- */
-export const labelMetricsScopedSet: (
-  labels: HashSet.HashSet<MetricLabel.MetricLabel>
-) => Effect<Scope.Scope, never, void> = fiberRuntime.labelMetricsScopedSet
-
-/**
  * Retrieves the metric labels associated with the current scope.
  *
  * @since 2.0.0
  * @category metrics
  */
-export const metricLabels: Effect<never, never, HashSet.HashSet<MetricLabel.MetricLabel>> = core.metricLabels
+export const metricLabels: Effect<never, never, ReadonlyArray<MetricLabel.MetricLabel>> = core.metricLabels
 
 /**
  * @since 2.0.0

--- a/src/FiberRef.ts
+++ b/src/FiberRef.ts
@@ -371,7 +371,7 @@ export const currentSupervisor: FiberRef<Supervisor.Supervisor<any>> = fiberRunt
  * @since 2.0.0
  * @category fiberRefs
  */
-export const currentMetricLabels: FiberRef<HashSet.HashSet<MetricLabel.MetricLabel>> = core.currentMetricLabels
+export const currentMetricLabels: FiberRef<ReadonlyArray<MetricLabel.MetricLabel>> = core.currentMetricLabels
 
 /**
  * @since 2.0.0

--- a/src/FiberRefs.ts
+++ b/src/FiberRefs.ts
@@ -123,7 +123,7 @@ export const setAll: (self: FiberRefs) => Effect.Effect<never, never, void> = in
  * @since 2.0.0
  * @category utils
  */
-export const updatedAs: {
+export const updateAs: {
   <A>(
     options: {
       readonly fiberId: FiberId.Runtime
@@ -139,7 +139,51 @@ export const updatedAs: {
       readonly value: A
     }
   ): FiberRefs
-} = internal.updatedAs
+} = internal.updateAs
+
+/**
+ * Updates the values of the specified `FiberRef` & value pairs using the provided `FiberId`
+ *
+ * @since 2.0.0
+ * @category utils
+ */
+export const updateManyAs: {
+  (
+    options: {
+      readonly forkAs?: FiberId.Runtime | undefined
+      readonly entries: readonly [
+        readonly [
+          FiberRef.FiberRef<any>,
+          readonly [readonly [FiberId.Runtime, any], ...Array<readonly [FiberId.Runtime, any]>]
+        ],
+        ...Array<
+          readonly [
+            FiberRef.FiberRef<any>,
+            readonly [readonly [FiberId.Runtime, any], ...Array<readonly [FiberId.Runtime, any]>]
+          ]
+        >
+      ]
+    }
+  ): (self: FiberRefs) => FiberRefs
+  (
+    self: FiberRefs,
+    options: {
+      readonly forkAs?: FiberId.Runtime | undefined
+      readonly entries: readonly [
+        readonly [
+          FiberRef.FiberRef<any>,
+          readonly [readonly [FiberId.Runtime, any], ...Array<readonly [FiberId.Runtime, any]>]
+        ],
+        ...Array<
+          readonly [
+            FiberRef.FiberRef<any>,
+            readonly [readonly [FiberId.Runtime, any], ...Array<readonly [FiberId.Runtime, any]>]
+          ]
+        >
+      ]
+    }
+  ): FiberRefs
+} = internal.updateManyAs
 
 /**
  * Note: it will not copy the provided Map, make sure to provide a fresh one.

--- a/src/Metric.ts
+++ b/src/Metric.ts
@@ -394,7 +394,7 @@ export const sync: <Out>(evaluate: LazyArg<Out>) => Metric<void, unknown, Out> =
  *   maxAge: "60 seconds", // Retain observations for 60 seconds.
  *   maxSize: 1000, // Keep a maximum of 1000 observations.
  *   error: 0.01, // Allow a 1% error when calculating quantiles.
- *   quantiles: Chunk.make(0.5, 0.9, 0.99), // Calculate 50th, 90th, and 99th percentiles.
+ *   quantiles: [0.5, 0.9, 0.99], // Calculate 50th, 90th, and 99th percentiles.
  *   description: "Measures the distribution of response times."
  * });
  *

--- a/src/Metric.ts
+++ b/src/Metric.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as Chunk from "./Chunk.js"
 import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import type { LazyArg } from "./Function.js"
@@ -409,7 +408,7 @@ export const summary: (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
     readonly description?: string | undefined
   }
 ) => Metric.Summary<number> = internal.summary
@@ -424,7 +423,7 @@ export const summaryTimestamp: (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
     readonly description?: string | undefined
   }
 ) => Metric.Summary<readonly [value: number, timestamp: number]> // readonly because contravariant
@@ -498,7 +497,7 @@ export const timer: (
  */
 export const timerWithBoundaries: (
   name: string,
-  boundaries: Chunk.Chunk<number>,
+  boundaries: ReadonlyArray<number>,
   description?: string
 ) => Metric<MetricKeyType.MetricKeyType.Histogram, Duration.Duration, MetricState.MetricState.Histogram> =
   internal.timerWithBoundaries

--- a/src/Metric.ts
+++ b/src/Metric.ts
@@ -4,7 +4,6 @@
 import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import type { LazyArg } from "./Function.js"
-import type * as HashSet from "./HashSet.js"
 import * as fiberRuntime from "./internal/fiberRuntime.js"
 import * as internal from "./internal/metric.js"
 import type * as MetricBoundaries from "./MetricBoundaries.js"
@@ -55,8 +54,8 @@ export interface Metric<in out Type, in In, out Out> extends Metric.Variance<Typ
    * `MetricKeyType.Counter` or `MetricKeyType.Gauge`.
    */
   readonly keyType: Type
-  unsafeUpdate(input: In, extraTags: HashSet.HashSet<MetricLabel.MetricLabel>): void
-  unsafeValue(extraTags: HashSet.HashSet<MetricLabel.MetricLabel>): Out
+  unsafeUpdate(input: In, extraTags: ReadonlyArray<MetricLabel.MetricLabel>): void
+  unsafeValue(extraTags: ReadonlyArray<MetricLabel.MetricLabel>): Out
   register(): this
   <R, E, A extends In>(effect: Effect.Effect<R, E, A>): Effect.Effect<R, E, A>
 }
@@ -68,8 +67,8 @@ export interface Metric<in out Type, in In, out Out> extends Metric.Variance<Typ
 export interface MetricApply {
   <Type, In, Out>(
     keyType: Type,
-    unsafeUpdate: (input: In, extraTags: HashSet.HashSet<MetricLabel.MetricLabel>) => void,
-    unsafeValue: (extraTags: HashSet.HashSet<MetricLabel.MetricLabel>) => Out
+    unsafeUpdate: (input: In, extraTags: ReadonlyArray<MetricLabel.MetricLabel>) => void,
+    unsafeValue: (extraTags: ReadonlyArray<MetricLabel.MetricLabel>) => Out
   ): Metric<Type, In, Out>
 }
 
@@ -356,7 +355,7 @@ export const set: {
  * @since 2.0.0
  * @category getters
  */
-export const snapshot: Effect.Effect<never, never, HashSet.HashSet<MetricPair.MetricPair.Untyped>> = internal.snapshot
+export const snapshot: Effect.Effect<never, never, ReadonlyArray<MetricPair.MetricPair.Untyped>> = internal.snapshot
 
 /**
  * Creates a metric that ignores input and produces constant output.
@@ -722,7 +721,7 @@ export const zip: {
  * @since 2.0.0
  * @category unsafe
  */
-export const unsafeSnapshot: (_: void) => HashSet.HashSet<MetricPair.MetricPair.Untyped> = internal.unsafeSnapshot
+export const unsafeSnapshot: (_: void) => ReadonlyArray<MetricPair.MetricPair.Untyped> = internal.unsafeSnapshot
 
 /**
  * @since 2.0.0

--- a/src/MetricBoundaries.ts
+++ b/src/MetricBoundaries.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as Chunk from "./Chunk.js"
 import type * as Equal from "./Equal.js"
 import * as internal from "./internal/metric/boundaries.js"
 import type { Pipeable } from "./Pipeable.js"
@@ -24,7 +23,7 @@ export type MetricBoundariesTypeId = typeof MetricBoundariesTypeId
  */
 export interface MetricBoundaries extends Equal.Equal, Pipeable {
   readonly [MetricBoundariesTypeId]: MetricBoundariesTypeId
-  readonly values: Chunk.Chunk<number>
+  readonly values: ReadonlyArray<number>
 }
 
 /**
@@ -37,7 +36,7 @@ export const isMetricBoundaries: (u: unknown) => u is MetricBoundaries = interna
  * @since 2.0.0
  * @category constructors
  */
-export const fromChunk: (chunk: Chunk.Chunk<number>) => MetricBoundaries = internal.fromChunk
+export const fromIterable: (iterable: Iterable<number>) => MetricBoundaries = internal.fromIterable
 
 /**
  * A helper method to create histogram bucket boundaries for a histogram

--- a/src/MetricKey.ts
+++ b/src/MetricKey.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as Chunk from "./Chunk.js"
 import type * as Duration from "./Duration.js"
 import type * as Equal from "./Equal.js"
 import type * as HashSet from "./HashSet.js"
@@ -178,7 +177,7 @@ export const summary: (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
     readonly description?: string | undefined
   }
 ) => MetricKey.Summary = internal.summary

--- a/src/MetricKey.ts
+++ b/src/MetricKey.ts
@@ -207,10 +207,10 @@ export const tagged: {
  */
 export const taggedWithLabels: {
   (
-    extraTags: Iterable<MetricLabel.MetricLabel>
+    extraTags: ReadonlyArray<MetricLabel.MetricLabel>
   ): <Type extends MetricKeyType.MetricKeyType<any, any>>(self: MetricKey<Type>) => MetricKey<Type>
   <Type extends MetricKeyType.MetricKeyType<any, any>>(
     self: MetricKey<Type>,
-    extraTags: Iterable<MetricLabel.MetricLabel>
+    extraTags: ReadonlyArray<MetricLabel.MetricLabel>
   ): MetricKey<Type>
 } = internal.taggedWithLabels

--- a/src/MetricKey.ts
+++ b/src/MetricKey.ts
@@ -3,7 +3,6 @@
  */
 import type * as Duration from "./Duration.js"
 import type * as Equal from "./Equal.js"
-import type * as HashSet from "./HashSet.js"
 import * as internal from "./internal/metric/key.js"
 import type * as MetricBoundaries from "./MetricBoundaries.js"
 import type * as MetricKeyType from "./MetricKeyType.js"
@@ -40,7 +39,7 @@ export interface MetricKey<out Type extends MetricKeyType.MetricKeyType<any, any
   readonly name: string
   readonly keyType: Type
   readonly description: Option.Option<string>
-  readonly tags: HashSet.HashSet<MetricLabel.MetricLabel>
+  readonly tags: ReadonlyArray<MetricLabel.MetricLabel>
 }
 
 /**
@@ -215,19 +214,3 @@ export const taggedWithLabels: {
     extraTags: Iterable<MetricLabel.MetricLabel>
   ): MetricKey<Type>
 } = internal.taggedWithLabels
-
-/**
- * Returns a new `MetricKey` with the specified tags appended.
- *
- * @since 2.0.0
- * @category constructors
- */
-export const taggedWithLabelSet: {
-  (
-    extraTags: HashSet.HashSet<MetricLabel.MetricLabel>
-  ): <Type extends MetricKeyType.MetricKeyType<any, any>>(self: MetricKey<Type>) => MetricKey<Type>
-  <Type extends MetricKeyType.MetricKeyType<any, any>>(
-    self: MetricKey<Type>,
-    extraTags: HashSet.HashSet<MetricLabel.MetricLabel>
-  ): MetricKey<Type>
-} = internal.taggedWithLabelSet

--- a/src/MetricKeyType.ts
+++ b/src/MetricKeyType.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as Chunk from "./Chunk.js"
 import type * as Duration from "./Duration.js"
 import type * as Equal from "./Equal.js"
 import * as internal from "./internal/metric/keyType.js"
@@ -143,7 +142,7 @@ export declare namespace MetricKeyType {
     readonly maxAge: Duration.Duration
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
   }
 
   /**
@@ -217,7 +216,7 @@ export const summary: (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
   }
 ) => MetricKeyType.Summary = internal.summary
 

--- a/src/MetricRegistry.ts
+++ b/src/MetricRegistry.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as HashSet from "./HashSet.js"
 import * as internal from "./internal/metric/registry.js"
 import type * as MetricHook from "./MetricHook.js"
 import type * as MetricKey from "./MetricKey.js"
@@ -26,7 +25,7 @@ export type MetricRegistryTypeId = typeof MetricRegistryTypeId
  */
 export interface MetricRegistry {
   readonly [MetricRegistryTypeId]: MetricRegistryTypeId
-  snapshot(): HashSet.HashSet<MetricPair.MetricPair.Untyped>
+  snapshot(): ReadonlyArray<MetricPair.MetricPair.Untyped>
   get<Type extends MetricKeyType.MetricKeyType<any, any>>(
     key: MetricKey.MetricKey<Type>
   ): MetricHook.MetricHook<

--- a/src/MetricState.ts
+++ b/src/MetricState.ts
@@ -1,9 +1,7 @@
 /**
  * @since 2.0.0
  */
-import type * as Chunk from "./Chunk.js"
 import type * as Equal from "./Equal.js"
-import type * as HashMap from "./HashMap.js"
 import * as internal from "./internal/metric/state.js"
 import type * as MetricKeyType from "./MetricKeyType.js"
 import type * as Option from "./Option.js"
@@ -119,7 +117,7 @@ export declare namespace MetricState {
    */
   export interface Frequency extends MetricState<MetricKeyType.MetricKeyType.Frequency> {
     readonly [FrequencyStateTypeId]: FrequencyStateTypeId
-    readonly occurrences: HashMap.HashMap<string, number>
+    readonly occurrences: ReadonlyMap<string, number>
   }
 
   /**
@@ -137,7 +135,7 @@ export declare namespace MetricState {
    */
   export interface Histogram extends MetricState<MetricKeyType.MetricKeyType.Histogram> {
     readonly [HistogramStateTypeId]: HistogramStateTypeId
-    readonly buckets: Chunk.Chunk<readonly [number, number]>
+    readonly buckets: ReadonlyArray<readonly [number, number]>
     readonly count: number
     readonly min: number
     readonly max: number
@@ -151,7 +149,7 @@ export declare namespace MetricState {
   export interface Summary extends MetricState<MetricKeyType.MetricKeyType.Summary> {
     readonly [SummaryStateTypeId]: SummaryStateTypeId
     readonly error: number
-    readonly quantiles: Chunk.Chunk<readonly [number, Option.Option<number>]>
+    readonly quantiles: ReadonlyArray<readonly [number, Option.Option<number>]>
     readonly count: number
     readonly min: number
     readonly max: number
@@ -182,7 +180,7 @@ export const counter: {
  * @since 2.0.0
  * @category constructors
  */
-export const frequency: (occurrences: HashMap.HashMap<string, number>) => MetricState.Frequency = internal.frequency
+export const frequency: (occurrences: ReadonlyMap<string, number>) => MetricState.Frequency = internal.frequency
 
 /**
  * @since 2.0.0
@@ -199,7 +197,7 @@ export const gauge: {
  */
 export const histogram: (
   options: {
-    readonly buckets: Chunk.Chunk<readonly [number, number]>
+    readonly buckets: ReadonlyArray<readonly [number, number]>
     readonly count: number
     readonly min: number
     readonly max: number
@@ -214,7 +212,7 @@ export const histogram: (
 export const summary: (
   options: {
     readonly error: number
-    readonly quantiles: Chunk.Chunk<readonly [number, Option.Option<number>]>
+    readonly quantiles: ReadonlyArray<readonly [number, Option.Option<number>]>
     readonly count: number
     readonly min: number
     readonly max: number

--- a/src/MutableHashMap.ts
+++ b/src/MutableHashMap.ts
@@ -1,13 +1,14 @@
 /**
  * @since 2.0.0
  */
-import * as Dual from "./Function.js"
-import * as HashMap from "./HashMap.js"
+import * as Equal from "./Equal.js"
+import { dual } from "./Function.js"
+import * as Hash from "./Hash.js"
 import { format, type Inspectable, NodeInspectSymbol, toJSON } from "./Inspectable.js"
-import * as MutableRef from "./MutableRef.js"
 import * as Option from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import { pipeArguments } from "./Pipeable.js"
+import type { NonEmptyArray } from "./ReadonlyArray.js"
 
 const TypeId: unique symbol = Symbol.for("effect/MutableHashMap") as TypeId
 
@@ -23,15 +24,18 @@ export type TypeId = typeof TypeId
  */
 export interface MutableHashMap<out K, out V> extends Iterable<[K, V]>, Pipeable, Inspectable {
   readonly [TypeId]: TypeId
-
   /** @internal */
-  readonly backingMap: MutableRef.MutableRef<HashMap.HashMap<K, V>>
+  readonly referential: Map<K, V>
+  /** @internal */
+  readonly buckets: Map<number, NonEmptyArray<readonly [K & Equal.Equal, V]>>
+  /** @internal */
+  bucketsSize: number
 }
 
-const MutableHashMapProto: Omit<MutableHashMap<unknown, unknown>, "backingMap"> = {
+const MutableHashMapProto: Omit<MutableHashMap<unknown, unknown>, "referential" | "buckets" | "bucketsSize"> = {
   [TypeId]: TypeId,
   [Symbol.iterator](this: MutableHashMap<unknown, unknown>): Iterator<[unknown, unknown]> {
-    return this.backingMap.current[Symbol.iterator]()
+    return new MutableHashMapIterator(this)
   },
   toString() {
     return format(this.toJSON())
@@ -50,17 +54,61 @@ const MutableHashMapProto: Omit<MutableHashMap<unknown, unknown>, "backingMap"> 
   }
 }
 
-const fromHashMap = <K, V>(backingMap: HashMap.HashMap<K, V>): MutableHashMap<K, V> => {
-  const map = Object.create(MutableHashMapProto)
-  map.backingMap = MutableRef.make(backingMap)
-  return map
+class MutableHashMapIterator<K, V> implements IterableIterator<[K, V]> {
+  readonly referentialIterator: Iterator<[K, V]>
+  bucketIterator: Iterator<[K, V]> | undefined
+
+  constructor(readonly self: MutableHashMap<K, V>) {
+    this.referentialIterator = self.referential[Symbol.iterator]()
+  }
+  next(): IteratorResult<[K, V]> {
+    if (this.bucketIterator !== undefined) {
+      return this.bucketIterator.next()
+    }
+    const result = this.referentialIterator.next()
+    if (result.done) {
+      this.bucketIterator = new BucketIterator(this.self.buckets.values())
+      return this.next()
+    }
+    return result
+  }
+
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return new MutableHashMapIterator(this.self)
+  }
+}
+
+class BucketIterator<K, V> implements Iterator<[K, V]> {
+  constructor(readonly backing: Iterator<NonEmptyArray<readonly [K, V]>>) {}
+  currentBucket: Iterator<readonly [K, V]> | undefined
+  next(): IteratorResult<[K, V]> {
+    if (this.currentBucket === undefined) {
+      const result = this.backing.next()
+      if (result.done) {
+        return result
+      }
+      this.currentBucket = result.value[Symbol.iterator]()
+    }
+    const result = this.currentBucket.next()
+    if (result.done) {
+      this.currentBucket = undefined
+      return this.next()
+    }
+    return result as IteratorResult<[K, V]>
+  }
 }
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const empty = <K = never, V = never>(): MutableHashMap<K, V> => fromHashMap<K, V>(HashMap.empty())
+export const empty = <K, V>(): MutableHashMap<K, V> => {
+  const self = Object.create(MutableHashMapProto)
+  self.referential = new Map()
+  self.buckets = new Map()
+  self.bucketsSize = 0
+  return self
+}
 
 /**
  * @since 2.0.0
@@ -79,8 +127,13 @@ export const make: <Entries extends Array<readonly [any, any]>>(
  * @since 2.0.0
  * @category constructors
  */
-export const fromIterable = <K, V>(entries: Iterable<readonly [K, V]>): MutableHashMap<K, V> =>
-  fromHashMap(HashMap.fromIterable(entries))
+export const fromIterable = <K, V>(entries: Iterable<readonly [K, V]>): MutableHashMap<K, V> => {
+  const self = empty<K, V>()
+  for (const [key, value] of entries) {
+    set(self, key, value)
+  }
+  return self
+}
 
 /**
  * @since 2.0.0
@@ -89,10 +142,42 @@ export const fromIterable = <K, V>(entries: Iterable<readonly [K, V]>): MutableH
 export const get: {
   <K>(key: K): <V>(self: MutableHashMap<K, V>) => Option.Option<V>
   <K, V>(self: MutableHashMap<K, V>, key: K): Option.Option<V>
-} = Dual.dual<
+} = dual<
   <K>(key: K) => <V>(self: MutableHashMap<K, V>) => Option.Option<V>,
   <K, V>(self: MutableHashMap<K, V>, key: K) => Option.Option<V>
->(2, <K, V>(self: MutableHashMap<K, V>, key: K) => HashMap.get(self.backingMap.current, key))
+>(2, <K, V>(self: MutableHashMap<K, V>, key: K): Option.Option<V> => {
+  if (Equal.isEqual(key) === false) {
+    return self.referential.has(key) ? Option.some(self.referential.get(key)!) : Option.none()
+  }
+
+  const hash = key[Hash.symbol]()
+  const bucket = self.buckets.get(hash)
+  if (bucket === undefined) {
+    return Option.none()
+  }
+
+  return getFromBucket(self, bucket, key)
+})
+
+const getFromBucket = <K, V>(
+  self: MutableHashMap<K, V>,
+  bucket: NonEmptyArray<readonly [K & Equal.Equal, V]>,
+  key: K & Equal.Equal,
+  remove = false
+): Option.Option<V> => {
+  for (let i = 0, len = bucket.length; i < len; i++) {
+    if (key[Equal.symbol](bucket[i][0])) {
+      const value = bucket[i][1]
+      if (remove) {
+        bucket.splice(i, 1)
+        self.bucketsSize--
+      }
+      return Option.some(value)
+    }
+  }
+
+  return Option.none()
+}
 
 /**
  * @since 2.0.0
@@ -101,10 +186,53 @@ export const get: {
 export const has: {
   <K>(key: K): <V>(self: MutableHashMap<K, V>) => boolean
   <K, V>(self: MutableHashMap<K, V>, key: K): boolean
-} = Dual.dual<
+} = dual<
   <K>(key: K) => <V>(self: MutableHashMap<K, V>) => boolean,
   <K, V>(self: MutableHashMap<K, V>, key: K) => boolean
 >(2, (self, key) => Option.isSome(get(self, key)))
+
+/**
+ * @since 2.0.0
+ */
+export const set: {
+  <K, V>(key: K, value: V): (self: MutableHashMap<K, V>) => MutableHashMap<K, V>
+  <K, V>(self: MutableHashMap<K, V>, key: K, value: V): MutableHashMap<K, V>
+} = dual<
+  <K, V>(key: K, value: V) => (self: MutableHashMap<K, V>) => MutableHashMap<K, V>,
+  <K, V>(self: MutableHashMap<K, V>, key: K, value: V) => MutableHashMap<K, V>
+>(3, <K, V>(self: MutableHashMap<K, V>, key: K, value: V) => {
+  if (Equal.isEqual(key) === false) {
+    self.referential.set(key, value)
+    return self
+  }
+
+  const hash = key[Hash.symbol]()
+  const bucket = self.buckets.get(hash)
+  if (bucket === undefined) {
+    self.buckets.set(hash, [[key, value]])
+    self.bucketsSize++
+    return self
+  }
+
+  removeFromBucket(self, bucket, key)
+  bucket.push([key, value])
+  self.bucketsSize++
+  return self
+})
+
+const removeFromBucket = <K, V>(
+  self: MutableHashMap<K, V>,
+  bucket: NonEmptyArray<readonly [K & Equal.Equal, V]>,
+  key: K & Equal.Equal
+) => {
+  for (let i = 0, len = bucket.length; i < len; i++) {
+    if (key[Equal.symbol](bucket[i][0])) {
+      bucket.splice(i, 1)
+      self.bucketsSize--
+      return
+    }
+  }
+}
 
 /**
  * Updates the value of the specified key within the `MutableHashMap` if it exists.
@@ -114,16 +242,31 @@ export const has: {
 export const modify: {
   <K, V>(key: K, f: (v: V) => V): (self: MutableHashMap<K, V>) => MutableHashMap<K, V>
   <K, V>(self: MutableHashMap<K, V>, key: K, f: (v: V) => V): MutableHashMap<K, V>
-} = Dual.dual<
+} = dual<
   <K, V>(key: K, f: (v: V) => V) => (self: MutableHashMap<K, V>) => MutableHashMap<K, V>,
   <K, V>(self: MutableHashMap<K, V>, key: K, f: (v: V) => V) => MutableHashMap<K, V>
->(
-  3,
-  <K, V>(self: MutableHashMap<K, V>, key: K, f: (v: V) => V) => {
-    MutableRef.update(self.backingMap, HashMap.modify(key, f))
+>(3, <K, V>(self: MutableHashMap<K, V>, key: K, f: (v: V) => V) => {
+  if (Equal.isEqual(key) === false) {
+    if (self.referential.has(key)) {
+      self.referential.set(key, f(self.referential.get(key)!))
+    }
     return self
   }
-)
+
+  const hash = key[Hash.symbol]()
+  const bucket = self.buckets.get(hash)
+  if (bucket === undefined) {
+    return self
+  }
+
+  const value = getFromBucket(self, bucket, key, true)
+  if (Option.isNone(value)) {
+    return self
+  }
+  bucket.push([key, f(value.value)])
+  self.bucketsSize++
+  return self
+})
 
 /**
  * Set or remove the specified key in the `MutableHashMap` using the specified
@@ -134,7 +277,7 @@ export const modify: {
 export const modifyAt: {
   <K, V>(key: K, f: (value: Option.Option<V>) => Option.Option<V>): (self: MutableHashMap<K, V>) => MutableHashMap<K, V>
   <K, V>(self: MutableHashMap<K, V>, key: K, f: (value: Option.Option<V>) => Option.Option<V>): MutableHashMap<K, V>
-} = Dual.dual<
+} = dual<
   <K, V>(
     key: K,
     f: (value: Option.Option<V>) => Option.Option<V>
@@ -145,12 +288,32 @@ export const modifyAt: {
     f: (value: Option.Option<V>) => Option.Option<V>
   ) => MutableHashMap<K, V>
 >(3, (self, key, f) => {
-  const result = f(get(self, key))
-  if (Option.isSome(result)) {
-    set(self, key, result.value)
-  } else {
-    remove(self, key)
+  if (Equal.isEqual(key) === false) {
+    const result = f(get(self, key))
+    if (Option.isSome(result)) {
+      set(self, key, result.value)
+    } else {
+      remove(self, key)
+    }
+    return self
   }
+
+  const hash = key[Hash.symbol]()
+  const bucket = self.buckets.get(hash)
+  if (bucket === undefined) {
+    const result = f(Option.none())
+    return Option.isSome(result) ? set(self, key, result.value) : self
+  }
+
+  const result = f(getFromBucket(self, bucket, key, true))
+  if (Option.isNone(result)) {
+    if (bucket.length === 0) {
+      self.buckets.delete(hash)
+    }
+    return self
+  }
+  bucket.push([key, result.value])
+  self.bucketsSize++
   return self
 })
 
@@ -160,25 +323,24 @@ export const modifyAt: {
 export const remove: {
   <K>(key: K): <V>(self: MutableHashMap<K, V>) => MutableHashMap<K, V>
   <K, V>(self: MutableHashMap<K, V>, key: K): MutableHashMap<K, V>
-} = Dual.dual<
+} = dual<
   <K>(key: K) => <V>(self: MutableHashMap<K, V>) => MutableHashMap<K, V>,
   <K, V>(self: MutableHashMap<K, V>, key: K) => MutableHashMap<K, V>
 >(2, <K, V>(self: MutableHashMap<K, V>, key: K) => {
-  MutableRef.update(self.backingMap, HashMap.remove(key))
-  return self
-})
+  if (Equal.isEqual(key) === false) {
+    self.referential.delete(key)
+    return self
+  }
 
-/**
- * @since 2.0.0
- */
-export const set: {
-  <K, V>(key: K, value: V): (self: MutableHashMap<K, V>) => MutableHashMap<K, V>
-  <K, V>(self: MutableHashMap<K, V>, key: K, value: V): MutableHashMap<K, V>
-} = Dual.dual<
-  <K, V>(key: K, value: V) => (self: MutableHashMap<K, V>) => MutableHashMap<K, V>,
-  <K, V>(self: MutableHashMap<K, V>, key: K, value: V) => MutableHashMap<K, V>
->(3, <K, V>(self: MutableHashMap<K, V>, key: K, value: V) => {
-  MutableRef.update(self.backingMap, HashMap.set(key, value))
+  const hash = key[Hash.symbol]()
+  const bucket = self.buckets.get(hash)
+  if (bucket === undefined) {
+    return self
+  }
+  removeFromBucket(self, bucket, key)
+  if (bucket.length === 0) {
+    self.buckets.delete(hash)
+  }
   return self
 })
 
@@ -186,4 +348,6 @@ export const set: {
  * @since 2.0.0
  * @category elements
  */
-export const size = <K, V>(self: MutableHashMap<K, V>): number => HashMap.size(MutableRef.get(self.backingMap))
+export const size = <K, V>(self: MutableHashMap<K, V>): number => {
+  return self.referential.size + self.bucketsSize
+}

--- a/src/internal/core-effect.ts
+++ b/src/internal/core-effect.ts
@@ -1398,17 +1398,9 @@ export const tagMetrics = dual<
 export const labelMetrics = dual<
   (labels: Iterable<MetricLabel.MetricLabel>) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<R, E, A>,
   <R, E, A>(self: Effect.Effect<R, E, A>, labels: Iterable<MetricLabel.MetricLabel>) => Effect.Effect<R, E, A>
->(2, (self, labels) => labelMetricsSet(self, HashSet.fromIterable(labels)))
-
-/* @internal */
-export const labelMetricsSet = dual<
-  (labels: HashSet.HashSet<MetricLabel.MetricLabel>) => <R, E, A>(
-    self: Effect.Effect<R, E, A>
-  ) => Effect.Effect<R, E, A>,
-  <R, E, A>(self: Effect.Effect<R, E, A>, labels: HashSet.HashSet<MetricLabel.MetricLabel>) => Effect.Effect<R, E, A>
 >(
   2,
-  (self, labels) => core.fiberRefLocallyWith(core.currentMetricLabels, (set) => pipe(set, HashSet.union(labels)))(self)
+  (self, labels) => core.fiberRefLocallyWith(self, core.currentMetricLabels, (old) => ReadonlyArray.union(old, labels))
 )
 
 /* @internal */

--- a/src/internal/core.ts
+++ b/src/internal/core.ts
@@ -17,7 +17,7 @@ import { dual, identity, pipe } from "../Function.js"
 import { globalValue } from "../GlobalValue.js"
 import * as Hash from "../Hash.js"
 import * as HashMap from "../HashMap.js"
-import * as HashSet from "../HashSet.js"
+import type * as HashSet from "../HashSet.js"
 import { format, NodeInspectSymbol, toJSON } from "../Inspectable.js"
 import * as List from "../List.js"
 import type * as LogLevel from "../LogLevel.js"
@@ -1771,6 +1771,17 @@ export const fiberRefUnsafeMakeHashSet = <A>(
 }
 
 /** @internal */
+export const fiberRefUnsafeMakeReadonlyArray = <A>(
+  initial: ReadonlyArray<A>
+): FiberRef.FiberRef<ReadonlyArray<A>> => {
+  const differ = internalDiffer.readonlyArray(internalDiffer.update<A>())
+  return fiberRefUnsafeMakePatch(initial, {
+    differ,
+    fork: differ.empty
+  })
+}
+
+/** @internal */
 export const fiberRefUnsafeMakeContext = <A>(
   initial: Context.Context<A>
 ): FiberRef.FiberRef<Context.Context<A>> => {
@@ -1886,13 +1897,13 @@ export const withUnhandledErrorLogLevel = dual<
 >(2, (self, level) => fiberRefLocally(self, currentUnhandledErrorLogLevel, level))
 
 /** @internal */
-export const currentMetricLabels: FiberRef.FiberRef<HashSet.HashSet<MetricLabel.MetricLabel>> = globalValue(
+export const currentMetricLabels: FiberRef.FiberRef<ReadonlyArray<MetricLabel.MetricLabel>> = globalValue(
   Symbol.for("effect/FiberRef/currentMetricLabels"),
-  () => fiberRefUnsafeMakeHashSet(HashSet.empty())
+  () => fiberRefUnsafeMakeReadonlyArray(ReadonlyArray.empty())
 )
 
 /* @internal */
-export const metricLabels: Effect.Effect<never, never, HashSet.HashSet<MetricLabel.MetricLabel>> = fiberRefGet(
+export const metricLabels: Effect.Effect<never, never, ReadonlyArray<MetricLabel.MetricLabel>> = fiberRefGet(
   currentMetricLabels
 )
 

--- a/src/internal/differ.ts
+++ b/src/internal/differ.ts
@@ -12,6 +12,7 @@ import * as ContextPatch from "./differ/contextPatch.js"
 import * as HashMapPatch from "./differ/hashMapPatch.js"
 import * as HashSetPatch from "./differ/hashSetPatch.js"
 import * as OrPatch from "./differ/orPatch.js"
+import * as ReadonlyArrayPatch from "./differ/readonlyArrayPatch.js"
 
 /** @internal */
 export const DifferTypeId: Differ.TypeId = Symbol.for("effect/Differ") as Differ.TypeId
@@ -108,6 +109,17 @@ export const orElseEither = Dual.dual<
         right: that
       })
   }))
+
+/** @internal */
+export const readonlyArray = <Value, Patch>(
+  differ: Differ.Differ<Value, Patch>
+): Differ.Differ<ReadonlyArray<Value>, Differ.Differ.ReadonlyArray.Patch<Value, Patch>> =>
+  make({
+    empty: ReadonlyArrayPatch.empty(),
+    combine: (first, second) => ReadonlyArrayPatch.combine(first, second),
+    diff: (oldValue, newValue) => ReadonlyArrayPatch.diff({ oldValue, newValue, differ }),
+    patch: (patch, oldValue) => ReadonlyArrayPatch.patch(patch, oldValue, differ)
+  })
 
 /** @internal */
 export const transform = Dual.dual<

--- a/src/internal/differ/chunkPatch.ts
+++ b/src/internal/differ/chunkPatch.ts
@@ -170,6 +170,9 @@ export const patch = Dual.dual<
   oldValue: Chunk.Chunk<Value>,
   differ: Differ.Differ<Value, Patch>
 ) => {
+  if ((self as Instruction)._tag === "Empty") {
+    return oldValue
+  }
   let chunk = oldValue
   let patches: Chunk.Chunk<Differ.Differ.Chunk.Patch<Value, Patch>> = Chunk.of(self)
   while (Chunk.isNonEmpty(patches)) {

--- a/src/internal/differ/contextPatch.ts
+++ b/src/internal/differ/contextPatch.ts
@@ -177,6 +177,9 @@ export const patch = Dual.dual<
     context: Context<Input>
   ) => Context<Output>
 >(2, <Input, Output>(self: Differ.Context.Patch<Input, Output>, context: Context<Input>) => {
+  if ((self as Instruction)._tag === "Empty") {
+    return context as any
+  }
   let wasServiceUpdated = false
   let patches: Chunk.Chunk<Differ.Context.Patch<unknown, unknown>> = Chunk.of(
     self as Differ.Context.Patch<unknown, unknown>

--- a/src/internal/differ/hashMapPatch.ts
+++ b/src/internal/differ/hashMapPatch.ts
@@ -179,6 +179,9 @@ export const patch = Dual.dual<
   oldValue: HashMap.HashMap<Key, Value>,
   differ: Differ.Differ<Value, Patch>
 ) => {
+  if ((self as Instruction)._tag === "Empty") {
+    return oldValue
+  }
   let map = oldValue
   let patches: Chunk.Chunk<Differ.Differ.HashMap.Patch<Key, Value, Patch>> = Chunk.of(self)
   while (Chunk.isNonEmpty(patches)) {

--- a/src/internal/differ/hashSetPatch.ts
+++ b/src/internal/differ/hashSetPatch.ts
@@ -144,6 +144,9 @@ export const patch = Dual.dual<
   self: Differ.HashSet.Patch<Value>,
   oldValue: HashSet.HashSet<Value>
 ) => {
+  if ((self as Instruction)._tag === "Empty") {
+    return oldValue
+  }
   let set = oldValue
   let patches: Chunk.Chunk<Differ.HashSet.Patch<Value>> = Chunk.of(self)
   while (Chunk.isNonEmpty(patches)) {

--- a/src/internal/differ/orPatch.ts
+++ b/src/internal/differ/orPatch.ts
@@ -264,6 +264,9 @@ export const patch = Dual.dual<
     right: Differ<Value2, Patch2>
   }
 ) => {
+  if ((self as Instruction)._tag === "Empty") {
+    return oldValue
+  }
   let patches: Chunk.Chunk<Differ.Or.Patch<Value, Value2, Patch, Patch2>> = Chunk.of(self)
   let result = oldValue
   while (Chunk.isNonEmpty(patches)) {

--- a/src/internal/differ/readonlyArrayPatch.ts
+++ b/src/internal/differ/readonlyArrayPatch.ts
@@ -169,6 +169,9 @@ export const patch = Dual.dual<
   oldValue: ReadonlyArray<Value>,
   differ: Differ.Differ<Value, Patch>
 ) => {
+  if ((self as Instruction)._tag === "Empty") {
+    return oldValue
+  }
   let readonlyArray = oldValue.slice()
   let patches: Array<Differ.Differ.ReadonlyArray.Patch<Value, Patch>> = ReadonlyArray.of(self)
   while (ReadonlyArray.isNonEmptyArray(patches)) {

--- a/src/internal/differ/readonlyArrayPatch.ts
+++ b/src/internal/differ/readonlyArrayPatch.ts
@@ -1,0 +1,205 @@
+import type * as Differ from "../../Differ.js"
+import * as Equal from "../../Equal.js"
+import * as Dual from "../../Function.js"
+import * as ReadonlyArray from "../../ReadonlyArray.js"
+import * as Data from "../data.js"
+
+/** @internal */
+export const ReadonlyArrayPatchTypeId: Differ.Differ.ReadonlyArray.TypeId = Symbol.for(
+  "effect/DifferReadonlyArrayPatch"
+) as Differ.Differ.ReadonlyArray.TypeId
+
+function variance<A, B>(a: A): B {
+  return a as unknown as B
+}
+
+const PatchProto = {
+  ...Data.Structural.prototype,
+  [ReadonlyArrayPatchTypeId]: {
+    _Value: variance,
+    _Patch: variance
+  }
+}
+
+interface Empty<Value, Patch> extends Differ.Differ.ReadonlyArray.Patch<Value, Patch> {
+  readonly _tag: "Empty"
+}
+
+const EmptyProto = Object.assign(Object.create(PatchProto), {
+  _tag: "Empty"
+})
+
+const _empty = Object.create(EmptyProto)
+
+/**
+ * @internal
+ */
+export const empty = <Value, Patch>(): Differ.Differ.ReadonlyArray.Patch<Value, Patch> => _empty
+
+interface AndThen<Value, Patch> extends Differ.Differ.ReadonlyArray.Patch<Value, Patch> {
+  readonly _tag: "AndThen"
+  readonly first: Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+  readonly second: Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+}
+
+const AndThenProto = Object.assign(Object.create(PatchProto), {
+  _tag: "AndThen"
+})
+
+const makeAndThen = <Value, Patch>(
+  first: Differ.Differ.ReadonlyArray.Patch<Value, Patch>,
+  second: Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+): Differ.Differ.ReadonlyArray.Patch<Value, Patch> => {
+  const o = Object.create(AndThenProto)
+  o.first = first
+  o.second = second
+  return o
+}
+
+interface Append<Value, Patch> extends Differ.Differ.ReadonlyArray.Patch<Value, Patch> {
+  readonly _tag: "Append"
+  readonly values: ReadonlyArray<Value>
+}
+
+const AppendProto = Object.assign(Object.create(PatchProto), {
+  _tag: "Append"
+})
+
+const makeAppend = <Value, Patch>(values: ReadonlyArray<Value>): Differ.Differ.ReadonlyArray.Patch<Value, Patch> => {
+  const o = Object.create(AppendProto)
+  o.values = values
+  return o
+}
+
+interface Slice<Value, Patch> extends Differ.Differ.ReadonlyArray.Patch<Value, Patch> {
+  readonly _tag: "Slice"
+  readonly from: number
+  readonly until: number
+}
+
+const SliceProto = Object.assign(Object.create(PatchProto), {
+  _tag: "Slice"
+})
+
+const makeSlice = <Value, Patch>(from: number, until: number): Differ.Differ.ReadonlyArray.Patch<Value, Patch> => {
+  const o = Object.create(SliceProto)
+  o.from = from
+  o.until = until
+  return o
+}
+
+interface Update<Value, Patch> extends Differ.Differ.ReadonlyArray.Patch<Value, Patch> {
+  readonly _tag: "Update"
+  readonly index: number
+  readonly patch: Patch
+}
+
+const UpdateProto = Object.assign(Object.create(PatchProto), {
+  _tag: "Update"
+})
+
+const makeUpdate = <Value, Patch>(index: number, patch: Patch): Differ.Differ.ReadonlyArray.Patch<Value, Patch> => {
+  const o = Object.create(UpdateProto)
+  o.index = index
+  o.patch = patch
+  return o
+}
+
+type Instruction =
+  | Empty<any, any>
+  | AndThen<any, any>
+  | Append<any, any>
+  | Slice<any, any>
+  | Update<any, any>
+
+/** @internal */
+export const diff = <Value, Patch>(
+  options: {
+    readonly oldValue: ReadonlyArray<Value>
+    readonly newValue: ReadonlyArray<Value>
+    readonly differ: Differ.Differ<Value, Patch>
+  }
+): Differ.Differ.ReadonlyArray.Patch<Value, Patch> => {
+  let i = 0
+  let patch = empty<Value, Patch>()
+  while (i < options.oldValue.length && i < options.newValue.length) {
+    const oldElement = options.oldValue[i]!
+    const newElement = options.newValue[i]!
+    const valuePatch = options.differ.diff(oldElement, newElement)
+    if (!Equal.equals(valuePatch, options.differ.empty)) {
+      patch = combine(patch, makeUpdate(i, valuePatch))
+    }
+    i = i + 1
+  }
+  if (i < options.oldValue.length) {
+    patch = combine(patch, makeSlice(0, i))
+  }
+  if (i < options.newValue.length) {
+    patch = combine(patch, makeAppend(ReadonlyArray.drop(i)(options.newValue)))
+  }
+  return patch
+}
+
+/** @internal */
+export const combine = Dual.dual<
+  <Value, Patch>(
+    that: Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+  ) => (
+    self: Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+  ) => Differ.Differ.ReadonlyArray.Patch<Value, Patch>,
+  <Value, Patch>(
+    self: Differ.Differ.ReadonlyArray.Patch<Value, Patch>,
+    that: Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+  ) => Differ.Differ.ReadonlyArray.Patch<Value, Patch>
+>(2, (self, that) => makeAndThen(self, that))
+
+/** @internal */
+export const patch = Dual.dual<
+  <Value, Patch>(
+    oldValue: ReadonlyArray<Value>,
+    differ: Differ.Differ<Value, Patch>
+  ) => (self: Differ.Differ.ReadonlyArray.Patch<Value, Patch>) => ReadonlyArray<Value>,
+  <Value, Patch>(
+    self: Differ.Differ.ReadonlyArray.Patch<Value, Patch>,
+    oldValue: ReadonlyArray<Value>,
+    differ: Differ.Differ<Value, Patch>
+  ) => ReadonlyArray<Value>
+>(3, <Value, Patch>(
+  self: Differ.Differ.ReadonlyArray.Patch<Value, Patch>,
+  oldValue: ReadonlyArray<Value>,
+  differ: Differ.Differ<Value, Patch>
+) => {
+  let readonlyArray = oldValue.slice()
+  let patches: Array<Differ.Differ.ReadonlyArray.Patch<Value, Patch>> = ReadonlyArray.of(self)
+  while (ReadonlyArray.isNonEmptyArray(patches)) {
+    const head: Instruction = ReadonlyArray.headNonEmpty(patches) as Instruction
+    const tail = ReadonlyArray.tailNonEmpty(patches)
+    switch (head._tag) {
+      case "Empty": {
+        patches = tail
+        break
+      }
+      case "AndThen": {
+        tail.unshift(head.first, head.second)
+        patches = tail
+        break
+      }
+      case "Append": {
+        readonlyArray.push(...head.values)
+        patches = tail
+        break
+      }
+      case "Slice": {
+        readonlyArray = readonlyArray.slice(head.from, head.until)
+        patches = tail
+        break
+      }
+      case "Update": {
+        readonlyArray[head.index] = differ.patch(head.patch, readonlyArray[head.index]!)
+        patches = tail
+        break
+      }
+    }
+  }
+  return readonlyArray
+})

--- a/src/internal/fiberId.ts
+++ b/src/internal/fiberId.ts
@@ -265,5 +265,5 @@ export const toSet = (self: FiberId.FiberId): HashSet.HashSet<FiberId.Runtime> =
 export const unsafeMake = (): FiberId.Runtime => {
   const id = MutableRef.get(_fiberCounter)
   pipe(_fiberCounter, MutableRef.set(id + 1))
-  return new Runtime(id, new Date().getTime())
+  return new Runtime(id, Date.now())
 }

--- a/src/internal/fiberRefs/patch.ts
+++ b/src/internal/fiberRefs/patch.ts
@@ -111,7 +111,7 @@ export const patch = dual<
         break
       }
       case OP_ADD: {
-        fiberRefs = _fiberRefs.updatedAs(fiberRefs, {
+        fiberRefs = _fiberRefs.updateAs(fiberRefs, {
           fiberId,
           fiberRef: head.fiberRef,
           value: head.value
@@ -126,7 +126,7 @@ export const patch = dual<
       }
       case OP_UPDATE: {
         const value = _fiberRefs.getOrDefault(fiberRefs, head.fiberRef)
-        fiberRefs = _fiberRefs.updatedAs(fiberRefs, {
+        fiberRefs = _fiberRefs.updateAs(fiberRefs, {
           fiberId,
           fiberRef: head.fiberRef,
           value: head.fiberRef.patch(head.patch)(value)

--- a/src/internal/fiberRuntime.ts
+++ b/src/internal/fiberRuntime.ts
@@ -2596,14 +2596,9 @@ export const tagMetricsScoped = (key: string, value: string): Effect.Effect<Scop
 
 /* @internal */
 export const labelMetricsScoped = (
-  labels: ReadonlyArray<MetricLabel.MetricLabel>
-): Effect.Effect<Scope.Scope, never, void> => labelMetricsScopedSet(HashSet.fromIterable(labels))
-
-/* @internal */
-export const labelMetricsScopedSet = (
-  labels: HashSet.HashSet<MetricLabel.MetricLabel>
+  labels: Iterable<MetricLabel.MetricLabel>
 ): Effect.Effect<Scope.Scope, never, void> =>
-  fiberRefLocallyScopedWith(core.currentMetricLabels, (set) => pipe(set, HashSet.union(labels)))
+  fiberRefLocallyScopedWith(core.currentMetricLabels, (old) => RA.union(old, labels))
 
 /* @internal */
 export const using = dual<

--- a/src/internal/fiberRuntime.ts
+++ b/src/internal/fiberRuntime.ts
@@ -126,6 +126,14 @@ const absurd = (_: never): never => {
   )
 }
 
+const YieldedOp = Symbol.for("effect/internal/fiberRuntime/YieldedOp")
+type YieldedOp = typeof YieldedOp
+const yieldedOpChannel: {
+  currentOp: core.Primitive | null
+} = globalValue("effect/internal/fiberRuntime/yieldedOpChannel", () => ({
+  currentOp: null
+}))
+
 const contOpSuccess = {
   [OpCodes.OP_ON_SUCCESS]: (
     _: FiberRuntime<any, any>,
@@ -539,7 +547,7 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
    * **NOTE**: This method must be invoked by the fiber itself.
    */
   setFiberRef<X>(fiberRef: FiberRef.FiberRef<X>, value: X): void {
-    this._fiberRefs = fiberRefs.updatedAs(this._fiberRefs, {
+    this._fiberRefs = fiberRefs.updateAs(this._fiberRefs, {
       fiberId: this._fiberId,
       fiberRef,
       value
@@ -745,7 +753,7 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
     if (_runtimeFlags.runtimeMetrics(this._runtimeFlags)) {
       const tags = this.getFiberRef(core.currentMetricLabels)
       const startTimeMillis = this.id().startTimeMillis
-      const endTimeMillis = new Date().getTime()
+      const endTimeMillis = Date.now()
       fiberLifetimes.unsafeUpdate(endTimeMillis - startTimeMillis, tags)
       fiberActive.unsafeUpdate(-1, tags)
       switch (exit._tag) {
@@ -867,9 +875,24 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
           core.exitFailCause(this.getInterruptedCause()) :
           effect0
       while (effect !== null) {
-        try {
-          const eff: Effect.Effect<any, any, any> = effect
-          const exit = this.runLoop(eff)
+        const eff: Effect.Effect<any, any, any> = effect
+        const exit = this.runLoop(eff)
+        if (exit === YieldedOp) {
+          const op = yieldedOpChannel.currentOp!
+          yieldedOpChannel.currentOp = null
+          if (op._op === OpCodes.OP_YIELD) {
+            if (_runtimeFlags.cooperativeYielding(this._runtimeFlags)) {
+              this.tell(FiberMessage.yieldNow())
+              this.tell(FiberMessage.resume(core.exitUnit))
+              effect = null
+            } else {
+              effect = core.exitUnit
+            }
+          } else if (op._op === OpCodes.OP_ASYNC) {
+            // Terminate this evaluation, async resumption will continue evaluation:
+            effect = null
+          }
+        } else {
           this._runtimeFlags = pipe(this._runtimeFlags, _runtimeFlags.enable(_runtimeFlags.WindDown))
           const interruption = this.interruptAllChildren()
           if (interruption !== null) {
@@ -885,23 +908,6 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
               this.tell(FiberMessage.resume(exit))
             }
             effect = null
-          }
-        } catch (e) {
-          if (core.isEffect(e)) {
-            if ((e as core.Primitive)._op === OpCodes.OP_YIELD) {
-              if (_runtimeFlags.cooperativeYielding(this._runtimeFlags)) {
-                this.tell(FiberMessage.yieldNow())
-                this.tell(FiberMessage.resume(core.exitUnit))
-                effect = null
-              } else {
-                effect = core.exitUnit
-              }
-            } else if ((e as core.Primitive)._op === OpCodes.OP_ASYNC) {
-              // Terminate this evaluation, async resumption will continue evaluation:
-              effect = null
-            }
-          } else {
-            throw e
           }
         }
       }
@@ -1065,7 +1071,8 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
       // @ts-expect-error
       return contOpSuccess[cont._op](this, cont, value)
     } else {
-      throw core.exitSucceed(value)
+      yieldedOpChannel.currentOp = core.exitSucceed(value) as any
+      return YieldedOp
     }
   }
 
@@ -1080,7 +1087,8 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
       // @ts-expect-error
       return contOpSuccess[cont._op](this, cont, oldCur.i0)
     } else {
-      throw oldCur
+      yieldedOpChannel.currentOp = oldCur
+      return YieldedOp
     }
   }
 
@@ -1117,7 +1125,8 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
         }
       }
     } else {
-      throw core.exitFailCause(cause)
+      yieldedOpChannel.currentOp = core.exitFailCause(cause) as any
+      return YieldedOp
     }
   }
 
@@ -1216,12 +1225,14 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
   [OpCodes.OP_ASYNC](op: core.Primitive & { _op: OpCodes.OP_ASYNC }) {
     this._asyncBlockingOn = op.i1
     this.initiateAsync(this._runtimeFlags, op.i0)
-    throw op
+    yieldedOpChannel.currentOp = op
+    return YieldedOp
   }
 
   [OpCodes.OP_YIELD](op: core.Primitive & { op: OpCodes.OP_YIELD }) {
     this.isYielding = false
-    throw op
+    yieldedOpChannel.currentOp = op
+    return YieldedOp
   }
 
   [OpCodes.OP_WHILE](op: core.Primitive & { _op: OpCodes.OP_WHILE }) {
@@ -1244,8 +1255,8 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
    *
    * **NOTE**: This method must be invoked by the fiber itself.
    */
-  runLoop(effect0: Effect.Effect<any, any, any>): Exit.Exit<any, any> {
-    let cur = effect0
+  runLoop(effect0: Effect.Effect<any, any, any>): Exit.Exit<any, any> | YieldedOp {
+    let cur: Effect.Effect<any, any, any> | YieldedOp = effect0
     this.currentOpCount = 0
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -1286,22 +1297,26 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
           },
           this
         )
-      } catch (e) {
-        if (core.isEffect(e)) {
+
+        if (cur === YieldedOp) {
+          const op = yieldedOpChannel.currentOp!
           if (
-            (e as core.Primitive)._op === OpCodes.OP_YIELD ||
-            (e as core.Primitive)._op === OpCodes.OP_ASYNC
+            op._op === OpCodes.OP_YIELD ||
+            op._op === OpCodes.OP_ASYNC
           ) {
-            throw e
-          } else if (
-            (e as core.Primitive)._op === OpCodes.OP_SUCCESS ||
-            (e as core.Primitive)._op === OpCodes.OP_FAILURE
-          ) {
-            return e as Exit.Exit<E, A>
-          } else {
-            cur = core.exitFailCause(internalCause.die(e))
+            return YieldedOp
           }
-        } else if (core.isEffectError(e)) {
+
+          yieldedOpChannel.currentOp = null
+          return (
+              op._op === OpCodes.OP_SUCCESS ||
+              op._op === OpCodes.OP_FAILURE
+            ) ?
+            op as unknown as Exit.Exit<E, A> :
+            core.exitFailCause(internalCause.die(op))
+        }
+      } catch (e) {
+        if (core.isEffectError(e)) {
           cur = core.exitFailCause(e.cause)
         } else if (core.isInterruptedException(e)) {
           cur = core.exitFailCause(

--- a/src/internal/fiberRuntime.ts
+++ b/src/internal/fiberRuntime.ts
@@ -744,6 +744,9 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
   reportExitValue(exit: Exit.Exit<E, A>) {
     if (_runtimeFlags.runtimeMetrics(this._runtimeFlags)) {
       const tags = this.getFiberRef(core.currentMetricLabels)
+      const startTimeMillis = this.id().startTimeMillis
+      const endTimeMillis = new Date().getTime()
+      fiberLifetimes.unsafeUpdate(endTimeMillis - startTimeMillis, tags)
       fiberActive.unsafeUpdate(-1, tags)
       switch (exit._tag) {
         case OpCodes.OP_SUCCESS: {
@@ -766,16 +769,7 @@ export class FiberRuntime<in out E, in out A> implements Fiber.RuntimeFiber<E, A
 
   setExitValue(exit: Exit.Exit<E, A>) {
     this._exitValue = exit
-
-    if (_runtimeFlags.runtimeMetrics(this._runtimeFlags)) {
-      const tags = this.getFiberRef(core.currentMetricLabels)
-      const startTimeMillis = this.id().startTimeMillis
-      const endTimeMillis = new Date().getTime()
-      fiberLifetimes.unsafeUpdate(endTimeMillis - startTimeMillis, tags)
-    }
-
     this.reportExitValue(exit)
-
     for (let i = this._observers.length - 1; i >= 0; i--) {
       this._observers[i](exit)
     }

--- a/src/internal/metric.ts
+++ b/src/internal/metric.ts
@@ -1,4 +1,3 @@
-import type * as Chunk from "../Chunk.js"
 import * as Clock from "../Clock.js"
 import * as Duration from "../Duration.js"
 import type * as Effect from "../Effect.js"
@@ -218,7 +217,7 @@ export const summary = (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
     readonly description?: string | undefined
   }
 ): Metric.Metric.Summary<number> => withNow(summaryTimestamp(options))
@@ -230,7 +229,7 @@ export const summaryTimestamp = (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
     readonly description?: string | undefined
   }
 ): Metric.Metric.Summary<readonly [value: number, timestamp: number]> => fromMetricKey(metricKey.summary(options))
@@ -300,7 +299,7 @@ export const timer = (name: string, description?: string): Metric.Metric<
 /** @internal */
 export const timerWithBoundaries = (
   name: string,
-  boundaries: Chunk.Chunk<number>,
+  boundaries: ReadonlyArray<number>,
   description?: string
 ): Metric.Metric<
   MetricKeyType.MetricKeyType.Histogram,
@@ -308,7 +307,7 @@ export const timerWithBoundaries = (
   MetricState.MetricState.Histogram
 > => {
   const base = pipe(
-    histogram(name, metricBoundaries.fromChunk(boundaries), description),
+    histogram(name, metricBoundaries.fromIterable(boundaries), description),
     tagged("time_unit", "milliseconds")
   )
   return mapInput(base, Duration.toMillis)

--- a/src/internal/metric.ts
+++ b/src/internal/metric.ts
@@ -118,7 +118,7 @@ export const fromMetricKey = <Type extends MetricKeyType.MetricKeyType<any, any>
   MetricKeyType.MetricKeyType.InType<Type>,
   MetricKeyType.MetricKeyType.OutType<Type>
 > => {
-  let untaggedHook_:
+  let untaggedHook:
     | MetricHook.MetricHook<
       MetricKeyType.MetricKeyType.InType<Type>,
       MetricKeyType.MetricKeyType.OutType<Type>
@@ -131,11 +131,11 @@ export const fromMetricKey = <Type extends MetricKeyType.MetricKeyType<any, any>
     MetricKeyType.MetricKeyType.OutType<Type>
   > => {
     if (extraTags.length === 0) {
-      if (untaggedHook_ !== undefined) {
-        return untaggedHook_
+      if (untaggedHook !== undefined) {
+        return untaggedHook
       }
-      untaggedHook_ = globalMetricRegistry.get(key)
-      return untaggedHook_
+      untaggedHook = globalMetricRegistry.get(key)
+      return untaggedHook
     }
 
     let hook = hookCache.get(extraTags)

--- a/src/internal/metric/boundaries.ts
+++ b/src/internal/metric/boundaries.ts
@@ -18,7 +18,7 @@ export const MetricBoundariesTypeId: MetricBoundaries.MetricBoundariesTypeId = S
 /** @internal */
 class MetricBoundariesImpl implements MetricBoundaries.MetricBoundaries {
   readonly [MetricBoundariesTypeId]: MetricBoundaries.MetricBoundariesTypeId = MetricBoundariesTypeId
-  constructor(readonly values: Chunk.Chunk<number>) {}
+  constructor(readonly values: ReadonlyArray<number>) {}
   [Hash.symbol](): number {
     return pipe(
       Hash.hash(MetricBoundariesSymbolKey),
@@ -38,11 +38,11 @@ export const isMetricBoundaries = (u: unknown): u is MetricBoundaries.MetricBoun
   hasProperty(u, MetricBoundariesTypeId)
 
 /** @internal */
-export const fromChunk = (chunk: Chunk.Chunk<number>): MetricBoundaries.MetricBoundaries => {
+export const fromIterable = (iterable: Iterable<number>): MetricBoundaries.MetricBoundaries => {
   const values = pipe(
-    chunk,
-    Chunk.appendAll(Chunk.of(Number.POSITIVE_INFINITY)),
-    Chunk.dedupe
+    iterable,
+    ReadonlyArray.appendAll(Chunk.of(Number.POSITIVE_INFINITY)),
+    ReadonlyArray.dedupe
   )
   return new MetricBoundariesImpl(values)
 }
@@ -56,7 +56,7 @@ export const linear = (options: {
   pipe(
     ReadonlyArray.makeBy(options.count - 1, (i) => options.start + i * options.width),
     Chunk.unsafeFromArray,
-    fromChunk
+    fromIterable
   )
 
 /** @internal */
@@ -68,5 +68,5 @@ export const exponential = (options: {
   pipe(
     ReadonlyArray.makeBy(options.count - 1, (i) => options.start * Math.pow(options.factor, i)),
     Chunk.unsafeFromArray,
-    fromChunk
+    fromIterable
   )

--- a/src/internal/metric/boundaries.ts
+++ b/src/internal/metric/boundaries.ts
@@ -18,12 +18,15 @@ export const MetricBoundariesTypeId: MetricBoundaries.MetricBoundariesTypeId = S
 /** @internal */
 class MetricBoundariesImpl implements MetricBoundaries.MetricBoundaries {
   readonly [MetricBoundariesTypeId]: MetricBoundaries.MetricBoundariesTypeId = MetricBoundariesTypeId
-  constructor(readonly values: ReadonlyArray<number>) {}
-  [Hash.symbol](): number {
-    return pipe(
-      Hash.hash(MetricBoundariesSymbolKey),
-      Hash.combine(Hash.hash(this.values))
+  constructor(readonly values: ReadonlyArray<number>) {
+    this._hash = pipe(
+      Hash.string(MetricBoundariesSymbolKey),
+      Hash.combine(Hash.array(this.values))
     )
+  }
+  readonly _hash: number;
+  [Hash.symbol](): number {
+    return this._hash
   }
   [Equal.symbol](u: unknown): boolean {
     return isMetricBoundaries(u) && Equal.equals(this.values, u.values)

--- a/src/internal/metric/key.ts
+++ b/src/internal/metric/key.ts
@@ -36,14 +36,16 @@ class MetricKeyImpl<out Type extends MetricKeyType.MetricKeyType<any, any>> impl
     readonly keyType: Type,
     readonly description: Option.Option<string>,
     readonly tags: ReadonlyArray<MetricLabel.MetricLabel> = []
-  ) {}
-  [Hash.symbol](): number {
-    return pipe(
-      Hash.hash(this.name),
+  ) {
+    this._hash = pipe(
+      Hash.string(this.name + this.description),
       Hash.combine(Hash.hash(this.keyType)),
-      Hash.combine(Hash.hash(this.description)),
       Hash.combine(Hash.array(this.tags))
     )
+  }
+  readonly _hash: number;
+  [Hash.symbol](): number {
+    return this._hash
   }
   [Equal.symbol](u: unknown): boolean {
     return isMetricKey(u) &&

--- a/src/internal/metric/key.ts
+++ b/src/internal/metric/key.ts
@@ -148,17 +148,15 @@ export const tagged = dual<
 /** @internal */
 export const taggedWithLabels = dual<
   (
-    extraTags: Iterable<MetricLabel.MetricLabel>
+    extraTags: ReadonlyArray<MetricLabel.MetricLabel>
   ) => <Type extends MetricKeyType.MetricKeyType<any, any>>(
     self: MetricKey.MetricKey<Type>
   ) => MetricKey.MetricKey<Type>,
   <Type extends MetricKeyType.MetricKeyType<any, any>>(
     self: MetricKey.MetricKey<Type>,
-    extraTags: Iterable<MetricLabel.MetricLabel>
+    extraTags: ReadonlyArray<MetricLabel.MetricLabel>
   ) => MetricKey.MetricKey<Type>
->(2, (self, extraTags) => {
-  const arr = ReadonlyArray.fromIterable(extraTags)
-  return arr.length === 0
+>(2, (self, extraTags) =>
+  extraTags.length === 0
     ? self
-    : new MetricKeyImpl(self.name, self.keyType, self.description, ReadonlyArray.union(self.tags, arr))
-})
+    : new MetricKeyImpl(self.name, self.keyType, self.description, ReadonlyArray.union(self.tags, extraTags)))

--- a/src/internal/metric/key.ts
+++ b/src/internal/metric/key.ts
@@ -1,4 +1,3 @@
-import type * as Chunk from "../../Chunk.js"
 import type * as Duration from "../../Duration.js"
 import * as Equal from "../../Equal.js"
 import { dual, pipe } from "../../Function.js"
@@ -119,7 +118,7 @@ export const summary = (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
     readonly description?: string | undefined
   }
 ): MetricKey.MetricKey.Summary =>

--- a/src/internal/metric/keyType.ts
+++ b/src/internal/metric/keyType.ts
@@ -66,9 +66,12 @@ const metricKeyTypeVariance = {
 class CounterKeyType<A extends (number | bigint)> implements MetricKeyType.MetricKeyType.Counter<A> {
   readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
   readonly [CounterKeyTypeTypeId]: MetricKeyType.CounterKeyTypeTypeId = CounterKeyTypeTypeId
-  constructor(readonly incremental: boolean, readonly bigint: boolean) {}
+  constructor(readonly incremental: boolean, readonly bigint: boolean) {
+    this._hash = Hash.string(CounterKeyTypeSymbolKey)
+  }
+  readonly _hash: number;
   [Hash.symbol](): number {
-    return Hash.hash(CounterKeyTypeSymbolKey)
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isCounterKey(that)
@@ -81,9 +84,10 @@ class CounterKeyType<A extends (number | bigint)> implements MetricKeyType.Metri
 /** @internal */
 class FrequencyKeyType implements MetricKeyType.MetricKeyType.Frequency {
   readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
-  readonly [FrequencyKeyTypeTypeId]: MetricKeyType.FrequencyKeyTypeTypeId = FrequencyKeyTypeTypeId;
+  readonly [FrequencyKeyTypeTypeId]: MetricKeyType.FrequencyKeyTypeTypeId = FrequencyKeyTypeTypeId
+  readonly _hash = Hash.string(FrequencyKeyTypeSymbolKey);
   [Hash.symbol](): number {
-    return Hash.hash(FrequencyKeyTypeSymbolKey)
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isFrequencyKey(that)
@@ -98,8 +102,9 @@ class GaugeKeyType<A extends (number | bigint)> implements MetricKeyType.MetricK
   readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
   readonly [GaugeKeyTypeTypeId]: MetricKeyType.GaugeKeyTypeTypeId = GaugeKeyTypeTypeId
   constructor(readonly bigint: boolean) {}
+  readonly _hash = Hash.string(GaugeKeyTypeSymbolKey);
   [Hash.symbol](): number {
-    return Hash.hash(GaugeKeyTypeSymbolKey)
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isGaugeKey(that)
@@ -116,12 +121,15 @@ class GaugeKeyType<A extends (number | bigint)> implements MetricKeyType.MetricK
 export class HistogramKeyType implements MetricKeyType.MetricKeyType.Histogram {
   readonly [MetricKeyTypeTypeId] = metricKeyTypeVariance
   readonly [HistogramKeyTypeTypeId]: MetricKeyType.HistogramKeyTypeTypeId = HistogramKeyTypeTypeId
-  constructor(readonly boundaries: MetricBoundaries.MetricBoundaries) {}
-  [Hash.symbol](): number {
-    return pipe(
-      Hash.hash(HistogramKeyTypeSymbolKey),
+  constructor(readonly boundaries: MetricBoundaries.MetricBoundaries) {
+    this._hash = pipe(
+      Hash.string(HistogramKeyTypeSymbolKey),
       Hash.combine(Hash.hash(this.boundaries))
     )
+  }
+  readonly _hash: number;
+  [Hash.symbol](): number {
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isHistogramKey(that) && Equal.equals(this.boundaries, that.boundaries)
@@ -140,15 +148,18 @@ class SummaryKeyType implements MetricKeyType.MetricKeyType.Summary {
     readonly maxSize: number,
     readonly error: number,
     readonly quantiles: ReadonlyArray<number>
-  ) {}
-  [Hash.symbol](): number {
-    return pipe(
-      Hash.hash(SummaryKeyTypeSymbolKey),
+  ) {
+    this._hash = pipe(
+      Hash.string(SummaryKeyTypeSymbolKey),
       Hash.combine(Hash.hash(this.maxAge)),
       Hash.combine(Hash.hash(this.maxSize)),
       Hash.combine(Hash.hash(this.error)),
-      Hash.combine(Hash.hash(this.quantiles))
+      Hash.combine(Hash.array(this.quantiles))
     )
+  }
+  readonly _hash: number;
+  [Hash.symbol](): number {
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isSummaryKey(that) &&

--- a/src/internal/metric/keyType.ts
+++ b/src/internal/metric/keyType.ts
@@ -1,4 +1,3 @@
-import type * as Chunk from "../../Chunk.js"
 import * as Duration from "../../Duration.js"
 import * as Equal from "../../Equal.js"
 import { pipe } from "../../Function.js"
@@ -140,7 +139,7 @@ class SummaryKeyType implements MetricKeyType.MetricKeyType.Summary {
     readonly maxAge: Duration.Duration,
     readonly maxSize: number,
     readonly error: number,
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
   ) {}
   [Hash.symbol](): number {
     return pipe(
@@ -210,7 +209,7 @@ export const summary = (
     readonly maxAge: Duration.DurationInput
     readonly maxSize: number
     readonly error: number
-    readonly quantiles: Chunk.Chunk<number>
+    readonly quantiles: ReadonlyArray<number>
   }
 ): MetricKeyType.MetricKeyType.Summary => {
   return new SummaryKeyType(Duration.decode(options.maxAge), options.maxSize, options.error, options.quantiles)

--- a/src/internal/metric/label.ts
+++ b/src/internal/metric/label.ts
@@ -1,5 +1,4 @@
 import * as Equal from "../../Equal.js"
-import { pipe } from "../../Function.js"
 import * as Hash from "../../Hash.js"
 import type * as MetricLabel from "../../MetricLabel.js"
 import { pipeArguments } from "../../Pipeable.js"
@@ -16,13 +15,12 @@ export const MetricLabelTypeId: MetricLabel.MetricLabelTypeId = Symbol.for(
 /** @internal */
 class MetricLabelImpl implements MetricLabel.MetricLabel {
   readonly [MetricLabelTypeId]: MetricLabel.MetricLabelTypeId = MetricLabelTypeId
-  constructor(readonly key: string, readonly value: string) {}
+  readonly _hash: number
+  constructor(readonly key: string, readonly value: string) {
+    this._hash = Hash.string(MetricLabelSymbolKey + this.key + this.value)
+  }
   [Hash.symbol](): number {
-    return pipe(
-      Hash.string(MetricLabelSymbolKey),
-      Hash.combine(Hash.string(this.key)),
-      Hash.combine(Hash.string(this.value))
-    )
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isMetricLabel(that) &&

--- a/src/internal/metric/label.ts
+++ b/src/internal/metric/label.ts
@@ -19,9 +19,9 @@ class MetricLabelImpl implements MetricLabel.MetricLabel {
   constructor(readonly key: string, readonly value: string) {}
   [Hash.symbol](): number {
     return pipe(
-      Hash.hash(MetricLabelSymbolKey),
-      Hash.combine(Hash.hash(this.key)),
-      Hash.combine(Hash.hash(this.value))
+      Hash.string(MetricLabelSymbolKey),
+      Hash.combine(Hash.string(this.key)),
+      Hash.combine(Hash.string(this.value))
     )
   }
   [Equal.symbol](that: unknown): boolean {

--- a/src/internal/metric/registry.ts
+++ b/src/internal/metric/registry.ts
@@ -1,5 +1,4 @@
 import { pipe } from "../../Function.js"
-import * as HashSet from "../../HashSet.js"
 import type * as MetricHook from "../../MetricHook.js"
 import type * as MetricKey from "../../MetricKey.js"
 import type * as MetricKeyType from "../../MetricKeyType.js"
@@ -28,12 +27,12 @@ class MetricRegistryImpl implements MetricRegistry.MetricRegistry {
     MetricHook.MetricHook.Root
   >()
 
-  snapshot(): HashSet.HashSet<MetricPair.MetricPair.Untyped> {
+  snapshot(): ReadonlyArray<MetricPair.MetricPair.Untyped> {
     const result: Array<MetricPair.MetricPair.Untyped> = []
     for (const [key, hook] of this.map) {
       result.push(metricPair.unsafeMake(key, hook.get()))
     }
-    return HashSet.fromIterable(result)
+    return result
   }
 
   get<Type extends MetricKeyType.MetricKeyType<any, any>>(

--- a/src/internal/metric/state.ts
+++ b/src/internal/metric/state.ts
@@ -5,6 +5,7 @@ import type * as MetricState from "../../MetricState.js"
 import type * as Option from "../../Option.js"
 import { pipeArguments } from "../../Pipeable.js"
 import { hasProperty } from "../../Predicate.js"
+import * as ReadonlyArray from "../../ReadonlyArray.js"
 
 /** @internal */
 const MetricStateSymbolKey = "effect/MetricState"
@@ -78,6 +79,8 @@ class CounterState<A extends (number | bigint)> implements MetricState.MetricSta
   }
 }
 
+const arrayEquals = ReadonlyArray.getEquivalence(Equal.equals)
+
 /** @internal */
 class FrequencyState implements MetricState.MetricState.Frequency {
   readonly [MetricStateTypeId] = metricStateVariance
@@ -86,11 +89,14 @@ class FrequencyState implements MetricState.MetricState.Frequency {
   [Hash.symbol](): number {
     return pipe(
       Hash.hash(FrequencyStateSymbolKey),
-      Hash.combine(Hash.structure(Object.fromEntries(Array.from(this.occurrences.entries()))))
+      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.occurrences.entries())))
     )
   }
   [Equal.symbol](that: unknown): boolean {
-    return isFrequencyState(that) && Equal.equals(this.occurrences, that.occurrences)
+    return isFrequencyState(that) && arrayEquals(
+      ReadonlyArray.fromIterable(this.occurrences.entries()),
+      ReadonlyArray.fromIterable(that.occurrences.entries())
+    )
   }
   pipe() {
     return pipeArguments(this, arguments)

--- a/src/internal/metric/state.ts
+++ b/src/internal/metric/state.ts
@@ -86,11 +86,16 @@ class FrequencyState implements MetricState.MetricState.Frequency {
   readonly [MetricStateTypeId] = metricStateVariance
   readonly [FrequencyStateTypeId]: MetricState.FrequencyStateTypeId = FrequencyStateTypeId
   constructor(readonly occurrences: ReadonlyMap<string, number>) {}
+  _hash: number | undefined;
   [Hash.symbol](): number {
-    return pipe(
-      Hash.hash(FrequencyStateSymbolKey),
+    if (this._hash !== undefined) {
+      return this._hash
+    }
+    this._hash = pipe(
+      Hash.string(FrequencyStateSymbolKey),
       Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.occurrences.entries())))
     )
+    return this._hash
   }
   [Equal.symbol](that: unknown): boolean {
     return isFrequencyState(that) && arrayEquals(

--- a/src/internal/metric/state.ts
+++ b/src/internal/metric/state.ts
@@ -1,8 +1,6 @@
-import type * as Chunk from "../../Chunk.js"
 import * as Equal from "../../Equal.js"
 import { pipe } from "../../Function.js"
 import * as Hash from "../../Hash.js"
-import type * as HashMap from "../../HashMap.js"
 import type * as MetricState from "../../MetricState.js"
 import type * as Option from "../../Option.js"
 import { pipeArguments } from "../../Pipeable.js"
@@ -84,11 +82,11 @@ class CounterState<A extends (number | bigint)> implements MetricState.MetricSta
 class FrequencyState implements MetricState.MetricState.Frequency {
   readonly [MetricStateTypeId] = metricStateVariance
   readonly [FrequencyStateTypeId]: MetricState.FrequencyStateTypeId = FrequencyStateTypeId
-  constructor(readonly occurrences: HashMap.HashMap<string, number>) {}
+  constructor(readonly occurrences: ReadonlyMap<string, number>) {}
   [Hash.symbol](): number {
     return pipe(
       Hash.hash(FrequencyStateSymbolKey),
-      Hash.combine(Hash.hash(this.occurrences))
+      Hash.combine(Hash.structure(Object.fromEntries(Array.from(this.occurrences.entries()))))
     )
   }
   [Equal.symbol](that: unknown): boolean {
@@ -123,7 +121,7 @@ export class HistogramState implements MetricState.MetricState.Histogram {
   readonly [MetricStateTypeId] = metricStateVariance
   readonly [HistogramStateTypeId]: MetricState.HistogramStateTypeId = HistogramStateTypeId
   constructor(
-    readonly buckets: Chunk.Chunk<readonly [number, number]>,
+    readonly buckets: ReadonlyArray<readonly [number, number]>,
     readonly count: number,
     readonly min: number,
     readonly max: number,
@@ -158,7 +156,7 @@ export class SummaryState implements MetricState.MetricState.Summary {
   readonly [SummaryStateTypeId]: MetricState.SummaryStateTypeId = SummaryStateTypeId
   constructor(
     readonly error: number,
-    readonly quantiles: Chunk.Chunk<readonly [number, Option.Option<number>]>,
+    readonly quantiles: ReadonlyArray<readonly [number, Option.Option<number>]>,
     readonly count: number,
     readonly min: number,
     readonly max: number,
@@ -196,7 +194,7 @@ export const counter: {
 } = (count) => new CounterState(count) as any
 
 /** @internal */
-export const frequency = (occurrences: HashMap.HashMap<string, number>): MetricState.MetricState.Frequency => {
+export const frequency = (occurrences: ReadonlyMap<string, number>): MetricState.MetricState.Frequency => {
   return new FrequencyState(occurrences)
 }
 
@@ -209,7 +207,7 @@ export const gauge: {
 /** @internal */
 export const histogram = (
   options: {
-    readonly buckets: Chunk.Chunk<readonly [number, number]>
+    readonly buckets: ReadonlyArray<readonly [number, number]>
     readonly count: number
     readonly min: number
     readonly max: number
@@ -228,7 +226,7 @@ export const histogram = (
 export const summary = (
   options: {
     readonly error: number
-    readonly quantiles: Chunk.Chunk<readonly [number, Option.Option<number>]>
+    readonly quantiles: ReadonlyArray<readonly [number, Option.Option<number>]>
     readonly count: number
     readonly min: number
     readonly max: number

--- a/test/Differ.test.ts
+++ b/test/Differ.test.ts
@@ -85,6 +85,10 @@ function randomHashSet(): HashSet.HashSet<number> {
   return HashSet.fromIterable(Array.from({ length: 20 }, smallInt))
 }
 
+function randomReadonlyArray(): ReadonlyArray<number> {
+  return Array.from({ length: 20 }, smallInt)
+}
+
 function randomPair(): readonly [number, number] {
   return [smallInt(), smallInt()]
 }
@@ -111,6 +115,14 @@ describe.concurrent("Differ", () => {
       Differ.hashSet<number>(),
       randomHashSet,
       Equal.equals
+    )
+  })
+
+  describe.concurrent("readonlyArray", () => {
+    diffLaws(
+      Differ.readonlyArray<number, (n: number) => number>(Differ.update()),
+      randomReadonlyArray,
+      RA.getEquivalence(Equal.equals)
     )
   })
 

--- a/test/FiberRefs.test.ts
+++ b/test/FiberRefs.test.ts
@@ -34,7 +34,7 @@ describe.concurrent("FiberRefs", () => {
     const parent = FiberId.make(1, Date.now()) as FiberId.Runtime
     const child = FiberId.make(2, Date.now()) as FiberId.Runtime
     const parentFiberRefs = FiberRefs.unsafeMake(new Map())
-    const childFiberRefs = FiberRefs.updatedAs(parentFiberRefs, {
+    const childFiberRefs = FiberRefs.updateAs(parentFiberRefs, {
       fiberId: child,
       fiberRef: FiberRef.interruptedCause,
       value: Cause.interrupt(parent)

--- a/test/Metric.test.ts
+++ b/test/Metric.test.ts
@@ -1,12 +1,10 @@
 import * as it from "effect-test/utils/extend"
-import * as Chunk from "effect/Chunk"
 import * as Clock from "effect/Clock"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
 import * as Fiber from "effect/Fiber"
 import { pipe } from "effect/Function"
-import * as HashMap from "effect/HashMap"
 import * as HashSet from "effect/HashSet"
 import * as Metric from "effect/Metric"
 import * as MetricBoundaries from "effect/MetricBoundaries"
@@ -19,7 +17,7 @@ import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Schedule from "effect/Schedule"
 import { assert, describe, expect } from "vitest"
 
-const labels = Chunk.make(MetricLabel.make("x", "a"), MetricLabel.make("y", "b"))
+const labels = [MetricLabel.make("x", "a"), MetricLabel.make("y", "b")]
 
 const makePollingGauge = (name: string, increment: number) => {
   const gauge = Metric.gauge(name)
@@ -268,7 +266,7 @@ describe.concurrent("Metric", () => {
             Effect.zipRight(Metric.value(frequency))
           )
         )
-        assert.deepStrictEqual(result.occurrences, HashMap.make(["hello", 2] as const, ["world", 1] as const))
+        assert.deepStrictEqual(result.occurrences, new Map([["hello", 2] as const, ["world", 1] as const]))
       }))
     it.effect("direct occurrences", () =>
       Effect.gen(function*($) {
@@ -283,7 +281,7 @@ describe.concurrent("Metric", () => {
             Effect.zipRight(Metric.value(frequency))
           )
         )
-        assert.deepStrictEqual(result.occurrences, HashMap.make(["hello", 2] as const, ["world", 1] as const))
+        assert.deepStrictEqual(result.occurrences, new Map([["hello", 2] as const, ["world", 1] as const]))
       }))
     it.effect("custom occurrences with mapInput", () =>
       Effect.gen(function*($) {
@@ -302,7 +300,7 @@ describe.concurrent("Metric", () => {
             Effect.zipRight(Metric.value(frequency))
           )
         )
-        assert.deepStrictEqual(result.occurrences, HashMap.make(["1", 2] as const, ["2", 1] as const))
+        assert.deepStrictEqual(result.occurrences, new Map([["1", 2] as const, ["2", 1] as const]))
       }))
     it.effect("occurences + taggedWith", () =>
       Effect.gen(function*($) {
@@ -325,9 +323,9 @@ describe.concurrent("Metric", () => {
             }))
           )
         )
-        assert.isTrue(HashMap.isEmpty(result1.occurrences))
-        assert.deepStrictEqual(result2.occurrences, HashMap.make(["hello", 2] as const))
-        assert.deepStrictEqual(result3.occurrences, HashMap.make(["world", 1] as const))
+        assert.isTrue(result1.occurrences.size === 0)
+        assert.deepStrictEqual(result2.occurrences, new Map([["hello", 2] as const]))
+        assert.deepStrictEqual(result3.occurrences, new Map([["world", 1] as const]))
       }))
   })
   describe.concurrent("Gauge", () => {
@@ -508,7 +506,7 @@ describe.concurrent("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: Chunk.make(0, 1, 10)
+          quantiles: [0, 1, 10]
         }).pipe(
           Metric.taggedWithLabels(labels)
         )
@@ -531,7 +529,7 @@ describe.concurrent("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: Chunk.make(0, 1, 10)
+          quantiles: [0, 1, 10]
         }).pipe(
           Metric.taggedWithLabels(labels)
         )
@@ -554,7 +552,7 @@ describe.concurrent("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: Chunk.make(0, 1, 10)
+          quantiles: [0, 1, 10]
         }).pipe(
           Metric.taggedWithLabels(labels),
           Metric.mapInput((s: string) => s.length)
@@ -578,7 +576,7 @@ describe.concurrent("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: Chunk.make(0, 1, 10)
+          quantiles: [0, 1, 10]
         }).pipe(
           Metric.taggedWithLabels(labels),
           Metric.mapInput((s: string) => s.length)

--- a/test/Metric.test.ts
+++ b/test/Metric.test.ts
@@ -5,7 +5,6 @@ import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
 import * as Fiber from "effect/Fiber"
 import { pipe } from "effect/Function"
-import * as HashSet from "effect/HashSet"
 import * as Metric from "effect/Metric"
 import * as MetricBoundaries from "effect/MetricBoundaries"
 import * as MetricKey from "effect/MetricKey"
@@ -221,7 +220,7 @@ describe.concurrent("Metric", () => {
         const base = pipe(Metric.counter(name), Metric.tagged("static", "0"), Metric.withConstantInput(1))
         const counter = pipe(
           base,
-          Metric.taggedWithLabelsInput((input: string) => HashSet.make(MetricLabel.make("dyn", input)))
+          Metric.taggedWithLabelsInput((input: string) => [MetricLabel.make("dyn", input)])
         )
         const result = yield* $(
           pipe(
@@ -308,7 +307,7 @@ describe.concurrent("Metric", () => {
         const base = pipe(Metric.frequency(name), Metric.taggedWithLabels(labels))
         const frequency = pipe(
           base,
-          Metric.taggedWithLabelsInput((s: string) => HashSet.make(MetricLabel.make("dyn", s)))
+          Metric.taggedWithLabelsInput((s: string) => [MetricLabel.make("dyn", s)])
         )
         const { result1, result2, result3 } = yield* $(
           pipe(
@@ -372,7 +371,7 @@ describe.concurrent("Metric", () => {
         const base = pipe(Metric.gauge(name), Metric.tagged("static", "0"), Metric.mapInput((s: string) => s.length))
         const gauge = pipe(
           base,
-          Metric.taggedWithLabelsInput((input: string) => HashSet.make(MetricLabel.make("dyn", input)))
+          Metric.taggedWithLabelsInput((input: string) => [MetricLabel.make("dyn", input)])
         )
         const result = yield* $(
           pipe(
@@ -480,7 +479,7 @@ describe.concurrent("Metric", () => {
           Metric.mapInput((s: string) => s.length)
         )
         const histogram = base.pipe(
-          Metric.taggedWithLabelsInput((input: string) => HashSet.make(MetricLabel.make("dyn", input)))
+          Metric.taggedWithLabelsInput((input: string) => [MetricLabel.make("dyn", input)])
         )
         const { result1, result2, result3 } = yield* $(
           Effect.succeed("x"),
@@ -582,7 +581,7 @@ describe.concurrent("Metric", () => {
           Metric.mapInput((s: string) => s.length)
         )
         const summary = base.pipe(
-          Metric.taggedWithLabelsInput((input: string) => HashSet.make(MetricLabel.make("dyn", input)))
+          Metric.taggedWithLabelsInput((input: string) => [MetricLabel.make("dyn", input)])
         )
         const { result1, result2, result3 } = yield* $(
           Effect.succeed("x"),

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "examples",
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.src.json"
+    }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/examples.tsbuildinfo",
+    "rootDir": "examples",
+    "noEmit": true
+  }
+}

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,16 +1,14 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": [
-    "examples",
-  ],
+  "include": ["examples"],
   "references": [
     {
       "path": "./tsconfig.src.json"
     }
   ],
   "compilerOptions": {
+    "outDir": "build/examples",
     "tsBuildInfoFile": ".tsbuildinfo/examples.tsbuildinfo",
-    "rootDir": "examples",
-    "noEmit": true
+    "rootDir": "examples"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,14 @@
 {
-    "extends": "./tsconfig.base.json",
-    "references": [
-        {
-            "path": "./tsconfig.src.json"
-        },
-        {
-            "path": "./tsconfig.test.json"
-        }
-    ]
+  "extends": "./tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.examples.json"
+    },
+    {
+      "path": "./tsconfig.src.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    }
+  ]
 }


### PR DESCRIPTION
- add POC MutableHashMapSimple module
- replace Chunk with ROA in metrics
- use ReadonlyArray for metric labels
- cache metric hooks
- clean up metric state equality
- changeset
- docs
- optimize fiber forking
- replace throw with symbol in run loop
- changeset
- fiber ref wip
- FiberRefs.updateManyAs
- add metric hash caching
- rename untaggedHook
- replace MutableHashMap
- remove benchmark
- remove test
