### PR TITLE
Swap Either type params

### DIFF
--- a/.changeset/cuddly-parrots-know.md
+++ b/.changeset/cuddly-parrots-know.md
@@ -1,0 +1,23 @@
+---
+"effect": minor
+---
+
+Consolidate `Effect.asyncOption`, `Effect.asyncEither`, `Stream.asyncOption`, `Stream.asyncEither`, and `Stream.asyncInterrupt`
+
+This PR removes `Effect.asyncOption` and `Effect.asyncEither` as their behavior can be entirely implemented with the new signature of `Effect.async`, which optionally returns a cleanup `Effect` from the registration callback.
+
+```ts
+declare const async: <A, E = never, R = never>(
+  register: (callback: (_: Effect<A, E, R>) => void, signal: AbortSignal) => void | Effect<void, never, R>,
+  blockingOn?: FiberId
+) => Effect<A, E, R>
+```
+
+Additionally, this PR removes `Stream.asyncOption`, `Stream.asyncEither`, and `Stream.asyncInterrupt` as their behavior can be entirely implemented with the new signature of `Stream.async`, which can optionally return a cleanup `Effect` from the registration callback.
+
+```ts
+declare const async: <A, E = never, R = never>(
+  register: (emit: Emit<R, E, A, void>) => Effect<void, never, R> | void,
+  outputBuffer?: number
+) => Stream<A, E, R>
+```

--- a/.changeset/olive-pants-sparkle.md
+++ b/.changeset/olive-pants-sparkle.md
@@ -1,0 +1,17 @@
+---
+"@effect/platform-node-shared": minor
+"@effect/typeclass": minor
+"effect": minor
+"@effect/schema": minor
+"@effect/cli": minor
+---
+
+Swap type params of Either from `Either<E, A>` to `Either<R, L = never>`.
+
+Along the same line of the other changes this allows to shorten the most common types such as:
+
+```ts
+import { Either } from "effect";
+
+const right: Either.Either<string> = Either.right("ok");
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@8.12.1",
+  "packageManager": "pnpm@8.15.1",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/cli/src/Options.ts
+++ b/packages/cli/src/Options.ts
@@ -419,8 +419,8 @@ export const orElse: {
  * @category combinators
  */
 export const orElseEither: {
-  <A>(that: Options<A>): <B>(self: Options<B>) => Options<Either<B, A>>
-  <A, B>(self: Options<A>, that: Options<B>): Options<Either<B, A>>
+  <A>(that: Options<A>): <B>(self: Options<B>) => Options<Either<A, B>>
+  <A, B>(self: Options<A>, that: Options<B>): Options<Either<A, B>>
 } = InternalOptions.orElseEither
 
 /**

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -505,8 +505,8 @@ export const orElse = dual<
 export const orElseEither = dual<
   <B>(
     that: Options.Options<B>
-  ) => <A>(self: Options.Options<A>) => Options.Options<Either.Either<A, B>>,
-  <A, B>(self: Options.Options<A>, that: Options.Options<B>) => Options.Options<Either.Either<A, B>>
+  ) => <A>(self: Options.Options<A>) => Options.Options<Either.Either<B, A>>,
+  <A, B>(self: Options.Options<A>, that: Options.Options<B>) => Options.Options<Either.Either<B, A>>
 >(2, (self, that) => makeOrElse(self, that))
 
 /** @internal */
@@ -980,7 +980,7 @@ const makeMap = <A, B>(
 const makeOrElse = <A, B>(
   left: Options.Options<A>,
   right: Options.Options<B>
-): Options.Options<Either.Either<A, B>> => {
+): Options.Options<Either.Either<B, A>> => {
   const op = Object.create(proto)
   op._tag = "OrElse"
   op.left = left

--- a/packages/effect/dtslint/Effect.ts
+++ b/packages/effect/dtslint/Effect.ts
@@ -84,7 +84,7 @@ Effect.all([string, number], { mode: "validate" })
 // $ExpectType Effect<void, [Option<"err-1">, Option<"err-2">], "dep-1" | "dep-2">
 Effect.all([string, number], { mode: "validate", discard: true })
 
-// $ExpectType Effect<[Either<"err-1", string>, Either<"err-2", number>], never, "dep-1" | "dep-2">
+// $ExpectType Effect<[Either<string, "err-1">, Either<number, "err-2">], never, "dep-1" | "dep-2">
 Effect.all([string, number], { mode: "either" })
 
 // $ExpectType Effect<void, never, "dep-1" | "dep-2">
@@ -118,7 +118,7 @@ Effect.all({ a: string, b: number }, { mode: "validate" })
 // $ExpectType Effect<void, { a: Option<"err-1">; b: Option<"err-2">; }, "dep-1" | "dep-2">
 Effect.all({ a: string, b: number }, { mode: "validate", discard: true })
 
-// $ExpectType Effect<{ a: Either<"err-1", string>; b: Either<"err-2", number>; }, never, "dep-1" | "dep-2">
+// $ExpectType Effect<{ a: Either<string, "err-1">; b: Either<number, "err-2">; }, never, "dep-1" | "dep-2">
 Effect.all({ a: string, b: number }, { mode: "either" })
 
 // $ExpectType Effect<void, never, "dep-1" | "dep-2">
@@ -152,7 +152,7 @@ Effect.all(stringArray, { mode: "validate" })
 // $ExpectType Effect<void, Option<"err-3">[], "dep-3">
 Effect.all(stringArray, { mode: "validate", discard: true })
 
-// $ExpectType Effect<Either<"err-3", string>[], never, "dep-3">
+// $ExpectType Effect<Either<string, "err-3">[], never, "dep-3">
 Effect.all(stringArray, { mode: "either" })
 
 // $ExpectType Effect<void, never, "dep-3">
@@ -186,7 +186,7 @@ Effect.all(numberRecord, { mode: "validate" })
 // $ExpectType Effect<void, { [x: string]: Option<"err-4">; }, "dep-4">
 Effect.all(numberRecord, { mode: "validate", discard: true })
 
-// $ExpectType Effect<{ [x: string]: Either<"err-4", number>; }, never, "dep-4">
+// $ExpectType Effect<{ [x: string]: Either<number, "err-4">; }, never, "dep-4">
 Effect.all(numberRecord, { mode: "either" })
 
 // $ExpectType Effect<void, never, "dep-4">
@@ -220,7 +220,7 @@ pipe([string, number] as const, Effect.allWith({ mode: "validate" }))
 // $ExpectType Effect<void, [Option<"err-1">, Option<"err-2">], "dep-1" | "dep-2">
 pipe([string, number] as const, Effect.allWith({ mode: "validate", discard: true }))
 
-// $ExpectType Effect<[Either<"err-1", string>, Either<"err-2", number>], never, "dep-1" | "dep-2">
+// $ExpectType Effect<[Either<string, "err-1">, Either<number, "err-2">], never, "dep-1" | "dep-2">
 pipe([string, number] as const, Effect.allWith({ mode: "either" }))
 
 // $ExpectType Effect<void, never, "dep-1" | "dep-2">
@@ -254,7 +254,7 @@ pipe({ a: string, b: number }, Effect.allWith({ mode: "validate" }))
 // $ExpectType Effect<void, { a: Option<"err-1">; b: Option<"err-2">; }, "dep-1" | "dep-2">
 pipe({ a: string, b: number }, Effect.allWith({ mode: "validate", discard: true }))
 
-// $ExpectType Effect<{ a: Either<"err-1", string>; b: Either<"err-2", number>; }, never, "dep-1" | "dep-2">
+// $ExpectType Effect<{ a: Either<string, "err-1">; b: Either<number, "err-2">; }, never, "dep-1" | "dep-2">
 pipe({ a: string, b: number }, Effect.allWith({ mode: "either" }))
 
 // $ExpectType Effect<void, never, "dep-1" | "dep-2">
@@ -288,7 +288,7 @@ pipe(stringArray, Effect.allWith({ mode: "validate" }))
 // $ExpectType Effect<void, Option<"err-3">[], "dep-3">
 pipe(stringArray, Effect.allWith({ mode: "validate", discard: true }))
 
-// $ExpectType Effect<Either<"err-3", string>[], never, "dep-3">
+// $ExpectType Effect<Either<string, "err-3">[], never, "dep-3">
 pipe(stringArray, Effect.allWith({ mode: "either" }))
 
 // $ExpectType Effect<void, never, "dep-3">
@@ -322,7 +322,7 @@ pipe(numberRecord, Effect.allWith({ mode: "validate" }))
 // $ExpectType Effect<void, { [x: string]: Option<"err-4">; }, "dep-4">
 pipe(numberRecord, Effect.allWith({ mode: "validate", discard: true }))
 
-// $ExpectType Effect<{ [x: string]: Either<"err-4", number>; }, never, "dep-4">
+// $ExpectType Effect<{ [x: string]: Either<number, "err-4">; }, never, "dep-4">
 pipe(numberRecord, Effect.allWith({ mode: "either" }))
 
 // $ExpectType Effect<void, never, "dep-4">

--- a/packages/effect/dtslint/Either.ts
+++ b/packages/effect/dtslint/Either.ts
@@ -4,11 +4,11 @@ import * as Predicate from "effect/Predicate"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 
 declare const string$string: Either.Either<string, string>
-declare const string$number: Either.Either<string, number>
-declare const string$boolean: Either.Either<string, boolean>
-declare const error$boolean: Either.Either<Error, boolean>
+declare const string$number: Either.Either<number, string>
+declare const string$boolean: Either.Either<boolean, string>
+declare const error$boolean: Either.Either<boolean, Error>
 
-declare const error$a: Either.Either<Error, "a">
+declare const error$a: Either.Either<"a", Error>
 
 declare const predicateUnknown: Predicate.Predicate<unknown>
 
@@ -16,107 +16,107 @@ declare const predicateUnknown: Predicate.Predicate<unknown>
 // flip
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Either<number, string>
+// $ExpectType Either<string, number>
 Either.flip(string$number)
 
 // -------------------------------------------------------------------------------------
 // try
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Either<unknown, number>
+// $ExpectType Either<number, unknown>
 Either.try(() => 1)
 
-// $ExpectType Either<Error, number>
+// $ExpectType Either<number, Error>
 Either.try({ try: () => 1, catch: () => new Error() })
 
 // -------------------------------------------------------------------------------------
 // all - tuple
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Either<never, []>
+// $ExpectType Either<[], never>
 Either.all([])
 
-// $ExpectType Either<string, [number]>
+// $ExpectType Either<[number], string>
 Either.all([string$number])
 
-// $ExpectType Either<string, [number, boolean]>
+// $ExpectType Either<[number, boolean], string>
 Either.all([string$number, string$boolean])
 
-// $ExpectType Either<string | Error, [number, boolean]>
+// $ExpectType Either<[number, boolean], string | Error>
 Either.all([string$number, error$boolean])
 
-// $ExpectType Either<string, [number, boolean]>
+// $ExpectType Either<[number, boolean], string>
 pipe([string$number, string$boolean] as const, Either.all)
 
-// $ExpectType Either<string | Error, [number, boolean]>
+// $ExpectType Either<[number, boolean], string | Error>
 pipe([string$number, error$boolean] as const, Either.all)
 
 // -------------------------------------------------------------------------------------
 // all - struct
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Either<never, {}>
+// $ExpectType Either<{}, never>
 Either.all({})
 
-// $ExpectType Either<string, { a: number; }>
+// $ExpectType Either<{ a: number; }, string>
 Either.all({ a: string$number })
 
-// $ExpectType Either<string, { a: number; b: boolean; }>
+// $ExpectType Either<{ a: number; b: boolean; }, string>
 Either.all({ a: string$number, b: string$boolean })
 
-// $ExpectType Either<string | Error, { a: number; b: boolean; }>
+// $ExpectType Either<{ a: number; b: boolean; }, string | Error>
 Either.all({ a: string$number, b: error$boolean })
 
-// $ExpectType Either<string, { a: number; b: boolean; }>
+// $ExpectType Either<{ a: number; b: boolean; }, string>
 pipe({ a: string$number, b: string$boolean }, Either.all)
 
-// $ExpectType Either<string | Error, { a: number; b: boolean; }>
+// $ExpectType Either<{ a: number; b: boolean; }, string | Error>
 pipe({ a: string$number, b: error$boolean }, Either.all)
 
 // -------------------------------------------------------------------------------------
 // all - array
 // -------------------------------------------------------------------------------------
 
-declare const eitherArray: Array<Either.Either<string, number>>
+declare const eitherArray: Array<Either.Either<number, string>>
 
-// $ExpectType Either<string, number[]>
+// $ExpectType Either<number[], string>
 Either.all(eitherArray)
 
-// $ExpectType Either<string, number[]>
+// $ExpectType Either<number[], string>
 pipe(eitherArray, Either.all)
 
 // -------------------------------------------------------------------------------------
 // all - record
 // -------------------------------------------------------------------------------------
 
-declare const eitherRecord: Record<string, Either.Either<string, number>>
+declare const eitherRecord: Record<string, Either.Either<number, string>>
 
-// $ExpectType Either<string, { [x: string]: number; }>
+// $ExpectType Either<{ [x: string]: number; }, string>
 Either.all(eitherRecord)
 
 // -------------------------------------------------------------------------------------
 // andThen
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Either<string, number>
+// $ExpectType Either<number, string>
 Either.andThen(string$string, string$number)
 
-// $ExpectType Either<string, number>
+// $ExpectType Either<number, string>
 Either.andThen(string$string, () => string$number)
 
-// $ExpectType Either<string, number>
+// $ExpectType Either<number, string>
 string$string.pipe(Either.andThen(string$number))
 
-// $ExpectType Either<string, number>
+// $ExpectType Either<number, string>
 string$string.pipe(Either.andThen(() => string$number))
 
 // -------------------------------------------------------------------------------------
 // filterOrLeft
 // -------------------------------------------------------------------------------------
 
-declare const error$arrayOfStrings: Either.Either<Error, Array<string>>
+declare const error$arrayOfStrings: Either.Either<Array<string>, Error>
 
-// $ExpectType Either<"b" | Error, [string, ...string[]]>
+// $ExpectType Either<[string, ...string[]], "b" | Error>
 pipe(
   error$arrayOfStrings,
   Either.filterOrLeft(ReadonlyArray.isNonEmptyArray, (
@@ -124,9 +124,9 @@ pipe(
   ) => "b" as const)
 )
 
-declare const error$readonlyArrayOfStrings: Either.Either<Error, ReadonlyArray<string>>
+declare const error$readonlyArrayOfStrings: Either.Either<ReadonlyArray<string>, Error>
 
-// $ExpectType Either<"b" | Error, readonly [string, ...string[]]>
+// $ExpectType Either<readonly [string, ...string[]], "b" | Error>
 pipe(
   error$readonlyArrayOfStrings,
   Either.filterOrLeft(ReadonlyArray.isNonEmptyReadonlyArray, (
@@ -134,7 +134,7 @@ pipe(
   ) => "b" as const)
 )
 
-// $ExpectType Either<"b" | Error, "a">
+// $ExpectType Either<"a", "b" | Error>
 pipe(
   error$a,
   Either.filterOrLeft(Predicate.isString, (
@@ -142,7 +142,7 @@ pipe(
   ) => "b" as const)
 )
 
-// $ExpectType Either<"b" | Error, "a">
+// $ExpectType Either<"a", "b" | Error>
 pipe(
   error$a,
   Either.filterOrLeft(Predicate.isString, (
@@ -150,7 +150,7 @@ pipe(
   ) => "b" as const)
 )
 
-// $ExpectType Either<"b" | Error, "a">
+// $ExpectType Either<"a", "b" | Error>
 pipe(
   error$a,
   Either.filterOrLeft(predicateUnknown, (
@@ -158,7 +158,7 @@ pipe(
   ) => "b" as const)
 )
 
-// $ExpectType Either<"b" | Error, "a">
+// $ExpectType Either<"a", "b" | Error>
 pipe(
   error$a,
   Either.filterOrLeft(predicateUnknown, (

--- a/packages/effect/dtslint/ReadonlyRecord.ts
+++ b/packages/effect/dtslint/ReadonlyRecord.ts
@@ -132,10 +132,10 @@ ReadonlyRecord.toEntries(brandedRecord)
 // collect
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Either<never, number>[]
+// $ExpectType Either<number, never>[]
 ReadonlyRecord.collect({ a: Either.right(1), b: Either.right(2), c: Either.right(3) }, (_, n) => n)
 
-// $ExpectType Either<never, number>[]
+// $ExpectType Either<number, never>[]
 pipe({ a: Either.right(1), b: Either.right(2), c: Either.right(3) }, ReadonlyRecord.collect((_, n) => n))
 
 // $ExpectType number[]

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -5,19 +5,19 @@ import * as Unify from "effect/Unify"
 // $ExpectType Option<string | number>
 export type option = Unify.Unify<Option.Option<number> | Option.Option<string>>
 
-// $ExpectType Either<"LA" | "LB", "RA" | "RB">
-export type either = Unify.Unify<Either.Either<"LA", "RA"> | Either.Either<"LB", "RB">>
+// $ExpectType Either<"RA" | "RB", "LA" | "LB">
+export type either = Unify.Unify<Either.Either<"RA", "LA"> | Either.Either<"RB", "LB">>
 
-// $ExpectType 0 | Option<string | number> | Either<"LA" | "LB", "RA" | "RB">
+// $ExpectType 0 | Option<string | number> | Either<"RA" | "RB", "LA" | "LB">
 export type both = Unify.Unify<
-  Either.Either<"LA", "RA"> | Either.Either<"LB", "RB"> | Option.Option<number> | Option.Option<string> | 0
+  Either.Either<"RA", "LA"> | Either.Either<"RB", "LB"> | Option.Option<number> | Option.Option<string> | 0
 >
 
 // $ExpectType { [k: string]: string; }
 export type obj = Unify.Unify<{ [k: string]: string }>
 
-// $ExpectType <N>(n: N) => Either<string, N>
+// $ExpectType <N>(n: N) => Either<N, string>
 Unify.unify(<N>(n: N) => Math.random() > 0 ? Either.right(n) : Either.left("ok"))
 
-// $ExpectType Either<string, number>
+// $ExpectType Either<number, string>
 Unify.unify(Math.random() > 0 ? Either.right(10) : Either.left("ok"))

--- a/packages/effect/mod.sh
+++ b/packages/effect/mod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dirs=(../platform-node-shared/src)
+dirs=(../typeclass/src ../typeclass/test ../typeclass/dtslint)
 for dir in ${dirs[@]};
 do
 echo Refactoring $dir

--- a/packages/effect/mod.ts
+++ b/packages/effect/mod.ts
@@ -2,6 +2,7 @@ import type k from "ast-types/gen/kinds.js"
 import type cs from "jscodeshift"
 
 const enabled = {
+  swapEitherParams: true,
   swapLayerParams: false,
   swapSTMParams: false,
   swapSTMGenParams: false,
@@ -15,7 +16,8 @@ const enabled = {
   swapResourceParams: false,
   swapTExitParams: false,
   swapChannelParams: false,
-  swapSinkParams: true,
+  swapSinkParams: false,
+  cleanupEither: true,
   cleanupSTM: false,
   cleanupEffect: false,
   cleanupStream: false,
@@ -42,6 +44,7 @@ const cleanupStream = cleanup("Stream")
 const cleanupExit = cleanup("Exit")
 const cleanupSTM = cleanup("STM")
 const cleanupTake = cleanup("Take")
+const cleanupEither = cleanup("Either")
 
 const filter = (ast: cs.ASTPath<cs.TSTypeReference>, nodeName: string) => {
   const name = ast.value.typeName
@@ -105,6 +108,7 @@ const swapFiberSetParams = swapParamsEA("FiberSet")
 const swapRequestParams = swapParamsEA("Request")
 const swapResourceParams = swapParamsEA("Resource")
 const swapTExitParams = swapParamsEA("TExit")
+const swapEitherParams = swapParamsEA("Either")
 
 // from: Channel<out Env, in InErr, in InElem, in InDone, out OutErr, out OutElem, out OutDone>
 // to: Channel<OutElem, InElem = unknown, OutErr = never, InErr = unknown, OutDone = void, InDone = unknown, Env = never>
@@ -169,6 +173,9 @@ export default function transformer(file: cs.FileInfo, api: cs.API) {
   }
 
   forEveryTypeReference(root, (ast) => {
+    if (enabled.swapEitherParams) {
+      swapEitherParams(ast)
+    }
     if (enabled.swapLayerParams) {
       swapLayerParams(ast)
     }
@@ -210,6 +217,9 @@ export default function transformer(file: cs.FileInfo, api: cs.API) {
     }
     if (enabled.swapSinkParams) {
       swapSinkParams(ast)
+    }
+    if (enabled.cleanupEither) {
+      cleanupEither(ast)
     }
     if (enabled.cleanupEffect) {
       cleanupEffect(ast)

--- a/packages/effect/src/Brand.ts
+++ b/packages/effect/src/Brand.ts
@@ -102,7 +102,7 @@ export declare namespace Brand {
      * Constructs a branded type from a value of type `A`, returning `Right<A>`
      * if the provided `A` is valid, `Left<BrandError>` otherwise.
      */
-    either(args: Brand.Unbranded<A>): Either.Either<Brand.BrandErrors, A>
+    either(args: Brand.Unbranded<A>): Either.Either<A, Brand.BrandErrors>
     /**
      * Attempts to refine the provided value of type `A`, returning `true` if
      * the provided `A` is valid, `false` otherwise.
@@ -218,7 +218,7 @@ export const refined: <A extends Brand<any>>(
   refinement: Predicate<Brand.Unbranded<A>>,
   onFailure: (a: Brand.Unbranded<A>) => Brand.BrandErrors
 ): Brand.Constructor<A> => {
-  const either = (args: Brand.Unbranded<A>): Either.Either<Brand.BrandErrors, A> =>
+  const either = (args: Brand.Unbranded<A>): Either.Either<A, Brand.BrandErrors> =>
     refinement(args) ? Either.right(args as A) : Either.left(onFailure(args))
   // @ts-expect-error
   return Object.assign((args) =>
@@ -305,8 +305,8 @@ export const all: <Brands extends readonly [Brand.Constructor<any>, ...Array<Bra
     }[number]
   > extends infer X extends Brand<any> ? X : Brand<any>
 > => {
-  const either = (args: any): Either.Either<Brand.BrandErrors, any> => {
-    let result: Either.Either<Brand.BrandErrors, any> = Either.right(args)
+  const either = (args: any): Either.Either<any, Brand.BrandErrors> => {
+    let result: Either.Either<any, Brand.BrandErrors> = Either.right(args)
     for (const brand of brands) {
       const nextResult = brand.either(args)
       if (Either.isLeft(result) && Either.isLeft(nextResult)) {

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -577,7 +577,7 @@ export const failureOption: <E>(self: Cause<E>) => Option.Option<E> = internal.f
  * @since 2.0.0
  * @category getters
  */
-export const failureOrCause: <E>(self: Cause<E>) => Either.Either<E, Cause<never>> = internal.failureOrCause
+export const failureOrCause: <E>(self: Cause<E>) => Either.Either<Cause<never>, E> = internal.failureOrCause
 
 /**
  * Converts the specified `Cause<Option<E>>` to an `Option<Cause<E>>` by

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -1077,7 +1077,7 @@ export const fromEffect: <A, E, R>(
  * @since 2.0.0
  * @category constructors
  */
-export const fromEither: <E, A>(either: Either.Either<E, A>) => Channel<never, unknown, E, unknown, A, unknown> =
+export const fromEither: <E, A>(either: Either.Either<A, E>) => Channel<never, unknown, E, unknown, A, unknown> =
   channel.fromEither
 
 /**
@@ -1097,7 +1097,7 @@ export const fromInput: <Err, Elem, Done>(
  * @category constructors
  */
 export const fromPubSub: <Done, Err, Elem>(
-  pubsub: PubSub.PubSub<Either.Either<Exit.Exit<Done, Err>, Elem>>
+  pubsub: PubSub.PubSub<Either.Either<Elem, Exit.Exit<Done, Err>>>
 ) => Channel<Elem, unknown, Err, unknown, Done, unknown> = channel.fromPubSub
 
 /**
@@ -1107,7 +1107,7 @@ export const fromPubSub: <Done, Err, Elem>(
  * @category constructors
  */
 export const fromPubSubScoped: <Done, Err, Elem>(
-  pubsub: PubSub.PubSub<Either.Either<Exit.Exit<Done, Err>, Elem>>
+  pubsub: PubSub.PubSub<Either.Either<Elem, Exit.Exit<Done, Err>>>
 ) => Effect.Effect<Channel<Elem, unknown, Err, unknown, Done, unknown>, never, Scope.Scope> = channel.fromPubSubScoped
 
 /**
@@ -1127,7 +1127,7 @@ export const fromOption: <A>(
  * @category constructors
  */
 export const fromQueue: <Done, Err, Elem>(
-  queue: Queue.Dequeue<Either.Either<Exit.Exit<Done, Err>, Elem>>
+  queue: Queue.Dequeue<Either.Either<Elem, Exit.Exit<Done, Err>>>
 ) => Channel<Elem, unknown, Err, unknown, Done, unknown> = channel.fromQueue
 
 /**
@@ -1986,7 +1986,7 @@ export const sync: <OutDone>(
  * @category destructors
  */
 export const toPubSub: <Done, Err, Elem>(
-  pubsub: PubSub.PubSub<Either.Either<Exit.Exit<Done, Err>, Elem>>
+  pubsub: PubSub.PubSub<Either.Either<Elem, Exit.Exit<Done, Err>>>
 ) => Channel<never, Elem, never, Err, unknown, Done> = channel.toPubSub
 
 /**
@@ -2000,7 +2000,7 @@ export const toPubSub: <Done, Err, Elem>(
  */
 export const toPull: <OutElem, InElem, OutErr, InErr, OutDone, InDone, Env>(
   self: Channel<OutElem, InElem, OutErr, InErr, OutDone, InDone, Env>
-) => Effect.Effect<Effect.Effect<Either.Either<OutDone, OutElem>, OutErr, Env>, never, Scope.Scope | Env> =
+) => Effect.Effect<Effect.Effect<Either.Either<OutElem, OutDone>, OutErr, Env>, never, Scope.Scope | Env> =
   channel.toPull
 
 /**
@@ -2010,7 +2010,7 @@ export const toPull: <OutElem, InElem, OutErr, InErr, OutDone, InDone, Env>(
  * @category destructors
  */
 export const toQueue: <Done, Err, Elem>(
-  queue: Queue.Enqueue<Either.Either<Exit.Exit<Done, Err>, Elem>>
+  queue: Queue.Enqueue<Either.Either<Elem, Exit.Exit<Done, Err>>>
 ) => Channel<never, Elem, never, Err, unknown, Done> = channel.toQueue
 
 /** Converts this channel to a `Sink`.

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -934,9 +934,9 @@ export const partition: {
  * @since 2.0.0
  */
 export const partitionMap: {
-  <A, B, C>(f: (a: A) => Either<B, C>): (self: Chunk<A>) => [left: Chunk<B>, right: Chunk<C>]
-  <A, B, C>(self: Chunk<A>, f: (a: A) => Either<B, C>): [left: Chunk<B>, right: Chunk<C>]
-} = dual(2, <A, B, C>(self: Chunk<A>, f: (a: A) => Either<B, C>): [left: Chunk<B>, right: Chunk<C>] =>
+  <A, B, C>(f: (a: A) => Either<C, B>): (self: Chunk<A>) => [left: Chunk<B>, right: Chunk<C>]
+  <A, B, C>(self: Chunk<A>, f: (a: A) => Either<C, B>): [left: Chunk<B>, right: Chunk<C>]
+} = dual(2, <A, B, C>(self: Chunk<A>, f: (a: A) => Either<C, B>): [left: Chunk<B>, right: Chunk<C>] =>
   pipe(
     RA.partitionMap(toReadonlyArray(self), f),
     ([l, r]) => [unsafeFromArray(l), unsafeFromArray(r)]
@@ -948,7 +948,7 @@ export const partitionMap: {
  * @category filtering
  * @since 2.0.0
  */
-export const separate = <A, B>(self: Chunk<Either<A, B>>): [Chunk<A>, Chunk<B>] =>
+export const separate = <A, B>(self: Chunk<Either<B, A>>): [Chunk<A>, Chunk<B>] =>
   pipe(
     RA.separate(toReadonlyArray(self)),
     ([l, r]) => [unsafeFromArray(l), unsafeFromArray(r)]

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -55,7 +55,7 @@ export declare namespace Config {
    */
   export interface Primitive<out A> extends Config<A> {
     readonly description: string
-    parse(text: string): Either.Either<ConfigError.ConfigError, A>
+    parse(text: string): Either.Either<A, ConfigError.ConfigError>
   }
 
   /**
@@ -233,8 +233,8 @@ export const mapAttempt: {
  * @category utils
  */
 export const mapOrFail: {
-  <A, B>(f: (a: A) => Either.Either<ConfigError.ConfigError, B>): (self: Config<A>) => Config<B>
-  <A, B>(self: Config<A>, f: (a: A) => Either.Either<ConfigError.ConfigError, B>): Config<B>
+  <A, B>(f: (a: A) => Either.Either<B, ConfigError.ConfigError>): (self: Config<A>) => Config<B>
+  <A, B>(self: Config<A>, f: (a: A) => Either.Either<B, ConfigError.ConfigError>): Config<B>
 } = internal.mapOrFail
 
 /**
@@ -303,7 +303,7 @@ export const option: <A>(self: Config<A>) => Config<Option.Option<A>> = internal
  */
 export const primitive: <A>(
   description: string,
-  parse: (text: string) => Either.Either<ConfigError.ConfigError, A>
+  parse: (text: string) => Either.Either<A, ConfigError.ConfigError>
 ) => Config<A> = internal.primitive
 
 /**

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -184,7 +184,7 @@ export const isParseError = (u: unknown): u is ParseError => hasProperty(u, Pars
  * @since 2.0.0
  * @category constructors
  */
-export const parse = (cron: string): Either.Either<ParseError, Cron> => {
+export const parse = (cron: string): Either.Either<Cron, ParseError> => {
   const segments = cron.split(" ").filter(String.isNonEmpty)
   if (segments.length !== 5) {
     return Either.left(ParseError(`Invalid number of segments in cron expression`, cron))
@@ -439,7 +439,7 @@ const weekdayOptions: SegmentOptions = {
 const parseSegment = (
   input: string,
   options: SegmentOptions
-): Either.Either<ParseError, ReadonlySet<number>> => {
+): Either.Either<ReadonlySet<number>, ParseError> => {
   const capacity = options.max - options.min + 1
   const values = new Set<number>()
   const fields = input.split(",")

--- a/packages/effect/src/Differ.ts
+++ b/packages/effect/src/Differ.ts
@@ -366,14 +366,14 @@ export const orElseEither: {
   <Value2, Patch2>(that: Differ<Value2, Patch2>): <Value, Patch>(
     self: Differ<Value, Patch>
   ) => Differ<
-    Either<Value, Value2>,
+    Either<Value2, Value>,
     Differ.Or.Patch<Value, Value2, Patch, Patch2>
   >
   <Value, Patch, Value2, Patch2>(
     self: Differ<Value, Patch>,
     that: Differ<Value2, Patch2>
   ): Differ<
-    Either<Value, Value2>,
+    Either<Value2, Value>,
     Differ.Or.Patch<Value, Value2, Patch, Patch2>
   >
 } = internal.orElseEither

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -976,17 +976,20 @@ export const validateFirst: {
 // -------------------------------------------------------------------------------------
 
 /**
- * Imports an asynchronous side-effect into a pure `Effect` value.
- * The callback function `Effect<A, E, R> => void` must be called at most once.
+ * Imports an asynchronous side-effect into a pure `Effect` value. The callback
+ * function `Effect<A, E, R> => void` **MUST** be called at most once.
  *
- * If an Effect is returned by the registration function, it will be executed
- * if the fiber executing the effect is interrupted.
+ * The registration function can optionally return an Effect, which will be
+ * executed if the `Fiber` executing this Effect is interrupted.
  *
  * The registration function can also receive an `AbortSignal` if required for
  * interruption.
  *
- * The `FiberId` of the fiber that may complete the async callback may be
- * provided to allow for better diagnostics.
+ * The `FiberId` of the fiber that may complete the async callback may also be
+ * specified. This is called the "blocking fiber" because it suspends the fiber
+ * executing the `async` Effect (i.e. semantically blocks the fiber from making
+ * progress). Specifying this fiber id in cases where it is known will improve
+ * diagnostics, but not affect the behavior of the returned effect.
  *
  * @since 2.0.0
  * @category constructors
@@ -1005,51 +1008,9 @@ export const async: <A, E = never, R = never>(
  * @since 2.0.0
  * @category constructors
  */
-export const asyncEffect: <A, E, R, X, E2, R2>(
-  register: (callback: (_: Effect<A, E, R>) => void) => Effect<X, E2, R2>
-) => Effect<A, E | E2, R | R2> = _runtime.asyncEffect
-
-/**
- * Imports an asynchronous effect into a pure `Effect` value, possibly returning
- * the value synchronously.
- *
- * If the register function returns a value synchronously, then the callback
- * function `Effect<A, E, R> => void` must not be called. Otherwise the callback
- * function must be called at most once.
- *
- * The `FiberId` of the fiber that may complete the async callback may be
- * provided to allow for better diagnostics.
- *
- * @since 2.0.0
- * @category constructors
- */
-export const asyncOption: <A, E = never, R = never>(
-  register: (callback: (_: Effect<A, E, R>) => void) => Option.Option<Effect<A, E, R>>,
-  blockingOn?: FiberId.FiberId
-) => Effect<A, E, R> = effect.asyncOption
-
-/**
- * Imports an asynchronous side-effect into an effect. It has the option of
- * returning the value synchronously, which is useful in cases where it cannot
- * be determined if the effect is synchronous or asynchronous until the register
- * is actually executed. It also has the option of returning a canceler,
- * which will be used by the runtime to cancel the asynchronous effect if the fiber
- * executing the effect is interrupted.
- *
- * If the register function returns a value synchronously, then the callback
- * function `Effect<A, E, R> => void` must not be called. Otherwise the callback
- * function must be called at most once.
- *
- * The `FiberId` of the fiber that may complete the async callback may be
- * provided to allow for better diagnostics.
- *
- * @since 2.0.0
- * @category constructors
- */
-export const asyncEither: <A, E = never, R = never>(
-  register: (callback: (effect: Effect<A, E, R>) => void) => Either.Either<Effect<void, never, R>, Effect<A, E, R>>,
-  blockingOn?: FiberId.FiberId
-) => Effect<A, E, R> = core.asyncEither
+export const asyncEffect: <A, E, R, R3, E2, R2>(
+  register: (callback: (_: Effect<A, E, R>) => void) => Effect<Effect<void, never, R3> | void, E2, R2>
+) => Effect<A, E | E2, R | R2 | R3> = _runtime.asyncEffect
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -401,7 +401,7 @@ export declare namespace All {
    */
   export type ReturnIterable<T extends Iterable<EffectAny>, Discard extends boolean, Mode> = [T] extends
     [Iterable<Effect.Variance<infer A, infer E, infer R>>] ? Effect<
-      Discard extends true ? void : Mode extends "either" ? Array<Either.Either<E, A>> : Array<A>,
+      Discard extends true ? void : Mode extends "either" ? Array<Either.Either<A, E>> : Array<A>,
       Mode extends "either" ? never
         : Mode extends "validate" ? Array<Option.Option<E>>
         : E,
@@ -417,7 +417,7 @@ export declare namespace All {
       : T[number] extends never ? []
       : Mode extends "either" ? {
           -readonly [K in keyof T]: [T[K]] extends [Effect.Variance<infer _A, infer _E, infer _R>] ?
-            Either.Either<_E, _A>
+            Either.Either<_A, _E>
             : never
         }
       : { -readonly [K in keyof T]: [T[K]] extends [Effect.Variance<infer _A, infer _E, infer _R>] ? _A : never },
@@ -441,7 +441,7 @@ export declare namespace All {
       Discard extends true ? void
         : Mode extends "either" ? {
             -readonly [K in keyof T]: [T[K]] extends [Effect.Variance<infer _A, infer _E, infer _R>] ?
-              Either.Either<_E, _A>
+              Either.Either<_A, _E>
               : never
           }
         : { -readonly [K in keyof T]: [T[K]] extends [Effect.Variance<infer _A, infer _E, infer _R>] ? _A : never },
@@ -3262,7 +3262,7 @@ export {
  * @since 2.0.0
  * @category conversions
  */
-export const either: <A, E, R>(self: Effect<A, E, R>) => Effect<Either.Either<E, A>, never, R> = core.either
+export const either: <A, E, R>(self: Effect<A, E, R>) => Effect<Either.Either<A, E>, never, R> = core.either
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Encoding.ts
+++ b/packages/effect/src/Encoding.ts
@@ -28,7 +28,7 @@ export const encodeBase64: (input: Uint8Array | string) => string = (input) =>
  * @category decoding
  * @since 2.0.0
  */
-export const decodeBase64 = (str: string): Either.Either<DecodeException, Uint8Array> => Base64.decode(str)
+export const decodeBase64 = (str: string): Either.Either<Uint8Array, DecodeException> => Base64.decode(str)
 
 /**
  * Decodes a base64 (RFC4648) encoded `string` into a UTF-8 `string`.
@@ -53,7 +53,7 @@ export const encodeBase64Url: (input: Uint8Array | string) => string = (input) =
  * @category decoding
  * @since 2.0.0
  */
-export const decodeBase64Url = (str: string): Either.Either<DecodeException, Uint8Array> => Base64Url.decode(str)
+export const decodeBase64Url = (str: string): Either.Either<Uint8Array, DecodeException> => Base64Url.decode(str)
 
 /**
  * Decodes a base64 (URL) encoded `string` into a UTF-8 `string`.
@@ -78,7 +78,7 @@ export const encodeHex: (input: Uint8Array | string) => string = (input) =>
  * @category decoding
  * @since 2.0.0
  */
-export const decodeHex = (str: string): Either.Either<DecodeException, Uint8Array> => Hex.decode(str)
+export const decodeHex = (str: string): Either.Either<Uint8Array, DecodeException> => Hex.decode(str)
 
 /**
  * Decodes a hex encoded `string` into a UTF-8 `string`.

--- a/packages/effect/src/Exit.ts
+++ b/packages/effect/src/Exit.ts
@@ -231,7 +231,7 @@ export const forEachEffect: {
  * @since 2.0.0
  * @category conversions
  */
-export const fromEither: <E, A>(either: Either.Either<E, A>) => Exit<A, E> = core.exitFromEither
+export const fromEither: <E, A>(either: Either.Either<A, E>) => Exit<A, E> = core.exitFromEither
 
 /**
  * Converts an `Option<A>` into an `Exit<void, A>`.

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -539,8 +539,8 @@ export const orElse: {
  * @category alternatives
  */
 export const orElseEither: {
-  <A2, E2>(that: Fiber<A2, E2>): <A, E>(self: Fiber<A, E>) => Fiber<Either.Either<A, A2>, E2 | E>
-  <A, E, A2, E2>(self: Fiber<A, E>, that: Fiber<A2, E2>): Fiber<Either.Either<A, A2>, E | E2>
+  <A2, E2>(that: Fiber<A2, E2>): <A, E>(self: Fiber<A, E>) => Fiber<Either.Either<A2, A>, E2 | E>
+  <A, E, A2, E2>(self: Fiber<A, E>, that: Fiber<A2, E2>): Fiber<Either.Either<A2, A>, E | E2>
 } = internal.orElseEither
 
 /**

--- a/packages/effect/src/List.ts
+++ b/packages/effect/src/List.ts
@@ -798,9 +798,9 @@ export const partition: {
  * @category combinators
  */
 export const partitionMap: {
-  <A, B, C>(f: (a: A) => Either.Either<B, C>): (self: List<A>) => [left: List<B>, right: List<C>]
-  <A, B, C>(self: List<A>, f: (a: A) => Either.Either<B, C>): [left: List<B>, right: List<C>]
-} = dual(2, <A, B, C>(self: List<A>, f: (a: A) => Either.Either<B, C>): [left: List<B>, right: List<C>] => {
+  <A, B, C>(f: (a: A) => Either.Either<C, B>): (self: List<A>) => [left: List<B>, right: List<C>]
+  <A, B, C>(self: List<A>, f: (a: A) => Either.Either<C, B>): [left: List<B>, right: List<C>]
+} = dual(2, <A, B, C>(self: List<A>, f: (a: A) => Either.Either<C, B>): [left: List<B>, right: List<C>] => {
   const left: Array<B> = []
   const right: Array<C> = []
   for (const a of self) {

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -57,7 +57,7 @@ export interface ValueMatcher<in Input, Filters, out Remaining, out Result, Prov
     readonly _result: Covariant<Result>
   }
   readonly provided: Provided
-  readonly value: Either.Either<Remaining, Provided>
+  readonly value: Either.Either<Provided, Remaining>
   add<I, R, RA, A, Pr>(_case: Case): ValueMatcher<I, R, RA, A, Pr>
 }
 
@@ -526,8 +526,8 @@ export const orElseAbsurd: <I, R, RA, A, Pr>(
  */
 export const either: <I, F, R, A, Pr>(
   self: Matcher<I, F, R, A, Pr>
-) => [Pr] extends [never] ? (input: I) => Either.Either<R, Unify<A>>
-  : Either.Either<R, Unify<A>> = internal.either
+) => [Pr] extends [never] ? (input: I) => Either.Either<Unify<A>, R>
+  : Either.Either<Unify<A>, R> = internal.either
 
 /**
  * @category conversions

--- a/packages/effect/src/MergeState.ts
+++ b/packages/effect/src/MergeState.ts
@@ -49,8 +49,8 @@ export interface BothRunning<_Env, out Err, out Err1, _Err2, out Elem, out Done,
   extends MergeState.Proto
 {
   readonly _tag: "BothRunning"
-  readonly left: Fiber.Fiber<Either.Either<Done, Elem>, Err>
-  readonly right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+  readonly left: Fiber.Fiber<Either.Either<Elem, Done>, Err>
+  readonly right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
 }
 
 /**
@@ -80,8 +80,8 @@ export interface RightDone<out Env, in Err, _Err1, out Err2, _Elem, in Done, _Do
  * @category constructors
  */
 export const BothRunning: <Env, Err, Err1, Err2, Elem, Done, Done1, Done2>(
-  left: Fiber.Fiber<Either.Either<Done, Elem>, Err>,
-  right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+  left: Fiber.Fiber<Either.Either<Elem, Done>, Err>,
+  right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
 ) => MergeState<Env, Err, Err1, Err2, Elem, Done, Done1, Done2> = internal.BothRunning
 
 /**
@@ -151,8 +151,8 @@ export const match: {
   <Env, Err, Err1, Err2, Elem, Done, Done1, Done2, Z>(
     options: {
       readonly onBothRunning: (
-        left: Fiber.Fiber<Either.Either<Done, Elem>, Err>,
-        right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+        left: Fiber.Fiber<Either.Either<Elem, Done>, Err>,
+        right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
       ) => Z
       readonly onLeftDone: (f: (exit: Exit.Exit<Done1, Err1>) => Effect.Effect<Done2, Err2, Env>) => Z
       readonly onRightDone: (f: (exit: Exit.Exit<Done, Err>) => Effect.Effect<Done2, Err2, Env>) => Z
@@ -162,8 +162,8 @@ export const match: {
     self: MergeState<Env, Err, Err1, Err2, Elem, Done, Done1, Done2>,
     options: {
       readonly onBothRunning: (
-        left: Fiber.Fiber<Either.Either<Done, Elem>, Err>,
-        right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+        left: Fiber.Fiber<Either.Either<Elem, Done>, Err>,
+        right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
       ) => Z
       readonly onLeftDone: (f: (exit: Exit.Exit<Done1, Err1>) => Effect.Effect<Done2, Err2, Env>) => Z
       readonly onRightDone: (f: (exit: Exit.Exit<Done, Err>) => Effect.Effect<Done2, Err2, Env>) => Z

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -255,7 +255,7 @@ export const fromIterable = <A>(collection: Iterable<A>): Option<A> => {
  * @category conversions
  * @since 2.0.0
  */
-export const getRight: <E, A>(self: Either<E, A>) => Option<A> = either.getRight
+export const getRight: <E, A>(self: Either<A, E>) => Option<A> = either.getRight
 
 /**
  * Converts a `Either` to an `Option` discarding the value.
@@ -270,7 +270,7 @@ export const getRight: <E, A>(self: Either<E, A>) => Option<A> = either.getRight
  * @category conversions
  * @since 2.0.0
  */
-export const getLeft: <E, A>(self: Either<E, A>) => Option<E> = either.getLeft
+export const getLeft: <E, A>(self: Either<A, E>) => Option<E> = either.getLeft
 
 /**
  * Returns the value of the `Option` if it is `Some`, otherwise returns `onNone`
@@ -395,11 +395,11 @@ export const orElseSome: {
  * @since 2.0.0
  */
 export const orElseEither: {
-  <B>(that: LazyArg<Option<B>>): <A>(self: Option<A>) => Option<Either<A, B>>
-  <A, B>(self: Option<A>, that: LazyArg<Option<B>>): Option<Either<A, B>>
+  <B>(that: LazyArg<Option<B>>): <A>(self: Option<A>) => Option<Either<B, A>>
+  <A, B>(self: Option<A>, that: LazyArg<Option<B>>): Option<Either<B, A>>
 } = dual(
   2,
-  <A, B>(self: Option<A>, that: LazyArg<Option<B>>): Option<Either<A, B>> =>
+  <A, B>(self: Option<A>, that: LazyArg<Option<B>>): Option<Either<B, A>> =>
     isNone(self) ? map(that(), either.right) : map(self, either.left)
 )
 
@@ -955,11 +955,11 @@ export const toArray = <A>(self: Option<A>): Array<A> => isNone(self) ? [] : [se
  * @since 2.0.0
  */
 export const partitionMap: {
-  <A, B, C>(f: (a: A) => Either<B, C>): (self: Option<A>) => [left: Option<B>, right: Option<C>]
-  <A, B, C>(self: Option<A>, f: (a: A) => Either<B, C>): [left: Option<B>, right: Option<C>]
+  <A, B, C>(f: (a: A) => Either<C, B>): (self: Option<A>) => [left: Option<B>, right: Option<C>]
+  <A, B, C>(self: Option<A>, f: (a: A) => Either<C, B>): [left: Option<B>, right: Option<C>]
 } = dual(2, <A, B, C>(
   self: Option<A>,
-  f: (a: A) => Either<B, C>
+  f: (a: A) => Either<C, B>
 ): [excluded: Option<B>, satisfying: Option<C>] => {
   if (isNone(self)) {
     return [none(), none()]

--- a/packages/effect/src/ReadonlyArray.ts
+++ b/packages/effect/src/ReadonlyArray.ts
@@ -1615,11 +1615,11 @@ export const filterMapWhile: {
  * @since 2.0.0
  */
 export const partitionMap: {
-  <A, B, C>(f: (a: A, i: number) => Either<B, C>): (self: Iterable<A>) => [left: Array<B>, right: Array<C>]
-  <A, B, C>(self: Iterable<A>, f: (a: A, i: number) => Either<B, C>): [left: Array<B>, right: Array<C>]
+  <A, B, C>(f: (a: A, i: number) => Either<C, B>): (self: Iterable<A>) => [left: Array<B>, right: Array<C>]
+  <A, B, C>(self: Iterable<A>, f: (a: A, i: number) => Either<C, B>): [left: Array<B>, right: Array<C>]
 } = dual(
   2,
-  <A, B, C>(self: Iterable<A>, f: (a: A, i: number) => Either<B, C>): [left: Array<B>, right: Array<C>] => {
+  <A, B, C>(self: Iterable<A>, f: (a: A, i: number) => Either<C, B>): [left: Array<B>, right: Array<C>] => {
     const left: Array<B> = []
     const right: Array<C> = []
     const as = fromIterable(self)
@@ -1667,7 +1667,7 @@ export const getSomes: <A>(self: Iterable<Option<A>>) => Array<A> = filterMap(id
  * @category filtering
  * @since 2.0.0
  */
-export const getLefts = <E, A>(self: Iterable<Either<E, A>>): Array<E> => {
+export const getLefts = <E, A>(self: Iterable<Either<A, E>>): Array<E> => {
   const out: Array<E> = []
   for (const a of self) {
     if (E.isLeft(a)) {
@@ -1693,7 +1693,7 @@ export const getLefts = <E, A>(self: Iterable<Either<E, A>>): Array<E> => {
  * @category filtering
  * @since 2.0.0
  */
-export const getRights = <E, A>(self: Iterable<Either<E, A>>): Array<A> => {
+export const getRights = <E, A>(self: Iterable<Either<A, E>>): Array<A> => {
   const out: Array<A> = []
   for (const a of self) {
     if (E.isRight(a)) {
@@ -1766,7 +1766,7 @@ export const partition: {
  * @category filtering
  * @since 2.0.0
  */
-export const separate: <E, A>(self: Iterable<Either<E, A>>) => [Array<E>, Array<A>] = partitionMap(
+export const separate: <E, A>(self: Iterable<Either<A, E>>) => [Array<E>, Array<A>] = partitionMap(
   identity
 )
 
@@ -1847,7 +1847,7 @@ export const flatMapNullable: {
  * @since 2.0.0
  */
 export const liftEither = <A extends Array<unknown>, E, B>(
-  f: (...a: A) => Either<E, B>
+  f: (...a: A) => Either<B, E>
 ) =>
 (...a: A): Array<B> => {
   const e = f(...a)

--- a/packages/effect/src/ReadonlyRecord.ts
+++ b/packages/effect/src/ReadonlyRecord.ts
@@ -629,7 +629,7 @@ export const getSomes: <A>(self: ReadonlyRecord<Option.Option<A>>) => Record<str
  * @category filtering
  * @since 2.0.0
  */
-export const getLefts = <E, A>(self: ReadonlyRecord<Either<E, A>>): Record<string, E> => {
+export const getLefts = <E, A>(self: ReadonlyRecord<Either<A, E>>): Record<string, E> => {
   const out: Record<string, E> = {}
   for (const key of Object.keys(self)) {
     const value = self[key]
@@ -656,7 +656,7 @@ export const getLefts = <E, A>(self: ReadonlyRecord<Either<E, A>>): Record<strin
  * @category filtering
  * @since 2.0.0
  */
-export const getRights = <E, A>(self: ReadonlyRecord<Either<E, A>>): Record<string, A> => {
+export const getRights = <E, A>(self: ReadonlyRecord<Either<A, E>>): Record<string, A> => {
   const out: Record<string, A> = {}
   for (const key of Object.keys(self)) {
     const value = self[key]
@@ -687,17 +687,17 @@ export const getRights = <E, A>(self: ReadonlyRecord<Either<E, A>>): Record<stri
  */
 export const partitionMap: {
   <K extends string, A, B, C>(
-    f: (a: A, key: K) => Either<B, C>
+    f: (a: A, key: K) => Either<C, B>
   ): (self: Record<K, A>) => [left: Record<string, B>, right: Record<string, C>]
   <K extends string, A, B, C>(
     self: Record<K, A>,
-    f: (a: A, key: K) => Either<B, C>
+    f: (a: A, key: K) => Either<C, B>
   ): [left: Record<string, B>, right: Record<string, C>]
 } = dual(
   2,
   <A, B, C>(
     self: Record<string, A>,
-    f: (a: A, key: string) => Either<B, C>
+    f: (a: A, key: string) => Either<C, B>
   ): [left: Record<string, B>, right: Record<string, C>] => {
     const left: Record<string, B> = {}
     const right: Record<string, C> = {}
@@ -732,7 +732,7 @@ export const partitionMap: {
  * @since 2.0.0
  */
 export const separate: <A, B>(
-  self: ReadonlyRecord<Either<A, B>>
+  self: ReadonlyRecord<Either<B, A>>
 ) => [Record<string, A>, Record<string, B>] = partitionMap(identity)
 
 /**

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -198,7 +198,7 @@ export const mapInputContext: {
 export const eitherWith: {
   <A extends Request.Request<any, any>, R2, B extends Request.Request<any, any>, C extends Request.Request<any, any>>(
     that: RequestResolver<B, R2>,
-    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<A>, Request.Entry<B>>
+    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<B>, Request.Entry<A>>
   ): <R>(self: RequestResolver<A, R>) => RequestResolver<C, R2 | R>
   <
     R,
@@ -209,7 +209,7 @@ export const eitherWith: {
   >(
     self: RequestResolver<A, R>,
     that: RequestResolver<B, R2>,
-    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<A>, Request.Entry<B>>
+    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<B>, Request.Entry<A>>
   ): RequestResolver<C, R | R2>
 } = internal.eitherWith
 

--- a/packages/effect/src/STM.ts
+++ b/packages/effect/src/STM.ts
@@ -517,7 +517,7 @@ export const dieSync: (evaluate: LazyArg<unknown>) => STM<never> = core.dieSync
  * @since 2.0.0
  * @category mutations
  */
-export const either: <A, E, R>(self: STM<A, E, R>) => STM<Either.Either<E, A>, never, R> = stm.either
+export const either: <A, E, R>(self: STM<A, E, R>) => STM<Either.Either<A, E>, never, R> = stm.either
 
 /**
  * Executes the specified finalization transaction whether or not this effect
@@ -817,7 +817,7 @@ export const forEach: {
  * @since 2.0.0
  * @category constructors
  */
-export const fromEither: <E, A>(either: Either.Either<E, A>) => STM<A, E> = stm.fromEither
+export const fromEither: <E, A>(either: Either.Either<A, E>) => STM<A, E> = stm.fromEither
 
 /**
  * Lifts an `Option` into a `STM`.
@@ -1396,8 +1396,8 @@ export const orElse: {
  * @category error handling
  */
 export const orElseEither: {
-  <R2, E2, A2>(that: LazyArg<STM<A2, E2, R2>>): <A, E, R>(self: STM<A, E, R>) => STM<Either.Either<A, A2>, E2, R2 | R>
-  <R, E, A, R2, E2, A2>(self: STM<A, E, R>, that: LazyArg<STM<A2, E2, R2>>): STM<Either.Either<A, A2>, E2, R | R2>
+  <R2, E2, A2>(that: LazyArg<STM<A2, E2, R2>>): <A, E, R>(self: STM<A, E, R>) => STM<Either.Either<A2, A>, E2, R2 | R>
+  <R, E, A, R2, E2, A2>(self: STM<A, E, R>, that: LazyArg<STM<A2, E2, R2>>): STM<Either.Either<A2, A>, E2, R | R2>
 } = stm.orElseEither
 
 /**

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -194,11 +194,11 @@ export const andThen: {
 export const andThenEither: {
   <Env2, In2, Out2>(
     that: Schedule<Env2, In2, Out2>
-  ): <Env, In, Out>(self: Schedule<Env, In, Out>) => Schedule<Env2 | Env, In & In2, Either.Either<Out, Out2>>
+  ): <Env, In, Out>(self: Schedule<Env, In, Out>) => Schedule<Env2 | Env, In & In2, Either.Either<Out2, Out>>
   <Env, In, Out, Env2, In2, Out2>(
     self: Schedule<Env, In, Out>,
     that: Schedule<Env2, In2, Out2>
-  ): Schedule<Env | Env2, In & In2, Either.Either<Out, Out2>>
+  ): Schedule<Env | Env2, In & In2, Either.Either<Out2, Out>>
 } = internal.andThenEither
 
 /**

--- a/packages/effect/src/SingleProducerAsyncInput.ts
+++ b/packages/effect/src/SingleProducerAsyncInput.ts
@@ -30,7 +30,7 @@ export interface SingleProducerAsyncInput<in out Err, in out Elem, in out Done>
   extends AsyncInputProducer<Err, Elem, Done>, AsyncInputConsumer<Err, Elem, Done>
 {
   readonly close: Effect.Effect<unknown>
-  readonly take: Effect.Effect<Exit.Exit<Elem, Either.Either<Err, Done>>>
+  readonly take: Effect.Effect<Exit.Exit<Elem, Either.Either<Done, Err>>>
 }
 
 /**

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -1014,7 +1014,7 @@ export const fromPubSub: <In>(
  */
 export const fromPush: <In, E, A, L, R>(
   push: Effect.Effect<
-    (_: Option.Option<Chunk.Chunk<In>>) => Effect.Effect<void, readonly [Either.Either<E, A>, Chunk.Chunk<L>], R>,
+    (_: Option.Option<Chunk.Chunk<In>>) => Effect.Effect<void, readonly [Either.Either<A, E>, Chunk.Chunk<L>], R>,
     never,
     R
   >
@@ -1189,12 +1189,12 @@ export const raceBoth: {
   <A1, In1, L1, E1, R1>(
     that: Sink<A1, In1, L1, E1, R1>,
     options?: { readonly capacity?: number | undefined } | undefined
-  ): <A, In, L, E, R>(self: Sink<A, In, L, E, R>) => Sink<Either.Either<A, A1>, In & In1, L1 | L, E1 | E, R1 | R>
+  ): <A, In, L, E, R>(self: Sink<A, In, L, E, R>) => Sink<Either.Either<A1, A>, In & In1, L1 | L, E1 | E, R1 | R>
   <A, In, L, E, R, A1, In1, L1, E1, R1>(
     self: Sink<A, In, L, E, R>,
     that: Sink<A1, In1, L1, E1, R1>,
     options?: { readonly capacity?: number | undefined } | undefined
-  ): Sink<Either.Either<A, A1>, In & In1, L | L1, E | E1, R | R1>
+  ): Sink<Either.Either<A1, A>, In & In1, L | L1, E | E1, R | R1>
 } = internal.raceBoth
 
 /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -236,12 +236,12 @@ export const aggregateWithinEither: {
   <B, A, A2, E2, R2, R3, C>(
     sink: Sink.Sink<B, A | A2, A2, E2, R2>,
     schedule: Schedule.Schedule<R3, Option.Option<B>, C>
-  ): <E, R>(self: Stream<A, E, R>) => Stream<Either.Either<C, B>, E2 | E, R2 | R3 | R>
+  ): <E, R>(self: Stream<A, E, R>) => Stream<Either.Either<B, C>, E2 | E, R2 | R3 | R>
   <A, E, R, B, A2, E2, R2, R3, C>(
     self: Stream<A, E, R>,
     sink: Sink.Sink<B, A | A2, A2, E2, R2>,
     schedule: Schedule.Schedule<R3, Option.Option<B>, C>
-  ): Stream<Either.Either<C, B>, E | E2, R | R2 | R3>
+  ): Stream<Either.Either<B, C>, E | E2, R | R2 | R3>
 } = internal.aggregateWithinEither
 
 /**
@@ -1027,7 +1027,7 @@ export const dropWhileEffect: {
  * @since 2.0.0
  * @category utils
  */
-export const either: <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<E, A>, never, R> = internal.either
+export const either: <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<A, E>, never, R> = internal.either
 
 /**
  * The empty stream.
@@ -2168,8 +2168,8 @@ export const mergeWith: {
 export const mergeEither: {
   <R2, E2, A2>(
     that: Stream<A2, E2, R2>
-  ): <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<A, A2>, E2 | E, R2 | R>
-  <R, E, A, R2, E2, A2>(self: Stream<A, E, R>, that: Stream<A2, E2, R2>): Stream<Either.Either<A, A2>, E | E2, R | R2>
+  ): <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<A2, A>, E2 | E, R2 | R>
+  <R, E, A, R2, E2, A2>(self: Stream<A, E, R>, that: Stream<A2, E2, R2>): Stream<Either.Either<A2, A>, E | E2, R | R2>
 } = internal.mergeEither
 
 /**
@@ -2289,11 +2289,11 @@ export const orElse: {
 export const orElseEither: {
   <R2, E2, A2>(
     that: LazyArg<Stream<A2, E2, R2>>
-  ): <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<A, A2>, E2, R2 | R>
+  ): <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<A2, A>, E2, R2 | R>
   <R, E, A, R2, E2, A2>(
     self: Stream<A, E, R>,
     that: LazyArg<Stream<A2, E2, R2>>
-  ): Stream<Either.Either<A, A2>, E2, R | R2>
+  ): Stream<Either.Either<A2, A>, E2, R | R2>
 } = internal.orElseEither
 
 /**
@@ -2445,14 +2445,14 @@ export const partition: {
  */
 export const partitionEither: {
   <A, R2, E2, A2, A3>(
-    predicate: (a: NoInfer<A>) => Effect.Effect<Either.Either<A2, A3>, E2, R2>,
+    predicate: (a: NoInfer<A>) => Effect.Effect<Either.Either<A3, A2>, E2, R2>,
     options?: { readonly bufferSize?: number | undefined } | undefined
   ): <R, E>(
     self: Stream<A, E, R>
   ) => Effect.Effect<[left: Stream<A2, E2 | E>, right: Stream<A3, E2 | E>], E2 | E, Scope.Scope | R2 | R>
   <R, E, A, R2, E2, A2, A3>(
     self: Stream<A, E, R>,
-    predicate: (a: A) => Effect.Effect<Either.Either<A2, A3>, E2, R2>,
+    predicate: (a: A) => Effect.Effect<Either.Either<A3, A2>, E2, R2>,
     options?: { readonly bufferSize?: number | undefined } | undefined
   ): Effect.Effect<[left: Stream<A2, E | E2>, right: Stream<A3, E | E2>], E | E2, Scope.Scope | R | R2>
 } = internal.partitionEither
@@ -2763,11 +2763,11 @@ export const repeatEffectWithSchedule: <R, E, A, A0 extends A, R2, _>(
 export const repeatEither: {
   <R2, B>(
     schedule: Schedule.Schedule<R2, unknown, B>
-  ): <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<B, A>, E, R2 | R>
+  ): <A, E, R>(self: Stream<A, E, R>) => Stream<Either.Either<A, B>, E, R2 | R>
   <R, E, A, R2, B>(
     self: Stream<A, E, R>,
     schedule: Schedule.Schedule<R2, unknown, B>
-  ): Stream<Either.Either<B, A>, E, R | R2>
+  ): Stream<Either.Either<A, B>, E, R | R2>
 } = internal.repeatEither
 
 /**
@@ -4378,7 +4378,7 @@ export const zipWithChunks: {
     f: (
       left: Chunk.Chunk<A>,
       right: Chunk.Chunk<A2>
-    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A>, Chunk.Chunk<A2>>]
+    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A2>, Chunk.Chunk<A>>]
   ): <R, E>(self: Stream<A, E, R>) => Stream<A3, E2 | E, R2 | R>
   <R, E, R2, E2, A2, A, A3>(
     self: Stream<A, E, R>,
@@ -4386,7 +4386,7 @@ export const zipWithChunks: {
     f: (
       left: Chunk.Chunk<A>,
       right: Chunk.Chunk<A2>
-    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A>, Chunk.Chunk<A2>>]
+    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A2>, Chunk.Chunk<A>>]
   ): Stream<A3, E | E2, R | R2>
 } = internal.zipWithChunks
 

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -256,15 +256,18 @@ export const as: {
 } = internal.as
 
 const _async: <A, E = never, R = never>(
-  register: (emit: Emit.Emit<R, E, A, void>) => void,
+  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<void, never, R> | void,
   outputBuffer?: number
 ) => Stream<A, E, R> = internal._async
 
 export {
   /**
    * Creates a stream from an asynchronous callback that can be called multiple
-   * times. The optionality of the error type `E` can be used to signal the end
-   * of the stream, by setting it to `None`.
+   * times. The optionality of the error type `E` in `Emit` can be used to
+   * signal the end of the stream by setting it to `None`.
+   *
+   * The registration function can optionally return an `Effect`, which will be
+   * executed if the `Fiber` executing this Effect is interrupted.
    *
    * @since 2.0.0
    * @category constructors
@@ -285,34 +288,6 @@ export const asyncEffect: <A, E = never, R = never>(
   register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<unknown, E, R>,
   outputBuffer?: number
 ) => Stream<A, E, R> = internal.asyncEffect
-
-/**
- * Creates a stream from an asynchronous callback that can be called multiple
- * times. The registration of the callback returns either a canceler or
- * synchronously returns a stream. The optionality of the error type `E` can
- * be used to signal the end of the stream, by setting it to `None`.
- *
- * @since 2.0.0
- * @category constructors
- */
-export const asyncInterrupt: <A, E = never, R = never>(
-  register: (emit: Emit.Emit<R, E, A, void>) => Either.Either<Effect.Effect<unknown, never, R>, Stream<A, E, R>>,
-  outputBuffer?: number
-) => Stream<A, E, R> = internal.asyncInterrupt
-
-/**
- * Creates a stream from an asynchronous callback that can be called multiple
- * times. The registration of the callback can possibly return the stream
- * synchronously. The optionality of the error type `E` can be used to signal
- * the end of the stream, by setting it to `None`.
- *
- * @since 2.0.0
- * @category constructors
- */
-export const asyncOption: <A, E = never, R = never>(
-  register: (emit: Emit.Emit<R, E, A, void>) => Option.Option<Stream<A, E, R>>,
-  outputBuffer?: number
-) => Stream<A, E, R> = internal.asyncOption
 
 /**
  * Creates a stream from an asynchronous callback that can be called multiple

--- a/packages/effect/src/TDeferred.ts
+++ b/packages/effect/src/TDeferred.ts
@@ -31,7 +31,7 @@ export interface TDeferred<in out A, in out E = never> extends TDeferred.Varianc
  */
 export interface TDeferred<in out A, in out E> {
   /** @internal */
-  readonly ref: TRef.TRef<Option.Option<Either.Either<E, A>>>
+  readonly ref: TRef.TRef<Option.Option<Either.Either<A, E>>>
 }
 
 /**
@@ -65,8 +65,8 @@ export {
  * @category mutations
  */
 export const done: {
-  <E, A>(either: Either.Either<E, A>): (self: TDeferred<A, E>) => STM.STM<boolean>
-  <A, E>(self: TDeferred<A, E>, either: Either.Either<E, A>): STM.STM<boolean>
+  <E, A>(either: Either.Either<A, E>): (self: TDeferred<A, E>) => STM.STM<boolean>
+  <A, E>(self: TDeferred<A, E>, either: Either.Either<A, E>): STM.STM<boolean>
 } = internal.done
 
 /**
@@ -88,7 +88,7 @@ export const make: <A, E = never>() => STM.STM<TDeferred<A, E>> = internal.make
  * @since 2.0.0
  * @category getters
  */
-export const poll: <A, E>(self: TDeferred<A, E>) => STM.STM<Option.Option<Either.Either<E, A>>> = internal.poll
+export const poll: <A, E>(self: TDeferred<A, E>) => STM.STM<Option.Option<Either.Either<A, E>>> = internal.poll
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/TestAnnotation.ts
+++ b/packages/effect/src/TestAnnotation.ts
@@ -80,9 +80,9 @@ export const make = <A>(
  * @since 2.0.0
  */
 export const compose = <A>(
-  left: Either.Either<number, Chunk.Chunk<A>>,
-  right: Either.Either<number, Chunk.Chunk<A>>
-): Either.Either<number, Chunk.Chunk<A>> => {
+  left: Either.Either<Chunk.Chunk<A>, number>,
+  right: Either.Either<Chunk.Chunk<A>, number>
+): Either.Either<Chunk.Chunk<A>, number> => {
   if (Either.isLeft(left) && Either.isLeft(right)) {
     return Either.left(left.left + right.left)
   }
@@ -102,12 +102,9 @@ export const compose = <A>(
  * @since 2.0.0
  */
 export const fibers: TestAnnotation<
-  Either.Either<
-    number,
-    Chunk.Chunk<MutableRef.MutableRef<SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>>>
-  >
+  Either.Either<Chunk.Chunk<MutableRef.MutableRef<SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>>>, number>
 > = make<
-  Either.Either<number, Chunk.Chunk<MutableRef.MutableRef<SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>>>>
+  Either.Either<Chunk.Chunk<MutableRef.MutableRef<SortedSet.SortedSet<Fiber.RuntimeFiber<unknown, unknown>>>>, number>
 >(
   "fibers",
   Either.left(0),

--- a/packages/effect/src/internal/blockedRequests.ts
+++ b/packages/effect/src/internal/blockedRequests.ts
@@ -103,7 +103,7 @@ export const reduce = <Z>(
   reducer: RequestBlock.RequestBlock.Reducer<Z>
 ): Z => {
   let input: List.List<RequestBlock.RequestBlock> = List.of(self)
-  let output = List.empty<Either.Either<BlockedRequestsCase, Z>>()
+  let output = List.empty<Either.Either<Z, BlockedRequestsCase>>()
   while (List.isCons(input)) {
     const current: RequestBlock.RequestBlock = input.head
     switch (current._tag) {

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -233,7 +233,7 @@ export const failureOption = <E>(self: Cause.Cause<E>): Option.Option<E> =>
       Option.none())
 
 /** @internal */
-export const failureOrCause = <E>(self: Cause.Cause<E>): Either.Either<E, Cause.Cause<never>> => {
+export const failureOrCause = <E>(self: Cause.Cause<E>): Either.Either<Cause.Cause<never>, E> => {
   const option = failureOption(self)
   switch (option._tag) {
     case "None": {
@@ -891,7 +891,7 @@ export const reduceWithContext = dual<
   <C, E, Z>(self: Cause.Cause<E>, context: C, reducer: Cause.CauseReducer<C, E, Z>) => Z
 >(3, <C, E, Z>(self: Cause.Cause<E>, context: C, reducer: Cause.CauseReducer<C, E, Z>) => {
   const input: Array<Cause.Cause<E>> = [self]
-  const output: Array<Either.Either<CauseCase, Z>> = []
+  const output: Array<Either.Either<Z, CauseCase>> = []
   while (input.length > 0) {
     const cause = input.pop()!
     switch (cause._tag) {

--- a/packages/effect/src/internal/channel/mergeState.ts
+++ b/packages/effect/src/internal/channel/mergeState.ts
@@ -22,8 +22,8 @@ const proto = {
 
 /** @internal */
 export const BothRunning = <Env, Err, Err1, Err2, Elem, Done, Done1, Done2>(
-  left: Fiber.Fiber<Either.Either<Done, Elem>, Err>,
-  right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+  left: Fiber.Fiber<Either.Either<Elem, Done>, Err>,
+  right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
 ): MergeState.MergeState<Env, Err, Err1, Err2, Elem, Done, Done1, Done2> => {
   const op = Object.create(proto)
   op._tag = OpCodes.OP_BOTH_RUNNING
@@ -84,8 +84,8 @@ export const match = dual<
   <Env, Err, Err1, Err2, Elem, Done, Done1, Done2, Z>(
     options: {
       readonly onBothRunning: (
-        left: Fiber.Fiber<Either.Either<Done, Elem>, Err>,
-        right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+        left: Fiber.Fiber<Either.Either<Elem, Done>, Err>,
+        right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
       ) => Z
       readonly onLeftDone: (f: (exit: Exit.Exit<Done1, Err1>) => Effect.Effect<Done2, Err2, Env>) => Z
       readonly onRightDone: (f: (exit: Exit.Exit<Done, Err>) => Effect.Effect<Done2, Err2, Env>) => Z
@@ -95,8 +95,8 @@ export const match = dual<
     self: MergeState.MergeState<Env, Err, Err1, Err2, Elem, Done, Done1, Done2>,
     options: {
       readonly onBothRunning: (
-        left: Fiber.Fiber<Either.Either<Done, Elem>, Err>,
-        right: Fiber.Fiber<Either.Either<Done1, Elem>, Err1>
+        left: Fiber.Fiber<Either.Either<Elem, Done>, Err>,
+        right: Fiber.Fiber<Either.Either<Elem, Done1>, Err1>
       ) => Z
       readonly onLeftDone: (f: (exit: Exit.Exit<Done1, Err1>) => Effect.Effect<Done2, Err2, Env>) => Z
       readonly onRightDone: (f: (exit: Exit.Exit<Done, Err>) => Effect.Effect<Done2, Err2, Env>) => Z

--- a/packages/effect/src/internal/channel/singleProducerAsyncInput.ts
+++ b/packages/effect/src/internal/channel/singleProducerAsyncInput.ts
@@ -47,7 +47,7 @@ interface Empty {
 /** @internal */
 interface Emit<Err, Elem, Done> {
   readonly _tag: OP_STATE_EMIT
-  readonly notifyConsumers: ReadonlyArray<Deferred.Deferred<Either.Either<Done, Elem>, Err>>
+  readonly notifyConsumers: ReadonlyArray<Deferred.Deferred<Either.Either<Elem, Done>, Err>>
 }
 
 /** @internal */
@@ -70,7 +70,7 @@ const stateEmpty = (notifyProducer: Deferred.Deferred<void>): State<never, never
 
 /** @internal */
 const stateEmit = <Err, Elem, Done>(
-  notifyConsumers: ReadonlyArray<Deferred.Deferred<Either.Either<Done, Elem>, Err>>
+  notifyConsumers: ReadonlyArray<Deferred.Deferred<Either.Either<Elem, Done>, Err>>
 ): State<Err, Elem, Done> => ({
   _tag: OP_STATE_EMIT,
   notifyConsumers
@@ -198,10 +198,10 @@ class SingleProducerAsyncInputImpl<in out Err, in out Elem, in out Done>
     )
   }
 
-  get take(): Effect.Effect<Exit.Exit<Elem, Either.Either<Err, Done>>> {
+  get take(): Effect.Effect<Exit.Exit<Elem, Either.Either<Done, Err>>> {
     return this.takeWith(
       (cause) => Exit.failCause(Cause.map(cause, Either.left)),
-      (elem) => Exit.succeed(elem) as Exit.Exit<Elem, Either.Either<Err, Done>>,
+      (elem) => Exit.succeed(elem) as Exit.Exit<Elem, Either.Either<Done, Err>>,
       (done) => Exit.fail(Either.right(done))
     )
   }
@@ -211,7 +211,7 @@ class SingleProducerAsyncInputImpl<in out Err, in out Elem, in out Done>
     onElement: (element: Elem) => A,
     onDone: (value: Done) => A
   ): Effect.Effect<A> {
-    return Effect.flatMap(Deferred.make<Either.Either<Done, Elem>, Err>(), (deferred) =>
+    return Effect.flatMap(Deferred.make<Either.Either<Elem, Done>, Err>(), (deferred) =>
       Effect.flatten(
         Ref.modify(this.ref, (state) => {
           switch (state._tag) {

--- a/packages/effect/src/internal/clock.ts
+++ b/packages/effect/src/internal/clock.ts
@@ -2,7 +2,6 @@ import type * as Clock from "../Clock.js"
 import * as Context from "../Context.js"
 import * as Duration from "../Duration.js"
 import type * as Effect from "../Effect.js"
-import * as Either from "../Either.js"
 import { constFalse } from "../Function.js"
 import * as core from "./core.js"
 
@@ -85,9 +84,9 @@ class ClockImpl implements Clock.Clock {
   }
 
   sleep(duration: Duration.Duration): Effect.Effect<void> {
-    return core.asyncEither<void>((cb) => {
-      const canceler = globalClockScheduler.unsafeSchedule(() => cb(core.unit), duration)
-      return Either.left(core.asUnit(core.sync(canceler)))
+    return core.async<void>((resume) => {
+      const canceler = globalClockScheduler.unsafeSchedule(() => resume(core.unit), duration)
+      return core.asUnit(core.sync(canceler))
     })
   }
 }

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -60,7 +60,7 @@ export type Op<Tag extends string, Body = {}> = Config.Config<never> & Body & {
 export interface Constant extends
   Op<OpCodes.OP_CONSTANT, {
     readonly value: unknown
-    parse(text: string): Either.Either<ConfigError.ConfigError, unknown>
+    parse(text: string): Either.Either<unknown, ConfigError.ConfigError>
   }>
 {}
 
@@ -85,7 +85,7 @@ export interface Fallback extends
 export interface Fail extends
   Op<OpCodes.OP_FAIL, {
     readonly message: string
-    parse(text: string): Either.Either<ConfigError.ConfigError, unknown>
+    parse(text: string): Either.Either<unknown, ConfigError.ConfigError>
   }>
 {}
 
@@ -100,7 +100,7 @@ export interface Lazy extends
 export interface MapOrFail extends
   Op<OpCodes.OP_MAP_OR_FAIL, {
     readonly original: Config.Config<unknown>
-    mapOrFail(value: unknown): Either.Either<ConfigError.ConfigError, unknown>
+    mapOrFail(value: unknown): Either.Either<unknown, ConfigError.ConfigError>
   }>
 {}
 
@@ -116,7 +116,7 @@ export interface Nested extends
 export interface Primitive extends
   Op<OpCodes.OP_PRIMITIVE, {
     readonly description: string
-    parse(text: string): Either.Either<ConfigError.ConfigError, unknown>
+    parse(text: string): Either.Either<unknown, ConfigError.ConfigError>
   }>
 {}
 
@@ -314,8 +314,8 @@ export const mapAttempt = dual<
 
 /** @internal */
 export const mapOrFail = dual<
-  <A, B>(f: (a: A) => Either.Either<ConfigError.ConfigError, B>) => (self: Config.Config<A>) => Config.Config<B>,
-  <A, B>(self: Config.Config<A>, f: (a: A) => Either.Either<ConfigError.ConfigError, B>) => Config.Config<B>
+  <A, B>(f: (a: A) => Either.Either<B, ConfigError.ConfigError>) => (self: Config.Config<A>) => Config.Config<B>,
+  <A, B>(self: Config.Config<A>, f: (a: A) => Either.Either<B, ConfigError.ConfigError>) => Config.Config<B>
 >(2, (self, f) => {
   const mapOrFail = Object.create(proto)
   mapOrFail._tag = OpCodes.OP_MAP_OR_FAIL
@@ -385,7 +385,7 @@ export const option = <A>(self: Config.Config<A>): Config.Config<Option.Option<A
 /** @internal */
 export const primitive = <A>(
   description: string,
-  parse: (text: string) => Either.Either<ConfigError.ConfigError, A>
+  parse: (text: string) => Either.Either<A, ConfigError.ConfigError>
 ): Config.Config<A> => {
   const primitive = Object.create(proto)
   primitive._tag = OpCodes.OP_PRIMITIVE

--- a/packages/effect/src/internal/configError.ts
+++ b/packages/effect/src/internal/configError.ts
@@ -215,7 +215,7 @@ export const reduceWithContext = dual<
   <C, Z>(self: ConfigError.ConfigError, context: C, reducer: ConfigError.ConfigErrorReducer<C, Z>) => Z
 >(3, <C, Z>(self: ConfigError.ConfigError, context: C, reducer: ConfigError.ConfigErrorReducer<C, Z>) => {
   const input: Array<ConfigError.ConfigError> = [self]
-  const output: Array<Either.Either<ConfigErrorCase, Z>> = []
+  const output: Array<Either.Either<Z, ConfigErrorCase>> = []
   while (input.length > 0) {
     const error = input.pop()!
     switch (error._tag) {

--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -438,7 +438,7 @@ const fromFlatLoop = <A>(
 }
 
 const fromFlatLoopFail =
-  (prefix: ReadonlyArray<string>, path: string) => (index: number): Either.Either<ConfigError.ConfigError, unknown> =>
+  (prefix: ReadonlyArray<string>, path: string) => (index: number): Either.Either<unknown, ConfigError.ConfigError> =>
     Either.left(
       configError.MissingData(
         prefix,

--- a/packages/effect/src/internal/configProvider/pathPatch.ts
+++ b/packages/effect/src/internal/configProvider/pathPatch.ts
@@ -46,11 +46,11 @@ export const patch = dual<
     patch: PathPatch.PathPatch
   ) => (
     path: ReadonlyArray<string>
-  ) => Either.Either<ConfigError.ConfigError, ReadonlyArray<string>>,
+  ) => Either.Either<ReadonlyArray<string>, ConfigError.ConfigError>,
   (
     path: ReadonlyArray<string>,
     patch: PathPatch.PathPatch
-  ) => Either.Either<ConfigError.ConfigError, ReadonlyArray<string>>
+  ) => Either.Either<ReadonlyArray<string>, ConfigError.ConfigError>
 >(2, (path, patch) => {
   let input: List.List<PathPatch.PathPatch> = List.of(patch)
   let output: ReadonlyArray<string> = path

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -4,9 +4,8 @@ import * as Clock from "../Clock.js"
 import * as Context from "../Context.js"
 import * as Duration from "../Duration.js"
 import type * as Effect from "../Effect.js"
-import * as Either from "../Either.js"
 import type * as Fiber from "../Fiber.js"
-import * as FiberId from "../FiberId.js"
+import type * as FiberId from "../FiberId.js"
 import type * as FiberRef from "../FiberRef.js"
 import * as FiberRefs from "../FiberRefs.js"
 import type * as FiberRefsPatch from "../FiberRefsPatch.js"
@@ -74,26 +73,6 @@ export const asSome = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Opt
 /* @internal */
 export const asSomeError = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, Option.Option<E>, R> =>
   core.mapError(self, Option.some)
-
-/* @internal */
-export const asyncOption = <A, E = never, R = never>(
-  register: (callback: (_: Effect.Effect<A, E, R>) => void) => Option.Option<Effect.Effect<A, E, R>>,
-  blockingOn: FiberId.FiberId = FiberId.none
-): Effect.Effect<A, E, R> =>
-  core.asyncEither(
-    (cb) => {
-      const option = register(cb)
-      switch (option._tag) {
-        case "None": {
-          return Either.left(core.unit)
-        }
-        case "Some": {
-          return Either.right(option.value)
-        }
-      }
-    },
-    blockingOn
-  )
 
 /* @internal */
 export const try_: {

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -634,7 +634,7 @@ export const dieMessage = (message: string): Effect.Effect<never> =>
 export const dieSync = (evaluate: LazyArg<unknown>): Effect.Effect<never> => flatMap(sync(evaluate), die)
 
 /* @internal */
-export const either = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Either.Either<E, A>, never, R> =>
+export const either = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Either.Either<A, E>, never, R> =>
   matchEffect(self, {
     onFailure: (e) => succeed(Either.left(e)),
     onSuccess: (a) => succeed(Either.right(a))
@@ -1126,7 +1126,7 @@ export const orDieWith: {
 /* @internal */
 export const partitionMap = <A, A1, A2>(
   elements: Iterable<A>,
-  f: (a: A) => Either.Either<A1, A2>
+  f: (a: A) => Either.Either<A2, A1>
 ): [left: Array<A1>, right: Array<A2>] =>
   ReadonlyArray.fromIterable(elements).reduceRight(
     ([lefts, rights], current) => {
@@ -2522,7 +2522,7 @@ export const exitForEachEffect: {
 })
 
 /** @internal */
-export const exitFromEither = <E, A>(either: Either.Either<E, A>): Exit.Exit<A, E> => {
+export const exitFromEither = <E, A>(either: Either.Either<A, E>): Exit.Exit<A, E> => {
   switch (either._tag) {
     case "Left":
       return exitFail(either.left)

--- a/packages/effect/src/internal/dataSource.ts
+++ b/packages/effect/src/internal/dataSource.ts
@@ -135,7 +135,7 @@ export const eitherWith = dual<
     C extends Request.Request<any, any>
   >(
     that: RequestResolver.RequestResolver<B, R2>,
-    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<A>, Request.Entry<B>>
+    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<B>, Request.Entry<A>>
   ) => <R>(
     self: RequestResolver.RequestResolver<A, R>
   ) => RequestResolver.RequestResolver<C, R | R2>,
@@ -148,7 +148,7 @@ export const eitherWith = dual<
   >(
     self: RequestResolver.RequestResolver<A, R>,
     that: RequestResolver.RequestResolver<B, R2>,
-    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<A>, Request.Entry<B>>
+    f: (_: Request.Entry<C>) => Either.Either<Request.Entry<B>, Request.Entry<A>>
   ) => RequestResolver.RequestResolver<C, R | R2>
 >(3, <
   R,
@@ -159,7 +159,7 @@ export const eitherWith = dual<
 >(
   self: RequestResolver.RequestResolver<A, R>,
   that: RequestResolver.RequestResolver<B, R2>,
-  f: (_: Request.Entry<C>) => Either.Either<Request.Entry<A>, Request.Entry<B>>
+  f: (_: Request.Entry<C>) => Either.Either<Request.Entry<B>, Request.Entry<A>>
 ) =>
   new core.RequestResolverImpl<R | R2, C>(
     (batch) =>

--- a/packages/effect/src/internal/differ.ts
+++ b/packages/effect/src/internal/differ.ts
@@ -86,11 +86,11 @@ export const hashSet = <Value>(): Differ.Differ<HashSet<Value>, Differ.Differ.Ha
 export const orElseEither = Dual.dual<
   <Value2, Patch2>(that: Differ.Differ<Value2, Patch2>) => <Value, Patch>(
     self: Differ.Differ<Value, Patch>
-  ) => Differ.Differ<Either<Value, Value2>, Differ.Differ.Or.Patch<Value, Value2, Patch, Patch2>>,
+  ) => Differ.Differ<Either<Value2, Value>, Differ.Differ.Or.Patch<Value, Value2, Patch, Patch2>>,
   <Value, Patch, Value2, Patch2>(
     self: Differ.Differ<Value, Patch>,
     that: Differ.Differ<Value2, Patch2>
-  ) => Differ.Differ<Either<Value, Value2>, Differ.Differ.Or.Patch<Value, Value2, Patch, Patch2>>
+  ) => Differ.Differ<Either<Value2, Value>, Differ.Differ.Or.Patch<Value, Value2, Patch, Patch2>>
 >(2, (self, that) =>
   make({
     empty: OrPatch.empty(),

--- a/packages/effect/src/internal/differ/orPatch.ts
+++ b/packages/effect/src/internal/differ/orPatch.ts
@@ -188,8 +188,8 @@ type Instruction =
 /** @internal */
 export const diff = <Value, Value2, Patch, Patch2>(
   options: {
-    readonly oldValue: Either<Value, Value2>
-    readonly newValue: Either<Value, Value2>
+    readonly oldValue: Either<Value2, Value>
+    readonly newValue: Either<Value2, Value>
     readonly left: Differ<Value, Patch>
     readonly right: Differ<Value2, Patch2>
   }
@@ -243,23 +243,23 @@ export const combine = Dual.dual<
 export const patch = Dual.dual<
   <Value, Value2, Patch, Patch2>(
     options: {
-      readonly oldValue: Either<Value, Value2>
+      readonly oldValue: Either<Value2, Value>
       readonly left: Differ<Value, Patch>
       readonly right: Differ<Value2, Patch2>
     }
-  ) => (self: Differ.Or.Patch<Value, Value2, Patch, Patch2>) => Either<Value, Value2>,
+  ) => (self: Differ.Or.Patch<Value, Value2, Patch, Patch2>) => Either<Value2, Value>,
   <Value, Value2, Patch, Patch2>(
     self: Differ.Or.Patch<Value, Value2, Patch, Patch2>,
     options: {
-      readonly oldValue: Either<Value, Value2>
+      readonly oldValue: Either<Value2, Value>
       readonly left: Differ<Value, Patch>
       readonly right: Differ<Value2, Patch2>
     }
-  ) => Either<Value, Value2>
+  ) => Either<Value2, Value>
 >(2, <Value, Value2, Patch, Patch2>(
   self: Differ.Or.Patch<Value, Value2, Patch, Patch2>,
   { left, oldValue, right }: {
-    oldValue: Either<Value, Value2>
+    oldValue: Either<Value2, Value>
     left: Differ<Value, Patch>
     right: Differ<Value2, Patch2>
   }

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -2,7 +2,6 @@ import type * as Cause from "../../Cause.js"
 import type * as Deferred from "../../Deferred.js"
 import * as Duration from "../../Duration.js"
 import type * as Effect from "../../Effect.js"
-import * as Either from "../../Either.js"
 import * as Equal from "../../Equal.js"
 import type { Equivalence } from "../../Equivalence.js"
 import * as Exit from "../../Exit.js"
@@ -45,7 +44,7 @@ class Semaphore {
   }
 
   readonly take = (n: number): Effect.Effect<number> =>
-    core.asyncEither<number>((resume) => {
+    core.async<number>((resume) => {
       if (this.free < n) {
         const observer = () => {
           if (this.free < n) {
@@ -56,12 +55,12 @@ class Semaphore {
           resume(core.succeed(n))
         }
         this.waiters.add(observer)
-        return Either.left(core.sync(() => {
+        return core.sync(() => {
           this.waiters.delete(observer)
-        }))
+        })
       }
       this.taken += n
-      return Either.right(core.succeed(n))
+      return resume(core.succeed(n))
     })
 
   readonly updateTaken = (f: (n: number) => number): Effect.Effect<number> =>

--- a/packages/effect/src/internal/either.ts
+++ b/packages/effect/src/internal/either.ts
@@ -22,7 +22,7 @@ const CommonProto = {
   [TypeId]: {
     _A: (_: never) => _
   },
-  [NodeInspectSymbol]<E, A>(this: Either.Either<E, A>) {
+  [NodeInspectSymbol]<E, A>(this: Either.Either<A, E>) {
     return this.toJSON()
   },
   toString<E, A>(this: Either.Left<E, A>) {
@@ -70,20 +70,20 @@ const LeftProto = Object.assign(Object.create(CommonProto), {
 export const isEither = (input: unknown): input is Either.Either<unknown, unknown> => hasProperty(input, TypeId)
 
 /** @internal */
-export const isLeft = <E, A>(ma: Either.Either<E, A>): ma is Either.Left<E, A> => ma._tag === "Left"
+export const isLeft = <E, A>(ma: Either.Either<A, E>): ma is Either.Left<E, A> => ma._tag === "Left"
 
 /** @internal */
-export const isRight = <E, A>(ma: Either.Either<E, A>): ma is Either.Right<E, A> => ma._tag === "Right"
+export const isRight = <E, A>(ma: Either.Either<A, E>): ma is Either.Right<E, A> => ma._tag === "Right"
 
 /** @internal */
-export const left = <E>(left: E): Either.Either<E, never> => {
+export const left = <E>(left: E): Either.Either<never, E> => {
   const a = Object.create(LeftProto)
   a.left = left
   return a
 }
 
 /** @internal */
-export const right = <A>(right: A): Either.Either<never, A> => {
+export const right = <A>(right: A): Either.Either<A> => {
   const a = Object.create(RightProto)
   a.right = right
   return a
@@ -91,17 +91,17 @@ export const right = <A>(right: A): Either.Either<never, A> => {
 
 /** @internal */
 export const getLeft = <E, A>(
-  self: Either.Either<E, A>
+  self: Either.Either<A, E>
 ): Option<E> => (isRight(self) ? option.none : option.some(self.left))
 
 /** @internal */
 export const getRight = <E, A>(
-  self: Either.Either<E, A>
+  self: Either.Either<A, E>
 ): Option<A> => (isLeft(self) ? option.none : option.some(self.right))
 
 /** @internal */
 export const fromOption = dual(
   2,
-  <A, E>(self: Option<A>, onNone: () => E): Either.Either<E, A> =>
+  <A, E>(self: Option<A>, onNone: () => E): Either.Either<A, E> =>
     option.isNone(self) ? left(onNone()) : right(self.value)
 )

--- a/packages/effect/src/internal/encoding/base64.ts
+++ b/packages/effect/src/internal/encoding/base64.ts
@@ -35,7 +35,7 @@ export const encode = (bytes: Uint8Array) => {
 }
 
 /** @internal */
-export const decode = (str: string): Either.Either<Encoding.DecodeException, Uint8Array> => {
+export const decode = (str: string): Either.Either<Uint8Array, Encoding.DecodeException> => {
   const length = str.length
   if (length % 4 !== 0) {
     return Either.left(

--- a/packages/effect/src/internal/encoding/base64Url.ts
+++ b/packages/effect/src/internal/encoding/base64Url.ts
@@ -8,7 +8,7 @@ export const encode = (data: Uint8Array) =>
   Base64.encode(data).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_")
 
 /** @internal */
-export const decode = (str: string): Either.Either<Encoding.DecodeException, Uint8Array> => {
+export const decode = (str: string): Either.Either<Uint8Array, Encoding.DecodeException> => {
   const length = str.length
   if (length % 4 === 1) {
     return Either.left(

--- a/packages/effect/src/internal/encoding/hex.ts
+++ b/packages/effect/src/internal/encoding/hex.ts
@@ -13,7 +13,7 @@ export const encode = (bytes: Uint8Array) => {
 }
 
 /** @internal */
-export const decode = (str: string): Either.Either<Encoding.DecodeException, Uint8Array> => {
+export const decode = (str: string): Either.Either<Uint8Array, Encoding.DecodeException> => {
   const bytes = new TextEncoder().encode(str)
   if (bytes.length % 2 !== 0) {
     return Either.left(DecodeException(str, `Length must be a multiple of 2, but is ${bytes.length}`))

--- a/packages/effect/src/internal/fiber.ts
+++ b/packages/effect/src/internal/fiber.ts
@@ -260,8 +260,8 @@ export const orElse = dual<
 
 /** @internal */
 export const orElseEither = dual<
-  <A2, E2>(that: Fiber.Fiber<A2, E2>) => <A, E>(self: Fiber.Fiber<A, E>) => Fiber.Fiber<Either.Either<A, A2>, E | E2>,
-  <A, E, A2, E2>(self: Fiber.Fiber<A, E>, that: Fiber.Fiber<A2, E2>) => Fiber.Fiber<Either.Either<A, A2>, E | E2>
+  <A2, E2>(that: Fiber.Fiber<A2, E2>) => <A, E>(self: Fiber.Fiber<A, E>) => Fiber.Fiber<Either.Either<A2, A>, E | E2>,
+  <A, E, A2, E2>(self: Fiber.Fiber<A, E>, that: Fiber.Fiber<A2, E2>) => Fiber.Fiber<Either.Either<A2, A>, E | E2>
 >(2, (self, that) => orElse(map(self, Either.left), map(that, Either.right)))
 
 /** @internal */

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -87,7 +87,7 @@ const ValueMatcherProto: Omit<
 
 function makeValueMatcher<I, R, RA, A, Pr>(
   provided: Pr,
-  value: Either.Either<RA, Pr>
+  value: Either.Either<Pr, RA>
 ): ValueMatcher<I, R, RA, A, Pr> {
   const matcher = Object.create(ValueMatcherProto)
   matcher.provided = provided
@@ -514,8 +514,8 @@ export const orElseAbsurd = <I, R, RA, A, Pr>(
 /** @internal */
 export const either: <I, F, R, A, Pr>(
   self: Matcher<I, F, R, A, Pr>
-) => [Pr] extends [never] ? (input: I) => Either.Either<R, Unify<A>>
-  : Either.Either<R, Unify<A>> = (<I, R, RA, A>(self: Matcher<I, R, RA, A, I>) => {
+) => [Pr] extends [never] ? (input: I) => Either.Either<Unify<A>, R>
+  : Either.Either<Unify<A>, R> = (<I, R, RA, A>(self: Matcher<I, R, RA, A, I>) => {
     if (self._tag === "ValueMatcher") {
       return self.value
     }
@@ -523,7 +523,7 @@ export const either: <I, F, R, A, Pr>(
     const len = self.cases.length
     if (len === 1) {
       const _case = self.cases[0]
-      return (input: I): Either.Either<RA, A> => {
+      return (input: I): Either.Either<A, RA> => {
         if (_case._tag === "When" && _case.guard(input) === true) {
           return Either.right(_case.evaluate(input))
         } else if (_case._tag === "Not" && _case.guard(input) === false) {
@@ -532,7 +532,7 @@ export const either: <I, F, R, A, Pr>(
         return Either.left(input as any)
       }
     }
-    return (input: I): Either.Either<RA, A> => {
+    return (input: I): Either.Either<A, RA> => {
       for (let i = 0; i < len; i++) {
         const _case = self.cases[i]
         if (_case._tag === "When" && _case.guard(input) === true) {

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -203,7 +203,7 @@ export const andThenEither = dual<
   ) => <Env, In, Out>(self: Schedule.Schedule<Env, In, Out>) => Schedule.Schedule<
     Env | Env2,
     In & In2,
-    Either.Either<Out, Out2>
+    Either.Either<Out2, Out>
   >,
   <Env, In, Out, Env2, In2, Out2>(
     self: Schedule.Schedule<Env, In, Out>,
@@ -211,7 +211,7 @@ export const andThenEither = dual<
   ) => Schedule.Schedule<
     Env | Env2,
     In & In2,
-    Either.Either<Out, Out2>
+    Either.Either<Out2, Out>
   >
 >(2, <Env, In, Out, Env2, In2, Out2>(
   self: Schedule.Schedule<Env, In, Out>,
@@ -219,7 +219,7 @@ export const andThenEither = dual<
 ): Schedule.Schedule<
   Env | Env2,
   In & In2,
-  Either.Either<Out, Out2>
+  Either.Either<Out2, Out>
 > =>
   makeWithState(
     [self.initial, that.initial, true as boolean] as const,
@@ -230,7 +230,7 @@ export const andThenEither = dual<
             return core.map(that.step(now, input, state[1]), ([rState, out, decision]) =>
               [
                 [lState, rState, false as boolean] as const,
-                Either.right(out) as Either.Either<Out, Out2>,
+                Either.right(out) as Either.Either<Out2, Out>,
                 decision as ScheduleDecision.ScheduleDecision
               ] as const)
           }
@@ -245,7 +245,7 @@ export const andThenEither = dual<
         core.map(that.step(now, input, state[1]), ([rState, out, decision]) =>
           [
             [state[0], rState, false as boolean] as const,
-            Either.right(out) as Either.Either<Out, Out2>,
+            Either.right(out) as Either.Either<Out2, Out>,
             decision
           ] as const)
   ))

--- a/packages/effect/src/internal/sink.ts
+++ b/packages/effect/src/internal/sink.ts
@@ -1435,7 +1435,7 @@ export const fromPubSub = <In>(
 /** @internal */
 export const fromPush = <In, E, A, L, R>(
   push: Effect.Effect<
-    (_: Option.Option<Chunk.Chunk<In>>) => Effect.Effect<void, readonly [Either.Either<E, A>, Chunk.Chunk<L>], R>,
+    (_: Option.Option<Chunk.Chunk<In>>) => Effect.Effect<void, readonly [Either.Either<A, E>, Chunk.Chunk<L>], R>,
     never,
     R
   >
@@ -1445,7 +1445,7 @@ export const fromPush = <In, E, A, L, R>(
 const fromPushPull = <R, E, In, L, Z>(
   push: (
     option: Option.Option<Chunk.Chunk<In>>
-  ) => Effect.Effect<void, readonly [Either.Either<E, Z>, Chunk.Chunk<L>], R>
+  ) => Effect.Effect<void, readonly [Either.Either<Z, E>, Chunk.Chunk<L>], R>
 ): Channel.Channel<Chunk.Chunk<L>, Chunk.Chunk<In>, E, never, Z, unknown, R> =>
   core.readWith({
     onInput: (input: Chunk.Chunk<In>) =>
@@ -1609,14 +1609,14 @@ export const raceBoth = dual<
     }
   ) => <A, In, L, E, R>(
     self: Sink.Sink<A, In, L, E, R>
-  ) => Sink.Sink<Either.Either<A, A1>, In & In1, L1 | L, E1 | E, R1 | R>,
+  ) => Sink.Sink<Either.Either<A1, A>, In & In1, L1 | L, E1 | E, R1 | R>,
   <A, In, L, E, R, A1, In1, L1, E1, R1>(
     self: Sink.Sink<A, In, L, E, R>,
     that: Sink.Sink<A1, In1, L1, E1, R1>,
     options?: {
       readonly capacity?: number | undefined
     }
-  ) => Sink.Sink<Either.Either<A, A1>, In & In1, L1 | L, E1 | E, R1 | R>
+  ) => Sink.Sink<Either.Either<A1, A>, In & In1, L1 | L, E1 | E, R1 | R>
 >(
   (args) => isSink(args[1]),
   (self, that, options) =>
@@ -1660,7 +1660,7 @@ export const raceWith = dual<
   ): Sink.Sink<A3 | A4, In & In2, L2 | L, E2 | E, R2 | R> => {
     const scoped = Effect.gen(function*($) {
       const pubsub = yield* $(
-        PubSub.bounded<Either.Either<Exit.Exit<unknown>, Chunk.Chunk<In & In2>>>(options?.capacity ?? 16)
+        PubSub.bounded<Either.Either<Chunk.Chunk<In & In2>, Exit.Exit<unknown>>>(options?.capacity ?? 16)
       )
       const channel1 = yield* $(channel.fromPubSubScoped(pubsub))
       const channel2 = yield* $(channel.fromPubSubScoped(pubsub))

--- a/packages/effect/src/internal/stm/stm.ts
+++ b/packages/effect/src/internal/stm/stm.ts
@@ -320,7 +320,7 @@ export const cond = <A, E>(
 }
 
 /** @internal */
-export const either = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<Either.Either<E, A>, never, R> =>
+export const either = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<Either.Either<A, E>, never, R> =>
   match(self, { onFailure: Either.left, onSuccess: Either.right })
 
 /** @internal */
@@ -595,7 +595,7 @@ export const forEach = dual<
 )
 
 /** @internal */
-export const fromEither = <E, A>(either: Either.Either<E, A>): STM.STM<A, E> => {
+export const fromEither = <E, A>(either: Either.Either<A, E>): STM.STM<A, E> => {
   switch (either._tag) {
     case "Left": {
       return core.fail(either.left)
@@ -909,17 +909,17 @@ export const orElseEither = dual<
     that: LazyArg<STM.STM<A2, E2, R2>>
   ) => <A, E, R>(
     self: STM.STM<A, E, R>
-  ) => STM.STM<Either.Either<A, A2>, E2, R2 | R>,
+  ) => STM.STM<Either.Either<A2, A>, E2, R2 | R>,
   <R, E, A, R2, E2, A2>(
     self: STM.STM<A, E, R>,
     that: LazyArg<STM.STM<A2, E2, R2>>
-  ) => STM.STM<Either.Either<A, A2>, E2, R2 | R>
+  ) => STM.STM<Either.Either<A2, A>, E2, R2 | R>
 >(
   2,
   <R, E, A, R2, E2, A2>(
     self: STM.STM<A, E, R>,
     that: LazyArg<STM.STM<A2, E2, R2>>
-  ): STM.STM<Either.Either<A, A2>, E2, R2 | R> =>
+  ): STM.STM<Either.Either<A2, A>, E2, R2 | R> =>
     orElse(core.map(self, Either.left), () => core.map(that(), Either.right))
 )
 

--- a/packages/effect/src/internal/stm/tDeferred.ts
+++ b/packages/effect/src/internal/stm/tDeferred.ts
@@ -27,7 +27,7 @@ const tDeferredVariance = {
 /** @internal */
 class TDeferredImpl<in out A, in out E = never> implements TDeferred.TDeferred<A, E> {
   readonly [TDeferredTypeId] = tDeferredVariance
-  constructor(readonly ref: TRef.TRef<Option.Option<Either.Either<E, A>>>) {}
+  constructor(readonly ref: TRef.TRef<Option.Option<Either.Either<A, E>>>) {}
 }
 
 /** @internal */
@@ -41,8 +41,8 @@ export const _await = <A, E>(self: TDeferred.TDeferred<A, E>): STM.STM<A, E> =>
 
 /** @internal */
 export const done = dual<
-  <E, A>(either: Either.Either<E, A>) => (self: TDeferred.TDeferred<A, E>) => STM.STM<boolean>,
-  <A, E>(self: TDeferred.TDeferred<A, E>, either: Either.Either<E, A>) => STM.STM<boolean>
+  <E, A>(either: Either.Either<A, E>) => (self: TDeferred.TDeferred<A, E>) => STM.STM<boolean>,
+  <A, E>(self: TDeferred.TDeferred<A, E>, either: Either.Either<A, E>) => STM.STM<boolean>
 >(2, (self, either) =>
   core.flatMap(
     tRef.get(self.ref),
@@ -65,14 +65,14 @@ export const fail = dual<
 /** @internal */
 export const make = <A, E = never>(): STM.STM<TDeferred.TDeferred<A, E>> =>
   core.map(
-    tRef.make<Option.Option<Either.Either<E, A>>>(Option.none()),
+    tRef.make<Option.Option<Either.Either<A, E>>>(Option.none()),
     (ref) => new TDeferredImpl(ref)
   )
 
 /** @internal */
 export const poll = <A, E>(
   self: TDeferred.TDeferred<A, E>
-): STM.STM<Option.Option<Either.Either<E, A>>> => tRef.get(self.ref)
+): STM.STM<Option.Option<Either.Either<A, E>>> => tRef.get(self.ref)
 
 /** @internal */
 export const succeed = dual<

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -48,7 +48,7 @@ import * as pull from "./stream/pull.js"
 import * as SinkEndReason from "./stream/sinkEndReason.js"
 import * as ZipAllState from "./stream/zipAllState.js"
 import * as ZipChunksState from "./stream/zipChunksState.js"
-import * as _take from "./take.js"
+import * as InternalTake from "./take.js"
 
 /** @internal */
 const StreamSymbolKey = "effect/Stream"
@@ -461,13 +461,57 @@ export const as = dual<
 
 /** @internal */
 export const _async = <A, E = never, R = never>(
-  register: (emit: Emit.Emit<R, E, A, void>) => void,
+  register: (
+    emit: Emit.Emit<R, E, A, void>
+  ) => Effect.Effect<void, never, R> | void,
   outputBuffer = 16
 ): Stream.Stream<A, E, R> =>
-  asyncOption((cb) => {
-    register(cb)
-    return Option.none()
-  }, outputBuffer)
+  Effect.acquireRelease(
+    Queue.bounded<Take.Take<A, E>>(outputBuffer),
+    (queue) => Queue.shutdown(queue)
+  ).pipe(
+    Effect.flatMap((output) =>
+      Effect.runtime<R>().pipe(
+        Effect.flatMap((runtime) =>
+          Effect.sync(() => {
+            const runPromiseExit = Runtime.runPromiseExit(runtime)
+            const canceler = register(emit.make<R, E, A, void>((resume) =>
+              InternalTake.fromPull(resume).pipe(
+                Effect.flatMap((take) => Queue.offer(output, take)),
+                Effect.asUnit,
+                runPromiseExit
+              ).then((exit) => {
+                if (Exit.isFailure(exit)) {
+                  if (!Cause.isInterrupted(exit.cause)) {
+                    throw Cause.squash(exit.cause)
+                  }
+                }
+              })
+            ))
+            return canceler
+          })
+        ),
+        Effect.map((value) => {
+          const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E, unknown, void, unknown> = Queue.take(output).pipe(
+            Effect.flatMap((take) => InternalTake.done(take)),
+            Effect.match({
+              onFailure: (maybeError) =>
+                core.fromEffect(Queue.shutdown(output)).pipe(
+                  channel.zipRight(Option.match(maybeError, {
+                    onNone: () => core.unit,
+                    onSome: (error) => core.fail(error)
+                  }))
+                ),
+              onSuccess: (chunk) => core.write(chunk).pipe(core.flatMap(() => loop))
+            }),
+            channel.unwrap
+          )
+          return fromChannel(loop).pipe(ensuring(value ?? Effect.unit))
+        })
+      )
+    ),
+    unwrapScoped
+  )
 
 /** @internal */
 export const asyncEffect = <A, E = never, R = never>(
@@ -487,7 +531,7 @@ export const asyncEffect = <A, E = never, R = never>(
             register(
               emit.make((k) =>
                 pipe(
-                  _take.fromPull(k),
+                  InternalTake.fromPull(k),
                   Effect.flatMap((take) => Queue.offer(output, take)),
                   Effect.asUnit,
                   Runtime.runPromiseExit(runtime)
@@ -503,7 +547,7 @@ export const asyncEffect = <A, E = never, R = never>(
             Effect.map(() => {
               const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E, unknown, void, unknown> = pipe(
                 Queue.take(output),
-                Effect.flatMap(_take.done),
+                Effect.flatMap(InternalTake.done),
                 Effect.match({
                   onFailure: (maybeError) =>
                     pipe(
@@ -525,84 +569,6 @@ export const asyncEffect = <A, E = never, R = never>(
   )
 
 /** @internal */
-export const asyncInterrupt = <A, E = never, R = never>(
-  register: (
-    emit: Emit.Emit<R, E, A, void>
-  ) => Either.Either<Effect.Effect<unknown, never, R>, Stream.Stream<A, E, R>>,
-  outputBuffer = 16
-): Stream.Stream<A, E, R> =>
-  pipe(
-    Effect.acquireRelease(
-      Queue.bounded<Take.Take<A, E>>(outputBuffer),
-      (queue) => Queue.shutdown(queue)
-    ),
-    Effect.flatMap((output) =>
-      pipe(
-        Effect.runtime<R>(),
-        Effect.flatMap((runtime) =>
-          pipe(
-            Effect.sync(() =>
-              register(
-                emit.make((k) =>
-                  pipe(
-                    _take.fromPull(k),
-                    Effect.flatMap((take) => Queue.offer(output, take)),
-                    Effect.asUnit,
-                    Runtime.runPromiseExit(runtime)
-                  ).then((exit) => {
-                    if (Exit.isFailure(exit)) {
-                      if (!Cause.isInterrupted(exit.cause)) {
-                        throw Cause.squash(exit.cause)
-                      }
-                    }
-                  })
-                )
-              )
-            ),
-            Effect.map(Either.match({
-              onLeft: (canceler) => {
-                const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E, unknown, void, unknown> = pipe(
-                  Queue.take(output),
-                  Effect.flatMap(_take.done),
-                  Effect.match({
-                    onFailure: (maybeError) =>
-                      channel.zipRight(
-                        core.fromEffect(Queue.shutdown(output)),
-                        Option.match(maybeError, {
-                          onNone: () => core.unit,
-                          onSome: core.fail
-                        })
-                      ),
-                    onSuccess: (chunk) => pipe(core.write(chunk), core.flatMap(() => loop))
-                  }),
-                  channel.unwrap
-                )
-                return pipe(fromChannel(loop), ensuring(canceler))
-              },
-              onRight: (stream) => unwrap(pipe(Queue.shutdown(output), Effect.as(stream)))
-            }))
-          )
-        )
-      )
-    ),
-    unwrapScoped
-  )
-
-/** @internal */
-export const asyncOption = <A, E = never, R = never>(
-  register: (emit: Emit.Emit<R, E, A, void>) => Option.Option<Stream.Stream<A, E, R>>,
-  outputBuffer = 16
-): Stream.Stream<A, E, R> =>
-  asyncInterrupt(
-    (emit) =>
-      Option.match(register(emit), {
-        onNone: () => Either.left(Effect.unit),
-        onSome: Either.right
-      }),
-    outputBuffer
-  )
-
-/** @internal */
 export const asyncScoped = <A, E = never, R = never>(
   register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<unknown, E, R | Scope.Scope>,
   outputBuffer = 16
@@ -620,7 +586,7 @@ export const asyncScoped = <A, E = never, R = never>(
             register(
               emit.make((k) =>
                 pipe(
-                  _take.fromPull(k),
+                  InternalTake.fromPull(k),
                   Effect.flatMap((take) => Queue.offer(output, take)),
                   Effect.asUnit,
                   Runtime.runPromiseExit(runtime)
@@ -642,7 +608,7 @@ export const asyncScoped = <A, E = never, R = never>(
                     pull.end() :
                     pipe(
                       Queue.take(output),
-                      Effect.flatMap(_take.done),
+                      Effect.flatMap(InternalTake.done),
                       Effect.onError(() =>
                         pipe(
                           Ref.set(ref, true),
@@ -884,7 +850,7 @@ export const bufferChunks = dual<
       Effect.map(queue, (queue) => {
         const process: Channel.Channel<Chunk.Chunk<A>, unknown, E, unknown, void, unknown> = pipe(
           core.fromEffect(Queue.take(queue)),
-          core.flatMap(_take.match({
+          core.flatMap(InternalTake.match({
             onEnd: () => core.unit,
             onFailure: core.failCause,
             onSuccess: (value) => pipe(core.write(value), core.flatMap(() => process))
@@ -947,7 +913,7 @@ const bufferUnbounded = <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<A
       Effect.map(queue, (queue) => {
         const process: Channel.Channel<Chunk.Chunk<A>, unknown, E, unknown, void, unknown> = pipe(
           core.fromEffect(Queue.take(queue)),
-          core.flatMap(_take.match({
+          core.flatMap(InternalTake.match({
             onEnd: () => core.unit,
             onFailure: core.failCause,
             onSuccess: (value) => core.flatMap(core.write(value), () => process)
@@ -989,7 +955,7 @@ const bufferSignal = <A, E, R>(
           Effect.flatMap(
             (deferred) =>
               pipe(
-                Queue.offer(queue, [_take.chunk(input), deferred] as const),
+                Queue.offer(queue, [InternalTake.chunk(input), deferred] as const),
                 Effect.flatMap((added) => pipe(Ref.set(ref, deferred), Effect.when(() => added)))
               )
           ),
@@ -997,8 +963,8 @@ const bufferSignal = <A, E, R>(
           core.fromEffect,
           core.flatMap(() => producer(queue, ref))
         ),
-      onFailure: (error) => terminate(_take.failCause(error)),
-      onDone: () => terminate(_take.end)
+      onFailure: (error) => terminate(InternalTake.failCause(error)),
+      onDone: () => terminate(InternalTake.end)
     })
   }
   const consumer = (
@@ -1009,7 +975,7 @@ const bufferSignal = <A, E, R>(
       core.flatMap(([take, deferred]) =>
         channel.zipRight(
           core.fromEffect(Deferred.succeed(deferred, void 0)),
-          _take.match(take, {
+          InternalTake.match(take, {
             onEnd: () => core.unit,
             onFailure: core.failCause,
             onSuccess: (value) => pipe(core.write(value), core.flatMap(() => process))
@@ -1469,7 +1435,7 @@ export const combineChunks = dual<
           core.flatMap(
             core.fromEffect(pipe(
               handoff,
-              Handoff.offer<Take.Take<Elem, Err>>(_take.chunk(input))
+              Handoff.offer<Take.Take<Elem, Err>>(InternalTake.chunk(input))
             )),
             () => producer(handoff, latch)
           ),
@@ -1477,11 +1443,11 @@ export const combineChunks = dual<
           core.fromEffect(
             Handoff.offer<Take.Take<Elem, Err>>(
               handoff,
-              _take.failCause(cause)
+              InternalTake.failCause(cause)
             )
           ),
         onDone: (): Channel.Channel<never, Chunk.Chunk<Elem>, never, Err, unknown, unknown, R> =>
-          core.fromEffect(Handoff.offer<Take.Take<Elem, Err>>(handoff, _take.end))
+          core.fromEffect(Handoff.offer<Take.Take<Elem, Err>>(handoff, InternalTake.end))
       })
     )
   return new StreamImpl(
@@ -1515,7 +1481,7 @@ export const combineChunks = dual<
           Effect.zipRight(
             pipe(
               Handoff.take(left),
-              Effect.flatMap(_take.done)
+              Effect.flatMap(InternalTake.done)
             )
           )
         )
@@ -1525,7 +1491,7 @@ export const combineChunks = dual<
           Effect.zipRight(
             pipe(
               Handoff.take(right),
-              Effect.flatMap(_take.done)
+              Effect.flatMap(InternalTake.done)
             )
           )
         )
@@ -3388,7 +3354,7 @@ export const interleaveWith = dual<
         onInput: (value: A | A2) =>
           core.flatMap(
             core.fromEffect(
-              Handoff.offer<Take.Take<A | A2, E | E2 | E3>>(handoff, _take.of(value))
+              Handoff.offer<Take.Take<A | A2, E | E2 | E3>>(handoff, InternalTake.of(value))
             ),
             () => producer(handoff)
           ),
@@ -3396,12 +3362,12 @@ export const interleaveWith = dual<
           core.fromEffect(
             Handoff.offer<Take.Take<A | A2, E | E2 | E3>>(
               handoff,
-              _take.failCause(cause)
+              InternalTake.failCause(cause)
             )
           ),
         onDone: () =>
           core.fromEffect(
-            Handoff.offer<Take.Take<A | A2, E | E2 | E3>>(handoff, _take.end)
+            Handoff.offer<Take.Take<A | A2, E | E2 | E3>>(handoff, InternalTake.end)
           )
       })
     return new StreamImpl(
@@ -3437,7 +3403,7 @@ export const interleaveWith = dual<
                   if (bool && !leftDone) {
                     return pipe(
                       core.fromEffect(Handoff.take(left)),
-                      core.flatMap(_take.match({
+                      core.flatMap(InternalTake.match({
                         onEnd: () => rightDone ? core.unit : process(true, rightDone),
                         onFailure: core.failCause,
                         onSuccess: (chunk) => pipe(core.write(chunk), core.flatMap(() => process(leftDone, rightDone)))
@@ -3447,7 +3413,7 @@ export const interleaveWith = dual<
                   if (!bool && !rightDone) {
                     return pipe(
                       core.fromEffect(Handoff.take(right)),
-                      core.flatMap(_take.match({
+                      core.flatMap(InternalTake.match({
                         onEnd: () => leftDone ? core.unit : process(leftDone, true),
                         onFailure: core.failCause,
                         onSuccess: (chunk) => pipe(core.write(chunk), core.flatMap(() => process(leftDone, rightDone)))
@@ -5450,9 +5416,9 @@ export const runIntoQueueScoped = dual<
 ): Effect.Effect<void, never, Scope.Scope | R> => {
   const writer: Channel.Channel<Take.Take<A, E>, Chunk.Chunk<A>, never, E, unknown, unknown, R> = core
     .readWithCause({
-      onInput: (input: Chunk.Chunk<A>) => core.flatMap(core.write(_take.chunk(input)), () => writer),
-      onFailure: (cause) => core.write(_take.failCause(cause)),
-      onDone: () => core.write(_take.end)
+      onInput: (input: Chunk.Chunk<A>) => core.flatMap(core.write(InternalTake.chunk(input)), () => writer),
+      onFailure: (cause) => core.write(InternalTake.failCause(cause)),
+      onDone: () => core.write(InternalTake.end)
     })
   return pipe(
     core.pipeTo(toChannel(self), writer),
@@ -6229,7 +6195,7 @@ export const tapSink = dual<
           .readWithCause({
             onInput: (chunk: Chunk.Chunk<A>) =>
               pipe(
-                core.fromEffect(Queue.offer(queue, _take.chunk(chunk))),
+                core.fromEffect(Queue.offer(queue, InternalTake.chunk(chunk))),
                 core.foldCauseChannel({
                   onFailure: () => core.flatMap(core.write(chunk), () => channel.identityChannel()),
                   onSuccess: () => core.flatMap(core.write(chunk), () => loop)
@@ -6237,7 +6203,7 @@ export const tapSink = dual<
               ) as Channel.Channel<Chunk.Chunk<A>, Chunk.Chunk<A>, E | E2, E, unknown, unknown, R2>,
             onFailure: (cause: Cause.Cause<E | E2>) =>
               pipe(
-                core.fromEffect(Queue.offer(queue, _take.failCause(cause))),
+                core.fromEffect(Queue.offer(queue, InternalTake.failCause(cause))),
                 core.foldCauseChannel({
                   onFailure: () => core.failCause(cause),
                   onSuccess: () => core.failCause(cause)
@@ -6245,7 +6211,7 @@ export const tapSink = dual<
               ),
             onDone: () =>
               pipe(
-                core.fromEffect(Queue.offer(queue, _take.end)),
+                core.fromEffect(Queue.offer(queue, InternalTake.end)),
                 core.foldCauseChannel({
                   onFailure: () => core.unit,
                   onSuccess: () => core.unit
@@ -6256,7 +6222,7 @@ export const tapSink = dual<
           new StreamImpl(pipe(
             core.pipeTo(toChannel(self), loop),
             channel.ensuring(Effect.zipRight(
-              Effect.forkDaemon(Queue.offer(queue, _take.end)),
+              Effect.forkDaemon(Queue.offer(queue, InternalTake.end)),
               Deferred.await(deferred)
             ))
           )),

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -164,19 +164,19 @@ export const aggregateWithinEither = dual<
   <B, A, A2, E2, R2, R3, C>(
     sink: Sink.Sink<B, A | A2, A2, E2, R2>,
     schedule: Schedule.Schedule<R3, Option.Option<B>, C>
-  ) => <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<C, B>, E2 | E, R2 | R3 | R>,
+  ) => <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<B, C>, E2 | E, R2 | R3 | R>,
   <A, E, R, B, A2, E2, R2, R3, C>(
     self: Stream.Stream<A, E, R>,
     sink: Sink.Sink<B, A | A2, A2, E2, R2>,
     schedule: Schedule.Schedule<R3, Option.Option<B>, C>
-  ) => Stream.Stream<Either.Either<C, B>, E2 | E, R2 | R3 | R>
+  ) => Stream.Stream<Either.Either<B, C>, E2 | E, R2 | R3 | R>
 >(
   3,
   <A, E, R, B, A2, E2, R2, R3, C>(
     self: Stream.Stream<A, E, R>,
     sink: Sink.Sink<B, A | A2, A2, E2, R2>,
     schedule: Schedule.Schedule<R3, Option.Option<B>, C>
-  ): Stream.Stream<Either.Either<C, B>, E2 | E, R2 | R3 | R> => {
+  ): Stream.Stream<Either.Either<B, C>, E2 | E, R2 | R3 | R> => {
     const layer = Effect.all([
       Handoff.make<HandoffSignal.HandoffSignal<A, E | E2>>(),
       Ref.make<SinkEndReason.SinkEndReason>(SinkEndReason.ScheduleEnd),
@@ -284,7 +284,7 @@ export const aggregateWithinEither = dual<
           sinkFiber: Fiber.RuntimeFiber<readonly [Chunk.Chunk<Chunk.Chunk<A | A2>>, B], E | E2>,
           scheduleFiber: Fiber.RuntimeFiber<C, Option.Option<never>>,
           scope: Scope.Scope
-        ): Channel.Channel<Chunk.Chunk<Either.Either<C, B>>, unknown, E | E2, unknown, unknown, unknown, R2 | R3> => {
+        ): Channel.Channel<Chunk.Chunk<Either.Either<B, C>>, unknown, E | E2, unknown, unknown, unknown, R2 | R3> => {
           const forkSink = pipe(
             Ref.set(consumed, false),
             Effect.zipRight(Ref.set(endAfterEmit, false)),
@@ -302,7 +302,7 @@ export const aggregateWithinEither = dual<
             leftovers: Chunk.Chunk<Chunk.Chunk<A | A2>>,
             b: B,
             c: Option.Option<C>
-          ): Channel.Channel<Chunk.Chunk<Either.Either<C, B>>, unknown, E | E2, unknown, unknown, unknown, R2 | R3> =>
+          ): Channel.Channel<Chunk.Chunk<Either.Either<B, C>>, unknown, E | E2, unknown, unknown, unknown, R2 | R3> =>
             pipe(
               Ref.set(sinkLeftovers, Chunk.flatten(leftovers)),
               Effect.zipRight(
@@ -319,8 +319,8 @@ export const aggregateWithinEither = dual<
                           const toWrite = pipe(
                             c,
                             Option.match({
-                              onNone: (): Chunk.Chunk<Either.Either<C, B>> => Chunk.of(Either.right(b)),
-                              onSome: (c): Chunk.Chunk<Either.Either<C, B>> =>
+                              onNone: (): Chunk.Chunk<Either.Either<B, C>> => Chunk.of(Either.right(b)),
+                              onSome: (c): Chunk.Chunk<Either.Either<B, C>> =>
                                 Chunk.make(Either.right(b), Either.left(c))
                             })
                           )
@@ -340,7 +340,7 @@ export const aggregateWithinEither = dual<
                         Ref.get(consumed),
                         Effect.map((wasConsumed) =>
                           wasConsumed ?
-                            core.write(Chunk.of<Either.Either<C, B>>(Either.right(b))) :
+                            core.write(Chunk.of<Either.Either<B, C>>(Either.right(b))) :
                             core.unit
                         ),
                         channel.unwrap
@@ -2246,7 +2246,7 @@ export const dropWhileEffect = dual<
 )
 
 /** @internal */
-export const either = <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<Either.Either<E, A>, never, R> =>
+export const either = <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<Either.Either<A, E>, never, R> =>
   pipe(self, map(Either.right), catchAll((error) => make(Either.left(error))))
 
 /** @internal */
@@ -3903,17 +3903,17 @@ export const mergeAll = dual<
 export const mergeEither = dual<
   <R2, E2, A2>(
     that: Stream.Stream<A2, E2, R2>
-  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<A, A2>, E2 | E, R2 | R>,
+  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<A2, A>, E2 | E, R2 | R>,
   <R, E, A, R2, E2, A2>(
     self: Stream.Stream<A, E, R>,
     that: Stream.Stream<A2, E2, R2>
-  ) => Stream.Stream<Either.Either<A, A2>, E2 | E, R2 | R>
+  ) => Stream.Stream<Either.Either<A2, A>, E2 | E, R2 | R>
 >(
   2,
   <R, E, A, R2, E2, A2>(
     self: Stream.Stream<A, E, R>,
     that: Stream.Stream<A2, E2, R2>
-  ): Stream.Stream<Either.Either<A, A2>, E2 | E, R2 | R> =>
+  ): Stream.Stream<Either.Either<A2, A>, E2 | E, R2 | R> =>
     mergeWith(self, that, { onSelf: Either.left, onOther: Either.right })
 )
 
@@ -4081,17 +4081,17 @@ export const orElse = dual<
 export const orElseEither = dual<
   <R2, E2, A2>(
     that: LazyArg<Stream.Stream<A2, E2, R2>>
-  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<A, A2>, E2, R2 | R>,
+  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<A2, A>, E2, R2 | R>,
   <R, E, A, R2, E2, A2>(
     self: Stream.Stream<A, E, R>,
     that: LazyArg<Stream.Stream<A2, E2, R2>>
-  ) => Stream.Stream<Either.Either<A, A2>, E2, R2 | R>
+  ) => Stream.Stream<Either.Either<A2, A>, E2, R2 | R>
 >(
   2,
   <R, E, A, R2, E2, A2>(
     self: Stream.Stream<A, E, R>,
     that: LazyArg<Stream.Stream<A2, E2, R2>>
-  ): Stream.Stream<Either.Either<A, A2>, E2, R2 | R> =>
+  ): Stream.Stream<Either.Either<A2, A>, E2, R2 | R> =>
     pipe(self, map(Either.left), orElse(() => pipe(that(), map(Either.right))))
 )
 
@@ -4391,7 +4391,7 @@ export const partition: {
 /** @internal */
 export const partitionEither = dual<
   <A, R2, E2, A2, A3>(
-    predicate: (a: NoInfer<A>) => Effect.Effect<Either.Either<A2, A3>, E2, R2>,
+    predicate: (a: NoInfer<A>) => Effect.Effect<Either.Either<A3, A2>, E2, R2>,
     options?: {
       readonly bufferSize?: number | undefined
     }
@@ -4404,7 +4404,7 @@ export const partitionEither = dual<
   >,
   <R, E, A, R2, E2, A2, A3>(
     self: Stream.Stream<A, E, R>,
-    predicate: (a: A) => Effect.Effect<Either.Either<A2, A3>, E2, R2>,
+    predicate: (a: A) => Effect.Effect<Either.Either<A3, A2>, E2, R2>,
     options?: {
       readonly bufferSize?: number | undefined
     }
@@ -4417,7 +4417,7 @@ export const partitionEither = dual<
   (args) => typeof args[1] === "function",
   <R, E, A, R2, E2, A2, A3>(
     self: Stream.Stream<A, E, R>,
-    predicate: (a: A) => Effect.Effect<Either.Either<A2, A3>, E2, R2>,
+    predicate: (a: A) => Effect.Effect<Either.Either<A3, A2>, E2, R2>,
     options?: {
       readonly bufferSize?: number | undefined
     }
@@ -4857,19 +4857,19 @@ export const repeatEffectOption = <A, E, R>(effect: Effect.Effect<A, Option.Opti
 export const repeatEither = dual<
   <R2, B>(
     schedule: Schedule.Schedule<R2, unknown, B>
-  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<B, A>, E, R2 | R>,
+  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Either.Either<A, B>, E, R2 | R>,
   <R, E, A, R2, B>(
     self: Stream.Stream<A, E, R>,
     schedule: Schedule.Schedule<R2, unknown, B>
-  ) => Stream.Stream<Either.Either<B, A>, E, R2 | R>
+  ) => Stream.Stream<Either.Either<A, B>, E, R2 | R>
 >(
   2,
   <R, E, A, R2, B>(
     self: Stream.Stream<A, E, R>,
     schedule: Schedule.Schedule<R2, unknown, B>
-  ): Stream.Stream<Either.Either<B, A>, E, R2 | R> =>
+  ): Stream.Stream<Either.Either<A, B>, E, R2 | R> =>
     repeatWith(self, schedule, {
-      onElement: (a): Either.Either<B, A> => Either.right(a),
+      onElement: (a): Either.Either<A, B> => Either.right(a),
       onSchedule: Either.left
     })
 )
@@ -7813,7 +7813,7 @@ export const zipWithChunks = dual<
     f: (
       left: Chunk.Chunk<A>,
       right: Chunk.Chunk<A2>
-    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A>, Chunk.Chunk<A2>>]
+    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A2>, Chunk.Chunk<A>>]
   ) => <R, E>(self: Stream.Stream<A, E, R>) => Stream.Stream<A3, E2 | E, R2 | R>,
   <R, E, R2, E2, A2, A, A3>(
     self: Stream.Stream<A, E, R>,
@@ -7821,7 +7821,7 @@ export const zipWithChunks = dual<
     f: (
       left: Chunk.Chunk<A>,
       right: Chunk.Chunk<A2>
-    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A>, Chunk.Chunk<A2>>]
+    ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A2>, Chunk.Chunk<A>>]
   ) => Stream.Stream<A3, E2 | E, R2 | R>
 >(3, <R, E, R2, E2, A2, A, A3>(
   self: Stream.Stream<A, E, R>,
@@ -7829,7 +7829,7 @@ export const zipWithChunks = dual<
   f: (
     left: Chunk.Chunk<A>,
     right: Chunk.Chunk<A2>
-  ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A>, Chunk.Chunk<A2>>]
+  ) => readonly [Chunk.Chunk<A3>, Either.Either<Chunk.Chunk<A2>, Chunk.Chunk<A>>]
 ): Stream.Stream<A3, E2 | E, R2 | R> => {
   const pull = (
     state: ZipChunksState.ZipChunksState<A, A2>,
@@ -7991,7 +7991,7 @@ const zipChunks = <A, B, C>(
   left: Chunk.Chunk<A>,
   right: Chunk.Chunk<B>,
   f: (a: A, b: B) => C
-): [Chunk.Chunk<C>, Either.Either<Chunk.Chunk<A>, Chunk.Chunk<B>>] => {
+): [Chunk.Chunk<C>, Either.Either<Chunk.Chunk<B>, Chunk.Chunk<A>>] => {
   if (left.length > right.length) {
     return [
       pipe(left, Chunk.take(right.length), Chunk.zipWith(right, f)),

--- a/packages/effect/test/Effect/concurrency.test.ts
+++ b/packages/effect/test/Effect/concurrency.test.ts
@@ -49,7 +49,7 @@ describe("Effect", () => {
       const release = yield* $(Deferred.make<number>())
       const acquire = yield* $(Deferred.make<void>())
       const fiber = yield* $(
-        Effect.asyncEffect<unknown, unknown, never, unknown, unknown, never>((_) =>
+        Effect.asyncEffect<void, never, never, never, never, never>((_) =>
           // This will never complete because the callback is never invoked
           Effect.acquireUseRelease(
             Deferred.succeed(acquire, void 0),

--- a/packages/effect/test/Effect/error-handling.test.ts
+++ b/packages/effect/test/Effect/error-handling.test.ts
@@ -405,8 +405,8 @@ describe("Effect", () => {
     const causes = causesArb(1, smallInts, fc.string())
     const successes = smallInts.map(Effect.succeed)
     const exits = fc.oneof(
-      causes.map((s): Either.Either<Cause.Cause<number>, Effect.Effect<number>> => Either.left(s)),
-      successes.map((s): Either.Either<Cause.Cause<number>, Effect.Effect<number>> => Either.right(s))
+      causes.map((s): Either.Either<Effect.Effect<number>, Cause.Cause<number>> => Either.left(s)),
+      successes.map((s): Either.Either<Effect.Effect<number>, Cause.Cause<number>> => Either.right(s))
     ).map(Either.match({
       onLeft: Exit.failCause,
       onRight: Exit.succeed

--- a/packages/effect/test/Effect/interruption.test.ts
+++ b/packages/effect/test/Effect/interruption.test.ts
@@ -546,11 +546,11 @@ describe("Effect", () => {
   it.effect("async cancelation", () =>
     Effect.gen(function*($) {
       const ref = MutableRef.make(0)
-      const effect = Effect.asyncEither(() => {
+      const effect = Effect.async(() => {
         pipe(ref, MutableRef.set(MutableRef.get(ref) + 1))
-        return Either.left(Effect.sync(() => {
+        return Effect.sync(() => {
           pipe(ref, MutableRef.set(MutableRef.get(ref) - 1))
-        }))
+        })
       })
       yield* $(Effect.unit, Effect.race(effect))
       const result = MutableRef.get(ref)

--- a/packages/effect/test/Effect/interruption.test.ts
+++ b/packages/effect/test/Effect/interruption.test.ts
@@ -314,7 +314,7 @@ describe("Effect", () => {
     }))
   it.effect("sandbox of interruptible", () =>
     Effect.gen(function*($) {
-      const recovered = yield* $(Ref.make<Option.Option<Either.Either<boolean, never>>>(Option.none()))
+      const recovered = yield* $(Ref.make<Option.Option<Either.Either<never, boolean>>>(Option.none()))
       const fiber = yield* $(withLatch((release) =>
         pipe(
           release,

--- a/packages/effect/test/Effect/structural.test.ts
+++ b/packages/effect/test/Effect/structural.test.ts
@@ -144,13 +144,13 @@ describe("Effect", () => {
       Effect.gen(function*($) {
         const res = yield* $(Effect.all([Effect.succeed(0), Effect.succeed(1)], { mode: "either" }))
         assert.deepEqual(res, [Either.right(0), Either.right(1)])
-        satisfies<true>(assertType<[Either.Either<never, number>, Either.Either<never, number>]>()(res))
+        satisfies<true>(assertType<[Either.Either<number>, Either.Either<number>]>()(res))
       }))
     it.effect("failure should work with one array argument", () =>
       Effect.gen(function*($) {
         const res = yield* $(Effect.all([Effect.fail(0), Effect.succeed(1)], { mode: "either" }))
         assert.deepEqual(res, [Either.left(0), Either.right(1)])
-        satisfies<true>(assertType<[Either.Either<number, never>, Either.Either<never, number>]>()(res))
+        satisfies<true>(assertType<[Either.Either<never, number>, Either.Either<number>]>()(res))
       }))
     it.effect("should work with one record argument", () =>
       Effect.gen(function*($) {
@@ -160,8 +160,8 @@ describe("Effect", () => {
         assert.deepEqual(b, Either.right(1))
         satisfies<true>(
           assertType<{
-            readonly a: Either.Either<never, number>
-            readonly b: Either.Either<never, number>
+            readonly a: Either.Either<number>
+            readonly b: Either.Either<number>
           }>()(result)
         )
       }))
@@ -175,8 +175,8 @@ describe("Effect", () => {
         assert.deepEqual(b, Either.right(1))
         satisfies<true>(
           assertType<{
-            readonly a: Either.Either<number, never>
-            readonly b: Either.Either<never, number>
+            readonly a: Either.Either<never, number>
+            readonly b: Either.Either<number>
           }>()(result)
         )
       }))
@@ -184,7 +184,7 @@ describe("Effect", () => {
       Effect.gen(function*($) {
         const result = yield* $(Effect.all(new Set([Effect.succeed(0), Effect.succeed(1)]), { mode: "either" }))
         assert.deepEqual(result, [Either.right(0), Either.right(1)])
-        satisfies<true>(assertType<Array<Either.Either<never, number>>>()(result))
+        satisfies<true>(assertType<Array<Either.Either<number>>>()(result))
       }))
   })
   describe("allWith", () => {

--- a/packages/effect/test/Either.test.ts
+++ b/packages/effect/test/Either.test.ts
@@ -285,7 +285,7 @@ describe("Either", () => {
       Either.left("b")
     )
     expect(
-      (Either.left("a") as Either.Either<string, typeof add>).pipe(
+      (Either.left("a") as Either.Either<typeof add, string>).pipe(
         Either.ap(Either.right(1)),
         Either.ap(Either.right(2))
       )

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -320,8 +320,8 @@ describe("Match", () => {
   it("unify", () => {
     const match = pipe(
       M.type<{ readonly _tag: "A" } | { readonly _tag: "B" }>(),
-      M.tag("A", () => E.right("a") as E.Either<number, string>),
-      M.tag("B", () => E.right(123) as E.Either<string, number>),
+      M.tag("A", () => E.right("a") as E.Either<string, number>),
+      M.tag("B", () => E.right(123) as E.Either<number, string>),
       M.exhaustive
     )
 
@@ -749,7 +749,7 @@ describe("Match", () => {
     )
 
     assertType<
-      E.Either<{ a: number; b: string }, string>
+      E.Either<string, { a: number; b: string }>
     >()(match({ a, b })) satisfies true
   })
 

--- a/packages/effect/test/ReadonlyRecord.test.ts
+++ b/packages/effect/test/ReadonlyRecord.test.ts
@@ -144,7 +144,7 @@ describe("ReadonlyRecord", () => {
       [{ a: "e" }, { b: 1 }]
     )
     // should ignore non own properties
-    const o: RR.ReadonlyRecord<Either.Either<string, number>> = Object.create({ a: 1 })
+    const o: RR.ReadonlyRecord<Either.Either<number, string>> = Object.create({ a: 1 })
     assert.deepStrictEqual(pipe(o, RR.separate), [{}, {}])
   })
 

--- a/packages/effect/test/Resource.test.ts
+++ b/packages/effect/test/Resource.test.ts
@@ -38,7 +38,7 @@ describe("Resource", () => {
     }))
   it.scopedLive("failed refresh doesn't affect cached value", () =>
     Effect.gen(function*($) {
-      const ref = yield* $(Ref.make<Either.Either<string, number>>(Either.right(0)))
+      const ref = yield* $(Ref.make<Either.Either<number, string>>(Either.right(0)))
       const cached = yield* $(Cached.auto(Effect.flatMap(Ref.get(ref), identity), Schedule.spaced(Duration.millis(4))))
       const result1 = yield* $(Cached.get(cached))
       const result2 = yield* $(

--- a/packages/effect/test/Stream/async.test.ts
+++ b/packages/effect/test/Stream/async.test.ts
@@ -3,7 +3,6 @@ import * as Cause from "effect/Cause"
 import * as Chunk from "effect/Chunk"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
-import * as Either from "effect/Either"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { pipe } from "effect/Function"
@@ -27,6 +26,97 @@ describe("Stream", () => {
         Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), array)
+    }))
+
+  it.effect("async - with cleanup", () =>
+    Effect.gen(function*($) {
+      const ref = yield* $(Ref.make(false))
+      const latch = yield* $(Deferred.make<void>())
+      const fiber = yield* $(
+        Stream.async<void>((emit) => {
+          emit.chunk(Chunk.of(void 0))
+          return Ref.set(ref, true)
+        }),
+        Stream.tap(() => Deferred.succeed(latch, void 0)),
+        Stream.runDrain,
+        Effect.fork
+      )
+      yield* $(Deferred.await(latch))
+      yield* $(Fiber.interrupt(fiber))
+      const result = yield* $(Ref.get(ref))
+      assert.isTrue(result)
+    }))
+
+  it.effect("async - signals the end of the stream", () =>
+    Effect.gen(function*($) {
+      const result = yield* $(
+        Stream.async<number>((emit) => {
+          emit.end()
+          return Effect.unit
+        }),
+        Stream.runCollect
+      )
+      assert.isTrue(Chunk.isEmpty(result))
+    }))
+
+  it.effect("async - handles errors", () =>
+    Effect.gen(function*($) {
+      const error = new Cause.RuntimeException("boom")
+      const result = yield* $(
+        Stream.async<number, Cause.RuntimeException>((emit) => {
+          emit.fromEffect(Effect.fail(error))
+          return Effect.unit
+        }),
+        Stream.runCollect,
+        Effect.exit
+      )
+      assert.deepStrictEqual(result, Exit.fail(error))
+    }))
+
+  it.effect("async - handles defects", () =>
+    Effect.gen(function*($) {
+      const error = new Cause.RuntimeException("boom")
+      const result = yield* $(
+        Stream.async<number, Cause.RuntimeException>(() => {
+          throw error
+        }),
+        Stream.runCollect,
+        Effect.exit
+      )
+      assert.deepStrictEqual(result, Exit.die(error))
+    }))
+
+  it.effect("async - backpressure", () =>
+    Effect.gen(function*($) {
+      const refCount = yield* $(Ref.make(0))
+      const refDone = yield* $(Ref.make(false))
+      const stream = Stream.async<number, Option.Option<never>>((emit) => {
+        Promise.all(
+          // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
+          [1, 2, 3, 4, 5, 6, 7].map((n) =>
+            emit.fromEffectChunk(
+              pipe(
+                Ref.set(refCount, n),
+                Effect.zipRight(Effect.succeed(Chunk.of(1)))
+              )
+            )
+          )
+        ).then(() =>
+          emit.fromEffect(
+            pipe(
+              Ref.set(refDone, true),
+              Effect.zipRight(Effect.fail(Option.none()))
+            )
+          )
+        )
+        return Effect.unit
+      }, 5)
+      const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
+      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
+      yield* $(Ref.get(refCount), Effect.repeat({ while: (n) => n !== 7 }))
+      const result = yield* $(Ref.get(refDone))
+      yield* $(Fiber.interrupt(fiber), Effect.exit)
+      assert.isFalse(result)
     }))
 
   it.effect("asyncEffect - simple example", () =>
@@ -124,204 +214,103 @@ describe("Stream", () => {
       assert.isFalse(result)
     }))
 
-  it.effect("asyncInterrupt - left", () =>
-    Effect.gen(function*($) {
-      const ref = yield* $(Ref.make(false))
-      const latch = yield* $(Deferred.make<void>())
-      const fiber = yield* $(
-        Stream.asyncInterrupt<void>((emit) => {
-          emit.chunk(Chunk.of(void 0))
-          return Either.left(Ref.set(ref, true))
-        }),
-        Stream.tap(() => Deferred.succeed(latch, void 0)),
-        Stream.runDrain,
-        Effect.fork
-      )
-      yield* $(Deferred.await(latch))
-      yield* $(Fiber.interrupt(fiber))
-      const result = yield* $(Ref.get(ref))
-      assert.isTrue(result)
-    }))
+  // it.effect("asyncOption - signals the end of the stream", () =>
+  //   Effect.gen(function*($) {
+  //     const result = yield* $(
+  //       Stream.asyncOption<number>((emit) => {
+  //         emit(Effect.fail(Option.none()))
+  //         return Option.none()
+  //       }),
+  //       Stream.runCollect
+  //     )
+  //     assert.isTrue(Chunk.isEmpty(result))
+  //   }))
 
-  it.effect("asyncInterrupt - right", () =>
-    Effect.gen(function*($) {
-      const chunk = Chunk.range(1, 5)
-      const result = yield* $(
-        Stream.asyncInterrupt<number>(() => Either.right(Stream.fromChunk(chunk))),
-        Stream.runCollect
-      )
-      assert.deepStrictEqual(Array.from(result), Array.from(chunk))
-    }))
+  // it.effect("asyncOption - some", () =>
+  //   Effect.gen(function*($) {
+  //     const chunk = Chunk.range(1, 5)
+  //     const result = yield* $(
+  //       Stream.asyncOption<number>(() => Option.some(Stream.fromChunk(chunk))),
+  //       Stream.runCollect
+  //     )
+  //     assert.deepStrictEqual(Array.from(result), Array.from(chunk))
+  //   }))
 
-  it.effect("asyncInterrupt - signals the end of the stream", () =>
-    Effect.gen(function*($) {
-      const result = yield* $(
-        Stream.asyncInterrupt<number>((emit) => {
-          emit.end()
-          return Either.left(Effect.unit)
-        }),
-        Stream.runCollect
-      )
-      assert.isTrue(Chunk.isEmpty(result))
-    }))
+  // it.effect("asyncOption - none", () =>
+  //   Effect.gen(function*($) {
+  //     const array = [1, 2, 3, 4, 5]
+  //     const result = yield* $(
+  //       Stream.asyncOption<number>((emit) => {
+  //         array.forEach((n) => {
+  //           emit(Effect.succeed(Chunk.of(n)))
+  //         })
+  //         return Option.none()
+  //       }),
+  //       Stream.take(array.length),
+  //       Stream.runCollect
+  //     )
+  //     assert.deepStrictEqual(Array.from(result), array)
+  //   }))
 
-  it.effect("asyncInterrupt - handles errors", () =>
-    Effect.gen(function*($) {
-      const error = new Cause.RuntimeException("boom")
-      const result = yield* $(
-        Stream.asyncInterrupt<number, Cause.RuntimeException>((emit) => {
-          emit.fromEffect(Effect.fail(error))
-          return Either.left(Effect.unit)
-        }),
-        Stream.runCollect,
-        Effect.exit
-      )
-      assert.deepStrictEqual(result, Exit.fail(error))
-    }))
+  // it.effect("asyncOption - handles errors", () =>
+  //   Effect.gen(function*($) {
+  //     const error = new Cause.RuntimeException("boom")
+  //     const result = yield* $(
+  //       Stream.asyncOption<number, Cause.RuntimeException>((emit) => {
+  //         emit.fromEffect(Effect.fail(error))
+  //         return Option.none()
+  //       }),
+  //       Stream.runCollect,
+  //       Effect.exit
+  //     )
+  //     assert.deepStrictEqual(result, Exit.fail(error))
+  //   }))
 
-  it.effect("asyncInterrupt - handles defects", () =>
-    Effect.gen(function*($) {
-      const error = new Cause.RuntimeException("boom")
-      const result = yield* $(
-        Stream.asyncInterrupt<number, Cause.RuntimeException>(() => {
-          throw error
-        }),
-        Stream.runCollect,
-        Effect.exit
-      )
-      assert.deepStrictEqual(result, Exit.die(error))
-    }))
+  // it.effect("asyncOption - handles defects", () =>
+  //   Effect.gen(function*($) {
+  //     const error = new Cause.RuntimeException("boom")
+  //     const result = yield* $(
+  //       Stream.asyncOption<number, Cause.RuntimeException>(() => {
+  //         throw error
+  //       }),
+  //       Stream.runCollect,
+  //       Effect.exit
+  //     )
+  //     assert.deepStrictEqual(result, Exit.die(error))
+  //   }))
 
-  it.effect("asyncInterrupt - backpressure", () =>
-    Effect.gen(function*($) {
-      const refCount = yield* $(Ref.make(0))
-      const refDone = yield* $(Ref.make(false))
-      const stream = Stream.asyncInterrupt<number, Option.Option<never>>((emit) => {
-        Promise.all(
-          // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
-          [1, 2, 3, 4, 5, 6, 7].map((n) =>
-            emit.fromEffectChunk(
-              pipe(
-                Ref.set(refCount, n),
-                Effect.zipRight(Effect.succeed(Chunk.of(1)))
-              )
-            )
-          )
-        ).then(() =>
-          emit.fromEffect(
-            pipe(
-              Ref.set(refDone, true),
-              Effect.zipRight(Effect.fail(Option.none()))
-            )
-          )
-        )
-        return Either.left(Effect.unit)
-      }, 5)
-      const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
-      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
-      yield* $(Ref.get(refCount), Effect.repeat({ while: (n) => n !== 7 }))
-      const result = yield* $(Ref.get(refDone))
-      yield* $(Fiber.interrupt(fiber), Effect.exit)
-      assert.isFalse(result)
-    }))
-
-  it.effect("asyncOption - signals the end of the stream", () =>
-    Effect.gen(function*($) {
-      const result = yield* $(
-        Stream.asyncOption<number>((emit) => {
-          emit(Effect.fail(Option.none()))
-          return Option.none()
-        }),
-        Stream.runCollect
-      )
-      assert.isTrue(Chunk.isEmpty(result))
-    }))
-
-  it.effect("asyncOption - some", () =>
-    Effect.gen(function*($) {
-      const chunk = Chunk.range(1, 5)
-      const result = yield* $(
-        Stream.asyncOption<number>(() => Option.some(Stream.fromChunk(chunk))),
-        Stream.runCollect
-      )
-      assert.deepStrictEqual(Array.from(result), Array.from(chunk))
-    }))
-
-  it.effect("asyncOption - none", () =>
-    Effect.gen(function*($) {
-      const array = [1, 2, 3, 4, 5]
-      const result = yield* $(
-        Stream.asyncOption<number>((emit) => {
-          array.forEach((n) => {
-            emit(Effect.succeed(Chunk.of(n)))
-          })
-          return Option.none()
-        }),
-        Stream.take(array.length),
-        Stream.runCollect
-      )
-      assert.deepStrictEqual(Array.from(result), array)
-    }))
-
-  it.effect("asyncOption - handles errors", () =>
-    Effect.gen(function*($) {
-      const error = new Cause.RuntimeException("boom")
-      const result = yield* $(
-        Stream.asyncOption<number, Cause.RuntimeException>((emit) => {
-          emit.fromEffect(Effect.fail(error))
-          return Option.none()
-        }),
-        Stream.runCollect,
-        Effect.exit
-      )
-      assert.deepStrictEqual(result, Exit.fail(error))
-    }))
-
-  it.effect("asyncOption - handles defects", () =>
-    Effect.gen(function*($) {
-      const error = new Cause.RuntimeException("boom")
-      const result = yield* $(
-        Stream.asyncOption<number, Cause.RuntimeException>(() => {
-          throw error
-        }),
-        Stream.runCollect,
-        Effect.exit
-      )
-      assert.deepStrictEqual(result, Exit.die(error))
-    }))
-
-  it.effect("asyncOption - backpressure", () =>
-    Effect.gen(function*($) {
-      const refCount = yield* $(Ref.make(0))
-      const refDone = yield* $(Ref.make(false))
-      const stream = Stream.asyncOption<number, Option.Option<never>>((emit) => {
-        Promise.all(
-          // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
-          [1, 2, 3, 4, 5, 6, 7].map((n) =>
-            emit.fromEffectChunk(
-              pipe(
-                Ref.set(refCount, n),
-                Effect.zipRight(Effect.succeed(Chunk.of(1)))
-              )
-            )
-          )
-        ).then(() =>
-          emit.fromEffect(
-            pipe(
-              Ref.set(refDone, true),
-              Effect.zipRight(Effect.fail(Option.none()))
-            )
-          )
-        )
-        return Option.none()
-      }, 5)
-      const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
-      const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
-      yield* $(Ref.get(refCount), Effect.repeat({ while: (n) => n !== 7 }))
-      const result = yield* $(Ref.get(refDone))
-      yield* $(Fiber.interrupt(fiber), Effect.exit)
-      assert.isFalse(result)
-    }))
+  // it.effect("asyncOption - backpressure", () =>
+  //   Effect.gen(function*($) {
+  //     const refCount = yield* $(Ref.make(0))
+  //     const refDone = yield* $(Ref.make(false))
+  //     const stream = Stream.asyncOption<number, Option.Option<never>>((emit) => {
+  //       Promise.all(
+  //         // 1st consumed by sink, 2-6 – in queue, 7th – back pressured
+  //         [1, 2, 3, 4, 5, 6, 7].map((n) =>
+  //           emit.fromEffectChunk(
+  //             pipe(
+  //               Ref.set(refCount, n),
+  //               Effect.zipRight(Effect.succeed(Chunk.of(1)))
+  //             )
+  //           )
+  //         )
+  //       ).then(() =>
+  //         emit.fromEffect(
+  //           pipe(
+  //             Ref.set(refDone, true),
+  //             Effect.zipRight(Effect.fail(Option.none()))
+  //           )
+  //         )
+  //       )
+  //       return Option.none()
+  //     }, 5)
+  //     const sink = pipe(Sink.take<number>(1), Sink.zipRight(Sink.never))
+  //     const fiber = yield* $(stream, Stream.run(sink), Effect.fork)
+  //     yield* $(Ref.get(refCount), Effect.repeat({ while: (n) => n !== 7 }))
+  //     const result = yield* $(Ref.get(refDone))
+  //     yield* $(Fiber.interrupt(fiber), Effect.exit)
+  //     assert.isFalse(result)
+  //   }))
 
   it.effect("asyncScoped", () =>
     Effect.gen(function*($) {

--- a/packages/platform-browser/src/internal/http/client.ts
+++ b/packages/platform-browser/src/internal/http/client.ts
@@ -6,7 +6,6 @@ import * as Headers from "@effect/platform/Http/Headers"
 import * as IncomingMessage from "@effect/platform/Http/IncomingMessage"
 import * as UrlParams from "@effect/platform/Http/UrlParams"
 import * as Effect from "effect/Effect"
-import * as Either from "effect/Either"
 import * as FiberRef from "effect/FiberRef"
 import type { LazyArg } from "effect/Function"
 import { globalValue } from "effect/GlobalValue"
@@ -183,7 +182,7 @@ export class IncomingMessageImpl<E> implements IncomingMessage.IncomingMessage<E
   }
 
   get stream(): Stream.Stream<Uint8Array, E> {
-    return Stream.asyncInterrupt<Uint8Array, E>((emit) => {
+    return Stream.async<Uint8Array, E>((emit) => {
       let offset = 0
       const onReadyStateChange = () => {
         if (this.source.readyState === 3) {
@@ -202,10 +201,10 @@ export class IncomingMessageImpl<E> implements IncomingMessage.IncomingMessage<E
       this.source.addEventListener("readystatechange", onReadyStateChange)
       this.source.addEventListener("error", onError)
       onReadyStateChange()
-      return Either.left(Effect.sync(() => {
+      return Effect.sync(() => {
         this.source.removeEventListener("readystatechange", onReadyStateChange)
         this.source.removeEventListener("error", onError)
-      }))
+      })
     })
   }
 

--- a/packages/platform-node-shared/src/internal/stream.ts
+++ b/packages/platform-node-shared/src/internal/stream.ts
@@ -117,7 +117,7 @@ export const fromDuplex = <IE, E, I = Uint8Array | string, O = Uint8Array>(
     Effect.tap(
       Effect.zip(
         Effect.sync(evaluate),
-        Queue.unbounded<Either.Either<Exit.Exit<void, IE | E>, void>>()
+        Queue.unbounded<Either.Either<void, Exit.Exit<void, IE | E>>>()
       ),
       ([duplex, queue]) => readableOffer(duplex, queue, onError)
     ),
@@ -199,7 +199,7 @@ export const fromReadableChannel = <E, A = Uint8Array>(
     Effect.tap(
       Effect.zip(
         Effect.sync(evaluate),
-        Queue.unbounded<Either.Either<Exit.Exit<void, E>, void>>()
+        Queue.unbounded<Either.Either<void, Exit.Exit<void, E>>>()
       ),
       ([readable, queue]) => readableOffer(readable, queue, onError)
     ),
@@ -270,7 +270,7 @@ export const writeEffect = <A>(
 
 const readableOffer = <E>(
   readable: Readable | NodeJS.ReadableStream,
-  queue: Queue.Queue<Either.Either<Exit.Exit<void, E>, void>>,
+  queue: Queue.Queue<Either.Either<void, Exit.Exit<void, E>>>,
   onError: (error: unknown) => E
 ) =>
   Effect.sync(() => {
@@ -293,7 +293,7 @@ const readableOffer = <E>(
 
 const readableTake = <E, A>(
   readable: Readable | NodeJS.ReadableStream,
-  queue: Queue.Queue<Either.Either<Exit.Exit<void, E>, void>>,
+  queue: Queue.Queue<Either.Either<void, Exit.Exit<void, E>>>,
   chunkSize: number | undefined
 ) => {
   const read = readChunkChannel<A>(readable, chunkSize)

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -54,18 +54,18 @@ export const parseError = (issue: ParseIssue): ParseError => new ParseError({ er
  * @category constructors
  * @since 1.0.0
  */
-export const succeed: <A>(a: A) => Either.Either<ParseIssue, A> = Either.right
+export const succeed: <A>(a: A) => Either.Either<A, ParseIssue> = Either.right
 
 /**
  * @category constructors
  * @since 1.0.0
  */
-export const fail: (issue: ParseIssue) => Either.Either<ParseIssue, never> = Either.left
+export const fail: (issue: ParseIssue) => Either.Either<never, ParseIssue> = Either.left
 
 const _try: <A>(options: {
   try: LazyArg<A>
   catch: (e: unknown) => ParseIssue
-}) => Either.Either<ParseIssue, A> = Either.try
+}) => Either.Either<A, ParseIssue> = Either.try
 
 export {
   /**

--- a/packages/schema/src/Parser.ts
+++ b/packages/schema/src/Parser.ts
@@ -35,7 +35,7 @@ export const mergeParseOptions = (
 
 const getEither = (ast: AST.AST, isDecoding: boolean, options?: AST.ParseOptions) => {
   const parser = goMemo(ast, isDecoding)
-  return (u: unknown, overrideOptions?: AST.ParseOptions): Either.Either<ParseResult.ParseIssue, any> =>
+  return (u: unknown, overrideOptions?: AST.ParseOptions): Either.Either<any, ParseResult.ParseIssue> =>
     parser(u, mergeParseOptions(options, overrideOptions)) as any
 }
 
@@ -82,7 +82,7 @@ export const decodeUnknownOption = <A, I>(
 export const decodeUnknownEither = <A, I>(
   schema: Schema.Schema<A, I, never>,
   options?: AST.ParseOptions
-): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<ParseResult.ParseIssue, A> =>
+): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<A, ParseResult.ParseIssue> =>
   getEither(schema.ast, true, options)
 
 /**
@@ -132,7 +132,7 @@ export const encodeUnknownOption = <A, I>(
 export const encodeUnknownEither = <A, I>(
   schema: Schema.Schema<A, I, never>,
   options?: AST.ParseOptions
-): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<ParseResult.ParseIssue, I> =>
+): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<I, ParseResult.ParseIssue> =>
   getEither(schema.ast, false, options)
 
 /**
@@ -182,7 +182,7 @@ export const decodeOption: <A, I>(
 export const decodeEither: <A, I>(
   schema: Schema.Schema<A, I, never>,
   options?: AST.ParseOptions
-) => (i: I, overrideOptions?: AST.ParseOptions) => Either.Either<ParseResult.ParseIssue, A> = decodeUnknownEither
+) => (i: I, overrideOptions?: AST.ParseOptions) => Either.Either<A, ParseResult.ParseIssue> = decodeUnknownEither
 
 /**
  * @category decoding
@@ -227,7 +227,7 @@ export const validateOption = <A, I, R>(
 export const validateEither = <A, I, R>(
   schema: Schema.Schema<A, I, R>,
   options?: AST.ParseOptions
-): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<ParseResult.ParseIssue, A> =>
+): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<A, ParseResult.ParseIssue> =>
   getEither(AST.to(schema.ast), true, options)
 
 /**
@@ -269,7 +269,7 @@ export const is = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseO
 export const asserts = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseOptions) => {
   const parser = goMemo(AST.to(schema.ast), true)
   return (u: unknown, overrideOptions?: AST.ParseOptions): asserts u is A => {
-    const result: Either.Either<ParseResult.ParseIssue, any> = parser(u, {
+    const result: Either.Either<any, ParseResult.ParseIssue> = parser(u, {
       ...mergeParseOptions(options, overrideOptions),
       isExact: true
     }) as any
@@ -304,7 +304,7 @@ export const encodeOption: <A, I>(
 export const encodeEither: <A, I>(
   schema: Schema.Schema<A, I, never>,
   options?: AST.ParseOptions
-) => (a: A, overrideOptions?: AST.ParseOptions) => Either.Either<ParseResult.ParseIssue, I> = encodeUnknownEither
+) => (a: A, overrideOptions?: AST.ParseOptions) => Either.Either<I, ParseResult.ParseIssue> = encodeUnknownEither
 
 /**
  * @category encoding

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -215,7 +215,7 @@ export const encodeUnknownEither = <A, I>(
   options?: ParseOptions
 ) => {
   const encodeUnknownEither = Parser.encodeUnknownEither(schema, options)
-  return (u: unknown, overrideOptions?: ParseOptions): Either.Either<ParseResult.ParseError, I> =>
+  return (u: unknown, overrideOptions?: ParseOptions): Either.Either<I, ParseResult.ParseError> =>
     Either.mapLeft(encodeUnknownEither(u, overrideOptions), ParseResult.parseError)
 }
 
@@ -247,7 +247,7 @@ export const encode: <A, I, R>(
 export const encodeEither: <A, I>(
   schema: Schema<A, I, never>,
   options?: ParseOptions
-) => (a: A, overrideOptions?: ParseOptions) => Either.Either<ParseResult.ParseError, I> = encodeUnknownEither
+) => (a: A, overrideOptions?: ParseOptions) => Either.Either<I, ParseResult.ParseError> = encodeUnknownEither
 
 /**
  * @category encoding
@@ -280,7 +280,7 @@ export const decodeUnknownEither = <A, I>(
   options?: ParseOptions
 ) => {
   const decodeUnknownEither = ParseResult.decodeUnknownEither(schema, options)
-  return (u: unknown, overrideOptions?: ParseOptions): Either.Either<ParseResult.ParseError, A> =>
+  return (u: unknown, overrideOptions?: ParseOptions): Either.Either<A, ParseResult.ParseError> =>
     Either.mapLeft(decodeUnknownEither(u, overrideOptions), ParseResult.parseError)
 }
 
@@ -312,7 +312,7 @@ export const decode: <A, I, R>(
 export const decodeEither: <A, I>(
   schema: Schema<A, I, never>,
   options?: ParseOptions
-) => (i: I, overrideOptions?: ParseOptions) => Either.Either<ParseResult.ParseError, A> = decodeUnknownEither
+) => (i: I, overrideOptions?: ParseOptions) => Either.Either<A, ParseResult.ParseError> = decodeUnknownEither
 
 /**
  * @category decoding
@@ -345,7 +345,7 @@ export const validateEither = <A, I, R>(
   options?: ParseOptions
 ) => {
   const validateEither = Parser.validateEither(schema, options)
-  return (u: unknown, overrideOptions?: ParseOptions): Either.Either<ParseResult.ParseError, A> =>
+  return (u: unknown, overrideOptions?: ParseOptions): Either.Either<A, ParseResult.ParseError> =>
     Either.mapLeft(validateEither(u, overrideOptions), ParseResult.parseError)
 }
 
@@ -3561,7 +3561,7 @@ export {
 
 const makeEncodingTransformation = (
   id: string,
-  decode: (s: string) => Either.Either<Encoding.DecodeException, Uint8Array>,
+  decode: (s: string) => Either.Either<Uint8Array, Encoding.DecodeException>,
   encode: (u: Uint8Array) => string
 ): Schema<Uint8Array, string> =>
   transformOrFail(
@@ -3907,8 +3907,13 @@ export const option = <A, I, R>(
     optionFromSelf(to(value)),
     optionDecode,
     Option.match({
-      onNone: () => ({ _tag: "None" }) as const,
-      onSome: (value) => ({ _tag: "Some", value }) as const
+      onNone: () => (({
+        _tag: "None"
+      }) as const),
+      onSome: (value) => (({
+        _tag: "Some",
+        value
+      }) as const)
     })
   )
 
@@ -3989,13 +3994,13 @@ const eitherFrom = <E, IE, R1, A, IA, R2>(
     description(`EitherFrom<${format(left)}, ${format(right)}>`)
   )
 
-const eitherDecode = <E, A>(input: EitherFrom<E, A>): Either.Either<E, A> =>
+const eitherDecode = <E, A>(input: EitherFrom<E, A>): Either.Either<A, E> =>
   input._tag === "Left" ? Either.left(input.left) : Either.right(input.right)
 
 const eitherArbitrary = <E, A>(
   left: Arbitrary<E>,
   right: Arbitrary<A>
-): Arbitrary<Either.Either<E, A>> => {
+): Arbitrary<Either.Either<A, E>> => {
   const arb = arbitrary.make(eitherFrom(schemaFromArbitrary(left), schemaFromArbitrary(right)))
   return (fc) => arb(fc).map(eitherDecode)
 }
@@ -4003,7 +4008,7 @@ const eitherArbitrary = <E, A>(
 const eitherPretty = <E, A>(
   left: Pretty.Pretty<E>,
   right: Pretty.Pretty<A>
-): Pretty.Pretty<Either.Either<E, A>> =>
+): Pretty.Pretty<Either.Either<A, E>> =>
   Either.match({
     onLeft: (e) => `left(${left(e)})`,
     onRight: (a) => `right(${right(a)})`
@@ -4012,7 +4017,7 @@ const eitherPretty = <E, A>(
 const eitherParse = <RE, E, RA, A>(
   decodeUnknownLeft: ParseResult.DecodeUnknown<E, RE>,
   parseright: ParseResult.DecodeUnknown<A, RA>
-): ParseResult.DeclarationDecodeUnknown<Either.Either<E, A>, RE | RA> =>
+): ParseResult.DeclarationDecodeUnknown<Either.Either<A, E>, RE | RA> =>
 (u, options, ast) =>
   Either.isEither(u) ?
     Either.match(u, {
@@ -4028,7 +4033,7 @@ const eitherParse = <RE, E, RA, A>(
 export const eitherFromSelf = <E, IE, RE, A, IA, RA>({ left, right }: {
   readonly left: Schema<E, IE, RE>
   readonly right: Schema<A, IA, RA>
-}): Schema<Either.Either<E, A>, Either.Either<IE, IA>, RE | RA> => {
+}): Schema<Either.Either<A, E>, Either.Either<IA, IE>, RE | RA> => {
   return declare(
     [left, right],
     (left, right) => eitherParse(ParseResult.decodeUnknown(left), ParseResult.decodeUnknown(right)),
@@ -4042,8 +4047,14 @@ export const eitherFromSelf = <E, IE, RE, A, IA, RA>({ left, right }: {
   )
 }
 
-const makeLeftFrom = <E>(left: E) => ({ _tag: "Left", left }) as const
-const makeRightFrom = <A>(right: A) => ({ _tag: "Right", right }) as const
+const makeLeftFrom = <E>(left: E) => (({
+  _tag: "Left",
+  left
+}) as const)
+const makeRightFrom = <A>(right: A) => (({
+  _tag: "Right",
+  right
+}) as const)
 
 /**
  * @category Either transformations
@@ -4052,7 +4063,7 @@ const makeRightFrom = <A>(right: A) => ({ _tag: "Right", right }) as const
 export const either = <E, IE, R1, A, IA, R2>({ left, right }: {
   readonly left: Schema<E, IE, R1>
   readonly right: Schema<A, IA, R2>
-}): Schema<Either.Either<E, A>, EitherFrom<IE, IA>, R1 | R2> =>
+}): Schema<Either.Either<A, E>, EitherFrom<IE, IA>, R1 | R2> =>
   transform(
     eitherFrom(left, right),
     eitherFromSelf({ left: to(left), right: to(right) }),
@@ -4073,7 +4084,7 @@ export const either = <E, IE, R1, A, IA, R2>({ left, right }: {
 export const eitherFromUnion = <EA, EI, R1, AA, AI, R2>({ left, right }: {
   readonly left: Schema<EA, EI, R1>
   readonly right: Schema<AA, AI, R2>
-}): Schema<Either.Either<EA, AA>, EI | AI, R1 | R2> => {
+}): Schema<Either.Either<AA, EA>, EI | AI, R1 | R2> => {
   const toleft = to(left)
   const toright = to(right)
   const fromLeft = transform(left, leftFrom(toleft), makeLeftFrom, (l) => l.left)

--- a/packages/schema/src/internal/parser.ts
+++ b/packages/schema/src/internal/parser.ts
@@ -65,7 +65,7 @@ export const mapError: {
 /** @internal */
 export const eitherOrUndefined = <A, E, R>(
   self: Effect.Effect<A, E, R>
-): Either.Either<E, A> | undefined => {
+): Either.Either<A, E> | undefined => {
   const s: any = self
   if (s["_tag"] === "Left" || s["_tag"] === "Right") {
     return s

--- a/packages/schema/test/util.ts
+++ b/packages/schema/test/util.ts
@@ -224,7 +224,7 @@ export const NumberFromChar = S.Char.pipe(S.compose(S.NumberFromString)).pipe(
 )
 
 export const expectFailure = async <A>(
-  effect: Either.Either<ParseResult.ParseError, A> | Effect.Effect<A, ParseResult.ParseError>,
+  effect: Either.Either<A, ParseResult.ParseError> | Effect.Effect<A, ParseResult.ParseError>,
   message: string
 ) => {
   if (Either.isEither(effect)) {
@@ -235,7 +235,7 @@ export const expectFailure = async <A>(
 }
 
 export const expectSuccess = async <E, A>(
-  effect: Either.Either<E, A> | Effect.Effect<A, E>,
+  effect: Either.Either<A, E> | Effect.Effect<A, E>,
   a: A
 ) => {
   if (Either.isEither(effect)) {
@@ -260,11 +260,11 @@ export const expectEffectSuccess = async <E, A>(effect: Effect.Effect<A, E>, a: 
   )
 }
 
-export const expectEitherLeft = <A>(e: Either.Either<ParseResult.ParseError, A>, message: string) => {
+export const expectEitherLeft = <A>(e: Either.Either<A, ParseResult.ParseError>, message: string) => {
   expect(Either.mapLeft(e, formatError)).toStrictEqual(Either.left(message))
 }
 
-export const expectEitherRight = <E, A>(e: Either.Either<E, A>, a: A) => {
+export const expectEitherRight = <E, A>(e: Either.Either<A, E>, a: A) => {
   expect(e).toStrictEqual(Either.right(a))
 }
 

--- a/packages/typeclass/src/Filterable.ts
+++ b/packages/typeclass/src/Filterable.ts
@@ -16,11 +16,11 @@ import type { Covariant } from "./Covariant.js"
 export interface Filterable<F extends TypeLambda> extends TypeClass<F> {
   readonly partitionMap: {
     <A, B, C>(
-      f: (a: A) => Either.Either<B, C>
+      f: (a: A) => Either.Either<C, B>
     ): <R, O, E>(self: Kind<F, R, O, E, A>) => [Kind<F, R, O, E, B>, Kind<F, R, O, E, C>]
     <R, O, E, A, B, C>(
       self: Kind<F, R, O, E, A>,
-      f: (a: A) => Either.Either<B, C>
+      f: (a: A) => Either.Either<C, B>
     ): [Kind<F, R, O, E, B>, Kind<F, R, O, E, C>]
   }
 
@@ -43,7 +43,7 @@ export const partitionMapComposition = <F extends TypeLambda, G extends TypeLamb
 ) =>
 <FR, FO, FE, GR, GO, GE, A, B, C>(
   self: Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, A>>,
-  f: (a: A) => Either.Either<B, C>
+  f: (a: A) => Either.Either<C, B>
 ): [Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, B>>, Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, C>>] => {
   const filterMap = filterMapComposition(F, G)
   return [
@@ -79,7 +79,7 @@ export const compact = <F extends TypeLambda>(
 export const separate = <F extends TypeLambda>(
   F: Filterable<F>
 ): <R, O, E, A, B>(
-  self: Kind<F, R, O, E, Either.Either<A, B>>
+  self: Kind<F, R, O, E, Either.Either<B, A>>
 ) => [Kind<F, R, O, E, A>, Kind<F, R, O, E, B>] => F.partitionMap(identity)
 
 /**

--- a/packages/typeclass/src/TraversableFilterable.ts
+++ b/packages/typeclass/src/TraversableFilterable.ts
@@ -24,13 +24,13 @@ export interface TraversableFilterable<T extends TypeLambda> extends TypeClass<T
     F: Applicative<F>
   ) => {
     <A, R, O, E, B, C>(
-      f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+      f: (a: A) => Kind<F, R, O, E, Either<C, B>>
     ): <TR, TO, TE>(
       self: Kind<T, TR, TO, TE, A>
     ) => Kind<F, R, O, E, [Kind<T, TR, TO, TE, B>, Kind<T, TR, TO, TE, C>]>
     <TR, TO, TE, A, R, O, E, B, C>(
       self: Kind<T, TR, TO, TE, A>,
-      f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+      f: (a: A) => Kind<F, R, O, E, Either<C, B>>
     ): Kind<F, R, O, E, [Kind<T, TR, TO, TE, B>, Kind<T, TR, TO, TE, C>]>
   }
 
@@ -58,7 +58,7 @@ export const traversePartitionMap = <T extends TypeLambda>(
   F: Applicative<F>
 ) => <TR, TO, TE, A, R, O, E, B, C>(
   self: Kind<T, TR, TO, TE, A>,
-  f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+  f: (a: A) => Kind<F, R, O, E, Either<C, B>>
 ) => Kind<F, R, O, E, [Kind<T, TR, TO, TE, B>, Kind<T, TR, TO, TE, C>]> =>
 (F) =>
 (self, f) => F.map(T.traverse(F)(self, f), filterable.separate(T))

--- a/packages/typeclass/src/data/Either.ts
+++ b/packages/typeclass/src/data/Either.ts
@@ -32,49 +32,49 @@ const bimap: {
   <E1, E2, A, B>(
     onLeft: (e: E1) => E2,
     onRight: (a: A) => B
-  ): (self: Either.Either<E1, A>) => Either.Either<E2, B>
+  ): (self: Either.Either<A, E1>) => Either.Either<B, E2>
   <E1, A, E2, B>(
-    self: Either.Either<E1, A>,
+    self: Either.Either<A, E1>,
     onLeft: (e: E1) => E2,
     onRight: (a: A) => B
-  ): Either.Either<E2, B>
+  ): Either.Either<B, E2>
 } = dual(
   3,
   <E1, A, E2, B>(
-    self: Either.Either<E1, A>,
+    self: Either.Either<A, E1>,
     onLeft: (e: E1) => E2,
     onRight: (a: A) => B
-  ): Either.Either<E2, B> => Either.mapBoth(self, { onLeft, onRight })
+  ): Either.Either<B, E2> => Either.mapBoth(self, { onLeft, onRight })
 )
 
 const flatMap: {
   <A, E2, B>(
-    f: (a: A) => Either.Either<E2, B>
-  ): <E1>(self: Either.Either<E1, A>) => Either.Either<E1 | E2, B>
+    f: (a: A) => Either.Either<B, E2>
+  ): <E1>(self: Either.Either<A, E1>) => Either.Either<B, E1 | E2>
   <E1, A, E2, B>(
-    self: Either.Either<E1, A>,
-    f: (a: A) => Either.Either<E2, B>
-  ): Either.Either<E1 | E2, B>
+    self: Either.Either<A, E1>,
+    f: (a: A) => Either.Either<B, E2>
+  ): Either.Either<B, E1 | E2>
 } = dual(
   2,
   <E1, A, E2, B>(
-    self: Either.Either<E1, A>,
-    f: (a: A) => Either.Either<E2, B>
-  ): Either.Either<E1 | E2, B> => Either.isLeft(self) ? Either.left(self.left) : f(self.right)
+    self: Either.Either<A, E1>,
+    f: (a: A) => Either.Either<B, E2>
+  ): Either.Either<B, E1 | E2> => Either.isLeft(self) ? Either.left(self.left) : f(self.right)
 )
 
 const product = <E1, A, E2, B>(
-  self: Either.Either<E1, A>,
-  that: Either.Either<E2, B>
-): Either.Either<E1 | E2, [A, B]> =>
+  self: Either.Either<A, E1>,
+  that: Either.Either<B, E2>
+): Either.Either<[A, B], E1 | E2> =>
   Either.isRight(self) ?
     (Either.isRight(that) ? Either.right([self.right, that.right]) : Either.left(that.left)) :
     Either.left(self.left)
 
 const productMany = <E, A>(
-  self: Either.Either<E, A>,
-  collection: Iterable<Either.Either<E, A>>
-): Either.Either<E, [A, ...Array<A>]> => {
+  self: Either.Either<A, E>,
+  collection: Iterable<Either.Either<A, E>>
+): Either.Either<[A, ...Array<A>], E> => {
   if (Either.isLeft(self)) {
     return Either.left(self.left)
   }
@@ -89,8 +89,8 @@ const productMany = <E, A>(
 }
 
 const productAll = <E, A>(
-  collection: Iterable<Either.Either<E, A>>
-): Either.Either<E, Array<A>> => {
+  collection: Iterable<Either.Either<A, E>>
+): Either.Either<Array<A>, E> => {
   const out: Array<A> = []
   for (const e of collection) {
     if (Either.isLeft(e)) {
@@ -102,14 +102,14 @@ const productAll = <E, A>(
 }
 
 const coproduct = <E1, A, E2, B>(
-  self: Either.Either<E1, A>,
-  that: Either.Either<E2, B>
-): Either.Either<E1 | E2, A | B> => Either.isRight(self) ? self : that
+  self: Either.Either<A, E1>,
+  that: Either.Either<B, E2>
+): Either.Either<A | B, E1 | E2> => Either.isRight(self) ? self : that
 
 const coproductMany = <E, A>(
-  self: Either.Either<E, A>,
-  collection: Iterable<Either.Either<E, A>>
-): Either.Either<E, A> => {
+  self: Either.Either<A, E>,
+  collection: Iterable<Either.Either<A, E>>
+): Either.Either<A, E> => {
   let out = self
   if (Either.isRight(out)) {
     return out
@@ -127,19 +127,19 @@ const traverse = <F extends TypeLambda>(
 ): {
   <A, R, O, E, B>(
     f: (a: A) => Kind<F, R, O, E, B>
-  ): <TE>(self: Either.Either<TE, A>) => Kind<F, R, O, E, Either.Either<TE, B>>
+  ): <TE>(self: Either.Either<A, TE>) => Kind<F, R, O, E, Either.Either<B, TE>>
   <TE, A, R, O, E, B>(
-    self: Either.Either<TE, A>,
+    self: Either.Either<A, TE>,
     f: (a: A) => Kind<F, R, O, E, B>
-  ): Kind<F, R, O, E, Either.Either<TE, B>>
+  ): Kind<F, R, O, E, Either.Either<B, TE>>
 } =>
   dual(2, <TE, A, R, O, E, B>(
-    self: Either.Either<TE, A>,
+    self: Either.Either<A, TE>,
     f: (a: A) => Kind<F, R, O, E, B>
-  ): Kind<F, R, O, E, Either.Either<TE, B>> =>
+  ): Kind<F, R, O, E, Either.Either<B, TE>> =>
     Either.isLeft(self) ?
-      F.of<Either.Either<TE, B>>(Either.left(self.left)) :
-      F.map<R, O, E, B, Either.Either<TE, B>>(f(self.right), Either.right))
+      F.of<Either.Either<B, TE>>(Either.left(self.left)) :
+      F.map<R, O, E, B, Either.Either<B, TE>>(f(self.right), Either.right))
 
 /**
  * @category instances
@@ -287,7 +287,7 @@ export const SemiAlternative: semiAlternative.SemiAlternative<Either.EitherTypeL
 export const Foldable: foldable.Foldable<Either.EitherTypeLambda> = {
   reduce: dual(
     3,
-    <E, A, B>(self: Either.Either<E, A>, b: B, f: (b: B, a: A) => B): B => Either.isLeft(self) ? b : f(b, self.right)
+    <E, A, B>(self: Either.Either<A, E>, b: B, f: (b: B, a: A) => B): B => Either.isLeft(self) ? b : f(b, self.right)
   )
 }
 

--- a/packages/typeclass/src/data/ReadonlyArray.ts
+++ b/packages/typeclass/src/data/ReadonlyArray.ts
@@ -70,16 +70,16 @@ const traversePartitionMap = <F extends TypeLambda>(
   F: applicative.Applicative<F>
 ): {
   <A, R, O, E, B, C>(
-    f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+    f: (a: A) => Kind<F, R, O, E, Either<C, B>>
   ): (self: ReadonlyArray<A>) => Kind<F, R, O, E, [Array<B>, Array<C>]>
   <A, R, O, E, B, C>(
     self: ReadonlyArray<A>,
-    f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+    f: (a: A) => Kind<F, R, O, E, Either<C, B>>
   ): Kind<F, R, O, E, [Array<B>, Array<C>]>
 } =>
   dual(2, <A, R, O, E, B, C>(
     self: ReadonlyArray<A>,
-    f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+    f: (a: A) => Kind<F, R, O, E, Either<C, B>>
   ): Kind<F, R, O, E, [Array<B>, Array<C>]> => {
     return F.map(traverse(F)(self, f), ReadonlyArray.separate)
   })

--- a/packages/typeclass/src/data/ReadonlyRecord.ts
+++ b/packages/typeclass/src/data/ReadonlyRecord.ts
@@ -45,18 +45,18 @@ const traversePartitionMap = <F extends TypeLambda>(
   F: applicative.Applicative<F>
 ): {
   <A, R, O, E, B, C>(
-    f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+    f: (a: A) => Kind<F, R, O, E, Either<C, B>>
   ): (
     self: ReadonlyRecord.ReadonlyRecord<A>
   ) => Kind<F, R, O, E, [Record<string, B>, Record<string, C>]>
   <A, R, O, E, B, C>(
     self: ReadonlyRecord.ReadonlyRecord<A>,
-    f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+    f: (a: A) => Kind<F, R, O, E, Either<C, B>>
   ): Kind<F, R, O, E, [Record<string, B>, Record<string, C>]>
 } =>
   dual(2, <A, R, O, E, B, C>(
     self: ReadonlyRecord.ReadonlyRecord<A>,
-    f: (a: A) => Kind<F, R, O, E, Either<B, C>>
+    f: (a: A) => Kind<F, R, O, E, Either<C, B>>
   ): Kind<F, R, O, E, [Record<string, B>, Record<string, C>]> => {
     return F.map(traverse(F)(self, f), ReadonlyRecord.separate)
   })

--- a/packages/typeclass/test/TraversableFilterable.test.ts
+++ b/packages/typeclass/test/TraversableFilterable.test.ts
@@ -10,7 +10,7 @@ describe.concurrent("TraversableFilterable", () => {
   it("traversePartitionMap", () => {
     const traversePartitionMap: <A, B, C>(
       self: ReadonlyArray<A>,
-      f: (a: A) => O.Option<E.Either<B, C>>
+      f: (a: A) => O.Option<E.Either<C, B>>
     ) => O.Option<[ReadonlyArray<B>, ReadonlyArray<C>]> = _.traversePartitionMap({
       ...ReadonlyArrayInstances.Traversable,
       ...ReadonlyArrayInstances.Covariant,

--- a/packages/typeclass/test/data/Either.test.ts
+++ b/packages/typeclass/test/data/Either.test.ts
@@ -43,9 +43,9 @@ describe.concurrent("Either", () => {
 
   it("SemiProduct.productMany", () => {
     const productMany: <E, A>(
-      self: Either.Either<E, A>,
-      collection: Iterable<Either.Either<E, A>>
-    ) => Either.Either<E, [A, ...Array<A>]> = EitherInstances.SemiProduct.productMany
+      self: Either.Either<A, E>,
+      collection: Iterable<Either.Either<A, E>>
+    ) => Either.Either<[A, ...Array<A>], E> = EitherInstances.SemiProduct.productMany
 
     Util.deepStrictEqual(productMany(Either.right(1), []), Either.right([1]))
     Util.deepStrictEqual(


### PR DESCRIPTION
Swap type params of Either from `Either<E, A>` to `Either<R, L = never>`.

Along the same line of the other changes this allows to shorten the most common types such as:

```ts
import { Either } from "effect";

const right: Either.Either<string> = Either.right("ok");
```

While it was confusing to use `Either<A, E>` I don't find it particularly confusing to use `Either<R, L>`, the type reads like "it's either a right or a left"