### PR TITLE
Default `batching` to `"inherit"` if not specified in `Effect.forEach`

### DIFF
--- a/.changeset/spotty-cameras-call.md
+++ b/.changeset/spotty-cameras-call.md
@@ -1,0 +1,23 @@
+---
+"effect": patch
+---
+
+Default `batching` to `"inherit"` if not specified in `Effect.forEach`
+
+With this change, the following:
+
+```ts
+Effect.forEach([1, 2, 3], myRequest)
+```
+
+is equivalent to:
+
+```ts
+Effect.forEach([1, 2, 3], myRequest, { batching: "inherit" })
+```
+
+Previously, it would have been equivalent to:
+
+```ts
+Effect.forEach([1, 2, 3], myRequest, { batching: false })
+```

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1860,7 +1860,7 @@ export const forEach: {
 ) =>
   core.withFiberRuntime<A | void, E, R>((r) => {
     const isRequestBatchingEnabled = options?.batching === true ||
-      (options?.batching === "inherit" && r.getFiberRef(core.currentRequestBatching))
+      ((options?.batching ?? "inherit") === "inherit" && r.getFiberRef(core.currentRequestBatching))
 
     if (options?.discard) {
       return concurrency.match(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

During the advanced workshop, it was noted by @tim-smart  and I that `Effect.forEach` does not inherit the regional value for request batching. 

This PR defaults `batching` to `"inherit"` if not specified in `Effect.forEach`, so the following code:

```ts
Effect.forEach([1, 2, 3], myRequest)
```

becomes equivalent to:

```ts
Effect.forEach([1, 2, 3], myRequest, { batching: "inherit" })
```

whereas previously, it would have been equivalent to:

```ts
Effect.forEach([1, 2, 3], myRequest, { batching: false })
```

cc-ing @mikearnaldi in case this was an intentional decision. If so, I will open a separate PR to document this behavior.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
