### PR TITLE
Remove duplicate word in wizard mode prompt

### DIFF
--- a/.changeset/proud-bees-breathe.md
+++ b/.changeset/proud-bees-breathe.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": minor
+---
+
+Remove duplicate 'should' in wizard mode prompt for variadic arguments

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1396,7 +1396,7 @@ const wizardInternal = (self: Instruction, config: CliConfig.CliConfig): Effect.
     }
     case "Variadic": {
       const repeatHelp = InternalHelpDoc.p(
-        "How many times should this argument should be repeated?"
+        "How many times should this argument be repeated?"
       )
       const message = pipe(
         getHelpInternal(self),


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Typo fix

## Description

This removes a superfluous 'should' in the prompt for variadic arguments.

This was caught by @dasJake while trying out wizard mode in an app that was built with this awesome cli library.
