### PR TITLE
Chunk difference methods

### DIFF
--- a/.changeset/four-garlics-wonder.md
+++ b/.changeset/four-garlics-wonder.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add Chunk.difference & Chunk.differenceWith

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -1417,3 +1417,23 @@ export const difference: {
   2,
   <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A> => unsafeFromArray(RA.difference(that, self))
 )
+
+/**
+ * Creates a `Chunk` of values not included in the other given `Chunk`.
+ * The order and references of result values are determined by the first `Chunk`.
+ *
+ * The first comparator `Chunk` may be wrapped in an `Option`. A `None` value is
+ * treated as an empty `Chunk` during comparison.
+ *
+ * This is primarily for convenience on zip operations, gets, or similar.
+ *
+ * @since 3.2.0
+ */
+export const differenceOption: {
+  <A>(that: Chunk<A>): (self: Option<Chunk<A>>) => Chunk<A>
+  <A>(self: Option<Chunk<A>>, that: Chunk<A>): Chunk<A>
+} = dual(
+  2,
+  <A>(self: Option<Chunk<A>>, that: Chunk<A>): Chunk<A> =>
+    unsafeFromArray(RA.difference(that, O.getOrElse(self, empty)))
+)

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -1417,23 +1417,3 @@ export const difference: {
   2,
   <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A> => unsafeFromArray(RA.difference(that, self))
 )
-
-/**
- * Creates a `Chunk` of values not included in the other given `Chunk`.
- * The order and references of result values are determined by the first `Chunk`.
- *
- * The first comparator `Chunk` may be wrapped in an `Option`. A `None` value is
- * treated as an empty `Chunk` during comparison.
- *
- * This is primarily for convenience on zip operations, gets, or similar.
- *
- * @since 3.2.0
- */
-export const differenceOption: {
-  <A>(that: Chunk<A>): (self: Option<Chunk<A>>) => Chunk<A>
-  <A>(self: Option<Chunk<A>>, that: Chunk<A>): Chunk<A>
-} = dual(
-  2,
-  <A>(self: Option<Chunk<A>>, that: Chunk<A>): Chunk<A> =>
-    unsafeFromArray(RA.difference(that, O.getOrElse(self, empty)))
-)

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -1387,3 +1387,33 @@ export const reduceRight: {
   <B, A>(b: B, f: (b: B, a: A, i: number) => B): (self: Chunk<A>) => B
   <A, B>(self: Chunk<A>, b: B, f: (b: B, a: A, i: number) => B): B
 } = RA.reduceRight
+
+/**
+ * Creates a `Chunk` of values not included in the other given `Chunk` using the provided `isEquivalent` function.
+ * The order and references of result values are determined by the first `Chunk`.
+ *
+ * @since 2.0.0
+ */
+export const differenceWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
+  (that: Chunk<A>): (self: Chunk<A>) => Chunk<A>
+  (self: Chunk<A>, that: Chunk<A>): Chunk<A>
+} => {
+  return dual(
+    2,
+    (self: Chunk<A>, that: Chunk<A>): Chunk<A> => unsafeFromArray(RA.differenceWith(isEquivalent)(that, self))
+  )
+}
+
+/**
+ * Creates a `Chunk` of values not included in the other given `Chunk`.
+ * The order and references of result values are determined by the first `Chunk`.
+ *
+ * @since 3.2.0
+ */
+export const difference: {
+  <A>(that: Chunk<A>): (self: Chunk<A>) => Chunk<A>
+  <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A>
+} = dual(
+  2,
+  <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A> => unsafeFromArray(RA.difference(that, self))
+)

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -1392,7 +1392,7 @@ export const reduceRight: {
  * Creates a `Chunk` of values not included in the other given `Chunk` using the provided `isEquivalent` function.
  * The order and references of result values are determined by the first `Chunk`.
  *
- * @since 2.0.0
+ * @since 3.2.0
  */
 export const differenceWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
   (that: Chunk<A>): (self: Chunk<A>) => Chunk<A>

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -19,7 +19,6 @@ describe("Chunk", () => {
     expect(Chunk.containsWith).exist
     expect(Chunk.difference).exist
     expect(Chunk.differenceWith).exist
-    expect(Chunk.differenceOption).exist
     expect(Chunk.findFirst).exist
     expect(Chunk.findFirstIndex).exist
     expect(Chunk.findLast).exist
@@ -897,17 +896,5 @@ describe("Chunk", () => {
     expect(Chunk.difference(Chunk.empty(), curr)).toEqual(curr)
     expect(Chunk.difference(curr, Chunk.empty())).toEqual(Chunk.empty())
     expect(Chunk.difference(curr, curr)).toEqual(Chunk.empty())
-  })
-
-  it("differenceOption", () => {
-    const curr = Chunk.make(1, 3, 5, 7, 9)
-
-    const { none, some } = Option
-
-    expect(Chunk.differenceOption(some(Chunk.make(1, 2, 3, 4, 5)), curr)).toEqual(Chunk.make(7, 9))
-    expect(Chunk.differenceOption(some(Chunk.empty()), curr)).toEqual(curr)
-    expect(Chunk.differenceOption(none(), curr)).toEqual(curr)
-    expect(Chunk.differenceOption(some(curr), Chunk.empty())).toEqual(Chunk.empty())
-    expect(Chunk.differenceOption(some(curr), curr)).toEqual(Chunk.empty())
   })
 })

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -17,6 +17,8 @@ describe("Chunk", () => {
     expect(Chunk.unsafeFromNonEmptyArray).exist
     expect(Chunk.contains).exist
     expect(Chunk.containsWith).exist
+    expect(Chunk.difference).exist
+    expect(Chunk.differenceWith).exist
     expect(Chunk.findFirst).exist
     expect(Chunk.findFirstIndex).exist
     expect(Chunk.findLast).exist
@@ -873,5 +875,26 @@ describe("Chunk", () => {
     expect(equivalence(Chunk.make(1, 2, 3), Chunk.make(1, 2, 3))).toBe(true)
     expect(equivalence(Chunk.make(1, 2, 3), Chunk.make(1, 2))).toBe(false)
     expect(equivalence(Chunk.make(1, 2, 3), Chunk.make(1, 2, 4))).toBe(false)
+  })
+
+  it("difference", () => {
+    const curr = Chunk.make(1, 3, 5, 7, 9)
+
+    expect(Chunk.difference(Chunk.make(1, 2, 3, 4, 5), curr)).toEqual(Chunk.make(7, 9))
+    expect(Chunk.difference(Chunk.empty(), curr)).toEqual(curr)
+    expect(Chunk.difference(curr, Chunk.empty())).toEqual(Chunk.empty())
+    expect(Chunk.difference(curr, curr)).toEqual(Chunk.empty())
+  })
+
+  it("differenceWith", () => {
+    const eq = <E extends { id: number }>(a: E, b: E) => a.id === b.id
+    const diffW = pipe(eq, Chunk.differenceWith)
+
+    const curr = Chunk.make({ id: 1 }, { id: 2 }, { id: 3 })
+
+    expect(diffW(Chunk.make({ id: 1 }, { id: 2 }), curr)).toEqual(Chunk.make({ id: 3 }))
+    expect(diffW(Chunk.empty(), curr)).toEqual(curr)
+    expect(diffW(curr, Chunk.empty())).toEqual(Chunk.empty())
+    expect(diffW(curr, curr)).toEqual(Chunk.empty())
   })
 })

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -19,6 +19,7 @@ describe("Chunk", () => {
     expect(Chunk.containsWith).exist
     expect(Chunk.difference).exist
     expect(Chunk.differenceWith).exist
+    expect(Chunk.differenceOption).exist
     expect(Chunk.findFirst).exist
     expect(Chunk.findFirstIndex).exist
     expect(Chunk.findLast).exist
@@ -877,15 +878,6 @@ describe("Chunk", () => {
     expect(equivalence(Chunk.make(1, 2, 3), Chunk.make(1, 2, 4))).toBe(false)
   })
 
-  it("difference", () => {
-    const curr = Chunk.make(1, 3, 5, 7, 9)
-
-    expect(Chunk.difference(Chunk.make(1, 2, 3, 4, 5), curr)).toEqual(Chunk.make(7, 9))
-    expect(Chunk.difference(Chunk.empty(), curr)).toEqual(curr)
-    expect(Chunk.difference(curr, Chunk.empty())).toEqual(Chunk.empty())
-    expect(Chunk.difference(curr, curr)).toEqual(Chunk.empty())
-  })
-
   it("differenceWith", () => {
     const eq = <E extends { id: number }>(a: E, b: E) => a.id === b.id
     const diffW = pipe(eq, Chunk.differenceWith)
@@ -896,5 +888,26 @@ describe("Chunk", () => {
     expect(diffW(Chunk.empty(), curr)).toEqual(curr)
     expect(diffW(curr, Chunk.empty())).toEqual(Chunk.empty())
     expect(diffW(curr, curr)).toEqual(Chunk.empty())
+  })
+
+  it("difference", () => {
+    const curr = Chunk.make(1, 3, 5, 7, 9)
+
+    expect(Chunk.difference(Chunk.make(1, 2, 3, 4, 5), curr)).toEqual(Chunk.make(7, 9))
+    expect(Chunk.difference(Chunk.empty(), curr)).toEqual(curr)
+    expect(Chunk.difference(curr, Chunk.empty())).toEqual(Chunk.empty())
+    expect(Chunk.difference(curr, curr)).toEqual(Chunk.empty())
+  })
+
+  it("differenceOption", () => {
+    const curr = Chunk.make(1, 3, 5, 7, 9)
+
+    const { none, some } = Option
+
+    expect(Chunk.differenceOption(some(Chunk.make(1, 2, 3, 4, 5)), curr)).toEqual(Chunk.make(7, 9))
+    expect(Chunk.differenceOption(some(Chunk.empty()), curr)).toEqual(curr)
+    expect(Chunk.differenceOption(none(), curr)).toEqual(curr)
+    expect(Chunk.differenceOption(some(curr), Chunk.empty())).toEqual(Chunk.empty())
+    expect(Chunk.differenceOption(some(curr), curr)).toEqual(Chunk.empty())
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a set of `difference` operations directly on the Chunk method. I also have a zipped stream use case, and can imagine other use cases getting chunk values from Map's etc. where a `differenceOption` function would be useful.

My initial implementation enforced the first "comparator" Chunk to be a `Option<Chunk<A>>` however I opted to separate the methods.

Please let me know if this is in accordance with the envisaged interface, or if you'd rather not split the option handling. For now my use case has less boilerplate when the first Chunk is Optional.
