### PR TITLE
rename `headOr` to `headOrElse` to align with the standard naming con…

### DIFF
--- a/.changeset/blue-apples-peel.md
+++ b/.changeset/blue-apples-peel.md
@@ -129,7 +129,8 @@
   ```
 
 - Updated the `pluck` function to return `Schema<A[K], { readonly [key]: I[K] }>` instead of `Schema<A[K], I>`. Removed the `{ transformation: false }` option in favor of selecting the specific field from the `fields` exposed by a struct.
-- Removed `propertySignatureAnnotations`, use `propertySignature(schema).annotations()`
+- Removed `propertySignatureAnnotations`, use `propertySignature(schema).annotations()`.
+- Updated the function name `headOr` to `headOrElse` to align with the standard naming convention.
 
 ## `Serializable` module
 

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1438,11 +1438,11 @@ pipe(S.struct({ a: S.string, b: S.number }), S.pluck("a"))
 S.head(S.array(S.number))
 
 // ---------------------------------------------
-// headOr
+// headOrElse
 // ---------------------------------------------
 
 // $ExpectType Schema<number, readonly number[], never>
-S.headOr(S.array(S.number))
+S.headOrElse(S.array(S.number))
 
 // ---------------------------------------------
 // Class

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4699,7 +4699,7 @@ export const head = <A, I, R>(self: Schema<ReadonlyArray<A>, I, R>): Schema<Opti
  * @category ReadonlyArray transformations
  * @since 1.0.0
  */
-export const headOr: {
+export const headOrElse: {
   <A>(fallback?: LazyArg<A>): <I, R>(self: Schema<ReadonlyArray<A>, I, R>) => Schema<A, I, R>
   <A, I, R>(self: Schema<ReadonlyArray<A>, I, R>, fallback?: LazyArg<A>): Schema<A, I, R>
 } = dual(

--- a/packages/schema/test/ReadonlyArray/headOrElse.test.ts
+++ b/packages/schema/test/ReadonlyArray/headOrElse.test.ts
@@ -2,9 +2,9 @@ import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 import { describe, it } from "vitest"
 
-describe("ReadonlyArray > headOr", () => {
+describe("ReadonlyArray > headOrElse", () => {
   it("decoding (without fallback)", async () => {
-    const schema = S.headOr(S.array(S.NumberFromString))
+    const schema = S.headOrElse(S.array(S.NumberFromString))
     await Util.expectDecodeUnknownSuccess(schema, ["1"], 1)
     await Util.expectDecodeUnknownFailure(
       schema,
@@ -27,7 +27,7 @@ describe("ReadonlyArray > headOr", () => {
   })
 
   it("decoding (with fallback)", async () => {
-    const schema = S.headOr(S.array(S.NumberFromString), () => 0)
+    const schema = S.headOrElse(S.array(S.NumberFromString), () => 0)
     await Util.expectDecodeUnknownSuccess(schema, ["1"], 1)
     await Util.expectDecodeUnknownSuccess(schema, [], 0)
     await Util.expectDecodeUnknownFailure(
@@ -42,13 +42,13 @@ describe("ReadonlyArray > headOr", () => {
                └─ Expected NumberFromString, actual "a"`
     )
 
-    const schema2 = S.array(S.NumberFromString).pipe(S.headOr(() => 0))
+    const schema2 = S.array(S.NumberFromString).pipe(S.headOrElse(() => 0))
     await Util.expectDecodeUnknownSuccess(schema2, ["1"], 1)
     await Util.expectDecodeUnknownSuccess(schema2, [], 0)
   })
 
   it("decoding (struct)", async () => {
-    const schema = S.headOr(
+    const schema = S.headOrElse(
       S.array(
         S.struct({
           id: S.string,
@@ -65,7 +65,7 @@ describe("ReadonlyArray > headOr", () => {
   })
 
   it("encoding", async () => {
-    const schema = S.headOr(S.array(S.number))
+    const schema = S.headOrElse(S.array(S.number))
     await Util.expectEncodeSuccess(schema, 1, [1])
   })
 })


### PR DESCRIPTION
…vention
