### PR TITLE
ReadonlyArray: fix `sort` signature, closes #2301

### DIFF
--- a/.changeset/swift-pugs-train.md
+++ b/.changeset/swift-pugs-train.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+ReadonlyArray: fix `sort` signature, closes #2301

--- a/packages/effect/dtslint/ReadonlyArray.ts
+++ b/packages/effect/dtslint/ReadonlyArray.ts
@@ -2,7 +2,7 @@ import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
 import { hole, identity, pipe } from "effect/Function"
 import * as Option from "effect/Option"
-import type * as Order from "effect/Order"
+import * as Order from "effect/Order"
 import * as Predicate from "effect/Predicate"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 
@@ -215,6 +215,15 @@ pipe(nonEmptyabs, ReadonlyArray.sort(ordera))
 
 // $ExpectType [AB, ...AB[]]
 ReadonlyArray.sort(ordera)(nonEmptyabs)
+
+// @ts-expect-error
+pipe([1], ReadonlyArray.sort(Order.string))
+
+// @ts-expect-error
+ReadonlyArray.sort([1], Order.string)
+
+// @ts-expect-error
+ReadonlyArray.sort(Order.string)([1])
 
 // -------------------------------------------------------------------------------------
 // sortWith

--- a/packages/effect/src/ReadonlyArray.ts
+++ b/packages/effect/src/ReadonlyArray.ts
@@ -883,7 +883,7 @@ export const reverse = <S extends Iterable<any> | NonEmptyReadonlyArray<any>>(
 export const sort: {
   <B>(
     O: Order.Order<B>
-  ): <S extends ReadonlyArray<any> | Iterable<any>>(self: S) => ReadonlyArray.With<S, ReadonlyArray.Infer<S>>
+  ): <A extends B, S extends ReadonlyArray<A> | Iterable<A>>(self: S) => ReadonlyArray.With<S, ReadonlyArray.Infer<S>>
   <A extends B, B>(self: NonEmptyReadonlyArray<A>, O: Order.Order<B>): NonEmptyArray<A>
   <A extends B, B>(self: Iterable<A>, O: Order.Order<B>): Array<A>
 } = dual(2, <A extends B, B>(self: Iterable<A>, O: Order.Order<B>): Array<A> => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2301
