### PR TITLE
Idea: stop gh test suite after first test fails

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,8 +63,8 @@ jobs:
         with:
           bun-version: 1.0.25
       - name: Test
-        run: pnpm vitest --shard ${{ matrix.shard }}
+        run: pnpm vitest --bail 1 --shard ${{ matrix.shard }}
         if: matrix.runtime == 'Node'
       - name: Test
-        run: bun vitest --shard ${{ matrix.shard }}
+        run: bun vitest --bail 1 --shard ${{ matrix.shard }}
         if: matrix.runtime == 'Bun'


### PR DESCRIPTION
Stop running test suite when the first test has failed. The down side is that you have to run the test suite locally to see all failures but that should be done anyway..