### PR TITLE
Introduce LazyArbitrary and new make

### DIFF
--- a/.changeset/wild-dodos-crash.md
+++ b/.changeset/wild-dodos-crash.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Rename Arbitrary.Arbitrary to Arbitrary.LazyArbitrary, rename Arbitrary.make to Arbitrary.makeLazy and introduce Arbitrary.make

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -30,8 +30,8 @@ S.declare(
   { decode: (_a, _b) => () => ParseResult.succeed("a"), encode: (_a, _b) => () => ParseResult.succeed(1) },
   {
     arbitrary: (
-      _a, // $ExpectType Arbitrary<string>
-      _b // $ExpectType Arbitrary<number>
+      _a, // $ExpectType LazyArbitrary<string>
+      _b // $ExpectType LazyArbitrary<number>
     ) =>
     (fc) => fc.string(),
     pretty: (

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1218,7 +1218,7 @@ pipe(
     ) => true,
     {
       arbitrary: (
-        _from // $ExpectType Arbitrary<string>
+        _from // $ExpectType LazyArbitrary<string>
       ) =>
       (fc) => fc.string(),
       pretty: (

--- a/packages/schema/test/Arbitrary/Arbitrary.test.ts
+++ b/packages/schema/test/Arbitrary/Arbitrary.test.ts
@@ -12,7 +12,7 @@ describe("Arbitrary > Arbitrary", () => {
 
   it("should throw on declarations without annotations", () => {
     const schema = S.declare(isUnknown)
-    expect(() => Arbitrary.make(schema)).toThrow(
+    expect(() => Arbitrary.makeLazy(schema)).toThrow(
       new Error("cannot build an Arbitrary for a declaration without annotations (<declaration schema>)")
     )
   })
@@ -71,7 +71,7 @@ describe("Arbitrary > Arbitrary", () => {
   })
 
   it("never", () => {
-    expect(() => Arbitrary.make(S.never)(fc)).toThrow(
+    expect(() => Arbitrary.makeLazy(S.never)(fc)).toThrow(
       new Error("cannot build an Arbitrary for `never`")
     )
   })
@@ -131,7 +131,7 @@ describe("Arbitrary > Arbitrary", () => {
   it("empty enums should throw", () => {
     enum Fruits {}
     const schema = S.enums(Fruits)
-    expect(() => Arbitrary.make(schema)(fc)).toThrow(
+    expect(() => Arbitrary.makeLazy(schema)(fc)).toThrow(
       new Error("cannot build an Arbitrary for an empty enum")
     )
   })
@@ -512,7 +512,7 @@ describe("Arbitrary > Arbitrary", () => {
   describe("should handle annotations", () => {
     const expectHook = <A, I>(source: S.Schema<A, I>) => {
       const schema = source.pipe(Arbitrary.arbitrary(() => (fc) => fc.constant("custom arbitrary") as any))
-      const arb = Arbitrary.make(schema)(fc)
+      const arb = Arbitrary.makeLazy(schema)(fc)
       expect(fc.sample(arb, 1)[0]).toEqual("custom arbitrary")
     }
 

--- a/packages/schema/test/Equivalence.test.ts
+++ b/packages/schema/test/Equivalence.test.ts
@@ -19,7 +19,7 @@ export const propertyType = <A, I>(
   schema: S.Schema<A, I>,
   params?: fc.Parameters<[A, ...Array<A>]>
 ) => {
-  const arb = A.make(schema)(fc)
+  const arb = A.makeLazy(schema)(fc)
   // console.log(fc.sample(arb, 10))
   const equivalence = E.make(schema)
 

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -29,7 +29,7 @@ const propertyType = <A, I>(schema: S.Schema<A, I>, options?: {
   if (!doProperty) {
     return
   }
-  const arbitrary = A.make(schema)
+  const arbitrary = A.makeLazy(schema)
   const is = S.is(schema)
   const jsonSchema = JSONSchema.make(schema)
   // console.log(JSON.stringify(jsonSchema, null, 2))

--- a/packages/schema/test/util.ts
+++ b/packages/schema/test/util.ts
@@ -84,7 +84,7 @@ export const roundtrip = <A, I>(schema: S.Schema<A, I, never>, params?: Paramete
   if (!doRoundtrip) {
     return
   }
-  const arb = A.make(schema)
+  const arb = A.makeLazy(schema)
   const is = S.is(schema)
   const encode = S.encode(schema)
   const decode = S.decode(schema)
@@ -186,7 +186,7 @@ export const expectValidArbitrary = <A, I>(schema: S.Schema<A, I, never>, params
   if (!doProperty) {
     return
   }
-  const arb = A.make(schema)(fc)
+  const arb = A.makeLazy(schema)(fc)
   const is = S.is(schema)
   fc.assert(fc.property(arb, (a) => is(a)), params)
 }
@@ -216,7 +216,7 @@ export const expectPromiseFailure = async <A>(promise: Promise<A>, message: stri
 }
 
 export const sample = <A, I>(schema: S.Schema<A, I>, n: number) => {
-  const arbitrary = A.make(schema)
+  const arbitrary = A.makeLazy(schema)
   const arb = arbitrary(fc)
   console.log(JSON.stringify(fc.sample(arb, n), null, 2))
 }


### PR DESCRIPTION
This PR makes it easier to generate fast-check compatible arbitraries by not requiring `Arbitrary.make` to take a `FastCheck` instance