### PR TITLE
fix: expose `LiteralValue` type

### DIFF
--- a/.changeset/smart-lizards-repeat.md
+++ b/.changeset/smart-lizards-repeat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Include Config.LiteralValue in dts.

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -77,6 +77,12 @@ export declare namespace Config {
 }
 
 /**
+ * @since 2.0.0
+ * @category models
+ */
+export type LiteralValue = string | number | boolean | null | bigint
+
+/**
  * Constructs a config from a tuple / struct / arguments of configs.
  *
  * @since 2.0.0
@@ -162,7 +168,7 @@ export const integer: (name?: string) => Config<number> = internal.integer
  * @since 2.0.0
  * @category constructors
  */
-export const literal: <Literals extends ReadonlyArray<internal.LiteralValue>>(...literals: Literals) => (
+export const literal: <Literals extends ReadonlyArray<LiteralValue>>(...literals: Literals) => (
   name?: string
 ) => Config<Literals[number]> = internal.literal
 

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -256,10 +256,7 @@ export const integer = (name?: string): Config.Config<number> => {
 }
 
 /** @internal */
-export type LiteralValue = string | number | boolean | null | bigint
-
-/** @internal */
-export const literal = <Literals extends ReadonlyArray<LiteralValue>>(...literals: Literals) =>
+export const literal = <Literals extends ReadonlyArray<Config.LiteralValue>>(...literals: Literals) =>
 (
   name?: string
 ): Config.Config<Literals[number]> => {


### PR DESCRIPTION
The type is internal (thus missing in `dist/dts`) but used in public code.