### PR TITLE
self-assign normalized `BigDecimal`

### DIFF
--- a/.changeset/witty-cobras-hide.md
+++ b/.changeset/witty-cobras-hide.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Self-assign normalized `BigDecimal`

--- a/src/BigDecimal.ts
+++ b/src/BigDecimal.ts
@@ -121,8 +121,8 @@ zero.normalized = zero
  * @example
  * import { normalize, make, unsafeFromString } from "effect/BigDecimal"
  *
- * assert.deepStrictEqual(normalize(unsafeFromString("123.00000")), make(123n, 0))
- * assert.deepStrictEqual(normalize(unsafeFromString("12300000")), make(123n, -5))
+ * assert.deepStrictEqual(normalize(unsafeFromString("123.00000")), normalize(make(123n, 0)))
+ * assert.deepStrictEqual(normalize(unsafeFromString("12300000")), normalize(make(123n, -5)))
  *
  * @since 2.0.0
  * @category scaling

--- a/src/BigDecimal.ts
+++ b/src/BigDecimal.ts
@@ -109,8 +109,14 @@ export const make = (value: bigint, scale: number): BigDecimal => {
 
 /**
  * Internal function used to create pre-normalized `BigDecimal`s.
+ *
+ * @internal
  */
-const makeNormalized = (value: bigint, scale: number): BigDecimal => {
+export const unsafeMakeNormalized = (value: bigint, scale: number): BigDecimal => {
+  if (value !== bigint0 && value % bigint10 === bigint0) {
+    throw new RangeError("Value must be normalized")
+  }
+
   const o = make(value, scale)
   o.normalized = o
   return o
@@ -119,7 +125,7 @@ const makeNormalized = (value: bigint, scale: number): BigDecimal => {
 const bigint0 = BigInt(0)
 const bigint1 = BigInt(1)
 const bigint10 = BigInt(10)
-const zero = makeNormalized(bigint0, 0)
+const zero = unsafeMakeNormalized(bigint0, 0)
 
 /**
  * Normalizes a given `BigDecimal` by removing trailing zeros.
@@ -157,7 +163,7 @@ export const normalize = (self: BigDecimal): BigDecimal => {
 
       const value = BigInt(digits.substring(0, digits.length - trail))
       const scale = self.scale - trail
-      self.normalized = makeNormalized(value, scale)
+      self.normalized = unsafeMakeNormalized(value, scale)
     }
   }
 

--- a/src/BigDecimal.ts
+++ b/src/BigDecimal.ts
@@ -111,6 +111,7 @@ const bigint0 = BigInt(0)
 const bigint1 = BigInt(1)
 const bigint10 = BigInt(10)
 const zero = make(bigint0, 0)
+zero.normalized = zero
 
 /**
  * Normalizes a given `BigDecimal` by removing trailing zeros.
@@ -148,7 +149,9 @@ export const normalize = (self: BigDecimal): BigDecimal => {
 
       const value = BigInt(digits.substring(0, digits.length - trail))
       const scale = self.scale - trail
+
       self.normalized = make(value, scale)
+      self.normalized.normalized = self.normalized
     }
   }
 

--- a/src/BigDecimal.ts
+++ b/src/BigDecimal.ts
@@ -107,11 +107,19 @@ export const make = (value: bigint, scale: number): BigDecimal => {
   return o
 }
 
+/**
+ * Internal function used to create pre-normalized `BigDecimal`s.
+ */
+const makeNormalized = (value: bigint, scale: number): BigDecimal => {
+  const o = make(value, scale)
+  o.normalized = o
+  return o
+}
+
 const bigint0 = BigInt(0)
 const bigint1 = BigInt(1)
 const bigint10 = BigInt(10)
-const zero = make(bigint0, 0)
-zero.normalized = zero
+const zero = makeNormalized(bigint0, 0)
 
 /**
  * Normalizes a given `BigDecimal` by removing trailing zeros.
@@ -149,9 +157,7 @@ export const normalize = (self: BigDecimal): BigDecimal => {
 
       const value = BigInt(digits.substring(0, digits.length - trail))
       const scale = self.scale - trail
-
-      self.normalized = make(value, scale)
-      self.normalized.normalized = self.normalized
+      self.normalized = makeNormalized(value, scale)
     }
   }
 

--- a/test/BigDecimal.test.ts
+++ b/test/BigDecimal.test.ts
@@ -240,17 +240,12 @@ describe.concurrent("BigDecimal", () => {
   })
 
   it("normalize", () => {
-    const normalized = (b: BigDecimal.BigDecimal) => {
-      b.normalized = b
-      return b
-    }
-
-    deepStrictEqual(BigDecimal.normalize(_("0")), normalized(_("0")))
-    deepStrictEqual(BigDecimal.normalize(_("0.123000")), normalized(_("0.123")))
-    deepStrictEqual(BigDecimal.normalize(_("123.000")), normalized(_("123")))
-    deepStrictEqual(BigDecimal.normalize(_("-0.000123000")), normalized(_("-0.000123")))
-    deepStrictEqual(BigDecimal.normalize(_("-123.000")), normalized(_("-123")))
-    deepStrictEqual(BigDecimal.normalize(_("12300000")), normalized(BigDecimal.make(123n, -5)))
+    deepStrictEqual(BigDecimal.normalize(_("0")), BigDecimal.unsafeMakeNormalized(0n, 0))
+    deepStrictEqual(BigDecimal.normalize(_("0.123000")), BigDecimal.unsafeMakeNormalized(123n, 3))
+    deepStrictEqual(BigDecimal.normalize(_("123.000")), BigDecimal.unsafeMakeNormalized(123n, 0))
+    deepStrictEqual(BigDecimal.normalize(_("-0.000123000")), BigDecimal.unsafeMakeNormalized(-123n, 6))
+    deepStrictEqual(BigDecimal.normalize(_("-123.000")), BigDecimal.unsafeMakeNormalized(-123n, 0))
+    deepStrictEqual(BigDecimal.normalize(_("12300000")), BigDecimal.unsafeMakeNormalized(123n, -5))
   })
 
   it("fromString", () => {

--- a/test/BigDecimal.test.ts
+++ b/test/BigDecimal.test.ts
@@ -240,12 +240,17 @@ describe.concurrent("BigDecimal", () => {
   })
 
   it("normalize", () => {
-    deepStrictEqual(BigDecimal.normalize(_("0")), _("0"))
-    deepStrictEqual(BigDecimal.normalize(_("0.123000")), _("0.123"))
-    deepStrictEqual(BigDecimal.normalize(_("123.000")), _("123"))
-    deepStrictEqual(BigDecimal.normalize(_("-0.000123000")), _("-0.000123"))
-    deepStrictEqual(BigDecimal.normalize(_("-123.000")), _("-123"))
-    deepStrictEqual(BigDecimal.normalize(_("12300000")), BigDecimal.make(123n, -5))
+    const normalized = (b: BigDecimal.BigDecimal) => {
+      b.normalized = b
+      return b
+    }
+
+    deepStrictEqual(BigDecimal.normalize(_("0")), normalized(_("0")))
+    deepStrictEqual(BigDecimal.normalize(_("0.123000")), normalized(_("0.123")))
+    deepStrictEqual(BigDecimal.normalize(_("123.000")), normalized(_("123")))
+    deepStrictEqual(BigDecimal.normalize(_("-0.000123000")), normalized(_("-0.000123")))
+    deepStrictEqual(BigDecimal.normalize(_("-123.000")), normalized(_("-123")))
+    deepStrictEqual(BigDecimal.normalize(_("12300000")), normalized(BigDecimal.make(123n, -5)))
   })
 
   it("fromString", () => {
@@ -257,7 +262,7 @@ describe.concurrent("BigDecimal", () => {
     deepStrictEqual(BigDecimal.fromString("-20000000"), Option.some(BigDecimal.make(-20000000n, 0)))
     deepStrictEqual(BigDecimal.fromString("2.00"), Option.some(BigDecimal.make(200n, 2)))
     deepStrictEqual(BigDecimal.fromString("0.0000200"), Option.some(BigDecimal.make(200n, 7)))
-    deepStrictEqual(BigDecimal.fromString(""), Option.some(BigDecimal.make(0n, 0)))
+    deepStrictEqual(BigDecimal.fromString(""), Option.some(BigDecimal.normalize(BigDecimal.make(0n, 0))))
     deepStrictEqual(BigDecimal.fromString("1E5"), Option.none())
   })
 


### PR DESCRIPTION
The constant `zero` case was surfaced as a DX / ergonomics issue due to the lazily assigned self-reference causing failures with `deepStrictEqual` assertions.

I ran into this while experimenting with thread isolation in vitest (for improving test runner performance).

Self-assigning the normalized BigDecimals also makes sense imho.