### PR TITLE
ReadonlyArray: fix `sortWith` sig, closes #1961

### DIFF
--- a/.changeset/cyan-insects-ring.md
+++ b/.changeset/cyan-insects-ring.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+ReadonlyArray: fix `sortWith` sig, closes #1961

--- a/packages/effect/dtslint/ReadonlyArray.ts
+++ b/packages/effect/dtslint/ReadonlyArray.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
-import { hole, pipe } from "effect/Function"
+import { hole, identity, pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import type * as Order from "effect/Order"
 import * as Predicate from "effect/Predicate"
@@ -207,6 +207,22 @@ pipe(nonEmptyabs, ReadonlyArray.sort(ordera))
 
 // $ExpectType [AB, ...AB[]]
 ReadonlyArray.sort(ordera)(nonEmptyabs)
+
+// -------------------------------------------------------------------------------------
+// sortWith
+// -------------------------------------------------------------------------------------
+
+// $ExpectType AB[]
+pipe(abs, ReadonlyArray.sortWith(identity, ordera))
+
+// $ExpectType AB[]
+ReadonlyArray.sortWith(abs, identity, ordera)
+
+// $ExpectType [AB, ...AB[]]
+pipe(nonEmptyabs, ReadonlyArray.sortWith(identity, ordera))
+
+// $ExpectType [AB, ...AB[]]
+ReadonlyArray.sortWith(nonEmptyabs, identity, ordera)
 
 // -------------------------------------------------------------------------------------
 // partition

--- a/packages/effect/src/ReadonlyArray.ts
+++ b/packages/effect/src/ReadonlyArray.ts
@@ -896,12 +896,15 @@ export const sort: {
  * @category elements
  */
 export const sortWith: {
-  <A, B>(f: (a: A) => B, order: Order.Order<B>): (self: ReadonlyArray<A>) => Array<A>
-  <A, B>(self: ReadonlyArray<A>, f: (a: A) => B, order: Order.Order<B>): Array<A>
+  <S extends Iterable<any> | NonEmptyReadonlyArray<any>, B>(
+    f: (a: ReadonlyArray.Infer<S>) => B,
+    order: Order.Order<B>
+  ): (self: S) => ReadonlyArray.With<S, ReadonlyArray.Infer<S>>
+  <A, B>(self: NonEmptyReadonlyArray<A>, f: (a: A) => B, O: Order.Order<B>): NonEmptyArray<A>
+  <A, B>(self: Iterable<A>, f: (a: A) => B, order: Order.Order<B>): Array<A>
 } = dual(
   3,
-  <A, B>(self: ReadonlyArray<A>, f: (a: A) => B, order: Order.Order<B>): Array<A> =>
-    sort(self, Order.mapInput(order, f))
+  <A, B>(self: Iterable<A>, f: (a: A) => B, order: Order.Order<B>): Array<A> => sort(self, Order.mapInput(order, f))
 )
 
 /**

--- a/packages/effect/test/ReadonlyArray.test.ts
+++ b/packages/effect/test/ReadonlyArray.test.ts
@@ -1206,7 +1206,7 @@ describe("ReadonlyArray", () => {
       a: string
       b: number
     }
-    const chunk: ReadonlyArray<X> = [{ a: "a", b: 2 }, { a: "b", b: 1 }]
-    expect(RA.sortWith(chunk, (x) => x.b, Order.number)).toEqual([{ a: "b", b: 1 }, { a: "a", b: 2 }])
+    const arr: ReadonlyArray<X> = [{ a: "a", b: 2 }, { a: "b", b: 1 }]
+    expect(RA.sortWith(arr, (x) => x.b, Order.number)).toEqual([{ a: "b", b: 1 }, { a: "a", b: 2 }])
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #1961
