### PR TITLE
Direct Port `RateLimiter` from Rezilience

### DIFF
--- a/.changeset/strong-peas-repeat.md
+++ b/.changeset/strong-peas-repeat.md
@@ -1,0 +1,51 @@
+---
+"effect": patch
+---
+
+Add `Ratelimiter` which limits the number of calls to a resource within a time window using the token bucket algorithm.
+
+Usage Example:
+
+```ts
+import { Effect, RateLimiter } from "effect";
+
+// we need a scope because the rate limiter needs to allocate a state and a background job
+const program = Effect.scoped(
+  Effect.gen(function* ($) {
+    // create a rate limiter that executes up to 10 requests within 2 seconds
+    const rateLimit = yield* $(RateLimiter.make(10, "2 seconds"));
+    // simulate repeated calls
+    for (let n = 0; n < 100; n++) {
+      // wrap the effect we want to limit with rateLimit
+      yield* $(rateLimit(Effect.log("Calling RateLimited Effect")));
+    }
+  })
+);
+
+// will print 10 calls immediately and then throttle
+program.pipe(Effect.runFork);
+```
+
+Or, in a more real world scenario, with a dedicated Service + Layer:
+
+```ts
+import { Context, Effect, Layer, RateLimiter } from "effect";
+
+class ApiLimiter extends Context.Tag("@services/ApiLimiter")<
+  ApiLimiter,
+  RateLimiter.RateLimiter
+>() {
+  static Live = RateLimiter.make(10, "2 seconds").pipe(
+    Layer.scoped(ApiLimiter)
+  );
+}
+
+const program = Effect.gen(function* ($) {
+  const rateLimit = yield* $(ApiLimiter);
+  for (let n = 0; n < 100; n++) {
+    yield* $(rateLimit(Effect.log("Calling RateLimited Effect")));
+  }
+});
+
+program.pipe(Effect.provide(ApiLimiter.Live), Effect.runFork);
+```

--- a/packages/effect/src/RateLimiter.ts
+++ b/packages/effect/src/RateLimiter.ts
@@ -1,0 +1,34 @@
+/**
+ * Limits the number of calls to a resource to a maximum amount in some interval using the token bucket algorithm.
+ *
+ * Note that only the moment of starting the effect is rate limited: the number of concurrent executions is not bounded.
+ *
+ * Calls are queued up in an unbounded queue until capacity becomes available.
+ *
+ * @since 2.0.0
+ */
+import type { DurationInput } from "./Duration.js"
+import type { Effect } from "./Effect.js"
+import * as internal from "./internal/rateLimiter.js"
+import type { Scope } from "./Scope.js"
+
+/**
+ * Limits the number of calls to a resource to a maximum amount in some interval using the token bucket algorithm.
+ *
+ * Note that only the moment of starting the effect is rate limited: the number of concurrent executions is not bounded.
+ *
+ * Calls are queued up in an unbounded queue until capacity becomes available.
+ *
+ * @since 2.0.0
+ * @category models
+ */
+export interface RateLimiter {
+  <A, E, R>(task: Effect<A, E, R>): Effect<A, E, R>
+}
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
+export const make = (limit: number, window: DurationInput): Effect<RateLimiter, never, Scope> =>
+  internal.make(limit, window)

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -545,6 +545,17 @@ export * as Queue from "./Queue.js"
 export * as Random from "./Random.js"
 
 /**
+ * Limits the number of calls to a resource to a maximum amount in some interval using the token bucket algorithm.
+ *
+ * Note that only the moment of starting the effect is rate limited: the number of concurrent executions is not bounded.
+ *
+ * Calls are queued up in an unbounded queue until capacity becomes available.
+ *
+ * @since 2.0.0
+ */
+export * as RateLimiter from "./RateLimiter.js"
+
+/**
  * This module provides utility functions for working with arrays in TypeScript.
  *
  * @since 2.0.0

--- a/packages/effect/src/internal/nextPow2.ts
+++ b/packages/effect/src/internal/nextPow2.ts
@@ -1,0 +1,5 @@
+/** @internal */
+export const nextPow2 = (n: number): number => {
+  const nextPow = Math.ceil(Math.log(n) / Math.log(2))
+  return Math.max(Math.pow(2, nextPow), 2)
+}

--- a/packages/effect/src/internal/pubsub.ts
+++ b/packages/effect/src/internal/pubsub.ts
@@ -12,6 +12,7 @@ import type * as Scope from "../Scope.js"
 import * as core from "./core.js"
 import * as executionStrategy from "./executionStrategy.js"
 import * as fiberRuntime from "./fiberRuntime.js"
+import { nextPow2 } from "./nextPow2.js"
 import * as queue from "./queue.js"
 
 const AbsentValue = Symbol.for("effect/PubSub/AbsentValue")
@@ -1169,12 +1170,6 @@ export const unsafeMakePubSub = <A>(
   strategy: PubSubStrategy<A>
 ): PubSub.PubSub<A> => {
   return new PubSubImpl(pubsub, subscribers, scope, shutdownHook, shutdownFlag, strategy)
-}
-
-/** @internal */
-const nextPow2 = (n: number): number => {
-  const nextPow = Math.ceil(Math.log(n) / Math.log(2.0))
-  return Math.max(Math.pow(2, nextPow), 2)
 }
 
 /** @internal */

--- a/packages/effect/src/internal/rateLimiter.ts
+++ b/packages/effect/src/internal/rateLimiter.ts
@@ -1,0 +1,79 @@
+/**
+ * This is a direct port of `RateLimiter` from Rezilience
+ * https://github.com/svroonland/rezilience/blob/master/rezilience/shared/src/main/scala/nl/vroste/rezilience/RateLimiter.scala
+ */
+
+import * as Chunk from "../Chunk.js"
+import * as Deferred from "../Deferred.js"
+import type { DurationInput } from "../Duration.js"
+import * as Effect from "../Effect.js"
+import { pipe } from "../Function.js"
+import * as Queue from "../Queue.js"
+import * as Ref from "../Ref.js"
+import * as Stream from "../Stream.js"
+import { nextPow2 } from "./nextPow2.js"
+
+/** @internal */
+export const make = (limit: number, window: DurationInput) => {
+  return Effect.gen(function*($) {
+    const q = yield* $(Queue.bounded<[Ref.Ref<boolean>, Effect.Effect<void>]>(nextPow2(limit)))
+
+    yield* $(
+      pipe(
+        Stream.fromQueue(q, { maxChunkSize: 1 }),
+        Stream.filterEffect(([interrupted]) => {
+          return pipe(
+            Ref.get(interrupted),
+            Effect.map((b) => !b)
+          )
+        }),
+        Stream.throttle({
+          strategy: "shape",
+          duration: window,
+          cost: Chunk.size,
+          units: limit
+        }),
+        Stream.mapEffect(([_interrupted, eff]) => eff, { concurrency: "unbounded", unordered: true }),
+        Stream.runDrain,
+        Effect.interruptible,
+        Effect.forkScoped
+      )
+    )
+
+    const apply = <A, E, R>(task: Effect.Effect<A, E, R>) =>
+      Effect.gen(function*($) {
+        const start = yield* $(Deferred.make<void>())
+        const done = yield* $(Deferred.make<void>())
+        const interruptedRef = yield* $(Ref.make(false))
+
+        const action = pipe(
+          Deferred.succeed(start, void 0),
+          Effect.flatMap(() => Deferred.await(done))
+        )
+
+        const onInterruptOrCompletion = pipe(
+          Ref.set(interruptedRef, true),
+          Effect.flatMap(() => Deferred.succeed(done, void 0))
+        )
+
+        const run = pipe(
+          Queue.offer(q, [interruptedRef, action]),
+          Effect.onInterrupt(() => onInterruptOrCompletion)
+        )
+
+        const result = yield* $(
+          Effect.scoped(
+            pipe(
+              Effect.acquireReleaseInterruptible(run, () => onInterruptOrCompletion),
+              Effect.flatMap(() => Deferred.await(start)),
+              Effect.flatMap(() => task)
+            )
+          )
+        )
+
+        return result
+      })
+
+    return apply
+  })
+}

--- a/packages/effect/test/RateLimiter.test.ts
+++ b/packages/effect/test/RateLimiter.test.ts
@@ -1,0 +1,223 @@
+import { Clock, Deferred, Effect, Either, Fiber, pipe, Ref, TestClock } from "effect"
+import * as it from "effect-test/utils/extend"
+import { none } from "effect/Option"
+import * as RateLimiter from "effect/RateLimiter"
+import { assert, describe } from "vitest"
+
+describe("RateLimiterSpec", () => {
+  it.effect("execute up to max calls immediately", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, 1000))
+        const now = yield* _(Clock.currentTimeMillis)
+        const times = yield* _(Effect.forEach(Array.from(Array(10)), () => rl(Clock.currentTimeMillis)))
+        assert(times.every((t) => t === now))
+      })
+    )
+  })
+
+  it.effect("is not affected by stream chunk size", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+        const now = yield* _(Clock.currentTimeMillis)
+        const times1 = yield* _(
+          Effect.forEach(Array.from(Array(5)), () => rl(Clock.currentTimeMillis), { concurrency: "unbounded" })
+        )
+
+        const secondCallFib = yield* _(
+          Effect.forEach(Array.from(Array(15)), () => Effect.fork(rl(Clock.currentTimeMillis)), {
+            concurrency: "unbounded"
+          })
+        )
+
+        yield* _(TestClock.adjust("1 seconds"))
+        const times2 = yield* _(Effect.forEach(secondCallFib, Fiber.join, { concurrency: "unbounded" }))
+        const times = times1.concat(times2)
+        assert(times.filter((x) => x === now).length === 10)
+      })
+    )
+  })
+
+  it.effect("succeed with the result of the call", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+        const result = yield* _(rl(Effect.succeed(3)))
+        assert(result === 3)
+      })
+    )
+  })
+
+  it.effect("fail with the result of a failed call", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+        const result = yield* _(rl(pipe(Effect.fail(none), Effect.either)))
+        assert(Either.isLeft(result))
+      })
+    )
+  })
+
+  it.effect("continue after a failed call", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+        yield* _(rl(pipe(Effect.fail(none), Effect.either)))
+        yield* _(rl(Effect.succeed(3)))
+      })
+    )
+  })
+
+  it.effect("holds back up calls after the max", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+        const now = yield* _(Clock.currentTimeMillis)
+
+        const fib = yield* _(
+          pipe(
+            Effect.forEach(Array.from(Array(20)), () => rl(Clock.currentTimeMillis), {
+              concurrency: "unbounded"
+            }),
+            Effect.fork
+          )
+        )
+
+        yield* _(TestClock.adjust("1 seconds"))
+
+        const times = yield* _(Fiber.join(fib))
+        const later = yield* _(Clock.currentTimeMillis)
+
+        assert(times.slice(0, 10).every((x) => x === now))
+        assert(times.slice(10).every((x) => x > now && x <= later))
+      })
+    )
+  })
+
+  it.effect("will interrupt the effect when a call is interrupted", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+        const latch = yield* _(Deferred.make<void>())
+        const interrupted = yield* _(Deferred.make<void>())
+        const fib = yield* _(pipe(
+          Deferred.succeed(latch, void 0),
+          Effect.flatMap(() => Effect.never),
+          Effect.onInterrupt(() => Deferred.succeed(interrupted, void 0)),
+          rl,
+          Effect.fork
+        ))
+
+        yield* _(Deferred.await(latch))
+        yield* _(Fiber.interrupt(fib))
+        yield* _(Deferred.await(interrupted))
+      })
+    )
+  })
+
+  it.effect("will not start execution of an effect when it is interrupted before getting its turn to execute", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(1, "1 seconds"))
+        const count = yield* _(Ref.make(0))
+        yield* _(rl(Effect.unit))
+
+        const fib = yield* _(rl(Ref.set(count, 1)).pipe(Effect.fork))
+        const interruption = yield* _(Fiber.interrupt(fib).pipe(Effect.fork))
+
+        yield* _(Fiber.join(interruption))
+        const c = yield* _(Ref.get(count))
+
+        assert(c === 0)
+      })
+    )
+  })
+
+  it.effect("will wait for interruption to complete of an effect that is already executing", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(1, "1 seconds"))
+        const latch = yield* _(Deferred.make<void>())
+        const effectInterrupted = yield* _(Ref.make(0))
+
+        const fib = yield* _(pipe(
+          Deferred.succeed(latch, void 0),
+          Effect.flatMap(() => Effect.never),
+          Effect.onInterrupt(() => Ref.set(effectInterrupted, 1)),
+          rl,
+          Effect.fork
+        ))
+
+        yield* _(Deferred.await(latch))
+        yield* _(Fiber.interrupt(fib))
+
+        const interruptions = yield* _(Ref.get(effectInterrupted))
+
+        assert(interruptions === 1)
+      })
+    )
+  })
+
+  it.effect("will make effects wait for interrupted effects to pass through the rate limiter", () => {
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(1, "1 seconds"))
+
+        yield* _(rl(Effect.unit))
+
+        const f1 = yield* _(rl(Effect.unit).pipe(Effect.fork))
+        yield* _(TestClock.adjust("1 seconds"))
+        yield* _(Fiber.interrupt(f1))
+
+        const fib = yield* _(pipe(
+          Clock.currentTimeMillis,
+          rl,
+          Effect.fork
+        ))
+
+        yield* _(TestClock.adjust("1 seconds"))
+
+        const lastExecutionTime = yield* _(Fiber.join(fib))
+
+        assert(lastExecutionTime === 2000)
+      })
+    )
+  })
+
+  it.effect("will not include interrupted effects in the throttling", () => {
+    const rate = 10
+
+    return Effect.scoped(
+      Effect.gen(function*(_) {
+        const rl = yield* _(RateLimiter.make(rate, "1 seconds"))
+        const latch = yield* _(Deferred.make<void>())
+        const latched = yield* _(Ref.make(0))
+        const continue_ = yield* _(Deferred.make<void>())
+
+        yield* _(
+          Effect.whenEffect(pipe(
+            latched,
+            Ref.updateAndGet((x) => x + 1),
+            Effect.map((x) => x === rate)
+          ))(Deferred.succeed(latch, void 0)).pipe(
+            Effect.flatMap(() => Deferred.await(continue_)),
+            rl,
+            Effect.fork,
+            Effect.replicateEffect(rate)
+          )
+        )
+
+        yield* _(Deferred.await(latch))
+
+        const fibers = yield* _(Effect.replicateEffect(1000)(rl(Effect.unit).pipe(Effect.fork)))
+
+        yield* _(Fiber.interruptAll(fibers))
+        const f1 = yield* _(rl(Effect.unit).pipe(Effect.fork))
+
+        yield* _(TestClock.adjust("1 seconds"))
+        yield* _(Fiber.join(f1))
+      })
+    )
+  }, { timeout: 10000 })
+})


### PR DESCRIPTION
Add `Ratelimiter` which limits the number of calls to a resource within a time window using the token bucket algorithm.

Usage Example:

```ts
import { Effect, RateLimiter } from "effect";

// we need a scope because the rate limiter needs to allocate a state and a background job
const program = Effect.scoped(
  Effect.gen(function* ($) {
    // create a rate limiter that executes up to 10 requests within 2 seconds
    const rateLimit = yield* $(RateLimiter.make(10, "2 seconds"));
    // simulate repeated calls
    for (let n = 0; n < 100; n++) {
      // wrap the effect we want to limit with rateLimit
      yield* $(rateLimit(Effect.log("Calling RateLimited Effect")));
    }
  })
);

// will print 10 calls immediately and then throttle
program.pipe(Effect.runFork);
```

closes #2031 & #1685, Thanks @hsubra89 