### PR TITLE
`RateLimiter.withCost` combinator + Rate Limiter composition tests

### DIFF
--- a/.changeset/gentle-suits-sparkle.md
+++ b/.changeset/gentle-suits-sparkle.md
@@ -1,0 +1,34 @@
+---
+"effect": patch
+---
+
+Update `RateLimiter` to support passing in a custom `cost` per effect. This is really useful for API(s) that have a "credit cost" per endpoint.
+
+Usage Example :
+
+```ts
+import { Effect, RateLimiter } from "effect";
+import { compose } from "effect/Function";
+
+const program = Effect.scoped(
+  Effect.gen(function* ($) {
+    // Create a rate limiter that has an hourly limit of 1000 credits
+    const rateLimiter = yield* $(RateLimiter.make(1000, "1 hours"));
+    // Query API costs 1 credit per call ( 1 is the default cost )
+    const queryAPIRL = compose(rateLimiter, RateLimiter.withCost(1));
+    // Mutation API costs 5 credits per call
+    const mutationAPIRL = compose(rateLimiter, RateLimiter.withCost(5));
+    // ...
+    // Use the pre-defined rate limiters
+    yield* $(queryAPIRL(Effect.log("Sample Query")));
+    yield* $(mutationAPIRL(Effect.log("Sample Mutation")));
+
+    // Or set a cost on-the-fly
+    yield* $(
+      rateLimiter(Effect.log("Another query with a different cost")).pipe(
+        RateLimiter.withCost(3)
+      )
+    );
+  })
+);
+```

--- a/packages/effect/src/RateLimiter.ts
+++ b/packages/effect/src/RateLimiter.ts
@@ -1,9 +1,6 @@
 /**
- * Limits the number of calls to a resource to a maximum amount in some interval using the token bucket algorithm.
- *
- * Note that only the moment of starting the effect is rate limited: the number of concurrent executions is not bounded.
- *
- * Calls are queued up in an unbounded queue until capacity becomes available.
+ * Limits the number of calls to a resource to a maximum amount in some interval
+ * using the token bucket algorithm.
  *
  * @since 2.0.0
  */
@@ -13,12 +10,6 @@ import * as internal from "./internal/rateLimiter.js"
 import type { Scope } from "./Scope.js"
 
 /**
- * Limits the number of calls to a resource to a maximum amount in some interval using the token bucket algorithm.
- *
- * Note that only the moment of starting the effect is rate limited: the number of concurrent executions is not bounded.
- *
- * Calls are queued up in an unbounded queue until capacity becomes available.
- *
  * @since 2.0.0
  * @category models
  */
@@ -27,6 +18,37 @@ export interface RateLimiter {
 }
 
 /**
+ * Constructs a new `RateLimiter` with the specified limit and window.
+ *
+ * Limits the number of calls to a resource to a maximum amount in some interval
+ * using the token bucket algorithm.
+ *
+ * Notes
+ * - Only the moment of starting the effect is rate limited. The number of concurrent executions is not bounded.
+ * - Instances of `RateLimiter` can be composed.
+ * - The "cost" per effect can be changed. See {@link withCost}
+ *
+ * @example
+ * import { Effect, RateLimiter } from "effect";
+ * import { compose } from "effect/Function"
+ *
+ * const program = Effect.scoped(
+ *   Effect.gen(function* ($) {
+ *     const perMinuteRL = yield* $(RateLimiter.make(30, "1 minutes"))
+ *     const perSecondRL = yield* $(RateLimiter.make(2, "1 seconds"))
+ *
+ *     // This rate limiter respects both the 30 calls per minute
+ *     // and the 2 calls per second constraints.
+ *      const rateLimit = compose(perMinuteRL, perSecondRL)
+ *
+ *     // simulate repeated calls
+ *     for (let n = 0; n < 100; n++) {
+ *       // wrap the effect we want to limit with rateLimit
+ *       yield* $(rateLimit(Effect.log("Calling RateLimited Effect")));
+ *     }
+ *   })
+ * );
+ *
  * @since 2.0.0
  * @category constructors
  */
@@ -35,3 +57,41 @@ export const make: (limit: number, window: DurationInput) => Effect<
   never,
   Scope
 > = internal.make
+
+/**
+ * Alters the per-effect cost of the rate-limiter.
+ *
+ * This can be used for "credit" based rate-limiting where different API endpoints
+ * cost a different number of credits within a time window.
+ * Eg: 1000 credits / hour, where a query costs 1 credit and a mutation costs 5 credits.
+ *
+ * @example
+ * import { Effect, RateLimiter } from "effect";
+ * import { compose } from "effect/Function";
+ *
+ * const program = Effect.scoped(
+ *   Effect.gen(function* ($) {
+ *     // Create a rate limiter that has an hourly limit of 1000 credits
+ *     const rateLimiter = yield* $(RateLimiter.make(1000, "1 hours"));
+ *     // Query API costs 1 credit per call ( 1 is the default cost )
+ *     const queryAPIRL = compose(rateLimiter, RateLimiter.withCost(1));
+ *     // Mutation API costs 5 credits per call
+ *     const mutationAPIRL = compose(rateLimiter, RateLimiter.withCost(5));
+
+ *     // Use the pre-defined rate limiters
+ *     yield* $(queryAPIRL(Effect.log("Sample Query")));
+ *     yield* $(mutationAPIRL(Effect.log("Sample Mutation")));
+ *
+ *     // Or set a cost on-the-fly
+ *     yield* $(
+ *       rateLimiter(Effect.log("Another query with a different cost")).pipe(
+ *         RateLimiter.withCost(3)
+ *       )
+ *     );
+ *   })
+ * );
+ *
+ * @since 2.0.0
+ * @category combinators
+ */
+export const withCost: (cost: number) => <A, E, R>(effect: Effect<A, E, R>) => Effect<A, E, R> = internal.withCost

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -548,9 +548,6 @@ export * as Random from "./Random.js"
  * Limits the number of calls to a resource to a maximum amount in some interval
  * using the token bucket algorithm.
  *
- * Note: Only the moment of starting the effect is rate limited.
- * The number of concurrent executions is not bounded.
- *
  * @since 2.0.0
  */
 export * as RateLimiter from "./RateLimiter.js"

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -545,11 +545,11 @@ export * as Queue from "./Queue.js"
 export * as Random from "./Random.js"
 
 /**
- * Limits the number of calls to a resource to a maximum amount in some interval using the token bucket algorithm.
+ * Limits the number of calls to a resource to a maximum amount in some interval
+ * using the token bucket algorithm.
  *
- * Note that only the moment of starting the effect is rate limited: the number of concurrent executions is not bounded.
- *
- * Calls are queued up in an unbounded queue until capacity becomes available.
+ * Note: Only the moment of starting the effect is rate limited.
+ * The number of concurrent executions is not bounded.
  *
  * @since 2.0.0
  */

--- a/packages/effect/src/internal/rateLimiter.ts
+++ b/packages/effect/src/internal/rateLimiter.ts
@@ -7,36 +7,8 @@ import type { Scope } from "../Scope.js"
 import * as SynchronizedRef from "../SynchronizedRef.js"
 
 /** @internal */
-export const makeWithCost = (limit: number, window: DurationInput): Effect.Effect<
-  (cost: number) => RateLimiter,
-  never,
-  Scope
-> =>
-  Effect.gen(function*(_) {
-    const scope = yield* _(Effect.scope)
-    const semaphore = yield* _(Effect.makeSemaphore(limit))
-    const ref = yield* _(SynchronizedRef.make(false))
-    const reset = SynchronizedRef.updateEffect(
-      ref,
-      (running) =>
-        running ? Effect.succeed(true) : Effect.sleep(window).pipe(
-          Effect.zipRight(SynchronizedRef.set(ref, false)),
-          Effect.zipRight(semaphore.releaseAll),
-          Effect.forkIn(scope),
-          Effect.interruptible,
-          Effect.as(true)
-        )
-    )
-
-    return (cost: number) => (effect) => {
-      const take = Effect.zipRight(semaphore.take(cost), reset)
-      return Effect.zipRight(take, effect)
-    }
-  })
-
-/** @internal */
-const defaultCost = globalValue(
-  Symbol.for("effect/RateLimiter/defaultCost"),
+const currentCost = globalValue(
+  Symbol.for("effect/RateLimiter/currentCost"),
   () => FiberRef.unsafeMake(1)
 )
 
@@ -62,11 +34,11 @@ export const make = (limit: number, window: DurationInput): Effect.Effect<
         )
     )
 
-    const cost = FiberRef.get(defaultCost).pipe(Effect.flatMap(semaphore.take))
+    const cost = FiberRef.get(currentCost).pipe(Effect.flatMap(semaphore.take))
     const take = Effect.zipRight(cost, reset)
 
     return (effect) => Effect.zipRight(take, effect)
   })
 
 /** @internal */
-export const withCost = (cost: number) => Effect.locallyWith(defaultCost, () => cost)
+export const withCost = (cost: number) => Effect.locally(currentCost, cost)

--- a/packages/effect/src/internal/rateLimiter.ts
+++ b/packages/effect/src/internal/rateLimiter.ts
@@ -1,8 +1,44 @@
 import type { DurationInput } from "../Duration.js"
 import * as Effect from "../Effect.js"
+import * as FiberRef from "../FiberRef.js"
+import { globalValue } from "../GlobalValue.js"
 import type { RateLimiter } from "../RateLimiter.js"
 import type { Scope } from "../Scope.js"
 import * as SynchronizedRef from "../SynchronizedRef.js"
+
+/** @internal */
+export const makeWithCost = (limit: number, window: DurationInput): Effect.Effect<
+  (cost: number) => RateLimiter,
+  never,
+  Scope
+> =>
+  Effect.gen(function*(_) {
+    const scope = yield* _(Effect.scope)
+    const semaphore = yield* _(Effect.makeSemaphore(limit))
+    const ref = yield* _(SynchronizedRef.make(false))
+    const reset = SynchronizedRef.updateEffect(
+      ref,
+      (running) =>
+        running ? Effect.succeed(true) : Effect.sleep(window).pipe(
+          Effect.zipRight(SynchronizedRef.set(ref, false)),
+          Effect.zipRight(semaphore.releaseAll),
+          Effect.forkIn(scope),
+          Effect.interruptible,
+          Effect.as(true)
+        )
+    )
+
+    return (cost: number) => (effect) => {
+      const take = Effect.zipRight(semaphore.take(cost), reset)
+      return Effect.zipRight(take, effect)
+    }
+  })
+
+/** @internal */
+const defaultCost = globalValue(
+  Symbol.for("effect/RateLimiter/defaultCost"),
+  () => FiberRef.unsafeMake(1)
+)
 
 /** @internal */
 export const make = (limit: number, window: DurationInput): Effect.Effect<
@@ -25,6 +61,12 @@ export const make = (limit: number, window: DurationInput): Effect.Effect<
           Effect.as(true)
         )
     )
-    const take = Effect.zipRight(semaphore.take(1), reset)
+
+    const cost = FiberRef.get(defaultCost).pipe(Effect.flatMap(semaphore.take))
+    const take = Effect.zipRight(cost, reset)
+
     return (effect) => Effect.zipRight(take, effect)
   })
+
+/** @internal */
+export const withCost = (cost: number) => Effect.locallyWith(defaultCost, () => cost)

--- a/packages/effect/test/RateLimiter.test.ts
+++ b/packages/effect/test/RateLimiter.test.ts
@@ -1,223 +1,300 @@
 import { Clock, Deferred, Effect, Either, Fiber, pipe, Ref, TestClock } from "effect"
 import * as it from "effect-test/utils/extend"
+import { compose } from "effect/Function"
 import { none } from "effect/Option"
 import * as RateLimiter from "effect/RateLimiter"
 import { assert, describe } from "vitest"
 
 describe("RateLimiterSpec", () => {
-  it.effect("execute up to max calls immediately", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, 1000))
-        const now = yield* _(Clock.currentTimeMillis)
-        const times = yield* _(Effect.forEach(Array.from(Array(10)), () => rl(Clock.currentTimeMillis)))
-        assert(times.every((t) => t === now))
-      })
-    )
+  it.scoped("execute up to max calls immediately", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, 1000))
+      const now = yield* _(Clock.currentTimeMillis)
+      const times = yield* _(Effect.forEach(Array.from(Array(10)), () => rl(Clock.currentTimeMillis)))
+      assert(times.every((t) => t === now))
+    })
   })
 
-  it.effect("is not affected by stream chunk size", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
-        const now = yield* _(Clock.currentTimeMillis)
-        const times1 = yield* _(
-          Effect.forEach(Array.from(Array(5)), () => rl(Clock.currentTimeMillis), { concurrency: "unbounded" })
-        )
+  it.scoped("is not affected by stream chunk size", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      const now = yield* _(Clock.currentTimeMillis)
+      const times1 = yield* _(
+        Effect.forEach(Array.from(Array(5)), () => rl(Clock.currentTimeMillis), { concurrency: "unbounded" })
+      )
 
-        const secondCallFib = yield* _(
-          Effect.forEach(Array.from(Array(15)), () => Effect.fork(rl(Clock.currentTimeMillis)), {
+      const secondCallFib = yield* _(
+        Effect.forEach(Array.from(Array(15)), () => Effect.fork(rl(Clock.currentTimeMillis)), {
+          concurrency: "unbounded"
+        })
+      )
+
+      yield* _(TestClock.adjust("1 seconds"))
+      const times2 = yield* _(Effect.forEach(secondCallFib, Fiber.join, { concurrency: "unbounded" }))
+      const times = times1.concat(times2)
+      assert(times.filter((x) => x === now).length === 10)
+    })
+  })
+
+  it.scoped("succeed with the result of the call", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      const result = yield* _(rl(Effect.succeed(3)))
+      assert(result === 3)
+    })
+  })
+
+  it.scoped("fail with the result of a failed call", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      const result = yield* _(rl(pipe(Effect.fail(none), Effect.either)))
+      assert(Either.isLeft(result))
+    })
+  })
+
+  it.scoped("continue after a failed call", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      yield* _(rl(pipe(Effect.fail(none), Effect.either)))
+      yield* _(rl(Effect.succeed(3)))
+    })
+  })
+
+  it.scoped("holds back up calls after the max", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      const now = yield* _(Clock.currentTimeMillis)
+
+      const fib = yield* _(
+        pipe(
+          Effect.forEach(Array.from(Array(20)), () => rl(Clock.currentTimeMillis), {
             concurrency: "unbounded"
-          })
+          }),
+          Effect.fork
         )
+      )
 
-        yield* _(TestClock.adjust("1 seconds"))
-        const times2 = yield* _(Effect.forEach(secondCallFib, Fiber.join, { concurrency: "unbounded" }))
-        const times = times1.concat(times2)
-        assert(times.filter((x) => x === now).length === 10)
-      })
-    )
+      yield* _(TestClock.adjust("1 seconds"))
+
+      const times = yield* _(Fiber.join(fib))
+      const later = yield* _(Clock.currentTimeMillis)
+
+      assert(times.slice(0, 10).every((x) => x === now))
+      assert(times.slice(10).every((x) => x > now && x <= later))
+    })
   })
 
-  it.effect("succeed with the result of the call", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
-        const result = yield* _(rl(Effect.succeed(3)))
-        assert(result === 3)
-      })
-    )
+  it.scoped("will interrupt the effect when a call is interrupted", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      const latch = yield* _(Deferred.make<void>())
+      const interrupted = yield* _(Deferred.make<void>())
+      const fib = yield* _(pipe(
+        Deferred.succeed(latch, void 0),
+        Effect.flatMap(() => Effect.never),
+        Effect.onInterrupt(() => Deferred.succeed(interrupted, void 0)),
+        rl,
+        Effect.fork
+      ))
+
+      yield* _(Deferred.await(latch))
+      yield* _(Fiber.interrupt(fib))
+      yield* _(Deferred.await(interrupted))
+    })
   })
 
-  it.effect("fail with the result of a failed call", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
-        const result = yield* _(rl(pipe(Effect.fail(none), Effect.either)))
-        assert(Either.isLeft(result))
-      })
-    )
+  it.scoped("will not start execution of an effect when it is interrupted before getting its turn to execute", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(1, "1 seconds"))
+      const count = yield* _(Ref.make(0))
+      yield* _(rl(Effect.unit))
+
+      const fib = yield* _(rl(Ref.set(count, 1)).pipe(Effect.fork))
+      const interruption = yield* _(Fiber.interrupt(fib).pipe(Effect.fork))
+
+      yield* _(Fiber.join(interruption))
+      const c = yield* _(Ref.get(count))
+
+      assert(c === 0)
+    })
   })
 
-  it.effect("continue after a failed call", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
-        yield* _(rl(pipe(Effect.fail(none), Effect.either)))
-        yield* _(rl(Effect.succeed(3)))
-      })
-    )
+  it.scoped("will wait for interruption to complete of an effect that is already executing", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(1, "1 seconds"))
+      const latch = yield* _(Deferred.make<void>())
+      const effectInterrupted = yield* _(Ref.make(0))
+
+      const fib = yield* _(pipe(
+        Deferred.succeed(latch, void 0),
+        Effect.flatMap(() => Effect.never),
+        Effect.onInterrupt(() => Ref.set(effectInterrupted, 1)),
+        rl,
+        Effect.fork
+      ))
+
+      yield* _(Deferred.await(latch))
+      yield* _(Fiber.interrupt(fib))
+
+      const interruptions = yield* _(Ref.get(effectInterrupted))
+
+      assert(interruptions === 1)
+    })
   })
 
-  it.effect("holds back up calls after the max", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
-        const now = yield* _(Clock.currentTimeMillis)
+  it.scoped("will make effects wait for interrupted effects to pass through the rate limiter", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(1, "1 seconds"))
 
-        const fib = yield* _(
-          pipe(
-            Effect.forEach(Array.from(Array(20)), () => rl(Clock.currentTimeMillis), {
-              concurrency: "unbounded"
-            }),
-            Effect.fork
-          )
-        )
+      yield* _(rl(Effect.unit))
 
-        yield* _(TestClock.adjust("1 seconds"))
+      const f1 = yield* _(rl(Effect.unit).pipe(Effect.fork))
+      yield* _(TestClock.adjust("1 seconds"))
+      yield* _(Fiber.interrupt(f1))
 
-        const times = yield* _(Fiber.join(fib))
-        const later = yield* _(Clock.currentTimeMillis)
+      const fib = yield* _(pipe(
+        Clock.currentTimeMillis,
+        rl,
+        Effect.fork
+      ))
 
-        assert(times.slice(0, 10).every((x) => x === now))
-        assert(times.slice(10).every((x) => x > now && x <= later))
-      })
-    )
+      yield* _(TestClock.adjust("1 seconds"))
+
+      const lastExecutionTime = yield* _(Fiber.join(fib))
+
+      assert(lastExecutionTime === 2000)
+    })
   })
 
-  it.effect("will interrupt the effect when a call is interrupted", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(10, "1 seconds"))
-        const latch = yield* _(Deferred.make<void>())
-        const interrupted = yield* _(Deferred.make<void>())
-        const fib = yield* _(pipe(
-          Deferred.succeed(latch, void 0),
-          Effect.flatMap(() => Effect.never),
-          Effect.onInterrupt(() => Deferred.succeed(interrupted, void 0)),
-          rl,
-          Effect.fork
-        ))
-
-        yield* _(Deferred.await(latch))
-        yield* _(Fiber.interrupt(fib))
-        yield* _(Deferred.await(interrupted))
-      })
-    )
-  })
-
-  it.effect("will not start execution of an effect when it is interrupted before getting its turn to execute", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(1, "1 seconds"))
-        const count = yield* _(Ref.make(0))
-        yield* _(rl(Effect.unit))
-
-        const fib = yield* _(rl(Ref.set(count, 1)).pipe(Effect.fork))
-        const interruption = yield* _(Fiber.interrupt(fib).pipe(Effect.fork))
-
-        yield* _(Fiber.join(interruption))
-        const c = yield* _(Ref.get(count))
-
-        assert(c === 0)
-      })
-    )
-  })
-
-  it.effect("will wait for interruption to complete of an effect that is already executing", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(1, "1 seconds"))
-        const latch = yield* _(Deferred.make<void>())
-        const effectInterrupted = yield* _(Ref.make(0))
-
-        const fib = yield* _(pipe(
-          Deferred.succeed(latch, void 0),
-          Effect.flatMap(() => Effect.never),
-          Effect.onInterrupt(() => Ref.set(effectInterrupted, 1)),
-          rl,
-          Effect.fork
-        ))
-
-        yield* _(Deferred.await(latch))
-        yield* _(Fiber.interrupt(fib))
-
-        const interruptions = yield* _(Ref.get(effectInterrupted))
-
-        assert(interruptions === 1)
-      })
-    )
-  })
-
-  it.effect("will make effects wait for interrupted effects to pass through the rate limiter", () => {
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(1, "1 seconds"))
-
-        yield* _(rl(Effect.unit))
-
-        const f1 = yield* _(rl(Effect.unit).pipe(Effect.fork))
-        yield* _(TestClock.adjust("1 seconds"))
-        yield* _(Fiber.interrupt(f1))
-
-        const fib = yield* _(pipe(
-          Clock.currentTimeMillis,
-          rl,
-          Effect.fork
-        ))
-
-        yield* _(TestClock.adjust("1 seconds"))
-
-        const lastExecutionTime = yield* _(Fiber.join(fib))
-
-        assert(lastExecutionTime === 2000)
-      })
-    )
-  })
-
-  it.effect("will not include interrupted effects in the throttling", () => {
+  it.scoped("will not include interrupted effects in the throttling", () => {
     const rate = 10
 
-    return Effect.scoped(
-      Effect.gen(function*(_) {
-        const rl = yield* _(RateLimiter.make(rate, "1 seconds"))
-        const latch = yield* _(Deferred.make<void>())
-        const latched = yield* _(Ref.make(0))
-        const continue_ = yield* _(Deferred.make<void>())
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(rate, "1 seconds"))
+      const latch = yield* _(Deferred.make<void>())
+      const latched = yield* _(Ref.make(0))
+      const continue_ = yield* _(Deferred.make<void>())
 
-        yield* _(
-          Effect.whenEffect(pipe(
-            latched,
-            Ref.updateAndGet((x) => x + 1),
-            Effect.map((x) => x === rate)
-          ))(Deferred.succeed(latch, void 0)).pipe(
-            Effect.flatMap(() => Deferred.await(continue_)),
-            rl,
-            Effect.fork,
-            Effect.replicateEffect(rate)
-          )
+      yield* _(
+        Effect.whenEffect(pipe(
+          latched,
+          Ref.updateAndGet((x) => x + 1),
+          Effect.map((x) => x === rate)
+        ))(Deferred.succeed(latch, void 0)).pipe(
+          Effect.flatMap(() => Deferred.await(continue_)),
+          rl,
+          Effect.fork,
+          Effect.replicateEffect(rate)
         )
+      )
 
-        yield* _(Deferred.await(latch))
+      yield* _(Deferred.await(latch))
 
-        const fibers = yield* _(Effect.replicateEffect(1000)(rl(Effect.unit).pipe(Effect.fork)))
+      const fibers = yield* _(Effect.replicateEffect(1000)(rl(Effect.unit).pipe(Effect.fork)))
 
-        yield* _(Fiber.interruptAll(fibers))
-        const f1 = yield* _(rl(Effect.unit).pipe(Effect.fork))
+      yield* _(Fiber.interruptAll(fibers))
+      const f1 = yield* _(rl(Effect.unit).pipe(Effect.fork))
 
-        yield* _(TestClock.adjust("1 seconds"))
-        yield* _(Fiber.join(f1))
-      })
-    )
-  }, { timeout: 10000 })
+      yield* _(TestClock.adjust("1 seconds"))
+      yield* _(Fiber.join(f1))
+    })
+  }, 10_000)
+
+  it.scoped("will use the provided cost", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(100, "1 seconds"))
+
+      const now = yield* _(Clock.currentTimeMillis)
+      const fib = yield* _(
+        Effect.forEach(Array.from(Array(20)), () => rl(Clock.currentTimeMillis).pipe(RateLimiter.withCost(10))).pipe(
+          Effect.fork
+        )
+      )
+
+      yield* _(TestClock.adjust("1 seconds"))
+      const nowAfter1Second = yield* _(Clock.currentTimeMillis)
+
+      const times = yield* _(Fiber.join(fib))
+      assert(times.slice(0, 10).every((t) => t === now))
+      assert(times.slice(10).every((t) => t === nowAfter1Second))
+    })
+  })
+
+  it.scoped("will respect different costs per effect and interleave them.", () => {
+    return Effect.gen(function*(_) {
+      const rl = yield* _(RateLimiter.make(10, "1 seconds"))
+      const rl1 = compose(rl, RateLimiter.withCost(7))
+      const rl2 = compose(rl, RateLimiter.withCost(3))
+
+      const start = yield* _(Clock.currentTimeMillis)
+
+      const tasks = [
+        rl1(Clock.currentTimeMillis).pipe(Effect.map((x) => ["rl1", x] as const)),
+        rl1(Clock.currentTimeMillis).pipe(Effect.map((x) => ["rl1", x] as const)),
+        rl2(Clock.currentTimeMillis).pipe(Effect.map((x) => ["rl2", x] as const)),
+        rl2(Clock.currentTimeMillis).pipe(Effect.map((x) => ["rl2", x] as const))
+      ]
+
+      const fib = yield* _(
+        Effect.all(tasks, { concurrency: "unbounded" }).pipe(Effect.fork)
+      )
+
+      yield* _(TestClock.adjust("1 seconds"))
+      const after1Second = yield* _(Clock.currentTimeMillis)
+
+      const times = yield* _(Fiber.join(fib))
+
+      assert.deepEqual(
+        times,
+        [
+          ["rl1", start],
+          ["rl1", after1Second],
+          ["rl2", start],
+          ["rl2", after1Second]
+        ]
+      )
+    })
+  })
+
+  it.scoped("will be composable with other `RateLimiters`", () => {
+    return Effect.gen(function*(_) {
+      // Max 30 calls per minute
+      const rl1 = yield* _(RateLimiter.make(30, "1 minutes"))
+      // Max 2 calls per second
+      const rl2 = yield* _(RateLimiter.make(2, "1 seconds"))
+      // This rate limiter respects both the 30 calls per minute
+      // and the 2 calls per second constraints.
+      const rl = compose(rl1, rl2)
+
+      const now = yield* _(Clock.currentTimeMillis)
+
+      // 32 calls should take 1 minute to complete based on the constraints
+      // of the rate limiter defined above.
+      // First 30 calls should trigger in the first 15 seconds
+      // and the next 2 calls should trigger at the 1 minute mark.
+      const fib = yield* _(
+        Effect.forEach(Array.from(Array(32)), () => rl(Clock.currentTimeMillis)).pipe(Effect.fork)
+      )
+
+      const timestamps = yield* _(
+        Effect.all(
+          Array.from(Array(60)).map(() => Effect.zipRight(TestClock.adjust("1 seconds"), Clock.currentTimeMillis))
+        )
+      )
+
+      const times = yield* _(Fiber.join(fib))
+
+      assert(timestamps.length === 60)
+      assert(times.length === 32)
+
+      const resultTimes = [
+        now,
+        now,
+        ...timestamps.slice(0, 14).flatMap((x) => [x, x]),
+        ...timestamps.slice(59).flatMap((x) => [x, x])
+      ]
+
+      assert.deepEqual(times, resultTimes)
+    })
+  }, 10_000)
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This patch updates the `RateLimiter` module to include another constructor which includes a sub-constructor which allows us to specify a cost while maintaining composability with other `RateLimiter` instances. This enables the use of this module to rate limit for the following cases : 
- Accessing resources with an "API Credit" limit over a time window.

- With composition, accounting for multiple "credit" limits. ( eg: [Github API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits) ) 

- Accounting for different "costs" per api per provider within a single credit limit. 
  - Many providers have different API costs for different endpoints within their ecosystem.

## Usage Example
```ts
import { Effect, RateLimiter } from "effect";
import { compose } from "effect/Function";

const program = Effect.scoped(
  Effect.gen(function* ($) {
    // Create a rate limiter that has an hourly limit of 1000 credits
    const rateLimiter = yield* $(RateLimiter.make(1000, "1 hours"));
    // Query API costs 1 credit per call ( 1 is the default cost )
    const queryAPIRL = compose(rateLimiter, RateLimiter.withCost(1));
    // Mutation API costs 5 credits per call
    const mutationAPIRL = compose(rateLimiter, RateLimiter.withCost(5));
    // ...
    // Use the pre-defined rate limiters
    yield* $(queryAPIRL(Effect.log("Sample Query")));
    yield* $(mutationAPIRL(Effect.log("Sample Mutation")));

    // Or set a cost on-the-fly
    const history = yield* $(
      rateLimiter(Effect.log("Another query with a different cost")).pipe(
        RateLimiter.withCost(3)
      )
    );
  })
);
```

