### PR TITLE
ReadonlyRecord: re-add `symbol` as valid key to some APIs

### DIFF
--- a/packages/effect/dtslint/ReadonlyRecord.ts
+++ b/packages/effect/dtslint/ReadonlyRecord.ts
@@ -5,15 +5,17 @@ import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as ReadonlyRecord from "effect/ReadonlyRecord"
 
-declare const numbers: Record<string, number>
-declare const numbersOrStrings: Record<string, number | string>
-declare const structAB: Record<"a" | "b", number>
-declare const structCD: Record<"c" | "d", string>
+declare const string$numbers: Record<string, number>
+declare const string$numbersOrStrings: Record<string, number | string>
+declare const string$structAB: Record<"a" | "b", number>
+declare const string$structCD: Record<"c" | "d", string>
 
 declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
 
 const symA = Symbol.for("a")
 const symB = Symbol.for("b")
+
+declare const symbol$numbers: Record<symbol, number>
 
 // -------------------------------------------------------------------------------------
 // NonLiteralKey
@@ -62,15 +64,18 @@ hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`a${number}b${string}c${number}
 // map
 // -------------------------------------------------------------------------------------
 
+// $ExpectType Record<string, number>
+ReadonlyRecord.map(symbol$numbers, (n) => n + 1)
+
 // $ExpectType Record<string, boolean>
-ReadonlyRecord.map(numbers, (
+ReadonlyRecord.map(string$numbers, (
   value, // $ExpectType number
   _key // $ExpectType string
 ) => value > 0)
 
 // $ExpectType Record<string, boolean>
 pipe(
-  numbers,
+  string$numbers,
   ReadonlyRecord.map((
     value, // $ExpectType number
     _key // $ExpectType string
@@ -78,14 +83,14 @@ pipe(
 )
 
 // $ExpectType Record<"a" | "b", boolean>
-ReadonlyRecord.map(structAB, (
+ReadonlyRecord.map(string$structAB, (
   value, // $ExpectType number
   _key // $ExpectType "a" | "b"
 ) => value > 0)
 
 // $ExpectType Record<"a" | "b", boolean>
 pipe(
-  structAB,
+  string$structAB,
   ReadonlyRecord.map((
     value, // $ExpectType number
     _key // $ExpectType "a" | "b"
@@ -106,37 +111,37 @@ mapToBoolean()
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Option<number>
-pipe(numbers, ReadonlyRecord.get("a"))
+pipe(string$numbers, ReadonlyRecord.get("a"))
 
 // -------------------------------------------------------------------------------------
 // replaceOption
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Option<Record<string, number>>
-pipe(numbers, ReadonlyRecord.replaceOption("a", 2))
+pipe(string$numbers, ReadonlyRecord.replaceOption("a", 2))
 
 // $ExpectType Option<Record<string, number | boolean>>
-pipe(numbers, ReadonlyRecord.replaceOption("a", true))
+pipe(string$numbers, ReadonlyRecord.replaceOption("a", true))
 
 // -------------------------------------------------------------------------------------
 // modify
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number>
-pipe(numbers, ReadonlyRecord.modify("a", () => 2))
+pipe(string$numbers, ReadonlyRecord.modify("a", () => 2))
 
 // $ExpectType Record<string, number | boolean>
-pipe(numbers, ReadonlyRecord.modify("a", () => true))
+pipe(string$numbers, ReadonlyRecord.modify("a", () => true))
 
 // -------------------------------------------------------------------------------------
 // modifyOption
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Option<Record<string, number>>
-pipe(numbers, ReadonlyRecord.modifyOption("a", () => 2))
+pipe(string$numbers, ReadonlyRecord.modifyOption("a", () => 2))
 
 // $ExpectType Option<Record<string, number | boolean>>
-pipe(numbers, ReadonlyRecord.modifyOption("a", () => true))
+pipe(string$numbers, ReadonlyRecord.modifyOption("a", () => true))
 
 // -------------------------------------------------------------------------------------
 // toEntries
@@ -144,9 +149,9 @@ pipe(numbers, ReadonlyRecord.modifyOption("a", () => true))
 
 // baseline
 // $ExpectType [string, number][]
-ReadonlyRecord.toEntries(numbers)
+ReadonlyRecord.toEntries(string$numbers)
 // $ExpectType ["a" | "b", number][]
-ReadonlyRecord.toEntries(structAB)
+ReadonlyRecord.toEntries(string$structAB)
 // $ExpectType ["a" | "b" | "c", string | number | boolean][]
 ReadonlyRecord.toEntries({ a: "a", b: 2, c: true })
 
@@ -167,11 +172,11 @@ ReadonlyRecord.collect({ a: Either.right(1), b: Either.right(2), c: Either.right
 pipe({ a: Either.right(1), b: Either.right(2), c: Either.right(3) }, ReadonlyRecord.collect((_, n) => n))
 
 // $ExpectType number[]
-ReadonlyRecord.collect(numbers, (_, a) => a)
+ReadonlyRecord.collect(string$numbers, (_, a) => a)
 
 // $ExpectType number[]
 pipe(
-  structAB,
+  string$structAB,
   ReadonlyRecord.collect((
     _key, // $ExpectType "a" | "b"
     value
@@ -179,7 +184,7 @@ pipe(
 )
 
 // $ExpectType number[]
-ReadonlyRecord.collect(structAB, (
+ReadonlyRecord.collect(string$structAB, (
   _key, // $ExpectType "a" | "b"
   value
 ) => value)
@@ -189,7 +194,7 @@ ReadonlyRecord.collect(structAB, (
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, string>
-ReadonlyRecord.filterMap(numbers, (
+ReadonlyRecord.filterMap(string$numbers, (
   value,
   // $ExpectType string
   _key
@@ -197,7 +202,7 @@ ReadonlyRecord.filterMap(numbers, (
 
 // $ExpectType Record<string, number>
 pipe(
-  structAB,
+  string$structAB,
   ReadonlyRecord.filterMap((
     value,
     // $ExpectType "a" | "b"
@@ -206,7 +211,7 @@ pipe(
 )
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filterMap(structAB, (
+ReadonlyRecord.filterMap(string$structAB, (
   value,
   // $ExpectType "a" | "b"
   key
@@ -217,7 +222,7 @@ ReadonlyRecord.filterMap(structAB, (
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filter(numbers, (
+ReadonlyRecord.filter(string$numbers, (
   // $ExpectType number
   value,
   // $ExpectType string
@@ -226,7 +231,7 @@ ReadonlyRecord.filter(numbers, (
 
 // $ExpectType Record<string, number>
 pipe(
-  structAB,
+  string$structAB,
   ReadonlyRecord.filter((
     // $ExpectType number
     _value,
@@ -236,7 +241,7 @@ pipe(
 )
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filter(structAB, (
+ReadonlyRecord.filter(string$structAB, (
   // $ExpectType number
   _value,
   // $ExpectType "a" | "b"
@@ -244,29 +249,29 @@ ReadonlyRecord.filter(structAB, (
 ) => key === "a")
 
 // $ExpectType Record<string, string | number>
-ReadonlyRecord.filter(numbersOrStrings, predicateNumbersOrStrings)
+ReadonlyRecord.filter(string$numbersOrStrings, predicateNumbersOrStrings)
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filter(numbers, predicateNumbersOrStrings)
+ReadonlyRecord.filter(string$numbers, predicateNumbersOrStrings)
 
 // $ExpectType Record<string, string | number>
-pipe(numbersOrStrings, ReadonlyRecord.filter(predicateNumbersOrStrings))
+pipe(string$numbersOrStrings, ReadonlyRecord.filter(predicateNumbersOrStrings))
 
 // $ExpectType Record<string, number>
-pipe(numbers, ReadonlyRecord.filter(predicateNumbersOrStrings))
+pipe(string$numbers, ReadonlyRecord.filter(predicateNumbersOrStrings))
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filter(numbersOrStrings, Predicate.isNumber)
+ReadonlyRecord.filter(string$numbersOrStrings, Predicate.isNumber)
 
 // $ExpectType Record<string, number>
-pipe(numbersOrStrings, ReadonlyRecord.filter(Predicate.isNumber))
+pipe(string$numbersOrStrings, ReadonlyRecord.filter(Predicate.isNumber))
 
 // -------------------------------------------------------------------------------------
 // partitionMap
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [left: Record<string, boolean>, right: Record<string, string>]
-ReadonlyRecord.partitionMap(numbers, (
+ReadonlyRecord.partitionMap(string$numbers, (
   value,
   // $ExpectType string
   _key
@@ -274,7 +279,7 @@ ReadonlyRecord.partitionMap(numbers, (
 
 // $ExpectType [left: Record<string, boolean>, right: Record<string, string>]
 pipe(
-  structAB,
+  string$structAB,
   ReadonlyRecord.partitionMap((
     _value,
     // $ExpectType "a" | "b"
@@ -283,7 +288,7 @@ pipe(
 )
 
 // $ExpectType [left: Record<string, boolean>, right: Record<string, string>]
-ReadonlyRecord.partitionMap(structAB, (
+ReadonlyRecord.partitionMap(string$structAB, (
   _value,
   // $ExpectType "a" | "b"
   key
@@ -294,7 +299,7 @@ ReadonlyRecord.partitionMap(structAB, (
 // -------------------------------------------------------------------------------------
 
 // $ExpectType [excluded: Record<string, number>, satisfying: Record<string, number>]
-ReadonlyRecord.partition(numbers, (
+ReadonlyRecord.partition(string$numbers, (
   // $ExpectType number
   value,
   // $ExpectType string
@@ -303,7 +308,7 @@ ReadonlyRecord.partition(numbers, (
 
 // $ExpectType [excluded: Record<string, number>, satisfying: Record<string, number>]
 pipe(
-  structAB,
+  string$structAB,
   ReadonlyRecord.partition((
     // $ExpectType number
     _value,
@@ -313,7 +318,7 @@ pipe(
 )
 
 // $ExpectType [excluded: Record<string, number>, satisfying: Record<string, number>]
-ReadonlyRecord.partition(structAB, (
+ReadonlyRecord.partition(string$structAB, (
   // $ExpectType number
   _value,
   // $ExpectType "a" | "b"
@@ -321,62 +326,62 @@ ReadonlyRecord.partition(structAB, (
 ) => key === "a")
 
 // $ExpectType [excluded: Record<string, string | number>, satisfying: Record<string, string | number>]
-ReadonlyRecord.partition(numbersOrStrings, predicateNumbersOrStrings)
+ReadonlyRecord.partition(string$numbersOrStrings, predicateNumbersOrStrings)
 
 // $ExpectType [excluded: Record<string, string | number>, satisfying: Record<string, string | number>]
-pipe(numbersOrStrings, ReadonlyRecord.partition(predicateNumbersOrStrings))
+pipe(string$numbersOrStrings, ReadonlyRecord.partition(predicateNumbersOrStrings))
 
 // $ExpectType [excluded: Record<string, string>, satisfying: Record<string, number>]
-ReadonlyRecord.partition(numbersOrStrings, Predicate.isNumber)
+ReadonlyRecord.partition(string$numbersOrStrings, Predicate.isNumber)
 
 // $ExpectType [excluded: Record<string, string>, satisfying: Record<string, number>]
-pipe(numbersOrStrings, ReadonlyRecord.partition(Predicate.isNumber))
+pipe(string$numbersOrStrings, ReadonlyRecord.partition(Predicate.isNumber))
 
 // -------------------------------------------------------------------------------------
 // keys
 // -------------------------------------------------------------------------------------
 
 // $ExpectType ("a" | "b")[]
-ReadonlyRecord.keys(structAB)
+ReadonlyRecord.keys(string$structAB)
 
 // -------------------------------------------------------------------------------------
 // values
 // -------------------------------------------------------------------------------------
 
 // $ExpectType number[]
-ReadonlyRecord.values(structAB)
+ReadonlyRecord.values(string$structAB)
 
 // -------------------------------------------------------------------------------------
 // set
 // -------------------------------------------------------------------------------------
 // $ExpectType Record<string, number | boolean>
-ReadonlyRecord.set(numbers, "a", true)
+ReadonlyRecord.set(string$numbers, "a", true)
 
 // -------------------------------------------------------------------------------------
 // set
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number | boolean>
-ReadonlyRecord.set(numbers, "a", true)
+ReadonlyRecord.set(string$numbers, "a", true)
 
 // $ExpectType Record<"a" | "b" | "c", number | boolean>
-ReadonlyRecord.set(structAB, "c", true)
+ReadonlyRecord.set(string$structAB, "c", true)
 
 // -------------------------------------------------------------------------------------
 // remove
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.remove(numbers, "a")
+ReadonlyRecord.remove(string$numbers, "a")
 
 // $ExpectType Record<"b", number>
-ReadonlyRecord.remove(structAB, "a")
+ReadonlyRecord.remove(string$structAB, "a")
 
 // -------------------------------------------------------------------------------------
 // reduce
 // -------------------------------------------------------------------------------------
 
-ReadonlyRecord.reduce(structAB, "", (
+ReadonlyRecord.reduce(string$structAB, "", (
   // $ExpectType string
   _acc,
   // $ExpectType number
@@ -389,14 +394,14 @@ ReadonlyRecord.reduce(structAB, "", (
 // some
 // -------------------------------------------------------------------------------------
 
-ReadonlyRecord.some(structAB, (
+ReadonlyRecord.some(string$structAB, (
   _value,
   // $ExpectType "a" | "b"
   _key
 ) => false)
 
 pipe(
-  numbersOrStrings,
+  string$numbersOrStrings,
   ReadonlyRecord.some((
     _item // $ExpectType string | number
   ) => true)
@@ -407,13 +412,13 @@ pipe(
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.union(numbers, numbers, (_, b) => b)
+ReadonlyRecord.union(string$numbers, string$numbers, (_, b) => b)
 
 // $ExpectType Record<string, string | number>
-ReadonlyRecord.union(numbers, numbersOrStrings, (_, b) => b)
+ReadonlyRecord.union(string$numbers, string$numbersOrStrings, (_, b) => b)
 
 // $ExpectType Record<"a" | "b" | "c" | "d", string | number>
-ReadonlyRecord.union(structAB, structCD, (_, b) => b)
+ReadonlyRecord.union(string$structAB, string$structCD, (_, b) => b)
 
 // -------------------------------------------------------------------------------------
 // singleton
@@ -427,25 +432,25 @@ ReadonlyRecord.singleton("a", 1)
 // -------------------------------------------------------------------------------------
 
 pipe(
-  numbersOrStrings,
+  string$numbersOrStrings,
   ReadonlyRecord.every((
     _item // $ExpectType string | number
   ) => true)
 )
 
-ReadonlyRecord.every(structAB, (
+ReadonlyRecord.every(string$structAB, (
   // $ExpectType number
   _value,
   // $ExpectType "a" | "b"
   _key
 ) => false)
 
-if (ReadonlyRecord.every(numbersOrStrings, Predicate.isString)) {
-  numbersOrStrings // $ExpectType ReadonlyRecord<string, string>
+if (ReadonlyRecord.every(string$numbersOrStrings, Predicate.isString)) {
+  string$numbersOrStrings // $ExpectType ReadonlyRecord<string, string>
 }
 
-if (ReadonlyRecord.every(numbersOrStrings, Predicate.isString)) {
-  numbersOrStrings // $ExpectType ReadonlyRecord<string, string>
+if (ReadonlyRecord.every(string$numbersOrStrings, Predicate.isString)) {
+  string$numbersOrStrings // $ExpectType ReadonlyRecord<string, string>
 }
 
 // -------------------------------------------------------------------------------------
@@ -453,30 +458,30 @@ if (ReadonlyRecord.every(numbersOrStrings, Predicate.isString)) {
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.intersection(numbers, numbersOrStrings, (a, _) => a)
+ReadonlyRecord.intersection(string$numbers, string$numbersOrStrings, (a, _) => a)
 
 // $ExpectType Record<string, string | number>
-ReadonlyRecord.intersection(numbers, numbersOrStrings, (_, b) => b)
+ReadonlyRecord.intersection(string$numbers, string$numbersOrStrings, (_, b) => b)
 
 // $ExpectType Record<never, string>
-ReadonlyRecord.intersection(structAB, structCD, (_, b) => b)
+ReadonlyRecord.intersection(string$structAB, string$structCD, (_, b) => b)
 
 // $ExpectType Record<never, number>
-ReadonlyRecord.intersection(structAB, structCD, (a, _) => a)
+ReadonlyRecord.intersection(string$structAB, string$structCD, (a, _) => a)
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.intersection(numbers, numbers, (a, _) => a)
+ReadonlyRecord.intersection(string$numbers, string$numbers, (a, _) => a)
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.intersection(numbers, structCD, (a, _) => a)
+ReadonlyRecord.intersection(string$numbers, string$structCD, (a, _) => a)
 
 // $ExpectType Record<never, number>
-ReadonlyRecord.intersection(structAB, {
+ReadonlyRecord.intersection(string$structAB, {
   c: 2
 }, (a, _) => a)
 
 // $ExpectType Record<"b", number>
-ReadonlyRecord.intersection(structAB, {
+ReadonlyRecord.intersection(string$structAB, {
   b: 2
 }, (a, _) => a)
 
@@ -484,13 +489,13 @@ ReadonlyRecord.intersection(structAB, {
 // has
 // -------------------------------------------------------------------------------------
 
-if (ReadonlyRecord.has(numbers, "a")) {
+if (ReadonlyRecord.has(string$numbers, "a")) {
   // $ExpectType Record<string, number>
-  numbers
+  string$numbers
 }
 
 // @ts-expect-error
-ReadonlyRecord.has(structAB, "c")
+ReadonlyRecord.has(string$structAB, "c")
 
 // -------------------------------------------------------------------------------------
 // empty

--- a/packages/effect/dtslint/ReadonlyRecord.ts
+++ b/packages/effect/dtslint/ReadonlyRecord.ts
@@ -1,19 +1,62 @@
 import type * as Brand from "effect/Brand"
 import * as Either from "effect/Either"
-import { pipe } from "effect/Function"
+import { hole, pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as ReadonlyRecord from "effect/ReadonlyRecord"
 
 declare const numbers: Record<string, number>
 declare const numbersOrStrings: Record<string, number | string>
-declare const readonlyNumbers: Readonly<Record<string, number>>
-declare const structNumbers: Record<"a" | "b", number>
-declare const structStrings: Record<"c" | "d", string>
-declare const readonlyStructNumbers: Readonly<Record<"a" | "b", number>>
-declare const readonlyStructStrings: Readonly<Record<"c" | "d", string>>
+declare const structAB: Record<"a" | "b", number>
+declare const structCD: Record<"c" | "d", string>
 
 declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
+
+const symA = Symbol.for("a")
+const symB = Symbol.for("b")
+
+// -------------------------------------------------------------------------------------
+// NonLiteralKey
+// -------------------------------------------------------------------------------------
+
+// $ExpectType string
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<string>>()
+
+// $ExpectType symbol
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<symbol>>()
+
+// $ExpectType string
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<"a">>()
+
+// $ExpectType string
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<"a" | "b">>()
+
+// $ExpectType symbol
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<typeof symA>>()
+
+// $ExpectType symbol
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<typeof symA | typeof symB>>()
+
+// $ExpectType string | symbol
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<"a" | typeof symA>>()
+
+// $ExpectType string
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`${string}`>>()
+
+// $ExpectType `a${string}`
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`a${string}`>>()
+
+// $ExpectType `${string}a`
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`${string}a`>>()
+
+// $ExpectType `a${string}b${string}`
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`a${string}b${string}`>>()
+
+// $ExpectType `a${number}`
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`a${number}`>>()
+
+// $ExpectType `a${number}b${string}c${number}`
+hole<ReadonlyRecord.ReadonlyRecord.NonLiteralKey<`a${number}b${string}c${number}`>>()
 
 // -------------------------------------------------------------------------------------
 // map
@@ -34,30 +77,15 @@ pipe(
   ) => value > 0)
 )
 
-// $ExpectType Record<string, boolean>
-ReadonlyRecord.map(readonlyNumbers, (
-  value, // $ExpectType number
-  _key // $ExpectType string
-) => value > 0)
-
-// $ExpectType Record<string, boolean>
-pipe(
-  readonlyNumbers,
-  ReadonlyRecord.map((
-    value, // $ExpectType number
-    _key // $ExpectType string
-  ) => value > 0)
-)
-
 // $ExpectType Record<"a" | "b", boolean>
-ReadonlyRecord.map(structNumbers, (
+ReadonlyRecord.map(structAB, (
   value, // $ExpectType number
   _key // $ExpectType "a" | "b"
 ) => value > 0)
 
 // $ExpectType Record<"a" | "b", boolean>
 pipe(
-  structNumbers,
+  structAB,
   ReadonlyRecord.map((
     value, // $ExpectType number
     _key // $ExpectType "a" | "b"
@@ -118,7 +146,7 @@ pipe(numbers, ReadonlyRecord.modifyOption("a", () => true))
 // $ExpectType [string, number][]
 ReadonlyRecord.toEntries(numbers)
 // $ExpectType ["a" | "b", number][]
-ReadonlyRecord.toEntries(structNumbers)
+ReadonlyRecord.toEntries(structAB)
 // $ExpectType ["a" | "b" | "c", string | number | boolean][]
 ReadonlyRecord.toEntries({ a: "a", b: 2, c: true })
 
@@ -142,11 +170,8 @@ pipe({ a: Either.right(1), b: Either.right(2), c: Either.right(3) }, ReadonlyRec
 ReadonlyRecord.collect(numbers, (_, a) => a)
 
 // $ExpectType number[]
-ReadonlyRecord.collect(readonlyNumbers, (_, a) => a)
-
-// $ExpectType number[]
 pipe(
-  structNumbers,
+  structAB,
   ReadonlyRecord.collect((
     _key, // $ExpectType "a" | "b"
     value
@@ -154,7 +179,7 @@ pipe(
 )
 
 // $ExpectType number[]
-ReadonlyRecord.collect(structNumbers, (
+ReadonlyRecord.collect(structAB, (
   _key, // $ExpectType "a" | "b"
   value
 ) => value)
@@ -170,16 +195,9 @@ ReadonlyRecord.filterMap(numbers, (
   _key
 ) => value > 0 ? Option.some("positive") : Option.none())
 
-// $ExpectType Record<string, string>
-ReadonlyRecord.filterMap(readonlyNumbers, (
-  value,
-  // $ExpectType string
-  _key
-) => value > 0 ? Option.some("positive") : Option.none())
-
 // $ExpectType Record<string, number>
 pipe(
-  structNumbers,
+  structAB,
   ReadonlyRecord.filterMap((
     value,
     // $ExpectType "a" | "b"
@@ -188,7 +206,7 @@ pipe(
 )
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filterMap(structNumbers, (
+ReadonlyRecord.filterMap(structAB, (
   value,
   // $ExpectType "a" | "b"
   key
@@ -207,16 +225,8 @@ ReadonlyRecord.filter(numbers, (
 ) => value > 0)
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filter(readonlyNumbers, (
-  // $ExpectType number
-  value,
-  // $ExpectType string
-  _key
-) => value > 0)
-
-// $ExpectType Record<string, number>
 pipe(
-  structNumbers,
+  structAB,
   ReadonlyRecord.filter((
     // $ExpectType number
     _value,
@@ -226,7 +236,7 @@ pipe(
 )
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.filter(structNumbers, (
+ReadonlyRecord.filter(structAB, (
   // $ExpectType number
   _value,
   // $ExpectType "a" | "b"
@@ -263,15 +273,8 @@ ReadonlyRecord.partitionMap(numbers, (
 ) => value > 0 ? Either.right("positive") : Either.left(false))
 
 // $ExpectType [left: Record<string, boolean>, right: Record<string, string>]
-ReadonlyRecord.partitionMap(readonlyNumbers, (
-  value,
-  // $ExpectType string
-  _key
-) => value > 0 ? Either.right("positive") : Either.left(false))
-
-// $ExpectType [left: Record<string, boolean>, right: Record<string, string>]
 pipe(
-  structNumbers,
+  structAB,
   ReadonlyRecord.partitionMap((
     _value,
     // $ExpectType "a" | "b"
@@ -280,7 +283,7 @@ pipe(
 )
 
 // $ExpectType [left: Record<string, boolean>, right: Record<string, string>]
-ReadonlyRecord.partitionMap(structNumbers, (
+ReadonlyRecord.partitionMap(structAB, (
   _value,
   // $ExpectType "a" | "b"
   key
@@ -299,16 +302,8 @@ ReadonlyRecord.partition(numbers, (
 ) => value > 0)
 
 // $ExpectType [excluded: Record<string, number>, satisfying: Record<string, number>]
-ReadonlyRecord.partition(readonlyNumbers, (
-  // $ExpectType number
-  value,
-  // $ExpectType string
-  _key
-) => value > 0)
-
-// $ExpectType [excluded: Record<string, number>, satisfying: Record<string, number>]
 pipe(
-  structNumbers,
+  structAB,
   ReadonlyRecord.partition((
     // $ExpectType number
     _value,
@@ -318,7 +313,7 @@ pipe(
 )
 
 // $ExpectType [excluded: Record<string, number>, satisfying: Record<string, number>]
-ReadonlyRecord.partition(structNumbers, (
+ReadonlyRecord.partition(structAB, (
   // $ExpectType number
   _value,
   // $ExpectType "a" | "b"
@@ -342,14 +337,14 @@ pipe(numbersOrStrings, ReadonlyRecord.partition(Predicate.isNumber))
 // -------------------------------------------------------------------------------------
 
 // $ExpectType ("a" | "b")[]
-ReadonlyRecord.keys(structNumbers)
+ReadonlyRecord.keys(structAB)
 
 // -------------------------------------------------------------------------------------
 // values
 // -------------------------------------------------------------------------------------
 
 // $ExpectType number[]
-ReadonlyRecord.values(structNumbers)
+ReadonlyRecord.values(structAB)
 
 // -------------------------------------------------------------------------------------
 // set
@@ -365,7 +360,7 @@ ReadonlyRecord.set(numbers, "a", true)
 ReadonlyRecord.set(numbers, "a", true)
 
 // $ExpectType Record<"a" | "b" | "c", number | boolean>
-ReadonlyRecord.set(structNumbers, "c", true)
+ReadonlyRecord.set(structAB, "c", true)
 
 // -------------------------------------------------------------------------------------
 // remove
@@ -375,13 +370,13 @@ ReadonlyRecord.set(structNumbers, "c", true)
 ReadonlyRecord.remove(numbers, "a")
 
 // $ExpectType Record<"b", number>
-ReadonlyRecord.remove(structNumbers, "a")
+ReadonlyRecord.remove(structAB, "a")
 
 // -------------------------------------------------------------------------------------
 // reduce
 // -------------------------------------------------------------------------------------
 
-ReadonlyRecord.reduce(structNumbers, "", (
+ReadonlyRecord.reduce(structAB, "", (
   // $ExpectType string
   _acc,
   // $ExpectType number
@@ -394,7 +389,7 @@ ReadonlyRecord.reduce(structNumbers, "", (
 // some
 // -------------------------------------------------------------------------------------
 
-ReadonlyRecord.some(structNumbers, (
+ReadonlyRecord.some(structAB, (
   _value,
   // $ExpectType "a" | "b"
   _key
@@ -412,13 +407,13 @@ pipe(
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.union(numbers, readonlyNumbers, (_, b) => b)
+ReadonlyRecord.union(numbers, numbers, (_, b) => b)
+
+// $ExpectType Record<string, string | number>
+ReadonlyRecord.union(numbers, numbersOrStrings, (_, b) => b)
 
 // $ExpectType Record<"a" | "b" | "c" | "d", string | number>
-ReadonlyRecord.union(structNumbers, structStrings, (_, b) => b)
-
-// $ExpectType Record<"a" | "b" | "c" | "d", string | number>
-ReadonlyRecord.union(readonlyStructNumbers, readonlyStructStrings, (_, b) => b)
+ReadonlyRecord.union(structAB, structCD, (_, b) => b)
 
 // -------------------------------------------------------------------------------------
 // singleton
@@ -438,7 +433,7 @@ pipe(
   ) => true)
 )
 
-ReadonlyRecord.every(structNumbers, (
+ReadonlyRecord.every(structAB, (
   // $ExpectType number
   _value,
   // $ExpectType "a" | "b"
@@ -464,24 +459,24 @@ ReadonlyRecord.intersection(numbers, numbersOrStrings, (a, _) => a)
 ReadonlyRecord.intersection(numbers, numbersOrStrings, (_, b) => b)
 
 // $ExpectType Record<never, string>
-ReadonlyRecord.intersection(structNumbers, structStrings, (_, b) => b)
+ReadonlyRecord.intersection(structAB, structCD, (_, b) => b)
 
 // $ExpectType Record<never, number>
-ReadonlyRecord.intersection(structNumbers, structStrings, (a, _) => a)
+ReadonlyRecord.intersection(structAB, structCD, (a, _) => a)
 
 // $ExpectType Record<string, number>
 ReadonlyRecord.intersection(numbers, numbers, (a, _) => a)
 
 // $ExpectType Record<string, number>
-ReadonlyRecord.intersection(numbers, structStrings, (a, _) => a)
+ReadonlyRecord.intersection(numbers, structCD, (a, _) => a)
 
 // $ExpectType Record<never, number>
-ReadonlyRecord.intersection(structNumbers, {
+ReadonlyRecord.intersection(structAB, {
   c: 2
 }, (a, _) => a)
 
 // $ExpectType Record<"b", number>
-ReadonlyRecord.intersection(structNumbers, {
+ReadonlyRecord.intersection(structAB, {
   b: 2
 }, (a, _) => a)
 
@@ -495,7 +490,7 @@ if (ReadonlyRecord.has(numbers, "a")) {
 }
 
 // @ts-expect-error
-ReadonlyRecord.has(structNumbers, "c")
+ReadonlyRecord.has(structAB, "c")
 
 // -------------------------------------------------------------------------------------
 // empty

--- a/packages/effect/src/ReadonlyRecord.ts
+++ b/packages/effect/src/ReadonlyRecord.ts
@@ -497,7 +497,7 @@ export const pop: {
   self: ReadonlyRecord<K, A>,
   key: X
 ): Option.Option<[A, Record<Exclude<K, X>, A>]> =>
-  has(self, key) ? Option.some([self[key], remove(self as any, key)]) : Option.none())
+  has(self, key) ? Option.some([self[key], remove(self, key)]) : Option.none())
 
 /**
  * Maps a record into another record by applying a transformation function to each of its values.

--- a/packages/effect/src/ReadonlyRecord.ts
+++ b/packages/effect/src/ReadonlyRecord.ts
@@ -26,7 +26,7 @@ export type ReadonlyRecord<in out K extends string | symbol, out A> = {
  */
 export declare namespace ReadonlyRecord {
   type IsFiniteString<T extends string> = [T] extends [`${infer Head}${infer Rest}`]
-    ? string extends Head ? false : Rest extends "" ? true : IsFiniteString<Rest> :
+    ? string extends Head ? false : `${number}` extends Head ? false : Rest extends "" ? true : IsFiniteString<Rest> :
     false
 
   /**
@@ -440,7 +440,7 @@ export const replaceOption: {
 
 /**
  * If the given key exists in the record, returns a new record with the key removed,
- * otherwise returns the original record.
+ * otherwise returns a copy of the original record.
  *
  * @param self - the record to remove the key from.
  * @param key - the key to remove from the record.

--- a/packages/effect/src/ReadonlyRecord.ts
+++ b/packages/effect/src/ReadonlyRecord.ts
@@ -17,7 +17,7 @@ import type { NoInfer } from "./Types.js"
  * @category models
  * @since 2.0.0
  */
-export type ReadonlyRecord<in out K extends string, out A> = {
+export type ReadonlyRecord<in out K extends string | symbol, out A> = {
   readonly [P in K]: A
 }
 
@@ -32,9 +32,8 @@ export declare namespace ReadonlyRecord {
   /**
    * @since 2.0.0
    */
-  export type NonLiteralKey<K extends string> = K extends never ? never
-    : IsFiniteString<K> extends true ? string
-    : K
+  export type NonLiteralKey<K extends string | symbol> = K extends string ? IsFiniteString<K> extends true ? string : K
+    : symbol
 
   /**
    * @since 2.0.0
@@ -58,7 +57,7 @@ export interface ReadonlyRecordTypeLambda<K extends string = string> extends Typ
  * @category constructors
  * @since 2.0.0
  */
-export const empty = <K extends string = never, V = never>(): Record<
+export const empty = <K extends string | symbol = never, V = never>(): Record<
   ReadonlyRecord.NonLiteralKey<K>,
   V
 > => ({} as any)
@@ -77,9 +76,8 @@ export const empty = <K extends string = never, V = never>(): Record<
  * @category guards
  * @since 2.0.0
  */
-export const isEmptyRecord = <K extends string, A>(self: Record<K, A>): self is Record<K, never> => {
-  return keys(self).length === 0
-}
+export const isEmptyRecord = <K extends string, A>(self: Record<K, A>): self is Record<K, never> =>
+  keys(self).length === 0
 
 /**
  * Determine if a record is empty.
@@ -120,10 +118,10 @@ export const isEmptyReadonlyRecord: <K extends string, A>(
  * @since 2.0.0
  */
 export const fromIterableWith: {
-  <A, K extends string, B>(
+  <A, K extends string | symbol, B>(
     f: (a: A) => readonly [K, B]
   ): (self: Iterable<A>) => Record<ReadonlyRecord.NonLiteralKey<K>, B>
-  <A, K extends string, B>(
+  <A, K extends string | symbol, B>(
     self: Iterable<A>,
     f: (a: A) => readonly [K, B]
   ): Record<ReadonlyRecord.NonLiteralKey<K>, B>
@@ -141,28 +139,6 @@ export const fromIterableWith: {
     return out
   }
 )
-
-/**
- * Builds a record from an iterable of key-value pairs.
- *
- * If there are conflicting keys when using `fromEntries`, the last occurrence of the key/value pair will overwrite the
- * previous ones. So the resulting record will only have the value of the last occurrence of each key.
- *
- * @param self - The iterable of key-value pairs.
- *
- * @example
- * import { fromEntries } from "effect/ReadonlyRecord"
- *
- * const input: Array<[string, number]> = [["a", 1], ["b", 2]]
- *
- * assert.deepStrictEqual(fromEntries(input), { a: 1, b: 2 })
- *
- * @since 2.0.0
- * @category constructors
- */
-export const fromEntries: <Entry extends readonly [string, any]>(
-  entries: Iterable<Entry>
-) => Record<ReadonlyRecord.NonLiteralKey<Entry[0]>, Entry[1]> = Object.fromEntries
 
 /**
  * Creates a new record from an iterable, utilizing the provided function to determine the key for each element.
@@ -189,10 +165,32 @@ export const fromEntries: <Entry extends readonly [string, any]>(
  * @category constructors
  * @since 2.0.0
  */
-export const fromIterableBy = <A, K extends string>(
+export const fromIterableBy = <A, K extends string | symbol>(
   items: Iterable<A>,
   f: (a: A) => K
 ): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(items, (a) => [f(a), a])
+
+/**
+ * Builds a record from an iterable of key-value pairs.
+ *
+ * If there are conflicting keys when using `fromEntries`, the last occurrence of the key/value pair will overwrite the
+ * previous ones. So the resulting record will only have the value of the last occurrence of each key.
+ *
+ * @param self - The iterable of key-value pairs.
+ *
+ * @example
+ * import { fromEntries } from "effect/ReadonlyRecord"
+ *
+ * const input: Array<[string, number]> = [["a", 1], ["b", 2]]
+ *
+ * assert.deepStrictEqual(fromEntries(input), { a: 1, b: 2 })
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const fromEntries: <Entry extends readonly [string | symbol, any]>(
+  entries: Iterable<Entry>
+) => Record<ReadonlyRecord.NonLiteralKey<Entry[0]>, Entry[1]> = Object.fromEntries
 
 /**
  * Transforms the values of a record into an `Array` with a custom mapping function.
@@ -271,16 +269,16 @@ export const size = <K extends string, A>(self: ReadonlyRecord<K, A>): number =>
  * @since 2.0.0
  */
 export const has: {
-  <K extends string>(
+  <K extends string | symbol>(
     key: NoInfer<K>
   ): <A>(self: ReadonlyRecord<K, A>) => boolean
-  <K extends string, A>(
+  <K extends string | symbol, A>(
     self: ReadonlyRecord<K, A>,
     key: NoInfer<K>
   ): boolean
 } = dual(
   2,
-  <K extends string, A>(
+  <K extends string | symbol, A>(
     self: ReadonlyRecord<K, A>,
     key: NoInfer<K>
   ): boolean => Object.prototype.hasOwnProperty.call(self, key)
@@ -304,11 +302,11 @@ export const has: {
  * @since 2.0.0
  */
 export const get: {
-  <K extends string>(key: NoInfer<K>): <A>(self: ReadonlyRecord<K, A>) => Option.Option<A>
-  <K extends string, A>(self: ReadonlyRecord<K, A>, key: NoInfer<K>): Option.Option<A>
+  <K extends string | symbol>(key: NoInfer<K>): <A>(self: ReadonlyRecord<K, A>) => Option.Option<A>
+  <K extends string | symbol, A>(self: ReadonlyRecord<K, A>, key: NoInfer<K>): Option.Option<A>
 } = dual(
   2,
-  <K extends string, A>(self: ReadonlyRecord<K, A>, key: NoInfer<K>): Option.Option<A> =>
+  <K extends string | symbol, A>(self: ReadonlyRecord<K, A>, key: NoInfer<K>): Option.Option<A> =>
     has(self, key) ? Option.some(self[key]) : Option.none()
 )
 
@@ -338,14 +336,14 @@ export const get: {
  * @since 2.0.0
  */
 export const modify: {
-  <K extends string, A, B>(
+  <K extends string | symbol, A, B>(
     key: NoInfer<K>,
     f: (a: A) => B
   ): (self: ReadonlyRecord<K, A>) => Record<K, A | B>
-  <K extends string, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, f: (a: A) => B): Record<K, A | B>
+  <K extends string | symbol, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, f: (a: A) => B): Record<K, A | B>
 } = dual(
   3,
-  <K extends string, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, f: (a: A) => B): Record<K, A | B> => {
+  <K extends string | symbol, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, f: (a: A) => B): Record<K, A | B> => {
     if (!has(self, key)) {
       return { ...self }
     }
@@ -379,18 +377,18 @@ export const modify: {
  * @since 2.0.0
  */
 export const modifyOption: {
-  <K extends string, A, B>(
+  <K extends string | symbol, A, B>(
     key: NoInfer<K>,
     f: (a: A) => B
   ): (self: ReadonlyRecord<K, A>) => Option.Option<Record<K, A | B>>
-  <K extends string, A, B>(
+  <K extends string | symbol, A, B>(
     self: ReadonlyRecord<K, A>,
     key: NoInfer<K>,
     f: (a: A) => B
   ): Option.Option<Record<K, A | B>>
 } = dual(
   3,
-  <K extends string, A, B>(
+  <K extends string | symbol, A, B>(
     self: ReadonlyRecord<K, A>,
     key: NoInfer<K>,
     f: (a: A) => B
@@ -422,18 +420,18 @@ export const modifyOption: {
  * @since 2.0.0
  */
 export const replaceOption: {
-  <K extends string, B>(
+  <K extends string | symbol, B>(
     key: NoInfer<K>,
     b: B
   ): <A>(self: ReadonlyRecord<K, A>) => Option.Option<Record<K, A | B>>
-  <K extends string, A, B>(
+  <K extends string | symbol, A, B>(
     self: ReadonlyRecord<K, A>,
     key: NoInfer<K>,
     b: B
   ): Option.Option<Record<K, A | B>>
 } = dual(
   3,
-  <K extends string, A, B>(
+  <K extends string | symbol, A, B>(
     self: ReadonlyRecord<K, A>,
     key: NoInfer<K>,
     b: B
@@ -455,11 +453,11 @@ export const replaceOption: {
  * @since 2.0.0
  */
 export const remove: {
-  <K extends string, X extends K>(key: X): <A>(self: ReadonlyRecord<K, A>) => Record<Exclude<K, X>, A>
-  <K extends string, A, X extends K>(self: ReadonlyRecord<K, A>, key: X): Record<Exclude<K, X>, A>
+  <K extends string | symbol, X extends K>(key: X): <A>(self: ReadonlyRecord<K, A>) => Record<Exclude<K, X>, A>
+  <K extends string | symbol, A, X extends K>(self: ReadonlyRecord<K, A>, key: X): Record<Exclude<K, X>, A>
 } = dual(
   2,
-  <K extends string, A, X extends K>(self: ReadonlyRecord<K, A>, key: X): Record<Exclude<K, X>, A> => {
+  <K extends string | symbol, A, X extends K>(self: ReadonlyRecord<K, A>, key: X): Record<Exclude<K, X>, A> => {
     if (!has(self, key)) {
       return { ...self }
     }
@@ -488,14 +486,14 @@ export const remove: {
  * @since 2.0.0
  */
 export const pop: {
-  <K extends string, X extends K>(
+  <K extends string | symbol, X extends K>(
     key: X
   ): <A>(self: ReadonlyRecord<K, A>) => Option.Option<[A, Record<Exclude<K, X>, A>]>
-  <K extends string, A, X extends K>(
+  <K extends string | symbol, A, X extends K>(
     self: ReadonlyRecord<K, A>,
     key: X
   ): Option.Option<[A, Record<Exclude<K, X>, A>]>
-} = dual(2, <K extends string, A, X extends K>(
+} = dual(2, <K extends string | symbol, A, X extends K>(
   self: ReadonlyRecord<K, A>,
   key: X
 ): Option.Option<[A, Record<Exclude<K, X>, A>]> =>
@@ -934,18 +932,18 @@ export const values = <K extends string, A>(self: ReadonlyRecord<K, A>): Array<A
  * @since 2.0.0
  */
 export const set: {
-  <K extends string, K1 extends K | ((string) & {}), B>(
+  <K extends string | symbol, K1 extends K | ((string | symbol) & {}), B>(
     key: K1,
     value: B
   ): <A>(self: ReadonlyRecord<K, A>) => Record<K | K1, A | B>
-  <K extends string, A, K1 extends K | ((string) & {}), B>(
+  <K extends string | symbol, A, K1 extends K | ((string | symbol) & {}), B>(
     self: ReadonlyRecord<K, A>,
     key: K1,
     value: B
   ): Record<K | K1, A | B>
 } = dual(
   3,
-  <K extends string, A, K1 extends K | ((string) & {}), B>(
+  <K extends string | symbol, A, K1 extends K | ((string | symbol) & {}), B>(
     self: ReadonlyRecord<K, A>,
     key: K1,
     value: B
@@ -956,7 +954,7 @@ export const set: {
 
 /**
  * Replace a key's value in a record and return the updated record.
- * If the key does not exist in the record, the original record is returned.
+ * If the key does not exist in the record, a copy of the original record is returned.
  *
  * @param self - The original record.
  * @param key - The key to replace.
@@ -972,11 +970,11 @@ export const set: {
  * @since 2.0.0
  */
 export const replace: {
-  <K extends string, B>(key: NoInfer<K>, value: B): <A>(self: ReadonlyRecord<K, A>) => Record<K, A | B>
-  <K extends string, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, value: B): Record<K, A | B>
+  <K extends string | symbol, B>(key: NoInfer<K>, value: B): <A>(self: ReadonlyRecord<K, A>) => Record<K, A | B>
+  <K extends string | symbol, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, value: B): Record<K, A | B>
 } = dual(
   3,
-  <K extends string, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, value: B): Record<K, A | B> => {
+  <K extends string | symbol, A, B>(self: ReadonlyRecord<K, A>, key: NoInfer<K>, value: B): Record<K, A | B> => {
     if (has(self, key)) {
       return { ...self, [key]: value }
     }
@@ -1259,6 +1257,6 @@ export const getEquivalence = <K extends string, A>(
  * @category constructors
  * @since 2.0.0
  */
-export const singleton = <K extends string, A>(key: K, value: A): Record<K, A> => ({
+export const singleton = <K extends string | symbol, A>(key: K, value: A): Record<K, A> => ({
   [key]: value
 } as any)

--- a/packages/effect/test/ReadonlyRecord.test.ts
+++ b/packages/effect/test/ReadonlyRecord.test.ts
@@ -7,345 +7,381 @@ import { assert, describe, expect, it } from "vitest"
 
 const symA = Symbol.for("a")
 const symB = Symbol.for("b")
+const symC = Symbol.for("c")
+
+const stringRecord: Record<string, number> = { a: 1, [symA]: null }
+const symbolRecord: Record<symbol, number> = { [symA]: 1, [symB]: 2 }
 
 describe("ReadonlyRecord", () => {
-  it("get", () => {
-    expect(pipe(RR.empty<string>(), RR.get("a"))).toEqual(Option.none())
-    expect(pipe({ a: 1 }, RR.get("a"))).toEqual(Option.some(1))
-  })
-
-  it("replaceOption", () => {
-    expect(pipe(RR.empty<string>(), RR.replaceOption("a", 2))).toEqual(Option.none())
-    expect(pipe({ a: 1, [symA]: null }, RR.replaceOption("a", 2))).toEqual(Option.some({ a: 2, [symA]: null }))
-    expect(pipe({ a: 1, [symA]: null }, RR.replaceOption("a", true))).toEqual(Option.some({ a: true, [symA]: null }))
-  })
-
-  it("modify", () => {
-    expect(pipe(RR.empty<string>(), RR.modify("a", (n: number) => n + 1))).toEqual({})
-    expect(pipe({ a: 1, [symA]: null }, RR.modify("a", (n: number) => n + 1))).toEqual({ a: 2, [symA]: null })
-    expect(pipe({ a: 1, [symA]: null }, RR.modify("a", (n: number) => String(n)))).toEqual(
-      { a: "1", [symA]: null }
-    )
-  })
-
-  it("modifyOption", () => {
-    expect(pipe(RR.empty<string>(), RR.modifyOption("a", (n) => n + 1))).toEqual(Option.none())
-    expect(pipe({ a: 1, [symA]: null }, RR.modifyOption("a", (n: number) => n + 1))).toEqual(
-      Option.some({ a: 2, [symA]: null })
-    )
-    expect(pipe({ a: 1, [symA]: null }, RR.modifyOption("a", (n: number) => String(n)))).toEqual(
-      Option.some({ a: "1", [symA]: null })
-    )
-  })
-
-  it("replaceOption", () => {
-    expect(pipe(RR.empty<string>(), RR.replaceOption("a", 2))).toEqual(Option.none())
-    expect(pipe({ a: 1, [symA]: null }, RR.replaceOption("a", 2))).toEqual(Option.some({ a: 2, [symA]: null }))
-    expect(pipe({ a: 1, [symA]: null }, RR.replaceOption("a", true))).toEqual(Option.some({ a: true, [symA]: null }))
-  })
-
-  it("map", () => {
-    expect(pipe({ a: 1, b: 2, [symA]: null } as Record<string, number>, RR.map((n) => n * 2))).toEqual({
-      a: 2,
-      b: 4,
-      [symA]: null
-    })
-    expect(pipe({ a: 1, b: 2, [symA]: null }, RR.map((n, k) => `${k}-${n}`))).toEqual({
-      a: "a-1",
-      b: "b-2",
-      [symA]: null
-    })
-    expect(pipe({ [symA]: 1, [symB]: 2 }, RR.map((n) => n * 2))).toEqual({ [symA]: 1, [symB]: 2 })
-  })
-
-  it("fromIterableWith", () => {
-    const input = [1, 2, 3, 4]
-    expect(RR.fromIterableWith(input, (a) => [a === 3 ? "a" : String(a), a * 2])).toEqual({
-      "1": 2,
-      "2": 4,
-      a: 6,
-      "4": 8
-    })
-  })
-
-  it("fromIterableBy", () => {
-    const users = [
-      { id: "2", name: "name2" },
-      { id: "1", name: "name1" }
-    ]
-    expect(RR.fromIterableBy(users, (user) => user.id)).toEqual({
-      "2": { id: "2", name: "name2" },
-      "1": { id: "1", name: "name1" }
-    })
-  })
-
-  it("fromEntries", () => {
-    const input = [["1", 2], ["2", 4], ["3", 6], ["4", 8]] as const
-    expect(RR.fromEntries(input)).toEqual({
-      "1": 2,
-      "2": 4,
-      "3": 6,
-      "4": 8
-    })
-  })
-
-  it("collect", () => {
-    const x = { a: 1, b: 2, c: 3, [symA]: null }
-    assert.deepStrictEqual(RR.collect(x, (key, n) => [key, n]), [["a", 1], ["b", 2], ["c", 3]])
-  })
-
-  it("toEntries", () => {
-    const x = { a: 1, b: 2, c: 3, [symA]: null }
-    assert.deepStrictEqual(RR.toEntries(x), [["a", 1], ["b", 2], ["c", 3]])
-  })
-
-  it("remove", () => {
-    assert.deepStrictEqual(RR.remove({ a: 1, b: 2, [symA]: null }, "a"), { b: 2, [symA]: null })
-    assert.deepStrictEqual(RR.remove({ a: 1, b: 2, [symA]: null } as Record<string, number>, "c"), {
-      a: 1,
-      b: 2,
-      [symA]: null
-    })
-  })
-
-  describe("pop", () => {
-    it("should return the value associated with the given key, if the key is present in the record", () => {
-      const record = { a: 1, b: 2, [symA]: null }
-      const result = RR.pop(record, "a")
-
-      assert.deepStrictEqual(result, Option.some([1, { b: 2, [symA]: null }] as [number, Record<string, number>]))
+  describe("string | symbol APIs", () => {
+    it("empty", () => {
+      expect(RR.empty()).toEqual({})
     })
 
-    it("should return none if the key is not present in the record", () => {
-      const record = { a: 1, b: 2, [symA]: null }
-      const result = RR.pop("c")(record)
+    it("fromIterableWith", () => {
+      expect(RR.fromIterableWith([1, 2, 3, 4], (a) => [a === 3 ? "a" : String(a), a * 2])).toEqual({
+        "1": 2,
+        "2": 4,
+        a: 6,
+        "4": 8
+      })
+      expect(RR.fromIterableWith([1, 2, 3, 4], (a) => [a === 3 ? symA : String(a), a * 2])).toEqual({
+        "1": 2,
+        "2": 4,
+        [symA]: 6,
+        "4": 8
+      })
+    })
 
-      assert.deepStrictEqual(result, Option.none())
+    it("fromIterableBy", () => {
+      const users = [
+        { id: "2", name: "name2" },
+        { id: "1", name: "name1" }
+      ]
+      expect(RR.fromIterableBy(users, (user) => user.id)).toEqual({
+        "2": { id: "2", name: "name2" },
+        "1": { id: "1", name: "name1" }
+      })
+
+      expect(RR.fromIterableBy(["a", symA], (s) => s))
+        .toEqual({ a: "a", [symA]: symA })
+    })
+
+    it("fromEntries", () => {
+      expect(RR.fromEntries([["1", 2], ["2", 4], ["3", 6], ["4", 8]])).toEqual({
+        "1": 2,
+        "2": 4,
+        "3": 6,
+        "4": 8
+      })
+      expect(RR.fromEntries([["1", 2], ["2", 4], ["3", 6], ["4", 8], [symA, 10], [symB, 12]])).toEqual({
+        "1": 2,
+        "2": 4,
+        "3": 6,
+        "4": 8,
+        [symA]: 10,
+        [symB]: 12
+      })
+    })
+
+    it("has", () => {
+      assert.deepStrictEqual(RR.has(stringRecord, "a"), true)
+      assert.deepStrictEqual(RR.has(stringRecord, "c"), false)
+
+      assert.deepStrictEqual(RR.has(symbolRecord, symA), true)
+      assert.deepStrictEqual(RR.has(symbolRecord, symC), false)
+    })
+
+    it("get", () => {
+      expect(pipe(RR.empty<string>(), RR.get("a"))).toEqual(Option.none())
+      expect(pipe(stringRecord, RR.get("a"))).toEqual(Option.some(1))
+
+      expect(pipe(RR.empty<symbol>(), RR.get(symA))).toEqual(Option.none())
+      expect(pipe(symbolRecord, RR.get(symA))).toEqual(Option.some(1))
+    })
+
+    it("modify", () => {
+      expect(pipe(RR.empty<string>(), RR.modify("a", (n: number) => n + 1))).toEqual({})
+      expect(pipe(stringRecord, RR.modify("a", (n: number) => n + 1))).toEqual({ a: 2, [symA]: null })
+      expect(pipe(stringRecord, RR.modify("a", (n: number) => String(n)))).toEqual(
+        { a: "1", [symA]: null }
+      )
+
+      expect(pipe(RR.empty<symbol>(), RR.modify(symA, (n: number) => n + 1))).toEqual({})
+      expect(pipe(symbolRecord, RR.modify(symA, (n: number) => n + 1))).toEqual({
+        [symA]: 2,
+        [symB]: 2
+      })
+      expect(pipe(symbolRecord, RR.modify(symA, (n: number) => String(n)))).toEqual(
+        { [symA]: "1", [symB]: 2 }
+      )
+    })
+
+    it("modifyOption", () => {
+      expect(pipe(RR.empty<string>(), RR.modifyOption("a", (n) => n + 1))).toEqual(Option.none())
+      expect(pipe(stringRecord, RR.modifyOption("a", (n: number) => n + 1))).toEqual(
+        Option.some({ a: 2, [symA]: null })
+      )
+      expect(pipe(stringRecord, RR.modifyOption("a", (n: number) => String(n)))).toEqual(
+        Option.some({ a: "1", [symA]: null })
+      )
+
+      expect(pipe(RR.empty<symbol>(), RR.modifyOption(symA, (n) => n + 1))).toEqual(Option.none())
+      expect(pipe(symbolRecord, RR.modifyOption(symA, (n: number) => n + 1))).toEqual(
+        Option.some({ [symA]: 2, [symB]: 2 })
+      )
+      expect(pipe(symbolRecord, RR.modifyOption(symA, (n: number) => String(n)))).toEqual(
+        Option.some({ [symA]: "1", [symB]: 2 })
+      )
+    })
+
+    it("replaceOption", () => {
+      expect(pipe(RR.empty<string>(), RR.replaceOption("a", 2))).toEqual(Option.none())
+      expect(pipe(stringRecord, RR.replaceOption("a", 2))).toEqual(Option.some({ a: 2, [symA]: null }))
+      expect(pipe(stringRecord, RR.replaceOption("a", true))).toEqual(Option.some({ a: true, [symA]: null }))
+
+      expect(pipe(RR.empty<symbol>(), RR.replaceOption(symA, 2))).toEqual(Option.none())
+      expect(pipe(symbolRecord, RR.replaceOption(symA, 2))).toEqual(Option.some({ [symA]: 2, [symB]: 2 }))
+      expect(pipe(symbolRecord, RR.replaceOption(symA, true))).toEqual(Option.some({ [symA]: true, [symB]: 2 }))
+    })
+
+    it("remove", () => {
+      assert.deepStrictEqual(RR.remove(stringRecord, "a"), { [symA]: null })
+      assert.deepStrictEqual(RR.remove(stringRecord, "c"), stringRecord)
+
+      assert.deepStrictEqual(RR.remove(symbolRecord, symA), { [symB]: 2 })
+      assert.deepStrictEqual(RR.remove(symbolRecord, symC), symbolRecord)
+    })
+
+    describe("pop", () => {
+      it("should return the value associated with the given key, if the key is present in the record", () => {
+        const result1 = RR.pop(stringRecord, "a")
+        assert.deepStrictEqual(result1, Option.some([1, { [symA]: null }] as [number, Record<string, number>]))
+
+        const result2 = RR.pop(symbolRecord, symA)
+        assert.deepStrictEqual(result2, Option.some([1, { [symB]: 2 }] as [number, Record<string, number>]))
+      })
+
+      it("should return none if the key is not present in the record", () => {
+        const result1 = RR.pop(stringRecord, "c")
+        assert.deepStrictEqual(result1, Option.none())
+
+        const result2 = RR.pop(symbolRecord, symC)
+        assert.deepStrictEqual(result2, Option.none())
+      })
+    })
+
+    describe("set", () => {
+      it("should replace an existing value", () => {
+        assert.deepStrictEqual(RR.set(stringRecord, "a", 2), { a: 2, [symA]: null })
+
+        assert.deepStrictEqual(RR.set(symbolRecord, symA, 2), { [symA]: 2, [symB]: 2 })
+      })
+
+      it("should add the key / value pair", () => {
+        assert.deepStrictEqual(RR.set(stringRecord, "c", 3), { a: 1, [symA]: null, c: 3 })
+
+        assert.deepStrictEqual(RR.set(symbolRecord, symC, 3), { [symA]: 1, [symB]: 2, [symC]: 3 })
+      })
+    })
+
+    it("replace", () => {
+      expect(RR.replace(stringRecord, "c", 3)).toStrictEqual(stringRecord)
+      expect(RR.replace(stringRecord, "a", 2)).toStrictEqual({ a: 2, [symA]: null })
+
+      expect(RR.replace(symbolRecord, symC, 3)).toStrictEqual(symbolRecord)
+      expect(RR.replace(symbolRecord, symA, 2)).toStrictEqual({ [symA]: 2, [symB]: 2 })
+    })
+
+    it("singleton", () => {
+      assert.deepStrictEqual(RR.singleton("a", 1), { a: 1 })
+
+      assert.deepStrictEqual(RR.singleton(symA, 1), { [symA]: 1 })
     })
   })
 
-  describe("filterMap", () => {
-    it("should filter the properties of an object", () => {
+  describe("string only APIs", () => {
+    it("map", () => {
+      expect(pipe(stringRecord, RR.map((n) => n * 2))).toEqual({ a: 2, [symA]: null })
+      expect(pipe(stringRecord, RR.map((n, k) => `${k}-${n}`))).toEqual({ a: "a-1", [symA]: null })
+    })
+
+    it("collect", () => {
+      const x = { a: 1, b: 2, c: 3, [symA]: null }
+      assert.deepStrictEqual(RR.collect(x, (key, n) => [key, n]), [["a", 1], ["b", 2], ["c", 3]])
+    })
+
+    it("toEntries", () => {
+      const x = { a: 1, b: 2, c: 3, [symA]: null }
+      assert.deepStrictEqual(RR.toEntries(x), [["a", 1], ["b", 2], ["c", 3]])
+    })
+
+    it("filterMap", () => {
       const x: Record<string, number> = { a: 1, b: 2, c: 3, [symA]: null }
       const filtered = RR.filterMap(x, (value, key) => (value > 2 ? Option.some(key) : Option.none()))
       expect(filtered).toEqual({ c: "c" })
     })
-  })
 
-  it("getSomes", () => {
-    const x = { a: Option.some(1), b: Option.none(), c: Option.some(2), [symA]: null }
-    assert.deepStrictEqual(RR.getSomes(x), { a: 1, c: 2 })
-  })
-
-  it("filter", () => {
-    const x: Record<string, number> = { a: 1, b: 2, c: 3, d: 4, [symA]: null }
-    assert.deepStrictEqual(RR.filter(x, (value) => value > 2), { c: 3, d: 4 })
-  })
-
-  it("partitionMap", () => {
-    const f = (n: number) => (n > 2 ? Either.right(n + 1) : Either.left(n - 1))
-    assert.deepStrictEqual(RR.partitionMap({}, f), [{}, {}])
-    assert.deepStrictEqual(RR.partitionMap({ a: 1, b: 3, [symA]: null }, f), [{ a: 0 }, { b: 4 }])
-  })
-
-  it("partition", () => {
-    const f = (n: number) => n > 2
-    assert.deepStrictEqual(RR.partition({}, f), [{}, {}])
-    assert.deepStrictEqual(RR.partition({ a: 1, b: 3, [symA]: null }, f), [{ a: 1 }, { b: 3 }])
-  })
-
-  it("separate", () => {
-    assert.deepStrictEqual(
-      RR.separate({ a: Either.left("e"), b: Either.right(1), [symA]: null }),
-      [{ a: "e" }, { b: 1 }]
-    )
-    // should ignore non own properties
-    const o: RR.ReadonlyRecord<"a", Either.Either<number, string>> = Object.create({ a: 1 })
-    assert.deepStrictEqual(pipe(o, RR.separate), [{}, {}])
-  })
-
-  it("empty", () => {
-    expect(RR.empty()).toEqual({})
-  })
-
-  it("isEmptyRecord", () => {
-    assert.deepStrictEqual(RR.isEmptyRecord({}), true)
-    assert.deepStrictEqual(RR.isEmptyRecord({ [symA]: null }), true)
-    assert.deepStrictEqual(RR.isEmptyRecord({ a: 3 }), false)
-  })
-
-  it("isEmptyReadonlyRecord", () => {
-    assert.deepStrictEqual(RR.isEmptyReadonlyRecord({}), true)
-    assert.deepStrictEqual(RR.isEmptyReadonlyRecord({ [symA]: null }), true)
-    assert.deepStrictEqual(RR.isEmptyReadonlyRecord({ a: 3 }), false)
-  })
-
-  it("size", () => {
-    assert.deepStrictEqual(RR.size({ a: "a", b: 1, c: true, [symA]: null }), 3)
-  })
-
-  it("has", () => {
-    assert.deepStrictEqual(RR.has({ a: 1, b: 2, [symA]: null }, "a"), true)
-    assert.deepStrictEqual(RR.has({ a: 1, b: 2, [symA]: null } as Record<string, number>, "c"), false)
-  })
-
-  it("keys", () => {
-    assert.deepStrictEqual(RR.keys({ a: 1, b: 2, [symA]: null }), ["a", "b"])
-  })
-
-  it("values", () => {
-    assert.deepStrictEqual(RR.values({ a: 1, b: 2, [symA]: null }), [1, 2])
-  })
-
-  it("set", () => {
-    assert.deepStrictEqual(RR.set({ a: 1, b: 2, [symA]: null }, "c", 3), { a: 1, b: 2, c: 3, [symA]: null })
-    assert.deepStrictEqual(RR.set({ a: 1, b: 2, [symA]: null }, "a", 3), { a: 3, b: 2, [symA]: null })
-  })
-
-  it("replace", () => {
-    expect(RR.replace({ a: 1, b: 2, [symA]: null } as Record<string, number>, "c", 3)).toStrictEqual({
-      a: 1,
-      b: 2,
-      [symA]: null
+    it("getSomes", () => {
+      const x = { a: Option.some(1), b: Option.none(), c: Option.some(2), [symA]: null }
+      assert.deepStrictEqual(RR.getSomes(x), { a: 1, c: 2 })
     })
-    expect(RR.replace({ a: 1, b: 2, [symA]: null }, "a", 3)).toStrictEqual({ a: 3, b: 2, [symA]: null })
-  })
 
-  it("isSubrecord", () => {
-    expect(RR.isSubrecord(RR.empty(), {})).toBe(true)
-    expect(RR.isSubrecord(RR.empty<string>(), { a: 1 })).toBe(true)
-    expect(RR.isSubrecord({ a: 1 }, { a: 1 })).toBe(true)
-    expect(RR.isSubrecord({ a: 1, [symA]: null }, { a: 1 })).toBe(true)
-    expect(RR.isSubrecord({ a: 1 }, { a: 1, [symA]: null })).toBe(true)
-    expect(RR.isSubrecord({ a: 1 } as Record<string, number>, { a: 1, b: 2 })).toBe(true)
-    expect(RR.isSubrecord({ b: 2, a: 1 }, { a: 1, b: 2 })).toBe(true)
-    expect(RR.isSubrecord({ a: 1 }, { a: 2 })).toBe(false)
-    expect(RR.isSubrecord({ b: 2 } as Record<string, number>, { a: 1 })).toBe(false)
-  })
-
-  it("reduce", () => {
-    // data-first
-    assert.deepStrictEqual(
-      RR.reduce({ k1: "a", k2: "b", [symA]: null }, "-", (accumulator, value, key) => accumulator + key + value),
-      "-k1ak2b"
-    )
-    // data-last
-    assert.deepStrictEqual(
-      pipe({ k1: "a", k2: "b", [symA]: null }, RR.reduce("-", (accumulator, value, key) => accumulator + key + value)),
-      "-k1ak2b"
-    )
-  })
-
-  it("every", () => {
-    assert.deepStrictEqual(RR.every((n: number) => n <= 2)({ a: 1, b: 2, [symA]: null }), true)
-    assert.deepStrictEqual(RR.every((n: number) => n <= 1)({ a: 1, b: 2, [symA]: null }), false)
-  })
-
-  it("some", () => {
-    assert.deepStrictEqual(RR.some((n: number) => n <= 1)({ a: 1, b: 2, [symA]: null }), true)
-    assert.deepStrictEqual(RR.some((n: number) => n <= 0)({ a: 1, b: 2, [symA]: null }), false)
-  })
-
-  it("union", () => {
-    const combine = (s1: string, s2: string) => s1 + s2
-    const x: RR.ReadonlyRecord<string, string> = {
-      a: "a1",
-      b: "b1",
-      c: "c1",
-      [symA]: null
-    }
-    const y: RR.ReadonlyRecord<string, string> = {
-      b: "b2",
-      c: "c2",
-      d: "d2",
-      [symA]: null
-    }
-    assert.deepStrictEqual(RR.union(x, {}, combine), x)
-    assert.deepStrictEqual(RR.union({}, x, combine), x)
-    assert.deepStrictEqual(RR.union(x, {}, combine), x)
-    assert.deepStrictEqual(RR.union({}, x, combine), x)
-    assert.deepStrictEqual(RR.union(x, y, combine), {
-      a: "a1",
-      b: "b1b2",
-      c: "c1c2",
-      d: "d2"
+    it("filter", () => {
+      const x: Record<string, number> = { a: 1, b: 2, c: 3, d: 4, [symA]: null }
+      assert.deepStrictEqual(RR.filter(x, (value) => value > 2), { c: 3, d: 4 })
     })
-  })
 
-  it("intersection", () => {
-    const combine = (s1: string, s2: string) => s1 + s2
-    const x: RR.ReadonlyRecord<string, string> = {
-      a: "a1",
-      b: "b1",
-      c: "c1",
-      [symA]: null
-    }
-    const y: RR.ReadonlyRecord<string, string> = {
-      b: "b2",
-      c: "c2",
-      d: "d2",
-      [symA]: null
-    }
-    assert.deepStrictEqual(RR.intersection(x, {}, combine), {})
-    assert.deepStrictEqual(RR.intersection({}, y, combine), {})
-    assert.deepStrictEqual(RR.intersection(x, y, combine), {
-      b: "b1b2",
-      c: "c1c2"
+    it("partitionMap", () => {
+      const f = (n: number) => (n > 2 ? Either.right(n + 1) : Either.left(n - 1))
+      assert.deepStrictEqual(RR.partitionMap({}, f), [{}, {}])
+      assert.deepStrictEqual(RR.partitionMap({ a: 1, b: 3, [symA]: null }, f), [{ a: 0 }, { b: 4 }])
     })
-  })
 
-  it("difference", () => {
-    const x: RR.ReadonlyRecord<string, string> = {
-      a: "a1",
-      b: "b1",
-      c: "c1",
-      [symA]: null
-    }
-    const y: RR.ReadonlyRecord<string, string> = {
-      b: "b2",
-      c: "c2",
-      d: "d2",
-      [symA]: null
-    }
-    assert.deepStrictEqual(RR.difference({}, x), x)
-    assert.deepStrictEqual(RR.difference(x, {}), x)
-    assert.deepStrictEqual(RR.difference({}, x), x)
-    assert.deepStrictEqual(RR.difference(x, {}), x)
-    assert.deepStrictEqual(RR.difference(x, y), {
-      a: "a1",
-      d: "d2"
+    it("partition", () => {
+      const f = (n: number) => n > 2
+      assert.deepStrictEqual(RR.partition({}, f), [{}, {}])
+      assert.deepStrictEqual(RR.partition({ a: 1, b: 3, [symA]: null }, f), [{ a: 1 }, { b: 3 }])
     })
-  })
 
-  it("getEquivalence", () => {
-    assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { a: 1 }), true)
-    assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { a: 1, [symA]: null }), true)
-    assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { a: 2 }), false)
-    assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { b: 1 }), false)
-    const noPrototype = Object.create(null)
-    assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)(noPrototype, { b: 1 }), false)
-  })
-
-  it("singleton", () => {
-    assert.deepStrictEqual(RR.singleton("a", 1), { a: 1 })
-  })
-
-  it("mapKeys", () => {
-    expect(pipe({ a: 1, b: 2, [symA]: null }, RR.mapKeys((key) => key.toUpperCase()))).toStrictEqual({
-      A: 1,
-      B: 2
-    })
-  })
-
-  it("mapEntries", () => {
-    expect(
-      pipe(
-        { a: 1, b: 2, [symA]: null } as Record<string, number>,
-        RR.mapEntries((a, key) => [key.toUpperCase(), a + 1])
+    it("separate", () => {
+      assert.deepStrictEqual(
+        RR.separate({ a: Either.left("e"), b: Either.right(1), [symA]: null }),
+        [{ a: "e" }, { b: 1 }]
       )
-    ).toStrictEqual({
-      A: 2,
-      B: 3
+      // should ignore non own properties
+      const o: RR.ReadonlyRecord<"a", Either.Either<number, string>> = Object.create({ a: 1 })
+      assert.deepStrictEqual(pipe(o, RR.separate), [{}, {}])
+    })
+
+    it("isEmptyRecord", () => {
+      assert.deepStrictEqual(RR.isEmptyRecord({}), true)
+      assert.deepStrictEqual(RR.isEmptyRecord({ [symA]: null }), true)
+      assert.deepStrictEqual(RR.isEmptyRecord({ a: 3 }), false)
+    })
+
+    it("isEmptyReadonlyRecord", () => {
+      assert.deepStrictEqual(RR.isEmptyReadonlyRecord({}), true)
+      assert.deepStrictEqual(RR.isEmptyReadonlyRecord({ [symA]: null }), true)
+      assert.deepStrictEqual(RR.isEmptyReadonlyRecord({ a: 3 }), false)
+    })
+
+    it("size", () => {
+      assert.deepStrictEqual(RR.size({ a: "a", b: 1, c: true, [symA]: null }), 3)
+    })
+
+    it("keys", () => {
+      assert.deepStrictEqual(RR.keys({ a: 1, b: 2, [symA]: null }), ["a", "b"])
+    })
+
+    it("values", () => {
+      assert.deepStrictEqual(RR.values({ a: 1, b: 2, [symA]: null }), [1, 2])
+    })
+
+    it("isSubrecord", () => {
+      expect(RR.isSubrecord(RR.empty(), {})).toBe(true)
+      expect(RR.isSubrecord(RR.empty<string>(), { a: 1 })).toBe(true)
+      expect(RR.isSubrecord({ a: 1 }, { a: 1 })).toBe(true)
+      expect(RR.isSubrecord(stringRecord, { a: 1 })).toBe(true)
+      expect(RR.isSubrecord({ a: 1 }, stringRecord)).toBe(true)
+      expect(RR.isSubrecord({ a: 1 } as Record<string, number>, { a: 1, b: 2 })).toBe(true)
+      expect(RR.isSubrecord({ b: 2, a: 1 }, { a: 1, b: 2 })).toBe(true)
+      expect(RR.isSubrecord({ a: 1 }, { a: 2 })).toBe(false)
+      expect(RR.isSubrecord({ b: 2 } as Record<string, number>, { a: 1 })).toBe(false)
+    })
+
+    it("reduce", () => {
+      // data-first
+      assert.deepStrictEqual(
+        RR.reduce({ k1: "a", k2: "b", [symA]: null }, "-", (accumulator, value, key) => accumulator + key + value),
+        "-k1ak2b"
+      )
+      // data-last
+      assert.deepStrictEqual(
+        pipe(
+          { k1: "a", k2: "b", [symA]: null },
+          RR.reduce("-", (accumulator, value, key) => accumulator + key + value)
+        ),
+        "-k1ak2b"
+      )
+    })
+
+    it("every", () => {
+      assert.deepStrictEqual(RR.every((n: number) => n <= 2)({ a: 1, b: 2, [symA]: null }), true)
+      assert.deepStrictEqual(RR.every((n: number) => n <= 1)({ a: 1, b: 2, [symA]: null }), false)
+    })
+
+    it("some", () => {
+      assert.deepStrictEqual(RR.some((n: number) => n <= 1)({ a: 1, b: 2, [symA]: null }), true)
+      assert.deepStrictEqual(RR.some((n: number) => n <= 0)({ a: 1, b: 2, [symA]: null }), false)
+    })
+
+    it("union", () => {
+      const combine = (s1: string, s2: string) => s1 + s2
+      const x: RR.ReadonlyRecord<string, string> = {
+        a: "a1",
+        b: "b1",
+        c: "c1",
+        [symA]: null
+      }
+      const y: RR.ReadonlyRecord<string, string> = {
+        b: "b2",
+        c: "c2",
+        d: "d2",
+        [symA]: null
+      }
+      assert.deepStrictEqual(RR.union(x, {}, combine), x)
+      assert.deepStrictEqual(RR.union({}, x, combine), x)
+      assert.deepStrictEqual(RR.union(x, {}, combine), x)
+      assert.deepStrictEqual(RR.union({}, x, combine), x)
+      assert.deepStrictEqual(RR.union(x, y, combine), {
+        a: "a1",
+        b: "b1b2",
+        c: "c1c2",
+        d: "d2"
+      })
+    })
+
+    it("intersection", () => {
+      const combine = (s1: string, s2: string) => s1 + s2
+      const x: RR.ReadonlyRecord<string, string> = {
+        a: "a1",
+        b: "b1",
+        c: "c1",
+        [symA]: null
+      }
+      const y: RR.ReadonlyRecord<string, string> = {
+        b: "b2",
+        c: "c2",
+        d: "d2",
+        [symA]: null
+      }
+      assert.deepStrictEqual(RR.intersection(x, {}, combine), {})
+      assert.deepStrictEqual(RR.intersection({}, y, combine), {})
+      assert.deepStrictEqual(RR.intersection(x, y, combine), {
+        b: "b1b2",
+        c: "c1c2"
+      })
+    })
+
+    it("difference", () => {
+      const x: RR.ReadonlyRecord<string, string> = {
+        a: "a1",
+        b: "b1",
+        c: "c1",
+        [symA]: null
+      }
+      const y: RR.ReadonlyRecord<string, string> = {
+        b: "b2",
+        c: "c2",
+        d: "d2",
+        [symA]: null
+      }
+      assert.deepStrictEqual(RR.difference({}, x), x)
+      assert.deepStrictEqual(RR.difference(x, {}), x)
+      assert.deepStrictEqual(RR.difference({}, x), x)
+      assert.deepStrictEqual(RR.difference(x, {}), x)
+      assert.deepStrictEqual(RR.difference(x, y), {
+        a: "a1",
+        d: "d2"
+      })
+    })
+
+    it("getEquivalence", () => {
+      assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { a: 1 }), true)
+      assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, stringRecord), true)
+      assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { a: 2 }), false)
+      assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)({ a: 1 }, { b: 1 }), false)
+      const noPrototype = Object.create(null)
+      assert.deepStrictEqual(RR.getEquivalence(N.Equivalence)(noPrototype, { b: 1 }), false)
+    })
+
+    it("mapKeys", () => {
+      expect(pipe({ a: 1, b: 2, [symA]: null }, RR.mapKeys((key) => key.toUpperCase()))).toStrictEqual({ A: 1, B: 2 })
+    })
+
+    it("mapEntries", () => {
+      expect(pipe(stringRecord, RR.mapEntries((a, key) => [key.toUpperCase(), a + 1]))).toStrictEqual({ A: 2 })
     })
   })
 })


### PR DESCRIPTION
- empty
- fromIterableWith
- fromIterableBy
- has
- get
- modify
- modifyOption
- replaceOption
- remove
- pop
- set
- replace
- singleton
