### PR TITLE
`Cache`, `ScopedCache` swap type parameters [another try]

### DIFF
--- a/.changeset/tough-jeans-allow.md
+++ b/.changeset/tough-jeans-allow.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+---
+
+`Cache<Key, Error, Value>` has been changed to `Cache<Key, Value, Error = never>`.
+`ScopedCache<Key, Error, Value>` has been changed to `ScopedCache<Key, Value, Error = never>`.
+`Lookup<Key, Environment, Error, Value>` has been changed to `Lookup<Key, Value, Error = never, Environment = never>`

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -43,7 +43,7 @@ export type CacheTypeId = typeof CacheTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Cache<in out Key, out Error, out Value> extends ConsumerCache<Key, Error, Value> {
+export interface Cache<in out Key, out Value, out Error = never> extends ConsumerCache<Key, Value, Error> {
   /**
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise computes the value with the lookup function, puts it in the
@@ -83,7 +83,7 @@ export interface Cache<in out Key, out Error, out Value> extends ConsumerCache<K
  * @since 2.0.0
  * @category models
  */
-export interface ConsumerCache<in out Key, out Error, out Value> extends Cache.Variance<Key, Error, Value> {
+export interface ConsumerCache<in out Key, out Value, out Error = never> extends Cache.Variance<Key, Value, Error> {
   /**
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
@@ -156,7 +156,7 @@ export declare namespace Cache {
    * @since 2.0.0
    * @category models
    */
-  export interface Variance<in out Key, out Error, out Value> {
+  export interface Variance<in out Key, out Value, out Error> {
     readonly [CacheTypeId]: {
       readonly _Key: Types.Invariant<Key>
       readonly _Error: Types.Covariant<Error>
@@ -172,13 +172,13 @@ export declare namespace Cache {
  * @since 2.0.0
  * @category constructors
  */
-export const make: <Key, Environment, Error, Value>(
+export const make: <Key, Value, Error = never, Environment = never>(
   options: {
     readonly capacity: number
     readonly timeToLive: Duration.DurationInput
-    readonly lookup: Lookup<Key, Environment, Error, Value>
+    readonly lookup: Lookup<Key, Value, Error, Environment>
   }
-) => Effect.Effect<Cache<Key, Error, Value>, never, Environment> = internal.make
+) => Effect.Effect<Cache<Key, Value, Error>, never, Environment> = internal.make
 
 /**
  * Constructs a new cache with the specified capacity, time to live, and
@@ -188,13 +188,13 @@ export const make: <Key, Environment, Error, Value>(
  * @since 2.0.0
  * @category constructors
  */
-export const makeWith: <Key, Environment, Error, Value>(
+export const makeWith: <Key, Value, Error = never, Environment = never>(
   options: {
     readonly capacity: number
-    readonly lookup: Lookup<Key, Environment, Error, Value>
+    readonly lookup: Lookup<Key, Value, Error, Environment>
     readonly timeToLive: (exit: Exit.Exit<Value, Error>) => Duration.DurationInput
   }
-) => Effect.Effect<Cache<Key, Error, Value>, never, Environment> = internal.makeWith
+) => Effect.Effect<Cache<Key, Value, Error>, never, Environment> = internal.makeWith
 
 /**
  * `CacheStats` represents a snapshot of statistics for the cache as of a
@@ -249,4 +249,6 @@ export const makeEntryStats: (loadedMillis: number) => EntryStats = internal.mak
  * @since 2.0.0
  * @category models
  */
-export type Lookup<Key, Environment, Error, Value> = (key: Key) => Effect.Effect<Value, Error, Environment>
+export type Lookup<Key, Value, Error = never, Environment = never> = (
+  key: Key
+) => Effect.Effect<Value, Error, Environment>

--- a/packages/effect/src/Request.ts
+++ b/packages/effect/src/Request.ts
@@ -256,7 +256,7 @@ export interface Listeners {
  * @since 2.0.0
  */
 export interface Cache extends
-  _Cache.ConsumerCache<Request<any, any>, never, {
+  _Cache.ConsumerCache<Request<any, any>, {
     listeners: Listeners
     handle: Deferred<unknown, unknown>
   }>

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -27,7 +27,9 @@ export type ScopedCacheTypeId = typeof ScopedCacheTypeId
  * @since 2.0.0
  * @category models
  */
-export interface ScopedCache<in Key, out Error, out Value> extends ScopedCache.Variance<Key, Error, Value>, Pipeable {
+export interface ScopedCache<in Key, out Value, out Error = never>
+  extends ScopedCache.Variance<Key, Value, Error>, Pipeable
+{
   /**
    * Retrieves the value associated with the specified key if it exists.
    * Otherwise returns `Option.none`.
@@ -98,7 +100,7 @@ export declare namespace ScopedCache {
    * @since 2.0.0
    * @category models
    */
-  export interface Variance<in Key, out Error, out Value> {
+  export interface Variance<in Key, out Value, out Error> {
     readonly [ScopedCacheTypeId]: {
       _Key: Types.Contravariant<Key>
       _Error: Types.Covariant<Error>
@@ -114,13 +116,13 @@ export declare namespace ScopedCache {
  * @since 2.0.0
  * @category constructors
  */
-export const make: <Key, Environment, Error, Value>(
+export const make: <Key, Value, Error = never, Environment = never>(
   options: {
-    readonly lookup: Lookup<Key, Environment, Error, Value>
+    readonly lookup: Lookup<Key, Value, Error, Environment>
     readonly capacity: number
     readonly timeToLive: Duration.DurationInput
   }
-) => Effect.Effect<ScopedCache<Key, Error, Value>, never, Scope.Scope | Environment> = internal.make
+) => Effect.Effect<ScopedCache<Key, Value, Error>, never, Scope.Scope | Environment> = internal.make
 
 /**
  * Constructs a new cache with the specified capacity, time to live, and
@@ -130,13 +132,13 @@ export const make: <Key, Environment, Error, Value>(
  * @since 2.0.0
  * @category constructors
  */
-export const makeWith: <Key, Environment, Error, Value>(
+export const makeWith: <Key, Value, Error = never, Environment = never>(
   options: {
     readonly capacity: number
-    readonly lookup: Lookup<Key, Environment, Error, Value>
+    readonly lookup: Lookup<Key, Value, Error, Environment>
     readonly timeToLive: (exit: Exit.Exit<Value, Error>) => Duration.DurationInput
   }
-) => Effect.Effect<ScopedCache<Key, Error, Value>, never, Scope.Scope | Environment> = internal.makeWith
+) => Effect.Effect<ScopedCache<Key, Value, Error>, never, Scope.Scope | Environment> = internal.makeWith
 
 /**
  * Similar to `Cache.Lookup`, but executes the lookup function within a `Scope`.
@@ -144,6 +146,6 @@ export const makeWith: <Key, Environment, Error, Value>(
  * @since 2.0.0
  * @category models
  */
-export type Lookup<Key, Environment, Error, Value> = (
+export type Lookup<Key, Value, Error = never, Environment = never> = (
   key: Key
 ) => Effect.Effect<Value, Error, Environment | Scope.Scope>

--- a/packages/effect/src/internal/cache.ts
+++ b/packages/effect/src/internal/cache.ts
@@ -29,13 +29,13 @@ import * as fiberRuntime from "./fiberRuntime.js"
  *
  * @internal
  */
-export type MapValue<Key, Error, Value> =
-  | Complete<Key, Error, Value>
-  | Pending<Key, Error, Value>
-  | Refreshing<Key, Error, Value>
+export type MapValue<Key, Value, Error> =
+  | Complete<Key, Value, Error>
+  | Pending<Key, Value, Error>
+  | Refreshing<Key, Value, Error>
 
 /** @internal */
-export interface Complete<out Key, out Error, out Value> {
+export interface Complete<out Key, out Value, out Error> {
   readonly _tag: "Complete"
   readonly key: MapKey<Key>
   readonly exit: Exit.Exit<Value, Error>
@@ -44,26 +44,26 @@ export interface Complete<out Key, out Error, out Value> {
 }
 
 /** @internal */
-export interface Pending<out Key, in out Error, in out Value> {
+export interface Pending<out Key, in out Value, in out Error> {
   readonly _tag: "Pending"
   readonly key: MapKey<Key>
   readonly deferred: Deferred.Deferred<Value, Error>
 }
 
 /** @internal */
-export interface Refreshing<out Key, in out Error, in out Value> {
+export interface Refreshing<out Key, in out Value, in out Error> {
   readonly _tag: "Refreshing"
   readonly deferred: Deferred.Deferred<Value, Error>
-  readonly complete: Complete<Key, Error, Value>
+  readonly complete: Complete<Key, Value, Error>
 }
 
 /** @internal */
-export const complete = <Key, Error, Value>(
+export const complete = <Key, Value, Error>(
   key: MapKey<Key>,
   exit: Exit.Exit<Value, Error>,
   entryStats: Cache.EntryStats,
   timeToLiveMillis: number
-): MapValue<Key, Error, Value> =>
+): MapValue<Key, Value, Error> =>
   Data.struct({
     _tag: "Complete" as const,
     key,
@@ -73,10 +73,10 @@ export const complete = <Key, Error, Value>(
   })
 
 /** @internal */
-export const pending = <Key, Error, Value>(
+export const pending = <Key, Value, Error>(
   key: MapKey<Key>,
   deferred: Deferred.Deferred<Value, Error>
-): MapValue<Key, Error, Value> =>
+): MapValue<Key, Value, Error> =>
   Data.struct({
     _tag: "Pending" as const,
     key,
@@ -84,10 +84,10 @@ export const pending = <Key, Error, Value>(
   })
 
 /** @internal */
-export const refreshing = <Key, Error, Value>(
+export const refreshing = <Key, Value, Error>(
   deferred: Deferred.Deferred<Value, Error>,
-  complete: Complete<Key, Error, Value>
-): MapValue<Key, Error, Value> =>
+  complete: Complete<Key, Value, Error>
+): MapValue<Key, Value, Error> =>
   Data.struct({
     _tag: "Refreshing" as const,
     deferred,
@@ -216,8 +216,8 @@ export const makeKeySet = <K>(): KeySet<K> => new KeySetImpl<K>()
  *
  * @internal
  */
-export interface CacheState<in out Key, in out Error, in out Value> {
-  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Error, Value>> // mutable by design
+export interface CacheState<in out Key, in out Value, in out Error> {
+  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Value, Error>> // mutable by design
   keys: KeySet<Key> // mutable by design
   accesses: MutableQueue.MutableQueue<MapKey<Key>> // mutable by design
   updating: MutableRef.MutableRef<boolean> // mutable by design
@@ -230,14 +230,14 @@ export interface CacheState<in out Key, in out Error, in out Value> {
  *
  * @internal
  */
-export const makeCacheState = <Key, Error, Value>(
-  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Error, Value>>,
+export const makeCacheState = <Key, Value, Error>(
+  map: MutableHashMap.MutableHashMap<Key, MapValue<Key, Value, Error>>,
   keys: KeySet<Key>,
   accesses: MutableQueue.MutableQueue<MapKey<Key>>,
   updating: MutableRef.MutableRef<boolean>,
   hits: number,
   misses: number
-): CacheState<Key, Error, Value> => ({
+): CacheState<Key, Value, Error> => ({
   map,
   keys,
   accesses,
@@ -251,7 +251,7 @@ export const makeCacheState = <Key, Error, Value>(
  *
  * @internal
  */
-export const initialCacheState = <Key, Error, Value>(): CacheState<Key, Error, Value> =>
+export const initialCacheState = <Key, Value, Error>(): CacheState<Key, Value, Error> =>
   makeCacheState(
     MutableHashMap.empty(),
     makeKeySet(),
@@ -292,14 +292,14 @@ export const makeEntryStats = (loadedMillis: number): Cache.EntryStats => ({
   loadedMillis
 })
 
-class CacheImpl<in out Key, in out Error, in out Value> implements Cache.Cache<Key, Error, Value> {
+class CacheImpl<in out Key, in out Value, in out Error> implements Cache.Cache<Key, Value, Error> {
   readonly [CacheTypeId] = cacheVariance
-  readonly cacheState: CacheState<Key, Error, Value>
+  readonly cacheState: CacheState<Key, Value, Error>
   constructor(
     readonly capacity: number,
     readonly context: Context.Context<any>,
     readonly fiberId: FiberId.FiberId,
-    readonly lookup: Cache.Lookup<Key, any, Error, Value>,
+    readonly lookup: Cache.Lookup<Key, Value, Error, any>,
     readonly timeToLive: (exit: Exit.Exit<Value, Error>) => Duration.DurationInput
   ) {
     this.cacheState = initialCacheState()
@@ -460,7 +460,7 @@ class CacheImpl<in out Key, in out Error, in out Value> implements Cache.Cache<K
                 effect.when(() => {
                   const current = Option.getOrUndefined(MutableHashMap.get(this.cacheState.map, k))
                   if (Equal.equals(current, value)) {
-                    const mapValue = refreshing(deferred, value as Complete<Key, Error, Value>)
+                    const mapValue = refreshing(deferred, value as Complete<Key, Value, Error>)
                     MutableHashMap.set(this.cacheState.map, k, mapValue)
                     return true
                   }
@@ -496,7 +496,7 @@ class CacheImpl<in out Key, in out Error, in out Value> implements Cache.Cache<K
         MutableHashMap.set(
           this.cacheState.map,
           k,
-          mapValue as Complete<Key, Error, Value>
+          mapValue as Complete<Key, Value, Error>
         )
       })
     )
@@ -545,7 +545,7 @@ class CacheImpl<in out Key, in out Error, in out Value> implements Cache.Cache<K
   }
 
   resolveMapValue(
-    value: MapValue<Key, Error, Value>,
+    value: MapValue<Key, Value, Error>,
     ignorePending = false
   ): Effect.Effect<Option.Option<Value>, Error> {
     return effect.clockWith((clock) => {
@@ -665,13 +665,13 @@ class CacheImpl<in out Key, in out Error, in out Value> implements Cache.Cache<K
 }
 
 /** @internal */
-export const make = <Key, Environment, Error, Value>(
+export const make = <Key, Value, Error = never, Environment = never>(
   options: {
     readonly capacity: number
     readonly timeToLive: Duration.DurationInput
-    readonly lookup: Cache.Lookup<Key, Environment, Error, Value>
+    readonly lookup: Cache.Lookup<Key, Value, Error, Environment>
   }
-): Effect.Effect<Cache.Cache<Key, Error, Value>, never, Environment> => {
+): Effect.Effect<Cache.Cache<Key, Value, Error>, never, Environment> => {
   const timeToLive = Duration.decode(options.timeToLive)
   return makeWith({
     capacity: options.capacity,
@@ -681,13 +681,13 @@ export const make = <Key, Environment, Error, Value>(
 }
 
 /** @internal */
-export const makeWith = <Key, Environment, Error, Value>(
+export const makeWith = <Key, Value, Error = never, Environment = never>(
   options: {
     readonly capacity: number
-    readonly lookup: Cache.Lookup<Key, Environment, Error, Value>
+    readonly lookup: Cache.Lookup<Key, Value, Error, Environment>
     readonly timeToLive: (exit: Exit.Exit<Value, Error>) => Duration.DurationInput
   }
-): Effect.Effect<Cache.Cache<Key, Error, Value>, never, Environment> =>
+): Effect.Effect<Cache.Cache<Key, Value, Error>, never, Environment> =>
   core.map(
     fiberRuntime.all([core.context<Environment>(), core.fiberId]),
     ([context, fiberId]) =>
@@ -701,12 +701,12 @@ export const makeWith = <Key, Environment, Error, Value>(
   )
 
 /** @internal */
-export const unsafeMakeWith = <Key, Error, Value>(
+export const unsafeMakeWith = <Key, Value, Error = never>(
   capacity: number,
-  lookup: Cache.Lookup<Key, never, Error, Value>,
+  lookup: Cache.Lookup<Key, Value, Error>,
   timeToLive: (exit: Exit.Exit<Value, Error>) => Duration.DurationInput
-): Cache.Cache<Key, Error, Value> =>
-  new CacheImpl<Key, Error, Value>(
+): Cache.Cache<Key, Value, Error> =>
+  new CacheImpl<Key, Value, Error>(
     capacity,
     Context.empty() as Context.Context<any>,
     none,

--- a/packages/effect/src/internal/query.ts
+++ b/packages/effect/src/internal/query.ts
@@ -13,7 +13,7 @@ import * as core from "./core.js"
 import { ensuring } from "./fiberRuntime.js"
 import { Listeners } from "./request.js"
 
-type RequestCache = Cache.Cache<Request.Request<any, any>, never, {
+type RequestCache = Cache.Cache<Request.Request<any, any>, {
   listeners: Request.Listeners
   handle: Deferred<any, any>
 }>
@@ -22,7 +22,7 @@ type RequestCache = Cache.Cache<Request.Request<any, any>, never, {
 export const currentCache = globalValue(
   Symbol.for("effect/FiberRef/currentCache"),
   () =>
-    core.fiberRefUnsafeMake<RequestCache>(unsafeMakeWith<Request.Request<any, any>, never, {
+    core.fiberRefUnsafeMake<RequestCache>(unsafeMakeWith<Request.Request<any, any>, {
       listeners: Request.Listeners
       handle: Deferred<any, any>
     }>(

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -10,7 +10,7 @@ describe("Cache", () => {
       const cache = yield* _(Cache.make({
         capacity: 100,
         timeToLive: "1 seconds",
-        lookup: (n: number) => Effect.succeed(n)
+        lookup: (n: number): Effect.Effect<number, 2> => Effect.succeed(n)
       }))
       yield* _(cache.get(42))
       yield* _(TestClock.adjust("2 seconds"))

--- a/packages/effect/test/ScopedCache.test.ts
+++ b/packages/effect/test/ScopedCache.test.ts
@@ -302,7 +302,7 @@ describe("ScopedCache", () => {
   it.effect("get - sequential use of a failing scoped effect should cache the error and immediately call the resource finalizer", () =>
     Effect.gen(function*($) {
       const watchableLookup = yield* $(
-        WatchableLookup.makeEffect<void, Cause.RuntimeException, never>(() =>
+        WatchableLookup.makeEffect<void, never, Cause.RuntimeException>(() =>
           Effect.fail(new Cause.RuntimeException("fail"))
         )
       )
@@ -355,7 +355,7 @@ describe("ScopedCache", () => {
   it.effect("get - concurrent use on a failing scoped effect should cache the error and immediately call the resource finalizer", () =>
     Effect.gen(function*($) {
       const watchableLookup = yield* $(
-        WatchableLookup.makeEffect<void, Cause.RuntimeException, never>(() =>
+        WatchableLookup.makeEffect<void, never, Cause.RuntimeException>(() =>
           Effect.fail(new Cause.RuntimeException("fail"))
         )
       )


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Cache<Key, Error, Value>` has been changed to `Cache<Key, Value, Error = never>`.
`ScopedCache<Key, Error, Value>` has been changed to `ScopedCache<Key, Value, Error = never>`.
`Lookup<Key, Environment, Error, Value>` has been changed to `Lookup<Key, Value, Error = never, Environment = never>`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
