### PR TITLE
Annotations for transform nodes

### DIFF
--- a/.changeset/brave-yaks-marry.md
+++ b/.changeset/brave-yaks-marry.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+annotations for transform nodes

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1455,6 +1455,7 @@ export const transform: {
       annotations
     )
 )
+
 /**
  * Creates a new `Schema` which transforms literal values.
  *

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1317,8 +1317,21 @@ export const transformOrFail: {
   ): <A>(self: Schema<A, B>) => Schema<A, D>
   <C, D, B>(
     to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<C>,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<B>,
+    annotations: AST.Annotated["annotations"]
+  ): <A>(self: Schema<A, B>) => Schema<A, D>
+  <C, D, B>(
+    to: Schema<C, D>,
     decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
     encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+    options: { strict: false }
+  ): <A>(self: Schema<A, B>) => Schema<A, D>
+  <C, D, B>(
+    to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+    annotations: AST.Annotated["annotations"],
     options: { strict: false }
   ): <A>(self: Schema<A, B>) => Schema<A, D>
   <A, B, C, D>(
@@ -1330,21 +1343,38 @@ export const transformOrFail: {
   <A, B, C, D>(
     from: Schema<A, B>,
     to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<C>,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<B>,
+    annotations: AST.Annotated["annotations"]
+  ): Schema<A, D>
+  <A, B, C, D>(
+    from: Schema<A, B>,
+    to: Schema<C, D>,
     decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
     encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+    options: { strict: false }
+  ): Schema<A, D>
+  <A, B, C, D>(
+    from: Schema<A, B>,
+    to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+    annotations: AST.Annotated["annotations"],
     options: { strict: false }
   ): Schema<A, D>
 } = dual((args) => isSchema(args[0]) && isSchema(args[1]), <A, B, C, D>(
   from: Schema<A, B>,
   to: Schema<C, D>,
   decode: (b: B, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
-  encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>
+  encode: (c: C, options: ParseOptions, ast: AST.AST) => ParseResult.ParseResult<unknown>,
+  annotations: AST.Annotated["annotations"] = {}
 ): Schema<A, D> =>
   make(
     AST.createTransform(
       from.ast,
       to.ast,
-      AST.createFinalTransformation(decode, encode)
+      AST.createFinalTransformation(decode, encode),
+      annotations
     )
   ))
 
@@ -1363,8 +1393,21 @@ export const transform: {
   ): <A>(self: Schema<A, B>) => Schema<A, D>
   <C, D, B>(
     to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => C,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => B,
+    annotations: AST.Annotated["annotations"]
+  ): <A>(self: Schema<A, B>) => Schema<A, D>
+  <C, D, B>(
+    to: Schema<C, D>,
     decode: (b: B, options: ParseOptions, ast: AST.AST) => unknown,
     encode: (c: C, options: ParseOptions, ast: AST.AST) => unknown,
+    options: { strict: false }
+  ): <A>(self: Schema<A, B>) => Schema<A, D>
+  <C, D, B>(
+    to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => unknown,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => unknown,
+    annotations: AST.Annotated["annotations"],
     options: { strict: false }
   ): <A>(self: Schema<A, B>) => Schema<A, D>
   <A, B, C, D>(
@@ -1376,8 +1419,23 @@ export const transform: {
   <A, B, C, D>(
     from: Schema<A, B>,
     to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => C,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => B,
+    annotations: AST.Annotated["annotations"]
+  ): Schema<A, D>
+  <A, B, C, D>(
+    from: Schema<A, B>,
+    to: Schema<C, D>,
     decode: (b: B, options: ParseOptions, ast: AST.AST) => unknown,
     encode: (c: C, options: ParseOptions, ast: AST.AST) => unknown,
+    options: { strict: false }
+  ): Schema<A, D>
+  <A, B, C, D>(
+    from: Schema<A, B>,
+    to: Schema<C, D>,
+    decode: (b: B, options: ParseOptions, ast: AST.AST) => unknown,
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => unknown,
+    annotations: AST.Annotated["annotations"],
     options: { strict: false }
   ): Schema<A, D>
 } = dual(
@@ -1386,16 +1444,17 @@ export const transform: {
     from: Schema<A, B>,
     to: Schema<C, D>,
     decode: (b: B, options: ParseOptions, ast: AST.AST) => C,
-    encode: (c: C, options: ParseOptions, ast: AST.AST) => B
+    encode: (c: C, options: ParseOptions, ast: AST.AST) => B,
+    annotations: AST.Annotated["annotations"] = {}
   ): Schema<A, D> =>
     transformOrFail(
       from,
       to,
       (a, options, ast) => Either.right(decode(a, options, ast)),
-      (b, options, ast) => Either.right(encode(b, options, ast))
+      (b, options, ast) => Either.right(encode(b, options, ast)),
+      annotations
     )
 )
-
 /**
  * Creates a new `Schema` which transforms literal values.
  *


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
I would like to add annotations directly to transform nodes while creating them. Is there a reason these function signatures aren't present other than there weren't needed? Does it go against some rule about adding annotations directly to transform nodes? 

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #