### PR TITLE
Schema: change the `MessageAnnotation` type to be non-parametric; now…

### DIFF
--- a/.changeset/gentle-hounds-juggle.md
+++ b/.changeset/gentle-hounds-juggle.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Change the `MessageAnnotation` type to be non-parametric; now it's simply `(u: unknown) => string` to accommodate custom error messages, which can be triggered by any circumstances

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -46,7 +46,7 @@ export const TypeAnnotationId = Symbol.for("@effect/schema/annotation/Type")
  * @category annotations
  * @since 1.0.0
  */
-export type MessageAnnotation<A> = (a: A) => string
+export type MessageAnnotation = (u: unknown) => string
 
 /**
  * @category annotations
@@ -173,7 +173,7 @@ export const getAnnotation: {
  * @category annotations
  * @since 1.0.0
  */
-export const getMessageAnnotation = getAnnotation<MessageAnnotation<unknown>>(
+export const getMessageAnnotation = getAnnotation<MessageAnnotation>(
   MessageAnnotationId
 )
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -517,7 +517,7 @@ const declarePrimitive = <A>(
  * @since 1.0.0
  */
 export interface DeclareAnnotations<P extends ReadonlyArray<any>, A> extends DocAnnotations {
-  readonly message?: AST.MessageAnnotation<A>
+  readonly message?: AST.MessageAnnotation
   readonly typeId?: AST.TypeAnnotation | { id: AST.TypeAnnotation; annotation: unknown }
   readonly arbitrary?: (...arbitraries: { readonly [K in keyof P]: Arbitrary<P[K]> }) => Arbitrary<A>
   readonly pretty?: (...pretties: { readonly [K in keyof P]: Pretty.Pretty<P[K]> }) => Pretty.Pretty<A>
@@ -1909,7 +1909,7 @@ export const annotations = (annotations: AST.Annotations) => <A, I, R>(self: Sch
  * @category annotations
  * @since 1.0.0
  */
-export const message = (message: AST.MessageAnnotation<unknown>) => <A, I, R>(self: Schema<A, I, R>): Schema<A, I, R> =>
+export const message = (message: AST.MessageAnnotation) => <A, I, R>(self: Schema<A, I, R>): Schema<A, I, R> =>
   make(AST.setAnnotation(self.ast, AST.MessageAnnotationId, message))
 
 /**

--- a/packages/schema/test/Schema/filter.test.ts
+++ b/packages/schema/test/Schema/filter.test.ts
@@ -6,7 +6,7 @@ import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
 describe("Schema > filter", () => {
-  it("filter/ annotation options", () => {
+  it("annotation options", () => {
     const schema = S.string.pipe(
       S.filter((s): s is string => s.length === 1, {
         typeId: Symbol.for("Char"),
@@ -57,5 +57,12 @@ describe("Schema > filter", () => {
 └─ Predicate refinement failure
    └─ b should be equal to a's value ("a")`
     )
+  })
+
+  it("custom message", async () => {
+    const schema = S.string.pipe(S.filter((s): s is string => s.length === 1, {
+      message: (u) => `invalid ${u}`
+    }))
+    await Util.expectDecodeUnknownFailure(schema, null, `invalid null`)
   })
 })


### PR DESCRIPTION
… it's simply `(u: unknown) => string` to accommodate custom error messages, which can be triggered by any circumstances

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
