### PR TITLE
chore: improves the display of `Struct.Type` and `Struct.Encoded` whe…

### DIFF
--- a/.changeset/eight-needles-clean.md
+++ b/.changeset/eight-needles-clean.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+chore: improves the display of `Struct.Type` and `Struct.Encoded` when the parameter is generic

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1567,6 +1567,12 @@ hole<ConstructorParameters<typeof VoidTaggedClass>>()
 // Struct.Type
 // ---------------------------------------------
 
+export const StructTypeTest1 = <S extends S.Schema.Any>(
+  input: S.Struct.Type<{ s: S }>
+) => {
+  input // $ExpectType Type<{ s: S; }>
+}
+
 // $ExpectType {}
 hole<Simplify<S.Struct.Type<{}>>>()
 
@@ -1632,6 +1638,12 @@ hole<
 // ---------------------------------------------
 // Struct.Encoded
 // ---------------------------------------------
+
+export const StructEncodedTest1 = <S extends S.Schema.Any>(
+  input: S.Struct.Encoded<{ s: S }>
+) => {
+  input // $ExpectType Encoded<{ s: S; }>
+}
 
 // $ExpectType {}
 hole<Simplify<S.Struct.Encoded<{}>>>()

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1768,16 +1768,16 @@ export declare namespace Struct {
   /**
    * @since 1.0.0
    */
-  export type Type<F extends Fields, OptionalKeys extends PropertyKey = TypeTokenKeys<F>> =
-    & { readonly [K in Exclude<keyof F, OptionalKeys>]: Schema.Type<F[K]> }
-    & { readonly [K in OptionalKeys]?: Schema.Type<F[K]> }
+  export type Type<F extends Fields> =
+    & { readonly [K in Exclude<keyof F, TypeTokenKeys<F>>]: Schema.Type<F[K]> }
+    & { readonly [K in TypeTokenKeys<F>]?: Schema.Type<F[K]> }
 
   /**
    * @since 1.0.0
    */
-  export type Encoded<F extends Fields, OptionalKeys extends PropertyKey = EncodedTokenKeys<F>> =
-    & { readonly [K in Exclude<keyof F, OptionalKeys> as Key<F, K>]: Schema.Encoded<F[K]> }
-    & { readonly [K in OptionalKeys as Key<F, K>]?: Schema.Encoded<F[K]> }
+  export type Encoded<F extends Fields> =
+    & { readonly [K in Exclude<keyof F, EncodedTokenKeys<F>> as Key<F, K>]: Schema.Encoded<F[K]> }
+    & { readonly [K in EncodedTokenKeys<F> as Key<F, K>]?: Schema.Encoded<F[K]> }
 
   /**
    * @since 1.0.0


### PR DESCRIPTION
…n the parameter is generic
