### PR TITLE
use TimeoutException for timeout

### DIFF
--- a/.changeset/violet-doors-share.md
+++ b/.changeset/violet-doors-share.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Use `TimeoutException` instead of `NoSuchElementException` for timeout.

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -115,6 +115,18 @@ export type InvalidPubSubCapacityExceptionTypeId = typeof InvalidPubSubCapacityE
  * @since 2.0.0
  * @category symbols
  */
+export const TimeoutExceptionTypeId: unique symbol = core.TimeoutExceptionTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type TimeoutExceptionTypeId = typeof TimeoutExceptionTypeId
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
 export const UnknownExceptionTypeId: unique symbol = core.UnknownExceptionTypeId
 
 /**
@@ -257,6 +269,18 @@ export interface NoSuchElementException extends YieldableError {
 export interface InvalidPubSubCapacityException extends YieldableError {
   readonly _tag: "InvalidPubSubCapacityException"
   readonly [InvalidPubSubCapacityExceptionTypeId]: InvalidPubSubCapacityExceptionTypeId
+}
+
+/**
+ * Represents a checked exception which occurs when a computation doesn't
+ * finish on schedule.
+ *
+ * @since 2.0.0
+ * @category models
+ */
+export interface TimeoutException extends YieldableError {
+  readonly _tag: "TimeoutException"
+  readonly [TimeoutExceptionTypeId]: TimeoutExceptionTypeId
 }
 
 /**
@@ -861,6 +885,15 @@ export const RuntimeException: new(message?: string | undefined) => RuntimeExcep
  * @category refinements
  */
 export const isRuntimeException: (u: unknown) => u is RuntimeException = core.isRuntimeException
+
+/**
+ * Represents a checked exception which occurs when a computation doesn't
+ * finish on schedule.
+ *
+ * @since 2.0.0
+ * @category errors
+ */
+export const TimeoutException: new(message?: string | undefined) => TimeoutException = core.TimeoutException
 
 /**
  * Represents a checked exception which occurs when an unknown error is thrown, such as

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2924,8 +2924,8 @@ export const timedWith: {
  * @category delays & timeouts
  */
 export const timeout: {
-  (duration: Duration.DurationInput): <R, E, A>(self: Effect<R, E, A>) => Effect<R, E | Cause.NoSuchElementException, A>
-  <R, E, A>(self: Effect<R, E, A>, duration: Duration.DurationInput): Effect<R, Cause.NoSuchElementException | E, A>
+  (duration: Duration.DurationInput): <R, E, A>(self: Effect<R, E, A>) => Effect<R, E | Cause.TimeoutException, A>
+  <R, E, A>(self: Effect<R, E, A>, duration: Duration.DurationInput): Effect<R, Cause.TimeoutException | E, A>
 } = circular.timeout
 
 /**

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -2274,6 +2274,19 @@ export const isInvalidCapacityError = (u: unknown): u is Cause.InvalidPubSubCapa
   hasProperty(u, InvalidPubSubCapacityExceptionTypeId)
 
 /** @internal */
+export const TimeoutExceptionTypeId: Cause.TimeoutExceptionTypeId = Symbol.for(
+  "effect/Cause/errors/Timeout"
+) as Cause.TimeoutExceptionTypeId
+
+/** @internal */
+export const TimeoutException = makeException<Cause.TimeoutException>({
+  [TimeoutExceptionTypeId]: TimeoutExceptionTypeId
+}, "TimeoutException")
+
+/** @internal */
+export const isTimeoutException = (u: unknown): u is Cause.TimeoutException => hasProperty(u, TimeoutExceptionTypeId)
+
+/** @internal */
 export const UnknownExceptionTypeId: Cause.UnknownExceptionTypeId = Symbol.for(
   "effect/Cause/errors/UnknownException"
 ) as Cause.UnknownExceptionTypeId

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -399,14 +399,14 @@ export const supervised = dual<
 export const timeout = dual<
   (
     duration: Duration.DurationInput
-  ) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<R, E | Cause.NoSuchElementException, A>,
+  ) => <R, E, A>(self: Effect.Effect<R, E, A>) => Effect.Effect<R, E | Cause.TimeoutException, A>,
   <R, E, A>(
     self: Effect.Effect<R, E, A>,
     duration: Duration.DurationInput
-  ) => Effect.Effect<R, E | Cause.NoSuchElementException, A>
+  ) => Effect.Effect<R, E | Cause.TimeoutException, A>
 >(2, (self, duration) =>
   timeoutFail(self, {
-    onTimeout: () => new core.NoSuchElementException(),
+    onTimeout: () => new core.TimeoutException(),
     duration
   }))
 

--- a/packages/effect/test/Effect/promise.test.ts
+++ b/packages/effect/test/Effect/promise.test.ts
@@ -17,7 +17,7 @@ describe("Effect", () => {
     })
     const program = effect.pipe(
       Effect.timeout("10 millis"),
-      Effect.optionFromOptional
+      Effect.option
     )
     const exit = await Effect.runPromiseExit(program)
     expect(exit._tag).toBe("Success")

--- a/packages/effect/test/Effect/tryPromise.test.ts
+++ b/packages/effect/test/Effect/tryPromise.test.ts
@@ -57,7 +57,8 @@ describe("Effect", () => {
     })
     const program = effect.pipe(
       Effect.timeout("10 millis"),
-      Effect.optionFromOptional
+      Effect.asSome,
+      Effect.catchTag("TimeoutException", () => Effect.succeedNone)
     )
     const exit = await Effect.runPromiseExit(program)
     expect(exit._tag).toBe("Success")
@@ -81,7 +82,8 @@ describe("Effect", () => {
     })
     const program = effect.pipe(
       Effect.timeout("10 millis"),
-      Effect.optionFromOptional
+      Effect.asSome,
+      Effect.catchTag("TimeoutException", () => Effect.succeedNone)
     )
     const exit = await Effect.runPromiseExit(program)
     expect(exit._tag).toBe("Success")

--- a/packages/platform-node/test/Http/NodeClient.test.ts
+++ b/packages/platform-node/test/Http/NodeClient.test.ts
@@ -101,7 +101,8 @@ describe("HttpClient", () => {
         client,
         Effect.flatMap((_) => _.text),
         Effect.timeout(1),
-        Effect.optionFromOptional
+        Effect.asSome,
+        Effect.catchTag("TimeoutException", () => Effect.succeedNone)
       )
       expect(response._tag).toEqual("None")
     }).pipe(Effect.provide(NodeClient.layer), Effect.runPromise))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I was staring at a failing test shouting `NoSuchElementException` at me and it took me some time to realise it is actually a timeout. 

While I somewhat get the point that being able to easily convert such an error to `Option` using `Effect.optionFromOptional` is convenient, I believe it is quite confusing. In such a case using explicit `Effect.catchTag("TimeoutException", () => Effect.succeedNone)` and communicating clearly what's happening to a reader of my code is IMHO better.

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->