### PR TITLE
allow type narrowing on brand constructor

### DIFF
--- a/packages/effect/src/Brand.ts
+++ b/packages/effect/src/Brand.ts
@@ -92,22 +92,22 @@ export declare namespace Brand {
      * Constructs a branded type from a value of type `A`, throwing an error if
      * the provided `A` is not valid.
      */
-    (args: Brand.Unbranded<A>): A
+    <V extends Brand.Unbranded<A>>(args: V): V & A
     /**
      * Constructs a branded type from a value of type `A`, returning `Some<A>`
      * if the provided `A` is valid, `None` otherwise.
      */
-    option(args: Brand.Unbranded<A>): Option.Option<A>
+    option<V extends Brand.Unbranded<A>>(args: V): Option.Option<V & A>
     /**
      * Constructs a branded type from a value of type `A`, returning `Right<A>`
      * if the provided `A` is valid, `Left<BrandError>` otherwise.
      */
-    either(args: Brand.Unbranded<A>): Either.Either<A, Brand.BrandErrors>
+    either<V extends Brand.Unbranded<A>>(args: V): Either.Either<V & A, Brand.BrandErrors>
     /**
      * Attempts to refine the provided value of type `A`, returning `true` if
      * the provided `A` is valid, `false` otherwise.
      */
-    is(a: Brand.Unbranded<A>): a is Brand.Unbranded<A> & A
+    is<V extends Brand.Unbranded<A>>(a: V): a is V & A
   }
 
   /**

--- a/packages/effect/test/Brand.test.ts
+++ b/packages/effect/test/Brand.test.ts
@@ -34,7 +34,7 @@ describe("Brand", () => {
     assert.throws(() => Int(1.1))
     assert.deepStrictEqual(Int.option(1), Option.some(1))
     assert.deepStrictEqual(Int.option(1.1), Option.none())
-    assert.deepStrictEqual(Int.either(1), Either.right(1 as Int))
+    assert.deepStrictEqual(Int.either(1), Either.right(Int(1)))
     assert.deepStrictEqual(
       Int.either(1.1),
       Either.left(Brand.error("Expected 1.1 to be an integer"))
@@ -66,7 +66,7 @@ describe("Brand", () => {
     assert.throws(() => PositiveInt(1.1))
     assert.deepStrictEqual(PositiveInt.option(1), Option.some(1))
     assert.deepStrictEqual(PositiveInt.option(1.1), Option.none())
-    assert.deepStrictEqual(PositiveInt.either(1), Either.right(1 as PositiveInt))
+    assert.deepStrictEqual(PositiveInt.either(1), Either.right(PositiveInt(1)))
     assert.deepStrictEqual(
       PositiveInt.either(1.1),
       Either.left(Brand.error("Expected 1.1 to be an integer"))

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -49,7 +49,7 @@ S.Struct({ a: S.String }).pipe(S.annotations({}))
 // $ExpectType Schema<A, { readonly a: string; }, never>
 A.pipe(S.annotations({}))
 
-// $ExpectType number & Brand<"Int">
+// $ExpectType 1 & Brand<"Int">
 S.Number.pipe(S.int(), S.brand("Int"))(1)
 
 // ---------------------------------------------


### PR DESCRIPTION
This would allow something like this:

```ts
import { Schema } from "@effect/schema"

const Foo = Schema.Literal(1, 2, 3, 4).pipe(Schema.brand("Foo"))
const Bar = Foo(1) // 1 & Brand<"Foo">
```

Currently:

```ts
import { Schema } from "@effect/schema"

const Foo = Schema.Literal(1, 2, 3, 4).pipe(Schema.brand("Foo"))
const Bar = Foo(1) // (1 | 2 | 3 | 4) & Brand<"Foo">
```