### PR TITLE
convert value bag classes to object literals

### DIFF
--- a/.changeset/loud-vans-rush.md
+++ b/.changeset/loud-vans-rush.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Converted value bag classes to object literals

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -79,14 +79,16 @@ interface MutableListImpl<A> extends MutableList<A> {
 interface LinkedListNode<T> {
   removed: boolean
   value: T
-  prev?: LinkedListNode<T> | undefined
-  next?: LinkedListNode<T> | undefined
+  prev: LinkedListNode<T> | undefined
+  next: LinkedListNode<T> | undefined
 }
 
 /** @internal */
 const makeNode = <T>(value: T): LinkedListNode<T> => ({
   value,
-  removed: false
+  removed: false,
+  prev: undefined,
+  next: undefined
 })
 
 /**

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -76,12 +76,18 @@ interface MutableListImpl<A> extends MutableList<A> {
 }
 
 /** @internal */
-class LinkedListNode<T> {
-  removed = false
-  prev: LinkedListNode<T> | undefined = undefined
-  next: LinkedListNode<T> | undefined = undefined
-  constructor(readonly value: T) {}
+interface LinkedListNode<T> {
+  removed: boolean
+  value: T
+  prev?: LinkedListNode<T> | undefined
+  next?: LinkedListNode<T> | undefined
 }
+
+/** @internal */
+const makeNode = <T>(value: T): LinkedListNode<T> => ({
+  value,
+  removed: false
+})
 
 /**
  * Creates an empty `MutableList`.
@@ -196,7 +202,7 @@ export const append: {
   <A>(value: A) => (self: MutableList<A>) => MutableList<A>,
   <A>(self: MutableList<A>, value: A) => MutableList<A>
 >(2, <A>(self: MutableList<A>, value: A) => {
-  const node = new LinkedListNode(value)
+  const node = makeNode(value)
   if (self.head === undefined) {
     self.head = node
   }
@@ -252,7 +258,7 @@ export const prepend: {
   <A>(value: A) => (self: MutableList<A>) => MutableList<A>,
   <A>(self: MutableList<A>, value: A) => MutableList<A>
 >(2, <A>(self: MutableList<A>, value: A) => {
-  const node = new LinkedListNode(value)
+  const node = makeNode(value)
   node.next = self.head
   if (self.head !== undefined) {
     self.head.prev = node

--- a/packages/effect/src/internal/hashMap/node.ts
+++ b/packages/effect/src/internal/hashMap/node.ts
@@ -2,7 +2,7 @@ import { equals } from "../../Equal.js"
 import type { HashMap } from "../../HashMap.js"
 import * as O from "../../Option.js"
 import { isTagged } from "../../Predicate.js"
-import { Stack } from "../stack.js"
+import * as Stack from "../stack.js"
 import { arraySpliceIn, arraySpliceOut, arrayUpdate } from "./array.js"
 import { fromBitmap, hashFragment, toBitmap } from "./bitwise.js"
 import { MAX_INDEX_NODE, MIN_ARRAY_NODE, SIZE } from "./config.js"
@@ -370,14 +370,14 @@ function mergeLeaves<K, V>(
   h2: number,
   n2: Node<K, V>
 ): Node<K, V> {
-  let stack: Stack<(node: Node<K, V>) => Node<K, V>> | undefined = undefined
+  let stack: Stack.Stack<(node: Node<K, V>) => Node<K, V>> | undefined = undefined
   let currentShift = shift
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const res = mergeLeavesInner(edit, currentShift, h1, n1, h2, n2)
 
     if (typeof res === "function") {
-      stack = new Stack(res, stack)
+      stack = Stack.make(res, stack)
       currentShift = currentShift + SIZE
     } else {
       let final = res

--- a/packages/effect/src/internal/pubsub.ts
+++ b/packages/effect/src/internal/pubsub.ts
@@ -645,27 +645,24 @@ class BoundedPubSubSingleSubscription<in out A> implements Subscription<A> {
 }
 
 /** @internal */
-class Node<out A> {
-  constructor(
-    public value: A | AbsentValue,
-    public subscribers: number,
-    public next: Node<A> | null
-  ) {
-  }
+interface Node<out A> {
+  value: A | AbsentValue
+  subscribers: number
+  next: Node<A> | null
 }
 
 /** @internal */
 class UnboundedPubSub<in out A> implements AtomicPubSub<A> {
-  publisherHead = new Node<A>(AbsentValue, 0, null)
+  publisherHead: Node<A> = {
+    value: AbsentValue,
+    subscribers: 0,
+    next: null
+  }
+  publisherTail = this.publisherHead
   publisherIndex = 0
-  publisherTail: Node<A>
   subscribersIndex = 0
 
   readonly capacity = Number.MAX_SAFE_INTEGER
-
-  constructor() {
-    this.publisherTail = this.publisherHead
-  }
 
   isEmpty(): boolean {
     return this.publisherHead === this.publisherTail
@@ -682,7 +679,11 @@ class UnboundedPubSub<in out A> implements AtomicPubSub<A> {
   publish(value: A): boolean {
     const subscribers = this.publisherTail.subscribers
     if (subscribers !== 0) {
-      this.publisherTail.next = new Node(value, subscribers, null)
+      this.publisherTail.next = {
+        value,
+        subscribers,
+        next: null
+      }
       this.publisherTail = this.publisherTail.next
       this.publisherIndex += 1
     }

--- a/packages/effect/src/internal/redBlackTree.ts
+++ b/packages/effect/src/internal/redBlackTree.ts
@@ -11,7 +11,7 @@ import { hasProperty } from "../Predicate.js"
 import type * as RBT from "../RedBlackTree.js"
 import { Direction, RedBlackTreeIterator } from "./redBlackTree/iterator.js"
 import * as Node from "./redBlackTree/node.js"
-import { Stack } from "./stack.js"
+import * as Stack from "./stack.js"
 
 const RedBlackTreeSymbolKey = "effect/RedBlackTree"
 
@@ -288,27 +288,34 @@ export const insert = dual<
     }
   }
   // Rebuild path to leaf node
-  n_stack.push(new Node.Node(Node.Color.Red, key, value, undefined, undefined, 1))
+  n_stack.push({
+    color: Node.Color.Red,
+    key,
+    value,
+    left: undefined,
+    right: undefined,
+    count: 1
+  })
   for (let s = n_stack.length - 2; s >= 0; --s) {
     const n2 = n_stack[s]!
     if (d_stack[s]! <= 0) {
-      n_stack[s] = new Node.Node(
-        n2.color,
-        n2.key,
-        n2.value,
-        n_stack[s + 1],
-        n2.right,
-        n2.count + 1
-      )
+      n_stack[s] = {
+        color: n2.color,
+        key: n2.key,
+        value: n2.value,
+        left: n_stack[s + 1],
+        right: n2.right,
+        count: n2.count + 1
+      }
     } else {
-      n_stack[s] = new Node.Node(
-        n2.color,
-        n2.key,
-        n2.value,
-        n2.left,
-        n_stack[s + 1],
-        n2.count + 1
-      )
+      n_stack[s] = {
+        color: n2.color,
+        key: n2.key,
+        value: n2.value,
+        left: n2.left,
+        right: n_stack[s + 1],
+        count: n2.count + 1
+      }
     }
   }
   // Rebalance tree using rotations
@@ -778,20 +785,34 @@ export const removeFirst = dual<
   }
   const cstack = new Array<Node.Node<K, V>>(stack.length)
   let n = stack[stack.length - 1]!
-  cstack[cstack.length - 1] = new Node.Node(
-    n.color,
-    n.key,
-    n.value,
-    n.left,
-    n.right,
-    n.count
-  )
+  cstack[cstack.length - 1] = {
+    color: n.color,
+    key: n.key,
+    value: n.value,
+    left: n.left,
+    right: n.right,
+    count: n.count
+  }
   for (let i = stack.length - 2; i >= 0; --i) {
     n = stack[i]!
     if (n.left === stack[i + 1]) {
-      cstack[i] = new Node.Node(n.color, n.key, n.value, cstack[i + 1], n.right, n.count)
+      cstack[i] = {
+        color: n.color,
+        key: n.key,
+        value: n.value,
+        left: cstack[i + 1],
+        right: n.right,
+        count: n.count
+      }
     } else {
-      cstack[i] = new Node.Node(n.color, n.key, n.value, n.left, cstack[i + 1], n.count)
+      cstack[i] = {
+        color: n.color,
+        key: n.key,
+        value: n.value,
+        left: n.left,
+        right: cstack[i + 1],
+        count: n.count
+      }
     }
   }
   // Get node
@@ -807,13 +828,27 @@ export const removeFirst = dual<
     }
     // Copy path to leaf
     const v = cstack[split - 1]
-    cstack.push(new Node.Node(n.color, v!.key, v!.value, n.left, n.right, n.count))
+    cstack.push({
+      color: n.color,
+      key: v!.key,
+      value: v!.value,
+      left: n.left,
+      right: n.right,
+      count: n.count
+    })
     cstack[split - 1]!.key = n.key
     cstack[split - 1]!.value = n.value
     // Fix up stack
     for (let i = cstack.length - 2; i >= split; --i) {
       n = cstack[i]!
-      cstack[i] = new Node.Node(n.color, n.key, n.value, n.left, cstack[i + 1], n.count)
+      cstack[i] = {
+        color: n.color,
+        key: n.key,
+        value: n.value,
+        left: n.left,
+        right: cstack[i + 1],
+        count: n.count
+      }
     }
     cstack[split - 1]!.left = cstack[split]
   }
@@ -913,11 +948,11 @@ const visitFull = <K, V, A>(
   visit: (key: K, value: V) => Option.Option<A>
 ): Option.Option<A> => {
   let current: Node.Node<K, V> | undefined = node
-  let stack: Stack<Node.Node<K, V>> | undefined = undefined
+  let stack: Stack.Stack<Node.Node<K, V>> | undefined = undefined
   let done = false
   while (!done) {
     if (current != null) {
-      stack = new Stack(current, stack)
+      stack = Stack.make(current, stack)
       current = current.left
     } else if (stack != null) {
       const value = visit(stack.value.key, stack.value.value)
@@ -940,11 +975,11 @@ const visitGreaterThanEqual = <K, V, A>(
   visit: (key: K, value: V) => Option.Option<A>
 ): Option.Option<A> => {
   let current: Node.Node<K, V> | undefined = node
-  let stack: Stack<Node.Node<K, V>> | undefined = undefined
+  let stack: Stack.Stack<Node.Node<K, V>> | undefined = undefined
   let done = false
   while (!done) {
     if (current !== undefined) {
-      stack = new Stack(current, stack)
+      stack = Stack.make(current, stack)
       if (ord(min, current.key) <= 0) {
         current = current.left
       } else {
@@ -973,11 +1008,11 @@ const visitLessThan = <K, V, A>(
   visit: (key: K, value: V) => Option.Option<A>
 ): Option.Option<A> => {
   let current: Node.Node<K, V> | undefined = node
-  let stack: Stack<Node.Node<K, V>> | undefined = undefined
+  let stack: Stack.Stack<Node.Node<K, V>> | undefined = undefined
   let done = false
   while (!done) {
     if (current !== undefined) {
-      stack = new Stack(current, stack)
+      stack = Stack.make(current, stack)
       current = current.left
     } else if (stack !== undefined && ord(max, stack.value.key) > 0) {
       const value = visit(stack.value.key, stack.value.value)
@@ -1001,11 +1036,11 @@ const visitBetween = <K, V, A>(
   visit: (key: K, value: V) => Option.Option<A>
 ): Option.Option<A> => {
   let current: Node.Node<K, V> | undefined = node
-  let stack: Stack<Node.Node<K, V>> | undefined = undefined
+  let stack: Stack.Stack<Node.Node<K, V>> | undefined = undefined
   let done = false
   while (!done) {
     if (current !== undefined) {
-      stack = new Stack(current, stack)
+      stack = Stack.make(current, stack)
       if (ord(min, current.key) <= 0) {
         current = current.left
       } else {

--- a/packages/effect/src/internal/redBlackTree/node.ts
+++ b/packages/effect/src/internal/redBlackTree/node.ts
@@ -10,22 +10,31 @@ export declare namespace Node {
   }
 }
 
-/** @internal */
-export class Node<out K, out V> {
-  constructor(
-    public color: Node.Color,
-    public key: K,
-    public value: V,
-    public left: Node<K, V> | undefined,
-    public right: Node<K, V> | undefined,
-    public count: number
-  ) {}
+export interface Node<out K, out V> {
+  color: Node.Color
+  key: K
+  value: V
+  left?: Node<K, V> | undefined
+  right?: Node<K, V> | undefined
+  count: number
 }
 
 /** @internal */
-export function clone<K, V>(node: Node<K, V>) {
-  return new Node(node.color, node.key, node.value, node.left, node.right, node.count)
-}
+export const clone = <K, V>({
+  color,
+  count,
+  key,
+  left,
+  right,
+  value
+}: Node<K, V>) => ({
+  color,
+  key,
+  value,
+  left,
+  right,
+  count
+})
 
 /** @internal */
 export function swap<K, V>(n: Node<K, V>, v: Node<K, V>) {
@@ -38,11 +47,22 @@ export function swap<K, V>(n: Node<K, V>, v: Node<K, V>) {
 }
 
 /** @internal */
-export function repaint<K, V>(node: Node<K, V>, color: Node.Color) {
-  return new Node(color, node.key, node.value, node.left, node.right, node.count)
-}
+export const repaint = <K, V>({
+  count,
+  key,
+  left,
+  right,
+  value
+}: Node<K, V>, color: Node.Color) => ({
+  color,
+  key,
+  value,
+  left,
+  right,
+  count
+})
 
 /** @internal */
-export function recount<K, V>(node: Node<K, V>) {
+export const recount = <K, V>(node: Node<K, V>) => {
   node.count = 1 + (node.left?.count ?? 0) + (node.right?.count ?? 0)
 }

--- a/packages/effect/src/internal/redBlackTree/node.ts
+++ b/packages/effect/src/internal/redBlackTree/node.ts
@@ -14,8 +14,8 @@ export interface Node<out K, out V> {
   color: Node.Color
   key: K
   value: V
-  left?: Node<K, V> | undefined
-  right?: Node<K, V> | undefined
+  left: Node<K, V> | undefined
+  right: Node<K, V> | undefined
   count: number
 }
 

--- a/packages/effect/src/internal/stack.ts
+++ b/packages/effect/src/internal/stack.ts
@@ -1,4 +1,10 @@
 /** @internal */
-export class Stack<out A> {
-  constructor(readonly value: A, readonly previous?: Stack<A>) {}
+export interface Stack<out A> {
+  readonly value: A
+  readonly previous?: Stack<A> | undefined
 }
+
+export const make = <A>(value: A, previous?: Stack<A>): Stack<A> => ({
+  value,
+  previous
+})

--- a/packages/effect/src/internal/stack.ts
+++ b/packages/effect/src/internal/stack.ts
@@ -1,7 +1,7 @@
 /** @internal */
 export interface Stack<out A> {
   readonly value: A
-  readonly previous?: Stack<A> | undefined
+  readonly previous: Stack<A> | undefined
 }
 
 export const make = <A>(value: A, previous?: Stack<A>): Stack<A> => ({


### PR DESCRIPTION
## Type

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Class instance initialization comes with a "substantial" (relatively speaking) overhead compared to raw object literals. They should therefore be avoided for plain value bags. 

## Related

- Related Issue #1871 
