### PR TITLE
fix snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -60,10 +60,6 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/setup
 
-      - name: Exit pre-release mode
-        if: ${{ hashFiles('.changeset/pre.json') != '' }}
-        run: pnpm changeset pre exit
-
       - name: Version snapshot
         run: pnpm changeset version --snapshot ${{ steps.command.outputs.snapshot }} | grep -q "All files have been updated"
         env:
@@ -83,8 +79,6 @@ jobs:
           output=$(echo "$output" | awk '/packages published successfully:/{flag=1; next} flag')
           output=$(echo "$output" | grep -o '[^ ]*@[^ ]*' | awk '{print "\"" $0 "\""}' | paste -sd ',')
           echo "tags=[$output]" >> $GITHUB_OUTPUT
-          # remove npm tag
-          npm dist-tag rm "$output" snapshot
 
       - name: Update comment (success)
         uses: actions/github-script@v6


### PR DESCRIPTION
This removes the pre-release mode handling in the `snapshot` workflow. If I understand & remember this correctly, we also don't need the `latest` tag cleanup anymore now that we are out of pre-release mode. Can you confirm that that's what this was for @tim-smart ?