### PR TITLE
Fix usage of Schema.TaggedError in combination with Unify

### DIFF
--- a/.changeset/wet-pugs-share.md
+++ b/.changeset/wet-pugs-share.md
@@ -1,0 +1,29 @@
+---
+"@effect/schema": minor
+---
+
+Fix usage of Schema.TaggedError in combination with Unify.
+
+When used with Unify we previously had:
+
+```ts
+import { Schema } from "@effect/schema";
+import type { Unify } from "effect";
+
+class Err extends Schema.TaggedError<Err>()("Err", {}) {}
+
+// $ExpectType Effect<unknown, unknown, unknown>
+export type IdErr = Unify.Unify<Err>;
+```
+
+With this fix we now have:
+
+```ts
+import { Schema } from "@effect/schema";
+import type { Unify } from "effect";
+
+class Err extends Schema.TaggedError<Err>()("Err", {}) {}
+
+// $ExpectType Err
+export type IdErr = Unify.Unify<Err>;
+```

--- a/packages/schema/dtslint/TaggedError.ts
+++ b/packages/schema/dtslint/TaggedError.ts
@@ -1,0 +1,13 @@
+import { Schema } from "@effect/schema"
+import type { Unify } from "effect"
+import { Effect } from "effect"
+
+class Err extends Schema.TaggedError<Err>()("Err", {}) {}
+
+// $ExpectType Err
+export type IdErr = Unify.Unify<Err>
+
+// $ExpectType Effect<never, Err, never>
+export const YieldErr = Effect.gen(function*($) {
+  return yield* $(new Err())
+})

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4555,7 +4555,7 @@ type MissingSelfGeneric<Usage extends string, Params extends string = ""> =
  * @category classes
  * @since 1.0.0
  */
-export interface Class<A, I, R, C, Self, Inherited, Proto> extends Schema<Self, I, R> {
+export interface Class<A, I, R, C, Self, Inherited = {}, Proto = {}> extends Schema<Self, I, R> {
   new(
     ...args: [R] extends [never] ? [
         props: Equals<C, {}> extends true ? void | {} : C,
@@ -4650,9 +4650,7 @@ export const Class = <Self>() =>
     Simplify<FromStruct<Fields>>,
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
-    Self,
-    {},
-    {}
+    Self
   > => makeClass(struct(fields), fields, Data.Class)
 
 /**
@@ -4669,9 +4667,7 @@ export const TaggedClass = <Self>() =>
     Simplify<{ readonly _tag: Tag } & FromStruct<Fields>>,
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
-    Self,
-    {},
-    {}
+    Self
   > =>
 {
   const fieldsWithTag: StructFields = { ...fields, _tag: literal(tag) }
@@ -4693,7 +4689,7 @@ export const TaggedError = <Self>() =>
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
     Self,
-    { readonly _tag: Tag },
+    {},
     Cause.YieldableError
   > =>
 {
@@ -4757,8 +4753,7 @@ export const TaggedRequest = <Self>() =>
       EA,
       AI,
       AA
-    >,
-    unknown
+    >
   > =>
 {
   class SerializableRequest extends Request.Class<any, any, { readonly _tag: string }> {

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4555,7 +4555,7 @@ type MissingSelfGeneric<Usage extends string, Params extends string = ""> =
  * @category classes
  * @since 1.0.0
  */
-export interface Class<A, I, R, C, Self, Inherited> extends Schema<Self, I, R> {
+export interface Class<A, I, R, C, Self, Inherited, Proto> extends Schema<Self, I, R> {
   new(
     ...args: [R] extends [never] ? [
         props: Equals<C, {}> extends true ? void | {} : C,
@@ -4565,7 +4565,7 @@ export interface Class<A, I, R, C, Self, Inherited> extends Schema<Self, I, R> {
         props: Equals<C, {}> extends true ? void | {} : C,
         disableValidation: true
       ]
-  ): A & Omit<Inherited, keyof A>
+  ): A & Omit<Inherited, keyof A> & Proto
 
   readonly struct: Schema<A, I, R>
 
@@ -4578,7 +4578,8 @@ export interface Class<A, I, R, C, Self, Inherited> extends Schema<Self, I, R> {
       R | Schema.Context<FieldsB[keyof FieldsB]>,
       Simplify<Omit<C, keyof FieldsB> & ToStruct<FieldsB>>,
       Extended,
-      Self
+      Self,
+      Proto
     >
 
   readonly transformOrFail: <Transformed>() => <
@@ -4604,7 +4605,8 @@ export interface Class<A, I, R, C, Self, Inherited> extends Schema<Self, I, R> {
       R | Schema.Context<FieldsB[keyof FieldsB]> | R2 | R3,
       Simplify<Omit<C, keyof FieldsB> & ToStruct<FieldsB>>,
       Transformed,
-      Self
+      Self,
+      Proto
     >
 
   readonly transformOrFailFrom: <Transformed>() => <
@@ -4630,7 +4632,8 @@ export interface Class<A, I, R, C, Self, Inherited> extends Schema<Self, I, R> {
       R | Schema.Context<FieldsB[keyof FieldsB]> | R2 | R3,
       Simplify<Omit<C, keyof FieldsB> & ToStruct<FieldsB>>,
       Transformed,
-      Self
+      Self,
+      Proto
     >
 }
 
@@ -4648,6 +4651,7 @@ export const Class = <Self>() =>
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
     Self,
+    {},
     {}
   > => makeClass(struct(fields), fields, Data.Class)
 
@@ -4666,6 +4670,7 @@ export const TaggedClass = <Self>() =>
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
     Self,
+    {},
     {}
   > =>
 {
@@ -4688,7 +4693,8 @@ export const TaggedError = <Self>() =>
     Schema.Context<Fields[keyof Fields]>,
     Simplify<ToStruct<Fields>>,
     Self,
-    Effect.Effect<never, Self, never> & globalThis.Error
+    { readonly _tag: Tag },
+    Cause.YieldableError
   > =>
 {
   const fieldsWithTag: StructFields = { ...fields, _tag: literal(tag) }
@@ -4751,7 +4757,8 @@ export const TaggedRequest = <Self>() =>
       EA,
       AI,
       AA
-    >
+    >,
+    unknown
   > =>
 {
   class SerializableRequest extends Request.Class<any, any, { readonly _tag: string }> {


### PR DESCRIPTION
Fix usage of Schema.TaggedError in combination with Unify.

When used with Unify we previously had:

```ts
import { Schema } from "@effect/schema";
import type { Unify } from "effect";

class Err extends Schema.TaggedError<Err>()("Err", {}) {}

// $ExpectType Effect<unknown, unknown, unknown>
export type IdErr = Unify.Unify<Err>;
```

With this fix we now have:

```ts
import { Schema } from "@effect/schema";
import type { Unify } from "effect";

class Err extends Schema.TaggedError<Err>()("Err", {}) {}

// $ExpectType Err
export type IdErr = Unify.Unify<Err>;
```

closes #2049