### PR TITLE
Support URL objects in client requests

### DIFF
--- a/.changeset/tricky-zebras-sneeze.md
+++ b/.changeset/tricky-zebras-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Support URL objects in client requests

--- a/packages/platform/src/Http/ClientRequest.ts
+++ b/packages/platform/src/Http/ClientRequest.ts
@@ -74,53 +74,53 @@ export declare namespace Options {
  * @category constructors
  */
 export const make: {
-  (method: "GET" | "HEAD"): (url: string, options?: Options.NoBody) => ClientRequest
+  (method: "GET" | "HEAD"): (url: string | URL, options?: Options.NoBody) => ClientRequest
   (
     method: Exclude<Method, "GET" | "HEAD">
-  ): (url: string, options?: Options.NoUrl) => ClientRequest
+  ): (url: string | URL, options?: Options.NoUrl) => ClientRequest
 } = internal.make
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const get: (url: string, options?: Options.NoBody) => ClientRequest = internal.get
+export const get: (url: string | URL, options?: Options.NoBody) => ClientRequest = internal.get
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const post: (url: string, options?: Options.NoUrl) => ClientRequest = internal.post
+export const post: (url: string | URL, options?: Options.NoUrl) => ClientRequest = internal.post
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const patch: (url: string, options?: Options.NoUrl) => ClientRequest = internal.patch
+export const patch: (url: string | URL, options?: Options.NoUrl) => ClientRequest = internal.patch
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const put: (url: string, options?: Options.NoUrl) => ClientRequest = internal.put
+export const put: (url: string | URL, options?: Options.NoUrl) => ClientRequest = internal.put
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const del: (url: string, options?: Options.NoUrl) => ClientRequest = internal.del
+export const del: (url: string | URL, options?: Options.NoUrl) => ClientRequest = internal.del
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const head: (url: string, options?: Options.NoBody) => ClientRequest = internal.head
+export const head: (url: string | URL, options?: Options.NoBody) => ClientRequest = internal.head
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const options: (url: string, options?: Options.NoUrl) => ClientRequest = internal.options
+export const options: (url: string | URL, options?: Options.NoUrl) => ClientRequest = internal.options
 
 /**
  * @since 1.0.0
@@ -196,7 +196,7 @@ export const acceptJson: (self: ClientRequest) => ClientRequest = internal.accep
  * @category combinators
  */
 export const setUrl: {
-  (url: string): (self: ClientRequest) => ClientRequest
+  (url: string | URL): (self: ClientRequest) => ClientRequest
   (self: ClientRequest, url: string): ClientRequest
 } = internal.setUrl
 
@@ -205,7 +205,7 @@ export const setUrl: {
  * @category combinators
  */
 export const prependUrl: {
-  (path: string): (self: ClientRequest) => ClientRequest
+  (path: string | URL): (self: ClientRequest) => ClientRequest
   (self: ClientRequest, path: string): ClientRequest
 } = internal.prependUrl
 

--- a/packages/platform/src/internal/http/clientRequest.ts
+++ b/packages/platform/src/internal/http/clientRequest.ts
@@ -46,14 +46,14 @@ export const empty: ClientRequest.ClientRequest = new ClientRequestImpl(
 
 /** @internal */
 export const make: {
-  (method: "GET" | "HEAD"): (url: string, options?: ClientRequest.Options.NoBody) => ClientRequest.ClientRequest
+  (method: "GET" | "HEAD"): (url: string | URL, options?: ClientRequest.Options.NoBody) => ClientRequest.ClientRequest
   (
     method: Exclude<Method, "GET" | "HEAD">
-  ): (url: string, options?: ClientRequest.Options.NoUrl) => ClientRequest.ClientRequest
-} = (method: Method) => (url: string, options?: ClientRequest.Options.NoUrl) =>
+  ): (url: string | URL, options?: ClientRequest.Options.NoUrl) => ClientRequest.ClientRequest
+} = (method: Method) => (url: string | URL, options?: ClientRequest.Options.NoUrl) =>
   modify(empty, {
     method,
-    url,
+    url: url.toString(),
     ...(options ?? undefined)
   })
 
@@ -172,12 +172,12 @@ export const setMethod = dual<
 
 /** @internal */
 export const setUrl = dual<
-  (url: string) => (self: ClientRequest.ClientRequest) => ClientRequest.ClientRequest,
+  (url: string | URL) => (self: ClientRequest.ClientRequest) => ClientRequest.ClientRequest,
   (self: ClientRequest.ClientRequest, url: string) => ClientRequest.ClientRequest
 >(2, (self, url) =>
   new ClientRequestImpl(
     self.method,
-    url,
+    url.toString(),
     self.urlParams,
     self.headers,
     self.body
@@ -198,12 +198,12 @@ export const appendUrl = dual<
 
 /** @internal */
 export const prependUrl = dual<
-  (path: string) => (self: ClientRequest.ClientRequest) => ClientRequest.ClientRequest,
+  (path: string | URL) => (self: ClientRequest.ClientRequest) => ClientRequest.ClientRequest,
   (self: ClientRequest.ClientRequest, path: string) => ClientRequest.ClientRequest
 >(2, (self, url) =>
   new ClientRequestImpl(
     self.method,
-    url + self.url,
+    url.toString() + self.url,
     self.urlParams,
     self.headers,
     self.body

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -20,7 +20,7 @@ const OkTodo = Schema.struct({
 const makeJsonPlaceholder = Effect.gen(function*(_) {
   const defaultClient = yield* _(Http.client.Client)
   const client = defaultClient.pipe(
-    Http.client.mapRequest(Http.request.prependUrl("https://jsonplaceholder.typicode.com"))
+    Http.client.mapRequest(Http.request.prependUrl(new URL("https://jsonplaceholder.typicode.com")))
   )
   const todoClient = client.pipe(
     Http.client.mapEffect(Http.response.schemaBodyJson(Todo))
@@ -54,7 +54,7 @@ describe("HttpClient", () => {
   it("google stream", () =>
     Effect.gen(function*(_) {
       const response = yield* _(
-        Http.request.get("https://www.google.com/"),
+        Http.request.get(new URL("https://www.google.com/")),
         Http.client.fetchOk(),
         Effect.map((_) => _.stream),
         Stream.unwrap,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Adds support for the `URL` object in the appropriate client request functions. I use it when including base URLs in configuration; this change saves having to convert it to a string myself.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
