### PR TITLE
feat: Add immediate:boolean to RunForkOptions

### DIFF
--- a/.changeset/fair-walls-sin.md
+++ b/.changeset/fair-walls-sin.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add immediate:boolean flag to runFork/runCallback

--- a/.changeset/silent-ways-tell.md
+++ b/.changeset/silent-ways-tell.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Allow providing Scope to Runtime.runFork

--- a/.changeset/thirty-jars-talk.md
+++ b/.changeset/thirty-jars-talk.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add RunForkOptions to Effect.runFork

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4749,7 +4749,7 @@ export const runFork: <E, A>(effect: Effect<never, E, A>) => Fiber.RuntimeFiber<
  */
 export const runCallback: <E, A>(
   effect: Effect<never, E, A>,
-  onExit?: (exit: Exit.Exit<E, A>) => void
+  options?: Runtime.RunCallbackOptions<E, A> | undefined
 ) => Runtime.Cancel<E, A> = _runtime.unsafeRunEffect
 
 /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4741,7 +4741,10 @@ export const makeSemaphore: (permits: number) => Effect<never, never, Semaphore>
  * @since 2.0.0
  * @category execution
  */
-export const runFork: <E, A>(effect: Effect<never, E, A>) => Fiber.RuntimeFiber<E, A> = _runtime.unsafeForkEffect
+export const runFork: <E, A>(
+  effect: Effect<never, E, A>,
+  options?: Runtime.RunForkOptions
+) => Fiber.RuntimeFiber<E, A> = _runtime.unsafeForkEffect
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Runtime.ts
+++ b/packages/effect/src/Runtime.ts
@@ -28,7 +28,7 @@ export interface AsyncFiberException<out E, out A> {
  * @category models
  */
 export interface Cancel<out E, out A> {
-  (fiberId?: FiberId.FiberId, onExit?: (exit: Exit.Exit<E, A>) => void): void
+  (fiberId?: FiberId.FiberId, options?: RunCallbackOptions<E, A> | undefined): void
 }
 
 /**
@@ -57,6 +57,7 @@ export interface Runtime<in R> extends Pipeable {
 export interface RunForkOptions {
   readonly scheduler?: Scheduler | undefined
   readonly updateRefs?: ((refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) => FiberRefs.FiberRefs) | undefined
+  readonly immediate?: boolean
 }
 
 /**
@@ -94,6 +95,14 @@ export const runSyncExit: <R>(runtime: Runtime<R>) => <E, A>(effect: Effect.Effe
 export const runSync: <R>(runtime: Runtime<R>) => <E, A>(effect: Effect.Effect<R, E, A>) => A = internal.unsafeRunSync
 
 /**
+ * @since 2.0.0
+ * @category models
+ */
+export interface RunCallbackOptions<E, A> extends RunForkOptions {
+  readonly onExit?: ((exit: Exit.Exit<E, A>) => void) | undefined
+}
+
+/**
  * Executes the effect asynchronously, eventually passing the exit value to
  * the specified callback.
  *
@@ -107,8 +116,8 @@ export const runCallback: <R>(
   runtime: Runtime<R>
 ) => <E, A>(
   effect: Effect.Effect<R, E, A>,
-  onExit?: ((exit: Exit.Exit<E, A>) => void) | undefined
-) => (fiberId?: FiberId.FiberId | undefined, onExit?: ((exit: Exit.Exit<E, A>) => void) | undefined) => void =
+  options?: RunCallbackOptions<E, A> | undefined
+) => (fiberId?: FiberId.FiberId | undefined, options?: RunCallbackOptions<E, A> | undefined) => void =
   internal.unsafeRunCallback
 
 /**

--- a/packages/effect/src/Runtime.ts
+++ b/packages/effect/src/Runtime.ts
@@ -13,6 +13,7 @@ import * as internal from "./internal/runtime.js"
 import type { Pipeable } from "./Pipeable.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
 import type { Scheduler } from "./Scheduler.js"
+import type { Scope } from "./Scope.js"
 
 /**
  * @since 2.0.0
@@ -58,6 +59,7 @@ export interface RunForkOptions {
   readonly scheduler?: Scheduler | undefined
   readonly updateRefs?: ((refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) => FiberRefs.FiberRefs) | undefined
   readonly immediate?: boolean
+  readonly scope?: Scope
 }
 
 /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Adds `immediate: boolean` to `RunForkOptions` to enable creating a Fiber which uses `fiberRuntime.start()` or `fiberRuntime.resume()`

- Adds `RunCallbackOptions<E, A>` which extends `RunForkOptions` with an `onExit` callback, such that runCallback has access to the same fork options as runFork.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
