### PR TITLE
Add Config.duration

### DIFF
--- a/.changeset/curvy-colts-clap.md
+++ b/.changeset/curvy-colts-clap.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add Config.duration

--- a/.changeset/curvy-colts-clap.md
+++ b/.changeset/curvy-colts-clap.md
@@ -3,3 +3,13 @@
 ---
 
 Add Config.duration
+
+This can be used to parse Duration's from environment variables:
+
+```ts
+import { Config, Effect } from "effect"
+
+Config.duration("CACHE_TTL").pipe(
+  Effect.andThen((duration) => ...)
+)
+```

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -3,6 +3,7 @@
  */
 import type * as Chunk from "./Chunk.js"
 import type * as ConfigError from "./ConfigError.js"
+import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import type * as Either from "./Either.js"
 import type { LazyArg } from "./Function.js"
@@ -179,6 +180,14 @@ export const literal: <Literals extends ReadonlyArray<LiteralValue>>(...literals
  * @category constructors
  */
 export const logLevel: (name?: string) => Config<LogLevel.LogLevel> = internal.logLevel
+
+/**
+ * Constructs a config for a duration value.
+ *
+ * @since 2.5.0
+ * @category constructors
+ */
+export const duration: (name?: string) => Config<Duration.Duration> = internal.duration
 
 /**
  * This function returns `true` if the specified value is an `Config` value,

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -131,6 +131,57 @@ export const decode = (input: DurationInput): Duration => {
   throw new Error("Invalid duration input")
 }
 
+/**
+ * @since 2.5.0
+ */
+export const decodeUnknown = (input: unknown): Option.Option<Duration> => {
+  if (isDuration(input)) {
+    return Option.some(input)
+  } else if (isNumber(input)) {
+    return Option.some(millis(input))
+  } else if (isBigInt(input)) {
+    return Option.some(nanos(input))
+  } else if (Array.isArray(input)) {
+    if (input.length === 2 && isNumber(input[0]) && isNumber(input[1])) {
+      return Option.some(nanos(BigInt(input[0]) * bigint1e9 + BigInt(input[1])))
+    }
+  } else if (typeof input === "string") {
+    DURATION_REGEX.lastIndex = 0 // Reset the lastIndex before each use
+    const match = DURATION_REGEX.exec(input)
+    if (match) {
+      const [_, valueStr, unit] = match
+      const value = Number(valueStr)
+      switch (unit) {
+        case "nano":
+        case "nanos":
+          return Option.some(nanos(BigInt(valueStr)))
+        case "micro":
+        case "micros":
+          return Option.some(micros(BigInt(valueStr)))
+        case "milli":
+        case "millis":
+          return Option.some(millis(value))
+        case "second":
+        case "seconds":
+          return Option.some(seconds(value))
+        case "minute":
+        case "minutes":
+          return Option.some(minutes(value))
+        case "hour":
+        case "hours":
+          return Option.some(hours(value))
+        case "day":
+        case "days":
+          return Option.some(days(value))
+        case "week":
+        case "weeks":
+          return Option.some(weeks(value))
+      }
+    }
+  }
+  return Option.none()
+}
+
 const zeroValue: DurationValue = { _tag: "Millis", millis: 0 }
 const infinityValue: DurationValue = { _tag: "Infinity" }
 

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -1,6 +1,7 @@
 import * as Chunk from "../Chunk.js"
 import type * as Config from "../Config.js"
 import * as ConfigError from "../ConfigError.js"
+import * as Duration from "../Duration.js"
 import * as Either from "../Either.js"
 import type { LazyArg } from "../Function.js"
 import { constTrue, dual, pipe } from "../Function.js"
@@ -284,6 +285,15 @@ export const logLevel = (name?: string): Config.Config<LogLevel.LogLevel> => {
     return level === undefined
       ? Either.left(configError.InvalidData([], `Expected a log level but received ${value}`))
       : Either.right(level)
+  })
+  return name === undefined ? config : nested(config, name)
+}
+
+/** @internal */
+export const duration = (name?: string): Config.Config<Duration.Duration> => {
+  const config = mapOrFail(string(), (value) => {
+    const duration = Duration.decodeUnknown(value)
+    return Either.fromOption(duration, () => configError.InvalidData([], `Expected a duration but received ${value}`))
   })
   return name === undefined ? config : nested(config, name)
 }

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -2,6 +2,7 @@ import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import * as ConfigError from "effect/ConfigError"
 import * as ConfigProvider from "effect/ConfigProvider"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
 import * as Exit from "effect/Exit"
@@ -192,6 +193,26 @@ describe("Config", () => {
         config,
         [["LOG_LEVEL", "-"]],
         ConfigError.InvalidData(["LOG_LEVEL"], "Expected a log level but received -")
+      )
+    })
+  })
+
+  describe("duration", () => {
+    it("name = undefined", () => {
+      const config = Config.duration()
+      assertSuccess(config, [["", "10 seconds"]], Duration.decode("10 seconds"))
+
+      assertFailure(config, [["", "-"]], ConfigError.InvalidData([], "Expected a duration but received -"))
+    })
+
+    it("name != undefined", () => {
+      const config = Config.duration("DURATION")
+      assertSuccess(config, [["DURATION", "10 seconds"]], Duration.decode("10 seconds"))
+
+      assertFailure(
+        config,
+        [["DURATION", "-"]],
+        ConfigError.InvalidData(["DURATION"], "Expected a duration but received -")
       )
     })
   })

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -44,6 +44,40 @@ describe("Duration", () => {
     expect(() => Duration.decode("1.5 secs" as any)).toThrowError(new Error("Invalid duration input"))
   })
 
+  it("decodeUnknown", () => {
+    const millis100 = Duration.millis(100)
+    expect(Duration.decodeUnknown(millis100)).toEqual(Option.some(millis100))
+
+    expect(Duration.decodeUnknown(100)).toEqual(Option.some(millis100))
+
+    expect(Duration.decodeUnknown(10n)).toEqual(Option.some(Duration.nanos(10n)))
+
+    expect(Duration.decodeUnknown("1 nano")).toEqual(Option.some(Duration.nanos(1n)))
+    expect(Duration.decodeUnknown("10 nanos")).toEqual(Option.some(Duration.nanos(10n)))
+    expect(Duration.decodeUnknown("1 micro")).toEqual(Option.some(Duration.micros(1n)))
+    expect(Duration.decodeUnknown("10 micros")).toEqual(Option.some(Duration.micros(10n)))
+    expect(Duration.decodeUnknown("1 milli")).toEqual(Option.some(Duration.millis(1)))
+    expect(Duration.decodeUnknown("10 millis")).toEqual(Option.some(Duration.millis(10)))
+    expect(Duration.decodeUnknown("1 second")).toEqual(Option.some(Duration.seconds(1)))
+    expect(Duration.decodeUnknown("10 seconds")).toEqual(Option.some(Duration.seconds(10)))
+    expect(Duration.decodeUnknown("1 minute")).toEqual(Option.some(Duration.minutes(1)))
+    expect(Duration.decodeUnknown("10 minutes")).toEqual(Option.some(Duration.minutes(10)))
+    expect(Duration.decodeUnknown("1 hour")).toEqual(Option.some(Duration.hours(1)))
+    expect(Duration.decodeUnknown("10 hours")).toEqual(Option.some(Duration.hours(10)))
+    expect(Duration.decodeUnknown("1 day")).toEqual(Option.some(Duration.days(1)))
+    expect(Duration.decodeUnknown("10 days")).toEqual(Option.some(Duration.days(10)))
+    expect(Duration.decodeUnknown("1 week")).toEqual(Option.some(Duration.weeks(1)))
+    expect(Duration.decodeUnknown("10 weeks")).toEqual(Option.some(Duration.weeks(10)))
+
+    expect(Duration.decodeUnknown("1.5 seconds")).toEqual(Option.some(Duration.seconds(1.5)))
+    expect(Duration.decodeUnknown("-1.5 seconds")).toEqual(Option.some(Duration.zero))
+
+    expect(Duration.decodeUnknown([500, 123456789])).toEqual(Option.some(Duration.nanos(500123456789n)))
+    expect(Duration.decodeUnknown([-500, 123456789])).toEqual(Option.some(Duration.zero))
+
+    expect(Duration.decodeUnknown("1.5 secs")).toEqual(Option.none())
+  })
+
   it("Order", () => {
     deepStrictEqual(Duration.Order(Duration.millis(1), Duration.millis(2)), -1)
     deepStrictEqual(Duration.Order(Duration.millis(2), Duration.millis(1)), 1)

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -42,6 +42,8 @@ describe("Duration", () => {
     expect(Duration.decode([-500, 123456789])).toEqual(Duration.zero)
 
     expect(() => Duration.decode("1.5 secs" as any)).toThrowError(new Error("Invalid duration input"))
+    expect(() => Duration.decode(true as any)).toThrowError(new Error("Invalid duration input"))
+    expect(() => Duration.decode({} as any)).toThrowError(new Error("Invalid duration input"))
   })
 
   it("decodeUnknown", () => {
@@ -76,6 +78,8 @@ describe("Duration", () => {
     expect(Duration.decodeUnknown([-500, 123456789])).toEqual(Option.some(Duration.zero))
 
     expect(Duration.decodeUnknown("1.5 secs")).toEqual(Option.none())
+    expect(Duration.decodeUnknown(true)).toEqual(Option.none())
+    expect(Duration.decodeUnknown({})).toEqual(Option.none())
   })
 
   it("Order", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I'd like to have an envvar containing a value like `10 seconds` turned into a `Duration`.

(A `DurationInput` refinement would work too.)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
