### PR TITLE
Fix JSDoc typos in `BooleanFromUnknown` and `split` functions for `Schema` package

### DIFF
--- a/.changeset/four-feet-fix.md
+++ b/.changeset/four-feet-fix.md
@@ -1,0 +1,6 @@
+---
+"@effect/schema": patch
+---
+
+- Fixed a typo in the JSDoc comment of the `BooleanFromUnknown` boolean constructors in `Schema.ts`
+- Fixed a typo in the JSDoc comment of the `split` string transformations combinator in `Schema.ts`

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -3518,7 +3518,7 @@ export const Trim: Trim = transform(
 ).annotations({ identifier: "Trim" })
 
 /**
- * Returns a achema that allows splitting a string into an array of strings.
+ * Returns a schema that allows splitting a string into an array of strings.
  *
  * @category string transformations
  * @since 1.0.0
@@ -7537,8 +7537,8 @@ const schemaFromArbitrary = <A>(value: LazyArbitrary<A>): Schema<A> =>
 export interface BooleanFromUnknown extends Annotable<BooleanFromUnknown, boolean, unknown> {}
 
 /**
- * Convers an arbitrary value to a `boolean` by testing whether it is truthy.
- * Uses `!!val` to convert the value to a `boolean`.
+ * Converts an arbitrary value to a `boolean` by testing whether it is truthy.
+ * Uses `!!val` to coerce the value to a `boolean`.
  *
  * @see https://developer.mozilla.org/docs/Glossary/Truthy
  * @category boolean constructors


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Fix typos found in the JSDocs for `split` string transformation and `BooleanFromUnknown` boolean constructor functions. 
