### PR TITLE
rename and export platform file schemas

### DIFF
--- a/.changeset/hungry-ghosts-kiss.md
+++ b/.changeset/hungry-ghosts-kiss.md
@@ -1,0 +1,9 @@
+---
+"@effect/platform-node": minor
+"@effect/platform-bun": minor
+"@effect/platform": minor
+---
+
+* capitalised Http.multipart.FileSchema and Http.multipart.FilesSchema
+* exported Http.multipart.FileSchema
+* added Http.multipart.SingleFileSchema

--- a/packages/platform-bun/examples/http-router.ts
+++ b/packages/platform-bun/examples/http-router.ts
@@ -19,7 +19,7 @@ const HttpLive = Http.router.empty.pipe(
     "/upload",
     Effect.gen(function*(_) {
       const data = yield* _(Http.request.schemaBodyForm(Schema.Struct({
-        files: Http.multipart.filesSchema
+        files: Http.multipart.FilesSchema
       })))
       console.log("got files", data.files)
       return Http.response.empty()

--- a/packages/platform-node/examples/http-router.ts
+++ b/packages/platform-node/examples/http-router.ts
@@ -24,7 +24,7 @@ const HttpLive = Http.router.empty.pipe(
     "/upload",
     Effect.gen(function*(_) {
       const data = yield* _(Http.request.schemaBodyForm(Schema.Struct({
-        files: Http.multipart.filesSchema
+        files: Http.multipart.FilesSchema
       })))
       console.log("got files", data.files)
       return Http.response.empty()

--- a/packages/platform-node/test/HttpServer.test.ts
+++ b/packages/platform-node/test/HttpServer.test.ts
@@ -115,7 +115,7 @@ describe("HttpServer", () => {
           "/upload",
           Effect.gen(function*(_) {
             const files = yield* _(Http.request.schemaBodyForm(Schema.Struct({
-              file: Http.multipart.filesSchema,
+              file: Http.multipart.FilesSchema,
               test: Schema.String
             })))
             expect(files).toHaveProperty("file")

--- a/packages/platform/src/Http/Multipart.ts
+++ b/packages/platform/src/Http/Multipart.ts
@@ -215,6 +215,12 @@ export const withFieldMimeTypes: {
  * @since 1.0.0
  * @category schema
  */
+export const fileSchema: Schema.Schema<PersistedFile> = internal.fileSchema
+
+/**
+ * @since 1.0.0
+ * @category schema
+ */
 export const filesSchema: Schema.Schema<ReadonlyArray<PersistedFile>> = internal.filesSchema
 
 /**

--- a/packages/platform/src/Http/Multipart.ts
+++ b/packages/platform/src/Http/Multipart.ts
@@ -215,13 +215,22 @@ export const withFieldMimeTypes: {
  * @since 1.0.0
  * @category schema
  */
-export const fileSchema: Schema.Schema<PersistedFile> = internal.fileSchema
+export const FileSchema: Schema.Schema<PersistedFile> = internal.FileSchema
 
 /**
  * @since 1.0.0
  * @category schema
  */
-export const filesSchema: Schema.Schema<ReadonlyArray<PersistedFile>> = internal.filesSchema
+export const FilesSchema: Schema.Schema<ReadonlyArray<PersistedFile>> = internal.FilesSchema
+
+/**
+ * @since 1.0.0
+ * @category schema
+ */
+export const SingleFileSchema: Schema.transform<
+  Schema.Schema<ReadonlyArray<PersistedFile>>,
+  Schema.Schema<PersistedFile>
+> = internal.SingleFileSchema
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/internal/http/multipart.ts
+++ b/packages/platform/src/internal/http/multipart.ts
@@ -101,12 +101,21 @@ export const withFieldMimeTypes = dual<
 >(2, (effect, mimeTypes) => Effect.locally(effect, fieldMimeTypes, Chunk.fromIterable(mimeTypes)))
 
 /** @internal */
-export const fileSchema: Schema.Schema<Multipart.PersistedFile> = Schema.declare(isPersistedFile, {
+export const FileSchema: Schema.Schema<Multipart.PersistedFile> = Schema.declare(isPersistedFile, {
   identifier: "PersistedFile"
 })
 
 /** @internal */
-export const filesSchema: Schema.Schema<ReadonlyArray<Multipart.PersistedFile>> = Schema.Array(fileSchema)
+export const FilesSchema: Schema.Schema<ReadonlyArray<Multipart.PersistedFile>> = Schema.Array(FileSchema)
+
+/** @internal */
+export const SingleFileSchema: Schema.transform<
+  Schema.Schema<ReadonlyArray<Multipart.PersistedFile>>,
+  Schema.Schema<Multipart.PersistedFile>
+> = Schema.transform(FilesSchema.pipe(Schema.itemsCount(1)), FileSchema, {
+  decode: ([file]) => file,
+  encode: (file) => [file]
+})
 
 /** @internal */
 export const schemaPersisted = <R, I extends Partial<Multipart.Persisted>, A>(

--- a/packages/platform/src/internal/http/multipart.ts
+++ b/packages/platform/src/internal/http/multipart.ts
@@ -100,7 +100,8 @@ export const withFieldMimeTypes = dual<
   <R, E, A>(effect: Effect.Effect<A, E, R>, mimeTypes: ReadonlyArray<string>) => Effect.Effect<A, E, R>
 >(2, (effect, mimeTypes) => Effect.locally(effect, fieldMimeTypes, Chunk.fromIterable(mimeTypes)))
 
-const fileSchema: Schema.Schema<Multipart.PersistedFile> = Schema.declare(isPersistedFile, {
+/** @internal */
+export const fileSchema: Schema.Schema<Multipart.PersistedFile> = Schema.declare(isPersistedFile, {
   identifier: "PersistedFile"
 })
 


### PR DESCRIPTION
Making `Http.multipart.fileSchema` externally available could be useful to users of `@effect/platform`

For example, if it were exported, I could create the following Schema: 

```ts
const SingleFileSchema = Schema.transform(
  Http.multipart.filesSchema.pipe(Schema.itemsCount(1)),
  Http.multipart.fileSchema,
  {
    decode: ([file]) => file,
    encode: (file) => [file]
  }
)
```
WDYT @tim-smart?

Second question: do you think it would be valuable to add `SingleFileSchema` into the `Http.multipart` module?
 