### PR TITLE
Equivalence: return `Equal.equals` instead of `Equivalence.strict()` …

### DIFF
--- a/.changeset/moody-chicken-juggle.md
+++ b/.changeset/moody-chicken-juggle.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Equivalence: return `Equal.equals` instead of `Equivalence.strict()` as default

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -62,4 +62,4 @@ export const isEqual = (u: unknown): u is Equal => hasProperty(u, symbol)
  * @since 2.0.0
  * @category instances
  */
-export const equivalence: <A>() => Equivalence<A> = () => (self, that) => equals(self, that)
+export const equivalence: <A>() => Equivalence<A> = () => equals

--- a/packages/schema/src/Equivalence.ts
+++ b/packages/schema/src/Equivalence.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 
+import * as Equal from "effect/Equal"
 import * as Equivalence from "effect/Equivalence"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
@@ -78,7 +79,7 @@ const go = (ast: AST.AST): Equivalence.Equivalence<any> => {
     case "VoidKeyword":
     case "Enums":
     case "ObjectKeyword":
-      return Equivalence.strict()
+      return Equal.equals
     case "Refinement":
       return go(ast.from)
     case "Suspend": {
@@ -127,7 +128,7 @@ const go = (ast: AST.AST): Equivalence.Equivalence<any> => {
     }
     case "TypeLiteral": {
       if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
-        return Equivalence.strict()
+        return Equal.equals
       }
       const propertySignatures = ast.propertySignatures.map((ps) => go(ps.type))
       const indexSignatures = ast.indexSignatures.map((is) => go(is.type))

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -3543,7 +3543,7 @@ export const Uint8ArrayFromSelf: Schema<Uint8Array> = declare(
     identifier: "Uint8ArrayFromSelf",
     pretty: (): Pretty.Pretty<Uint8Array> => (u8arr) => `new Uint8Array(${JSON.stringify(Array.from(u8arr))})`,
     arbitrary: (): Arbitrary<Uint8Array> => (fc) => fc.uint8Array(),
-    equivalence: (): Equivalence.Equivalence<Uint8Array> => ReadonlyArray.getEquivalence(Equivalence.strict()) as any
+    equivalence: (): Equivalence.Equivalence<Uint8Array> => ReadonlyArray.getEquivalence(Equal.equals) as any
   }
 )
 
@@ -4667,8 +4667,7 @@ export const dataFromSelf = <
     {
       description: `Data<${format(item)}>`,
       pretty: dataPretty,
-      arbitrary: dataArbitrary,
-      equivalence: () => Equal.equals
+      arbitrary: dataArbitrary
     }
   )
 }
@@ -5099,8 +5098,7 @@ export const FiberIdFromSelf: Schema<FiberId.FiberId> = declare(
   {
     identifier: "FiberIdFromSelf",
     pretty: () => fiberIdPretty,
-    arbitrary: () => fiberIdArbitrary,
-    equivalence: () => Equal.equals
+    arbitrary: () => fiberIdArbitrary
   }
 )
 
@@ -5278,8 +5276,7 @@ export const causeFromSelf = <A, I, R1, R2 = never>({ defect = unknown, error }:
     {
       description: `Cause<${format(error)}>`,
       pretty: causePretty,
-      arbitrary: causeArbitrary,
-      equivalence: () => Equal.equals
+      arbitrary: causeArbitrary
     }
   )
 }
@@ -5455,8 +5452,7 @@ export const exitFromSelf = <E, IE, RE, A, IA, RA, RD = never>({ defect = unknow
     {
       description: `Exit<${format(failure)}, ${format(success)}>`,
       pretty: exitPretty,
-      arbitrary: exitArbitrary,
-      equivalence: () => Equal.equals
+      arbitrary: exitArbitrary
     }
   )
 


### PR DESCRIPTION
…as default
