### PR TITLE
Fix 's handling of key renames

### DIFF
--- a/.changeset/great-tips-think.md
+++ b/.changeset/great-tips-think.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Make `Schema.pick()` correctly handle key renames that are defined by the PropertySignature.

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -2038,9 +2038,25 @@ export const pick = (ast: AST, keys: ReadonlyArray<PropertyKey>): TypeLiteral | 
       case "TypeLiteralTransformation": {
         const propertySignatureTransformations = ast.transformation.propertySignatureTransformations
           .filter((t) => (keys as ReadonlyArray<PropertyKey>).includes(t.to))
+
+        const pstToKeys = propertySignatureTransformations.map(pst => pst.to)
+        const pstFromKeys = propertySignatureTransformations.map(pst => pst.from)
+
+        const toKeys = ReadonlyArray.union(
+            pstToKeys,
+            ReadonlyArray.difference(keys, pstFromKeys),
+          )
+        
+        const fromKeys = ReadonlyArray.union(
+          pstFromKeys,
+          ReadonlyArray.difference(keys, pstToKeys),
+        )
+        
         return new Transformation(
-          pick(ast.from, keys),
-          pick(ast.to, keys),
+          // pick(ast.from, keys),
+          // pick(ast.to, keys),
+          pick(ast.from, fromKeys),
+          pick(ast.to, toKeys),
           ReadonlyArray.isNonEmptyReadonlyArray(propertySignatureTransformations)
             ? new TypeLiteralTransformation(propertySignatureTransformations)
             : composeTransformation

--- a/packages/schema/test/AST/pick.test.ts
+++ b/packages/schema/test/AST/pick.test.ts
@@ -22,6 +22,15 @@ describe("AST > pick", () => {
       expect(ast.from).toStrictEqual(S.struct({ a: S.optional(S.NumberFromString) }).ast)
       expect(ast.to).toStrictEqual(S.struct({ a: S.number }).ast)
       expect(ast.transformation).toStrictEqual((schema.ast as AST.Transformation).transformation)
+
+      const schema2 = S.struct({
+        a: S.propertySignature(S.number).pipe(S.fromKey('c')),
+        b: S.number,
+      })
+      const ast2 = schema2.pipe(S.pick("a")).ast as AST.Transformation
+      expect(ast2.from).toStrictEqual(S.struct({ c: S.number }).ast)
+      expect(ast2.to).toStrictEqual(S.struct({ a: S.number }).ast)
+      expect(ast2.transformation).toStrictEqual((schema2.ast as AST.Transformation).transformation)
     })
 
     it("with SurrogateAnnotation", async () => {

--- a/packages/schema/test/Schema/omit.test.ts
+++ b/packages/schema/test/Schema/omit.test.ts
@@ -90,12 +90,13 @@ describe("Schema > omit", () => {
     const schema = S.struct({
       a: S.optional(S.string, { exact: true, default: () => "" }),
       b: S.NumberFromString,
-      c: S.boolean
+      c: S.boolean,
+      d: S.propertySignature(S.string).pipe(S.fromKey('e'))
     }).pipe(
       S.omit("c")
     )
-    await Util.expectDecodeUnknownSuccess(schema, { a: "a", b: "1" }, { a: "a", b: 1 })
-    await Util.expectDecodeUnknownSuccess(schema, { b: "1" }, { a: "", b: 1 })
+    await Util.expectDecodeUnknownSuccess(schema, { a: "a", b: "1", e: "e" }, { a: "a", b: 1, d: "e" })
+    await Util.expectDecodeUnknownSuccess(schema, { b: "1", e: "e" }, { a: "", b: 1, d: "e" })
   })
 
   it("typeSchema(Class)", () => {

--- a/packages/schema/test/Schema/pick.test.ts
+++ b/packages/schema/test/Schema/pick.test.ts
@@ -90,12 +90,13 @@ describe("Schema > pick", () => {
     const schema = S.struct({
       a: S.optional(S.string, { exact: true, default: () => "" }),
       b: S.NumberFromString,
-      c: S.boolean
+      c: S.boolean,
+      d: S.propertySignature(S.string).pipe(S.fromKey('e'))
     }).pipe(
-      S.pick("a", "b")
+      S.pick("a", "b", "d")
     )
-    await Util.expectDecodeUnknownSuccess(schema, { a: "a", b: "1" }, { a: "a", b: 1 })
-    await Util.expectDecodeUnknownSuccess(schema, { b: "1" }, { a: "", b: 1 })
+    await Util.expectDecodeUnknownSuccess(schema, { a: "a", b: "1", e: "e" }, { a: "a", b: 1, d: "e" })
+    await Util.expectDecodeUnknownSuccess(schema, { b: "1", e: "e" }, { a: "", b: 1, d: "e" })
   })
 
   it("record(string, number)", async () => {

--- a/packages/schema/test/Schema/pluck.test.ts
+++ b/packages/schema/test/Schema/pluck.test.ts
@@ -107,4 +107,14 @@ describe("Schema > pluck", () => {
     await Util.expectEncodeSuccess(schema, undefined, {})
     await Util.expectEncodeSuccess(schema, "a", { a: "a" })
   })
+
+  // it("struct with renamed key", async () => {
+  //   const origin = S.struct({ a: S.propertySignature(S.string).pipe(S.fromKey("b")) })
+  //   // The `pluck` typing explicitly depends on `I`, resulting in:
+  //   // Property 'b' is missing in type '{ a?: any; }' but required in type '{ readonly b: string; }'
+  //   // It isn't clear if the `pluck` typings should be fixed, or the test
+  //   const schema = S.pluck(origin, "a")
+  //   await Util.expectEncodeSuccess(schema, "a", { "b": "a" })
+  //   await Util.expectDecodeUnknownSuccess(schema, { b: "a" }, "a")
+  // })
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`S.pluck()` and derived APIs would keep track of property signature transformations, but not the changes in keys that correspond to them making it difficult to use the APIs on renamed keys.

```typescript
import * as S from '@effect/schema/Schema'
import { pipe } from 'effect/Function'

const schema = S.struct({
  a: S.string, b: S.propertySignature(S.literal(1)).pipe(S.fromKey('c'))
})
console.log(S.decodeSync(schema)({ a: 'a', c: 1 }))
// Good, as expected
// { b: 1, a: 'a' }

const schema2 = pipe(
  S.struct({
    a: S.string, b: S.propertySignature(S.literal(1)).pipe(S.fromKey('c'))
  }),
  S.omit('a')
)
console.log(S.decodeSync(schema2)({ c: 1 }))
// What?
// Error: ({ b: never } <-> { b: 1 })
// └─ Encoded side transformation failure
//    └─ { b: never }
//       └─ ["b"]
//          └─ is missing
```