### PR TITLE
explicitly tag changeset releases with `latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm update-version
-          publish: pnpm changeset publish
+          publish: pnpm changeset publish --tag latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This circumvents a problem in pre-release mode where snapshot releases would otherwise cause subsequent changeset releases to publish under the `next` tag.