### PR TITLE
Schema: add `{ exact: true }` optional argument to the `partial` API,…

### DIFF
--- a/.changeset/fast-eels-buy.md
+++ b/.changeset/fast-eels-buy.md
@@ -1,0 +1,45 @@
+---
+"@effect/schema": patch
+---
+
+add `{ exact: true }` optional argument to the `partial` API, mirroring the implementation in the `optional` API, closes #2140
+
+The `partial` operation allows you to make all properties within a schema optional.
+
+By default, the `partial` operation adds a union with `undefined` to the types. If you wish to avoid this, you can opt-out by passing a `{ exact: true }` argument to the `partial` operation.
+
+**Example**
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+/*
+const schema: S.Schema<{
+    readonly a?: string | undefined;
+}, {
+    readonly a?: string | undefined;
+}, never>
+*/
+const schema = S.partial(S.struct({ a: S.string }));
+
+S.decodeUnknownSync(schema)({ a: "a" }); // ok
+S.decodeUnknownSync(schema)({ a: undefined }); // ok
+
+/*
+const exact: S.Schema<{
+    readonly a?: string;
+}, {
+    readonly a?: string;
+}, never>
+*/
+const exactSchema = S.partial(S.struct({ a: S.string }), { exact: true });
+
+S.decodeUnknownSync(exactSchema)({ a: "a" }); // ok
+S.decodeUnknownSync(exactSchema)({ a: undefined });
+/*
+throws:
+Error: { a?: string }
+└─ ["a"]
+   └─ Expected a string, actual undefined
+*/
+```

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -2082,11 +2082,42 @@ S.struct({ a: S.string, b: S.number, c: S.boolean }).pipe(S.omit("a", "c"));
 
 The `partial` operation makes all properties within a schema optional.
 
+By default, the `partial` operation adds a union with `undefined` to the types. If you wish to avoid this, you can opt-out by passing a `{ exact: true }` argument to the `partial` operation.
+
+**Example**
+
 ```ts
 import * as S from "@effect/schema/Schema";
 
-// Schema<{ readonly a?: string; readonly b?: number; }>
-S.partial(S.struct({ a: S.string, b: S.number }));
+/*
+const schema: S.Schema<{
+    readonly a?: string | undefined;
+}, {
+    readonly a?: string | undefined;
+}, never>
+*/
+const schema = S.partial(S.struct({ a: S.string }));
+
+S.decodeUnknownSync(schema)({ a: "a" }); // ok
+S.decodeUnknownSync(schema)({ a: undefined }); // ok
+
+/*
+const exact: S.Schema<{
+    readonly a?: string;
+}, {
+    readonly a?: string;
+}, never>
+*/
+const exactSchema = S.partial(S.struct({ a: S.string }), { exact: true });
+
+S.decodeUnknownSync(exactSchema)({ a: "a" }); // ok
+S.decodeUnknownSync(exactSchema)({ a: undefined });
+/*
+throws:
+Error: { a?: string }
+└─ ["a"]
+   └─ Expected a string, actual undefined
+*/
 ```
 
 ## Required

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -190,14 +190,14 @@ aContext.pipe(Schema.brand("a"))
 // ---------------------------------------------
 
 // $ExpectType Schema<{ readonly a?: string; readonly b?: number; }, { readonly a?: string; readonly b?: number; }, "a" | "b">
-Schema.partial(Schema.struct({ a: aContext, b: bContext }))
+Schema.partial(Schema.struct({ a: aContext, b: bContext }), { exact: true })
 
 // ---------------------------------------------
 // required
 // ---------------------------------------------
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly a: string; readonly b: number; }, "a" | "b">
-Schema.required(Schema.partial(Schema.struct({ a: aContext, b: bContext })))
+Schema.required(Schema.partial(Schema.struct({ a: aContext, b: bContext }), { exact: true }))
 
 // ---------------------------------------------
 // mutable

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -433,9 +433,15 @@ pipe(S.NumberFromString, S.int(), S.brand("Int"))
 // ---------------------------------------------
 
 // $ExpectType Schema<{ readonly a?: string; readonly b?: number; }, { readonly a?: string; readonly b?: number; }, never>
-S.partial(S.struct({ a: S.string, b: S.number }))
+S.partial(S.struct({ a: S.string, b: S.number }), { exact: true })
 
 // $ExpectType Schema<{ readonly a?: string; readonly b?: number; }, { readonly a?: string; readonly b?: string; }, never>
+S.partial(S.struct({ a: S.string, b: S.NumberFromString }), { exact: true })
+
+// $ExpectType Schema<{ readonly a?: string | undefined; readonly b?: number | undefined; }, { readonly a?: string | undefined; readonly b?: number | undefined; }, never>
+S.partial(S.struct({ a: S.string, b: S.number }))
+
+// $ExpectType Schema<{ readonly a?: string | undefined; readonly b?: number | undefined; }, { readonly a?: string | undefined; readonly b?: string | undefined; }, never>
 S.partial(S.struct({ a: S.string, b: S.NumberFromString }))
 
 // ---------------------------------------------

--- a/packages/schema/test/AST/partial.test.ts
+++ b/packages/schema/test/AST/partial.test.ts
@@ -1,54 +1,128 @@
 import * as AST from "@effect/schema/AST"
+import * as S from "@effect/schema/Schema"
 import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
-describe("AST/partial", () => {
-  it("tuple/ e", () => {
-    // type A = [string]
-    // type B = Partial<A>
-    const tuple = AST.createTuple(
-      [AST.createElement(AST.stringKeyword, false)],
-      Option.none(),
-      true
-    )
-    expect(AST.partial(tuple)).toEqual(
-      AST.createTuple([AST.createElement(AST.stringKeyword, true)], Option.none(), true)
-    )
+describe("AST > partial", () => {
+  describe("{ exact: false }", () => {
+    it("struct", () => {
+      // type A = { readonly a: string }
+      // type B = Partial<A>
+      const schema = S.partial(S.struct({ a: S.string }))
+      const expected = S.struct({ a: S.optional(S.string) })
+      expect(schema.ast).toStrictEqual(expected.ast)
+    })
+
+    describe("tuple", () => {
+      it("e", () => {
+        // type A = [string]
+        // type B = Partial<A>
+        const tuple = AST.createTuple(
+          [AST.createElement(AST.stringKeyword, false)],
+          Option.none(),
+          true
+        )
+        expect(AST.partial(tuple)).toEqual(
+          AST.createTuple([AST.createElement(AST.orUndefined(AST.stringKeyword), true)], Option.none(), true)
+        )
+      })
+
+      it("e + r", () => {
+        // type A = readonly [string, ...Array<number>]
+        // type B = Partial<A>
+        const tuple = AST.createTuple(
+          [AST.createElement(AST.stringKeyword, false)],
+          Option.some([AST.numberKeyword]),
+          true
+        )
+        expect(AST.partial(tuple)).toEqual(
+          AST.createTuple(
+            [AST.createElement(AST.orUndefined(AST.stringKeyword), true)],
+            Option.some([AST.orUndefined(AST.numberKeyword)]),
+            true
+          )
+        )
+      })
+
+      it("e + r + e", () => {
+        // type A = readonly [string, ...Array<number>, boolean]
+        // type B = Partial<A>
+        const tuple = AST.createTuple(
+          [AST.createElement(AST.stringKeyword, false)],
+          Option.some([AST.numberKeyword, AST.booleanKeyword]),
+          true
+        )
+        expect(AST.partial(tuple)).toEqual(
+          AST.createTuple(
+            [AST.createElement(AST.orUndefined(AST.stringKeyword), true)],
+            Option.some([
+              AST.createUnion([AST.numberKeyword, AST.booleanKeyword, AST.undefinedKeyword])
+            ]),
+            true
+          )
+        )
+      })
+    })
   })
 
-  it("tuple/ e + r", () => {
-    // type A = readonly [string, ...Array<number>]
-    // type B = Partial<A>
-    const tuple = AST.createTuple(
-      [AST.createElement(AST.stringKeyword, false)],
-      Option.some([AST.numberKeyword]),
-      true
-    )
-    expect(AST.partial(tuple)).toEqual(
-      AST.createTuple(
-        [AST.createElement(AST.stringKeyword, true)],
-        Option.some([AST.createUnion([AST.numberKeyword, AST.undefinedKeyword])]),
-        true
-      )
-    )
-  })
+  describe("{ exact: true }", () => {
+    it("struct", () => {
+      // type A = { readonly a: string }
+      // type B = Partial<A>
+      const schema = S.partial(S.struct({ a: S.string }), { exact: true })
+      const expected = S.struct({ a: S.optional(S.string, { exact: true }) })
+      expect(schema.ast).toStrictEqual(expected.ast)
+    })
 
-  it("tuple/ e + r + e", () => {
-    // type A = readonly [string, ...Array<number>, boolean]
-    // type B = Partial<A>
-    const tuple = AST.createTuple(
-      [AST.createElement(AST.stringKeyword, false)],
-      Option.some([AST.numberKeyword, AST.booleanKeyword]),
-      true
-    )
-    expect(AST.partial(tuple)).toEqual(
-      AST.createTuple(
-        [AST.createElement(AST.stringKeyword, true)],
-        Option.some([
-          AST.createUnion([AST.numberKeyword, AST.booleanKeyword, AST.undefinedKeyword])
-        ]),
-        true
-      )
-    )
+    describe("tuple", () => {
+      it("e", () => {
+        // type A = [string]
+        // type B = Partial<A>
+        const tuple = AST.createTuple(
+          [AST.createElement(AST.stringKeyword, false)],
+          Option.none(),
+          true
+        )
+        expect(AST.partial(tuple, { exact: true })).toEqual(
+          AST.createTuple([AST.createElement(AST.stringKeyword, true)], Option.none(), true)
+        )
+      })
+
+      it("e + r", () => {
+        // type A = readonly [string, ...Array<number>]
+        // type B = Partial<A>
+        const tuple = AST.createTuple(
+          [AST.createElement(AST.stringKeyword, false)],
+          Option.some([AST.numberKeyword]),
+          true
+        )
+        expect(AST.partial(tuple, { exact: true })).toEqual(
+          AST.createTuple(
+            [AST.createElement(AST.stringKeyword, true)],
+            Option.some([AST.orUndefined(AST.numberKeyword)]),
+            true
+          )
+        )
+      })
+
+      it("e + r + e", () => {
+        // type A = readonly [string, ...Array<number>, boolean]
+        // type B = Partial<A>
+        const tuple = AST.createTuple(
+          [AST.createElement(AST.stringKeyword, false)],
+          Option.some([AST.numberKeyword, AST.booleanKeyword]),
+          true
+        )
+        expect(AST.partial(tuple, { exact: true })).toEqual(
+          AST.createTuple(
+            [AST.createElement(AST.stringKeyword, true)],
+            Option.some([
+              AST.createUnion([AST.numberKeyword, AST.booleanKeyword, AST.undefinedKeyword])
+            ]),
+            true
+          )
+        )
+      })
+    })
   })
 })

--- a/packages/schema/test/Option/optionFromOrUndefined.test.ts
+++ b/packages/schema/test/Option/optionFromOrUndefined.test.ts
@@ -19,28 +19,28 @@ describe("Option > optionFromOrUndefined", () => {
     await Util.expectDecodeUnknownFailure(
       schema,
       null,
-      `(undefined | NumberFromString <-> Option<number>)
+      `(NumberFromString | undefined <-> Option<number>)
 └─ From side transformation failure
-   └─ undefined | NumberFromString
+   └─ NumberFromString | undefined
       ├─ Union member
-      │  └─ Expected undefined, actual null
+      │  └─ NumberFromString
+      │     └─ From side transformation failure
+      │        └─ Expected a string, actual null
       └─ Union member
-         └─ NumberFromString
-            └─ From side transformation failure
-               └─ Expected a string, actual null`
+         └─ Expected undefined, actual null`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       {},
-      `(undefined | NumberFromString <-> Option<number>)
+      `(NumberFromString | undefined <-> Option<number>)
 └─ From side transformation failure
-   └─ undefined | NumberFromString
+   └─ NumberFromString | undefined
       ├─ Union member
-      │  └─ Expected undefined, actual {}
+      │  └─ NumberFromString
+      │     └─ From side transformation failure
+      │        └─ Expected a string, actual {}
       └─ Union member
-         └─ NumberFromString
-            └─ From side transformation failure
-               └─ Expected a string, actual {}`
+         └─ Expected undefined, actual {}`
     )
   })
 

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -62,15 +62,15 @@ describe("optional APIs", () => {
       await Util.expectDecodeUnknownFailure(
         schema,
         { a: "a" },
-        `{ a?: undefined | NumberFromString }
+        `{ a?: NumberFromString | undefined }
 └─ ["a"]
-   └─ undefined | NumberFromString
+   └─ NumberFromString | undefined
       ├─ Union member
-      │  └─ Expected undefined, actual "a"
+      │  └─ NumberFromString
+      │     └─ Transformation process failure
+      │        └─ Expected NumberFromString, actual "a"
       └─ Union member
-         └─ NumberFromString
-            └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+         └─ Expected undefined, actual "a"`
       )
 
       await Util.expectEncodeSuccess(schema, {}, {})
@@ -147,17 +147,17 @@ describe("optional APIs", () => {
         {
           a: "a"
         },
-        `({ a?: undefined | NumberFromString } <-> { a: Option<number> })
+        `({ a?: NumberFromString | undefined } <-> { a: Option<number> })
 └─ From side transformation failure
-   └─ { a?: undefined | NumberFromString }
+   └─ { a?: NumberFromString | undefined }
       └─ ["a"]
-         └─ undefined | NumberFromString
+         └─ NumberFromString | undefined
             ├─ Union member
-            │  └─ Expected undefined, actual "a"
+            │  └─ NumberFromString
+            │     └─ Transformation process failure
+            │        └─ Expected NumberFromString, actual "a"
             └─ Union member
-               └─ NumberFromString
-                  └─ Transformation process failure
-                     └─ Expected NumberFromString, actual "a"`
+               └─ Expected undefined, actual "a"`
       )
 
       await Util.expectEncodeSuccess(schema, { a: O.some(1) }, { a: "1" })
@@ -234,17 +234,17 @@ describe("optional APIs", () => {
       await Util.expectDecodeUnknownFailure(
         schema,
         { a: "a" },
-        `({ a?: undefined | NumberFromString } <-> { a: number })
+        `({ a?: NumberFromString | undefined } <-> { a: number })
 └─ From side transformation failure
-   └─ { a?: undefined | NumberFromString }
+   └─ { a?: NumberFromString | undefined }
       └─ ["a"]
-         └─ undefined | NumberFromString
+         └─ NumberFromString | undefined
             ├─ Union member
-            │  └─ Expected undefined, actual "a"
+            │  └─ NumberFromString
+            │     └─ Transformation process failure
+            │        └─ Expected NumberFromString, actual "a"
             └─ Union member
-               └─ NumberFromString
-                  └─ Transformation process failure
-                     └─ Expected NumberFromString, actual "a"`
+               └─ Expected undefined, actual "a"`
       )
 
       await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })

--- a/packages/schema/test/Schema/partial.test.ts
+++ b/packages/schema/test/Schema/partial.test.ts
@@ -3,60 +3,160 @@ import * as Util from "@effect/schema/test/util"
 import { identity } from "effect/Function"
 import { describe, expect, it } from "vitest"
 
-const NumberFromString = S.NumberFromString
-
 describe("Schema > partial", () => {
-  it("struct", async () => {
-    const schema = S.partial(S.struct({ a: S.number }))
-    await Util.expectDecodeUnknownSuccess(schema, {})
-    await Util.expectDecodeUnknownSuccess(schema, { a: 1 })
+  describe("{ exact: false }", () => {
+    it("struct", async () => {
+      const schema = S.partial(S.struct({ a: S.number }))
+      await Util.expectDecodeUnknownSuccess(schema, {})
+      await Util.expectDecodeUnknownSuccess(schema, { a: 1 })
+      await Util.expectDecodeUnknownSuccess(schema, { a: undefined })
 
-    await Util.expectDecodeUnknownFailure(
-      schema,
-      { a: undefined },
-      `{ a?: number }
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        { a: null },
+        `{ a?: number | undefined }
 └─ ["a"]
-   └─ Expected a number, actual undefined`
-    )
-  })
+   └─ number | undefined
+      ├─ Union member
+      │  └─ Expected a number, actual null
+      └─ Union member
+         └─ Expected undefined, actual null`
+      )
+    })
 
-  it("tuple", async () => {
-    const schema = S.partial(S.tuple(S.string, S.number))
-    await Util.expectDecodeUnknownSuccess(schema, [])
-    await Util.expectDecodeUnknownSuccess(schema, ["a"])
-    await Util.expectDecodeUnknownSuccess(schema, ["a", 1])
-  })
+    it("record", async () => {
+      const schema = S.partial(S.record(S.string, S.NumberFromString))
+      await Util.expectDecodeUnknownSuccess(schema, {}, {})
+      await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: 1 })
+      await Util.expectDecodeUnknownSuccess(schema, { a: undefined })
+    })
 
-  it("array", async () => {
-    const schema = S.partial(S.array(S.number))
-    await Util.expectDecodeUnknownSuccess(schema, [])
-    await Util.expectDecodeUnknownSuccess(schema, [1])
-    await Util.expectDecodeUnknownSuccess(schema, [undefined])
+    describe("tuple", () => {
+      it("e", async () => {
+        const schema = S.partial(S.tuple(S.NumberFromString))
+        await Util.expectDecodeUnknownSuccess(schema, ["1"], [1])
+        await Util.expectDecodeUnknownSuccess(schema, [], [])
+        await Util.expectDecodeUnknownSuccess(schema, [undefined])
+      })
 
-    await Util.expectDecodeUnknownFailure(
-      schema,
-      ["a"],
-      `ReadonlyArray<number | undefined>
+      it("e r", async () => {
+        const schema = S.partial(S.tuple(S.NumberFromString).pipe(S.rest(S.NumberFromString)))
+        await Util.expectDecodeUnknownSuccess(schema, ["1"], [1])
+        await Util.expectDecodeUnknownSuccess(schema, [], [])
+        await Util.expectDecodeUnknownSuccess(schema, ["1", "2"], [1, 2])
+        await Util.expectDecodeUnknownSuccess(schema, ["1", undefined], [1, undefined])
+        await Util.expectDecodeUnknownSuccess(schema, [undefined])
+      })
+    })
+
+    it("array", async () => {
+      const schema = S.partial(S.array(S.number))
+      await Util.expectDecodeUnknownSuccess(schema, [])
+      await Util.expectDecodeUnknownSuccess(schema, [1])
+      await Util.expectDecodeUnknownSuccess(schema, [undefined])
+
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        ["a"],
+        `ReadonlyArray<number | undefined>
 └─ [0]
    └─ number | undefined
       ├─ Union member
       │  └─ Expected a number, actual "a"
       └─ Union member
          └─ Expected undefined, actual "a"`
-    )
+      )
+    })
   })
 
-  it("union", async () => {
-    const schema = S.partial(S.union(S.string, S.array(S.number)))
-    await Util.expectDecodeUnknownSuccess(schema, "a")
-    await Util.expectDecodeUnknownSuccess(schema, [])
-    await Util.expectDecodeUnknownSuccess(schema, [1])
-    await Util.expectDecodeUnknownSuccess(schema, [undefined])
+  describe("{ exact: true }", () => {
+    it("struct", async () => {
+      const schema = S.partial(S.struct({ a: S.number }), { exact: true })
+      await Util.expectDecodeUnknownSuccess(schema, {})
+      await Util.expectDecodeUnknownSuccess(schema, { a: 1 })
 
-    await Util.expectDecodeUnknownFailure(
-      schema,
-      ["a"],
-      `ReadonlyArray<number | undefined> | string
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        { a: undefined },
+        `{ a?: number }
+└─ ["a"]
+   └─ Expected a number, actual undefined`
+      )
+    })
+
+    it("record", async () => {
+      const schema = S.partial(S.record(S.string, S.NumberFromString), { exact: true })
+      await Util.expectDecodeUnknownSuccess(schema, {}, {})
+      await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: 1 })
+      await Util.expectDecodeUnknownSuccess(schema, { a: undefined })
+    })
+
+    describe("tuple", () => {
+      it("e", async () => {
+        const schema = S.partial(S.tuple(S.NumberFromString), { exact: true })
+        await Util.expectDecodeUnknownSuccess(schema, ["1"], [1])
+        await Util.expectDecodeUnknownSuccess(schema, [], [])
+
+        await Util.expectDecodeUnknownFailure(
+          schema,
+          [undefined],
+          `readonly [NumberFromString?]
+└─ [0]
+   └─ NumberFromString
+      └─ From side transformation failure
+         └─ Expected a string, actual undefined`
+        )
+      })
+
+      it("e + r", async () => {
+        const schema = S.partial(S.tuple(S.NumberFromString).pipe(S.rest(S.NumberFromString)), { exact: true })
+        await Util.expectDecodeUnknownSuccess(schema, ["1"], [1])
+        await Util.expectDecodeUnknownSuccess(schema, [], [])
+        await Util.expectDecodeUnknownSuccess(schema, ["1", "2"], [1, 2])
+        await Util.expectDecodeUnknownSuccess(schema, ["1", undefined], [1, undefined])
+
+        await Util.expectDecodeUnknownFailure(
+          schema,
+          [undefined],
+          `readonly [NumberFromString?, ...(NumberFromString | undefined)[]]
+└─ [0]
+   └─ NumberFromString
+      └─ From side transformation failure
+         └─ Expected a string, actual undefined`
+        )
+      })
+    })
+
+    it("array", async () => {
+      const schema = S.partial(S.array(S.number), { exact: true })
+      await Util.expectDecodeUnknownSuccess(schema, [])
+      await Util.expectDecodeUnknownSuccess(schema, [1])
+      await Util.expectDecodeUnknownSuccess(schema, [undefined])
+
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        ["a"],
+        `ReadonlyArray<number | undefined>
+└─ [0]
+   └─ number | undefined
+      ├─ Union member
+      │  └─ Expected a number, actual "a"
+      └─ Union member
+         └─ Expected undefined, actual "a"`
+      )
+    })
+
+    it("union", async () => {
+      const schema = S.partial(S.union(S.string, S.array(S.number)), { exact: true })
+      await Util.expectDecodeUnknownSuccess(schema, "a")
+      await Util.expectDecodeUnknownSuccess(schema, [])
+      await Util.expectDecodeUnknownSuccess(schema, [1])
+      await Util.expectDecodeUnknownSuccess(schema, [undefined])
+
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        ["a"],
+        `ReadonlyArray<number | undefined> | string
 ├─ Union member
 │  └─ ReadonlyArray<number | undefined>
 │     └─ [0]
@@ -67,71 +167,55 @@ describe("Schema > partial", () => {
 │              └─ Expected undefined, actual "a"
 └─ Union member
    └─ Expected a string, actual ["a"]`
-    )
-  })
+      )
+    })
 
-  it("tuple/ e", async () => {
-    const schema = S.partial(S.tuple(NumberFromString))
-    await Util.expectDecodeUnknownSuccess(schema, ["1"], [1])
-    await Util.expectDecodeUnknownSuccess(schema, [], [])
-  })
-
-  it("tuple/ e r", async () => {
-    const schema = S.partial(S.tuple(NumberFromString).pipe(S.rest(NumberFromString)))
-    await Util.expectDecodeUnknownSuccess(schema, ["1"], [1])
-    await Util.expectDecodeUnknownSuccess(schema, [], [])
-    await Util.expectDecodeUnknownSuccess(schema, ["1", "2"], [1, 2])
-    await Util.expectDecodeUnknownSuccess(schema, ["1", undefined], [1, undefined])
-  })
-
-  it("record", async () => {
-    const schema = S.partial(S.record(S.string, NumberFromString))
-    await Util.expectDecodeUnknownSuccess(schema, {}, {})
-    await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: 1 })
-  })
-
-  it("suspend", async () => {
-    interface A {
-      readonly a?: null | A
-    }
-    const schema: S.Schema<A> = S.partial(S.suspend( // intended outer suspend
-      () =>
-        S.struct({
-          a: S.union(S.null, schema)
-        })
-    ))
-    await Util.expectDecodeUnknownSuccess(schema, {})
-    await Util.expectDecodeUnknownSuccess(schema, { a: null })
-    await Util.expectDecodeUnknownSuccess(schema, { a: {} })
-    await Util.expectDecodeUnknownSuccess(schema, { a: { a: null } })
-    await Util.expectDecodeUnknownFailure(
-      schema,
-      { a: 1 },
-      `{ a?: <suspended schema> | null }
+    it("suspend", async () => {
+      interface A {
+        readonly a?: null | A
+      }
+      const schema: S.Schema<A> = S.partial(
+        S.suspend( // intended outer suspend
+          () =>
+            S.struct({
+              a: S.union(S.null, schema)
+            })
+        ),
+        { exact: true }
+      )
+      await Util.expectDecodeUnknownSuccess(schema, {})
+      await Util.expectDecodeUnknownSuccess(schema, { a: null })
+      await Util.expectDecodeUnknownSuccess(schema, { a: {} })
+      await Util.expectDecodeUnknownSuccess(schema, { a: { a: null } })
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        { a: 1 },
+        `{ a?: <suspended schema> | null }
 └─ ["a"]
    └─ <suspended schema> | null
       ├─ Union member
       │  └─ Expected { a?: <suspended schema> | null }, actual 1
       └─ Union member
          └─ Expected null, actual 1`
-    )
-  })
+      )
+    })
 
-  it("declarations should throw", async () => {
-    expect(() => S.partial(S.optionFromSelf(S.string))).toThrow(
-      new Error("`partial` cannot handle declarations")
-    )
-  })
+    it("declarations should throw", async () => {
+      expect(() => S.partial(S.optionFromSelf(S.string), { exact: true })).toThrow(
+        new Error("`partial` cannot handle declarations")
+      )
+    })
 
-  it("refinements should throw", async () => {
-    expect(() => S.partial(S.string.pipe(S.minLength(2)))).toThrow(
-      new Error("`partial` cannot handle refinements")
-    )
-  })
+    it("refinements should throw", async () => {
+      expect(() => S.partial(S.string.pipe(S.minLength(2)), { exact: true })).toThrow(
+        new Error("`partial` cannot handle refinements")
+      )
+    })
 
-  it("transformations should throw", async () => {
-    expect(() => S.partial(S.transform(S.string, S.string, identity, identity))).toThrow(
-      new Error("`partial` cannot handle transformations")
-    )
+    it("transformations should throw", async () => {
+      expect(() => S.partial(S.transform(S.string, S.string, identity, identity), { exact: true })).toThrow(
+        new Error("`partial` cannot handle transformations")
+      )
+    })
   })
 })


### PR DESCRIPTION
… mirroring the implementation in the `optional` API, closes #2140

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `partial` operation makes all properties within a schema optional.

By default, the `partial` operation adds a union with `undefined` to the types. If you wish to avoid this, you can opt-out by passing a `{ exact: true }` argument to the `partial` operation.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2140
