### PR TITLE
Schema: add `transformation: false` option to `pluck`

### DIFF
--- a/.changeset/curly-beers-buy.md
+++ b/.changeset/curly-beers-buy.md
@@ -1,0 +1,52 @@
+---
+"@effect/schema": patch
+---
+
+Schema: add `transformation: false` option to `pluck`.
+
+Given a schema `Schema<A, I, R>` and a key `K`, this function extracts a specific field from the `A` type, producing a new schema that represents a transformation from the `I` type to `A[K]`.
+
+**If the option `{ transformation: false }` is provided**, the returned schema `Schema<A[K], I[K], R>` only represents the value of the field without any transformation.
+
+**Example**
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+// ---------------------------------------------
+// use case: pull out a single field from a
+// struct through a transformation
+// ---------------------------------------------
+
+const mytable = S.struct({
+  column1: S.NumberFromString,
+  column2: S.number,
+});
+
+// const pullOutColumn1: S.Schema<number, {
+//     readonly column1: string;
+//     readonly column2: number;
+// }, never>
+const pullOutColumn1 = mytable.pipe(S.pluck("column1"));
+
+console.log(
+  S.decode(S.array(pullOutColumn1))([
+    { column1: "1", column2: 100 },
+    { column1: "2", column2: 300 },
+  ])
+);
+// Output: { _id: 'Either', _tag: 'Right', right: [ 1, 2 ] }
+
+// ---------------------------------------------
+// use case: pull out a single field from a
+// struct (no transformation)
+// ---------------------------------------------
+
+// const pullOutColumn1Value: S.Schema<number, string, never>
+const pullOutColumn1Value = mytable.pipe(
+  S.pluck("column1", { transformation: false })
+);
+
+console.log(S.decode(S.array(pullOutColumn1Value))(["1", "2"]));
+// Output: { _id: 'Either', _tag: 'Right', right: [ 1, 2 ] }
+```

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1247,22 +1247,80 @@ export const omit = <A, Keys extends ReadonlyArray<keyof A>>(...keys: Keys) =>
 }
 
 /**
+ * Given a schema `Schema<A, I, R>` and a key `K`, this function extracts a specific field from the `A` type, producing a new schema that represents a transformation from the `I` type to `A[K]`.
+ *
+ * If the option `{ transformation: false }` is provided, the returned schema `Schema<A[K], I[K], R>` only represents the value of the field without any transformation.
+ *
+ * @example
+ * import * as S from "@effect/schema/Schema"
+ *
+ * // ---------------------------------------------
+ * // use case: pull out a single field from a
+ * // struct through a transformation
+ * // ---------------------------------------------
+ *
+ * const mytable = S.struct({
+ *   column1: S.NumberFromString,
+ *   column2: S.number
+ * })
+ *
+ * // const pullOutColumn1: S.Schema<number, {
+ * //     readonly column1: string;
+ * //     readonly column2: number;
+ * // }, never>
+ * const pullOutColumn1 = mytable.pipe(S.pluck("column1"))
+ *
+ * console.log(S.decode(S.array(pullOutColumn1))([{ column1: "1", column2: 100 }, { column1: "2", column2: 300 }]))
+ * // Output: { _id: 'Either', _tag: 'Right', right: [ 1, 2 ] }
+ *
+ * // ---------------------------------------------
+ * // use case: pull out a single field from a
+ * // struct (no transformation)
+ * // ---------------------------------------------
+ *
+ * // const pullOutColumn1Value: S.Schema<number, string, never>
+ * const pullOutColumn1Value = mytable.pipe(S.pluck("column1", { transformation: false }))
+ *
+ * console.log(S.decode(S.array(pullOutColumn1Value))(["1", "2"]))
+ * // Output: { _id: 'Either', _tag: 'Right', right: [ 1, 2 ] }
+ *
  * @category struct transformations
  * @since 1.0.0
  */
 export const pluck: {
+  <A, K extends keyof A>(
+    key: K,
+    options: { readonly transformation: false }
+  ): <I extends { [P in K]?: any }, R>(schema: Schema<A, I, R>) => Schema<A[K], I[K], R>
   <A, K extends keyof A>(key: K): <I, R>(schema: Schema<A, I, R>) => Schema<A[K], I, R>
+  <A, I extends { [P in K]?: any }, R, K extends keyof A>(
+    schema: Schema<A, I, R>,
+    key: K,
+    options: { readonly transformation: false }
+  ): Schema<A[K], I[K], R>
   <A, I, R, K extends keyof A>(schema: Schema<A, I, R>, key: K): Schema<A[K], I, R>
-} = dual(2, <A, I, R, K extends keyof A>(schema: Schema<A, I, R>, key: K): Schema<A[K], I, R> => {
-  const ps = AST.getPropertyKeyIndexedAccess(to(schema).ast, key)
-  const value = make<A[K], A[K], R>(ps.isOptional ? AST.createUnion([AST.undefinedKeyword, ps.type]) : ps.type)
-  return transform(
-    schema,
-    value,
-    (a) => a[key],
-    (ak) => ps.isOptional && ak === undefined ? {} : { [key]: ak } as any
-  )
-})
+} = dual(
+  (args) => isSchema(args[0]),
+  <A, I, R, K extends keyof A>(
+    schema: Schema<A, I, R>,
+    key: K,
+    options?: { readonly transformation: false }
+  ): Schema<A[K], I, R> => {
+    if (options && options.transformation == false) {
+      const ps = AST.getPropertyKeyIndexedAccess(schema.ast, key)
+      return make(ps.isOptional ? AST.createUnion([AST.undefinedKeyword, ps.type]) : ps.type)
+    } else {
+      const ps = AST.getPropertyKeyIndexedAccess(to(schema).ast, key)
+      const value = make<A[K], A[K], R>(ps.isOptional ? AST.createUnion([AST.undefinedKeyword, ps.type]) : ps.type)
+      return transform(
+        schema,
+        value,
+        (a) => a[key],
+        (ak) => ps.isOptional && ak === undefined ? {} : { [key]: ak } as any
+      )
+    }
+  }
+)
 
 /**
  * @category model


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

/cc @schickling 

Given a schema `Schema<A, I, R>` and a key `K`, this function extracts a specific field from the `A` type, producing a new schema that represents a transformation from the `I` type to `A[K]`.

**If the option `{ transformation: false }` is provided**, the returned schema `Schema<A[K], I[K], R>` only represents the value of the field without any transformation.

**Example**

```ts
import * as S from "@effect/schema/Schema";

// ---------------------------------------------
// use case: pull out a single field from a
// struct through a transformation
// ---------------------------------------------

const mytable = S.struct({
  column1: S.NumberFromString,
  column2: S.number,
});

// const pullOutColumn1: S.Schema<number, {
//     readonly column1: string;
//     readonly column2: number;
// }, never>
const pullOutColumn1 = mytable.pipe(S.pluck("column1"));

console.log(
  S.decode(S.array(pullOutColumn1))([
    { column1: "1", column2: 100 },
    { column1: "2", column2: 300 },
  ])
);
// Output: { _id: 'Either', _tag: 'Right', right: [ 1, 2 ] }

// ---------------------------------------------
// use case: pull out a single field from a
// struct (no transformation)
// ---------------------------------------------

// const pullOutColumn1Value: S.Schema<number, string, never>
const pullOutColumn1Value = mytable.pipe(
  S.pluck("column1", { transformation: false })
);

console.log(S.decode(S.array(pullOutColumn1Value))(["1", "2"]));
// Output: { _id: 'Either', _tag: 'Right', right: [ 1, 2 ] }
```
