### PR TITLE
Default `Options.repeated` to an empty array if option not provided

### DIFF
--- a/.changeset/big-lizards-juggle.md
+++ b/.changeset/big-lizards-juggle.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": minor
+---
+
+default Options.repeated to return an empty array if option is not provided

--- a/packages/cli/src/Options.ts
+++ b/packages/cli/src/Options.ts
@@ -440,6 +440,12 @@ export const parse: {
 } = InternalOptions.parse
 
 /**
+ * Indicates that the specified command-line option can be repeated `0` or more
+ * times.
+ *
+ * **NOTE**: if the command-line option is not provided, and empty array will be
+ * returned as the value for said option.
+ *
  * @since 1.0.0
  * @category combinators
  */

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -475,12 +475,14 @@ describe("Options", () => {
   it("repeated", () =>
     Effect.gen(function*(_) {
       const option = Options.integer("foo").pipe(Options.repeated)
-      const args1 = ["--foo", "1", "--foo", "2", "--foo", "3"]
-      const args2 = ["--foo", "1", "--foo", "v2", "--foo", "3"]
-      const result1 = yield* _(process(option, args1, CliConfig.defaultConfig))
-      const result2 = yield* _(Effect.flip(process(option, args2, CliConfig.defaultConfig)))
-      expect(result1).toEqual([ReadonlyArray.empty(), [1, 2, 3]])
-      expect(result2).toEqual(ValidationError.invalidValue(HelpDoc.p("'v2' is not a integer")))
+      const args2 = ["--foo", "1", "--foo", "2", "--foo", "3"]
+      const args3 = ["--foo", "1", "--foo", "v2", "--foo", "3"]
+      const result1 = yield* _(process(option, [], CliConfig.defaultConfig))
+      const result2 = yield* _(process(option, args2, CliConfig.defaultConfig))
+      const result3 = yield* _(Effect.flip(process(option, args3, CliConfig.defaultConfig)))
+      expect(result1).toEqual([ReadonlyArray.empty(), []])
+      expect(result2).toEqual([ReadonlyArray.empty(), [1, 2, 3]])
+      expect(result3).toEqual(ValidationError.invalidValue(HelpDoc.p("'v2' is not a integer")))
     }).pipe(runEffect))
 
   it("atLeast", () =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #1973
