### PR TITLE
Schema.eitherFromUnion improve error description

### DIFF
--- a/.changeset/twenty-panthers-relate.md
+++ b/.changeset/twenty-panthers-relate.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Schema.eitherFromUnion improve error description

--- a/packages/schema/test/Either/eitherFromUnion.test.ts
+++ b/packages/schema/test/Either/eitherFromUnion.test.ts
@@ -32,6 +32,23 @@ describe("Either/eitherFromUnion", () => {
     )
   })
 
+  it("decoding error transformation process", async () => {
+    const schema = S.eitherFromUnion(S.number, S.compose(S.boolean, S.string))
+    await Util.expectParseFailure(
+      schema,
+      true,
+      `(boolean | number <-> Either<number, string>)
+└─ Transformation process failure
+   └─ (boolean <-> string) | (number <-> number)
+      ├─ Union member
+      │  └─ (boolean <-> string)
+      │     └─ To side transformation failure
+      │        └─ Expected a string, actual true
+      └─ Union member
+         └─ Expected a number, actual true`
+    )
+  })
+
   it("decoding prefer right", async () => {
     const schema = S.eitherFromUnion(S.NumberFromString, S.NumberFromString)
     await Util.expectParseSuccess(schema, "1", E.right(1))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Given this example:
```typescript
S.parseSync(S.eitherFromUnion(S.number, S.compose(S.boolean, S.string)))(true)
```

It was showing the error for only one of the union cases:
```
(boolean | number <-> Either<number, string>)
└─ Transformation process failure
   └─ Expected a number, actual true
```

Now shows for both:
```
(boolean | number <-> Either<number, string>)
└─ Transformation process failure
   └─ (boolean <-> string) | (number <-> number)
      ├─ Union member
      │  └─ (boolean <-> string)
      │     └─ To side transformation failure
      │        └─ Expected a string, actual true
      └─ Union member
         └─ Expected a number, actual true
```