### PR TITLE
Schema: treat missing properties as `undefined` (excluding `is` and `…

### DIFF
--- a/.changeset/chilly-months-knock.md
+++ b/.changeset/chilly-months-knock.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Schema: treat missing properties as `undefined` (excluding `is` and `asserts`), closes #1882

--- a/packages/schema/src/Parser.ts
+++ b/packages/schema/src/Parser.ts
@@ -79,8 +79,8 @@ const getPromise = (ast: AST.AST, isDecoding: boolean, outerOptions?: AST.ParseO
  */
 export const parseSync = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (i: unknown, options?: AST.ParseOptions) => A => getSync(schema.ast, true, options)
+  outerOptions?: AST.ParseOptions
+): (i: unknown, options?: AST.ParseOptions) => A => getSync(schema.ast, true, outerOptions)
 
 /**
  * @category parsing
@@ -88,15 +88,15 @@ export const parseSync = <I, A>(
  */
 export const parseOption = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (i: unknown, options?: AST.ParseOptions) => Option.Option<A> => getOption(schema.ast, true, options)
+  outerOptions?: AST.ParseOptions
+): (i: unknown, options?: AST.ParseOptions) => Option.Option<A> => getOption(schema.ast, true, outerOptions)
 
 /**
  * @category parsing
  * @since 1.0.0
  */
-export const parseEither = <I, A>(schema: Schema.Schema<I, A>, options?: AST.ParseOptions) => {
-  const parser = getEither(schema.ast, true, options)
+export const parseEither = <I, A>(schema: Schema.Schema<I, A>, outerOptions?: AST.ParseOptions) => {
+  const parser = getEither(schema.ast, true, outerOptions)
   return (i: unknown, options?: AST.ParseOptions): Either.Either<ParseResult.ParseError, A> =>
     Either.mapLeft(parser(i, options), ParseResult.parseError)
 }
@@ -107,8 +107,8 @@ export const parseEither = <I, A>(schema: Schema.Schema<I, A>, options?: AST.Par
  */
 export const parsePromise = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (i: unknown, options?: AST.ParseOptions) => Promise<A> => getPromise(schema.ast, true, options)
+  outerOptions?: AST.ParseOptions
+): (i: unknown, options?: AST.ParseOptions) => Promise<A> => getPromise(schema.ast, true, outerOptions)
 
 /**
  * @category parsing
@@ -116,9 +116,9 @@ export const parsePromise = <I, A>(
  */
 export const parse = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ): (i: unknown, options?: AST.ParseOptions) => Effect.Effect<never, ParseResult.ParseError, A> =>
-  getEffect(schema.ast, true, options)
+  getEffect(schema.ast, true, outerOptions)
 
 /**
  * @category decoding
@@ -126,7 +126,7 @@ export const parse = <I, A>(
  */
 export const decodeSync: <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => (i: I, options?: AST.ParseOptions) => A = parseSync
 
 /**
@@ -135,7 +135,7 @@ export const decodeSync: <I, A>(
  */
 export const decodeOption: <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => (i: I, options?: AST.ParseOptions) => Option.Option<A> = parseOption
 
 /**
@@ -144,7 +144,7 @@ export const decodeOption: <I, A>(
  */
 export const decodeEither: <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => (i: I, options?: AST.ParseOptions) => Either.Either<ParseResult.ParseError, A> = parseEither
 
 /**
@@ -153,7 +153,7 @@ export const decodeEither: <I, A>(
  */
 export const decodePromise: <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => (i: I, options?: AST.ParseOptions) => Promise<A> = parsePromise
 
 /**
@@ -162,7 +162,7 @@ export const decodePromise: <I, A>(
  */
 export const decode: <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => (i: I, options?: AST.ParseOptions) => Effect.Effect<never, ParseResult.ParseError, A> = parse
 
 /**
@@ -171,8 +171,8 @@ export const decode: <I, A>(
  */
 export const validateSync = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (a: unknown, options?: AST.ParseOptions) => A => getSync(AST.to(schema.ast), true, options)
+  outerOptions?: AST.ParseOptions
+): (a: unknown, options?: AST.ParseOptions) => A => getSync(AST.to(schema.ast), true, outerOptions)
 
 /**
  * @category validation
@@ -180,8 +180,8 @@ export const validateSync = <I, A>(
  */
 export const validateOption = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (a: unknown, options?: AST.ParseOptions) => Option.Option<A> => getOption(AST.to(schema.ast), true, options)
+  outerOptions?: AST.ParseOptions
+): (a: unknown, options?: AST.ParseOptions) => Option.Option<A> => getOption(AST.to(schema.ast), true, outerOptions)
 
 /**
  * @category validation
@@ -189,9 +189,9 @@ export const validateOption = <I, A>(
  */
 export const validateEither = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => {
-  const parser = getEither(AST.to(schema.ast), true, options)
+  const parser = getEither(AST.to(schema.ast), true, outerOptions)
   return (a: unknown, options?: AST.ParseOptions): Either.Either<ParseResult.ParseError, A> =>
     Either.mapLeft(parser(a, options), ParseResult.parseError)
 }
@@ -202,8 +202,8 @@ export const validateEither = <I, A>(
  */
 export const validatePromise = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (i: unknown, options?: AST.ParseOptions) => Promise<A> => getPromise(AST.to(schema.ast), true, options)
+  outerOptions?: AST.ParseOptions
+): (i: unknown, options?: AST.ParseOptions) => Promise<A> => getPromise(AST.to(schema.ast), true, outerOptions)
 
 /**
  * @category validation
@@ -211,27 +211,34 @@ export const validatePromise = <I, A>(
  */
 export const validate = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ): (a: unknown, options?: AST.ParseOptions) => Effect.Effect<never, ParseResult.ParseError, A> =>
-  getEffect(AST.to(schema.ast), true, options)
+  getEffect(AST.to(schema.ast), true, outerOptions)
 
 /**
  * @category validation
  * @since 1.0.0
  */
-export const is = <I, A>(schema: Schema.Schema<I, A>, options?: AST.ParseOptions) => {
-  const getEither = validateEither(schema, options)
-  return (a: unknown, options?: AST.ParseOptions): a is A => Either.isRight(getEither(a, options))
+export const is = <I, A>(schema: Schema.Schema<I, A>, outerOptions?: AST.ParseOptions) => {
+  const parser = goMemo(AST.to(schema.ast), true)
+  return (a: unknown, options?: AST.ParseOptions): a is A =>
+    Either.isRight(parser(a, { ...mergeParseOptions(outerOptions, options), isExact: true }) as any)
 }
 
 /**
  * @category validation
  * @since 1.0.0
  */
-export const asserts = <I, A>(schema: Schema.Schema<I, A>, options?: AST.ParseOptions) => {
-  const get = validateSync(schema, options)
+export const asserts = <I, A>(schema: Schema.Schema<I, A>, outerOptions?: AST.ParseOptions) => {
+  const parser = goMemo(AST.to(schema.ast), true)
   return (a: unknown, options?: AST.ParseOptions): asserts a is A => {
-    get(a, options)
+    const result: Either.Either<ParseResult.ParseIssue, any> = parser(a, {
+      ...mergeParseOptions(outerOptions, options),
+      isExact: true
+    }) as any
+    if (Either.isLeft(result)) {
+      throw new Error(TreeFormatter.formatIssue(result.left))
+    }
   }
 }
 
@@ -241,8 +248,8 @@ export const asserts = <I, A>(schema: Schema.Schema<I, A>, options?: AST.ParseOp
  */
 export const encodeSync = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (a: A, options?: AST.ParseOptions) => I => getSync(schema.ast, false, options)
+  outerOptions?: AST.ParseOptions
+): (a: A, options?: AST.ParseOptions) => I => getSync(schema.ast, false, outerOptions)
 
 /**
  * @category encoding
@@ -250,8 +257,8 @@ export const encodeSync = <I, A>(
  */
 export const encodeOption = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (input: A, options?: AST.ParseOptions) => Option.Option<I> => getOption(schema.ast, false, options)
+  outerOptions?: AST.ParseOptions
+): (input: A, options?: AST.ParseOptions) => Option.Option<I> => getOption(schema.ast, false, outerOptions)
 
 /**
  * @category encoding
@@ -259,9 +266,9 @@ export const encodeOption = <I, A>(
  */
 export const encodeEither = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ) => {
-  const parser = getEither(schema.ast, false, options)
+  const parser = getEither(schema.ast, false, outerOptions)
   return (a: A, options?: AST.ParseOptions): Either.Either<ParseResult.ParseError, I> =>
     Either.mapLeft(parser(a, options), ParseResult.parseError)
 }
@@ -272,8 +279,8 @@ export const encodeEither = <I, A>(
  */
 export const encodePromise = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
-): (a: A, options?: AST.ParseOptions) => Promise<I> => getPromise(schema.ast, false, options)
+  outerOptions?: AST.ParseOptions
+): (a: A, options?: AST.ParseOptions) => Promise<I> => getPromise(schema.ast, false, outerOptions)
 
 /**
  * @category encoding
@@ -281,16 +288,17 @@ export const encodePromise = <I, A>(
  */
 export const encode = <I, A>(
   schema: Schema.Schema<I, A>,
-  options?: AST.ParseOptions
+  outerOptions?: AST.ParseOptions
 ): (a: A, options?: AST.ParseOptions) => Effect.Effect<never, ParseResult.ParseError, I> =>
-  getEffect(schema.ast, false, options)
+  getEffect(schema.ast, false, outerOptions)
 
-interface ParseEffectOptions extends AST.ParseOptions {
+interface InternalOptions extends AST.ParseOptions {
   readonly isEffectAllowed?: boolean
+  readonly isExact?: boolean
 }
 
 interface Parser<I, A> {
-  (i: I, options?: ParseEffectOptions): Effect.Effect<never, ParseResult.ParseIssue, A>
+  (i: I, options?: InternalOptions): Effect.Effect<never, ParseResult.ParseIssue, A>
 }
 
 /**
@@ -695,54 +703,15 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser<any, any> => {
           | Array<(state: State) => Effect.Effect<never, ParseResult.ParseIssue, void>>
           | undefined = undefined
 
+        const isExact = options?.isExact === true
         for (let i = 0; i < propertySignatures.length; i++) {
           const ps = ast.propertySignatures[i]
-          const parser = propertySignatures[i]
           const name = ps.name
-          if (Object.prototype.hasOwnProperty.call(input, name)) {
-            const te = parser(input[name], options)
-            const eu = ParseResult.eitherOrUndefined(te)
-            if (eu) {
-              if (Either.isLeft(eu)) {
-                // the input key is present but is not valid
-                const e = ParseResult.key(name, eu.left)
-                if (allErrors) {
-                  es.push([stepKey++, e])
-                  continue
-                } else {
-                  return Either.left(ParseResult.typeLiteral(ast, input, [e]))
-                }
-              }
-              output[name] = eu.right
-            } else {
-              const nk = stepKey++
-              const index = name
-              if (!queue) {
-                queue = []
-              }
-              queue.push(
-                ({ es, output }: State) =>
-                  Effect.flatMap(Effect.either(te), (t) => {
-                    if (Either.isLeft(t)) {
-                      // the input key is present but is not valid
-                      const e = ParseResult.key(index, t.left)
-                      if (allErrors) {
-                        es.push([nk, e])
-                        return Effect.unit
-                      } else {
-                        return Either.left(ParseResult.typeLiteral(ast, input, [e]))
-                      }
-                    }
-                    output[index] = t.right
-                    return Effect.unit
-                  })
-              )
-            }
-          } else {
-            // ---------------------------------------------
-            // handle missing keys
-            // ---------------------------------------------
-            if (!ps.isOptional) {
+          const hasKey = Object.prototype.hasOwnProperty.call(input, name)
+          if (!hasKey) {
+            if (ps.isOptional) {
+              continue
+            } else if (isExact) {
               const e = ParseResult.key(name, ParseResult.missing)
               if (allErrors) {
                 es.push([stepKey++, e])
@@ -751,6 +720,43 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser<any, any> => {
                 return Either.left(ParseResult.typeLiteral(ast, input, [e]))
               }
             }
+          }
+          const parser = propertySignatures[i]
+          const te = parser(input[name], options)
+          const eu = ParseResult.eitherOrUndefined(te)
+          if (eu) {
+            if (Either.isLeft(eu)) {
+              const e = ParseResult.key(name, hasKey ? eu.left : ParseResult.missing)
+              if (allErrors) {
+                es.push([stepKey++, e])
+                continue
+              } else {
+                return Either.left(ParseResult.typeLiteral(ast, input, [e]))
+              }
+            }
+            output[name] = eu.right
+          } else {
+            const nk = stepKey++
+            const index = name
+            if (!queue) {
+              queue = []
+            }
+            queue.push(
+              ({ es, output }: State) =>
+                Effect.flatMap(Effect.either(te), (t) => {
+                  if (Either.isLeft(t)) {
+                    const e = ParseResult.key(index, hasKey ? t.left : ParseResult.missing)
+                    if (allErrors) {
+                      es.push([nk, e])
+                      return Effect.unit
+                    } else {
+                      return Either.left(ParseResult.typeLiteral(ast, input, [e]))
+                    }
+                  }
+                  output[index] = t.right
+                  return Effect.unit
+                })
+            )
           }
         }
 
@@ -1085,7 +1091,7 @@ const dropRightRefinement = (ast: AST.AST): AST.AST => AST.isRefinement(ast) ? d
 const handleForbidden = <A>(
   effect: Effect.Effect<never, ParseResult.ParseIssue, A>,
   actual: unknown,
-  options?: ParseEffectOptions
+  options?: InternalOptions
 ): Effect.Effect<never, ParseResult.ParseIssue, A> => {
   const eu = ParseResult.eitherOrUndefined(effect)
   return eu

--- a/packages/schema/test/Schema/asserts.test.ts
+++ b/packages/schema/test/Schema/asserts.test.ts
@@ -2,19 +2,17 @@ import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 import { describe, expect, it } from "vitest"
 
+const expectAssertsSuccess = <I, A>(schema: S.Schema<I, A>, input: unknown) => {
+  expect(S.asserts(schema)(input)).toEqual(undefined)
+}
+
+const expectAssertsFailure = <I, A>(schema: S.Schema<I, A>, input: unknown, message: string) => {
+  expect(() => S.asserts(schema)(input)).toThrow(new Error(message))
+}
+
 describe("Schema > asserts", () => {
-  const schema = S.struct({ a: Util.NumberFromChar })
-
-  it("should throw on invalid values", () => {
-    expect(S.asserts(schema)({ a: 1 })).toEqual(undefined)
-    expect(() => S.asserts(schema)({ a: null })).toThrow(
-      new Error(`{ a: number }
-└─ ["a"]
-   └─ Expected a number, actual null`)
-    )
-  })
-
   it("should respect outer/inner options", () => {
+    const schema = S.struct({ a: Util.NumberFromChar })
     const input = { a: 1, b: "b" }
     expect(() => S.asserts(schema)(input, { onExcessProperty: "error" })).toThrow(
       new Error(`{ a: number }
@@ -28,5 +26,46 @@ describe("Schema > asserts", () => {
     )
     expect(S.asserts(schema, { onExcessProperty: "error" })(input, { onExcessProperty: "ignore" }))
       .toEqual(undefined)
+  })
+
+  describe("struct", () => {
+    it("required property signature", () => {
+      const schema = S.struct({ a: Util.NumberFromChar })
+      expectAssertsSuccess(schema, { a: 1 })
+      expectAssertsFailure(
+        schema,
+        { a: null },
+        `{ a: number }
+└─ ["a"]
+   └─ Expected a number, actual null`
+      )
+    })
+
+    it("required property signature with undefined", () => {
+      const schema = S.struct({ a: S.union(S.number, S.undefined) })
+      expectAssertsSuccess(schema, { a: 1 })
+      expectAssertsSuccess(schema, { a: undefined })
+      expectAssertsSuccess(schema, { a: 1, b: "b" })
+
+      expectAssertsFailure(
+        schema,
+        {},
+        `{ a: number | undefined }
+└─ ["a"]
+   └─ is missing`
+      )
+      expectAssertsFailure(schema, null, `Expected { a: number | undefined }, actual null`)
+      expectAssertsFailure(
+        schema,
+        { a: "a" },
+        `{ a: number | undefined }
+└─ ["a"]
+   └─ number | undefined
+      ├─ Union member
+      │  └─ Expected a number, actual "a"
+      └─ Union member
+         └─ Expected undefined, actual "a"`
+      )
+    })
   })
 })

--- a/packages/schema/test/Schema/is.test.ts
+++ b/packages/schema/test/Schema/is.test.ts
@@ -284,8 +284,8 @@ describe("Schema > is", () => {
       expect(is({ a: undefined })).toEqual(true)
       expect(is({ a: 1, b: "b" })).toEqual(true)
 
-      expect(is(null)).toEqual(false)
       expect(is({})).toEqual(false)
+      expect(is(null)).toEqual(false)
       expect(is({ a: "a" })).toEqual(false)
     })
 

--- a/packages/schema/test/Schema/parseJson.test.ts
+++ b/packages/schema/test/Schema/parseJson.test.ts
@@ -1,5 +1,6 @@
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
+import * as Exit from "effect/Exit"
 import { describe, it } from "vitest"
 
 describe("Schema > parseJson", () => {
@@ -100,6 +101,14 @@ describe("Schema > parseJson", () => {
     it("encoding", async () => {
       const schema = S.parseJson(S.struct({ a: S.number }))
       await Util.expectEncodeSuccess(schema, { a: 1 }, `{"a":1}`)
+    })
+
+    describe("roundtrip", () => {
+      it("Exit", async () => {
+        const schema = S.parseJson(S.exit(S.never, S.void))
+        const encoding = S.encodeSync(schema)(Exit.unit)
+        await Util.expectParseSuccess(schema, encoding, Exit.unit)
+      })
     })
   })
 

--- a/packages/schema/test/Schema/struct.test.ts
+++ b/packages/schema/test/Schema/struct.test.ts
@@ -68,18 +68,12 @@ describe("Schema > struct", () => {
       const schema = S.struct({ a: S.union(S.number, S.undefined) })
       await Util.expectParseSuccess(schema, { a: 1 })
       await Util.expectParseSuccess(schema, { a: undefined })
+      await Util.expectParseSuccess(schema, {}, { a: undefined })
 
       await Util.expectParseFailure(
         schema,
         null,
         `Expected { a: number | undefined }, actual null`
-      )
-      await Util.expectParseFailure(
-        schema,
-        {},
-        `{ a: number | undefined }
-└─ ["a"]
-   └─ is missing`
       )
       await Util.expectParseFailure(
         schema,

--- a/packages/schema/test/Schema/validate.test.ts
+++ b/packages/schema/test/Schema/validate.test.ts
@@ -2,6 +2,18 @@ import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 import { describe, it } from "vitest"
 
+const expectValidateSuccess = async <I, A>(
+  schema: S.Schema<I, A>,
+  input: unknown,
+  expected: A = input as any
+) => Util.expectSuccess(S.validate(schema)(input), expected)
+
+const expectValidateFailure = async <I, A>(
+  schema: S.Schema<I, A>,
+  input: unknown,
+  message: string
+) => Util.expectFailure(S.validate(schema)(input), message)
+
 describe("Schema > validate", () => {
   const schema = S.struct({ a: Util.NumberFromChar })
 
@@ -35,5 +47,39 @@ describe("Schema > validate", () => {
         a: 1
       }
     )
+  })
+
+  describe("struct", () => {
+    it("required property signature", async () => {
+      const schema = S.struct({ a: Util.NumberFromChar })
+      await expectValidateSuccess(schema, { a: 1 })
+      await expectValidateFailure(
+        schema,
+        { a: null },
+        `{ a: number }
+└─ ["a"]
+   └─ Expected a number, actual null`
+      )
+    })
+
+    it("required property signature with undefined", async () => {
+      const schema = S.struct({ a: S.union(S.number, S.undefined) })
+      await expectValidateSuccess(schema, { a: 1 })
+      await expectValidateSuccess(schema, { a: undefined })
+      await expectValidateSuccess(schema, { a: 1, b: "b" }, { a: 1 })
+      await expectValidateSuccess(schema, {}, { a: undefined })
+      await expectValidateFailure(schema, null, `Expected { a: number | undefined }, actual null`)
+      await expectValidateFailure(
+        schema,
+        { a: "a" },
+        `{ a: number | undefined }
+└─ ["a"]
+   └─ number | undefined
+      ├─ Union member
+      │  └─ Expected a number, actual "a"
+      └─ Union member
+         └─ Expected undefined, actual "a"`
+      )
+    })
   })
 })


### PR DESCRIPTION
…asserts`), closes #1882

## Type

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

- Discord: https://discord.com/channels/795981131316985866/1194240394620325918/1194300335792062495
- Closes #1882
