### PR TITLE
add Effect.genFn, for turning a Effect.gen with arguments into a function

### DIFF
--- a/.changeset/soft-pillows-divide.md
+++ b/.changeset/soft-pillows-divide.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add Effect.genFn, for turning a Effect.gen with arguments into a function

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -1140,6 +1140,20 @@ export const gen: {
 } = effect.gen
 
 /**
+ * @since 3.2.0
+ * @category constructors
+ */
+export const genFn: <Args extends ReadonlyArray<any>, Eff extends YieldWrap<Effect<any, any, any>>, AEff>(
+  f: (...args: Args) => Generator<Eff, AEff, never>
+) => (
+  ...args: Args
+) => Effect<
+  AEff,
+  [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect<infer _A, infer E, infer _R>>] ? E : never,
+  [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect<infer _A, infer _E, infer R>>] ? R : never
+> = effect.genFn
+
+/**
  * @since 2.0.0
  * @category models
  */


### PR DESCRIPTION
Not so sure I like it though, as it kills composability (you can't just tack on a `.pipe()` after the definition.
