### PR TITLE
Prefix `pnpm` calls in root `package.json` scripts with `corepack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@8.15.1",
+  "packageManager": "pnpm@8.15.1+sha256.245fe901f8e7fa8782d7f17d32b6a83995e2ae03984cb5b62b8949bfdc27c7b5",
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
     "clean": "node scripts/clean.mjs",
-    "codegen": "pnpm --recursive --parallel run codegen",
-    "build": "tsc -b tsconfig.build.json && pnpm --recursive --parallel run build",
+    "codegen": "corepack pnpm --recursive --parallel run codegen",
+    "build": "tsc -b tsconfig.build.json && corepack pnpm --recursive --parallel run build",
     "circular": "node scripts/circular.mjs",
     "test": "vitest",
     "coverage": "vitest --coverage",
     "check": "tsc -b tsconfig.json",
-    "check-recursive": "pnpm --recursive exec tsc -b tsconfig.json",
+    "check-recursive": "corepack pnpm --recursive exec tsc -b tsconfig.json",
     "lint": "eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
-    "lint-fix": "pnpm lint --fix",
-    "docgen": "pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
-    "dtslint": "pnpm --recursive --parallel run dtslint",
+    "lint-fix": "corepack pnpm lint --fix",
+    "docgen": "corepack pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
+    "dtslint": "corepack pnpm --recursive --parallel run dtslint",
     "dtslint-clean": "dtslint --installAll",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "pnpm build && changeset publish"
+    "changeset-publish": "corepack pnpm build && changeset publish"
   },
   "resolutions": {
     "dependency-tree": "^10.0.9",


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While working on #2572, I ran into errors running several scripts in the root `package.json`:

```sh
$ pnpm dtslint

> @ dtslint /Users/nick/dev/effect
> pnpm --recursive --parallel run dtslint

sh: pnpm: command not found
ELIFECYCLE  Command failed.
```

I fixed the issue by prefixing `pnpm` calls in `package.json` scripts with `corepack ...` to make sure `corepack` resolves `pnpm`'s binary. 

This is likely a quirk of my environment which I manage using Nix + Home Manager, but the changes potentially help others as well.

Then, I locked the version of `pnpm` specified in `packageManager` to the exact hash of the version, to make sure everyone's `corepack` uses that exact version. Set/upgrade using `corepack use pnpm@<semver>`.
