### PR TITLE
Add `Cron` module and `Schedule.cron` constructor

### DIFF
--- a/.changeset/cuddly-turkeys-eat.md
+++ b/.changeset/cuddly-turkeys-eat.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Added `Cron` module

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -326,6 +326,20 @@ export const next = (cron: Cron, now?: Date): Date => {
   throw new Error("Unable to find next cron date")
 }
 
+/**
+ * Returns an `IterableIterator` which yields the sequence of `Date`s that match the `Cron` instance.
+ *
+ * @param cron - The `Cron` instance.
+ * @param now - The `Date` to start searching from.
+ *
+ * @since 2.0.0
+ */
+export const sequence = function*(cron: Cron, now?: Date): IterableIterator<Date> {
+  while (true) {
+    yield now = next(cron, now)
+  }
+}
+
 interface SegmentOptions {
   segment: string
   min: number

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -155,7 +155,7 @@ export const isParseError = (u: unknown): u is ParseError => hasProperty(u, Pars
 export const parse = (cron: string): Either.Either<ParseError, Cron> => {
   const segments = cron.split(" ").filter(String.isNonEmpty)
   if (segments.length !== 5) {
-    return Either.left(ParseError(`Invalid cron expression`, cron))
+    return Either.left(ParseError(`Invalid number of segments in cron expression`, cron))
   }
 
   const [minutes, hours, days, months, weekdays] = segments
@@ -237,11 +237,11 @@ export const match = (cron: Cron, date: Date): boolean => {
  * assert.deepStrictEqual(Cron.next(cron, after), Option.some(new Date("2021-01-08 04:00:00")))
  *
  * @param cron - The `Cron` instance.
- * @param after - The `Date` to start searching from.
+ * @param now - The `Date` to start searching from.
  *
  * @since 2.0.0
  */
-export const next = (cron: Cron, after?: Date): Option.Option<Date> => {
+export const next = (cron: Cron, now?: Date): Option.Option<Date> => {
   const { days, hours, minutes, months, weekdays } = cron
 
   const restrictMinutes = minutes.size !== 0
@@ -250,10 +250,11 @@ export const next = (cron: Cron, after?: Date): Option.Option<Date> => {
   const restrictMonths = months.size !== 0
   const restrictWeekdays = weekdays.size !== 0
 
-  const current = after ? new Date(after.getTime()) : new Date()
+  const current = now ? new Date(now.getTime()) : new Date()
   // Increment by one minute to ensure we don't match the current date.
   current.setMinutes(current.getMinutes() + 1)
   current.setSeconds(0)
+  current.setMilliseconds(0)
 
   // Only search 8 years into the future.
   const limit = new Date(current).setFullYear(current.getFullYear() + 8)

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -201,7 +201,7 @@ export const parse = (cron: string): Either.Either<ParseError, Cron> => {
 }
 
 /**
- * Checks if a given date matches the `Cron` instance.
+ * Checks if a given `Date` falls within an active `Cron` time window.
  *
  * @param cron - The `Cron` instance.
  * @param date - The `Date` to check against.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -345,26 +345,17 @@ export const sequence = function*(cron: Cron, now?: Date): IterableIterator<Date
  * @category instances
  * @since 2.0.0
  */
-export const Equivalence: equivalence.Equivalence<Cron> = equivalence.make((self, that) => {
-  const eq = equivalence.array(equivalence.number)
-  if (!eq(ReadonlyArray.fromIterable(self.minutes), ReadonlyArray.fromIterable(that.minutes))) {
-    return false
-  }
-  if (!eq(ReadonlyArray.fromIterable(self.hours), ReadonlyArray.fromIterable(that.hours))) {
-    return false
-  }
-  if (!eq(ReadonlyArray.fromIterable(self.days), ReadonlyArray.fromIterable(that.days))) {
-    return false
-  }
-  if (!eq(ReadonlyArray.fromIterable(self.months), ReadonlyArray.fromIterable(that.months))) {
-    return false
-  }
-  if (!eq(ReadonlyArray.fromIterable(self.weekdays), ReadonlyArray.fromIterable(that.weekdays))) {
-    return false
-  }
+export const Equivalence: equivalence.Equivalence<Cron> = equivalence.make((self, that) =>
+  restrictionsEquals(self.minutes, that.minutes) &&
+  restrictionsEquals(self.hours, that.hours) &&
+  restrictionsEquals(self.days, that.days) &&
+  restrictionsEquals(self.months, that.months) &&
+  restrictionsEquals(self.weekdays, that.weekdays)
+)
 
-  return true
-})
+const restrictionsArrayEquals = equivalence.array(equivalence.number)
+const restrictionsEquals = (self: ReadonlySet<number>, that: ReadonlySet<number>): boolean =>
+  restrictionsArrayEquals(ReadonlyArray.fromIterable(self), ReadonlyArray.fromIterable(that))
 
 /**
  * Checks if two `Cron`s are equal.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -224,24 +224,20 @@ export const match = (cron: Cron, date: Date): boolean => {
  *
  * If no date is provided, the current date is used.
  *
- * If no date can be found, `Option.none()` is returned. This should be a
- * no-op, but it's possible that the cron expression is invalid.
- *
  * @example
  * import * as Cron from "effect/Cron"
  * import * as Either from "effect/Either"
- * import * as Option from "effect/Option"
  *
  * const after = new Date("2021-01-01 00:00:00")
  * const cron = Either.getOrThrow(Cron.parse("0 4 8-14 * *"))
- * assert.deepStrictEqual(Cron.next(cron, after), Option.some(new Date("2021-01-08 04:00:00")))
+ * assert.deepStrictEqual(Cron.next(cron, after), new Date("2021-01-08 04:00:00"))
  *
  * @param cron - The `Cron` instance.
  * @param now - The `Date` to start searching from.
  *
  * @since 2.0.0
  */
-export const next = (cron: Cron, now?: Date): Option.Option<Date> => {
+export const next = (cron: Cron, now?: Date): Date => {
   const { days, hours, minutes, months, weekdays } = cron
 
   const restrictMinutes = minutes.size !== 0
@@ -292,10 +288,10 @@ export const next = (cron: Cron, now?: Date): Option.Option<Date> => {
       continue
     }
 
-    return Option.some(current)
+    return current
   }
 
-  return Option.none()
+  throw new Error("Unable to find next cron date")
 }
 
 interface SegmentOptions {

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -252,9 +252,9 @@ export const match = (cron: Cron, date: Date): boolean => {
 }
 
 /**
- * Returns the next date that matches the `Cron` instance.
+ * Returns the next run `Date` for the given `Cron` instance.
  *
- * If no date is provided, the current date is used.
+ * Uses the current time as a starting point if no value is provided for `now`.
  *
  * @example
  * import * as Cron from "effect/Cron"
@@ -295,18 +295,27 @@ export const next = (cron: Cron, now?: Date): Date => {
       continue
     }
 
-    if (restrictDays && !days.has(current.getDate())) {
-      current.setDate(current.getDate() + 1)
-      current.setHours(0)
-      current.setMinutes(0)
-      continue
-    }
-
-    if (restrictWeekdays && !weekdays.has(current.getDay())) {
-      current.setDate(current.getDate() + 1)
-      current.setHours(0)
-      current.setMinutes(0)
-      continue
+    if (restrictDays && restrictWeekdays) {
+      if (!days.has(current.getDate()) && !weekdays.has(current.getDay())) {
+        current.setDate(current.getDate() + 1)
+        current.setHours(0)
+        current.setMinutes(0)
+        continue
+      }
+    } else if (restrictDays) {
+      if (!days.has(current.getDate())) {
+        current.setDate(current.getDate() + 1)
+        current.setHours(0)
+        current.setMinutes(0)
+        continue
+      }
+    } else if (restrictWeekdays) {
+      if (!weekdays.has(current.getDay())) {
+        current.setDate(current.getDate() + 1)
+        current.setHours(0)
+        current.setMinutes(0)
+        continue
+      }
     }
 
     if (restrictHours && !hours.has(current.getHours())) {

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -46,8 +46,7 @@ const CronProto: Omit<Cron, "minutes" | "hours" | "days" | "months" | "weekdays"
   },
   [Hash.symbol](this: Cron): number {
     return pipe(
-      Hash.hash(TypeId),
-      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.minutes))),
+      Hash.array(ReadonlyArray.fromIterable(this.minutes)),
       Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.hours))),
       Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.days))),
       Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.months))),

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -1,0 +1,297 @@
+/**
+ * @since 2.0.0
+ */
+import * as Either from "./Either.js"
+import { pipe } from "./Function.js"
+import * as N from "./Number.js"
+import { type Pipeable, pipeArguments } from "./Pipeable.js"
+import { hasProperty } from "./Predicate.js"
+import * as ReadonlyArray from "./ReadonlyArray.js"
+import * as String from "./String.js"
+import type { Mutable } from "./Types.js"
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export const TypeId: unique symbol = Symbol.for("effect/Cron")
+
+/**
+ * @since 2.0.0
+ * @category symbol
+ */
+export type TypeId = typeof TypeId
+
+/**
+ * @since 2.0.0
+ * @category models
+ */
+export interface Segments {
+  readonly minutes: ReadonlyArray<number>
+  readonly hours: ReadonlyArray<number>
+  readonly days: ReadonlyArray<number>
+  readonly months: ReadonlyArray<number>
+  readonly weekdays: ReadonlyArray<number>
+}
+
+/**
+ * @since 2.0.0
+ * @category models
+ */
+export interface Cron extends Pipeable {
+  readonly [TypeId]: TypeId
+  readonly segments: Segments
+}
+
+const CronProto: Omit<Cron, "segments"> = {
+  [TypeId]: TypeId,
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+} as const
+
+/**
+ * Checks if a given value is a `Cron` instance.
+ *
+ * @param u - The value to check.
+ *
+ * @since 2.0.0
+ * @category guards
+ */
+export const isCron = (u: unknown): u is Cron => hasProperty(u, TypeId)
+
+/**
+ * Creates a `Cron` instance from.
+ *
+ * @param segments - The cron segments.
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const make = (segments: Segments): Cron => {
+  const o = Object.create(CronProto)
+  o.segments = segments
+  return o
+}
+
+/**
+ * @since 2.0.0
+ * @category symbol
+ */
+export const ParseErrorTypeId: unique symbol = Symbol.for("effect/Cron/errors/ParseError")
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type ParseErrorTypeId = typeof ParseErrorTypeId
+
+/**
+ * Represents a checked exception which occurs when decoding fails.
+ *
+ * @since 2.0.0
+ * @category models
+ */
+export interface ParseError {
+  readonly _tag: "ParseError"
+  readonly [ParseErrorTypeId]: ParseErrorTypeId
+  readonly message: string
+  readonly input?: string
+}
+
+const ParseErrorProto: Omit<ParseError, "segment" | "input" | "message"> = {
+  _tag: "ParseError",
+  [ParseErrorTypeId]: ParseErrorTypeId
+}
+
+const ParseError = (message: string, input?: string): ParseError => {
+  const o: Mutable<ParseError> = Object.create(ParseErrorProto)
+  o.message = message
+  if (input !== undefined) {
+    o.input = input
+  }
+  return o
+}
+
+/**
+ * Returns `true` if the specified value is an `ParseError`, `false` otherwise.
+ *
+ * @param u - The value to check.
+ *
+ * @since 2.0.0
+ * @category guards
+ */
+export const isParseError = (u: unknown): u is ParseError => hasProperty(u, ParseErrorTypeId)
+
+/**
+ * Parses a cron expression into a `Cron` instance.
+ *
+ * @param cron - The cron expression to parse.
+ *
+ * @example
+ * import { parse, make } from "effect/Cron"
+ * import { right } from "effect/Either"
+ *
+ * // At 04:00 on every day-of-month from 8 through 14.
+ * assert.deepStrictEqual(parse("0 4 8-14 * *"), right(make({
+ *   minutes: [0],
+ *   hours: [4],
+ *   days: [8, 9, 10, 11, 12, 13, 14],
+ *   months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+ *   weekdays: [0, 1, 2, 3, 4, 5, 6]
+ * })))
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const parse = (cron: string): Either.Either<ParseError, Cron> => {
+  const segments = cron.split(" ").filter(String.isNonEmpty)
+  if (segments.length !== 5) {
+    return Either.left(ParseError(`Invalid cron`, cron))
+  }
+
+  const [minutes, hours, days, months, weekdays] = segments
+  return Either.all({
+    minutes: parseSegment(minutes, minuteOptions),
+    hours: parseSegment(hours, hourOptions),
+    days: parseSegment(days, dayOptions),
+    months: parseSegment(months, monthOptions),
+    weekdays: parseSegment(weekdays, weekdayOptions)
+  }).pipe(Either.map((segments) => make(segments)))
+}
+
+interface SegmentOptions {
+  segment: string
+  min: number
+  max: number
+  aliases?: Record<string, number> | undefined
+}
+
+const minuteOptions: SegmentOptions = {
+  segment: "minute",
+  min: 0,
+  max: 59
+}
+
+const hourOptions: SegmentOptions = {
+  segment: "hour",
+  min: 0,
+  max: 23
+}
+
+const dayOptions: SegmentOptions = {
+  segment: "day",
+  min: 1,
+  max: 31
+}
+
+const monthOptions: SegmentOptions = {
+  segment: "month",
+  min: 1,
+  max: 12,
+  aliases: {
+    jan: 1,
+    feb: 2,
+    mar: 3,
+    apr: 4,
+    may: 5,
+    jun: 6,
+    jul: 7,
+    aug: 8,
+    sep: 9,
+    oct: 10,
+    nov: 11,
+    dec: 12
+  }
+}
+
+const weekdayOptions: SegmentOptions = {
+  segment: "weekday",
+  min: 0,
+  max: 6,
+  aliases: {
+    sun: 0,
+    mon: 1,
+    tue: 2,
+    wed: 3,
+    thu: 4,
+    fri: 5,
+    sat: 6
+  }
+}
+
+const parseSegment = (input: string, options: SegmentOptions): Either.Either<ParseError, ReadonlyArray<number>> => {
+  const values = new Set<number>()
+  const fields = input.split(",")
+
+  for (const field of fields) {
+    const [raw, step] = splitStep(field)
+    if (step !== undefined) {
+      if (!Number.isInteger(step)) {
+        return Either.left(ParseError(`Expected step value to be a positive integer`, input))
+      }
+      if (step < 1) {
+        return Either.left(ParseError(`Expected step value to be greater than 0`, input))
+      }
+      if (step > options.max) {
+        return Either.left(ParseError(`Expected step value to be less than ${options.max}`, input))
+      }
+    }
+
+    if (raw === "*") {
+      for (let i = options.min; i <= options.max; i += step ?? 1) {
+        values.add(i)
+      }
+    } else {
+      const [left, right] = splitRange(raw, options.aliases)
+      if (!Number.isInteger(left)) {
+        return Either.left(ParseError(`Expected a positive integer`, input))
+      }
+      if (left < options.min || left > options.max) {
+        return Either.left(ParseError(`Expected a value between ${options.min} and ${options.max}`, input))
+      }
+
+      if (right === undefined) {
+        values.add(left)
+      } else {
+        if (!Number.isInteger(right)) {
+          return Either.left(ParseError(`Expected a positive integer`, input))
+        }
+        if (right < options.min || right > options.max) {
+          return Either.left(ParseError(`Expected a value between ${options.min} and ${options.max}`, input))
+        }
+        if (left > right) {
+          return Either.left(ParseError(`Invalid range`, input))
+        }
+
+        for (let i = left; i <= right; i += step ?? 1) {
+          values.add(i)
+        }
+      }
+    }
+  }
+
+  return Either.right(pipe(ReadonlyArray.fromIterable(values), ReadonlyArray.sort(N.Order)))
+}
+
+const splitStep = (input: string): [string, number | undefined] => {
+  const seperator = input.indexOf("/")
+  if (seperator !== -1) {
+    return [input.slice(0, seperator), Number(input.slice(seperator + 1))]
+  }
+
+  return [input, undefined]
+}
+
+const splitRange = (input: string, aliases?: Record<string, number>): [number, number | undefined] => {
+  const seperator = input.indexOf("-")
+  if (seperator !== -1) {
+    return [aliasOrValue(input.slice(0, seperator), aliases), aliasOrValue(input.slice(seperator + 1), aliases)]
+  }
+
+  return [aliasOrValue(input, aliases), undefined]
+}
+
+function aliasOrValue(field: string, aliases?: Record<string, number>): number {
+  return aliases?.[field.toLocaleLowerCase()] ?? Number(field)
+}

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -5,6 +5,7 @@ import * as Either from "./Either.js"
 import * as Equal from "./Equal.js"
 import { pipe } from "./Function.js"
 import * as Hash from "./Hash.js"
+import { format, type Inspectable, NodeInspectSymbol } from "./Inspectable.js"
 import * as N from "./Number.js"
 import { type Pipeable, pipeArguments } from "./Pipeable.js"
 import { hasProperty } from "./Predicate.js"
@@ -28,7 +29,7 @@ export type TypeId = typeof TypeId
  * @since 2.0.0
  * @category models
  */
-export interface Cron extends Pipeable, Equal.Equal {
+export interface Cron extends Pipeable, Equal.Equal, Inspectable {
   readonly [TypeId]: TypeId
   readonly minutes: ReadonlySet<number>
   readonly hours: ReadonlySet<number>
@@ -51,6 +52,22 @@ const CronProto: Omit<Cron, "minutes" | "hours" | "days" | "months" | "weekdays"
       Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.months.values()))),
       Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.weekdays.values())))
     )
+  },
+  toString(this: Cron) {
+    return format(this.toJSON())
+  },
+  toJSON(this: Cron) {
+    return {
+      _id: "Cron",
+      minutes: ReadonlyArray.fromIterable(this.minutes.values()),
+      hours: ReadonlyArray.fromIterable(this.hours.values()),
+      days: ReadonlyArray.fromIterable(this.days.values()),
+      months: ReadonlyArray.fromIterable(this.months.values()),
+      weekdays: ReadonlyArray.fromIterable(this.weekdays.values())
+    }
+  },
+  [NodeInspectSymbol](this: Cron) {
+    return this.toJSON()
   },
   pipe() {
     return pipeArguments(this, arguments)

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -2,6 +2,9 @@
  * @since 2.0.0
  */
 import * as Either from "./Either.js"
+import * as Equal from "./Equal.js"
+import { pipe } from "./Function.js"
+import * as Hash from "./Hash.js"
 import * as N from "./Number.js"
 import { type Pipeable, pipeArguments } from "./Pipeable.js"
 import { hasProperty } from "./Predicate.js"
@@ -25,7 +28,7 @@ export type TypeId = typeof TypeId
  * @since 2.0.0
  * @category models
  */
-export interface Cron extends Pipeable {
+export interface Cron extends Pipeable, Equal.Equal {
   readonly [TypeId]: TypeId
   readonly minutes: ReadonlySet<number>
   readonly hours: ReadonlySet<number>
@@ -36,6 +39,19 @@ export interface Cron extends Pipeable {
 
 const CronProto: Omit<Cron, "minutes" | "hours" | "days" | "months" | "weekdays"> = {
   [TypeId]: TypeId,
+  [Equal.symbol](this: Cron, that: unknown) {
+    return isCron(that) && Equal.equals(this, that)
+  },
+  [Hash.symbol](this: Cron): number {
+    return pipe(
+      Hash.hash(TypeId),
+      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.minutes.values()))),
+      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.hours.values()))),
+      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.days.values()))),
+      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.months.values()))),
+      Hash.combine(Hash.array(ReadonlyArray.fromIterable(this.weekdays.values())))
+    )
+  },
   pipe() {
     return pipeArguments(this, arguments)
   }

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -137,8 +137,8 @@ export const isParseError = (u: unknown): u is ParseError => hasProperty(u, Pars
  *   minutes: [0],
  *   hours: [4],
  *   days: [8, 9, 10, 11, 12, 13, 14],
- *   months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
- *   weekdays: [0, 1, 2, 3, 4, 5, 6]
+ *   months: [],
+ *   weekdays: []
  * })))
  *
  * @since 2.0.0

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -3,7 +3,6 @@
  */
 import * as Either from "./Either.js"
 import * as N from "./Number.js"
-import * as Option from "./Option.js"
 import { type Pipeable, pipeArguments } from "./Pipeable.js"
 import { hasProperty } from "./Predicate.js"
 import * as ReadonlyArray from "./ReadonlyArray.js"

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -408,14 +408,14 @@ export const count: Schedule<never, unknown, number> = internal.count
 /**
  * Cron schedule that recurs every `minute` that matches the schedule.
  *
- * It triggers at zero second of the minute. Producing the timestamp of the cron window.
+ * It triggers at zero second of the minute. Producing the timestamps of the cron window.
  *
  * NOTE: `expression` parameter is validated lazily. Must be a valid cron expression.
  *
  * @since 2.0.0
  * @category constructors
  */
-export const cron: (expression: string) => Schedule<never, unknown, number> = internal.cron
+export const cron: (expression: string) => Schedule<never, unknown, [number, number]> = internal.cron
 
 /**
  * Cron-like schedule that recurs every specified `day` of month. Won't recur

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -407,10 +407,13 @@ export const count: Schedule<never, unknown, number> = internal.count
 
 /**
  * Cron schedule that recurs every `minute` that matches the schedule.
- * 
+ *
  * It triggers at zero second of the minute. Producing a count of repeats: 0, 1, 2.
- * 
+ *
  * NOTE: `expression` parameter is validated lazily. Must be a valid cron expression.
+ *
+ * @since 2.0.0
+ * @category constructors
  */
 export const cron: (expression: string) => Schedule<never, unknown, Date> = internal.cron
 

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -408,14 +408,14 @@ export const count: Schedule<never, unknown, number> = internal.count
 /**
  * Cron schedule that recurs every `minute` that matches the schedule.
  *
- * It triggers at zero second of the minute. Producing a count of repeats: 0, 1, 2.
+ * It triggers at zero second of the minute. Producing the timestamp of the cron window.
  *
  * NOTE: `expression` parameter is validated lazily. Must be a valid cron expression.
  *
  * @since 2.0.0
  * @category constructors
  */
-export const cron: (expression: string) => Schedule<never, unknown, Date> = internal.cron
+export const cron: (expression: string) => Schedule<never, unknown, number> = internal.cron
 
 /**
  * Cron-like schedule that recurs every specified `day` of month. Won't recur

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -406,6 +406,15 @@ export const mapInputEffect: {
 export const count: Schedule<never, unknown, number> = internal.count
 
 /**
+ * Cron schedule that recurs every `minute` that matches the schedule.
+ * 
+ * It triggers at zero second of the minute. Producing a count of repeats: 0, 1, 2.
+ * 
+ * NOTE: `expression` parameter is validated lazily. Must be a valid cron expression.
+ */
+export const cron: (expression: string) => Schedule<never, unknown, Date> = internal.cron
+
+/**
  * Cron-like schedule that recurs every specified `day` of month. Won't recur
  * on months containing less days than specified in `day` param.
  *

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -173,6 +173,11 @@ export * as Context from "./Context.js"
 /**
  * @since 2.0.0
  */
+export * as Cron from "./Cron.js"
+
+/**
+ * @since 2.0.0
+ */
 export * as Data from "./Data.js"
 
 /**

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -430,7 +430,7 @@ export const cron = (expression: string): Schedule.Schedule<never, unknown, numb
         const [next, start, end] = previous
         const interval = Interval.make(start, end)
         return core.succeed([
-          [false, next],
+          [false, [next, start, end]],
           next,
           ScheduleDecision.continueWith(interval)
         ])

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -427,12 +427,10 @@ export const cron = (expression: string): Schedule.Schedule<never, unknown, numb
     [true, [Number.MIN_SAFE_INTEGER, 0, 0]],
     (now, _, [initial, previous]) => {
       if (now < previous[0]) {
-        const [next, start, end] = previous
-        const interval = Interval.make(start, end)
         return core.succeed([
-          [false, [next, start, end]],
-          next,
-          ScheduleDecision.continueWith(interval)
+          [false, previous],
+          previous[0],
+          ScheduleDecision.continueWith(Interval.make(previous[1], previous[2]))
         ])
       }
 

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -421,15 +421,15 @@ export const mapInputEffect = dual<
     )))
 
 /** @internal */
-export const cron = (expression: string): Schedule.Schedule<never, unknown, number> => {
+export const cron = (expression: string): Schedule.Schedule<never, unknown, [number, number]> => {
   const parsed = Cron.parse(expression)
-  return makeWithState<[initial: boolean, previous: [number, number, number]], never, unknown, number>(
+  return makeWithState<[boolean, [number, number, number]], never, unknown, [number, number]>(
     [true, [Number.MIN_SAFE_INTEGER, 0, 0]],
     (now, _, [initial, previous]) => {
       if (now < previous[0]) {
         return core.succeed([
           [false, previous],
-          previous[0],
+          [previous[1], previous[2]],
           ScheduleDecision.continueWith(Interval.make(previous[1], previous[2]))
         ])
       }
@@ -454,7 +454,7 @@ export const cron = (expression: string): Schedule.Schedule<never, unknown, numb
       const interval = Interval.make(start, end)
       return core.succeed([
         [false, [next, start, end]],
-        next,
+        [start, end],
         ScheduleDecision.continueWith(interval)
       ])
     }

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -435,7 +435,7 @@ export const cron = (expression: string): Schedule.Schedule<never, unknown, [num
       }
 
       if (Either.isLeft(parsed)) {
-        return core.dieSync(() => parsed.left)
+        return core.die(parsed.left)
       }
 
       const cron = parsed.right

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -2,13 +2,11 @@ import { assertFalse, assertTrue, deepStrictEqual } from "effect-test/util"
 import * as Cron from "effect/Cron"
 import * as Either from "effect/Either"
 import { identity } from "effect/Function"
-import * as Option from "effect/Option"
 import { describe, it } from "vitest"
 
 const parse = (input: string) => Either.getOrThrowWith(Cron.parse(input), identity)
 const match = (input: string, date: Date) => Cron.match(parse(input), date)
-const next = (input: string, after?: Date) =>
-  Option.getOrThrowWith(Cron.next(parse(input), after), () => new Error("No next date found for"))
+const next = (input: string, after?: Date) => Cron.next(parse(input), after)
 
 describe("Cron", () => {
   it("parse", () => {

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -1,0 +1,43 @@
+import { deepStrictEqual } from "effect-test/util"
+import * as Cron from "effect/Cron"
+import * as Either from "effect/Either"
+import { describe, it } from "vitest"
+import { ReadonlyArray } from "../src/index.js"
+
+describe("Cron", () => {
+  it("parse", () => {
+    // At 04:00 on every day-of-month from 8 through 14.
+    deepStrictEqual(
+      Cron.parse("0 4 8-14 * *"),
+      Either.right(Cron.make({
+        minutes: [0],
+        hours: [4],
+        days: ReadonlyArray.range(8, 14),
+        months: ReadonlyArray.range(1, 12),
+        weekdays: ReadonlyArray.range(0, 6)
+      }))
+    )
+    // At 00:00 on day-of-month 1 and 15 and on Wednesday.
+    deepStrictEqual(
+      Cron.parse("0 0 1,15 * 3"),
+      Either.right(Cron.make({
+        minutes: [0],
+        hours: [0],
+        days: [1, 15],
+        months: ReadonlyArray.range(1, 12),
+        weekdays: [3]
+      }))
+    )
+    // At 00:00 on day-of-month 1 and 15 and on Wednesday.
+    deepStrictEqual(
+      Cron.parse("23 0-20/2 * * *"),
+      Either.right(Cron.make({
+        minutes: [23],
+        hours: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+        days: ReadonlyArray.range(1, 31),
+        months: ReadonlyArray.range(1, 12),
+        weekdays: ReadonlyArray.range(0, 6)
+      }))
+    )
+  })
+})

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -1,20 +1,23 @@
-import { deepStrictEqual } from "effect-test/util"
+import { assertFalse, assertTrue, deepStrictEqual } from "effect-test/util"
 import * as Cron from "effect/Cron"
 import * as Either from "effect/Either"
+import { identity } from "effect/Function"
+import * as ReadonlyArray from "effect/ReadonlyArray"
 import { describe, it } from "vitest"
-import { ReadonlyArray } from "../src/index.js"
+
+const _ = (input: string) => Either.getOrThrowWith(Cron.parse(input), identity)
 
 describe("Cron", () => {
   it("parse", () => {
     // At 04:00 on every day-of-month from 8 through 14.
     deepStrictEqual(
-      Cron.parse("0 4 8-14 * *"),
+      Cron.parse("0 4 8-14 * 0-6"),
       Either.right(Cron.make({
         minutes: [0],
         hours: [4],
         days: ReadonlyArray.range(8, 14),
-        months: ReadonlyArray.range(1, 12),
-        weekdays: ReadonlyArray.range(0, 6)
+        months: [],
+        weekdays: []
       }))
     )
     // At 00:00 on day-of-month 1 and 15 and on Wednesday.
@@ -24,7 +27,7 @@ describe("Cron", () => {
         minutes: [0],
         hours: [0],
         days: [1, 15],
-        months: ReadonlyArray.range(1, 12),
+        months: [],
         weekdays: [3]
       }))
     )
@@ -34,10 +37,32 @@ describe("Cron", () => {
       Either.right(Cron.make({
         minutes: [23],
         hours: [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
-        days: ReadonlyArray.range(1, 31),
-        months: ReadonlyArray.range(1, 12),
-        weekdays: ReadonlyArray.range(0, 6)
+        days: [],
+        months: [],
+        weekdays: []
       }))
     )
+  })
+
+  it("match", () => {
+    assertTrue(Cron.match(_("5 0 * 8 *"), new Date("2024-08-01 00:05:00")))
+    assertFalse(Cron.match(_("5 0 * 8 *"), new Date("2024-09-01 00:05:00")))
+    assertFalse(Cron.match(_("5 0 * 8 *"), new Date("2024-08-01 01:05:00")))
+
+    assertTrue(Cron.match(_("15 14 1 * *"), new Date("2024-02-01 14:15:00")))
+    assertFalse(Cron.match(_("15 14 1 * *"), new Date("2024-02-01 15:15:00")))
+    assertFalse(Cron.match(_("15 14 1 * *"), new Date("2024-02-02 14:15:00")))
+
+    assertTrue(Cron.match(_("23 0-20/2 * * 0"), new Date("2024-01-07 00:23:00")))
+    assertFalse(Cron.match(_("23 0-20/2 * * 0"), new Date("2024-01-07 03:23:00")))
+    assertFalse(Cron.match(_("23 0-20/2 * * 0"), new Date("2024-01-08 00:23:00")))
+
+    assertTrue(Cron.match(_("5 4 * * SUN"), new Date("2024-01-07 04:05:00")))
+    assertFalse(Cron.match(_("5 4 * * SUN"), new Date("2024-01-08 04:05:00")))
+    assertFalse(Cron.match(_("5 4 * * SUN"), new Date("2025-01-07 04:05:00")))
+
+    assertTrue(Cron.match(_("5 4 * DEC SUN"), new Date("2024-12-01 04:05:00")))
+    assertFalse(Cron.match(_("5 4 * DEC SUN"), new Date("2024-12-01 04:06:00")))
+    assertFalse(Cron.match(_("5 4 * DEC SUN"), new Date("2024-12-02 04:05:00")))
   })
 })

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -3,7 +3,6 @@ import * as Cron from "effect/Cron"
 import * as Either from "effect/Either"
 import { identity } from "effect/Function"
 import * as Option from "effect/Option"
-import * as ReadonlyArray from "effect/ReadonlyArray"
 import { describe, it } from "vitest"
 
 const parse = (input: string) => Either.getOrThrowWith(Cron.parse(input), identity)
@@ -19,7 +18,7 @@ describe("Cron", () => {
       Either.right(Cron.make({
         minutes: [0],
         hours: [4],
-        days: ReadonlyArray.range(8, 14),
+        days: [8, 9, 10, 11, 12, 13, 14],
         months: [],
         weekdays: []
       }))

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -75,4 +75,13 @@ describe("Cron", () => {
     deepStrictEqual(next("5 4 * * SUN", after), new Date("2024-01-07 04:05:00"))
     deepStrictEqual(next("5 4 * DEC SUN", after), new Date("2024-12-01 04:05:00"))
   })
+
+  it("sequence", () => {
+    const generator = Cron.sequence(parse("23 0-20/2 * * 0"))
+    deepStrictEqual(generator.next().value, new Date("2024-01-07 00:23:00"))
+    deepStrictEqual(generator.next().value, new Date("2024-01-07 02:23:00"))
+    deepStrictEqual(generator.next().value, new Date("2024-01-07 04:23:00"))
+    deepStrictEqual(generator.next().value, new Date("2024-01-07 06:23:00"))
+    deepStrictEqual(generator.next().value, new Date("2024-01-07 08:23:00"))
+  })
 })

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -2,10 +2,14 @@ import { assertFalse, assertTrue, deepStrictEqual } from "effect-test/util"
 import * as Cron from "effect/Cron"
 import * as Either from "effect/Either"
 import { identity } from "effect/Function"
+import * as Option from "effect/Option"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import { describe, it } from "vitest"
 
-const _ = (input: string) => Either.getOrThrowWith(Cron.parse(input), identity)
+const parse = (input: string) => Either.getOrThrowWith(Cron.parse(input), identity)
+const match = (input: string, date: Date) => Cron.match(parse(input), date)
+const next = (input: string, after?: Date) =>
+  Option.getOrThrowWith(Cron.next(parse(input), after), () => new Error("No next date found for"))
 
 describe("Cron", () => {
   it("parse", () => {
@@ -45,24 +49,33 @@ describe("Cron", () => {
   })
 
   it("match", () => {
-    assertTrue(Cron.match(_("5 0 * 8 *"), new Date("2024-08-01 00:05:00")))
-    assertFalse(Cron.match(_("5 0 * 8 *"), new Date("2024-09-01 00:05:00")))
-    assertFalse(Cron.match(_("5 0 * 8 *"), new Date("2024-08-01 01:05:00")))
+    assertTrue(match("5 0 * 8 *", new Date("2024-08-01 00:05:00")))
+    assertFalse(match("5 0 * 8 *", new Date("2024-09-01 00:05:00")))
+    assertFalse(match("5 0 * 8 *", new Date("2024-08-01 01:05:00")))
 
-    assertTrue(Cron.match(_("15 14 1 * *"), new Date("2024-02-01 14:15:00")))
-    assertFalse(Cron.match(_("15 14 1 * *"), new Date("2024-02-01 15:15:00")))
-    assertFalse(Cron.match(_("15 14 1 * *"), new Date("2024-02-02 14:15:00")))
+    assertTrue(match("15 14 1 * *", new Date("2024-02-01 14:15:00")))
+    assertFalse(match("15 14 1 * *", new Date("2024-02-01 15:15:00")))
+    assertFalse(match("15 14 1 * *", new Date("2024-02-02 14:15:00")))
 
-    assertTrue(Cron.match(_("23 0-20/2 * * 0"), new Date("2024-01-07 00:23:00")))
-    assertFalse(Cron.match(_("23 0-20/2 * * 0"), new Date("2024-01-07 03:23:00")))
-    assertFalse(Cron.match(_("23 0-20/2 * * 0"), new Date("2024-01-08 00:23:00")))
+    assertTrue(match("23 0-20/2 * * 0", new Date("2024-01-07 00:23:00")))
+    assertFalse(match("23 0-20/2 * * 0", new Date("2024-01-07 03:23:00")))
+    assertFalse(match("23 0-20/2 * * 0", new Date("2024-01-08 00:23:00")))
 
-    assertTrue(Cron.match(_("5 4 * * SUN"), new Date("2024-01-07 04:05:00")))
-    assertFalse(Cron.match(_("5 4 * * SUN"), new Date("2024-01-08 04:05:00")))
-    assertFalse(Cron.match(_("5 4 * * SUN"), new Date("2025-01-07 04:05:00")))
+    assertTrue(match("5 4 * * SUN", new Date("2024-01-07 04:05:00")))
+    assertFalse(match("5 4 * * SUN", new Date("2024-01-08 04:05:00")))
+    assertFalse(match("5 4 * * SUN", new Date("2025-01-07 04:05:00")))
 
-    assertTrue(Cron.match(_("5 4 * DEC SUN"), new Date("2024-12-01 04:05:00")))
-    assertFalse(Cron.match(_("5 4 * DEC SUN"), new Date("2024-12-01 04:06:00")))
-    assertFalse(Cron.match(_("5 4 * DEC SUN"), new Date("2024-12-02 04:05:00")))
+    assertTrue(match("5 4 * DEC SUN", new Date("2024-12-01 04:05:00")))
+    assertFalse(match("5 4 * DEC SUN", new Date("2024-12-01 04:06:00")))
+    assertFalse(match("5 4 * DEC SUN", new Date("2024-12-02 04:05:00")))
+  })
+
+  it("next", () => {
+    const after = new Date("2024-01-04 16:21:00")
+    deepStrictEqual(next("5 0 8 2 *", after), new Date("2024-02-08 00:05:00"))
+    deepStrictEqual(next("15 14 1 * *", after), new Date("2024-02-01 14:15:00"))
+    deepStrictEqual(next("23 0-20/2 * * 0", after), new Date("2024-01-07 00:23:00"))
+    deepStrictEqual(next("5 4 * * SUN", after), new Date("2024-01-07 04:05:00"))
+    deepStrictEqual(next("5 4 * DEC SUN", after), new Date("2024-12-01 04:05:00"))
   })
 })

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -1,6 +1,7 @@
 import { assertFalse, assertTrue, deepStrictEqual } from "effect-test/util"
 import * as Cron from "effect/Cron"
 import * as Either from "effect/Either"
+import * as Equal from "effect/Equal"
 import { identity } from "effect/Function"
 import { describe, it } from "vitest"
 
@@ -83,5 +84,14 @@ describe("Cron", () => {
     deepStrictEqual(generator.next().value, new Date("2024-01-07 04:23:00"))
     deepStrictEqual(generator.next().value, new Date("2024-01-07 06:23:00"))
     deepStrictEqual(generator.next().value, new Date("2024-01-07 08:23:00"))
+  })
+
+  it("equal", () => {
+    const cron = parse("23 0-20/2 * * 0")
+    assertTrue(Equal.equals(cron, cron))
+    assertTrue(Equal.equals(cron, parse("23 0-20/2 * * 0")))
+    assertFalse(Equal.equals(cron, parse("23 0-20/2 * * 1")))
+    assertFalse(Equal.equals(cron, parse("23 0-20/2 * * 0-6")))
+    assertFalse(Equal.equals(cron, parse("23 0-20/2 1 * 0")))
   })
 })

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -570,6 +570,31 @@ describe("Schedule", () => {
       }))
   })
   describe("cron-like scheduling - repeats at point of time (minute of hour, day of week, ...)", () => {
+    it.effect("recur at time matching cron expression", () =>
+      Effect.gen(function*($) {
+        const ref = yield* $(Ref.make<ReadonlyArray<string>>([]))
+        yield* $(TestClock.setTime(new Date(2024, 0, 1, 0, 0, 0).getTime()))
+        // At 04:30 on day-of-month 5 and 15 and on Wednesday.
+        const schedule = Schedule.cron("30 4 5,15 * WED")
+        yield* $(
+          TestClock.currentTimeMillis,
+          Effect.tap((instant) => Ref.update(ref, ReadonlyArray.append(cronTime(new Date(instant))))),
+          Effect.repeat(schedule),
+          Effect.fork
+        )
+        yield* $(TestClock.adjust("4 weeks"))
+        const result = yield* $(Ref.get(ref))
+        const expected = [
+          "Mon Jan 01 2024 00:00:00",
+          "Wed Jan 03 2024 04:30:00",
+          "Fri Jan 05 2024 04:30:00",
+          "Wed Jan 10 2024 04:30:00",
+          "Mon Jan 15 2024 04:30:00",
+          "Wed Jan 17 2024 04:30:00",
+          "Wed Jan 24 2024 04:30:00"
+        ]
+        assert.deepStrictEqual(result, expected)
+      }))
     it.effect("recur at 01 second of each minute", () =>
       Effect.gen(function*($) {
         const originOffset = new Date(new Date(new Date().setMinutes(0)).setSeconds(0)).setMilliseconds(0)
@@ -752,6 +777,15 @@ describe("Schedule", () => {
       }))
   })
 })
+
+const cronTime = (value: Date): string => {
+  const date = value.toDateString()
+  const hours = `0${value.getHours()}`.slice(-2)
+  const minutes = `0${value.getMinutes()}`.slice(-2)
+  const seconds = `0${value.getSeconds()}`.slice(-2)
+  return `${date} ${hours}:${minutes}:${seconds}`
+}
+
 const ioSucceed = () => Effect.succeed("OrElse")
 const ioFail = () => Effect.fail("OrElseFailed")
 const failOn0 = (ref: Ref.Ref<number>): Effect.Effect<never, string, number> => {

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -578,7 +578,7 @@ describe("Schedule", () => {
         const schedule = Schedule.cron("30 4 5,15 * WED")
         yield* $(
           TestClock.currentTimeMillis,
-          Effect.tap((instant) => Ref.update(ref, ReadonlyArray.append(cronTime(new Date(instant))))),
+          Effect.tap((instant) => Ref.update(ref, ReadonlyArray.append(format(instant)))),
           Effect.repeat(schedule),
           Effect.fork
         )
@@ -778,12 +778,12 @@ describe("Schedule", () => {
   })
 })
 
-const cronTime = (value: Date): string => {
-  const date = value.toDateString()
-  const hours = `0${value.getHours()}`.slice(-2)
-  const minutes = `0${value.getMinutes()}`.slice(-2)
-  const seconds = `0${value.getSeconds()}`.slice(-2)
-  return `${date} ${hours}:${minutes}:${seconds}`
+const format = (value: number): string => {
+  const date = new Date(value)
+  const hours = `0${date.getHours()}`.slice(-2)
+  const minutes = `0${date.getMinutes()}`.slice(-2)
+  const seconds = `0${date.getSeconds()}`.slice(-2)
+  return `${date.toDateString()} ${hours}:${minutes}:${seconds}`
 }
 
 const ioSucceed = () => Effect.succeed("OrElse")


### PR DESCRIPTION
- [x] Add cron expression parser
- [x] Add cron `match` calculator
- [x] Add cron `next` calculator
- [x] Add `Schedule.cron` constructor
- [x] Write tests for `Schedule.cron`

Fixes #1524 