### PR TITLE
Update `@opentelemetry/*` peer dependencies to ensure allowed versions include used imports

### DIFF
--- a/.changeset/selfish-insects-impress.md
+++ b/.changeset/selfish-insects-impress.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": minor
+---
+
+Update @opentelemetry/\* peer dependencies to ensure allowed versions include used imports

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@8.15.1",
+  "packageManager": "pnpm@8.15.1+sha256.245fe901f8e7fa8782d7f17d32b6a83995e2ae03984cb5b62b8949bfdc27c7b5",
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
     "clean": "node scripts/clean.mjs",
-    "codegen": "pnpm --recursive --parallel run codegen",
-    "build": "tsc -b tsconfig.build.json && pnpm --recursive --parallel run build",
+    "codegen": "corepack pnpm --recursive --parallel run codegen",
+    "build": "tsc -b tsconfig.build.json && corepack pnpm --recursive --parallel run build",
     "circular": "node scripts/circular.mjs",
     "test": "vitest",
     "coverage": "vitest --coverage",
     "check": "tsc -b tsconfig.json",
-    "check-recursive": "pnpm --recursive exec tsc -b tsconfig.json",
+    "check-recursive": "corepack pnpm --recursive exec tsc -b tsconfig.json",
     "lint": "eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
-    "lint-fix": "pnpm lint --fix",
-    "docgen": "pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
+    "lint-fix": "corepack pnpm lint --fix",
+    "docgen": "corepack pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
     "dtslint": "pnpm --recursive --parallel run dtslint",
     "dtslint-clean": "dtslint --installAll",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "pnpm build && changeset publish"
+    "changeset-publish": "corepack pnpm build && changeset publish"
   },
   "resolutions": {
     "dependency-tree": "^10.0.9",

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@8.15.1+sha256.245fe901f8e7fa8782d7f17d32b6a83995e2ae03984cb5b62b8949bfdc27c7b5",
+  "packageManager": "pnpm@8.15.1",
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
     "clean": "node scripts/clean.mjs",
-    "codegen": "corepack pnpm --recursive --parallel run codegen",
-    "build": "tsc -b tsconfig.build.json && corepack pnpm --recursive --parallel run build",
+    "codegen": "pnpm --recursive --parallel run codegen",
+    "build": "tsc -b tsconfig.build.json && pnpm --recursive --parallel run build",
     "circular": "node scripts/circular.mjs",
     "test": "vitest",
     "coverage": "vitest --coverage",
     "check": "tsc -b tsconfig.json",
-    "check-recursive": "corepack pnpm --recursive exec tsc -b tsconfig.json",
+    "check-recursive": "pnpm --recursive exec tsc -b tsconfig.json",
     "lint": "eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
-    "lint-fix": "corepack pnpm lint --fix",
-    "docgen": "corepack pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
+    "lint-fix": "pnpm lint --fix",
+    "docgen": "pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
     "dtslint": "pnpm --recursive --parallel run dtslint",
     "dtslint-clean": "dtslint --installAll",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "corepack pnpm build && changeset publish"
+    "changeset-publish": "pnpm build && changeset publish"
   },
   "resolutions": {
     "dependency-tree": "^10.0.9",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -48,12 +48,12 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.6",
-    "@opentelemetry/resources": "^1.17",
-    "@opentelemetry/sdk-metrics": "^1.17",
-    "@opentelemetry/sdk-trace-base": "^1.17",
-    "@opentelemetry/sdk-trace-node": "^1.17",
-    "@opentelemetry/sdk-trace-web": "^1.17",
-    "@opentelemetry/semantic-conventions": "^1.17",
+    "@opentelemetry/resources": "^1.22",
+    "@opentelemetry/sdk-metrics": "^1.22",
+    "@opentelemetry/sdk-trace-base": "^1.22",
+    "@opentelemetry/sdk-trace-node": "^1.22",
+    "@opentelemetry/sdk-trace-web": "^1.22",
+    "@opentelemetry/semantic-conventions": "^1.22",
     "effect": "workspace:^"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The main thing is updating `@opentelemetry/*` peer dependencies to ensure the allowed version range includes imports used in `@effect/opentelemetry`.

Specifically, `Resource.ts` in `@effect/opentelemetry` contains imports from `@opentelemetry/semantic-resources` that are not present in that package until version `1.22`.

