### PR TITLE
Replace Order {  min, max } with { gt, gte, lt, lte }

### DIFF
--- a/packages/effect/test/Order.test.ts
+++ b/packages/effect/test/Order.test.ts
@@ -57,14 +57,14 @@ describe("Order", () => {
   })
 
   it("between", () => {
-    const between = _.between(_.number)({ minimum: 1, maximum: 10 })
+    const between = _.between(_.number)({ gte: 1, lte: 10 })
     U.deepStrictEqual(between(2), true)
     U.deepStrictEqual(between(10), true)
     U.deepStrictEqual(between(20), false)
     U.deepStrictEqual(between(1), true)
     U.deepStrictEqual(between(-10), false)
 
-    U.deepStrictEqual(_.between(_.number)(2, { minimum: 1, maximum: 10 }), true)
+    U.deepStrictEqual(_.between(_.number)(2, { gte: 1, lte: 10 }), true)
   })
 
   it("reverse", () => {


### PR DESCRIPTION
`Order.between({ minimum, maximum })` is not as flexable or as clear as `Order.between({ gt, gte, lt, lte })`. I'm just curious what people think before doing a complete refactor.  