### PR TITLE
Schema: add pickLiteral to Schema literal

### DIFF
--- a/.changeset/quiet-coins-add.md
+++ b/.changeset/quiet-coins-add.md
@@ -1,0 +1,22 @@
+---
+"@effect/schema": patch
+---
+
+Add `pickLiteral` to Schema so that we can pick values from a Schema literal as follows:
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+const schema = S.literal("a", "b", "c").pipe(S.pickLiteral("a", "b")); // same as S.literal("a", "b")
+
+S.decodeUnknownSync(schema)("a"); // ok
+S.decodeUnknownSync(schema)("b"); // ok
+S.decodeUnknownSync(schema)("c");
+/*
+Error: "a" | "b"
+├─ Union member
+│  └─ Expected "a", actual "c"
+└─ Union member
+   └─ Expected "b", actual "c"
+*/
+```

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1130,6 +1130,40 @@ S.literal(2n); // bigint literal
 S.literal(true);
 ```
 
+We can also `pickLiteral` from a literal schema.
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+S.literal("a", "b", "c").pipe(S.pickLiteral("a", "b")); //same as S.literal("a", "b")
+```
+
+Sometimes we need to reuse a schema literal in other parts of the code. Let's see an example:
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+const FruitId = S.number;
+// the source of truth regarding the Fruit category
+const FruitCategory = S.literal("sweet", "citrus", "tropical");
+
+const Fruit = S.struct({
+  id: FruitId,
+  category: FruitCategory,
+});
+
+// Here, we want to reuse our FruitCategory definition to create a subtype of Fruit
+const SweetAndCitrusFruit = S.struct({
+  fruitId: FruitId,
+  category: FruitCategory.pipe(S.pickLiteral("sweet", "citrus")),
+  /*
+    By using pickLiteral from the FruitCategory, we ensure that the values selected
+    are those defined in the category definition above.
+    If we remove "sweet" from the FruitCategory definition, TypeScript will notify us.
+    */
+});
+```
+
 ## Template literals
 
 The `templateLiteral` combinator allows you to create a schema for a TypeScript template literal type.

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -388,6 +388,26 @@ export const literal = <Literals extends ReadonlyArray<AST.LiteralValue>>(
 ): Schema<Literals[number]> => union(...literals.map((literal) => makeLiteral(literal)))
 
 /**
+ * Creates a new `Schema` from a literal schema.
+ *
+ * @example
+ * import * as S from "@effect/schema/Schema"
+ * import { Either } from "effect"
+ *
+ * const schema = S.literal("a", "b", "c").pipe(S.pickLiteral("a", "b"))
+ *
+ * assert.deepStrictEqual(S.decodeSync(schema)("a"), "a")
+ * assert.deepStrictEqual(S.decodeSync(schema)("b"), "b")
+ * assert.strictEqual(Either.isLeft(S.decodeUnknownEither(schema)("c")), true)
+ *
+ * @category constructors
+ * @since 1.0.0
+ */
+export const pickLiteral =
+  <A extends AST.LiteralValue, L extends ReadonlyArray<A>>(...literals: L) =>
+  <I, R>(_schema: Schema<A, I, R>): Schema<L[number]> => literal(...literals)
+
+/**
  * @category constructors
  * @since 1.0.0
  */

--- a/packages/schema/test/Schema/pickLiteral.test.ts
+++ b/packages/schema/test/Schema/pickLiteral.test.ts
@@ -1,0 +1,51 @@
+import * as AST from "@effect/schema/AST"
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+import { describe, expect, it } from "vitest"
+
+describe("Schema/literal > pickLiteral", () => {
+  it("should return never with no literals", () => {
+    expect(S.literal().pipe(S.pickLiteral()).ast).toEqual(AST.neverKeyword)
+  })
+  it("should return an unwrapped AST with exactly one literal", () => {
+    expect(S.literal("a").pipe(S.pickLiteral("a")).ast).toEqual(AST.createLiteral("a"))
+  })
+
+  it("should return a union with more than one literal", () => {
+    expect(S.literal("a", "b", "c").pipe(S.pickLiteral("a", "b")).ast).toEqual(
+      AST.createUnion([AST.createLiteral("a"), AST.createLiteral("b")])
+    )
+  })
+
+  describe("decoding", () => {
+    it("1 member", async () => {
+      const schema = S.literal("a").pipe(S.pickLiteral("a"))
+      await Util.expectDecodeUnknownSuccess(schema, "a")
+
+      await Util.expectDecodeUnknownFailure(schema, 1, `Expected "a", actual 1`)
+      await Util.expectDecodeUnknownFailure(schema, null, `Expected "a", actual null`)
+    })
+
+    it("2 members", async () => {
+      const schema = S.literal("a", "b", "c").pipe(S.pickLiteral("a", "b"))
+
+      await Util.expectDecodeUnknownSuccess(schema, "a")
+      await Util.expectDecodeUnknownSuccess(schema, "b")
+
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        null,
+        `"a" | "b"
+├─ Union member
+│  └─ Expected "a", actual null
+└─ Union member
+   └─ Expected "b", actual null`
+      )
+    })
+  })
+
+  it("encoding", async () => {
+    const schema = S.literal(null).pipe(S.pickLiteral(null))
+    await Util.expectEncodeSuccess(schema, null, null)
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add `pickLiteral` to Schema so that we can pick values from a Schema literal.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #2192 
- Closes #2192 
