### PR TITLE
Schema: add `compose` overloads to enable a subtyping relationship in both di…

### DIFF
--- a/.changeset/hot-chicken-trade.md
+++ b/.changeset/hot-chicken-trade.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+add `compose` overloads to enable a subtyping relationship in both directions between `C` and `B`.

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1241,7 +1241,7 @@ pipe(
 )
 
 // ---------------------------------------------
-// Compose
+// compose
 // ---------------------------------------------
 
 // A -> B -> C
@@ -1252,37 +1252,53 @@ S.compose(S.split(","), S.Array(S.NumberFromString))
 // $ExpectType Schema<readonly number[], string, never>
 S.split(",").pipe(S.compose(S.Array(S.NumberFromString)))
 
-// decoding (strict: false)
+// $ExpectType Schema<readonly number[], string, never>
+S.compose(S.split(","), S.Array(S.NumberFromString), { strict: true })
+
+// // $ExpectType Schema<readonly number[], string, never>
+// S.split(",").pipe(S.compose(S.Array(S.NumberFromString), { strict: true }))
+
+// @ts-expect-error
+S.compose(S.String, S.Number)
+
+// @ts-expect-error
+S.String.pipe(S.compose(S.Number))
+
+// A -> B+, B -> C
+
+// $ExpectType Schema<number, string | null, never>
+S.compose(S.Union(S.Null, S.String), S.NumberFromString)
 
 // $ExpectType Schema<number, string | null, never>
 S.compose(S.Union(S.Null, S.String), S.NumberFromString, { strict: false })
 
+// // $ExpectType Schema<number, string | null, never>
+// S.Union(S.Null, S.String).pipe(S.compose(S.NumberFromString))
+
 // $ExpectType Schema<number, string | null, never>
 S.Union(S.Null, S.String).pipe(S.compose(S.NumberFromString, { strict: false }))
 
-// decoding (strict: true)
+// A -> B, B+ -> C
 
-// @ts-expect-error
-S.compose(S.Union(S.Null, S.String), S.NumberFromString)
-
-// @ts-expect-error
-S.Union(S.Null, S.String).pipe(S.compose(S.NumberFromString))
-
-// encoding (strict: false)
+// $ExpectType Schema<number | null, string, never>
+S.compose(S.NumberFromString, S.Union(S.Null, S.Number))
 
 // $ExpectType Schema<number | null, string, never>
 S.compose(S.NumberFromString, S.Union(S.Null, S.Number), { strict: false })
 
+// // $ExpectType Schema<number | null, string, never>
+// S.NumberFromString.pipe(S.compose(S.Union(S.Null, S.Number)))
+
 // $ExpectType Schema<number | null, string, never>
 S.NumberFromString.pipe(S.compose(S.Union(S.Null, S.Number), { strict: false }))
 
-// encoding (strict: true)
+// A -> B -> C -> D
 
-// @ts-expect-error
-S.compose(S.NumberFromString, S.Union(S.Null, S.Number))
+// $ExpectType Schema<number, string, never>
+S.compose(S.String, S.Number, { strict: false })
 
-// @ts-expect-error
-S.NumberFromString.pipe(S.compose(S.Union(S.Null, S.Number)))
+// $ExpectType Schema<number, string, never>
+S.String.pipe(S.compose(S.Number, { strict: false }))
 
 // ---------------------------------------------
 // FromBrand

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -2531,7 +2531,7 @@ export const extend: {
 export const compose: {
   <C, B, R2>(
     to: Schema<C, B, R2>
-  ): <A, R1>(from: Schema<B, A, R1>, options?: { readonly strict: true }) => Schema<C, A, R1 | R2>
+  ): <A, R1>(from: Schema<B, A, R1>) => Schema<C, A, R1 | R2>
   <D, C, R2>(
     to: Schema<D, C, R2>,
     options: { readonly strict: false }
@@ -2541,14 +2541,22 @@ export const compose: {
     to: Schema<C, B, R2>,
     options?: { readonly strict: true }
   ): Schema<C, A, R1 | R2>
-  <A, B, R1, D, C, R2>(
+  <B, A, R1, D, C extends B, R2>(
+    from: Schema<B, A, R1>,
+    to: Schema<D, C, R2>
+  ): Schema<D, A, R1 | R2>
+  <B extends C, A, R1, D, C, R2>(
+    from: Schema<B, A, R1>,
+    to: Schema<D, C, R2>
+  ): Schema<D, A, R1 | R2>
+  <B, A, R1, D, C, R2>(
     from: Schema<B, A, R1>,
     to: Schema<D, C, R2>,
     options: { readonly strict: false }
   ): Schema<D, A, R1 | R2>
 } = dual(
   (args) => isSchema(args[1]),
-  <A, B, R1, D, C, R2>(from: Schema<A, B, R1>, to: Schema<D, C, R2>): Schema<D, A, R1 | R2> =>
+  <B, A, R1, D, C, R2>(from: Schema<B, A, R1>, to: Schema<D, C, R2>): Schema<D, A, R1 | R2> =>
     make(AST.compose(from.ast, to.ast))
 )
 


### PR DESCRIPTION
…rections between `C` and `B`.
