### PR TITLE
fix: Schema.filter error reporting

### DIFF
--- a/.changeset/quiet-bobcats-walk.md
+++ b/.changeset/quiet-bobcats-walk.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Propagate an original error of schema with `Schema.filter`.

--- a/packages/schema/src/TreeFormatter.ts
+++ b/packages/schema/src/TreeFormatter.ts
@@ -114,7 +114,7 @@ const getParseIsssueMessage = (
 /** @internal */
 export const getRefinementMessage = (e: ParseResult.Refinement, actual: unknown): Option.Option<string> => {
   if (e.kind === "From") {
-    return getParseIsssueMessage(e.error, () => getMessage(e.ast, actual))
+    return getParseIsssueMessage(e.error, () => getMessage(e.ast.from, actual))
   }
   return getMessage(e.ast, actual)
 }

--- a/packages/schema/test/ArrayFormatter.test.ts
+++ b/packages/schema/test/ArrayFormatter.test.ts
@@ -251,9 +251,9 @@ describe("ArrayFormatter", () => {
         )
 
         expectIssues(schema, null, [{
-          _tag: "Refinement",
+          _tag: "Type",
           path: [],
-          message: "my custom message null"
+          message: "Expected a string, actual null"
         }])
         expectIssues(schema, "", [{
           _tag: "Refinement",

--- a/packages/schema/test/Schema/filter.test.ts
+++ b/packages/schema/test/Schema/filter.test.ts
@@ -58,4 +58,26 @@ describe("Schema > filter", () => {
    └─ b should be equal to a's value ("a")`
     )
   })
+
+  it("Error from the original schema is propagated", async () => {
+    const schema = S.struct({ a: S.string, b: S.string }).pipe(
+      S.filter((o) => o.b === o.a, { message: () => "b should be equal to a" })
+    )
+
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      { a: "a", b: "b" },
+      `b should be equal to a`
+    )
+
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      { a: "a", b: 2 },
+      `<refinement schema>
+└─ From side refinement failure
+   └─ { a: string; b: string }
+      └─ ["b"]
+         └─ Expected a string, actual 2`
+    )
+  })
 })

--- a/packages/schema/test/TreeFormatter.test.ts
+++ b/packages/schema/test/TreeFormatter.test.ts
@@ -352,7 +352,9 @@ describe("TreeFormatter", () => {
         await Util.expectDecodeUnknownFailure(
           schema,
           null,
-          `my custom message null`
+          `a string at least 1 character(s) long
+└─ From side refinement failure
+   └─ Expected a string, actual null`
         )
         await Util.expectDecodeUnknownFailure(
           schema,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When I have schema like `MySchema.pipe(Schema.filter(..., { message: (value) => 'filter message' }))` and the decoding fails because of `MySchema` and not because of the filter, it currently reports the `'filter message'` anyway.

Additionally, the `value` within `{ message: (value) => 'filter message' }` is typed as `A` of the `MySchema` which is not correct because it receives whatever is the input value because the parsing of `MySchema` might have failed.