### PR TITLE
Fix the root command name in generated shell completion scripts

### DIFF
--- a/.changeset/thick-chefs-float.md
+++ b/.changeset/thick-chefs-float.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Fixes the root command name in generated shell completion scripts

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -181,19 +181,20 @@ const handleBuiltInOption = <R, E, A>(
       return Console.log(InternalHelpDoc.toAnsiText(helpDoc))
     }
     case "ShowCompletions": {
+      const command = Array.from(InternalCommand.getNames(self.command))[0]!
       switch (builtIn.shellType) {
         case "bash": {
-          return InternalCommand.getBashCompletions(self.command, executable).pipe(
+          return InternalCommand.getBashCompletions(self.command, command).pipe(
             Effect.flatMap((completions) => Console.log(ReadonlyArray.join(completions, "\n")))
           )
         }
         case "fish": {
-          return InternalCommand.getFishCompletions(self.command, executable).pipe(
+          return InternalCommand.getFishCompletions(self.command, command).pipe(
             Effect.flatMap((completions) => Console.log(ReadonlyArray.join(completions, "\n")))
           )
         }
         case "zsh":
-          return InternalCommand.getZshCompletions(self.command, executable).pipe(
+          return InternalCommand.getZshCompletions(self.command, command).pipe(
             Effect.flatMap((completions) => Console.log(ReadonlyArray.join(completions, "\n")))
           )
       }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR corrects the root command name in the generated completion scripts. The root command name should not _necessarily_ be the name of the executable, but should instead be the name of the script that is called from the command line.

For example, if installing a package from NPM with a `"bin"` registered in the package JSON and the file referenced by `"bin"` contains the `#!/usr/bin/env node` shebang, then one can call the script directly using the package name (or whatever alias(es) is registered in the `"bin"` field). This means the script will be called from the command line as `package-name`, but the program that is executed will be `node script-in-bin-field`.

Take `docgen` for example, the `"bin"` field in the package JSON points to `./dist/bin.cjs` in the distributable. So even though we call `docgen` from the command line, the program that is executed is `./dist/bin.cjs`. 

However, because of the way completions are associated with what is typed on the command-line, the completions should be triggered by the user typing `docgen`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
