### PR TITLE
Add a way to redact HTTP headers

### DIFF
--- a/.changeset/warm-jeans-rush.md
+++ b/.changeset/warm-jeans-rush.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Add a way to redact HTTP headers

--- a/packages/platform/src/Http/Headers.ts
+++ b/packages/platform/src/Http/Headers.ts
@@ -147,12 +147,9 @@ export const remove: {
  * @since 1.0.0
  */
 export const redact: {
-  (key: string | Array<string>): (self: Headers) => ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>
-  (self: Headers, key: string | Array<string>): ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>
+  (key: string): (self: Headers) => Record<string, string | Secret.Secret>
+  (self: Headers, key: string): Record<string, string | Secret.Secret>
 } = dual<
-  (key: string | Array<string>) => (self: Headers) => ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>,
-  (self: Headers, key: string | Array<string>) => ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>
->(2, (self, key) =>
-  Array.isArray(key) ?
-    key.reduce((headers, key) => ReadonlyRecord.modify(headers, key.toLowerCase(), Secret.fromString), self) :
-    ReadonlyRecord.modify(self, key.toLowerCase(), Secret.fromString))
+  (key: string) => (self: Headers) => Record<string, string | Secret.Secret>,
+  (self: Headers, key: string) => Record<string, string | Secret.Secret>
+>(2, (self, key) => ReadonlyRecord.modify(self, key.toLowerCase(), Secret.fromString))

--- a/packages/platform/src/Http/Headers.ts
+++ b/packages/platform/src/Http/Headers.ts
@@ -6,6 +6,7 @@ import { dual } from "effect/Function"
 import type * as Option from "effect/Option"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as ReadonlyRecord from "effect/ReadonlyRecord"
+import * as Secret from "effect/Secret"
 
 /**
  * @since 1.0.0
@@ -141,3 +142,17 @@ export const remove: {
   (key: string) => (self: Headers) => Headers,
   (self: Headers, key: string) => Headers
 >(2, (self, key) => ReadonlyRecord.remove(self, key.toLowerCase()) as Headers)
+
+/**
+ * @since 1.0.0
+ */
+export const redact: {
+  (key: string | Array<string>): (self: Headers) => ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>
+  (self: Headers, key: string | Array<string>): ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>
+} = dual<
+  (key: string | Array<string>) => (self: Headers) => ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>,
+  (self: Headers, key: string | Array<string>) => ReadonlyRecord.ReadonlyRecord<string | Secret.Secret>
+>(2, (self, key) =>
+  Array.isArray(key) ?
+    key.reduce((headers, key) => ReadonlyRecord.modify(headers, key.toLowerCase(), Secret.fromString), self) :
+    ReadonlyRecord.modify(self, key.toLowerCase(), Secret.fromString))

--- a/packages/platform/src/Http/Headers.ts
+++ b/packages/platform/src/Http/Headers.ts
@@ -147,9 +147,17 @@ export const remove: {
  * @since 1.0.0
  */
 export const redact: {
-  (key: string): (self: Headers) => Record<string, string | Secret.Secret>
-  (self: Headers, key: string): Record<string, string | Secret.Secret>
+  (key: string | ReadonlyArray<string>): (self: Headers) => Record<string, string | Secret.Secret>
+  (self: Headers, key: string | ReadonlyArray<string>): Record<string, string | Secret.Secret>
 } = dual<
-  (key: string) => (self: Headers) => Record<string, string | Secret.Secret>,
-  (self: Headers, key: string) => Record<string, string | Secret.Secret>
->(2, (self, key) => ReadonlyRecord.modify(self, key.toLowerCase(), Secret.fromString))
+  (key: string | ReadonlyArray<string>) => (self: Headers) => Record<string, string | Secret.Secret>,
+  (self: Headers, key: string | ReadonlyArray<string>) => Record<string, string | Secret.Secret>
+>(
+  2,
+  (self, key) =>
+    typeof key === "string"
+      ? ReadonlyRecord.modify(self, key.toLowerCase(), Secret.fromString)
+      : key.reduce<Record<string, string | Secret.Secret>>((headers, key) =>
+        ReadonlyRecord.modify(headers, key.toLowerCase(), (value) =>
+          typeof value === "string" ? Secret.fromString(value) : value), self)
+)

--- a/packages/platform/test/Http/Headers.test.ts
+++ b/packages/platform/test/Http/Headers.test.ts
@@ -3,20 +3,40 @@ import * as Secret from "effect/Secret"
 import { assert, describe, it } from "vitest"
 
 describe("Headers", () => {
-  it("redact", () => {
-    const headers = Headers.fromInput({
-      "Content-Type": "application/json",
-      "Authorization": "Bearer some-token",
-      "X-Api-Key": "some-key"
+  describe("redact", () => {
+    it("one key", () => {
+      const headers = Headers.fromInput({
+        "Content-Type": "application/json",
+        "Authorization": "Bearer some-token",
+        "X-Api-Key": "some-key"
+      })
+
+      const redacted = Headers.redact(headers, "Authorization")
+
+      assert.deepEqual(redacted, {
+        "content-type": "application/json",
+        "authorization": Secret.fromString("some secret"),
+        "x-api-key": "some-key"
+      })
+      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
     })
 
-    const redacted = Headers.redact(headers, "Authorization")
+    it("multiple keys", () => {
+      const headers = Headers.fromInput({
+        "Content-Type": "application/json",
+        "Authorization": "Bearer some-token",
+        "X-Api-Key": "some-key"
+      })
 
-    assert.deepEqual(redacted, {
-      "content-type": "application/json",
-      "authorization": Secret.fromString("some secret"),
-      "x-api-key": "some-key"
+      const redacted = Headers.redact(headers, ["Authorization", "authorization", "X-Api-Token", "x-api-key"])
+
+      assert.deepEqual(redacted, {
+        "content-type": "application/json",
+        "authorization": Secret.fromString("some secret"),
+        "x-api-key": Secret.fromString("some secret")
+      })
+      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
+      assert.strictEqual(Secret.value(redacted["x-api-key"] as Secret.Secret), "some-key")
     })
-    assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
   })
 })

--- a/packages/platform/test/Http/Headers.test.ts
+++ b/packages/platform/test/Http/Headers.test.ts
@@ -3,40 +3,20 @@ import * as Secret from "effect/Secret"
 import { assert, describe, it } from "vitest"
 
 describe("Headers", () => {
-  describe("redact", () => {
-    it("one key", () => {
-      const headers = Headers.fromInput({
-        "Content-Type": "application/json",
-        "Authorization": "Bearer some-token",
-        "X-Api-Key": "some-key"
-      })
-
-      const redacted = Headers.redact(headers, "Authorization")
-
-      assert.deepEqual(redacted, {
-        "content-type": "application/json",
-        "authorization": Secret.fromString("some secret"),
-        "x-api-key": "some-key"
-      })
-      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
+  it("redact", () => {
+    const headers = Headers.fromInput({
+      "Content-Type": "application/json",
+      "Authorization": "Bearer some-token",
+      "X-Api-Key": "some-key"
     })
 
-    it("multiple keys", () => {
-      const headers = Headers.fromInput({
-        "Content-Type": "application/json",
-        "Authorization": "Bearer some-token",
-        "X-Api-Key": "some-key"
-      })
+    const redacted = Headers.redact(headers, "Authorization")
 
-      const redacted = Headers.redact(headers, ["Authorization", "X-Api-Token", "x-api-key"])
-
-      assert.deepEqual(redacted, {
-        "content-type": "application/json",
-        "authorization": Secret.fromString("some secret"),
-        "x-api-key": Secret.fromString("some secret")
-      })
-      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
-      assert.strictEqual(Secret.value(redacted["x-api-key"] as Secret.Secret), "some-key")
+    assert.deepEqual(redacted, {
+      "content-type": "application/json",
+      "authorization": Secret.fromString("some secret"),
+      "x-api-key": "some-key"
     })
+    assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
   })
 })

--- a/packages/platform/test/Http/Headers.test.ts
+++ b/packages/platform/test/Http/Headers.test.ts
@@ -1,0 +1,42 @@
+import * as Headers from "@effect/platform/Http/Headers"
+import * as Secret from "effect/Secret"
+import { assert, describe, it } from "vitest"
+
+describe("Headers", () => {
+  describe("redact", () => {
+    it("one key", () => {
+      const headers = Headers.fromInput({
+        "Content-Type": "application/json",
+        "Authorization": "Bearer some-token",
+        "X-Api-Key": "some-key"
+      })
+
+      const redacted = Headers.redact(headers, "Authorization")
+
+      assert.deepEqual(redacted, {
+        "content-type": "application/json",
+        "authorization": Secret.fromString("some secret"),
+        "x-api-key": "some-key"
+      })
+      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
+    })
+
+    it("multiple keys", () => {
+      const headers = Headers.fromInput({
+        "Content-Type": "application/json",
+        "Authorization": "Bearer some-token",
+        "X-Api-Key": "some-key"
+      })
+
+      const redacted = Headers.redact(headers, ["Authorization", "X-Api-Token", "x-api-key"])
+
+      assert.deepEqual(redacted, {
+        "content-type": "application/json",
+        "authorization": Secret.fromString("some secret"),
+        "x-api-key": Secret.fromString("some secret")
+      })
+      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
+      assert.strictEqual(Secret.value(redacted["x-api-key"] as Secret.Secret), "some-key")
+    })
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a way to redact specified HTTP headers by turning them into secrets. This changes the type from `Headers` to a `ReadonlyRecord<string | Secret>`.

This doesn't solve the problem of accidentally logging the whole `Headers` object, but the change to use secrets for certain/any header is fairly explosive. This does make it easier to redact headers manually, though, as opposed to https://github.com/PREreview/orcid-sync/blob/b4b92c6996ab7f0716c0f8615e038253f98b290c/src/index.ts#L14 (where keys are case-sensitive etc).

## Related

https://discord.com/channels/795981131316985866/1206639016464613486/1206720315565015040
