### PR TITLE
Fix ConfigError tag bug and make ConfigError a TaggedError

### DIFF
--- a/.changeset/slimy-beers-share.md
+++ b/.changeset/slimy-beers-share.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fixed ConfigError tag bug

--- a/packages/effect/dtslint/Config.ts
+++ b/packages/effect/dtslint/Config.ts
@@ -1,5 +1,7 @@
 import * as Config from "effect/Config"
+import type * as ConfigError from "effect/ConfigError"
 import { pipe } from "effect/Function"
+import type { Tags } from "effect/Types"
 
 declare const string: Config.Config<string>
 declare const number: Config.Config<number>
@@ -45,3 +47,6 @@ Config.all(numberRecord)
 
 // $ExpectType Config<{ [x: string]: number; }>
 pipe(numberRecord, Config.all)
+
+// $ExpectType "ConfigError"
+export type T = Tags<ConfigError.ConfigError>

--- a/packages/effect/src/ConfigError.ts
+++ b/packages/effect/src/ConfigError.ts
@@ -17,6 +17,18 @@ export const ConfigErrorTypeId: unique symbol = internal.ConfigErrorTypeId
 export type ConfigErrorTypeId = typeof ConfigErrorTypeId
 
 /**
+ * @since 2.0.0
+ * @category symbols
+ */
+export const Discriminant: unique symbol = internal.Discriminant
+
+/**
+ * @since 2.0.0
+ * @category symbols
+ */
+export type Discriminant = typeof Discriminant
+
+/**
  * The possible ways that loading configuration data may fail.
  *
  * @since 2.0.0
@@ -39,6 +51,7 @@ export declare namespace ConfigError {
    * @category models
    */
   export interface Proto {
+    readonly _tag: "ConfigError"
     readonly [ConfigErrorTypeId]: ConfigErrorTypeId
   }
 
@@ -72,7 +85,7 @@ export interface ConfigErrorReducer<in C, in out Z> {
  * @category models
  */
 export interface And extends ConfigError.Proto {
-  readonly _tag: "And"
+  readonly [Discriminant]: "And"
   readonly left: ConfigError
   readonly right: ConfigError
 }
@@ -82,7 +95,7 @@ export interface And extends ConfigError.Proto {
  * @category models
  */
 export interface Or extends ConfigError.Proto {
-  readonly _tag: "Or"
+  readonly [Discriminant]: "Or"
   readonly left: ConfigError
   readonly right: ConfigError
 }
@@ -92,7 +105,7 @@ export interface Or extends ConfigError.Proto {
  * @category models
  */
 export interface InvalidData extends ConfigError.Proto {
-  readonly _tag: "InvalidData"
+  readonly [Discriminant]: "InvalidData"
   readonly path: Array<string>
   readonly message: string
 }
@@ -102,7 +115,7 @@ export interface InvalidData extends ConfigError.Proto {
  * @category models
  */
 export interface MissingData extends ConfigError.Proto {
-  readonly _tag: "MissingData"
+  readonly [Discriminant]: "MissingData"
   readonly path: Array<string>
   readonly message: string
 }
@@ -112,7 +125,7 @@ export interface MissingData extends ConfigError.Proto {
  * @category models
  */
 export interface SourceUnavailable extends ConfigError.Proto {
-  readonly _tag: "SourceUnavailable"
+  readonly [Discriminant]: "SourceUnavailable"
   readonly path: Array<string>
   readonly message: string
   readonly cause: Cause.Cause<unknown>
@@ -123,7 +136,7 @@ export interface SourceUnavailable extends ConfigError.Proto {
  * @category models
  */
 export interface Unsupported extends ConfigError.Proto {
-  readonly _tag: "Unsupported"
+  readonly [Discriminant]: "Unsupported"
   readonly path: Array<string>
   readonly message: string
 }

--- a/packages/effect/src/ConfigError.ts
+++ b/packages/effect/src/ConfigError.ts
@@ -69,12 +69,12 @@ export type Discriminant = typeof Discriminant
  * @category models
  */
 export type ConfigError =
-  | internal.And
-  | internal.Or
-  | internal.InvalidData
-  | internal.MissingData
-  | internal.SourceUnavailable
-  | internal.Unsupported
+  | And
+  | Or
+  | InvalidData
+  | MissingData
+  | SourceUnavailable
+  | Unsupported
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/ConfigError.ts
+++ b/packages/effect/src/ConfigError.ts
@@ -2,7 +2,41 @@
  * @since 2.0.0
  */
 import type * as Cause from "./Cause.js"
+import type { And, InvalidData, MissingData, Or, SourceUnavailable, Unsupported } from "./internal/configError.js"
 import * as internal from "./internal/configError.js"
+
+export {
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  And,
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  InvalidData,
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  MissingData,
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  Or,
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  SourceUnavailable,
+  /**
+   * @since 2.0.0
+   * @category models
+   */
+  Unsupported
+} from "./internal/configError.js"
 
 /**
  * @since 2.0.0
@@ -35,12 +69,12 @@ export type Discriminant = typeof Discriminant
  * @category models
  */
 export type ConfigError =
-  | And
-  | Or
-  | InvalidData
-  | MissingData
-  | SourceUnavailable
-  | Unsupported
+  | internal.And
+  | internal.Or
+  | internal.InvalidData
+  | internal.MissingData
+  | internal.SourceUnavailable
+  | internal.Unsupported
 
 /**
  * @since 2.0.0
@@ -69,76 +103,15 @@ export declare namespace ConfigError {
 export interface ConfigErrorReducer<in C, in out Z> {
   andCase(context: C, left: Z, right: Z): Z
   orCase(context: C, left: Z, right: Z): Z
-  invalidDataCase(context: C, path: Array<string>, message: string): Z
-  missingDataCase(context: C, path: Array<string>, message: string): Z
+  invalidDataCase(context: C, path: ReadonlyArray<string>, message: string): Z
+  missingDataCase(context: C, path: ReadonlyArray<string>, message: string): Z
   sourceUnavailableCase(
     context: C,
-    path: Array<string>,
+    path: ReadonlyArray<string>,
     message: string,
     cause: Cause.Cause<unknown>
   ): Z
-  unsupportedCase(context: C, path: Array<string>, message: string): Z
-}
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface And extends ConfigError.Proto {
-  readonly [Discriminant]: "And"
-  readonly left: ConfigError
-  readonly right: ConfigError
-}
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface Or extends ConfigError.Proto {
-  readonly [Discriminant]: "Or"
-  readonly left: ConfigError
-  readonly right: ConfigError
-}
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface InvalidData extends ConfigError.Proto {
-  readonly [Discriminant]: "InvalidData"
-  readonly path: Array<string>
-  readonly message: string
-}
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface MissingData extends ConfigError.Proto {
-  readonly [Discriminant]: "MissingData"
-  readonly path: Array<string>
-  readonly message: string
-}
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface SourceUnavailable extends ConfigError.Proto {
-  readonly [Discriminant]: "SourceUnavailable"
-  readonly path: Array<string>
-  readonly message: string
-  readonly cause: Cause.Cause<unknown>
-}
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface Unsupported extends ConfigError.Proto {
-  readonly [Discriminant]: "Unsupported"
-  readonly path: Array<string>
-  readonly message: string
+  unsupportedCase(context: C, path: ReadonlyArray<string>, message: string): Z
 }
 
 /**
@@ -148,50 +121,6 @@ export interface Unsupported extends ConfigError.Proto {
 export interface Options {
   readonly pathDelim: string
 }
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const And: (self: ConfigError, that: ConfigError) => ConfigError = internal.And
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const Or: (self: ConfigError, that: ConfigError) => ConfigError = internal.Or
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const MissingData: (path: Array<string>, message: string, options?: Options) => ConfigError =
-  internal.MissingData
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const InvalidData: (path: Array<string>, message: string, options?: Options) => ConfigError =
-  internal.InvalidData
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const SourceUnavailable: (
-  path: Array<string>,
-  message: string,
-  cause: Cause.Cause<unknown>,
-  options?: Options
-) => ConfigError = internal.SourceUnavailable
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const Unsupported: (path: Array<string>, message: string, options?: Options) => ConfigError =
-  internal.Unsupported
 
 /**
  * Returns `true` if the specified value is a `ConfigError`, `false` otherwise.

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -164,7 +164,7 @@ export const boolean = (name?: string): Config.Config<boolean> => {
           return Either.right(false)
         }
         default: {
-          const error = configError.InvalidData(
+          const error = new configError.InvalidData(
             [],
             `Expected a boolean value but received ${text}`
           )
@@ -194,7 +194,7 @@ export const date = (name?: string): Config.Config<Date> => {
       const result = Date.parse(text)
       if (Number.isNaN(result)) {
         return Either.left(
-          configError.InvalidData(
+          new configError.InvalidData(
             [],
             `Expected a Date value but received ${text}`
           )
@@ -211,7 +211,7 @@ export const fail = (message: string): Config.Config<never> => {
   const fail = Object.create(proto)
   fail._tag = OpCodes.OP_FAIL
   fail.message = message
-  fail.parse = () => Either.left(configError.Unsupported([], message))
+  fail.parse = () => Either.left(new configError.Unsupported([], message))
   return fail
 }
 
@@ -223,7 +223,7 @@ export const number = (name?: string): Config.Config<number> => {
       const result = Number.parseFloat(text)
       if (Number.isNaN(result)) {
         return Either.left(
-          configError.InvalidData(
+          new configError.InvalidData(
             [],
             `Expected a number value but received ${text}`
           )
@@ -243,7 +243,7 @@ export const integer = (name?: string): Config.Config<number> => {
       const result = Number.parseInt(text, 10)
       if (Number.isNaN(result)) {
         return Either.left(
-          configError.InvalidData(
+          new configError.InvalidData(
             [],
             `Expected an integer value but received ${text}`
           )
@@ -265,7 +265,7 @@ export const literal = <Literals extends ReadonlyArray<Config.LiteralValue>>(...
     const found = literals.find((value) => String(value) === text)
     if (found === undefined) {
       return Either.left(
-        configError.InvalidData(
+        new configError.InvalidData(
           [],
           `Expected one of (${valuesString}) but received ${text}`
         )
@@ -282,7 +282,7 @@ export const logLevel = (name?: string): Config.Config<LogLevel.LogLevel> => {
     const label = value.toUpperCase()
     const level = core.allLogLevels.find((level) => level.label === label)
     return level === undefined
-      ? Either.left(configError.InvalidData([], `Expected a log level but received ${value}`))
+      ? Either.left(new configError.InvalidData([], `Expected a log level but received ${value}`))
       : Either.right(level)
   })
   return name === undefined ? config : nested(config, name)
@@ -304,7 +304,7 @@ export const mapAttempt = dual<
       return Either.right(f(a))
     } catch (error) {
       return Either.left(
-        configError.InvalidData(
+        new configError.InvalidData(
           [],
           error instanceof Error ? error.message : `${error}`
         )
@@ -567,7 +567,7 @@ export const validate = dual<
     if (validation(a)) {
       return Either.right(a)
     }
-    return Either.left(configError.InvalidData([], message))
+    return Either.left(new configError.InvalidData([], message))
   }))
 
 /** @internal */

--- a/packages/effect/src/internal/configError.ts
+++ b/packages/effect/src/internal/configError.ts
@@ -15,6 +15,14 @@ export const ConfigErrorTypeId: ConfigError.ConfigErrorTypeId = Symbol.for(
 ) as ConfigError.ConfigErrorTypeId
 
 /** @internal */
+const DiscriminantSymbolKey = "effect/ConfigError.Discriminant"
+
+/** @internal */
+export const Discriminant: ConfigError.Discriminant = Symbol.for(
+  DiscriminantSymbolKey
+) as ConfigError.Discriminant
+
+/** @internal */
 export const proto = {
   [ConfigErrorTypeId]: ConfigErrorTypeId
 }
@@ -22,7 +30,8 @@ export const proto = {
 /** @internal */
 export const And = (self: ConfigError.ConfigError, that: ConfigError.ConfigError): ConfigError.ConfigError => {
   const error = Object.create(proto)
-  error._tag = OpCodes.OP_AND
+  error._tag = "ConfigError"
+  error[Discriminant] = OpCodes.OP_AND
   error.left = self
   error.right = that
   Object.defineProperty(error, "toString", {
@@ -37,7 +46,8 @@ export const And = (self: ConfigError.ConfigError, that: ConfigError.ConfigError
 /** @internal */
 export const Or = (self: ConfigError.ConfigError, that: ConfigError.ConfigError): ConfigError.ConfigError => {
   const error = Object.create(proto)
-  error._tag = OpCodes.OP_OR
+  error._tag = "ConfigError"
+  error[Discriminant] = OpCodes.OP_OR
   error.left = self
   error.right = that
   Object.defineProperty(error, "toString", {
@@ -56,7 +66,8 @@ export const InvalidData = (
   options: ConfigError.Options = { pathDelim: "." }
 ): ConfigError.ConfigError => {
   const error = Object.create(proto)
-  error._tag = OpCodes.OP_INVALID_DATA
+  error._tag = "ConfigError"
+  error[Discriminant] = OpCodes.OP_INVALID_DATA
   error.path = path
   error.message = message
   Object.defineProperty(error, "toString", {
@@ -76,7 +87,8 @@ export const MissingData = (
   options: ConfigError.Options = { pathDelim: "." }
 ): ConfigError.ConfigError => {
   const error = Object.create(proto)
-  error._tag = OpCodes.OP_MISSING_DATA
+  error._tag = "ConfigError"
+  error[Discriminant] = OpCodes.OP_MISSING_DATA
   error.path = path
   error.message = message
   Object.defineProperty(error, "toString", {
@@ -97,7 +109,8 @@ export const SourceUnavailable = (
   options: ConfigError.Options = { pathDelim: "." }
 ): ConfigError.ConfigError => {
   const error = Object.create(proto)
-  error._tag = OpCodes.OP_SOURCE_UNAVAILABLE
+  error._tag = "ConfigError"
+  error[Discriminant] = OpCodes.OP_SOURCE_UNAVAILABLE
   error.path = path
   error.message = message
   error.cause = cause
@@ -118,7 +131,8 @@ export const Unsupported = (
   options: ConfigError.Options = { pathDelim: "." }
 ): ConfigError.ConfigError => {
   const error = Object.create(proto)
-  error._tag = OpCodes.OP_UNSUPPORTED
+  error._tag = "ConfigError"
+  error[Discriminant] = OpCodes.OP_UNSUPPORTED
   error.path = path
   error.message = message
   Object.defineProperty(error, "toString", {
@@ -135,26 +149,26 @@ export const Unsupported = (
 export const isConfigError = (u: unknown): u is ConfigError.ConfigError => hasProperty(u, ConfigErrorTypeId)
 
 /** @internal */
-export const isAnd = (self: ConfigError.ConfigError): self is ConfigError.And => self._tag === OpCodes.OP_AND
+export const isAnd = (self: ConfigError.ConfigError): self is ConfigError.And => self[Discriminant] === OpCodes.OP_AND
 
 /** @internal */
-export const isOr = (self: ConfigError.ConfigError): self is ConfigError.Or => self._tag === OpCodes.OP_OR
+export const isOr = (self: ConfigError.ConfigError): self is ConfigError.Or => self[Discriminant] === OpCodes.OP_OR
 
 /** @internal */
 export const isInvalidData = (self: ConfigError.ConfigError): self is ConfigError.InvalidData =>
-  self._tag === OpCodes.OP_INVALID_DATA
+  self[Discriminant] === OpCodes.OP_INVALID_DATA
 
 /** @internal */
 export const isMissingData = (self: ConfigError.ConfigError): self is ConfigError.MissingData =>
-  self._tag === OpCodes.OP_MISSING_DATA
+  self[Discriminant] === OpCodes.OP_MISSING_DATA
 
 /** @internal */
 export const isSourceUnavailable = (self: ConfigError.ConfigError): self is ConfigError.SourceUnavailable =>
-  self._tag === OpCodes.OP_SOURCE_UNAVAILABLE
+  self[Discriminant] === OpCodes.OP_SOURCE_UNAVAILABLE
 
 /** @internal */
 export const isUnsupported = (self: ConfigError.ConfigError): self is ConfigError.Unsupported =>
-  self._tag === OpCodes.OP_UNSUPPORTED
+  self[Discriminant] === OpCodes.OP_UNSUPPORTED
 
 /** @internal */
 export const prefixed: {
@@ -164,7 +178,7 @@ export const prefixed: {
   (prefix: ReadonlyArray<string>) => (self: ConfigError.ConfigError) => ConfigError.ConfigError,
   (self: ConfigError.ConfigError, prefix: ReadonlyArray<string>) => ConfigError.ConfigError
 >(2, (self, prefix) => {
-  switch (self._tag) {
+  switch (self[Discriminant]) {
     case OpCodes.OP_AND: {
       return And(prefixed(self.left, prefix), prefixed(self.right, prefix))
     }
@@ -218,7 +232,7 @@ export const reduceWithContext = dual<
   const output: Array<Either.Either<ConfigErrorCase, Z>> = []
   while (input.length > 0) {
     const error = input.pop()!
-    switch (error._tag) {
+    switch (error[Discriminant]) {
       case OpCodes.OP_AND: {
         input.push(error.right)
         input.push(error.left)

--- a/packages/effect/src/internal/configError.ts
+++ b/packages/effect/src/internal/configError.ts
@@ -1,5 +1,6 @@
 import type * as Cause from "../Cause.js"
 import type * as ConfigError from "../ConfigError.js"
+import { TaggedError } from "../Data.js"
 import * as Either from "../Either.js"
 import { constFalse, constTrue, dual, pipe } from "../Function.js"
 import { hasProperty } from "../Predicate.js"
@@ -28,146 +29,133 @@ export const proto = {
 }
 
 /** @internal */
-export const And = (self: ConfigError.ConfigError, that: ConfigError.ConfigError): ConfigError.ConfigError => {
-  const error = Object.create(proto)
-  error._tag = "ConfigError"
-  error[Discriminant] = OpCodes.OP_AND
-  error.left = self
-  error.right = that
-  Object.defineProperty(error, "toString", {
-    enumerable: false,
-    value(this: ConfigError.And) {
-      return `${this.left} and ${this.right}`
-    }
-  })
-  return error
+export class And extends TaggedError("ConfigError") implements ConfigError.ConfigError.Proto {
+  [ConfigErrorTypeId]: typeof ConfigError.ConfigErrorTypeId
+  readonly [Discriminant] = OpCodes.OP_AND
+  constructor(readonly left: ConfigError.ConfigError, readonly right: ConfigError.ConfigError) {
+    super()
+    this[ConfigErrorTypeId] = ConfigErrorTypeId
+  }
+
+  toString(): string {
+    return `${this.left} and ${this.right}`
+  }
 }
 
 /** @internal */
-export const Or = (self: ConfigError.ConfigError, that: ConfigError.ConfigError): ConfigError.ConfigError => {
-  const error = Object.create(proto)
-  error._tag = "ConfigError"
-  error[Discriminant] = OpCodes.OP_OR
-  error.left = self
-  error.right = that
-  Object.defineProperty(error, "toString", {
-    enumerable: false,
-    value(this: ConfigError.Or) {
-      return `${this.left} or ${this.right}`
-    }
-  })
-  return error
+export class Or extends TaggedError("ConfigError") implements ConfigError.ConfigError.Proto {
+  [ConfigErrorTypeId]: typeof ConfigError.ConfigErrorTypeId
+  readonly [Discriminant] = OpCodes.OP_OR
+  constructor(readonly left: ConfigError.ConfigError, readonly right: ConfigError.ConfigError) {
+    super()
+    this[ConfigErrorTypeId] = ConfigErrorTypeId
+  }
+
+  toString(): string {
+    return `${this.left} or ${this.right}`
+  }
 }
 
 /** @internal */
-export const InvalidData = (
-  path: ReadonlyArray<string>,
-  message: string,
-  options: ConfigError.Options = { pathDelim: "." }
-): ConfigError.ConfigError => {
-  const error = Object.create(proto)
-  error._tag = "ConfigError"
-  error[Discriminant] = OpCodes.OP_INVALID_DATA
-  error.path = path
-  error.message = message
-  Object.defineProperty(error, "toString", {
-    enumerable: false,
-    value(this: ConfigError.InvalidData) {
-      const path = pipe(this.path, RA.join(options.pathDelim))
-      return `(Invalid data at ${path}: "${this.message}")`
-    }
-  })
-  return error
+export class InvalidData extends TaggedError("ConfigError") implements ConfigError.ConfigError.Proto {
+  readonly [ConfigErrorTypeId]: typeof ConfigError.ConfigErrorTypeId
+  readonly [Discriminant] = OpCodes.OP_INVALID_DATA
+  constructor(
+    readonly path: ReadonlyArray<string>,
+    readonly message: string,
+    readonly options: ConfigError.Options = { pathDelim: "." }
+  ) {
+    super()
+    this[ConfigErrorTypeId] = ConfigErrorTypeId
+  }
+
+  toString() {
+    const path = pipe(this.path, RA.join(this.options.pathDelim))
+    return `(Invalid data at ${path}: "${this.message}")`
+  }
 }
 
 /** @internal */
-export const MissingData = (
-  path: ReadonlyArray<string>,
-  message: string,
-  options: ConfigError.Options = { pathDelim: "." }
-): ConfigError.ConfigError => {
-  const error = Object.create(proto)
-  error._tag = "ConfigError"
-  error[Discriminant] = OpCodes.OP_MISSING_DATA
-  error.path = path
-  error.message = message
-  Object.defineProperty(error, "toString", {
-    enumerable: false,
-    value(this: ConfigError.MissingData) {
-      const path = pipe(this.path, RA.join(options.pathDelim))
-      return `(Missing data at ${path}: "${this.message}")`
-    }
-  })
-  return error
+export class MissingData extends TaggedError("ConfigError") implements ConfigError.ConfigError.Proto {
+  readonly [ConfigErrorTypeId]: typeof ConfigError.ConfigErrorTypeId
+  readonly [Discriminant] = OpCodes.OP_MISSING_DATA
+  constructor(
+    readonly path: ReadonlyArray<string>,
+    readonly message: string,
+    readonly options: ConfigError.Options = { pathDelim: "." }
+  ) {
+    super()
+    this[ConfigErrorTypeId] = ConfigErrorTypeId
+  }
+
+  toString() {
+    const path = pipe(this.path, RA.join(this.options.pathDelim))
+    return `(Missing data at ${path}: "${this.message}")`
+  }
 }
 
 /** @internal */
-export const SourceUnavailable = (
-  path: ReadonlyArray<string>,
-  message: string,
-  cause: Cause.Cause<unknown>,
-  options: ConfigError.Options = { pathDelim: "." }
-): ConfigError.ConfigError => {
-  const error = Object.create(proto)
-  error._tag = "ConfigError"
-  error[Discriminant] = OpCodes.OP_SOURCE_UNAVAILABLE
-  error.path = path
-  error.message = message
-  error.cause = cause
-  Object.defineProperty(error, "toString", {
-    enumerable: false,
-    value(this: ConfigError.SourceUnavailable) {
-      const path = pipe(this.path, RA.join(options.pathDelim))
-      return `(Source unavailable at ${path}: "${this.message}")`
-    }
-  })
-  return error
+export class SourceUnavailable extends TaggedError("ConfigError") implements ConfigError.ConfigError.Proto {
+  readonly [ConfigErrorTypeId]: typeof ConfigError.ConfigErrorTypeId
+  readonly [Discriminant] = OpCodes.OP_SOURCE_UNAVAILABLE
+  constructor(
+    readonly path: ReadonlyArray<string>,
+    readonly message: string,
+    readonly cause: Cause.Cause<unknown>,
+    readonly options: ConfigError.Options = { pathDelim: "." }
+  ) {
+    super()
+    this[ConfigErrorTypeId] = ConfigErrorTypeId
+  }
+
+  toString() {
+    const path = pipe(this.path, RA.join(this.options.pathDelim))
+    return `(Source unavailable at ${path}: "${this.message}")`
+  }
 }
 
 /** @internal */
-export const Unsupported = (
-  path: ReadonlyArray<string>,
-  message: string,
-  options: ConfigError.Options = { pathDelim: "." }
-): ConfigError.ConfigError => {
-  const error = Object.create(proto)
-  error._tag = "ConfigError"
-  error[Discriminant] = OpCodes.OP_UNSUPPORTED
-  error.path = path
-  error.message = message
-  Object.defineProperty(error, "toString", {
-    enumerable: false,
-    value(this: ConfigError.Unsupported) {
-      const path = pipe(this.path, RA.join(options.pathDelim))
-      return `(Unsupported operation at ${path}: "${this.message}")`
-    }
-  })
-  return error
+export class Unsupported extends TaggedError("ConfigError") implements ConfigError.ConfigError.Proto {
+  readonly [ConfigErrorTypeId]: typeof ConfigError.ConfigErrorTypeId
+  readonly [Discriminant] = OpCodes.OP_UNSUPPORTED
+  constructor(
+    readonly path: ReadonlyArray<string>,
+    readonly message: string,
+    readonly options: ConfigError.Options = { pathDelim: "." }
+  ) {
+    super()
+    this[ConfigErrorTypeId] = ConfigErrorTypeId
+  }
+
+  toString() {
+    const path = pipe(this.path, RA.join(this.options.pathDelim))
+    return `(Unsupported operation at ${path}: "${this.message}")`
+  }
 }
 
 /** @internal */
 export const isConfigError = (u: unknown): u is ConfigError.ConfigError => hasProperty(u, ConfigErrorTypeId)
 
 /** @internal */
-export const isAnd = (self: ConfigError.ConfigError): self is ConfigError.And => self[Discriminant] === OpCodes.OP_AND
+export const isAnd = (self: ConfigError.ConfigError): self is And => self[Discriminant] === OpCodes.OP_AND
 
 /** @internal */
-export const isOr = (self: ConfigError.ConfigError): self is ConfigError.Or => self[Discriminant] === OpCodes.OP_OR
+export const isOr = (self: ConfigError.ConfigError): self is Or => self[Discriminant] === OpCodes.OP_OR
 
 /** @internal */
-export const isInvalidData = (self: ConfigError.ConfigError): self is ConfigError.InvalidData =>
+export const isInvalidData = (self: ConfigError.ConfigError): self is InvalidData =>
   self[Discriminant] === OpCodes.OP_INVALID_DATA
 
 /** @internal */
-export const isMissingData = (self: ConfigError.ConfigError): self is ConfigError.MissingData =>
+export const isMissingData = (self: ConfigError.ConfigError): self is MissingData =>
   self[Discriminant] === OpCodes.OP_MISSING_DATA
 
 /** @internal */
-export const isSourceUnavailable = (self: ConfigError.ConfigError): self is ConfigError.SourceUnavailable =>
+export const isSourceUnavailable = (self: ConfigError.ConfigError): self is SourceUnavailable =>
   self[Discriminant] === OpCodes.OP_SOURCE_UNAVAILABLE
 
 /** @internal */
-export const isUnsupported = (self: ConfigError.ConfigError): self is ConfigError.Unsupported =>
+export const isUnsupported = (self: ConfigError.ConfigError): self is Unsupported =>
   self[Discriminant] === OpCodes.OP_UNSUPPORTED
 
 /** @internal */
@@ -180,22 +168,22 @@ export const prefixed: {
 >(2, (self, prefix) => {
   switch (self[Discriminant]) {
     case OpCodes.OP_AND: {
-      return And(prefixed(self.left, prefix), prefixed(self.right, prefix))
+      return new And(prefixed(self.left, prefix), prefixed(self.right, prefix))
     }
     case OpCodes.OP_OR: {
-      return Or(prefixed(self.left, prefix), prefixed(self.right, prefix))
+      return new Or(prefixed(self.left, prefix), prefixed(self.right, prefix))
     }
     case OpCodes.OP_INVALID_DATA: {
-      return InvalidData([...prefix, ...self.path], self.message)
+      return new InvalidData([...prefix, ...self.path], self.message)
     }
     case OpCodes.OP_MISSING_DATA: {
-      return MissingData([...prefix, ...self.path], self.message)
+      return new MissingData([...prefix, ...self.path], self.message)
     }
     case OpCodes.OP_SOURCE_UNAVAILABLE: {
-      return SourceUnavailable([...prefix, ...self.path], self.message, self.cause)
+      return new SourceUnavailable([...prefix, ...self.path], self.message, self.cause)
     }
     case OpCodes.OP_UNSUPPORTED: {
-      return Unsupported([...prefix, ...self.path], self.message)
+      return new Unsupported([...prefix, ...self.path], self.message)
     }
   }
 })

--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -88,7 +88,7 @@ export const fromFlat = (flat: ConfigProvider.ConfigProvider.Flat): ConfigProvid
         Option.match(ReadonlyArray.head(chunk), {
           onNone: () =>
             core.fail(
-              configError.MissingData(
+              new configError.MissingData(
                 ReadonlyArray.empty(),
                 `Expected a single value having structure: ${config}`
               )
@@ -119,7 +119,7 @@ export const fromEnv = (
     const valueOpt = pathString in current ? Option.some(current[pathString]!) : Option.none()
     return pipe(
       valueOpt,
-      core.mapError(() => configError.MissingData(path, `Expected ${pathString} to exist in the process context`)),
+      core.mapError(() => new configError.MissingData(path, `Expected ${pathString} to exist in the process context`)),
       core.flatMap((value) => parsePrimitive(value, path, primitive, seqDelim, split))
     )
   }
@@ -171,7 +171,7 @@ export const fromMap = (
       Option.none()
     return pipe(
       valueOpt,
-      core.mapError(() => configError.MissingData(path, `Expected ${pathString} to exist in the provided map`)),
+      core.mapError(() => new configError.MissingData(path, `Expected ${pathString} to exist in the provided map`)),
       core.flatMap((value) => parsePrimitive(value, path, primitive, seqDelim, split))
     )
   }
@@ -251,7 +251,7 @@ const fromFlatLoop = <A>(
       ) as unknown as Effect.Effect<ReadonlyArray<A>, ConfigError.ConfigError>
     }
     case OpCodes.OP_FAIL: {
-      return core.fail(configError.MissingData(prefix, op.message)) as Effect.Effect<
+      return core.fail(new configError.MissingData(prefix, op.message)) as Effect.Effect<
         ReadonlyArray<A>,
         ConfigError.ConfigError
       >
@@ -263,7 +263,7 @@ const fromFlatLoop = <A>(
           if (op.condition(error1)) {
             return pipe(
               fromFlatLoop(flat, prefix, op.second, split),
-              core.catchAll((error2) => core.fail(configError.Or(error1, error2)))
+              core.catchAll((error2) => core.fail(new configError.Or(error1, error2)))
             )
           }
           return core.fail(error1)
@@ -310,7 +310,7 @@ const fromFlatLoop = <A>(
             core.flatMap((values) => {
               if (values.length === 0) {
                 const name = pipe(ReadonlyArray.last(prefix), Option.getOrElse(() => "<n/a>"))
-                return core.fail(configError.MissingData([], `Expected ${op.description} with name ${name}`))
+                return core.fail(new configError.MissingData([], `Expected ${op.description} with name ${name}`))
               }
               return core.succeed(values)
             })
@@ -397,7 +397,7 @@ const fromFlatLoop = <A>(
               core.either,
               core.flatMap((right) => {
                 if (Either.isLeft(left) && Either.isLeft(right)) {
-                  return core.fail(configError.And(left.left, right.left))
+                  return core.fail(new configError.And(left.left, right.left))
                 }
                 if (Either.isLeft(left) && Either.isRight(right)) {
                   return core.fail(left.left)
@@ -440,7 +440,7 @@ const fromFlatLoop = <A>(
 const fromFlatLoopFail =
   (prefix: ReadonlyArray<string>, path: string) => (index: number): Either.Either<ConfigError.ConfigError, unknown> =>
     Either.left(
-      configError.MissingData(
+      new configError.MissingData(
         prefix,
         `The element at index ${index} in a sequence at path "${path}" was missing`
       )
@@ -513,7 +513,7 @@ const orElseFlat = (
               pipe(
                 pathPatch.patch(path, that.patch),
                 core.flatMap((patch) => that.load(patch, config, split)),
-                core.catchAll((error2) => core.fail(configError.Or(error1, error2)))
+                core.catchAll((error2) => core.fail(new configError.Or(error1, error2)))
               )
             )
           )
@@ -534,7 +534,7 @@ const orElseFlat = (
                 core.either,
                 core.flatMap((right) => {
                   if (Either.isLeft(left) && Either.isLeft(right)) {
-                    return core.fail(configError.And(left.left, right.left))
+                    return core.fail(new configError.And(left.left, right.left))
                   }
                   if (Either.isLeft(left) && Either.isRight(right)) {
                     return core.succeed(right.right)

--- a/packages/effect/src/internal/configProvider/pathPatch.ts
+++ b/packages/effect/src/internal/configProvider/pathPatch.ts
@@ -84,10 +84,12 @@ export const patch = dual<
           output = RA.tailNonEmpty(output as RA.NonEmptyArray<string>)
           input = input.tail
         } else {
-          return Either.left(configError.MissingData(
-            output,
-            `Expected ${patch.name} to be in path in ConfigProvider#unnested`
-          ))
+          return Either.left(
+            new configError.MissingData(
+              output,
+              `Expected ${patch.name} to be in path in ConfigProvider#unnested`
+            )
+          )
         }
         break
       }

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -40,7 +40,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["ITEMS", "value"]],
-        ConfigError.InvalidData(["ITEMS"], "Expected a boolean value but received value")
+        new ConfigError.InvalidData(["ITEMS"], "Expected a boolean value but received value")
       )
     })
 
@@ -55,11 +55,11 @@ describe("Config", () => {
       assertSuccess(config, [["BOOL", "off"]], false)
       assertSuccess(config, [["BOOL", "0"]], false)
 
-      assertFailure(config, [], ConfigError.MissingData(["BOOL"], "Expected BOOL to exist in the provided map"))
+      assertFailure(config, [], new ConfigError.MissingData(["BOOL"], "Expected BOOL to exist in the provided map"))
       assertFailure(
         config,
         [["BOOL", "value"]],
-        ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
+        new ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
       )
     })
   })
@@ -71,7 +71,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["ITEMS", "value"]],
-        ConfigError.InvalidData(["ITEMS"], "Expected a number value but received value")
+        new ConfigError.InvalidData(["ITEMS"], "Expected a number value but received value")
       )
     })
 
@@ -84,11 +84,11 @@ describe("Config", () => {
       assertSuccess(config, [["NUMBER", "0"]], 0)
       assertSuccess(config, [["NUMBER", "-0"]], -0)
 
-      assertFailure(config, [], ConfigError.MissingData(["NUMBER"], "Expected NUMBER to exist in the provided map"))
+      assertFailure(config, [], new ConfigError.MissingData(["NUMBER"], "Expected NUMBER to exist in the provided map"))
       assertFailure(
         config,
         [["NUMBER", "value"]],
-        ConfigError.InvalidData(["NUMBER"], "Expected a number value but received value")
+        new ConfigError.InvalidData(["NUMBER"], "Expected a number value but received value")
       )
     })
   })
@@ -100,7 +100,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["ITEMS", "value"]],
-        ConfigError.InvalidData(["ITEMS"], "Expected one of (a, b) but received value")
+        new ConfigError.InvalidData(["ITEMS"], "Expected one of (a, b) but received value")
       )
     })
 
@@ -113,11 +113,15 @@ describe("Config", () => {
       assertSuccess(config, [["LITERAL", "false"]], false)
       assertSuccess(config, [["LITERAL", "null"]], null)
 
-      assertFailure(config, [], ConfigError.MissingData(["LITERAL"], "Expected LITERAL to exist in the provided map"))
+      assertFailure(
+        config,
+        [],
+        new ConfigError.MissingData(["LITERAL"], "Expected LITERAL to exist in the provided map")
+      )
       assertFailure(
         config,
         [["LITERAL", "value"]],
-        ConfigError.InvalidData(["LITERAL"], "Expected one of (a, 0, -0.3, 5, false, null) but received value")
+        new ConfigError.InvalidData(["LITERAL"], "Expected one of (a, 0, -0.3, 5, false, null) but received value")
       )
     })
   })
@@ -129,7 +133,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["", "value"]],
-        ConfigError.InvalidData([], "Expected a Date value but received value")
+        new ConfigError.InvalidData([], "Expected a Date value but received value")
       )
     })
 
@@ -137,18 +141,18 @@ describe("Config", () => {
       const config = Config.date("DATE")
       assertSuccess(config, [["DATE", "0"]], new Date(Date.parse("0")))
 
-      assertFailure(config, [], ConfigError.MissingData(["DATE"], "Expected DATE to exist in the provided map"))
+      assertFailure(config, [], new ConfigError.MissingData(["DATE"], "Expected DATE to exist in the provided map"))
       assertFailure(
         config,
         [["DATE", "value"]],
-        ConfigError.InvalidData(["DATE"], "Expected a Date value but received value")
+        new ConfigError.InvalidData(["DATE"], "Expected a Date value but received value")
       )
     })
   })
 
   it("fail", () => {
     const config = Config.fail("failure message")
-    assertFailure(config, [], ConfigError.MissingData([], "failure message"))
+    assertFailure(config, [], new ConfigError.MissingData([], "failure message"))
   })
 
   it("mapAttempt", () => {
@@ -166,14 +170,14 @@ describe("Config", () => {
     assertFailure(
       config,
       [["STRING", "value"]],
-      ConfigError.InvalidData(["STRING"], "invalid number")
+      new ConfigError.InvalidData(["STRING"], "invalid number")
     )
     assertFailure(
       config,
       [["STRING", "-1"]],
-      ConfigError.InvalidData(["STRING"], "invalid negative number")
+      new ConfigError.InvalidData(["STRING"], "invalid negative number")
     )
-    assertFailure(config, [], ConfigError.MissingData(["STRING"], "Expected STRING to exist in the provided map"))
+    assertFailure(config, [], new ConfigError.MissingData(["STRING"], "Expected STRING to exist in the provided map"))
   })
 
   describe("logLevel", () => {
@@ -181,7 +185,7 @@ describe("Config", () => {
       const config = Config.logLevel()
       assertSuccess(config, [["", "DEBUG"]], LogLevel.Debug)
 
-      assertFailure(config, [["", "-"]], ConfigError.InvalidData([], "Expected a log level but received -"))
+      assertFailure(config, [["", "-"]], new ConfigError.InvalidData([], "Expected a log level but received -"))
     })
 
     it("name != undefined", () => {
@@ -191,7 +195,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["LOG_LEVEL", "-"]],
-        ConfigError.InvalidData(["LOG_LEVEL"], "Expected a log level but received -")
+        new ConfigError.InvalidData(["LOG_LEVEL"], "Expected a log level but received -")
       )
     })
   })
@@ -209,7 +213,7 @@ describe("Config", () => {
       assertFailure(
         flat,
         [["NUMBER", "-1"]],
-        ConfigError.InvalidData(["NUMBER"], "a positive number")
+        new ConfigError.InvalidData(["NUMBER"], "a positive number")
       )
 
       const nested = flat.pipe(
@@ -220,7 +224,7 @@ describe("Config", () => {
       assertFailure(
         nested,
         [["NESTED1.NUMBER", "-1"]],
-        ConfigError.InvalidData(["NESTED1", "NUMBER"], "a positive number")
+        new ConfigError.InvalidData(["NESTED1", "NUMBER"], "a positive number")
       )
 
       const doubleNested = nested.pipe(Config.nested("NESTED2"))
@@ -229,7 +233,7 @@ describe("Config", () => {
       assertFailure(
         doubleNested,
         [["NESTED2.NESTED1.NUMBER", "-1"]],
-        ConfigError.InvalidData(["NESTED2", "NESTED1", "NUMBER"], "a positive number")
+        new ConfigError.InvalidData(["NESTED2", "NESTED1", "NUMBER"], "a positive number")
       )
     })
   })
@@ -256,7 +260,7 @@ describe("Config", () => {
         config,
         [["key", "value"]],
         // available data but not an integer
-        ConfigError.InvalidData(["key"], "Expected an integer value but received value")
+        new ConfigError.InvalidData(["key"], "Expected an integer value but received value")
       )
     })
 
@@ -271,9 +275,9 @@ describe("Config", () => {
       assertFailure(
         config,
         [["key2", "value"]],
-        ConfigError.And(
-          ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
-          ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
+        new ConfigError.And(
+          new ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
+          new ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
         )
       )
     })
@@ -290,9 +294,9 @@ describe("Config", () => {
       assertFailure(
         config,
         [["key2", "value"]],
-        ConfigError.Or(
-          ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
-          ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
+        new ConfigError.Or(
+          new ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
+          new ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
         )
       )
     })
@@ -310,7 +314,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["key", "value"]],
-        ConfigError.InvalidData(["key"], "Expected an integer value but received value")
+        new ConfigError.InvalidData(["key"], "Expected an integer value but received value")
       )
     })
 
@@ -324,17 +328,17 @@ describe("Config", () => {
       assertFailure(
         config,
         [["key1", "value"]],
-        ConfigError.And(
-          ConfigError.InvalidData(["key1"], "Expected an integer value but received value"),
-          ConfigError.MissingData(["key2"], "Expected key2 to exist in the provided map")
+        new ConfigError.And(
+          new ConfigError.InvalidData(["key1"], "Expected an integer value but received value"),
+          new ConfigError.MissingData(["key2"], "Expected key2 to exist in the provided map")
         )
       )
       assertFailure(
         config,
         [["key2", "value"]],
-        ConfigError.And(
-          ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
-          ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
+        new ConfigError.And(
+          new ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
+          new ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
         )
       )
     })
@@ -350,9 +354,9 @@ describe("Config", () => {
       assertFailure(
         config,
         [["key2", "value"]],
-        ConfigError.Or(
-          ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
-          ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
+        new ConfigError.Or(
+          new ConfigError.MissingData(["key1"], "Expected key1 to exist in the provided map"),
+          new ConfigError.InvalidData(["key2"], "Expected an integer value but received value")
         )
       )
     })
@@ -387,7 +391,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["key1", "123"], ["items", "1,value,3"], ["key2", "value"]],
-        ConfigError.InvalidData(["items"], "Expected an integer value but received value")
+        new ConfigError.InvalidData(["items"], "Expected an integer value but received value")
       )
     })
   })
@@ -415,12 +419,12 @@ describe("Config", () => {
         assertFailure(
           config,
           [["NUMBER", "value"], ["BOOL", "true"]],
-          ConfigError.InvalidData(["NUMBER"], "Expected a number value but received value")
+          new ConfigError.InvalidData(["NUMBER"], "Expected a number value but received value")
         )
         assertFailure(
           config,
           [["NUMBER", "1"], ["BOOL", "value"]],
-          ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
+          new ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
         )
       })
     })
@@ -432,12 +436,12 @@ describe("Config", () => {
       assertFailure(
         config,
         [["NUMBER", "value"], ["BOOL", "true"]],
-        ConfigError.InvalidData(["NUMBER"], "Expected a number value but received value")
+        new ConfigError.InvalidData(["NUMBER"], "Expected a number value but received value")
       )
       assertFailure(
         config,
         [["NUMBER", "1"], ["BOOL", "value"]],
-        ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
+        new ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
       )
     })
   })

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -196,7 +196,7 @@ describe("ConfigProvider", () => {
       assert.deepStrictEqual(
         result,
         Exit.fail(
-          ConfigError.MissingData(
+          new ConfigError.MissingData(
             ["hostPorts"],
             "The element at index 1 in a sequence at path \"hostPorts\" was missing"
           )
@@ -559,7 +559,7 @@ describe("ConfigProvider", () => {
       assert.deepStrictEqual(
         result,
         Exit.fail(
-          ConfigError.MissingData(
+          new ConfigError.MissingData(
             ["k1", "k2"],
             "Expected k1.k2 to exist in the provided map"
           )
@@ -668,10 +668,12 @@ describe("ConfigProvider", () => {
       expect(result1).toBe("value1")
       expect(result2).toBe("value2")
       expect(result31).toEqual(Option.none())
-      expect(result32).toEqual(Either.left(ConfigError.Or(
-        ConfigError.MissingData(["key3"], "Expected key3 to exist in the provided map"),
-        ConfigError.MissingData(["key3"], "Expected key3 to exist in the provided map")
-      )))
+      expect(result32).toEqual(Either.left(
+        new ConfigError.Or(
+          new ConfigError.MissingData(["key3"], "Expected key3 to exist in the provided map"),
+          new ConfigError.MissingData(["key3"], "Expected key3 to exist in the provided map")
+        )
+      ))
       expect(result4).toBe("value41")
     }))
 
@@ -750,16 +752,18 @@ describe("ConfigProvider", () => {
 
       expect(result1).toEqual([[1, 2], [3, 4]])
       expect(result2).toEqual([[11, 21], [31, 41]])
-      expect(result3).toEqual(Either.left(ConfigError.And(
-        ConfigError.MissingData(
-          ["parent3", "child", "employees"],
-          "Expected parent1 to be in path in ConfigProvider#unnested"
-        ),
-        ConfigError.MissingData(
-          ["parent3", "child", "employees"],
-          "Expected parent2 to be in path in ConfigProvider#unnested"
+      expect(result3).toEqual(Either.left(
+        new ConfigError.And(
+          new ConfigError.MissingData(
+            ["parent3", "child", "employees"],
+            "Expected parent1 to be in path in ConfigProvider#unnested"
+          ),
+          new ConfigError.MissingData(
+            ["parent3", "child", "employees"],
+            "Expected parent2 to be in path in ConfigProvider#unnested"
+          )
         )
-      )))
+      ))
     }))
 
   it.effect("orElse - with index sequences and combined provider unnested", () =>
@@ -847,7 +851,7 @@ describe("ConfigProvider", () => {
       )
       const config = Config.string("key")
       const result = yield* $(Effect.exit(configProvider.load(config)))
-      const error = ConfigError.MissingData(
+      const error = new ConfigError.MissingData(
         ["key"],
         "Expected nested to be in path in ConfigProvider#unnested"
       )


### PR DESCRIPTION
Fix for #2199. Replaces the use of `_tag` for discriminating sub-types(e.g. Add, Or, etc.) with a `ConfigError.Discriminant` symbol and reserves `_tag` for the top level type(i.e. "ConfigError"). Also, converts ConfigError to a TaggedError.