### PR TITLE
Schema: extend should un-nest sub-unions

### DIFF
--- a/.changeset/many-readers-promise.md
+++ b/.changeset/many-readers-promise.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+extend: un-nest sub-unions

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1345,15 +1345,9 @@ const literalMap = {
   bigint: "BigIntKeyword"
 } as const
 
-const flatten = (candidates: ReadonlyArray<AST>): Array<AST> =>
-  ReadonlyArray.flatMap(candidates, (ast: AST) => {
-    switch (ast._tag) {
-      case "Union":
-        return ast.types
-      default:
-        return [ast]
-    }
-  })
+/** @internal */
+export const flatten = (candidates: ReadonlyArray<AST>): Array<AST> =>
+  ReadonlyArray.flatMap(candidates, (ast) => isUnion(ast) ? flatten(ast.types) : [ast])
 
 /** @internal */
 export const unify = (candidates: ReadonlyArray<AST>): Array<AST> => {

--- a/packages/schema/test/AST/Union.test.ts
+++ b/packages/schema/test/AST/Union.test.ts
@@ -3,7 +3,12 @@ import * as S from "@effect/schema/Schema"
 import { describe, expect, it } from "vitest"
 
 describe("AST.Union", () => {
-  it("should remove never from members", () => {
+  it("flatten should un-nest union members", () => {
+    const asts = AST.flatten([S.union(S.literal("a", "b"), S.literal("c", "d")).ast])
+    expect(asts.length).toBe(4)
+  })
+
+  it("make should remove never from members", () => {
     expect(AST.Union.make([AST.neverKeyword, AST.neverKeyword])).toEqual(
       AST.neverKeyword
     )
@@ -34,7 +39,7 @@ describe("AST.Union", () => {
     expect(String(schema)).toStrictEqual("<suspended schema>")
   })
 
-  it("description for nested unions", () => {
+  it("descriptions of nested unions should be preserved", () => {
     const u = S.union(S.string, S.number)
     const nested1 = u.annotations({ identifier: "nested1" })
     const nested2 = u.annotations({ identifier: "nested2" })

--- a/packages/schema/test/Schema/extend.test.ts
+++ b/packages/schema/test/Schema/extend.test.ts
@@ -1,3 +1,4 @@
+import * as AST from "@effect/schema/AST"
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 import { describe, expect, it } from "vitest"
@@ -115,7 +116,7 @@ describe("Schema > extend", () => {
       expect(is({ a: "b" })).toBe(false)
     })
 
-    it(`union extend on nested union`, () => {
+    it(`nested union extends struct`, () => {
       const schema = S.union(
         S.union(
           S.struct({ a: S.literal("a") }),
@@ -125,6 +126,11 @@ describe("Schema > extend", () => {
       ).pipe(
         S.extend(S.struct({ c: S.boolean }))
       )
+      expect(AST.isUnion(schema.ast)).toBe(true)
+      const ast = schema.ast as AST.Union
+      expect(ast.types.length).toBe(3)
+      expect(ast.types.every(AST.isTypeLiteral)).toBe(true)
+
       const is = S.is(schema)
 
       expect(is({ a: "a", c: false })).toBe(true)


### PR DESCRIPTION
@sukovanej RE `extend`, since we're creating a new union I think we should take advantage of it to unnest the sub-unions.