### PR TITLE
passthrough vitest context to test factory

### DIFF
--- a/.changeset/tender-cooks-scream.md
+++ b/.changeset/tender-cooks-scream.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Passthrough vitest context to test factory

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -33,30 +33,29 @@ const TestEnv = TestEnvironment.TestContext.pipe(
 export const effect = (() => {
   const f = <E, A>(
     name: string,
-    self: Effect.Effect<A, E, TestServices.TestServices> | (() => Effect.Effect<A, E, TestServices.TestServices>),
+    self: Effect.Effect<A, E, TestServices.TestServices> | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
     timeout: number | V.TestOptions = 5_000
   ) =>
     it(
       name,
-      () =>
-        pipe(
-          Effect.isEffect(self) ? self : Effect.suspend(self),
-          Effect.provide(TestEnv),
-          Effect.runPromise
-        ),
+      (ctx) => pipe(
+        Effect.isEffect(self) ? self: self(ctx),
+        Effect.provide(TestEnv),
+        Effect.runPromise
+      ),
       timeout
     )
   return Object.assign(f, {
     skip: <E, A>(
       name: string,
-      self: Effect.Effect<A, E, TestServices.TestServices> | (() => Effect.Effect<A, E, TestServices.TestServices>),
+      self: Effect.Effect<A, E, TestServices.TestServices> | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
       timeout = 5_000
     ) =>
       it.skip(
         name,
-        () =>
+        (ctx) =>
           pipe(
-            Effect.isEffect(self) ? self : Effect.suspend(self),
+            Effect.isEffect(self) ? self : self(ctx),
             Effect.provide(TestEnv),
             Effect.runPromise
           ),
@@ -85,14 +84,14 @@ export const effect = (() => {
  */
 export const live = <E, A>(
   name: string,
-  self: Effect.Effect<A, E> | (() => Effect.Effect<A, E>),
+  self: Effect.Effect<A, E> | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E>),
   timeout = 5_000
 ) =>
   it(
     name,
-    () =>
+    (ctx) =>
       pipe(
-        Effect.isEffect(self) ? self : Effect.suspend(self),
+        Effect.isEffect(self) ? self : self(ctx),
         Effect.runPromise
       ),
     timeout
@@ -124,14 +123,14 @@ export const scoped = <E, A>(
   name: string,
   self:
     | Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>
-    | (() => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>),
+    | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>),
   timeout = 5_000
 ) =>
   it(
     name,
-    () =>
+    (ctx) =>
       pipe(
-        Effect.isEffect(self) ? self : Effect.suspend(self),
+        Effect.isEffect(self) ? self : self(ctx),
         Effect.scoped,
         Effect.provide(TestEnv),
         Effect.runPromise
@@ -146,14 +145,14 @@ export const scopedLive = <E, A>(
   name: string,
   self:
     | Effect.Effect<A, E, Scope.Scope>
-    | (() => Effect.Effect<A, E, Scope.Scope>),
+    | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, Scope.Scope>),
   timeout = 5_000
 ) =>
   it(
     name,
-    () =>
+    (ctx) =>
       pipe(
-        Effect.isEffect(self) ? self : Effect.suspend(self),
+        Effect.isEffect(self) ? self : self(ctx),
         Effect.scoped,
         Effect.runPromise
       ),

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -33,16 +33,14 @@ const TestEnv = TestEnvironment.TestContext.pipe(
 export const effect = (() => {
   const f = <E, A>(
     name: string,
-    self:
-      | Effect.Effect<A, E, TestServices.TestServices>
-      | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
+    self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>,
     timeout: number | V.TestOptions = 5_000
   ) =>
     it(
       name,
       (ctx) =>
         pipe(
-          Effect.isEffect(self) ? self : self(ctx),
+          self(ctx),
           Effect.provide(TestEnv),
           Effect.runPromise
         ),
@@ -51,16 +49,14 @@ export const effect = (() => {
   return Object.assign(f, {
     skip: <E, A>(
       name: string,
-      self:
-        | Effect.Effect<A, E, TestServices.TestServices>
-        | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
+      self:(ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>,
       timeout = 5_000
     ) =>
       it.skip(
         name,
         (ctx) =>
           pipe(
-            Effect.isEffect(self) ? self : self(ctx),
+            self(ctx),
             Effect.provide(TestEnv),
             Effect.runPromise
           ),
@@ -68,14 +64,14 @@ export const effect = (() => {
       ),
     only: <E, A>(
       name: string,
-      self: Effect.Effect<A, E, TestServices.TestServices> | (() => Effect.Effect<A, E, TestServices.TestServices>),
+      self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>,
       timeout = 5_000
     ) =>
       it.only(
         name,
-        () =>
+        (ctx) =>
           pipe(
-            Effect.isEffect(self) ? self : Effect.suspend(self),
+            self(ctx),
             Effect.provide(TestEnv),
             Effect.runPromise
           ),
@@ -89,14 +85,14 @@ export const effect = (() => {
  */
 export const live = <E, A>(
   name: string,
-  self: Effect.Effect<A, E> | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E>),
+  self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E>,
   timeout = 5_000
 ) =>
   it(
     name,
     (ctx) =>
       pipe(
-        Effect.isEffect(self) ? self : self(ctx),
+        self(ctx),
         Effect.runPromise
       ),
     timeout
@@ -126,18 +122,16 @@ export const flakyTest = <A, E, R>(
  */
 export const scoped = <E, A>(
   name: string,
-  self:
-    | Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>
-    | ((
+  self:(
       ctx: V.TaskContext<V.Test<{}>> & V.TestContext
-    ) => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>),
+    ) => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>,
   timeout = 5_000
 ) =>
   it(
     name,
     (ctx) =>
       pipe(
-        Effect.isEffect(self) ? self : self(ctx),
+        self(ctx),
         Effect.scoped,
         Effect.provide(TestEnv),
         Effect.runPromise
@@ -150,16 +144,14 @@ export const scoped = <E, A>(
  */
 export const scopedLive = <E, A>(
   name: string,
-  self:
-    | Effect.Effect<A, E, Scope.Scope>
-    | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, Scope.Scope>),
+  self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, Scope.Scope>,
   timeout = 5_000
 ) =>
   it(
     name,
     (ctx) =>
       pipe(
-        Effect.isEffect(self) ? self : self(ctx),
+        self(ctx),
         Effect.scoped,
         Effect.runPromise
       ),

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -33,22 +33,27 @@ const TestEnv = TestEnvironment.TestContext.pipe(
 export const effect = (() => {
   const f = <E, A>(
     name: string,
-    self: Effect.Effect<A, E, TestServices.TestServices> | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
+    self:
+      | Effect.Effect<A, E, TestServices.TestServices>
+      | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
     timeout: number | V.TestOptions = 5_000
   ) =>
     it(
       name,
-      (ctx) => pipe(
-        Effect.isEffect(self) ? self: self(ctx),
-        Effect.provide(TestEnv),
-        Effect.runPromise
-      ),
+      (ctx) =>
+        pipe(
+          Effect.isEffect(self) ? self : self(ctx),
+          Effect.provide(TestEnv),
+          Effect.runPromise
+        ),
       timeout
     )
   return Object.assign(f, {
     skip: <E, A>(
       name: string,
-      self: Effect.Effect<A, E, TestServices.TestServices> | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
+      self:
+        | Effect.Effect<A, E, TestServices.TestServices>
+        | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>),
       timeout = 5_000
     ) =>
       it.skip(
@@ -123,7 +128,9 @@ export const scoped = <E, A>(
   name: string,
   self:
     | Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>
-    | ((ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>),
+    | ((
+      ctx: V.TaskContext<V.Test<{}>> & V.TestContext
+    ) => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>),
   timeout = 5_000
 ) =>
   it(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This will passthrough vitest context into test factory function, so test-scoped assertions can be used:
```
it.effect(`Global expect can't be used here`, ({ expect }) =>  Effect.gen(function* ($) {
   expect.assertions(1)
   // Code that does condition-based assertions
})
```
If using expect.assertions from global vitest scope, test result above might be interfered by other tests, using expect.assertions, running simultaneously

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
