### PR TITLE
[experiment] Improve Effects assignability after adding `Symbol.iterator` by replacing `void`s with `unknown`

### DIFF
--- a/packages/cli/src/Command.ts
+++ b/packages/cli/src/Command.ts
@@ -435,9 +435,9 @@ export const run: {
     config: Omit<CliApp.ConstructorArgs<never>, "command">
   ): <Name extends string, R, E, A>(
     self: Command<Name, R, E, A>
-  ) => (args: ReadonlyArray<string>) => Effect<void, E | ValidationError, R | CliApp.Environment>
+  ) => (args: ReadonlyArray<string>) => Effect<unknown, E | ValidationError, R | CliApp.Environment>
   <Name extends string, R, E, A>(
     self: Command<Name, R, E, A>,
     config: Omit<CliApp.ConstructorArgs<never>, "command">
-  ): (args: ReadonlyArray<string>) => Effect<void, E | ValidationError, R | CliApp.Environment>
+  ): (args: ReadonlyArray<string>) => Effect<unknown, E | ValidationError, R | CliApp.Environment>
 } = Internal.run

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -53,20 +53,20 @@ export const make = <A>(config: CliApp.CliApp.ConstructorArgs<A>): CliApp.CliApp
 export const run = dual<
   <R, E, A>(
     args: ReadonlyArray<string>,
-    execute: (a: A) => Effect.Effect<void, E, R>
+    execute: (a: A) => Effect.Effect<unknown, E, R>
   ) => (
     self: CliApp.CliApp<A>
-  ) => Effect.Effect<void, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>,
+  ) => Effect.Effect<unknown, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>,
   <R, E, A>(
     self: CliApp.CliApp<A>,
     args: ReadonlyArray<string>,
-    execute: (a: A) => Effect.Effect<void, E, R>
-  ) => Effect.Effect<void, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>
+    execute: (a: A) => Effect.Effect<unknown, E, R>
+  ) => Effect.Effect<unknown, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>
 >(3, <R, E, A>(
   self: CliApp.CliApp<A>,
   args: ReadonlyArray<string>,
-  execute: (a: A) => Effect.Effect<void, E, R>
-): Effect.Effect<void, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment> =>
+  execute: (a: A) => Effect.Effect<unknown, E, R>
+): Effect.Effect<unknown, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment> =>
   Effect.contextWithEffect((context: Context.Context<CliApp.CliApp.Environment>) => {
     // Attempt to parse the CliConfig from the environment, falling back to the
     // default CliConfig if none was provided
@@ -140,10 +140,10 @@ const handleBuiltInOption = <R, E, A>(
   executable: string,
   args: ReadonlyArray<string>,
   builtIn: BuiltInOptions.BuiltInOptions,
-  execute: (a: A) => Effect.Effect<void, E, R>,
+  execute: (a: A) => Effect.Effect<unknown, E, R>,
   config: CliConfig.CliConfig
 ): Effect.Effect<
-  void,
+  unknown,
   E | ValidationError.ValidationError,
   R | CliApp.CliApp.Environment | Terminal.Terminal
 > => {

--- a/packages/cli/src/internal/command.ts
+++ b/packages/cli/src/internal/command.ts
@@ -542,13 +542,13 @@ export const run = dual<
     self: Command.Command<Name, R, E, A>
   ) => (
     args: ReadonlyArray<string>
-  ) => Effect.Effect<void, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>,
+  ) => Effect.Effect<unknown, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>,
   <Name extends string, R, E, A>(
     self: Command.Command<Name, R, E, A>,
     config: Omit<CliApp.CliApp.ConstructorArgs<never>, "command">
   ) => (
     args: ReadonlyArray<string>
-  ) => Effect.Effect<void, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>
+  ) => Effect.Effect<unknown, E | ValidationError.ValidationError, R | CliApp.CliApp.Environment>
 >(2, (self, config) => {
   const app = InternalCliApp.make({
     ...config,

--- a/packages/cli/src/internal/commandDescriptor.ts
+++ b/packages/cli/src/internal/commandDescriptor.ts
@@ -970,7 +970,7 @@ const traverseCommand = <S>(
       parentCommands: ReadonlyArray<string>,
       subcommands: ReadonlyArray<[string, Standard | GetUserInput]>,
       level: number
-    ): Effect.Effect<void, never, never> => {
+    ): Effect.Effect<unknown, never, never> => {
       switch (self._tag) {
         case "Standard": {
           const info: CommandInfo = {

--- a/packages/cli/src/internal/primitive.ts
+++ b/packages/cli/src/internal/primitive.ts
@@ -476,7 +476,7 @@ const validatePathExistence = (
   path: string,
   shouldPathExist: Primitive.Primitive.PathExists,
   pathExists: boolean
-): Effect.Effect<void, string> => {
+): Effect.Effect<unknown, string> => {
   if (shouldPathExist === "no" && pathExists) {
     return Effect.fail(`Path '${path}' must not exist`)
   }
@@ -490,7 +490,7 @@ const validatePathType = (
   path: string,
   pathType: Primitive.Primitive.PathType,
   fileSystem: FileSystem.FileSystem
-): Effect.Effect<void, string> => {
+): Effect.Effect<unknown, string> => {
   switch (pathType) {
     case "file": {
       const checkIsFile = fileSystem.stat(path).pipe(

--- a/packages/cli/test/Command.test.ts
+++ b/packages/cli/test/Command.test.ts
@@ -135,7 +135,7 @@ describe("Command", () => {
 // --
 
 interface Messages {
-  readonly log: (message: string) => Effect.Effect<void>
+  readonly log: (message: string) => Effect.Effect<unknown>
   readonly messages: Effect.Effect<ReadonlyArray<string>>
 }
 const Messages = Context.GenericTag<Messages>("Messages")

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -67,7 +67,7 @@ export interface Cache<in out Key, out Value, out Error = never> extends Consume
    * by the lookup function. Additionally, `refresh` always triggers the
    * lookup function, disregarding the last `Error`.
    */
-  refresh(key: Key): Effect.Effect<void, Error>
+  refresh(key: Key): Effect.Effect<unknown, Error>
 
   /**
    * Associates the specified value with the specified key in the cache.

--- a/packages/effect/src/Console.ts
+++ b/packages/effect/src/Console.ts
@@ -26,27 +26,27 @@ export type TypeId = typeof TypeId
  */
 export interface Console {
   readonly [TypeId]: TypeId
-  assert(condition: boolean, ...args: ReadonlyArray<any>): Effect<void>
-  readonly clear: Effect<void>
-  count(label?: string): Effect<void>
-  countReset(label?: string): Effect<void>
-  debug(...args: ReadonlyArray<any>): Effect<void>
-  dir(item: any, options?: any): Effect<void>
-  dirxml(...args: ReadonlyArray<any>): Effect<void>
-  error(...args: ReadonlyArray<any>): Effect<void>
+  assert(condition: boolean, ...args: ReadonlyArray<any>): Effect<unknown>
+  readonly clear: Effect<unknown>
+  count(label?: string): Effect<unknown>
+  countReset(label?: string): Effect<unknown>
+  debug(...args: ReadonlyArray<any>): Effect<unknown>
+  dir(item: any, options?: any): Effect<unknown>
+  dirxml(...args: ReadonlyArray<any>): Effect<unknown>
+  error(...args: ReadonlyArray<any>): Effect<unknown>
   group(options?: {
     readonly label?: string | undefined
     readonly collapsed?: boolean | undefined
-  }): Effect<void>
-  readonly groupEnd: Effect<void>
-  info(...args: ReadonlyArray<any>): Effect<void>
-  log(...args: ReadonlyArray<any>): Effect<void>
-  table(tabularData: any, properties?: ReadonlyArray<string>): Effect<void>
-  time(label?: string): Effect<void>
-  timeEnd(label?: string): Effect<void>
-  timeLog(label?: string, ...args: ReadonlyArray<any>): Effect<void>
-  trace(...args: ReadonlyArray<any>): Effect<void>
-  warn(...args: ReadonlyArray<any>): Effect<void>
+  }): Effect<unknown>
+  readonly groupEnd: Effect<unknown>
+  info(...args: ReadonlyArray<any>): Effect<unknown>
+  log(...args: ReadonlyArray<any>): Effect<unknown>
+  table(tabularData: any, properties?: ReadonlyArray<string>): Effect<unknown>
+  time(label?: string): Effect<unknown>
+  timeEnd(label?: string): Effect<unknown>
+  timeLog(label?: string, ...args: ReadonlyArray<any>): Effect<unknown>
+  trace(...args: ReadonlyArray<any>): Effect<unknown>
+  warn(...args: ReadonlyArray<any>): Effect<unknown>
   readonly unsafe: UnsafeConsole
 }
 
@@ -109,49 +109,49 @@ export const consoleWith: <A, E, R>(f: (console: Console) => Effect<A, E, R>) =>
  * @since 2.0.0
  * @category accessor
  */
-export const assert: (condition: boolean, ...args: ReadonlyArray<any>) => Effect<void> = internal.assert
+export const assert: (condition: boolean, ...args: ReadonlyArray<any>) => Effect<unknown> = internal.assert
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const clear: Effect<void> = internal.clear
+export const clear: Effect<unknown> = internal.clear
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const count: (label?: string) => Effect<void> = internal.count
+export const count: (label?: string) => Effect<unknown> = internal.count
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const countReset: (label?: string) => Effect<void> = internal.countReset
+export const countReset: (label?: string) => Effect<unknown> = internal.countReset
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const debug: (...args: ReadonlyArray<any>) => Effect<void> = internal.debug
+export const debug: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.debug
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const dir: (item: any, options?: any) => Effect<void> = internal.dir
+export const dir: (item: any, options?: any) => Effect<unknown> = internal.dir
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const dirxml: (...args: ReadonlyArray<any>) => Effect<void> = internal.dirxml
+export const dirxml: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.dirxml
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const error: (...args: ReadonlyArray<any>) => Effect<void> = internal.error
+export const error: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.error
 
 /**
  * @since 2.0.0
@@ -159,49 +159,49 @@ export const error: (...args: ReadonlyArray<any>) => Effect<void> = internal.err
  */
 export const group: (
   options?: { label?: string | undefined; collapsed?: boolean | undefined } | undefined
-) => Effect<void, never, Scope> = internal.group
+) => Effect<unknown, never, Scope> = internal.group
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const info: (...args: ReadonlyArray<any>) => Effect<void> = internal.info
+export const info: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.info
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const log: (...args: ReadonlyArray<any>) => Effect<void> = internal.log
+export const log: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.log
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const table: (tabularData: any, properties?: ReadonlyArray<string>) => Effect<void> = internal.table
+export const table: (tabularData: any, properties?: ReadonlyArray<string>) => Effect<unknown> = internal.table
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const time: (label?: string | undefined) => Effect<void, never, Scope> = internal.time
+export const time: (label?: string | undefined) => Effect<unknown, never, Scope> = internal.time
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const timeLog: (label?: string, ...args: ReadonlyArray<any>) => Effect<void> = internal.timeLog
+export const timeLog: (label?: string, ...args: ReadonlyArray<any>) => Effect<unknown> = internal.timeLog
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const trace: (...args: ReadonlyArray<any>) => Effect<void> = internal.trace
+export const trace: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.trace
 
 /**
  * @since 2.0.0
  * @category accessor
  */
-export const warn: (...args: ReadonlyArray<any>) => Effect<void> = internal.warn
+export const warn: (...args: ReadonlyArray<any>) => Effect<unknown> = internal.warn
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -94,6 +94,8 @@ export interface Effect<out A, out E = never, out R = never> extends Effect.Vari
   readonly [Unify.typeSymbol]?: unknown
   readonly [Unify.unifySymbol]?: EffectUnify<this>
   readonly [Unify.ignoreSymbol]?: EffectUnifyIgnore
+
+  [Symbol.iterator](): Generator<Effect<A, E, R>, A>
 }
 
 /**
@@ -994,7 +996,7 @@ export const validateFirst: {
  * @category constructors
  */
 export const async: <A, E = never, R = never>(
-  register: (callback: (_: Effect<A, E, R>) => void, signal: AbortSignal) => void | Effect<void, never, R>,
+  register: (callback: (_: Effect<A, E, R>) => void, signal: AbortSignal) => void | Effect<unknown, never, R>,
   blockingOn?: FiberId.FiberId
 ) => Effect<A, E, R> = core.async
 
@@ -1466,7 +1468,7 @@ export const suspend: <A, E, R>(effect: LazyArg<Effect<A, E, R>>) => Effect<A, E
  */
 export const sync: <A>(evaluate: LazyArg<A>) => Effect<A> = core.sync
 
-const _void: Effect<void> = core.void
+const _void: Effect<unknown> = core.void
 export {
   /**
    * @since 2.0.0
@@ -2354,7 +2356,7 @@ export const acquireUseRelease: {
  */
 export const addFinalizer: <X, R>(
   finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect<X, never, R>
-) => Effect<void, never, Scope.Scope | R> = fiberRuntime.addFinalizer
+) => Effect<unknown, never, Scope.Scope | R> = fiberRuntime.addFinalizer
 
 /**
  * Returns an effect that, if this effect _starts_ execution, then the
@@ -5005,7 +5007,7 @@ export const request: {
 export const cacheRequestResult: <A extends Request.Request<any, any>>(
   request: A,
   result: Request.Request.Result<A>
-) => Effect<void> = query.cacheRequest
+) => Effect<unknown> = query.cacheRequest
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/FiberHandle.ts
+++ b/packages/effect/src/FiberHandle.ts
@@ -259,7 +259,7 @@ export const get = <A, E>(self: FiberHandle<A, E>): Effect.Effect<Fiber.RuntimeF
  * @since 2.0.0
  * @categories combinators
  */
-export const clear = <A, E>(self: FiberHandle<A, E>): Effect.Effect<void> =>
+export const clear = <A, E>(self: FiberHandle<A, E>): Effect.Effect<unknown> =>
   Effect.uninterruptibleMask((restore) =>
     Effect.suspend(() => {
       if (self.state._tag === "Closed" || self.state.fiber === undefined) {

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -338,16 +338,16 @@ export const has: {
  * @categories combinators
  */
 export const remove: {
-  <K>(key: K): <A, E>(self: FiberMap<K, A, E>) => Effect.Effect<void>
-  <K, A, E>(self: FiberMap<K, A, E>, key: K): Effect.Effect<void>
+  <K>(key: K): <A, E>(self: FiberMap<K, A, E>) => Effect.Effect<unknown>
+  <K, A, E>(self: FiberMap<K, A, E>, key: K): Effect.Effect<unknown>
 } = dual<
   <K>(
     key: K
-  ) => <A, E>(self: FiberMap<K, A, E>) => Effect.Effect<void>,
+  ) => <A, E>(self: FiberMap<K, A, E>) => Effect.Effect<unknown>,
   <K, A, E>(
     self: FiberMap<K, A, E>,
     key: K
-  ) => Effect.Effect<void>
+  ) => Effect.Effect<unknown>
 >(2, (self, key) =>
   Effect.suspend(() => {
     if (self.state._tag === "Closed") {
@@ -365,7 +365,7 @@ export const remove: {
  * @since 2.0.0
  * @categories combinators
  */
-export const clear = <K, A, E>(self: FiberMap<K, A, E>): Effect.Effect<void> =>
+export const clear = <K, A, E>(self: FiberMap<K, A, E>): Effect.Effect<unknown> =>
   Effect.suspend(() => {
     if (self.state._tag === "Closed") {
       return Effect.void

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -230,7 +230,7 @@ export const add: {
  * @since 2.0.0
  * @categories combinators
  */
-export const clear = <A, E>(self: FiberSet<A, E>): Effect.Effect<void> =>
+export const clear = <A, E>(self: FiberSet<A, E>): Effect.Effect<unknown> =>
   Effect.suspend(() => {
     if (self.state._tag === "Closed") {
       return Effect.void

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -370,7 +370,7 @@ export const snapshot: Effect.Effect<ReadonlyArray<MetricPair.MetricPair.Untyped
  * @since 2.0.0
  * @category constructors
  */
-export const succeed: <Out>(out: Out) => Metric<void, unknown, Out> = internal.succeed
+export const succeed: <Out>(out: Out) => Metric<undefined, unknown, Out> = internal.succeed
 
 /**
  * Creates a metric that ignores input and produces constant output.
@@ -378,7 +378,7 @@ export const succeed: <Out>(out: Out) => Metric<void, unknown, Out> = internal.s
  * @since 2.0.0
  * @category constructors
  */
-export const sync: <Out>(evaluate: LazyArg<Out>) => Metric<void, unknown, Out> = internal.sync
+export const sync: <Out>(evaluate: LazyArg<Out>) => Metric<undefined, unknown, Out> = internal.sync
 
 /**
  * Creates a Summary metric that records observations and calculates quantiles.

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -55,7 +55,7 @@ export interface RequestResolver<in A, out R = never> extends RequestResolver.Va
    * of requests that must be performed sequentially. The inner `Chunk`
    * represents a batch of requests that can be performed in parallel.
    */
-  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<void, never, R>
+  runAll(requests: Array<Array<Request.Entry<A>>>): Effect.Effect<unknown, never, R>
 
   /**
    * Identify the data source using the specific identifier
@@ -116,7 +116,7 @@ export const isRequestResolver: (u: unknown) => u is RequestResolver<unknown, un
  * @category constructors
  */
 export const make: <A, R>(
-  runAll: (requests: Array<Array<A>>) => Effect.Effect<void, never, R>
+  runAll: (requests: Array<Array<A>>) => Effect.Effect<unknown, never, R>
 ) => RequestResolver<A, R> = internal.make
 
 /**
@@ -127,7 +127,7 @@ export const make: <A, R>(
  * @category constructors
  */
 export const makeWithEntry: <A, R>(
-  runAll: (requests: Array<Array<Request.Entry<A>>>) => Effect.Effect<void, never, R>
+  runAll: (requests: Array<Array<Request.Entry<A>>>) => Effect.Effect<unknown, never, R>
 ) => RequestResolver<A, R> = internal.makeWithEntry
 
 /**
@@ -138,7 +138,7 @@ export const makeWithEntry: <A, R>(
  * @category constructors
  */
 export const makeBatched: <A extends Request.Request<any, any>, R>(
-  run: (requests: Array<A>) => Effect.Effect<void, never, R>
+  run: (requests: Array<A>) => Effect.Effect<unknown, never, R>
 ) => RequestResolver<A, R> = internal.makeBatched
 
 /**

--- a/packages/effect/src/STM.ts
+++ b/packages/effect/src/STM.ts
@@ -295,7 +295,7 @@ export const asSomeError: <A, E, R>(self: STM<A, E, R>) => STM<A, Option.Option<
  * @since 2.0.0
  * @category mapping
  */
-export const asVoid: <A, E, R>(self: STM<A, E, R>) => STM<void, E, R> = stm.asVoid
+export const asVoid: <A, E, R>(self: STM<A, E, R>) => STM<unknown, E, R> = stm.asVoid
 
 /**
  * Creates an `STM` value from a partial (but pure) function.
@@ -1128,7 +1128,7 @@ export {
  * @since 2.0.0
  * @category mutations
  */
-export const ignore: <A, E, R>(self: STM<A, E, R>) => STM<void, never, R> = stm.ignore
+export const ignore: <A, E, R>(self: STM<A, E, R>) => STM<unknown, never, R> = stm.ignore
 
 /**
  * Interrupts the fiber running the effect.

--- a/packages/effect/src/Scope.ts
+++ b/packages/effect/src/Scope.ts
@@ -48,7 +48,7 @@ export interface Scope extends Pipeable {
   /**
    * @internal
    */
-  addFinalizer(finalizer: Scope.Finalizer): Effect.Effect<void>
+  addFinalizer(finalizer: Scope.Finalizer): Effect.Effect<unknown>
 }
 
 /**
@@ -78,7 +78,7 @@ export declare namespace Scope {
    * @since 2.0.0
    * @category model
    */
-  export type Finalizer = (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>
+  export type Finalizer = (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<unknown>
   /**
    * @since 2.0.0
    * @category model
@@ -96,7 +96,7 @@ export declare namespace Scope {
 export const addFinalizer: (
   self: Scope,
   finalizer: Effect.Effect<unknown>
-) => Effect.Effect<void> = core.scopeAddFinalizer
+) => Effect.Effect<unknown> = core.scopeAddFinalizer
 
 /**
  * A simplified version of `addFinalizerWith` when the `finalizer` does not
@@ -105,7 +105,7 @@ export const addFinalizer: (
  * @since 2.0.0
  * @category utils
  */
-export const addFinalizerExit: (self: Scope, finalizer: Scope.Finalizer) => Effect.Effect<void> =
+export const addFinalizerExit: (self: Scope, finalizer: Scope.Finalizer) => Effect.Effect<unknown> =
   core.scopeAddFinalizerExit
 
 /**

--- a/packages/effect/src/ScopedCache.ts
+++ b/packages/effect/src/ScopedCache.ts
@@ -69,7 +69,7 @@ export interface ScopedCache<in Key, out Value, out Error = never>
   /**
    * Invalidates the resource associated with the specified key.
    */
-  invalidate(key: Key): Effect.Effect<void>
+  invalidate(key: Key): Effect.Effect<unknown>
 
   /**
    * Invalidates all values in the cache.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -256,7 +256,7 @@ export const as: {
 } = internal.as
 
 const _async: <A, E = never, R = never>(
-  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<void, never, R> | void,
+  register: (emit: Emit.Emit<R, E, A, void>) => Effect.Effect<unknown, never, R> | void,
   outputBuffer?: number
 ) => Stream<A, E, R> = internal._async
 

--- a/packages/effect/src/TArray.ts
+++ b/packages/effect/src/TArray.ts
@@ -293,8 +293,8 @@ export const findLastSTM: {
  * @category elements
  */
 export const forEach: {
-  <A, R, E>(f: (value: A) => STM.STM<void, E, R>): (self: TArray<A>) => STM.STM<void, E, R>
-  <A, R, E>(self: TArray<A>, f: (value: A) => STM.STM<void, E, R>): STM.STM<void, E, R>
+  <A, R, E>(f: (value: A) => STM.STM<unknown, E, R>): (self: TArray<A>) => STM.STM<unknown, E, R>
+  <A, R, E>(self: TArray<A>, f: (value: A) => STM.STM<unknown, E, R>): STM.STM<unknown, E, R>
 } = internal.forEach
 
 /**

--- a/packages/effect/src/TMap.ts
+++ b/packages/effect/src/TMap.ts
@@ -128,8 +128,8 @@ export const findAllSTM: {
  * @category elements
  */
 export const forEach: {
-  <K, V, X, E, R>(f: (key: K, value: V) => STM.STM<X, E, R>): (self: TMap<K, V>) => STM.STM<void, E, R>
-  <K, V, X, E, R>(self: TMap<K, V>, f: (key: K, value: V) => STM.STM<X, E, R>): STM.STM<void, E, R>
+  <K, V, X, E, R>(f: (key: K, value: V) => STM.STM<X, E, R>): (self: TMap<K, V>) => STM.STM<unknown, E, R>
+  <K, V, X, E, R>(self: TMap<K, V>, f: (key: K, value: V) => STM.STM<X, E, R>): STM.STM<unknown, E, R>
 } = internal.forEach
 
 /**

--- a/packages/effect/src/TQueue.ts
+++ b/packages/effect/src/TQueue.ts
@@ -271,8 +271,8 @@ export const isShutdown: <A>(self: TQueue<A>) => STM.STM<boolean> = internal.isS
  * @category mutations
  */
 export const offer: {
-  <A>(value: A): (self: TEnqueue<A>) => STM.STM<void>
-  <A>(self: TEnqueue<A>, value: A): STM.STM<void>
+  <A>(value: A): (self: TEnqueue<A>) => STM.STM<unknown>
+  <A>(self: TEnqueue<A>, value: A): STM.STM<unknown>
 } = internal.offer
 
 /**

--- a/packages/effect/src/TSet.ts
+++ b/packages/effect/src/TSet.ts
@@ -91,8 +91,8 @@ export const empty: <A>() => STM.STM<TSet<A>> = internal.empty
  * @category elements
  */
 export const forEach: {
-  <A, R, E>(f: (value: A) => STM.STM<void, E, R>): (self: TSet<A>) => STM.STM<void, E, R>
-  <A, R, E>(self: TSet<A>, f: (value: A) => STM.STM<void, E, R>): STM.STM<void, E, R>
+  <A, R, E>(f: (value: A) => STM.STM<unknown, E, R>): (self: TSet<A>) => STM.STM<unknown, E, R>
+  <A, R, E>(self: TSet<A>, f: (value: A) => STM.STM<unknown, E, R>): STM.STM<unknown, E, R>
 } = internal.forEach
 
 /**
@@ -360,6 +360,6 @@ export const transformSTM: {
  * @category mutations
  */
 export const union: {
-  <A>(other: TSet<A>): (self: TSet<A>) => STM.STM<void>
-  <A>(self: TSet<A>, other: TSet<A>): STM.STM<void>
+  <A>(other: TSet<A>): (self: TSet<A>) => STM.STM<unknown>
+  <A>(self: TSet<A>, other: TSet<A>): STM.STM<unknown>
 } = internal.union

--- a/packages/effect/src/internal/cache.ts
+++ b/packages/effect/src/internal/cache.ts
@@ -429,7 +429,7 @@ class CacheImpl<in out Key, in out Value, in out Error> implements Cache.Cache<K
     })
   }
 
-  refresh(key: Key): Effect.Effect<void, Error> {
+  refresh(key: Key): Effect.Effect<unknown, Error> {
     return effect.clockWith((clock) =>
       core.suspend(() => {
         const k = key

--- a/packages/effect/src/internal/channel/channelState.ts
+++ b/packages/effect/src/internal/channel/channelState.ts
@@ -126,8 +126,8 @@ export const isFromEffect = <E, R>(self: ChannelState<E, R>): self is FromEffect
 export const isRead = <E, R>(self: ChannelState<E, R>): self is Read => (self as Primitive)._tag === OpCodes.OP_READ
 
 /** @internal */
-export const effect = <E, R>(self: ChannelState<E, R>): Effect.Effect<void, E, R> =>
-  isFromEffect(self) ? self.effect as Effect.Effect<void, E, R> : Effect.void
+export const effect = <E, R>(self: ChannelState<E, R>): Effect.Effect<unknown, E, R> =>
+  isFromEffect(self) ? self.effect as Effect.Effect<unknown, E, R> : Effect.void
 
 /** @internal */
 export const effectOrUndefinedIgnored = <E, R>(self: ChannelState<E, R>): Effect.Effect<void, E, R> | undefined =>

--- a/packages/effect/src/internal/channel/singleProducerAsyncInput.ts
+++ b/packages/effect/src/internal/channel/singleProducerAsyncInput.ts
@@ -41,7 +41,7 @@ type OP_STATE_DONE = typeof OP_STATE_DONE
 /** @internal */
 interface Empty {
   readonly _tag: OP_STATE_EMPTY
-  readonly notifyProducer: Deferred.Deferred<void>
+  readonly notifyProducer: Deferred.Deferred<unknown>
 }
 
 /** @internal */
@@ -63,7 +63,7 @@ interface Done<_Done> {
 }
 
 /** @internal */
-const stateEmpty = (notifyProducer: Deferred.Deferred<void>): State<never, never, never> => ({
+const stateEmpty = (notifyProducer: Deferred.Deferred<unknown>): State<never, never, never> => ({
   _tag: OP_STATE_EMPTY,
   notifyProducer
 })
@@ -137,7 +137,7 @@ class SingleProducerAsyncInputImpl<in out Err, in out Elem, in out Done>
   }
 
   emit(element: Elem): Effect.Effect<unknown> {
-    return Effect.flatMap(Deferred.make<void>(), (deferred) =>
+    return Effect.flatMap(Deferred.make<unknown>(), (deferred) =>
       Effect.flatten(
         Ref.modify(this.ref, (state) => {
           switch (state._tag) {
@@ -253,7 +253,7 @@ export const make = <Err, Elem, Done>(): Effect.Effect<
   SingleProducerAsyncInput.SingleProducerAsyncInput<Err, Elem, Done>
 > =>
   pipe(
-    Deferred.make<void>(),
+    Deferred.make<unknown>(),
     Effect.flatMap((deferred) => Ref.make(stateEmpty(deferred) as State<Err, Elem, Done>)),
     Effect.map((ref) => new SingleProducerAsyncInputImpl(ref))
   )

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -430,7 +430,7 @@ export const as: {
 )
 
 /* @internal */
-export const asVoid = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<void, E, R> => as(self, void 0)
+export const asVoid = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<undefined, E, R> => as(self, void 0)
 
 /* @internal */
 export const custom: {
@@ -481,7 +481,7 @@ export const async = <A, E = never, R = never>(
   register: (
     callback: (_: Effect.Effect<A, E, R>) => void,
     signal: AbortSignal
-  ) => void | Effect.Effect<void, never, R>,
+  ) => void | Effect.Effect<unknown, never, R>,
   blockingOn: FiberId.FiberId = FiberId.none
 ): Effect.Effect<A, E, R> => {
   return custom(register, function() {
@@ -502,7 +502,7 @@ export const async = <A, E = never, R = never>(
       }
     }
     effect.effect_instruction_i1 = blockingOn
-    let cancelerRef: Effect.Effect<void, never, R> | void = undefined
+    let cancelerRef: Effect.Effect<unknown, never, R> | void = undefined
     let controllerRef: AbortController | void = undefined
     if (this.effect_instruction_i0.length !== 1) {
       controllerRef = new AbortController()
@@ -1300,7 +1300,7 @@ export const uninterruptibleMask = <A, E, R>(
     return effect
   })
 
-const void_: Effect.Effect<void> = succeed(void 0)
+const void_: Effect.Effect<undefined> = succeed(void 0)
 export {
   /* @internal */
   void_ as void
@@ -1750,7 +1750,7 @@ export class RequestResolverImpl<in A, out R> implements RequestResolver.Request
   constructor(
     readonly runAll: (
       requests: Array<Array<Request.Entry<A>>>
-    ) => Effect.Effect<void, never, R>,
+    ) => Effect.Effect<unknown, never, R>,
     readonly target?: unknown
   ) {
     this.runAll = runAll as any
@@ -2068,13 +2068,13 @@ export const CloseableScopeTypeId: Scope.CloseableScopeTypeId = Symbol.for(
 export const scopeAddFinalizer = (
   self: Scope.Scope,
   finalizer: Effect.Effect<unknown>
-): Effect.Effect<void> => self.addFinalizer(() => asVoid(finalizer))
+): Effect.Effect<unknown> => self.addFinalizer(() => asVoid(finalizer))
 
 /* @internal */
 export const scopeAddFinalizerExit = (
   self: Scope.Scope,
   finalizer: Scope.Scope.Finalizer
-): Effect.Effect<void> => self.addFinalizer(finalizer)
+): Effect.Effect<unknown> => self.addFinalizer(finalizer)
 
 /* @internal */
 export const scopeClose = (

--- a/packages/effect/src/internal/dataSource.ts
+++ b/packages/effect/src/internal/dataSource.ts
@@ -13,18 +13,18 @@ import { complete } from "./request.js"
 
 /** @internal */
 export const make = <A, R>(
-  runAll: (requests: Array<Array<A>>) => Effect.Effect<void, never, R>
+  runAll: (requests: Array<Array<A>>) => Effect.Effect<unknown, never, R>
 ): RequestResolver.RequestResolver<A, R> =>
   new core.RequestResolverImpl((requests) => runAll(requests.map((_) => _.map((_) => _.request))))
 
 /** @internal */
 export const makeWithEntry = <A, R>(
-  runAll: (requests: Array<Array<Request.Entry<A>>>) => Effect.Effect<void, never, R>
+  runAll: (requests: Array<Array<Request.Entry<A>>>) => Effect.Effect<unknown, never, R>
 ): RequestResolver.RequestResolver<A, R> => new core.RequestResolverImpl((requests) => runAll(requests))
 
 /** @internal */
 export const makeBatched = <A extends Request.Request<any, any>, R>(
-  run: (requests: Array<A>) => Effect.Effect<void, never, R>
+  run: (requests: Array<A>) => Effect.Effect<unknown, never, R>
 ): RequestResolver.RequestResolver<A, R> =>
   new core.RequestResolverImpl<A, R>(
     (requests) => {

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -267,7 +267,7 @@ export const forkAll: {
   }): Effect.Effect<void, never, Effect.Effect.Context<Eff>>
 } = dual((args) => Predicate.isIterable(args[0]), <A, E, R>(effects: Iterable<Effect.Effect<A, E, R>>, options: {
   readonly discard: true
-}): Effect.Effect<void, never, R> =>
+}): Effect.Effect<unknown, never, R> =>
   options?.discard ?
     core.forEachSequentialDiscard(effects, fiberRuntime.fork) :
     core.map(core.forEachSequential(effects, fiberRuntime.fork), fiberRuntime.fiberAll))

--- a/packages/effect/src/internal/effectable.ts
+++ b/packages/effect/src/internal/effectable.ts
@@ -75,6 +75,9 @@ export const EffectPrototype: Effect.Effect<never> & Equal.Equal = {
   [Hash.symbol]() {
     return Hash.cached(this, Hash.random(this))
   },
+  [Symbol.iterator]() {
+    return this as any // TODO: fix
+  },
   pipe() {
     return pipeArguments(this, arguments)
   }

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1536,7 +1536,7 @@ export const acquireReleaseInterruptible: {
 /* @internal */
 export const addFinalizer = <X, R>(
   finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<X, never, R>
-): Effect.Effect<void, never, R | Scope.Scope> =>
+): Effect.Effect<unknown, never, R | Scope.Scope> =>
   core.withFiberRuntime(
     (runtime) => {
       const acquireRefs = runtime.getFiberRefs()
@@ -1926,7 +1926,7 @@ export const forEach: {
     readonly discard?: boolean | undefined
   }
 ) =>
-  core.withFiberRuntime<A | void, E, R>((r) => {
+  core.withFiberRuntime<A | null | undefined | {}, E, R>((r) => {
     const isRequestBatchingEnabled = options?.batching === true ||
       (options?.batching === "inherit" && r.getFiberRef(core.currentRequestBatching))
 
@@ -3503,7 +3503,7 @@ export const invokeWithInterrupt: <A, E, R>(
       core.flatMap(
         forkDaemon(core.interruptible(self)),
         (processing) =>
-          core.async<void, E>((cb) => {
+          core.async<unknown, E>((cb) => {
             const counts = entries.map((_) => _.listeners.count)
             const checkDone = () => {
               if (counts.every((count) => count === 0)) {

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -451,7 +451,7 @@ export const flatMap = Dual.dual<
 export const forEach = Dual.dual<
   <V, K>(f: (value: V, key: K) => void) => (self: HM.HashMap<K, V>) => void,
   <V, K>(self: HM.HashMap<K, V>, f: (value: V, key: K) => void) => void
->(2, (self, f) => reduce(self, void 0 as void, (_, value, key) => f(value, key)))
+>(2, (self, f) => reduce(self, void 0 as unknown, (_, value, key) => f(value, key)))
 
 /** @internal */
 export const reduce = Dual.dual<

--- a/packages/effect/src/internal/metric.ts
+++ b/packages/effect/src/internal/metric.ts
@@ -223,11 +223,11 @@ export const set = dual<
 >(2, (self, value) => update(self as any, value))
 
 /** @internal */
-export const succeed = <Out>(out: Out): Metric.Metric<void, unknown, Out> => make(void 0 as void, constVoid, () => out)
+export const succeed = <Out>(out: Out): Metric.Metric<undefined, unknown, Out> => make(void 0, constVoid, () => out)
 
 /** @internal */
-export const sync = <Out>(evaluate: LazyArg<Out>): Metric.Metric<void, unknown, Out> =>
-  make(void 0 as void, constVoid, evaluate)
+export const sync = <Out>(evaluate: LazyArg<Out>): Metric.Metric<undefined, unknown, Out> =>
+  make(void 0, constVoid, evaluate)
 
 /** @internal */
 export const summary = (

--- a/packages/effect/src/internal/query.ts
+++ b/packages/effect/src/internal/query.ts
@@ -146,7 +146,7 @@ export const fromRequest = <
 export const cacheRequest = <A extends Request.Request<any, any>>(
   request: A,
   result: Request.Request.Result<A>
-): Effect.Effect<void> => {
+): Effect.Effect<unknown> => {
   return core.fiberRefGetWith(currentCacheEnabled, (cacheEnabled) => {
     if (cacheEnabled) {
       return core.fiberRefGetWith(currentCache, (cache) =>

--- a/packages/effect/src/internal/rateLimiter.ts
+++ b/packages/effect/src/internal/rateLimiter.ts
@@ -35,7 +35,7 @@ const tokenBucket = (limit: number, window: DurationInput): Effect.Effect<
     const millisPerToken = Math.ceil(Duration.toMillis(window) / limit)
     const semaphore = yield* _(Effect.makeSemaphore(limit))
     const latch = yield* _(Effect.makeSemaphore(0))
-    const refill: Effect.Effect<void> = Effect.sleep(millisPerToken).pipe(
+    const refill: Effect.Effect<unknown> = Effect.sleep(millisPerToken).pipe(
       Effect.zipRight(latch.releaseAll),
       Effect.zipRight(semaphore.release(1)),
       Effect.flatMap((free) => free === limit ? Effect.void : refill)

--- a/packages/effect/src/internal/scopedCache.ts
+++ b/packages/effect/src/internal/scopedCache.ts
@@ -158,7 +158,7 @@ export const toScoped = <Key, Value, Error = never>(
 /** @internal */
 export const releaseOwner = <Key, Value, Error = never>(
   self: Complete<Key, Value, Error>
-): Effect.Effect<void> =>
+): Effect.Effect<unknown> =>
   Exit.matchEffect(self.exit, {
     onFailure: () => core.void,
     onSuccess: ([, finalizer]) =>
@@ -305,7 +305,7 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
     )
   }
 
-  invalidate(key: Key): Effect.Effect<void> {
+  invalidate(key: Key): Effect.Effect<unknown> {
     return core.suspend(() => {
       if (MutableHashMap.has(this.cacheState.map, key)) {
         const mapValue = Option.getOrUndefined(MutableHashMap.get(this.cacheState.map, key))!
@@ -558,7 +558,7 @@ class ScopedCacheImpl<in out Key, in out Environment, in out Error, in out Value
     return cleanedKeys
   }
 
-  cleanMapValue(mapValue: MapValue<Key, Value, Error> | undefined): Effect.Effect<void> {
+  cleanMapValue(mapValue: MapValue<Key, Value, Error> | undefined): Effect.Effect<unknown> {
     if (mapValue === undefined) {
       return core.void
     }

--- a/packages/effect/src/internal/stm/core.ts
+++ b/packages/effect/src/internal/stm/core.ts
@@ -154,7 +154,10 @@ class STMPrimitive implements STM.STM<any, any, any> {
   [Effect.EffectTypeId]: any;
   [StreamTypeId]: any;
   [SinkTypeId]: any;
-  [ChannelTypeId]: any
+  [ChannelTypeId]: any;
+  [Symbol.iterator]() {
+    return this as any // TODO: fix
+  }
   get [STMTypeId]() {
     return stmVariance
   }

--- a/packages/effect/src/internal/stm/stm.ts
+++ b/packages/effect/src/internal/stm/stm.ts
@@ -98,7 +98,7 @@ export const asSomeError = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<A, Option.
   pipe(self, mapError(Option.some))
 
 /** @internal */
-export const asVoid = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<void, E, R> => pipe(self, core.map(constVoid))
+export const asVoid = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<unknown, E, R> => pipe(self, core.map(constVoid))
 
 /** @internal */
 export const attempt = <A>(evaluate: LazyArg<A>): STM.STM<A, unknown> =>
@@ -712,7 +712,7 @@ export const if_ = dual<
 )
 
 /** @internal */
-export const ignore = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<void, never, R> =>
+export const ignore = <A, E, R>(self: STM.STM<A, E, R>): STM.STM<unknown, never, R> =>
   match(self, { onFailure: () => void_, onSuccess: () => void_ })
 
 /** @internal */

--- a/packages/effect/src/internal/stm/tArray.ts
+++ b/packages/effect/src/internal/stm/tArray.ts
@@ -338,9 +338,9 @@ export const findLastSTM = dual<
 
 /** @internal */
 export const forEach = dual<
-  <A, R, E>(f: (value: A) => STM.STM<void, E, R>) => (self: TArray.TArray<A>) => STM.STM<void, E, R>,
-  <A, R, E>(self: TArray.TArray<A>, f: (value: A) => STM.STM<void, E, R>) => STM.STM<void, E, R>
->(2, (self, f) => reduceSTM(self, void 0 as void, (_, a) => f(a)))
+  <A, R, E>(f: (value: A) => STM.STM<unknown, E, R>) => (self: TArray.TArray<A>) => STM.STM<unknown, E, R>,
+  <A, R, E>(self: TArray.TArray<A>, f: (value: A) => STM.STM<unknown, E, R>) => STM.STM<unknown, E, R>
+>(2, (self, f) => reduceSTM(self, void 0 as unknown, (_, a) => f(a)))
 
 /** @internal */
 export const fromIterable = <A>(iterable: Iterable<A>): STM.STM<TArray.TArray<A>> =>

--- a/packages/effect/src/internal/stm/tMap.ts
+++ b/packages/effect/src/internal/stm/tMap.ts
@@ -181,12 +181,12 @@ export const findAllSTM = dual<
 
 /** @internal */
 export const forEach = dual<
-  <K, V, X, E, R>(f: (key: K, value: V) => STM.STM<X, E, R>) => (self: TMap.TMap<K, V>) => STM.STM<void, E, R>,
-  <K, V, X, E, R>(self: TMap.TMap<K, V>, f: (key: K, value: V) => STM.STM<X, E, R>) => STM.STM<void, E, R>
+  <K, V, X, E, R>(f: (key: K, value: V) => STM.STM<X, E, R>) => (self: TMap.TMap<K, V>) => STM.STM<unknown, E, R>,
+  <K, V, X, E, R>(self: TMap.TMap<K, V>, f: (key: K, value: V) => STM.STM<X, E, R>) => STM.STM<unknown, E, R>
 >(2, (self, f) =>
   reduceSTM(
     self,
-    void 0 as void,
+    void 0 as unknown,
     (_, value, key) => stm.asVoid(f(key, value))
   ))
 

--- a/packages/effect/src/internal/stm/tQueue.ts
+++ b/packages/effect/src/internal/stm/tQueue.ts
@@ -277,8 +277,8 @@ export const isShutdown = <A>(self: TQueue.TDequeue<A> | TQueue.TEnqueue<A>): ST
 
 /** @internal */
 export const offer = dual<
-  <A>(value: A) => (self: TQueue.TEnqueue<A>) => STM.STM<void>,
-  <A>(self: TQueue.TEnqueue<A>, value: A) => STM.STM<void>
+  <A>(value: A) => (self: TQueue.TEnqueue<A>) => STM.STM<unknown>,
+  <A>(self: TQueue.TEnqueue<A>, value: A) => STM.STM<unknown>
 >(2, (self, value) => self.offer(value))
 
 /** @internal */

--- a/packages/effect/src/internal/stm/tSet.ts
+++ b/packages/effect/src/internal/stm/tSet.ts
@@ -35,7 +35,7 @@ const isTSet = (u: unknown) => hasProperty(u, TSetTypeId)
 export const add = dual<
   <A>(value: A) => (self: TSet.TSet<A>) => STM.STM<void>,
   <A>(self: TSet.TSet<A>, value: A) => STM.STM<void>
->(2, (self, value) => tMap.set(self.tMap, value, void 0 as void))
+>(2, (self, value) => tMap.set(self.tMap, value, void 0))
 
 /** @internal */
 export const difference = dual<
@@ -52,9 +52,9 @@ export const empty = <A>(): STM.STM<TSet.TSet<A>> => fromIterable<A>([])
 
 /** @internal */
 export const forEach = dual<
-  <A, R, E>(f: (value: A) => STM.STM<void, E, R>) => (self: TSet.TSet<A>) => STM.STM<void, E, R>,
-  <A, R, E>(self: TSet.TSet<A>, f: (value: A) => STM.STM<void, E, R>) => STM.STM<void, E, R>
->(2, (self, f) => reduceSTM(self, void 0 as void, (_, value) => f(value)))
+  <A, R, E>(f: (value: A) => STM.STM<unknown, E, R>) => (self: TSet.TSet<A>) => STM.STM<unknown, E, R>,
+  <A, R, E>(self: TSet.TSet<A>, f: (value: A) => STM.STM<unknown, E, R>) => STM.STM<unknown, E, R>
+>(2, (self, f) => reduceSTM(self, void 0 as unknown, (_, value) => f(value)))
 
 /** @internal */
 export const fromIterable = <A>(iterable: Iterable<A>): STM.STM<TSet.TSet<A>> =>
@@ -254,6 +254,6 @@ export const transformSTM = dual<
 
 /** @internal */
 export const union = dual<
-  <A>(other: TSet.TSet<A>) => (self: TSet.TSet<A>) => STM.STM<void>,
-  <A>(self: TSet.TSet<A>, other: TSet.TSet<A>) => STM.STM<void>
+  <A>(other: TSet.TSet<A>) => (self: TSet.TSet<A>) => STM.STM<unknown>,
+  <A>(self: TSet.TSet<A>, other: TSet.TSet<A>) => STM.STM<unknown>
 >(2, (self, other) => forEach(other, (value) => add(self, value)))

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -463,7 +463,7 @@ export const as = dual<
 export const _async = <A, E = never, R = never>(
   register: (
     emit: Emit.Emit<R, E, A, void>
-  ) => Effect.Effect<void, never, R> | void,
+  ) => Effect.Effect<unknown, never, R> | void,
   outputBuffer = 16
 ): Stream.Stream<A, E, R> =>
   Effect.acquireRelease(

--- a/packages/effect/src/internal/trie.ts
+++ b/packages/effect/src/internal/trie.ts
@@ -324,7 +324,7 @@ export const compact = <A>(self: TR.Trie<Option.Option<A>>) => filterMap(self, i
 export const forEach = dual<
   <V>(f: (value: V, key: string) => void) => (self: TR.Trie<V>) => void,
   <V>(self: TR.Trie<V>, f: (value: V, key: string) => void) => void
->(2, (self, f) => reduce(self, void 0 as void, (_, value, key) => f(value, key)))
+>(2, (self, f) => reduce(self, void 0 as unknown, (_, value, key) => f(value, key)))
 
 /** @internal */
 export const keysWithPrefix = dual<

--- a/packages/effect/test/Effect/async.test.ts
+++ b/packages/effect/test/Effect/async.test.ts
@@ -100,7 +100,7 @@ describe("Effect", () => {
       const unexpectedPlace = yield* $(Ref.make(Chunk.empty<number>()))
       const runtime = yield* $(Effect.runtime<never>())
       const fiber = yield* $(
-        Effect.async<void, never, never>((resume) => {
+        Effect.async<unknown, never, never>((resume) => {
           Runtime.runCallback(runtime)(pipe(
             Deferred.await(step),
             Effect.zipRight(Effect.sync(() => resume(Ref.update(unexpectedPlace, Chunk.prepend(1)))))
@@ -108,7 +108,7 @@ describe("Effect", () => {
           return Effect.void
         }),
         Effect.flatMap(() =>
-          Effect.async<void, never, never>(() => {
+          Effect.async<unknown, never, never>(() => {
             // The callback is never called so this never completes
             Runtime.runCallback(runtime)(Deferred.succeed(step, void 0))
           })

--- a/packages/effect/test/Effect/error.test.ts
+++ b/packages/effect/test/Effect/error.test.ts
@@ -4,7 +4,11 @@ import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import { assert, describe, expect } from "vitest"
 
-class TestError extends Data.TaggedError("TestError")<{}> {}
+class TestError extends Data.TaggedError("TestError")<{}> {
+  [Symbol.iterator]() {
+    return this as any // TODO: fix
+  }
+}
 
 describe("Effect", () => {
   it.effect("TaggedError has a stack", () =>

--- a/packages/effect/test/Effect/finalization.test.ts
+++ b/packages/effect/test/Effect/finalization.test.ts
@@ -20,7 +20,7 @@ const asyncExampleError = <A>(): Effect.Effect<A, unknown> => {
   })
 }
 
-const asyncVoid = <E>(): Effect.Effect<void, E> => {
+const asyncVoid = <E>(): Effect.Effect<unknown, E> => {
   return Effect.async((cb) => {
     cb(Effect.void)
   })

--- a/packages/effect/test/Effect/traversing.test.ts
+++ b/packages/effect/test/Effect/traversing.test.ts
@@ -446,8 +446,8 @@ describe("Effect", () => {
     }))
   it.effect("mergeAll - return error if it exists in list", () =>
     Effect.gen(function*($) {
-      const effects: ReadonlyArray<Effect.Effect<void, number>> = [Effect.void, Effect.fail(1)]
-      const result = yield* $(effects, Effect.mergeAll(void 0 as void, constVoid), Effect.exit)
+      const effects: ReadonlyArray<Effect.Effect<unknown, number>> = [Effect.void, Effect.fail(1)]
+      const result = yield* $(effects, Effect.mergeAll(void 0, constVoid), Effect.exit)
       assert.deepStrictEqual(result, Exit.fail(1))
     }))
   it.effect("mergeAll/concurrency - return zero element on empty input", () =>
@@ -476,10 +476,10 @@ describe("Effect", () => {
     }))
   it.effect("mergeAll/concurrency - return error if it exists in list", () =>
     Effect.gen(function*($) {
-      const effects: ReadonlyArray<Effect.Effect<void, number>> = [Effect.void, Effect.fail(1)]
+      const effects: ReadonlyArray<Effect.Effect<unknown, number>> = [Effect.void, Effect.fail(1)]
       const result = yield* $(
         effects,
-        Effect.mergeAll(void 0 as void, constVoid, {
+        Effect.mergeAll(void 0, constVoid, {
           concurrency: "unbounded"
         }),
         Effect.exit
@@ -665,7 +665,7 @@ describe("Effect", () => {
     }))
   it.effect("reduceEffect/concurrency - return error if it exists in list", () =>
     Effect.gen(function*($) {
-      const effects: ReadonlyArray<Effect.Effect<void, number>> = [Effect.void, Effect.fail(1)]
+      const effects: ReadonlyArray<Effect.Effect<unknown, number>> = [Effect.void, Effect.fail(1)]
       const result = yield* $(
         pipe(
           effects,

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -41,7 +41,7 @@ describe("Fiber", () => {
       const blockingOn = yield* $(
         Fiber.status(fiber),
         Effect.flatMap(
-          (status) => FiberStatus.isSuspended(status) ? Effect.succeed(status.blockingOn) : Effect.fail(void 0 as void)
+          (status) => FiberStatus.isSuspended(status) ? Effect.succeed(status.blockingOn) : Effect.fail(void 0)
         ),
         Effect.eventually
       )

--- a/packages/effect/test/STM.test.ts
+++ b/packages/effect/test/STM.test.ts
@@ -127,7 +127,7 @@ const compute3TRefN = (
     Effect.repeatN(n)
   )
 
-const permutation = (ref1: TRef.TRef<number>, ref2: TRef.TRef<number>): STM.STM<void> =>
+const permutation = (ref1: TRef.TRef<number>, ref2: TRef.TRef<number>): STM.STM<unknown> =>
   pipe(
     STM.all([TRef.get(ref1), TRef.get(ref2)]),
     STM.flatMap(([a, b]) =>
@@ -535,7 +535,7 @@ describe("STM", () => {
     Effect.gen(function*($) {
       const transaction = pipe(
         [STM.void, STM.fail(1)] as Array<STM.STM<void, number>>,
-        STM.mergeAll(void 0 as void, constVoid)
+        STM.mergeAll(void 0, constVoid)
       )
       const result = yield* $(Effect.exit(STM.commit(transaction)))
       assert.deepStrictEqual(result, Exit.fail(1))

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -74,7 +74,7 @@ describe("Schedule", () => {
     }))
   it.effect("reset after some inactivity", () =>
     Effect.gen(function*($) {
-      const io = (ref: Ref.Ref<number>, latch: Deferred.Deferred<void, never>): Effect.Effect<void, string> => {
+      const io = (ref: Ref.Ref<number>, latch: Deferred.Deferred<void, never>): Effect.Effect<unknown, string> => {
         return Ref.updateAndGet(ref, (n) => n + 1).pipe(
           Effect.flatMap((retries) => {
             // The 5th retry will fail after 10 seconds to let the schedule reset

--- a/packages/effect/test/utils/cache/WatchableLookup.ts
+++ b/packages/effect/test/utils/cache/WatchableLookup.ts
@@ -13,8 +13,8 @@ import { expect } from "vitest"
 
 export interface WatchableLookup<Key, Value, Error = never> {
   (key: Key): Effect.Effect<Value, Error, Scope.Scope>
-  lock: () => Effect.Effect<void>
-  unlock: () => Effect.Effect<void>
+  lock: () => Effect.Effect<unknown>
+  unlock: () => Effect.Effect<unknown>
   createdResources: () => Effect.Effect<
     HashMap.HashMap<Key, Chunk.Chunk<ObservableResource.ObservableResource<Error, Value>>>
   >
@@ -22,12 +22,12 @@ export interface WatchableLookup<Key, Value, Error = never> {
   getCalledTimes: (key: Key) => Effect.Effect<number>
   resourcesCleaned: (
     resources: Iterable<ObservableResource.ObservableResource<Error, Value>>
-  ) => Effect.Effect<void>
-  assertCalledTimes: (key: Key, sizeAssertion: (value: number) => void) => Effect.Effect<void>
-  assertFirstNCreatedResourcesCleaned: (key: Key, n: number) => Effect.Effect<void>
-  assertAllCleaned: () => Effect.Effect<void>
-  assertAllCleanedForKey: (key: Key) => Effect.Effect<void>
-  assertAtLeastOneResourceNotCleanedForKey: (key: Key) => Effect.Effect<void>
+  ) => Effect.Effect<unknown>
+  assertCalledTimes: (key: Key, sizeAssertion: (value: number) => void) => Effect.Effect<unknown>
+  assertFirstNCreatedResourcesCleaned: (key: Key, n: number) => Effect.Effect<unknown>
+  assertAllCleaned: () => Effect.Effect<unknown>
+  assertAllCleanedForKey: (key: Key) => Effect.Effect<unknown>
+  assertAtLeastOneResourceNotCleanedForKey: (key: Key) => Effect.Effect<unknown>
 }
 
 export const make = <Key, Value>(

--- a/packages/experimental/src/DevTools/Server.ts
+++ b/packages/experimental/src/DevTools/Server.ts
@@ -26,7 +26,7 @@ export interface ServerImpl {
  */
 export interface Client {
   readonly queue: Queue.Dequeue<Domain.Request.WithoutPing>
-  readonly request: (_: Domain.Response.WithoutPong) => Effect.Effect<void>
+  readonly request: (_: Domain.Response.WithoutPong) => Effect.Effect<unknown>
 }
 
 /**

--- a/packages/experimental/src/Machine/Procedure.ts
+++ b/packages/experimental/src/Machine/Procedure.ts
@@ -143,7 +143,7 @@ export declare namespace Procedure {
    * @category models
    */
   export interface ContextProto<Requests extends TaggedRequest.Any, State> extends BaseContext {
-    readonly send: <Req extends Requests>(request: Req) => Effect.Effect<void>
+    readonly send: <Req extends Requests>(request: Req) => Effect.Effect<unknown>
     readonly sendAwait: <Req extends Requests>(request: Req) => Effect.Effect<
       Request.Success<Req>,
       Request.Error<Req>
@@ -151,33 +151,33 @@ export declare namespace Procedure {
     readonly forkWith: {
       (state: State): <A, E, R>(
         effect: Effect.Effect<A, E, R>
-      ) => Effect.Effect<readonly [void, State], never, R>
+      ) => Effect.Effect<readonly [unknown, State], never, R>
       <A, E, R>(
         effect: Effect.Effect<A, E, R>,
         state: State
-      ): Effect.Effect<readonly [void, State], never, R>
+      ): Effect.Effect<readonly [unknown, State], never, R>
     }
     readonly forkOneWith: {
       (
         id: string,
         state: State
-      ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<readonly [void, State], never, R>
+      ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<readonly [unknown, State], never, R>
       <A, E, R>(
         effect: Effect.Effect<A, E, R>,
         id: string,
         state: State
-      ): Effect.Effect<readonly [void, State], never, R>
+      ): Effect.Effect<readonly [unknown, State], never, R>
     }
     readonly forkReplaceWith: {
       (
         id: string,
         state: State
-      ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<readonly [void, State], never, R>
+      ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<readonly [unknown, State], never, R>
       <A, E, R>(
         effect: Effect.Effect<A, E, R>,
         id: string,
         state: State
-      ): Effect.Effect<readonly [void, State], never, R>
+      ): Effect.Effect<readonly [unknown, State], never, R>
     }
   }
 

--- a/packages/experimental/src/Persistence.ts
+++ b/packages/experimental/src/Persistence.ts
@@ -108,9 +108,9 @@ export interface BackingPersistenceStore {
     key: string,
     value: unknown,
     ttl: Option.Option<Duration.Duration>
-  ) => Effect.Effect<void, PersistenceError>
-  readonly remove: (key: string) => Effect.Effect<void, PersistenceError>
-  readonly clear: Effect.Effect<void, PersistenceError>
+  ) => Effect.Effect<unknown, PersistenceError>
+  readonly remove: (key: string) => Effect.Effect<unknown, PersistenceError>
+  readonly clear: Effect.Effect<unknown, PersistenceError>
 }
 
 /**
@@ -158,11 +158,11 @@ export interface ResultPersistenceStore {
   readonly set: <R, IE, E, IA, A>(
     key: ResultPersistence.Key<R, IE, E, IA, A>,
     value: Exit.Exit<A, E>
-  ) => Effect.Effect<void, PersistenceError, R>
+  ) => Effect.Effect<unknown, PersistenceError, R>
   readonly remove: <R, IE, E, IA, A>(
     key: ResultPersistence.Key<R, IE, E, IA, A>
-  ) => Effect.Effect<void, PersistenceError>
-  readonly clear: Effect.Effect<void, PersistenceError>
+  ) => Effect.Effect<unknown, PersistenceError>
+  readonly clear: Effect.Effect<unknown, PersistenceError>
 }
 
 /**

--- a/packages/opentelemetry/examples/metrics.ts
+++ b/packages/opentelemetry/examples/metrics.ts
@@ -71,7 +71,7 @@ const MetricsLive = NodeSdk.layer(() => ({
   resource: {
     serviceName: "example"
   },
-  metricReader: new PrometheusExporter({ port: 9464 })
+  metricReader: new PrometheusExporter({ port: 9464 }) as any // TODO: fix type
 }))
 
 pipe(

--- a/packages/platform-bun/src/internal/worker.ts
+++ b/packages/platform-bun/src/internal/worker.ts
@@ -13,7 +13,7 @@ const platformWorkerImpl = Worker.PlatformWorker.of({
 
       yield* _(Effect.addFinalizer(() =>
         pipe(
-          Effect.async<void>((resume, signal) => {
+          Effect.async<unknown>((resume, signal) => {
             port.addEventListener("close", () => resume(Effect.void), { once: true, signal })
             port.postMessage([1])
           }),

--- a/packages/platform-node-shared/src/NodeSocket.ts
+++ b/packages/platform-node-shared/src/NodeSocket.ts
@@ -87,7 +87,7 @@ export const fromNetSocket = (
         yield* _(
           Queue.take(sendQueue),
           Effect.tap((chunk) =>
-            Effect.async<void, Socket.SocketError, never>((resume) => {
+            Effect.async<unknown, Socket.SocketError, never>((resume) => {
               if (Socket.isCloseEvent(chunk)) {
                 conn.destroy(chunk.code > 1000 ? new Error(`closed with code ${chunk.code}`) : undefined)
               } else if (chunk === EOF) {
@@ -107,7 +107,7 @@ export const fromNetSocket = (
           run(handler(chunk))
         })
         yield* _(
-          Effect.async<void, Socket.SocketError, never>((resume) => {
+          Effect.async<unknown, Socket.SocketError, never>((resume) => {
             conn.on("end", () => {
               resume(Effect.void)
             })

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -328,7 +328,7 @@ const makeFile = (() => {
       )
     }
 
-    private writeAllChunk(buffer: Uint8Array): Effect.Effect<void, Error.PlatformError> {
+    private writeAllChunk(buffer: Uint8Array): Effect.Effect<unknown, Error.PlatformError> {
       return Effect.flatMap(
         Effect.suspend(() =>
           nodeWriteAll(this.fd, buffer, undefined, undefined, this.append ? undefined : Number(this.position))
@@ -575,7 +575,7 @@ const watch = (backend: Option.Option<Context.Tag.Service<FileSystem.WatchBacken
 // == writeFile
 
 const writeFile = (path: string, data: Uint8Array, options?: FileSystem.WriteFileOptions) =>
-  Effect.async<void, Error.PlatformError>((resume, signal) => {
+  Effect.async<unknown, Error.PlatformError>((resume, signal) => {
     try {
       NFS.writeFile(path, data, {
         signal,

--- a/packages/platform-node-shared/src/internal/sink.ts
+++ b/packages/platform-node-shared/src/internal/sink.ts
@@ -24,7 +24,7 @@ export const fromWritableChannel = <IE, OE, A>(
   Channel.flatMap(
     Effect.zip(
       Effect.sync(() => writable()),
-      Deferred.make<void, IE | OE>()
+      Deferred.make<unknown, IE | OE>()
     ),
     ([writable, deferred]) =>
       Channel.embedInput(
@@ -40,7 +40,7 @@ export const fromWritableChannel = <IE, OE, A>(
 
 const writableOutput = <IE, E>(
   writable: Writable | NodeJS.WritableStream,
-  deferred: Deferred.Deferred<void, IE | E>,
+  deferred: Deferred.Deferred<unknown, IE | E>,
   onError: (error: unknown) => E
 ) =>
   Effect.suspend(() => {

--- a/packages/platform-node-shared/src/internal/stream.ts
+++ b/packages/platform-node-shared/src/internal/stream.ts
@@ -222,13 +222,13 @@ export const fromReadableChannel = <E, A = Uint8Array>(
 /** @internal */
 export const writeInput = <IE, A>(
   writable: Writable | NodeJS.WritableStream,
-  onFailure: (cause: Cause.Cause<IE>) => Effect.Effect<void>,
+  onFailure: (cause: Cause.Cause<IE>) => Effect.Effect<unknown>,
   { encoding, endOnDone = true }: FromWritableOptions = {},
   onDone = Effect.void
 ): AsyncInput.AsyncInputProducer<IE, Chunk.Chunk<A>, unknown> => {
   const write = writeEffect(writable, encoding)
   const close = endOnDone
-    ? Effect.async<void>((resume) => {
+    ? Effect.async<unknown>((resume) => {
       if ("closed" in writable && writable.closed) {
         resume(Effect.void)
       } else {
@@ -253,7 +253,7 @@ export const writeEffect = <A>(
 (chunk: Chunk.Chunk<A>) =>
   chunk.length === 0 ?
     Effect.void :
-    Effect.async<void>((resume) => {
+    Effect.async<unknown>((resume) => {
       const iterator = chunk[Symbol.iterator]()
       let next = iterator.next()
       function loop() {

--- a/packages/platform-node-shared/src/internal/terminal.ts
+++ b/packages/platform-node-shared/src/internal/terminal.ts
@@ -91,7 +91,7 @@ export const make = (
       releaseReadlineInterface
     )
 
-    const display = (prompt: string): Effect.Effect<void, Error.PlatformError> =>
+    const display = (prompt: string): Effect.Effect<unknown, Error.PlatformError> =>
       Effect.uninterruptible(
         Effect.async((resume) => {
           output.write(prompt, (err) => {

--- a/packages/platform-node/src/internal/http/client.ts
+++ b/packages/platform-node/src/internal/http/client.ts
@@ -81,8 +81,8 @@ const sendBody = (
   nodeRequest: Http.ClientRequest,
   request: ClientRequest.ClientRequest,
   body: Body.Body
-): Effect.Effect<void, Error.RequestError> =>
-  Effect.suspend((): Effect.Effect<void, Error.RequestError> => {
+): Effect.Effect<unknown, Error.RequestError> =>
+  Effect.suspend((): Effect.Effect<unknown, Error.RequestError> => {
     switch (body._tag) {
       case "Empty": {
         nodeRequest.end()
@@ -157,7 +157,7 @@ const waitForResponse = (nodeRequest: Http.ClientRequest, request: ClientRequest
   })
 
 const waitForFinish = (nodeRequest: Http.ClientRequest, request: ClientRequest.ClientRequest) =>
-  Effect.async<void, Error.RequestError>((resume) => {
+  Effect.async<unknown, Error.RequestError>((resume) => {
     function onError(error: Error) {
       resume(Effect.fail(
         new Error.RequestError({

--- a/packages/platform-node/src/internal/http/server.ts
+++ b/packages/platform-node/src/internal/http/server.ts
@@ -46,7 +46,7 @@ export const make = (
     const server = yield* _(Effect.acquireRelease(
       Effect.sync(evaluate),
       (server) =>
-        Effect.async<void>((resume) => {
+        Effect.async<unknown>((resume) => {
           server.close((error) => {
             if (error) {
               resume(Effect.die(error))
@@ -57,7 +57,7 @@ export const make = (
         })
     ))
 
-    yield* _(Effect.async<void, Error.ServeError>((resume) => {
+    yield* _(Effect.async<unknown, Error.ServeError>((resume) => {
       server.on("error", (error) => {
         resume(Effect.fail(new Error.ServeError({ error })))
       })
@@ -72,7 +72,7 @@ export const make = (
       Effect.acquireRelease(
         Effect.sync(() => new WS.WebSocketServer({ noServer: true })),
         (wss) =>
-          Effect.async<void>((resume) => {
+          Effect.async<unknown>((resume) => {
             wss.close(() => resume(Effect.void))
           })
       ),
@@ -377,7 +377,7 @@ export const layerConfig = (
   )
 
 const handleResponse = (request: ServerRequest.ServerRequest, response: ServerResponse.ServerResponse) =>
-  Effect.suspend((): Effect.Effect<void, Error.ResponseError> => {
+  Effect.suspend((): Effect.Effect<unknown, Error.ResponseError> => {
     const nodeResponse = (request as ServerRequestImpl).resolvedResponse
     if (nodeResponse.writableEnded) {
       return Effect.void
@@ -431,7 +431,7 @@ const handleResponse = (request: ServerRequest.ServerRequest, response: ServerRe
         return Effect.void
       }
       case "FormData": {
-        return Effect.async<void, Error.ResponseError>((resume) => {
+        return Effect.async<unknown, Error.ResponseError>((resume) => {
           const r = new Response(body.formData)
           nodeResponse.writeHead(response.status, {
             ...headers,

--- a/packages/platform-node/src/internal/worker.ts
+++ b/packages/platform-node/src/internal/worker.ts
@@ -13,7 +13,7 @@ const platformWorkerImpl = Worker.PlatformWorker.of({
       const worker = worker_ as WorkerThreads.Worker
       yield* _(Effect.addFinalizer(() =>
         pipe(
-          Effect.async<void>((resume) => {
+          Effect.async<unknown>((resume) => {
             worker.once("exit", () => {
               resume(Effect.void)
             })

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -26,7 +26,7 @@ export interface FileSystem {
   readonly access: (
     path: string,
     options?: AccessFileOptions
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Copy a file or directory from `fromPath` to `toPath`.
    *
@@ -36,21 +36,21 @@ export interface FileSystem {
     fromPath: string,
     toPath: string,
     options?: CopyOptions
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Copy a file from `fromPath` to `toPath`.
    */
   readonly copyFile: (
     fromPath: string,
     toPath: string
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Change the permissions of a file.
    */
   readonly chmod: (
     path: string,
     mode: number
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Change the owner and group of a file.
    */
@@ -58,7 +58,7 @@ export interface FileSystem {
     path: string,
     uid: number,
     gid: number
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Check if a path exists.
    */
@@ -71,7 +71,7 @@ export interface FileSystem {
   readonly link: (
     fromPath: string,
     toPath: string
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Create a directory at `path`. You can optionally specify the mode and
    * whether to recursively create nested directories.
@@ -79,7 +79,7 @@ export interface FileSystem {
   readonly makeDirectory: (
     path: string,
     options?: MakeDirectoryOptions
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Create a temporary directory.
    *
@@ -169,14 +169,14 @@ export interface FileSystem {
   readonly remove: (
     path: string,
     options?: RemoveOptions
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Rename a file or directory.
    */
   readonly rename: (
     oldPath: string,
     newPath: string
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Create a writable `Sink` for the specified `path`.
    */
@@ -212,7 +212,7 @@ export interface FileSystem {
   readonly symlink: (
     fromPath: string,
     toPath: string
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Truncate a file to a specified length. If the `length` is not specified,
    * the file will be truncated to length `0`.
@@ -220,7 +220,7 @@ export interface FileSystem {
   readonly truncate: (
     path: string,
     length?: SizeInput
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Change the file system timestamps of the file at `path`.
    */
@@ -228,7 +228,7 @@ export interface FileSystem {
     path: string,
     atime: Date | number,
     mtime: Date | number
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Watch a directory or file for changes
    */
@@ -240,7 +240,7 @@ export interface FileSystem {
     path: string,
     data: Uint8Array,
     options?: WriteFileOptions
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
   /**
    * Write a string to a file at `path`.
    */
@@ -248,7 +248,7 @@ export interface FileSystem {
     path: string,
     data: string,
     options?: WriteFileStringOptions
-  ) => Effect.Effect<void, PlatformError>
+  ) => Effect.Effect<unknown, PlatformError>
 }
 
 /**
@@ -490,12 +490,12 @@ export interface File {
   readonly [FileTypeId]: FileTypeId
   readonly fd: File.Descriptor
   readonly stat: Effect.Effect<File.Info, PlatformError>
-  readonly seek: (offset: SizeInput, from: SeekMode) => Effect.Effect<void>
+  readonly seek: (offset: SizeInput, from: SeekMode) => Effect.Effect<unknown>
   readonly read: (buffer: Uint8Array) => Effect.Effect<Size, PlatformError>
   readonly readAlloc: (size: SizeInput) => Effect.Effect<Option<Uint8Array>, PlatformError>
-  readonly truncate: (length?: SizeInput) => Effect.Effect<void, PlatformError>
+  readonly truncate: (length?: SizeInput) => Effect.Effect<unknown, PlatformError>
   readonly write: (buffer: Uint8Array) => Effect.Effect<Size, PlatformError>
-  readonly writeAll: (buffer: Uint8Array) => Effect.Effect<void, PlatformError>
+  readonly writeAll: (buffer: Uint8Array) => Effect.Effect<unknown, PlatformError>
 }
 
 /**

--- a/packages/platform/src/KeyValueStore.ts
+++ b/packages/platform/src/KeyValueStore.ts
@@ -38,17 +38,17 @@ export interface KeyValueStore {
   /**
    * Sets the value of the specified key.
    */
-  readonly set: (key: string, value: string) => Effect.Effect<void, PlatformError.PlatformError>
+  readonly set: (key: string, value: string) => Effect.Effect<unknown, PlatformError.PlatformError>
 
   /**
    * Removes the specified key.
    */
-  readonly remove: (key: string) => Effect.Effect<void, PlatformError.PlatformError>
+  readonly remove: (key: string) => Effect.Effect<unknown, PlatformError.PlatformError>
 
   /**
    * Removes all entries.
    */
-  readonly clear: Effect.Effect<void, PlatformError.PlatformError>
+  readonly clear: Effect.Effect<unknown, PlatformError.PlatformError>
 
   /**
    * Returns the number of entries.
@@ -158,17 +158,17 @@ export interface SchemaStore<R, A> {
   readonly set: (
     key: string,
     value: A
-  ) => Effect.Effect<void, PlatformError.PlatformError | ParseResult.ParseError, R>
+  ) => Effect.Effect<unknown, PlatformError.PlatformError | ParseResult.ParseError, R>
 
   /**
    * Removes the specified key.
    */
-  readonly remove: (key: string) => Effect.Effect<void, PlatformError.PlatformError>
+  readonly remove: (key: string) => Effect.Effect<unknown, PlatformError.PlatformError>
 
   /**
    * Removes all entries.
    */
-  readonly clear: Effect.Effect<void, PlatformError.PlatformError>
+  readonly clear: Effect.Effect<unknown, PlatformError.PlatformError>
 
   /**
    * Returns the number of entries.

--- a/packages/platform/src/Socket.ts
+++ b/packages/platform/src/Socket.ts
@@ -50,7 +50,11 @@ export interface Socket {
   readonly runRaw: <R, E, _>(
     handler: (_: string | Uint8Array) => Effect.Effect<_, E, R>
   ) => Effect.Effect<void, SocketError | E, R>
-  readonly writer: Effect.Effect<(chunk: Uint8Array | string | CloseEvent) => Effect.Effect<void>, never, Scope.Scope>
+  readonly writer: Effect.Effect<
+    (chunk: Uint8Array | string | CloseEvent) => Effect.Effect<unknown>,
+    never,
+    Scope.Scope
+  >
 }
 
 /**
@@ -348,7 +352,7 @@ export const fromWebSocket = (
 
         if (ws.readyState !== 1) {
           yield* _(
-            Effect.async<void, SocketError, never>((resume) => {
+            Effect.async<unknown, SocketError, never>((resume) => {
               ws.onopen = () => {
                 resume(Effect.void)
               }

--- a/packages/platform/src/Terminal.ts
+++ b/packages/platform/src/Terminal.ts
@@ -31,7 +31,7 @@ export interface Terminal {
   /**
    * Displays text to the the default standard output.
    */
-  readonly display: (text: string) => Effect<void, PlatformError>
+  readonly display: (text: string) => Effect<unknown, PlatformError>
 }
 
 /**

--- a/packages/platform/src/Transferable.ts
+++ b/packages/platform/src/Transferable.ts
@@ -65,7 +65,7 @@ export const makeCollector: Effect.Effect<CollectorService> = Effect.sync(unsafe
  * @since 1.0.0
  * @category accessors
  */
-export const addAll = (tranferables: Iterable<globalThis.Transferable>): Effect.Effect<void> =>
+export const addAll = (tranferables: Iterable<globalThis.Transferable>): Effect.Effect<unknown> =>
   Effect.flatMap(
     Effect.serviceOption(Collector),
     Option.match({

--- a/packages/platform/src/Worker.ts
+++ b/packages/platform/src/Worker.ts
@@ -175,9 +175,9 @@ export declare namespace WorkerPool {
  * @since 1.0.0
  */
 export interface WorkerQueue<I> {
-  readonly offer: (id: number, item: I, span: Option.Option<Tracer.Span>) => Effect.Effect<void>
+  readonly offer: (id: number, item: I, span: Option.Option<Tracer.Span>) => Effect.Effect<unknown>
   readonly take: Effect.Effect<readonly [id: number, item: I, span: Option.Option<Tracer.Span>]>
-  readonly shutdown: Effect.Effect<void>
+  readonly shutdown: Effect.Effect<unknown>
 }
 
 /**

--- a/packages/platform/src/WorkerError.ts
+++ b/packages/platform/src/WorkerError.ts
@@ -47,6 +47,9 @@ export class WorkerError extends Schema.TaggedError<WorkerError>()("WorkerError"
   reason: Schema.Literal("spawn", "decode", "send", "unknown", "encode"),
   error: causeDefectPretty
 }) {
+  [Symbol.iterator]() {
+    return this as any // TODO: fix
+  }
   /**
    * @since 1.0.0
    */

--- a/packages/platform/src/internal/worker.ts
+++ b/packages/platform/src/internal/worker.ts
@@ -78,7 +78,7 @@ export const makeManager = Effect.gen(function*(_) {
         const semaphore = yield* _(Effect.makeSemaphore(permits))
         const requestMap = new Map<
           number,
-          readonly [Queue.Queue<Exit.Exit<ReadonlyArray<O>, E | WorkerError>>, Deferred.Deferred<void>]
+          readonly [Queue.Queue<Exit.Exit<ReadonlyArray<O>, E | WorkerError>>, Deferred.Deferred<unknown>]
         >()
         const sendQueue = yield* _(Effect.acquireRelease(
           Queue.unbounded<readonly [message: Worker.Worker.Request, transfers?: ReadonlyArray<unknown>]>(),
@@ -99,7 +99,7 @@ export const makeManager = Effect.gen(function*(_) {
 
         yield* _(
           Effect.gen(function*(_) {
-            const readyLatch = yield* _(Deferred.make<void>())
+            const readyLatch = yield* _(Deferred.make<unknown>())
             const backing = yield* _(
               platform.spawn<Worker.Worker.Request, Worker.Worker.Response<E, O>>(spawn(id))
             )
@@ -187,7 +187,7 @@ export const makeManager = Effect.gen(function*(_) {
             Effect.all([
               Effect.sync(() => requestIdCounter++),
               Queue.unbounded<Exit.Exit<ReadonlyArray<O>, E | WorkerError>>(),
-              Deferred.make<void>(),
+              Deferred.make<unknown>(),
               Effect.map(
                 Effect.serviceOption(Tracer.ParentSpan),
                 Option.filter((span): span is Tracer.Span => span._tag === "Span")
@@ -204,7 +204,7 @@ export const makeManager = Effect.gen(function*(_) {
           [id, , deferred]: [
             number,
             Queue.Queue<Exit.Exit<ReadonlyArray<O>, E | WorkerError>>,
-            Deferred.Deferred<void>,
+            Deferred.Deferred<unknown>,
             Option.Option<Tracer.Span>
           ],
           exit: Exit.Exit<unknown, unknown>

--- a/packages/rpc/test/Router.test.ts
+++ b/packages/rpc/test/Router.test.ts
@@ -19,7 +19,11 @@ const Name = Context.GenericTag<Name, string>("Name")
 
 class SomeError extends S.TaggedError<SomeError>()("SomeError", {
   message: S.String
-}) {}
+}) {
+  [Symbol.iterator]() {
+    return this as any // TODO: fix this
+  }
+}
 
 class Post extends S.Class<Post>("Post")({
   id: S.Number,

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -967,7 +967,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
           output: typeof output
         }
         let queue:
-          | Array<(_: State) => Effect.Effect<void, ParseIssue, any>>
+          | Array<(_: State) => Effect.Effect<unknown, ParseIssue, any>>
           | undefined = undefined
 
         // ---------------------------------------------
@@ -1210,7 +1210,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
           output: typeof output
         }
         let queue:
-          | Array<(state: State) => Effect.Effect<void, ParseIssue, any>>
+          | Array<(state: State) => Effect.Effect<unknown, ParseIssue, any>>
           | undefined = undefined
 
         const isExact = options?.isExact === true

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -866,7 +866,7 @@ export const Undefined: Undefined = make(AST.undefinedKeyword)
  * @category api interface
  * @since 1.0.0
  */
-export interface Void extends Annotable<Void, void> {}
+export interface Void extends Annotable<Void, unknown> {}
 
 /**
  * @category primitives

--- a/packages/schema/test/Schema/Class/Class.test.ts
+++ b/packages/schema/test/Schema/Class/Class.test.ts
@@ -644,7 +644,11 @@ describe("Class APIs", () => {
   it("TaggedError", () => {
     class MyError extends S.TaggedError<MyError>()("MyError", {
       id: S.Number
-    }) {}
+    }) {
+      [Symbol.iterator]() {
+        return this as any // TODO: fix this
+      }
+    }
 
     let err = new MyError({ id: 1 })
 

--- a/packages/sql-mssql/src/Client.ts
+++ b/packages/sql-mssql/src/Client.ts
@@ -84,10 +84,10 @@ interface MssqlConnection extends Connection {
     procedure: Procedure.ProcedureWithValues<any, any, any>
   ) => Effect.Effect<any, SqlError>
 
-  readonly begin: Effect.Effect<void, SqlError>
-  readonly commit: Effect.Effect<void, SqlError>
-  readonly savepoint: (name: string) => Effect.Effect<void, SqlError>
-  readonly rollback: (name?: string) => Effect.Effect<void, SqlError>
+  readonly begin: Effect.Effect<unknown, SqlError>
+  readonly commit: Effect.Effect<unknown, SqlError>
+  readonly savepoint: (name: string) => Effect.Effect<unknown, SqlError>
+  readonly rollback: (name?: string) => Effect.Effect<unknown, SqlError>
 }
 
 const TransactionConnection = Client.TransactionConnection as unknown as Context.Tag<
@@ -142,7 +142,7 @@ export const make = (
       yield* _(Effect.addFinalizer(() => Effect.sync(() => conn.close())))
 
       yield* _(
-        Effect.async<void, SqlError>((resume) => {
+        Effect.async<unknown, SqlError>((resume) => {
           conn.connect((error) => {
             if (error) {
               resume(Effect.fail(new SqlError({ error })))
@@ -260,7 +260,7 @@ export const make = (
         call: (procedure) => {
           return runProcedure(procedure)
         },
-        begin: Effect.async<void, SqlError>((resume) => {
+        begin: Effect.async<unknown, SqlError>((resume) => {
           conn.beginTransaction((error) => {
             if (error) {
               resume(Effect.fail(new SqlError({ error })))
@@ -269,7 +269,7 @@ export const make = (
             }
           })
         }),
-        commit: Effect.async<void, SqlError>((resume) => {
+        commit: Effect.async<unknown, SqlError>((resume) => {
           conn.commitTransaction((error) => {
             if (error) {
               resume(Effect.fail(new SqlError({ error })))
@@ -279,7 +279,7 @@ export const make = (
           })
         }),
         savepoint: (name: string) =>
-          Effect.async<void, SqlError>((resume) => {
+          Effect.async<unknown, SqlError>((resume) => {
             conn.saveTransaction((error) => {
               if (error) {
                 resume(Effect.fail(new SqlError({ error })))
@@ -289,7 +289,7 @@ export const make = (
             }, name)
           }),
         rollback: (name?: string) =>
-          Effect.async<void, SqlError>((resume) => {
+          Effect.async<unknown, SqlError>((resume) => {
             conn.rollbackTransaction((error) => {
               if (error) {
                 resume(Effect.fail(new SqlError({ error })))

--- a/packages/sql-mysql2/src/Client.ts
+++ b/packages/sql-mysql2/src/Client.ts
@@ -141,7 +141,7 @@ export const make = (
       } as Mysql.PoolOptions)
 
     yield* _(Effect.addFinalizer(() =>
-      Effect.async<void>((resume) => {
+      Effect.async<unknown>((resume) => {
         pool.end(() => resume(Effect.void))
       })
     ))

--- a/packages/sql-sqlite-node/src/Client.ts
+++ b/packages/sql-sqlite-node/src/Client.ts
@@ -23,7 +23,7 @@ import * as Scope from "effect/Scope"
 export interface SqliteClient extends Client.Client {
   readonly config: SqliteClientConfig
   readonly export: Effect.Effect<Uint8Array, SqlError>
-  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
+  readonly loadExtension: (path: string) => Effect.Effect<unknown, SqlError>
 }
 
 /**
@@ -51,7 +51,7 @@ export interface SqliteClientConfig {
 
 interface SqliteConnection extends Connection {
   readonly export: Effect.Effect<Uint8Array, SqlError>
-  readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
+  readonly loadExtension: (path: string) => Effect.Effect<unknown, SqlError>
 }
 
 /**

--- a/packages/sql/src/Error.ts
+++ b/packages/sql/src/Error.ts
@@ -18,6 +18,9 @@ export type SqlErrorTypeId = typeof SqlErrorTypeId
  * @since 1.0.0
  */
 export class SqlError extends RefailError(SqlErrorTypeId, "SqlError")<{}> {
+  [Symbol.iterator]() {
+    return this as any // TODO: fix
+  }
   get code() {
     if (Predicate.hasProperty(this.error, "code")) {
       return this.error.code

--- a/packages/sql/src/Migrator.ts
+++ b/packages/sql/src/Migrator.ts
@@ -64,7 +64,11 @@ export class MigrationError extends Data.TaggedError("MigrationError")<{
     | "duplicates"
     | "locked"
   readonly message: string
-}> {}
+}> {
+  [Symbol.iterator]() {
+    return this as any // TOOD: fix
+  }
+}
 
 /**
  * @category constructor
@@ -77,13 +81,13 @@ export const make = <R extends Client, RD, RE, RL, R2 = never>({
   lockTable = () => Effect.void
 }: {
   getClient: Effect.Effect<R, SqlError, R>
-  ensureTable: (sql: R, table: string) => Effect.Effect<void, SqlError, RE>
+  ensureTable: (sql: R, table: string) => Effect.Effect<unknown, SqlError, RE>
   dumpSchema?: (
     sql: R,
     path: string,
     migrationsTable: string
-  ) => Effect.Effect<void, MigrationError, RD>
-  lockTable?: (sql: R, table: string) => Effect.Effect<void, SqlError, RL>
+  ) => Effect.Effect<unknown, MigrationError, RD>
+  lockTable?: (sql: R, table: string) => Effect.Effect<unknown, SqlError, RL>
 }) =>
 ({
   loader,

--- a/packages/sql/src/Resolver.ts
+++ b/packages/sql/src/Resolver.ts
@@ -100,8 +100,8 @@ export interface SqlResolver<T extends string, I, A, E, R>
   readonly cachePopulate: (
     id: I,
     result: A
-  ) => Effect.Effect<void, ParseError, R>
-  readonly cacheInvalidate: (id: I) => Effect.Effect<void, ParseError, R>
+  ) => Effect.Effect<unknown, ParseError, R>
+  readonly cacheInvalidate: (id: I) => Effect.Effect<unknown, ParseError, R>
   readonly request: (input: I) => Effect.Effect<SqlRequest<T, A, E>, ParseError, R>
 }
 


### PR DESCRIPTION
This is not for merging, I just put it together since I was curious if I could make it work this way. This work was started based on the initial commit from https://github.com/Effect-TS/effect/pull/2602

It doesn't (yet?) allow you to remove the adapter thing from this branch but perhaps this is just missing some minor thing. I'm not sure if there were any extra changes done by @tim-smart to allow that. This PR focuses solely on making this to typecheck with the added `Symbol.iterator` method.

There are a few minor TODO comments here but all of them (but one!) are really about the same thing - adding `Symbol.iterator` properly to your error classes.