### PR TITLE
Introducing Optional Annotations in `optional` API

### DIFF
--- a/.changeset/fair-boats-sniff.md
+++ b/.changeset/fair-boats-sniff.md
@@ -1,0 +1,33 @@
+---
+"@effect/schema": patch
+---
+
+Introducing Optional Annotations in `optional` API.
+
+Previously, when adding annotations to an optional field using `optional` API, you needed to use `propertySignatureAnnotations`. However, a new optional argument `annotations` is now available to simplify this process.
+
+Before:
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+const myschema = S.struct({
+  a: S.optional(S.string).pipe(
+    S.propertySignatureAnnotations({ description: "my description..." })
+  ),
+});
+```
+
+Now:
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+const myschema = S.struct({
+  a: S.optional(S.string, {
+    annotations: { description: "my description..." },
+  }),
+});
+```
+
+With this update, you can easily include annotations directly within the `optional` API without the need for additional calls.

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -1,9 +1,22 @@
+import * as AST from "@effect/schema/AST"
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 import * as O from "effect/Option"
-import { describe, it } from "vitest"
+import { describe, expect, it } from "vitest"
 
 describe("optional APIs", () => {
+  it("annotations", async () => {
+    const schema = S.struct({
+      a: S.optional(S.NumberFromString, {
+        exact: true,
+        annotations: { description: "my description" }
+      })
+    })
+    expect((schema.ast as any).propertySignatures[0].annotations).toStrictEqual({
+      [AST.DescriptionAnnotationId]: "my description"
+    })
+  })
+
   describe("optional > { exact: true }", () => {
     it("decoding / encoding", async () => {
       const schema = S.struct({


### PR DESCRIPTION
Previously, when adding annotations to an optional field using `optional` API, you needed to use `propertySignatureAnnotations`. However, a new optional argument `annotations` is now available to simplify this process.

Before:

```ts
import * as S from "@effect/schema/Schema";

const myschema = S.struct({
  a: S.optional(S.string).pipe(
    S.propertySignatureAnnotations({ description: "my description..." })
  ),
});
```

Now:

```ts
import * as S from "@effect/schema/Schema";

const myschema = S.struct({
  a: S.optional(S.string, {
    annotations: { description: "my description..." },
  }),
});
```

With this update, you can easily include annotations directly within the `optional` API without the need for additional calls.
