### PR TITLE
Fix for possible stack overflow issues due to Array.push in combination with spread operator

### DIFF
--- a/.changeset/tall-nails-retire.md
+++ b/.changeset/tall-nails-retire.md
@@ -1,7 +1,7 @@
 ---
-"effect": minor
-"@effect/platform": minor
-"@effect/schema": minor
+"effect": patch
+"@effect/platform": patch
+"@effect/schema": patch
 ---
 
 Fix for possible stack overflow errors when using Array.push with spread operator arguments

--- a/.changeset/tall-nails-retire.md
+++ b/.changeset/tall-nails-retire.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+"@effect/platform": minor
+"@effect/schema": minor
+---
+
+Fix for possible stack overflow errors when using Array.push with spread operator arguments

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,7 +40,7 @@ module.exports = {
     "no-unused-vars": "off",
     "no-restricted-syntax": ["error", {
         "selector": "CallExpression[callee.property.name='push'] > SpreadElement.arguments",
-        "message": "Do use spread arguments in Array.push"
+        "message": "Do not use spread arguments in Array.push"
     }],
     "prefer-rest-params": "off",
     "prefer-spread": "off",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,10 @@ module.exports = {
     "prefer-destructuring": "off",
     "sort-imports": "off",
     "no-unused-vars": "off",
+    "no-restricted-syntax": ["error", {
+        "selector": "CallExpression[callee.property.name='push'] > SpreadElement.arguments",
+        "message": "Do use spread arguments in Array.push"
+    }],
     "prefer-rest-params": "off",
     "prefer-spread": "off",
     "import/first": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,11 +37,11 @@ module.exports = {
     "object-shorthand": "error",
     "prefer-destructuring": "off",
     "sort-imports": "off",
-    "no-unused-vars": "off",
     "no-restricted-syntax": ["error", {
         "selector": "CallExpression[callee.property.name='push'] > SpreadElement.arguments",
         "message": "Do not use spread arguments in Array.push"
     }],
+    "no-unused-vars": "off",
     "prefer-rest-params": "off",
     "prefer-spread": "off",
     "import/first": "error",

--- a/packages/effect/src/ReadonlyArray.ts
+++ b/packages/effect/src/ReadonlyArray.ts
@@ -1545,7 +1545,10 @@ export const flatMap: {
     }
     const out: Array<B> = []
     for (let i = 0; i < self.length; i++) {
-      out.push(...f(self[i], i))
+      const inner = f(self[i], i)
+      for (let j = 0; j < inner.length; j++) {
+        out.push(inner[j])
+      }
     }
     return out
   }

--- a/packages/effect/src/internal/differ/readonlyArrayPatch.ts
+++ b/packages/effect/src/internal/differ/readonlyArrayPatch.ts
@@ -188,7 +188,9 @@ export const patch = Dual.dual<
         break
       }
       case "Append": {
-        readonlyArray.push(...head.values)
+        for (const value of head.values) {
+          readonlyArray.push(value)
+        }
         patches = tail
         break
       }

--- a/packages/effect/src/internal/stm/tMap.ts
+++ b/packages/effect/src/internal/stm/tMap.ts
@@ -661,7 +661,9 @@ const toReadonlyArray = <K, V>(self: TMap.TMap<K, V>): STM.STM<never, never, Rea
     let index = 0
     while (index < capacity) {
       const bucket = buckets.chunk[index]
-      builder.push(...tRef.unsafeGet(bucket, journal))
+      for (const entry of tRef.unsafeGet(bucket, journal)) {
+        builder.push(entry)
+      }
       index = index + 1
     }
     return builder

--- a/packages/effect/src/internal/stm/tPriorityQueue.ts
+++ b/packages/effect/src/internal/stm/tPriorityQueue.ts
@@ -189,7 +189,9 @@ export const takeAll = <A>(self: TPriorityQueue.TPriorityQueue<A>): STM.STM<neve
   tRef.modify(self.ref, (map) => {
     const builder: Array<A> = []
     for (const entry of map) {
-      builder.push(...entry[1])
+      for (const value of entry[1]) {
+        builder.push(value)
+      }
     }
     return [builder, SortedMap.empty(SortedMap.getOrder(map))]
   })
@@ -228,7 +230,9 @@ export const takeUpTo = dual<
     while ((next = iterator.next()) && !next.done && index < n) {
       const [key, value] = next.value
       const [left, right] = pipe(value, ReadonlyArray.splitAt(n - index))
-      builder.push(...left)
+      for (const value of left) {
+        builder.push(value)
+      }
       if (right.length > 0) {
         updated = SortedMap.set(updated, key, right as [A, ...Array<A>])
       } else {
@@ -244,7 +248,9 @@ export const toChunk = <A>(self: TPriorityQueue.TPriorityQueue<A>): STM.STM<neve
   tRef.modify(self.ref, (map) => {
     const builder: Array<A> = []
     for (const entry of map) {
-      builder.push(...entry[1])
+      for (const value of entry[1]) {
+        builder.push(value)
+      }
     }
     return [Chunk.unsafeFromArray(builder), map]
   })
@@ -254,7 +260,9 @@ export const toArray = <A>(self: TPriorityQueue.TPriorityQueue<A>): STM.STM<neve
   tRef.modify(self.ref, (map) => {
     const builder: Array<A> = []
     for (const entry of map) {
-      builder.push(...entry[1])
+      for (const value of entry[1]) {
+        builder.push(value)
+      }
     }
     return [builder, map]
   })

--- a/packages/platform/src/internal/workerRunner.ts
+++ b/packages/platform/src/internal/workerRunner.ts
@@ -106,7 +106,9 @@ export const make = <I, R, E, O>(
               return Effect.flatMap(
                 Effect.forEach(data, (data) => {
                   if (options?.transfers) {
-                    transfers.push(...options.transfers(data))
+                    for (const option of options.transfers(data)) {
+                      transfers.push(option)
+                    }
                   }
                   return Effect.orDie(options.encodeOutput!(req[2], data))
                 }),

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1296,7 +1296,9 @@ export const getNumberIndexedAccess = (ast: AST): AST => {
         out.push(undefinedKeyword)
       }
       if (Option.isSome(ast.rest)) {
-        out.push(...ast.rest.value)
+        for (const e of ast.rest.value) {
+          out.push(e)
+        }
       }
       return createUnion(out)
     }


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Will fix stack overflow issues when using large arrays in combination with Array.push, like in ReadonlyArray.flatMap.

I've changed all occurrences of the possible stack overflow, and added a eslint rule to prevent future introductions of a similar issue.
-->

## Related

- Closes #2048
