### PR TITLE
fix: runFork with Scope should not run OOM

### DIFF
--- a/.changeset/blue-turkeys-relate.md
+++ b/.changeset/blue-turkeys-relate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix runFork with Scope

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -69,7 +69,7 @@ export const unsafeFork = <R>(runtime: Runtime.Runtime<R>) =>
               equals(id, fiberRuntime.id()) ? core.unit : core.interruptAsFiber(fiberRuntime, id)
             )
           ),
-          core.onExit(effect, (exit) => _scope.close(closeableScope, exit))
+          core.onExit(self, (exit) => _scope.close(closeableScope, exit))
         )
     )
   }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Avoids an out-of-memory issue caused by `effect` being re-assigned _before_ the `flatMap` call is done which causes the Effect to circularly call itself.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #1944
