### PR TITLE
JSONSchema: prune `UndefinedKeyword` if the property signature is mar…

### DIFF
--- a/.changeset/stale-scissors-decide.md
+++ b/.changeset/stale-scissors-decide.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+JSONSchema: prune `UndefinedKeyword` if the property signature is marked as optional and contains a union that includes `UndefinedKeyword`, closes #2068

--- a/packages/schema/src/JSONSchema.ts
+++ b/packages/schema/src/JSONSchema.ts
@@ -221,13 +221,13 @@ const objectJsonSchema: JsonSchema7 = {
   ]
 }
 
-const emptyJsonSchema: JsonSchema7 = {
+const empty = (): JsonSchema7 => ({
   "$id": "/schemas/{}",
   "oneOf": [
     { "type": "object" },
     { "type": "array" }
   ]
-}
+})
 
 const $schema = "http://json-schema.org/draft-07/schema#"
 
@@ -273,6 +273,14 @@ const goWithMetaData = (ast: AST.AST, $defs: Record<string, JsonSchema7>): JsonS
     ...go(ast, $defs),
     ...getMetaData(ast)
   }
+}
+
+const pruneUndefinedKeyword = (ps: AST.PropertySignature): AST.AST => {
+  const type = ps.type
+  if (ps.isOptional && AST.isUnion(type) && Option.isNone(AST.getJSONSchemaAnnotation(type))) {
+    return AST.createUnion(type.types.filter((type) => !AST.isUndefinedKeyword(type)), type.annotations)
+  }
+  return type
 }
 
 /** @internal */
@@ -374,7 +382,7 @@ const go = (ast: AST.AST, $defs: Record<string, JsonSchema7>): JsonSchema7 => {
     }
     case "TypeLiteral": {
       if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
-        return { ...emptyJsonSchema }
+        return empty()
       }
       let additionalProperties: JsonSchema7 | undefined = undefined
       let patternProperties: Record<string, JsonSchema7> | undefined = undefined
@@ -415,7 +423,7 @@ const go = (ast: AST.AST, $defs: Record<string, JsonSchema7>): JsonSchema7 => {
         }
       }
       const propertySignatures = ast.propertySignatures.map((ps) => {
-        return { ...goWithIdentifier(ps.type, $defs), ...getMetaData(ps) }
+        return { ...goWithIdentifier(pruneUndefinedKeyword(ps), $defs), ...getMetaData(ps) }
       })
       const output: JsonSchema7Object = {
         type: "object",

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -720,6 +720,35 @@ describe("JSONSchema", () => {
         new Error("Cannot encode Symbol(@effect/schema/test/a) key to JSON Schema")
       )
     })
+
+    it("should prune `UndefinedKeyword` if the property signature is marked as optional and contains a union that includes `UndefinedKeyword`", () => {
+      const schema = S.struct({
+        a: S.optional(S.string)
+      })
+      const jsonSchema = JSONSchema.make(schema)
+      expect(jsonSchema).toStrictEqual({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string",
+            "title": "string",
+            "description": "a string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      })
+    })
+
+    it("should raise an error if the property signature is not marked as optional and contains a union that includes `UndefinedKeyword`", () => {
+      const schema = S.struct({
+        a: S.orUndefined(S.string)
+      })
+      expect(() => JSONSchema.make(schema)).toThrow(
+        new Error("cannot build a JSON Schema for `undefined` without a JSON Schema annotation")
+      )
+    })
   })
 
   describe("record", () => {


### PR DESCRIPTION
…ked as optional and contains a union that includes `UndefinedKeyword`, closes #2068

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #2068
- Discord: https://discord.com/channels/795981131316985866/847382157861060618/1212003178527334421