### PR TITLE
ParseResult refactoring

### DIFF
--- a/.changeset/shiny-seahorses-crash.md
+++ b/.changeset/shiny-seahorses-crash.md
@@ -1,0 +1,9 @@
+---
+"@effect/schema": minor
+---
+
+ParseResult refactoring:
+
+- remove `ParseResult` type
+- rename `mapLeft` to `mapError`
+- rename `bimap` to `mapBoth`

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 
+import type { Effect } from "effect/Effect"
 import { dual, identity, pipe } from "effect/Function"
 import * as Number from "effect/Number"
 import * as Option from "effect/Option"
@@ -9,7 +10,7 @@ import * as Order from "effect/Order"
 import * as Predicate from "effect/Predicate"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Internal from "./internal/ast.js"
-import type * as ParseResult from "./ParseResult.js"
+import type { ParseError } from "./ParseResult.js"
 
 // -------------------------------------------------------------------------------------
 // annotations
@@ -267,7 +268,7 @@ export interface Declaration extends Annotated {
   readonly decode: (
     isDecoding: boolean,
     ...typeParameters: ReadonlyArray<AST>
-  ) => (input: any, options: ParseOptions, self: AST) => ParseResult.ParseResult<any>
+  ) => (input: any, options: ParseOptions, self: AST) => Effect<never, ParseError, any>
 }
 
 /**
@@ -944,7 +945,7 @@ export interface Refinement<From = AST> extends Annotated {
     input: any,
     options: ParseOptions,
     self: AST
-  ) => Option.Option<ParseResult.ParseError>
+  ) => Option.Option<ParseError>
 }
 
 /**
@@ -1019,8 +1020,8 @@ export type Transformation =
  */
 export interface FinalTransformation {
   readonly _tag: "FinalTransformation"
-  readonly decode: (input: any, options: ParseOptions, self: AST) => ParseResult.ParseResult<any>
-  readonly encode: (input: any, options: ParseOptions, self: AST) => ParseResult.ParseResult<any>
+  readonly decode: (input: any, options: ParseOptions, self: AST) => Effect<never, ParseError, any>
+  readonly encode: (input: any, options: ParseOptions, self: AST) => Effect<never, ParseError, any>
 }
 
 /**

--- a/packages/schema/src/internal/schema.ts
+++ b/packages/schema/src/internal/schema.ts
@@ -12,8 +12,11 @@ export const TypeId: Schema.TypeId = Symbol.for("@effect/schema/Schema") as Sche
 /** @internal */
 export const make = <I, A>(ast: AST.AST): Schema.Schema<I, A> => new SchemaImpl(ast)
 
-const variance = {
+/** @internal */
+export const variance = {
+  /* c8 ignore next */
   From: (_: any) => _,
+  /* c8 ignore next */
   To: (_: any) => _
 }
 

--- a/packages/schema/test/ParseResult.test.ts
+++ b/packages/schema/test/ParseResult.test.ts
@@ -70,41 +70,41 @@ describe("ParseResult", () => {
   })
 
   it("mapLeft (Either)", () => {
-    expect(ParseResult.mapLeft(Either.right(1), () => typeParseError)).toStrictEqual(
+    expect(ParseResult.mapError(Either.right(1), () => typeParseError)).toStrictEqual(
       Either.right(1)
     )
-    expect(ParseResult.mapLeft(Either.left(forbiddenParseError), () => typeParseError))
+    expect(ParseResult.mapError(Either.left(forbiddenParseError), () => typeParseError))
       .toStrictEqual(Either.left(typeParseError))
   })
 
   it("mapLeft (Effect)", () => {
-    expect(Effect.runSyncExit(ParseResult.mapLeft(Effect.succeed(1), () => typeParseError)))
+    expect(Effect.runSyncExit(ParseResult.mapError(Effect.succeed(1), () => typeParseError)))
       .toStrictEqual(Exit.succeed(1))
     expect(
       Effect.runSyncExit(
-        ParseResult.mapLeft(Effect.fail(forbiddenParseError), () => typeParseError)
+        ParseResult.mapError(Effect.fail(forbiddenParseError), () => typeParseError)
       )
     ).toStrictEqual(Exit.fail(typeParseError))
   })
 
   it("bimap (Either)", () => {
-    expect(ParseResult.bimap(Either.right(1), () => typeParseError, (n) => n + 1)).toStrictEqual(
+    expect(ParseResult.mapBoth(Either.right(1), () => typeParseError, (n) => n + 1)).toStrictEqual(
       Either.right(2)
     )
     expect(
-      ParseResult.bimap(Either.left(forbiddenParseError), () => typeParseError, (n) => n + 1)
+      ParseResult.mapBoth(Either.left(forbiddenParseError), () => typeParseError, (n) => n + 1)
     ).toStrictEqual(Either.left(typeParseError))
   })
 
   it("bimap (Effect)", () => {
     expect(
       Effect.runSyncExit(
-        ParseResult.bimap(Effect.succeed(1), () => typeParseError, (n) => n + 1)
+        ParseResult.mapBoth(Effect.succeed(1), () => typeParseError, (n) => n + 1)
       )
     ).toStrictEqual(Exit.succeed(2))
     expect(
       Effect.runSyncExit(
-        ParseResult.bimap(Effect.fail(forbiddenParseError), () => typeParseError, (n) => n + 1)
+        ParseResult.mapBoth(Effect.fail(forbiddenParseError), () => typeParseError, (n) => n + 1)
       )
     ).toStrictEqual(Exit.fail(typeParseError))
   })

--- a/packages/schema/test/util.ts
+++ b/packages/schema/test/util.ts
@@ -20,8 +20,8 @@ const doRoundtrip = true
 export const sleep = Effect.sleep(Duration.millis(10))
 
 const effectifyDecode = (
-  decode: (input: any, options: ParseOptions, self: AST.AST) => ParseResult.ParseResult<any>
-): (input: any, options: ParseOptions, self: AST.AST) => ParseResult.ParseResult<any> =>
+  decode: (input: any, options: ParseOptions, self: AST.AST) => Effect.Effect<never, ParseResult.ParseError, any>
+): (input: any, options: ParseOptions, self: AST.AST) => Effect.Effect<never, ParseResult.ParseError, any> =>
 (input, options, ast) => ParseResult.flatMap(sleep, () => decode(input, options, ast))
 
 const effectifyAST = (ast: AST.AST): AST.AST => {


### PR DESCRIPTION
- remove `ParseResult` type
- rename `mapLeft` to `mapError`
- rename `bimap` to `mapBoth`

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
