### PR TITLE
feat: add `withDefaultConstructor`

### DIFF
--- a/.changeset/fair-items-tell.md
+++ b/.changeset/fair-items-tell.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+feat: add `withDefaultConstructor`

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -164,21 +164,21 @@ S.NonEmptyArray(aContext)
 // propertySignatureDeclaration
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<":", string, never, ":", string, "aContext">
+// $ExpectType PropertySignature<":", string, never, ":", string, false, "aContext">
 S.propertySignature(aContext)
 
 // ---------------------------------------------
 // optionalToRequired
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<":", string, never, "?:", string, "aContext">
+// $ExpectType PropertySignature<":", string, never, "?:", string, false, "aContext">
 S.optionalToRequired(aContext, S.String, { decode: Option.getOrElse(() => ""), encode: Option.some })
 
 // ---------------------------------------------
 // optional
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<"?:", string | undefined, never, "?:", string | undefined, "aContext">
+// $ExpectType PropertySignature<"?:", string | undefined, never, "?:", string | undefined, false, "aContext">
 S.optional(aContext)
 
 // ---------------------------------------------

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -8,8 +8,8 @@ import type { Simplify } from "effect/Types"
 
 declare const anyNever: S.Schema<any, never>
 declare const neverAny: S.Schema<never, any>
-declare const anyNeverPropertySignature: S.PropertySignature<"?:", any, never, "?:", never, never>
-declare const neverAnyPropertySignature: S.PropertySignature<"?:", never, never, "?:", any, never>
+declare const anyNeverPropertySignature: S.PropertySignature<"?:", any, never, "?:", never, any, never>
+declare const neverAnyPropertySignature: S.PropertySignature<"?:", never, never, "?:", any, any, never>
 
 class A extends S.Class<A>("A")({ a: S.NonEmpty }) {}
 
@@ -597,25 +597,25 @@ S.asSchema(S.Struct({ a: neverAnyPropertySignature }))
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c?: boolean; }, { readonly a: string; readonly b: number; readonly c?: boolean; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { exact: true }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", boolean, never, "?:", boolean, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", boolean, never, "?:", boolean, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { exact: true }) })
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c?: number; }, { readonly a: string; readonly b: number; readonly c?: string; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { exact: true }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", number, never, "?:", string, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", number, never, "?:", string, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { exact: true }) })
 
 // $ExpectType Schema<{ readonly a?: never; }, { readonly a?: never; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.Never, { exact: true }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<"?:", never, never, "?:", never, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<"?:", never, never, "?:", never, false, never>; }>
 S.Struct({ a: S.optional(S.Never, { exact: true }) })
 
 // $ExpectType Schema<{ readonly a?: string; }, { readonly a?: string; }, never>
 S.asSchema(S.Struct({ a: S.String.pipe(S.optional({ exact: true })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<"?:", string, never, "?:", string, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<"?:", string, never, "?:", string, false, never>; }>
 S.Struct({ a: S.String.pipe(S.optional({ exact: true })) })
 
 // ---------------------------------------------
@@ -634,25 +634,25 @@ S.optional(S.String, { default: null })
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, { readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", boolean | undefined, never, "?:", boolean | undefined, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", boolean | undefined, never, "?:", boolean | undefined, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean) })
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c?: number | undefined; }, { readonly a: string; readonly b: number; readonly c?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", number | undefined, never, "?:", string | undefined, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<"?:", number | undefined, never, "?:", string | undefined, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString) })
 
 // $ExpectType Schema<{ readonly a?: undefined; }, { readonly a?: undefined; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.Never) }))
 
-// $ExpectType Struct<{ a: PropertySignature<"?:", undefined, never, "?:", undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<"?:", undefined, never, "?:", undefined, false, never>; }>
 S.Struct({ a: S.optional(S.Never) })
 
 // $ExpectType Schema<{ readonly a?: string | undefined; }, { readonly a?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String.pipe(S.optional()) }))
 
-// $ExpectType Struct<{ a: PropertySignature<"?:", string | undefined, never, "?:", string | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<"?:", string | undefined, never, "?:", string | undefined, false, never>; }>
 S.Struct({ a: S.String.pipe(S.optional()) })
 
 // ---------------------------------------------
@@ -666,7 +666,7 @@ S.asSchema(S.Struct({
   c: S.optional(S.Boolean, { exact: true, default: () => false })
 }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", boolean, never, "?:", boolean, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", boolean, never, "?:", boolean, false, never>; }>
 S.Struct({
   a: S.String,
   b: S.Number,
@@ -680,20 +680,20 @@ S.asSchema(S.Struct({
   c: S.optional(S.NumberFromString, { exact: true, default: () => 0 })
 }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", number, never, "?:", string, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", number, never, "?:", string, false, never>; }>
 S.Struct({
   a: S.String,
   b: S.Number,
   c: S.optional(S.NumberFromString, { exact: true, default: () => 0 })
 })
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", false, never>; }>
 S.Struct({ a: S.optional(S.Literal("a", "b"), { default: () => "a", exact: true }) })
 
 // $ExpectType Schema<{ readonly a: "a" | "b"; }, { readonly a?: "a" | "b"; }, never>
 S.asSchema(S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, exact: true })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", false, never>; }>
 S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, exact: true })) })
 
 // ---------------------------------------------
@@ -703,22 +703,22 @@ S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const,
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: boolean; }, { readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { default: () => false }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", boolean, never, "?:", boolean | undefined, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", boolean, never, "?:", boolean | undefined, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { default: () => false }) })
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: number; }, { readonly a: string; readonly b: number; readonly c?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { default: () => 0 }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", number, never, "?:", string | undefined, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", number, never, "?:", string | undefined, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { default: () => 0 }) })
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, false, never>; }>
 S.Struct({ a: S.optional(S.Literal("a", "b"), { default: () => "a" }) })
 
 // $ExpectType Schema<{ readonly a: "a" | "b"; }, { readonly a?: "a" | "b" | undefined; }, never>
 S.asSchema(S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, false, never>; }>
 S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const })) })
 
 // ---------------------------------------------
@@ -728,22 +728,22 @@ S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const 
 // $ExpectType Schema<{ readonly a: number; }, { readonly a?: string | null | undefined; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { nullable: true, default: () => 0 }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null | undefined, false, never>; }>
 S.Struct({ a: S.optional(S.NumberFromString, { nullable: true, default: () => 0 }) })
 
 // $ExpectType Schema<{ readonly a: number; }, { readonly a?: string | null; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null, false, never>; }>
 S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, false, never>; }>
 S.Struct({ a: S.optional(S.Literal("a", "b"), { default: () => "a", nullable: true }) })
 
 // $ExpectType Schema<{ readonly a: "a" | "b"; }, { readonly a?: "a" | "b" | null | undefined; }, never>
 S.asSchema(S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, nullable: true })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, false, never>; }>
 S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, nullable: true })) })
 
 // ---------------------------------------------
@@ -753,7 +753,7 @@ S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const,
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: Option<boolean>; }, { readonly a: string; readonly b: number; readonly c?: boolean; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { exact: true, as: "Option" }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<boolean>, never, "?:", boolean, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<boolean>, never, "?:", boolean, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { exact: true, as: "Option" }) })
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: Option<number>; }, { readonly a: string; readonly b: number; readonly c?: string; }, never>
@@ -763,7 +763,7 @@ S.asSchema(S.Struct({
   c: S.optional(S.NumberFromString, { exact: true, as: "Option" })
 }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<number>, never, "?:", string, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<number>, never, "?:", string, false, never>; }>
 S.Struct({
   a: S.String,
   b: S.Number,
@@ -773,7 +773,7 @@ S.Struct({
 // $ExpectType Schema<{ readonly a: Option<string>; }, { readonly a?: string; }, never>
 S.asSchema(S.Struct({ a: S.String.pipe(S.optional({ exact: true, as: "Option" })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string, false, never>; }>
 S.Struct({ a: S.String.pipe(S.optional({ exact: true, as: "Option" })) })
 
 // ---------------------------------------------
@@ -783,19 +783,19 @@ S.Struct({ a: S.String.pipe(S.optional({ exact: true, as: "Option" })) })
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: Option<boolean>; }, { readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { as: "Option" }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<boolean>, never, "?:", boolean | undefined, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<boolean>, never, "?:", boolean | undefined, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { as: "Option" }) })
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: Option<number>; }, { readonly a: string; readonly b: number; readonly c?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { as: "Option" }) }))
 
-// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<number>, never, "?:", string | undefined, never>; }>
+// $ExpectType Struct<{ a: $String; b: $Number; c: PropertySignature<":", Option<number>, never, "?:", string | undefined, false, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { as: "Option" }) })
 
 // $ExpectType Schema<{ readonly a: Option<string>; }, { readonly a?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String.pipe(S.optional({ as: "Option" })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string | undefined, false, never>; }>
 S.Struct({ a: S.String.pipe(S.optional({ as: "Option" })) })
 
 // ---------------------------------------------
@@ -805,13 +805,13 @@ S.Struct({ a: S.String.pipe(S.optional({ as: "Option" })) })
 // $ExpectType Schema<{ readonly a: Option<number>; }, { readonly a?: string | null | undefined; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { nullable: true, as: "Option" }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", Option<number>, never, "?:", string | null | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", Option<number>, never, "?:", string | null | undefined, false, never>; }>
 S.Struct({ a: S.optional(S.NumberFromString, { nullable: true, as: "Option" }) })
 
 // $ExpectType Schema<{ readonly a: Option<string>; }, { readonly a?: string | null | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String.pipe(S.optional({ nullable: true, as: "Option" })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string | null | undefined, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string | null | undefined, false, never>; }>
 S.Struct({ a: S.String.pipe(S.optional({ nullable: true, as: "Option" })) })
 
 // ---------------------------------------------
@@ -821,13 +821,13 @@ S.Struct({ a: S.String.pipe(S.optional({ nullable: true, as: "Option" })) })
 // $ExpectType Schema<{ readonly a: Option<number>; }, { readonly a?: string | null; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, as: "Option" }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", Option<number>, never, "?:", string | null, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", Option<number>, never, "?:", string | null, false, never>; }>
 S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, as: "Option" }) })
 
 // $ExpectType Schema<{ readonly a: Option<string>; }, { readonly a?: string | null; }, never>
 S.asSchema(S.Struct({ a: S.String.pipe(S.optional({ exact: true, nullable: true, as: "Option" })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string | null, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", Option<string>, never, "?:", string | null, false, never>; }>
 S.Struct({ a: S.String.pipe(S.optional({ exact: true, nullable: true, as: "Option" })) })
 
 // ---------------------------------------------
@@ -1551,14 +1551,14 @@ S.SecretFromSelf
 // propertySignature
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<":", string, never, ":", string, never>
+// $ExpectType PropertySignature<":", string, never, ":", string, false, never>
 S.propertySignature(S.String).annotations({ description: "description" })
 
 // ---------------------------------------------
 // PropertySignature .annotations({}) method
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<"?:", string | undefined, never, "?:", string | undefined, never>
+// $ExpectType PropertySignature<"?:", string | undefined, never, "?:", string | undefined, false, never>
 S.optional(S.String).annotations({ description: "description" })
 
 // ---------------------------------------------
@@ -1726,56 +1726,72 @@ hole<Simplify<S.Struct.Type<{ a: S.Schema<number, string> }>>>()
 // $ExpectType { readonly a: number; readonly b: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, ":", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, ":", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, "?:", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, "?:", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", ":", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", ":", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", "?:", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", "?:", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b?: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, ":", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, ":", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b?: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, "?:", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, "?:", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b?: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", ":", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", ":", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: number; readonly b?: number; }
 hole<
   Simplify<
-    S.Struct.Type<{ a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", "?:", string, "context"> }>
+    S.Struct.Type<
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", "?:", string, false, "context"> }
+    >
   >
 >()
 
@@ -1799,7 +1815,7 @@ hole<Simplify<S.Struct.Encoded<{ a: S.Schema<number, string> }>>>()
 hole<
   Simplify<
     S.Struct.Encoded<
-      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, ":", string, "context"> }
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, ":", string, false, "context"> }
     >
   >
 >()
@@ -1808,7 +1824,7 @@ hole<
 hole<
   Simplify<
     S.Struct.Encoded<
-      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, "?:", string, "context"> }
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, never, "?:", string, false, "context"> }
     >
   >
 >()
@@ -1816,14 +1832,18 @@ hole<
 // $ExpectType { readonly a: string; readonly c: string; }
 hole<
   Simplify<
-    S.Struct.Encoded<{ a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", ":", string, "context"> }>
+    S.Struct.Encoded<
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", ":", string, false, "context"> }
+    >
   >
 >()
 
 // $ExpectType { readonly a: string; readonly c?: string; }
 hole<
   Simplify<
-    S.Struct.Encoded<{ a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", "?:", string, "context"> }>
+    S.Struct.Encoded<
+      { a: S.Schema<number, string>; b: S.PropertySignature<":", number, "c", "?:", string, false, "context"> }
+    >
   >
 >()
 
@@ -1831,7 +1851,7 @@ hole<
 hole<
   Simplify<
     S.Struct.Encoded<
-      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, ":", string, "context"> }
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, ":", string, false, "context"> }
     >
   >
 >()
@@ -1840,7 +1860,7 @@ hole<
 hole<
   Simplify<
     S.Struct.Encoded<
-      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, "?:", string, "context"> }
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, never, "?:", string, false, "context"> }
     >
   >
 >()
@@ -1848,7 +1868,9 @@ hole<
 // $ExpectType { readonly a: string; readonly c: string; }
 hole<
   Simplify<
-    S.Struct.Encoded<{ a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", ":", string, "context"> }>
+    S.Struct.Encoded<
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", ":", string, false, "context"> }
+    >
   >
 >()
 
@@ -1856,7 +1878,7 @@ hole<
 hole<
   Simplify<
     S.Struct.Encoded<
-      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", "?:", string, "context"> }
+      { a: S.Schema<number, string>; b: S.PropertySignature<"?:", number, "c", "?:", string, false, "context"> }
     >
   >
 >()

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -6286,6 +6286,13 @@ export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited
     disableValidation?: boolean | undefined
   ): A & Omit<Inherited, keyof A> & Proto
 
+  make(
+    props: Types.Equals<C, {}> extends true ? void | {}
+      : Types.Equals<FilterOptionalKeys<C>, {}> extends true ? void | C
+      : C,
+    disableValidation?: boolean | undefined
+  ): A & Omit<Inherited, keyof A> & Proto
+
   readonly fields: { readonly [K in keyof Fields]: Fields[K] }
 
   readonly identifier: string
@@ -6583,6 +6590,10 @@ const makeClass = ({ Base, annotations, fields, fromSchema, identifier, kind, ta
 
     toString() {
       return toStringOverride !== undefined ? toStringOverride(this) : pretty_.make(this.constructor as any)(this)
+    }
+
+    static make(inp: any, ...args: any[]) {
+      return new this(inp, ...args)
     }
 
     static pipe() {

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1330,16 +1330,16 @@ export declare namespace PropertySignature {
   /**
    * @since 1.0.0
    */
-  export type Any<Key extends PropertyKey = PropertyKey> = PropertySignature<Token, any, Key, Token, any, unknown>
+  export type Any<Key extends PropertyKey = PropertyKey> = PropertySignature<Token, any, Key, Token, any, any, unknown>
 
   /**
    * @since 1.0.0
    */
   export type All<Key extends PropertyKey = PropertyKey> =
     | Any<Key>
-    | PropertySignature<Token, never, Key, Token, any, unknown>
-    | PropertySignature<Token, any, Key, Token, never, unknown>
-    | PropertySignature<Token, never, Key, Token, never, unknown>
+    | PropertySignature<Token, never, Key, Token, any, any, unknown>
+    | PropertySignature<Token, any, Key, Token, never, any, unknown>
+    | PropertySignature<Token, never, Key, Token, never, any, unknown>
 
   /**
    * @since 1.0.0
@@ -1369,7 +1369,8 @@ export class PropertySignatureDeclaration {
     readonly type: AST.AST,
     readonly isOptional: boolean,
     readonly isReadonly: boolean,
-    readonly annotations: AST.Annotations
+    readonly annotations: AST.Annotations,
+    readonly defaultConstructor?: (() => any) | undefined
   ) {}
   /**
    * @since 1.0.0
@@ -1404,7 +1405,8 @@ export class ToPropertySignature implements AST.Annotated {
     readonly type: AST.AST,
     readonly isOptional: boolean,
     readonly isReadonly: boolean,
-    readonly annotations: AST.Annotations
+    readonly annotations: AST.Annotations,
+    readonly defaultConstructor: (() => any) | undefined
   ) {}
 }
 
@@ -1465,7 +1467,8 @@ const propertySignatureAnnotations_ = (
         ast.type,
         ast.isOptional,
         ast.isReadonly,
-        { ...ast.annotations, ...annotations }
+        { ...ast.annotations, ...annotations },
+        ast.defaultConstructor
       )
     }
     case "PropertySignatureTransformation": {
@@ -1479,7 +1482,7 @@ const propertySignatureAnnotations_ = (
         new ToPropertySignature(ast.to.type, ast.to.isOptional, ast.to.isReadonly, {
           ...ast.to.annotations,
           ...annotations
-        }),
+        }, ast.to.defaultConstructor),
         ast.decode,
         ast.encode
       )
@@ -1497,17 +1500,19 @@ export interface PropertySignature<
   Key extends PropertyKey,
   EncodedToken extends PropertySignature.Token,
   Encoded,
+  HasDefault extends boolean,
   R = never
 > extends Schema.Variance<Type, Encoded, R>, Pipeable {
   readonly [PropertySignatureTypeId]: null
   readonly _EncodedToken: EncodedToken
   readonly _TypeToken: TypeToken
   readonly _Key: Key
+  readonly _HasDefault: HasDefault
   readonly ast: PropertySignature.AST
 
   annotations(
     annotations: PropertySignature.Annotations<Type>
-  ): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, R>
+  ): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
 }
 
 /** @internal */
@@ -1517,13 +1522,15 @@ export class PropertySignatureImpl<
   Key extends PropertyKey,
   EncodedToken extends PropertySignature.Token,
   Encoded,
+  HasDefault extends boolean,
   R = never
-> implements PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, R> {
+> implements PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
   readonly [TypeId]!: Schema.Variance<Type, Encoded, R>[TypeId]
   readonly [PropertySignatureTypeId] = null
   readonly _Key!: Key
   readonly _EncodedToken!: EncodedToken
   readonly _TypeToken!: TypeToken
+  readonly _HasDefault!: HasDefault
 
   constructor(
     readonly ast: PropertySignature.AST
@@ -1535,7 +1542,7 @@ export class PropertySignatureImpl<
 
   annotations(
     annotations: PropertySignature.Annotations<Type>
-  ): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, R> {
+  ): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
     return new PropertySignatureImpl(propertySignatureAnnotations_(this.ast, toASTAnnotations(annotations)))
   }
 
@@ -1550,7 +1557,7 @@ export class PropertySignatureImpl<
  */
 export const propertySignature = <A, I, R>(
   self: Schema<A, I, R>
-): PropertySignature<PropertySignature.GetToken<false>, A, never, PropertySignature.GetToken<false>, I, R> =>
+): PropertySignature<PropertySignature.GetToken<false>, A, never, PropertySignature.GetToken<false>, I, false, R> =>
   new PropertySignatureImpl(new PropertySignatureDeclaration(self.ast, false, true, {}))
 
 /**
@@ -1563,32 +1570,35 @@ export const fromKey: {
     TypeToken extends PropertySignature.Token,
     Encoded,
     EncodedToken extends PropertySignature.Token,
+    HasDefault extends boolean,
     R
   >(
-    self: PropertySignature<TypeToken, Type, PropertyKey, EncodedToken, Encoded, R>
-  ) => PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, R>
+    self: PropertySignature<TypeToken, Type, PropertyKey, EncodedToken, Encoded, HasDefault, R>
+  ) => PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
   <
     Type,
     TypeToken extends PropertySignature.Token,
     Encoded,
     EncodedToken extends PropertySignature.Token,
+    HasDefault extends boolean,
     R,
     Key extends PropertyKey
   >(
-    self: PropertySignature<TypeToken, Type, PropertyKey, EncodedToken, Encoded, R>,
+    self: PropertySignature<TypeToken, Type, PropertyKey, EncodedToken, Encoded, HasDefault, R>,
     key: Key
-  ): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, R>
+  ): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
 } = dual(2, <
   Type,
   TypeToken extends PropertySignature.Token,
   Encoded,
   EncodedToken extends PropertySignature.Token,
+  HasDefault extends boolean,
   R,
   Key extends PropertyKey
 >(
-  self: PropertySignature<TypeToken, Type, PropertyKey, EncodedToken, Encoded, R>,
+  self: PropertySignature<TypeToken, Type, PropertyKey, EncodedToken, Encoded, HasDefault, R>,
   key: Key
-): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, R> => {
+): PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> => {
   const ast = self.ast
   switch (ast._tag) {
     case "PropertySignatureDeclaration": {
@@ -1601,7 +1611,7 @@ export const fromKey: {
             ast.annotations,
             key
           ),
-          new ToPropertySignature(AST.typeAST(ast.type), ast.isOptional, ast.isReadonly, {}),
+          new ToPropertySignature(AST.typeAST(ast.type), ast.isOptional, ast.isReadonly, {}, ast.defaultConstructor),
           identity,
           identity
         )
@@ -1626,6 +1636,15 @@ export const fromKey: {
 })
 
 /**
+ * @category PropertySignature
+ * @since 1.0.0
+ */
+export const withDefaultConstructor: <A, I, R>(
+  makeDefault: () => NoInfer<A>
+) => (self: Schema<A, I, R>) => PropertySignature<":", A, never, ":", I, true, R> = (makeDefault) => (self) =>
+  new PropertySignatureImpl(new PropertySignatureDeclaration(self.ast, false, true, {}, makeDefault))
+
+/**
  * - `decode`: `none` as argument means: the value is missing in the input
  * - `encode`: `none` as return value means: the value will be missing in the output
  *
@@ -1639,11 +1658,11 @@ export const optionalToRequired = <FA, FI, FR, TA, TI, TR>(
     readonly decode: (o: option_.Option<FA>) => TI
     readonly encode: (ti: TI) => option_.Option<FA>
   }
-): PropertySignature<":", TA, never, "?:", FI, FR | TR> =>
+): PropertySignature<":", TA, never, "?:", FI, false, FR | TR> =>
   new PropertySignatureImpl(
     new PropertySignatureTransformation(
       new FromPropertySignature(from.ast, true, true, {}, undefined),
-      new ToPropertySignature(to.ast, false, true, {}),
+      new ToPropertySignature(to.ast, false, true, {}, undefined),
       (o) => option_.some(options.decode(o)),
       option_.flatMap(options.encode)
     )
@@ -1667,11 +1686,11 @@ export const optionalToOptional = <FA, FI, FR, TA, TI, TR>(
     readonly decode: (o: option_.Option<FA>) => option_.Option<TI>
     readonly encode: (o: option_.Option<TI>) => option_.Option<FA>
   }
-): PropertySignature<"?:", TA, never, "?:", FI, FR | TR> =>
+): PropertySignature<"?:", TA, never, "?:", FI, false, FR | TR> =>
   new PropertySignatureImpl(
     new PropertySignatureTransformation(
       new FromPropertySignature(from.ast, true, true, {}, undefined),
-      new ToPropertySignature(to.ast, true, true, {}),
+      new ToPropertySignature(to.ast, true, true, {}, undefined),
       options.decode,
       options.encode
     )
@@ -1708,6 +1727,7 @@ export const optional: {
       never,
       "?:",
       I | undefined,
+      false,
       R
     > :
     PropertySignature<
@@ -1719,6 +1739,7 @@ export const optional: {
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),
+      false,
       R
     >
   <
@@ -1750,6 +1771,7 @@ export const optional: {
       never,
       "?:",
       I | undefined,
+      false,
       R
     > :
     PropertySignature<
@@ -1761,6 +1783,7 @@ export const optional: {
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),
+      false,
       R
     >
 } = dual((args) => isSchema(args[0]), <A, I, R>(
@@ -1771,7 +1794,7 @@ export const optional: {
     readonly nullable?: true
     readonly as?: "Option"
   }
-): PropertySignature<any, any, never, any, any, any> => {
+): PropertySignature<any, any, never, any, any, any, any> => {
   const isExact = options?.exact
   const defaultValue = options?.default
   const isNullable = options?.nullable
@@ -1890,10 +1913,10 @@ export declare namespace Struct {
 
   type EncodedTokenKeys<Fields extends Struct.Fields> = {
     [K in keyof Fields]: Fields[K] extends
-      | PropertySignature<PropertySignature.Token, any, PropertyKey, "?:", any, unknown>
-      | PropertySignature<PropertySignature.Token, any, PropertyKey, "?:", never, unknown>
-      | PropertySignature<PropertySignature.Token, never, PropertyKey, "?:", any, unknown>
-      | PropertySignature<PropertySignature.Token, never, PropertyKey, "?:", never, unknown> ? K
+      | PropertySignature<PropertySignature.Token, any, PropertyKey, "?:", any, any, unknown>
+      | PropertySignature<PropertySignature.Token, any, PropertyKey, "?:", never, any, unknown>
+      | PropertySignature<PropertySignature.Token, never, PropertyKey, "?:", any, any, unknown>
+      | PropertySignature<PropertySignature.Token, never, PropertyKey, "?:", never, any, unknown> ? K
       : never
   }[keyof Fields]
 
@@ -1902,10 +1925,10 @@ export declare namespace Struct {
   }[keyof Fields]
 
   type OptionalPropertySignature =
-    | PropertySignature<"?:", any, PropertyKey, PropertySignature.Token, any, unknown>
-    | PropertySignature<"?:", any, PropertyKey, PropertySignature.Token, never, unknown>
-    | PropertySignature<"?:", never, PropertyKey, PropertySignature.Token, any, unknown>
-    | PropertySignature<"?:", never, PropertyKey, PropertySignature.Token, never, unknown>
+    | PropertySignature<"?:", any, PropertyKey, PropertySignature.Token, any, any, unknown>
+    | PropertySignature<"?:", any, PropertyKey, PropertySignature.Token, never, any, unknown>
+    | PropertySignature<"?:", never, PropertyKey, PropertySignature.Token, any, any, unknown>
+    | PropertySignature<"?:", never, PropertyKey, PropertySignature.Token, never, any, unknown>
 
   /**
    * @since 1.0.0
@@ -6204,12 +6227,44 @@ type MissingSelfGeneric<Usage extends string, Params extends string = ""> =
   `Missing \`Self\` generic - use \`class Self extends ${Usage}<Self>()(${Params}{ ... })\``
 
 /**
+ * @since 1.0.0
+ */
+export type ToOptionalConstructorKeys<Fields> = {
+  [K in keyof Fields]: Fields[K] extends PropertySignature<any, any, any, any, any, true, any> ? K
+    : never
+}[keyof Fields]
+
+/**
+ * @since 1.0.0
+ */
+export type ToStructConstructor<
+  F extends Struct.Fields,
+  OptionalKeys extends PropertyKey = Struct.TypeTokenKeys<F>
+> =
+  & {
+    readonly [
+      K in Exclude<keyof F, ToOptionalConstructorKeys<F> | OptionalKeys>
+    ]: Schema.Type<F[K]>
+  }
+  & { readonly [K in OptionalKeys]?: Schema.Type<F[K]> }
+  & { readonly [K in ToOptionalConstructorKeys<F>]?: Schema.Type<F[K]> }
+
+type _OptionalKeys<O> = {
+  [K in keyof O]-?: {} extends Pick<O, K> ? K
+    : never
+}[keyof O]
+
+type FilterOptionalKeys<A> = Omit<A, _OptionalKeys<A>>
+
+/**
  * @category api interface
  * @since 1.0.0
  */
 export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited, Proto> extends Schema<Self, I, R> {
   new(
-    props: keyof C extends never ? void | {} : C,
+    props: Types.Equals<C, {}> extends true ? void | {}
+      : Types.Equals<FilterOptionalKeys<C>, {}> extends true ? void | C
+      : C,
     disableValidation?: boolean | undefined
   ): A & Omit<Inherited, keyof A> & Proto
 
@@ -6227,7 +6282,7 @@ export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited
       Types.Simplify<A & Struct.Type<newFields>>,
       Types.Simplify<I & Struct.Encoded<newFields>>,
       R | Struct.Context<newFields>,
-      Types.Simplify<C & Struct.Type<newFields>>,
+      Types.Simplify<C & ToStructConstructor<newFields>>,
       Self,
       Proto
     >
@@ -6258,7 +6313,7 @@ export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited
       Types.Simplify<A & Struct.Type<newFields>>,
       I,
       R | Struct.Context<newFields> | R2 | R3,
-      Types.Simplify<C & Struct.Type<newFields>>,
+      Types.Simplify<C & ToStructConstructor<newFields>>,
       Self,
       Proto
     >
@@ -6289,7 +6344,7 @@ export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited
       Types.Simplify<A & Struct.Type<newFields>>,
       I,
       R | Struct.Context<newFields> | R2 | R3,
-      Types.Simplify<C & Struct.Type<newFields>>,
+      Types.Simplify<C & ToStructConstructor<newFields>>,
       Self,
       Proto
     >
@@ -6310,7 +6365,7 @@ export const Class = <Self = never>(identifier: string) =>
     Types.Simplify<Struct.Type<Fields>>,
     Types.Simplify<Struct.Encoded<Fields>>,
     Struct.Context<Fields>,
-    Types.Simplify<Struct.Type<Fields>>,
+    Types.Simplify<ToStructConstructor<Fields>>,
     {},
     {}
   > => makeClass({ kind: "Class", identifier, fields, Base: data_.Class, annotations })
@@ -6331,7 +6386,7 @@ export const TaggedClass = <Self = never>(identifier?: string) =>
     Types.Simplify<{ readonly _tag: Tag } & Struct.Type<Fields>>,
     Types.Simplify<{ readonly _tag: Tag } & Struct.Encoded<Fields>>,
     Struct.Context<Fields>,
-    Types.Simplify<Struct.Type<Fields>>,
+    Types.Simplify<ToStructConstructor<Fields>>,
     {},
     {}
   > =>
@@ -6360,7 +6415,7 @@ export const TaggedError = <Self = never>(identifier?: string) =>
     Types.Simplify<{ readonly _tag: Tag } & Struct.Type<Fields>>,
     Types.Simplify<{ readonly _tag: Tag } & Struct.Encoded<Fields>>,
     Struct.Context<Fields>,
-    Types.Simplify<Struct.Type<Fields>>,
+    Types.Simplify<ToStructConstructor<Fields>>,
     {},
     cause_.YieldableError
   > =>
@@ -6430,7 +6485,7 @@ export const TaggedRequest =
       Types.Simplify<{ readonly _tag: Tag } & Struct.Type<Fields>>,
       Types.Simplify<{ readonly _tag: Tag } & Struct.Encoded<Fields>>,
       Struct.Context<Fields>,
-      Types.Simplify<Struct.Type<Fields>>,
+      Types.Simplify<ToStructConstructor<Fields>>,
       TaggedRequest<
         Tag,
         Self,
@@ -6488,7 +6543,7 @@ const makeClass = ({ Base, annotations, fields, fromSchema, identifier, kind, ta
   const schema = fromSchema ?? Struct(fields)
   const validate = ParseResult.validateSync(schema)
 
-  return class extends Base {
+  const cls = class extends Base {
     constructor(
       props: { [x: string | symbol]: unknown } = {},
       disableValidation: boolean = false
@@ -6622,6 +6677,25 @@ const makeClass = ({ Base, annotations, fields, fromSchema, identifier, kind, ta
       }
     }
   }
+
+  return class extends cls {
+    constructor(props: any = {}, disableValidation = false) {
+      const p = { ...props }
+      Object.entries(fields).forEach(([k, v]) => {
+        if (p[k] === undefined) {
+          const ast = v.ast._tag === "PropertySignatureDeclaration"
+            ? v.ast
+            : v.ast._tag === "PropertySignatureTransformation"
+            ? v.ast.to
+            : undefined
+          if (ast?.defaultConstructor) {
+            p[k] = ast.defaultConstructor()
+          }
+        }
+      })
+      super(p, disableValidation)
+    }
+  } as any
 }
 
 /**

--- a/packages/schema/test/Schema/Class/Class.test.ts
+++ b/packages/schema/test/Schema/Class/Class.test.ts
@@ -176,6 +176,16 @@ describe("Class APIs", () => {
       expect({ ...new A({}) }).toStrictEqual({})
     })
 
+    it("supports defaults", () => {
+      class A extends S.Class<A>("A")({
+        a: S.String,
+        b: S.Number.pipe(S.withDefaultConstructor(() => 1)),
+        c: S.Number.pipe(S.withDefaultConstructor(() => 1), S.fromKey("d"))
+      }) {}
+      expect({ ...new A({ a: "abc" }) }).toStrictEqual({ a: "abc", b: 1, c: 1 })
+      expect({ ...new A({ a: "abc", b: 2, c: 2 }) }).toStrictEqual({ a: "abc", b: 2, c: 2 })
+    })
+
     it("should support methods", () => {
       class A extends S.Class<A>("A")({ a: S.String }) {
         method(b: string) {

--- a/packages/schema/test/Schema/PropertySignature.test.ts
+++ b/packages/schema/test/Schema/PropertySignature.test.ts
@@ -84,10 +84,10 @@ describe("PropertySignature", () => {
   })
 
   it("add a default to an optional field", async () => {
-    const ps: S.PropertySignature<":", number, never, "?:", string, never> = new S.PropertySignatureImpl(
+    const ps: S.PropertySignature<":", number, never, "?:", string, false, never> = new S.PropertySignatureImpl(
       new S.PropertySignatureTransformation(
         new S.FromPropertySignature(S.NumberFromString.ast, true, true, {}, undefined),
-        new S.ToPropertySignature(S.Number.ast, false, true, {}),
+        new S.ToPropertySignature(S.Number.ast, false, true, {}, undefined),
         Option.orElse(() => Option.some(0)),
         identity
       )
@@ -113,10 +113,10 @@ describe("PropertySignature", () => {
   })
 
   it("add a bidirectional default to an optional field", async () => {
-    const ps: S.PropertySignature<":", number, never, "?:", string, never> = new S.PropertySignatureImpl(
+    const ps: S.PropertySignature<":", number, never, "?:", string, false, never> = new S.PropertySignatureImpl(
       new S.PropertySignatureTransformation(
         new S.FromPropertySignature(S.NumberFromString.ast, true, true, {}, undefined),
-        new S.ToPropertySignature(S.Number.ast, false, true, {}),
+        new S.ToPropertySignature(S.Number.ast, false, true, {}, undefined),
         Option.orElse(() => Option.some(0)),
         (o) => Option.flatMap(o, Option.liftPredicate((v) => v !== 0))
       )
@@ -142,10 +142,10 @@ describe("PropertySignature", () => {
   })
 
   it("empty string as optional", async () => {
-    const ps: S.PropertySignature<"?:", string, never, ":", string, never> = new S.PropertySignatureImpl(
+    const ps: S.PropertySignature<"?:", string, never, ":", string, false, never> = new S.PropertySignatureImpl(
       new S.PropertySignatureTransformation(
         new S.FromPropertySignature(S.String.ast, false, true, {}, undefined),
-        new S.ToPropertySignature(S.String.ast, true, true, {}),
+        new S.ToPropertySignature(S.String.ast, true, true, {}, undefined),
         Option.flatMap(Option.liftPredicate((v) => v !== "")),
         identity
       )
@@ -159,10 +159,10 @@ describe("PropertySignature", () => {
   })
 
   it("reversed default", async () => {
-    const ps: S.PropertySignature<"?:", number, never, ":", number, never> = new S.PropertySignatureImpl(
+    const ps: S.PropertySignature<"?:", number, never, ":", number, false, never> = new S.PropertySignatureImpl(
       new S.PropertySignatureTransformation(
         new S.FromPropertySignature(S.Number.ast, false, true, {}, undefined),
-        new S.ToPropertySignature(S.Number.ast, true, true, {}),
+        new S.ToPropertySignature(S.Number.ast, true, true, {}, undefined),
         identity,
         Option.orElse(() => Option.some(0))
       )

--- a/packages/schema/test/Schema/Struct/Struct.test.ts
+++ b/packages/schema/test/Schema/Struct/Struct.test.ts
@@ -279,4 +279,14 @@ describe("Struct", () => {
       await Util.expectEncodeSuccess(schema, { [a]: "a" }, { [a]: "a" })
     })
   })
+
+  it("constructor", () => {
+    const A = S.Struct({
+      a: S.String,
+      b: S.Number.pipe(S.withDefaultConstructor(() => 1)),
+      c: S.Number.pipe(S.withDefaultConstructor(() => 1), S.fromKey("d"))
+    })
+    expect({ ...A.make({ a: "abc" }) }).toStrictEqual({ a: "abc", b: 1, c: 1 })
+    expect({ ...A.make({ a: "abc", b: 2, c: 2 }) }).toStrictEqual({ a: "abc", b: 2, c: 2 })
+  })
 })


### PR DESCRIPTION
#1997

- the defaults are carried with on the fields so that they can be picked and transferred to build other classes

```ts
    it("supports defaults", () => {
      class A extends S.Class<A>("A")({
        a: S.string,
        b: S.number.pipe(S.withDefaultConstructor(() => 1)),
        c: S.number.pipe(S.withDefaultConstructor(() => 1), S.fromKey("d"))
      }) {}
      expect({ ...new A({ a: "abc" }) }).toStrictEqual({ a: "abc", b: 1, c: 1 })
      expect({ ...new A({ a: "abc", b: 2, c: 2 }) }).toStrictEqual({ a: "abc", b: 2, c: 2 })
    })
```
this is where defaults really matter 90% of my usecases.