### PR TITLE
Fix `transformOrFail` and `transformOrFailFrom` signatures in the exp…

### DIFF
--- a/.changeset/soft-cows-sell.md
+++ b/.changeset/soft-cows-sell.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Fix `transformOrFail` and `transformOrFailFrom` signatures in the exported `Class` interface by adding the missing `annotations` optional argument

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -6249,7 +6249,8 @@ export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited
         options: ParseOptions,
         ast: AST.Transformation
       ) => Effect.Effect<A, ParseResult.ParseIssue, R3>
-    }
+    },
+    annotations?: Annotations.Schema<Transformed>
   ) => [Transformed] extends [never] ? MissingSelfGeneric<"Base.transform">
     : Class<
       Transformed,
@@ -6279,7 +6280,8 @@ export interface Class<Self, Fields extends Struct.Fields, A, I, R, C, Inherited
         options: ParseOptions,
         ast: AST.Transformation
       ) => Effect.Effect<I, ParseResult.ParseIssue, R3>
-    }
+    },
+    annotations?: Annotations.Schema<Transformed>
   ) => [Transformed] extends [never] ? MissingSelfGeneric<"Base.transformFrom">
     : Class<
       Transformed,


### PR DESCRIPTION
…orted `Class` interface by adding the missing `annotations` optional argument

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2548 
