### PR TITLE
Ensure that both top-level fields and nested fields can be read with `ConfigProvider.fromJson`

### DIFF
--- a/.changeset/plenty-buttons-thank.md
+++ b/.changeset/plenty-buttons-thank.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+ensure that both top-level fields and nested fields can be read with ConfigProvider.fromJson

--- a/src/internal/configProvider.ts
+++ b/src/internal/configProvider.ts
@@ -732,6 +732,7 @@ export const fromJson = (json: unknown): ConfigProvider.ConfigProvider => {
     getIndexedEntries(json as JsonMap),
     ([key, value]): [string, string] => [configPathToString(key).join(hiddenDelimiter), value]
   )
+  console.log(indexedEntries)
   return fromMap(new Map(indexedEntries), {
     pathDelim: hiddenDelimiter,
     seqDelim: hiddenDelimiter
@@ -776,10 +777,10 @@ const getIndexedEntries = (
       return ReadonlyArray.make([path, String(value)] as [ReadonlyArray<KeyComponent>, string])
     }
     if (Array.isArray(value)) {
-      return loopArray(path, value)
+      return ReadonlyArray.prepend(loopArray(path, value), [path, JSON.stringify(value)])
     }
     if (typeof value === "object" && value !== null) {
-      return loopObject(path, value)
+      return ReadonlyArray.prepend(loopObject(path, value), [path, JSON.stringify(value)])
     }
     return ReadonlyArray.empty<[ReadonlyArray<KeyComponent>, string]>()
   }

--- a/test/ConfigProvider.test.ts
+++ b/test/ConfigProvider.test.ts
@@ -917,6 +917,26 @@ describe("ConfigProvider", () => {
 
   it.effect("fromJson - should load configs from nested JSON", () =>
     Effect.gen(function*($) {
+      const config = Config.primitive<Record<string, unknown>>(
+        "a JSON record",
+        (json) => Either.right(JSON.parse(json))
+      ).pipe(Config.nested("hostPorts"))
+      const result = yield* $(
+        ConfigProvider.fromJson({
+          hostPorts: {
+            host: "localhost",
+            port: 8080
+          }
+        }).load(config)
+      )
+      assert.deepStrictEqual(result, {
+        host: "localhost",
+        port: 8080
+      })
+    }))
+
+  it.effect("fromJson - should load configs from nested JSON fields", () =>
+    Effect.gen(function*($) {
       const result = yield* $(
         ConfigProvider.fromJson({
           hostPorts: [{


### PR DESCRIPTION
This PR makes sure we add the top-level field (with nested fields `JSON.stringify`'ed) to the underlying `ConfigProvider` map. This allows external consumers to create more elaborate configs with `Config.primitive`, for example using `@effect/schema` and `Schema.parseEither`.
```ts
  it.effect("fromJson - should load configs from nested JSON", () =>
    Effect.gen(function*($) {
      const config = Config.primitive<Record<string, unknown>>(
        "a JSON record",
        (json) => Either.right(JSON.parse(json))
      ).pipe(Config.nested("hostPorts"))
      const result = yield* $(
        ConfigProvider.fromJson({
          hostPorts: {
            host: "localhost",
            port: 8080
          }
        }).load(config)
      )
      assert.deepStrictEqual(result, {
        host: "localhost",
        port: 8080
      })
    }))
```