### PR TITLE
Schema: Class constructor: avoid overwriting `props` with `additional…

### DIFF
--- a/.changeset/sweet-pumpkins-applaud.md
+++ b/.changeset/sweet-pumpkins-applaud.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Class constructor: avoid overwriting `props` with `additionalProps`, closes #1987

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4763,7 +4763,7 @@ const makeClass = <R, I, A>(
   return class extends Base {
     constructor(props?: any, disableValidation = false) {
       if (additionalProps !== undefined) {
-        props = additionalProps ? { ...props, ...additionalProps } : props
+        props = { ...additionalProps, ...props }
       }
       if (disableValidation !== true) {
         props = validator(props)

--- a/packages/schema/test/Schema/Class.test.ts
+++ b/packages/schema/test/Schema/Class.test.ts
@@ -348,6 +348,20 @@ describe("Schema > Class", () => {
     expect(person.upperName).toEqual("JOHN")
   })
 
+  it("extending a TaggedClass with props containing a _tag field", async () => {
+    class A extends S.TaggedClass<A>()("A", {
+      id: S.number
+    }) {}
+    class B extends A.transformOrFail<B>()(
+      { _tag: S.literal("B") },
+      (input) => ParseResult.succeed({ ...input, _tag: "B" as const }),
+      (input) => ParseResult.succeed({ ...input, _tag: "A" })
+    ) {}
+
+    await Util.expectDecodeUnknownSuccess(B, { _tag: "A", id: 1 }, new B({ _tag: "B", id: 1 }))
+    await Util.expectEncodeSuccess(B, new B({ _tag: "B", id: 1 }), { _tag: "A", id: 1 })
+  })
+
   it("TaggedError", () => {
     class MyError extends S.TaggedError<MyError>()("MyError", {
       id: S.number


### PR DESCRIPTION
…Props`, closes #1987

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #1987
