### PR TITLE
Improve Struct `pick` to support optional properties

### DIFF
--- a/.changeset/dirty-badgers-add.md
+++ b/.changeset/dirty-badgers-add.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve types of Struct `pick` to support optional properties

--- a/packages/effect/dtslint/Struct.ts
+++ b/packages/effect/dtslint/Struct.ts
@@ -87,7 +87,7 @@ pipe(stringStruct, S.pick("d"))
 // @ts-expect-error
 S.pick("d")(stringStruct)
 
-// $ExpectType { [x: string]: unknown; }
+// @ts-expect-error
 S.pick("d" as string)(stringStruct)
 
 // $ExpectType { a: string; b: number; }
@@ -102,7 +102,7 @@ pipe(symbolStruct, S.pick(dsym))
 // @ts-expect-error
 S.pick(dsym)(symbolStruct)
 
-// $ExpectType { [x: symbol]: unknown; }
+// @ts-expect-error
 S.pick(dsym as symbol)(symbolStruct)
 
 // $ExpectType { [asym]: string; [bsym]: number; }
@@ -120,7 +120,7 @@ pipe(numberStruct, S.pick(4))
 // @ts-expect-error
 S.pick(4)(numberStruct)
 
-// $ExpectType { [x: number]: unknown; }
+// @ts-expect-error
 S.pick(4 as number)(numberStruct)
 
 // $ExpectType { 1: number | undefined; 2: number | undefined; }

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -7,7 +7,7 @@
 import * as Equivalence from "./Equivalence.js"
 import { dual } from "./Function.js"
 import * as order from "./Order.js"
-import type { MatchRecord, Simplify } from "./Types.js"
+import type { MatchRecord, OptionalPropertyOf, RequiredPropertyOf, Simplify } from "./Types.js"
 
 /**
  * Create a new object by picking properties of an existing object.
@@ -20,15 +20,21 @@ import type { MatchRecord, Simplify } from "./Types.js"
  *
  * @since 2.0.0
  */
-export const pick = <Keys extends Array<PropertyKey>>(
-  ...keys: Keys
-) =>
-<S extends Record<Keys[number], any>>(
-  s: S
-): MatchRecord<S, { [K in Keys[number]]: S[K] | undefined }, { [K in Keys[number]]: S[K] }> => {
+export const pick = <Keys extends Array<PropertyKey>>(...keys: Keys) =>
+<S extends Partial<Record<Keys[number], any>>>(
+  s: Keys[number] extends keyof S ? S : never
+): MatchRecord<
+  S,
+  { [K in Keys[number]]: S[K] | undefined },
+  Simplify<
+    { [K in Keys[number] & OptionalPropertyOf<S>]?: S[K] } & { [K in Keys[number] & RequiredPropertyOf<S>]: S[K] }
+  >
+> => {
   const out: any = {}
   for (const k of keys) {
-    out[k] = (s as any)[k]
+    if (k in s) {
+      out[k] = (s as any)[k]
+    }
   }
   return out
 }

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -179,3 +179,25 @@ export type Contravariant<A> = (_: A) => void
  * @since 2.0.0
  */
 export type MatchRecord<S, onTrue, onFalse> = {} extends S ? onTrue : onFalse
+
+/**
+ * Extract optional property keys from a record
+ * @since 2.3.5
+ */
+export type OptionalPropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]> ? never : K
+  }[keyof T],
+  undefined
+>
+
+/**
+ * Extract required property keys from a record
+ * @since 2.3.5
+ */
+export type RequiredPropertyOf<T extends object> = Exclude<
+  {
+    [K in keyof T]: T extends Record<K, T[K]> ? K : never
+  }[keyof T],
+  undefined
+>

--- a/packages/effect/test/Struct.test.ts
+++ b/packages/effect/test/Struct.test.ts
@@ -11,8 +11,8 @@ describe("Struct", () => {
 
   it("pick", () => {
     expect(pipe({ a: "a", b: 1, c: true }, Struct.pick("a", "b"))).toEqual({ a: "a", b: 1 })
-    const record: Record<string, number> = {}
-    expect(pipe(record, Struct.pick("a", "b"))).toStrictEqual({ a: undefined, b: undefined })
+    const record: Record<string, number> = { a: 1 }
+    expect(pipe(record, Struct.pick("a", "b"))).toStrictEqual({ a: 1 })
   })
 
   it("omit", () => {


### PR DESCRIPTION
Makes `pick` behave more consistently. Allow picking optional properties and have them as optional in the result.

~~dtslint complains about this change, I'm not sure how to interpret the results however, happy to make any necessary changes~~