### PR TITLE
Schema template literal regex escape special characters

### DIFF
--- a/.changeset/angry-coins-notice.md
+++ b/.changeset/angry-coins-notice.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Template literal regex escape special characters

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1819,15 +1819,21 @@ export const keyof = (ast: AST): AST => Union.unify(_keyof(ast))
  * @since 1.0.0
  */
 export const getTemplateLiteralRegExp = (ast: TemplateLiteral): RegExp => {
-  let pattern = `^${ast.head}`
+  const reRegExpChar = /[\\^$.*+?()[\]{}|]/g
+  const reHasRegExpChar = RegExp(reRegExpChar.source)
+  let pattern = `^${reHasRegExpChar.test(ast.head) ? ast.head.replace(reRegExpChar, "\\$&") : ast.head}`
+
   for (const span of ast.spans) {
     if (isStringKeyword(span.type)) {
       pattern += ".*"
     } else if (isNumberKeyword(span.type)) {
       pattern += "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
     }
-    pattern += span.literal
+    pattern += span.literal && reHasRegExpChar.test(span.literal)
+      ? span.literal.replace(reRegExpChar, "\\$&")
+      : span.literal
   }
+
   pattern += "$"
   return new RegExp(pattern)
 }

--- a/packages/schema/test/Schema/templateLiteral.test.ts
+++ b/packages/schema/test/Schema/templateLiteral.test.ts
@@ -86,6 +86,13 @@ describe("Schema > templateLiteral", () => {
       await Util.expectDecodeUnknownFailure(schema, "a  b", `Expected "a b", actual "a  b"`)
     })
 
+    it("[${string}]", async () => {
+      const schema = S.templateLiteral(S.literal("["), S.string, S.literal("]"))
+      await Util.expectDecodeUnknownSuccess(schema, "[a]", "[a]")
+
+      await Util.expectDecodeUnknownFailure(schema, "a", "Expected `[${string}]`, actual \"a\"")
+    })
+
     it("a${string}", async () => {
       const schema = S.templateLiteral(S.literal("a"), S.string)
       await Util.expectDecodeUnknownSuccess(schema, "a", "a")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Literals inside template literals were not escaped, so when creating the regex for the overall template literal it might not find a match correctly. This solution is based on [Lodash's escapeRegExp](https://lodash.com/docs#escapeRegExp).

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
