### PR TITLE
Uncommented linesIterator string function

### DIFF
--- a/.changeset/warm-zoos-doubt.md
+++ b/.changeset/warm-zoos-doubt.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Uncommented linesIterator string function

--- a/packages/effect/src/String.ts
+++ b/packages/effect/src/String.ts
@@ -576,7 +576,7 @@ const LF = 0x0a
  *
  * @since 2.0.0
  */
-// export const linesIterator = (self: string): LinesIterator => linesSeparated(self, true)
+export const linesIterator = (self: string): LinesIterator => linesSeparated(self, true)
 
 /**
  * Returns an `IterableIterator` which yields each line contained within the

--- a/packages/effect/test/String.test.ts
+++ b/packages/effect/test/String.test.ts
@@ -272,4 +272,12 @@ describe("String", () => {
       deepStrictEqual(Array.from(result), ["\n", "$\n", "    $Hello,\r\n", "    $World!\n", " $"])
     })
   })
+
+  describe("linesIterator", () => {
+    it("should split a string into lines", () => {
+      const string = "\n$\n    $Hello,\r\n    $World!\n $"
+      const result = S.linesIterator(string)
+      deepStrictEqual(Array.from(result), ["", "$", "    $Hello,", "    $World!", " $"])
+    })
+  })
 })


### PR DESCRIPTION
Not sure why this was commented out but I would like to use it. The [blame](https://github.com/Effect-TS/effect/blame/main/packages/effect/src/String.ts#L579) leads to a [huge commit](https://github.com/Effect-TS/effect/commit/ed79588f9de708570587e55392579b8fc1891c55) from a mega pr, so not sure that will be much help, I couldn't find TODO/FIXME anywhere that would lead me to think it should be commented out though.