### PR TITLE
Improve the typings of Array.isArray

### DIFF
--- a/.changeset/slimy-dogs-warn.md
+++ b/.changeset/slimy-dogs-warn.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve typings of Array.isArray

--- a/packages/effect/dtslint/Array.ts
+++ b/packages/effect/dtslint/Array.ts
@@ -19,9 +19,26 @@ declare const pimitiveNumber: number
 declare const pimitiveNumerOrString: string | number
 declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
 
+declare const unknownValue: unknown
+declare const stringOrStringArrayOrUnion: string | Array<string> | null
+
 const symA = Symbol.for("a")
 const symB = Symbol.for("b")
 const symC = Symbol.for("c")
+
+// -------------------------------------------------------------------------------------
+// isArray
+// -------------------------------------------------------------------------------------
+
+if (Array.isArray(unknownValue)) {
+  // $ExpectType unknown[]
+  unknownValue
+}
+
+if (Array.isArray(stringOrStringArrayOrUnion)) {
+  // $ExpectType string[]
+  stringOrStringArrayOrUnion
+}
 
 // -------------------------------------------------------------------------------------
 // isEmptyReadonlyArray

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -345,7 +345,10 @@ export const scanRight: {
  * @category guards
  * @since 2.0.0
  */
-export const isArray: (self: unknown) => self is Array<unknown> = Array.isArray
+export const isArray: {
+  (self: unknown): self is Array<unknown>
+  <T>(self: T): self is Extract<T, ReadonlyArray<any>>
+} = Array.isArray
 
 /**
  * Determine if an `Array` is empty narrowing down the type to `[]`.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updates the `Array.isArray` type with a second overload which can extract any subtypes of ReadonlyArray when the input value is not unknown.
