### PR TITLE
fix: Data looses information about Equal living on prototype, not as a value in the object.

### DIFF
--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -2,7 +2,8 @@
  * @since 2.0.0
  */
 import type * as Cause from "./Cause.js"
-import type * as Equal from "./Equal.js"
+import * as Equal from "./Equal.js"
+import * as Hash from "./Hash.js"
 import * as core from "./internal/core.js"
 import * as internal from "./internal/data.js"
 import { StructuralPrototype } from "./internal/effectable.js"
@@ -14,7 +15,25 @@ import type * as Types from "./Types.js"
  */
 export type Data<A> =
   & { readonly [P in keyof A]: A[P] }
-  & Equal.Equal
+  & CasePrototype
+
+/**
+ * @internal
+ * this only exists to make sure Data tracks Hash and Equal being on the prototype
+ *
+ * class C extends Class<{}> {}
+ * let c = new C()
+ * c = { ...c }
+ * ^ should error: "is missing the following properties from type 'CasePrototype': [Hash.symbol], [Equal.symbol]"
+ */
+export abstract class CasePrototype implements Case {
+  [Hash.symbol](this: Equal.Equal): number {
+    throw new global.Error("Method not implemented.")
+  }
+  [Equal.symbol](this: Equal.Equal, _: Equal.Equal): boolean {
+    throw new global.Error("Method not implemented.")
+  }
+}
 
 /**
  * `Case` represents a datatype similar to a case class in Scala. Namely, a

--- a/packages/effect/src/internal/data.ts
+++ b/packages/effect/src/internal/data.ts
@@ -22,7 +22,7 @@ export const ArrayProto: Equal.Equal = Object.assign(Object.create(Array.prototy
 export const Structural: new<A>(
   args: Types.Equals<Omit<A, keyof Equal.Equal>, {}> extends true ? void
     : { readonly [P in keyof A as P extends keyof Equal.Equal ? never : P]: A[P] }
-) => Data.Case = (function() {
+) => Data.CasePrototype = (function() {
   function Structural(this: any, args: any) {
     if (args) {
       Object.assign(this, args)

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4629,7 +4629,7 @@ export const Class = <Self>() =>
     Simplify<ToStruct<Fields>>,
     Simplify<ToStruct<Fields>>,
     Self,
-    Data.Case
+    Data.CasePrototype
   > => makeClass(struct(fields), fields, Data.Class)
 
 /**
@@ -4647,7 +4647,7 @@ export const TaggedClass = <Self>() =>
     Simplify<{ readonly _tag: Tag } & ToStruct<Fields>>,
     Simplify<ToStruct<Fields>>,
     Self,
-    Data.Case
+    Data.CasePrototype
   > =>
 {
   const fieldsWithTag: StructFields = { ...fields, _tag: literal(tag) }


### PR DESCRIPTION
```ts
export class A extends Data.Class<{ n: 1 }> {}

let a: A = new A({ n: 1 })
a = { ...a }
```
silently compiles, but `a` is no longer a `Data.Class`, as Equal/Hash is on the prototype, but the compiler thinks they are values.

Begs the question if `Case` should be removed in favour of `CasePrototype`, or does it still has a place?

There are many more of these issues though, e.g all props of `Option.none()` are on the prototype,
but according to it's interface they're all values.
`console.log({ ...Option.none() }, { ...Option.none() }._tag)` will yield you `{}, undefined` but type checks; 
the compiler happily thinks you still have an Option.