### PR TITLE
fix: Schema.omit on a union

### DIFF
--- a/.changeset/witty-wombats-dream.md
+++ b/.changeset/witty-wombats-dream.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Fix `Schema.omit` on a union schema.

--- a/packages/schema/test/Schema/union.test.ts
+++ b/packages/schema/test/Schema/union.test.ts
@@ -1,5 +1,6 @@
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
+import { Option } from "effect"
 import { describe, it } from "vitest"
 
 describe("Schema > union", () => {
@@ -180,5 +181,15 @@ describe("Schema > union", () => {
         Util.onExcessPropertyError
       )
     })
+  })
+
+  it("omit with union", () => {
+    const schema1 = S.union(
+      S.struct({ a: S.string, b: S.optionFromNullable(S.string) }),
+      S.struct({ a: S.string, c: S.string })
+    )
+    const schema2 = schema1.pipe(S.omit("a"))
+
+    Util.expectDecodeUnknownSuccess(schema2, { b: "a" }, { b: Option.some("a") })
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

I included a test example how we discovered the problem. 

Result without the change:

```
  Object {
    "_id": "Either",
    "_tag": "Right",
    "right": Object {
-     "b": Object {
-       "_id": "Option",
-       "_tag": "Some",
-       "value": "a",
-     },
+     "b": "a",
    },
  }
```