### PR TITLE
Allow duration inputs to be singular

### DIFF
--- a/.changeset/honest-drinks-cross.md
+++ b/.changeset/honest-drinks-cross.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow duration inputs to be singular

--- a/packages/effect/dtslint/Duration.ts
+++ b/packages/effect/dtslint/Duration.ts
@@ -9,19 +9,35 @@ Duration.decode(100)
 // $ExpectType Duration
 Duration.decode(10n)
 // $ExpectType Duration
+Duration.decode("1 nano")
+// $ExpectType Duration
 Duration.decode("10 nanos")
+// $ExpectType Duration
+Duration.decode("1 micro")
 // $ExpectType Duration
 Duration.decode("10 micros")
 // $ExpectType Duration
+Duration.decode("1 milli")
+// $ExpectType Duration
 Duration.decode("10 millis")
+// $ExpectType Duration
+Duration.decode("1 second")
 // $ExpectType Duration
 Duration.decode("10 seconds")
 // $ExpectType Duration
+Duration.decode("1 minute")
+// $ExpectType Duration
 Duration.decode("10 minutes")
+// $ExpectType Duration
+Duration.decode("1 hour")
 // $ExpectType Duration
 Duration.decode("10 hours")
 // $ExpectType Duration
+Duration.decode("1 day")
+// $ExpectType Duration
 Duration.decode("10 days")
+// $ExpectType Duration
+Duration.decode("1 nano")
 // $ExpectType Duration
 Duration.decode("10 nanos")
 

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -46,13 +46,21 @@ export type DurationValue =
  * @category models
  */
 export type Unit =
+  | "nano"
   | "nanos"
+  | "micro"
   | "micros"
+  | "milli"
   | "millis"
+  | "second"
   | "seconds"
+  | "minute"
   | "minutes"
+  | "hour"
   | "hours"
+  | "day"
   | "days"
+  | "week"
   | "weeks"
 
 /**
@@ -66,7 +74,7 @@ export type DurationInput =
   | [seconds: number, nanos: number]
   | `${number} ${Unit}`
 
-const DURATION_REGEX = /^(-?\d+(?:\.\d+)?)\s+(nanos|micros|millis|seconds|minutes|hours|days|weeks)$/
+const DURATION_REGEX = /^(-?\d+(?:\.\d+)?)\s+(nanos?|micros?|millis?|seconds?|minutes?|hours?|days?|weeks?)$/
 
 /**
  * @since 2.0.0
@@ -89,20 +97,28 @@ export const decode = (input: DurationInput): Duration => {
       const [_, valueStr, unit] = match
       const value = Number(valueStr)
       switch (unit) {
+        case "nano":
         case "nanos":
           return nanos(BigInt(valueStr))
+        case "micro":
         case "micros":
           return micros(BigInt(valueStr))
+        case "milli":
         case "millis":
           return millis(value)
+        case "second":
         case "seconds":
           return seconds(value)
+        case "minute":
         case "minutes":
           return minutes(value)
+        case "hour":
         case "hours":
           return hours(value)
+        case "day":
         case "days":
           return days(value)
+        case "week":
         case "weeks":
           return weeks(value)
       }

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -18,13 +18,21 @@ describe("Duration", () => {
 
     expect(Duration.decode(10n)).toEqual(Duration.nanos(10n))
 
+    expect(Duration.decode("1 nano")).toEqual(Duration.nanos(1n))
     expect(Duration.decode("10 nanos")).toEqual(Duration.nanos(10n))
+    expect(Duration.decode("1 micro")).toEqual(Duration.micros(1n))
     expect(Duration.decode("10 micros")).toEqual(Duration.micros(10n))
+    expect(Duration.decode("1 milli")).toEqual(Duration.millis(1))
     expect(Duration.decode("10 millis")).toEqual(Duration.millis(10))
+    expect(Duration.decode("1 second")).toEqual(Duration.seconds(1))
     expect(Duration.decode("10 seconds")).toEqual(Duration.seconds(10))
+    expect(Duration.decode("1 minute")).toEqual(Duration.minutes(1))
     expect(Duration.decode("10 minutes")).toEqual(Duration.minutes(10))
+    expect(Duration.decode("1 hour")).toEqual(Duration.hours(1))
     expect(Duration.decode("10 hours")).toEqual(Duration.hours(10))
+    expect(Duration.decode("1 day")).toEqual(Duration.days(1))
     expect(Duration.decode("10 days")).toEqual(Duration.days(10))
+    expect(Duration.decode("1 week")).toEqual(Duration.weeks(1))
     expect(Duration.decode("10 weeks")).toEqual(Duration.weeks(10))
 
     expect(Duration.decode("1.5 seconds")).toEqual(Duration.seconds(1.5))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add support for durations like '1 hour', rather than having to write '1 hours'. (There's deliberately no grammar checking, so '1 hours' is still supported, as is '2 hour'.)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
