### PR TITLE
Fix UrlParams.makeUrl when globalThis.location is set to `undefined`

### DIFF
--- a/.changeset/stale-bugs-roll.md
+++ b/.changeset/stale-bugs-roll.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix HTTP Client's compatibility with Deno due to globalThis.location.

--- a/.changeset/stale-bugs-roll.md
+++ b/.changeset/stale-bugs-roll.md
@@ -2,4 +2,4 @@
 "@effect/platform": patch
 ---
 
-Fix HTTP Client's compatibility with Deno due to globalThis.location.
+Fix UrlParams.makeUrl when globalThis.location is set to `undefined`

--- a/packages/platform/src/Http/UrlParams.ts
+++ b/packages/platform/src/Http/UrlParams.ts
@@ -207,15 +207,7 @@ export const makeUrl = <E>(url: string, params: UrlParams, onError: (e: unknown)
     catch: onError
   })
 
-/**
- * Get the base URL out of `globalThis.location`.
- *
- * @internal
- */
-export const baseUrl = (): string | undefined => {
-  // Need to check both "in" and "undefined" for location to support Deno.
-  // As Deno has "globalThis.location" defined but with value "undefined" by default.
-  // See https://docs.deno.com/runtime/manual/runtime/location_api
+const baseUrl = (): string | undefined => {
   if ("location" in globalThis && globalThis.location !== undefined) {
     return location.origin + location.pathname
   }

--- a/packages/platform/src/Http/UrlParams.ts
+++ b/packages/platform/src/Http/UrlParams.ts
@@ -208,8 +208,8 @@ export const makeUrl = <E>(url: string, params: UrlParams, onError: (e: unknown)
   })
 
 export const baseUrl = (): string | undefined => {
-  // Need to both "in" and "undefined" for location to support Deno.
-  // As by default, Deno has "globalThis.location" defined but with value "undefined".
+  // Need to check both "in" and "undefined" for location to support Deno.
+  // As Deno has "globalThis.location" defined but with value "undefined" by default.
   // See https://docs.deno.com/runtime/manual/runtime/location_api
   if ("location" in globalThis && globalThis.location !== undefined) {
     return location.origin + location.pathname

--- a/packages/platform/src/Http/UrlParams.ts
+++ b/packages/platform/src/Http/UrlParams.ts
@@ -207,6 +207,12 @@ export const makeUrl = <E>(url: string, params: UrlParams, onError: (e: unknown)
     catch: onError
   })
 
+/**
+ * Get the base URL out of `globalThis.location`.
+ *
+ * @since 1.0.0
+ * @category utils
+ */
 export const baseUrl = (): string | undefined => {
   // Need to check both "in" and "undefined" for location to support Deno.
   // As Deno has "globalThis.location" defined but with value "undefined" by default.

--- a/packages/platform/src/Http/UrlParams.ts
+++ b/packages/platform/src/Http/UrlParams.ts
@@ -207,8 +207,11 @@ export const makeUrl = <E>(url: string, params: UrlParams, onError: (e: unknown)
     catch: onError
   })
 
-const baseUrl = (): string | undefined => {
-  if ("location" in globalThis) {
+export const baseUrl = (): string | undefined => {
+  // Need to both "in" and "undefined" for location to support Deno.
+  // As by default, Deno has "globalThis.location" defined but with value "undefined".
+  // See https://docs.deno.com/runtime/manual/runtime/location_api
+  if ("location" in globalThis && globalThis.location !== undefined) {
     return location.origin + location.pathname
   }
   return undefined

--- a/packages/platform/src/Http/UrlParams.ts
+++ b/packages/platform/src/Http/UrlParams.ts
@@ -210,8 +210,7 @@ export const makeUrl = <E>(url: string, params: UrlParams, onError: (e: unknown)
 /**
  * Get the base URL out of `globalThis.location`.
  *
- * @since 1.0.0
- * @category utils
+ * @internal
  */
 export const baseUrl = (): string | undefined => {
   // Need to check both "in" and "undefined" for location to support Deno.

--- a/packages/platform/test/Http/UrlParams.test.ts
+++ b/packages/platform/test/Http/UrlParams.test.ts
@@ -1,0 +1,26 @@
+import * as UrlParams from "@effect/platform/Http/UrlParams"
+import { assert, describe, it } from "vitest"
+
+describe("UrlParams", () => {
+  describe("baseUrl", () => {
+    it("should return undefined when `location` is not in `globalThis` or `globalThis.location` is undefined", () => {
+      const originalLocation = globalThis.location
+
+      // `globalThis.location` is undefined
+      // @ts-expect-error
+      globalThis.location = undefined
+      assert.strictEqual("location" in globalThis, true)
+      assert.strictEqual(globalThis.location, undefined)
+      assert.strictEqual(UrlParams.baseUrl(), undefined)
+
+      // `location` is not in globalThis
+      // @ts-expect-error
+      delete globalThis.location
+      assert.strictEqual("location" in globalThis, false)
+      assert.strictEqual(globalThis.location, undefined)
+      assert.strictEqual(UrlParams.baseUrl(), undefined)
+
+      globalThis.location = originalLocation
+    })
+  })
+})

--- a/packages/platform/test/Http/UrlParams.test.ts
+++ b/packages/platform/test/Http/UrlParams.test.ts
@@ -1,26 +1,26 @@
 import * as UrlParams from "@effect/platform/Http/UrlParams"
-import { assert, describe, it } from "vitest"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
 
 describe("UrlParams", () => {
-  describe("baseUrl", () => {
-    it("should return undefined when `location` is not in `globalThis` or `globalThis.location` is undefined", () => {
-      const originalLocation = globalThis.location
+  describe("makeUrl", () => {
+    it.effect("does not throw if `location` is set to `undefined`", () =>
+      Effect.gen(function*(_) {
+        const originalLocation = globalThis.location
 
-      // `globalThis.location` is undefined
-      // @ts-expect-error
-      globalThis.location = undefined
-      assert.strictEqual("location" in globalThis, true)
-      assert.strictEqual(globalThis.location, undefined)
-      assert.strictEqual(UrlParams.baseUrl(), undefined)
+        // `globalThis.location` is undefined
+        // @ts-expect-error
+        globalThis.location = undefined
+        let url = yield* _(UrlParams.makeUrl("http://example.com", [], () => "error"))
+        assert.strictEqual(url.toString(), "http://example.com/")
 
-      // `location` is not in globalThis
-      // @ts-expect-error
-      delete globalThis.location
-      assert.strictEqual("location" in globalThis, false)
-      assert.strictEqual(globalThis.location, undefined)
-      assert.strictEqual(UrlParams.baseUrl(), undefined)
+        // `location` is not in globalThis
+        // @ts-expect-error
+        delete globalThis.location
+        url = yield* _(UrlParams.makeUrl("http://example.com", [], () => "error"))
+        assert.strictEqual(url.toString(), "http://example.com/")
 
-      globalThis.location = originalLocation
-    })
+        globalThis.location = originalLocation
+      }))
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Deno has `globalThis.location` defined as `undefined` by default. This breaks the HTTP Client in `@effect/platform`. As the current implemention of `baseUrl()` [as per v0.48.27](https://github.com/Effect-TS/effect/blob/%40effect/platform%400.48.27/packages/platform/src/Http/UrlParams.ts#L211) only checks `"location" in globalThis`, but not `globalThis.location !== undefined`. This PR fixes it by adding the latter.

Here a test script to demostrate the bug:

```ts
// filename: test.ts
import { NodeRuntime } from "@effect/platform-node"
import { HttpClient } from "@effect/platform"
import { Console, Effect, pipe } from "effect"

pipe(
  Console.log("location in globalThis:", "location" in globalThis),
  Effect.andThen(Console.log("globalThis.location:", globalThis.location)),
  Effect.as(
    HttpClient.request.get("https://jsonplaceholder.typicode.com/posts/1"),
  ),
  Effect.andThen(HttpClient.client.fetch()),
  Effect.andThen((response) => Console.log("Status:", response.status)),
  Effect.scoped,
  NodeRuntime.runMain,
)
```

### Before the fix:

```sh
$ deno run -A ./test.ts
location in globalThis: true
globalThis.location: undefined
timestamp=2024-04-14T11:55:59.777Z level=ERROR fiber=#0 cause="RequestError: InvalidUrl error (GET https://jsonplaceholder.typicode.com/posts/1): Cannot read properties of undefined (reading 'origin')
    at baseUrl (file:///Users/roc/Library/Caches/deno/npm/registry.npmjs.org/@effect/platform/0.48.27/dist/esm/Http/UrlParams.js:98:21)
    at try (file:///Users/roc/Library/Caches/deno/npm/registry.npmjs.org/@effect/platform/0.48.27/dist/esm/Http/UrlParams.js:86:38)
    at file:///Users/roc/Library/Caches/deno/npm/registry.npmjs.org/effect/2.4.18/dist/esm/internal/core-effect.js:46:14"

$ deno run -A --location https://example.com/path ./test.ts
location in globalThis: true
globalThis.location: Location {
  hash: "",
  host: "example.com",
  hostname: "example.com",
  href: "https://example.com/path",
  origin: "https://example.com",
  pathname: "/path",
  port: "",
  protocol: "https:",
  search: ""
}
Status: 200
```

### After the fix:

```sh
$ deno run -A ./test.ts                                    
location in globalThis: true
globalThis.location: undefined
Status: 200

$ deno run -A --location https://example.com/path ./test.ts
location in globalThis: true
globalThis.location: Location {
  hash: "",
  host: "example.com",
  hostname: "example.com",
  href: "https://example.com/path",
  origin: "https://example.com",
  pathname: "/path",
  port: "",
  protocol: "https:",
  search: ""
}
Status: 200
```
A unit test is added for this in the PR.

See also [Deno's Location API.](https://docs.deno.com/runtime/manual/runtime/location_api)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #1806
- Closes # N/A
