### PR TITLE
Use literal strings for service tags

### DIFF
--- a/.changeset/real-elephants-begin.md
+++ b/.changeset/real-elephants-begin.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+make data-last FiberSet.run accept an Effect

--- a/.changeset/selfish-elephants-juggle.md
+++ b/.changeset/selfish-elephants-juggle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add Fiber{Map,Set}.makeRuntime

--- a/.changeset/serious-news-tease.md
+++ b/.changeset/serious-news-tease.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add Fiber{Set,Map}.runtime api

--- a/.changeset/seven-parents-run.md
+++ b/.changeset/seven-parents-run.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+make data-last FiberMap.run accept an Effect

--- a/.changeset/wise-singers-yawn.md
+++ b/.changeset/wise-singers-yawn.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Refactor effect to use literal tags for services

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -23,7 +23,6 @@ import type { Predicate } from "./Predicate.js"
 import type * as PubSub from "./PubSub.js"
 import type * as Queue from "./Queue.js"
 import type * as Ref from "./Ref.js"
-import type * as Scope from "./Scope.js"
 import type * as SingleProducerAsyncInput from "./SingleProducerAsyncInput.js"
 import type * as Sink from "./Sink.js"
 import type * as Stream from "./Stream.js"
@@ -1090,7 +1089,7 @@ export const fromPubSub: <Err, Done, Elem>(
  */
 export const fromPubSubScoped: <Err, Done, Elem>(
   pubsub: PubSub.PubSub<Either.Either<Exit.Exit<Err, Done>, Elem>>
-) => Effect.Effect<Scope.Scope, never, Channel<never, unknown, unknown, unknown, Err, Elem, Done>> =
+) => Effect.Effect<"Scope", never, Channel<never, unknown, unknown, unknown, Err, Elem, Done>> =
   channel.fromPubSubScoped
 
 /**
@@ -1932,7 +1931,7 @@ export const runDrain: <Env, InErr, InDone, OutElem, OutErr, OutDone>(
  */
 export const scoped: <R, E, A>(
   effect: Effect.Effect<R, E, A>
-) => Channel<Exclude<R, Scope.Scope>, unknown, unknown, unknown, E, A, unknown> = channel.scoped
+) => Channel<Exclude<R, "Scope">, unknown, unknown, unknown, E, A, unknown> = channel.scoped
 
 /**
  * Constructs a channel that succeeds immediately with the specified value.
@@ -1983,8 +1982,7 @@ export const toPubSub: <Err, Done, Elem>(
  */
 export const toPull: <Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
   self: Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-) => Effect.Effect<Scope.Scope | Env, never, Effect.Effect<Env, OutErr, Either.Either<OutDone, OutElem>>> =
-  channel.toPull
+) => Effect.Effect<"Scope" | Env, never, Effect.Effect<Env, OutErr, Either.Either<OutDone, OutElem>>> = channel.toPull
 
 /**
  * Converts a `Channel` to a `Queue`.
@@ -2039,7 +2037,7 @@ export const unwrap: <R, E, R2, InErr, InElem, InDone, OutErr, OutElem, OutDone>
  */
 export const unwrapScoped: <R, E, Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
   self: Effect.Effect<R, E, Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>>
-) => Channel<Env | Exclude<R, Scope.Scope>, InErr, InElem, InDone, E | OutErr, OutElem, OutDone> = channel.unwrapScoped
+) => Channel<Env | Exclude<R, "Scope">, InErr, InElem, InDone, E | OutErr, OutElem, OutDone> = channel.unwrapScoped
 
 /**
  * Updates a service in the context of this channel.

--- a/packages/effect/src/Clock.ts
+++ b/packages/effect/src/Clock.ts
@@ -108,4 +108,4 @@ export const clockWith: <R, E, A>(f: (clock: Clock) => Effect.Effect<R, E, A>) =
  * @since 2.0.0
  * @category context
  */
-export const Clock: Context.Tag<Clock, Clock> = internal.clockTag
+export const Clock: Context.Tag<"Clock", Clock> = internal.clockTag

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -136,7 +136,7 @@ export declare namespace ConfigProvider {
  * @since 2.0.0
  * @category context
  */
-export const ConfigProvider: Context.Tag<ConfigProvider, ConfigProvider> = internal.configProviderTag
+export const ConfigProvider: Context.Tag<"ConfigProvider", ConfigProvider> = internal.configProviderTag
 
 /**
  * Creates a new config provider.

--- a/packages/effect/src/Console.ts
+++ b/packages/effect/src/Console.ts
@@ -6,7 +6,6 @@ import type { Effect } from "./Effect.js"
 import * as internal from "./internal/console.js"
 import * as defaultConsole from "./internal/defaultServices/console.js"
 import type * as Layer from "./Layer.js"
-import type { Scope } from "./Scope.js"
 
 /**
  * @since 2.0.0
@@ -82,7 +81,7 @@ export interface UnsafeConsole {
  * @since 2.0.0
  * @category context
  */
-export const Console: Context.Tag<Console, Console> = defaultConsole.consoleTag
+export const Console: Context.Tag<"Console", Console> = defaultConsole.consoleTag
 
 /**
  * @since 2.0.0
@@ -158,11 +157,8 @@ export const error: (...args: ReadonlyArray<any>) => Effect<never, never, void> 
  * @category accessor
  */
 export const group: (
-  options?: {
-    label?: string | undefined
-    collapsed?: boolean | undefined
-  }
-) => Effect<Scope, never, void> = internal.group
+  options?: { label?: string | undefined; collapsed?: boolean | undefined } | undefined
+) => Effect<"Scope", never, void> = internal.group
 
 /**
  * @since 2.0.0
@@ -187,7 +183,7 @@ export const table: (tabularData: any, properties?: ReadonlyArray<string>) => Ef
  * @since 2.0.0
  * @category accessor
  */
-export const time: (label?: string) => Effect<Scope, never, void> = internal.time
+export const time: (label?: string | undefined) => Effect<"Scope", never, void> = internal.time
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -27,7 +27,7 @@ export type TagTypeId = typeof TagTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Tag<in out Identifier, in out Service> extends Pipeable, Inspectable {
+export interface Tag<in out Identifier extends string, in out Service> extends Pipeable, Inspectable {
   readonly _tag: "Tag"
   readonly _op: "Tag"
   readonly [TagTypeId]: {
@@ -37,7 +37,7 @@ export interface Tag<in out Identifier, in out Service> extends Pipeable, Inspec
   of(self: Service): Service
   context(self: Service): Context<Identifier>
   readonly stack?: string | undefined
-  readonly identifier?: unknown
+  readonly identifier: Identifier
   [Unify.typeSymbol]?: unknown
   [Unify.unifySymbol]?: TagUnify<this>
   [Unify.ignoreSymbol]?: TagUnifyIgnore
@@ -91,7 +91,7 @@ export declare namespace Tag {
  * @since 2.0.0
  * @category constructors
  */
-export const Tag: <Identifier, Service = Identifier>(identifier?: unknown) => Tag<Identifier, Service> =
+export const Tag: <Identifier extends string>(identifier: Identifier) => <Service>() => Tag<Identifier, Service> =
   internal.makeTag
 
 const TypeId: unique symbol = internal.TypeId as TypeId
@@ -106,7 +106,7 @@ export type TypeId = typeof TypeId
  * @since 2.0.0
  * @category models
  */
-export type ValidTagsById<R> = R extends infer S ? Tag<S, any> : never
+export type ValidTagsById<R> = R extends infer S extends string ? Tag<S, any> : never
 
 /**
  * @since 2.0.0
@@ -272,8 +272,8 @@ export const get: {
  * @category unsafe
  */
 export const unsafeGet: {
-  <S, I>(tag: Tag<I, S>): <Services>(self: Context<Services>) => S
-  <Services, S, I>(self: Context<Services>, tag: Tag<I, S>): S
+  <S, I extends string>(tag: Tag<I, S>): <Services>(self: Context<Services>) => S
+  <Services, S, I extends string>(self: Context<Services>, tag: Tag<I, S>): S
 } = internal.unsafeGet
 
 /**
@@ -299,8 +299,8 @@ export const unsafeGet: {
  * @category getters
  */
 export const getOption: {
-  <S, I>(tag: Tag<I, S>): <Services>(self: Context<Services>) => Option<S>
-  <Services, S, I>(self: Context<Services>, tag: Tag<I, S>): Option<S>
+  <S, I extends string>(tag: Tag<I, S>): <Services>(self: Context<Services>) => Option<S>
+  <Services, S, I extends string>(self: Context<Services>, tag: Tag<I, S>): Option<S>
 } = internal.getOption
 
 /**

--- a/packages/effect/src/DefaultServices.ts
+++ b/packages/effect/src/DefaultServices.ts
@@ -1,25 +1,20 @@
 /**
  * @since 2.0.0
  */
-import type * as Clock from "./Clock.js"
-import type * as ConfigProvider from "./ConfigProvider.js"
-import type * as Console from "./Console.js"
 import type * as Context from "./Context.js"
 import type * as FiberRef from "./FiberRef.js"
 import * as internal from "./internal/defaultServices.js"
-import type * as Random from "./Random.js"
-import type * as Tracer from "./Tracer.js"
 
 /**
  * @since 2.0.0
  * @category models
  */
 export type DefaultServices =
-  | Clock.Clock
-  | Console.Console
-  | Random.Random
-  | ConfigProvider.ConfigProvider
-  | Tracer.Tracer
+  | "Clock"
+  | "Console"
+  | "Random"
+  | "ConfigProvider"
+  | "Tracer"
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2239,11 +2239,11 @@ export const negate: <R, E>(self: Effect<R, E, boolean>) => Effect<R, E, boolean
 export const acquireRelease: {
   <A, R2, X>(
     release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect<R2, never, X>
-  ): <R, E>(acquire: Effect<R, E, A>) => Effect<Scope.Scope | R2 | R, E, A>
+  ): <R, E>(acquire: Effect<R, E, A>) => Effect<"Scope" | R2 | R, E, A>
   <R, E, A, R2, X>(
     acquire: Effect<R, E, A>,
     release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect<R2, never, X>
-  ): Effect<Scope.Scope | R | R2, E, A>
+  ): Effect<"Scope" | R | R2, E, A>
 } = fiberRuntime.acquireRelease
 
 /**
@@ -2272,11 +2272,11 @@ export const acquireRelease: {
 export const acquireReleaseInterruptible: {
   <A, R2, X>(
     release: (exit: Exit.Exit<unknown, unknown>) => Effect<R2, never, X>
-  ): <R, E>(acquire: Effect<R, E, A>) => Effect<Scope.Scope | R2 | R, E, A>
+  ): <R, E>(acquire: Effect<R, E, A>) => Effect<"Scope" | R2 | R, E, A>
   <R, E, A, R2, X>(
     acquire: Effect<R, E, A>,
     release: (exit: Exit.Exit<unknown, unknown>) => Effect<R2, never, X>
-  ): Effect<Scope.Scope | R | R2, E, A>
+  ): Effect<"Scope" | R | R2, E, A>
 } = fiberRuntime.acquireReleaseInterruptible
 
 /**
@@ -2342,7 +2342,7 @@ export const acquireUseRelease: {
  */
 export const addFinalizer: <R, X>(
   finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect<R, never, X>
-) => Effect<R | Scope.Scope, never, void> = fiberRuntime.addFinalizer
+) => Effect<R | "Scope", never, void> = fiberRuntime.addFinalizer
 
 /**
  * Returns an effect that, if this effect _starts_ execution, then the
@@ -2428,7 +2428,7 @@ export const sequentialFinalizers: <R, E, A>(self: Effect<R, E, A>) => Effect<R,
  * @since 2.0.0
  * @category scoping, resources & finalization
  */
-export const scope: Effect<Scope.Scope, never, Scope.Scope> = fiberRuntime.scope
+export const scope: Effect<"Scope", never, Scope.Scope> = fiberRuntime.scope
 
 /**
  * Accesses the current scope and uses it to perform the specified effect.
@@ -2436,7 +2436,7 @@ export const scope: Effect<Scope.Scope, never, Scope.Scope> = fiberRuntime.scope
  * @since 2.0.0
  * @category scoping, resources & finalization
  */
-export const scopeWith: <R, E, A>(f: (scope: Scope.Scope) => Effect<R, E, A>) => Effect<R | Scope.Scope, E, A> =
+export const scopeWith: <R, E, A>(f: (scope: Scope.Scope) => Effect<R, E, A>) => Effect<R | "Scope", E, A> =
   fiberRuntime.scopeWith
 
 /**
@@ -2447,8 +2447,7 @@ export const scopeWith: <R, E, A>(f: (scope: Scope.Scope) => Effect<R, E, A>) =>
  * @since 2.0.0
  * @category scoping, resources & finalization
  */
-export const scoped: <R, E, A>(effect: Effect<R, E, A>) => Effect<Exclude<R, Scope.Scope>, E, A> =
-  fiberRuntime.scopedEffect
+export const scoped: <R, E, A>(effect: Effect<R, E, A>) => Effect<Exclude<R, "Scope">, E, A> = fiberRuntime.scopedEffect
 
 /**
  * Scopes all resources acquired by `resource` to the lifetime of `use`
@@ -2460,11 +2459,11 @@ export const scoped: <R, E, A>(effect: Effect<R, E, A>) => Effect<Exclude<R, Sco
 export const using: {
   <A, R2, E2, A2>(
     use: (a: A) => Effect<R2, E2, A2>
-  ): <R, E>(self: Effect<R, E, A>) => Effect<R2 | Exclude<R, Scope.Scope>, E2 | E, A2>
+  ): <R, E>(self: Effect<R, E, A>) => Effect<R2 | Exclude<R, "Scope">, E2 | E, A2>
   <R, E, A, R2, E2, A2>(
     self: Effect<R, E, A>,
     use: (a: A) => Effect<R2, E2, A2>
-  ): Effect<R2 | Exclude<R, Scope.Scope>, E | E2, A2>
+  ): Effect<R2 | Exclude<R, "Scope">, E | E2, A2>
 } = fiberRuntime.using
 
 /**
@@ -2476,7 +2475,7 @@ export const using: {
  */
 export const withEarlyRelease: <R, E, A>(
   self: Effect<R, E, A>
-) => Effect<Scope.Scope | R, E, [Effect<never, never, void>, A]> = fiberRuntime.withEarlyRelease
+) => Effect<"Scope" | R, E, [Effect<never, never, void>, A]> = fiberRuntime.withEarlyRelease
 
 // -------------------------------------------------------------------------------------
 // supervision & fibers
@@ -2658,7 +2657,7 @@ export const forkIn: {
  * @since 2.0.0
  * @category supervision & fibers
  */
-export const forkScoped: <R, E, A>(self: Effect<R, E, A>) => Effect<Scope.Scope | R, never, Fiber.RuntimeFiber<E, A>> =
+export const forkScoped: <R, E, A>(self: Effect<R, E, A>) => Effect<"Scope" | R, never, Fiber.RuntimeFiber<E, A>> =
   circular.forkScoped
 
 /**
@@ -2797,7 +2796,7 @@ export const clockWith: <R, E, A>(f: (clock: Clock.Clock) => Effect<R, E, A>) =>
  * @since 2.0.0
  * @category constructors
  */
-export const withClockScoped: <A extends Clock.Clock>(value: A) => Effect<Scope.Scope, never, void> =
+export const withClockScoped: <A extends Clock.Clock>(value: A) => Effect<"Scope", never, void> =
   fiberRuntime.withClockScoped
 
 /**
@@ -2840,7 +2839,7 @@ export const consoleWith: <R, E, A>(f: (console: Console) => Effect<R, E, A>) =>
  * @since 2.0.0
  * @category constructors
  */
-export const withConsoleScoped: <A extends Console>(console: A) => Effect<Scope.Scope, never, void> =
+export const withConsoleScoped: <A extends Console>(console: A) => Effect<"Scope", never, void> =
   _console.withConsoleScoped
 
 /**
@@ -3032,7 +3031,7 @@ export const withConfigProvider: {
  * @since 2.0.0
  * @category config
  */
-export const withConfigProviderScoped: (value: ConfigProvider) => Effect<Scope.Scope, never, void> =
+export const withConfigProviderScoped: (value: ConfigProvider) => Effect<"Scope", never, void> =
   fiberRuntime.withConfigProviderScoped
 
 // -------------------------------------------------------------------------------------
@@ -3194,15 +3193,16 @@ export const serviceMembers: <SR, SE, S>(getService: Effect<SR, SE, S>) => {
  * @since 2.0.0
  * @category context
  */
-export const serviceOption: <I, S>(tag: Context.Tag<I, S>) => Effect<never, never, Option.Option<S>> =
+export const serviceOption: <I extends string, S>(tag: Context.Tag<I, S>) => Effect<never, never, Option.Option<S>> =
   effect.serviceOption
 
 /**
  * @since 2.0.0
  * @category context
  */
-export const serviceOptional: <I, S>(tag: Context.Tag<I, S>) => Effect<never, Cause.NoSuchElementException, S> =
-  effect.serviceOptional
+export const serviceOptional: <I extends string, S>(
+  tag: Context.Tag<I, S>
+) => Effect<never, Cause.NoSuchElementException, S> = effect.serviceOptional
 
 /**
  * Updates the service with the required service entry.
@@ -4097,11 +4097,11 @@ export const schedule: {
 export const scheduleForked: {
   <R2, Out>(
     schedule: Schedule.Schedule<R2, unknown, Out>
-  ): <R, E, A>(self: Effect<R, E, A>) => Effect<Scope.Scope | R2 | R, never, Fiber.RuntimeFiber<E, Out>>
+  ): <R, E, A>(self: Effect<R, E, A>) => Effect<"Scope" | R2 | R, never, Fiber.RuntimeFiber<E, Out>>
   <R, E, A, R2, Out>(
     self: Effect<R, E, A>,
     schedule: Schedule.Schedule<R2, unknown, Out>
-  ): Effect<Scope.Scope | R | R2, never, Fiber.RuntimeFiber<E, Out>>
+  ): Effect<"Scope" | R | R2, never, Fiber.RuntimeFiber<E, Out>>
 } = circular.scheduleForked
 
 /**
@@ -4180,8 +4180,8 @@ export const locallyWith: {
  * @category fiber refs
  */
 export const locallyScoped: {
-  <A>(value: A): (self: FiberRef.FiberRef<A>) => Effect<Scope.Scope, never, void>
-  <A>(self: FiberRef.FiberRef<A>, value: A): Effect<Scope.Scope, never, void>
+  <A>(value: A): (self: FiberRef.FiberRef<A>) => Effect<"Scope", never, void>
+  <A>(self: FiberRef.FiberRef<A>, value: A): Effect<"Scope", never, void>
 } = fiberRuntime.fiberRefLocallyScoped
 
 /**
@@ -4189,8 +4189,8 @@ export const locallyScoped: {
  * @category fiber refs
  */
 export const locallyScopedWith: {
-  <A>(f: (a: A) => A): (self: FiberRef.FiberRef<A>) => Effect<Scope.Scope, never, void>
-  <A>(self: FiberRef.FiberRef<A>, f: (a: A) => A): Effect<Scope.Scope, never, void>
+  <A>(f: (a: A) => A): (self: FiberRef.FiberRef<A>) => Effect<"Scope", never, void>
+  <A>(self: FiberRef.FiberRef<A>, f: (a: A) => A): Effect<"Scope", never, void>
 } = fiberRuntime.fiberRefLocallyScopedWith
 
 /**
@@ -4581,7 +4581,7 @@ export const withRuntimeFlagsPatch: {
  */
 export const withRuntimeFlagsPatchScoped: (
   update: RuntimeFlagsPatch.RuntimeFlagsPatch
-) => Effect<Scope.Scope, never, void> = fiberRuntime.withRuntimeFlagsScoped
+) => Effect<"Scope", never, void> = fiberRuntime.withRuntimeFlagsScoped
 
 // -------------------------------------------------------------------------------------
 // metrics
@@ -4617,7 +4617,7 @@ export const labelMetrics: {
  * @since 2.0.0
  * @category metrics
  */
-export const tagMetricsScoped: (key: string, value: string) => Effect<Scope.Scope, never, void> =
+export const tagMetricsScoped: (key: string, value: string) => Effect<"Scope", never, void> =
   fiberRuntime.tagMetricsScoped
 
 /**
@@ -4628,7 +4628,7 @@ export const tagMetricsScoped: (key: string, value: string) => Effect<Scope.Scop
  */
 export const labelMetricsScoped: (
   labels: ReadonlyArray<MetricLabel.MetricLabel>
-) => Effect<Scope.Scope, never, void> = fiberRuntime.labelMetricsScoped
+) => Effect<"Scope", never, void> = fiberRuntime.labelMetricsScoped
 
 /**
  * Retrieves the metric labels associated with the current scope.
@@ -5028,8 +5028,7 @@ export const withTracer: {
  * @since 2.0.0
  * @category tracing
  */
-export const withTracerScoped: (value: Tracer.Tracer) => Effect<Scope.Scope, never, void> =
-  fiberRuntime.withTracerScoped
+export const withTracerScoped: (value: Tracer.Tracer) => Effect<"Scope", never, void> = fiberRuntime.withTracerScoped
 
 /**
  * @since 2.0.0
@@ -5143,7 +5142,7 @@ export const makeSpanScoped: (
     readonly root?: boolean | undefined
     readonly context?: Context.Context<never> | undefined
   }
-) => Effect<Scope.Scope, never, Tracer.Span> = fiberRuntime.makeSpanScoped
+) => Effect<"Scope", never, Tracer.Span> = fiberRuntime.makeSpanScoped
 
 /**
  * Create a new span for tracing, and automatically close it when the effect
@@ -5185,8 +5184,8 @@ export const withSpan: {
       readonly parent?: Tracer.ParentSpan | undefined
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
-    }
-  ): <R, E, A>(self: Effect<R, E, A>) => Effect<Exclude<R, Tracer.ParentSpan>, E, A>
+    } | undefined
+  ): <R, E, A>(self: Effect<R, E, A>) => Effect<Exclude<R, "ParentSpan">, E, A>
   <R, E, A>(
     self: Effect<R, E, A>,
     name: string,
@@ -5196,8 +5195,8 @@ export const withSpan: {
       readonly parent?: Tracer.ParentSpan | undefined
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
-    }
-  ): Effect<Exclude<R, Tracer.ParentSpan>, E, A>
+    } | undefined
+  ): Effect<Exclude<R, "ParentSpan">, E, A>
 } = effect.withSpan
 
 /**
@@ -5217,8 +5216,8 @@ export const withSpanScoped: {
       readonly parent?: Tracer.ParentSpan | undefined
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
-    }
-  ): <R, E, A>(self: Effect<R, E, A>) => Effect<Exclude<R, Tracer.ParentSpan> | Scope.Scope, E, A>
+    } | undefined
+  ): <R, E, A>(self: Effect<R, E, A>) => Effect<"Scope" | Exclude<R, "ParentSpan">, E, A>
   <R, E, A>(
     self: Effect<R, E, A>,
     name: string,
@@ -5228,8 +5227,8 @@ export const withSpanScoped: {
       readonly parent?: Tracer.ParentSpan | undefined
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
-    }
-  ): Effect<Scope.Scope | Exclude<R, Tracer.ParentSpan>, E, A>
+    } | undefined
+  ): Effect<"Scope" | Exclude<R, "ParentSpan">, E, A>
 } = fiberRuntime.withSpanScoped
 
 /**
@@ -5239,8 +5238,8 @@ export const withSpanScoped: {
  * @category tracing
  */
 export const withParentSpan: {
-  (span: Tracer.ParentSpan): <R, E, A>(self: Effect<R, E, A>) => Effect<Exclude<R, Tracer.ParentSpan>, E, A>
-  <R, E, A>(self: Effect<R, E, A>, span: Tracer.ParentSpan): Effect<Exclude<R, Tracer.ParentSpan>, E, A>
+  (span: Tracer.ParentSpan): <R, E, A>(self: Effect<R, E, A>) => Effect<Exclude<R, "ParentSpan">, E, A>
+  <R, E, A>(self: Effect<R, E, A>, span: Tracer.ParentSpan): Effect<Exclude<R, "ParentSpan">, E, A>
 } = effect.withParentSpan
 
 // -------------------------------------------------------------------------------------

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -18,7 +18,6 @@ import type * as Option from "./Option.js"
 import type * as order from "./Order.js"
 import type { Pipeable } from "./Pipeable.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
-import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
 
 /**
@@ -588,8 +587,7 @@ export const unsafeRoots: (_: void) => Array<RuntimeFiber<any, any>> = internal.
  * @since 2.0.0
  * @category destructors
  */
-export const scoped: <E, A>(self: Fiber<E, A>) => Effect.Effect<Scope.Scope, never, Fiber<E, A>> =
-  fiberRuntime.fiberScoped
+export const scoped: <E, A>(self: Fiber<E, A>) => Effect.Effect<"Scope", never, Fiber<E, A>> = fiberRuntime.fiberScoped
 
 /**
  * Returns the `FiberStatus` of a `RuntimeFiber`.

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -7,11 +7,13 @@ import type { NoSuchElementException } from "./Cause.js"
 import * as Fiber from "./Fiber.js"
 import * as FiberId from "./FiberId.js"
 import { dual } from "./Function.js"
+import type { FiberMap } from "./index.js"
 import * as Inspectable from "./Inspectable.js"
 import * as MutableHashMap from "./MutableHashMap.js"
 import * as Option from "./Option.js"
 import { type Pipeable, pipeArguments } from "./Pipeable.js"
 import * as Predicate from "./Predicate.js"
+import * as Runtime from "./Runtime.js"
 
 /**
  * @since 2.0.0
@@ -97,6 +99,26 @@ const unsafeMake = <K, E = unknown, A = unknown>(): FiberMap<K, E, A> => {
  */
 export const make = <K, E = unknown, A = unknown>(): Effect.Effect<Scope.Scope, never, FiberMap<K, E, A>> =>
   Effect.acquireRelease(Effect.sync(() => unsafeMake<K, E, A>()), clear)
+
+/**
+ * Create an Effect run function that is backed by a FiberMap.
+ *
+ * @since 2.0.0
+ * @categories constructors
+ */
+export const makeRuntime = <R, K, E = unknown, A = unknown>(): Effect.Effect<
+  Scope.Scope | R,
+  never,
+  <XE extends E, XA extends A>(
+    key: K,
+    effect: Effect.Effect<R, XE, XA>,
+    options?: Runtime.RunForkOptions | undefined
+  ) => Fiber.RuntimeFiber<XE, XA>
+> =>
+  Effect.flatMap(
+    make<K, E, A>(),
+    (self) => runtime(self)<R>()
+  )
 
 /**
  * Add a fiber to the FiberMap. When the fiber completes, it will be removed from the FiberMap.
@@ -263,30 +285,89 @@ export const clear = <K, E, A>(self: FiberMap<K, E, A>): Effect.Effect<never, ne
  * @categories combinators
  */
 export const run: {
-  <K, E, A, R, XE extends E, XA extends A>(
-    key: K,
+  <K, E, A>(
+    self: FiberMap<K, E, A>,
+    key: K
+  ): <R, XE extends E, XA extends A>(
     effect: Effect.Effect<R, XE, XA>
-  ): (self: FiberMap<K, E, A>) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
+  ) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
   <K, E, A, R, XE extends E, XA extends A>(
     self: FiberMap<K, E, A>,
     key: K,
     effect: Effect.Effect<R, XE, XA>
   ): Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
-} = dual<
-  <K, E, A, R, XE extends E, XA extends A>(
-    key: K,
-    effect: Effect.Effect<R, XE, XA>
-  ) => (self: FiberMap<K, E, A>) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>,
-  <K, E, A, R, XE extends E, XA extends A>(
-    self: FiberMap<K, E, A>,
-    key: K,
-    effect: Effect.Effect<R, XE, XA>
-  ) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
->(3, (self, key, effect) =>
-  Effect.tap(
+} = function() {
+  if (arguments.length === 2) {
+    const self = arguments[0] as FiberMap<any>
+    const key = arguments[1]
+    return (effect: Effect.Effect<any, any, any>) =>
+      Effect.tap(
+        Effect.forkDaemon(effect),
+        (fiber) => set(self, key, fiber)
+      )
+  }
+  const self = arguments[0] as FiberMap<any>
+  const key = arguments[1]
+  const effect = arguments[2] as Effect.Effect<any, any, any>
+  return Effect.tap(
     Effect.forkDaemon(effect),
     (fiber) => set(self, key, fiber)
-  ))
+  ) as any
+}
+
+/**
+ * Capture a Runtime and use it to fork Effect's, adding the forked fibers to the FiberMap.
+ *
+ * @example
+ * import { Context, Effect, FiberMap } from "effect"
+ *
+ * interface Users {
+ *   readonly _: unique symbol
+ * }
+ * const Users = Context.Tag<Users, {
+ *    getAll: Effect.Effect<never, never, Array<unknown>>
+ * }>()
+ *
+ * Effect.gen(function*(_) {
+ *   const map = yield* _(FiberMap.make<string>())
+ *   const run = yield* _(FiberMap.runtime(map)<Users>())
+ *
+ *   // run some effects and add the fibers to the map
+ *   run("effect-a", Effect.andThen(Users, _ => _.getAll))
+ *   run("effect-b", Effect.andThen(Users, _ => _.getAll))
+ * }).pipe(
+ *   Effect.scoped // The fibers will be interrupted when the scope is closed
+ * )
+ *
+ * @since 2.0.0
+ * @categories combinators
+ */
+export const runtime: <K, E, A>(
+  self: FiberMap<K, E, A>
+) => <R>() => Effect.Effect<
+  R,
+  never,
+  <XE extends E, XA extends A>(
+    key: K,
+    effect: Effect.Effect<R, XE, XA>,
+    options?: Runtime.RunForkOptions | undefined
+  ) => Fiber.RuntimeFiber<XE, XA>
+> = <K, E, A>(self: FiberMap<K, E, A>) => <R>() =>
+  Effect.map(
+    Effect.runtime<R>(),
+    (runtime) => {
+      const runFork = Runtime.runFork(runtime)
+      return <XE extends E, XA extends A>(
+        key: K,
+        effect: Effect.Effect<R, XE, XA>,
+        options?: Runtime.RunForkOptions | undefined
+      ) => {
+        const fiber = runFork(effect, options)
+        unsafeSet(self, key, fiber)
+        return fiber
+      }
+    }
+  )
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -2,7 +2,6 @@
  * @since 2.0.0
  */
 import * as Effect from "effect/Effect"
-import type * as Scope from "effect/Scope"
 import type { NoSuchElementException } from "./Cause.js"
 import * as Fiber from "./Fiber.js"
 import * as FiberId from "./FiberId.js"
@@ -97,7 +96,7 @@ const unsafeMake = <K, E = unknown, A = unknown>(): FiberMap<K, E, A> => {
  * @since 2.0.0
  * @categories constructors
  */
-export const make = <K, E = unknown, A = unknown>(): Effect.Effect<Scope.Scope, never, FiberMap<K, E, A>> =>
+export const make = <K, E = unknown, A = unknown>(): Effect.Effect<"Scope", never, FiberMap<K, E, A>> =>
   Effect.acquireRelease(Effect.sync(() => unsafeMake<K, E, A>()), clear)
 
 /**

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -106,7 +106,7 @@ export const make = <K, E = unknown, A = unknown>(): Effect.Effect<"Scope", neve
  * @categories constructors
  */
 export const makeRuntime = <R, K, E = unknown, A = unknown>(): Effect.Effect<
-  Scope.Scope | R,
+  "Scope" | R,
   never,
   <XE extends E, XA extends A>(
     key: K,

--- a/packages/effect/src/FiberRef.ts
+++ b/packages/effect/src/FiberRef.ts
@@ -22,7 +22,6 @@ import type { Pipeable } from "./Pipeable.js"
 import type * as Request from "./Request.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
 import * as Scheduler from "./Scheduler.js"
-import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
 import type * as Types from "./Types.js"
@@ -78,13 +77,13 @@ export const make: <A>(
     readonly fork?: ((a: A) => A) | undefined
     readonly join?: ((left: A, right: A) => A) | undefined
   }
-) => Effect.Effect<Scope.Scope, never, FiberRef<A>> = fiberRuntime.fiberRefMake
+) => Effect.Effect<"Scope", never, FiberRef<A>> = fiberRuntime.fiberRefMake
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const makeWith: <Value>(ref: LazyArg<FiberRef<Value>>) => Effect.Effect<Scope.Scope, never, FiberRef<Value>> =
+export const makeWith: <Value>(ref: LazyArg<FiberRef<Value>>) => Effect.Effect<"Scope", never, FiberRef<Value>> =
   fiberRuntime.fiberRefMakeWith
 
 /**
@@ -93,7 +92,7 @@ export const makeWith: <Value>(ref: LazyArg<FiberRef<Value>>) => Effect.Effect<S
  */
 export const makeContext: <A>(
   initial: Context.Context<A>
-) => Effect.Effect<Scope.Scope, never, FiberRef<Context.Context<A>>> = fiberRuntime.fiberRefMakeContext
+) => Effect.Effect<"Scope", never, FiberRef<Context.Context<A>>> = fiberRuntime.fiberRefMakeContext
 
 /**
  * @since 2.0.0
@@ -101,7 +100,7 @@ export const makeContext: <A>(
  */
 export const makeRuntimeFlags: (
   initial: RuntimeFlags.RuntimeFlags
-) => Effect.Effect<Scope.Scope, never, FiberRef<RuntimeFlags.RuntimeFlags>> = fiberRuntime.fiberRefMakeRuntimeFlags
+) => Effect.Effect<"Scope", never, FiberRef<RuntimeFlags.RuntimeFlags>> = fiberRuntime.fiberRefMakeRuntimeFlags
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -101,7 +101,7 @@ export const make = <E = unknown, A = unknown>(): Effect.Effect<"Scope", never, 
  * @categories constructors
  */
 export const makeRuntime = <R, E = unknown, A = unknown>(): Effect.Effect<
-  Scope.Scope | R,
+  "Scope" | R,
   never,
   <XE extends E, XA extends A>(
     effect: Effect.Effect<R, XE, XA>,

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -8,6 +8,7 @@ import { dual } from "./Function.js"
 import * as Inspectable from "./Inspectable.js"
 import { type Pipeable, pipeArguments } from "./Pipeable.js"
 import * as Predicate from "./Predicate.js"
+import * as Runtime from "./Runtime.js"
 
 /**
  * @since 2.0.0
@@ -95,6 +96,25 @@ export const make = <E = unknown, A = unknown>(): Effect.Effect<Scope.Scope, nev
   Effect.acquireRelease(Effect.sync(() => unsafeMake<E, A>()), clear)
 
 /**
+ * Create an Effect run function that is backed by a FiberSet.
+ *
+ * @since 2.0.0
+ * @categories constructors
+ */
+export const makeRuntime = <R, E = unknown, A = unknown>(): Effect.Effect<
+  Scope.Scope | R,
+  never,
+  <XE extends E, XA extends A>(
+    effect: Effect.Effect<R, XE, XA>,
+    options?: Runtime.RunForkOptions | undefined
+  ) => Fiber.RuntimeFiber<XE, XA>
+> =>
+  Effect.flatMap(
+    make<E, A>(),
+    (self) => runtime(self)<R>()
+  )
+
+/**
  * Add a fiber to the FiberSet. When the fiber completes, it will be removed.
  *
  * @since 2.0.0
@@ -165,26 +185,79 @@ export const clear = <E, A>(self: FiberSet<E, A>): Effect.Effect<never, never, v
  * @categories combinators
  */
 export const run: {
-  <E, A, R, XE extends E, XA extends A>(
+  <E, A>(self: FiberSet<E, A>): <R, XE extends E, XA extends A>(
     effect: Effect.Effect<R, XE, XA>
-  ): (self: FiberSet<E, A>) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
+  ) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
   <E, A, R, XE extends E, XA extends A>(
     self: FiberSet<E, A>,
     effect: Effect.Effect<R, XE, XA>
   ): Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
-} = dual<
-  <E, A, R, XE extends E, XA extends A>(
-    effect: Effect.Effect<R, XE, XA>
-  ) => (self: FiberSet<E, A>) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>,
-  <E, A, R, XE extends E, XA extends A>(
-    self: FiberSet<E, A>,
-    effect: Effect.Effect<R, XE, XA>
-  ) => Effect.Effect<R, never, Fiber.RuntimeFiber<XE, XA>>
->(2, (self, effect) =>
-  Effect.tap(
+} = function() {
+  const self = arguments[0] as FiberSet<any>
+  if (arguments.length === 1) {
+    return (effect: Effect.Effect<any, any, any>) =>
+      Effect.tap(
+        Effect.forkDaemon(effect),
+        (fiber) => add(self, fiber)
+      )
+  }
+  const effect = arguments[1] as Effect.Effect<any, any, any>
+  return Effect.tap(
     Effect.forkDaemon(effect),
     (fiber) => add(self, fiber)
-  ))
+  ) as any
+}
+
+/**
+ * Capture a Runtime and use it to fork Effect's, adding the forked fibers to the FiberSet.
+ *
+ * @example
+ * import { Context, Effect, FiberSet } from "effect"
+ *
+ * interface Users {
+ *   readonly _: unique symbol
+ * }
+ * const Users = Context.Tag<Users, {
+ *    getAll: Effect.Effect<never, never, Array<unknown>>
+ * }>()
+ *
+ * Effect.gen(function*(_) {
+ *   const set = yield* _(FiberSet.make())
+ *   const run = yield* _(FiberSet.runtime(set)<Users>())
+ *
+ *   // run some effects and add the fibers to the set
+ *   run(Effect.andThen(Users, _ => _.getAll))
+ * }).pipe(
+ *   Effect.scoped // The fibers will be interrupted when the scope is closed
+ * )
+ *
+ * @since 2.0.0
+ * @categories combinators
+ */
+export const runtime: <E, A>(
+  self: FiberSet<E, A>
+) => <R>() => Effect.Effect<
+  R,
+  never,
+  <XE extends E, XA extends A>(
+    effect: Effect.Effect<R, XE, XA>,
+    options?: Runtime.RunForkOptions | undefined
+  ) => Fiber.RuntimeFiber<XE, XA>
+> = <E, A>(self: FiberSet<E, A>) => <R>() =>
+  Effect.map(
+    Effect.runtime<R>(),
+    (runtime) => {
+      const runFork = Runtime.runFork(runtime)
+      return <XE extends E, XA extends A>(
+        effect: Effect.Effect<R, XE, XA>,
+        options?: Runtime.RunForkOptions | undefined
+      ) => {
+        const fiber = runFork(effect, options)
+        unsafeAdd(self, fiber)
+        return fiber
+      }
+    }
+  )
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -2,7 +2,6 @@
  * @since 2.0.0
  */
 import * as Effect from "effect/Effect"
-import type * as Scope from "effect/Scope"
 import * as Fiber from "./Fiber.js"
 import { dual } from "./Function.js"
 import * as Inspectable from "./Inspectable.js"
@@ -92,7 +91,7 @@ const unsafeMake = <E = unknown, A = unknown>(): FiberSet<E, A> => {
  * @since 2.0.0
  * @categories constructors
  */
-export const make = <E = unknown, A = unknown>(): Effect.Effect<Scope.Scope, never, FiberSet<E, A>> =>
+export const make = <E = unknown, A = unknown>(): Effect.Effect<"Scope", never, FiberSet<E, A>> =>
   Effect.acquireRelease(Effect.sync(() => unsafeMake<E, A>()), clear)
 
 /**

--- a/packages/effect/src/KeyedPool.ts
+++ b/packages/effect/src/KeyedPool.ts
@@ -5,7 +5,6 @@ import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/keyedPool.js"
 import type { Pipeable } from "./Pipeable.js"
-import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
 
 /**
@@ -34,7 +33,7 @@ export interface KeyedPool<in K, out E, in out A> extends KeyedPool.Variance<K, 
    * for that same reason. Retrying a failed acquisition attempt will repeat the
    * acquisition attempt.
    */
-  get(key: K): Effect.Effect<Scope.Scope, E, A>
+  get(key: K): Effect.Effect<"Scope", E, A>
 
   /**
    * Invalidates the specified item. This will cause the pool to eventually
@@ -75,7 +74,7 @@ export const make: <K, R, E, A>(
     readonly acquire: (key: K) => Effect.Effect<R, E, A>
     readonly size: number
   }
-) => Effect.Effect<Scope.Scope | R, never, KeyedPool<K, E, A>> = internal.make
+) => Effect.Effect<"Scope" | R, never, KeyedPool<K, E, A>> = internal.make
 
 /**
  * Makes a new pool of the specified fixed size. The pool is returned in a
@@ -93,7 +92,7 @@ export const makeWith: <K, R, E, A>(
     readonly acquire: (key: K) => Effect.Effect<R, E, A>
     readonly size: (key: K) => number
   }
-) => Effect.Effect<Scope.Scope | R, never, KeyedPool<K, E, A>> = internal.makeWith
+) => Effect.Effect<"Scope" | R, never, KeyedPool<K, E, A>> = internal.makeWith
 
 /**
  * Makes a new pool with the specified minimum and maximum sizes and time to
@@ -115,7 +114,7 @@ export const makeWithTTL: <K, R, E, A>(
     readonly max: (key: K) => number
     readonly timeToLive: Duration.DurationInput
   }
-) => Effect.Effect<Scope.Scope | R, never, KeyedPool<K, E, A>> = internal.makeWithTTL
+) => Effect.Effect<"Scope" | R, never, KeyedPool<K, E, A>> = internal.makeWithTTL
 
 /**
  * Makes a new pool with the specified minimum and maximum sizes and time to
@@ -137,7 +136,7 @@ export const makeWithTTLBy: <K, R, E, A>(
     readonly max: (key: K) => number
     readonly timeToLive: (key: K) => Duration.DurationInput
   }
-) => Effect.Effect<Scope.Scope | R, never, KeyedPool<K, E, A>> = internal.makeWithTTLBy
+) => Effect.Effect<"Scope" | R, never, KeyedPool<K, E, A>> = internal.makeWithTTLBy
 
 /**
  * Retrieves an item from the pool belonging to the given key in a scoped
@@ -149,8 +148,8 @@ export const makeWithTTLBy: <K, R, E, A>(
  * @category combinators
  */
 export const get: {
-  <K>(key: K): <E, A>(self: KeyedPool<K, E, A>) => Effect.Effect<Scope.Scope, E, A>
-  <K, E, A>(self: KeyedPool<K, E, A>, key: K): Effect.Effect<Scope.Scope, E, A>
+  <K>(key: K): <E, A>(self: KeyedPool<K, E, A>) => Effect.Effect<"Scope", E, A>
+  <K, E, A>(self: KeyedPool<K, E, A>, key: K): Effect.Effect<"Scope", E, A>
 } = internal.get
 
 /**

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -144,7 +144,7 @@ export const isFresh: <R, E, A>(self: Layer<R, E, A>) => boolean = internal.isFr
  */
 export const build: <RIn, E, ROut>(
   self: Layer<RIn, E, ROut>
-) => Effect.Effect<Scope.Scope | RIn, E, Context.Context<ROut>> = internal.build
+) => Effect.Effect<"Scope" | RIn, E, Context.Context<ROut>> = internal.build
 
 /**
  * Builds a layer into an `Effect` value. Any resources associated with this
@@ -273,7 +273,7 @@ export const empty: Layer<never, never, never> = internal.empty
  * @since 2.0.0
  * @category utils
  */
-export const extendScope: <RIn, E, ROut>(self: Layer<RIn, E, ROut>) => Layer<Scope.Scope | RIn, E, ROut> =
+export const extendScope: <RIn, E, ROut>(self: Layer<RIn, E, ROut>) => Layer<"Scope" | RIn, E, ROut> =
   internal.extendScope
 
 /**
@@ -331,8 +331,13 @@ export const flatMap: {
  * @category sequencing
  */
 export const flatten: {
-  <R2, E2, A, I>(tag: Context.Tag<I, Layer<R2, E2, A>>): <R, E>(self: Layer<R, E, I>) => Layer<R2 | R, E2 | E, A>
-  <R, E, A, R2, E2, I>(self: Layer<R, E, I>, tag: Context.Tag<I, Layer<R2, E2, A>>): Layer<R | R2, E | E2, A>
+  <R2, E2, A, I extends string>(
+    tag: Context.Tag<I, Layer<R2, E2, A>>
+  ): <R, E>(self: Layer<R, E, I>) => Layer<R2 | R, E2 | E, A>
+  <R, E, A, R2, E2, I extends string>(
+    self: Layer<R, E, I>,
+    tag: Context.Tag<I, Layer<R2, E2, A>>
+  ): Layer<R | R2, E | E2, A>
 } = internal.flatten
 
 /**
@@ -447,7 +452,7 @@ export const matchCause: {
  */
 export const memoize: <RIn, E, ROut>(
   self: Layer<RIn, E, ROut>
-) => Effect.Effect<Scope.Scope, never, Layer<RIn, E, ROut>> = internal.memoize
+) => Effect.Effect<"Scope", never, Layer<RIn, E, ROut>> = internal.memoize
 
 /**
  * Merges this layer with the specified layer concurrently, producing a new layer with combined input and output types.
@@ -608,7 +613,7 @@ export const retry: {
  * @since 2.0.0
  * @category constructors
  */
-export const scope: Layer<never, never, Scope.CloseableScope> = internal.scope
+export const scope: Layer<never, never, "Scope"> = internal.scope
 
 /**
  * Constructs a layer from the specified scoped effect.
@@ -621,11 +626,11 @@ export const scoped: {
     tag: T
   ): <R, E>(
     effect: Effect.Effect<R, E, Context.Tag.Service<T>>
-  ) => Layer<Exclude<R, Scope.Scope>, E, Context.Tag.Identifier<T>>
+  ) => Layer<Exclude<R, "Scope">, E, Context.Tag.Identifier<T>>
   <T extends Context.Tag<any, any>, R, E>(
     tag: T,
     effect: Effect.Effect<R, E, Context.Tag.Service<T>>
-  ): Layer<Exclude<R, Scope.Scope>, E, Context.Tag.Identifier<T>>
+  ): Layer<Exclude<R, "Scope">, E, Context.Tag.Identifier<T>>
 } = internal.scoped
 
 /**
@@ -634,7 +639,7 @@ export const scoped: {
  * @since 2.0.0
  * @category constructors
  */
-export const scopedDiscard: <R, E, T>(effect: Effect.Effect<R, E, T>) => Layer<Exclude<R, Scope.Scope>, E, never> =
+export const scopedDiscard: <R, E, T>(effect: Effect.Effect<R, E, T>) => Layer<Exclude<R, "Scope">, E, never> =
   internal.scopedDiscard
 
 /**
@@ -646,7 +651,7 @@ export const scopedDiscard: <R, E, T>(effect: Effect.Effect<R, E, T>) => Layer<E
  */
 export const scopedContext: <R, E, A>(
   effect: Effect.Effect<R, E, Context.Context<A>>
-) => Layer<Exclude<R, Scope.Scope>, E, A> = internal.scopedContext
+) => Layer<Exclude<R, "Scope">, E, A> = internal.scopedContext
 
 /**
  * Constructs a layer that accesses and returns the specified service from the
@@ -775,7 +780,7 @@ export const tapErrorCause: {
  */
 export const toRuntime: <RIn, E, ROut>(
   self: Layer<RIn, E, ROut>
-) => Effect.Effect<Scope.Scope | RIn, E, Runtime.Runtime<ROut>> = internal.toRuntime
+) => Effect.Effect<"Scope" | RIn, E, Runtime.Runtime<ROut>> = internal.toRuntime
 
 /**
  * Feeds the output services of this builder into the input of the specified
@@ -845,7 +850,7 @@ export const unwrapEffect: <R, E, R1, E1, A>(self: Effect.Effect<R, E, Layer<R1,
  */
 export const unwrapScoped: <R, E, R1, E1, A>(
   self: Effect.Effect<R, E, Layer<R1, E1, A>>
-) => Layer<R1 | Exclude<R, Scope.Scope>, E | E1, A> = internal.unwrapScoped
+) => Layer<R1 | Exclude<R, "Scope">, E | E1, A> = internal.unwrapScoped
 
 /**
  * @since 2.0.0
@@ -873,7 +878,7 @@ export const setConfigProvider: (configProvider: ConfigProvider) => Layer<never,
  * @since 2.0.0
  * @category tracing
  */
-export const parentSpan: (span: Tracer.ParentSpan) => Layer<never, never, Tracer.ParentSpan> = circularLayer.parentSpan
+export const parentSpan: (span: Tracer.ParentSpan) => Layer<never, never, "ParentSpan"> = circularLayer.parentSpan
 
 /**
  * @since 2.0.0
@@ -904,7 +909,7 @@ export const setRequestCaching: (requestCaching: boolean) => Layer<never, never,
 export const setRequestCache: {
   <R, E>(
     cache: Effect.Effect<R, E, Request.Cache>
-  ): Layer<Exclude<R, Scope.Scope>, E, never>
+  ): Layer<Exclude<R, "Scope">, E, never>
   (
     cache: Request.Cache
   ): Layer<never, never, never>
@@ -946,7 +951,7 @@ export const span: (
       | ((span: Tracer.Span, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<never, never, void>)
       | undefined
   }
-) => Layer<never, never, Tracer.ParentSpan> = circularLayer.span
+) => Layer<never, never, "ParentSpan"> = circularLayer.span
 
 /**
  * Create a Layer that sets the current Tracer
@@ -993,7 +998,7 @@ export const withSpan: {
         | ((span: Tracer.Span, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<never, never, void>)
         | undefined
     }
-  ): <R, E, A>(self: Layer<R, E, A>) => Layer<Exclude<R, Tracer.ParentSpan>, E, A>
+  ): <R, E, A>(self: Layer<R, E, A>) => Layer<Exclude<R, "ParentSpan">, E, A>
   <R, E, A>(
     self: Layer<R, E, A>,
     name: string,
@@ -1007,7 +1012,7 @@ export const withSpan: {
         | ((span: Tracer.Span, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<never, never, void>)
         | undefined
     }
-  ): Layer<Exclude<R, Tracer.ParentSpan>, E, A>
+  ): Layer<Exclude<R, "ParentSpan">, E, A>
 } = internal.withSpan
 
 /**
@@ -1015,8 +1020,8 @@ export const withSpan: {
  * @category tracing
  */
 export const withParentSpan: {
-  (span: Tracer.ParentSpan): <R, E, A>(self: Layer<R, E, A>) => Layer<Exclude<R, Tracer.ParentSpan>, E, A>
-  <R, E, A>(self: Layer<R, E, A>, span: Tracer.ParentSpan): Layer<Exclude<R, Tracer.ParentSpan>, E, A>
+  (span: Tracer.ParentSpan): <R, E, A>(self: Layer<R, E, A>) => Layer<Exclude<R, "ParentSpan">, E, A>
+  <R, E, A>(self: Layer<R, E, A>, span: Tracer.ParentSpan): Layer<Exclude<R, "ParentSpan">, E, A>
 } = internal.withParentSpan
 
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -97,7 +97,7 @@ export const addEffect: <R, E, A>(effect: Effect<R, E, Logger<unknown, A>>) => L
  */
 export const addScoped: <R, E, A>(
   effect: Effect<R, E, Logger<unknown, A>>
-) => Layer.Layer<Exclude<R, Scope>, E, never> = circular.addLoggerScoped
+) => Layer.Layer<Exclude<R, "Scope">, E, never> = circular.addLoggerScoped
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/MetricPolling.ts
+++ b/packages/effect/src/MetricPolling.ts
@@ -7,7 +7,6 @@ import * as internal from "./internal/metric/polling.js"
 import type * as Metric from "./Metric.js"
 import type { Pipeable } from "./Pipeable.js"
 import type * as Schedule from "./Schedule.js"
-import type * as Scope from "./Scope.js"
 
 /**
  * @since 2.0.0
@@ -74,11 +73,11 @@ export const launch: {
     schedule: Schedule.Schedule<R2, unknown, A2>
   ): <Type, In, R, E, Out>(
     self: MetricPolling<Type, In, R, E, Out>
-  ) => Effect.Effect<R2 | R | Scope.Scope, never, Fiber.Fiber<E, A2>>
+  ) => Effect.Effect<R2 | R | "Scope", never, Fiber.Fiber<E, A2>>
   <Type, In, R, E, Out, R2, A2>(
     self: MetricPolling<Type, In, R, E, Out>,
     schedule: Schedule.Schedule<R2, unknown, A2>
-  ): Effect.Effect<Scope.Scope | R | R2, never, Fiber.Fiber<E, A2>>
+  ): Effect.Effect<"Scope" | R | R2, never, Fiber.Fiber<E, A2>>
 } = internal.launch
 
 /**

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -6,7 +6,6 @@ import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/pool.js"
 import type { Pipeable } from "./Pipeable.js"
-import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
 
 /**
@@ -35,7 +34,7 @@ export interface Pool<out E, in out A> extends Data.Case, Pool.Variance<E, A>, P
    * acquisition fails, then the returned effect will fail for that same reason.
    * Retrying a failed acquisition attempt will repeat the acquisition attempt.
    */
-  readonly get: Effect.Effect<Scope.Scope, E, A>
+  readonly get: Effect.Effect<"Scope", E, A>
 
   /**
    * Invalidates the specified item. This will cause the pool to eventually
@@ -83,7 +82,7 @@ export const make: <R, E, A>(
     readonly acquire: Effect.Effect<R, E, A>
     readonly size: number
   }
-) => Effect.Effect<Scope.Scope | R, never, Pool<E, A>> = internal.make
+) => Effect.Effect<"Scope" | R, never, Pool<E, A>> = internal.make
 
 /**
  * Makes a new pool with the specified minimum and maximum sizes and time to
@@ -121,7 +120,7 @@ export const makeWithTTL: <R, E, A>(options: {
   readonly min: number
   readonly max: number
   readonly timeToLive: Duration.DurationInput
-}) => Effect.Effect<Scope.Scope | R, never, Pool<E, A>> = internal.makeWithTTL
+}) => Effect.Effect<"Scope" | R, never, Pool<E, A>> = internal.makeWithTTL
 
 /**
  * Retrieves an item from the pool in a scoped effect. Note that if
@@ -131,7 +130,7 @@ export const makeWithTTL: <R, E, A>(options: {
  * @since 2.0.0
  * @category getters
  */
-export const get: <E, A>(self: Pool<E, A>) => Effect.Effect<Scope.Scope, E, A> = internal.get
+export const get: <E, A>(self: Pool<E, A>) => Effect.Effect<"Scope", E, A> = internal.get
 
 /**
  * Invalidates the specified item. This will cause the pool to eventually
@@ -142,6 +141,6 @@ export const get: <E, A>(self: Pool<E, A>) => Effect.Effect<Scope.Scope, E, A> =
  * @category combinators
  */
 export const invalidate: {
-  <A>(value: A): <E>(self: Pool<E, A>) => Effect.Effect<Scope.Scope, never, void>
-  <E, A>(self: Pool<E, A>, value: A): Effect.Effect<Scope.Scope, never, void>
+  <A>(value: A): <E>(self: Pool<E, A>) => Effect.Effect<"Scope", never, void>
+  <E, A>(self: Pool<E, A>, value: A): Effect.Effect<"Scope", never, void>
 } = internal.invalidate

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -5,7 +5,6 @@ import type * as Effect from "./Effect.js"
 import * as internal from "./internal/pubsub.js"
 import type { Pipeable } from "./Pipeable.js"
 import type * as Queue from "./Queue.js"
-import type * as Scope from "./Scope.js"
 
 /**
  * A `PubSub<A>` is an asynchronous message hub into which publishers can publish
@@ -33,7 +32,7 @@ export interface PubSub<in out A> extends Queue.Enqueue<A>, Pipeable {
    * be evaluated multiple times within the scope to take a message from the `PubSub`
    * each time.
    */
-  readonly subscribe: Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>>
+  readonly subscribe: Effect.Effect<"Scope", never, Queue.Dequeue<A>>
 }
 
 /**
@@ -172,4 +171,4 @@ export const publishAll: {
  * @since 2.0.0
  * @category utils
  */
-export const subscribe: <A>(self: PubSub<A>) => Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>> = internal.subscribe
+export const subscribe: <A>(self: PubSub<A>) => Effect.Effect<"Scope", never, Queue.Dequeue<A>> = internal.subscribe

--- a/packages/effect/src/Reloadable.ts
+++ b/packages/effect/src/Reloadable.ts
@@ -68,7 +68,11 @@ export const auto: <Out extends Context.Tag<any, any>, In, E, R>(
     readonly layer: Layer.Layer<In, E, Context.Tag.Identifier<Out>>
     readonly schedule: Schedule.Schedule<R, unknown, unknown>
   }
-) => Layer.Layer<In | R, E, Reloadable<Context.Tag.Identifier<Out>>> = internal.auto
+) => Layer.Layer<
+  Exclude<R, "Scope"> | Exclude<Exclude<In, "Scope">, "Scope">,
+  E,
+  `Reloadable<${Context.Tag.Identifier<Out>}>`
+> = internal.auto
 
 /**
  * Makes a new reloadable service from a layer that describes the construction
@@ -84,7 +88,8 @@ export const autoFromConfig: <Out extends Context.Tag<any, any>, In, E, R>(
     readonly layer: Layer.Layer<In, E, Context.Tag.Identifier<Out>>
     readonly scheduleFromConfig: (context: Context.Context<In>) => Schedule.Schedule<R, unknown, unknown>
   }
-) => Layer.Layer<In | R, E, Reloadable<Context.Tag.Identifier<Out>>> = internal.autoFromConfig
+) => Layer.Layer<Exclude<In, "Scope"> | Exclude<R, "Scope">, E, `Reloadable<${Context.Tag.Identifier<Out>}>`> =
+  internal.autoFromConfig
 
 /**
  * Retrieves the current version of the reloadable service.
@@ -94,7 +99,7 @@ export const autoFromConfig: <Out extends Context.Tag<any, any>, In, E, R>(
  */
 export const get: <T extends Context.Tag<any, any>>(
   tag: T
-) => Effect.Effect<Reloadable<Context.Tag.Identifier<T>>, never, Context.Tag.Service<T>> = internal.get
+) => Effect.Effect<`Reloadable<${Context.Tag.Identifier<T>}>`, never, Context.Tag.Service<T>> = internal.get
 
 /**
  * Makes a new reloadable service from a layer that describes the construction
@@ -106,7 +111,7 @@ export const get: <T extends Context.Tag<any, any>>(
 export const manual: <Out extends Context.Tag<any, any>, In, E>(
   tag: Out,
   options: { readonly layer: Layer.Layer<In, E, Context.Tag.Identifier<Out>> }
-) => Layer.Layer<In, E, Reloadable<Context.Tag.Identifier<Out>>> = internal.manual
+) => Layer.Layer<Exclude<In, "Scope">, E, `Reloadable<${Context.Tag.Identifier<Out>}>`> = internal.manual
 
 /**
  * Reloads the specified service.
@@ -116,7 +121,7 @@ export const manual: <Out extends Context.Tag<any, any>, In, E>(
  */
 export const reload: <T extends Context.Tag<any, any>>(
   tag: T
-) => Effect.Effect<Reloadable<Context.Tag.Identifier<T>>, unknown, void> = internal.reload
+) => Effect.Effect<`Reloadable<${Context.Tag.Identifier<T>}>`, unknown, void> = internal.reload
 
 /**
  * @since 2.0.0
@@ -124,7 +129,8 @@ export const reload: <T extends Context.Tag<any, any>>(
  */
 export const tag: <T extends Context.Tag<any, any>>(
   tag: T
-) => Context.Tag<Reloadable<Context.Tag.Identifier<T>>, Reloadable<Context.Tag.Service<T>>> = internal.reloadableTag
+) => Context.Tag<`Reloadable<${Context.Tag.Identifier<T>}>`, Reloadable<Context.Tag.Service<T>>> =
+  internal.reloadableTag
 
 /**
  * Forks the reload of the service in the background, ignoring any errors.
@@ -134,4 +140,4 @@ export const tag: <T extends Context.Tag<any, any>>(
  */
 export const reloadFork: <T extends Context.Tag<any, any>>(
   tag: T
-) => Effect.Effect<Reloadable<Context.Tag.Identifier<T>>, unknown, void> = internal.reloadFork
+) => Effect.Effect<`Reloadable<${Context.Tag.Identifier<T>}>`, unknown, void> = internal.reloadFork

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -98,7 +98,7 @@ export const contextFromServices =
     { [k in keyof Services]: Effect.Effect.Context<Services[k]> }[number],
     never,
     RequestResolver<A, Exclude<R, { [k in keyof Services]: Effect.Effect.Context<Services[k]> }[number]>>
-  > => Effect.contextWith((_) => provideContext(self as any, Context.pick(...services)(_ as any)))
+  > => Effect.contextWith((_) => provideContext(self as any, Context.pick(...(services as never))(_ as any)))
 
 /**
  * Returns `true` if the specified value is a `RequestResolver`, `false` otherwise.

--- a/packages/effect/src/Resource.ts
+++ b/packages/effect/src/Resource.ts
@@ -5,7 +5,6 @@ import type * as Effect from "./Effect.js"
 import type * as Exit from "./Exit.js"
 import * as internal from "./internal/resource.js"
 import type * as Schedule from "./Schedule.js"
-import type * as Scope from "./Scope.js"
 import type * as ScopedRef from "./ScopedRef.js"
 import type * as Types from "./Types.js"
 
@@ -32,7 +31,7 @@ export interface Resource<in out E, in out A> extends Resource.Variance<E, A> {
   /** @internal */
   readonly scopedRef: ScopedRef.ScopedRef<Exit.Exit<E, A>>
   /** @internal */
-  readonly acquire: Effect.Effect<Scope.Scope, E, A>
+  readonly acquire: Effect.Effect<"Scope", E, A>
 }
 
 /**
@@ -64,7 +63,7 @@ export declare namespace Resource {
 export const auto: <R, E, A, R2, Out>(
   acquire: Effect.Effect<R, E, A>,
   policy: Schedule.Schedule<R2, unknown, Out>
-) => Effect.Effect<Scope.Scope | R | R2, never, Resource<E, A>> = internal.auto
+) => Effect.Effect<"Scope" | R | R2, never, Resource<E, A>> = internal.auto
 
 /**
  * Retrieves the current value stored in the cache.
@@ -86,7 +85,7 @@ export const get: <E, A>(self: Resource<E, A>) => Effect.Effect<never, E, A> = i
  */
 export const manual: <R, E, A>(
   acquire: Effect.Effect<R, E, A>
-) => Effect.Effect<Scope.Scope | R, never, Resource<E, A>> = internal.manual
+) => Effect.Effect<"Scope" | R, never, Resource<E, A>> = internal.manual
 
 /**
  * Refreshes the cache. This method will not return until either the refresh

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -932,15 +932,15 @@ export const provideContext: {
  * @category context
  */
 export const provideService: {
-  <T, T1 extends T>(
-    tag: any,
-    service: T1
-  ): <Env, In, Out>(self: Schedule<T | Env, In, Out>) => Schedule<Exclude<Env, T>, In, Out>
-  <Env, T, In, Out, T1 extends T>(
-    self: Schedule<Env | T, In, Out>,
-    tag: any,
-    service: T1
-  ): Schedule<Exclude<Env, T>, In, Out>
+  <T extends Context.Tag<any, any>>(
+    tag: T,
+    service: Context.Tag.Service<T>
+  ): <R, In, Out>(self: Schedule<R, In, Out>) => Schedule<Exclude<R, Context.Tag.Identifier<T>>, In, Out>
+  <R, In, Out, T extends Context.Tag<any, any>>(
+    self: Schedule<R, In, Out>,
+    tag: T,
+    service: Context.Tag.Service<T>
+  ): Schedule<Exclude<R, Context.Tag.Identifier<T>>, In, Out>
 } = internal.provideService
 
 /**

--- a/packages/effect/src/Scope.ts
+++ b/packages/effect/src/Scope.ts
@@ -68,7 +68,7 @@ export interface CloseableScope extends Scope, Pipeable {
  * @since 2.0.0
  * @category context
  */
-export const Scope: Context.Tag<Scope, Scope> = fiberRuntime.scopeTag
+export const Scope: Context.Tag<"Scope", Scope> = fiberRuntime.scopeTag
 
 /**
  * @since 2.0.0
@@ -128,8 +128,8 @@ export const close: (self: CloseableScope, exit: Exit.Exit<unknown, unknown>) =>
  * @category utils
  */
 export const extend: {
-  (scope: Scope): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Scope>, E, A>
-  <R, E, A>(effect: Effect.Effect<R, E, A>, scope: Scope): Effect.Effect<Exclude<R, Scope>, E, A>
+  (scope: Scope): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "Scope">, E, A>
+  <R, E, A>(effect: Effect.Effect<R, E, A>, scope: Scope): Effect.Effect<Exclude<R, "Scope">, E, A>
 } = fiberRuntime.scopeExtend
 
 /**
@@ -154,8 +154,8 @@ export const fork: (
  * @category destructors
  */
 export const use: {
-  (scope: CloseableScope): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Scope>, E, A>
-  <R, E, A>(effect: Effect.Effect<R, E, A>, scope: CloseableScope): Effect.Effect<Exclude<R, Scope>, E, A>
+  (scope: CloseableScope): <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "Scope">, E, A>
+  <R, E, A>(effect: Effect.Effect<R, E, A>, scope: CloseableScope): Effect.Effect<Exclude<R, "Scope">, E, A>
 } = fiberRuntime.scopeUse
 
 /**

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -8,7 +8,6 @@ import type * as Exit from "./Exit.js"
 import * as internal from "./internal/scopedCache.js"
 import type * as Option from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
-import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
 
 /**
@@ -32,13 +31,13 @@ export interface ScopedCache<in Key, out Error, out Value> extends ScopedCache.V
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
    */
-  getOption(key: Key): Effect.Effect<Scope.Scope, Error, Option.Option<Value>>
+  getOption(key: Key): Effect.Effect<"Scope", Error, Option.Option<Value>>
 
   /**
    * Retrieves the value associated with the specified key if it exists and the
    * lookup function has completed. Otherwise returns `Option.none`.
    */
-  getOptionComplete(key: Key): Effect.Effect<Scope.Scope, never, Option.Option<Value>>
+  getOptionComplete(key: Key): Effect.Effect<"Scope", never, Option.Option<Value>>
 
   /**
    * Returns statistics for this cache.
@@ -62,7 +61,7 @@ export interface ScopedCache<in Key, out Error, out Value> extends ScopedCache.V
    * release action signals to the cache that the value is no longer being used
    * and can potentially be finalized subject to the policies of the cache.
    */
-  get(key: Key): Effect.Effect<Scope.Scope, Error, Value>
+  get(key: Key): Effect.Effect<"Scope", Error, Value>
 
   /**
    * Invalidates the resource associated with the specified key.
@@ -120,7 +119,7 @@ export const make: <Key, Environment, Error, Value>(
     readonly capacity: number
     readonly timeToLive: Duration.DurationInput
   }
-) => Effect.Effect<Scope.Scope | Environment, never, ScopedCache<Key, Error, Value>> = internal.make
+) => Effect.Effect<"Scope" | Environment, never, ScopedCache<Key, Error, Value>> = internal.make
 
 /**
  * Constructs a new cache with the specified capacity, time to live, and
@@ -136,7 +135,7 @@ export const makeWith: <Key, Environment, Error, Value>(
     readonly lookup: Lookup<Key, Environment, Error, Value>
     readonly timeToLive: (exit: Exit.Exit<Error, Value>) => Duration.DurationInput
   }
-) => Effect.Effect<Scope.Scope | Environment, never, ScopedCache<Key, Error, Value>> = internal.makeWith
+) => Effect.Effect<"Scope" | Environment, never, ScopedCache<Key, Error, Value>> = internal.makeWith
 
 /**
  * Similar to `Cache.Lookup`, but executes the lookup function within a `Scope`.
@@ -146,4 +145,4 @@ export const makeWith: <Key, Environment, Error, Value>(
  */
 export type Lookup<Key, Environment, Error, Value> = (
   key: Key
-) => Effect.Effect<Environment | Scope.Scope, Error, Value>
+) => Effect.Effect<Environment | "Scope", Error, Value>

--- a/packages/effect/src/ScopedRef.ts
+++ b/packages/effect/src/ScopedRef.ts
@@ -60,7 +60,7 @@ export declare namespace ScopedRef {
  */
 export const fromAcquire: <R, E, A>(
   acquire: Effect.Effect<R, E, A>
-) => Effect.Effect<Scope.Scope | R, E, ScopedRef<A>> = internal.fromAcquire
+) => Effect.Effect<"Scope" | R, E, ScopedRef<A>> = internal.fromAcquire
 
 /**
  * Retrieves the current value of the scoped reference.
@@ -77,7 +77,7 @@ export const get: <A>(self: ScopedRef<A>) => Effect.Effect<never, never, A> = in
  * @since 2.0.0
  * @category constructors
  */
-export const make: <A>(evaluate: LazyArg<A>) => Effect.Effect<Scope.Scope, never, ScopedRef<A>> = internal.make
+export const make: <A>(evaluate: LazyArg<A>) => Effect.Effect<"Scope", never, ScopedRef<A>> = internal.make
 
 /**
  * Sets the value of this reference to the specified resourcefully-created
@@ -91,6 +91,6 @@ export const make: <A>(evaluate: LazyArg<A>) => Effect.Effect<Scope.Scope, never
  * @category getters
  */
 export const set: {
-  <A, R, E>(acquire: Effect.Effect<R, E, A>): (self: ScopedRef<A>) => Effect.Effect<Exclude<R, Scope.Scope>, E, void>
-  <A, R, E>(self: ScopedRef<A>, acquire: Effect.Effect<R, E, A>): Effect.Effect<Exclude<R, Scope.Scope>, E, void>
+  <A, R, E>(acquire: Effect.Effect<R, E, A>): (self: ScopedRef<A>) => Effect.Effect<Exclude<R, "Scope">, E, void>
+  <A, R, E>(self: ScopedRef<A>, acquire: Effect.Effect<R, E, A>): Effect.Effect<Exclude<R, "Scope">, E, void>
 } = internal.set

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -19,7 +19,6 @@ import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
 import type * as PubSub from "./PubSub.js"
 import type * as Queue from "./Queue.js"
-import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
 import type * as Unify from "./Unify.js"
 
@@ -1029,7 +1028,7 @@ export const fromPush: <R, E, In, L, Z>(
     never,
     (_: Option.Option<Chunk.Chunk<In>>) => Effect.Effect<R, readonly [Either.Either<E, Z>, Chunk.Chunk<L>], void>
   >
-) => Sink<Exclude<R, Scope.Scope>, E, In, L, Z> = internal.fromPush
+) => Sink<Exclude<R, "Scope">, E, In, L, Z> = internal.fromPush
 
 /**
  * Create a sink which enqueues each element into the specified queue.
@@ -1363,7 +1362,7 @@ export const unwrap: <R, E, R2, E2, In, L, Z>(
  */
 export const unwrapScoped: <R, E, In, L, Z>(
   effect: Effect.Effect<R, E, Sink<R, E, In, L, Z>>
-) => Sink<Exclude<R, Scope.Scope>, E, In, L, Z> = internal.unwrapScoped
+) => Sink<Exclude<R, "Scope">, E, In, L, Z> = internal.unwrapScoped
 
 /**
  * Returns the sink that executes this one and times its execution.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -23,7 +23,6 @@ import type { Predicate, Refinement } from "./Predicate.js"
 import type * as PubSub from "./PubSub.js"
 import type * as Queue from "./Queue.js"
 import type * as Schedule from "./Schedule.js"
-import type * as Scope from "./Scope.js"
 import type * as Sink from "./Sink.js"
 import type * as Emit from "./StreamEmit.js"
 import type * as HaltStrategy from "./StreamHaltStrategy.js"
@@ -321,9 +320,9 @@ export const asyncOption: <R, E, A>(
  * @category constructors
  */
 export const asyncScoped: <R, E, A>(
-  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<R | Scope.Scope, E, unknown>,
+  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<R | "Scope", E, unknown>,
   outputBuffer?: number
-) => Stream<Exclude<R, Scope.Scope>, E, A> = internal.asyncScoped
+) => Stream<Exclude<R, "Scope">, E, A> = internal.asyncScoped
 
 /**
  * Returns a `Stream` that first collects `n` elements from the input `Stream`,
@@ -359,12 +358,12 @@ export const broadcast: {
     maximumLag: number
   ): <R, E, A>(
     self: Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.DynamicTuple<Stream<never, E, A>, N>>
+  ) => Effect.Effect<"Scope" | R, never, Stream.DynamicTuple<Stream<never, E, A>, N>>
   <R, E, A, N extends number>(
     self: Stream<R, E, A>,
     n: N,
     maximumLag: number
-  ): Effect.Effect<Scope.Scope | R, never, Stream.DynamicTuple<Stream<never, E, A>, N>>
+  ): Effect.Effect<"Scope" | R, never, Stream.DynamicTuple<Stream<never, E, A>, N>>
 } = internal.broadcast
 
 /**
@@ -376,8 +375,8 @@ export const broadcast: {
  * @category utils
  */
 export const broadcastDynamic: {
-  (maximumLag: number): <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, Stream<never, E, A>>
-  <R, E, A>(self: Stream<R, E, A>, maximumLag: number): Effect.Effect<Scope.Scope | R, never, Stream<never, E, A>>
+  (maximumLag: number): <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, Stream<never, E, A>>
+  <R, E, A>(self: Stream<R, E, A>, maximumLag: number): Effect.Effect<"Scope" | R, never, Stream<never, E, A>>
 } = internal.broadcastDynamic
 
 /**
@@ -396,12 +395,12 @@ export const broadcastedQueues: {
     maximumLag: number
   ): <R, E, A>(
     self: Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>
+  ) => Effect.Effect<"Scope" | R, never, Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>
   <R, E, A, N extends number>(
     self: Stream<R, E, A>,
     n: N,
     maximumLag: number
-  ): Effect.Effect<Scope.Scope | R, never, Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>
+  ): Effect.Effect<"Scope" | R, never, Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>
 } = internal.broadcastedQueues
 
 /**
@@ -419,11 +418,11 @@ export const broadcastedQueuesDynamic: {
     maximumLag: number
   ): <R, E, A>(
     self: Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Effect.Effect<Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>>
+  ) => Effect.Effect<"Scope" | R, never, Effect.Effect<"Scope", never, Queue.Dequeue<Take.Take<E, A>>>>
   <R, E, A>(
     self: Stream<R, E, A>,
     maximumLag: number
-  ): Effect.Effect<Scope.Scope | R, never, Effect.Effect<Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>>
+  ): Effect.Effect<"Scope" | R, never, Effect.Effect<"Scope", never, Queue.Dequeue<Take.Take<E, A>>>>
 } = internal.broadcastedQueuesDynamic
 
 /**
@@ -893,7 +892,7 @@ export const distributedWith: {
     }
   ): <R, E>(
     self: Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>>
+  ) => Effect.Effect<"Scope" | R, never, Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>>
   <R, E, N extends number, A>(
     self: Stream<R, E, A>,
     options: {
@@ -901,7 +900,7 @@ export const distributedWith: {
       readonly maximumLag: number
       readonly decide: (a: A) => Effect.Effect<never, never, Predicate<number>>
     }
-  ): Effect.Effect<Scope.Scope | R, never, Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>>
+  ): Effect.Effect<"Scope" | R, never, Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>>
 } = internal.distributedWith
 
 /**
@@ -924,7 +923,7 @@ export const distributedWithDynamic: {
   ): <R>(
     self: Stream<R, E, A>
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
   >
@@ -935,7 +934,7 @@ export const distributedWithDynamic: {
       readonly decide: (a: A) => Effect.Effect<never, never, Predicate<number>>
     }
   ): Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
   >
@@ -1472,7 +1471,7 @@ export const fromChunkPubSub: {
       readonly scoped: true
       readonly shutdown?: boolean | undefined
     }
-  ): Effect.Effect<Scope.Scope, never, Stream<never, never, A>>
+  ): Effect.Effect<"Scope", never, Stream<never, never, A>>
   <A>(
     pubsub: PubSub.PubSub<Chunk.Chunk<A>>,
     options?: {
@@ -1538,7 +1537,7 @@ export const fromPubSub: {
       readonly maxChunkSize?: number | undefined
       readonly shutdown?: boolean | undefined
     }
-  ): Effect.Effect<Scope.Scope, never, Stream<never, never, A>>
+  ): Effect.Effect<"Scope", never, Stream<never, never, A>>
   <A>(
     pubsub: PubSub.PubSub<A>,
     options?: {
@@ -1584,8 +1583,8 @@ export const fromIteratorSucceed: <A>(iterator: IterableIterator<A>, maxChunkSiz
  * @category constructors
  */
 export const fromPull: <R, R2, E, A>(
-  effect: Effect.Effect<Scope.Scope | R, never, Effect.Effect<R2, Option.Option<E>, Chunk.Chunk<A>>>
-) => Stream<Exclude<R, Scope.Scope> | R2, E, A> = internal.fromPull
+  effect: Effect.Effect<"Scope" | R, never, Effect.Effect<R2, Option.Option<E>, Chunk.Chunk<A>>>
+) => Stream<Exclude<R, "Scope"> | R2, E, A> = internal.fromPull
 
 /**
  * Creates a stream from a queue of values
@@ -2486,7 +2485,7 @@ export const partition: {
     }
   ): <R, E>(
     self: Stream<R, E, C>
-  ) => Effect.Effect<Scope.Scope | R, E, [excluded: Stream<never, E, Exclude<C, B>>, satisfying: Stream<never, E, B>]>
+  ) => Effect.Effect<"Scope" | R, E, [excluded: Stream<never, E, Exclude<C, B>>, satisfying: Stream<never, E, B>]>
   <A>(
     predicate: Predicate<A>,
     options?: {
@@ -2494,21 +2493,21 @@ export const partition: {
     }
   ): <R, E, B extends A>(
     self: Stream<R, E, B>
-  ) => Effect.Effect<Scope.Scope | R, E, [excluded: Stream<never, E, B>, satisfying: Stream<never, E, B>]>
+  ) => Effect.Effect<"Scope" | R, E, [excluded: Stream<never, E, B>, satisfying: Stream<never, E, B>]>
   <R, E, A, B extends A>(
     self: Stream<R, E, A>,
     refinement: Refinement<A, B>,
     options?: {
       bufferSize?: number | undefined
     }
-  ): Effect.Effect<Scope.Scope | R, E, [excluded: Stream<never, E, Exclude<A, B>>, satisfying: Stream<never, E, B>]>
+  ): Effect.Effect<"Scope" | R, E, [excluded: Stream<never, E, Exclude<A, B>>, satisfying: Stream<never, E, B>]>
   <R, E, A>(
     self: Stream<R, E, A>,
     predicate: Predicate<A>,
     options?: {
       bufferSize?: number | undefined
     }
-  ): Effect.Effect<Scope.Scope | R, E, [excluded: Stream<never, E, A>, satisfying: Stream<never, E, A>]>
+  ): Effect.Effect<"Scope" | R, E, [excluded: Stream<never, E, A>, satisfying: Stream<never, E, A>]>
 } = internal.partition
 
 /**
@@ -2526,14 +2525,14 @@ export const partitionEither: {
     }
   ): <R, E>(
     self: Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, [left: Stream<never, E2 | E, A2>, right: Stream<never, E2 | E, A3>]>
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, [left: Stream<never, E2 | E, A2>, right: Stream<never, E2 | E, A3>]>
   <R, E, A, R2, E2, A2, A3>(
     self: Stream<R, E, A>,
     predicate: (a: A) => Effect.Effect<R2, E2, Either.Either<A2, A3>>,
     options?: {
       readonly bufferSize?: number | undefined
     }
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, [left: Stream<never, E | E2, A2>, right: Stream<never, E | E2, A3>]>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, [left: Stream<never, E | E2, A2>, right: Stream<never, E | E2, A3>]>
 } = internal.partitionEither
 
 /**
@@ -2548,11 +2547,11 @@ export const partitionEither: {
 export const peel: {
   <R2, E2, A, Z>(
     sink: Sink.Sink<R2, E2, A, A, Z>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, [Z, Stream<never, E, A>]>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, [Z, Stream<never, E, A>]>
   <R, E, R2, E2, A, Z>(
     self: Stream<R, E, A>,
     sink: Sink.Sink<R2, E2, A, A, Z>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, [Z, Stream<never, E, A>]>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, [Z, Stream<never, E, A>]>
 } = internal.peel
 
 /**
@@ -3027,8 +3026,8 @@ export const runFoldEffect: {
  * @category destructors
  */
 export const runFoldScoped: {
-  <S, A>(s: S, f: (s: S, a: A) => S): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, E, S>
-  <R, E, S, A>(self: Stream<R, E, A>, s: S, f: (s: S, a: A) => S): Effect.Effect<Scope.Scope | R, E, S>
+  <S, A>(s: S, f: (s: S, a: A) => S): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R, E, S>
+  <R, E, S, A>(self: Stream<R, E, A>, s: S, f: (s: S, a: A) => S): Effect.Effect<"Scope" | R, E, S>
 } = internal.runFoldScoped
 
 /**
@@ -3042,12 +3041,12 @@ export const runFoldScopedEffect: {
   <S, A, R2, E2>(
     s: S,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, S>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, S>
   <R, E, S, A, R2, E2>(
     self: Stream<R, E, A>,
     s: S,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, S>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, S>
 } = internal.runFoldScopedEffect
 
 /**
@@ -3096,13 +3095,13 @@ export const runFoldWhileScoped: {
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => S
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<R | Scope.Scope, E, S>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<R | "Scope", E, S>
   <R, E, S, A>(
     self: Stream<R, E, A>,
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => S
-  ): Effect.Effect<Scope.Scope | R, E, S>
+  ): Effect.Effect<"Scope" | R, E, S>
 } = internal.runFoldWhileScoped
 
 /**
@@ -3118,13 +3117,13 @@ export const runFoldWhileScopedEffect: {
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, S>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, S>
   <R, E, S, A, R2, E2>(
     self: Stream<R, E, A>,
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, S>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, S>
 } = internal.runFoldWhileScopedEffect
 
 /**
@@ -3171,11 +3170,11 @@ export const runForEachChunk: {
 export const runForEachChunkScoped: {
   <A, R2, E2, _>(
     f: (a: Chunk.Chunk<A>) => Effect.Effect<R2, E2, _>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, void>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, void>
   <R, E, A, R2, E2, _>(
     self: Stream<R, E, A>,
     f: (a: Chunk.Chunk<A>) => Effect.Effect<R2, E2, _>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, void>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, void>
 } = internal.runForEachChunkScoped
 
 /**
@@ -3188,11 +3187,11 @@ export const runForEachChunkScoped: {
 export const runForEachScoped: {
   <A, R2, E2, _>(
     f: (a: A) => Effect.Effect<R2, E2, _>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, void>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, void>
   <R, E, A, R2, E2, _>(
     self: Stream<R, E, A>,
     f: (a: A) => Effect.Effect<R2, E2, _>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, void>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, void>
 } = internal.runForEachScoped
 
 /**
@@ -3222,11 +3221,11 @@ export const runForEachWhile: {
 export const runForEachWhileScoped: {
   <A, R2, E2>(
     f: (a: A) => Effect.Effect<R2, E2, boolean>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, void>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, void>
   <R, E, A, R2, E2>(
     self: Stream<R, E, A>,
     f: (a: A) => Effect.Effect<R2, E2, boolean>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, void>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, void>
 } = internal.runForEachWhileScoped
 
 /**
@@ -3260,8 +3259,8 @@ export const runIntoPubSub: {
 export const runIntoPubSubScoped: {
   <E, A>(
     pubsub: PubSub.PubSub<Take.Take<E, A>>
-  ): <R>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, void>
-  <R, E, A>(self: Stream<R, E, A>, pubsub: PubSub.PubSub<Take.Take<E, A>>): Effect.Effect<Scope.Scope | R, never, void>
+  ): <R>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, void>
+  <R, E, A>(self: Stream<R, E, A>, pubsub: PubSub.PubSub<Take.Take<E, A>>): Effect.Effect<"Scope" | R, never, void>
 } = internal.runIntoPubSubScoped
 
 /**
@@ -3286,11 +3285,11 @@ export const runIntoQueue: {
 export const runIntoQueueElementsScoped: {
   <E, A>(
     queue: Queue.Enqueue<Exit.Exit<Option.Option<E>, A>>
-  ): <R>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, void>
+  ): <R>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, void>
   <R, E, A>(
     self: Stream<R, E, A>,
     queue: Queue.Enqueue<Exit.Exit<Option.Option<E>, A>>
-  ): Effect.Effect<Scope.Scope | R, never, void>
+  ): Effect.Effect<"Scope" | R, never, void>
 } = internal.runIntoQueueElementsScoped
 
 /**
@@ -3303,8 +3302,8 @@ export const runIntoQueueElementsScoped: {
 export const runIntoQueueScoped: {
   <E, A>(
     queue: Queue.Enqueue<Take.Take<E, A>>
-  ): <R>(self: Stream<R, E, A>) => Effect.Effect<R | Scope.Scope, never, void>
-  <R, E, A>(self: Stream<R, E, A>, queue: Queue.Enqueue<Take.Take<E, A>>): Effect.Effect<Scope.Scope | R, never, void>
+  ): <R>(self: Stream<R, E, A>) => Effect.Effect<R | "Scope", never, void>
+  <R, E, A>(self: Stream<R, E, A>, queue: Queue.Enqueue<Take.Take<E, A>>): Effect.Effect<"Scope" | R, never, void>
 } = internal.runIntoQueueScoped
 
 /**
@@ -3323,11 +3322,11 @@ export const runLast: <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<R, E, Op
 export const runScoped: {
   <R2, E2, A, A2>(
     sink: Sink.Sink<R2, E2, A, unknown, A2>
-  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, A2>
+  ): <R, E>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, A2>
   <R, E, R2, E2, A, A2>(
     self: Stream<R, E, A>,
     sink: Sink.Sink<R2, E2, A, unknown, A2>
-  ): Effect.Effect<Scope.Scope | R | R2, E | E2, A2>
+  ): Effect.Effect<"Scope" | R | R2, E | E2, A2>
 } = internal.runScoped
 
 /**
@@ -3441,8 +3440,7 @@ export const scheduleWith: {
  * @since 2.0.0
  * @category constructors
  */
-export const scoped: <R, E, A>(effect: Effect.Effect<R, E, A>) => Stream<Exclude<R, Scope.Scope>, E, A> =
-  internal.scoped
+export const scoped: <R, E, A>(effect: Effect.Effect<R, E, A>) => Stream<Exclude<R, "Scope">, E, A> = internal.scoped
 
 /**
  * Emits a sliding window of `n` elements.
@@ -3879,11 +3877,11 @@ export const timeoutTo: {
 export const toPubSub: {
   (
     capacity: number
-  ): <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, PubSub.PubSub<Take.Take<E, A>>>
+  ): <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, PubSub.PubSub<Take.Take<E, A>>>
   <R, E, A>(
     self: Stream<R, E, A>,
     capacity: number
-  ): Effect.Effect<Scope.Scope | R, never, PubSub.PubSub<Take.Take<E, A>>>
+  ): Effect.Effect<"Scope" | R, never, PubSub.PubSub<Take.Take<E, A>>>
 } = internal.toPubSub
 
 /**
@@ -3897,7 +3895,7 @@ export const toPubSub: {
  */
 export const toPull: <R, E, A>(
   self: Stream<R, E, A>
-) => Effect.Effect<Scope.Scope | R, never, Effect.Effect<R, Option.Option<E>, Chunk.Chunk<A>>> = internal.toPull
+) => Effect.Effect<"Scope" | R, never, Effect.Effect<R, Option.Option<E>, Chunk.Chunk<A>>> = internal.toPull
 
 /**
  * Converts the stream to a scoped queue of chunks. After the scope is closed,
@@ -3916,7 +3914,7 @@ export const toQueue: {
     } | {
       readonly strategy: "unbounded"
     }
-  ): <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, Queue.Dequeue<Take.Take<E, A>>>
+  ): <R, E, A>(self: Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, Queue.Dequeue<Take.Take<E, A>>>
   <R, E, A>(
     self: Stream<R, E, A>,
     options?: {
@@ -3925,7 +3923,7 @@ export const toQueue: {
     } | {
       readonly strategy: "unbounded"
     }
-  ): Effect.Effect<Scope.Scope | R, never, Queue.Dequeue<Take.Take<E, A>>>
+  ): Effect.Effect<"Scope" | R, never, Queue.Dequeue<Take.Take<E, A>>>
 } = internal.toQueue
 
 /**
@@ -3944,13 +3942,13 @@ export const toQueueOfElements: {
     }
   ): <R, E, A>(
     self: Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>
+  ) => Effect.Effect<"Scope" | R, never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>
   <R, E, A>(
     self: Stream<R, E, A>,
     options?: {
       readonly capacity?: number | undefined
     }
-  ): Effect.Effect<Scope.Scope | R, never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>
+  ): Effect.Effect<"Scope" | R, never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>
 } = internal.toQueueOfElements
 
 /**
@@ -4043,7 +4041,7 @@ export const unwrap: <R, E, R2, E2, A>(effect: Effect.Effect<R, E, Stream<R2, E2
  */
 export const unwrapScoped: <R, E, R2, E2, A>(
   effect: Effect.Effect<R, E, Stream<R2, E2, A>>
-) => Stream<R2 | Exclude<R, Scope.Scope>, E | E2, A> = internal.unwrapScoped
+) => Stream<R2 | Exclude<R, "Scope">, E | E2, A> = internal.unwrapScoped
 
 /**
  * Updates the specified service within the context of the `Stream`.

--- a/packages/effect/src/TPubSub.ts
+++ b/packages/effect/src/TPubSub.ts
@@ -5,7 +5,6 @@ import type * as Effect from "./Effect.js"
 import type * as HashSet from "./HashSet.js"
 import * as internal from "./internal/stm/tPubSub.js"
 import type * as tQueue from "./internal/stm/tQueue.js"
-import type * as Scope from "./Scope.js"
 import type * as STM from "./STM.js"
 import type * as TQueue from "./TQueue.js"
 import type * as TRef from "./TRef.js"
@@ -179,7 +178,7 @@ export const subscribe: <A>(self: TPubSub<A>) => STM.STM<never, never, TQueue.TD
  * @since 2.0.0
  * @category mutations
  */
-export const subscribeScoped: <A>(self: TPubSub<A>) => Effect.Effect<Scope.Scope, never, TQueue.TDequeue<A>> =
+export const subscribeScoped: <A>(self: TPubSub<A>) => Effect.Effect<"Scope", never, TQueue.TDequeue<A>> =
   internal.subscribeScoped
 
 /**

--- a/packages/effect/src/TRandom.ts
+++ b/packages/effect/src/TRandom.ts
@@ -68,7 +68,7 @@ export interface TRandom {
  * @since 2.0.0
  * @category context
  */
-export const Tag: Context.Tag<TRandom, TRandom> = internal.Tag
+export const Tag: Context.Tag<"TRandom", TRandom> = internal.Tag
 
 /**
  * The "live" `TRandom` service wrapped into a `Layer`.
@@ -76,7 +76,7 @@ export const Tag: Context.Tag<TRandom, TRandom> = internal.Tag
  * @since 2.0.0
  * @category context
  */
-export const live: Layer.Layer<never, never, TRandom> = internal.live
+export const live: Layer.Layer<never, never, "TRandom"> = internal.live
 
 /**
  * Returns the next number from the pseudo-random number generator.
@@ -84,7 +84,7 @@ export const live: Layer.Layer<never, never, TRandom> = internal.live
  * @since 2.0.0
  * @category random
  */
-export const next: STM.STM<TRandom, never, number> = internal.next
+export const next: STM.STM<"TRandom", never, number> = internal.next
 
 /**
  * Returns the next boolean value from the pseudo-random number generator.
@@ -92,7 +92,7 @@ export const next: STM.STM<TRandom, never, number> = internal.next
  * @since 2.0.0
  * @category random
  */
-export const nextBoolean: STM.STM<TRandom, never, boolean> = internal.nextBoolean
+export const nextBoolean: STM.STM<"TRandom", never, boolean> = internal.nextBoolean
 
 /**
  * Returns the next integer from the pseudo-random number generator.
@@ -100,7 +100,7 @@ export const nextBoolean: STM.STM<TRandom, never, boolean> = internal.nextBoolea
  * @since 2.0.0
  * @category random
  */
-export const nextInt: STM.STM<TRandom, never, number> = internal.nextInt
+export const nextInt: STM.STM<"TRandom", never, number> = internal.nextInt
 
 /**
  * Returns the next integer in the specified range from the pseudo-random number
@@ -109,7 +109,7 @@ export const nextInt: STM.STM<TRandom, never, number> = internal.nextInt
  * @since 2.0.0
  * @category random
  */
-export const nextIntBetween: (low: number, high: number) => STM.STM<TRandom, never, number> = internal.nextIntBetween
+export const nextIntBetween: (low: number, high: number) => STM.STM<"TRandom", never, number> = internal.nextIntBetween
 
 /**
  * Returns the next number in the specified range from the pseudo-random number
@@ -118,7 +118,7 @@ export const nextIntBetween: (low: number, high: number) => STM.STM<TRandom, nev
  * @since 2.0.0
  * @category random
  */
-export const nextRange: (min: number, max: number) => STM.STM<TRandom, never, number> = internal.nextRange
+export const nextRange: (min: number, max: number) => STM.STM<"TRandom", never, number> = internal.nextRange
 
 /**
  * Uses the pseudo-random number generator to shuffle the specified iterable.
@@ -126,4 +126,4 @@ export const nextRange: (min: number, max: number) => STM.STM<TRandom, never, nu
  * @since 2.0.0
  * @category random
  */
-export const shuffle: <A>(elements: Iterable<A>) => STM.STM<TRandom, never, Array<A>> = internal.shuffle
+export const shuffle: <A>(elements: Iterable<A>) => STM.STM<"TRandom", never, Array<A>> = internal.shuffle

--- a/packages/effect/src/TReentrantLock.ts
+++ b/packages/effect/src/TReentrantLock.ts
@@ -3,7 +3,6 @@
  */
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/stm/tReentrantLock.js"
-import type * as Scope from "./Scope.js"
 import type * as STM from "./STM.js"
 import type * as TRef from "./TRef.js"
 
@@ -106,7 +105,7 @@ export const fiberWriteLocks: (self: TReentrantLock) => STM.STM<never, never, nu
  * @since 2.0.0
  * @category mutations
  */
-export const lock: (self: TReentrantLock) => Effect.Effect<Scope.Scope, never, number> = internal.lock
+export const lock: (self: TReentrantLock) => Effect.Effect<"Scope", never, number> = internal.lock
 
 /**
  * Determines if any fiber has a read or write lock.
@@ -130,7 +129,7 @@ export const make: STM.STM<never, never, TReentrantLock> = internal.make
  * @since 2.0.0
  * @category mutations
  */
-export const readLock: (self: TReentrantLock) => Effect.Effect<Scope.Scope, never, number> = internal.readLock
+export const readLock: (self: TReentrantLock) => Effect.Effect<"Scope", never, number> = internal.readLock
 
 /**
  * Retrieves the total number of acquired read locks.
@@ -205,7 +204,7 @@ export const withWriteLock: {
  * @since 2.0.0
  * @category mutations
  */
-export const writeLock: (self: TReentrantLock) => Effect.Effect<Scope.Scope, never, number> = internal.writeLock
+export const writeLock: (self: TReentrantLock) => Effect.Effect<"Scope", never, number> = internal.writeLock
 
 /**
  * Determines if a write lock is held by some fiber.

--- a/packages/effect/src/TSemaphore.ts
+++ b/packages/effect/src/TSemaphore.ts
@@ -4,7 +4,6 @@
 
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/stm/tSemaphore.js"
-import type * as Scope from "./Scope.js"
 import type * as STM from "./STM.js"
 import type * as TRef from "./TRef.js"
 
@@ -111,15 +110,15 @@ export const withPermits: {
  * @since 2.0.0
  * @category mutations
  */
-export const withPermitScoped: (self: TSemaphore) => Effect.Effect<Scope.Scope, never, void> = internal.withPermitScoped
+export const withPermitScoped: (self: TSemaphore) => Effect.Effect<"Scope", never, void> = internal.withPermitScoped
 
 /**
  * @since 2.0.0
  * @category mutations
  */
 export const withPermitsScoped: {
-  (permits: number): (self: TSemaphore) => Effect.Effect<Scope.Scope, never, void>
-  (self: TSemaphore, permits: number): Effect.Effect<Scope.Scope, never, void>
+  (permits: number): (self: TSemaphore) => Effect.Effect<"Scope", never, void>
+  (self: TSemaphore, permits: number): Effect.Effect<"Scope", never, void>
 } = internal.withPermitsScoped
 
 /**

--- a/packages/effect/src/TestAnnotations.ts
+++ b/packages/effect/src/TestAnnotations.ts
@@ -99,9 +99,9 @@ class AnnotationsImpl implements TestAnnotations {
 /**
  * @since 2.0.0
  */
-export const TestAnnotations: Context.Tag<TestAnnotations, TestAnnotations> = Context.Tag<TestAnnotations>(
-  Symbol.for("effect/Annotations")
-)
+export const TestAnnotations: Context.Tag<"TestAnnotations", TestAnnotations> = Context.Tag("TestAnnotations")<
+  TestAnnotations
+>()
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/TestClock.ts
+++ b/packages/effect/src/TestClock.ts
@@ -107,9 +107,7 @@ export const makeData = (
 /**
  * @since 2.0.0
  */
-export const TestClock: Context.Tag<TestClock, TestClock> = Context.Tag<TestClock>(
-  Symbol.for("effect/TestClock")
-)
+export const TestClock = Context.Tag("TestClock")<TestClock>()
 
 /**
  * The warning message that will be displayed if a test is using time but is
@@ -431,7 +429,7 @@ export class TestClockImpl implements TestClock {
 /**
  * @since 2.0.0
  */
-export const live = (data: Data): Layer.Layer<Annotations.TestAnnotations | Live.TestLive, never, TestClock> =>
+export const live = (data: Data): Layer.Layer<"TestAnnotations" | "TestLive", never, "TestClock"> =>
   layer.scoped(
     TestClock,
     effect.gen(function*($) {
@@ -452,7 +450,7 @@ export const live = (data: Data): Layer.Layer<Annotations.TestAnnotations | Live
 /**
  * @since 2.0.0
  */
-export const defaultTestClock: Layer.Layer<Annotations.TestAnnotations | Live.TestLive, never, TestClock> = live(
+export const defaultTestClock: Layer.Layer<"TestAnnotations" | "TestLive", never, "TestClock"> = live(
   makeData(new Date(0).getTime(), Chunk.empty())
 )
 

--- a/packages/effect/src/TestConfig.ts
+++ b/packages/effect/src/TestConfig.ts
@@ -34,9 +34,7 @@ export interface TestConfig {
 /**
  * @since 2.0.0
  */
-export const TestConfig: Context.Tag<TestConfig, TestConfig> = Context.Tag<TestConfig>(
-  Symbol.for("effect/TestConfig")
-)
+export const TestConfig: Context.Tag<"TestConfig", TestConfig> = Context.Tag("TestConfig")<TestConfig>()
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/TestLive.ts
+++ b/packages/effect/src/TestLive.ts
@@ -33,9 +33,7 @@ export interface TestLive {
 /**
  * @since 2.0.0
  */
-export const TestLive: Context.Tag<TestLive, TestLive> = Context.Tag<TestLive>(
-  Symbol.for("effect/TestLive")
-)
+export const TestLive = Context.Tag("TestLive")<TestLive>()
 
 /** @internal */
 class LiveImpl implements TestLive {

--- a/packages/effect/src/TestServices.ts
+++ b/packages/effect/src/TestServices.ts
@@ -13,7 +13,6 @@ import * as fiberRuntime from "./internal/fiberRuntime.js"
 import * as layer from "./internal/layer.js"
 import * as ref from "./internal/ref.js"
 import type * as Layer from "./Layer.js"
-import type * as Scope from "./Scope.js"
 import type * as SortedSet from "./SortedSet.js"
 import type * as TestAnnotation from "./TestAnnotation.js"
 import * as TestAnnotationMap from "./TestAnnotationMap.js"
@@ -26,10 +25,10 @@ import * as Sized from "./TestSized.js"
  * @since 2.0.0
  */
 export type TestServices =
-  | Annotations.TestAnnotations
-  | Live.TestLive
-  | Sized.TestSized
-  | TestConfig.TestConfig
+  | "TestAnnotations"
+  | "TestLive"
+  | "TestSized"
+  | "TestConfig"
 
 /**
  * The default Effect test services.
@@ -94,7 +93,7 @@ export const withAnnotations = dual<
  */
 export const withAnnotationsScoped = (
   annotations: Annotations.TestAnnotations
-): Effect.Effect<Scope.Scope, never, void> =>
+): Effect.Effect<"Scope", never, void> =>
   fiberRuntime.fiberRefLocallyScopedWith(
     currentServices,
     Context.add(Annotations.TestAnnotations, annotations)
@@ -105,7 +104,7 @@ export const withAnnotationsScoped = (
  *
  * @since 2.0.0
  */
-export const annotationsLayer = (): Layer.Layer<never, never, Annotations.TestAnnotations> =>
+export const annotationsLayer = (): Layer.Layer<never, never, "TestAnnotations"> =>
   layer.scoped(
     Annotations.TestAnnotations,
     pipe(
@@ -181,7 +180,7 @@ export const withLive = dual<
  *
  * @since 2.0.0
  */
-export const withLiveScoped = (live: Live.TestLive): Effect.Effect<Scope.Scope, never, void> =>
+export const withLiveScoped = (live: Live.TestLive): Effect.Effect<"Scope", never, void> =>
   fiberRuntime.fiberRefLocallyScopedWith(currentServices, Context.add(Live.TestLive, live))
 
 /**
@@ -189,7 +188,7 @@ export const withLiveScoped = (live: Live.TestLive): Effect.Effect<Scope.Scope, 
  *
  * @since 2.0.0
  */
-export const liveLayer = (): Layer.Layer<DefaultServices.DefaultServices, never, Live.TestLive> =>
+export const liveLayer = (): Layer.Layer<DefaultServices.DefaultServices, never, "TestLive"> =>
   layer.scoped(
     Live.TestLive,
     pipe(
@@ -267,13 +266,13 @@ export const withSized = dual<
  *
  * @since 2.0.0
  */
-export const withSizedScoped = (sized: Sized.TestSized): Effect.Effect<Scope.Scope, never, void> =>
+export const withSizedScoped = (sized: Sized.TestSized): Effect.Effect<"Scope", never, void> =>
   fiberRuntime.fiberRefLocallyScopedWith(currentServices, Context.add(Sized.TestSized, sized))
 
 /**
  * @since 2.0.0
  */
-export const sizedLayer = (size: number): Layer.Layer<never, never, Sized.TestSized> =>
+export const sizedLayer = (size: number): Layer.Layer<never, never, "TestSized"> =>
   layer.scoped(
     Sized.TestSized,
     pipe(
@@ -338,7 +337,7 @@ export const withTestConfig = dual<
  *
  * @since 2.0.0
  */
-export const withTestConfigScoped = (config: TestConfig.TestConfig): Effect.Effect<Scope.Scope, never, void> =>
+export const withTestConfigScoped = (config: TestConfig.TestConfig): Effect.Effect<"Scope", never, void> =>
   fiberRuntime.fiberRefLocallyScopedWith(currentServices, Context.add(TestConfig.TestConfig, config))
 
 /**
@@ -351,7 +350,7 @@ export const testConfigLayer = (params: {
   readonly retries: number
   readonly samples: number
   readonly shrinks: number
-}): Layer.Layer<never, never, TestConfig.TestConfig> =>
+}): Layer.Layer<never, never, "TestConfig"> =>
   layer.scoped(
     TestConfig.TestConfig,
     Effect.suspend(() => {

--- a/packages/effect/src/TestSized.ts
+++ b/packages/effect/src/TestSized.ts
@@ -29,7 +29,7 @@ export interface TestSized {
 /**
  * @since 2.0.0
  */
-export const TestSized: Context.Tag<TestSized, TestSized> = Context.Tag(TestSizedTypeId)
+export const TestSized = Context.Tag("TestSized")<TestSized>()
 
 /** @internal */
 class SizedImpl implements TestSized {

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -58,7 +58,7 @@ export type ParentSpan = Span | ExternalSpan
  * @since 2.0.0
  * @category tags
  */
-export const ParentSpan: Context.Tag<ParentSpan, ParentSpan> = internal.spanTag
+export const ParentSpan: Context.Tag<"ParentSpan", ParentSpan> = internal.spanTag
 
 /**
  * @since 2.0.0
@@ -106,7 +106,7 @@ export interface SpanLink {
  * @since 2.0.0
  * @category tags
  */
-export const Tracer: Context.Tag<Tracer, Tracer> = internal.tracerTag
+export const Tracer: Context.Tag<"Tracer", Tracer> = internal.tracerTag
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/internal/channel.ts
+++ b/packages/effect/src/internal/channel.ts
@@ -701,7 +701,7 @@ export const fromPubSub = <Err, Done, Elem>(
 /** @internal */
 export const fromPubSubScoped = <Err, Done, Elem>(
   pubsub: PubSub.PubSub<Either.Either<Exit.Exit<Err, Done>, Elem>>
-): Effect.Effect<Scope.Scope, never, Channel.Channel<never, unknown, unknown, unknown, Err, Elem, Done>> =>
+): Effect.Effect<"Scope", never, Channel.Channel<never, unknown, unknown, unknown, Err, Elem, Done>> =>
   Effect.map(PubSub.subscribe(pubsub), fromQueue)
 
 /** @internal */
@@ -2121,7 +2121,7 @@ export const runDrain = <Env, InErr, InDone, OutElem, OutErr, OutDone>(
 /** @internal */
 export const scoped = <R, E, A>(
   effect: Effect.Effect<R, E, A>
-): Channel.Channel<Exclude<R, Scope.Scope>, unknown, unknown, unknown, E, A, unknown> =>
+): Channel.Channel<Exclude<R, "Scope">, unknown, unknown, unknown, E, A, unknown> =>
   unwrap(
     Effect.uninterruptibleMask((restore) =>
       Effect.map(Scope.make(), (scope) =>
@@ -2170,7 +2170,7 @@ export const toPubSub = <Err, Done, Elem>(
 /** @internal */
 export const toPull = <Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
   self: Channel.Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-): Effect.Effect<Env | Scope.Scope, never, Effect.Effect<Env, OutErr, Either.Either<OutDone, OutElem>>> =>
+): Effect.Effect<Env | "Scope", never, Effect.Effect<Env, OutErr, Either.Either<OutDone, OutElem>>> =>
   Effect.map(
     Effect.acquireRelease(
       Effect.sync(() => new executor.ChannelExecutor(self, void 0, identity)),
@@ -2254,7 +2254,7 @@ export const unwrapScoped = <
 >(
   self: Effect.Effect<R, E, Channel.Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>>
 ): Channel.Channel<
-  Exclude<R, Scope.Scope> | Env,
+  Exclude<R, "Scope"> | Env,
   InErr,
   InElem,
   InDone,
@@ -2305,7 +2305,7 @@ export const withSpan = dual<
     }
   ) => <Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
     self: Channel.Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>
-  ) => Channel.Channel<Exclude<Env, Tracer.ParentSpan>, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
+  ) => Channel.Channel<Exclude<Env, "ParentSpan">, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
   <Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>(
     self: Channel.Channel<Env, InErr, InElem, InDone, OutErr, OutElem, OutDone>,
     name: string,
@@ -2316,7 +2316,7 @@ export const withSpan = dual<
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
     }
-  ) => Channel.Channel<Exclude<Env, Tracer.ParentSpan>, InErr, InElem, InDone, OutErr, OutElem, OutDone>
+  ) => Channel.Channel<Exclude<Env, "ParentSpan">, InErr, InElem, InDone, OutErr, OutElem, OutDone>
 >(3, (self, name, options) =>
   unwrapScoped(
     Effect.flatMap(

--- a/packages/effect/src/internal/channel/channelExecutor.ts
+++ b/packages/effect/src/internal/channel/channelExecutor.ts
@@ -1108,7 +1108,7 @@ export const run = <Env, InErr, InDone, OutErr, OutDone>(
 /** @internal */
 export const runScoped = <Env, InErr, InDone, OutErr, OutDone>(
   self: Channel.Channel<Env, InErr, unknown, InDone, OutErr, never, OutDone>
-): Effect.Effect<Env | Scope.Scope, OutErr, OutDone> => {
+): Effect.Effect<Env | "Scope", OutErr, OutDone> => {
   const run = (
     channelDeferred: Deferred.Deferred<OutErr, OutDone>,
     scopeDeferred: Deferred.Deferred<never, void>,

--- a/packages/effect/src/internal/clock.ts
+++ b/packages/effect/src/internal/clock.ts
@@ -14,7 +14,7 @@ const ClockSymbolKey = "effect/Clock"
 export const ClockTypeId: Clock.ClockTypeId = Symbol.for(ClockSymbolKey) as Clock.ClockTypeId
 
 /** @internal */
-export const clockTag: Context.Tag<Clock.Clock, Clock.Clock> = Context.Tag(ClockTypeId)
+export const clockTag = Context.Tag("Clock")<Clock.Clock>()
 
 /** @internal */
 export const MAX_TIMER_MILLIS = 2 ** 31 - 1

--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -33,9 +33,7 @@ export const ConfigProviderTypeId: ConfigProvider.ConfigProviderTypeId = Symbol.
 ) as ConfigProvider.ConfigProviderTypeId
 
 /** @internal */
-export const configProviderTag: Context.Tag<ConfigProvider.ConfigProvider, ConfigProvider.ConfigProvider> = Context.Tag(
-  ConfigProviderTypeId
-)
+export const configProviderTag = Context.Tag("ConfigProvider")<ConfigProvider.ConfigProvider>()
 
 /** @internal */
 const FlatConfigProviderSymbolKey = "effect/ConfigProviderFlat"

--- a/packages/effect/src/internal/console.ts
+++ b/packages/effect/src/internal/console.ts
@@ -3,7 +3,6 @@ import * as Context from "../Context.js"
 import type * as Effect from "../Effect.js"
 import { dual } from "../Function.js"
 import type * as Layer from "../Layer.js"
-import type * as Scope from "../Scope.js"
 import * as core from "./core.js"
 import * as defaultServices from "./defaultServices.js"
 import * as defaultConsole from "./defaultServices/console.js"
@@ -35,7 +34,7 @@ export const withConsole = dual<
   ))
 
 /** @internal */
-export const withConsoleScoped = <A extends Console.Console>(console: A): Effect.Effect<Scope.Scope, never, void> =>
+export const withConsoleScoped = <A extends Console.Console>(console: A): Effect.Effect<"Scope", never, void> =>
   fiberRuntime.fiberRefLocallyScopedWith(
     defaultServices.currentServices,
     Context.add(defaultConsole.consoleTag, console)

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -1893,10 +1893,11 @@ export const serviceMembers = <SR, SE, S>(getService: Effect.Effect<SR, SE, S>):
 })
 
 /** @internal */
-export const serviceOption = <I, S>(tag: Context.Tag<I, S>) => core.map(core.context<never>(), Context.getOption(tag))
+export const serviceOption = <I extends string, S>(tag: Context.Tag<I, S>) =>
+  core.map(core.context<never>(), Context.getOption(tag))
 
 /** @internal */
-export const serviceOptional = <I, S>(tag: Context.Tag<I, S>) =>
+export const serviceOptional = <I extends string, S>(tag: Context.Tag<I, S>) =>
   core.flatMap(core.context<never>(), Context.getOption(tag))
 
 // -----------------------------------------------------------------------------
@@ -2108,8 +2109,8 @@ export const useSpan: {
 export const withParentSpan = dual<
   (
     span: Tracer.ParentSpan
-  ) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Tracer.ParentSpan>, E, A>,
-  <R, E, A>(self: Effect.Effect<R, E, A>, span: Tracer.ParentSpan) => Effect.Effect<Exclude<R, Tracer.ParentSpan>, E, A>
+  ) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "ParentSpan">, E, A>,
+  <R, E, A>(self: Effect.Effect<R, E, A>, span: Tracer.ParentSpan) => Effect.Effect<Exclude<R, "ParentSpan">, E, A>
 >(2, (self, span) => provideService(self, internalTracer.spanTag, span))
 
 /** @internal */
@@ -2120,14 +2121,14 @@ export const withSpan = dual<
     readonly parent?: Tracer.ParentSpan | undefined
     readonly root?: boolean | undefined
     readonly context?: Context.Context<never> | undefined
-  }) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Tracer.ParentSpan>, E, A>,
+  }) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "ParentSpan">, E, A>,
   <R, E, A>(self: Effect.Effect<R, E, A>, name: string, options?: {
     readonly attributes?: Record<string, unknown> | undefined
     readonly links?: ReadonlyArray<Tracer.SpanLink> | undefined
     readonly parent?: Tracer.ParentSpan | undefined
     readonly root?: boolean | undefined
     readonly context?: Context.Context<never> | undefined
-  }) => Effect.Effect<Exclude<R, Tracer.ParentSpan>, E, A>
+  }) => Effect.Effect<Exclude<R, "ParentSpan">, E, A>
 >(
   (args) => typeof args[0] !== "string",
   (self, name, options) =>

--- a/packages/effect/src/internal/defaultServices/console.ts
+++ b/packages/effect/src/internal/defaultServices/console.ts
@@ -6,7 +6,7 @@ import * as core from "../core.js"
 export const TypeId: Console.TypeId = Symbol.for("effect/Console") as Console.TypeId
 
 /** @internal */
-export const consoleTag: Context.Tag<Console.Console, Console.Console> = Context.Tag<Console.Console>(TypeId)
+export const consoleTag: Context.Tag<"Console", Console.Console> = Context.Tag("Console")<Console.Console>()
 
 /** @internal */
 export const defaultConsole: Console.Console = {

--- a/packages/effect/src/internal/differ/contextPatch.ts
+++ b/packages/effect/src/internal/differ/contextPatch.ts
@@ -61,9 +61,9 @@ const makeAndThen = <Input, Output, Output2>(
 }
 
 /** @internal */
-export interface AddService<in out Env, in out T, in out I> extends Differ.Context.Patch<Env, Env | I> {
+export interface AddService<in out Env, in out T, in out I extends string> extends Differ.Context.Patch<Env, Env | I> {
   readonly _tag: "AddService"
-  readonly tag: Tag<T, I>
+  readonly tag: Tag<I, T>
   readonly service: T
 }
 
@@ -71,8 +71,8 @@ const AddServiceProto = Object.assign(Object.create(PatchProto), {
   _tag: "AddService"
 })
 
-const makeAddService = <Env, I, T>(
-  tag: Tag<T, I>,
+const makeAddService = <Env, I extends string, T>(
+  tag: Tag<I, T>,
   service: T
 ): Differ.Context.Patch<Env, Env | I> => {
   const o = Object.create(AddServiceProto)
@@ -82,17 +82,19 @@ const makeAddService = <Env, I, T>(
 }
 
 /** @internal */
-export interface RemoveService<in out Env, in out T, in out I> extends Differ.Context.Patch<Env, Exclude<Env, I>> {
+export interface RemoveService<in out Env, in out T, in out I extends string>
+  extends Differ.Context.Patch<Env, Exclude<Env, I>>
+{
   readonly _tag: "RemoveService"
-  readonly tag: Tag<T, I>
+  readonly tag: Tag<I, T>
 }
 
 const RemoveServiceProto = Object.assign(Object.create(PatchProto), {
   _tag: "RemoveService"
 })
 
-const makeRemoveService = <Env, I, T>(
-  tag: Tag<T, I>
+const makeRemoveService = <Env, I extends string, T>(
+  tag: Tag<I, T>
 ): Differ.Context.Patch<Env, Exclude<Env, I>> => {
   const o = Object.create(RemoveServiceProto)
   o.tag = tag
@@ -100,9 +102,11 @@ const makeRemoveService = <Env, I, T>(
 }
 
 /** @internal */
-export interface UpdateService<in out Env, in out T, in out I> extends Differ.Context.Patch<Env | I, Env | I> {
+export interface UpdateService<in out Env, in out T, in out I extends string>
+  extends Differ.Context.Patch<Env | I, Env | I>
+{
   readonly _tag: "UpdateService"
-  readonly tag: Tag<T, I>
+  readonly tag: Tag<I, T>
   update(service: T): T
 }
 
@@ -110,8 +114,8 @@ const UpdateServiceProto = Object.assign(Object.create(PatchProto), {
   _tag: "UpdateService"
 })
 
-const makeUpdateService = <Env, I, T>(
-  tag: Tag<T, I>,
+const makeUpdateService = <Env, I extends string, T>(
+  tag: Tag<I, T>,
   update: (service: T) => T
 ): Differ.Context.Patch<Env | I, Env | I> => {
   const o = Object.create(UpdateServiceProto)

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -288,8 +288,7 @@ export const forkIn = dual<
 /** @internal */
 export const forkScoped = <R, E, A>(
   self: Effect.Effect<R, E, A>
-): Effect.Effect<R | Scope.Scope, never, Fiber.RuntimeFiber<E, A>> =>
-  fiberRuntime.scopeWith((scope) => forkIn(self, scope))
+): Effect.Effect<R | "Scope", never, Fiber.RuntimeFiber<E, A>> => fiberRuntime.scopeWith((scope) => forkIn(self, scope))
 
 /** @internal */
 export const fromFiber = <E, A>(fiber: Fiber.Fiber<E, A>): Effect.Effect<never, E, A> => internalFiber.join(fiber)
@@ -379,11 +378,11 @@ export const scheduleForked = dual<
     schedule: Schedule.Schedule<R2, unknown, Out>
   ) => <R, E, A>(
     self: Effect.Effect<R, E, A>
-  ) => Effect.Effect<R | R2 | Scope.Scope, never, Fiber.RuntimeFiber<E, Out>>,
+  ) => Effect.Effect<R | R2 | "Scope", never, Fiber.RuntimeFiber<E, Out>>,
   <R, E, A, R2, Out>(
     self: Effect.Effect<R, E, A>,
     schedule: Schedule.Schedule<R2, unknown, Out>
-  ) => Effect.Effect<R | R2 | Scope.Scope, never, Fiber.RuntimeFiber<E, Out>>
+  ) => Effect.Effect<R | R2 | "Scope", never, Fiber.RuntimeFiber<E, Out>>
 >(2, (self, schedule) => pipe(self, _schedule.schedule_Effect(schedule), forkScoped))
 
 /** @internal */

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1438,22 +1438,22 @@ export const currentLoggers: FiberRef.FiberRef<
 export const acquireRelease: {
   <A, R2, X>(
     release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-  ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<R2 | R | Scope.Scope, E, A>
+  ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<R2 | R | "Scope", E, A>
   <R, E, A, R2, X>(
     acquire: Effect.Effect<R, E, A>,
     release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-  ): Effect.Effect<Scope.Scope | R | R2, E, A>
+  ): Effect.Effect<"Scope" | R | R2, E, A>
 } = dual<
   {
     <A, R2, X>(
       release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-    ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<R | R2 | Scope.Scope, E, A>
+    ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<R | R2 | "Scope", E, A>
   },
   {
     <R, E, A, R2, X>(
       acquire: Effect.Effect<R, E, A>,
       release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-    ): Effect.Effect<R | R2 | Scope.Scope, E, A>
+    ): Effect.Effect<R | R2 | "Scope", E, A>
   }
 >((args) => core.isEffect(args[0]), (acquire, release) => {
   return core.uninterruptible(
@@ -1465,22 +1465,22 @@ export const acquireRelease: {
 export const acquireReleaseInterruptible: {
   <A, R2, X>(
     release: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-  ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E, A>
+  ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E, A>
   <R, E, A, R2, X>(
     acquire: Effect.Effect<R, E, A>,
     release: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-  ): Effect.Effect<Scope.Scope | R | R2, E, A>
+  ): Effect.Effect<"Scope" | R | R2, E, A>
 } = dual<
   {
     <A, R2, X>(
       release: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-    ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<R | R2 | Scope.Scope, E, A>
+    ): <R, E>(acquire: Effect.Effect<R, E, A>) => Effect.Effect<R | R2 | "Scope", E, A>
   },
   {
     <R, E, A, R2, X>(
       acquire: Effect.Effect<R, E, A>,
       release: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R2, never, X>
-    ): Effect.Effect<R | R2 | Scope.Scope, E, A>
+    ): Effect.Effect<R | R2 | "Scope", E, A>
   }
 >((args) => core.isEffect(args[0]), (acquire, release) => {
   return ensuring(
@@ -1492,7 +1492,7 @@ export const acquireReleaseInterruptible: {
 /* @internal */
 export const addFinalizer = <R, X>(
   finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<R, never, X>
-): Effect.Effect<R | Scope.Scope, never, void> =>
+): Effect.Effect<R | "Scope", never, void> =>
   core.withFiberRuntime(
     (runtime) => {
       const acquireRefs = runtime.getFiberRefs()
@@ -2573,10 +2573,10 @@ export const finalizersMask = (strategy: ExecutionStrategy.ExecutionStrategy) =>
 /* @internal */
 export const scopeWith = <R, E, A>(
   f: (scope: Scope.Scope) => Effect.Effect<R, E, A>
-): Effect.Effect<R | Scope.Scope, E, A> => core.flatMap(scopeTag, f)
+): Effect.Effect<R | "Scope", E, A> => core.flatMap(scopeTag, f)
 
 /* @internal */
-export const scopedEffect = <R, E, A>(effect: Effect.Effect<R, E, A>): Effect.Effect<Exclude<R, Scope.Scope>, E, A> =>
+export const scopedEffect = <R, E, A>(effect: Effect.Effect<R, E, A>): Effect.Effect<Exclude<R, "Scope">, E, A> =>
   core.flatMap(scopeMake(), (scope) => scopeUse(scope)(effect))
 
 /* @internal */
@@ -2600,24 +2600,24 @@ export const sequentialFinalizers = <R, E, A>(self: Effect.Effect<R, E, A>): Eff
   )
 
 /* @internal */
-export const tagMetricsScoped = (key: string, value: string): Effect.Effect<Scope.Scope, never, void> =>
+export const tagMetricsScoped = (key: string, value: string): Effect.Effect<"Scope", never, void> =>
   labelMetricsScoped([metricLabel.make(key, value)])
 
 /* @internal */
 export const labelMetricsScoped = (
   labels: Iterable<MetricLabel.MetricLabel>
-): Effect.Effect<Scope.Scope, never, void> =>
+): Effect.Effect<"Scope", never, void> =>
   fiberRefLocallyScopedWith(core.currentMetricLabels, (old) => RA.union(old, labels))
 
 /* @internal */
 export const using = dual<
   <A, R2, E2, A2>(
     use: (a: A) => Effect.Effect<R2, E2, A2>
-  ) => <R, E>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Scope.Scope> | R2, E | E2, A2>,
+  ) => <R, E>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "Scope"> | R2, E | E2, A2>,
   <R, E, A, R2, E2, A2>(
     self: Effect.Effect<R, E, A>,
     use: (a: A) => Effect.Effect<R2, E2, A2>
-  ) => Effect.Effect<Exclude<R, Scope.Scope> | R2, E | E2, A2>
+  ) => Effect.Effect<Exclude<R, "Scope"> | R2, E | E2, A2>
 >(2, (self, use) =>
   core.acquireUseRelease(
     scopeMake(),
@@ -2737,7 +2737,7 @@ export const withConfigProviderScoped = (value: ConfigProvider) =>
 /* @internal */
 export const withEarlyRelease = <R, E, A>(
   self: Effect.Effect<R, E, A>
-): Effect.Effect<R | Scope.Scope, E, [Effect.Effect<never, never, void>, A]> =>
+): Effect.Effect<R | "Scope", E, [Effect.Effect<never, never, void>, A]> =>
   scopeWith((parent) =>
     core.flatMap(core.scopeFork(parent, executionStrategy.sequential), (child) =>
       pipe(
@@ -2859,7 +2859,7 @@ export const zipWithOptions = dual<
 /* @internal */
 export const withRuntimeFlagsScoped = (
   update: RuntimeFlagsPatch.RuntimeFlagsPatch
-): Effect.Effect<Scope.Scope, never, void> => {
+): Effect.Effect<"Scope", never, void> => {
   if (update === RuntimeFlagsPatch.empty) {
     return core.unit
   }
@@ -2936,10 +2936,10 @@ export const releaseMapReleaseAll = (
 // circular with Scope
 
 /** @internal */
-export const scopeTag = Context.Tag<Scope.Scope>(core.ScopeTypeId)
+export const scopeTag = Context.Tag("Scope")<Scope.Scope>()
 
 /* @internal */
-export const scope: Effect.Effect<Scope.Scope, never, Scope.Scope> = scopeTag
+export const scope: Effect.Effect<"Scope", never, Scope.Scope> = scopeTag
 
 /* @internal */
 export const scopeMake = (
@@ -2971,12 +2971,12 @@ export const scopeMake = (
 
 /* @internal */
 export const scopeExtend = dual<
-  (scope: Scope.Scope) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Scope.Scope>, E, A>,
-  <R, E, A>(effect: Effect.Effect<R, E, A>, scope: Scope.Scope) => Effect.Effect<Exclude<R, Scope.Scope>, E, A>
+  (scope: Scope.Scope) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "Scope">, E, A>,
+  <R, E, A>(effect: Effect.Effect<R, E, A>, scope: Scope.Scope) => Effect.Effect<Exclude<R, "Scope">, E, A>
 >(
   2,
   <R, E, A>(effect: Effect.Effect<R, E, A>, scope: Scope.Scope) =>
-    core.mapInputContext<Exclude<R, Scope.Scope>, R, E, A>(
+    core.mapInputContext<Exclude<R, "Scope">, R, E, A>(
       effect,
       // @ts-expect-error
       Context.merge(Context.make(scopeTag, scope))
@@ -2987,11 +2987,11 @@ export const scopeExtend = dual<
 export const scopeUse = dual<
   (
     scope: Scope.Scope.Closeable
-  ) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Scope.Scope>, E, A>,
+  ) => <R, E, A>(effect: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "Scope">, E, A>,
   <R, E, A>(
     effect: Effect.Effect<R, E, A>,
     scope: Scope.Scope.Closeable
-  ) => Effect.Effect<Exclude<R, Scope.Scope>, E, A>
+  ) => Effect.Effect<Exclude<R, "Scope">, E, A>
 >(2, (effect, scope) =>
   pipe(
     effect,
@@ -3014,8 +3014,8 @@ export const fiberRefUnsafeMakeSupervisor = (
 
 /* @internal */
 export const fiberRefLocallyScoped = dual<
-  <A>(value: A) => (self: FiberRef.FiberRef<A>) => Effect.Effect<Scope.Scope, never, void>,
-  <A>(self: FiberRef.FiberRef<A>, value: A) => Effect.Effect<Scope.Scope, never, void>
+  <A>(value: A) => (self: FiberRef.FiberRef<A>) => Effect.Effect<"Scope", never, void>,
+  <A>(self: FiberRef.FiberRef<A>, value: A) => Effect.Effect<"Scope", never, void>
 >(2, (self, value) =>
   core.asUnit(
     acquireRelease(
@@ -3029,8 +3029,8 @@ export const fiberRefLocallyScoped = dual<
 
 /* @internal */
 export const fiberRefLocallyScopedWith = dual<
-  <A>(f: (a: A) => A) => (self: FiberRef.FiberRef<A>) => Effect.Effect<Scope.Scope, never, void>,
-  <A>(self: FiberRef.FiberRef<A>, f: (a: A) => A) => Effect.Effect<Scope.Scope, never, void>
+  <A>(f: (a: A) => A) => (self: FiberRef.FiberRef<A>) => Effect.Effect<"Scope", never, void>,
+  <A>(self: FiberRef.FiberRef<A>, f: (a: A) => A) => Effect.Effect<"Scope", never, void>
 >(2, (self, f) => core.fiberRefGetWith(self, (a) => fiberRefLocallyScoped(self, f(a))))
 
 /* @internal */
@@ -3040,13 +3040,13 @@ export const fiberRefMake = <A>(
     readonly fork?: ((a: A) => A) | undefined
     readonly join?: ((left: A, right: A) => A) | undefined
   }
-): Effect.Effect<Scope.Scope, never, FiberRef.FiberRef<A>> =>
+): Effect.Effect<"Scope", never, FiberRef.FiberRef<A>> =>
   fiberRefMakeWith(() => core.fiberRefUnsafeMake(initial, options))
 
 /* @internal */
 export const fiberRefMakeWith = <Value>(
   ref: LazyArg<FiberRef.FiberRef<Value>>
-): Effect.Effect<Scope.Scope, never, FiberRef.FiberRef<Value>> =>
+): Effect.Effect<"Scope", never, FiberRef.FiberRef<Value>> =>
   acquireRelease(
     core.tap(core.sync(ref), (ref) => core.fiberRefUpdate(ref, identity)),
     (fiberRef) => core.fiberRefDelete(fiberRef)
@@ -3055,13 +3055,13 @@ export const fiberRefMakeWith = <Value>(
 /* @internal */
 export const fiberRefMakeContext = <A>(
   initial: Context.Context<A>
-): Effect.Effect<Scope.Scope, never, FiberRef.FiberRef<Context.Context<A>>> =>
+): Effect.Effect<"Scope", never, FiberRef.FiberRef<Context.Context<A>>> =>
   fiberRefMakeWith(() => core.fiberRefUnsafeMakeContext(initial))
 
 /* @internal */
 export const fiberRefMakeRuntimeFlags = (
   initial: RuntimeFlags.RuntimeFlags
-): Effect.Effect<Scope.Scope, never, FiberRef.FiberRef<RuntimeFlags.RuntimeFlags>> =>
+): Effect.Effect<"Scope", never, FiberRef.FiberRef<RuntimeFlags.RuntimeFlags>> =>
   fiberRefMakeWith(() => core.fiberRefUnsafeMakeRuntimeFlags(initial))
 
 /** @internal */
@@ -3130,7 +3130,7 @@ export const fiberJoinAll = <E, A>(fibers: Iterable<Fiber.Fiber<E, A>>): Effect.
   core.asUnit(internalFiber.join(fiberAll(fibers)))
 
 /* @internal */
-export const fiberScoped = <E, A>(self: Fiber.Fiber<E, A>): Effect.Effect<Scope.Scope, never, Fiber.Fiber<E, A>> =>
+export const fiberScoped = <E, A>(self: Fiber.Fiber<E, A>): Effect.Effect<"Scope", never, Fiber.Fiber<E, A>> =>
   acquireRelease(core.succeed(self), core.interruptFiber)
 
 //
@@ -3451,7 +3451,7 @@ export const makeSpanScoped = (
     readonly root?: boolean | undefined
     readonly context?: Context.Context<never> | undefined
   }
-): Effect.Effect<Scope.Scope, never, Tracer.Span> =>
+): Effect.Effect<"Scope", never, Tracer.Span> =>
   acquireRelease(
     internalEffect.makeSpan(name, options),
     (span, exit) =>
@@ -3462,7 +3462,7 @@ export const makeSpanScoped = (
   )
 
 /* @internal */
-export const withTracerScoped = (value: Tracer.Tracer): Effect.Effect<Scope.Scope, never, void> =>
+export const withTracerScoped = (value: Tracer.Tracer): Effect.Effect<"Scope", never, void> =>
   fiberRefLocallyScopedWith(defaultServices.currentServices, Context.add(tracer.tracerTag, value))
 
 /** @internal */
@@ -3473,14 +3473,14 @@ export const withSpanScoped = dual<
     readonly parent?: Tracer.ParentSpan | undefined
     readonly root?: boolean | undefined
     readonly context?: Context.Context<never> | undefined
-  }) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, Tracer.ParentSpan> | Scope.Scope, E, A>,
+  }) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<Exclude<R, "ParentSpan"> | "Scope", E, A>,
   <R, E, A>(self: Effect.Effect<R, E, A>, name: string, options?: {
     readonly attributes?: Record<string, unknown> | undefined
     readonly links?: ReadonlyArray<Tracer.SpanLink> | undefined
     readonly parent?: Tracer.ParentSpan | undefined
     readonly root?: boolean | undefined
     readonly context?: Context.Context<never> | undefined
-  }) => Effect.Effect<Exclude<R, Tracer.ParentSpan> | Scope.Scope, E, A>
+  }) => Effect.Effect<Exclude<R, "ParentSpan"> | "Scope", E, A>
 >(
   (args) => typeof args[0] !== "string",
   (self, name, options) =>

--- a/packages/effect/src/internal/layer/circular.ts
+++ b/packages/effect/src/internal/layer/circular.ts
@@ -7,7 +7,6 @@ import * as HashSet from "../../HashSet.js"
 import type * as Layer from "../../Layer.js"
 import type * as Logger from "../../Logger.js"
 import type * as LogLevel from "../../LogLevel.js"
-import type { Scope } from "../../Scope.js"
 import type * as Supervisor from "../../Supervisor.js"
 import type * as Tracer from "../../Tracer.js"
 import * as core from "../core.js"
@@ -59,7 +58,7 @@ export const addLoggerEffect = <R, E, A>(
 /** @internal */
 export const addLoggerScoped = <R, E, A>(
   effect: Effect.Effect<R, E, Logger.Logger<unknown, A>>
-): Layer.Layer<Exclude<R, Scope>, E, never> =>
+): Layer.Layer<Exclude<R, "Scope">, E, never> =>
   layer.unwrapScoped(
     core.map(effect, addLogger)
   )
@@ -94,11 +93,11 @@ export const replaceLoggerEffect = dual<
 export const replaceLoggerScoped = dual<
   <R, E, B>(
     that: Effect.Effect<R, E, Logger.Logger<unknown, B>>
-  ) => <A>(self: Logger.Logger<unknown, A>) => Layer.Layer<Exclude<R, Scope>, E, never>,
+  ) => <A>(self: Logger.Logger<unknown, A>) => Layer.Layer<Exclude<R, "Scope">, E, never>,
   <A, R, E, B>(
     self: Logger.Logger<unknown, A>,
     that: Effect.Effect<R, E, Logger.Logger<unknown, B>>
-  ) => Layer.Layer<Exclude<R, Scope>, E, never>
+  ) => Layer.Layer<Exclude<R, "Scope">, E, never>
 >(2, (self, that) => layer.flatMap(removeLogger(self), () => addLoggerScoped(that)))
 
 /** @internal */
@@ -185,7 +184,7 @@ export const setConfigProvider = (configProvider: ConfigProvider.ConfigProvider)
   layer.scopedDiscard(fiberRuntime.withConfigProviderScoped(configProvider))
 
 /** @internal */
-export const parentSpan = (span: Tracer.ParentSpan): Layer.Layer<never, never, Tracer.ParentSpan> =>
+export const parentSpan = (span: Tracer.ParentSpan): Layer.Layer<never, never, "ParentSpan"> =>
   layer.succeedContext(Context.make(tracer.spanTag, span))
 
 /** @internal */
@@ -201,7 +200,7 @@ export const span = (
       | ((span: Tracer.Span, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<never, never, void>)
       | undefined
   }
-): Layer.Layer<never, never, Tracer.ParentSpan> =>
+): Layer.Layer<never, never, "ParentSpan"> =>
   layer.scoped(
     tracer.spanTag,
     options?.onEnd

--- a/packages/effect/src/internal/metric/polling.ts
+++ b/packages/effect/src/internal/metric/polling.ts
@@ -5,7 +5,6 @@ import type * as Metric from "../../Metric.js"
 import type * as MetricPolling from "../../MetricPolling.js"
 import { pipeArguments } from "../../Pipeable.js"
 import type * as Schedule from "../../Schedule.js"
-import type * as Scope from "../../Scope.js"
 import * as core from "../core.js"
 import * as circular from "../effect/circular.js"
 import * as metric from "../metric.js"
@@ -68,11 +67,11 @@ export const launch = dual<
     schedule: Schedule.Schedule<R2, unknown, A2>
   ) => <Type, In, R, E, Out>(
     self: MetricPolling.MetricPolling<Type, In, R, E, Out>
-  ) => Effect.Effect<R | R2 | Scope.Scope, never, Fiber.Fiber<E, A2>>,
+  ) => Effect.Effect<R | R2 | "Scope", never, Fiber.Fiber<E, A2>>,
   <Type, In, R, E, Out, R2, A2>(
     self: MetricPolling.MetricPolling<Type, In, R, E, Out>,
     schedule: Schedule.Schedule<R2, unknown, A2>
-  ) => Effect.Effect<R | R2 | Scope.Scope, never, Fiber.Fiber<E, A2>>
+  ) => Effect.Effect<R | R2 | "Scope", never, Fiber.Fiber<E, A2>>
 >(2, (self, schedule) =>
   pipe(
     pollAndUpdate(self),

--- a/packages/effect/src/internal/pubsub.ts
+++ b/packages/effect/src/internal/pubsub.ts
@@ -133,8 +133,7 @@ export const publishAll = dual<
 >(2, (self, elements) => self.publishAll(elements))
 
 /** @internal */
-export const subscribe = <A>(self: PubSub.PubSub<A>): Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>> =>
-  self.subscribe
+export const subscribe = <A>(self: PubSub.PubSub<A>): Effect.Effect<"Scope", never, Queue.Dequeue<A>> => self.subscribe
 
 /** @internal */
 const makeBoundedPubSub = <A>(requestedCapacity: number): AtomicPubSub<A> => {
@@ -1113,7 +1112,7 @@ class PubSubImpl<in out A> implements PubSub.PubSub<A> {
     })
   }
 
-  get subscribe(): Effect.Effect<Scope.Scope, never, Queue.Dequeue<A>> {
+  get subscribe(): Effect.Effect<"Scope", never, Queue.Dequeue<A>> {
     const acquire = core.tap(
       fiberRuntime.all([
         this.scope.fork(executionStrategy.sequential),

--- a/packages/effect/src/internal/random.ts
+++ b/packages/effect/src/internal/random.ts
@@ -15,7 +15,8 @@ export const RandomTypeId: Random.RandomTypeId = Symbol.for(
 ) as Random.RandomTypeId
 
 /** @internal */
-export const randomTag: Context.Tag<Random.Random, Random.Random> = Context.Tag(RandomTypeId)
+export const randomTag = Context.Tag("Random")<Random.Random>()
+
 /** @internal */
 class RandomImpl implements Random.Random {
   readonly [RandomTypeId]: Random.RandomTypeId = RandomTypeId

--- a/packages/effect/src/internal/resource.ts
+++ b/packages/effect/src/internal/resource.ts
@@ -2,7 +2,6 @@ import type * as Effect from "../Effect.js"
 import { identity, pipe } from "../Function.js"
 import type * as Resource from "../Resource.js"
 import type * as Schedule from "../Schedule.js"
-import type * as Scope from "../Scope.js"
 import * as core from "./core.js"
 import * as fiberRuntime from "./fiberRuntime.js"
 import * as _schedule from "./schedule.js"
@@ -27,7 +26,7 @@ const resourceVariance = {
 export const auto = <R, E, A, R2, Out>(
   acquire: Effect.Effect<R, E, A>,
   policy: Schedule.Schedule<R2, unknown, Out>
-): Effect.Effect<R | R2 | Scope.Scope, never, Resource.Resource<E, A>> =>
+): Effect.Effect<R | R2 | "Scope", never, Resource.Resource<E, A>> =>
   core.tap(manual(acquire), (manual) =>
     fiberRuntime.acquireRelease(
       pipe(
@@ -42,7 +41,7 @@ export const auto = <R, E, A, R2, Out>(
 /** @internal */
 export const manual = <R, E, A>(
   acquire: Effect.Effect<R, E, A>
-): Effect.Effect<R | Scope.Scope, never, Resource.Resource<E, A>> =>
+): Effect.Effect<R | "Scope", never, Resource.Resource<E, A>> =>
   core.flatMap(core.context<R>(), (env) =>
     pipe(
       scopedRef.fromAcquire(core.exit(acquire)),

--- a/packages/effect/src/internal/scopedCache.ts
+++ b/packages/effect/src/internal/scopedCache.ts
@@ -93,13 +93,13 @@ export interface Complete<out Key, out Error, out Value> {
 export interface Pending<out Key, out Error, out Value> {
   readonly _tag: "Pending"
   readonly key: _cache.MapKey<Key>
-  readonly scoped: Effect.Effect<never, never, Effect.Effect<Scope.Scope, Error, Value>>
+  readonly scoped: Effect.Effect<never, never, Effect.Effect<"Scope", Error, Value>>
 }
 
 /** @internal */
 export interface Refreshing<out Key, out Error, out Value> {
   readonly _tag: "Refreshing"
-  readonly scoped: Effect.Effect<never, never, Effect.Effect<Scope.Scope, Error, Value>>
+  readonly scoped: Effect.Effect<never, never, Effect.Effect<"Scope", Error, Value>>
   readonly complete: Complete<Key, Error, Value>
 }
 
@@ -123,7 +123,7 @@ export const complete = <Key, Error, Value>(
 /** @internal */
 export const pending = <Key, Error, Value>(
   key: _cache.MapKey<Key>,
-  scoped: Effect.Effect<never, never, Effect.Effect<Scope.Scope, Error, Value>>
+  scoped: Effect.Effect<never, never, Effect.Effect<"Scope", Error, Value>>
 ): Pending<Key, Error, Value> =>
   Data.struct({
     _tag: "Pending",
@@ -133,7 +133,7 @@ export const pending = <Key, Error, Value>(
 
 /** @internal */
 export const refreshing = <Key, Error, Value>(
-  scoped: Effect.Effect<never, never, Effect.Effect<Scope.Scope, Error, Value>>,
+  scoped: Effect.Effect<never, never, Effect.Effect<"Scope", Error, Value>>,
   complete: Complete<Key, Error, Value>
 ): Refreshing<Key, Error, Value> =>
   Data.struct({
@@ -145,7 +145,7 @@ export const refreshing = <Key, Error, Value>(
 /** @internal */
 export const toScoped = <Key, Error, Value>(
   self: Complete<Key, Error, Value>
-): Effect.Effect<Scope.Scope, Error, Value> =>
+): Effect.Effect<"Scope", Error, Value> =>
   Exit.matchEffect(self.exit, {
     onFailure: (cause) => core.failCause(cause),
     onSuccess: ([value]) =>
@@ -214,7 +214,7 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
     )
   }
 
-  getOption(key: Key): Effect.Effect<Scope.Scope, Error, Option.Option<Value>> {
+  getOption(key: Key): Effect.Effect<"Scope", Error, Option.Option<Value>> {
     return core.suspend(() =>
       Option.match(MutableHashMap.get(this.cacheState.map, key), {
         onNone: () => effect.succeedNone,
@@ -223,12 +223,12 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
     )
   }
 
-  getOptionComplete(key: Key): Effect.Effect<Scope.Scope, never, Option.Option<Value>> {
+  getOptionComplete(key: Key): Effect.Effect<"Scope", never, Option.Option<Value>> {
     return core.suspend(() =>
       Option.match(MutableHashMap.get(this.cacheState.map, key), {
         onNone: () => effect.succeedNone,
         onSome: (value) =>
-          core.flatten(this.resolveMapValue(value, true)) as Effect.Effect<Scope.Scope, never, Option.Option<Value>>
+          core.flatten(this.resolveMapValue(value, true)) as Effect.Effect<"Scope", never, Option.Option<Value>>
       })
     )
   }
@@ -257,7 +257,7 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
     })
   }
 
-  get(key: Key): Effect.Effect<Scope.Scope, Error, Value> {
+  get(key: Key): Effect.Effect<"Scope", Error, Value> {
     return pipe(
       this.lookupValueOf(key),
       effect.memoize,
@@ -350,7 +350,7 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
             MutableHashMap.set(this.cacheState.map, key, pending(newKey, scoped))
           }
         }
-        let finalScoped: Effect.Effect<never, never, Effect.Effect<Scope.Scope, Error, Value>>
+        let finalScoped: Effect.Effect<never, never, Effect.Effect<"Scope", Error, Value>>
         if (value === undefined) {
           finalScoped = core.zipRight(
             this.ensureMapSizeNotExceeded(newKey!),
@@ -435,7 +435,7 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
     }
   }
 
-  lookupValueOf(key: Key): Effect.Effect<never, never, Effect.Effect<Scope.Scope, Error, Value>> {
+  lookupValueOf(key: Key): Effect.Effect<never, never, Effect.Effect<"Scope", Error, Value>> {
     return pipe(
       core.onInterrupt(
         core.flatMap(Scope.make(), (scope) =>
@@ -589,7 +589,7 @@ export const make = <Key, Environment, Error, Value>(
     readonly capacity: number
     readonly timeToLive: Duration.DurationInput
   }
-): Effect.Effect<Environment | Scope.Scope, never, ScopedCache.ScopedCache<Key, Error, Value>> => {
+): Effect.Effect<Environment | "Scope", never, ScopedCache.ScopedCache<Key, Error, Value>> => {
   const timeToLive = Duration.decode(options.timeToLive)
   return makeWith({
     capacity: options.capacity,
@@ -605,7 +605,7 @@ export const makeWith = <Key, Environment, Error, Value>(
     readonly lookup: ScopedCache.Lookup<Key, Environment, Error, Value>
     readonly timeToLive: (exit: Exit.Exit<Error, Value>) => Duration.DurationInput
   }
-): Effect.Effect<Environment | Scope.Scope, never, ScopedCache.ScopedCache<Key, Error, Value>> =>
+): Effect.Effect<Environment | "Scope", never, ScopedCache.ScopedCache<Key, Error, Value>> =>
   core.flatMap(
     effect.clock,
     (clock) =>
@@ -622,7 +622,7 @@ const buildWith = <Key, Environment, Error, Value>(
   scopedLookup: ScopedCache.Lookup<Key, Environment, Error, Value>,
   clock: Clock.Clock,
   timeToLive: (exit: Exit.Exit<Error, Value>) => Duration.Duration
-): Effect.Effect<Environment | Scope.Scope, never, ScopedCache.ScopedCache<Key, Error, Value>> =>
+): Effect.Effect<Environment | "Scope", never, ScopedCache.ScopedCache<Key, Error, Value>> =>
   fiberRuntime.acquireRelease(
     core.flatMap(
       core.context<Environment>(),

--- a/packages/effect/src/internal/sink.ts
+++ b/packages/effect/src/internal/sink.ts
@@ -7,8 +7,8 @@ import * as Duration from "../Duration.js"
 import * as Effect from "../Effect.js"
 import * as Either from "../Either.js"
 import * as Exit from "../Exit.js"
-import { constTrue, dual, identity, pipe } from "../Function.js"
 import type { LazyArg } from "../Function.js"
+import { constTrue, dual, identity, pipe } from "../Function.js"
 import * as HashMap from "../HashMap.js"
 import * as HashSet from "../HashSet.js"
 import type * as MergeDecision from "../MergeDecision.js"
@@ -19,7 +19,6 @@ import * as PubSub from "../PubSub.js"
 import * as Queue from "../Queue.js"
 import * as ReadonlyArray from "../ReadonlyArray.js"
 import * as Ref from "../Ref.js"
-import type * as Scope from "../Scope.js"
 import type * as Sink from "../Sink.js"
 import * as channel from "./channel.js"
 import * as mergeDecision from "./channel/mergeDecision.js"
@@ -1470,7 +1469,7 @@ export const fromPush = <R, E, In, L, Z>(
     never,
     (_: Option.Option<Chunk.Chunk<In>>) => Effect.Effect<R, readonly [Either.Either<E, Z>, Chunk.Chunk<L>], void>
   >
-): Sink.Sink<Exclude<R, Scope.Scope>, E, In, L, Z> =>
+): Sink.Sink<Exclude<R, "Scope">, E, In, L, Z> =>
   new SinkImpl(channel.unwrapScoped(pipe(push, Effect.map(fromPushPull))))
 
 const fromPushPull = <R, E, In, L, Z>(
@@ -1983,7 +1982,7 @@ export const unwrap = <R, E, R2, E2, In, L, Z>(
 /** @internal */
 export const unwrapScoped = <R, E, In, L, Z>(
   effect: Effect.Effect<R, E, Sink.Sink<R, E, In, L, Z>>
-): Sink.Sink<Exclude<R, Scope.Scope>, E, In, L, Z> => {
+): Sink.Sink<Exclude<R, "Scope">, E, In, L, Z> => {
   return new SinkImpl(channel.unwrapScoped(pipe(effect, Effect.map((sink) => toChannel(sink)))))
 }
 

--- a/packages/effect/src/internal/stm/tPubSub.ts
+++ b/packages/effect/src/internal/stm/tPubSub.ts
@@ -3,7 +3,6 @@ import { dual, identity, pipe } from "../../Function.js"
 import * as HashSet from "../../HashSet.js"
 import * as Option from "../../Option.js"
 import * as RA from "../../ReadonlyArray.js"
-import type * as Scope from "../../Scope.js"
 import type * as STM from "../../STM.js"
 import type * as TPubSub from "../../TPubSub.js"
 import type * as TQueue from "../../TQueue.js"
@@ -540,7 +539,7 @@ export const subscribe = <A>(self: TPubSub.TPubSub<A>): STM.STM<never, never, TQ
   )
 
 /** @internal */
-export const subscribeScoped = <A>(self: TPubSub.TPubSub<A>): Effect.Effect<Scope.Scope, never, TQueue.TDequeue<A>> =>
+export const subscribeScoped = <A>(self: TPubSub.TPubSub<A>): Effect.Effect<"Scope", never, TQueue.TDequeue<A>> =>
   Effect.acquireRelease(
     subscribe(self),
     (dequeue) => tQueue.shutdown(dequeue)

--- a/packages/effect/src/internal/stm/tRandom.ts
+++ b/packages/effect/src/internal/stm/tRandom.ts
@@ -83,7 +83,7 @@ const shuffleWith = <A>(
 }
 
 /** @internal */
-export const Tag = Context.Tag<TRandom.TRandom>()
+export const Tag = Context.Tag("TRandom")<TRandom.TRandom>()
 
 class TRandomImpl implements TRandom.TRandom {
   readonly [TRandomTypeId]: TRandom.TRandomTypeId = TRandomTypeId
@@ -109,7 +109,7 @@ class TRandomImpl implements TRandom.TRandom {
 }
 
 /** @internal */
-export const live: Layer.Layer<never, never, TRandom.TRandom> = Layer.effect(
+export const live: Layer.Layer<never, never, "TRandom"> = Layer.effect(
   Tag,
   pipe(
     tRef.make(new Random.PCGRandom((Math.random() * 4294967296) >>> 0).getState()),
@@ -119,22 +119,22 @@ export const live: Layer.Layer<never, never, TRandom.TRandom> = Layer.effect(
 )
 
 /** @internal */
-export const next: STM.STM<TRandom.TRandom, never, number> = core.flatMap(Tag, (random) => random.next)
+export const next: STM.STM<"TRandom", never, number> = core.flatMap(Tag, (random) => random.next)
 
 /** @internal */
-export const nextBoolean: STM.STM<TRandom.TRandom, never, boolean> = core.flatMap(Tag, (random) => random.nextBoolean)
+export const nextBoolean: STM.STM<"TRandom", never, boolean> = core.flatMap(Tag, (random) => random.nextBoolean)
 
 /** @internal */
-export const nextInt: STM.STM<TRandom.TRandom, never, number> = core.flatMap(Tag, (random) => random.nextInt)
+export const nextInt: STM.STM<"TRandom", never, number> = core.flatMap(Tag, (random) => random.nextInt)
 
 /** @internal */
-export const nextIntBetween = (low: number, high: number): STM.STM<TRandom.TRandom, never, number> =>
+export const nextIntBetween = (low: number, high: number): STM.STM<"TRandom", never, number> =>
   core.flatMap(Tag, (random) => random.nextIntBetween(low, high))
 
 /** @internal */
-export const nextRange = (min: number, max: number): STM.STM<TRandom.TRandom, never, number> =>
+export const nextRange = (min: number, max: number): STM.STM<"TRandom", never, number> =>
   core.flatMap(Tag, (random) => random.nextRange(min, max))
 
 /** @internal */
-export const shuffle = <A>(elements: Iterable<A>): STM.STM<TRandom.TRandom, never, Array<A>> =>
+export const shuffle = <A>(elements: Iterable<A>): STM.STM<"TRandom", never, Array<A>> =>
   core.flatMap(Tag, (random) => random.shuffle(elements))

--- a/packages/effect/src/internal/stm/tReentrantLock.ts
+++ b/packages/effect/src/internal/stm/tReentrantLock.ts
@@ -4,7 +4,6 @@ import * as FiberId from "../../FiberId.js"
 import { dual } from "../../Function.js"
 import * as HashMap from "../../HashMap.js"
 import * as Option from "../../Option.js"
-import type * as Scope from "../../Scope.js"
 import type * as STM from "../../STM.js"
 import type * as TReentrantLock from "../../TReentrantLock.js"
 import type * as TRef from "../../TRef.js"
@@ -225,7 +224,7 @@ export const fiberWriteLocks = (self: TReentrantLock.TReentrantLock): STM.STM<ne
   )
 
 /** @internal */
-export const lock = (self: TReentrantLock.TReentrantLock): Effect.Effect<Scope.Scope, never, number> => writeLock(self)
+export const lock = (self: TReentrantLock.TReentrantLock): Effect.Effect<"Scope", never, number> => writeLock(self)
 
 /** @internal */
 export const locked = (self: TReentrantLock.TReentrantLock): STM.STM<never, never, boolean> =>
@@ -242,7 +241,7 @@ export const make: STM.STM<never, never, TReentrantLock.TReentrantLock> = core.m
 )
 
 /** @internal */
-export const readLock = (self: TReentrantLock.TReentrantLock): Effect.Effect<Scope.Scope, never, number> =>
+export const readLock = (self: TReentrantLock.TReentrantLock): Effect.Effect<"Scope", never, number> =>
   Effect.acquireRelease(
     core.commit(acquireRead(self)),
     () => core.commit(releaseRead(self))
@@ -331,7 +330,7 @@ export const withWriteLock = dual<
   ))
 
 /** @internal */
-export const writeLock = (self: TReentrantLock.TReentrantLock): Effect.Effect<Scope.Scope, never, number> =>
+export const writeLock = (self: TReentrantLock.TReentrantLock): Effect.Effect<"Scope", never, number> =>
   Effect.acquireRelease(
     core.commit(acquireWrite(self)),
     () => core.commit(releaseWrite(self))

--- a/packages/effect/src/internal/stm/tSemaphore.ts
+++ b/packages/effect/src/internal/stm/tSemaphore.ts
@@ -1,7 +1,6 @@
 import * as Cause from "../../Cause.js"
 import * as Effect from "../../Effect.js"
 import { dual } from "../../Function.js"
-import type * as Scope from "../../Scope.js"
 import * as STM from "../../STM.js"
 import type * as TRef from "../../TRef.js"
 import type * as TSemaphore from "../../TSemaphore.js"
@@ -94,13 +93,13 @@ export const withPermits = dual<
   ))
 
 /** @internal */
-export const withPermitScoped = (self: TSemaphore.TSemaphore): Effect.Effect<Scope.Scope, never, void> =>
+export const withPermitScoped = (self: TSemaphore.TSemaphore): Effect.Effect<"Scope", never, void> =>
   withPermitsScoped(self, 1)
 
 /** @internal */
 export const withPermitsScoped = dual<
-  (permits: number) => (self: TSemaphore.TSemaphore) => Effect.Effect<Scope.Scope, never, void>,
-  (self: TSemaphore.TSemaphore, permits: number) => Effect.Effect<Scope.Scope, never, void>
+  (permits: number) => (self: TSemaphore.TSemaphore) => Effect.Effect<"Scope", never, void>,
+  (self: TSemaphore.TSemaphore, permits: number) => Effect.Effect<"Scope", never, void>
 >(2, (self, permits) =>
   Effect.acquireReleaseInterruptible(
     core.commit(acquireN(self, permits)),

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -604,9 +604,9 @@ export const asyncOption = <R, E, A>(
 
 /** @internal */
 export const asyncScoped = <R, E, A>(
-  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<R | Scope.Scope, E, unknown>,
+  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<R | "Scope", E, unknown>,
   outputBuffer = 16
-): Stream.Stream<Exclude<R, Scope.Scope>, E, A> =>
+): Stream.Stream<Exclude<R, "Scope">, E, A> =>
   pipe(
     Effect.acquireRelease(
       Queue.bounded<Take.Take<E, A>>(outputBuffer),
@@ -717,17 +717,17 @@ export const broadcast = dual<
     maximumLag: number
   ) => <R, E, A>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.Stream.DynamicTuple<Stream.Stream<never, E, A>, N>>,
+  ) => Effect.Effect<"Scope" | R, never, Stream.Stream.DynamicTuple<Stream.Stream<never, E, A>, N>>,
   <R, E, A, N extends number>(
     self: Stream.Stream<R, E, A>,
     n: N,
     maximumLag: number
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.Stream.DynamicTuple<Stream.Stream<never, E, A>, N>>
+  ) => Effect.Effect<"Scope" | R, never, Stream.Stream.DynamicTuple<Stream.Stream<never, E, A>, N>>
 >(3, <R, E, A, N extends number>(
   self: Stream.Stream<R, E, A>,
   n: N,
   maximumLag: number
-): Effect.Effect<R | Scope.Scope, never, Stream.Stream.DynamicTuple<Stream.Stream<never, E, A>, N>> =>
+): Effect.Effect<R | "Scope", never, Stream.Stream.DynamicTuple<Stream.Stream<never, E, A>, N>> =>
   pipe(
     self,
     broadcastedQueues(n, maximumLag),
@@ -743,15 +743,15 @@ export const broadcast = dual<
 export const broadcastDynamic = dual<
   (
     maximumLag: number
-  ) => <R, E, A>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, Stream.Stream<never, E, A>>,
+  ) => <R, E, A>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, Stream.Stream<never, E, A>>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     maximumLag: number
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.Stream<never, E, A>>
+  ) => Effect.Effect<"Scope" | R, never, Stream.Stream<never, E, A>>
 >(2, <R, E, A>(
   self: Stream.Stream<R, E, A>,
   maximumLag: number
-): Effect.Effect<R | Scope.Scope, never, Stream.Stream<never, E, A>> =>
+): Effect.Effect<R | "Scope", never, Stream.Stream<never, E, A>> =>
   pipe(
     self,
     broadcastedQueuesDynamic(maximumLag),
@@ -765,17 +765,17 @@ export const broadcastedQueues = dual<
     maximumLag: number
   ) => <R, E, A>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>,
+  ) => Effect.Effect<"Scope" | R, never, Stream.Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>,
   <R, E, A, N extends number>(
     self: Stream.Stream<R, E, A>,
     n: N,
     maximumLag: number
-  ) => Effect.Effect<Scope.Scope | R, never, Stream.Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>
+  ) => Effect.Effect<"Scope" | R, never, Stream.Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>>
 >(3, <R, E, A, N extends number>(
   self: Stream.Stream<R, E, A>,
   n: N,
   maximumLag: number
-): Effect.Effect<R | Scope.Scope, never, Stream.Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>> =>
+): Effect.Effect<R | "Scope", never, Stream.Stream.DynamicTuple<Queue.Dequeue<Take.Take<E, A>>, N>> =>
   Effect.flatMap(PubSub.bounded<Take.Take<E, A>>(maximumLag), (pubsub) =>
     pipe(
       Effect.all(Array.from({ length: n }, () => PubSub.subscribe(pubsub))) as Effect.Effect<
@@ -792,15 +792,15 @@ export const broadcastedQueuesDynamic = dual<
     maximumLag: number
   ) => <R, E, A>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, never, Effect.Effect<Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>>,
+  ) => Effect.Effect<"Scope" | R, never, Effect.Effect<"Scope", never, Queue.Dequeue<Take.Take<E, A>>>>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     maximumLag: number
-  ) => Effect.Effect<Scope.Scope | R, never, Effect.Effect<Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>>
+  ) => Effect.Effect<"Scope" | R, never, Effect.Effect<"Scope", never, Queue.Dequeue<Take.Take<E, A>>>>
 >(2, <R, E, A>(
   self: Stream.Stream<R, E, A>,
   maximumLag: number
-): Effect.Effect<R | Scope.Scope, never, Effect.Effect<Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>> =>
+): Effect.Effect<R | "Scope", never, Effect.Effect<"Scope", never, Queue.Dequeue<Take.Take<E, A>>>> =>
   Effect.map(toPubSub(self, maximumLag), PubSub.subscribe))
 
 /** @internal */
@@ -961,7 +961,7 @@ const bufferUnbounded = <R, E, A>(self: Stream.Stream<R, E, A>): Stream.Stream<R
 
 /** @internal */
 const bufferSignal = <R, E, A>(
-  scoped: Effect.Effect<Scope.Scope, never, Queue.Queue<readonly [Take.Take<E, A>, Deferred.Deferred<never, void>]>>,
+  scoped: Effect.Effect<"Scope", never, Queue.Queue<readonly [Take.Take<E, A>, Deferred.Deferred<never, void>]>>,
   bufferChannel: Channel.Channel<R, unknown, unknown, unknown, E, Chunk.Chunk<A>, void>
 ): Channel.Channel<R, unknown, unknown, unknown, E, Chunk.Chunk<A>, void> => {
   const producer = (
@@ -1802,7 +1802,7 @@ export const distributedWith = dual<
   ) => <R, E>(
     self: Stream.Stream<R, E, A>
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Stream.Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>
   >,
@@ -1814,7 +1814,7 @@ export const distributedWith = dual<
       readonly decide: (a: A) => Effect.Effect<never, never, Predicate<number>>
     }
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Stream.Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>
   >
@@ -1828,7 +1828,7 @@ export const distributedWith = dual<
       readonly decide: (a: A) => Effect.Effect<never, never, Predicate<number>>
     }
   ): Effect.Effect<
-    R | Scope.Scope,
+    R | "Scope",
     never,
     Stream.Stream.DynamicTuple<Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>, N>
   > =>
@@ -1897,7 +1897,7 @@ export const distributedWithDynamic = dual<
   ) => <R>(
     self: Stream.Stream<R, E, A>
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
   >,
@@ -1908,7 +1908,7 @@ export const distributedWithDynamic = dual<
       readonly decide: (a: A) => Effect.Effect<never, never, Predicate<number>>
     }
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
   >
@@ -1919,7 +1919,7 @@ export const distributedWithDynamic = dual<
     readonly decide: (a: A) => Effect.Effect<never, never, Predicate<number>>
   }
 ): Effect.Effect<
-  R | Scope.Scope,
+  R | "Scope",
   never,
   Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
 > => distributedWithDynamicCallback(self, options.maximumLag, options.decide, () => Effect.unit))
@@ -1933,7 +1933,7 @@ export const distributedWithDynamicCallback = dual<
   ) => <R>(
     self: Stream.Stream<R, E, A>
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
   >,
@@ -1943,7 +1943,7 @@ export const distributedWithDynamicCallback = dual<
     decide: (a: A) => Effect.Effect<never, never, Predicate<number>>,
     done: (exit: Exit.Exit<Option.Option<E>, never>) => Effect.Effect<never, never, _>
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     never,
     Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
   >
@@ -1953,7 +1953,7 @@ export const distributedWithDynamicCallback = dual<
   decide: (a: A) => Effect.Effect<never, never, Predicate<number>>,
   done: (exit: Exit.Exit<Option.Option<E>, never>) => Effect.Effect<never, never, _>
 ): Effect.Effect<
-  R | Scope.Scope,
+  R | "Scope",
   never,
   Effect.Effect<never, never, [number, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>]>
 > =>
@@ -2879,7 +2879,7 @@ export const fromChunkPubSub: {
   <A>(pubsub: PubSub.PubSub<Chunk.Chunk<A>>, options: {
     readonly scoped: true
     readonly shutdown?: boolean | undefined
-  }): Effect.Effect<Scope.Scope, never, Stream.Stream<never, never, A>>
+  }): Effect.Effect<"Scope", never, Stream.Stream<never, never, A>>
   <A>(pubsub: PubSub.PubSub<Chunk.Chunk<A>>, options?: {
     readonly scoped?: false | undefined
     readonly shutdown?: boolean | undefined
@@ -2942,7 +2942,7 @@ export const fromPubSub: {
     readonly scoped: true
     readonly maxChunkSize?: number | undefined
     readonly shutdown?: boolean | undefined
-  }): Effect.Effect<Scope.Scope, never, Stream.Stream<never, never, A>>
+  }): Effect.Effect<"Scope", never, Stream.Stream<never, never, A>>
   <A>(pubsub: PubSub.PubSub<A>, options?: {
     readonly scoped?: false | undefined
     readonly maxChunkSize?: number | undefined
@@ -3030,8 +3030,8 @@ export const fromIteratorSucceed = <A>(
 
 /** @internal */
 export const fromPull = <R, R2, E, A>(
-  effect: Effect.Effect<R | Scope.Scope, never, Effect.Effect<R2, Option.Option<E>, Chunk.Chunk<A>>>
-): Stream.Stream<Exclude<R, Scope.Scope> | R2, E, A> => pipe(effect, Effect.map(repeatEffectChunkOption), unwrapScoped)
+  effect: Effect.Effect<R | "Scope", never, Effect.Effect<R2, Option.Option<E>, Chunk.Chunk<A>>>
+): Stream.Stream<Exclude<R, "Scope"> | R2, E, A> => pipe(effect, Effect.map(repeatEffectChunkOption), unwrapScoped)
 
 /** @internal */
 export const fromQueue = <A>(
@@ -4261,15 +4261,15 @@ export const peel = dual<
     sink: Sink.Sink<R2, E2, A, A, Z>
   ) => <R, E>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, [Z, Stream.Stream<never, E, A>]>,
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, [Z, Stream.Stream<never, E, A>]>,
   <R, E, R2, E2, A, Z>(
     self: Stream.Stream<R, E, A>,
     sink: Sink.Sink<R2, E2, A, A, Z>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, [Z, Stream.Stream<never, E, A>]>
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, [Z, Stream.Stream<never, E, A>]>
 >(2, <R, E, R2, E2, A, Z>(
   self: Stream.Stream<R, E, A>,
   sink: Sink.Sink<R2, E2, A, A, Z>
-): Effect.Effect<R | R2 | Scope.Scope, E2 | E, [Z, Stream.Stream<never, E, A>]> => {
+): Effect.Effect<R | R2 | "Scope", E2 | E, [Z, Stream.Stream<never, E, A>]> => {
   type Signal = Emit | Halt | End
   const OP_EMIT = "Emit" as const
   type OP_EMIT = typeof OP_EMIT
@@ -4387,7 +4387,7 @@ export const partition: {
   ): <R, E>(
     self: Stream.Stream<R, E, C>
   ) => Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     E,
     [excluded: Stream.Stream<never, E, Exclude<C, B>>, satisfying: Stream.Stream<never, E, B>]
   >
@@ -4398,7 +4398,7 @@ export const partition: {
     }
   ): <R, E>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<Scope.Scope | R, E, [excluded: Stream.Stream<never, E, A>, satisfying: Stream.Stream<never, E, A>]>
+  ) => Effect.Effect<"Scope" | R, E, [excluded: Stream.Stream<never, E, A>, satisfying: Stream.Stream<never, E, A>]>
   <R, E, C extends A, B extends A, A = C>(
     self: Stream.Stream<R, E, C>,
     refinement: Refinement<A, B>,
@@ -4406,7 +4406,7 @@ export const partition: {
       bufferSize?: number | undefined
     }
   ): Effect.Effect<
-    Scope.Scope | R,
+    "Scope" | R,
     E,
     [excluded: Stream.Stream<never, E, Exclude<C, B>>, satisfying: Stream.Stream<never, E, B>]
   >
@@ -4416,7 +4416,7 @@ export const partition: {
     options?: {
       bufferSize?: number | undefined
     }
-  ): Effect.Effect<Scope.Scope | R, E, [excluded: Stream.Stream<never, E, A>, satisfying: Stream.Stream<never, E, A>]>
+  ): Effect.Effect<"Scope" | R, E, [excluded: Stream.Stream<never, E, A>, satisfying: Stream.Stream<never, E, A>]>
 } = dual(
   (args) => typeof args[1] === "function",
   <R, E, A>(
@@ -4426,7 +4426,7 @@ export const partition: {
       readonly bufferSize?: number | undefined
     }
   ): Effect.Effect<
-    R | Scope.Scope,
+    R | "Scope",
     E,
     [Stream.Stream<never, E, A>, Stream.Stream<never, E, A>]
   > =>
@@ -4447,7 +4447,7 @@ export const partitionEither = dual<
   ) => <R, E>(
     self: Stream.Stream<R, E, A>
   ) => Effect.Effect<
-    Scope.Scope | R2 | R,
+    "Scope" | R2 | R,
     E2 | E,
     [left: Stream.Stream<never, E2 | E, A2>, right: Stream.Stream<never, E2 | E, A3>]
   >,
@@ -4458,7 +4458,7 @@ export const partitionEither = dual<
       readonly bufferSize?: number | undefined
     }
   ) => Effect.Effect<
-    Scope.Scope | R2 | R,
+    "Scope" | R2 | R,
     E2 | E,
     [left: Stream.Stream<never, E2 | E, A2>, right: Stream.Stream<never, E2 | E, A3>]
   >
@@ -4471,7 +4471,7 @@ export const partitionEither = dual<
       readonly bufferSize?: number | undefined
     }
   ): Effect.Effect<
-    R | R2 | Scope.Scope,
+    R | R2 | "Scope",
     E | E2,
     [Stream.Stream<never, E | E2, A2>, Stream.Stream<never, E | E2, A3>]
   > =>
@@ -5198,11 +5198,11 @@ export const runFoldEffect = dual<
 
 /** @internal */
 export const runFoldScoped = dual<
-  <S, A>(s: S, f: (s: S, a: A) => S) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, E, S>,
-  <R, E, S, A>(self: Stream.Stream<R, E, A>, s: S, f: (s: S, a: A) => S) => Effect.Effect<Scope.Scope | R, E, S>
+  <S, A>(s: S, f: (s: S, a: A) => S) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, E, S>,
+  <R, E, S, A>(self: Stream.Stream<R, E, A>, s: S, f: (s: S, a: A) => S) => Effect.Effect<"Scope" | R, E, S>
 >(
   3,
-  <R, E, S, A>(self: Stream.Stream<R, E, A>, s: S, f: (s: S, a: A) => S): Effect.Effect<R | Scope.Scope, E, S> =>
+  <R, E, S, A>(self: Stream.Stream<R, E, A>, s: S, f: (s: S, a: A) => S): Effect.Effect<R | "Scope", E, S> =>
     pipe(self, runFoldWhileScoped(s, constTrue, f))
 )
 
@@ -5211,17 +5211,17 @@ export const runFoldScopedEffect = dual<
   <S, A, R2, E2>(
     s: S,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, S>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, S>,
   <R, E, S, A, R2, E2>(
     self: Stream.Stream<R, E, A>,
     s: S,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, S>
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, S>
 >(3, <R, E, S, A, R2, E2>(
   self: Stream.Stream<R, E, A>,
   s: S,
   f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-): Effect.Effect<R | R2 | Scope.Scope, E | E2, S> => pipe(self, runFoldWhileScopedEffect(s, constTrue, f)))
+): Effect.Effect<R | R2 | "Scope", E | E2, S> => pipe(self, runFoldWhileScopedEffect(s, constTrue, f)))
 
 /** @internal */
 export const runFoldWhile = dual<
@@ -5264,19 +5264,19 @@ export const runFoldWhileScoped = dual<
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => S
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, E, S>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, E, S>,
   <R, E, S, A>(
     self: Stream.Stream<R, E, A>,
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => S
-  ) => Effect.Effect<Scope.Scope | R, E, S>
+  ) => Effect.Effect<"Scope" | R, E, S>
 >(4, <R, E, S, A>(
   self: Stream.Stream<R, E, A>,
   s: S,
   cont: Predicate<S>,
   f: (s: S, a: A) => S
-): Effect.Effect<R | Scope.Scope, E, S> => pipe(self, runScoped(_sink.fold(s, cont, f))))
+): Effect.Effect<R | "Scope", E, S> => pipe(self, runScoped(_sink.fold(s, cont, f))))
 
 /** @internal */
 export const runFoldWhileScopedEffect = dual<
@@ -5284,19 +5284,19 @@ export const runFoldWhileScopedEffect = dual<
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, S>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, S>,
   <R, E, S, A, R2, E2>(
     self: Stream.Stream<R, E, A>,
     s: S,
     cont: Predicate<S>,
     f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, S>
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, S>
 >(4, <R, E, S, A, R2, E2>(
   self: Stream.Stream<R, E, A>,
   s: S,
   cont: Predicate<S>,
   f: (s: S, a: A) => Effect.Effect<R2, E2, S>
-): Effect.Effect<R | R2 | Scope.Scope, E | E2, S> => pipe(self, runScoped(_sink.foldEffect(s, cont, f))))
+): Effect.Effect<R | R2 | "Scope", E | E2, S> => pipe(self, runScoped(_sink.foldEffect(s, cont, f))))
 
 /** @internal */
 export const runForEach = dual<
@@ -5330,29 +5330,29 @@ export const runForEachChunk = dual<
 export const runForEachChunkScoped = dual<
   <A, R2, E2, _>(
     f: (a: Chunk.Chunk<A>) => Effect.Effect<R2, E2, _>
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, void>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, void>,
   <R, E, A, R2, E2, _>(
     self: Stream.Stream<R, E, A>,
     f: (a: Chunk.Chunk<A>) => Effect.Effect<R2, E2, _>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, void>
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, void>
 >(2, <R, E, A, R2, E2, _>(
   self: Stream.Stream<R, E, A>,
   f: (a: Chunk.Chunk<A>) => Effect.Effect<R2, E2, _>
-): Effect.Effect<R | R2 | Scope.Scope, E | E2, void> => pipe(self, runScoped(_sink.forEachChunk(f))))
+): Effect.Effect<R | R2 | "Scope", E | E2, void> => pipe(self, runScoped(_sink.forEachChunk(f))))
 
 /** @internal */
 export const runForEachScoped = dual<
   <A, R2, E2, _>(
     f: (a: A) => Effect.Effect<R2, E2, _>
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<R2 | R | Scope.Scope, E2 | E, void>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<R2 | R | "Scope", E2 | E, void>,
   <R, E, A, R2, E2, _>(
     self: Stream.Stream<R, E, A>,
     f: (a: A) => Effect.Effect<R2, E2, _>
-  ) => Effect.Effect<R2 | R | Scope.Scope, E2 | E, void>
+  ) => Effect.Effect<R2 | R | "Scope", E2 | E, void>
 >(2, <R, E, A, R2, E2, _>(
   self: Stream.Stream<R, E, A>,
   f: (a: A) => Effect.Effect<R2, E2, _>
-): Effect.Effect<R | R2 | Scope.Scope, E | E2, void> => pipe(self, runScoped(_sink.forEach(f))))
+): Effect.Effect<R | R2 | "Scope", E | E2, void> => pipe(self, runScoped(_sink.forEach(f))))
 
 /** @internal */
 export const runForEachWhile = dual<
@@ -5372,15 +5372,15 @@ export const runForEachWhile = dual<
 export const runForEachWhileScoped = dual<
   <A, R2, E2>(
     f: (a: A) => Effect.Effect<R2, E2, boolean>
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<R2 | R | Scope.Scope, E2 | E, void>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<R2 | R | "Scope", E2 | E, void>,
   <R, E, A, R2, E2>(
     self: Stream.Stream<R, E, A>,
     f: (a: A) => Effect.Effect<R2, E2, boolean>
-  ) => Effect.Effect<R2 | R | Scope.Scope, E2 | E, void>
+  ) => Effect.Effect<R2 | R | "Scope", E2 | E, void>
 >(2, <R, E, A, R2, E2>(
   self: Stream.Stream<R, E, A>,
   f: (a: A) => Effect.Effect<R2, E2, boolean>
-): Effect.Effect<R | R2 | Scope.Scope, E | E2, void> => pipe(self, runScoped(_sink.forEachWhile(f))))
+): Effect.Effect<R | R2 | "Scope", E | E2, void> => pipe(self, runScoped(_sink.forEachWhile(f))))
 
 /** @internal */
 export const runHead = <R, E, A>(self: Stream.Stream<R, E, A>): Effect.Effect<R, E, Option.Option<A>> =>
@@ -5400,15 +5400,15 @@ export const runIntoPubSub = dual<
 export const runIntoPubSubScoped = dual<
   <E, A>(
     pubsub: PubSub.PubSub<Take.Take<E, A>>
-  ) => <R>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, void>,
+  ) => <R>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, void>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     pubsub: PubSub.PubSub<Take.Take<E, A>>
-  ) => Effect.Effect<Scope.Scope | R, never, void>
+  ) => Effect.Effect<"Scope" | R, never, void>
 >(2, <R, E, A>(
   self: Stream.Stream<R, E, A>,
   pubsub: PubSub.PubSub<Take.Take<E, A>>
-): Effect.Effect<R | Scope.Scope, never, void> => pipe(self, runIntoQueueScoped(pubsub)))
+): Effect.Effect<R | "Scope", never, void> => pipe(self, runIntoQueueScoped(pubsub)))
 
 /** @internal */
 export const runIntoQueue = dual<
@@ -5424,15 +5424,15 @@ export const runIntoQueue = dual<
 export const runIntoQueueElementsScoped = dual<
   <E, A>(
     queue: Queue.Enqueue<Exit.Exit<Option.Option<E>, A>>
-  ) => <R>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, void>,
+  ) => <R>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, void>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     queue: Queue.Enqueue<Exit.Exit<Option.Option<E>, A>>
-  ) => Effect.Effect<Scope.Scope | R, never, void>
+  ) => Effect.Effect<"Scope" | R, never, void>
 >(2, <R, E, A>(
   self: Stream.Stream<R, E, A>,
   queue: Queue.Enqueue<Exit.Exit<Option.Option<E>, A>>
-): Effect.Effect<R | Scope.Scope, never, void> => {
+): Effect.Effect<R | "Scope", never, void> => {
   const writer: Channel.Channel<R, E, Chunk.Chunk<A>, unknown, never, Exit.Exit<Option.Option<E>, A>, unknown> = core
     .readWithCause({
       onInput: (input: Chunk.Chunk<A>) =>
@@ -5455,15 +5455,15 @@ export const runIntoQueueElementsScoped = dual<
 export const runIntoQueueScoped = dual<
   <E, A>(
     queue: Queue.Enqueue<Take.Take<E, A>>
-  ) => <R>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, void>,
+  ) => <R>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, void>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     queue: Queue.Enqueue<Take.Take<E, A>>
-  ) => Effect.Effect<Scope.Scope | R, never, void>
+  ) => Effect.Effect<"Scope" | R, never, void>
 >(2, <R, E, A>(
   self: Stream.Stream<R, E, A>,
   queue: Queue.Enqueue<Take.Take<E, A>>
-): Effect.Effect<R | Scope.Scope, never, void> => {
+): Effect.Effect<R | "Scope", never, void> => {
   const writer: Channel.Channel<R, E, Chunk.Chunk<A>, unknown, never, Take.Take<E, A>, unknown> = core
     .readWithCause({
       onInput: (input: Chunk.Chunk<A>) => core.flatMap(core.write(_take.chunk(input)), () => writer),
@@ -5487,15 +5487,15 @@ export const runLast = <R, E, A>(self: Stream.Stream<R, E, A>): Effect.Effect<R,
 export const runScoped = dual<
   <R2, E2, A, A2>(
     sink: Sink.Sink<R2, E2, A, unknown, A2>
-  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, A2>,
+  ) => <R, E>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R2 | R, E2 | E, A2>,
   <R, E, R2, E2, A, A2>(
     self: Stream.Stream<R, E, A>,
     sink: Sink.Sink<R2, E2, A, unknown, A2>
-  ) => Effect.Effect<Scope.Scope | R2 | R, E2 | E, A2>
+  ) => Effect.Effect<"Scope" | R2 | R, E2 | E, A2>
 >(2, <R, E, R2, E2, A, A2>(
   self: Stream.Stream<R, E, A>,
   sink: Sink.Sink<R2, E2, A, unknown, A2>
-): Effect.Effect<R | R2 | Scope.Scope, E | E2, A2> =>
+): Effect.Effect<R | R2 | "Scope", E | E2, A2> =>
   pipe(
     toChannel(self),
     channel.pipeToOrFail(_sink.toChannel(sink)),
@@ -5690,7 +5690,7 @@ export const scanEffect = dual<
 /** @internal */
 export const scoped = <R, E, A>(
   effect: Effect.Effect<R, E, A>
-): Stream.Stream<Exclude<R, Scope.Scope>, E, A> =>
+): Stream.Stream<Exclude<R, "Scope">, E, A> =>
   new StreamImpl(channel.ensuring(channel.scoped(pipe(effect, Effect.map(Chunk.of))), Effect.unit))
 
 /** @internal */
@@ -6561,15 +6561,15 @@ export const timeoutTo = dual<
 export const toPubSub = dual<
   (
     capacity: number
-  ) => <R, E, A>(self: Stream.Stream<R, E, A>) => Effect.Effect<Scope.Scope | R, never, PubSub.PubSub<Take.Take<E, A>>>,
+  ) => <R, E, A>(self: Stream.Stream<R, E, A>) => Effect.Effect<"Scope" | R, never, PubSub.PubSub<Take.Take<E, A>>>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     capacity: number
-  ) => Effect.Effect<Scope.Scope | R, never, PubSub.PubSub<Take.Take<E, A>>>
+  ) => Effect.Effect<"Scope" | R, never, PubSub.PubSub<Take.Take<E, A>>>
 >(2, <R, E, A>(
   self: Stream.Stream<R, E, A>,
   capacity: number
-): Effect.Effect<R | Scope.Scope, never, PubSub.PubSub<Take.Take<E, A>>> =>
+): Effect.Effect<R | "Scope", never, PubSub.PubSub<Take.Take<E, A>>> =>
   pipe(
     Effect.acquireRelease(
       PubSub.bounded<Take.Take<E, A>>(capacity),
@@ -6581,7 +6581,7 @@ export const toPubSub = dual<
 /** @internal */
 export const toPull = <R, E, A>(
   self: Stream.Stream<R, E, A>
-): Effect.Effect<R | Scope.Scope, never, Effect.Effect<R, Option.Option<E>, Chunk.Chunk<A>>> =>
+): Effect.Effect<R | "Scope", never, Effect.Effect<R, Option.Option<E>, Chunk.Chunk<A>>> =>
   Effect.map(channel.toPull(toChannel(self)), (pull) =>
     pipe(
       pull,
@@ -6603,7 +6603,7 @@ export const toQueue = dual<
     }
   ) => <R, E, A>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<R | Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>,
+  ) => Effect.Effect<R | "Scope", never, Queue.Dequeue<Take.Take<E, A>>>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     options?: {
@@ -6612,7 +6612,7 @@ export const toQueue = dual<
     } | {
       readonly strategy: "unbounded"
     }
-  ) => Effect.Effect<R | Scope.Scope, never, Queue.Dequeue<Take.Take<E, A>>>
+  ) => Effect.Effect<R | "Scope", never, Queue.Dequeue<Take.Take<E, A>>>
 >((args) => isStream(args[0]), <R, E, A>(
   self: Stream.Stream<R, E, A>,
   options?: {
@@ -6642,13 +6642,13 @@ export const toQueueOfElements = dual<
     readonly capacity?: number | undefined
   }) => <R, E, A>(
     self: Stream.Stream<R, E, A>
-  ) => Effect.Effect<R | Scope.Scope, never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>,
+  ) => Effect.Effect<R | "Scope", never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     options?: {
       readonly capacity?: number | undefined
     }
-  ) => Effect.Effect<R | Scope.Scope, never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>
+  ) => Effect.Effect<R | "Scope", never, Queue.Dequeue<Exit.Exit<Option.Option<E>, A>>>
 >((args) => isStream(args[0]), <R, E, A>(
   self: Stream.Stream<R, E, A>,
   options?: {
@@ -6835,7 +6835,7 @@ export const unwrap = <R, E, R2, E2, A>(
 /** @internal */
 export const unwrapScoped = <R, E, R2, E2, A>(
   effect: Effect.Effect<R, E, Stream.Stream<R2, E2, A>>
-): Stream.Stream<Exclude<R, Scope.Scope> | R2, E | E2, A> => flatten(scoped(effect))
+): Stream.Stream<Exclude<R, "Scope"> | R2, E | E2, A> => flatten(scoped(effect))
 
 /** @internal */
 export const updateService = dual<
@@ -6931,7 +6931,7 @@ export const withSpan = dual<
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
     }
-  ) => <R, E, A>(self: Stream.Stream<R, E, A>) => Stream.Stream<Exclude<R, Tracer.ParentSpan>, E, A>,
+  ) => <R, E, A>(self: Stream.Stream<R, E, A>) => Stream.Stream<Exclude<R, "ParentSpan">, E, A>,
   <R, E, A>(
     self: Stream.Stream<R, E, A>,
     name: string,
@@ -6942,7 +6942,7 @@ export const withSpan = dual<
       readonly root?: boolean | undefined
       readonly context?: Context.Context<never> | undefined
     }
-  ) => Stream.Stream<Exclude<R, Tracer.ParentSpan>, E, A>
+  ) => Stream.Stream<Exclude<R, "ParentSpan">, E, A>
 >(3, (self, name, options) => new StreamImpl(channel.withSpan(toChannel(self), name, options)))
 
 /** @internal */

--- a/packages/effect/src/internal/tracer.ts
+++ b/packages/effect/src/internal/tracer.ts
@@ -18,14 +18,10 @@ export const make = (options: Omit<Tracer.Tracer, Tracer.TracerTypeId>): Tracer.
 })
 
 /** @internal */
-export const tracerTag = Context.Tag<Tracer.Tracer>(
-  Symbol.for("effect/Tracer")
-)
+export const tracerTag = Context.Tag("Tracer")<Tracer.Tracer>()
 
 /** @internal */
-export const spanTag = Context.Tag<Tracer.ParentSpan>(
-  Symbol.for("effect/ParentSpan")
-)
+export const spanTag = Context.Tag("ParentSpan")<Tracer.ParentSpan>()
 
 const ids = globalValue("effect/Tracer/SpanId.ids", () => MutableRef.make(0))
 

--- a/packages/effect/test/Channel/environment.test.ts
+++ b/packages/effect/test/Channel/environment.test.ts
@@ -18,7 +18,7 @@ export interface NumberService extends Equal.Equal {
   readonly n: number
 }
 
-export const NumberService = Context.Tag<NumberService>()
+export const NumberService = Context.Tag("NumberService")<NumberService>()
 
 export class NumberServiceImpl implements NumberService {
   readonly [NumberServiceTypeId]: NumberServiceTypeId = NumberServiceTypeId

--- a/packages/effect/test/Channel/foreign.test.ts
+++ b/packages/effect/test/Channel/foreign.test.ts
@@ -12,7 +12,7 @@ import { assert, describe } from "vitest"
 describe("Channel.Foreign", () => {
   it.effect("Tag", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(tag, Channel.run, Effect.provideService(tag, 10))
       assert.deepEqual(result, 10)
     }))

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -7,17 +7,17 @@ import { assert, describe, expect, it } from "vitest"
 interface A {
   a: number
 }
-const A = Context.Tag<A>()
+const A = Context.Tag("A")<A>()
 
 interface B {
   b: number
 }
-const B = Context.Tag<B>()
+const B = Context.Tag("B")<B>()
 
 interface C {
   c: number
 }
-const C = Context.Tag<C>("C")
+const C = Context.Tag("C")<C>()
 
 describe("Context", () => {
   it("Tag.toJson()", () => {
@@ -34,8 +34,8 @@ describe("Context", () => {
   })
 
   it("global tag", () => {
-    const a = Context.Tag<number>("effect-test/Context/Tag")
-    const b = Context.Tag<number>("effect-test/Context/Tag")
+    const a = Context.Tag("a")<number>()
+    const b = Context.Tag("a")<number>()
     expect(a).toBe(b)
   })
 
@@ -46,10 +46,7 @@ describe("Context", () => {
     interface Bar {
       readonly _tag: "Bar"
     }
-    interface FooBar {
-      readonly FooBar: unique symbol
-    }
-    const Service = Context.Tag<FooBar, Foo | Bar>()
+    const Service = Context.Tag("FooBar")<Foo | Bar>()
     const context = Context.make(Service, { _tag: "Foo" })
     expect(Context.get(context, Service)).toStrictEqual({ _tag: "Foo" })
   })
@@ -153,13 +150,13 @@ describe("Context", () => {
       Context.add(A, a),
       Context.add(B, b),
       Context.add(C, c)
-    ) as Context.Context<A | B | C>
+    ) as Context.Context<"A" | "B" | "C">
     const newEnv = pipe(
       Context.empty(),
       Context.add(A, a),
       Context.add(B, { b: 3 })
-    ) as Context.Context<A | B | C>
-    const differ = Differ.environment<A | B | C>()
+    ) as Context.Context<"A" | "B" | "C">
+    const differ = Differ.environment<"A" | "B" | "C">()
     const patch = differ.diff(oldEnv, newEnv)
     const result = differ.patch(patch, oldEnv)
 
@@ -178,13 +175,13 @@ describe("Context", () => {
       Context.add(A, a),
       Context.add(B, b),
       Context.add(C, c)
-    ) as Context.Context<A | B | C>
+    ) as Context.Context<"A" | "B" | "C">
     const newEnv = pipe(
       Context.empty(),
       Context.add(A, a),
       Context.add(B, { b: 3 })
-    ) as Context.Context<A | B | C>
-    const differ = Differ.environment<A | B | C>()
+    ) as Context.Context<"A" | "B" | "C">
+    const differ = Differ.environment<"A" | "B" | "C">()
     const result = differ.diff(oldEnv, newEnv)
 
     assert.deepNestedPropertyVal(result, "first._tag", "AndThen")
@@ -236,7 +233,7 @@ describe("Context", () => {
   })
 
   it("isTag", () => {
-    expect(Context.isTag(Context.Tag())).toEqual(true)
+    expect(Context.isTag(Context.Tag("")())).toEqual(true)
     expect(Context.isContext(null)).toEqual(false)
   })
 })

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -23,7 +23,7 @@ describe("Context", () => {
   it("Tag.toJson()", () => {
     const json: any = A.toJSON()
     expect(json["_id"]).toEqual("Tag")
-    expect(json["identifier"]).toEqual(undefined)
+    expect(json["identifier"]).toEqual("A")
     expect(typeof json["stack"]).toEqual("string")
   })
 
@@ -211,7 +211,7 @@ describe("Context", () => {
       } catch (e) {
         assert.match(
           String(e),
-          new RegExp(/Error: Service not found: C \(defined at (.*)Context.test.ts:20:19\)/)
+          new RegExp(/Error: Service not found: C \(defined at (.*)Context.test.ts:20:26\)/)
         )
       }
     }

--- a/packages/effect/test/Effect/environment.test.ts
+++ b/packages/effect/test/Effect/environment.test.ts
@@ -8,13 +8,13 @@ interface NumberService {
   readonly n: number
 }
 
-const NumberService = Context.Tag<NumberService>()
+const NumberService = Context.Tag("NumberService")<NumberService>()
 
 interface StringService {
   readonly s: string
 }
 
-const StringService = Context.Tag<StringService>()
+const StringService = Context.Tag("StringService")<StringService>()
 
 describe("Effect", () => {
   it.effect("environment - provide is modular", () =>
@@ -49,7 +49,7 @@ describe("Effect", () => {
   it.effect("environment - async can use environment", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        Effect.async<NumberService, never, number>((cb) => cb(Effect.map(NumberService, ({ n }) => n))),
+        Effect.async<"NumberService", never, number>((cb) => cb(Effect.map(NumberService, ({ n }) => n))),
         Effect.provide(Context.make(NumberService, { n: 10 }))
       )
       assert.strictEqual(result, 10)
@@ -86,7 +86,7 @@ describe("Effect", () => {
     interface Service {
       foo: (x: string, y: number) => Effect.Effect<never, never, string>
     }
-    const Service = Context.Tag<Service>()
+    const Service = Context.Tag("Service")<Service>()
     const { foo } = Effect.serviceFunctions(Service)
     return pipe(
       Effect.gen(function*(_) {
@@ -105,7 +105,7 @@ describe("Effect", () => {
     interface Service {
       baz: Effect.Effect<never, never, string>
     }
-    const Service = Context.Tag<Service>()
+    const Service = Context.Tag("Service")<Service>()
     const { baz } = Effect.serviceConstants(Service)
     return pipe(
       Effect.gen(function*(_) {
@@ -125,7 +125,7 @@ describe("Effect", () => {
       foo: (x: string, y: number) => Effect.Effect<never, never, string>
       baz: Effect.Effect<never, never, string>
     }
-    const Service = Context.Tag<Service>()
+    const Service = Context.Tag("Service")<Service>()
     const { constants, functions } = Effect.serviceMembers(Service)
     return pipe(
       Effect.gen(function*(_) {

--- a/packages/effect/test/Effect/foreign.test.ts
+++ b/packages/effect/test/Effect/foreign.test.ts
@@ -23,7 +23,7 @@ describe("Foreign", () => {
     }))
   it.effect("Tag", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(tag, Effect.provideService(tag, 10))
       assert.deepEqual(result, 10)
     }))

--- a/packages/effect/test/Effect/provide-runtime.test.ts
+++ b/packages/effect/test/Effect/provide-runtime.test.ts
@@ -12,7 +12,7 @@ import { assert, describe } from "vitest"
 interface A {
   readonly value: number
 }
-const A = Context.Tag<A>()
+const A = Context.Tag("A")<A>()
 const LiveA = Layer.succeed(A, { value: 1 })
 const ref = FiberRef.unsafeMake(0)
 const LiveEnv = Layer.mergeAll(
@@ -26,10 +26,7 @@ describe("Effect", () => {
     const someServiceImpl = {
       value: 42
     } as const
-    interface SomeService {
-      readonly _: unique symbol
-    }
-    const SomeService = Context.Tag<SomeService, typeof someServiceImpl>()
+    const SomeService = Context.Tag("SomeService")<typeof someServiceImpl>()
     return Effect.gen(function*(_) {
       const rt = yield* _(Layer.succeedContext(Context.empty()), Layer.toRuntime)
       const pre = yield* _(Effect.context<never>())

--- a/packages/effect/test/Effect/query-nested.test.ts
+++ b/packages/effect/test/Effect/query-nested.test.ts
@@ -8,14 +8,8 @@ import * as Request from "effect/Request"
 import * as Resolver from "effect/RequestResolver"
 import { describe, expect } from "vitest"
 
-interface Counter {
-  readonly _: unique symbol
-}
-const Counter = Context.Tag<Counter, { count: number }>()
-interface Requests {
-  readonly _: unique symbol
-}
-const Requests = Context.Tag<Requests, { count: number }>()
+const Counter = Context.Tag("Counter")<{ count: number }>()
+const Requests = Context.Tag("Requests")<{ count: number }>()
 
 interface Parent {
   readonly id: number

--- a/packages/effect/test/Effect/query.test.ts
+++ b/packages/effect/test/Effect/query.test.ts
@@ -15,14 +15,8 @@ import * as TestClock from "effect/TestClock"
 import type { Concurrency } from "effect/Types"
 import { describe, expect } from "vitest"
 
-interface Counter {
-  readonly _: unique symbol
-}
-const Counter = Context.Tag<Counter, { count: number }>()
-interface Requests {
-  readonly _: unique symbol
-}
-const Requests = Context.Tag<Requests, { count: number }>()
+const Counter = Context.Tag("Counter")<{ count: number }>()
+const Requests = Context.Tag("Requests")<{ count: number }>()
 
 export const userIds: ReadonlyArray<number> = ReadonlyArray.range(1, 26)
 

--- a/packages/effect/test/Effect/scope-ref.test.ts
+++ b/packages/effect/test/Effect/scope-ref.test.ts
@@ -8,7 +8,7 @@ import * as Logger from "effect/Logger"
 import { assert, describe } from "vitest"
 
 const ref = FiberRef.unsafeMake(List.empty<string>())
-const env = Tag<"context", number>()
+const env = Tag("context")<number>()
 
 const withValue = (value: string) => Effect.locallyWith(ref, List.prepend(value))
 

--- a/packages/effect/test/FiberMap.test.ts
+++ b/packages/effect/test/FiberMap.test.ts
@@ -12,14 +12,36 @@ describe("FiberMap", () => {
           const map = yield* _(FiberMap.make<number>())
           yield* _(
             Effect.forEach(ReadonlyArray.range(1, 10), (i) =>
-              FiberMap.run(
-                map,
-                i,
-                Effect.onInterrupt(
-                  Effect.never,
-                  () => Ref.update(ref, (n) => n + 1)
-                )
+              Effect.onInterrupt(
+                Effect.never,
+                () => Ref.update(ref, (n) => n + 1)
+              ).pipe(
+                FiberMap.run(map, i)
               ))
+          )
+          yield* _(Effect.yieldNow())
+        }),
+        Effect.scoped
+      )
+
+      assert.strictEqual(yield* _(Ref.get(ref)), 10)
+    }))
+
+  it.effect("runtime", () =>
+    Effect.gen(function*(_) {
+      const ref = yield* _(Ref.make(0))
+      yield* _(
+        Effect.gen(function*(_) {
+          const map = yield* _(FiberMap.make<number>())
+          const run = yield* _(FiberMap.runtime(map)<never>())
+          ReadonlyArray.range(1, 10).forEach((i) =>
+            run(
+              i,
+              Effect.onInterrupt(
+                Effect.never,
+                () => Ref.update(ref, (n) => n + 1)
+              )
+            )
           )
           yield* _(Effect.yieldNow())
         }),

--- a/packages/effect/test/FiberSet.test.ts
+++ b/packages/effect/test/FiberSet.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Ref } from "effect"
+import { Effect, ReadonlyArray, Ref } from "effect"
 import * as it from "effect-test/utils/extend"
 import * as FiberSet from "effect/FiberSet"
 import { assert, describe } from "vitest"
@@ -11,14 +11,36 @@ describe("FiberSet", () => {
         Effect.gen(function*(_) {
           const set = yield* _(FiberSet.make())
           yield* _(
-            FiberSet.run(
-              set,
+            Effect.onInterrupt(
+              Effect.never,
+              () => Ref.update(ref, (n) => n + 1)
+            ).pipe(
+              FiberSet.run(set)
+            ),
+            Effect.replicateEffect(10)
+          )
+          yield* _(Effect.yieldNow())
+        }),
+        Effect.scoped
+      )
+
+      assert.strictEqual(yield* _(Ref.get(ref)), 10)
+    }))
+
+  it.effect("runtime", () =>
+    Effect.gen(function*(_) {
+      const ref = yield* _(Ref.make(0))
+      yield* _(
+        Effect.gen(function*(_) {
+          const set = yield* _(FiberSet.make())
+          const run = yield* _(FiberSet.runtime(set)<never>())
+          ReadonlyArray.range(1, 10).forEach(() =>
+            run(
               Effect.onInterrupt(
                 Effect.never,
                 () => Ref.update(ref, (n) => n + 1)
               )
-            ),
-            Effect.replicateEffect(10)
+            )
           )
           yield* _(Effect.yieldNow())
         }),

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -24,7 +24,7 @@ export const release3 = "Releasing Module 3"
 describe("Layer", () => {
   it.effect("layers can be acquired in parallel", () =>
     Effect.gen(function*($) {
-      const BoolTag = Context.Tag<boolean>()
+      const BoolTag = Context.Tag("boolean")<boolean>()
       const deferred = yield* $(Deferred.make<never, void>())
       const layer1 = Layer.effectContext<never, never, never>(Effect.never)
       const layer2 = Layer.scopedContext(
@@ -43,7 +43,7 @@ describe("Layer", () => {
     }))
   it.effect("preserves identity of acquired resources", () =>
     Effect.gen(function*($) {
-      const ChunkTag = Context.Tag<Ref.Ref<Chunk.Chunk<string>>>()
+      const ChunkTag = Context.Tag("Ref.Ref<Chunk.Chunk<string>>")<Ref.Ref<Chunk.Chunk<string>>>()
       const testRef = yield* $(Ref.make<Chunk.Chunk<string>>(Chunk.empty()))
       const layer = Layer.scoped(
         ChunkTag,
@@ -107,21 +107,21 @@ describe("Layer", () => {
       class Config {
         constructor(readonly value: number) {}
       }
-      const ConfigTag = Context.Tag<Config>()
+      const ConfigTag = Context.Tag("Config")<Config>()
       class A {
         constructor(readonly value: number) {}
       }
-      const ATag = Context.Tag<A>()
+      const ATag = Context.Tag("A")<A>()
       const aLayer = Layer.function(ConfigTag, ATag, (config) => new A(config.value))
       class B {
         constructor(readonly value: number) {}
       }
-      const BTag = Context.Tag<B>()
+      const BTag = Context.Tag("B")<B>()
       const bLayer = Layer.function(ATag, BTag, (_: A) => new B(_.value))
       class C {
         constructor(readonly value: number) {}
       }
-      const CTag = Context.Tag<C>()
+      const CTag = Context.Tag("C")<C>()
       const cLayer = Layer.function(ATag, CTag, (_: A) => new C(_.value))
       const fedB = bLayer.pipe(
         Layer.provideMerge(aLayer),
@@ -161,12 +161,12 @@ describe("Layer", () => {
       interface Bar {
         readonly bar: string
       }
-      const BarTag = Context.Tag<Bar>()
+      const BarTag = Context.Tag("Bar")<Bar>()
       interface Baz {
         readonly baz: string
       }
-      const BazTag = Context.Tag<Baz>()
-      const ScopedTag = Context.Tag<void>()
+      const BazTag = Context.Tag("Baz")<Baz>()
+      const ScopedTag = Context.Tag("void")<void>()
       const sleep = Effect.sleep(Duration.millis(100))
       const layer1 = Layer.fail("foo")
       const layer2 = Layer.succeed(BarTag, { bar: "bar" })
@@ -311,12 +311,12 @@ describe("Layer", () => {
         readonly name: string
         readonly value: number
       }
-      const ServiceATag = Context.Tag<ServiceA>()
+      const ServiceATag = Context.Tag("ServiceA")<ServiceA>()
       interface ServiceB {
         readonly name: string
       }
-      const ServiceBTag = Context.Tag<ServiceB>()
-      const StringTag = Context.Tag<string>()
+      const ServiceBTag = Context.Tag("ServiceB")<ServiceB>()
+      const StringTag = Context.Tag("string")<string>()
       const layer1 = Layer.succeed(ServiceATag, { name: "name", value: 1 })
       const layer2 = Layer.function(StringTag, ServiceBTag, (name) => ({ name }))
       const live = layer2.pipe(
@@ -334,9 +334,9 @@ describe("Layer", () => {
       yield* $(
         memoized,
         Effect.flatMap((layer) =>
-          Effect.context<Service1>().pipe(
+          Effect.context<"Service1">().pipe(
             Effect.provide(layer),
-            Effect.flatMap(() => Effect.context<Service1>().pipe(Effect.provide(layer)))
+            Effect.flatMap(() => Effect.context<"Service1">().pipe(Effect.provide(layer)))
           )
         ),
         Effect.scoped
@@ -347,7 +347,7 @@ describe("Layer", () => {
   it.scoped("fiberRef changes are memoized", () =>
     Effect.gen(function*($) {
       const fiberRef = yield* $(FiberRef.make<boolean>(false))
-      const tag = Context.Tag<boolean>()
+      const tag = Context.Tag("boolean")<boolean>()
       const layer1 = Layer.scopedDiscard(Effect.locallyScoped(fiberRef, true))
       const layer2 = Layer.effect(tag, FiberRef.get(fiberRef))
       const layer3 = layer2.pipe(
@@ -359,8 +359,8 @@ describe("Layer", () => {
     }))
   it.effect("provides a partial environment to an effect", () =>
     Effect.gen(function*($) {
-      const NumberTag = Context.Tag<number>()
-      const StringTag = Context.Tag<string>()
+      const NumberTag = Context.Tag("number")<number>()
+      const StringTag = Context.Tag("string")<string>()
       const needsNumberAndString = Effect.all([NumberTag, StringTag])
       const providesNumber = Layer.succeed(NumberTag, 10)
       const providesString = Layer.succeed(StringTag, "hi")
@@ -371,8 +371,8 @@ describe("Layer", () => {
     }))
   it.effect("to provides a partial environment to another layer", () =>
     Effect.gen(function*($) {
-      const StringTag = Context.Tag<string>()
-      const NumberRefTag = Context.Tag<Ref.Ref<number>>()
+      const StringTag = Context.Tag("string")<string>()
+      const NumberRefTag = Context.Tag("Ref<number>")<Ref.Ref<number>>()
       interface FooService {
         readonly ref: Ref.Ref<number>
         readonly string: string
@@ -385,8 +385,8 @@ describe("Layer", () => {
           ]
         >
       }
-      const FooTag = Context.Tag<FooService>()
-      const fooBuilder = Layer.context<string | Ref.Ref<number>>().pipe(
+      const FooTag = Context.Tag("FooService")<FooService>()
+      const fooBuilder = Layer.context<"string" | "Ref<number>">().pipe(
         Layer.map((context) => {
           const s = Context.get(context, StringTag)
           const ref = Context.get(context, NumberRefTag)
@@ -407,8 +407,8 @@ describe("Layer", () => {
     }))
   it.effect("andTo provides a partial environment to another layer", () =>
     Effect.gen(function*($) {
-      const StringTag = Context.Tag<string>()
-      const NumberRefTag = Context.Tag<Ref.Ref<number>>()
+      const StringTag = Context.Tag("string")<string>()
+      const NumberRefTag = Context.Tag("Ref<number>")<Ref.Ref<number>>()
       interface FooService {
         readonly ref: Ref.Ref<number>
         readonly string: string
@@ -421,8 +421,8 @@ describe("Layer", () => {
           ]
         >
       }
-      const FooTag = Context.Tag<FooService>()
-      const fooBuilder = Layer.context<string | Ref.Ref<number>>().pipe(
+      const FooTag = Context.Tag("FooService")<FooService>()
+      const fooBuilder = Layer.context<"string" | "Ref<number>">().pipe(
         Layer.map((context) => {
           const s = Context.get(context, StringTag)
           const ref = Context.get(context, NumberRefTag)
@@ -453,11 +453,11 @@ describe("Layer", () => {
       interface NumberService {
         readonly value: number
       }
-      const NumberTag = Context.Tag<NumberService>()
+      const NumberTag = Context.Tag("NumberService")<NumberService>()
       interface ToStringService {
         readonly value: string
       }
-      const ToStringTag = Context.Tag<ToStringService>()
+      const ToStringTag = Context.Tag("ToStringService")<ToStringService>()
       const layer = Layer.function(NumberTag, ToStringTag, (numberService) => ({
         value: numberService.value.toString()
       }))
@@ -480,8 +480,8 @@ describe("Layer", () => {
       }
       interface AgeService extends Pick<PersonService, "age"> {
       }
-      const PersonTag = Context.Tag<PersonService>()
-      const AgeTag = Context.Tag<AgeService>()
+      const PersonTag = Context.Tag("PersonService")<PersonService>()
+      const AgeTag = Context.Tag("AgeService")<AgeService>()
       const personLayer = Layer.succeed(PersonTag, { name: "User", age: 42 })
       const ageLayer = personLayer.pipe(Layer.project(PersonTag, AgeTag, (_) => ({ age: _.age })))
       const { age } = yield* $(AgeTag, Effect.provide(ageLayer))
@@ -614,7 +614,7 @@ describe("Layer", () => {
       interface BarService {
         readonly bar: string
       }
-      const BarTag = Context.Tag<BarService>()
+      const BarTag = Context.Tag("BarService")<BarService>()
       const ref: Ref.Ref<string> = yield* $(Ref.make("foo"))
       const layer = Layer.succeed(BarTag, { bar: "bar" }).pipe(
         Layer.tap((context) => Ref.set(ref, context.pipe(Context.get(BarTag)).bar))
@@ -628,7 +628,7 @@ describe("Layer", () => {
       interface BarService {
         readonly bar: string
       }
-      const BarTag = Context.Tag<BarService>()
+      const BarTag = Context.Tag("BarService")<BarService>()
       const fiberRef = FiberRef.unsafeMake(0)
       const layer = Layer.locally(fiberRef, 100)(
         Layer.effect(
@@ -648,7 +648,7 @@ describe("Layer", () => {
       interface BarService {
         readonly bar: string
       }
-      const BarTag = Context.Tag<BarService>()
+      const BarTag = Context.Tag("BarService")<BarService>()
       const fiberRef = FiberRef.unsafeMake(0)
       const layer = Layer.locallyWith(fiberRef, (n) => n + 1)(
         Layer.effect(
@@ -715,8 +715,8 @@ export class Service1 {
     return Effect.succeed(1)
   }
 }
-export const Service1Tag = Context.Tag<Service1>()
-export const makeLayer1 = (ref: Ref.Ref<Chunk.Chunk<string>>): Layer.Layer<never, never, Service1> => {
+export const Service1Tag = Context.Tag("Service1")<Service1>()
+export const makeLayer1 = (ref: Ref.Ref<Chunk.Chunk<string>>): Layer.Layer<never, never, "Service1"> => {
   return Layer.scoped(
     Service1Tag,
     Effect.acquireRelease(
@@ -730,8 +730,8 @@ export class Service2 {
     return Effect.succeed(2)
   }
 }
-export const Service2Tag = Context.Tag<Service2>()
-export const makeLayer2 = (ref: Ref.Ref<Chunk.Chunk<string>>): Layer.Layer<never, never, Service2> => {
+export const Service2Tag = Context.Tag("Service2")<Service2>()
+export const makeLayer2 = (ref: Ref.Ref<Chunk.Chunk<string>>): Layer.Layer<never, never, "Service2"> => {
   return Layer.scoped(
     Service2Tag,
     Effect.acquireRelease(
@@ -745,8 +745,8 @@ export class Service3 {
     return Effect.succeed(3)
   }
 }
-export const Service3Tag = Context.Tag<Service3>()
-export const makeLayer3 = (ref: Ref.Ref<Chunk.Chunk<string>>): Layer.Layer<never, never, Service3> => {
+export const Service3Tag = Context.Tag("Service3")<Service3>()
+export const makeLayer3 = (ref: Ref.Ref<Chunk.Chunk<string>>): Layer.Layer<never, never, "Service3"> => {
   return Layer.scoped(
     Service3Tag,
     Effect.acquireRelease(

--- a/packages/effect/test/Reloadable.test.ts
+++ b/packages/effect/test/Reloadable.test.ts
@@ -18,7 +18,7 @@ const DummyService: DummyService = {
   [DummyServiceTypeId]: DummyServiceTypeId
 }
 
-const Tag = Context.Tag<DummyService>()
+const Tag = Context.Tag("DummyService")<DummyService>()
 
 describe("Reloadable", () => {
   it.effect("initialization", () =>

--- a/packages/effect/test/STM.test.ts
+++ b/packages/effect/test/STM.test.ts
@@ -20,7 +20,7 @@ interface STMEnv {
   readonly ref: TRef.TRef<number>
 }
 
-const STMEnv = Context.Tag<STMEnv>()
+const STMEnv = Context.Tag("STMEnv")<STMEnv>()
 
 const makeSTMEnv = (n: number): Effect.Effect<never, never, STMEnv> =>
   pipe(

--- a/packages/effect/test/Scope.test.ts
+++ b/packages/effect/test/Scope.test.ts
@@ -39,7 +39,7 @@ const isAcquire = (self: Action): self is Use => self.op === OP_ACQUIRE
 const isUse = (self: Action): self is Use => self.op === OP_USE
 const isRelease = (self: Action): self is Use => self.op === OP_RELEASE
 
-const resource = (id: number, ref: Ref.Ref<ReadonlyArray<Action>>): Effect.Effect<Scope.Scope, never, number> => {
+const resource = (id: number, ref: Ref.Ref<ReadonlyArray<Action>>): Effect.Effect<"Scope", never, number> => {
   return pipe(
     Ref.update(ref, (actions) => [...actions, acquire(id)]),
     Effect.as(id),

--- a/packages/effect/test/Sink/environment.test.ts
+++ b/packages/effect/test/Sink/environment.test.ts
@@ -9,9 +9,9 @@ import { assert, describe } from "vitest"
 describe("Sink", () => {
   it.effect("contextWithSink", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<string>()
+      const tag = Context.Tag("string")<string>()
       const sink = pipe(
-        Sink.contextWithSink((env: Context.Context<string>) => Sink.succeed(pipe(env, Context.get(tag)))),
+        Sink.contextWithSink((env: Context.Context<"string">) => Sink.succeed(pipe(env, Context.get(tag)))),
         Sink.provideContext(pipe(Context.empty(), Context.add(tag, "use this")))
       )
       const result = yield* $(Stream.make("ignore this"), Stream.run(sink))

--- a/packages/effect/test/Sink/foreign.test.ts
+++ b/packages/effect/test/Sink/foreign.test.ts
@@ -15,7 +15,7 @@ const runSink = <R, E, A>(sink: Sink.Sink<R, E, unknown, unknown, A>) => Stream.
 describe("Channel.Foreign", () => {
   it.effect("Tag", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(tag, runSink, Effect.provideService(tag, 10))
       assert.deepEqual(result, 10)
     }))

--- a/packages/effect/test/Stream/environment.test.ts
+++ b/packages/effect/test/Stream/environment.test.ts
@@ -14,7 +14,7 @@ interface StringService {
   readonly string: string
 }
 
-const StringService = Context.Tag<StringService>()
+const StringService = Context.Tag("StringService")<StringService>()
 
 describe("Stream", () => {
   it.effect("context", () =>
@@ -24,7 +24,7 @@ describe("Stream", () => {
         Context.add(StringService, { string: "test" })
       )
       const result = yield* $(
-        Stream.context<StringService>(),
+        Stream.context<"StringService">(),
         Stream.map(Context.get(StringService)),
         Stream.provideContext(context),
         Stream.runCollect
@@ -51,7 +51,7 @@ describe("Stream", () => {
   it.effect("contextWithEffect - success", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        Stream.contextWithEffect((context: Context.Context<StringService>) =>
+        Stream.contextWithEffect((context: Context.Context<"StringService">) =>
           Effect.succeed(pipe(context, Context.get(StringService)))
         ),
         Stream.provideContext(
@@ -69,7 +69,7 @@ describe("Stream", () => {
   it.effect("contextWithEffect - fails", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        Stream.contextWithEffect((_: Context.Context<StringService>) => Effect.fail("boom")),
+        Stream.contextWithEffect((_: Context.Context<"StringService">) => Effect.fail("boom")),
         Stream.provideContext(
           pipe(
             Context.empty(),
@@ -85,7 +85,7 @@ describe("Stream", () => {
   it.effect("contextWithStream - success", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        Stream.contextWithStream((context: Context.Context<StringService>) =>
+        Stream.contextWithStream((context: Context.Context<"StringService">) =>
           Stream.succeed(pipe(context, Context.get(StringService)))
         ),
         Stream.provideContext(
@@ -103,7 +103,7 @@ describe("Stream", () => {
   it.effect("contextWithStream - fails", () =>
     Effect.gen(function*($) {
       const result = yield* $(
-        Stream.contextWithStream((_: Context.Context<StringService>) => Stream.fail("boom")),
+        Stream.contextWithStream((_: Context.Context<"StringService">) => Stream.fail("boom")),
         Stream.provideContext(
           pipe(
             Context.empty(),

--- a/packages/effect/test/Stream/foreign.test.ts
+++ b/packages/effect/test/Stream/foreign.test.ts
@@ -14,7 +14,7 @@ import { assert, describe } from "vitest"
 describe("Stream.Foreign", () => {
   it.effect("Tag", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(
         tag,
         Stream.runCollect,
@@ -38,7 +38,7 @@ describe("Stream.Foreign", () => {
 
   it.effect("Either.right", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
 
       const result = yield* $(
         Either.right(10),
@@ -51,7 +51,7 @@ describe("Stream.Foreign", () => {
 
   it.effect("Either.left", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(
         Either.left(10),
         Stream.runCollect,
@@ -63,7 +63,7 @@ describe("Stream.Foreign", () => {
 
   it.effect("Option.some", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(
         Option.some(10),
         Stream.runCollect,
@@ -75,7 +75,7 @@ describe("Stream.Foreign", () => {
 
   it.effect("Option.none", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(
         Option.none(),
         Stream.runCollect,
@@ -87,7 +87,7 @@ describe("Stream.Foreign", () => {
 
   it.effect("Effect.fail", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(
         Effect.fail("ok"),
         Stream.runCollect,
@@ -99,7 +99,7 @@ describe("Stream.Foreign", () => {
 
   it.effect("Effect.succeed", () =>
     Effect.gen(function*($) {
-      const tag = Context.Tag<number>()
+      const tag = Context.Tag("number")<number>()
       const result = yield* $(
         Effect.succeed("ok"),
         Stream.runCollect,

--- a/packages/effect/test/utils/cache/ObservableResource.ts
+++ b/packages/effect/test/utils/cache/ObservableResource.ts
@@ -6,7 +6,7 @@ import * as Scope from "effect/Scope"
 import { expect } from "vitest"
 
 export interface ObservableResource<E, V> {
-  readonly scoped: Effect.Effect<Scope.Scope, E, V>
+  readonly scoped: Effect.Effect<"Scope", E, V>
   assertNotAcquired(): Effect.Effect<never, never, void>
   assertAcquiredOnceAndCleaned(): Effect.Effect<never, never, void>
   assertAcquiredOnceAndNotCleaned(): Effect.Effect<never, never, void>
@@ -14,7 +14,7 @@ export interface ObservableResource<E, V> {
 
 class ObservableResourceImpl<E, V> implements ObservableResource<E, V> {
   constructor(
-    readonly scoped: Effect.Effect<Scope.Scope, E, V>,
+    readonly scoped: Effect.Effect<"Scope", E, V>,
     readonly getState: Effect.Effect<never, never, readonly [number, number]>
   ) {}
 

--- a/packages/effect/test/utils/cache/WatchableLookup.ts
+++ b/packages/effect/test/utils/cache/WatchableLookup.ts
@@ -7,12 +7,11 @@ import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
-import type * as Scope from "effect/Scope"
 import * as TestServices from "effect/TestServices"
 import { expect } from "vitest"
 
 export interface WatchableLookup<Key, Error, Value> {
-  (key: Key): Effect.Effect<Scope.Scope, Error, Value>
+  (key: Key): Effect.Effect<"Scope", Error, Value>
   lock(): Effect.Effect<never, never, void>
   unlock(): Effect.Effect<never, never, void>
   createdResources(): Effect.Effect<
@@ -48,7 +47,7 @@ export const makeEffect = <Key, Error, Value>(
       Ref.make(HashMap.empty<Key, Chunk.Chunk<ObservableResource.ObservableResource<Error, Value>>>())
     ),
     ([blocked, resources]): WatchableLookup<Key, Error, Value> => {
-      function lookup(key: Key): Effect.Effect<Scope.Scope, Error, Value> {
+      function lookup(key: Key): Effect.Effect<"Scope", Error, Value> {
         return Effect.flatten(Effect.gen(function*($) {
           const observableResource = yield* $(ObservableResource.makeEffect(concreteLookup(key)))
           yield* $(Ref.update(resources, (resourceMap) => {

--- a/packages/effect/test/utils/counter.ts
+++ b/packages/effect/test/utils/counter.ts
@@ -1,10 +1,9 @@
 import * as Effect from "effect/Effect"
 import { pipe } from "effect/Function"
 import * as Ref from "effect/Ref"
-import type * as Scope from "effect/Scope"
 
 interface Counter {
-  acquire(): Effect.Effect<Scope.Scope, never, number>
+  acquire(): Effect.Effect<"Scope", never, number>
   incrementAcquire(): Effect.Effect<never, never, number>
   incrementRelease(): Effect.Effect<never, never, number>
   acquired(): Effect.Effect<never, never, number>
@@ -14,7 +13,7 @@ interface Counter {
 class CounterImpl implements Counter {
   constructor(readonly ref: Ref.Ref<readonly [number, number]>) {}
 
-  acquire(): Effect.Effect<Scope.Scope, never, number> {
+  acquire(): Effect.Effect<"Scope", never, number> {
     return pipe(
       this.incrementAcquire(),
       Effect.zipRight(Effect.addFinalizer(() => this.incrementRelease())),

--- a/packages/effect/test/utils/extend.ts
+++ b/packages/effect/test/utils/extend.ts
@@ -4,7 +4,6 @@ import { pipe } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Logger from "effect/Logger"
 import * as Schedule from "effect/Schedule"
-import type * as Scope from "effect/Scope"
 import * as TestEnvironment from "effect/TestContext"
 import type * as TestServices from "effect/TestServices"
 import type { TestAPI } from "vitest"
@@ -106,7 +105,7 @@ export const flakyTest = <R, E, A>(
 
 export const scoped = <E, A>(
   name: string,
-  self: () => Effect.Effect<Scope.Scope | TestServices.TestServices, E, A>,
+  self: () => Effect.Effect<"Scope" | TestServices.TestServices, E, A>,
   timeout = 5_000
 ) => {
   return it(
@@ -124,7 +123,7 @@ export const scoped = <E, A>(
 
 export const scopedLive = <E, A>(
   name: string,
-  self: () => Effect.Effect<Scope.Scope, E, A>,
+  self: () => Effect.Effect<"Scope", E, A>,
   timeout = 5_000
 ) => {
   return it(

--- a/packages/opentelemetry/src/Metrics.ts
+++ b/packages/opentelemetry/src/Metrics.ts
@@ -11,7 +11,7 @@ import * as internal from "./internal/metrics.js"
  * @since 1.0.0
  * @category producer
  */
-export const makeProducer: Effect.Effect<"Otel.Resource", never, MetricProducer> = internal.makeProducer
+export const makeProducer: Effect.Effect<"Otel/Resource", never, MetricProducer> = internal.makeProducer
 
 /**
  * @since 1.0.0
@@ -26,4 +26,4 @@ export const registerProducer: (
  * @since 1.0.0
  * @category layers
  */
-export const layer: (evaluate: LazyArg<MetricReader>) => Layer<"Otel.Resource", never, never> = internal.layer
+export const layer: (evaluate: LazyArg<MetricReader>) => Layer<"Otel/Resource", never, never> = internal.layer

--- a/packages/opentelemetry/src/Metrics.ts
+++ b/packages/opentelemetry/src/Metrics.ts
@@ -5,15 +5,13 @@ import type { MetricProducer, MetricReader } from "@opentelemetry/sdk-metrics"
 import type * as Effect from "effect/Effect"
 import type { LazyArg } from "effect/Function"
 import type { Layer } from "effect/Layer"
-import type * as Scope from "effect/Scope"
 import * as internal from "./internal/metrics.js"
-import type { Resource } from "./Resource.js"
 
 /**
  * @since 1.0.0
  * @category producer
  */
-export const makeProducer: Effect.Effect<Resource, never, MetricProducer> = internal.makeProducer
+export const makeProducer: Effect.Effect<"Otel.Resource", never, MetricProducer> = internal.makeProducer
 
 /**
  * @since 1.0.0
@@ -22,10 +20,10 @@ export const makeProducer: Effect.Effect<Resource, never, MetricProducer> = inte
 export const registerProducer: (
   self: MetricProducer,
   metricReader: LazyArg<MetricReader>
-) => Effect.Effect<Scope.Scope, never, MetricReader> = internal.registerProducer
+) => Effect.Effect<"Scope", never, MetricReader> = internal.registerProducer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layer: (evaluate: LazyArg<MetricReader>) => Layer<Resource, never, never> = internal.layer
+export const layer: (evaluate: LazyArg<MetricReader>) => Layer<"Otel.Resource", never, never> = internal.layer

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-import type { TracerProvider } from "@opentelemetry/api"
 import type * as Resources from "@opentelemetry/resources"
 import type { MetricReader } from "@opentelemetry/sdk-metrics"
 import type { SpanProcessor, TracerConfig } from "@opentelemetry/sdk-trace-base"
@@ -12,6 +11,7 @@ import * as Layer from "effect/Layer"
 import * as Metrics from "./Metrics.js"
 import * as Resource from "./Resource.js"
 import * as Tracer from "./Tracer.js"
+import * as TracerProviderJs from "./TracerProvider.js"
 
 /**
  * @since 1.0.0
@@ -35,9 +35,9 @@ export interface Configuration {
 export const layerTracerProvider = (
   processor: SpanProcessor,
   config?: Omit<TracerConfig, "resource">
-): Layer.Layer<Resource.Resource, never, TracerProvider> =>
+): Layer.Layer<"Otel.Resource", never, "Otel.TracerProvider"> =>
   Layer.scoped(
-    Tracer.TracerProvider,
+    TracerProviderJs.TracerProvider,
     Effect.flatMap(
       Resource.Resource,
       (resource) =>
@@ -60,11 +60,11 @@ export const layerTracerProvider = (
  * @category layer
  */
 export const layer: {
-  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, Resource.Resource>
-  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, Resource.Resource>
+  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, "Otel.Resource">
+  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, "Otel.Resource">
 } = (
   evaluate: LazyArg<Configuration> | Effect.Effect<any, any, Configuration>
-): Layer.Layer<never, never, Resource.Resource> =>
+): Layer.Layer<never, never, "Otel.Resource"> =>
   Layer.unwrapEffect(
     Effect.map(
       Effect.isEffect(evaluate)

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -35,7 +35,7 @@ export interface Configuration {
 export const layerTracerProvider = (
   processor: SpanProcessor,
   config?: Omit<TracerConfig, "resource">
-): Layer.Layer<"Otel.Resource", never, "Otel.TracerProvider"> =>
+): Layer.Layer<"Otel/Resource", never, "Otel/TracerProvider"> =>
   Layer.scoped(
     TracerProviderJs.TracerProvider,
     Effect.flatMap(
@@ -60,11 +60,11 @@ export const layerTracerProvider = (
  * @category layer
  */
 export const layer: {
-  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, "Otel.Resource">
-  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, "Otel.Resource">
+  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, "Otel/Resource">
+  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, "Otel/Resource">
 } = (
   evaluate: LazyArg<Configuration> | Effect.Effect<any, any, Configuration>
-): Layer.Layer<never, never, "Otel.Resource"> =>
+): Layer.Layer<never, never, "Otel/Resource"> =>
   Layer.unwrapEffect(
     Effect.map(
       Effect.isEffect(evaluate)

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -8,17 +8,9 @@ import * as Layer from "effect/Layer"
 
 /**
  * @since 1.0.0
- * @category identifier
- */
-export interface Resource {
-  readonly _: unique symbol
-}
-
-/**
- * @since 1.0.0
  * @category tag
  */
-export const Resource = Tag<Resource, Resources.Resource>("@effect/opentelemetry/Resource")
+export const Resource = Tag("Otel.Resource")<Resources.Resource>()
 
 /**
  * @since 1.0.0

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -10,7 +10,7 @@ import * as Layer from "effect/Layer"
  * @since 1.0.0
  * @category tag
  */
-export const Resource = Tag("Otel.Resource")<Resources.Resource>()
+export const Resource = Tag("Otel/Resource")<Resources.Resource>()
 
 /**
  * @since 1.0.0

--- a/packages/opentelemetry/src/Tracer.ts
+++ b/packages/opentelemetry/src/Tracer.ts
@@ -8,13 +8,12 @@ import type { Effect } from "effect/Effect"
 import type { Layer } from "effect/Layer"
 import type { ExternalSpan, Tracer as EffectTracer } from "effect/Tracer"
 import * as internal from "./internal/tracer.js"
-import type { Resource } from "./Resource.js"
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const make: Effect<Otel.Tracer, never, EffectTracer> = internal.make
+export const make: Effect<"Otel.Tracer", never, EffectTracer> = internal.make
 
 /**
  * @since 1.0.0
@@ -39,46 +38,46 @@ export const currentOtelSpan: Effect<never, NoSuchElementException, Otel.Span> =
  * @since 1.0.0
  * @category layers
  */
-export const layer: Layer<Resource | Otel.TracerProvider, never, never> = internal.layer
+export const layer: Layer<"Otel.Resource" | "Otel.TracerProvider", never, never> = internal.layer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerGlobal: Layer<Resource, never, never> = internal.layerGlobal
+export const layerGlobal: Layer<"Otel.Resource", never, never> = internal.layerGlobal
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerTracer: Layer<Resource | Otel.TracerProvider, never, Otel.Tracer> = internal.layerTracer
+export const layerTracer: Layer<"Otel.Resource" | "Otel.TracerProvider", never, "Otel.Tracer"> = internal.layerTracer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerGlobalTracer: Layer<Resource, never, Otel.Tracer> = internal.layerGlobalTracer
+export const layerGlobalTracer: Layer<"Otel.Resource", never, "Otel.Tracer"> = internal.layerGlobalTracer
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const TracerProvider: Tag<Otel.TracerProvider, Otel.TracerProvider> = internal.TracerProvider
+export const TracerProvider: Tag<"Otel.TracerProvider", Otel.TracerProvider> = internal.TracerProvider
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const Tracer: Tag<Otel.Tracer, Otel.Tracer> = internal.Tracer
+export const Tracer: Tag<"Otel.Tracer", Otel.Tracer> = internal.Tracer
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const TraceFlags: Tag<Otel.TraceFlags, Otel.TraceFlags> = internal.traceFlagsTag
+export const TraceFlags: Tag<"Otel.TraceFlags", Otel.TraceFlags> = internal.traceFlagsTag
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const TraceState: Tag<Otel.TraceState, Otel.TraceState> = internal.traceStateTag
+export const TraceState: Tag<"Otel.TraceState", Otel.TraceState> = internal.traceStateTag

--- a/packages/opentelemetry/src/Tracer.ts
+++ b/packages/opentelemetry/src/Tracer.ts
@@ -13,7 +13,7 @@ import * as internal from "./internal/tracer.js"
  * @since 1.0.0
  * @category constructors
  */
-export const make: Effect<"Otel.Tracer", never, EffectTracer> = internal.make
+export const make: Effect<"Otel/Tracer", never, EffectTracer> = internal.make
 
 /**
  * @since 1.0.0
@@ -38,46 +38,46 @@ export const currentOtelSpan: Effect<never, NoSuchElementException, Otel.Span> =
  * @since 1.0.0
  * @category layers
  */
-export const layer: Layer<"Otel.Resource" | "Otel.TracerProvider", never, never> = internal.layer
+export const layer: Layer<"Otel/Resource" | "Otel/TracerProvider", never, never> = internal.layer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerGlobal: Layer<"Otel.Resource", never, never> = internal.layerGlobal
+export const layerGlobal: Layer<"Otel/Resource", never, never> = internal.layerGlobal
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerTracer: Layer<"Otel.Resource" | "Otel.TracerProvider", never, "Otel.Tracer"> = internal.layerTracer
+export const layerTracer: Layer<"Otel/Resource" | "Otel/TracerProvider", never, "Otel/Tracer"> = internal.layerTracer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerGlobalTracer: Layer<"Otel.Resource", never, "Otel.Tracer"> = internal.layerGlobalTracer
+export const layerGlobalTracer: Layer<"Otel/Resource", never, "Otel/Tracer"> = internal.layerGlobalTracer
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const TracerProvider: Tag<"Otel.TracerProvider", Otel.TracerProvider> = internal.TracerProvider
+export const TracerProvider: Tag<"Otel/TracerProvider", Otel.TracerProvider> = internal.TracerProvider
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const Tracer: Tag<"Otel.Tracer", Otel.Tracer> = internal.Tracer
+export const Tracer: Tag<"Otel/Tracer", Otel.Tracer> = internal.Tracer
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const TraceFlags: Tag<"Otel.TraceFlags", Otel.TraceFlags> = internal.traceFlagsTag
+export const TraceFlags: Tag<"Otel/TraceFlags", Otel.TraceFlags> = internal.traceFlagsTag
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const TraceState: Tag<"Otel.TraceState", Otel.TraceState> = internal.traceStateTag
+export const TraceState: Tag<"Otel/TraceState", Otel.TraceState> = internal.traceStateTag

--- a/packages/opentelemetry/src/TracerProvider.ts
+++ b/packages/opentelemetry/src/TracerProvider.ts
@@ -1,0 +1,10 @@
+import type * as Otel from "@opentelemetry/api"
+import type { Tag } from "effect/Context"
+import * as internal from "./internal/tracer.js"
+
+/**
+ * @since 1.0.0
+ * @category tags
+ */
+
+export const TracerProvider: Tag<"Otel.TracerProvider", Otel.TracerProvider> = internal.TracerProvider

--- a/packages/opentelemetry/src/TracerProvider.ts
+++ b/packages/opentelemetry/src/TracerProvider.ts
@@ -7,4 +7,4 @@ import * as internal from "./internal/tracer.js"
  * @category tags
  */
 
-export const TracerProvider: Tag<"Otel.TracerProvider", Otel.TracerProvider> = internal.TracerProvider
+export const TracerProvider: Tag<"Otel/TracerProvider", Otel.TracerProvider> = internal.TracerProvider

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-import type { TracerProvider } from "@opentelemetry/api"
 import type * as Resources from "@opentelemetry/resources"
 import type { MetricReader } from "@opentelemetry/sdk-metrics"
 import type { SpanProcessor, TracerConfig } from "@opentelemetry/sdk-trace-base"
@@ -12,6 +11,7 @@ import * as Layer from "effect/Layer"
 import * as Metrics from "./Metrics.js"
 import * as Resource from "./Resource.js"
 import * as Tracer from "./Tracer.js"
+import * as TracerProviderJs from "./TracerProvider.js"
 
 /**
  * @since 1.0.0
@@ -35,9 +35,9 @@ export interface Configuration {
 export const layerTracerProvider = (
   processor: SpanProcessor,
   config?: Omit<TracerConfig, "resource">
-): Layer.Layer<Resource.Resource, never, TracerProvider> =>
+): Layer.Layer<"Otel.Resource", never, "Otel.TracerProvider"> =>
   Layer.scoped(
-    Tracer.TracerProvider,
+    TracerProviderJs.TracerProvider,
     Effect.flatMap(
       Resource.Resource,
       (resource) =>
@@ -60,11 +60,11 @@ export const layerTracerProvider = (
  * @category layer
  */
 export const layer: {
-  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, Resource.Resource>
-  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, Resource.Resource>
+  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, "Otel.Resource">
+  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, "Otel.Resource">
 } = (
   evaluate: LazyArg<Configuration> | Effect.Effect<any, any, Configuration>
-): Layer.Layer<never, never, Resource.Resource> =>
+): Layer.Layer<never, never, "Otel.Resource"> =>
   Layer.unwrapEffect(
     Effect.map(
       Effect.isEffect(evaluate)

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -35,7 +35,7 @@ export interface Configuration {
 export const layerTracerProvider = (
   processor: SpanProcessor,
   config?: Omit<TracerConfig, "resource">
-): Layer.Layer<"Otel.Resource", never, "Otel.TracerProvider"> =>
+): Layer.Layer<"Otel/Resource", never, "Otel/TracerProvider"> =>
   Layer.scoped(
     TracerProviderJs.TracerProvider,
     Effect.flatMap(
@@ -60,11 +60,11 @@ export const layerTracerProvider = (
  * @category layer
  */
 export const layer: {
-  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, "Otel.Resource">
-  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, "Otel.Resource">
+  (evaluate: LazyArg<Configuration>): Layer.Layer<never, never, "Otel/Resource">
+  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<R, E, "Otel/Resource">
 } = (
   evaluate: LazyArg<Configuration> | Effect.Effect<any, any, Configuration>
-): Layer.Layer<never, never, "Otel.Resource"> =>
+): Layer.Layer<never, never, "Otel/Resource"> =>
   Layer.unwrapEffect(
     Effect.map(
       Effect.isEffect(evaluate)

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -20,5 +20,11 @@ export * as Tracer from "./Tracer.js"
 
 /**
  * @since 1.0.0
+ * @category tags
+ */
+export * as TracerProvider from "./TracerProvider.js"
+
+/**
+ * @since 1.0.0
  */
 export * as WebSdk from "./WebSdk.js"

--- a/packages/opentelemetry/src/internal/tracer.ts
+++ b/packages/opentelemetry/src/internal/tracer.ts
@@ -104,10 +104,10 @@ export class OtelSpan implements EffectTracer.Span {
 }
 
 /** @internal */
-export const TracerProvider = Context.Tag("Otel.TracerProvider")<OtelApi.TracerProvider>()
+export const TracerProvider = Context.Tag("Otel/TracerProvider")<OtelApi.TracerProvider>()
 
 /** @internal */
-export const Tracer = Context.Tag("Otel.Tracer")<OtelApi.Tracer>()
+export const Tracer = Context.Tag("Otel/Tracer")<OtelApi.Tracer>()
 
 /** @internal */
 export const make = Effect.map(Tracer, (tracer) =>
@@ -140,10 +140,10 @@ export const make = Effect.map(Tracer, (tracer) =>
   }))
 
 /** @internal */
-export const traceFlagsTag = Context.Tag("Otel.TraceFlags")<OtelApi.TraceFlags>()
+export const traceFlagsTag = Context.Tag("Otel/TraceFlags")<OtelApi.TraceFlags>()
 
 /** @internal */
-export const traceStateTag = Context.Tag("Otel.TraceState")<OtelApi.TraceState>()
+export const traceStateTag = Context.Tag("Otel/TraceState")<OtelApi.TraceState>()
 
 /** @internal */
 export const makeExternalSpan = (options: {

--- a/packages/opentelemetry/src/internal/tracer.ts
+++ b/packages/opentelemetry/src/internal/tracer.ts
@@ -104,10 +104,10 @@ export class OtelSpan implements EffectTracer.Span {
 }
 
 /** @internal */
-export const TracerProvider = Context.Tag<OtelApi.TracerProvider>("@effect/opentelemetry/Tracer/TracerProvider")
+export const TracerProvider = Context.Tag("Otel.TracerProvider")<OtelApi.TracerProvider>()
 
 /** @internal */
-export const Tracer = Context.Tag<OtelApi.Tracer>("@effect/opentelemetry/Tracer/Tracer")
+export const Tracer = Context.Tag("Otel.Tracer")<OtelApi.Tracer>()
 
 /** @internal */
 export const make = Effect.map(Tracer, (tracer) =>
@@ -140,10 +140,10 @@ export const make = Effect.map(Tracer, (tracer) =>
   }))
 
 /** @internal */
-export const traceFlagsTag = Context.Tag<OtelApi.TraceFlags>("@effect/opentelemetry/traceFlags")
+export const traceFlagsTag = Context.Tag("Otel.TraceFlags")<OtelApi.TraceFlags>()
 
 /** @internal */
-export const traceStateTag = Context.Tag<OtelApi.TraceState>("@effect/opentelemetry/traceState")
+export const traceStateTag = Context.Tag("Otel.TraceState")<OtelApi.TraceState>()
 
 /** @internal */
 export const makeExternalSpan = (options: {
@@ -262,7 +262,7 @@ const makeSpanContext = (span: EffectTracer.ParentSpan, context?: Context.Contex
   ) as OtelApi.TraceState
 })
 
-const extractTraceTag = <I, S>(
+const extractTraceTag = <I extends string, S>(
   parent: EffectTracer.ParentSpan,
   context: Context.Context<never>,
   tag: Context.Tag<I, S>

--- a/packages/platform/src/Command.ts
+++ b/packages/platform/src/Command.ts
@@ -6,10 +6,9 @@ import type { HashMap } from "effect/HashMap"
 import type { Option } from "effect/Option"
 import type { Pipeable } from "effect/Pipeable"
 import type { NonEmptyReadonlyArray } from "effect/ReadonlyArray"
-import type { Scope } from "effect/Scope"
 import type { Sink } from "effect/Sink"
 import type { Stream } from "effect/Stream"
-import type { CommandExecutor, ExitCode, Process } from "./CommandExecutor.js"
+import type { ExitCode, Process } from "./CommandExecutor.js"
 import type { PlatformError } from "./Error.js"
 import * as internal from "./internal/command.js"
 
@@ -131,7 +130,8 @@ export const env: {
  * @since 1.0.0
  * @category execution
  */
-export const exitCode: (self: Command) => Effect<CommandExecutor, PlatformError, ExitCode> = internal.exitCode
+export const exitCode: (self: Command) => Effect<"Platform/CommandExecutor", PlatformError, ExitCode> =
+  internal.exitCode
 
 /**
  * Feed a string to standard input (default encoding of UTF-8).
@@ -166,7 +166,7 @@ export const flatten: (self: Command) => NonEmptyReadonlyArray<StandardCommand> 
 export const lines: (
   command: Command,
   encoding?: string
-) => Effect<CommandExecutor, PlatformError, ReadonlyArray<string>> = internal.lines
+) => Effect<"Platform/CommandExecutor", PlatformError, ReadonlyArray<string>> = internal.lines
 
 /**
  * Create a command with the specified process name and an optional list of
@@ -212,7 +212,8 @@ export const runInShell: {
  * @since 1.0.0
  * @category execution
  */
-export const start: (command: Command) => Effect<CommandExecutor | Scope, PlatformError, Process> = internal.start
+export const start: (command: Command) => Effect<"Platform/CommandExecutor" | "Scope", PlatformError, Process> =
+  internal.start
 
 /**
  * Start running the command and return the output as a `Stream`.
@@ -220,7 +221,8 @@ export const start: (command: Command) => Effect<CommandExecutor | Scope, Platfo
  * @since 1.0.0
  * @category execution
  */
-export const stream: (command: Command) => Stream<CommandExecutor, PlatformError, Uint8Array> = internal.stream
+export const stream: (command: Command) => Stream<"Platform/CommandExecutor", PlatformError, Uint8Array> =
+  internal.stream
 
 /**
  * Runs the command returning the output as an stream of lines with the
@@ -229,7 +231,8 @@ export const stream: (command: Command) => Stream<CommandExecutor, PlatformError
  * @since 1.0.0
  * @category execution
  */
-export const streamLines: (command: Command) => Stream<CommandExecutor, PlatformError, string> = internal.streamLines
+export const streamLines: (command: Command) => Stream<"Platform/CommandExecutor", PlatformError, string> =
+  internal.streamLines
 
 /**
  * Runs the command returning the entire output as a string with the
@@ -241,8 +244,8 @@ export const streamLines: (command: Command) => Stream<CommandExecutor, Platform
  * @category execution
  */
 export const string: {
-  (encoding?: string): (command: Command) => Effect<CommandExecutor, PlatformError, string>
-  (command: Command, encoding?: string): Effect<CommandExecutor, PlatformError, string>
+  (encoding?: string | undefined): (command: Command) => Effect<"Platform/CommandExecutor", PlatformError, string>
+  (command: Command, encoding?: string | undefined): Effect<"Platform/CommandExecutor", PlatformError, string>
 } = internal.string
 
 /**

--- a/packages/platform/src/CommandExecutor.ts
+++ b/packages/platform/src/CommandExecutor.ts
@@ -4,7 +4,6 @@
 import type * as Brand from "effect/Brand"
 import type { Tag } from "effect/Context"
 import type { Effect } from "effect/Effect"
-import type { Scope } from "effect/Scope"
 import type { Sink } from "effect/Sink"
 import type { Stream } from "effect/Stream"
 import type { Command } from "./Command.js"
@@ -24,7 +23,7 @@ export interface CommandExecutor {
   /**
    * Start running the command and return a handle to the running process.
    */
-  readonly start: (command: Command) => Effect<Scope, PlatformError, Process>
+  readonly start: (command: Command) => Effect<"Scope", PlatformError, Process>
   /**
    * Runs the command returning the entire output as a string with the
    * specified encoding.
@@ -52,7 +51,7 @@ export interface CommandExecutor {
  * @since 1.0.0
  * @category tags
  */
-export const CommandExecutor: Tag<CommandExecutor, CommandExecutor> = internal.CommandExecutor
+export const CommandExecutor: Tag<"Platform/CommandExecutor", CommandExecutor> = internal.CommandExecutor
 
 /**
  * @since 1.0.0
@@ -187,6 +186,5 @@ export const ProcessId: Brand.Brand.Constructor<Process.Id> = internal.ProcessId
  * @since 1.0.0
  * @category constructors
  */
-export const makeExecutor: (
-  start: (command: Command) => Effect<Scope, PlatformError, Process>
-) => CommandExecutor = internal.makeExecutor
+export const makeExecutor: (start: (command: Command) => Effect<"Scope", PlatformError, Process>) => CommandExecutor =
+  internal.makeExecutor

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -5,7 +5,6 @@ import * as Brand from "effect/Brand"
 import type { Tag } from "effect/Context"
 import type * as Effect from "effect/Effect"
 import type { Option } from "effect/Option"
-import type { Scope } from "effect/Scope"
 import type { Sink } from "effect/Sink"
 import type { Stream } from "effect/Stream"
 import type { PlatformError } from "./Error.js"
@@ -98,7 +97,7 @@ export interface FileSystem {
    */
   readonly makeTempDirectoryScoped: (
     options?: MakeTempDirectoryOptions
-  ) => Effect.Effect<Scope, PlatformError, string>
+  ) => Effect.Effect<"Scope", PlatformError, string>
   /**
    * Create a temporary file.
    * The directory creation is functionally equivalent to `makeTempDirectory`.
@@ -115,7 +114,7 @@ export interface FileSystem {
    */
   readonly makeTempFileScoped: (
     options?: MakeTempFileOptions
-  ) => Effect.Effect<Scope, PlatformError, string>
+  ) => Effect.Effect<"Scope", PlatformError, string>
   /**
    * Open a file at `path` with the specified `options`.
    *
@@ -124,7 +123,7 @@ export interface FileSystem {
   readonly open: (
     path: string,
     options?: OpenFileOptions
-  ) => Effect.Effect<Scope, PlatformError, File>
+  ) => Effect.Effect<"Scope", PlatformError, File>
   /**
    * List the contents of a directory.
    *
@@ -425,7 +424,7 @@ export interface WriteFileStringOptions {
  * @since 1.0.0
  * @category tag
  */
-export const FileSystem: Tag<FileSystem, FileSystem> = internal.tag
+export const FileSystem: Tag<"Platform/FileSystem", FileSystem> = internal.tag
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/Http/App.ts
+++ b/packages/platform/src/Http/App.ts
@@ -20,7 +20,7 @@ import * as ServerResponse from "./ServerResponse.js"
  * @since 1.0.0
  * @category models
  */
-export interface HttpApp<R, E, A> extends Effect.Effect<R | ServerRequest.ServerRequest, E, A> {}
+export interface HttpApp<R, E, A> extends Effect.Effect<R | "Platform/ServerRequest", E, A> {}
 
 /**
  * @since 1.0.0
@@ -109,7 +109,7 @@ export const withPreResponseHandler = dual<
  */
 export const toWebHandlerRuntime = <R>(runtime: Runtime.Runtime<R>) => {
   const run = Runtime.runFork(runtime)
-  return <E>(self: Default<R | Scope.Scope, E>) => {
+  return <E>(self: Default<R | "Scope", E>) => {
     self = withDefaultMiddleware(self)
     return (request: Request): Promise<Response> =>
       new Promise((resolve, reject) => {
@@ -138,7 +138,7 @@ export const toWebHandlerRuntime = <R>(runtime: Runtime.Runtime<R>) => {
  * @since 1.0.0
  * @category conversions
  */
-export const toWebHandler: <E>(self: Default<Scope.Scope, E>) => (request: Request) => Promise<Response> =
+export const toWebHandler: <E>(self: Default<"Scope", E>) => (request: Request) => Promise<Response> =
   toWebHandlerRuntime(Runtime.defaultRuntime)
 
 /**
@@ -146,7 +146,7 @@ export const toWebHandler: <E>(self: Default<Scope.Scope, E>) => (request: Reque
  * @category conversions
  */
 export const toWebHandlerLayer = <R, E, RE>(
-  self: Default<R | Scope.Scope, E>,
+  self: Default<R | "Scope", E>,
   layer: Layer.Layer<never, RE, R>
 ): {
   readonly close: () => Promise<void>

--- a/packages/platform/src/Http/Body.ts
+++ b/packages/platform/src/Http/Body.ts
@@ -217,8 +217,8 @@ export const stream: (
  */
 export const file: (
   path: string,
-  options?: FileSystem.StreamOptions & { readonly contentType?: string }
-) => Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, Stream> = internal.file
+  options?: (FileSystem.StreamOptions & { readonly contentType?: string | undefined }) | undefined
+) => Effect.Effect<"Platform/FileSystem", PlatformError.PlatformError, Stream> = internal.file
 
 /**
  * @since 1.0.0
@@ -227,8 +227,8 @@ export const file: (
 export const fileInfo: (
   path: string,
   info: FileSystem.File.Info,
-  options?: FileSystem.StreamOptions & { readonly contentType?: string }
-) => Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, Stream> = internal.fileInfo
+  options?: (FileSystem.StreamOptions & { readonly contentType?: string | undefined }) | undefined
+) => Effect.Effect<"Platform/FileSystem", never, Stream> = internal.fileInfo
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/Http/Client.ts
+++ b/packages/platform/src/Http/Client.ts
@@ -72,29 +72,24 @@ export declare namespace Client {
 
 /**
  * @since 1.0.0
- * @category models
+ * @category tags
  */
-export interface Fetch {
-  readonly _: unique symbol
-}
+export const Client: Context.Tag<"Platform/HttpClient", Client.Default> = internal.tag
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const Client: Context.Tag<Client.Default, Client.Default> = internal.tag
-
-/**
- * @since 1.0.0
- * @category tags
- */
-export const Fetch: Context.Tag<Fetch, typeof globalThis.fetch> = internal.Fetch
+export const Fetch: Context.Tag<
+  "Platform/HttpClient/Fetch",
+  (input: URL | RequestInfo, init?: RequestInit | undefined) => Promise<Response>
+> = internal.Fetch
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layer: Layer.Layer<never, never, Client.Default> = internal.layer
+export const layer: Layer.Layer<never, never, "Platform/HttpClient"> = internal.layer
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/Http/ClientRequest.ts
+++ b/packages/platform/src/Http/ClientRequest.ts
@@ -349,13 +349,13 @@ export const streamBody: {
 export const fileBody: {
   (
     path: string,
-    options?: FileSystem.StreamOptions & { readonly contentType?: string }
-  ): (self: ClientRequest) => Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, ClientRequest>
+    options?: (FileSystem.StreamOptions & { readonly contentType?: string | undefined }) | undefined
+  ): (self: ClientRequest) => Effect.Effect<"Platform/FileSystem", PlatformError.PlatformError, ClientRequest>
   (
     self: ClientRequest,
     path: string,
-    options?: FileSystem.StreamOptions & { readonly contentType?: string }
-  ): Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, ClientRequest>
+    options?: (FileSystem.StreamOptions & { readonly contentType?: string | undefined }) | undefined
+  ): Effect.Effect<"Platform/FileSystem", PlatformError.PlatformError, ClientRequest>
 } = internal.fileBody
 
 /**

--- a/packages/platform/src/Http/Etag.ts
+++ b/packages/platform/src/Http/Etag.ts
@@ -63,4 +63,4 @@ export interface Generator {
  * @since 1.0.0
  * @category tags
  */
-export const Generator: Context.Tag<Generator, Generator> = internal.tag
+export const Generator: Context.Tag<"Platform/HttpEtagGenerator", Generator> = internal.tag

--- a/packages/platform/src/Http/Multipart.ts
+++ b/packages/platform/src/Http/Multipart.ts
@@ -9,12 +9,10 @@ import type * as Data from "effect/Data"
 import type * as Effect from "effect/Effect"
 import type * as FiberRef from "effect/FiberRef"
 import type * as Option from "effect/Option"
-import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
 import type * as Multipasta from "multipasta"
 import type * as FileSystem from "../FileSystem.js"
 import * as internal from "../internal/http/multipart.js"
-import type * as Path from "../Path.js"
 
 /**
  * @since 1.0.0
@@ -238,5 +236,5 @@ export const makeConfig: (headers: Record<string, string>) => Effect.Effect<neve
  */
 export const toPersisted: (
   stream: Stream.Stream<never, MultipartError, Part>,
-  writeFile?: (path: string, file: File) => Effect.Effect<FileSystem.FileSystem, MultipartError, void>
-) => Effect.Effect<FileSystem.FileSystem | Path.Path | Scope.Scope, MultipartError, Persisted> = internal.toPersisted
+  writeFile?: (path: string, file: File) => Effect.Effect<"Platform/FileSystem", MultipartError, void>
+) => Effect.Effect<"Platform/FileSystem" | "Platform/Path" | "Scope", MultipartError, Persisted> = internal.toPersisted

--- a/packages/platform/src/Http/Platform.ts
+++ b/packages/platform/src/Http/Platform.ts
@@ -7,7 +7,6 @@ import type * as Error from "../Error.js"
 import type * as FileSystem from "../FileSystem.js"
 import * as internal from "../internal/http/platform.js"
 import type * as Body from "./Body.js"
-import type * as Etag from "./Etag.js"
 import type * as Headers from "./Headers.js"
 import type * as ServerResponse from "./ServerResponse.js"
 
@@ -27,7 +26,7 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category tags
  */
-export const Platform: Context.Tag<Platform, Platform> = internal.tag
+export const Platform: Context.Tag<"Platform/HttpPlatform", Platform> = internal.tag
 
 /**
  * @since 1.0.0
@@ -68,4 +67,4 @@ export const make: (
       options?: FileSystem.StreamOptions | undefined
     ) => ServerResponse.ServerResponse
   }
-) => Effect.Effect<FileSystem.FileSystem | Etag.Generator, never, Platform> = internal.make
+) => Effect.Effect<"Platform/FileSystem" | "Platform/HttpEtagGenerator", never, Platform> = internal.make

--- a/packages/platform/src/Http/Router.ts
+++ b/packages/platform/src/Http/Router.ts
@@ -32,7 +32,7 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category models
  */
-export interface Router<R, E> extends App.Default<Exclude<R, RouteContext>, E | Error.RouteNotFound> {
+export interface Router<R, E> extends App.Default<Exclude<R, "Platform/RouteContext">, E | Error.RouteNotFound> {
   readonly [TypeId]: TypeId
   readonly routes: Chunk.Chunk<Route<R, E>>
   readonly mounts: Chunk.Chunk<readonly [string, App.Default<R, E>]>
@@ -45,7 +45,7 @@ export declare namespace Router {
   /**
    * @since 1.0.0
    */
-  export type ExcludeProvided<A> = Exclude<A, RouteContext | ServerRequest.ServerRequest | Scope.Scope>
+  export type ExcludeProvided<A> = Exclude<A, "Platform/RouteContext" | "Platform/ServerRequest" | "Scope">
 }
 
 /**
@@ -86,7 +86,7 @@ export declare namespace Route {
    * @since 1.0.0
    */
   export type Handler<R, E> = Effect.Effect<
-    R | RouteContext | ServerRequest.ServerRequest,
+    R | "Platform/RouteContext" | "Platform/ServerRequest",
     E,
     ServerResponse.ServerResponse
   >
@@ -119,27 +119,21 @@ export interface RouteContext {
  * @since 1.0.0
  * @category route context
  */
-export const RouteContext: Context.Tag<RouteContext, RouteContext> = internal.RouteContext
+export const RouteContext: Context.Tag<"Platform/RouteContext", RouteContext> = internal.RouteContext
 
 /**
  * @since 1.0.0
  * @category route context
  */
-export const params: Effect.Effect<
-  RouteContext,
-  never,
-  Readonly<Record<string, string | undefined>>
-> = internal.params
+export const params: Effect.Effect<"Platform/RouteContext", never, Readonly<Record<string, string | undefined>>> =
+  internal.params
 
 /**
  * @since 1.0.0
  * @category route context
  */
-export const searchParams: Effect.Effect<
-  RouteContext,
-  never,
-  Readonly<Record<string, string>>
-> = internal.searchParams
+export const searchParams: Effect.Effect<"Platform/RouteContext", never, Readonly<Record<string, string>>> =
+  internal.searchParams
 
 /**
  * @since 1.0.0
@@ -147,7 +141,7 @@ export const searchParams: Effect.Effect<
  */
 export const schemaParams: <I extends Readonly<Record<string, string>>, A>(
   schema: Schema.Schema<I, A>
-) => Effect.Effect<RouteContext, ParseResult.ParseError, A> = internal.schemaParams
+) => Effect.Effect<"Platform/RouteContext", ParseResult.ParseError, A> = internal.schemaParams
 
 /**
  * @since 1.0.0
@@ -155,7 +149,7 @@ export const schemaParams: <I extends Readonly<Record<string, string>>, A>(
  */
 export const schemaPathParams: <I extends Readonly<Record<string, string>>, A>(
   schema: Schema.Schema<I, A>
-) => Effect.Effect<RouteContext, ParseResult.ParseError, A> = internal.schemaPathParams
+) => Effect.Effect<"Platform/RouteContext", ParseResult.ParseError, A> = internal.schemaPathParams
 
 /**
  * @since 1.0.0
@@ -163,7 +157,7 @@ export const schemaPathParams: <I extends Readonly<Record<string, string>>, A>(
  */
 export const schemaSearchParams: <I extends Readonly<Record<string, string>>, A>(
   schema: Schema.Schema<I, A>
-) => Effect.Effect<RouteContext, ParseResult.ParseError, A> = internal.schemaSearchParams
+) => Effect.Effect<"Platform/RouteContext", ParseResult.ParseError, A> = internal.schemaSearchParams
 
 /**
  * @since 1.0.0
@@ -188,7 +182,7 @@ export const makeRoute: <R, E>(
   path: PathInput,
   handler: Route.Handler<R, E>,
   prefix?: Option.Option<string>
-) => Route<Exclude<R, RouteContext | ServerRequest.ServerRequest | Scope.Scope>, E> = internal.makeRoute
+) => Route<Exclude<R, "Platform/RouteContext" | "Platform/ServerRequest" | "Scope">, E> = internal.makeRoute
 
 /**
  * @since 1.0.0
@@ -640,14 +634,17 @@ export const provideService: {
   ): <R, E>(
     self: Router<R, E>
   ) => Router<
-    Exclude<Exclude<R, Context.Tag.Identifier<T>>, RouteContext | ServerRequest.ServerRequest | Scope.Scope>,
+    Exclude<Exclude<R, Context.Tag.Identifier<T>>, "Platform/RouteContext" | "Platform/ServerRequest" | "Scope">,
     E
   >
   <R, E, T extends Context.Tag<any, any>>(
     self: Router<R, E>,
     tag: T,
     service: Context.Tag.Service<T>
-  ): Router<Exclude<Exclude<R, Context.Tag.Identifier<T>>, RouteContext | ServerRequest.ServerRequest | Scope.Scope>, E>
+  ): Router<
+    Exclude<Exclude<R, Context.Tag.Identifier<T>>, "Platform/RouteContext" | "Platform/ServerRequest" | "Scope">,
+    E
+  >
 } = internal.provideService
 
 /**

--- a/packages/platform/src/Http/Server.ts
+++ b/packages/platform/src/Http/Server.ts
@@ -4,7 +4,6 @@
 import type * as Context from "effect/Context"
 import type * as Effect from "effect/Effect"
 import type * as Layer from "effect/Layer"
-import type * as Scope from "effect/Scope"
 import * as internal from "../internal/http/server.js"
 import type * as App from "./App.js"
 import type * as Middleware from "./Middleware.js"
@@ -30,7 +29,7 @@ export interface Server {
   readonly [TypeId]: TypeId
   readonly serve: {
     <R, E>(httpApp: App.Default<R, E>): Effect.Effect<
-      Exclude<R, ServerRequest.ServerRequest> | Scope.Scope,
+      Exclude<R, ServerRequest.ServerRequest> | "Scope",
       never,
       void
     >
@@ -38,7 +37,7 @@ export interface Server {
       httpApp: App.Default<R, E>,
       middleware: Middleware.Middleware.Applied<R, E, App>
     ): Effect.Effect<
-      Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest> | Scope.Scope,
+      Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest> | "Scope",
       never,
       void
     >
@@ -83,7 +82,7 @@ export interface UnixAddress {
  * @since 1.0.0
  * @category constructors
  */
-export const Server: Context.Tag<Server, Server> = internal.serverTag
+export const Server: Context.Tag<"Platform/Server", Server> = internal.serverTag
 
 /**
  * @since 1.0.0
@@ -93,8 +92,8 @@ export const make: (
   options: {
     readonly serve: (
       httpApp: App.Default<never, unknown>,
-      middleware?: Middleware.Middleware
-    ) => Effect.Effect<Scope.Scope, never, void>
+      middleware?: Middleware.Middleware | undefined
+    ) => Effect.Effect<"Scope", never, void>
     readonly address: Address
   }
 ) => Server = internal.make
@@ -106,23 +105,23 @@ export const make: (
 export const serve: {
   (): <R, E>(
     httpApp: App.Default<R, E>
-  ) => Layer.Layer<Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>, never, never>
+  ) => Layer.Layer<Server | Exclude<R, ServerRequest.ServerRequest | "Scope">, never, never>
   <R, E, App extends App.Default<any, any>>(
     middleware: Middleware.Middleware.Applied<R, E, App>
   ): (
     httpApp: App.Default<R, E>
   ) => Layer.Layer<
-    Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>,
+    Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | "Scope">,
     never,
     never
   >
   <R, E>(
     httpApp: App.Default<R, E>
-  ): Layer.Layer<Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>, never, never>
+  ): Layer.Layer<Server | Exclude<R, ServerRequest.ServerRequest | "Scope">, never, never>
   <R, E, App extends App.Default<any, any>>(
     httpApp: App.Default<R, E>,
     middleware: Middleware.Middleware.Applied<R, E, App>
-  ): Layer.Layer<Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>, never, never>
+  ): Layer.Layer<Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | "Scope">, never, never>
 } = internal.serve
 
 /**
@@ -132,21 +131,21 @@ export const serve: {
 export const serveEffect: {
   (): <R, E>(
     httpApp: App.Default<R, E>
-  ) => Effect.Effect<Scope.Scope | Server | Exclude<R, ServerRequest.ServerRequest>, never, void>
+  ) => Effect.Effect<"Scope" | Server | Exclude<R, ServerRequest.ServerRequest>, never, void>
   <R, E, App extends App.Default<any, any>>(
     middleware: Middleware.Middleware.Applied<R, E, App>
   ): (
     httpApp: App.Default<R, E>
   ) => Effect.Effect<
-    Scope.Scope | Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>,
+    "Scope" | Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>,
     never,
     void
   >
   <R, E>(
     httpApp: App.Default<R, E>
-  ): Effect.Effect<Scope.Scope | Server | Exclude<R, ServerRequest.ServerRequest>, never, void>
+  ): Effect.Effect<"Scope" | Server | Exclude<R, ServerRequest.ServerRequest>, never, void>
   <R, E, App extends App.Default<any, any>>(
     httpApp: App.Default<R, E>,
     middleware: Middleware.Middleware.Applied<R, E, App>
-  ): Effect.Effect<Scope.Scope | Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>, never, void>
+  ): Effect.Effect<"Scope" | Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>, never, void>
 } = internal.serveEffect

--- a/packages/platform/src/Http/ServerRequest.ts
+++ b/packages/platform/src/Http/ServerRequest.ts
@@ -5,11 +5,8 @@ import type * as ParseResult from "@effect/schema/ParseResult"
 import type * as Schema from "@effect/schema/Schema"
 import type * as Context from "effect/Context"
 import type * as Effect from "effect/Effect"
-import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
-import type * as FileSystem from "../FileSystem.js"
 import * as internal from "../internal/http/serverRequest.js"
-import type * as Path from "../Path.js"
 import type * as Headers from "./Headers.js"
 import type * as IncomingMessage from "./IncomingMessage.js"
 import type { Method } from "./Method.js"
@@ -48,7 +45,7 @@ export interface ServerRequest extends IncomingMessage.IncomingMessage<Error.Req
   readonly method: Method
 
   readonly multipart: Effect.Effect<
-    Scope.Scope | FileSystem.FileSystem | Path.Path,
+    "Scope" | "Platform/FileSystem" | "Platform/Path",
     Multipart.MultipartError,
     Multipart.Persisted
   >
@@ -67,14 +64,14 @@ export interface ServerRequest extends IncomingMessage.IncomingMessage<Error.Req
  * @since 1.0.0
  * @category context
  */
-export const ServerRequest: Context.Tag<ServerRequest, ServerRequest> = internal.serverRequestTag
+export const ServerRequest: Context.Tag<"Platform/ServerRequest", ServerRequest> = internal.serverRequestTag
 
 /**
  * @since 1.0.0
  * @category accessors
  */
 export const persistedMultipart: Effect.Effect<
-  Scope.Scope | FileSystem.FileSystem | Path.Path | ServerRequest,
+  "Scope" | "Platform/FileSystem" | "Platform/Path" | "Platform/ServerRequest",
   Multipart.MultipartError,
   unknown
 > = internal.multipartPersisted
@@ -85,7 +82,7 @@ export const persistedMultipart: Effect.Effect<
  */
 export const schemaHeaders: <I extends Readonly<Record<string, string>>, A>(
   schema: Schema.Schema<I, A>
-) => Effect.Effect<ServerRequest, ParseResult.ParseError, A> = internal.schemaHeaders
+) => Effect.Effect<"Platform/ServerRequest", ParseResult.ParseError, A> = internal.schemaHeaders
 
 /**
  * @since 1.0.0
@@ -93,7 +90,7 @@ export const schemaHeaders: <I extends Readonly<Record<string, string>>, A>(
  */
 export const schemaBodyJson: <I, A>(
   schema: Schema.Schema<I, A>
-) => Effect.Effect<ServerRequest, Error.RequestError | ParseResult.ParseError, A> = internal.schemaBodyJson
+) => Effect.Effect<"Platform/ServerRequest", Error.RequestError | ParseResult.ParseError, A> = internal.schemaBodyJson
 
 /**
  * @since 1.0.0
@@ -102,7 +99,7 @@ export const schemaBodyJson: <I, A>(
 export const schemaBodyForm: <I extends Multipart.Persisted, A>(
   schema: Schema.Schema<I, A>
 ) => Effect.Effect<
-  ServerRequest | Scope.Scope | FileSystem.FileSystem | Path.Path,
+  "Platform/ServerRequest" | "Scope" | "Platform/FileSystem" | "Platform/Path",
   Multipart.MultipartError | Error.RequestError | ParseResult.ParseError,
   A
 > = internal.schemaBodyForm
@@ -113,7 +110,8 @@ export const schemaBodyForm: <I extends Multipart.Persisted, A>(
  */
 export const schemaBodyUrlParams: <I extends Readonly<Record<string, string>>, A>(
   schema: Schema.Schema<I, A>
-) => Effect.Effect<ServerRequest, Error.RequestError | ParseResult.ParseError, A> = internal.schemaBodyUrlParams
+) => Effect.Effect<"Platform/ServerRequest", Error.RequestError | ParseResult.ParseError, A> =
+  internal.schemaBodyUrlParams
 
 /**
  * @since 1.0.0
@@ -122,7 +120,7 @@ export const schemaBodyUrlParams: <I extends Readonly<Record<string, string>>, A
 export const schemaBodyMultipart: <I extends Multipart.Persisted, A>(
   schema: Schema.Schema<I, A>
 ) => Effect.Effect<
-  ServerRequest | Scope.Scope | FileSystem.FileSystem | Path.Path,
+  "Platform/ServerRequest" | "Scope" | "Platform/FileSystem" | "Platform/Path",
   Multipart.MultipartError | ParseResult.ParseError,
   A
 > = internal.schemaBodyMultipart
@@ -136,7 +134,7 @@ export const schemaBodyFormJson: <I, A>(
 ) => (
   field: string
 ) => Effect.Effect<
-  ServerRequest | Scope.Scope | FileSystem.FileSystem | Path.Path,
+  "Platform/ServerRequest" | "Scope" | "Platform/FileSystem" | "Platform/Path",
   Error.RequestError | ParseResult.ParseError,
   A
 > = internal.schemaBodyFormJson

--- a/packages/platform/src/Http/ServerResponse.ts
+++ b/packages/platform/src/Http/ServerResponse.ts
@@ -9,7 +9,6 @@ import type * as FileSystem from "../FileSystem.js"
 import * as internal from "../internal/http/serverResponse.js"
 import type * as Body from "./Body.js"
 import type * as Headers from "./Headers.js"
-import type * as Platform from "./Platform.js"
 import type * as UrlParams from "./UrlParams.js"
 
 /**
@@ -143,8 +142,8 @@ export const stream: (body: Stream.Stream<never, unknown, Uint8Array>, options?:
  */
 export const file: (
   path: string,
-  options?: Options & FileSystem.StreamOptions
-) => Effect.Effect<Platform.Platform, PlatformError.PlatformError, ServerResponse> = internal.file
+  options?: (Options & FileSystem.StreamOptions) | undefined
+) => Effect.Effect<"Platform/HttpPlatform", PlatformError.PlatformError, ServerResponse> = internal.file
 
 /**
  * @since 1.0.0
@@ -152,8 +151,8 @@ export const file: (
  */
 export const fileWeb: (
   file: Body.Body.FileLike,
-  options?: Options.WithContent & FileSystem.StreamOptions
-) => Effect.Effect<Platform.Platform, never, ServerResponse> = internal.fileWeb
+  options?: (Options.WithContent & FileSystem.StreamOptions) | undefined
+) => Effect.Effect<"Platform/HttpPlatform", never, ServerResponse> = internal.fileWeb
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/KeyValueStore.ts
+++ b/packages/platform/src/KeyValueStore.ts
@@ -8,9 +8,7 @@ import type * as Effect from "effect/Effect"
 import type * as Layer from "effect/Layer"
 import type * as Option from "effect/Option"
 import type * as PlatformError from "./Error.js"
-import type * as FileSystem from "./FileSystem.js"
 import * as internal from "./internal/keyValueStore.js"
-import type * as Path from "./Path.js"
 
 /**
  * @since 1.0.0
@@ -93,7 +91,7 @@ export declare namespace KeyValueStore {
  * @since 1.0.0
  * @category tags
  */
-export const KeyValueStore: Context.Tag<KeyValueStore, KeyValueStore> = internal.keyValueStoreTag
+export const KeyValueStore: Context.Tag<"Platform/KeyValueStore", KeyValueStore> = internal.keyValueStoreTag
 
 /**
  * @since 1.0.0
@@ -116,7 +114,7 @@ export const prefix: {
  * @since 1.0.0
  * @category layers
  */
-export const layerMemory: Layer.Layer<never, never, KeyValueStore> = internal.layerMemory
+export const layerMemory: Layer.Layer<never, never, "Platform/KeyValueStore"> = internal.layerMemory
 
 /**
  * @since 1.0.0
@@ -124,7 +122,7 @@ export const layerMemory: Layer.Layer<never, never, KeyValueStore> = internal.la
  */
 export const layerFileSystem: (
   directory: string
-) => Layer.Layer<FileSystem.FileSystem | Path.Path, PlatformError.PlatformError, KeyValueStore> =
+) => Layer.Layer<"Platform/FileSystem" | "Platform/Path", PlatformError.PlatformError, "Platform/KeyValueStore"> =
   internal.layerFileSystem
 
 /**
@@ -198,10 +196,8 @@ export interface SchemaStore<A> {
  * @since 1.0.0
  * @category layers
  */
-export const layerSchema: <I, A>(
-  schema: Schema.Schema<I, A>,
-  tagIdentifier?: unknown
-) => {
-  readonly tag: Context.Tag<SchemaStore<A>, SchemaStore<A>>
-  readonly layer: Layer.Layer<KeyValueStore, never, SchemaStore<A>>
-} = internal.layerSchema
+export const layerSchema: <I, A, K extends string>(
+  tagIdentifier: K,
+  schema: Schema.Schema<I, A>
+) => { readonly tag: Context.Tag<K, SchemaStore<A>>; readonly layer: Layer.Layer<"Platform/KeyValueStore", never, K> } =
+  internal.layerSchema

--- a/packages/platform/src/Path.ts
+++ b/packages/platform/src/Path.ts
@@ -50,7 +50,7 @@ export declare namespace Path {
  * @since 1.0.0
  * @category tag
  */
-export const Path: Tag<Path, Path> = internal.Path
+export const Path: Tag<"Platform/Path", Path> = internal.Path
 
 /**
  * An implementation of the Path interface that can be used in all environments
@@ -61,4 +61,4 @@ export const Path: Tag<Path, Path> = internal.Path
  * @since 1.0.0
  * @category layer
  */
-export const layer: Layer<never, never, Path> = internal.layer
+export const layer: Layer<never, never, "Platform/Path"> = internal.layer

--- a/packages/platform/src/Terminal.ts
+++ b/packages/platform/src/Terminal.ts
@@ -85,4 +85,4 @@ export class QuitException extends TaggedError("QuitException")<{}> {}
  * @since 1.0.0
  * @category tag
  */
-export const Terminal: Tag<Terminal, Terminal> = InternalTerminal.tag
+export const Terminal: Tag<"Platform/Terminal", Terminal> = InternalTerminal.tag

--- a/packages/platform/src/Worker.ts
+++ b/packages/platform/src/Worker.ts
@@ -59,14 +59,14 @@ export type PlatformWorkerTypeId = typeof PlatformWorkerTypeId
  */
 export interface PlatformWorker {
   readonly [PlatformWorkerTypeId]: PlatformWorkerTypeId
-  readonly spawn: <I, O>(worker: unknown) => Effect.Effect<Scope.Scope, WorkerError, BackingWorker<I, O>>
+  readonly spawn: <I, O>(worker: unknown) => Effect.Effect<"Scope", WorkerError, BackingWorker<I, O>>
 }
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const PlatformWorker: Context.Tag<PlatformWorker, PlatformWorker> = internal.PlatformWorker
+export const PlatformWorker: Context.Tag<"Platform/PlatformWorker", PlatformWorker> = internal.PlatformWorker
 
 /**
  * @since 1.0.0
@@ -185,26 +185,27 @@ export interface WorkerManager {
   readonly [WorkerManagerTypeId]: WorkerManagerTypeId
   readonly spawn: <I, E, O>(
     options: Worker.Options<I>
-  ) => Effect.Effect<Scope.Scope, WorkerError, Worker<I, E, O>>
+  ) => Effect.Effect<"Scope", WorkerError, Worker<I, E, O>>
 }
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const WorkerManager: Context.Tag<WorkerManager, WorkerManager> = internal.WorkerManager
+export const WorkerManager: Context.Tag<"Platform/WorkerManager", WorkerManager> = internal.WorkerManager
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const makeManager: Effect.Effect<PlatformWorker, never, WorkerManager> = internal.makeManager
+export const makeManager: Effect.Effect<"Platform/PlatformWorker", never, WorkerManager> = internal.makeManager
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerManager: Layer.Layer<PlatformWorker, never, WorkerManager> = internal.layerManager
+export const layerManager: Layer.Layer<"Platform/PlatformWorker", never, "Platform/WorkerManager"> =
+  internal.layerManager
 
 /**
  * @since 1.0.0
@@ -212,7 +213,7 @@ export const layerManager: Layer.Layer<PlatformWorker, never, WorkerManager> = i
  */
 export const makePool: <W>() => <I, E, O>(
   options: WorkerPool.Options<I, W>
-) => Effect.Effect<WorkerManager | Scope.Scope, never, WorkerPool<I, E, O>> = internal.makePool
+) => Effect.Effect<"Platform/WorkerManager" | "Scope" | Scope.Scope, never, WorkerPool<I, E, O>> = internal.makePool
 
 /**
  * @since 1.0.0
@@ -220,10 +221,10 @@ export const makePool: <W>() => <I, E, O>(
  */
 export const makePoolLayer: <W>(
   managerLayer: Layer.Layer<never, never, WorkerManager>
-) => <Tag, I, E, O>(
+) => <Tag extends string, I, E, O>(
   tag: Context.Tag<Tag, WorkerPool<I, E, O>>,
   options: WorkerPool.Options<I, W>
-) => Layer.Layer<never, never, Tag> = internal.makePoolLayer
+) => Layer.Layer<"Platform/WorkerManager" | Scope.Scope, never, Tag> = internal.makePoolLayer
 
 /**
  * @since 1.0.0
@@ -322,7 +323,7 @@ export declare namespace SerializedWorkerPool {
  */
 export const makeSerialized: <I extends Schema.TaggedRequest.Any, W = unknown>(
   options: SerializedWorker.Options<I, W>
-) => Effect.Effect<WorkerManager | Scope.Scope, WorkerError, SerializedWorker<I>> = internal.makeSerialized
+) => Effect.Effect<"Scope" | "Platform/WorkerManager", WorkerError, SerializedWorker<I>> = internal.makeSerialized
 
 /**
  * @since 1.0.0
@@ -330,7 +331,7 @@ export const makeSerialized: <I extends Schema.TaggedRequest.Any, W = unknown>(
  */
 export const makePoolSerialized: <W>() => <I extends Schema.TaggedRequest.Any>(
   options: SerializedWorkerPool.Options<I, W>
-) => Effect.Effect<WorkerManager | Scope.Scope, never, SerializedWorkerPool<I>> = internal.makePoolSerialized
+) => Effect.Effect<"Platform/WorkerManager" | "Scope", never, SerializedWorkerPool<I>> = internal.makePoolSerialized
 
 /**
  * @since 1.0.0
@@ -338,7 +339,7 @@ export const makePoolSerialized: <W>() => <I extends Schema.TaggedRequest.Any>(
  */
 export const makePoolSerializedLayer: <W>(
   managerLayer: Layer.Layer<never, never, WorkerManager>
-) => <Tag, I extends Schema.TaggedRequest.Any>(
+) => <Tag extends string, I extends Schema.TaggedRequest.Any>(
   tag: Context.Tag<Tag, SerializedWorkerPool<I>>,
   options: SerializedWorkerPool.Options<I, W>
-) => Layer.Layer<never, never, Tag> = internal.makePoolSerializedLayer
+) => Layer.Layer<"Platform/WorkerManager", never, Tag> = internal.makePoolSerializedLayer

--- a/packages/platform/src/WorkerRunner.ts
+++ b/packages/platform/src/WorkerRunner.ts
@@ -7,7 +7,6 @@ import type * as Context from "effect/Context"
 import type * as Effect from "effect/Effect"
 import type * as Layer from "effect/Layer"
 import type * as Queue from "effect/Queue"
-import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
 import * as internal from "./internal/workerRunner.js"
 import type { WorkerError } from "./WorkerError.js"
@@ -53,14 +52,14 @@ export interface PlatformRunner {
   readonly [PlatformRunnerTypeId]: PlatformRunnerTypeId
   readonly start: <I, O>(
     shutdown: Effect.Effect<never, never, void>
-  ) => Effect.Effect<Scope.Scope, WorkerError, BackingRunner<I, O>>
+  ) => Effect.Effect<"Scope", WorkerError, BackingRunner<I, O>>
 }
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const PlatformRunner: Context.Tag<PlatformRunner, PlatformRunner> = internal.PlatformRunner
+export const PlatformRunner: Context.Tag<"Platform/PlatformRunner", PlatformRunner> = internal.PlatformRunner
 
 /**
  * @since 1.0.0
@@ -86,7 +85,7 @@ export declare namespace Runner {
 export const make: <I, R, E, O>(
   process: (request: I) => Stream.Stream<R, E, O> | Effect.Effect<R, E, O>,
   options?: Runner.Options<I, E, O> | undefined
-) => Effect.Effect<Scope.Scope | R | PlatformRunner, WorkerError, void> = internal.make
+) => Effect.Effect<"Platform/PlatformRunner" | R | "Scope", WorkerError, void> = internal.make
 
 /**
  * @since 1.0.0
@@ -95,7 +94,8 @@ export const make: <I, R, E, O>(
 export const layer: <I, R, E, O>(
   process: (request: I) => Stream.Stream<R, E, O> | Effect.Effect<R, E, O>,
   options?: Runner.Options<I, E, O> | undefined
-) => Layer.Layer<R | PlatformRunner, WorkerError, never> = internal.layer
+) => Layer.Layer<"Platform/PlatformRunner" | Exclude<R, "Scope"> | "Platform/FileSystem", WorkerError, never> =
+  internal.layer
 
 /**
  * @since 1.0.0
@@ -155,8 +155,11 @@ export const makeSerialized: <
 >(
   schema: Schema.Schema<I, A>,
   handlers: Handlers
-) => Effect.Effect<PlatformRunner | Scope.Scope | SerializedRunner.HandlersContext<Handlers>, WorkerError, void> =
-  internal.makeSerialized
+) => Effect.Effect<
+  "Platform/PlatformRunner" | "Scope" | SerializedRunner.HandlersContext<Handlers>,
+  WorkerError,
+  void
+> = internal.makeSerialized
 
 /**
  * @since 1.0.0
@@ -169,5 +172,5 @@ export const layerSerialized: <
 >(
   schema: Schema.Schema<I, A>,
   handlers: Handlers
-) => Layer.Layer<PlatformRunner | SerializedRunner.HandlersContext<Handlers>, WorkerError, never> =
+) => Layer.Layer<"Platform/PlatformRunner" | SerializedRunner.HandlersContext<Handlers>, WorkerError, never> =
   internal.layerSerialized

--- a/packages/platform/src/internal/command.ts
+++ b/packages/platform/src/internal/command.ts
@@ -5,7 +5,6 @@ import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import { pipeArguments } from "effect/Pipeable"
 import type * as ReadonlyArray from "effect/ReadonlyArray"
-import type { Scope } from "effect/Scope"
 import * as Stream from "effect/Stream"
 import type * as Command from "../Command.js"
 import type * as CommandExecutor from "../CommandExecutor.js"
@@ -39,7 +38,7 @@ export const env: {
 /** @internal */
 export const exitCode = (
   self: Command.Command
-): Effect.Effect<CommandExecutor.CommandExecutor, PlatformError, CommandExecutor.ExitCode> =>
+): Effect.Effect<"Platform/CommandExecutor", PlatformError, CommandExecutor.ExitCode> =>
   Effect.flatMap(commandExecutor.CommandExecutor, (executor) => executor.exitCode(self))
 
 /** @internal */
@@ -91,7 +90,7 @@ export const runInShell = dual<
 export const lines = (
   command: Command.Command,
   encoding = "utf-8"
-): Effect.Effect<CommandExecutor.CommandExecutor, PlatformError, ReadonlyArray<string>> =>
+): Effect.Effect<"Platform/CommandExecutor", PlatformError, ReadonlyArray<string>> =>
   Effect.flatMap(commandExecutor.CommandExecutor, (executor) => executor.lines(command, encoding))
 
 /** @internal */
@@ -192,27 +191,27 @@ export const stdout: {
 /** @internal */
 export const start = (
   command: Command.Command
-): Effect.Effect<CommandExecutor.CommandExecutor | Scope, PlatformError, CommandExecutor.Process> =>
+): Effect.Effect<"Platform/CommandExecutor" | "Scope", PlatformError, CommandExecutor.Process> =>
   Effect.flatMap(commandExecutor.CommandExecutor, (executor) => executor.start(command))
 
 /** @internal */
 export const stream = (
   command: Command.Command
-): Stream.Stream<CommandExecutor.CommandExecutor, PlatformError, Uint8Array> =>
+): Stream.Stream<"Platform/CommandExecutor", PlatformError, Uint8Array> =>
   Stream.flatMap(commandExecutor.CommandExecutor, (process) => process.stream(command))
 
 /** @internal */
 export const streamLines = (
   command: Command.Command
-): Stream.Stream<CommandExecutor.CommandExecutor, PlatformError, string> =>
+): Stream.Stream<"Platform/CommandExecutor", PlatformError, string> =>
   Stream.flatMap(commandExecutor.CommandExecutor, (process) => process.streamLines(command))
 
 /** @internal */
 export const string = dual<
   (
     encoding?: string
-  ) => (command: Command.Command) => Effect.Effect<CommandExecutor.CommandExecutor, PlatformError, string>,
-  (command: Command.Command, encoding?: string) => Effect.Effect<CommandExecutor.CommandExecutor, PlatformError, string>
+  ) => (command: Command.Command) => Effect.Effect<"Platform/CommandExecutor", PlatformError, string>,
+  (command: Command.Command, encoding?: string) => Effect.Effect<"Platform/CommandExecutor", PlatformError, string>
 >(
   (args) => isCommand(args[0]),
   (command, encoding) =>

--- a/packages/platform/src/internal/commandExecutor.ts
+++ b/packages/platform/src/internal/commandExecutor.ts
@@ -19,7 +19,7 @@ export const ExitCode = Brand.nominal<_CommandExecutor.ExitCode>()
 export const ProcessId = Brand.nominal<_CommandExecutor.Process.Id>()
 
 /** @internal */
-export const CommandExecutor = Tag<_CommandExecutor.CommandExecutor>("@effect/platform/CommandExecutor")
+export const CommandExecutor = Tag("Platform/CommandExecutor")<_CommandExecutor.CommandExecutor>()
 
 /** @internal */
 export const makeExecutor = (start: _CommandExecutor.CommandExecutor["start"]): _CommandExecutor.CommandExecutor => {

--- a/packages/platform/src/internal/fileSystem.ts
+++ b/packages/platform/src/internal/fileSystem.ts
@@ -10,7 +10,7 @@ import * as Error from "../Error.js"
 import type { File, FileSystem, Size as Size_, SizeInput, StreamOptions } from "../FileSystem.js"
 
 /** @internal */
-export const tag = Tag<FileSystem>("@effect/platform/FileSystem")
+export const tag = Tag("Platform/FileSystem")<FileSystem>()
 
 /** @internal */
 export const Size = (bytes: SizeInput) => typeof bytes === "bigint" ? bytes as Size_ : BigInt(bytes) as Size_

--- a/packages/platform/src/internal/http/body.ts
+++ b/packages/platform/src/internal/http/body.ts
@@ -103,7 +103,7 @@ export const jsonSchema = <I, A>(schema: Schema.Schema<I, A>) => {
 export const file = (
   path: string,
   options?: FileSystem.StreamOptions & { readonly contentType?: string }
-): Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, Body.Stream> =>
+): Effect.Effect<"Platform/FileSystem", PlatformError.PlatformError, Body.Stream> =>
   Effect.flatMap(
     FileSystem.FileSystem,
     (fs) =>
@@ -120,7 +120,7 @@ export const fileInfo = (
   path: string,
   info: FileSystem.File.Info,
   options?: FileSystem.StreamOptions & { readonly contentType?: string }
-): Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, Body.Stream> =>
+): Effect.Effect<"Platform/FileSystem", never, Body.Stream> =>
   Effect.map(
     FileSystem.FileSystem,
     (fs) =>

--- a/packages/platform/src/internal/http/client.ts
+++ b/packages/platform/src/internal/http/client.ts
@@ -26,7 +26,7 @@ export const TypeId: Client.TypeId = Symbol.for(
 ) as Client.TypeId
 
 /** @internal */
-export const tag = Context.Tag<Client.Client.Default>(TypeId)
+export const tag = Context.Tag("Platform/HttpClient")<Client.Client.Default>()
 
 const clientProto = {
   [TypeId]: TypeId,
@@ -76,9 +76,7 @@ export const makeDefault = (
 ): Client.Client.Default => make(Effect.flatMap(f), addB3Headers)
 
 /** @internal */
-export const Fetch = Context.Tag<Client.Fetch, typeof globalThis.fetch>(
-  Symbol.for("@effect/platform/Http/Client/Fetch")
-)
+export const Fetch = Context.Tag("Platform/HttpClient/Fetch")<typeof globalThis.fetch>()
 
 /** @internal */
 export const fetch = (options?: RequestInit): Client.Client.Default =>

--- a/packages/platform/src/internal/http/clientRequest.ts
+++ b/packages/platform/src/internal/http/clientRequest.ts
@@ -345,12 +345,12 @@ export const fileBody = dual<
     options?: FileSystem.StreamOptions & { readonly contentType?: string }
   ) => (
     self: ClientRequest.ClientRequest
-  ) => Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, ClientRequest.ClientRequest>,
+  ) => Effect.Effect<"Platform/FileSystem", PlatformError.PlatformError, ClientRequest.ClientRequest>,
   (
     self: ClientRequest.ClientRequest,
     path: string,
     options?: FileSystem.StreamOptions & { readonly contentType?: string }
-  ) => Effect.Effect<FileSystem.FileSystem, PlatformError.PlatformError, ClientRequest.ClientRequest>
+  ) => Effect.Effect<"Platform/FileSystem", PlatformError.PlatformError, ClientRequest.ClientRequest>
 >(
   (args) => isClientRequest(args[0]),
   (self, path, options) => Effect.map(internalBody.file(path, options), (body) => setBody(self, body))

--- a/packages/platform/src/internal/http/etag.ts
+++ b/packages/platform/src/internal/http/etag.ts
@@ -7,7 +7,7 @@ export const GeneratorTypeId: Etag.GeneratorTypeId = Symbol.for(
 ) as Etag.GeneratorTypeId
 
 /** @internal */
-export const tag = Context.Tag<Etag.Generator>(GeneratorTypeId)
+export const tag = Context.Tag("Platform/HttpEtagGenerator")<Etag.Generator>()
 
 /** @internal */
 export const toString = (self: Etag.Etag): string => {

--- a/packages/platform/src/internal/http/multipart.ts
+++ b/packages/platform/src/internal/http/multipart.ts
@@ -11,7 +11,6 @@ import { globalValue } from "effect/GlobalValue"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as Queue from "effect/Queue"
-import type * as Scope from "effect/Scope"
 import type * as AsyncInput from "effect/SingleProducerAsyncInput"
 import * as Stream from "effect/Stream"
 import * as MP from "multipasta"
@@ -378,7 +377,11 @@ const defaultWriteFile = (path: string, file: Multipart.File) =>
 export const toPersisted = (
   stream: Stream.Stream<never, Multipart.MultipartError, Multipart.Part>,
   writeFile = defaultWriteFile
-): Effect.Effect<FileSystem.FileSystem | Path.Path | Scope.Scope, Multipart.MultipartError, Multipart.Persisted> =>
+): Effect.Effect<
+  "Platform/FileSystem" | "Platform/Path" | "Scope",
+  Multipart.MultipartError,
+  Multipart.Persisted
+> =>
   pipe(
     Effect.Do,
     Effect.bind("fs", () => FileSystem.FileSystem),

--- a/packages/platform/src/internal/http/multiplex.ts
+++ b/packages/platform/src/internal/http/multiplex.ts
@@ -12,7 +12,7 @@ import type * as ServerResponse from "../../Http/ServerResponse.js"
 export const TypeId: Multiplex.TypeId = Symbol.for("@effect/platform/Http/Multiplex") as Multiplex.TypeId
 
 class MultiplexImpl<R, E>
-  extends Effectable.Class<R | ServerRequest.ServerRequest, E | Error.RouteNotFound, ServerResponse.ServerResponse>
+  extends Effectable.Class<R | "Platform/ServerRequest", E | Error.RouteNotFound, ServerResponse.ServerResponse>
   implements Multiplex.Multiplex<R, E>
 {
   readonly [TypeId]: Multiplex.TypeId

--- a/packages/platform/src/internal/http/platform.ts
+++ b/packages/platform/src/internal/http/platform.ts
@@ -12,7 +12,7 @@ import type * as ServerResponse from "../../Http/ServerResponse.js"
 export const TypeId: Platform.TypeId = Symbol.for("@effect/platform/Http/Platform") as Platform.TypeId
 
 /** @internal */
-export const tag = Context.Tag<Platform.Platform>(TypeId)
+export const tag = Context.Tag("Platform/HttpPlatform")<Platform.Platform>()
 
 /** @internal */
 export const make = (impl: {
@@ -32,7 +32,7 @@ export const make = (impl: {
     headers: Headers.Headers,
     options?: FileSystem.StreamOptions
   ) => ServerResponse.ServerResponse
-}): Effect.Effect<FileSystem.FileSystem | Etag.Generator, never, Platform.Platform> =>
+}): Effect.Effect<"Platform/FileSystem" | "Platform/HttpEtagGenerator", never, Platform.Platform> =>
   Effect.gen(function*(_) {
     const fs = yield* _(FileSystem.FileSystem)
     const etagGen = yield* _(Etag.Generator)

--- a/packages/platform/src/internal/http/router.ts
+++ b/packages/platform/src/internal/http/router.ts
@@ -27,7 +27,7 @@ export const RouteContextTypeId: Router.RouteContextTypeId = Symbol.for(
 ) as Router.RouteContextTypeId
 
 /** @internal */
-export const RouteContext = Context.Tag<Router.RouteContext>("@effect/platform/Http/Router/RouteContext")
+export const RouteContext = Context.Tag("Platform/RouteContext")<Router.RouteContext>()
 
 /** @internal */
 export const params = Effect.map(RouteContext, (_) => _.params)
@@ -54,7 +54,7 @@ export const schemaSearchParams = <I extends Readonly<Record<string, string>>, A
 }
 
 class RouterImpl<R, E> extends Effectable.StructuralClass<
-  Exclude<R, Router.RouteContext>,
+  Exclude<R, "Platform/RouteContext">,
   E | Error.RouteNotFound,
   ServerResponse.ServerResponse
 > implements Router.Router<R, E> {
@@ -68,7 +68,7 @@ class RouterImpl<R, E> extends Effectable.StructuralClass<
     this.httpApp = toHttpApp(this) as any
   }
   private httpApp: Effect.Effect<
-    Exclude<R, Router.RouteContext>,
+    Exclude<R, "Platform/RouteContext">,
     E | Error.RouteNotFound,
     ServerResponse.ServerResponse
   >

--- a/packages/platform/src/internal/http/server.ts
+++ b/packages/platform/src/internal/http/server.ts
@@ -2,7 +2,6 @@ import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import { dual } from "effect/Function"
 import * as Layer from "effect/Layer"
-import type * as Scope from "effect/Scope"
 import type * as App from "../../Http/App.js"
 import type * as Middleware from "../../Http/Middleware.js"
 import type * as Server from "../../Http/Server.js"
@@ -12,7 +11,7 @@ import type * as ServerRequest from "../../Http/ServerRequest.js"
 export const TypeId: Server.TypeId = Symbol.for("@effect/platform/Http/Server") as Server.TypeId
 
 /** @internal */
-export const serverTag = Context.Tag<Server.Server>(TypeId)
+export const serverTag = Context.Tag("Platform/Server")<Server.Server>()
 
 const serverProto = {
   [TypeId]: TypeId
@@ -27,7 +26,7 @@ export const make = (
     readonly serve: (
       httpApp: App.Default<never, unknown>,
       middleware?: Middleware.Middleware
-    ) => Effect.Effect<Scope.Scope, never, void>
+    ) => Effect.Effect<"Scope", never, void>
     readonly address: Server.Address
   }
 ): Server.Server => Object.assign(Object.create(serverProto), options)
@@ -38,14 +37,14 @@ export const serve = dual<
     (): <R, E>(
       httpApp: App.Default<R, E>
     ) => Layer.Layer<
-      Server.Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>,
+      Server.Server | Exclude<R, ServerRequest.ServerRequest | "Scope">,
       never,
       never
     >
     <R, E, App extends App.Default<any, any>>(middleware: Middleware.Middleware.Applied<R, E, App>): (
       httpApp: App.Default<R, E>
     ) => Layer.Layer<
-      Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>,
+      Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | "Scope">,
       never,
       never
     >
@@ -53,12 +52,12 @@ export const serve = dual<
   {
     <R, E>(
       httpApp: App.Default<R, E>
-    ): Layer.Layer<Server.Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>, never, never>
+    ): Layer.Layer<Server.Server | Exclude<R, ServerRequest.ServerRequest | "Scope">, never, never>
     <R, E, App extends App.Default<any, any>>(
       httpApp: App.Default<R, E>,
       middleware: Middleware.Middleware.Applied<R, E, App>
     ): Layer.Layer<
-      Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>,
+      Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | "Scope">,
       never,
       never
     >
@@ -69,7 +68,7 @@ export const serve = dual<
     httpApp: App.Default<R, E>,
     middleware?: Middleware.Middleware.Applied<R, E, App>
   ): Layer.Layer<
-    Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>,
+    Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | "Scope">,
     never,
     never
   > =>
@@ -87,14 +86,14 @@ export const serveEffect = dual<
     (): <R, E>(
       httpApp: App.Default<R, E>
     ) => Effect.Effect<
-      Server.Server | Scope.Scope | Exclude<R, ServerRequest.ServerRequest>,
+      Server.Server | "Scope" | Exclude<R, ServerRequest.ServerRequest>,
       never,
       void
     >
     <R, E, App extends App.Default<any, any>>(middleware: Middleware.Middleware.Applied<R, E, App>): (
       httpApp: App.Default<R, E>
     ) => Effect.Effect<
-      Server.Server | Scope.Scope | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>,
+      Server.Server | "Scope" | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>,
       never,
       void
     >
@@ -102,12 +101,12 @@ export const serveEffect = dual<
   {
     <R, E>(
       httpApp: App.Default<R, E>
-    ): Effect.Effect<Server.Server | Scope.Scope | Exclude<R, ServerRequest.ServerRequest>, never, void>
+    ): Effect.Effect<Server.Server | "Scope" | Exclude<R, ServerRequest.ServerRequest>, never, void>
     <R, E, App extends App.Default<any, any>>(
       httpApp: App.Default<R, E>,
       middleware: Middleware.Middleware.Applied<R, E, App>
     ): Effect.Effect<
-      Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest> | Scope.Scope,
+      Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest> | "Scope",
       never,
       void
     >
@@ -118,7 +117,7 @@ export const serveEffect = dual<
     httpApp: App.Default<R, E>,
     middleware: Middleware.Middleware.Applied<R, E, App>
   ): Effect.Effect<
-    Server.Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest> | Scope.Scope,
+    "Platform/Server" | "Scope" | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>,
     never,
     void
   > =>

--- a/packages/platform/src/internal/http/serverRequest.ts
+++ b/packages/platform/src/internal/http/serverRequest.ts
@@ -3,9 +3,7 @@ import type * as Schema from "@effect/schema/Schema"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
-import type * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
-import type * as FileSystem from "../../FileSystem.js"
 import * as Headers from "../../Http/Headers.js"
 import * as IncomingMessage from "../../Http/IncomingMessage.js"
 import type { Method } from "../../Http/Method.js"
@@ -13,13 +11,12 @@ import * as Multipart from "../../Http/Multipart.js"
 import * as Error from "../../Http/ServerError.js"
 import type * as ServerRequest from "../../Http/ServerRequest.js"
 import * as UrlParams from "../../Http/UrlParams.js"
-import type * as Path from "../../Path.js"
 
 /** @internal */
 export const TypeId: ServerRequest.TypeId = Symbol.for("@effect/platform/Http/ServerRequest") as ServerRequest.TypeId
 
 /** @internal */
-export const serverRequestTag = Context.Tag<ServerRequest.ServerRequest>(TypeId)
+export const serverRequestTag = Context.Tag("Platform/ServerRequest")<ServerRequest.ServerRequest>()
 
 /** @internal */
 export const multipartPersisted = Effect.flatMap(serverRequestTag, (request) => request.multipart)
@@ -46,7 +43,7 @@ export const schemaBodyForm = <I extends Multipart.Persisted, A>(
   const parseMultipart = Multipart.schemaPersisted(schema)
   const parseUrlParams = IncomingMessage.schemaBodyUrlParams(schema as Schema.Schema<any, A>)
   return Effect.flatMap(serverRequestTag, (request): Effect.Effect<
-    ServerRequest.ServerRequest | Scope.Scope | FileSystem.FileSystem | Path.Path,
+    "Platform/ServerRequest" | "Scope" | "Platform/FileSystem" | "Platform/Path",
     Multipart.MultipartError | ParseResult.ParseError | Error.RequestError,
     A
   > => {
@@ -81,7 +78,7 @@ export const schemaBodyFormJson = <I, A>(schema: Schema.Schema<I, A>) => {
       (
         request
       ): Effect.Effect<
-        FileSystem.FileSystem | Path.Path | Scope.Scope | ServerRequest.ServerRequest,
+        "Platform/FileSystem" | "Platform/Path" | "Scope" | "Platform/ServerRequest",
         ParseResult.ParseError | Error.RequestError,
         A
       > => {
@@ -206,13 +203,13 @@ class ServerRequestImpl implements ServerRequest.ServerRequest {
 
   private multipartEffect:
     | Effect.Effect<
-      Scope.Scope | FileSystem.FileSystem | Path.Path,
+      "Scope" | "Platform/FileSystem" | "Platform/Path",
       Multipart.MultipartError,
       Multipart.Persisted
     >
     | undefined
   get multipart(): Effect.Effect<
-    Scope.Scope | FileSystem.FileSystem | Path.Path,
+    "Scope" | "Platform/FileSystem" | "Platform/Path",
     Multipart.MultipartError,
     Multipart.Persisted
   > {

--- a/packages/platform/src/internal/http/serverResponse.ts
+++ b/packages/platform/src/internal/http/serverResponse.ts
@@ -138,7 +138,7 @@ export const schemaJson = <I, A>(
 export const file = (
   path: string,
   options?: ServerResponse.Options & FileSystem.StreamOptions
-): Effect.Effect<Platform.Platform, PlatformError.PlatformError, ServerResponse.ServerResponse> =>
+): Effect.Effect<"Platform/HttpPlatform", PlatformError.PlatformError, ServerResponse.ServerResponse> =>
   Effect.flatMap(
     Platform.Platform,
     (platform) => platform.fileResponse(path, options)
@@ -148,7 +148,7 @@ export const file = (
 export const fileWeb = (
   file: Body.Body.FileLike,
   options?: ServerResponse.Options.WithContent & FileSystem.StreamOptions
-): Effect.Effect<Platform.Platform, never, ServerResponse.ServerResponse> =>
+): Effect.Effect<"Platform/HttpPlatform", never, ServerResponse.ServerResponse> =>
   Effect.flatMap(
     Platform.Platform,
     (platform) => platform.fileWebResponse(file, options)

--- a/packages/platform/src/internal/keyValueStore.ts
+++ b/packages/platform/src/internal/keyValueStore.ts
@@ -14,7 +14,7 @@ export const TypeId: KeyValueStore.TypeId = Symbol.for(
 ) as KeyValueStore.TypeId
 
 /** @internal */
-export const keyValueStoreTag = Context.Tag<KeyValueStore.KeyValueStore>(TypeId)
+export const keyValueStoreTag = Context.Tag("Platform/KeyValueStore")<KeyValueStore.KeyValueStore>()
 
 /** @internal */
 export const make: (
@@ -166,11 +166,11 @@ export const layerFileSystem = (directory: string) =>
   )
 
 /** @internal */
-export const layerSchema = <I, A>(
-  schema: Schema.Schema<I, A>,
-  tagIdentifier?: unknown
+export const layerSchema = <I, A, K extends string>(
+  tagIdentifier: K,
+  schema: Schema.Schema<I, A>
 ) => {
-  const tag = Context.Tag<KeyValueStore.SchemaStore<A>>(tagIdentifier)
+  const tag = Context.Tag(tagIdentifier)<KeyValueStore.SchemaStore<A>>()
   const layer = Layer.effect(tag, Effect.map(keyValueStoreTag, (store) => store.forSchema(schema)))
   return { tag, layer } as const
 }

--- a/packages/platform/src/internal/path.ts
+++ b/packages/platform/src/internal/path.ts
@@ -7,7 +7,7 @@ import { BadArgument } from "../Error.js"
 import type { Path as _Path } from "../Path.js"
 
 /** @internal */
-export const Path = Tag<_Path>("@effect/platform/Path")
+export const Path = Tag("Platform/Path")<_Path>()
 
 /** @internal */
 export const layer = Layer.succeed(

--- a/packages/platform/src/internal/terminal.ts
+++ b/packages/platform/src/internal/terminal.ts
@@ -2,4 +2,4 @@ import { Tag } from "effect/Context"
 import type * as Terminal from "../Terminal.js"
 
 /** @internal */
-export const tag = Tag<Terminal.Terminal>("@effect/platform/Terminal")
+export const tag = Tag("Platform/Terminal")<Terminal.Terminal>()

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -36,7 +36,7 @@ const makeJsonPlaceholder = Effect.gen(function*(_) {
   } as const
 })
 interface JsonPlaceholder extends Effect.Effect.Success<typeof makeJsonPlaceholder> {}
-const JsonPlaceholder = Context.Tag<JsonPlaceholder>()
+const JsonPlaceholder = Context.Tag("JsonPlaceholder")<JsonPlaceholder>()
 const JsonPlaceholderLive = Layer.effect(JsonPlaceholder, makeJsonPlaceholder)
   .pipe(Layer.provide(Http.client.layer))
 

--- a/packages/platform/test/KeyValueStore.test.ts
+++ b/packages/platform/test/KeyValueStore.test.ts
@@ -6,8 +6,8 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import { afterEach, describe, expect, it } from "vitest"
 
-export const testLayer = <E>(layer: Layer.Layer<never, E, KeyValueStore.KeyValueStore>) => {
-  const run = <E, A>(effect: Effect.Effect<KeyValueStore.KeyValueStore, E, A>) =>
+export const testLayer = <E>(layer: Layer.Layer<never, E, "Platform/KeyValueStore">) => {
+  const run = <E, A>(effect: Effect.Effect<"Platform/KeyValueStore", E, A>) =>
     Effect.runPromise(Effect.provide(effect, layer))
 
   afterEach(() =>
@@ -114,8 +114,8 @@ class User extends Schema.Class<User>()({
   name: Schema.string,
   age: Schema.number
 }) {}
-const UserStore = KeyValueStore.layerSchema(User)
-const runUserStore = <E, A>(effect: Effect.Effect<KeyValueStore.SchemaStore<User>, E, A>) =>
+const UserStore = KeyValueStore.layerSchema("UserStore", User)
+const runUserStore = <E, A>(effect: Effect.Effect<"UserStore", E, A>) =>
   Effect.runPromise(Effect.provide(effect, UserStore.layer.pipe(Layer.provide(KeyValueStore.layerMemory))))
 
 describe("KeyValueStore / SchemaStore", () => {

--- a/packages/platform/test/Path.test.ts
+++ b/packages/platform/test/Path.test.ts
@@ -3,7 +3,7 @@ import * as Path from "@effect/platform/Path"
 import * as Effect from "effect/Effect"
 import { describe, expect, it } from "vitest"
 
-const runPromise = <E, A>(effect: Effect.Effect<Path.Path, E, A>) =>
+const runPromise = <E, A>(effect: Effect.Effect<"Platform/Path", E, A>) =>
   Effect.runPromise(Effect.provide(effect, Path.layer))
 
 describe("Path", () => {


### PR DESCRIPTION
Requesting early review for feedback before refactoring the rest.

This PR standardises tags to use string literals, basically a service is now represented by a tag like:

```ts
const UserRepo = Context.Tag("UserRepo")<UserRepo>()
```

and will be identified with the literal `"UseRepo"` in types.

This solves in one shot multiple issues, assignability of potentially similar types (uniqueness at the type level) and automatically makes tags global, meaning instantiating multiple times the same tag will lead to the same instance.

Debuggability also gains from having human readable names for every service in context and arguably the types are overall much simpler.

There is a degree of awkwardness in layers that now look like `Layer<"Database", never, "UserRepo" | "TodoRepo">` but I quite like it