### PR TITLE
Enhancement: Add toJSON for Secret

### DIFF
--- a/.changeset/twenty-clouds-behave.md
+++ b/.changeset/twenty-clouds-behave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add toJSON for Secret

--- a/packages/effect/src/internal/secret.ts
+++ b/packages/effect/src/internal/secret.ts
@@ -40,6 +40,12 @@ export const make = (bytes: Array<number>): Secret.Secret => {
       return "Secret(<redacted>)"
     }
   })
+  Object.defineProperty(secret, "toJSON", {
+    enumerable: false,
+    value() {
+      return "<redacted>"
+    }
+  })
   Object.defineProperty(secret, "raw", {
     enumerable: false,
     value: bytes

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -471,6 +471,11 @@ describe("Config", () => {
       assert.strictEqual(`${secret}`, "Secret(<redacted>)")
     })
 
+    it("toJSON", () => {
+      const secret = Secret.fromString("secret")
+      assert.strictEqual(JSON.stringify(secret), "\"<redacted>\"")
+    })
+
     it("wipe", () => {
       const secret = Secret.fromString("secret")
       Secret.unsafeWipe(secret)


### PR DESCRIPTION
## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Since Secrets are "special" strings it would be nice if JSON.stringify transforms the Secret back into a "redacted" string.

However the current behavior is:
```
const s = Secret.fromString('SECRET')
console.log(JSON.stringify(s))
// Output: {}
```

This PR changes the behavior to:
```
const s = Secret.fromString('SECRET')
console.log(JSON.stringify(s))
// Output: "<redacted>"
```

## Related

n/a
