### PR TITLE
fix(platform-node): change MAX_SAFE_INTEGER to a valid number

### DIFF
--- a/.changeset/nice-olives-travel.md
+++ b/.changeset/nice-olives-travel.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+change to an actually allowed number

--- a/packages/platform-node/src/internal/runtime.ts
+++ b/packages/platform-node/src/internal/runtime.ts
@@ -7,7 +7,7 @@ export const runMain: RunMain = <E, A>(
   effect: Effect.Effect<never, E, A>,
   teardown = defaultTeardown
 ) => {
-  const keepAlive = setInterval(() => {}, Number.MAX_SAFE_INTEGER)
+  const keepAlive = setInterval(() => {}, 2 ** 31 - 1)
 
   const fiber = Effect.runFork(
     Effect.tapErrorCause(effect, (cause) => {


### PR DESCRIPTION
setInterval only allows up to 2 ** 31 - 1

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
SOMEONE, not gonna say who..... passed 9,007,199,254,740,991 to a function that says in its inline documentation that it only accepts up to 2,147,483,647 and didn't even wonder why node is crying foul!
Anyways, it's a big deal because:

> When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
set to `1`.


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue ¯\_(ツ)_/¯
- Closes ¯\_(ツ)_/¯
