### PR TITLE
Schema: refactor the `declare` signature to ensure that the decoding …

### DIFF
--- a/.changeset/spicy-houses-type.md
+++ b/.changeset/spicy-houses-type.md
@@ -1,0 +1,20 @@
+---
+"@effect/schema": patch
+---
+
+Refactor the `declare` signature to ensure that the decoding and encoding functions do not utilize context.
+
+As a result, we can relax the signature of the following functions to accept `R !== never`:
+
+- `Parser.validateSync`
+- `Parser.validateOption`
+- `Parser.validateEither`
+- `Parser.is`
+- `Parser.asserts`
+- `Schema.validateSync`
+- `Schema.validateOption`
+- `Schema.validateEither`
+- `Schema.is`
+- `Schema.asserts`
+
+Additionally, the `Class` API no longer requires the optional argument `disableValidation` to be `true` when `R !== never`.

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -3186,6 +3186,9 @@ Error: ReadonlySet<NumberFromString>
 */
 ```
 
+> [!WARNING]
+> The decoding and encoding functions cannot use context (the `R` type parameter) and cannot use async effects.
+
 ## Adding Annotations
 
 When you define a new data type, some compilers like `Arbitrary` or `Pretty` may not know how to handle the newly defined data. For instance:

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -45,23 +45,23 @@ Schema.declare(
   }
 )
 
-// $ExpectType Schema<string, number, "a" | "b">
 Schema.declare(
   [aContext, bContext],
+  // @ts-expect-error
   (_a, _b) => () => Taga.pipe(Effect.flatMap(ParseResult.succeed)),
   (_a, _b) => () => ParseResult.succeed(1)
 )
 
-// $ExpectType Schema<string, number, "a" | "b">
 Schema.declare(
   [aContext, bContext],
   (_a, _b) => () => ParseResult.succeed("a"),
+  // @ts-expect-error
   (_a, _b) => () => Tagb.pipe(Effect.flatMap(ParseResult.succeed))
 )
 
-// $ExpectType Schema<string, number, "a" | "b">
 Schema.declare(
   [aContext, bContext],
+  // @ts-expect-error
   (_a, _b) => () => Taga.pipe(Effect.flatMap(ParseResult.succeed)),
   (_a, _b) => () => Tagb.pipe(Effect.flatMap(ParseResult.succeed))
 )
@@ -346,7 +346,7 @@ export type MyClassContext = Schema.Schema.Context<typeof MyClass>
 // $ExpectType Schema<{ readonly a: string; }, { readonly a: string; }, "a">
 MyClass.struct
 
-// $ExpectType [props: { readonly a: string; }, disableValidation: true]
+// $ExpectType [props: { readonly a: string; }, disableValidation?: boolean | undefined]
 export type MyClassParams = ConstructorParameters<typeof MyClass>
 
 // ---------------------------------------------
@@ -367,7 +367,7 @@ export type MyClassWithTransformContext = Schema.Schema.Context<typeof MyClassWi
 // $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly a: string; }, "a" | "b" | "Tag1" | "Tag2">
 MyClassWithTransform.struct
 
-// $ExpectType [props: { readonly a: string; readonly b: number; }, disableValidation: true]
+// $ExpectType [props: { readonly a: string; readonly b: number; }, disableValidation?: boolean | undefined]
 export type MyClassWithTransformParams = ConstructorParameters<typeof MyClassWithTransform>
 
 // ---------------------------------------------
@@ -388,7 +388,7 @@ export type MyClassWithTransformFromContext = Schema.Schema.Context<typeof MyCla
 // $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly a: string; }, "a" | "b" | "Tag1" | "Tag2">
 MyClassWithTransformFrom.struct
 
-// $ExpectType [props: { readonly a: string; readonly b: number; }, disableValidation: true]
+// $ExpectType [props: { readonly a: string; readonly b: number; }, disableValidation?: boolean | undefined]
 export type MyClassWithTransformFromParams = ConstructorParameters<typeof MyClassWithTransformFrom>
 
 // ---------------------------------------------

--- a/packages/schema/src/Parser.ts
+++ b/packages/schema/src/Parser.ts
@@ -206,8 +206,8 @@ export const decode: <A, I, R>(
  * @category validation
  * @since 1.0.0
  */
-export const validateSync = <A, I>(
-  schema: Schema.Schema<A, I, never>,
+export const validateSync = <A, I, R>(
+  schema: Schema.Schema<A, I, R>,
   options?: AST.ParseOptions
 ): (u: unknown, overrideOptions?: AST.ParseOptions) => A => getSync(AST.to(schema.ast), true, options)
 
@@ -215,8 +215,8 @@ export const validateSync = <A, I>(
  * @category validation
  * @since 1.0.0
  */
-export const validateOption = <A, I>(
-  schema: Schema.Schema<A, I, never>,
+export const validateOption = <A, I, R>(
+  schema: Schema.Schema<A, I, R>,
   options?: AST.ParseOptions
 ): (u: unknown, overrideOptions?: AST.ParseOptions) => Option.Option<A> => getOption(AST.to(schema.ast), true, options)
 
@@ -224,8 +224,8 @@ export const validateOption = <A, I>(
  * @category validation
  * @since 1.0.0
  */
-export const validateEither = <A, I>(
-  schema: Schema.Schema<A, I, never>,
+export const validateEither = <A, I, R>(
+  schema: Schema.Schema<A, I, R>,
   options?: AST.ParseOptions
 ): (u: unknown, overrideOptions?: AST.ParseOptions) => Either.Either<ParseResult.ParseIssue, A> =>
   getEither(AST.to(schema.ast), true, options)
@@ -256,7 +256,7 @@ export const validate = <A, I, R>(
  * @category validation
  * @since 1.0.0
  */
-export const is = <A, I>(schema: Schema.Schema<A, I, never>, options?: AST.ParseOptions) => {
+export const is = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseOptions) => {
   const parser = goMemo(AST.to(schema.ast), true)
   return (u: unknown, overrideOptions?: AST.ParseOptions): u is A =>
     Either.isRight(parser(u, { ...mergeParseOptions(options, overrideOptions), isExact: true }) as any)
@@ -266,7 +266,7 @@ export const is = <A, I>(schema: Schema.Schema<A, I, never>, options?: AST.Parse
  * @category validation
  * @since 1.0.0
  */
-export const asserts = <A, I>(schema: Schema.Schema<A, I, never>, options?: AST.ParseOptions) => {
+export const asserts = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseOptions) => {
   const parser = goMemo(AST.to(schema.ast), true)
   return (u: unknown, overrideOptions?: AST.ParseOptions): asserts u is A => {
     const result: Either.Either<ParseResult.ParseIssue, any> = parser(u, {


### PR DESCRIPTION
…and encoding functions do not utilize context
