### PR TITLE
Add functional analogue of `satisfies` operator

### DIFF
--- a/.changeset/mean-dancers-judge.md
+++ b/.changeset/mean-dancers-judge.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add functional analogue of satisfies operator

--- a/.changeset/mean-dancers-judge.md
+++ b/.changeset/mean-dancers-judge.md
@@ -2,4 +2,16 @@
 "effect": patch
 ---
 
-add functional analogue of satisfies operator
+Add functional analogue of `satisfies` operator.
+This is a convenient operator to use in the `pipe` chain to localize type errors closer to their source.
+
+```typescript
+import { satisfies } from "effect/Function"
+
+const test1 = satisfies<number>()(5 as const)
+      // ^? const test: 5
+const test2 = satisfies<string>()(5)
+      // ^? Argument of type 'number' is not assignable to parameter of type 'string'
+
+assert.deepStrictEqual(satisfies<number>()(5), 5)
+```

--- a/.changeset/mean-dancers-judge.md
+++ b/.changeset/mean-dancers-judge.md
@@ -5,7 +5,7 @@
 Add functional analogue of `satisfies` operator.
 This is a convenient operator to use in the `pipe` chain to localize type errors closer to their source.
 
-```typescript
+```ts
 import { satisfies } from "effect/Function"
 
 const test1 = satisfies<number>()(5 as const)

--- a/.changeset/mean-dancers-judge.md
+++ b/.changeset/mean-dancers-judge.md
@@ -12,6 +12,4 @@ const test1 = satisfies<number>()(5 as const)
       // ^? const test: 5
 const test2 = satisfies<string>()(5)
       // ^? Argument of type 'number' is not assignable to parameter of type 'string'
-
-assert.deepStrictEqual(satisfies<number>()(5), 5)
 ```

--- a/.changeset/mean-dancers-judge.md
+++ b/.changeset/mean-dancers-judge.md
@@ -10,6 +10,8 @@ import { satisfies } from "effect/Function"
 
 const test1 = satisfies<number>()(5 as const)
       // ^? const test: 5
+
+      // @ts-expect-error
 const test2 = satisfies<string>()(5)
       // ^? Argument of type 'number' is not assignable to parameter of type 'string'
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 docs/
 scratchpad/
 .direnv/
+.idea/

--- a/packages/effect/src/Function.ts
+++ b/packages/effect/src/Function.ts
@@ -211,6 +211,7 @@ export const identity = <A>(a: A): A => a
  *
  * const test1 = satisfies<number>()(5 as const)
  *     //^? const test: 5
+ *     // @ts-expect-error
  * const test2 = satisfies<string>()(5)
  *     //^? Argument of type 'number' is not assignable to parameter of type 'string'
  *

--- a/packages/effect/src/Function.ts
+++ b/packages/effect/src/Function.ts
@@ -203,6 +203,24 @@ export interface FunctionN<A extends ReadonlyArray<unknown>, B> {
 export const identity = <A>(a: A): A => a
 
 /**
+ * A function that ensures that the type of an expression matches some type,
+ * without changing the resulting type of that expression.
+ *
+ * @example
+ * import { satisfies } from "effect/Function"
+ *
+ * const test1 = satisfies<number>()(5 as const)
+ *     //^? const test: 5
+ * const test2 = satisfies<string>()(5)
+ *     //^? Argument of type 'number' is not assignable to parameter of type 'string'
+ *
+ * assert.deepStrictEqual(satisfies<number>()(5), 5)
+ *
+ * @since 2.0.0
+ */
+export const satisfies = <A>() => <B extends A>(b: B) => b
+
+/**
  * Casts the result to the specified type.
  *
  * @param a - The value to be casted to the target type.

--- a/packages/effect/test/Function.test.ts
+++ b/packages/effect/test/Function.test.ts
@@ -28,6 +28,13 @@ describe("Function", () => {
     deepStrictEqual(Function.unsafeCoerce, Function.identity)
   })
 
+  it("satisfies", () => {
+    deepStrictEqual(Function.satisfies(), Function.identity)
+    deepStrictEqual(Function.satisfies<number>()(5), 5)
+    // @ts-expect-error
+    deepStrictEqual(Function.satisfies<string>()(5), 5)
+  })
+
   it("constant", () => {
     deepStrictEqual(Function.constant("a")(), "a")
   })

--- a/packages/effect/test/Function.test.ts
+++ b/packages/effect/test/Function.test.ts
@@ -29,7 +29,6 @@ describe("Function", () => {
   })
 
   it("satisfies", () => {
-    deepStrictEqual(Function.satisfies(), Function.identity)
     deepStrictEqual(Function.satisfies<number>()(5), 5)
     // @ts-expect-error
     deepStrictEqual(Function.satisfies<string>()(5), 5)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add functional analogue of `satisfies` operator.
I believe this is a convenient operator to use in the pipe chain to localize type errors closer to their source.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->