### PR TITLE
Schema: show error message when throw ParseError

### DIFF
--- a/.changeset/olive-guests-begin.md
+++ b/.changeset/olive-guests-begin.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Schema: show error message when throw ParseError

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -21,6 +21,9 @@ export interface ParseResult<A> extends Effect.Effect<never, ParseError, A> {}
  * @since 1.0.0
  */
 export class ParseError extends TaggedError("ParseError")<{ readonly error: ParseIssue }> {
+  get message() {
+    return this.toString()
+  }
   /**
    * @since 1.0.0
    */

--- a/packages/schema/test/ParseResult.test.ts
+++ b/packages/schema/test/ParseResult.test.ts
@@ -43,6 +43,10 @@ describe("ParseResult", () => {
       )
   })
 
+  it.only("Error.stack", () => {
+    expect(ParseResult.parseError(ParseResult.forbidden(1)).stack?.startsWith("ParseError: is forbidden")).toEqual(true)
+  })
+
   it("Effect.catchTag can be used to catch ParseError", () => {
     const program = Effect.fail(forbiddenParseError).pipe(
       Effect.catchTag("ParseError", () => Effect.succeed(1))

--- a/packages/schema/test/ParseResult.test.ts
+++ b/packages/schema/test/ParseResult.test.ts
@@ -43,7 +43,7 @@ describe("ParseResult", () => {
       )
   })
 
-  it.only("Error.stack", () => {
+  it("Error.stack", () => {
     expect(ParseResult.parseError(ParseResult.forbidden(1)).stack?.startsWith("ParseError: is forbidden")).toEqual(true)
   })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When throw ParseError it was printing
```
ParseError:
    at Object.parseError...
```
now it prints
```
ParseError: <TreeFormatter message>
    at Object.parseError...
```

<!--
Please add a brief summary/description of the pull request here.
-->
