### PR TITLE
Prevent Effect.if from crashing when first argument is not an Effect

### DIFF
--- a/.changeset/wicked-apples-press.md
+++ b/.changeset/wicked-apples-press.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-fix: Effect.if (#2271)
+Prevent Effect.if from crashing when first argument is not an Effect

--- a/.changeset/wicked-apples-press.md
+++ b/.changeset/wicked-apples-press.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix: Effect.if (#2271)

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -916,6 +916,7 @@ export const if_ = dual<
   (self: boolean | Effect.Effect<unknown, unknown, unknown>, { onFalse, onTrue }: {
     readonly onTrue: Effect.Effect<unknown, unknown, unknown>
     readonly onFalse: Effect.Effect<unknown, unknown, unknown>
+    // eslint-disable-next-line no-extra-boolean-cast
   }) => isEffect(self) ? flatMap(self, (b) => (b ? onTrue : onFalse)) : Boolean(self) ? onTrue : onFalse
 )
 

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -916,7 +916,7 @@ export const if_ = dual<
   (self: boolean | Effect.Effect<unknown, unknown, unknown>, { onFalse, onTrue }: {
     readonly onTrue: Effect.Effect<unknown, unknown, unknown>
     readonly onFalse: Effect.Effect<unknown, unknown, unknown>
-  }) => typeof self === "boolean" ? (self ? onTrue : onFalse) : flatMap(self, (b) => (b ? onTrue : onFalse))
+  }) => isEffect(self) ? flatMap(self, (b) => (b ? onTrue : onFalse)) : Boolean(self) ? onTrue : onFalse
 )
 
 /* @internal */


### PR DESCRIPTION
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Prevents Effect.if from crashing when first argument is not an Effect. 

## Related

- Related Issue #2271 
- Closes #2271 
