### PR TITLE
feat: Make Equal an implicit trait, namely remove the type Data.Data

### DIFF
--- a/.changeset/mighty-donuts-behave.md
+++ b/.changeset/mighty-donuts-behave.md
@@ -1,0 +1,33 @@
+---
+"@effect/platform": minor
+"effect": minor
+"@effect/schema": minor
+"@effect/cli": minor
+"@effect/rpc": minor
+---
+
+With this change we remove the `Data.Data` type and we make `Equal.Equal` & `Hash.Hash` implicit traits.
+
+The main reason is that `Data.Data<A>` was structurally equivalent to `A & Equal.Equal` but extending `Equal.Equal` doesn't mean that the equality is implemented by-value, so the type was simply adding noise without gaining any level of safety.
+
+The module `Data` remains unchanged at the value level, all the functions previously available are supposed to work in exactly the same manner.
+
+At the type level instead the functions return `Readonly` variants, so for example we have:
+
+```ts
+import { Data } from "effect";
+
+const obj = Data.struct({
+  a: 0,
+  b: 1,
+});
+```
+
+will have the `obj` typed as:
+
+```ts
+declare const obj: {
+  readonly a: number;
+  readonly b: number;
+};
+```

--- a/packages/cli/src/Options.ts
+++ b/packages/cli/src/Options.ts
@@ -177,13 +177,13 @@ export const choice: <A extends string, C extends NonEmptyReadonlyArray<A>>(
  *
  * export type Animal = Dog | Cat
  *
- * export interface Dog extends Data.Case {
+ * export interface Dog {
  *   readonly _tag: "Dog"
  * }
  *
  * export const Dog = Data.tagged<Dog>("Dog")
  *
- * export interface Cat extends Data.Case {
+ * export interface Cat {
  *   readonly _tag: "Cat"
  * }
  *

--- a/packages/effect/dtslint/Data.ts
+++ b/packages/effect/dtslint/Data.ts
@@ -10,13 +10,13 @@ declare const mutableArray: Array<string>
 // struct
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Data<{ readonly a: string; }>
+// $ExpectType { readonly a: string; }
 const struct1 = Data.struct(mutableStruct)
 
 // @ts-expect-error
 struct1.a = "a"
 
-// $ExpectType Data<{ readonly a: string; }>
+// $ExpectType { readonly a: string; }
 const struct2 = Data.struct(readonlyStruct)
 
 // @ts-expect-error
@@ -26,13 +26,13 @@ struct2.a = "a"
 // unsafeStruct
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Data<{ readonly a: string; }>
+// $ExpectType { readonly a: string; }
 const struct3 = Data.unsafeStruct(mutableStruct)
 
 // @ts-expect-error
 struct3.a = "a"
 
-// $ExpectType Data<{ readonly a: string; }>
+// $ExpectType { readonly a: string; }
 const struct4 = Data.unsafeStruct(readonlyStruct)
 
 // @ts-expect-error
@@ -42,7 +42,7 @@ struct4.a = "a"
 // tuple
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Data<readonly [string, number]>
+// $ExpectType readonly [string, number]
 const tuple1 = Data.tuple("a", 1)
 
 // @ts-expect-error
@@ -54,13 +54,13 @@ tuple1[1] = 1
 // array
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Data<readonly string[]>
+// $ExpectType readonly string[]
 const array1 = Data.array(mutableArray)
 
 // @ts-expect-error
 array1[0] = "a"
 
-// $ExpectType Data<readonly string[]>
+// $ExpectType readonly string[]
 const array2 = Data.array(readonlyArray)
 
 // @ts-expect-error
@@ -70,13 +70,13 @@ array2[0] = "a"
 // unsafeArray
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Data<readonly string[]>
+// $ExpectType readonly string[]
 const array3 = Data.unsafeArray(mutableArray)
 
 // @ts-expect-error
 array3[0] = "a"
 
-// $ExpectType Data<readonly string[]>
+// $ExpectType readonly string[]
 const array4 = Data.unsafeArray(readonlyArray)
 
 // @ts-expect-error
@@ -86,7 +86,7 @@ array4[0] = "a"
 // case
 // -------------------------------------------------------------------------------------
 
-interface Person extends Data.Case {
+interface Person {
   readonly name: string
 }
 
@@ -96,13 +96,13 @@ const person = Data.case<Person>()
 export type PersonInput = Parameters<typeof person>[0]
 
 // @ts-expect-error
-person.name = "a"
+person({ name: "" }).name = "a"
 
 // -------------------------------------------------------------------------------------
 // tagged
 // -------------------------------------------------------------------------------------
 
-interface TaggedPerson extends Data.Case {
+interface TaggedPerson {
   readonly _tag: "Person"
   readonly name: string
   readonly optional?: string
@@ -124,9 +124,9 @@ type HttpError = Data.TaggedEnum<{
   BadRequest: { readonly status: 400; readonly a: string }
   NotFound: { readonly status: 404; readonly b: number }
 }>
-// $ExpectType Data<{ readonly _tag: "BadRequest"; readonly status: 400; readonly a: string; }>
+// $ExpectType { readonly _tag: "BadRequest"; readonly status: 400; readonly a: string; }
 export type BadRequest = Extract<HttpError, { _tag: "BadRequest" }>
-// $ExpectType Data<{ readonly _tag: "NotFound"; readonly status: 404; readonly b: number; }>
+// $ExpectType { readonly _tag: "NotFound"; readonly status: 404; readonly b: number; }
 export type NotFound = Extract<HttpError, { _tag: "NotFound" }>
 
 // @ts-expect-error
@@ -140,14 +140,14 @@ export type Err = Data.TaggedEnum<{
 // -------------------------------------------------------------------------------------
 
 const { NotFound } = Data.taggedEnum<
-  | Data.Data<{ readonly _tag: "BadRequest"; readonly status: 400; readonly message: string }>
-  | Data.Data<{ readonly _tag: "NotFound"; readonly status: 404; readonly message: string }>
+  | { readonly _tag: "BadRequest"; readonly status: 400; readonly message: string }
+  | { readonly _tag: "NotFound"; readonly status: 404; readonly message: string }
 >()
 
 // $ExpectType { readonly status: 404; readonly message: string; }
 export type notFoundInput = Parameters<typeof NotFound>[0]
 
-// $ExpectType Data<{ readonly _tag: "NotFound"; readonly status: 404; readonly message: string; }>
+// $ExpectType { readonly _tag: "NotFound"; readonly status: 404; readonly message: string; }
 export type notFoundOutput = ReturnType<typeof NotFound>
 
 const notFound = NotFound({ status: 404, message: "mesage" })

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -23,7 +23,6 @@
  */
 import type * as Channel from "./Channel.js"
 import type * as Chunk from "./Chunk.js"
-import type * as Data from "./Data.js"
 import type * as Effect from "./Effect.js"
 import type * as Either from "./Either.js"
 import type * as Equal from "./Equal.js"
@@ -190,7 +189,7 @@ export interface CauseReducer<in C, in E, in out Z> {
  * @since 2.0.0
  * @category models
  */
-export interface YieldableError extends Data.Case, Pipeable, Inspectable, Readonly<Error> {
+export interface YieldableError extends Pipeable, Inspectable, Readonly<Error> {
   readonly [Effect.EffectTypeId]: Effect.Effect.VarianceStruct<never, this, never>
   readonly [Stream.StreamTypeId]: Effect.Effect.VarianceStruct<never, this, never>
   readonly [Sink.SinkTypeId]: Sink.Sink.VarianceStruct<never, this, unknown, never, never>

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -10,7 +10,6 @@ import type * as Context from "./Context.js"
 import type * as Deferred from "./Deferred.js"
 import type * as Duration from "./Duration.js"
 import type * as Either from "./Either.js"
-import type * as Equal from "./Equal.js"
 import type { Equivalence } from "./Equivalence.js"
 import type { ExecutionStrategy } from "./ExecutionStrategy.js"
 import type * as Exit from "./Exit.js"
@@ -54,7 +53,7 @@ import * as Scheduler from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
-import type { Concurrency, Covariant, NoInfer } from "./Types.js"
+import type * as Types from "./Types.js"
 import type * as Unify from "./Unify.js"
 
 // -------------------------------------------------------------------------------------
@@ -99,7 +98,7 @@ export type EffectTypeId = typeof EffectTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Effect<out R, out E, out A> extends Effect.Variance<R, E, A>, Equal.Equal, Pipeable {
+export interface Effect<out R, out E, out A> extends Effect.Variance<R, E, A>, Pipeable {
   readonly [Unify.typeSymbol]?: unknown
   readonly [Unify.unifySymbol]?: EffectUnify<this>
   readonly [Unify.ignoreSymbol]?: EffectUnifyIgnore
@@ -209,9 +208,9 @@ export declare namespace Effect {
    */
   export interface VarianceStruct<out R, out E, out A> {
     readonly _V: string
-    readonly _R: Covariant<R>
-    readonly _E: Covariant<E>
-    readonly _A: Covariant<A>
+    readonly _R: Types.Covariant<R>
+    readonly _E: Types.Covariant<E>
+    readonly _A: Types.Covariant<A>
   }
   /**
    * @since 2.0.0
@@ -358,7 +357,7 @@ export const once: <R, E, A>(self: Effect<R, E, A>) => Effect<never, never, Effe
 export const all: <
   const Arg extends Iterable<Effect<any, any, any>> | Record<string, Effect<any, any, any>>,
   O extends {
-    readonly concurrency?: Concurrency | undefined
+    readonly concurrency?: Types.Concurrency | undefined
     readonly batching?: boolean | "inherit" | undefined
     readonly discard?: boolean | undefined
     readonly mode?: "default" | "validate" | "either" | undefined
@@ -377,7 +376,7 @@ export const all: <
  */
 export const allWith: <
   O extends {
-    readonly concurrency?: Concurrency | undefined
+    readonly concurrency?: Types.Concurrency | undefined
     readonly batching?: boolean | "inherit" | undefined
     readonly discard?: boolean | undefined
     readonly mode?: "default" | "validate" | "either" | undefined
@@ -475,7 +474,7 @@ export declare namespace All {
   export type Return<
     Arg extends Iterable<EffectAny> | Record<string, EffectAny>,
     O extends {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: boolean | undefined
       readonly mode?: "default" | "validate" | "either" | undefined
@@ -496,7 +495,7 @@ export declare namespace All {
 export const allSuccesses: <R, E, A>(
   elements: Iterable<Effect<R, E, A>>,
   options?: {
-    readonly concurrency?: Concurrency | undefined
+    readonly concurrency?: Types.Concurrency | undefined
     readonly batching?: boolean | "inherit" | undefined
   }
 ) => Effect<R, never, Array<A>> = fiberRuntime.allSuccesses
@@ -509,7 +508,7 @@ export const allSuccesses: <R, E, A>(
  */
 export const dropUntil: {
   <A, R, E>(
-    predicate: (a: NoInfer<A>, i: number) => Effect<R, E, boolean>
+    predicate: (a: Types.NoInfer<A>, i: number) => Effect<R, E, boolean>
   ): (elements: Iterable<A>) => Effect<R, E, Array<A>>
   <A, R, E>(elements: Iterable<A>, predicate: (a: A, i: number) => Effect<R, E, boolean>): Effect<R, E, Array<A>>
 } = effect.dropUntil
@@ -522,7 +521,7 @@ export const dropUntil: {
  */
 export const dropWhile: {
   <A, R, E>(
-    predicate: (a: NoInfer<A>, i: number) => Effect<R, E, boolean>
+    predicate: (a: Types.NoInfer<A>, i: number) => Effect<R, E, boolean>
   ): (elements: Iterable<A>) => Effect<R, E, Array<A>>
   <A, R, E>(elements: Iterable<A>, predicate: (a: A, i: number) => Effect<R, E, boolean>): Effect<R, E, Array<A>>
 } = effect.dropWhile
@@ -550,7 +549,7 @@ export const exists: {
   <R, E, A>(
     f: (a: A, i: number) => Effect<R, E, boolean>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): (elements: Iterable<A>) => Effect<R, E, boolean>
@@ -558,7 +557,7 @@ export const exists: {
     elements: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, boolean>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): Effect<R, E, boolean>
@@ -574,7 +573,7 @@ export const filter: {
   <A, R, E>(
     f: (a: A, i: number) => Effect<R, E, boolean>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly negate?: boolean | undefined
     }
@@ -583,7 +582,7 @@ export const filter: {
     elements: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, boolean>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly negate?: boolean | undefined
     }
@@ -630,7 +629,7 @@ export const forEach: {
   <A, R, E, B>(
     f: (a: A, i: number) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: false | undefined
     }
@@ -638,7 +637,7 @@ export const forEach: {
   <A, R, E, B>(
     f: (a: A, i: number) => Effect<R, E, B>,
     options: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard: true
     }
@@ -647,7 +646,7 @@ export const forEach: {
     self: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: false | undefined
     }
@@ -656,7 +655,7 @@ export const forEach: {
     self: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, B>,
     options: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard: true
     }
@@ -685,7 +684,7 @@ export const mergeAll: {
     zero: Z,
     f: (z: Z, a: A, i: number) => Z,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): <R, E>(elements: Iterable<Effect<R, E, A>>) => Effect<R, E, Z>
@@ -694,7 +693,7 @@ export const mergeAll: {
     zero: Z,
     f: (z: Z, a: A, i: number) => Z,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): Effect<R, E, Z>
@@ -711,12 +710,12 @@ export const partition: {
   <R, E, A, B>(
     f: (a: A) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): (elements: Iterable<A>) => Effect<R, never, [excluded: Array<E>, satisfying: Array<B>]>
   <R, E, A, B>(elements: Iterable<A>, f: (a: A) => Effect<R, E, B>, options?: {
-    readonly concurrency?: Concurrency | undefined
+    readonly concurrency?: Types.Concurrency | undefined
     readonly batching?: boolean | "inherit" | undefined
   }): Effect<R, never, [excluded: Array<E>, satisfying: Array<B>]>
 } = fiberRuntime.partition
@@ -744,7 +743,7 @@ export const reduceEffect: {
     zero: Effect<R, E, A>,
     f: (acc: A, a: A, i: number) => A,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): (elements: Iterable<Effect<R, E, A>>) => Effect<R, E, A>
@@ -753,7 +752,7 @@ export const reduceEffect: {
     zero: Effect<R, E, A>,
     f: (acc: A, a: A, i: number) => A,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): Effect<R, E, A>
@@ -817,7 +816,7 @@ export const replicateEffect: {
   (
     n: number,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: false | undefined
     }
@@ -825,7 +824,7 @@ export const replicateEffect: {
   (
     n: number,
     options: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard: true
     }
@@ -834,7 +833,7 @@ export const replicateEffect: {
     self: Effect<R, E, A>,
     n: number,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: false | undefined
     }
@@ -843,7 +842,7 @@ export const replicateEffect: {
     self: Effect<R, E, A>,
     n: number,
     options: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard: true
     }
@@ -858,7 +857,7 @@ export const replicateEffect: {
  */
 export const takeUntil: {
   <A, R, E>(
-    predicate: (a: NoInfer<A>, i: number) => Effect<R, E, boolean>
+    predicate: (a: Types.NoInfer<A>, i: number) => Effect<R, E, boolean>
   ): (elements: Iterable<A>) => Effect<R, E, Array<A>>
   <R, E, A>(elements: Iterable<A>, predicate: (a: A, i: number) => Effect<R, E, boolean>): Effect<R, E, Array<A>>
 } = effect.takeUntil
@@ -871,7 +870,7 @@ export const takeUntil: {
  */
 export const takeWhile: {
   <R, E, A>(
-    predicate: (a: NoInfer<A>, i: number) => Effect<R, E, boolean>
+    predicate: (a: Types.NoInfer<A>, i: number) => Effect<R, E, boolean>
   ): (elements: Iterable<A>) => Effect<R, E, Array<A>>
   <R, E, A>(elements: Iterable<A>, predicate: (a: A, i: number) => Effect<R, E, boolean>): Effect<R, E, Array<A>>
 } = effect.takeWhile
@@ -890,7 +889,7 @@ export const validateAll: {
   <R, E, A, B>(
     f: (a: A, i: number) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: false | undefined
     }
@@ -898,7 +897,7 @@ export const validateAll: {
   <R, E, A, B>(
     f: (a: A, i: number) => Effect<R, E, B>,
     options: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard: true
     }
@@ -907,7 +906,7 @@ export const validateAll: {
     elements: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard?: false | undefined
     }
@@ -916,7 +915,7 @@ export const validateAll: {
     elements: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, B>,
     options: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
       readonly discard: true
     }
@@ -948,7 +947,7 @@ export const validateFirst: {
   <R, E, A, B>(
     f: (a: A, i: number) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): (elements: Iterable<A>) => Effect<R, Array<E>, B>
@@ -956,7 +955,7 @@ export const validateFirst: {
     elements: Iterable<A>,
     f: (a: A, i: number) => Effect<R, E, B>,
     options?: {
-      readonly concurrency?: Concurrency | undefined
+      readonly concurrency?: Types.Concurrency | undefined
       readonly batching?: boolean | "inherit" | undefined
     }
   ): Effect<R, Array<E>, B>
@@ -1560,12 +1559,12 @@ export const catchAllDefect: {
  */
 export const catchIf: {
   <E, EB extends E, R2, E2, A2>(
-    refinement: Refinement<NoInfer<E>, EB>,
+    refinement: Refinement<Types.NoInfer<E>, EB>,
     f: (e: EB) => Effect<R2, E2, A2>
   ): <R, A>(self: Effect<R, E, A>) => Effect<R2 | R, E2 | Exclude<E, EB>, A2 | A>
   <E, R2, E2, A2>(
-    predicate: Predicate<NoInfer<E>>,
-    f: (e: NoInfer<E>) => Effect<R2, E2, A2>
+    predicate: Predicate<Types.NoInfer<E>>,
+    f: (e: Types.NoInfer<E>) => Effect<R2, E2, A2>
   ): <R, A>(self: Effect<R, E, A>) => Effect<R2 | R, E | E2, A2 | A>
   <R, E, A, EA extends E, EB extends EA, R2, E2, A2>(
     self: Effect<R, E, A>,
@@ -3364,12 +3363,12 @@ export {
  */
 export const filterOrDie: {
   <A, B extends A>(
-    refinement: Refinement<NoInfer<A>, B>,
-    orDieWith: (a: NoInfer<A>) => unknown
+    refinement: Refinement<Types.NoInfer<A>, B>,
+    orDieWith: (a: Types.NoInfer<A>) => unknown
   ): <R, E>(self: Effect<R, E, A>) => Effect<R, E, B>
   <A>(
-    predicate: Predicate<NoInfer<A>>,
-    orDieWith: (a: NoInfer<A>) => unknown
+    predicate: Predicate<Types.NoInfer<A>>,
+    orDieWith: (a: Types.NoInfer<A>) => unknown
   ): <R, E>(self: Effect<R, E, A>) => Effect<R, E, A>
   <R, E, A, B extends A>(
     self: Effect<R, E, A>,
@@ -3388,10 +3387,10 @@ export const filterOrDie: {
  */
 export const filterOrDieMessage: {
   <A, B extends A>(
-    refinement: Refinement<NoInfer<A>, B>,
+    refinement: Refinement<Types.NoInfer<A>, B>,
     message: string
   ): <R, E>(self: Effect<R, E, A>) => Effect<R, E, B>
-  <A>(predicate: Predicate<NoInfer<A>>, message: string): <R, E>(self: Effect<R, E, A>) => Effect<R, E, A>
+  <A>(predicate: Predicate<Types.NoInfer<A>>, message: string): <R, E>(self: Effect<R, E, A>) => Effect<R, E, A>
   <R, E, A, B extends A>(self: Effect<R, E, A>, refinement: Refinement<A, B>, message: string): Effect<R, E, B>
   <R, E, A>(self: Effect<R, E, A>, predicate: Predicate<A>, message: string): Effect<R, E, A>
 } = effect.filterOrDieMessage
@@ -3405,12 +3404,12 @@ export const filterOrDieMessage: {
  */
 export const filterOrElse: {
   <A, B extends A, R2, E2, C>(
-    refinement: Refinement<NoInfer<A>, B>,
-    orElse: (a: NoInfer<A>) => Effect<R2, E2, C>
+    refinement: Refinement<Types.NoInfer<A>, B>,
+    orElse: (a: Types.NoInfer<A>) => Effect<R2, E2, C>
   ): <R, E>(self: Effect<R, E, A>) => Effect<R2 | R, E2 | E, B | C>
   <A, R2, E2, B>(
-    predicate: Predicate<NoInfer<A>>,
-    orElse: (a: NoInfer<A>) => Effect<R2, E2, B>
+    predicate: Predicate<Types.NoInfer<A>>,
+    orElse: (a: Types.NoInfer<A>) => Effect<R2, E2, B>
   ): <R, E>(self: Effect<R, E, A>) => Effect<R2 | R, E2 | E, A | B>
   <R, E, A, B extends A, R2, E2, C>(
     self: Effect<R, E, A>,
@@ -3459,12 +3458,12 @@ export const filterOrElse: {
  */
 export const filterOrFail: {
   <A, B extends A, E2>(
-    refinement: Refinement<NoInfer<A>, B>,
-    orFailWith: (a: NoInfer<A>) => E2
+    refinement: Refinement<Types.NoInfer<A>, B>,
+    orFailWith: (a: Types.NoInfer<A>) => E2
   ): <R, E>(self: Effect<R, E, A>) => Effect<R, E2 | E, B>
   <A, E2>(
-    predicate: Predicate<NoInfer<A>>,
-    orFailWith: (a: NoInfer<A>) => E2
+    predicate: Predicate<Types.NoInfer<A>>,
+    orFailWith: (a: Types.NoInfer<A>) => E2
   ): <R, E>(self: Effect<R, E, A>) => Effect<R, E2 | E, A>
   <R, E, A, B extends A, E2>(
     self: Effect<R, E, A>,
@@ -3622,7 +3621,7 @@ export const flatMap: {
  */
 export const andThen: {
   <A, X>(
-    f: (a: NoInfer<A>) => X
+    f: (a: Types.NoInfer<A>) => X
   ): <R, E>(
     self: Effect<R, E, A>
   ) => [X] extends [Effect<infer R1, infer E1, infer A1>] ? Effect<R | R1, E | E1, A1>
@@ -3637,7 +3636,7 @@ export const andThen: {
     : Effect<R, E, X>
   <A, R, E, X>(
     self: Effect<R, E, A>,
-    f: (a: NoInfer<A>) => X
+    f: (a: Types.NoInfer<A>) => X
   ): [X] extends [Effect<infer R1, infer E1, infer A1>] ? Effect<R | R1, E | E1, A1>
     : [X] extends [Promise<infer A1>] ? Effect<R, Cause.UnknownException | E, A1>
     : Effect<R, E, X>
@@ -3751,7 +3750,7 @@ export const summarized: {
  */
 export const tap: {
   <A, X>(
-    f: (a: NoInfer<A>) => X
+    f: (a: Types.NoInfer<A>) => X
   ): <R, E>(
     self: Effect<R, E, A>
   ) => [X] extends [Effect<infer R1, infer E1, infer _A1>] ? Effect<R | R1, E | E1, A>
@@ -3766,7 +3765,7 @@ export const tap: {
     : Effect<R, E, A>
   <A, R, E, X>(
     self: Effect<R, E, A>,
-    f: (a: NoInfer<A>) => X
+    f: (a: Types.NoInfer<A>) => X
   ): [X] extends [Effect<infer R1, infer E1, infer _A1>] ? Effect<R | R1, E | E1, A>
     : [X] extends [Promise<infer _A1>] ? Effect<R, Cause.UnknownException | E, A>
     : Effect<R, E, A>

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -2,7 +2,6 @@
  * @since 2.0.0
  */
 
-import type * as Data from "./Data.js"
 import * as Equivalence from "./Equivalence.js"
 import type { LazyArg } from "./Function.js"
 import { constNull, constUndefined, dual, identity } from "./Function.js"
@@ -39,7 +38,7 @@ export type TypeId = typeof TypeId
  * @category models
  * @since 2.0.0
  */
-export interface Left<out E, out A> extends Data.Case, Pipeable, Inspectable {
+export interface Left<out E, out A> extends Pipeable, Inspectable {
   readonly _tag: "Left"
   readonly _op: "Left"
   readonly left: E
@@ -56,7 +55,7 @@ export interface Left<out E, out A> extends Data.Case, Pipeable, Inspectable {
  * @category models
  * @since 2.0.0
  */
-export interface Right<out E, out A> extends Data.Case, Pipeable, Inspectable {
+export interface Right<out E, out A> extends Pipeable, Inspectable {
   readonly _tag: "Right"
   readonly _op: "Right"
   readonly right: A

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as Data from "./Data.js"
 import type { Either } from "./Either.js"
 import * as Equal from "./Equal.js"
 import * as Equivalence from "./Equivalence.js"
@@ -41,7 +40,7 @@ export type TypeId = typeof TypeId
  * @category models
  * @since 2.0.0
  */
-export interface None<out A> extends Data.Case, Pipeable, Inspectable {
+export interface None<out A> extends Pipeable, Inspectable {
   readonly _tag: "None"
   readonly _op: "None"
   readonly [TypeId]: {
@@ -56,7 +55,7 @@ export interface None<out A> extends Data.Case, Pipeable, Inspectable {
  * @category models
  * @since 2.0.0
  */
-export interface Some<out A> extends Data.Case, Pipeable, Inspectable {
+export interface Some<out A> extends Pipeable, Inspectable {
   readonly _tag: "Some"
   readonly _op: "Some"
   readonly value: A

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type * as Data from "./Data.js"
 import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/pool.js"
@@ -29,7 +28,7 @@ export type PoolTypeId = typeof PoolTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Pool<out E, in out A> extends Data.Case, Pool.Variance<E, A>, Pipeable {
+export interface Pool<out E, in out A> extends Pool.Variance<E, A>, Pipeable {
   /**
    * Retrieves an item from the pool in a scoped effect. Note that if
    * acquisition fails, then the returned effect will fail for that same reason.

--- a/packages/effect/src/Request.ts
+++ b/packages/effect/src/Request.ts
@@ -3,7 +3,6 @@
  */
 import type * as _Cache from "./Cache.js"
 import type { Cause } from "./Cause.js"
-import type * as Data from "./Data.js"
 import type { Deferred } from "./Deferred.js"
 import type { DurationInput } from "./Duration.js"
 import type * as Effect from "./Effect.js"
@@ -36,7 +35,7 @@ export type RequestTypeId = typeof RequestTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Request<out E, out A> extends Request.Variance<E, A>, Data.Case {}
+export interface Request<out E, out A> extends Request.Variance<E, A> {}
 
 /**
  * @since 2.0.0
@@ -58,7 +57,7 @@ export declare namespace Request {
    * @category models
    */
   export interface Constructor<R extends Request<any, any>, T extends keyof R = never> {
-    (args: Omit<R, T | keyof (Data.Case & Request.Variance<Request.Error<R>, Request.Success<R>>)>): R
+    (args: Omit<R, T | keyof (Request.Variance<Request.Error<R>, Request.Success<R>>)>): R
   }
 
   /**

--- a/packages/effect/src/internal/cache.ts
+++ b/packages/effect/src/internal/cache.ts
@@ -65,7 +65,7 @@ export const complete = <Key, Error, Value>(
   timeToLiveMillis: number
 ): MapValue<Key, Error, Value> =>
   Data.struct({
-    _tag: "Complete",
+    _tag: "Complete" as const,
     key,
     exit,
     entryStats,
@@ -78,7 +78,7 @@ export const pending = <Key, Error, Value>(
   deferred: Deferred.Deferred<Error, Value>
 ): MapValue<Key, Error, Value> =>
   Data.struct({
-    _tag: "Pending",
+    _tag: "Pending" as const,
     key,
     deferred
   })
@@ -89,7 +89,7 @@ export const refreshing = <Key, Error, Value>(
   complete: Complete<Key, Error, Value>
 ): MapValue<Key, Error, Value> =>
   Data.struct({
-    _tag: "Refreshing",
+    _tag: "Refreshing" as const,
     deferred,
     complete
   })

--- a/packages/effect/src/internal/data.ts
+++ b/packages/effect/src/internal/data.ts
@@ -1,4 +1,3 @@
-import type * as Data from "../Data.js"
 import * as Equal from "../Equal.js"
 import * as Hash from "../Hash.js"
 import type * as Types from "../Types.js"
@@ -22,7 +21,7 @@ export const ArrayProto: Equal.Equal = Object.assign(Object.create(Array.prototy
 export const Structural: new<A>(
   args: Types.Equals<Omit<A, keyof Equal.Equal>, {}> extends true ? void
     : { readonly [P in keyof A as P extends keyof Equal.Equal ? never : P]: A[P] }
-) => Data.Case = (function() {
+) => {} = (function() {
   function Structural(this: any, args: any) {
     if (args) {
       Object.assign(this, args)
@@ -33,5 +32,5 @@ export const Structural: new<A>(
 })()
 
 /** @internal */
-export const struct = <As extends Readonly<Record<string, any>>>(as: As): Data.Data<As> =>
+export const struct = <As extends Readonly<Record<string, any>>>(as: As): As =>
   Object.assign(Object.create(StructuralPrototype), as)

--- a/packages/effect/src/internal/effectable.ts
+++ b/packages/effect/src/internal/effectable.ts
@@ -64,7 +64,7 @@ const channelVariance = {
 }
 
 /** @internal */
-export const EffectPrototype: Effect.Effect<never, never, never> = {
+export const EffectPrototype: Effect.Effect<never, never, never> & Equal.Equal = {
   [EffectTypeId]: effectVariance,
   [StreamTypeId]: effectVariance,
   [SinkTypeId]: sinkVariance,

--- a/packages/effect/test/Data.test.ts
+++ b/packages/effect/test/Data.test.ts
@@ -14,9 +14,9 @@ describe("Data", () => {
     expect(Equal.equals(x, Data.struct({ a: 0 }))).toBe(false)
 
     // different keys length
-    expect(Data.struct({ a: 0, b: 1 })[Equal.symbol](Data.struct({ a: 0 }))).toBe(false)
+    expect(Equal.equals(Data.struct({ a: 0, b: 1 }), Data.struct({ a: 0 }))).toBe(false)
     // same length but different keys
-    expect(Data.struct({ a: 0 })[Equal.symbol](Data.struct({ b: 1 }))).toBe(false)
+    expect(Equal.equals(Data.struct({ a: 0 }), Data.struct({ b: 1 }))).toBe(false)
   })
 
   it("unsafeStruct", () => {
@@ -52,11 +52,11 @@ describe("Data", () => {
     expect(Equal.equals(x, Data.array([0, 1]))).toBe(false)
 
     // different length
-    expect(Data.array([0, 1, 2])[Equal.symbol](Data.array([0, 1]))).toBe(false)
+    expect(Equal.equals(Data.array([0, 1, 2]), Data.array([0, 1]))).toBe(false)
   })
 
   it("case", () => {
-    interface Person extends Data.Case {
+    interface Person {
       readonly name: string
     }
 
@@ -77,7 +77,7 @@ describe("Data", () => {
   })
 
   it("tagged", () => {
-    interface Person extends Data.Case {
+    interface Person {
       readonly _tag: "Person"
       readonly name: string
     }
@@ -111,11 +111,11 @@ describe("Data", () => {
     // different keys length
     class D extends Data.Class<{ d: string; e: string }> {}
     const d = new D({ d: "d", e: "e" })
-    expect(a[Equal.symbol](d)).toBe(false)
+    expect(Equal.equals(a, d)).toBe(false)
     // same length but different keys
     class E extends Data.Class<{ e: string }> {}
     const e = new E({ e: "e" })
-    expect(a[Equal.symbol](e)).toBe(false)
+    expect(Equal.equals(a, e)).toBe(false)
   })
 
   it("tagged class", () => {
@@ -133,7 +133,7 @@ describe("Data", () => {
   })
 
   it("tagged - empty", () => {
-    interface Person extends Data.Case {
+    interface Person {
       readonly _tag: "Person"
     }
 
@@ -155,12 +155,12 @@ describe("Data", () => {
   })
 
   it("tagged - don't override tag", () => {
-    interface Foo extends Data.Case {
+    interface Foo {
       readonly _tag: "Foo"
       readonly value: string
     }
     const Foo = Data.tagged<Foo>("Foo")
-    interface Bar extends Data.Case {
+    interface Bar {
       readonly _tag: "Bar"
       readonly value: number
     }

--- a/packages/platform/src/Error.ts
+++ b/packages/platform/src/Error.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-import type * as Data from "effect/Data"
 import * as internal from "./internal/error.js"
 
 /**
@@ -30,7 +29,7 @@ export declare namespace PlatformError {
    * @since 1.0.0
    * @category models
    */
-  export interface Base extends Data.Case {
+  export interface Base {
     readonly [PlatformErrorTypeId]: typeof PlatformErrorTypeId
     readonly _tag: string
     readonly module: "Clipboard" | "Command" | "FileSystem" | "KeyValueStore" | "Path" | "Stream" | "Terminal"
@@ -41,7 +40,7 @@ export declare namespace PlatformError {
   /**
    * @since 1.0.0
    */
-  export type ProvidedFields = PlatformErrorTypeId | "_tag" | keyof Data.Case
+  export type ProvidedFields = PlatformErrorTypeId | "_tag"
 }
 
 /**

--- a/packages/platform/src/Http/Body.ts
+++ b/packages/platform/src/Http/Body.ts
@@ -3,7 +3,6 @@
  */
 import type * as ParseResult from "@effect/schema/ParseResult"
 import type * as Schema from "@effect/schema/Schema"
-import type * as Data from "effect/Data"
 import type * as Effect from "effect/Effect"
 import type * as Stream_ from "effect/Stream"
 import type * as PlatformError from "../Error.js"
@@ -73,7 +72,7 @@ export type ErrorTypeId = typeof ErrorTypeId
  * @since 1.0.0
  * @category errors
  */
-export interface BodyError extends Data.Case {
+export interface BodyError {
   readonly [ErrorTypeId]: ErrorTypeId
   readonly _tag: "BodyError"
   readonly reason: BodyErrorReason

--- a/packages/platform/src/Http/ClientError.ts
+++ b/packages/platform/src/Http/ClientError.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-import type * as Data from "effect/Data"
 import * as internal from "../internal/http/clientError.js"
 import type * as ClientRequest from "./ClientRequest.js"
 import type * as ClientResponse from "./ClientResponse.js"
@@ -32,7 +31,7 @@ export declare namespace HttpError {
    * @since 1.0.0
    * @category models
    */
-  export interface Proto extends Data.Case {
+  export interface Proto {
     readonly [TypeId]: TypeId
     readonly _tag: string
   }
@@ -40,7 +39,7 @@ export declare namespace HttpError {
   /**
    * @since 1.0.0
    */
-  export type ProvidedFields = TypeId | "_tag" | keyof Data.Case
+  export type ProvidedFields = TypeId | "_tag"
 }
 
 /**

--- a/packages/platform/src/Http/Multipart.ts
+++ b/packages/platform/src/Http/Multipart.ts
@@ -5,7 +5,6 @@ import type * as ParseResult from "@effect/schema/ParseResult"
 import type * as Schema from "@effect/schema/Schema"
 import type * as Channel from "effect/Channel"
 import type * as Chunk from "effect/Chunk"
-import type * as Data from "effect/Data"
 import type * as Effect from "effect/Effect"
 import type * as FiberRef from "effect/FiberRef"
 import type * as Option from "effect/Option"
@@ -107,7 +106,7 @@ export type ErrorTypeId = typeof ErrorTypeId
  * @since 1.0.0
  * @category errors
  */
-export interface MultipartError extends Data.Case {
+export interface MultipartError {
   readonly [ErrorTypeId]: ErrorTypeId
   readonly _tag: "MultipartError"
   readonly reason: "FileTooLarge" | "FieldTooLarge" | "BodyTooLarge" | "TooManyParts" | "InternalError" | "Parse"

--- a/packages/platform/src/Http/ServerError.ts
+++ b/packages/platform/src/Http/ServerError.ts
@@ -2,7 +2,6 @@
  * @since 1.0.0
  */
 import type * as Cause from "effect/Cause"
-import type * as Data from "effect/Data"
 import type * as FiberId from "effect/FiberId"
 import * as internal from "../internal/http/serverError.js"
 import type * as ServerRequest from "./ServerRequest.js"
@@ -34,7 +33,7 @@ export declare namespace HttpError {
    * @since 1.0.0
    * @category models
    */
-  export interface Proto extends Data.Case {
+  export interface Proto {
     readonly [TypeId]: TypeId
     readonly _tag: string
   }
@@ -42,7 +41,7 @@ export declare namespace HttpError {
   /**
    * @since 1.0.0
    */
-  export type ProvidedFields = TypeId | "_tag" | keyof Data.Case
+  export type ProvidedFields = TypeId | "_tag"
 }
 
 /**

--- a/packages/platform/src/WorkerError.ts
+++ b/packages/platform/src/WorkerError.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-import type * as Data from "effect/Data"
 import * as internal from "./internal/workerError.js"
 
 /**
@@ -20,7 +19,7 @@ export type WorkerErrorTypeId = typeof WorkerErrorTypeId
  * @since 1.0.0
  * @category errors
  */
-export interface WorkerError extends Data.Case {
+export interface WorkerError {
   readonly [WorkerErrorTypeId]: WorkerErrorTypeId
   readonly _tag: "WorkerError"
   readonly reason: "spawn" | "decode" | "send" | "unknown" | "encode"

--- a/packages/rpc/src/SchemaC.ts
+++ b/packages/rpc/src/SchemaC.ts
@@ -99,18 +99,18 @@ export const withConstructorTagged: {
 export const withConstructorDataTagged: {
   <A extends { readonly _tag: string }>(
     tag: A["_tag"]
-  ): <I>(self: Schema.Schema<A, I>) => SchemaC<I, Data.Data<A>, Omit<A, "_tag">>
+  ): <I>(self: Schema.Schema<A, I>) => SchemaC<I, A, Omit<A, "_tag">>
 
   <A extends { readonly _tag: string }, I extends Record<string, any>>(
     self: Schema.Schema<A, I>,
     tag: A["_tag"]
-  ): SchemaC<I, Data.Data<A>, Omit<A, "_tag">>
+  ): SchemaC<I, A, Omit<A, "_tag">>
 } = dual(
   2,
   <A extends { readonly _tag: string }, I extends Record<string, any>>(
     self: Schema.Schema<A, I>,
     tag: A["_tag"]
-  ): SchemaC<I, Data.Data<A>, Omit<A, "_tag">> => withConstructor(Schema.data(self), Data.tagged(tag) as any)
+  ): SchemaC<I, A, Omit<A, "_tag">> => withConstructor(Schema.data(self), Data.tagged(tag) as any)
 )
 
 /**

--- a/packages/rpc/src/internal/resolver.ts
+++ b/packages/rpc/src/internal/resolver.ts
@@ -10,7 +10,7 @@ import type { RpcError, RpcTransportError } from "../Error.js"
 import type * as resolver from "../Resolver.js"
 import * as Codec from "./codec.js"
 
-const requestProto: Request.Request<any, any> = {
+const requestProto: Request.Request<any, any> & Equal.Equal = {
   [Request.RequestTypeId]: {
     _E: (_: never) => _,
     _A: (_: never) => _
@@ -19,7 +19,7 @@ const requestProto: Request.Request<any, any> = {
     return this.hash
   },
   [Equal.symbol](this: resolver.RpcRequest, that: Equal.Equal) {
-    return this.hash === (that as resolver.RpcRequest).hash
+    return this.hash === (that as resolver.RpcRequest & Equal.Equal).hash
   }
 }
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4475,22 +4475,22 @@ export const chunk = <A, I, R>(item: Schema<A, I, R>): Schema<Chunk.Chunk<A>, Re
     Chunk.toReadonlyArray
   )
 
-const toData = <A extends Readonly<Record<string, any>> | ReadonlyArray<any>>(a: A): Data.Data<A> =>
+const toData = <A extends Readonly<Record<string, any>> | ReadonlyArray<any>>(a: A): A =>
   Array.isArray(a) ? Data.array(a) : Data.struct(a)
 
 const dataArbitrary = <A extends Readonly<Record<string, any>> | ReadonlyArray<any>>(
   item: Arbitrary<A>
-): Arbitrary<Data.Data<A>> =>
+): Arbitrary<A> =>
 (fc) => item(fc).map(toData)
 
 const dataPretty = <A extends Readonly<Record<string, any>> | ReadonlyArray<any>>(
   item: Pretty.Pretty<A>
-): Pretty.Pretty<Data.Data<A>> =>
+): Pretty.Pretty<A> =>
 (d) => `Data(${item(d)})`
 
 const dataParse = <R, A extends Readonly<Record<string, any>> | ReadonlyArray<any>>(
   decodeUnknown: ParseResult.DecodeUnknown<R, A>
-): ParseResult.DeclarationDecodeUnknown<R, Data.Data<A>> =>
+): ParseResult.DeclarationDecodeUnknown<R, A> =>
 (u, options, ast) =>
   Equal.isEqual(u) ?
     ParseResult.map(decodeUnknown(u, options), toData)
@@ -4506,7 +4506,7 @@ export const dataFromSelf = <
   A extends Readonly<Record<string, any>> | ReadonlyArray<any>
 >(
   item: Schema<A, I, R>
-): Schema<Data.Data<A>, Data.Data<I>, R> => {
+): Schema<A, I, R> => {
   return declare(
     [item],
     (item) => dataParse(ParseResult.decodeUnknown(item)),
@@ -4530,7 +4530,7 @@ export const data = <
   A extends Readonly<Record<string, any>> | ReadonlyArray<any>
 >(
   item: Schema<A, I, R>
-): Schema<Data.Data<A>, I, R> =>
+): Schema<A, I, R> =>
   transform(
     item,
     dataFromSelf(to(item)),
@@ -4639,7 +4639,7 @@ export const Class = <Self>() =>
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
     Self,
-    Data.Case
+    {}
   > => makeClass(struct(fields), fields, Data.Class)
 
 /**
@@ -4657,7 +4657,7 @@ export const TaggedClass = <Self>() =>
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
     Self,
-    Data.Case
+    {}
   > =>
 {
   const fieldsWithTag: StructFields = { ...fields, _tag: literal(tag) }


### PR DESCRIPTION
With this change we remove the `Data.Data` type and we make `Equal.Equal` & `Hash.Hash` an implicit traits.

The main reason is that `Data.Data<A>` was structurally equivalent to `A & Equal.Equal` but extending `Equal.Equal` doesn't mean that the equality is implemented by-value, so the type was simply adding noice without gaining any level of safety.

The module `Data` remains unchanged at the value level, all the functions priorly available are supposed to work in exactly the same manner.

At the type level instead the functions return `Readonly` variants, so for example we have:

```ts
import { Data } from "effect";

const obj = Data.struct({
  a: 0,
  b: 1,
});
```

will have the `obj` typed as:

```ts
declare const obj: {
  readonly a: number;
  readonly b: number;
};
```

closes #1962