### PR TITLE
Fix wizard mode to show root command name instead of executable

### DIFF
--- a/.changeset/mighty-experts-prove.md
+++ b/.changeset/mighty-experts-prove.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Ensure wizard mode does not prompt further for 0 input to variadic arg / option

--- a/.changeset/odd-geese-shout.md
+++ b/.changeset/odd-geese-shout.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Fix the display of CLI wizard mode to show the root command name and not the current executable

--- a/packages/cli/src/internal/args.ts
+++ b/packages/cli/src/internal/args.ts
@@ -927,16 +927,18 @@ const wizardInternal = (self: Instruction, config: CliConfig.CliConfig): Effect.
       }).pipe(
         Effect.zipLeft(Console.log()),
         Effect.flatMap((n) =>
-          Ref.make(ReadonlyArray.empty<string>()).pipe(
-            Effect.flatMap((ref) =>
-              wizardInternal(self.args as Instruction, config).pipe(
-                Effect.flatMap((args) => Ref.update(ref, ReadonlyArray.appendAll(args))),
-                Effect.repeatN(n - 1),
-                Effect.zipRight(Ref.get(ref)),
-                Effect.tap((args) => validateInternal(self, args, config))
+          n <= 0
+            ? Effect.succeed(ReadonlyArray.empty<string>())
+            : Ref.make(ReadonlyArray.empty<string>()).pipe(
+              Effect.flatMap((ref) =>
+                wizardInternal(self.args as Instruction, config).pipe(
+                  Effect.flatMap((args) => Ref.update(ref, ReadonlyArray.appendAll(args))),
+                  Effect.repeatN(n - 1),
+                  Effect.zipRight(Ref.get(ref)),
+                  Effect.tap((args) => validateInternal(self, args, config))
+                )
               )
             )
-          )
         )
       )
     }

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -245,8 +245,12 @@ const handleBuiltInOption = <R, E, A>(
             active: "yes",
             inactive: "no"
           }).pipe(Effect.flatMap((shouldRunCommand) => {
+            const finalArgs = pipe(
+              ReadonlyArray.drop(args, 1),
+              ReadonlyArray.prependAll(executable.split(/\s+/))
+            )
             return shouldRunCommand
-              ? Console.log().pipe(Effect.zipRight(run(self, args, execute)))
+              ? Console.log().pipe(Effect.zipRight(run(self, finalArgs, execute)))
               : Effect.unit
           }))
         ),

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -233,7 +233,8 @@ const handleBuiltInOption = <R, E, A>(
       )
       const help = InternalHelpDoc.sequence(header, description)
       const text = InternalHelpDoc.toAnsiText(help)
-      const wizardPrefix = getWizardPrefix(builtIn, executable, args)
+      const command = Array.from(InternalCommand.getNames(self.command))[0]!
+      const wizardPrefix = getWizardPrefix(builtIn, command, args)
       return Console.log(text).pipe(
         Effect.zipRight(InternalCommand.wizard(builtIn.command, wizardPrefix, config)),
         Effect.tap((args) => Console.log(InternalHelpDoc.toAnsiText(renderWizardArgs(args)))),

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1408,15 +1408,17 @@ const wizardInternal = (self: Instruction, config: CliConfig.CliConfig): Effect.
         max: getMaxSizeInternal(self)
       }).pipe(
         Effect.flatMap((n) =>
-          Ref.make(ReadonlyArray.empty<string>()).pipe(
-            Effect.flatMap((ref) =>
-              wizardInternal(self.argumentOption as Instruction, config).pipe(
-                Effect.flatMap((args) => Ref.update(ref, ReadonlyArray.appendAll(args))),
-                Effect.repeatN(n - 1),
-                Effect.zipRight(Ref.get(ref))
+          n <= 0
+            ? Effect.succeed(ReadonlyArray.empty<string>())
+            : Ref.make(ReadonlyArray.empty<string>()).pipe(
+              Effect.flatMap((ref) =>
+                wizardInternal(self.argumentOption as Instruction, config).pipe(
+                  Effect.flatMap((args) => Ref.update(ref, ReadonlyArray.appendAll(args))),
+                  Effect.repeatN(n - 1),
+                  Effect.zipRight(Ref.get(ref))
+                )
               )
             )
-          )
         )
       )
     }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Two Fixes:

1. Makes sure that if a user enters `0` into a variadic `Args` / `Options` wizard prompt, that they do not get further prompted for input on that argument or option.

2. Instead of seeing the executable in the rendered wizard output, display the root command name

**Before**

![image](https://github.com/Effect-TS/effect/assets/38051499/cf337a28-5007-4f2c-b70a-11d6668915f9)

**After**

![image](https://github.com/Effect-TS/effect/assets/38051499/7dbf8fe4-9c1f-42a5-aeeb-4504880d5b78)


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
