### PR TITLE
Opentelemetry: export an empty NodeSDK layer

### DIFF
--- a/.changeset/rotten-bananas-wave.md
+++ b/.changeset/rotten-bananas-wave.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Exports an empty NodeSDK layer suitable for incremental adoption and unit testing purposes

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -86,3 +86,9 @@ export const layer: {
       }
     )
   )
+
+/**
+ * @since 2.0.0
+ * @category layer
+ */
+export const empty: Layer.Layer<Resource.Resource> = Resource.empty

--- a/packages/opentelemetry/src/NodeSdk.ts
+++ b/packages/opentelemetry/src/NodeSdk.ts
@@ -91,4 +91,4 @@ export const layer: {
  * @since 2.0.0
  * @category layer
  */
-export const empty: Layer.Layer<Resource.Resource> = Resource.empty
+export const layerEmpty: Layer.Layer<Resource.Resource> = Resource.layerEmpty

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -57,7 +57,7 @@ export const layer = (config: {
  * @since 2.0.0
  * @category layer
  */
-export const empty = Layer.succeed(
+export const layerEmpty = Layer.succeed(
   Resource,
   Resources.Resource.empty()
 )

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -52,3 +52,12 @@ export const layer = (config: {
     new Resources.Resource(attributes)
   )
 }
+
+/**
+ * @since 2.0.0
+ * @category layer
+ */
+export const empty = Layer.succeed(
+  Resource,
+  Resources.Resource.empty()
+)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Exposes a `NodeSdk.empty` layer for incremental adoption and unit testing purposes.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #2432
