### PR TITLE
Request : swap Error and Success type params + make Effect.request dual

### DIFF
--- a/.changeset/few-islands-beg.md
+++ b/.changeset/few-islands-beg.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Request: swap Success and Error params

--- a/.changeset/hip-berries-cheat.md
+++ b/.changeset/hip-berries-cheat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+make Effect.request dual

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4914,25 +4914,27 @@ export const step: <A, E, R>(self: Effect<A, E, R>) => Effect<Exit.Exit<A, E> | 
  * @category requests & batching
  */
 export const request: {
-  <A extends Request.Request<any, any>>(
-    request: A
-  ): <Ds extends RequestResolver<A> | Effect<RequestResolver<A>, any, any>>(dataSource: Ds) => Effect<
+  <A extends Request.Request<any, any>, Ds extends RequestResolver<A> | Effect<RequestResolver<A>, any, any>>(
+    dataSource: Ds
+  ): (
+    self: A
+  ) => Effect<
     Request.Request.Success<A>,
     Request.Request.Error<A>,
     [Ds] extends [Effect<any, any, any>] ? Effect.Context<Ds> : never
   >
   <
-    A extends Request.Request<any, any>,
-    Ds extends RequestResolver<A> | Effect<RequestResolver<A>, any, any>
+    Ds extends RequestResolver<A> | Effect<RequestResolver<A>, any, any>,
+    A extends Request.Request<any, any>
   >(
-    request: A,
+    self: A,
     dataSource: Ds
   ): Effect<
     Request.Request.Success<A>,
     Request.Request.Error<A>,
     [Ds] extends [Effect<any, any, any>] ? Effect.Context<Ds> : never
   >
-} = dual((args) => !Request.isRequest(args), query.fromRequest as any)
+} = dual((args) => Request.isRequest(args[0]), query.fromRequest)
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -42,7 +42,7 @@ import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
 import type * as Random from "./Random.js"
 import type * as Ref from "./Ref.js"
-import type * as Request from "./Request.js"
+import * as Request from "./Request.js"
 import type { RequestBlock } from "./RequestBlock.js"
 import type { RequestResolver } from "./RequestResolver.js"
 import type * as Runtime from "./Runtime.js"
@@ -4914,6 +4914,13 @@ export const step: <A, E, R>(self: Effect<A, E, R>) => Effect<Exit.Exit<A, E> | 
  * @category requests & batching
  */
 export const request: {
+  <A extends Request.Request<any, any>>(
+    request: A
+  ): <Ds extends RequestResolver<A> | Effect<RequestResolver<A>, any, any>>(dataSource: Ds) => Effect<
+    Request.Request.Success<A>,
+    Request.Request.Error<A>,
+    [Ds] extends [Effect<any, any, any>] ? Effect.Context<Ds> : never
+  >
   <
     A extends Request.Request<any, any>,
     Ds extends RequestResolver<A> | Effect<RequestResolver<A>, any, any>
@@ -4925,7 +4932,7 @@ export const request: {
     Request.Request.Error<A>,
     [Ds] extends [Effect<any, any, any>] ? Effect.Context<Ds> : never
   >
-} = query.fromRequest as any
+} = dual((args) => !Request.isRequest(args), query.fromRequest as any)
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Request.ts
+++ b/packages/effect/src/Request.ts
@@ -57,7 +57,7 @@ export declare namespace Request {
    * @category models
    */
   export interface Constructor<R extends Request<any, any>, T extends keyof R = never> {
-    (args: Omit<R, T | keyof (Request.Variance<Request.Error<R>, Request.Success<R>>)>): R
+    (args: Omit<R, T | keyof (Request.Variance<Request.Success<R>, Request.Error<R>>)>): R
   }
 
   /**
@@ -127,17 +127,17 @@ export const tagged: <R extends Request<any, any> & { _tag: string }>(
  * @example
  * import * as Request from "effect/Request"
  *
- * type Error = never
  * type Success = string
+ * type Error = never
  *
- * class MyRequest extends Request.Class<Error, Success, {
+ * class MyRequest extends Request.Class<Success, Error, {
  *   readonly id: string
  * }> {}
  *
  * @since 2.0.0
  * @category constructors
  */
-export const Class: new<Error, Success, A extends Record<string, any>>(
+export const Class: new<Success, Error, A extends Record<string, any>>(
   args: Types.Equals<Omit<A, keyof Request<unknown, unknown>>, {}> extends true ? void
     : { readonly [P in keyof A as P extends keyof Request<unknown, unknown> ? never : P]: A[P] }
 ) => Request<Success, Error> & Readonly<A> = internal.Class as any
@@ -148,10 +148,10 @@ export const Class: new<Error, Success, A extends Record<string, any>>(
  * @example
  * import * as Request from "effect/Request"
  *
- * type Error = never
  * type Success = string
+ * type Error = never
  *
- * class MyRequest extends Request.TaggedClass("MyRequest")<Error, Success, {
+ * class MyRequest extends Request.TaggedClass("MyRequest")<Success, Error, {
  *   readonly name: string
  * }> {}
  *
@@ -160,7 +160,7 @@ export const Class: new<Error, Success, A extends Record<string, any>>(
  */
 export const TaggedClass: <Tag extends string>(
   tag: Tag
-) => new<Error, Success, A extends Record<string, any>>(
+) => new<Success, Error, A extends Record<string, any>>(
   args: Types.Equals<Omit<A, keyof Request<unknown, unknown>>, {}> extends true ? void
     : { readonly [P in keyof A as P extends "_tag" | keyof Request<unknown, unknown> ? never : P]: A[P] }
 ) => Request<Success, Error> & Readonly<A> & { readonly _tag: Tag } = internal.TaggedClass as any

--- a/packages/effect/src/internal/request.ts
+++ b/packages/effect/src/internal/request.ts
@@ -46,7 +46,7 @@ export const tagged = <R extends Request.Request<any, any> & { _tag: string }>(
 }
 
 /** @internal */
-export const Class: new<Error, Success, A extends Record<string, any>>(
+export const Class: new<Success, Error, A extends Record<string, any>>(
   args: Types.Equals<Omit<A, keyof Request.Request<unknown, unknown>>, {}> extends true ? void
     : { readonly [P in keyof A as P extends keyof Request.Request<unknown, unknown> ? never : P]: A[P] }
 ) => Request.Request<Success, Error> & Readonly<A> = (function() {
@@ -62,7 +62,7 @@ export const Class: new<Error, Success, A extends Record<string, any>>(
 /** @internal */
 export const TaggedClass = <Tag extends string>(
   tag: Tag
-): new<Error, Success, A extends Record<string, any>>(
+): new<Success, Error, A extends Record<string, any>>(
   args: Types.Equals<Omit<A, keyof Request.Request<unknown, unknown>>, {}> extends true ? void
     : { readonly [P in keyof A as P extends "_tag" | keyof Request.Request<unknown, unknown> ? never : P]: A[P] }
 ) => Request.Request<Success, Error> & Readonly<A> & { readonly _tag: Tag } => {


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As discussed on this message https://discord.com/channels/795981131316985866/795983589644304396/1212891296944103424

> Should the type param order for Request.TaggedClass be swapped? It's currently <Error, Success, A> instead of <Success, Error, A>.

Since the message author did not respond to @mikearnaldi, I created the PR.