### PR TITLE
feat: add force option to FileSystem.remove

### DIFF
--- a/.changeset/large-hats-judge.md
+++ b/.changeset/large-hats-judge.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node-shared": patch
+"@effect/platform": patch
+---
+
+add force option to FileSystem.remove

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -147,7 +147,7 @@ const removeFactory = (method: string) => {
   return (path: string, options?: FileSystem.RemoveOptions) =>
     nodeRm(
       path,
-      { recursive: options?.recursive ?? false }
+      { recursive: options?.recursive ?? false, force: options?.force ?? false }
     )
 }
 const remove = removeFactory("remove")

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -163,9 +163,6 @@ export interface FileSystem {
   ) => Effect.Effect<string, PlatformError>
   /**
    * Remove a file or directory.
-   *
-   * By setting the `recursive` option to `true`, you can recursively remove
-   * nested directories.
    */
   readonly remove: (
     path: string,
@@ -388,7 +385,14 @@ export interface ReadDirectoryOptions {
  * @category options
  */
 export interface RemoveOptions {
+  /**
+   * When `true`, you can recursively remove nested directories.
+   */
   readonly recursive?: boolean
+  /**
+   * When `true`, exceptions will be ignored if `path` does not exist.
+   */
+  readonly force?: boolean
 }
 
 /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Add `force` option to `FileSystem.remove`. 

I didn't add any new tests, as this is an existing option of [node fs rm](https://nodejs.org/api/fs.html#fsrmpath-options-callback).

I also moved the JSDocs into `RemoveOptions` type which should be more accurate than before on the `remove` function. 

Let me know if I need to change anything!

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
