### PR TITLE
swap type parameters for /platform data types

### DIFF
--- a/.changeset/mighty-trees-wait.md
+++ b/.changeset/mighty-trees-wait.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Reverses the HttpClient type args, i.e.: Client<R, E, A> -> Client<A, E, R>

--- a/.changeset/mighty-trees-wait.md
+++ b/.changeset/mighty-trees-wait.md
@@ -1,5 +1,9 @@
 ---
 "@effect/platform": minor
+"@effect/platform-browser": minor
+"@effect/platform-bun": minor
+"@effect/platform-node": minor
+"@effect/platform-node-shared": minor
 ---
 
 Swap type parameters in /platform data types

--- a/.changeset/mighty-trees-wait.md
+++ b/.changeset/mighty-trees-wait.md
@@ -2,4 +2,10 @@
 "@effect/platform": minor
 ---
 
-Reverses the HttpClient type args, i.e.: Client<R, E, A> -> Client<A, E, R>
+Swap type parameters in /platform data types
+
+A codemod has been released to make migration easier:
+
+```
+npx @effect/codemod platform-0.49 src/**/*
+```

--- a/packages/platform-bun/src/internal/http/server.ts
+++ b/packages/platform-bun/src/internal/http/server.ts
@@ -110,7 +110,7 @@ export const make = (
           Effect.asUnit
         )
       }
-    });
+    })
   })
 
 const makeResponse = (request: ServerRequest.ServerRequest, response: ServerResponse.ServerResponse): Response => {

--- a/packages/platform-bun/src/internal/http/server.ts
+++ b/packages/platform-bun/src/internal/http/server.ts
@@ -78,7 +78,7 @@ export const make = (
           middleware
             ? middleware(App.withDefaultMiddleware(respond(httpApp)))
             : App.withDefaultMiddleware(respond(httpApp))
-        ) as App.Default<never, unknown>
+        ) as App.Default<unknown>
 
         return pipe(
           Effect.runtime<never>(),
@@ -110,7 +110,7 @@ export const make = (
           Effect.asUnit
         )
       }
-    })
+    });
   })
 
 const makeResponse = (request: ServerRequest.ServerRequest, response: ServerResponse.ServerResponse): Response => {

--- a/packages/platform-node/src/Http/Server.ts
+++ b/packages/platform-node/src/Http/Server.ts
@@ -38,15 +38,15 @@ export const make: (
  */
 export const makeHandler: {
   <R, E>(
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ): Effect.Effect<
     (nodeRequest: Http.IncomingMessage, nodeResponse: Http.ServerResponse<Http.IncomingMessage>) => void,
     never,
     Exclude<R, Scope.Scope | ServerRequest.ServerRequest>
   >
   <R, E, App extends App.Default<any, any>>(
-    httpApp: App.Default<R, E>,
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    httpApp: App.Default<E, R>,
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): Effect.Effect<
     (nodeRequest: Http.IncomingMessage, nodeResponse: Http.ServerResponse<Http.IncomingMessage>) => void,
     never,

--- a/packages/platform-node/src/internal/http/server.ts
+++ b/packages/platform-node/src/internal/http/server.ts
@@ -112,20 +112,20 @@ export const make = (
 
 /** @internal */
 export const makeHandler: {
-  <R, E>(httpApp: App.Default<R, E>): Effect.Effect<
+  <R, E>(httpApp: App.Default<E, R>): Effect.Effect<
     (nodeRequest: Http.IncomingMessage, nodeResponse: Http.ServerResponse) => void,
     never,
     Exclude<R, ServerRequest.ServerRequest | Scope.Scope>
   >
   <R, E, App extends App.Default<any, any>>(
-    httpApp: App.Default<R, E>,
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    httpApp: App.Default<E, R>,
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): Effect.Effect<
     (nodeRequest: Http.IncomingMessage, nodeResponse: Http.ServerResponse) => void,
     never,
     Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>
   >
-} = <R, E>(httpApp: App.Default<R, E>, middleware?: Middleware.Middleware) => {
+} = <R, E>(httpApp: App.Default<E, R>, middleware?: Middleware.Middleware) => {
   const handledApp = Effect.scoped(
     middleware
       ? middleware(App.withDefaultMiddleware(respond(httpApp)))
@@ -160,7 +160,7 @@ export const makeHandler: {
 /** @internal */
 export const makeUpgradeHandler = <R, E>(
   lazyWss: Effect.Effect<WS.WebSocketServer>,
-  httpApp: App.Default<R, E>,
+  httpApp: App.Default<E, R>,
   middleware?: Middleware.Middleware
 ) => {
   const handledApp = Effect.scoped(

--- a/packages/platform/src/Http/Client.ts
+++ b/packages/platform/src/Http/Client.ts
@@ -32,11 +32,11 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category models
  */
-export interface Client<R, E, A> extends Pipeable, Inspectable {
+export interface Client<A, E, R> extends Pipeable, Inspectable {
   (request: ClientRequest.ClientRequest): Effect.Effect<A, E, R>
   readonly [TypeId]: TypeId
-  readonly preprocess: Client.Preprocess<R, E>
-  readonly execute: Client.Execute<R, E, A>
+  readonly preprocess: Client.Preprocess<E, R>
+  readonly execute: Client.Execute<A, E, R>
 }
 
 /**
@@ -47,7 +47,7 @@ export declare namespace Client {
    * @since 1.0.0
    * @category models
    */
-  export type Preprocess<R, E> = (
+  export type Preprocess<E, R> = (
     request: ClientRequest.ClientRequest
   ) => Effect.Effect<ClientRequest.ClientRequest, E, R>
 
@@ -55,7 +55,7 @@ export declare namespace Client {
    * @since 1.0.0
    * @category models
    */
-  export type Execute<R, E, A> = (
+  export type Execute<A, E, R> = (
     request: Effect.Effect<ClientRequest.ClientRequest, E, R>
   ) => Effect.Effect<A, E, R>
 
@@ -63,13 +63,13 @@ export declare namespace Client {
    * @since 1.0.0
    * @category models
    */
-  export type WithResponse<R, E> = Client<R, E, ClientResponse.ClientResponse>
+  export type WithResponse<E, R> = Client<ClientResponse.ClientResponse, E, R>
 
   /**
    * @since 1.0.0
    * @category models
    */
-  export type Default = WithResponse<Scope.Scope, Error.HttpClientError>
+  export type Default = WithResponse<Error.HttpClientError, Scope.Scope>
 }
 
 /**
@@ -115,8 +115,8 @@ export const fetchOk: (options?: RequestInit) => Client.Default = internal.fetch
  * @category error handling
  */
 export const catchAll: {
-  <E, R2, E2, A2>(f: (e: E) => Effect.Effect<A2, E2, R2>): <R, A>(self: Client<R, E, A>) => Client<R2 | R, E2, A2 | A>
-  <R, E, A, R2, E2, A2>(self: Client<R, E, A>, f: (e: E) => Effect.Effect<A2, E2, R2>): Client<R | R2, E2, A | A2>
+  <E, R2, E2, A2>(f: (e: E) => Effect.Effect<A2, E2, R2>): <A, R>(self: Client<A, E, R>) => Client<A2 | A, E2, R2 | R>
+  <A, E, R, R2, E2, A2>(self: Client<A, E, R>, f: (e: E) => Effect.Effect<A2, E2, R2>): Client<A | A2, E2, R | R2>
 } = internal.catchAll
 
 /**
@@ -127,12 +127,12 @@ export const catchTag: {
   <E extends { _tag: string }, K extends E["_tag"] & string, R1, E1, A1>(
     tag: K,
     f: (e: Extract<E, { _tag: K }>) => Effect.Effect<A1, E1, R1>
-  ): <R, A>(self: Client<R, E, A>) => Client<R1 | R, E1 | Exclude<E, { _tag: K }>, A1 | A>
+  ): <A, R>(self: Client<A, E, R>) => Client<A1 | A, E1 | Exclude<E, { _tag: K }>, R1 | R>
   <R, E extends { _tag: string }, A, K extends E["_tag"] & string, E1, R1, A1>(
-    self: Client<R, E, A>,
+    self: Client<A, E, R>,
     tag: K,
     f: (e: Extract<E, { _tag: K }>) => Effect.Effect<A1, E1, R1>
-  ): Client<R | R1, E1 | Exclude<E, { _tag: K }>, A | A1>
+  ): Client<A | A1, E1 | Exclude<E, { _tag: K }>, R | R1>
 } = internal.catchTag
 
 /**
@@ -145,42 +145,42 @@ export const catchTags: {
     Cases extends { [K in E["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any>) | undefined }
   >(
     cases: Cases
-  ): <R, A>(
-    self: Client<R, E, A>
+  ): <A, R>(
+    self: Client<A, E, R>
   ) => Client<
-    | R
+    | A
     | {
-      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R> ? R : never
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A, any, any> ? A : never
     }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, infer E, any> ? E : never
     }[keyof Cases],
-    | A
+    | R
     | {
-      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A, any, any> ? A : never
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R> ? R : never
     }[keyof Cases]
   >
   <
-    R,
-    E extends { _tag: string },
     A,
+    E extends { _tag: string },
+    R,
     Cases extends { [K in E["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any>) | undefined }
   >(
-    self: Client<R, E, A>,
+    self: Client<A, E, R>,
     cases: Cases
   ): Client<
-    | R
+    | A
     | {
-      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R> ? R : never
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A, any, any> ? A : never
     }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, infer E, any> ? E : never
     }[keyof Cases],
-    | A
+    | R
     | {
-      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A, any, any> ? A : never
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R> ? R : never
     }[keyof Cases]
   >
 } = internal.catchTags
@@ -193,12 +193,12 @@ export const filterOrElse: {
   <A, R2, E2, B>(
     f: Predicate.Predicate<A>,
     orElse: (a: A) => Effect.Effect<B, E2, R2>
-  ): <R, E>(self: Client<R, E, A>) => Client<R2 | R, E2 | E, A | B>
-  <R, E, A, R2, E2, B>(
-    self: Client<R, E, A>,
+  ): <E, R>(self: Client<A, E, R>) => Client<A | B, E2 | E, R2 | R>
+  <A, E, R, R2, E2, B>(
+    self: Client<A, E, R>,
     f: Predicate.Predicate<A>,
     orElse: (a: A) => Effect.Effect<B, E2, R2>
-  ): Client<R | R2, E | E2, A | B>
+  ): Client<A | B, E | E2, R | R2>
 } = internal.filterOrElse
 
 /**
@@ -206,8 +206,8 @@ export const filterOrElse: {
  * @category filters
  */
 export const filterOrFail: {
-  <A, E2>(f: Predicate.Predicate<A>, orFailWith: (a: A) => E2): <R, E>(self: Client<R, E, A>) => Client<R, E2 | E, A>
-  <R, E, A, E2>(self: Client<R, E, A>, f: Predicate.Predicate<A>, orFailWith: (a: A) => E2): Client<R, E | E2, A>
+  <A, E2>(f: Predicate.Predicate<A>, orFailWith: (a: A) => E2): <E, R>(self: Client<A, E, R>) => Client<A, E2 | E, R>
+  <A, E, R, E2>(self: Client<A, E, R>, f: Predicate.Predicate<A>, orFailWith: (a: A) => E2): Client<A, E | E2, R>
 } = internal.filterOrFail
 
 /**
@@ -217,29 +217,29 @@ export const filterOrFail: {
 export const filterStatus: {
   (
     f: (status: number) => boolean
-  ): <R, E>(self: Client.WithResponse<R, E>) => Client.WithResponse<R, E | Error.ResponseError>
-  <R, E>(
-    self: Client.WithResponse<R, E>,
+  ): <E, R>(self: Client.WithResponse<E, R>) => Client.WithResponse<E | Error.ResponseError, R>
+  <E, R>(
+    self: Client.WithResponse<E, R>,
     f: (status: number) => boolean
-  ): Client.WithResponse<R, Error.ResponseError | E>
+  ): Client.WithResponse<Error.ResponseError | E, R>
 } = internal.filterStatus
 
 /**
  * @since 1.0.0
  * @category filters
  */
-export const filterStatusOk: <R, E>(
-  self: Client.WithResponse<R, E>
-) => Client.WithResponse<R, Error.ResponseError | E> = internal.filterStatusOk
+export const filterStatusOk: <E, R>(
+  self: Client.WithResponse<E, R>
+) => Client.WithResponse<Error.ResponseError | E, R> = internal.filterStatusOk
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const make: <R, E, A, R2, E2>(
+export const make: <A, E, R, R2, E2>(
   execute: (request: Effect.Effect<ClientRequest.ClientRequest, E2, R2>) => Effect.Effect<A, E, R>,
-  preprocess: Client.Preprocess<R2, E2>
-) => Client<R, E, A> = internal.make
+  preprocess: Client.Preprocess<E2, R2>
+) => Client<A, E, R> = internal.make
 
 /**
  * @since 1.0.0
@@ -256,13 +256,13 @@ export const makeDefault: (
  * @category mapping & sequencing
  */
 export const transform: {
-  <R, E, A, R1, E1, A1>(
+  <A, E, R, R1, E1, A1>(
     f: (effect: Effect.Effect<A, E, R>, request: ClientRequest.ClientRequest) => Effect.Effect<A1, E1, R1>
-  ): (self: Client<R, E, A>) => Client<R | R1, E | E1, A1>
-  <R, E, A, R1, E1, A1>(
-    self: Client<R, E, A>,
+  ): (self: Client<A, E, R>) => Client<A1, E | E1, R | R1>
+  <A, E, R, R1, E1, A1>(
+    self: Client<A, E, R>,
     f: (effect: Effect.Effect<A, E, R>, request: ClientRequest.ClientRequest) => Effect.Effect<A1, E1, R1>
-  ): Client<R | R1, E | E1, A1>
+  ): Client<A1, E | E1, R | R1>
 } = internal.transform
 
 /**
@@ -270,13 +270,13 @@ export const transform: {
  * @category mapping & sequencing
  */
 export const transformResponse: {
-  <R, E, A, R1, E1, A1>(
+  <A, E, R, R1, E1, A1>(
     f: (effect: Effect.Effect<A, E, R>) => Effect.Effect<A1, E1, R1>
-  ): (self: Client<R, E, A>) => Client<R1, E1, A1>
-  <R, E, A, R1, E1, A1>(
-    self: Client<R, E, A>,
+  ): (self: Client<A, E, R>) => Client<A1, E1, R1>
+  <A, E, R, R1, E1, A1>(
+    self: Client<A, E, R>,
     f: (effect: Effect.Effect<A, E, R>) => Effect.Effect<A1, E1, R1>
-  ): Client<R1, E1, A1>
+  ): Client<A1, E1, R1>
 } = internal.transformResponse
 
 /**
@@ -284,8 +284,8 @@ export const transformResponse: {
  * @category mapping & sequencing
  */
 export const map: {
-  <A, B>(f: (a: A) => B): <R, E>(self: Client<R, E, A>) => Client<R, E, B>
-  <R, E, A, B>(self: Client<R, E, A>, f: (a: A) => B): Client<R, E, B>
+  <A, B>(f: (a: A) => B): <E, R>(self: Client<A, E, R>) => Client<B, E, R>
+  <A, E, R, B>(self: Client<A, E, R>, f: (a: A) => B): Client<B, E, R>
 } = internal.map
 
 /**
@@ -293,8 +293,8 @@ export const map: {
  * @category mapping & sequencing
  */
 export const mapEffect: {
-  <A, R2, E2, B>(f: (a: A) => Effect.Effect<B, E2, R2>): <R, E>(self: Client<R, E, A>) => Client<R2 | R, E2 | E, B>
-  <R, E, A, R2, E2, B>(self: Client<R, E, A>, f: (a: A) => Effect.Effect<B, E2, R2>): Client<R | R2, E | E2, B>
+  <A, R2, E2, B>(f: (a: A) => Effect.Effect<B, E2, R2>): <E, R>(self: Client<A, E, R>) => Client<B, E2 | E, R2 | R>
+  <A, E, R, R2, E2, B>(self: Client<A, E, R>, f: (a: A) => Effect.Effect<B, E2, R2>): Client<B, E | E2, R2 | R>
 } = internal.mapEffect
 
 /**
@@ -304,11 +304,11 @@ export const mapEffect: {
 export const mapEffectScoped: {
   <A, R2, E2, B>(
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ): <R, E>(self: Client<R, E, A>) => Client<Exclude<R2, Scope.Scope> | Exclude<R, Scope.Scope>, E2 | E, B>
-  <R, E, A, R2, E2, B>(
-    self: Client<R, E, A>,
+  ): <E, R>(self: Client<A, E, R>) => Client<B, E2 | E, Exclude<R2, Scope.Scope> | Exclude<R, Scope.Scope>>
+  <A, E, R, R2, E2, B>(
+    self: Client<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ): Client<Exclude<R, Scope.Scope> | Exclude<R2, Scope.Scope>, E | E2, B>
+  ): Client<B, E | E2, Exclude<R2, Scope.Scope> | Exclude<R, Scope.Scope>>
 } = internal.mapEffectScoped
 
 /**
@@ -318,8 +318,8 @@ export const mapEffectScoped: {
 export const mapRequest: {
   (
     f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest
-  ): <R, E, A>(self: Client<R, E, A>) => Client<R, E, A>
-  <R, E, A>(self: Client<R, E, A>, f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest): Client<R, E, A>
+  ): <A, E, R>(self: Client<A, E, R>) => Client<A, E, R>
+  <A, E, R>(self: Client<A, E, R>, f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest): Client<A, E, R>
 } = internal.mapRequest
 
 /**
@@ -329,11 +329,11 @@ export const mapRequest: {
 export const mapRequestEffect: {
   <R2, E2>(
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ): <R, E, A>(self: Client<R, E, A>) => Client<R2 | R, E2 | E, A>
-  <R, E, A, R2, E2>(
-    self: Client<R, E, A>,
+  ): <A, E, R>(self: Client<A, E, R>) => Client<A, E2 | E, R2 | R>
+  <A, E, R, R2, E2>(
+    self: Client<A, E, R>,
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ): Client<R | R2, E | E2, A>
+  ): Client<A, E | E2, R | R2>
 } = internal.mapRequestEffect
 
 /**
@@ -343,8 +343,8 @@ export const mapRequestEffect: {
 export const mapInputRequest: {
   (
     f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest
-  ): <R, E, A>(self: Client<R, E, A>) => Client<R, E, A>
-  <R, E, A>(self: Client<R, E, A>, f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest): Client<R, E, A>
+  ): <A, E, R>(self: Client<A, E, R>) => Client<A, E, R>
+  <A, E, R>(self: Client<A, E, R>, f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest): Client<A, E, R>
 } = internal.mapInputRequest
 
 /**
@@ -354,11 +354,11 @@ export const mapInputRequest: {
 export const mapInputRequestEffect: {
   <R2, E2>(
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ): <R, E, A>(self: Client<R, E, A>) => Client<R2 | R, E2 | E, A>
-  <R, E, A, R2, E2>(
-    self: Client<R, E, A>,
+  ): <A, E, R>(self: Client<A, E, R>) => Client<A, E2 | E, R2 | R>
+  <A, E, R, R2, E2>(
+    self: Client<A, E, R>,
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ): Client<R | R2, E | E2, A>
+  ): Client<A, E | E2, R2 | R>
 } = internal.mapInputRequestEffect
 
 /**
@@ -366,15 +366,15 @@ export const mapInputRequestEffect: {
  * @category error handling
  */
 export const retry: {
-  <R1, E extends E0, E0, B>(policy: Schedule.Schedule<B, E0, R1>): <R, A>(self: Client<R, E, A>) => Client<R1 | R, E, A>
-  <R, E extends E0, E0, A, R1, B>(self: Client<R, E, A>, policy: Schedule.Schedule<B, E0, R1>): Client<R | R1, E, A>
+  <B, E extends E0, E0, R1>(policy: Schedule.Schedule<B, E0, R1>): <A, R>(self: Client<A, E, R>) => Client<A, E, R1 | R>
+  <A, E extends E0, E0, R, R1, B>(self: Client<A, E, R>, policy: Schedule.Schedule<B, E0, R1>): Client<A, E, R1 | R>
 } = internal.retry
 
 /**
  * @since 1.0.0
  * @category resources & finalizers
  */
-export const scoped: <R, E, A>(self: Client<R, E, A>) => Client<Exclude<R, Scope.Scope>, E, A> = internal.scoped
+export const scoped: <A, E, R>(self: Client<A, E, R>) => Client<A, E, Exclude<R, Scope.Scope>> = internal.scoped
 
 /**
  * @since 1.0.0
@@ -383,13 +383,13 @@ export const scoped: <R, E, A>(self: Client<R, E, A>) => Client<Exclude<R, Scope
 export const schemaFunction: {
   <SA, SI, SR>(
     schema: Schema.Schema<SA, SI, SR>
-  ): <R, E, A>(
-    self: Client<R, E, A>
+  ): <A, E, R>(
+    self: Client<A, E, R>
   ) => (
     request: ClientRequest.ClientRequest
   ) => (a: SA) => Effect.Effect<A, E | ParseResult.ParseError | Error.RequestError, SR | R>
-  <R, E, A, SA, SI, SR>(
-    self: Client<R, E, A>,
+  <A, E, R, SA, SI, SR>(
+    self: Client<A, E, R>,
     schema: Schema.Schema<SA, SI, SR>
   ): (
     request: ClientRequest.ClientRequest
@@ -401,8 +401,8 @@ export const schemaFunction: {
  * @category mapping & sequencing
  */
 export const tap: {
-  <A, R2, E2, _>(f: (a: A) => Effect.Effect<_, E2, R2>): <R, E>(self: Client<R, E, A>) => Client<R2 | R, E2 | E, A>
-  <R, E, A, R2, E2, _>(self: Client<R, E, A>, f: (a: A) => Effect.Effect<_, E2, R2>): Client<R | R2, E | E2, A>
+  <A, R2, E2, _>(f: (a: A) => Effect.Effect<_, E2, R2>): <E, R>(self: Client<A, E, R>) => Client<A, E2 | E, R2 | R>
+  <A, E, R, R2, E2, _>(self: Client<A, E, R>, f: (a: A) => Effect.Effect<_, E2, R2>): Client<A, E | E2, R2 | R>
 } = internal.tap
 
 /**
@@ -412,9 +412,9 @@ export const tap: {
 export const tapRequest: {
   <R2, E2, _>(
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<_, E2, R2>
-  ): <R, E, A>(self: Client<R, E, A>) => Client<R2 | R, E2 | E, A>
-  <R, E, A, R2, E2, _>(
-    self: Client<R, E, A>,
+  ): <A, E, R>(self: Client<A, E, R>) => Client<A, E2 | E, R2 | R>
+  <A, E, R, R2, E2, _>(
+    self: Client<A, E, R>,
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<_, E2, R2>
-  ): Client<R | R2, E | E2, A>
+  ): Client<A, E | E2, R | R2>
 } = internal.tapRequest

--- a/packages/platform/src/Http/Client.ts
+++ b/packages/platform/src/Http/Client.ts
@@ -32,7 +32,7 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category models
  */
-export interface Client<A, E, R> extends Pipeable, Inspectable {
+export interface Client<A = ClientResponse.ClientResponse, E = never, R = never> extends Pipeable, Inspectable {
   (request: ClientRequest.ClientRequest): Effect.Effect<A, E, R>
   readonly [TypeId]: TypeId
   readonly preprocess: Client.Preprocess<E, R>
@@ -55,7 +55,7 @@ export declare namespace Client {
    * @since 1.0.0
    * @category models
    */
-  export type Execute<A, E, R> = (
+  export type Execute<A, E = never, R = never> = (
     request: Effect.Effect<ClientRequest.ClientRequest, E, R>
   ) => Effect.Effect<A, E, R>
 
@@ -63,7 +63,7 @@ export declare namespace Client {
    * @since 1.0.0
    * @category models
    */
-  export type WithResponse<E, R> = Client<ClientResponse.ClientResponse, E, R>
+  export type WithResponse<E = never, R = never> = Client<ClientResponse.ClientResponse, E, R>
 
   /**
    * @since 1.0.0

--- a/packages/platform/src/Http/Middleware.ts
+++ b/packages/platform/src/Http/Middleware.ts
@@ -13,7 +13,7 @@ import type * as ServerRequest from "./ServerRequest.js"
  * @category models
  */
 export interface Middleware {
-  <R, E>(self: App.Default<R, E>): App.Default<any, any>
+  <R, E>(self: App.Default<E, R>): App.Default<any, any>
 }
 
 /**
@@ -23,8 +23,8 @@ export declare namespace Middleware {
   /**
    * @since 1.0.0
    */
-  export interface Applied<R, E, A extends App.Default<any, any>> {
-    (self: App.Default<R, E>): A
+  export interface Applied<A extends App.Default<any, any>, E, R> {
+    (self: App.Default<E, R>): A
   }
 }
 
@@ -38,7 +38,7 @@ export const make: <M extends Middleware>(middleware: M) => M = internal.make
  * @since 1.0.0
  * @category constructors
  */
-export const logger: <R, E>(httpApp: App.Default<R, E>) => App.Default<R, E> = internal.logger
+export const logger: <R, E>(httpApp: App.Default<E, R>) => App.Default<E, R> = internal.logger
 
 /**
  * @since 1.0.0
@@ -78,4 +78,4 @@ export const withTracerDisabledWhen: {
  * @since 1.0.0
  * @category constructors
  */
-export const xForwardedHeaders: <R, E>(httpApp: App.Default<R, E>) => App.Default<R, E> = internal.xForwardedHeaders
+export const xForwardedHeaders: <R, E>(httpApp: App.Default<E, R>) => App.Default<E, R> = internal.xForwardedHeaders

--- a/packages/platform/src/Http/Multiplex.ts
+++ b/packages/platform/src/Http/Multiplex.ts
@@ -24,12 +24,12 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category models
  */
-export interface Multiplex<R, E> extends App.Default<R, E | Error.RouteNotFound>, Inspectable {
+export interface Multiplex<E = never, R = never> extends App.Default<E | Error.RouteNotFound, R>, Inspectable {
   readonly [TypeId]: TypeId
   readonly apps: ReadonlyArray<
     readonly [
       predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E, R>,
-      app: App.Default<R, E>
+      app: App.Default<E, R>
     ]
   >
 }
@@ -38,7 +38,7 @@ export interface Multiplex<R, E> extends App.Default<R, E | Error.RouteNotFound>
  * @since 1.0.0
  * @category constructors
  */
-export const empty: Multiplex<never, never> = internal.empty
+export const empty: Multiplex<never> = internal.empty
 
 /**
  * @since 1.0.0
@@ -46,9 +46,9 @@ export const empty: Multiplex<never, never> = internal.empty
  */
 export const make: <R, E>(
   apps: Iterable<
-    readonly [predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E, R>, app: App.Default<R, E>]
+    readonly [predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E, R>, app: App.Default<E, R>]
   >
-) => Multiplex<R, E> = internal.make
+) => Multiplex<E, R> = internal.make
 
 /**
  * @since 1.0.0
@@ -57,13 +57,13 @@ export const make: <R, E>(
 export const add: {
   <R2, E2, R3, E3>(
     predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E2, R2>,
-    app: App.Default<R3, E3>
-  ): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R3 | R, E2 | E3 | E>
+    app: App.Default<E3, R3>
+  ): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E3 | E, R2 | R3 | R>
   <R, E, R2, E2, R3, E3>(
-    self: Multiplex<R, E>,
+    self: Multiplex<E, R>,
     predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E2, R2>,
-    app: App.Default<R3, E3>
-  ): Multiplex<R | R2 | R3, E | E2 | E3>
+    app: App.Default<E3, R3>
+  ): Multiplex<E | E2 | E3, R | R2 | R3>
 } = internal.add
 
 /**
@@ -74,14 +74,14 @@ export const headerExact: {
   <R2, E2>(
     header: string,
     value: string,
-    app: App.Default<R2, E2>
-  ): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
+    app: App.Default<E2, R2>
+  ): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
   <R, E, R2, E2>(
-    self: Multiplex<R, E>,
+    self: Multiplex<E, R>,
     header: string,
     value: string,
-    app: App.Default<R2, E2>
-  ): Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ): Multiplex<E | E2, R | R2>
 } = internal.headerExact
 
 /**
@@ -92,14 +92,14 @@ export const headerRegex: {
   <R2, E2>(
     header: string,
     regex: RegExp,
-    app: App.Default<R2, E2>
-  ): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
+    app: App.Default<E2, R2>
+  ): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
   <R, E, R2, E2>(
-    self: Multiplex<R, E>,
+    self: Multiplex<E, R>,
     header: string,
     regex: RegExp,
-    app: App.Default<R2, E2>
-  ): Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ): Multiplex<E | E2, R | R2>
 } = internal.headerRegex
 
 /**
@@ -110,14 +110,14 @@ export const headerStartsWith: {
   <R2, E2>(
     header: string,
     prefix: string,
-    app: App.Default<R2, E2>
-  ): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
+    app: App.Default<E2, R2>
+  ): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
   <R, E, R2, E2>(
-    self: Multiplex<R, E>,
+    self: Multiplex<E, R>,
     header: string,
     prefix: string,
-    app: App.Default<R2, E2>
-  ): Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ): Multiplex<E | E2, R | R2>
 } = internal.headerStartsWith
 
 /**
@@ -128,14 +128,14 @@ export const headerEndsWith: {
   <R2, E2>(
     header: string,
     suffix: string,
-    app: App.Default<R2, E2>
-  ): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
+    app: App.Default<E2, R2>
+  ): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
   <R, E, R2, E2>(
-    self: Multiplex<R, E>,
+    self: Multiplex<E, R>,
     header: string,
     suffix: string,
-    app: App.Default<R2, E2>
-  ): Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ): Multiplex<E | E2, R | R2>
 } = internal.headerEndsWith
 
 /**
@@ -143,8 +143,8 @@ export const headerEndsWith: {
  * @category combinators
  */
 export const hostExact: {
-  <R2, E2>(host: string, app: App.Default<R2, E2>): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
-  <R, E, R2, E2>(self: Multiplex<R, E>, host: string, app: App.Default<R2, E2>): Multiplex<R | R2, E | E2>
+  <R2, E2>(host: string, app: App.Default<E2, R2>): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
+  <R, E, R2, E2>(self: Multiplex<E, R>, host: string, app: App.Default<E2, R2>): Multiplex<E | E2, R | R2>
 } = internal.hostExact
 
 /**
@@ -152,8 +152,8 @@ export const hostExact: {
  * @category combinators
  */
 export const hostRegex: {
-  <R2, E2>(regex: RegExp, app: App.Default<R2, E2>): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
-  <R, E, R2, E2>(self: Multiplex<R, E>, regex: RegExp, app: App.Default<R2, E2>): Multiplex<R | R2, E | E2>
+  <R2, E2>(regex: RegExp, app: App.Default<E2, R2>): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
+  <R, E, R2, E2>(self: Multiplex<E, R>, regex: RegExp, app: App.Default<E2, R2>): Multiplex<E | E2, R | R2>
 } = internal.hostRegex
 
 /**
@@ -161,8 +161,8 @@ export const hostRegex: {
  * @category combinators
  */
 export const hostStartsWith: {
-  <R2, E2>(prefix: string, app: App.Default<R2, E2>): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
-  <R, E, R2, E2>(self: Multiplex<R, E>, prefix: string, app: App.Default<R2, E2>): Multiplex<R | R2, E | E2>
+  <R2, E2>(prefix: string, app: App.Default<E2, R2>): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
+  <R, E, R2, E2>(self: Multiplex<E, R>, prefix: string, app: App.Default<E2, R2>): Multiplex<E | E2, R | R2>
 } = internal.hostStartsWith
 
 /**
@@ -170,6 +170,6 @@ export const hostStartsWith: {
  * @category combinators
  */
 export const hostEndsWith: {
-  <R2, E2>(suffix: string, app: App.Default<R2, E2>): <R, E>(self: Multiplex<R, E>) => Multiplex<R2 | R, E2 | E>
-  <R, E, R2, E2>(self: Multiplex<R, E>, suffix: string, app: App.Default<R2, E2>): Multiplex<R | R2, E | E2>
+  <R2, E2>(suffix: string, app: App.Default<E2, R2>): <R, E>(self: Multiplex<E, R>) => Multiplex<E2 | E, R2 | R>
+  <R, E, R2, E2>(self: Multiplex<E, R>, suffix: string, app: App.Default<E2, R2>): Multiplex<E | E2, R | R2>
 } = internal.hostEndsWith

--- a/packages/platform/src/Http/Server.ts
+++ b/packages/platform/src/Http/Server.ts
@@ -29,14 +29,14 @@ export type TypeId = typeof TypeId
 export interface Server {
   readonly [TypeId]: TypeId
   readonly serve: {
-    <R, E>(httpApp: App.Default<R, E>): Effect.Effect<
+    <R, E>(httpApp: App.Default<E, R>): Effect.Effect<
       void,
       never,
       Exclude<R, ServerRequest.ServerRequest> | Scope.Scope
     >
     <R, E, App extends App.Default<any, any>>(
-      httpApp: App.Default<R, E>,
-      middleware: Middleware.Middleware.Applied<R, E, App>
+      httpApp: App.Default<E, R>,
+      middleware: Middleware.Middleware.Applied<App, E, R>
     ): Effect.Effect<
       void,
       never,
@@ -92,7 +92,7 @@ export const Server: Context.Tag<Server, Server> = internal.serverTag
 export const make: (
   options: {
     readonly serve: (
-      httpApp: App.Default<never, unknown>,
+      httpApp: App.Default<unknown>,
       middleware?: Middleware.Middleware
     ) => Effect.Effect<void, never, Scope.Scope>
     readonly address: Address
@@ -105,23 +105,23 @@ export const make: (
  */
 export const serve: {
   (): <R, E>(
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ) => Layer.Layer<never, never, Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>>
   <R, E, App extends App.Default<any, any>>(
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): (
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ) => Layer.Layer<
     never,
     never,
     Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>
   >
   <R, E>(
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ): Layer.Layer<never, never, Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>>
   <R, E, App extends App.Default<any, any>>(
-    httpApp: App.Default<R, E>,
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    httpApp: App.Default<E, R>,
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): Layer.Layer<never, never, Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest | Scope.Scope>>
 } = internal.serve
 
@@ -131,23 +131,23 @@ export const serve: {
  */
 export const serveEffect: {
   (): <R, E>(
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ) => Effect.Effect<void, never, Scope.Scope | Server | Exclude<R, ServerRequest.ServerRequest>>
   <R, E, App extends App.Default<any, any>>(
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): (
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ) => Effect.Effect<
     void,
     never,
     Scope.Scope | Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>
   >
   <R, E>(
-    httpApp: App.Default<R, E>
+    httpApp: App.Default<E, R>
   ): Effect.Effect<void, never, Scope.Scope | Server | Exclude<R, ServerRequest.ServerRequest>>
   <R, E, App extends App.Default<any, any>>(
-    httpApp: App.Default<R, E>,
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    httpApp: App.Default<E, R>,
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): Effect.Effect<void, never, Scope.Scope | Server | Exclude<Effect.Effect.Context<App>, ServerRequest.ServerRequest>>
 } = internal.serveEffect
 

--- a/packages/platform/src/Worker.ts
+++ b/packages/platform/src/Worker.ts
@@ -72,7 +72,7 @@ export const PlatformWorker: Context.Tag<PlatformWorker, PlatformWorker> = inter
  * @since 1.0.0
  * @category models
  */
-export interface Worker<I, E, O> {
+export interface Worker<I, O, E = never> {
   readonly id: number
   readonly execute: (message: I) => Stream.Stream<O, E | WorkerError>
   readonly executeEffect: (message: I) => Effect.Effect<O, E | WorkerError>
@@ -141,8 +141,8 @@ export declare namespace Worker {
  * @since 1.0.0
  * @category models
  */
-export interface WorkerPool<I, E, O> {
-  readonly backing: Pool.Pool<Worker<I, E, O>, WorkerError>
+export interface WorkerPool<I, O, E = never> {
+  readonly backing: Pool.Pool<Worker<I, O, E>, WorkerError>
   readonly broadcast: (message: I) => Effect.Effect<void, E | WorkerError>
   readonly execute: (message: I) => Stream.Stream<O, E | WorkerError>
   readonly executeEffect: (message: I) => Effect.Effect<O, E | WorkerError>
@@ -198,9 +198,9 @@ export type WorkerManagerTypeId = typeof WorkerManagerTypeId
  */
 export interface WorkerManager {
   readonly [WorkerManagerTypeId]: WorkerManagerTypeId
-  readonly spawn: <I, E, O>(
+  readonly spawn: <I, O, E>(
     options: Worker.Options<I>
-  ) => Effect.Effect<Worker<I, E, O>, WorkerError, Scope.Scope | Spawner>
+  ) => Effect.Effect<Worker<I, O, E>, WorkerError, Scope.Scope | Spawner>
 }
 
 /**
@@ -225,16 +225,16 @@ export const layerManager: Layer.Layer<WorkerManager, never, PlatformWorker> = i
  * @since 1.0.0
  * @category constructors
  */
-export const makePool: <I, E, O>(
+export const makePool: <I, O, E>(
   options: WorkerPool.Options<I>
-) => Effect.Effect<WorkerPool<I, E, O>, never, WorkerManager | Spawner | Scope.Scope> = internal.makePool
+) => Effect.Effect<WorkerPool<I, O, E>, never, WorkerManager | Spawner | Scope.Scope> = internal.makePool
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const makePoolLayer: <Tag, I, E, O>(
-  tag: Context.Tag<Tag, WorkerPool<I, E, O>>,
+export const makePoolLayer: <Tag, I, O, E>(
+  tag: Context.Tag<Tag, WorkerPool<I, O, E>>,
   options: WorkerPool.Options<I>
 ) => Layer.Layer<Tag, never, WorkerManager | Spawner> = internal.makePoolLayer
 

--- a/packages/platform/src/WorkerRunner.ts
+++ b/packages/platform/src/WorkerRunner.ts
@@ -74,7 +74,7 @@ export declare namespace Runner {
    * @since 1.0.0
    * @category models
    */
-  export interface Options<I, E, O> {
+  export interface Options<I, O, E> {
     readonly decode?: (
       message: unknown
     ) => Effect.Effect<I, WorkerError>
@@ -96,7 +96,7 @@ export declare namespace Runner {
  */
 export const make: <I, R, E, O>(
   process: (request: I) => Stream.Stream<O, E, R> | Effect.Effect<O, E, R>,
-  options?: Runner.Options<I, E, O> | undefined
+  options?: Runner.Options<I, O, E> | undefined
 ) => Effect.Effect<void, WorkerError, Scope.Scope | R | PlatformRunner> = internal.make
 
 /**
@@ -105,7 +105,7 @@ export const make: <I, R, E, O>(
  */
 export const layer: <I, R, E, O>(
   process: (request: I) => Stream.Stream<O, E, R> | Effect.Effect<O, E, R>,
-  options?: Runner.Options<I, E, O> | undefined
+  options?: Runner.Options<I, O, E> | undefined
 ) => Layer.Layer<never, WorkerError, R | PlatformRunner> = internal.layer
 
 /**

--- a/packages/platform/src/internal/http/client.ts
+++ b/packages/platform/src/internal/http/client.ts
@@ -36,12 +36,12 @@ const clientProto = {
 }
 
 /** @internal */
-export const make = <R, E, A, R2, E2>(
+export const make = <A, E, R, R2, E2>(
   execute: (
     request: Effect.Effect<ClientRequest.ClientRequest, E2, R2>
   ) => Effect.Effect<A, E, R>,
-  preprocess: Client.Client.Preprocess<R2, E2>
-): Client.Client<R, E, A> => {
+  preprocess: Client.Client.Preprocess<E2, R2>
+): Client.Client<A, E, R> => {
   function client(request: ClientRequest.ClientRequest) {
     return execute(preprocess(request))
   }
@@ -148,19 +148,19 @@ export const layer = Layer.succeed(tag, fetch())
 
 /** @internal */
 export const transform = dual<
-  <R, E, A, R1, E1, A1>(
+  <A, E, R, R1, E1, A1>(
     f: (
       effect: Effect.Effect<A, E, R>,
       request: ClientRequest.ClientRequest
     ) => Effect.Effect<A1, E1, R1>
-  ) => (self: Client.Client<R, E, A>) => Client.Client<R | R1, E | E1, A1>,
-  <R, E, A, R1, E1, A1>(
-    self: Client.Client<R, E, A>,
+  ) => (self: Client.Client<A, E, R>) => Client.Client<A1, E | E1, R | R1>,
+  <A, E, R, R1, E1, A1>(
+    self: Client.Client<A, E, R>,
     f: (
       effect: Effect.Effect<A, E, R>,
       request: ClientRequest.ClientRequest
     ) => Effect.Effect<A1, E1, R1>
-  ) => Client.Client<R | R1, E | E1, A1>
+  ) => Client.Client<A1, E | E1, R | R1>
 >(2, (self, f) =>
   make(
     Effect.flatMap((request) => f(self.execute(Effect.succeed(request)), request)),
@@ -169,13 +169,13 @@ export const transform = dual<
 
 /** @internal */
 export const transformResponse = dual<
-  <R, E, A, R1, E1, A1>(
+  <A, E, R, R1, E1, A1>(
     f: (effect: Effect.Effect<A, E, R>) => Effect.Effect<A1, E1, R1>
-  ) => (self: Client.Client<R, E, A>) => Client.Client<R1, E1, A1>,
-  <R, E, A, R1, E1, A1>(
-    self: Client.Client<R, E, A>,
+  ) => (self: Client.Client<A, E, R>) => Client.Client<A1, E1, R1>,
+  <A, E, R, R1, E1, A1>(
+    self: Client.Client<A, E, R>,
     f: (effect: Effect.Effect<A, E, R>) => Effect.Effect<A1, E1, R1>
-  ) => Client.Client<R1, E1, A1>
+  ) => Client.Client<A1, E1, R1>
 >(2, (self, f) => make((request) => f(self.execute(request)), self.preprocess))
 
 /** @internal */
@@ -183,9 +183,9 @@ export const catchTag: {
   <K extends E extends { _tag: string } ? E["_tag"] : never, E, R1, E1, A1>(
     tag: K,
     f: (e: Extract<E, { _tag: K }>) => Effect.Effect<A1, E1, R1>
-  ): <R, A>(
-    self: Client.Client<R, E, A>
-  ) => Client.Client<R1 | R, E1 | Exclude<E, { _tag: K }>, A1 | A>
+  ): <A, R>(
+    self: Client.Client<A, E, R>
+  ) => Client.Client<A1 | A, E1 | Exclude<E, { _tag: K }>, R1 | R>
   <
     R,
     E,
@@ -195,10 +195,10 @@ export const catchTag: {
     E1,
     A1
   >(
-    self: Client.Client<R, E, A>,
+    self: Client.Client<A, E, R>,
     tag: K,
     f: (e: Extract<E, { _tag: K }>) => Effect.Effect<A1, E1, R1>
-  ): Client.Client<R1 | R, E1 | Exclude<E, { _tag: K }>, A1 | A>
+  ): Client.Client<A1 | A, E1 | Exclude<E, { _tag: K }>, R1 | R>
 } = dual(
   3,
   <
@@ -210,10 +210,10 @@ export const catchTag: {
     E1,
     A1
   >(
-    self: Client.Client<R, E, A>,
+    self: Client.Client<A, E, R>,
     tag: K,
     f: (e: Extract<E, { _tag: K }>) => Effect.Effect<A1, E1, R1>
-  ): Client.Client<R1 | R, E1 | Exclude<E, { _tag: K }>, A1 | A> => transformResponse(self, Effect.catchTag(tag, f))
+  ): Client.Client<A1 | A, E1 | Exclude<E, { _tag: K }>, R1 | R> => transformResponse(self, Effect.catchTag(tag, f))
 )
 
 /** @internal */
@@ -237,14 +237,14 @@ export const catchTags: {
         })
   >(
     cases: Cases
-  ): <R, A>(
-    self: Client.Client<R, E, A>
+  ): <A, R>(
+    self: Client.Client<A, E, R>
   ) => Client.Client<
-    | R
+    | A
     | {
       [K in keyof Cases]: Cases[K] extends (
         ...args: Array<any>
-      ) => Effect.Effect<any, any, infer R> ? R
+      ) => Effect.Effect<infer A, any, any> ? A
         : never
     }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
@@ -254,18 +254,18 @@ export const catchTags: {
       ) => Effect.Effect<any, infer E, any> ? E
         : never
     }[keyof Cases],
-    | A
+    | R
     | {
       [K in keyof Cases]: Cases[K] extends (
         ...args: Array<any>
-      ) => Effect.Effect<infer A, any, any> ? A
+      ) => Effect.Effect<any, any, infer R> ? R
         : never
     }[keyof Cases]
   >
   <
-    R,
-    E extends { _tag: string },
     A,
+    E extends { _tag: string },
+    R,
     Cases extends
       & {
         [K in Extract<E, { _tag: string }>["_tag"]]+?: (
@@ -282,14 +282,14 @@ export const catchTags: {
           ]: never
         })
   >(
-    self: Client.Client<R, E, A>,
+    self: Client.Client<A, E, R>,
     cases: Cases
   ): Client.Client<
-    | R
+    | A
     | {
       [K in keyof Cases]: Cases[K] extends (
         ...args: Array<any>
-      ) => Effect.Effect<any, any, infer R> ? R
+      ) => Effect.Effect<infer A, any, any> ? A
         : never
     }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
@@ -299,20 +299,20 @@ export const catchTags: {
       ) => Effect.Effect<any, infer E, any> ? E
         : never
     }[keyof Cases],
-    | A
+    | R
     | {
       [K in keyof Cases]: Cases[K] extends (
         ...args: Array<any>
-      ) => Effect.Effect<infer A, any, any> ? A
+      ) => Effect.Effect<any, any, infer R> ? R
         : never
     }[keyof Cases]
   >
 } = dual(
   2,
   <
-    R,
-    E extends { _tag: string },
     A,
+    E extends { _tag: string },
+    R,
     Cases extends
       & {
         [K in Extract<E, { _tag: string }>["_tag"]]+?: (
@@ -329,14 +329,14 @@ export const catchTags: {
           ]: never
         })
   >(
-    self: Client.Client<R, E, A>,
+    self: Client.Client<A, E, R>,
     cases: Cases
   ): Client.Client<
-    | R
+    | A
     | {
       [K in keyof Cases]: Cases[K] extends (
         ...args: Array<any>
-      ) => Effect.Effect<any, any, infer R> ? R
+      ) => Effect.Effect<infer A, any, any> ? A
         : never
     }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
@@ -346,11 +346,11 @@ export const catchTags: {
       ) => Effect.Effect<any, infer E, any> ? E
         : never
     }[keyof Cases],
-    | A
+    | R
     | {
       [K in keyof Cases]: Cases[K] extends (
         ...args: Array<any>
-      ) => Effect.Effect<infer A, any, any> ? A
+      ) => Effect.Effect<any, any, infer R> ? R
         : never
     }[keyof Cases]
   > => transformResponse(self, Effect.catchTags(cases))
@@ -360,17 +360,17 @@ export const catchTags: {
 export const catchAll: {
   <E, R2, E2, A2>(
     f: (e: E) => Effect.Effect<A2, E2, R2>
-  ): <R, A>(self: Client.Client<R, E, A>) => Client.Client<R | R2, E2, A2 | A>
-  <R, E, A, R2, E2, A2>(
-    self: Client.Client<R, E, A>,
+  ): <A, R>(self: Client.Client<A, E, R>) => Client.Client<A2 | A, E2, R | R2>
+  <A, E, R, R2, E2, A2>(
+    self: Client.Client<A, E, R>,
     f: (e: E) => Effect.Effect<A2, E2, R2>
-  ): Client.Client<R | R2, E2, A2 | A>
+  ): Client.Client<A2 | A, E2, R | R2>
 } = dual(
   2,
-  <R, E, A, R2, E2, A2>(
-    self: Client.Client<R, E, A>,
+  <A, E, R, R2, E2, A2>(
+    self: Client.Client<A, E, R>,
     f: (e: E) => Effect.Effect<A2, E2, R2>
-  ): Client.Client<R | R2, E2, A2 | A> => transformResponse(self, Effect.catchAll(f))
+  ): Client.Client<A2 | A, E2, R | R2> => transformResponse(self, Effect.catchAll(f))
 )
 
 /** @internal */
@@ -378,14 +378,14 @@ export const filterOrElse = dual<
   <A, R2, E2, B>(
     f: Predicate.Predicate<A>,
     orElse: (a: A) => Effect.Effect<B, E2, R2>
-  ) => <R, E>(
-    self: Client.Client<R, E, A>
-  ) => Client.Client<R2 | R, E2 | E, A | B>,
-  <R, E, A, R2, E2, B>(
-    self: Client.Client<R, E, A>,
+  ) => <E, R>(
+    self: Client.Client<A, E, R>
+  ) => Client.Client<A | B, E2 | E, R2 | R>,
+  <A, E, R, R2, E2, B>(
+    self: Client.Client<A, E, R>,
     f: Predicate.Predicate<A>,
     orElse: (a: A) => Effect.Effect<B, E2, R2>
-  ) => Client.Client<R2 | R, E2 | E, A | B>
+  ) => Client.Client<A | B, E2 | E, R2 | R>
 >(3, (self, f, orElse) => transformResponse(self, Effect.filterOrElse(f, orElse)))
 
 /** @internal */
@@ -393,25 +393,25 @@ export const filterOrFail = dual<
   <A, E2>(
     f: Predicate.Predicate<A>,
     orFailWith: (a: A) => E2
-  ) => <R, E>(self: Client.Client<R, E, A>) => Client.Client<R, E2 | E, A>,
-  <R, E, A, E2>(
-    self: Client.Client<R, E, A>,
+  ) => <E, R>(self: Client.Client<A, E, R>) => Client.Client<A, E2 | E, R>,
+  <A, E, R, E2>(
+    self: Client.Client<A, E, R>,
     f: Predicate.Predicate<A>,
     orFailWith: (a: A) => E2
-  ) => Client.Client<R, E2 | E, A>
+  ) => Client.Client<A, E2 | E, R>
 >(3, (self, f, orFailWith) => transformResponse(self, Effect.filterOrFail(f, orFailWith)))
 
 /** @internal */
 export const filterStatus = dual<
   (
     f: (status: number) => boolean
-  ) => <R, E>(
-    self: Client.Client.WithResponse<R, E>
-  ) => Client.Client.WithResponse<R, E | Error.ResponseError>,
-  <R, E>(
-    self: Client.Client.WithResponse<R, E>,
+  ) => <E, R>(
+    self: Client.Client.WithResponse<E, R>
+  ) => Client.Client.WithResponse<E | Error.ResponseError, R>,
+  <E, R>(
+    self: Client.Client.WithResponse<E, R>,
     f: (status: number) => boolean
-  ) => Client.Client.WithResponse<R, E | Error.ResponseError>
+  ) => Client.Client.WithResponse<E | Error.ResponseError, R>
 >(2, (self, f) =>
   transform(self, (effect, request) =>
     Effect.filterOrFail(
@@ -427,9 +427,9 @@ export const filterStatus = dual<
     )))
 
 /** @internal */
-export const filterStatusOk: <R, E>(
-  self: Client.Client.WithResponse<R, E>
-) => Client.Client.WithResponse<R, E | Error.ResponseError> = filterStatus(
+export const filterStatusOk: <E, R>(
+  self: Client.Client.WithResponse<E, R>
+) => Client.Client.WithResponse<E | Error.ResponseError, R> = filterStatus(
   (status) => status >= 200 && status < 300
 )
 
@@ -437,49 +437,49 @@ export const filterStatusOk: <R, E>(
 export const map = dual<
   <A, B>(
     f: (a: A) => B
-  ) => <R, E>(self: Client.Client<R, E, A>) => Client.Client<R, E, B>,
-  <R, E, A, B>(
-    self: Client.Client<R, E, A>,
+  ) => <E, R>(self: Client.Client<A, E, R>) => Client.Client<B, E, R>,
+  <A, E, R, B>(
+    self: Client.Client<A, E, R>,
     f: (a: A) => B
-  ) => Client.Client<R, E, B>
+  ) => Client.Client<B, E, R>
 >(2, (self, f) => transformResponse(self, Effect.map(f)))
 
 /** @internal */
 export const mapEffect = dual<
   <A, R2, E2, B>(
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ) => <R, E>(self: Client.Client<R, E, A>) => Client.Client<R | R2, E | E2, B>,
-  <R, E, A, R2, E2, B>(
-    self: Client.Client<R, E, A>,
+  ) => <E, R>(self: Client.Client<A, E, R>) => Client.Client<B, E | E2, R | R2>,
+  <A, E, R, R2, E2, B>(
+    self: Client.Client<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ) => Client.Client<R | R2, E | E2, B>
+  ) => Client.Client<B, E | E2, R | R2>
 >(2, (self, f) => transformResponse(self, Effect.flatMap(f)))
 
 /** @internal */
-export const scoped = <R, E, A>(
-  self: Client.Client<R, E, A>
-): Client.Client<Exclude<R, Scope.Scope>, E, A> => transformResponse(self, Effect.scoped)
+export const scoped = <A, E, R>(
+  self: Client.Client<A, E, R>
+): Client.Client<A, E, Exclude<R, Scope.Scope>> => transformResponse(self, Effect.scoped)
 
 /** @internal */
 export const mapEffectScoped = dual<
   <A, R2, E2, B>(
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ) => <R, E>(self: Client.Client<R, E, A>) => Client.Client<Exclude<R | R2, Scope.Scope>, E | E2, B>,
-  <R, E, A, R2, E2, B>(
-    self: Client.Client<R, E, A>,
+  ) => <E, R>(self: Client.Client<A, E, R>) => Client.Client<B, E | E2, Exclude<R | R2, Scope.Scope>>,
+  <A, E, R, R2, E2, B>(
+    self: Client.Client<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
-  ) => Client.Client<Exclude<R | R2, Scope.Scope>, E | E2, B>
+  ) => Client.Client<B, E | E2, Exclude<R | R2, Scope.Scope>>
 >(2, (self, f) => scoped(mapEffect(self, f)))
 
 /** @internal */
 export const mapRequest = dual<
   (
     f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest
-  ) => <R, E, A>(self: Client.Client<R, E, A>) => Client.Client<R, E, A>,
-  <R, E, A>(
-    self: Client.Client<R, E, A>,
+  ) => <A, E, R>(self: Client.Client<A, E, R>) => Client.Client<A, E, R>,
+  <A, E, R>(
+    self: Client.Client<A, E, R>,
     f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest
-  ) => Client.Client<R, E, A>
+  ) => Client.Client<A, E, R>
 >(2, (self, f) => make(self.execute, (request) => Effect.map(self.preprocess(request), f)))
 
 /** @internal */
@@ -488,26 +488,26 @@ export const mapRequestEffect = dual<
     f: (
       a: ClientRequest.ClientRequest
     ) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ) => <R, E, A>(
-    self: Client.Client<R, E, A>
-  ) => Client.Client<R | R2, E | E2, A>,
-  <R, E, A, R2, E2>(
-    self: Client.Client<R, E, A>,
+  ) => <A, E, R>(
+    self: Client.Client<A, E, R>
+  ) => Client.Client<A, E | E2, R | R2>,
+  <A, E, R, R2, E2>(
+    self: Client.Client<A, E, R>,
     f: (
       a: ClientRequest.ClientRequest
     ) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ) => Client.Client<R | R2, E | E2, A>
+  ) => Client.Client<A, E | E2, R | R2>
 >(2, (self, f) => make(self.execute as any, (request) => Effect.flatMap(self.preprocess(request), f)))
 
 /** @internal */
 export const mapInputRequest = dual<
   (
     f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest
-  ) => <R, E, A>(self: Client.Client<R, E, A>) => Client.Client<R, E, A>,
-  <R, E, A>(
-    self: Client.Client<R, E, A>,
+  ) => <A, E, R>(self: Client.Client<A, E, R>) => Client.Client<A, E, R>,
+  <A, E, R>(
+    self: Client.Client<A, E, R>,
     f: (a: ClientRequest.ClientRequest) => ClientRequest.ClientRequest
-  ) => Client.Client<R, E, A>
+  ) => Client.Client<A, E, R>
 >(2, (self, f) => make(self.execute, (request) => self.preprocess(f(request))))
 
 /** @internal */
@@ -516,47 +516,47 @@ export const mapInputRequestEffect = dual<
     f: (
       a: ClientRequest.ClientRequest
     ) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ) => <R, E, A>(
-    self: Client.Client<R, E, A>
-  ) => Client.Client<R | R2, E | E2, A>,
-  <R, E, A, R2, E2>(
-    self: Client.Client<R, E, A>,
+  ) => <A, E, R>(
+    self: Client.Client<A, E, R>
+  ) => Client.Client<A, E | E2, R | R2>,
+  <A, E, R, R2, E2>(
+    self: Client.Client<A, E, R>,
     f: (
       a: ClientRequest.ClientRequest
     ) => Effect.Effect<ClientRequest.ClientRequest, E2, R2>
-  ) => Client.Client<R | R2, E | E2, A>
+  ) => Client.Client<A, E | E2, R | R2>
 >(2, (self, f) => make(self.execute as any, (request) => Effect.flatMap(f(request), self.preprocess)))
 
 /** @internal */
 export const retry: {
   <R1, E extends E0, E0, B>(
     policy: Schedule.Schedule<B, E0, R1>
-  ): <R, A>(self: Client.Client<R, E, A>) => Client.Client<R1 | R, E, A>
-  <R, E extends E0, E0, A, R1, B>(
-    self: Client.Client<R, E, A>,
+  ): <A, R>(self: Client.Client<A, E, R>) => Client.Client<A, E, R1 | R>
+  <A, E extends E0, E0, R, R1, B>(
+    self: Client.Client<A, E, R>,
     policy: Schedule.Schedule<B, E0, R1>
-  ): Client.Client<R | R1, E, A>
+  ): Client.Client<A, E, R | R1>
 } = dual(
   2,
-  <R, E extends E0, E0, A, R1, B>(
-    self: Client.Client<R, E, A>,
+  <A, E extends E0, E0, R, R1, B>(
+    self: Client.Client<A, E, R>,
     policy: Schedule.Schedule<B, E0, R1>
-  ): Client.Client<R | R1, E, A> => transformResponse(self, Effect.retry(policy))
+  ): Client.Client<A, E, R | R1> => transformResponse(self, Effect.retry(policy))
 )
 
 /** @internal */
 export const schemaFunction = dual<
   <SA, SI, SR>(
     schema: Schema.Schema<SA, SI, SR>
-  ) => <R, E, A>(
-    self: Client.Client<R, E, A>
+  ) => <A, E, R>(
+    self: Client.Client<A, E, R>
   ) => (
     request: ClientRequest.ClientRequest
   ) => (
     a: SA
   ) => Effect.Effect<A, E | ParseResult.ParseError | Error.RequestError, SR | R>,
-  <R, E, A, SA, SI, SR>(
-    self: Client.Client<R, E, A>,
+  <A, E, R, SA, SI, SR>(
+    self: Client.Client<A, E, R>,
     schema: Schema.Schema<SA, SI, SR>
   ) => (
     request: ClientRequest.ClientRequest
@@ -590,22 +590,22 @@ export const schemaFunction = dual<
 export const tap = dual<
   <A, R2, E2, _>(
     f: (a: A) => Effect.Effect<_, E2, R2>
-  ) => <R, E>(self: Client.Client<R, E, A>) => Client.Client<R | R2, E | E2, A>,
-  <R, E, A, R2, E2, _>(
-    self: Client.Client<R, E, A>,
+  ) => <E, R>(self: Client.Client<A, E, R>) => Client.Client<A, E | E2, R | R2>,
+  <A, E, R, R2, E2, _>(
+    self: Client.Client<A, E, R>,
     f: (a: A) => Effect.Effect<_, E2, R2>
-  ) => Client.Client<R | R2, E | E2, A>
+  ) => Client.Client<A, E | E2, R | R2>
 >(2, (self, f) => transformResponse(self, Effect.tap(f)))
 
 /** @internal */
 export const tapRequest = dual<
   <R2, E2, _>(
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<_, E2, R2>
-  ) => <R, E, A>(
-    self: Client.Client<R, E, A>
-  ) => Client.Client<R | R2, E | E2, A>,
-  <R, E, A, R2, E2, _>(
-    self: Client.Client<R, E, A>,
+  ) => <A, E, R>(
+    self: Client.Client<A, E, R>
+  ) => Client.Client<A, E | E2, R | R2>,
+  <A, E, R, R2, E2, _>(
+    self: Client.Client<A, E, R>,
     f: (a: ClientRequest.ClientRequest) => Effect.Effect<_, E2, R2>
-  ) => Client.Client<R | R2, E | E2, A>
+  ) => Client.Client<A, E | E2, R | R2>
 >(2, (self, f) => make(self.execute as any, (request) => Effect.tap(self.preprocess(request), f)))

--- a/packages/platform/src/internal/http/multiplex.ts
+++ b/packages/platform/src/internal/http/multiplex.ts
@@ -12,9 +12,9 @@ import type * as ServerResponse from "../../Http/ServerResponse.js"
 /** @internal */
 export const TypeId: Multiplex.TypeId = Symbol.for("@effect/platform/Http/Multiplex") as Multiplex.TypeId
 
-class MultiplexImpl<R, E>
+class MultiplexImpl<E = never, R = never>
   extends Effectable.Class<ServerResponse.ServerResponse, E | Error.RouteNotFound, R | ServerRequest.ServerRequest>
-  implements Multiplex.Multiplex<R, E>
+  implements Multiplex.Multiplex<E, R>
 {
   readonly [TypeId]: Multiplex.TypeId
 
@@ -22,14 +22,14 @@ class MultiplexImpl<R, E>
     readonly apps: ReadonlyArray<
       readonly [
         predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E, R>,
-        app: App.Default<R, E>
+        app: App.Default<E, R>
       ]
     >
   ) {
     super()
     this[TypeId] = TypeId
 
-    let execute: (request: ServerRequest.ServerRequest) => App.Default<R, E | Error.RouteNotFound> = (request) =>
+    let execute: (request: ServerRequest.ServerRequest) => App.Default<E | Error.RouteNotFound, R> = (request) =>
       Effect.fail(new Error.RouteNotFound({ request }))
 
     for (let i = apps.length - 1; i >= 0; i--) {
@@ -45,7 +45,7 @@ class MultiplexImpl<R, E>
     this.execute = Effect.flatMap(ServerRequest.ServerRequest, execute)
   }
 
-  execute: App.Default<R, E | Error.RouteNotFound>
+  execute: App.Default<E | Error.RouteNotFound, R>
 
   commit() {
     return this.execute
@@ -65,26 +65,26 @@ class MultiplexImpl<R, E>
 }
 
 /** @internal */
-export const empty: Multiplex.Multiplex<never, never> = new MultiplexImpl([])
+export const empty: Multiplex.Multiplex<never> = new MultiplexImpl([])
 
 /** @internal */
 export const make = <R, E>(
   apps: Iterable<
-    readonly [predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E, R>, app: App.Default<R, E>]
+    readonly [predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E, R>, app: App.Default<E, R>]
   >
-): Multiplex.Multiplex<R, E> => new MultiplexImpl(ReadonlyArray.fromIterable(apps))
+): Multiplex.Multiplex<E, R> => new MultiplexImpl(ReadonlyArray.fromIterable(apps))
 
 /** @internal */
 export const add = dual<
   <R2, E2, R3, E3>(
     predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E2, R2>,
-    app: App.Default<R3, E3>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2 | R3, E | E2 | E3>,
+    app: App.Default<E3, R3>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2 | E3, R | R2 | R3>,
   <R, E, R2, E2, R3, E3>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     predicate: (request: ServerRequest.ServerRequest) => Effect.Effect<boolean, E2, R2>,
-    app: App.Default<R3, E3>
-  ) => Multiplex.Multiplex<R | R2 | R3, E | E2 | E3>
+    app: App.Default<E3, R3>
+  ) => Multiplex.Multiplex<E | E2 | E3, R | R2 | R3>
 >(
   3,
   (self, predicate, app) =>
@@ -99,14 +99,14 @@ export const headerExact = dual<
   <R2, E2>(
     header: string,
     value: string,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     header: string,
     value: string,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(
   4,
   (self, header, value, app) =>
@@ -121,14 +121,14 @@ export const headerRegex = dual<
   <R2, E2>(
     header: string,
     regex: RegExp,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     header: string,
     regex: RegExp,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(
   4,
   (self, header, regex, app) =>
@@ -143,14 +143,14 @@ export const headerStartsWith = dual<
   <R2, E2>(
     header: string,
     prefix: string,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     header: string,
     prefix: string,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(
   4,
   (self, header, prefix, app) =>
@@ -165,14 +165,14 @@ export const headerEndsWith = dual<
   <R2, E2>(
     header: string,
     suffix: string,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     header: string,
     suffix: string,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(
   4,
   (self, header, suffix, app) =>
@@ -186,50 +186,50 @@ export const headerEndsWith = dual<
 export const hostRegex = dual<
   <R2, E2>(
     regex: RegExp,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     regex: RegExp,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(3, (self, regex, app) => headerRegex(self, "host", regex, app))
 
 /** @internal */
 export const hostStartsWith = dual<
   <R2, E2>(
     prefix: string,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     prefix: string,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(3, (self, prefix, app) => headerStartsWith(self, "host", prefix, app))
 
 /** @internal */
 export const hostEndsWith = dual<
   <R2, E2>(
     suffix: string,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     suffix: string,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(3, (self, suffix, app) => headerEndsWith(self, "host", suffix, app))
 
 /** @internal */
 export const hostExact = dual<
   <R2, E2>(
     host: string,
-    app: App.Default<R2, E2>
-  ) => <R, E>(self: Multiplex.Multiplex<R, E>) => Multiplex.Multiplex<R | R2, E | E2>,
+    app: App.Default<E2, R2>
+  ) => <R, E>(self: Multiplex.Multiplex<E, R>) => Multiplex.Multiplex<E | E2, R | R2>,
   <R, E, R2, E2>(
-    self: Multiplex.Multiplex<R, E>,
+    self: Multiplex.Multiplex<E, R>,
     host: string,
-    app: App.Default<R2, E2>
-  ) => Multiplex.Multiplex<R | R2, E | E2>
+    app: App.Default<E2, R2>
+  ) => Multiplex.Multiplex<E | E2, R | R2>
 >(3, (self, host, app) => headerExact(self, "host", host, app))

--- a/packages/platform/src/internal/http/router.ts
+++ b/packages/platform/src/internal/http/router.ts
@@ -56,18 +56,18 @@ export const schemaSearchParams = <R, I extends Readonly<Record<string, string>>
   return Effect.flatMap(RouteContext, (_) => parse(_.searchParams))
 }
 
-class RouterImpl<R, E> extends Effectable.StructuralClass<
+class RouterImpl<E = never, R = never> extends Effectable.StructuralClass<
   ServerResponse.ServerResponse,
   E | Error.RouteNotFound,
   Exclude<R, Router.RouteContext>
-> implements Router.Router<R, E> {
+> implements Router.Router<E, R> {
   readonly [TypeId]: Router.TypeId
   constructor(
-    readonly routes: Chunk.Chunk<Router.Route<R, E>>,
+    readonly routes: Chunk.Chunk<Router.Route<E, R>>,
     readonly mounts: Chunk.Chunk<
       readonly [
         prefix: string,
-        httpApp: App.Default<R, E>,
+        httpApp: App.Default<E, R>,
         options?: { readonly includePrefix?: boolean | undefined } | undefined
       ]
     >
@@ -101,9 +101,9 @@ class RouterImpl<R, E> extends Effectable.StructuralClass<
 }
 
 const toHttpApp = <R, E>(
-  self: Router.Router<R, E>
-): App.Default<R, E | Error.RouteNotFound> => {
-  const router = FindMyWay.make<Router.Route<R, E>>()
+  self: Router.Router<E, R>
+): App.Default<E | Error.RouteNotFound, R> => {
+  const router = FindMyWay.make<Router.Route<E, R>>()
   const mounts = Chunk.toReadonlyArray(self.mounts).map(([path, app, options]) =>
     [
       path,
@@ -130,14 +130,14 @@ const toHttpApp = <R, E>(
   })
   return Effect.flatMap(
     ServerRequest.ServerRequest,
-    (request): App.Default<R, E | Error.RouteNotFound> => {
+    (request): App.Default<E | Error.RouteNotFound, R> => {
       if (mountsLen > 0) {
         for (let i = 0; i < mountsLen; i++) {
           const [path, context, options] = mounts[i]
           if (request.url.startsWith(path)) {
             return Effect.provideService(
               Effect.provideService(
-                context.route.handler as App.Default<R, E>,
+                context.route.handler as App.Default<E, R>,
                 RouteContext,
                 context
               ),
@@ -179,7 +179,7 @@ function sliceRequestUrl(request: ServerRequest.ServerRequest, prefix: string) {
   return request.modify({ url: request.url.length <= prefexLen ? "/" : request.url.slice(prefexLen) })
 }
 
-class RouteImpl<R, E> extends Inspectable.Class implements Router.Route<R, E> {
+class RouteImpl<E = never, R = never> extends Inspectable.Class implements Router.Route<E, R> {
   readonly [RouteTypeId]: Router.RouteTypeId
   constructor(
     readonly method: Method.Method | "*",
@@ -212,14 +212,14 @@ class RouteContextImpl implements Router.RouteContext {
 }
 
 /** @internal */
-export const empty: Router.Router<never, never> = new RouterImpl(Chunk.empty(), Chunk.empty())
+export const empty: Router.Router<never> = new RouterImpl(Chunk.empty(), Chunk.empty())
 
 /** @internal */
 export const fromIterable = <R extends Router.Route<any, any>>(
   routes: Iterable<R>
 ): Router.Router<
-  R extends Router.Route<infer Env, infer _> ? Env : never,
-  R extends Router.Route<infer _, infer E> ? E : never
+  R extends Router.Route<infer E, infer _> ? E : never,
+  R extends Router.Route<infer _, infer Env> ? Env : never
 > => new RouterImpl(Chunk.fromIterable(routes), Chunk.empty()) as any
 
 /** @internal */
@@ -228,12 +228,12 @@ export const makeRoute = <R, E>(
   path: Router.PathInput,
   handler: Router.Route.Handler<R, E>,
   prefix: Option.Option<string> = Option.none()
-): Router.Route<Router.Router.ExcludeProvided<R>, E> => new RouteImpl(method, path, handler, prefix) as any
+): Router.Route<E, Router.Router.ExcludeProvided<R>> => new RouteImpl(method, path, handler, prefix) as any
 
 /** @internal */
 export const concat = dual<
-  <R1, E1>(that: Router.Router<R1, E1>) => <R, E>(self: Router.Router<R, E>) => Router.Router<R | R1, E | E1>,
-  <R, E, R1, E1>(self: Router.Router<R, E>, that: Router.Router<R1, E1>) => Router.Router<R | R1, E | E1>
+  <R1, E1>(that: Router.Router<E1, R1>) => <R, E>(self: Router.Router<E, R>) => Router.Router<E | E1, R | R1>,
+  <R, E, R1, E1>(self: Router.Router<E, R>, that: Router.Router<E1, R1>) => Router.Router<E | E1, R | R1>
 >(2, (self, that) => new RouterImpl(Chunk.appendAll(self.routes, that.routes) as any, self.mounts))
 
 const removeTrailingSlash = (
@@ -242,8 +242,8 @@ const removeTrailingSlash = (
 
 /** @internal */
 export const prefixAll = dual<
-  (prefix: Router.PathInput) => <R, E>(self: Router.Router<R, E>) => Router.Router<R, E>,
-  <R, E>(self: Router.Router<R, E>, prefix: Router.PathInput) => Router.Router<R, E>
+  (prefix: Router.PathInput) => <R, E>(self: Router.Router<E, R>) => Router.Router<E, R>,
+  <R, E>(self: Router.Router<E, R>, prefix: Router.PathInput) => Router.Router<E, R>
 >(
   2,
   (self, prefix) => {
@@ -268,13 +268,13 @@ export const prefixAll = dual<
 export const mount = dual<
   <R1, E1>(
     path: `/${string}`,
-    that: Router.Router<R1, E1>
-  ) => <R, E>(self: Router.Router<R, E>) => Router.Router<R | R1, E | E1>,
+    that: Router.Router<E1, R1>
+  ) => <R, E>(self: Router.Router<E, R>) => Router.Router<E | E1, R | R1>,
   <R, E, R1, E1>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     path: `/${string}`,
-    that: Router.Router<R1, E1>
-  ) => Router.Router<R | R1, E | E1>
+    that: Router.Router<E1, R1>
+  ) => Router.Router<E | E1, R | R1>
 >(
   3,
   (self, path, that) => concat(self, prefixAll(that, path))
@@ -284,31 +284,31 @@ export const mount = dual<
 export const mountApp = dual<
   <R1, E1>(
     path: `/${string}`,
-    that: App.Default<R1, E1>,
+    that: App.Default<E1, R1>,
     options?: {
       readonly includePrefix?: boolean | undefined
     } | undefined
   ) => <R, E>(
-    self: Router.Router<R, E>
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, E | E1>,
+    self: Router.Router<E, R>
+  ) => Router.Router<E | E1, R | Router.Router.ExcludeProvided<R1>>,
   <R, E, R1, E1>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     path: `/${string}`,
-    that: App.Default<R1, E1>,
+    that: App.Default<E1, R1>,
     options?: {
       readonly includePrefix?: boolean | undefined
     } | undefined
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, E | E1>
+  ) => Router.Router<E | E1, R | Router.Router.ExcludeProvided<R1>>
 >(
   (args) => Predicate.hasProperty(args[0], TypeId),
   <R, E, R1, E1>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     path: `/${string}`,
-    that: App.Default<R1, E1>,
+    that: App.Default<E1, R1>,
     options?: {
       readonly includePrefix?: boolean | undefined
     } | undefined
-  ): Router.Router<R | Router.Router.ExcludeProvided<R1>, E | E1> =>
+  ): Router.Router<E | E1, R | Router.Router.ExcludeProvided<R1>> =>
     new RouterImpl<any, any>(self.routes, Chunk.append(self.mounts, [removeTrailingSlash(path), that, options])) as any
 )
 
@@ -318,26 +318,26 @@ export const route = (method: Method.Method | "*"): {
     path: Router.PathInput,
     handler: Router.Route.Handler<R1, E1>
   ): <R, E>(
-    self: Router.Router<R, E>
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, E1 | E>
+    self: Router.Router<E, R>
+  ) => Router.Router<E1 | E, R | Router.Router.ExcludeProvided<R1>>
   <R, E, R1, E1>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     path: Router.PathInput,
     handler: Router.Route.Handler<R1, E1>
-  ): Router.Router<R | Router.Router.ExcludeProvided<R1>, E1 | E>
+  ): Router.Router<E1 | E, R | Router.Router.ExcludeProvided<R1>>
 } =>
   dual<
     <R1, E1>(
       path: Router.PathInput,
       handler: Router.Route.Handler<R1, E1>
     ) => <R, E>(
-      self: Router.Router<R, E>
-    ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, E | E1>,
+      self: Router.Router<E, R>
+    ) => Router.Router<E | E1, R | Router.Router.ExcludeProvided<R1>>,
     <R, E, R1, E1>(
-      self: Router.Router<R, E>,
+      self: Router.Router<E, R>,
       path: Router.PathInput,
       handler: Router.Route.Handler<R1, E1>
-    ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, E | E1>
+    ) => Router.Router<E | E1, R | Router.Router.ExcludeProvided<R1>>
   >(3, (self, path, handler) =>
     new RouterImpl<any, any>(
       Chunk.append(self.routes, new RouteImpl(method, path, handler)),
@@ -371,12 +371,12 @@ export const options = route("OPTIONS")
 /** @internal */
 export const use = dual<
   <R, E, R1, E1>(
-    f: (self: Router.Route.Handler<R, E>) => App.Default<R1, E1>
-  ) => (self: Router.Router<R, E>) => Router.Router<Router.Router.ExcludeProvided<R1>, E1>,
+    f: (self: Router.Route.Handler<R, E>) => App.Default<E1, R1>
+  ) => (self: Router.Router<E, R>) => Router.Router<E1, Router.Router.ExcludeProvided<R1>>,
   <R, E, R1, E1>(
-    self: Router.Router<R, E>,
-    f: (self: Router.Route.Handler<R, E>) => App.Default<R1, E1>
-  ) => Router.Router<Router.Router.ExcludeProvided<R1>, E1>
+    self: Router.Router<E, R>,
+    f: (self: Router.Route.Handler<R, E>) => App.Default<E1, R1>
+  ) => Router.Router<E1, Router.Router.ExcludeProvided<R1>>
 >(2, (self, f) =>
   new RouterImpl<any, any>(
     Chunk.map(
@@ -393,22 +393,22 @@ export const use = dual<
 export const catchAll = dual<
   <E, R2, E2>(
     f: (e: E) => Router.Route.Handler<R2, E2>
-  ) => <R>(self: Router.Router<R, E>) => Router.Router<R | Router.Router.ExcludeProvided<R2>, E2>,
+  ) => <R>(self: Router.Router<E, R>) => Router.Router<E2, R | Router.Router.ExcludeProvided<R2>>,
   <R, E, R2, E2>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     f: (e: E) => Router.Route.Handler<R2, E2>
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R2>, E2>
+  ) => Router.Router<E2, R | Router.Router.ExcludeProvided<R2>>
 >(2, (self, f) => use(self, Effect.catchAll(f)))
 
 /** @internal */
 export const catchAllCause = dual<
   <E, R2, E2>(
     f: (e: Cause.Cause<E>) => Router.Route.Handler<R2, E2>
-  ) => <R>(self: Router.Router<R, E>) => Router.Router<R | Router.Router.ExcludeProvided<R2>, E2>,
+  ) => <R>(self: Router.Router<E, R>) => Router.Router<E2, R | Router.Router.ExcludeProvided<R2>>,
   <R, E, R2, E2>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     f: (e: Cause.Cause<E>) => Router.Route.Handler<R2, E2>
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R2>, E2>
+  ) => Router.Router<E2, R | Router.Router.ExcludeProvided<R2>>
 >(2, (self, f) => use(self, Effect.catchAllCause(f)))
 
 /** @internal */
@@ -417,13 +417,13 @@ export const catchTag = dual<
     k: K,
     f: (e: Extract<E, { _tag: K }>) => Router.Route.Handler<R1, E1>
   ) => <R>(
-    self: Router.Router<R, E>
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, Exclude<E, { _tag: K }> | E1>,
+    self: Router.Router<E, R>
+  ) => Router.Router<Exclude<E, { _tag: K }> | E1, R | Router.Router.ExcludeProvided<R1>>,
   <R, E, K extends (E extends { _tag: string } ? E["_tag"] : never), R1, E1>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     k: K,
     f: (e: Extract<E, { _tag: K }>) => Router.Route.Handler<R1, E1>
-  ) => Router.Router<R | Router.Router.ExcludeProvided<R1>, Exclude<E, { _tag: K }> | E1>
+  ) => Router.Router<Exclude<E, { _tag: K }> | E1, R | Router.Router.ExcludeProvided<R1>>
 >(3, (self, k, f) => use(self, Effect.catchTag(k, f)))
 
 /** @internal */
@@ -436,17 +436,17 @@ export const catchTags: {
       {})
   >(
     cases: Cases
-  ): <R>(self: Router.Router<R, E>) => Router.Router<
+  ): <R>(self: Router.Router<E, R>) => Router.Router<
+    | Exclude<E, { _tag: keyof Cases }>
+    | {
+      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
+    }[keyof Cases],
     | R
     | Router.Router.ExcludeProvided<
       {
         [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, any, infer R>) ? R : never
       }[keyof Cases]
-    >,
-    | Exclude<E, { _tag: keyof Cases }>
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
-    }[keyof Cases]
+    >
   >
   <
     R,
@@ -456,19 +456,19 @@ export const catchTags: {
       } :
       {})
   >(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     cases: Cases
   ): Router.Router<
+    | Exclude<E, { _tag: keyof Cases }>
+    | {
+      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
+    }[keyof Cases],
     | R
     | Router.Router.ExcludeProvided<
       {
         [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, any, infer R>) ? R : never
       }[keyof Cases]
-    >,
-    | Exclude<E, { _tag: keyof Cases }>
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
-    }[keyof Cases]
+    >
   >
 } = dual(2, (self: Router.Router<any, any>, cases: {}) => use(self, Effect.catchTags(cases)))
 
@@ -477,18 +477,18 @@ export const provideService = dual<
     tag: T,
     service: Context.Tag.Service<T>
   ) => <R, E>(
-    self: Router.Router<R, E>
-  ) => Router.Router<Exclude<R, Context.Tag.Identifier<T>>, E>,
+    self: Router.Router<E, R>
+  ) => Router.Router<E, Exclude<R, Context.Tag.Identifier<T>>>,
   <R, E, T extends Context.Tag<any, any>>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     tag: T,
     service: Context.Tag.Service<T>
-  ) => Router.Router<Exclude<R, Context.Tag.Identifier<T>>, E>
+  ) => Router.Router<E, Exclude<R, Context.Tag.Identifier<T>>>
 >(3, <R, E, T extends Context.Tag<any, any>>(
-  self: Router.Router<R, E>,
+  self: Router.Router<E, R>,
   tag: T,
   service: Context.Tag.Service<T>
-): Router.Router<Exclude<R, Context.Tag.Identifier<T>>, E> => use(self, Effect.provideService(tag, service)))
+): Router.Router<E, Exclude<R, Context.Tag.Identifier<T>>> => use(self, Effect.provideService(tag, service)))
 
 /* @internal */
 export const provideServiceEffect = dual<
@@ -496,33 +496,33 @@ export const provideServiceEffect = dual<
     tag: T,
     effect: Effect.Effect<Context.Tag.Service<T>, E1, R1>
   ) => <R, E>(
-    self: Router.Router<R, E>
+    self: Router.Router<E, R>
   ) => Router.Router<
+    E | E1,
     Exclude<
       R | Router.Router.ExcludeProvided<R1>,
       Context.Tag.Identifier<T>
-    >,
-    E | E1
+    >
   >,
   <R, E, T extends Context.Tag<any, any>, R1, E1>(
-    self: Router.Router<R, E>,
+    self: Router.Router<E, R>,
     tag: T,
     effect: Effect.Effect<Context.Tag.Service<T>, E1, R1>
   ) => Router.Router<
+    E | E1,
     Exclude<
       R | Router.Router.ExcludeProvided<R1>,
       Context.Tag.Identifier<T>
-    >,
-    E | E1
+    >
   >
 >(3, <R, E, T extends Context.Tag<any, any>, R1, E1>(
-  self: Router.Router<R, E>,
+  self: Router.Router<E, R>,
   tag: T,
   effect: Effect.Effect<Context.Tag.Service<T>, E1, R1>
 ): Router.Router<
+  E | E1,
   Exclude<
     R | Router.Router.ExcludeProvided<R1>,
     Context.Tag.Identifier<T>
-  >,
-  E | E1
+  >
 > => use(self, Effect.provideServiceEffect(tag, effect)) as any)

--- a/packages/platform/src/internal/http/server.ts
+++ b/packages/platform/src/internal/http/server.ts
@@ -25,7 +25,7 @@ export const isServer = (u: unknown): u is Server.Server => typeof u === "object
 export const make = (
   options: {
     readonly serve: (
-      httpApp: App.Default<never, unknown>,
+      httpApp: App.Default<unknown>,
       middleware?: Middleware.Middleware
     ) => Effect.Effect<void, never, Scope.Scope>
     readonly address: Server.Address
@@ -36,10 +36,10 @@ export const make = (
 export const serve = dual<
   {
     (): <R, E>(
-      httpApp: App.Default<R, E>
+      httpApp: App.Default<E, R>
     ) => Layer.Layer<never, never, Server.Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>>
-    <R, E, App extends App.Default<any, any>>(middleware: Middleware.Middleware.Applied<R, E, App>): (
-      httpApp: App.Default<R, E>
+    <R, E, App extends App.Default<any, any>>(middleware: Middleware.Middleware.Applied<App, E, R>): (
+      httpApp: App.Default<E, R>
     ) => Layer.Layer<
       never,
       never,
@@ -48,11 +48,11 @@ export const serve = dual<
   },
   {
     <R, E>(
-      httpApp: App.Default<R, E>
+      httpApp: App.Default<E, R>
     ): Layer.Layer<never, never, Server.Server | Exclude<R, ServerRequest.ServerRequest | Scope.Scope>>
     <R, E, App extends App.Default<any, any>>(
-      httpApp: App.Default<R, E>,
-      middleware: Middleware.Middleware.Applied<R, E, App>
+      httpApp: App.Default<E, R>,
+      middleware: Middleware.Middleware.Applied<App, E, R>
     ): Layer.Layer<
       never,
       never,
@@ -62,8 +62,8 @@ export const serve = dual<
 >(
   (args) => Effect.isEffect(args[0]),
   <R, E, App extends App.Default<any, any>>(
-    httpApp: App.Default<R, E>,
-    middleware?: Middleware.Middleware.Applied<R, E, App>
+    httpApp: App.Default<E, R>,
+    middleware?: Middleware.Middleware.Applied<App, E, R>
   ): Layer.Layer<
     never,
     never,
@@ -81,14 +81,14 @@ export const serve = dual<
 export const serveEffect = dual<
   {
     (): <R, E>(
-      httpApp: App.Default<R, E>
+      httpApp: App.Default<E, R>
     ) => Effect.Effect<
       void,
       never,
       Server.Server | Scope.Scope | Exclude<R, ServerRequest.ServerRequest>
     >
-    <R, E, App extends App.Default<any, any>>(middleware: Middleware.Middleware.Applied<R, E, App>): (
-      httpApp: App.Default<R, E>
+    <R, E, App extends App.Default<any, any>>(middleware: Middleware.Middleware.Applied<App, E, R>): (
+      httpApp: App.Default<E, R>
     ) => Effect.Effect<
       void,
       never,
@@ -97,11 +97,11 @@ export const serveEffect = dual<
   },
   {
     <R, E>(
-      httpApp: App.Default<R, E>
+      httpApp: App.Default<E, R>
     ): Effect.Effect<void, never, Server.Server | Scope.Scope | Exclude<R, ServerRequest.ServerRequest>>
     <R, E, App extends App.Default<any, any>>(
-      httpApp: App.Default<R, E>,
-      middleware: Middleware.Middleware.Applied<R, E, App>
+      httpApp: App.Default<E, R>,
+      middleware: Middleware.Middleware.Applied<App, E, R>
     ): Effect.Effect<
       void,
       never,
@@ -111,8 +111,8 @@ export const serveEffect = dual<
 >(
   (args) => Effect.isEffect(args[0]),
   (<R, E, App extends App.Default<any, any>>(
-    httpApp: App.Default<R, E>,
-    middleware: Middleware.Middleware.Applied<R, E, App>
+    httpApp: App.Default<E, R>,
+    middleware: Middleware.Middleware.Applied<App, E, R>
   ): Effect.Effect<
     void,
     never,

--- a/packages/platform/src/internal/workerRunner.ts
+++ b/packages/platform/src/internal/workerRunner.ts
@@ -32,7 +32,7 @@ export const PlatformRunner = Context.GenericTag<WorkerRunner.PlatformRunner>(
 /** @internal */
 export const make = <I, R, E, O>(
   process: (request: I) => Stream.Stream<O, E, R> | Effect.Effect<O, E, R>,
-  options?: WorkerRunner.Runner.Options<I, E, O>
+  options?: WorkerRunner.Runner.Options<I, O, E>
 ) =>
   Effect.gen(function*(_) {
     const scope = yield* _(Scope.fork(yield* _(Effect.scope), ExecutionStrategy.parallel))
@@ -170,7 +170,7 @@ export const make = <I, R, E, O>(
 /** @internal */
 export const layer = <I, R, E, O>(
   process: (request: I) => Stream.Stream<O, E, R> | Effect.Effect<O, E, R>,
-  options?: WorkerRunner.Runner.Options<I, E, O>
+  options?: WorkerRunner.Runner.Options<I, O, E>
 ): Layer.Layer<never, WorkerError, WorkerRunner.PlatformRunner | R> => Layer.scopedDiscard(make(process, options))
 
 /** @internal */

--- a/packages/rpc-http/src/HttpRouter.ts
+++ b/packages/rpc-http/src/HttpRouter.ts
@@ -16,8 +16,8 @@ import * as Stream from "effect/Stream"
  * @category conversions
  */
 export const toHttpApp = <R extends Router.Router<any, any>>(self: R): App.Default<
-  Router.Router.Context<R>,
-  ServerError.RequestError
+  ServerError.RequestError,
+  Router.Router.Context<R>
 > => {
   const handler = Router.toHandler(self)
   return Effect.map(
@@ -43,8 +43,8 @@ export const toHttpApp = <R extends Router.Router<any, any>>(self: R): App.Defau
  * @category conversions
  */
 export const toHttpAppEffect = <R extends Router.Router<any, any>>(self: R): App.Default<
-  Router.Router.Context<R>,
-  ServerError.RequestError | ParseError
+  ServerError.RequestError | ParseError,
+  Router.Router.Context<R>
 > => {
   const handler = Router.toHandlerEffect(self)
   return ServerRequest.ServerRequest.pipe(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Following the reverse of Effect's type args, this PR reverses the type args of `@effect/platform/Http`'s ` Client type as well.
I.e.: `Client<R, E,A>` became `Client<A, E, R>`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
