### PR TITLE
docs: add Url example to schema readme

### DIFF
--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -2787,33 +2787,61 @@ const Email = S.pattern(/^(?!\.)(?!.*\.\.)([A-Z0-9_+-\.]*)[A-Z0-9_+-]@([A-Z0-9][
 
 ## Url
 
-Multiple environments like the Browser or Node provide a built-in `URL` class that can be used to validate URLs. Here we demonstrate how to leverage it to validate if a string is a valid URL while the returned value is still a string.
+Multiple environments like the Browser or Node provide a built-in `URL` class that can be used to validate URLs. Here we demonstrate how to leverage it to validate if a string is a valid URL.
 
 ```ts
 import * as S from "@effect/schema/Schema";
 import * as ParseResult from "@effect/schema/ParseResult";
 
-const Url: S.Schema<string, string> = S.transformOrFail(
+const UrlString: S.Schema<string, string> = S.string.pipe(
+  S.filter((value) => {
+    try {
+      new URL(value);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }),
+);
+
+const parser = S.parseSync(UrlString);
+const validUrlString = parser("https://www.effect.website");
+```
+
+In case you prefer to normalize URLs you can combine `transformOrFail` with `URL`:
+
+```ts
+const NormalizedUrlString: S.Schema<string, string> = S.string.pipe(
+  S.filter((value) => {
+    try {
+      return new URL(value).toString() === value;
+    } catch (_) {
+      return false;
+    }
+  }),
+);
+
+const NormalizeUrlString: S.Schema<string, string> = S.transformOrFail(
   S.string,
-  S.string,
+  NormalizedUrlString,
   (value, _, ast) =>
     ParseResult.try({
       try: () => new URL(value).toString(),
-      catch: (err) => {
-        return ParseResult.parseError([
+      catch: (err) =>
+        ParseResult.parseError([
           ParseResult.type(
             ast,
             value,
             err instanceof Error ? err.message : undefined,
           ),
-        ]);
-      },
+        ]),
     }),
-  (value) => ParseResult.succeed(value),
+  ParseResult.succeed,
 );
 
-const parser = S.parseSync(Url);
-const validUrlString = parser("https://www.effect.website/");
+const parser = S.parseSync(NormalizeUrlString);
+const validUrlString = parser("https://www.effect.website");
+// validUrlString will be "https://www.effect.website/"
 ```
 
 # Technical overview

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -2785,6 +2785,37 @@ import * as S from "@effect/schema/Schema";
 const Email = S.pattern(/^(?!\.)(?!.*\.\.)([A-Z0-9_+-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i);
 ```
 
+## Url
+
+Multiple environments like the Browser or Node provide a built-in `URL` class that can be used to validate URLs. Here we demonstrate how to leverage it to validate if a string is a valid URL while the returned value is still a string.
+
+```ts
+import * as S from "@effect/schema/Schema";
+import * as ParseResult from "@effect/schema/ParseResult";
+
+const Url: S.Schema<string, string> = S.transformOrFail(
+  S.string,
+  S.string,
+  (value, _, ast) =>
+    ParseResult.try({
+      try: () => new URL(value).toString(),
+      catch: (err) => {
+        return ParseResult.parseError([
+          ParseResult.type(
+            ast,
+            value,
+            err instanceof Error ? err.message : undefined,
+          ),
+        ]);
+      },
+    }),
+  (value) => ParseResult.succeed(value),
+);
+
+const parser = S.parseSync(Url);
+const validUrlString = parser("https://www.effect.website/");
+```
+
 # Technical overview
 
 ## Understanding Schemas


### PR DESCRIPTION
Needed an Url combinator to validate that a string is a valid URL and thought this might be useful to others as well. Tested it here in isolation to make sure the code works as expected: https://stackblitz.com/edit/effect-ts-examples-q6pwrk?file=package.json,src%2Findex.ts

Note: there could be another example to actually parse it to a URL instance. Happy to add this as well if there is interest.
