### PR TITLE
Schema: fix ParseIssue.actual on transformation

### DIFF
--- a/.changeset/blue-starfishes-doubt.md
+++ b/.changeset/blue-starfishes-doubt.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Schema: fix ParseIssue.actual on transformation

--- a/packages/schema/src/Parser.ts
+++ b/packages/schema/src/Parser.ts
@@ -368,11 +368,11 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser<any, any> => {
               ParseResult.flatMap(
                 ParseResult.mapLeft(
                   transform(a, options ?? defaultParseOption, ast),
-                  (e) => ParseResult.transform(ast, a, "Transformation", e.error)
+                  (e) => ParseResult.transform(ast, i1, "Transformation", e.error)
                 ),
                 (i2) =>
                   ParseResult.mapLeft(to(i2, options), (e) =>
-                    ParseResult.transform(ast, i2, isDecoding ? "To" : "From", e))
+                    ParseResult.transform(ast, i1, isDecoding ? "To" : "From", e))
               )
           ),
           i1,

--- a/packages/schema/test/ParseResult.test.ts
+++ b/packages/schema/test/ParseResult.test.ts
@@ -125,3 +125,43 @@ describe("ParseResult", () => {
     ).toStrictEqual(Exit.succeed(2))
   })
 })
+
+describe("ParseIssue.actual", () => {
+  it("transform decode", () => {
+    const result = S.decodeEither(S.transformOrFail(
+      S.NumberFromString,
+      S.boolean,
+      (_) => ParseResult.fail(ParseResult.forbidden(_)),
+      (_) => ParseResult.fail(ParseResult.forbidden(_))
+    ))("1")
+    if (Either.isRight(result)) throw new Error("Expected failure")
+    expect(result.left.error.actual).toEqual("1")
+    expect((result.left.error as ParseResult.Transform).error.actual).toEqual(1)
+  })
+
+  it("transform encode", () => {
+    const result = S.encodeEither(S.transformOrFail(
+      S.boolean,
+      S.NumberFromString,
+      (_) => ParseResult.fail(ParseResult.forbidden(_)),
+      (_) => ParseResult.fail(ParseResult.forbidden(_))
+    ))(1)
+    if (Either.isRight(result)) throw new Error("Expected failure")
+    expect(result.left.error.actual).toEqual(1)
+    expect((result.left.error as ParseResult.Transform).error.actual).toEqual("1")
+  })
+
+  it("compose decode", () => {
+    const result = S.decodeEither(S.compose(S.NumberFromString, S.negative()(S.number)))("1")
+    if (Either.isRight(result)) throw new Error("Expected failure")
+    expect(result.left.error.actual).toEqual("1")
+    expect((result.left.error as ParseResult.Transform).error.actual).toEqual(1)
+  })
+
+  it("compose encode", () => {
+    const result = S.encodeEither(S.compose(S.length(5)(S.string), S.NumberFromString))(1)
+    if (Either.isRight(result)) throw new Error("Expected failure")
+    expect(result.left.error.actual).toEqual(1)
+    expect((result.left.error as ParseResult.Transform).error.actual).toEqual("1")
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It was showing the partially transformed value instead of the original value.

<!--
Please add a brief summary/description of the pull request here.
-->
