### PR TITLE
fix: tap and andThen fallthrough function

### DIFF
--- a/.changeset/angry-shirts-repair.md
+++ b/.changeset/angry-shirts-repair.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+catch unmatched function fallthrough in andThen

--- a/.changeset/angry-shirts-repair.md
+++ b/.changeset/angry-shirts-repair.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-catch unmatched function fallthrough in andThen
+fix: unmatched function fallthrough in `andThen` and `tap`

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -54,7 +54,7 @@ import * as Scheduler from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
-import type { Concurrency, Covariant, MergeRecord, NoInfer } from "./Types.js"
+import type { Concurrency, Covariant, MergeRecord, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 
 // -------------------------------------------------------------------------------------
@@ -3548,6 +3548,7 @@ export const flatMap: {
  * @since 2.0.0
  * @category sequencing
  */
+
 export const andThen: {
   <A, X>(
     f: (a: NoInfer<A>) => X
@@ -3557,7 +3558,7 @@ export const andThen: {
     : [X] extends [Promise<infer A1>] ? Effect<A1, E | Cause.UnknownException, R>
     : Effect<X, E, R>
   <X>(
-    f: X
+    f: NotFunction<X>
   ): <A, E, R>(
     self: Effect<A, E, R>
   ) => [X] extends [Effect<infer A1, infer E1, infer R1>] ? Effect<A1, E | E1, R | R1>
@@ -3571,7 +3572,7 @@ export const andThen: {
     : Effect<X, E, R>
   <A, E, R, X>(
     self: Effect<A, E, R>,
-    f: X
+    f: NotFunction<X>
   ): [X] extends [Effect<infer A1, infer E1, infer R1>] ? Effect<A1, E | E1, R | R1>
     : [X] extends [Promise<infer A1>] ? Effect<A1, E | Cause.UnknownException, R>
     : Effect<X, E, R>
@@ -3686,7 +3687,7 @@ export const tap: {
     : [X] extends [Promise<infer _A1>] ? Effect<A, E | Cause.UnknownException, R>
     : Effect<A, E, R>
   <X>(
-    f: X
+    f: NotFunction<X>
   ): <A, E, R>(
     self: Effect<A, E, R>
   ) => [X] extends [Effect<infer _A1, infer E1, infer R1>] ? Effect<A, E | E1, R | R1>
@@ -3700,7 +3701,7 @@ export const tap: {
     : Effect<A, E, R>
   <A, E, R, X>(
     self: Effect<A, E, R>,
-    f: X
+    f: NotFunction<X>
   ): [X] extends [Effect<infer _A1, infer E1, infer R1>] ? Effect<A, E | E1, R | R1>
     : [X] extends [Promise<infer _A1>] ? Effect<A, E | Cause.UnknownException, R>
     : Effect<A, E, R>

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3548,7 +3548,6 @@ export const flatMap: {
  * @since 2.0.0
  * @category sequencing
  */
-
 export const andThen: {
   <A, X>(
     f: (a: NoInfer<A>) => X

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -12,7 +12,7 @@ import type { Option } from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
 import { isFunction } from "./Predicate.js"
-import type { Covariant, MergeRecord, NoInfer } from "./Types.js"
+import type { Covariant, MergeRecord, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 import * as Gen from "./Utils.js"
 
@@ -587,11 +587,11 @@ export const andThen: {
   <R, R2, L2>(f: (right: R) => Either<R2, L2>): <L>(self: Either<R, L>) => Either<R2, L | L2>
   <R2, L2>(f: Either<R2, L2>): <L, R1>(self: Either<R1, L>) => Either<R2, L | L2>
   <R, R2>(f: (right: R) => R2): <L>(self: Either<R, L>) => Either<R2, L>
-  <R2>(right: R2): <R1, L>(self: Either<R1, L>) => Either<R2, L>
+  <R2>(right: NotFunction<R2>): <R1, L>(self: Either<R1, L>) => Either<R2, L>
   <R, L, R2, L2>(self: Either<R, L>, f: (right: R) => Either<R2, L2>): Either<R2, L | L2>
   <R, L, R2, L2>(self: Either<R, L>, f: Either<R2, L2>): Either<R2, L | L2>
   <R, L, R2>(self: Either<R, L>, f: (right: R) => R2): Either<R2, L>
-  <R, L, R2>(self: Either<R, L>, f: R2): Either<R2, L>
+  <R, L, R2>(self: Either<R, L>, f: NotFunction<R2>): Either<R2, L>
 } = dual(
   2,
   <R, L, R2, L2>(self: Either<R, L>, f: (right: R) => Either<R2, L2> | Either<R2, L2>): Either<R2, L | L2> =>

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -659,11 +659,11 @@ export const flatMap: {
 export const andThen: {
   <A, B>(f: (a: A) => Option<B>): (self: Option<A>) => Option<B>
   <B>(f: Option<B>): <A>(self: Option<A>) => Option<B>
-  <A, B>(f: (a: NoInfer<A>) => B): (self: Option<A>) => Option<B>
+  <A, B>(f: (a: A) => B): (self: Option<A>) => Option<B>
   <B>(f: NotFunction<B>): <A>(self: Option<A>) => Option<B>
-  <A, B>(self: Option<A>, f: (a: NoInfer<A>) => Option<B>): Option<B>
+  <A, B>(self: Option<A>, f: (a: A) => Option<B>): Option<B>
   <A, B>(self: Option<A>, f: Option<B>): Option<B>
-  <A, B>(self: Option<A>, f: (a: NoInfer<A>) => B): Option<B>
+  <A, B>(self: Option<A>, f: (a: A) => B): Option<B>
   <A, B>(self: Option<A>, f: NotFunction<B>): Option<B>
 } = dual(
   2,

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -14,7 +14,7 @@ import type { Order } from "./Order.js"
 import * as order from "./Order.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
-import type { Covariant, NoInfer } from "./Types.js"
+import type { Covariant, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 import * as Gen from "./Utils.js"
 
@@ -659,12 +659,12 @@ export const flatMap: {
 export const andThen: {
   <A, B>(f: (a: A) => Option<B>): (self: Option<A>) => Option<B>
   <B>(f: Option<B>): <A>(self: Option<A>) => Option<B>
-  <A, B>(f: (a: A) => B): (self: Option<A>) => Option<B>
-  <B>(f: B): <A>(self: Option<A>) => Option<B>
-  <A, B>(self: Option<A>, f: (a: A) => Option<B>): Option<B>
+  <A, B>(f: (a: NoInfer<A>) => B): (self: Option<A>) => Option<B>
+  <B>(f: NotFunction<B>): <A>(self: Option<A>) => Option<B>
+  <A, B>(self: Option<A>, f: (a: NoInfer<A>) => Option<B>): Option<B>
   <A, B>(self: Option<A>, f: Option<B>): Option<B>
-  <A, B>(self: Option<A>, f: (a: A) => B): Option<B>
-  <A, B>(self: Option<A>, f: B): Option<B>
+  <A, B>(self: Option<A>, f: (a: NoInfer<A>) => B): Option<B>
+  <A, B>(self: Option<A>, f: NotFunction<B>): Option<B>
 } = dual(
   2,
   <A, B>(self: Option<A>, f: (a: A) => Option<B> | Option<B>): Option<B> =>

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -190,3 +190,8 @@ export type Contravariant<A> = (_: A) => void
  * @since 2.0.0
  */
 export type MatchRecord<S, onTrue, onFalse> = {} extends S ? onTrue : onFalse
+
+/**
+ * @since 2.0.0
+ */
+export type NotFunction<T> = T extends Function ? never : T

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -726,7 +726,7 @@ export const andThen: {
       })
     }
     return succeed(b)
-  })) as any
+  }))
 
 /* @internal */
 export const step = <A, E, R>(

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -35,7 +35,7 @@ import type * as RuntimeFlags from "../RuntimeFlags.js"
 import * as RuntimeFlagsPatch from "../RuntimeFlagsPatch.js"
 import type * as Scope from "../Scope.js"
 import type * as Tracer from "../Tracer.js"
-import type { NoInfer } from "../Types.js"
+import type { NoInfer, NotFunction } from "../Types.js"
 import * as _blockedRequests from "./blockedRequests.js"
 import * as internalCause from "./cause.js"
 import * as deferred from "./deferred.js"
@@ -697,7 +697,7 @@ export const andThen: {
     : [X] extends [Promise<infer A1>] ? Effect.Effect<A1, E | Cause.UnknownException, R>
     : Effect.Effect<X, E, R>
   <X>(
-    f: X
+    f: NotFunction<X>
   ): <A, E, R>(
     self: Effect.Effect<A, E, R>
   ) => [X] extends [Effect.Effect<infer A1, infer E1, infer R1>] ? Effect.Effect<A1, E | E1, R | R1>
@@ -711,7 +711,7 @@ export const andThen: {
     : Effect.Effect<X, E, R>
   <A, E, R, X>(
     self: Effect.Effect<A, E, R>,
-    f: X
+    f: NotFunction<X>
   ): [X] extends [Effect.Effect<infer A1, infer E1, infer R1>] ? Effect.Effect<A1, E | E1, R | R1>
     : [X] extends [Promise<infer A1>] ? Effect.Effect<A1, E | Cause.UnknownException, R>
     : Effect.Effect<X, E, R>
@@ -726,7 +726,7 @@ export const andThen: {
       })
     }
     return succeed(b)
-  }))
+  })) as any
 
 /* @internal */
 export const step = <A, E, R>(
@@ -1169,7 +1169,7 @@ export const tap = dual<
       : [X] extends [Promise<infer _A1>] ? Effect.Effect<A, E | Cause.UnknownException, R>
       : Effect.Effect<A, E, R>
     <X>(
-      f: X
+      f: NotFunction<X>
     ): <A, E, R>(
       self: Effect.Effect<A, E, R>
     ) => [X] extends [Effect.Effect<infer _A1, infer E1, infer R1>] ? Effect.Effect<A, E | E1, R | R1>
@@ -1185,7 +1185,7 @@ export const tap = dual<
       : Effect.Effect<A, E, R>
     <A, E, R, X>(
       self: Effect.Effect<A, E, R>,
-      f: X
+      f: NotFunction<X>
     ): [X] extends [Effect.Effect<infer _A1, infer E1, infer R1>] ? Effect.Effect<A, E | E1, R | R1>
       : [X] extends [Promise<infer _A1>] ? Effect.Effect<A, E | Cause.UnknownException, R>
       : Effect.Effect<A, E, R>

--- a/packages/platform/src/internal/worker.ts
+++ b/packages/platform/src/internal/worker.ts
@@ -405,7 +405,11 @@ export const makePoolSerialized = <I extends Schema.TaggedRequest.Any>(
       makeSerialized<I>(options),
       Effect.tap((worker) => Effect.sync(() => workers.add(worker))),
       Effect.tap((worker) => Effect.addFinalizer(() => Effect.sync(() => workers.delete(worker)))),
-      options.onCreate ? Effect.tap(options.onCreate) : identity,
+      options.onCreate
+        ? Effect.tap(
+          options.onCreate as (worker: Worker.SerializedWorker<I>) => Effect.Effect<void, WorkerError>
+        )
+        : identity,
       Effect.provideService(WorkerManager, manager)
     )
     const backing = yield* _(


### PR DESCRIPTION
fixes for example:
```ts
declare const foo: (x: number) => Effect.Effect<void>;
Effect.succeed(true).pipe(Effect.tap(foo)); // no error
Effect.succeed(true).pipe(Effect.tap(x => foo(x))); // error
```