### PR TITLE
add ReadonlyArray.findFirstMap/findLastMap

### DIFF
--- a/.changeset/perfect-falcons-stare.md
+++ b/.changeset/perfect-falcons-stare.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add ReadonlyArray.findFirstMap/findLastMap

--- a/packages/effect/src/ReadonlyArray.ts
+++ b/packages/effect/src/ReadonlyArray.ts
@@ -8,15 +8,15 @@ import type { Either } from "./Either.js"
 import * as E from "./Either.js"
 import * as Equal from "./Equal.js"
 import * as Equivalence from "./Equivalence.js"
-import { dual, identity } from "./Function.js"
 import type { LazyArg } from "./Function.js"
+import { dual, identity } from "./Function.js"
 import type { TypeLambda } from "./HKT.js"
 import * as readonlyArray from "./internal/readonlyArray.js"
 import type { Option } from "./Option.js"
 import * as O from "./Option.js"
 import * as Order from "./Order.js"
-import { not } from "./Predicate.js"
 import type { Predicate, Refinement } from "./Predicate.js"
+import { not } from "./Predicate.js"
 import * as RR from "./ReadonlyRecord.js"
 import * as Tuple from "./Tuple.js"
 
@@ -734,6 +734,53 @@ export const findLast: {
   }
   return O.none()
 })
+
+/**
+ * Find and transform the first element for which a value could be produced.
+ *
+ * @category elements
+ * @since 2.0.0
+ */
+export const findFirstMap: {
+  <A, B>(predicate: (a: A, i: number) => Option<B>): (self: Iterable<A>) => Option<B>
+  <A, B>(self: Iterable<A>, predicate: (a: A, i: number) => Option<B>): Option<B>
+} = dual(
+  2,
+  <A, B>(self: Iterable<A>, predicate: (a: A, i: number) => Option<B>): Option<B> => {
+    let i = 0
+    for (const a of self) {
+      const o = predicate(a, i)
+      if (O.isSome(o)) {
+        return o
+      }
+      i++
+    }
+    return O.none()
+  }
+)
+
+/**
+ * Find and transform the last element for which a value could be produced.
+ *
+ * @category elements
+ * @since 2.0.0
+ */
+export const findLastMap: {
+  <A, B>(predicate: (a: A, i: number) => Option<B>): (self: Iterable<A>) => Option<B>
+  <A, B>(self: Iterable<A>, predicate: (a: A, i: number) => Option<B>): Option<B>
+} = dual(
+  2,
+  <A, B>(self: Iterable<A>, predicate: (a: A, i: number) => Option<B>): Option<B> => {
+    const input = fromIterable(self)
+    for (let i = input.length - 1; i >= 0; i--) {
+      const o = predicate(input[i], i)
+      if (O.isSome(o)) {
+        return o
+      }
+    }
+    return O.none()
+  }
+)
 
 /**
  * Insert an element at the specified index, creating a new `NonEmptyArray`,

--- a/packages/effect/test/ReadonlyArray.test.ts
+++ b/packages/effect/test/ReadonlyArray.test.ts
@@ -307,6 +307,56 @@ describe("ReadonlyArray", () => {
       deepStrictEqual(pipe(new Set([1, 2, 3, 4]), RA.findLast((n) => n % 2 === 0)), O.some(4))
     })
 
+    it("findFirstMap", () => {
+      deepStrictEqual(pipe([], RA.findFirstMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())), O.none())
+      deepStrictEqual(
+        pipe([1, 2, 3], RA.findFirstMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([2, 1])
+      )
+      deepStrictEqual(
+        pipe([1, 2, 3, 4], RA.findFirstMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([2, 1])
+      )
+
+      deepStrictEqual(
+        pipe(new Set<number>(), RA.findFirstMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.none()
+      )
+      deepStrictEqual(
+        pipe(new Set([1, 2, 3]), RA.findFirstMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([2, 1])
+      )
+      deepStrictEqual(
+        pipe(new Set([1, 2, 3, 4]), RA.findFirstMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([2, 1])
+      )
+    })
+
+    it("findLastMap", () => {
+      deepStrictEqual(pipe([], RA.findLastMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())), O.none())
+      deepStrictEqual(
+        pipe([1, 2, 3], RA.findLastMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([2, 1])
+      )
+      deepStrictEqual(
+        pipe([1, 2, 3, 4], RA.findLastMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([4, 3])
+      )
+
+      deepStrictEqual(
+        pipe(new Set<number>(), RA.findLastMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.none()
+      )
+      deepStrictEqual(
+        pipe(new Set([1, 2, 3]), RA.findLastMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([2, 1])
+      )
+      deepStrictEqual(
+        pipe(new Set([1, 2, 3, 4]), RA.findLastMap((n, i) => n % 2 === 0 ? O.some([n, i]) : O.none())),
+        O.some([4, 3])
+      )
+    })
+
     it("insertAt", () => {
       deepStrictEqual(RA.insertAt(1, 1)([]), O.none())
       deepStrictEqual(RA.insertAt(0, 1)([]), O.some([1]))


### PR DESCRIPTION
Have many use cases:

Find item and index at the same time:
```typescript
const items = [1, 2, 3]
// Option<readonly [value: number, index: number]>
const found = A.findFirstMap(items, (n, i) => n % 2 === 0 ? O.some([n, i] as const) : O.none())
```

Find and refine:
```typescript
const items = [{ _tag: "A" }, { _tag: "B" }, { _tag: "A" }] as const
// Option<{ readonly _tag: "B" }>
const found = A.findFirstMap(items, (v) => v._tag === "B" ? O.some(v) : O.none())
```

Find and transform without having to rerun the function with the found item:
```typescript
const expensiveCalculation = (_: number): number => 0
const items = [1, 2, 3]
// Option<{ item: number, result: number }>
const found = A.findFirstMap(items, (item) => {
  const result = expensiveCalculation(item)
  return result > 5 ? O.some({ item, result }) : O.none()
})
```