### PR TITLE
Add Either.tryPromise

### DIFF
--- a/.changeset/calm-dodos-jump.md
+++ b/.changeset/calm-dodos-jump.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add Either.tryPromise

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -187,6 +187,40 @@ export {
   try_ as try
 }
 
+const tryPromise_: {
+  <A, E>(
+    options: {
+      readonly try: LazyArg<Promise<A>>
+      readonly catch: (error: unknown) => E
+    }
+  ): Promise<Either<E, A>>
+  <A>(evaluate: LazyArg<Promise<A>>): Promise<Either<unknown, A>>
+} = (<A, E>(
+  evaluate: LazyArg<Promise<A>> | {
+    readonly try: LazyArg<Promise<A>>
+    readonly catch: (error: unknown) => E
+  }
+) => {
+  if (isFunction(evaluate)) {
+    return evaluate().then((value) => right(value)).catch((e) => left(e))
+  } else {
+    evaluate.try()
+      .then((value) => right(value))
+      .catch((e) => left(evaluate.catch(e)))
+  }
+}) as any
+
+export {
+  /**
+   * Imports an asynchronous side-effect into a `Promise<Either<E, A>>` value, translating any
+   * rejections into typed failed eithers created with `Either.left`.
+   *
+   * @category constructors
+   * @since 2.0.0
+   */
+  tryPromise_ as tryPromise
+}
+
 /**
  * Tests if a value is a `Either`.
  *

--- a/packages/effect/test/Either.test.ts
+++ b/packages/effect/test/Either.test.ts
@@ -221,6 +221,36 @@ describe("Either", () => {
     )
   })
 
+  it("tryPromise", async () => {
+    const promise = () => new Promise<number>((resolve) => resolve(1))
+    Util.deepStrictEqual(
+      await Either.tryPromise(promise),
+      Either.right(1)
+    )
+    Util.deepStrictEqual(
+      await Either.tryPromise(async () => {
+        throw "b"
+      }),
+      Either.left("b")
+    )
+    Util.deepStrictEqual(
+      await Either.tryPromise({
+        try: promise,
+        catch: (e) => new Error(String(e))
+      }),
+      Either.right(1)
+    )
+    Util.deepStrictEqual(
+      await Either.tryPromise({
+        try: async () => {
+          throw "b"
+        },
+        catch: (e) => new Error(String(e))
+      }),
+      Either.left(new Error("b"))
+    )
+  })
+
   it("getOrElse", () => {
     Util.deepStrictEqual(Either.getOrElse(Either.right(1), (error) => error + "!"), 1)
     Util.deepStrictEqual(Either.getOrElse(Either.left("not a number"), (error) => error + "!"), "not a number!")


### PR DESCRIPTION
Add a helper for streamlined wrapping of promise in an Either. I'd like to introduce Effect into our codebase, without going all in on the Effect type yet. I think this will help illustrate the value of using things like `Either`, `Data.TaggedError`, `Match` and `Schema` without needing to adopt fully effectual code paths.

Feedback welcome if there is another approach or a way to use an effect in a similar manner

```typescript
// Example
function getUser(id: number): Promise<Either.Either<UserNotFound, User>> {
  return Either.tryPromise({
    try: async () => {
       const result = await db.sql("...");
       // process result
    },
    catch: (error) => new UserNotFound(...)
  });
}
```