### PR TITLE
Change `Effect/Stream.acquireRelease` function signatures in favor of using an object with named functions

### DIFF
--- a/.changeset/olive-chefs-yawn.md
+++ b/.changeset/olive-chefs-yawn.md
@@ -1,0 +1,12 @@
+---
+"effect": minor
+"@effect/platform-node-shared": patch
+"@effect/platform-browser": patch
+"@effect/opentelemetry": patch
+"@effect/platform-node": patch
+"@effect/experimental": patch
+"@effect/platform": patch
+"@effect/cli": patch
+---
+
+change `Effect.acquireRelease`, `Effect.acquireReleaseInterruptible`, `Stream.acquireRelease` function signatures in favor of using an object with named functions

--- a/packages/cli/test/services/MockTerminal.ts
+++ b/packages/cli/test/services/MockTerminal.ts
@@ -40,10 +40,10 @@ export const MockTerminal = Context.GenericTag<Terminal.Terminal, MockTerminal>(
 // =============================================================================
 
 export const make = Effect.gen(function*(_) {
-  const queue = yield* _(Effect.acquireRelease(
-    Queue.unbounded<Terminal.UserInput>(),
-    Queue.shutdown
-  ))
+  const queue = yield* _(Effect.acquireRelease({
+    acquire: Queue.unbounded<Terminal.UserInput>(),
+    release: Queue.shutdown
+  }))
 
   const inputText: MockTerminal["inputText"] = (text: string) => {
     const inputs = ReadonlyArray.map(text.split(""), (key) => toUserInput(key))

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2186,13 +2186,13 @@ export const negate: <E, R>(self: Effect<boolean, E, R>) => Effect<boolean, E, R
  * @category scoping, resources & finalization
  */
 export const acquireRelease: {
+  <A, E, R, X, R2>(options: {
+    readonly acquire: Effect<A, E, R>
+    readonly release: (a: NoInfer<A>, exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R2>
+  }): Effect<A, E, Scope.Scope | R | R2>
   <A, X, R2>(
     release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R2>
   ): <E, R>(acquire: Effect<A, E, R>) => Effect<A, E, Scope.Scope | R2 | R>
-  <A, E, R, X, R2>(
-    acquire: Effect<A, E, R>,
-    release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R2>
-  ): Effect<A, E, Scope.Scope | R | R2>
 } = fiberRuntime.acquireRelease
 
 /**
@@ -2219,13 +2219,13 @@ export const acquireRelease: {
  * @category scoping, resources & finalization
  */
 export const acquireReleaseInterruptible: {
+  <A, E, R, X, R2>(options: {
+    acquire: Effect<A, E, R>
+    release: (exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R2>
+  }): Effect<A, E, Scope.Scope | R | R2>
   <X, R2>(
     release: (exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R2>
   ): <A, E, R>(acquire: Effect<A, E, R>) => Effect<A, E, Scope.Scope | R2 | R>
-  <A, E, R, X, R2>(
-    acquire: Effect<A, E, R>,
-    release: (exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R2>
-  ): Effect<A, E, Scope.Scope | R | R2>
 } = fiberRuntime.acquireReleaseInterruptible
 
 /**

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -97,7 +97,10 @@ const unsafeMake = <K, A = unknown, E = unknown>(): FiberMap<K, A, E> => {
  * @categories constructors
  */
 export const make = <K, A = unknown, E = unknown>(): Effect.Effect<FiberMap<K, A, E>, never, Scope.Scope> =>
-  Effect.acquireRelease(Effect.sync(() => unsafeMake<K, A, E>()), clear)
+  Effect.acquireRelease({
+    acquire: Effect.sync(() => unsafeMake<K, A, E>()),
+    release: clear
+  })
 
 /**
  * Create an Effect run function that is backed by a FiberMap.

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -93,7 +93,10 @@ const unsafeMake = <A, E>(): FiberSet<A, E> => {
  * @categories constructors
  */
 export const make = <A = unknown, E = unknown>(): Effect.Effect<FiberSet<A, E>, never, Scope.Scope> =>
-  Effect.acquireRelease(Effect.sync(() => unsafeMake<A, E>()), clear)
+  Effect.acquireRelease({
+    acquire: Effect.sync(() => unsafeMake<A, E>()),
+    release: clear
+  })
 
 /**
  * Create an Effect run function that is backed by a FiberSet.

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -96,10 +96,10 @@ export const make: <A, E, R>(
  * import { createConnection } from "mysql2";
  * import { Duration, Effect, Pool } from "effect"
  *
- * const acquireDBConnection = Effect.acquireRelease(
- *   Effect.sync(() => createConnection('mysql://...')),
- *   (connection) => Effect.sync(() => connection.end(() => {})),
- * )
+ * const acquireDBConnection = Effect.acquireRelease({
+ *   acquire: Effect.sync(() => createConnection('mysql://...')),
+ *   release: (connection) => Effect.sync(() => connection.end(() => {})),
+ * })
  *
  * const connectionPool = Effect.flatMap(
  *  Pool.makeWithTTL({

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -169,10 +169,15 @@ export const accumulateChunks: <A, E, R>(self: Stream<A, E, R>) => Stream<A, E, 
  * @since 2.0.0
  * @category constructors
  */
-export const acquireRelease: <A, E, R, R2, X>(
-  acquire: Effect.Effect<A, E, R>,
-  release: (resource: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<X, never, R2>
-) => Stream<A, E, R | R2> = internal.acquireRelease
+export const acquireRelease: {
+  <A, E, R, R2, X>(options: {
+    readonly acquire: Effect.Effect<A, E, R>
+    readonly release: (resource: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<X, never, R2>
+  }): Stream<A, E, R | R2>
+  <A, X, R2>(
+    release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<X, never, R2>
+  ): <E, R>(acquire: Effect.Effect<A, E, R>) => Stream<A, E, R | R2>
+} = internal.acquireRelease
 
 /**
  * Aggregates elements of this stream using the provided sink for as long as

--- a/packages/effect/src/internal/console.ts
+++ b/packages/effect/src/internal/console.ts
@@ -81,10 +81,10 @@ export const group = (options?: {
   collapsed?: boolean | undefined
 }) =>
   consoleWith((_) =>
-    fiberRuntime.acquireRelease(
-      _.group(options),
-      () => _.groupEnd
-    )
+    fiberRuntime.acquireRelease({
+      acquire: _.group(options),
+      release: () => _.groupEnd
+    })
   )
 
 /** @internal */
@@ -100,10 +100,10 @@ export const table = (tabularData: any, properties?: ReadonlyArray<string>) =>
 /** @internal */
 export const time = (label?: string) =>
   consoleWith((_) =>
-    fiberRuntime.acquireRelease(
-      _.time(label),
-      () => _.timeEnd(label)
-    )
+    fiberRuntime.acquireRelease({
+      acquire: _.time(label),
+      release: () => _.timeEnd(label)
+    })
   )
 
 /** @internal */

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -870,10 +870,10 @@ export const scopedContext = <A, E, R>(
 /** @internal */
 export const scope: Layer.Layer<Scope.Scope.Closeable> = scopedContext(
   core.map(
-    fiberRuntime.acquireRelease(
-      fiberRuntime.scopeMake(),
-      (scope, exit) => scope.close(exit)
-    ),
+    fiberRuntime.acquireRelease({
+      acquire: fiberRuntime.scopeMake(),
+      release: (scope, exit) => scope.close(exit)
+    }),
     (scope) => Context.make(Scope.Scope, scope)
   )
 )

--- a/packages/effect/src/internal/pubsub.ts
+++ b/packages/effect/src/internal/pubsub.ts
@@ -1123,7 +1123,10 @@ class PubSubImpl<in out A> implements PubSub.PubSub<A> {
       (tuple) => tuple[0].addFinalizer(() => tuple[1].shutdown)
     )
     return core.map(
-      fiberRuntime.acquireRelease(acquire, (tuple, exit) => tuple[0].close(exit)),
+      fiberRuntime.acquireRelease({
+        acquire,
+        release: (tuple, exit) => tuple[0].close(exit)
+      }),
       (tuple) => tuple[1]
     )
   }

--- a/packages/effect/src/internal/reloadable.ts
+++ b/packages/effect/src/internal/reloadable.ts
@@ -38,15 +38,15 @@ export const auto = <Out extends Context.Tag<any, any>, E, In, R>(
       _layer.build(manual(tag, { layer: options.layer })),
       core.map(Context.unsafeGet(reloadableTag(tag))),
       core.tap((reloadable) =>
-        fiberRuntime.acquireRelease(
-          pipe(
+        fiberRuntime.acquireRelease({
+          acquire: pipe(
             reloadable.reload,
             effect.ignoreLogged,
             _schedule.schedule_Effect(options.schedule),
             fiberRuntime.forkDaemon
           ),
-          core.interruptFiber
-        )
+          release: core.interruptFiber
+        })
       )
     )
   )

--- a/packages/effect/src/internal/resource.ts
+++ b/packages/effect/src/internal/resource.ts
@@ -29,15 +29,15 @@ export const auto = <A, E, R, Out, R2>(
   policy: Schedule.Schedule<Out, unknown, R2>
 ): Effect.Effect<Resource.Resource<A, E>, never, R | R2 | Scope.Scope> =>
   core.tap(manual(acquire), (manual) =>
-    fiberRuntime.acquireRelease(
-      pipe(
+    fiberRuntime.acquireRelease({
+      acquire: pipe(
         refresh(manual),
         _schedule.schedule_Effect(policy),
         core.interruptible,
         fiberRuntime.forkDaemon
       ),
-      core.interruptFiber
-    ))
+      release: core.interruptFiber
+    }))
 
 /** @internal */
 export const manual = <A, E, R>(

--- a/packages/effect/src/internal/sink.ts
+++ b/packages/effect/src/internal/sink.ts
@@ -1482,7 +1482,10 @@ export const fromQueue = <In>(
   options?.shutdown ?
     unwrapScoped(
       Effect.map(
-        Effect.acquireRelease(Effect.succeed(queue), Queue.shutdown),
+        Effect.acquireRelease({
+          acquire: Effect.succeed(queue),
+          release: Queue.shutdown
+        }),
         fromQueue
       )
     ) :

--- a/packages/effect/src/internal/stm/tPubSub.ts
+++ b/packages/effect/src/internal/stm/tPubSub.ts
@@ -541,10 +541,10 @@ export const subscribe = <A>(self: TPubSub.TPubSub<A>): STM.STM<TQueue.TDequeue<
 
 /** @internal */
 export const subscribeScoped = <A>(self: TPubSub.TPubSub<A>): Effect.Effect<TQueue.TDequeue<A>, never, Scope.Scope> =>
-  Effect.acquireRelease(
-    subscribe(self),
-    (dequeue) => tQueue.shutdown(dequeue)
-  )
+  Effect.acquireRelease({
+    acquire: subscribe(self),
+    release: (dequeue) => tQueue.shutdown(dequeue)
+  })
 
 /** @internal */
 export const unbounded = <A>(): STM.STM<TPubSub.TPubSub<A>> => makeTPubSub<A>(Number.MAX_SAFE_INTEGER, tQueue.Dropping)

--- a/packages/effect/src/internal/stm/tReentrantLock.ts
+++ b/packages/effect/src/internal/stm/tReentrantLock.ts
@@ -243,10 +243,10 @@ export const make: STM.STM<TReentrantLock.TReentrantLock> = core.map(
 
 /** @internal */
 export const readLock = (self: TReentrantLock.TReentrantLock): Effect.Effect<number, never, Scope.Scope> =>
-  Effect.acquireRelease(
-    core.commit(acquireRead(self)),
-    () => core.commit(releaseRead(self))
-  )
+  Effect.acquireRelease({
+    acquire: core.commit(acquireRead(self)),
+    release: () => core.commit(releaseRead(self))
+  })
 
 /** @internal */
 export const readLocks = (self: TReentrantLock.TReentrantLock): STM.STM<number> =>
@@ -332,10 +332,10 @@ export const withWriteLock = dual<
 
 /** @internal */
 export const writeLock = (self: TReentrantLock.TReentrantLock): Effect.Effect<number, never, Scope.Scope> =>
-  Effect.acquireRelease(
-    core.commit(acquireWrite(self)),
-    () => core.commit(releaseWrite(self))
-  )
+  Effect.acquireRelease({
+    acquire: core.commit(acquireWrite(self)),
+    release: () => core.commit(releaseWrite(self))
+  })
 
 /** @internal */
 export const writeLocked = (self: TReentrantLock.TReentrantLock): STM.STM<boolean> =>

--- a/packages/effect/src/internal/stm/tSemaphore.ts
+++ b/packages/effect/src/internal/stm/tSemaphore.ts
@@ -102,10 +102,10 @@ export const withPermitsScoped = dual<
   (permits: number) => (self: TSemaphore.TSemaphore) => Effect.Effect<void, never, Scope.Scope>,
   (self: TSemaphore.TSemaphore, permits: number) => Effect.Effect<void, never, Scope.Scope>
 >(2, (self, permits) =>
-  Effect.acquireReleaseInterruptible(
-    core.commit(acquireN(self, permits)),
-    () => core.commit(releaseN(self, permits))
-  ))
+  Effect.acquireReleaseInterruptible({
+    acquire: core.commit(acquireN(self, permits)),
+    release: () => core.commit(releaseN(self, permits))
+  }))
 
 /** @internal */
 export const unsafeMakeSemaphore = (permits: number): TSemaphore.TSemaphore => {

--- a/packages/effect/test/Channel/scoping.test.ts
+++ b/packages/effect/test/Channel/scoping.test.ts
@@ -38,7 +38,7 @@ describe("Channel", () => {
       const ref = yield* $(Ref.make(0))
       const acquire = Effect.zipRight(Ref.update(ref, (n) => n + 1), Effect.yieldNow())
       const release = () => Ref.update(ref, (n) => n - 1)
-      const scoped = Effect.acquireRelease(acquire, release)
+      const scoped = Effect.acquireRelease({ acquire, release })
       yield* $(
         Channel.unwrapScoped(pipe(scoped, Effect.as(Channel.fromEffect(Deferred.await(latch))))),
         Channel.runDrain,

--- a/packages/effect/test/Effect/scope-ref.test.ts
+++ b/packages/effect/test/Effect/scope-ref.test.ts
@@ -34,10 +34,10 @@ describe("Effect", () => {
       )
 
       yield* $(
-        Effect.acquireRelease(
-          withValue("A")(logRef("acquire")),
-          () => withValue("R")(logRef("release"))
-        ),
+        Effect.acquireRelease({
+          acquire: withValue("A")(logRef("acquire")),
+          release: () => withValue("R")(logRef("release"))
+        }),
         withValue("INNER"),
         Effect.scoped,
         withValue("OUTER"),

--- a/packages/effect/test/Sink/scoping.test.ts
+++ b/packages/effect/test/Sink/scoping.test.ts
@@ -10,10 +10,10 @@ describe("Sink", () => {
   it.effect("unwrapScoped - happy path", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
-      const resource = Effect.acquireRelease(
-        Effect.succeed(100),
-        () => Ref.set(ref, true)
-      )
+      const resource = Effect.acquireRelease({
+        acquire: Effect.succeed(100),
+        release: () => Ref.set(ref, true)
+      })
       const sink = pipe(
         resource,
         Effect.map((n) =>
@@ -39,10 +39,10 @@ describe("Sink", () => {
   it.effect("unwrapScoped - error", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
-      const resource = Effect.acquireRelease(
-        Effect.succeed(100),
-        () => Ref.set(ref, true)
-      )
+      const resource = Effect.acquireRelease({
+        acquire: Effect.succeed(100),
+        release: () => Ref.set(ref, true)
+      })
       const sink = pipe(resource, Effect.as(Sink.succeed("ok")), Sink.unwrapScoped)
       const result = yield* $(Stream.fail("fail"), Stream.run(sink))
       const finalState = yield* $(Ref.get(ref))

--- a/packages/effect/test/Stream/constructors.test.ts
+++ b/packages/effect/test/Stream/constructors.test.ts
@@ -46,10 +46,10 @@ describe("Stream", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(Chunk.empty<string>()))
       yield* $(
-        Stream.acquireRelease(
-          Ref.update(ref, Chunk.append("Acquire")),
-          () => Ref.update(ref, Chunk.append("Release"))
-        ),
+        Stream.acquireRelease({
+          acquire: Ref.update(ref, Chunk.append("Acquire")),
+          release: () => Ref.update(ref, Chunk.append("Release"))
+        }),
         Stream.flatMap(() => Stream.finalizer(Ref.update(ref, Chunk.append("Use")))),
         Stream.ensuring(Ref.update(ref, Chunk.append("Ensuring"))),
         Stream.runDrain

--- a/packages/effect/test/Stream/environment.test.ts
+++ b/packages/effect/test/Stream/environment.test.ts
@@ -175,10 +175,10 @@ describe("Stream", () => {
   it.effect("deep provide", () =>
     Effect.gen(function*($) {
       const messages: Array<string> = []
-      const effect = Effect.acquireRelease(
-        pipe(StringService, Effect.tap((s) => Effect.sync(() => messages.push(s.string)))),
-        () => pipe(StringService, Effect.tap((s) => Effect.sync(() => messages.push(s.string))))
-      )
+      const effect = Effect.acquireRelease({
+        acquire: pipe(StringService, Effect.tap((s) => Effect.sync(() => messages.push(s.string)))),
+        release: () => pipe(StringService, Effect.tap((s) => Effect.sync(() => messages.push(s.string))))
+      })
       const L0 = Layer.succeed(StringService, { string: "test0" })
       const L1 = Layer.succeed(StringService, { string: "test1" })
       const L2 = Layer.succeed(StringService, { string: "test2" })

--- a/packages/effect/test/Stream/error-handling.test.ts
+++ b/packages/effect/test/Stream/error-handling.test.ts
@@ -142,10 +142,10 @@ describe("Stream", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make<Exit.Exit<unknown, unknown>>(Exit.unit))
       yield* $(
-        Stream.acquireRelease(
-          Effect.unit,
-          (_, exit) => Ref.set(ref, exit)
-        ),
+        Stream.acquireRelease({
+          acquire: Effect.unit,
+          release: (_, exit) => Ref.set(ref, exit)
+        }),
         Stream.flatMap(() => Stream.fail("boom")),
         Stream.either,
         Stream.runDrain,

--- a/packages/effect/test/Stream/running.test.ts
+++ b/packages/effect/test/Stream/running.test.ts
@@ -136,10 +136,10 @@ describe("Stream", () => {
   it.effect("runScoped - properly closes resources", () =>
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(false))
-      const resource = Effect.acquireRelease(
-        Effect.succeed(1),
-        () => Ref.set(ref, true)
-      )
+      const resource = Effect.acquireRelease({
+        acquire: Effect.succeed(1),
+        release: () => Ref.set(ref, true)
+      })
       const stream = pipe(Stream.scoped(resource), Stream.flatMap((a) => Stream.make(a, a, a)))
       const [result, state] = yield* $(
         stream,

--- a/packages/effect/test/utils/cache/ObservableResource.ts
+++ b/packages/effect/test/utils/cache/ObservableResource.ts
@@ -60,10 +60,10 @@ export const makeEffect = <V, E>(
           const child = yield* $(Scope.fork(parent, ExecutionStrategy.sequential))
           yield* $(Ref.update(resourceAcquisitionCount, (n) => n + 1))
           yield* $(Scope.addFinalizer(child, Ref.update(resourceAcquisitionReleasing, (n) => n + 1)))
-          return yield* $(Effect.acquireReleaseInterruptible(
-            restore(effect),
-            (exit) => Scope.close(child, exit)
-          ))
+          return yield* $(Effect.acquireReleaseInterruptible({
+            acquire: restore(effect),
+            release: (exit) => Scope.close(child, exit)
+          }))
         })
       )
       return new ObservableResourceImpl(scoped, getState)

--- a/packages/experimental/src/DevTools/Client.ts
+++ b/packages/experimental/src/DevTools/Client.ts
@@ -44,10 +44,10 @@ export const Client = Context.GenericTag<Client, ClientImpl>("@effect/experiment
  */
 export const make: Effect.Effect<ClientImpl, never, Scope.Scope | Socket.Socket> = Effect.gen(function*(_) {
   const socket = yield* _(Socket.Socket)
-  const requests = yield* _(Effect.acquireRelease(
-    Queue.sliding<Domain.Request>(1024),
-    Queue.shutdown
-  ))
+  const requests = yield* _(Effect.acquireRelease({
+    acquire: Queue.sliding<Domain.Request>(1024),
+    release: Queue.shutdown
+  }))
 
   function metricsSnapshot(): Domain.MetricsSnapshot {
     const snapshot = Metric.unsafeSnapshot()

--- a/packages/experimental/src/Persistence/Lmdb.ts
+++ b/packages/experimental/src/Persistence/Lmdb.ts
@@ -14,19 +14,19 @@ import * as Persistence from "../Persistence.js"
  */
 export const make = (options: Lmdb.RootDatabaseOptionsWithPath) =>
   Effect.gen(function*(_) {
-    const lmdb = yield* _(Effect.acquireRelease(
-      Effect.sync(() => Lmdb.open(options)),
-      (lmdb) => Effect.promise(() => lmdb.close())
-    ))
+    const lmdb = yield* _(Effect.acquireRelease({
+      acquire: Effect.sync(() => Lmdb.open(options)),
+      release: (lmdb) => Effect.promise(() => lmdb.close())
+    }))
 
     return Persistence.BackingPersistence.of({
       [Persistence.BackingPersistenceTypeId]: Persistence.BackingPersistenceTypeId,
       make: (storeId) =>
         Effect.gen(function*(_) {
-          const store = yield* _(Effect.acquireRelease(
-            Effect.sync(() => lmdb.openDB({ name: storeId })),
-            (store) => Effect.promise(() => store.close())
-          ))
+          const store = yield* _(Effect.acquireRelease({
+            acquire: Effect.sync(() => lmdb.openDB({ name: storeId })),
+            release: (store) => Effect.promise(() => store.close())
+          }))
           return identity<Persistence.BackingPersistenceStore>({
             get: (key) =>
               Effect.try({

--- a/packages/experimental/src/RequestResolver.ts
+++ b/packages/experimental/src/RequestResolver.ts
@@ -54,10 +54,10 @@ export const dataLoader = dual<
 ) =>
   Effect.gen(function*(_) {
     const queue = yield* _(
-      Effect.acquireRelease(
-        Queue.unbounded<DataLoaderItem<A>>(),
-        Queue.shutdown
-      )
+      Effect.acquireRelease({
+        acquire: Queue.unbounded<DataLoaderItem<A>>(),
+        release: Queue.shutdown
+      })
     )
     const batch = yield* _(Ref.make(ReadonlyArray.empty<DataLoaderItem<A>>()))
     const takeOne = Effect.flatMap(Queue.take(queue), (item) => Ref.updateAndGet(batch, ReadonlyArray.append(item)))

--- a/packages/experimental/src/Socket.ts
+++ b/packages/experimental/src/Socket.ts
@@ -170,16 +170,17 @@ export const makeWebSocket = (url: string | Effect.Effect<string>, options?: {
   readonly closeCodeIsError?: (code: number) => boolean
 }): Effect.Effect<Socket> =>
   fromWebSocket(
-    Effect.acquireRelease(
-      Effect.map(
+    Effect.acquireRelease({
+      acquire: Effect.map(
         typeof url === "string" ? Effect.succeed(url) : url,
         (url) => {
           const WS = "WebSocket" in globalThis ? globalThis.WebSocket : IsoWebSocket
           return new WS(url) as globalThis.WebSocket
         }
       ),
-      (ws) => Effect.sync(() => ws.close())
-    ),
+
+      release: (ws) => Effect.sync(() => ws.close())
+    }),
     options
   )
 

--- a/packages/experimental/src/SocketServer/Node.ts
+++ b/packages/experimental/src/SocketServer/Node.ts
@@ -70,16 +70,17 @@ export const make = (
             server.on("connection", (conn) => {
               pipe(
                 Socket.fromNetSocket(
-                  Effect.acquireRelease(
-                    Effect.succeed(conn),
-                    (conn) =>
+                  Effect.acquireRelease({
+                    acquire: Effect.succeed(conn),
+
+                    release: (conn) =>
                       Effect.sync(() => {
                         if (conn.closed === false) {
                           conn.destroySoon()
                         }
                         conn.removeAllListeners()
                       })
-                  )
+                  })
                 ),
                 Effect.flatMap(handler),
                 Effect.catchAllCause((cause) => Effect.log(cause, "Unhandled error in SocketServer handler")),
@@ -171,13 +172,14 @@ export const makeWebSocket = (
             server.on("connection", (conn, req) => {
               pipe(
                 Socket.fromWebSocket(
-                  Effect.acquireRelease(
-                    Effect.succeed(conn as unknown as globalThis.WebSocket),
-                    (conn) =>
+                  Effect.acquireRelease({
+                    acquire: Effect.succeed(conn as unknown as globalThis.WebSocket),
+
+                    release: (conn) =>
                       Effect.sync(() => {
                         conn.close()
                       })
-                  )
+                  })
                 ),
                 Effect.flatMap(handler),
                 Effect.catchAllCause((cause) => Effect.log(cause, "Unhandled error in SocketServer handler")),

--- a/packages/experimental/test/Socket.test.ts
+++ b/packages/experimental/test/Socket.test.ts
@@ -42,14 +42,15 @@ describe("Socket", () => {
   describe("WebSocket", () => {
     const url = `ws://localhost:1234`
 
-    const makeServer = Effect.acquireRelease(
-      Effect.sync(() => new WS(url)),
-      (ws) =>
+    const makeServer = Effect.acquireRelease({
+      acquire: Effect.sync(() => new WS(url)),
+
+      release: (ws) =>
         Effect.sync(() => {
           ws.close()
           WS.clean()
         })
-    )
+    })
 
     test("messages", () =>
       Effect.gen(function*(_) {

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -41,8 +41,8 @@ export const layerTracerProvider = (
     Effect.flatMap(
       Resource.Resource,
       (resource) =>
-        Effect.acquireRelease(
-          Effect.sync(() => {
+        Effect.acquireRelease({
+          acquire: Effect.sync(() => {
             const provider = new NodeTracerProvider({
               ...(config ?? undefined),
               resource
@@ -50,8 +50,9 @@ export const layerTracerProvider = (
             provider.addSpanProcessor(processor)
             return provider
           }),
-          (provider) => Effect.ignoreLogged(Effect.promise(() => provider.shutdown()))
-        )
+
+          release: (provider) => Effect.ignoreLogged(Effect.promise(() => provider.shutdown()))
+        })
     )
   )
 

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -41,8 +41,8 @@ export const layerTracerProvider = (
     Effect.flatMap(
       Resource.Resource,
       (resource) =>
-        Effect.acquireRelease(
-          Effect.sync(() => {
+        Effect.acquireRelease({
+          acquire: Effect.sync(() => {
             const provider = new WebTracerProvider({
               ...(config ?? undefined),
               resource
@@ -50,8 +50,8 @@ export const layerTracerProvider = (
             provider.addSpanProcessor(processor)
             return provider
           }),
-          (provider) => Effect.ignoreLogged(Effect.promise(() => provider.shutdown()))
-        )
+          release: (provider) => Effect.ignoreLogged(Effect.promise(() => provider.shutdown()))
+        })
     )
   )
 

--- a/packages/opentelemetry/src/internal/metrics.ts
+++ b/packages/opentelemetry/src/internal/metrics.ts
@@ -246,14 +246,15 @@ export const makeProducer = Effect.map(
 
 /** @internal */
 export const registerProducer = (self: MetricProducer, metricReader: LazyArg<MetricReader>) =>
-  Effect.acquireRelease(
-    Effect.sync(() => {
+  Effect.acquireRelease({
+    acquire: Effect.sync(() => {
       const reader = metricReader()
       reader.setMetricProducer(self)
       return reader
     }),
-    (reader) => Effect.ignoreLogged(Effect.promise(() => reader.shutdown()))
-  )
+
+    release: (reader) => Effect.ignoreLogged(Effect.promise(() => reader.shutdown()))
+  })
 
 /** @internal */
 export const layer = (evaluate: LazyArg<MetricReader>) =>

--- a/packages/platform-browser/src/internal/http/client.ts
+++ b/packages/platform-browser/src/internal/http/client.ts
@@ -30,14 +30,14 @@ export const makeXMLHttpRequest = Client.makeDefault((request) =>
     })).pipe(
       Effect.zip(
         Effect.flatMap(FiberRef.get(currentXMLHttpRequest), (makeXhr) =>
-          Effect.acquireRelease(
-            Effect.sync(() => makeXhr()),
-            (xhr) =>
+          Effect.acquireRelease({
+            acquire: Effect.sync(() => makeXhr()),
+            release: (xhr) =>
               Effect.sync(() => {
                 xhr.abort()
                 xhr.onreadystatechange = null
               })
-          ))
+          }))
       ),
       Effect.flatMap(([url, xhr]) => {
         xhr.open(request.method, url.toString(), true)

--- a/packages/platform-node-shared/src/internal/commandExecutor.ts
+++ b/packages/platform-node-shared/src/internal/commandExecutor.ts
@@ -80,9 +80,10 @@ const runCommand =
             onSome: (dir) => fileSystem.access(dir)
           }),
           Effect.zipRight(
-            Effect.acquireRelease(
-              spawn,
-              ([handle, exitCode]) =>
+            Effect.acquireRelease({
+              acquire: spawn,
+
+              release: ([handle, exitCode]) =>
                 Effect.flatMap(Deferred.isDone(exitCode), (done) =>
                   done ? Effect.unit : Effect.suspend(() => {
                     if (handle.kill("SIGTERM")) {
@@ -90,7 +91,7 @@ const runCommand =
                     }
                     return Effect.unit
                   }))
-            )
+            })
           ),
           Effect.map(([handle, exitCodeDeferred]): CommandExecutor.Process => {
             let stdin: Sink.Sink<void, unknown, never, Error.PlatformError> = Sink.drain

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -157,10 +157,10 @@ const makeTempDirectoryScoped = (() => {
   return (
     options?: FileSystem.MakeTempDirectoryOptions
   ) =>
-    Effect.acquireRelease(
-      makeDirectory(options),
-      (directory) => Effect.orDie(removeDirectory(directory, { recursive: true }))
-    )
+    Effect.acquireRelease({
+      acquire: makeDirectory(options),
+      release: (directory) => Effect.orDie(removeDirectory(directory, { recursive: true }))
+    })
 })()
 
 // == open
@@ -179,10 +179,10 @@ const openFactory = (method: string) => {
 
   return (path: string, options?: FileSystem.OpenFileOptions) =>
     pipe(
-      Effect.acquireRelease(
-        nodeOpen(path, options?.flag ?? "r", options?.mode),
-        (fd) => Effect.orDie(nodeClose(fd))
-      ),
+      Effect.acquireRelease({
+        acquire: nodeOpen(path, options?.flag ?? "r", options?.mode),
+        release: (fd) => Effect.orDie(nodeClose(fd))
+      }),
       Effect.map((fd) => makeFile(FileSystem.FileDescriptor(fd), options?.flag?.startsWith("a") ?? false))
     )
 }
@@ -380,10 +380,10 @@ const makeTempFileScoped = (() => {
   const makeFile = makeTempFileFactory("makeTempFileScoped")
   const removeFile = removeFactory("makeTempFileScoped")
   return (options?: FileSystem.MakeTempFileOptions) =>
-    Effect.acquireRelease(
-      makeFile(options),
-      (file) => Effect.orDie(removeFile(file))
-    )
+    Effect.acquireRelease({
+      acquire: makeFile(options),
+      release: (file) => Effect.orDie(removeFile(file))
+    })
 })()
 
 // == readDirectory

--- a/packages/platform-node/src/internal/http/client.ts
+++ b/packages/platform-node/src/internal/http/client.ts
@@ -30,14 +30,14 @@ export const HttpAgent = Context.GenericTag<NodeClient.HttpAgent>("@effect/platf
 export const makeAgent = (options?: Https.AgentOptions): Effect.Effect<NodeClient.HttpAgent, never, Scope.Scope> =>
   Effect.map(
     Effect.all([
-      Effect.acquireRelease(
-        Effect.sync(() => new Http.Agent(options)),
-        (agent) => Effect.sync(() => agent.destroy())
-      ),
-      Effect.acquireRelease(
-        Effect.sync(() => new Https.Agent(options)),
-        (agent) => Effect.sync(() => agent.destroy())
-      )
+      Effect.acquireRelease({
+        acquire: Effect.sync(() => new Http.Agent(options)),
+        release: (agent) => Effect.sync(() => agent.destroy())
+      }),
+      Effect.acquireRelease({
+        acquire: Effect.sync(() => new Https.Agent(options)),
+        release: (agent) => Effect.sync(() => agent.destroy())
+      })
     ]),
     ([http, https]) => ({
       [HttpAgentTypeId]: HttpAgentTypeId,
@@ -53,10 +53,10 @@ export const makeAgentLayer = (options?: Https.AgentOptions): Layer.Layer<NodeCl
 /** @internal */
 export const agentLayer = makeAgentLayer()
 
-const makeAbortController = Effect.acquireRelease(
-  Effect.sync(() => new AbortController()),
-  (controller) => Effect.sync(() => controller.abort())
-)
+const makeAbortController = Effect.acquireRelease({
+  acquire: Effect.sync(() => new AbortController()),
+  release: (controller) => Effect.sync(() => controller.abort())
+})
 
 const fromAgent = (agent: NodeClient.HttpAgent): Client.Client.Default =>
   Client.makeDefault((request) =>

--- a/packages/platform-node/src/internal/http/server.ts
+++ b/packages/platform-node/src/internal/http/server.ts
@@ -36,9 +36,10 @@ export const make = (
   options: Net.ListenOptions
 ): Effect.Effect<Server.Server, Error.ServeError, Scope.Scope> =>
   Effect.gen(function*(_) {
-    const server = yield* _(Effect.acquireRelease(
-      Effect.sync(evaluate),
-      (server) =>
+    const server = yield* _(Effect.acquireRelease({
+      acquire: Effect.sync(evaluate),
+
+      release: (server) =>
         Effect.async<void>((resume) => {
           server.close((error) => {
             if (error) {
@@ -48,7 +49,7 @@ export const make = (
             }
           })
         })
-    ))
+    }))
 
     yield* _(Effect.async<void, Error.ServeError>((resume) => {
       server.on("error", (error) => {

--- a/packages/platform/src/internal/http/client.ts
+++ b/packages/platform/src/internal/http/client.ts
@@ -93,10 +93,10 @@ export const fetch = (options?: RequestInit): Client.Client.Default =>
           const headers = new Headers(request.headers)
           const send = (body: BodyInit | undefined) =>
             pipe(
-              Effect.acquireRelease(
-                Effect.sync(() => new AbortController()),
-                (controller) => Effect.sync(() => controller.abort())
-              ),
+              Effect.acquireRelease({
+                acquire: Effect.sync(() => new AbortController()),
+                release: (controller) => Effect.sync(() => controller.abort())
+              }),
               Effect.flatMap((controller) =>
                 Effect.tryPromise({
                   try: () =>

--- a/packages/platform/src/internal/worker.ts
+++ b/packages/platform/src/internal/worker.ts
@@ -80,10 +80,10 @@ export const makeManager = Effect.gen(function*(_) {
           number,
           readonly [Queue.Queue<Exit.Exit<ReadonlyArray<O>, E | WorkerError>>, Deferred.Deferred<void>]
         >()
-        const sendQueue = yield* _(Effect.acquireRelease(
-          Queue.unbounded<readonly [message: Worker.Worker.Request, transfers?: ReadonlyArray<unknown>]>(),
-          Queue.shutdown
-        ))
+        const sendQueue = yield* _(Effect.acquireRelease({
+          acquire: Queue.unbounded<readonly [message: Worker.Worker.Request, transfers?: ReadonlyArray<unknown>]>(),
+          release: Queue.shutdown
+        }))
 
         const collector = Transferable.unsafeMakeCollector()
         const wrappedEncode = encode ?
@@ -220,10 +220,10 @@ export const makeManager = Effect.gen(function*(_) {
 
         const execute = (request: I) =>
           Stream.flatMap(
-            Stream.acquireRelease(
-              executeAcquire(request),
-              executeRelease
-            ),
+            Stream.acquireRelease({
+              acquire: executeAcquire(request),
+              release: executeRelease
+            }),
             ([, queue]) => {
               const loop: Channel.Channel<Chunk.Chunk<O>, unknown, E | WorkerError, unknown, void, unknown> = Channel
                 .flatMap(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Using an object improves readability. 
Brings the signature of a function to the same pattern as used in `Effect.tryPromise({ try, catch })`

```ts
// before: 
 const acquireDBConnection = Effect.acquireRelease(
   Effect.sync(() => createConnection('mysql://...')),
   (connection) => Effect.sync(() => connection.end(() => {})),
 )

// after:
 const acquireDBConnection = Effect.acquireRelease({
   acquire: Effect.sync(() => createConnection('mysql://...')),
   release: (connection) => Effect.sync(() => connection.end(() => {})),
 })
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
