### PR TITLE
CLI: Print unknown argument errors

### DIFF
--- a/.changeset/selfish-kangaroos-sparkle.md
+++ b/.changeset/selfish-kangaroos-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": minor
+---
+
+Print unknown argument errors

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -96,7 +96,7 @@ export const run = dual<
                 ),
               onNonEmpty: (head) => {
                 const error = InternalHelpDoc.p(`Received unknown argument: '${head}'`)
-                return Effect.fail(InternalValidationError.invalidValue(error))
+                return Effect.zipRight(printDocs(error), Effect.fail(InternalValidationError.invalidValue(error)))
               }
             })
           }


### PR DESCRIPTION

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Minor improvement

## Description
All other validation errors are handled and printed in cliApp.ts:83. These errors were previously not printed and silently returned to the user on the error channel. We should either print all validation errors or handle all of them silently and leave printing/reporting to the caller. This commit implements the former option.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
