### PR TITLE
remove no longer necessary './internal/timeout'

### DIFF
--- a/.changeset/stupid-hornets-jump.md
+++ b/.changeset/stupid-hornets-jump.md
@@ -1,0 +1,8 @@
+---
+"effect": patch
+---
+
+removed unneccesary `isBun` check in `./internal/timeout`
+
+previously bun had an issue with `setTimeout`, that caused incorrect behavior
+that bug has since been fixed, and the `isBun` check is no longer needed

--- a/.changeset/stupid-hornets-jump.md
+++ b/.changeset/stupid-hornets-jump.md
@@ -2,7 +2,8 @@
 "effect": patch
 ---
 
-removed unneccesary `isBun` check in `./internal/timeout`
+removed `./internal/timeout` and replaced all usages with `setTimeout` directly
 
-previously bun had an issue with `setTimeout`, that caused incorrect behavior
+previously it was required to abstract away conditionally solving an bun had an issue with `setTimeout`, that caused incorrect behavior
 that bug has since been fixed, and the `isBun` check is no longer needed
+as such the timeout module is also no longer needed

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -8,7 +8,6 @@ import type { FiberRef } from "./FiberRef.js"
 import { dual } from "./Function.js"
 import { globalValue } from "./GlobalValue.js"
 import * as core from "./internal/core.js"
-import * as timeout from "./internal/timeout.js"
 
 /**
  * @since 2.0.0
@@ -107,7 +106,7 @@ export class MixedScheduler implements Scheduler {
    */
   private starve(depth = 0) {
     if (depth >= this.maxNextTickBeforeTimer) {
-      timeout.set(() => this.starveInternal(0), 0)
+      setTimeout(() => this.starveInternal(0), 0)
     } else {
       Promise.resolve(void 0).then(() => this.starveInternal(depth + 1))
     }
@@ -337,14 +336,14 @@ export const makeBatched = (
  * @category constructors
  */
 export const timer = (ms: number, shouldYield: Scheduler["shouldYield"] = defaultShouldYield) =>
-  make((task) => timeout.set(task, ms), shouldYield)
+  make((task) => setTimeout(task, ms), shouldYield)
 
 /**
  * @since 2.0.0
  * @category constructors
  */
 export const timerBatched = (ms: number, shouldYield: Scheduler["shouldYield"] = defaultShouldYield) =>
-  makeBatched((task) => timeout.set(task, ms), shouldYield)
+  makeBatched((task) => setTimeout(task, ms), shouldYield)
 
 /** @internal */
 export const currentScheduler: FiberRef<Scheduler> = globalValue(

--- a/packages/effect/src/internal/clock.ts
+++ b/packages/effect/src/internal/clock.ts
@@ -5,7 +5,6 @@ import type * as Effect from "../Effect.js"
 import * as Either from "../Either.js"
 import { constFalse } from "../Function.js"
 import * as core from "./core.js"
-import * as timeout from "./timeout.js"
 
 /** @internal */
 const ClockSymbolKey = "effect/Clock"
@@ -29,12 +28,12 @@ export const globalClockScheduler: Clock.ClockScheduler = {
       return constFalse
     }
     let completed = false
-    const handle = timeout.set(() => {
+    const handle = setTimeout(() => {
       completed = true
       task()
     }, millis)
     return () => {
-      timeout.clear(handle)
+      clearTimeout(handle)
       return !completed
     }
   }

--- a/packages/effect/src/internal/timeout.ts
+++ b/packages/effect/src/internal/timeout.ts
@@ -1,23 +1,6 @@
-/**
- * Bun currently has a bug where `setTimeout` doesn't behave correctly with a 0ms delay.
- *
- * @see https://github.com/oven-sh/bun/issues/3333
- */
+/** @internal */
+export const clear: (id: NodeJS.Timeout) => void = (id) => clearTimeout(id)
 
 /** @internal */
-const isBun = typeof process === "undefined" ? false : !!((process as any)?.isBun)
-
-/** @internal */
-export const clear: (id: NodeJS.Timeout) => void = isBun ? (id) => clearInterval(id) : (id) => clearTimeout(id)
-
-/** @internal */
-export const set: (fn: () => void, ms: number) => NodeJS.Timeout = isBun ?
-  (fn: () => void, ms: number) => {
-    const id = setInterval(() => {
-      fn()
-      clearInterval(id)
-    }, ms)
-
-    return id
-  } :
+export const set: (fn: () => void, ms: number) => NodeJS.Timeout = 
   (fn: () => void, ms: number) => setTimeout(fn, ms)

--- a/packages/effect/src/internal/timeout.ts
+++ b/packages/effect/src/internal/timeout.ts
@@ -1,6 +1,0 @@
-/** @internal */
-export const clear: (id: NodeJS.Timeout) => void = (id) => clearTimeout(id)
-
-/** @internal */
-export const set: (fn: () => void, ms: number) => NodeJS.Timeout = 
-  (fn: () => void, ms: number) => setTimeout(fn, ms)

--- a/packages/effect/test/Effect/promise.test.ts
+++ b/packages/effect/test/Effect/promise.test.ts
@@ -1,5 +1,4 @@
 import * as Effect from "effect/Effect"
-import * as timeout from "effect/internal/timeout"
 import { describe, expect, it } from "vitest"
 
 describe("Effect", () => {
@@ -10,7 +9,7 @@ describe("Effect", () => {
         aborted = true
       })
       return new Promise((resolve) => {
-        timeout.set(() => {
+        setTimeout(() => {
           resolve()
         }, 100)
       })

--- a/packages/effect/test/Effect/query.test.ts
+++ b/packages/effect/test/Effect/query.test.ts
@@ -6,7 +6,6 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as FiberRef from "effect/FiberRef"
-import * as timeout from "effect/internal/timeout"
 import * as Layer from "effect/Layer"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as Request from "effect/Request"
@@ -48,7 +47,7 @@ export class GetNameById extends Request.TaggedClass("GetNameById")<string, stri
 
 const delay = <A, E, R>(self: Effect.Effect<A, E, R>) =>
   Effect.zipRight(
-    Effect.promise(() => new Promise((r) => timeout.set(() => r(0), 0))),
+    Effect.promise(() => new Promise((r) => setTimeout(() => r(0), 0))),
     self
   )
 

--- a/packages/effect/test/Effect/scheduler.test.ts
+++ b/packages/effect/test/Effect/scheduler.test.ts
@@ -1,6 +1,5 @@
 import * as it from "effect-test/utils/extend"
 import * as Effect from "effect/Effect"
-import * as timeout from "effect/internal/timeout"
 import * as Scheduler from "effect/Scheduler"
 import { assert, describe } from "vitest"
 
@@ -15,27 +14,27 @@ describe("Effect", () => {
           0,
           Scheduler.makeBatched((runBatch) => {
             ps000.push(0)
-            timeout.set(runBatch, 0)
+            setTimeout(runBatch, 0)
           })
         ],
         [
           100,
           Scheduler.makeBatched((runBatch) => {
             ps100.push(100)
-            timeout.set(runBatch, 0)
+            setTimeout(runBatch, 0)
           })
         ],
         [
           200,
           Scheduler.makeBatched((runBatch) => {
             ps200.push(200)
-            timeout.set(runBatch, 0)
+            setTimeout(runBatch, 0)
           })
         ],
         [
           300,
           Scheduler.makeBatched((runBatch) => {
-            timeout.set(runBatch, 0)
+            setTimeout(runBatch, 0)
           })
         ]
       )

--- a/packages/effect/test/Effect/tryPromise.test.ts
+++ b/packages/effect/test/Effect/tryPromise.test.ts
@@ -1,14 +1,13 @@
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
-import * as timeout from "effect/internal/timeout"
 import { describe, expect, it } from "vitest"
 
 describe("Effect", () => {
   it("tryPromise - success, no catch, no AbortSignal", async () => {
     const effect = Effect.tryPromise<number>(() =>
       new Promise((resolve) => {
-        timeout.set(() => {
+        setTimeout(() => {
           resolve(1)
         }, 100)
       })
@@ -20,7 +19,7 @@ describe("Effect", () => {
   it("tryPromise - failure, no catch, no AbortSignal", async () => {
     const effect = Effect.tryPromise<void>(() =>
       new Promise((_resolve, reject) => {
-        timeout.set(() => {
+        setTimeout(() => {
           reject("error")
         }, 100)
       })
@@ -33,7 +32,7 @@ describe("Effect", () => {
     const effect = Effect.tryPromise({
       try: () =>
         new Promise((_resolve, reject) => {
-          timeout.set(() => {
+          setTimeout(() => {
             reject("error")
           }, 100)
         }),
@@ -50,7 +49,7 @@ describe("Effect", () => {
         aborted = true
       })
       return new Promise((resolve) => {
-        timeout.set(() => {
+        setTimeout(() => {
           resolve()
         }, 100)
       })
@@ -73,7 +72,7 @@ describe("Effect", () => {
           aborted = true
         })
         return new Promise((resolve) => {
-          timeout.set(() => {
+          setTimeout(() => {
             resolve()
           }, 100)
         })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

oven-sh/bun#3333 was closed back in october to have behavior 1-1 with node, so this `isBun` check is no longer necessary

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
