### PR TITLE
internal: centralize code related to do notation

### DIFF
--- a/packages/effect/dtslint/Effect.ts
+++ b/packages/effect/dtslint/Effect.ts
@@ -1074,3 +1074,33 @@ string.pipe(Effect.retryOrElse(Schedule.forever, (_e: string) => Effect.succeed(
 string.pipe(Effect.retryOrElse(Schedule.forever, (
   _e // $ExpectType "err-1"
 ) => Effect.succeed(0)))
+
+// -------------------------------------------------------------------------------------
+// do notation
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Effect<{ a: number; b: string; c: boolean; }, never, never>
+pipe(
+  Effect.Do,
+  Effect.bind("a", (
+    _scope // $ExpectType {}
+  ) => Effect.succeed(1)),
+  Effect.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Effect.succeed("b")),
+  Effect.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)
+
+// $ExpectType Effect<{ a: number; b: string; c: boolean; }, never, never>
+pipe(
+  Effect.succeed(1),
+  Effect.bindTo("a"),
+  Effect.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Effect.succeed("b")),
+  Effect.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)

--- a/packages/effect/dtslint/Either.ts
+++ b/packages/effect/dtslint/Either.ts
@@ -171,3 +171,33 @@ export type R = Either.Either.Right<typeof string$number>
 
 // $ExpectType string
 export type L = Either.Either.Left<typeof string$number>
+
+// -------------------------------------------------------------------------------------
+// do notation
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Either<{ a: number; b: string; c: boolean; }, never>
+pipe(
+  Either.Do,
+  Either.bind("a", (
+    _scope // $ExpectType {}
+  ) => Either.right(1)),
+  Either.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Either.right("b")),
+  Either.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)
+
+// $ExpectType Either<{ a: number; b: string; c: boolean; }, never>
+pipe(
+  Either.right(1),
+  Either.bindTo("a"),
+  Either.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Either.right("b")),
+  Either.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)

--- a/packages/effect/dtslint/Option.ts
+++ b/packages/effect/dtslint/Option.ts
@@ -49,17 +49,6 @@ pipe(
 pipe(Option.some("a"), Option.getOrElse(() => null))
 
 // -------------------------------------------------------------------------------------
-// do notation
-// -------------------------------------------------------------------------------------
-
-// $ExpectType Option<{ a: number; b: string; }>
-pipe(
-  Option.Do,
-  Option.bind("a", () => Option.some(1)),
-  Option.bind("b", () => Option.some("b"))
-)
-
-// -------------------------------------------------------------------------------------
 // filter
 // -------------------------------------------------------------------------------------
 
@@ -198,3 +187,33 @@ numberOrString.pipe(Option.andThen(() => numberOrString))
 
 // $ExpectType string | number
 export type V = Option.Option.Value<typeof numberOrString>
+
+// -------------------------------------------------------------------------------------
+// do notation
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Option<{ a: number; b: string; c: boolean; }>
+pipe(
+  Option.Do,
+  Option.bind("a", (
+    _scope // $ExpectType {}
+  ) => Option.some(1)),
+  Option.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Option.some("b")),
+  Option.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)
+
+// $ExpectType Option<{ a: number; b: string; c: boolean; }>
+pipe(
+  Option.some(1),
+  Option.bindTo("a"),
+  Option.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Option.some("b")),
+  Option.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)

--- a/packages/effect/dtslint/Stream.ts
+++ b/packages/effect/dtslint/Stream.ts
@@ -206,3 +206,33 @@ Stream.takeUntil(numbersOrStrings, Predicate.isNumber)
 
 // $ExpectType Stream<string | number, never, never>
 pipe(numbersOrStrings, Stream.takeUntil(Predicate.isNumber))
+
+// -------------------------------------------------------------------------------------
+// do notation
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Stream<{ a: number; b: string; c: boolean; }, never, never>
+pipe(
+  Stream.Do,
+  Stream.bind("a", (
+    _scope // $ExpectType {}
+  ) => Stream.succeed(1)),
+  Stream.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Stream.succeed("b")),
+  Stream.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)
+
+// $ExpectType Stream<{ a: number; b: string; c: boolean; }, never, never>
+pipe(
+  Stream.succeed(1),
+  Stream.bindTo("a"),
+  Stream.bind("b", (
+    _scope // $ExpectType { a: number; }
+  ) => Stream.succeed("b")),
+  Stream.let("c", (
+    _scope // $ExpectType { a: number; b: string; }
+  ) => true)
+)

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3291,8 +3291,8 @@ export const bind: {
  * @since 2.0.0
  */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E, R>(self: Effect<A, E, R>) => Effect<{ [K in N]: A }, E, R>
-  <A, E, R, N extends string>(self: Effect<A, E, R>, tag: N): Effect<{ [K in N]: A }, E, R>
+  <N extends string>(name: N): <A, E, R>(self: Effect<A, E, R>) => Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect<A, E, R>, name: N): Effect<{ [K in N]: A }, E, R>
 } = effect.bindTo
 
 const let_: {

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -56,7 +56,7 @@ import * as Scheduler from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
-import type { Concurrency, Covariant, MergeRecord, NoInfer, NotFunction } from "./Types.js"
+import type { Concurrency, Covariant, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 import type { YieldWrap } from "./Utils.js"
 
@@ -3275,15 +3275,15 @@ export const Do: Effect<{}> = effect.Do
  * @category do notation
  */
 export const bind: {
-  <N extends string, K, A, E2, R2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect<A, E2, R2>
-  ): <E, R>(self: Effect<K, E, R>) => Effect<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R>
-  <K, E, R, N extends string, A, E2, R2>(
-    self: Effect<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect<A, E2, R2>
-  ): Effect<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R>
+  <N extends string, A extends object, B, E2, R2>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Effect<B, E2, R2>
+  ): <E1, R1>(self: Effect<A, E1, R1>) => Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E2 | E1, R2 | R1>
+  <A extends object, N extends string, E1, R1, B, E2, R2>(
+    self: Effect<A, E1, R1>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Effect<B, E2, R2>
+  ): Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E1 | E2, R1 | R2>
 } = effect.bind
 
 /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3263,16 +3263,62 @@ export const updateService: {
 // -------------------------------------------------------------------------------------
 
 /**
- * @since 2.0.0
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Effect` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link bind}
+ * @see {@link bindTo}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Effect, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Effect.Do,
+ *   Effect.bind("x", () => Effect.succeed(2)),
+ *   Effect.bind("y", () => Effect.succeed(3)),
+ *   Effect.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(Effect.runSync(result), { x: 2, y: 3, sum: 5 })
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const Do: Effect<{}> = effect.Do
 
 /**
- * Binds an effectful value in a `do` scope
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
- * @since 2.0.0
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Effect` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link Do}
+ * @see {@link bindTo}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Effect, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Effect.Do,
+ *   Effect.bind("x", () => Effect.succeed(2)),
+ *   Effect.bind("y", () => Effect.succeed(3)),
+ *   Effect.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(Effect.runSync(result), { x: 2, y: 3, sum: 5 })
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const bind: {
   <N extends string, A extends object, B, E2, R2>(
@@ -3287,6 +3333,30 @@ export const bind: {
 } = effect.bind
 
 /**
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Effect` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link Do}
+ * @see {@link bind}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Effect, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Effect.Do,
+ *   Effect.bind("x", () => Effect.succeed(2)),
+ *   Effect.bind("y", () => Effect.succeed(3)),
+ *   Effect.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(Effect.runSync(result), { x: 2, y: 3, sum: 5 })
+ *
  * @category do notation
  * @since 2.0.0
  */
@@ -3309,10 +3379,32 @@ const let_: {
 
 export {
   /**
-   * Like bind for values
+   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
-   * @since 2.0.0
+   * Here's how the do simulation works:
+   *
+   * 1. Start the do simulation using the `Do` value
+   * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Effect` values
+   * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+   * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+   *
+   * @see {@link Do}
+   * @see {@link bind}
+   * @see {@link bindTo}
+   *
+   * @example
+   * import { Effect, pipe } from "effect"
+   *
+   * const result = pipe(
+   *   Effect.Do,
+   *   Effect.bind("x", () => Effect.succeed(2)),
+   *   Effect.bind("y", () => Effect.succeed(3)),
+   *   Effect.let("sum", ({ x, y }) => x + y)
+   * )
+   * assert.deepStrictEqual(Effect.runSync(result), { x: 2, y: 3, sum: 5 })
+   *
    * @category do notation
+   * @since 2.0.0
    */
   let_ as let
 }

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3291,8 +3291,8 @@ export const bind: {
  * @since 2.0.0
  */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E, R>(self: Effect<A, E, R>) => Effect<Record<N, A>, E, R>
-  <A, E, R, N extends string>(self: Effect<A, E, R>, tag: N): Effect<Record<N, A>, E, R>
+  <N extends string>(tag: N): <A, E, R>(self: Effect<A, E, R>) => Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect<A, E, R>, tag: N): Effect<{ [K in N]: A }, E, R>
 } = effect.bindTo
 
 const let_: {

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3296,15 +3296,15 @@ export const bindTo: {
 } = effect.bindTo
 
 const let_: {
-  <N extends string, K, A>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): <E, R>(self: Effect<K, E, R>) => Effect<MergeRecord<K, { [k in N]: A }>, E, R>
-  <K, E, R, N extends string, A>(
-    self: Effect<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): Effect<MergeRecord<K, { [k in N]: A }>, E, R>
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): <E, R>(self: Effect<A, E, R>) => Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
+  <A extends object, N extends string, E, R, B>(
+    self: Effect<A, E, R>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
 } = effect.let_
 
 export {

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -743,16 +743,62 @@ export const gen: Gen.Gen<EitherTypeLambda, Gen.Adapter<EitherTypeLambda>> = (f)
 // -------------------------------------------------------------------------------------
 
 /**
- * @since 2.4.0
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Either` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link bind}
+ * @see {@link bindTo}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Either, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Either.Do,
+ *   Either.bind("x", () => Either.right(2)),
+ *   Either.bind("y", () => Either.right(3)),
+ *   Either.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(result, Either.right({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const Do: Either<{}> = right({})
 
 /**
- * Binds an effectful value in a `do` scope
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
- * @since 2.4.0
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Either` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link Do}
+ * @see {@link bindTo}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Either, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Either.Do,
+ *   Either.bind("x", () => Either.right(2)),
+ *   Either.bind("y", () => Either.right(3)),
+ *   Either.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(result, Either.right({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const bind: {
   <N extends string, A extends object, B, L2>(
@@ -767,8 +813,32 @@ export const bind: {
 } = doNotation.bind<EitherTypeLambda>(map, flatMap)
 
 /**
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Either` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link Do}
+ * @see {@link bind}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Either, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Either.Do,
+ *   Either.bind("x", () => Either.right(2)),
+ *   Either.bind("y", () => Either.right(3)),
+ *   Either.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(result, Either.right({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
- * @since 2.4.0
+ * @since 2.0.0
  */
 export const bindTo: {
   <N extends string>(name: N): <R, L>(self: Either<R, L>) => Either<{ [K in N]: R }, L>
@@ -789,10 +859,32 @@ const let_: {
 
 export {
   /**
-   * Like bind for values
+   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
-   * @since 2.4.0
+   * Here's how the do simulation works:
+   *
+   * 1. Start the do simulation using the `Do` value
+   * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Either` values
+   * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+   * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+   *
+   * @see {@link Do}
+   * @see {@link bindTo}
+   * @see {@link bind}
+   *
+   * @example
+   * import { Either, pipe } from "effect"
+   *
+   * const result = pipe(
+   *   Either.Do,
+   *   Either.bind("x", () => Either.right(2)),
+   *   Either.bind("y", () => Either.right(3)),
+   *   Either.let("sum", ({ x, y }) => x + y)
+   * )
+   * assert.deepStrictEqual(result, Either.right({ x: 2, y: 3, sum: 5 }))
+   *
    * @category do notation
+   * @since 2.0.0
    */
   let_ as let
 }

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -7,6 +7,7 @@ import type { LazyArg } from "./Function.js"
 import { constNull, constUndefined, dual, identity } from "./Function.js"
 import type { TypeLambda } from "./HKT.js"
 import type { Inspectable } from "./Inspectable.js"
+import * as doNotation from "./internal/doNotation.js"
 import * as either from "./internal/either.js"
 import type { Option } from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
@@ -788,24 +789,16 @@ export const bindTo: {
 )
 
 const let_: {
-  <N extends string, K, A>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): <E>(self: Either<K, E>) => Either<MergeRecord<K, { [k in N]: A }>, E>
-  <K, E, N extends string, A>(
-    self: Either<K, E>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): Either<MergeRecord<K, { [k in N]: A }>, E>
-} = dual(3, <K, E, N extends string, A>(
-  self: Either<K, E>,
-  tag: Exclude<N, keyof K>,
-  f: (_: K) => A
-): Either<MergeRecord<K, { [k in N]: A }>, E> =>
-  map(
-    self,
-    (k): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: f(k) } as any)
-  ))
+  <N extends string, R extends object, B>(
+    name: Exclude<N, keyof R>,
+    f: (r: R) => B
+  ): <L>(self: Either<R, L>) => Either<{ [K in N | keyof R]: K extends keyof R ? R[K] : B }, L>
+  <R extends object, L, N extends string, B>(
+    self: Either<R, L>,
+    name: Exclude<N, keyof R>,
+    f: (r: R) => B
+  ): Either<{ [K in N | keyof R]: K extends keyof R ? R[K] : B }, L>
+} = doNotation.let_<EitherTypeLambda>(map)
 
 export {
   /**

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -13,7 +13,7 @@ import type { Option } from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
 import { isFunction } from "./Predicate.js"
-import type { Covariant, MergeRecord, NoInfer, NotFunction } from "./Types.js"
+import type { Covariant, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 import * as Gen from "./Utils.js"
 
@@ -755,25 +755,16 @@ export const Do: Either<{}> = right({})
  * @category do notation
  */
 export const bind: {
-  <N extends string, K, A, E2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Either<A, E2>
-  ): <E>(self: Either<K, E>) => Either<MergeRecord<K, { [k in N]: A }>, E2 | E>
-  <K, E, N extends string, A, E2>(
-    self: Either<E, K>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Either<A, E2>
-  ): Either<MergeRecord<K, { [k in N]: A }>, E2 | E>
-} = dual(3, <K, E, N extends string, A, E2>(
-  self: Either<K, E>,
-  tag: Exclude<N, keyof K>,
-  f: (_: K) => Either<A, E2>
-): Either<MergeRecord<K, { [k in N]: A }>, E2 | E> =>
-  flatMap(self, (k) =>
-    map(
-      f(k),
-      (a): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: a } as any)
-    )))
+  <N extends string, A extends object, B, L2>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Either<B, L2>
+  ): <L1>(self: Either<A, L1>) => Either<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, L1 | L2>
+  <A extends object, L1, N extends string, B, L2>(
+    self: Either<A, L1>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Either<B, L2>
+  ): Either<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, L1 | L2>
+} = doNotation.bind<EitherTypeLambda>(map, flatMap)
 
 /**
  * @category do notation

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -779,12 +779,12 @@ export const bind: {
  * @since 2.4.0
  */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E>(self: Either<A, E>) => Either<Record<N, A>, E>
-  <A, E, N extends string>(self: Either<A, E>, tag: N): Either<Record<N, A>, E>
+  <N extends string>(tag: N): <A, E>(self: Either<A, E>) => Either<{ [K in N]: A }, E>
+  <A, E, N extends string>(self: Either<A, E>, tag: N): Either<{ [K in N]: A }, E>
 } = dual(
   2,
-  <A, E, N extends string>(self: Either<A, E>, tag: N): Either<Record<N, A>, E> =>
-    map(self, (a) => ({ [tag]: a } as Record<N, A>))
+  <A, E, N extends string>(self: Either<A, E>, tag: N): Either<{ [K in N]: A }, E> =>
+    map(self, (a) => ({ [tag]: a } as { [K in N]: A }))
 )
 
 const let_: {

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -780,13 +780,9 @@ export const bind: {
  * @since 2.4.0
  */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E>(self: Either<A, E>) => Either<{ [K in N]: A }, E>
-  <A, E, N extends string>(self: Either<A, E>, tag: N): Either<{ [K in N]: A }, E>
-} = dual(
-  2,
-  <A, E, N extends string>(self: Either<A, E>, tag: N): Either<{ [K in N]: A }, E> =>
-    map(self, (a) => ({ [tag]: a } as { [K in N]: A }))
-)
+  <N extends string>(name: N): <R, L>(self: Either<R, L>) => Either<{ [K in N]: R }, L>
+  <R, L, N extends string>(self: Either<R, L>, name: N): Either<{ [K in N]: R }, L>
+} = doNotation.bindTo<EitherTypeLambda>(map)
 
 const let_: {
   <N extends string, R extends object, B>(

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1199,6 +1199,32 @@ export const exists: {
 // -------------------------------------------------------------------------------------
 
 /**
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Option` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+ *
+ * @see {@link Do}
+ * @see {@link bind}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Option, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Option.Do,
+ *   Option.bind("x", () => Option.some(2)),
+ *   Option.bind("y", () => Option.some(3)),
+ *   Option.let("sum", ({ x, y }) => x + y),
+ *   Option.filter(({ x, y }) => x * y > 5)
+ * )
+ * assert.deepStrictEqual(result, Option.some({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
  * @since 2.0.0
  */
@@ -1221,6 +1247,32 @@ const let_: {
 
 export {
   /**
+   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+   *
+   * Here's how the do simulation works:
+   *
+   * 1. Start the do simulation using the `Do` value
+   * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Option` values
+   * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+   * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+   * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+   *
+   * @see {@link Do}
+   * @see {@link bind}
+   * @see {@link bindTo}
+   *
+   * @example
+   * import { Option, pipe } from "effect"
+   *
+   * const result = pipe(
+   *   Option.Do,
+   *   Option.bind("x", () => Option.some(2)),
+   *   Option.bind("y", () => Option.some(3)),
+   *   Option.let("sum", ({ x, y }) => x + y),
+   *   Option.filter(({ x, y }) => x * y > 5)
+   * )
+   * assert.deepStrictEqual(result, Option.some({ x: 2, y: 3, sum: 5 }))
+   *
    * @category do notation
    * @since 2.0.0
    */
@@ -1228,6 +1280,32 @@ export {
 }
 
 /**
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Option` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+ *
+ * @see {@link Do}
+ * @see {@link bindTo}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Option, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Option.Do,
+ *   Option.bind("x", () => Option.some(2)),
+ *   Option.bind("y", () => Option.some(3)),
+ *   Option.let("sum", ({ x, y }) => x + y),
+ *   Option.filter(({ x, y }) => x * y > 5)
+ * )
+ * assert.deepStrictEqual(result, Option.some({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
  * @since 2.0.0
  */
@@ -1244,6 +1322,32 @@ export const bind: {
 } = doNotation.bind<OptionTypeLambda>(map, flatMap)
 
 /**
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Option` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+ *
+ * @see {@link bindTo}
+ * @see {@link bind}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Option, pipe } from "effect"
+ *
+ * const result = pipe(
+ *   Option.Do,
+ *   Option.bind("x", () => Option.some(2)),
+ *   Option.bind("y", () => Option.some(3)),
+ *   Option.let("sum", ({ x, y }) => x + y),
+ *   Option.filter(({ x, y }) => x * y > 5)
+ * )
+ * assert.deepStrictEqual(result, Option.some({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
  * @since 2.0.0
  */

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1241,12 +1241,7 @@ export const bind: {
     name: Exclude<N, keyof A>,
     f: (a: A) => Option<B>
   ): Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = dual(3, <A, N extends string, B>(
-  self: Option<A>,
-  name: Exclude<N, keyof A>,
-  f: (a: A) => Option<B>
-): Option<{ [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
-  flatMap(self, (a) => map(f(a), (b) => Object.assign({}, a, { [name]: b }) as any)))
+} = doNotation.bind<OptionTypeLambda>(map, flatMap)
 
 /**
  * @category do notation

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1205,10 +1205,7 @@ export const exists: {
 export const bindTo: {
   <N extends string>(name: N): <A>(self: Option<A>) => Option<{ [K in N]: A }>
   <A, N extends string>(self: Option<A>, name: N): Option<{ [K in N]: A }>
-} = dual(
-  2,
-  <A, N extends string>(self: Option<A>, name: N): Option<{ [K in N]: A }> => map(self, (a) => ({ [name]: a } as any))
-)
+} = doNotation.bindTo<OptionTypeLambda>(map)
 
 const let_: {
   <N extends string, A extends object, B>(

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -8,6 +8,7 @@ import type { LazyArg } from "./Function.js"
 import { constNull, constUndefined, dual, identity, isFunction } from "./Function.js"
 import type { TypeLambda } from "./HKT.js"
 import type { Inspectable } from "./Inspectable.js"
+import * as doNotation from "./internal/doNotation.js"
 import * as either from "./internal/either.js"
 import * as option from "./internal/option.js"
 import type { Order } from "./Order.js"
@@ -1219,12 +1220,7 @@ const let_: {
     name: Exclude<N, keyof A>,
     f: (a: A) => B
   ): Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = dual(3, <A extends object, N extends string, B>(
-  self: Option<A>,
-  name: Exclude<N, keyof A>,
-  f: (a: A) => B
-): Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }> =>
-  map(self, (a) => Object.assign({}, a, { [name]: f(a) }) as any))
+} = doNotation.let_<OptionTypeLambda>(map)
 
 export {
   /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4498,8 +4498,8 @@ export const bindEffect: {
  * @category do notation
  */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E, R>(self: Stream<A, E, R>) => Stream<Record<N, A>, E, R>
-  <A, E, R, N extends string>(self: Stream<A, E, R>, tag: N): Stream<Record<N, A>, E, R>
+  <N extends string>(tag: N): <A, E, R>(self: Stream<A, E, R>) => Stream<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Stream<A, E, R>, tag: N): Stream<{ [K in N]: A }, E, R>
 } = internal.bindTo
 
 const let_: {

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4503,15 +4503,15 @@ export const bindTo: {
 } = internal.bindTo
 
 const let_: {
-  <N extends string, K, A>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): <E, R>(self: Stream<K, E, R>) => Stream<MergeRecord<K, { [k in N]: A }>, E, R>
-  <K, E, R, N extends string, A>(
-    self: Stream<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): Stream<MergeRecord<K, { [k in N]: A }>, E, R>
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): <E, R>(self: Stream<A, E, R>) => Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
+  <A extends object, E, R, N extends string, B>(
+    self: Stream<A, E, R>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
 } = internal.let_
 
 export {

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4498,8 +4498,8 @@ export const bindEffect: {
  * @category do notation
  */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E, R>(self: Stream<A, E, R>) => Stream<{ [K in N]: A }, E, R>
-  <A, E, R, N extends string>(self: Stream<A, E, R>, tag: N): Stream<{ [K in N]: A }, E, R>
+  <N extends string>(name: N): <A, E, R>(self: Stream<A, E, R>) => Stream<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Stream<A, E, R>, name: N): Stream<{ [K in N]: A }, E, R>
 } = internal.bindTo
 
 const let_: {

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -29,7 +29,7 @@ import type * as Emit from "./StreamEmit.js"
 import type * as HaltStrategy from "./StreamHaltStrategy.js"
 import type * as Take from "./Take.js"
 import type * as Tracer from "./Tracer.js"
-import type { Covariant, MergeRecord, NoInfer } from "./Types.js"
+import type { Covariant, NoInfer } from "./Types.js"
 import type * as Unify from "./Unify.js"
 
 /**
@@ -4452,21 +4452,21 @@ export const Do: Stream<{}> = internal.Do
  * @category do notation
  */
 export const bind: {
-  <N extends string, K, A, E2, R2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Stream<A, E2, R2>,
+  <N extends string, A, B, E2, R2>(
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Stream<B, E2, R2>,
     options?:
       | { readonly concurrency?: number | "unbounded" | undefined; readonly bufferSize?: number | undefined }
       | undefined
-  ): <E, R>(self: Stream<K, E, R>) => Stream<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R>
-  <K, E, R, N extends string, A, E2, R2>(
-    self: Stream<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Stream<A, E2, R2>,
+  ): <E, R>(self: Stream<A, E, R>) => Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E2 | E, R2 | R>
+  <A, E, R, N extends string, B, E2, R2>(
+    self: Stream<A, E, R>,
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Stream<B, E2, R2>,
     options?:
       | { readonly concurrency?: number | "unbounded" | undefined; readonly bufferSize?: number | undefined }
       | undefined
-  ): Stream<MergeRecord<K, { [k in N]: A }>, E | E2, R | R2>
+  ): Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E | E2, R | R2>
 } = internal.bind
 
 /**
@@ -4476,21 +4476,21 @@ export const bind: {
  * @category do notation
  */
 export const bindEffect: {
-  <N extends string, K, A, E2, R2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect.Effect<A, E2, R2>,
+  <N extends string, A, B, E2, R2>(
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Effect.Effect<B, E2, R2>,
     options?:
       | { readonly concurrency?: number | "unbounded" | undefined; readonly bufferSize?: number | undefined }
       | undefined
-  ): <E, R>(self: Stream<K, E, R>) => Stream<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R>
-  <K, E, R, N extends string, A, E2, R2>(
-    self: Stream<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect.Effect<A, E2, R2>,
+  ): <E, R>(self: Stream<A, E, R>) => Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E2 | E, R2 | R>
+  <A, E, R, N extends string, B, E2, R2>(
+    self: Stream<A, E, R>,
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Effect.Effect<B, E2, R2>,
     options?:
       | { readonly concurrency?: number | "unbounded" | undefined; readonly unordered?: boolean | undefined }
       | undefined
-  ): Stream<MergeRecord<K, { [k in N]: A }>, E | E2, R | R2>
+  ): Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E | E2, R | R2>
 } = _groupBy.bindEffect
 
 /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4440,16 +4440,64 @@ export const zipWithIndex: <A, E, R>(self: Stream<A, E, R>) => Stream<[A, number
 // -------------------------------------------------------------------------------------
 
 /**
- * @since 2.0.0
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Stream` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link bindTo}
+ * @see {@link bind}
+ * @see {@link bindEffect}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Chunk, Effect, pipe, Stream } from "effect"
+ *
+ * const result = pipe(
+ *   Stream.Do,
+ *   Stream.bind("x", () => Stream.succeed(2)),
+ *   Stream.bind("y", () => Stream.succeed(3)),
+ *   Stream.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(Effect.runSync(Stream.runCollect(result)), Chunk.of({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const Do: Stream<{}> = internal.Do
 
 /**
- * Binds a value from a stream in a `do` scope
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
- * @since 2.0.0
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Stream` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link Do}
+ * @see {@link bindTo}
+ * @see {@link bindEffect}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Chunk, Effect, pipe, Stream } from "effect"
+ *
+ * const result = pipe(
+ *   Stream.Do,
+ *   Stream.bind("x", () => Stream.succeed(2)),
+ *   Stream.bind("y", () => Stream.succeed(3)),
+ *   Stream.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(Effect.runSync(Stream.runCollect(result)), Chunk.of({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const bind: {
   <N extends string, A, B, E2, R2>(
@@ -4471,6 +4519,11 @@ export const bind: {
 
 /**
  * Binds an effectful value in a `do` scope
+ *
+ * @see {@link Do}
+ * @see {@link bindTo}
+ * @see {@link bind}
+ * @see {@link let_ let}
  *
  * @since 2.0.0
  * @category do notation
@@ -4494,8 +4547,33 @@ export const bindEffect: {
 } = _groupBy.bindEffect
 
 /**
- * @since 2.0.0
+ * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ *
+ * Here's how the do simulation works:
+ *
+ * 1. Start the do simulation using the `Do` value
+ * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Stream` values
+ * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+ * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+ *
+ * @see {@link Do}
+ * @see {@link bind}
+ * @see {@link bindEffect}
+ * @see {@link let_ let}
+ *
+ * @example
+ * import { Chunk, Effect, pipe, Stream } from "effect"
+ *
+ * const result = pipe(
+ *   Stream.Do,
+ *   Stream.bind("x", () => Stream.succeed(2)),
+ *   Stream.bind("y", () => Stream.succeed(3)),
+ *   Stream.let("sum", ({ x, y }) => x + y)
+ * )
+ * assert.deepStrictEqual(Effect.runSync(Stream.runCollect(result)), Chunk.of({ x: 2, y: 3, sum: 5 }))
+ *
  * @category do notation
+ * @since 2.0.0
  */
 export const bindTo: {
   <N extends string>(name: N): <A, E, R>(self: Stream<A, E, R>) => Stream<{ [K in N]: A }, E, R>
@@ -4516,10 +4594,33 @@ const let_: {
 
 export {
   /**
-   * Bind a value in a `do` scope
+   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
-   * @since 2.0.0
+   * Here's how the do simulation works:
+   *
+   * 1. Start the do simulation using the `Do` value
+   * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Stream` values
+   * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
+   * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
+   *
+   * @see {@link Do}
+   * @see {@link bindTo}
+   * @see {@link bind}
+   * @see {@link bindEffect}
+   *
+   * @example
+   * import { Chunk, Effect, pipe, Stream } from "effect"
+   *
+   * const result = pipe(
+   *   Stream.Do,
+   *   Stream.bind("x", () => Stream.succeed(2)),
+   *   Stream.bind("y", () => Stream.succeed(3)),
+   *   Stream.let("sum", ({ x, y }) => x + y)
+   * )
+   * assert.deepStrictEqual(Effect.runSync(Stream.runCollect(result)), Chunk.of({ x: 2, y: 3, sum: 5 }))
+   *
    * @category do notation
+   * @since 2.0.0
    */
   let_ as let
 }

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -31,6 +31,7 @@ import * as internalCause from "./cause.js"
 import { clockTag } from "./clock.js"
 import * as core from "./core.js"
 import * as defaultServices from "./defaultServices.js"
+import * as doNotation from "./doNotation.js"
 import * as fiberRefsPatch from "./fiberRefs/patch.js"
 import type { FiberRuntime } from "./fiberRuntime.js"
 import * as metricLabel from "./metric/label.js"
@@ -401,24 +402,18 @@ export const bindTo: {
 
 /* @internal */
 export const let_: {
-  <N extends string, K, A>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): <E, R>(self: Effect.Effect<K, E, R>) => Effect.Effect<MergeRecord<K, { [k in N]: A }>, E, R>
-  <K, E, R, N extends string, A>(
-    self: Effect.Effect<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ): Effect.Effect<MergeRecord<K, { [k in N]: A }>, E, R>
-} = dual(3, <K, E, R, N extends string, A>(
-  self: Effect.Effect<K, E, R>,
-  tag: Exclude<N, keyof K>,
-  f: (_: K) => A
-): Effect.Effect<MergeRecord<K, { [k in N]: A }>, E, R> =>
-  core.map(
-    self,
-    (k): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: f(k) } as any)
-  ))
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): <E, R>(
+    self: Effect.Effect<A, E, R>
+  ) => Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
+  <A extends object, N extends string, E, R, B>(
+    self: Effect.Effect<A, E, R>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
+} = doNotation.let_<Effect.EffectTypeLambda>(core.map)
 
 /* @internal */
 export const dropUntil: {

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -392,13 +392,9 @@ export const bind: {
 
 /* @internal */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<{ [K in N]: A }, E, R>
-  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, tag: N): Effect.Effect<{ [K in N]: A }, E, R>
-} = dual(
-  2,
-  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, tag: N): Effect.Effect<{ [K in N]: A }, E, R> =>
-    core.map(self, (a) => ({ [tag]: a } as { [K in N]: A }))
-)
+  <N extends string>(name: N): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, name: N): Effect.Effect<{ [K in N]: A }, E, R>
+} = doNotation.bindTo<Effect.EffectTypeLambda>(core.map)
 
 /* @internal */
 export const let_: {

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -391,12 +391,12 @@ export const bind: {
 
 /* @internal */
 export const bindTo: {
-  <N extends string>(tag: N): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<Record<N, A>, E, R>
-  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, tag: N): Effect.Effect<Record<N, A>, E, R>
+  <N extends string>(tag: N): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, tag: N): Effect.Effect<{ [K in N]: A }, E, R>
 } = dual(
   2,
-  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, tag: N): Effect.Effect<Record<N, A>, E, R> =>
-    core.map(self, (a) => ({ [tag]: a } as Record<N, A>))
+  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, tag: N): Effect.Effect<{ [K in N]: A }, E, R> =>
+    core.map(self, (a) => ({ [tag]: a } as { [K in N]: A }))
 )
 
 /* @internal */

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -25,7 +25,7 @@ import type * as Random from "../Random.js"
 import * as Ref from "../Ref.js"
 import type * as runtimeFlagsPatch from "../RuntimeFlagsPatch.js"
 import * as Tracer from "../Tracer.js"
-import type { MergeRecord, NoInfer } from "../Types.js"
+import type { NoInfer } from "../Types.js"
 import { yieldWrapGet } from "../Utils.js"
 import * as internalCause from "./cause.js"
 import { clockTag } from "./clock.js"
@@ -370,25 +370,18 @@ export const Do: Effect.Effect<{}> = core.succeed({})
 
 /* @internal */
 export const bind: {
-  <N extends string, K, A, E2, R2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect.Effect<A, E2, R2>
-  ): <E, R>(self: Effect.Effect<K, E, R>) => Effect.Effect<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R>
-  <K, E, R, N extends string, A, E2, R2>(
-    self: Effect.Effect<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect.Effect<A, E2, R2>
-  ): Effect.Effect<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R>
-} = dual(3, <K, E, R, N extends string, A, E2, R2>(
-  self: Effect.Effect<K, E, R>,
-  tag: Exclude<N, keyof K>,
-  f: (_: K) => Effect.Effect<A, E2, R2>
-): Effect.Effect<MergeRecord<K, { [k in N]: A }>, E2 | E, R2 | R> =>
-  core.flatMap(self, (k) =>
-    core.map(
-      f(k),
-      (a): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: a } as any)
-    )))
+  <N extends string, A extends object, B, E2, R2>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Effect.Effect<B, E2, R2>
+  ): <E1, R1>(
+    self: Effect.Effect<A, E1, R1>
+  ) => Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E2 | E1, R2 | R1>
+  <A extends object, N extends string, E1, R1, B, E2, R2>(
+    self: Effect.Effect<A, E1, R1>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Effect.Effect<B, E2, R2>
+  ): Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E1 | E2, R1 | R2>
+} = doNotation.bind<Effect.EffectTypeLambda>(core.map, core.flatMap)
 
 /* @internal */
 export const bindTo: {

--- a/packages/effect/src/internal/doNotation.ts
+++ b/packages/effect/src/internal/doNotation.ts
@@ -6,6 +6,7 @@ type Map<F extends TypeLambda> = {
   <R, O, E, A, B>(self: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
 }
 
+/** @internal */
 export const let_ = <F extends TypeLambda>(
   map: Map<F>
 ): {
@@ -27,3 +28,18 @@ export const let_ = <F extends TypeLambda>(
     f: (a: A) => B
   ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
     map(self, (a) => Object.assign({}, a, { [name]: f(a) }) as any))
+
+/** @internal */
+export const bindTo = <F extends TypeLambda>(map: Map<F>): {
+  <N extends string>(
+    name: N
+  ): <R, O, E, A>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, { [K in N]: A }>
+  <R, O, E, A, N extends string>(
+    self: Kind<F, R, O, E, A>,
+    name: N
+  ): Kind<F, R, O, E, { [K in N]: A }>
+} =>
+  dual(2, <R, O, E, A, N extends string>(
+    self: Kind<F, R, O, E, A>,
+    name: N
+  ): Kind<F, R, O, E, { [K in N]: A }> => map(self, (a) => ({ [name]: a } as { [K in N]: A })))

--- a/packages/effect/src/internal/doNotation.ts
+++ b/packages/effect/src/internal/doNotation.ts
@@ -6,6 +6,16 @@ type Map<F extends TypeLambda> = {
   <R, O, E, A, B>(self: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
 }
 
+type FlatMap<F extends TypeLambda> = {
+  <A, R2, O2, E2, B>(
+    f: (a: A) => Kind<F, R2, O2, E2, B>
+  ): <R1, O1, E1>(self: Kind<F, R1, O1, E1, A>) => Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+  <R1, O1, E1, A, R2, O2, E2, B>(
+    self: Kind<F, R1, O1, E1, A>,
+    f: (a: A) => Kind<F, R2, O2, E2, B>
+  ): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+}
+
 /** @internal */
 export const let_ = <F extends TypeLambda>(
   map: Map<F>
@@ -43,3 +53,25 @@ export const bindTo = <F extends TypeLambda>(map: Map<F>): {
     self: Kind<F, R, O, E, A>,
     name: N
   ): Kind<F, R, O, E, { [K in N]: A }> => map(self, (a) => ({ [name]: a } as { [K in N]: A })))
+
+/** @internal */
+export const bind = <F extends TypeLambda>(map: Map<F>, flatMap: FlatMap<F>): {
+  <N extends string, A extends object, R2, O2, E2, B>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Kind<F, R2, O2, E2, B>
+  ): <R1, O1, E1>(
+    self: Kind<F, R1, O1, E1, A>
+  ) => Kind<F, R1 & R2, O1 | O2, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+  <R1, O1, E1, A extends object, N extends string, R2, O2, E2, B>(
+    self: Kind<F, R1, O1, E1, A>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Kind<F, R2, O2, E2, B>
+  ): Kind<F, R1 & R2, O1 | O2, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+} =>
+  dual(3, <R1, O1, E1, A, N extends string, R2, O2, E2, B>(
+    self: Kind<F, R1, O1, E1, A>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => Kind<F, R2, O2, E2, B>
+  ): Kind<F, R1 & R2, O1 | O2, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
+    flatMap(self, (a) =>
+      map(f(a), (b) => Object.assign({}, a, { [name]: b }) as { [K in keyof A | N]: K extends keyof A ? A[K] : B })))

--- a/packages/effect/src/internal/doNotation.ts
+++ b/packages/effect/src/internal/doNotation.ts
@@ -1,0 +1,29 @@
+import { dual } from "../Function.js"
+import type { Kind, TypeLambda } from "../HKT.js"
+
+type Map<F extends TypeLambda> = {
+  <A, B>(f: (a: A) => B): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+  <R, O, E, A, B>(self: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
+}
+
+export const let_ = <F extends TypeLambda>(
+  map: Map<F>
+): {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): <R, O, E>(
+    self: Kind<F, R, O, E, A>
+  ) => Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+  <R, O, E, A extends object, N extends string, B>(
+    self: Kind<F, R, O, E, A>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+} =>
+  dual(3, <R, O, E, A extends object, N extends string, B>(
+    self: Kind<F, R, O, E, A>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
+    map(self, (a) => Object.assign({}, a, { [name]: f(a) }) as any))

--- a/packages/effect/src/internal/groupBy.ts
+++ b/packages/effect/src/internal/groupBy.ts
@@ -13,7 +13,7 @@ import * as Queue from "../Queue.js"
 import * as Ref from "../Ref.js"
 import type * as Stream from "../Stream.js"
 import type * as Take from "../Take.js"
-import type { MergeRecord, NoInfer } from "../Types.js"
+import type { NoInfer } from "../Types.js"
 import * as channel from "./channel.js"
 import * as channelExecutor from "./channel/channelExecutor.js"
 import * as core from "./core-stream.js"
@@ -274,35 +274,35 @@ export const mapEffectOptions = dual<
 
 /** @internal */
 export const bindEffect = dual<
-  <N extends string, K, A, E2, R2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect.Effect<A, E2, R2>,
+  <N extends string, A, B, E2, R2>(
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Effect.Effect<B, E2, R2>,
     options?: {
       readonly concurrency?: number | "unbounded" | undefined
       readonly bufferSize?: number | undefined
     }
-  ) => <E, R>(self: Stream.Stream<K, E, R>) => Stream.Stream<
-    MergeRecord<K, { [k in N]: A }>,
+  ) => <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<
+    { [K in keyof A | N]: K extends keyof A ? A[K] : B },
     E | E2,
     R | R2
   >,
-  <K, E, R, N extends string, A, E2, R2>(
-    self: Stream.Stream<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Effect.Effect<A, E2, R2>,
+  <A, E, R, N extends string, B, E2, R2>(
+    self: Stream.Stream<A, E, R>,
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Effect.Effect<B, E2, R2>,
     options?: {
       readonly concurrency?: number | "unbounded" | undefined
       readonly unordered?: boolean | undefined
     }
   ) => Stream.Stream<
-    MergeRecord<K, { [k in N]: A }>,
+    { [K in keyof A | N]: K extends keyof A ? A[K] : B },
     E | E2,
     R | R2
   >
->((args) => typeof args[0] !== "string", <K, E, R, N extends string, A, E2, R2>(
-  self: Stream.Stream<K, E, R>,
-  tag: Exclude<N, keyof K>,
-  f: (_: K) => Effect.Effect<A, E2, R2>,
+>((args) => typeof args[0] !== "string", <A, E, R, N extends string, B, E2, R2>(
+  self: Stream.Stream<A, E, R>,
+  tag: Exclude<N, keyof A>,
+  f: (_: A) => Effect.Effect<B, E2, R2>,
   options?: {
     readonly concurrency?: number | "unbounded" | undefined
     readonly unordered?: boolean | undefined
@@ -311,7 +311,7 @@ export const bindEffect = dual<
   mapEffectOptions(self, (k) =>
     Effect.map(
       f(k),
-      (a): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: a } as any)
+      (a) => ({ ...k, [tag]: a } as { [K in keyof A | N]: K extends keyof A ? A[K] : B })
     ), options))
 
 const mapDequeue = <A, B>(dequeue: Queue.Dequeue<A>, f: (a: A) => B): Queue.Dequeue<B> => new MapDequeue(dequeue, f)

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -37,6 +37,7 @@ import * as channelExecutor from "./channel/channelExecutor.js"
 import * as MergeStrategy from "./channel/mergeStrategy.js"
 import * as singleProducerAsyncInput from "./channel/singleProducerAsyncInput.js"
 import * as core from "./core-stream.js"
+import * as doNotation from "./doNotation.js"
 import { RingBuffer } from "./ringBuffer.js"
 import * as _sink from "./sink.js"
 import * as DebounceState from "./stream/debounceState.js"
@@ -7983,29 +7984,19 @@ export const bindTo = dual<
 )
 
 /* @internal */
-export const let_ = dual<
-  <N extends string, K, A>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ) => <E, R>(self: Stream.Stream<K, E, R>) => Stream.Stream<
-    MergeRecord<K, { [k in N]: A }>,
-    E,
-    R
-  >,
-  <K, E, R, N extends string, A>(
-    self: Stream.Stream<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => A
-  ) => Stream.Stream<
-    MergeRecord<K, { [k in N]: A }>,
-    E,
-    R
-  >
->(3, <K, E, R, N extends string, A>(self: Stream.Stream<K, E, R>, tag: Exclude<N, keyof K>, f: (_: K) => A) =>
-  map(
-    self,
-    (k): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: f(k) } as any)
-  ))
+export const let_: {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): <E, R>(
+    self: Stream.Stream<A, E, R>
+  ) => Stream.Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
+  <A extends object, E, R, N extends string, B>(
+    self: Stream.Stream<A, E, R>,
+    name: Exclude<N, keyof A>,
+    f: (a: A) => B
+  ): Stream.Stream<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
+} = doNotation.let_<Stream.StreamTypeLambda>(map)
 
 // Circular with Channel
 

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -7963,25 +7963,10 @@ export const bind = dual<
     ), options))
 
 /* @internal */
-export const bindTo = dual<
-  <N extends string>(tag: N) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<
-    { [K in N]: A },
-    E,
-    R
-  >,
-  <A, E, R, N extends string>(
-    self: Stream.Stream<A, E, R>,
-    tag: N
-  ) => Stream.Stream<
-    { [K in N]: A },
-    E,
-    R
-  >
->(
-  2,
-  <A, E, R, N extends string>(self: Stream.Stream<A, E, R>, tag: N): Stream.Stream<{ [K in N]: A }, E, R> =>
-    map(self, (a) => ({ [tag]: a } as { [K in N]: A }))
-)
+export const bindTo: {
+  <N extends string>(name: N): <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Stream.Stream<A, E, R>, name: N): Stream.Stream<{ [K in N]: A }, E, R>
+} = doNotation.bindTo<Stream.StreamTypeLambda>(map)
 
 /* @internal */
 export const let_: {

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -7964,7 +7964,7 @@ export const bind = dual<
 /* @internal */
 export const bindTo = dual<
   <N extends string>(tag: N) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<
-    Record<N, A>,
+    { [K in N]: A },
     E,
     R
   >,
@@ -7972,14 +7972,14 @@ export const bindTo = dual<
     self: Stream.Stream<A, E, R>,
     tag: N
   ) => Stream.Stream<
-    Record<N, A>,
+    { [K in N]: A },
     E,
     R
   >
 >(
   2,
-  <A, E, R, N extends string>(self: Stream.Stream<A, E, R>, tag: N): Stream.Stream<Record<N, A>, E, R> =>
-    map(self, (a) => ({ [tag]: a } as Record<N, A>))
+  <A, E, R, N extends string>(self: Stream.Stream<A, E, R>, tag: N): Stream.Stream<{ [K in N]: A }, E, R> =>
+    map(self, (a) => ({ [tag]: a } as { [K in N]: A }))
 )
 
 /* @internal */

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -31,7 +31,7 @@ import * as HaltStrategy from "../StreamHaltStrategy.js"
 import type * as Take from "../Take.js"
 import type * as Tracer from "../Tracer.js"
 import * as Tuple from "../Tuple.js"
-import type { MergeRecord, NoInfer } from "../Types.js"
+import type { NoInfer } from "../Types.js"
 import * as channel from "./channel.js"
 import * as channelExecutor from "./channel/channelExecutor.js"
 import * as MergeStrategy from "./channel/mergeStrategy.js"
@@ -7922,35 +7922,35 @@ export const Do: Stream.Stream<{}> = succeed({})
 
 /** @internal */
 export const bind = dual<
-  <N extends string, K, A, E2, R2>(
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Stream.Stream<A, E2, R2>,
+  <N extends string, A, B, E2, R2>(
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Stream.Stream<B, E2, R2>,
     options?: {
       readonly concurrency?: number | "unbounded" | undefined
       readonly bufferSize?: number | undefined
     }
-  ) => <E, R>(self: Stream.Stream<K, E, R>) => Stream.Stream<
-    MergeRecord<K, { [k in N]: A }>,
+  ) => <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<
+    { [K in keyof A | N]: K extends keyof A ? A[K] : B },
     E | E2,
     R | R2
   >,
-  <K, E, R, N extends string, A, E2, R2>(
-    self: Stream.Stream<K, E, R>,
-    tag: Exclude<N, keyof K>,
-    f: (_: K) => Stream.Stream<A, E2, R2>,
+  <A, E, R, N extends string, B, E2, R2>(
+    self: Stream.Stream<A, E, R>,
+    tag: Exclude<N, keyof A>,
+    f: (_: A) => Stream.Stream<B, E2, R2>,
     options?: {
       readonly concurrency?: number | "unbounded" | undefined
       readonly bufferSize?: number | undefined
     }
   ) => Stream.Stream<
-    MergeRecord<K, { [k in N]: A }>,
+    { [K in keyof A | N]: K extends keyof A ? A[K] : B },
     E | E2,
     R | R2
   >
->((args) => typeof args[0] !== "string", <K, E, R, N extends string, A, E2, R2>(
-  self: Stream.Stream<K, E, R>,
-  tag: Exclude<N, keyof K>,
-  f: (_: K) => Stream.Stream<A, E2, R2>,
+>((args) => typeof args[0] !== "string", <A, E, R, N extends string, B, E2, R2>(
+  self: Stream.Stream<A, E, R>,
+  tag: Exclude<N, keyof A>,
+  f: (_: A) => Stream.Stream<B, E2, R2>,
   options?: {
     readonly concurrency?: number | "unbounded" | undefined
     readonly bufferSize?: number | undefined
@@ -7959,7 +7959,7 @@ export const bind = dual<
   flatMap(self, (k) =>
     map(
       f(k),
-      (a): MergeRecord<K, { [k in N]: A }> => ({ ...k, [tag]: a } as any)
+      (a) => ({ ...k, [tag]: a } as { [K in keyof A | N]: K extends keyof A ? A[K] : B })
     ), options))
 
 /* @internal */

--- a/packages/effect/test/Effect/do-notation.test.ts
+++ b/packages/effect/test/Effect/do-notation.test.ts
@@ -1,0 +1,47 @@
+import * as Util from "effect-test/util"
+import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import { describe, it } from "vitest"
+
+const expectRight = <R, L>(e: Effect.Effect<R, L>, expected: R) => {
+  Util.deepStrictEqual(Effect.runSync(Effect.either(e)), Either.right(expected))
+}
+
+const expectLeft = <R, L>(e: Effect.Effect<R, L>, expected: L) => {
+  Util.deepStrictEqual(Effect.runSync(Effect.either(e)), Either.left(expected))
+}
+
+describe("do notation", () => {
+  it("Do", () => {
+    expectRight(Effect.Do, {})
+  })
+
+  it("bindTo", () => {
+    expectRight(pipe(Effect.succeed(1), Effect.bindTo("a")), { a: 1 })
+    expectLeft(pipe(Effect.fail("left"), Effect.bindTo("a")), "left")
+  })
+
+  it("bind", () => {
+    expectRight(pipe(Effect.succeed(1), Effect.bindTo("a"), Effect.bind("b", ({ a }) => Effect.succeed(a + 1))), {
+      a: 1,
+      b: 2
+    })
+    expectLeft(
+      pipe(Effect.succeed(1), Effect.bindTo("a"), Effect.bind("b", () => Effect.fail("left"))),
+      "left"
+    )
+    expectLeft(
+      pipe(Effect.fail("left"), Effect.bindTo("a"), Effect.bind("b", () => Effect.succeed(2))),
+      "left"
+    )
+  })
+
+  it("let", () => {
+    expectRight(pipe(Effect.succeed(1), Effect.bindTo("a"), Effect.let("b", ({ a }) => a + 1)), { a: 1, b: 2 })
+    expectLeft(
+      pipe(Effect.fail("left"), Effect.bindTo("a"), Effect.let("b", () => 2)),
+      "left"
+    )
+  })
+})

--- a/packages/effect/test/Either.test.ts
+++ b/packages/effect/test/Either.test.ts
@@ -2,10 +2,18 @@ import * as Util from "effect-test/util"
 import * as Chunk from "effect/Chunk"
 import * as Either from "effect/Either"
 import { flow, pipe } from "effect/Function"
-import * as N from "effect/Number"
-import * as O from "effect/Option"
-import * as S from "effect/String"
+import * as Num from "effect/Number"
+import * as Option from "effect/Option"
+import * as Str from "effect/String"
 import { describe, expect, it } from "vitest"
+
+const expectRight = <R, L>(e: Either.Either<R, L>, expected: R) => {
+  Util.deepStrictEqual(e, Either.right(expected))
+}
+
+const expectLeft = <R, L>(e: Either.Either<R, L>, expected: L) => {
+  Util.deepStrictEqual(e, Either.left(expected))
+}
 
 describe("Either", () => {
   it("gen", () => {
@@ -104,28 +112,28 @@ describe("Either", () => {
   it("isEither", () => {
     Util.deepStrictEqual(pipe(Either.right(1), Either.isEither), true)
     Util.deepStrictEqual(pipe(Either.left("e"), Either.isEither), true)
-    Util.deepStrictEqual(pipe(O.some(1), Either.isEither), false)
+    Util.deepStrictEqual(pipe(Option.some(1), Either.isEither), false)
   })
 
   it("getRight", () => {
-    Util.deepStrictEqual(pipe(Either.right(1), Either.getRight), O.some(1))
-    Util.deepStrictEqual(pipe(Either.left("a"), Either.getRight), O.none())
+    Util.deepStrictEqual(pipe(Either.right(1), Either.getRight), Option.some(1))
+    Util.deepStrictEqual(pipe(Either.left("a"), Either.getRight), Option.none())
   })
 
   it("getLeft", () => {
-    Util.deepStrictEqual(pipe(Either.right(1), Either.getLeft), O.none())
-    Util.deepStrictEqual(pipe(Either.left("e"), Either.getLeft), O.some("e"))
+    Util.deepStrictEqual(pipe(Either.right(1), Either.getLeft), Option.none())
+    Util.deepStrictEqual(pipe(Either.left("e"), Either.getLeft), Option.some("e"))
   })
 
   it("map", () => {
-    const f = Either.map(S.length)
+    const f = Either.map(Str.length)
     Util.deepStrictEqual(pipe(Either.right("abc"), f), Either.right(3))
     Util.deepStrictEqual(pipe(Either.left("s"), f), Either.left("s"))
   })
 
   it("mapBoth", () => {
     const f = Either.mapBoth({
-      onLeft: S.length,
+      onLeft: Str.length,
       onRight: (n: number) => n > 2
     })
     Util.deepStrictEqual(pipe(Either.right(1), f), Either.right(false))
@@ -177,7 +185,7 @@ describe("Either", () => {
   })
 
   it("getEquivalence", () => {
-    const isEquivalent = Either.getEquivalence({ right: N.Equivalence, left: S.Equivalence })
+    const isEquivalent = Either.getEquivalence({ right: Num.Equivalence, left: Str.Equivalence })
     Util.deepStrictEqual(isEquivalent(Either.right(1), Either.right(1)), true)
     Util.deepStrictEqual(isEquivalent(Either.right(1), Either.right(2)), false)
     Util.deepStrictEqual(isEquivalent(Either.right(1), Either.left("foo")), false)
@@ -197,8 +205,8 @@ describe("Either", () => {
   })
 
   it("fromOption", () => {
-    Util.deepStrictEqual(Either.fromOption(O.none(), () => "none"), Either.left("none"))
-    Util.deepStrictEqual(Either.fromOption(O.some(1), () => "none"), Either.right(1))
+    Util.deepStrictEqual(Either.fromOption(Option.none(), () => "none"), Either.left("none"))
+    Util.deepStrictEqual(Either.fromOption(Option.some(1), () => "none"), Either.right(1))
   })
 
   it("try", () => {
@@ -252,7 +260,7 @@ describe("Either", () => {
   })
 
   it("flatMap", () => {
-    const f = Either.flatMap(flow(S.length, Either.right))
+    const f = Either.flatMap(flow(Str.length, Either.right))
     Util.deepStrictEqual(pipe(Either.right("abc"), f), Either.right(3))
     Util.deepStrictEqual(pipe(Either.left("maError"), f), Either.left("maError"))
   })
@@ -318,53 +326,6 @@ describe("Either", () => {
     Util.deepStrictEqual(pipe(Either.left("a"), Either.orElse(() => Either.left("b"))), Either.left("b"))
   })
 
-  it("Do", () => {
-    Util.deepStrictEqual(Either.Do, Either.right({}))
-  })
-
-  it("bindTo", () => {
-    Util.deepStrictEqual(
-      pipe(
-        Either.right(1),
-        Either.bindTo("a")
-      ),
-      Either.right({ a: 1 })
-    )
-    Util.deepStrictEqual(
-      pipe(
-        Either.left("b"),
-        Either.bindTo("a")
-      ),
-      Either.left("b")
-    )
-  })
-
-  it("bind", () => {
-    Util.deepStrictEqual(
-      pipe(Either.right(1), Either.bindTo("a"), Either.bind("b", ({ a }) => Either.right(a + 1))),
-      Either.right({ a: 1, b: 2 })
-    )
-    Util.deepStrictEqual(
-      pipe(Either.right(1), Either.bindTo("a"), Either.bind("b", () => Either.left("c"))),
-      Either.left("c")
-    )
-    Util.deepStrictEqual(
-      pipe(Either.left("d"), Either.bindTo("a"), Either.bind("b", () => Either.right(2))),
-      Either.left("d")
-    )
-  })
-
-  it("let", () => {
-    Util.deepStrictEqual(
-      pipe(Either.Do, Either.bind("a", () => Either.right(1)), Either.let("b", ({ a }) => a + 1)),
-      Either.right({ a: 1, b: 2 })
-    )
-    Util.deepStrictEqual(
-      pipe(Either.left("d"), Either.bindTo("a"), Either.let("b", () => Either.right(2))),
-      Either.left("d")
-    )
-  })
-
   it("vitest equality", () => {
     expect(Either.right(1)).toStrictEqual(Either.right(1))
     expect(Either.left(1)).toStrictEqual(Either.left(1))
@@ -373,5 +334,39 @@ describe("Either", () => {
     expect(Either.left(2)).not.toStrictEqual(Either.left(1))
     expect(Either.left(1)).not.toStrictEqual(Either.right(1))
     expect(Either.left(1)).not.toStrictEqual(Either.right(2))
+  })
+
+  describe("do notation", () => {
+    it("Do", () => {
+      expectRight(Either.Do, {})
+    })
+
+    it("bindTo", () => {
+      expectRight(pipe(Either.right(1), Either.bindTo("a")), { a: 1 })
+      expectLeft(pipe(Either.left("left"), Either.bindTo("a")), "left")
+    })
+
+    it("bind", () => {
+      expectRight(pipe(Either.right(1), Either.bindTo("a"), Either.bind("b", ({ a }) => Either.right(a + 1))), {
+        a: 1,
+        b: 2
+      })
+      expectLeft(
+        pipe(Either.right(1), Either.bindTo("a"), Either.bind("b", () => Either.left("left"))),
+        "left"
+      )
+      expectLeft(
+        pipe(Either.left("left"), Either.bindTo("a"), Either.bind("b", () => Either.right(2))),
+        "left"
+      )
+    })
+
+    it("let", () => {
+      expectRight(pipe(Either.right(1), Either.bindTo("a"), Either.let("b", ({ a }) => a + 1)), { a: 1, b: 2 })
+      expectLeft(
+        pipe(Either.left("left"), Either.bindTo("a"), Either.let("b", () => 2)),
+        "left"
+      )
+    })
   })
 })

--- a/packages/effect/test/Option.test.ts
+++ b/packages/effect/test/Option.test.ts
@@ -5,58 +5,66 @@ import * as Equal from "effect/Equal"
 import { pipe } from "effect/Function"
 import * as Hash from "effect/Hash"
 import * as N from "effect/Number"
-import * as _ from "effect/Option"
+import * as Option from "effect/Option"
 import * as S from "effect/String"
 import { assert, assertType, describe, expect, it } from "vitest"
 
 const p = (n: number): boolean => n > 2
 
+const expectNone = <A>(o: Option.Option<A>) => {
+  Util.deepStrictEqual(o, Option.none())
+}
+
+const expectSome = <A>(o: Option.Option<A>, expected: A) => {
+  Util.deepStrictEqual(o, Option.some(expected))
+}
+
 describe("Option", () => {
   it("gen", () => {
-    const a = _.gen(function*() {
-      const x = yield* _.some(1)
-      const y = yield* _.some(2)
+    const a = Option.gen(function*() {
+      const x = yield* Option.some(1)
+      const y = yield* Option.some(2)
       return x + y
     })
     // eslint-disable-next-line require-yield
-    const b = _.gen(function*() {
+    const b = Option.gen(function*() {
       return 10
     })
-    const c = _.gen(function*($) {
-      yield* $(_.some(1))
-      yield* $(_.some(2))
+    const c = Option.gen(function*($) {
+      yield* $(Option.some(1))
+      yield* $(Option.some(2))
     })
-    const d = _.gen(function*($) {
-      yield* $(_.some(1))
-      return yield* $(_.some(2))
+    const d = Option.gen(function*($) {
+      yield* $(Option.some(1))
+      return yield* $(Option.some(2))
     })
-    const e = _.gen(function*($) {
-      yield* $(_.some(1))
-      yield* $(_.none())
-      return yield* $(_.some(2))
+    const e = Option.gen(function*($) {
+      yield* $(Option.some(1))
+      yield* $(Option.none())
+      return yield* $(Option.some(2))
     })
-    const f = _.gen(function*($) {
-      yield* $(_.none())
+    const f = Option.gen(function*($) {
+      yield* $(Option.none())
     })
-    expect(a).toEqual(_.some(3))
-    expect(b).toEqual(_.some(10))
-    expect(c).toEqual(_.some(undefined))
-    expect(d).toEqual(_.some(2))
-    expect(e).toEqual(_.none())
-    expect(f).toEqual(_.none())
+    expect(a).toEqual(Option.some(3))
+    expect(b).toEqual(Option.some(10))
+    expect(c).toEqual(Option.some(undefined))
+    expect(d).toEqual(Option.some(2))
+    expect(e).toEqual(Option.none())
+    expect(f).toEqual(Option.none())
   })
 
   it("toString", () => {
-    expect(String(_.none())).toEqual(`{
+    expect(String(Option.none())).toEqual(`{
   "_id": "Option",
   "_tag": "None"
 }`)
-    expect(String(_.some(1))).toEqual(`{
+    expect(String(Option.some(1))).toEqual(`{
   "_id": "Option",
   "_tag": "Some",
   "value": 1
 }`)
-    expect(String(_.some(Chunk.make(1, 2, 3)))).toEqual(`{
+    expect(String(Option.some(Chunk.make(1, 2, 3)))).toEqual(`{
   "_id": "Option",
   "_tag": "Some",
   "value": {
@@ -71,10 +79,10 @@ describe("Option", () => {
   })
 
   it("toJSON", () => {
-    expect(_.none().toJSON()).toEqual(
+    expect(Option.none().toJSON()).toEqual(
       { _id: "Option", _tag: "None" }
     )
-    expect(_.some(1).toJSON()).toEqual(
+    expect(Option.some(1).toJSON()).toEqual(
       { _id: "Option", _tag: "Some", value: 1 }
     )
   })
@@ -85,207 +93,207 @@ describe("Option", () => {
     }
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { inspect } = require("node:util")
-    expect(inspect(_.none())).toEqual(inspect({ _id: "Option", _tag: "None" }))
-    expect(inspect(_.some(1))).toEqual(inspect({ _id: "Option", _tag: "Some", value: 1 }))
+    expect(inspect(Option.none())).toEqual(inspect({ _id: "Option", _tag: "None" }))
+    expect(inspect(Option.some(1))).toEqual(inspect({ _id: "Option", _tag: "Some", value: 1 }))
   })
 
   it("Equal", () => {
-    expect(Equal.equals(_.some(1), _.some(1))).toEqual(true)
-    expect(Equal.equals(_.some(1), _.some(2))).toEqual(false)
-    expect(Equal.equals(_.none(), _.none())).toEqual(true)
+    expect(Equal.equals(Option.some(1), Option.some(1))).toEqual(true)
+    expect(Equal.equals(Option.some(1), Option.some(2))).toEqual(false)
+    expect(Equal.equals(Option.none(), Option.none())).toEqual(true)
   })
 
   it("Hash", () => {
-    expect(Hash.hash(_.some(1))).toEqual(Hash.hash(_.some(1)))
-    expect(Hash.hash(_.some(1)) === Hash.hash(_.some(2))).toEqual(false)
-    expect(Hash.hash(_.none())).toEqual(Hash.hash(_.none()))
+    expect(Hash.hash(Option.some(1))).toEqual(Hash.hash(Option.some(1)))
+    expect(Hash.hash(Option.some(1)) === Hash.hash(Option.some(2))).toEqual(false)
+    expect(Hash.hash(Option.none())).toEqual(Hash.hash(Option.none()))
   })
 
   it("getRight", () => {
-    expect(_.getRight(E.right(1))).toEqual(_.some(1))
-    expect(_.getRight(E.left("a"))).toEqual(_.none())
+    expect(Option.getRight(E.right(1))).toEqual(Option.some(1))
+    expect(Option.getRight(E.left("a"))).toEqual(Option.none())
   })
 
   it("getLeft", () => {
-    expect(_.getLeft(E.right(1))).toEqual(_.none())
-    expect(_.getLeft(E.left("a"))).toEqual(_.some("a"))
+    expect(Option.getLeft(E.right(1))).toEqual(Option.none())
+    expect(Option.getLeft(E.left("a"))).toEqual(Option.some("a"))
   })
 
   it("toRefinement", () => {
     const f = (
       s: string | number
-    ): _.Option<string> => (typeof s === "string" ? _.some(s) : _.none())
-    const isString = _.toRefinement(f)
+    ): Option.Option<string> => (typeof s === "string" ? Option.some(s) : Option.none())
+    const isString = Option.toRefinement(f)
     Util.deepStrictEqual(isString("s"), true)
     Util.deepStrictEqual(isString(1), false)
     type A = { readonly type: "A" }
     type B = { readonly type: "B" }
     type C = A | B
-    const isA = _.toRefinement<C, A>((c) => (c.type === "A" ? _.some(c) : _.none()))
+    const isA = Option.toRefinement<C, A>((c) => (c.type === "A" ? Option.some(c) : Option.none()))
     Util.deepStrictEqual(isA({ type: "A" }), true)
     Util.deepStrictEqual(isA({ type: "B" }), false)
   })
 
   it("isOption", () => {
-    Util.deepStrictEqual(pipe(_.some(1), _.isOption), true)
-    Util.deepStrictEqual(pipe(_.none(), _.isOption), true)
-    Util.deepStrictEqual(pipe(E.right(1), _.isOption), false)
+    Util.deepStrictEqual(pipe(Option.some(1), Option.isOption), true)
+    Util.deepStrictEqual(pipe(Option.none(), Option.isOption), true)
+    Util.deepStrictEqual(pipe(E.right(1), Option.isOption), false)
   })
 
   it("firstSomeOf", () => {
-    Util.deepStrictEqual(_.firstSomeOf([]), _.none())
-    Util.deepStrictEqual(_.firstSomeOf([_.some(1)]), _.some(1))
-    Util.deepStrictEqual(_.firstSomeOf([_.none()]), _.none())
+    Util.deepStrictEqual(Option.firstSomeOf([]), Option.none())
+    Util.deepStrictEqual(Option.firstSomeOf([Option.some(1)]), Option.some(1))
+    Util.deepStrictEqual(Option.firstSomeOf([Option.none()]), Option.none())
     Util.deepStrictEqual(
-      _.firstSomeOf([_.none(), _.none(), _.none(), _.none(), _.some(1)]),
-      _.some(1)
+      Option.firstSomeOf([Option.none(), Option.none(), Option.none(), Option.none(), Option.some(1)]),
+      Option.some(1)
     )
     Util.deepStrictEqual(
-      _.firstSomeOf([_.none(), _.none(), _.none(), _.none()]),
-      _.none()
+      Option.firstSomeOf([Option.none(), Option.none(), Option.none(), Option.none()]),
+      Option.none()
     )
   })
 
   it("orElseEither", () => {
-    expect(pipe(_.some(1), _.orElseEither(() => _.some(2)))).toEqual(_.some(E.left(1)))
-    expect(pipe(_.some(1), _.orElseEither(() => _.none()))).toEqual(_.some(E.left(1)))
-    expect(pipe(_.none(), _.orElseEither(() => _.some(2)))).toEqual(_.some(E.right(2)))
-    expect(pipe(_.none(), _.orElseEither(() => _.none()))).toEqual(_.none())
+    expect(pipe(Option.some(1), Option.orElseEither(() => Option.some(2)))).toEqual(Option.some(E.left(1)))
+    expect(pipe(Option.some(1), Option.orElseEither(() => Option.none()))).toEqual(Option.some(E.left(1)))
+    expect(pipe(Option.none(), Option.orElseEither(() => Option.some(2)))).toEqual(Option.some(E.right(2)))
+    expect(pipe(Option.none(), Option.orElseEither(() => Option.none()))).toEqual(Option.none())
   })
 
   it("orElseSome", () => {
-    expect(pipe(_.some(1), _.orElseSome(() => 2))).toEqual(_.some(1))
-    expect(pipe(_.none(), _.orElseSome(() => 2))).toEqual(_.some(2))
+    expect(pipe(Option.some(1), Option.orElseSome(() => 2))).toEqual(Option.some(1))
+    expect(pipe(Option.none(), Option.orElseSome(() => 2))).toEqual(Option.some(2))
   })
 
   it("getOrThrow", () => {
-    expect(pipe(_.some(1), _.getOrThrow)).toEqual(1)
-    expect(() => pipe(_.none(), _.getOrThrow)).toThrowError(
+    expect(pipe(Option.some(1), Option.getOrThrow)).toEqual(1)
+    expect(() => pipe(Option.none(), Option.getOrThrow)).toThrowError(
       new Error("getOrThrow called on a None")
     )
   })
 
   it("getOrThrowWith", () => {
-    expect(pipe(_.some(1), _.getOrThrowWith(() => new Error("Unexpected None")))).toEqual(1)
-    expect(() => pipe(_.none(), _.getOrThrowWith(() => new Error("Unexpected None")))).toThrowError(
+    expect(pipe(Option.some(1), Option.getOrThrowWith(() => new Error("Unexpected None")))).toEqual(1)
+    expect(() => pipe(Option.none(), Option.getOrThrowWith(() => new Error("Unexpected None")))).toThrowError(
       new Error("Unexpected None")
     )
   })
 
   it("unit", () => {
-    Util.deepStrictEqual(_.void, _.some(undefined))
+    Util.deepStrictEqual(Option.void, Option.some(undefined))
   })
 
   it("product", () => {
-    const product = _.product
-    Util.deepStrictEqual(product(_.none(), _.none()), _.none())
-    Util.deepStrictEqual(product(_.some(1), _.none()), _.none())
-    Util.deepStrictEqual(product(_.none(), _.some("a")), _.none())
+    const product = Option.product
+    Util.deepStrictEqual(product(Option.none(), Option.none()), Option.none())
+    Util.deepStrictEqual(product(Option.some(1), Option.none()), Option.none())
+    Util.deepStrictEqual(product(Option.none(), Option.some("a")), Option.none())
     Util.deepStrictEqual(
-      product(_.some(1), _.some("a")),
-      _.some([1, "a"])
+      product(Option.some(1), Option.some("a")),
+      Option.some([1, "a"])
     )
   })
 
   it("productMany", () => {
-    const productMany = _.productMany
-    Util.deepStrictEqual(productMany(_.none(), []), _.none())
-    Util.deepStrictEqual(productMany(_.some(1), []), _.some([1]))
-    Util.deepStrictEqual(productMany(_.some(1), [_.none()]), _.none())
-    Util.deepStrictEqual(productMany(_.some(1), [_.some(2)]), _.some([1, 2]))
+    const productMany = Option.productMany
+    Util.deepStrictEqual(productMany(Option.none(), []), Option.none())
+    Util.deepStrictEqual(productMany(Option.some(1), []), Option.some([1]))
+    Util.deepStrictEqual(productMany(Option.some(1), [Option.none()]), Option.none())
+    Util.deepStrictEqual(productMany(Option.some(1), [Option.some(2)]), Option.some([1, 2]))
   })
 
   it("fromIterable", () => {
-    Util.deepStrictEqual(_.fromIterable([]), _.none())
-    Util.deepStrictEqual(_.fromIterable(["a"]), _.some("a"))
+    Util.deepStrictEqual(Option.fromIterable([]), Option.none())
+    Util.deepStrictEqual(Option.fromIterable(["a"]), Option.some("a"))
   })
 
   it("map", () => {
-    Util.deepStrictEqual(pipe(_.some(2), _.map(Util.double)), _.some(4))
-    Util.deepStrictEqual(pipe(_.none(), _.map(Util.double)), _.none())
+    Util.deepStrictEqual(pipe(Option.some(2), Option.map(Util.double)), Option.some(4))
+    Util.deepStrictEqual(pipe(Option.none(), Option.map(Util.double)), Option.none())
   })
 
   it("flatMap", () => {
-    const f = (n: number) => _.some(n * 2)
-    const g = () => _.none()
-    Util.deepStrictEqual(pipe(_.some(1), _.flatMap(f)), _.some(2))
-    Util.deepStrictEqual(pipe(_.none(), _.flatMap(f)), _.none())
-    Util.deepStrictEqual(pipe(_.some(1), _.flatMap(g)), _.none())
-    Util.deepStrictEqual(pipe(_.none(), _.flatMap(g)), _.none())
+    const f = (n: number) => Option.some(n * 2)
+    const g = () => Option.none()
+    Util.deepStrictEqual(pipe(Option.some(1), Option.flatMap(f)), Option.some(2))
+    Util.deepStrictEqual(pipe(Option.none(), Option.flatMap(f)), Option.none())
+    Util.deepStrictEqual(pipe(Option.some(1), Option.flatMap(g)), Option.none())
+    Util.deepStrictEqual(pipe(Option.none(), Option.flatMap(g)), Option.none())
   })
 
   it("andThen", () => {
-    expect(pipe(_.some(1), _.andThen(() => _.some(2)))).toStrictEqual(_.some(2))
-    expect(pipe(_.some(1), _.andThen(_.some(2)))).toStrictEqual(_.some(2))
-    expect(pipe(_.some(1), _.andThen(2))).toStrictEqual(_.some(2))
-    expect(pipe(_.some(1), _.andThen(() => 2))).toStrictEqual(_.some(2))
-    expect(pipe(_.some(1), _.andThen((a) => a))).toStrictEqual(_.some(1))
-    expect(_.andThen(_.some(1), () => _.some(2))).toStrictEqual(_.some(2))
-    expect(_.andThen(_.some(1), _.some(2))).toStrictEqual(_.some(2))
-    expect(_.andThen(_.some(1), 2)).toStrictEqual(_.some(2))
-    expect(_.andThen(_.some(1), () => 2)).toStrictEqual(_.some(2))
-    expect(_.andThen(_.some(1), (a) => a)).toStrictEqual(_.some(1))
+    expect(pipe(Option.some(1), Option.andThen(() => Option.some(2)))).toStrictEqual(Option.some(2))
+    expect(pipe(Option.some(1), Option.andThen(Option.some(2)))).toStrictEqual(Option.some(2))
+    expect(pipe(Option.some(1), Option.andThen(2))).toStrictEqual(Option.some(2))
+    expect(pipe(Option.some(1), Option.andThen(() => 2))).toStrictEqual(Option.some(2))
+    expect(pipe(Option.some(1), Option.andThen((a) => a))).toStrictEqual(Option.some(1))
+    expect(Option.andThen(Option.some(1), () => Option.some(2))).toStrictEqual(Option.some(2))
+    expect(Option.andThen(Option.some(1), Option.some(2))).toStrictEqual(Option.some(2))
+    expect(Option.andThen(Option.some(1), 2)).toStrictEqual(Option.some(2))
+    expect(Option.andThen(Option.some(1), () => 2)).toStrictEqual(Option.some(2))
+    expect(Option.andThen(Option.some(1), (a) => a)).toStrictEqual(Option.some(1))
   })
 
   it("orElse", () => {
     const assertAlt = (
-      a: _.Option<number>,
-      b: _.Option<number>,
-      expected: _.Option<number>
+      a: Option.Option<number>,
+      b: Option.Option<number>,
+      expected: Option.Option<number>
     ) => {
-      Util.deepStrictEqual(pipe(a, _.orElse(() => b)), expected)
+      Util.deepStrictEqual(pipe(a, Option.orElse(() => b)), expected)
     }
-    assertAlt(_.some(1), _.some(2), _.some(1))
-    assertAlt(_.some(1), _.none(), _.some(1))
-    assertAlt(_.none(), _.some(2), _.some(2))
-    assertAlt(_.none(), _.none(), _.none())
+    assertAlt(Option.some(1), Option.some(2), Option.some(1))
+    assertAlt(Option.some(1), Option.none(), Option.some(1))
+    assertAlt(Option.none(), Option.some(2), Option.some(2))
+    assertAlt(Option.none(), Option.none(), Option.none())
   })
 
   it("partitionMap", () => {
     const f = (n: number) => (p(n) ? E.right(n + 1) : E.left(n - 1))
-    assert.deepStrictEqual(pipe(_.none(), _.partitionMap(f)), [_.none(), _.none()])
-    assert.deepStrictEqual(pipe(_.some(1), _.partitionMap(f)), [_.some(0), _.none()])
-    assert.deepStrictEqual(pipe(_.some(3), _.partitionMap(f)), [_.none(), _.some(4)])
+    assert.deepStrictEqual(pipe(Option.none(), Option.partitionMap(f)), [Option.none(), Option.none()])
+    assert.deepStrictEqual(pipe(Option.some(1), Option.partitionMap(f)), [Option.some(0), Option.none()])
+    assert.deepStrictEqual(pipe(Option.some(3), Option.partitionMap(f)), [Option.none(), Option.some(4)])
   })
 
   it("filterMap", () => {
-    const f = (n: number) => (p(n) ? _.some(n + 1) : _.none())
-    Util.deepStrictEqual(pipe(_.none(), _.filterMap(f)), _.none())
-    Util.deepStrictEqual(pipe(_.some(1), _.filterMap(f)), _.none())
-    Util.deepStrictEqual(pipe(_.some(3), _.filterMap(f)), _.some(4))
+    const f = (n: number) => (p(n) ? Option.some(n + 1) : Option.none())
+    Util.deepStrictEqual(pipe(Option.none(), Option.filterMap(f)), Option.none())
+    Util.deepStrictEqual(pipe(Option.some(1), Option.filterMap(f)), Option.none())
+    Util.deepStrictEqual(pipe(Option.some(3), Option.filterMap(f)), Option.some(4))
   })
 
   it("match", () => {
     const onNone = () => "none"
     const onSome = (s: string) => `some${s.length}`
-    const match = _.match({ onNone, onSome })
-    Util.deepStrictEqual(match(_.none()), "none")
-    Util.deepStrictEqual(match(_.some("abc")), "some3")
+    const match = Option.match({ onNone, onSome })
+    Util.deepStrictEqual(match(Option.none()), "none")
+    Util.deepStrictEqual(match(Option.some("abc")), "some3")
   })
 
   it("getOrElse", () => {
-    Util.deepStrictEqual(pipe(_.some(1), _.getOrElse(() => 0)), 1)
-    Util.deepStrictEqual(pipe(_.none(), _.getOrElse(() => 0)), 0)
+    Util.deepStrictEqual(pipe(Option.some(1), Option.getOrElse(() => 0)), 1)
+    Util.deepStrictEqual(pipe(Option.none(), Option.getOrElse(() => 0)), 0)
   })
 
   it("getOrNull", () => {
-    Util.deepStrictEqual(_.getOrNull(_.none()), null)
-    Util.deepStrictEqual(_.getOrNull(_.some(1)), 1)
+    Util.deepStrictEqual(Option.getOrNull(Option.none()), null)
+    Util.deepStrictEqual(Option.getOrNull(Option.some(1)), 1)
   })
 
   it("getOrUndefined", () => {
-    Util.deepStrictEqual(_.getOrUndefined(_.none()), undefined)
-    Util.deepStrictEqual(_.getOrUndefined(_.some(1)), 1)
+    Util.deepStrictEqual(Option.getOrUndefined(Option.none()), undefined)
+    Util.deepStrictEqual(Option.getOrUndefined(Option.some(1)), 1)
   })
 
   it("getOrder", () => {
-    const OS = _.getOrder(S.Order)
-    Util.deepStrictEqual(OS(_.none(), _.none()), 0)
-    Util.deepStrictEqual(OS(_.some("a"), _.none()), 1)
-    Util.deepStrictEqual(OS(_.none(), _.some("a")), -1)
-    Util.deepStrictEqual(OS(_.some("a"), _.some("a")), 0)
-    Util.deepStrictEqual(OS(_.some("a"), _.some("b")), -1)
-    Util.deepStrictEqual(OS(_.some("b"), _.some("a")), 1)
+    const OS = Option.getOrder(S.Order)
+    Util.deepStrictEqual(OS(Option.none(), Option.none()), 0)
+    Util.deepStrictEqual(OS(Option.some("a"), Option.none()), 1)
+    Util.deepStrictEqual(OS(Option.none(), Option.some("a")), -1)
+    Util.deepStrictEqual(OS(Option.some("a"), Option.some("a")), 0)
+    Util.deepStrictEqual(OS(Option.some("a"), Option.some("b")), -1)
+    Util.deepStrictEqual(OS(Option.some("b"), Option.some("a")), 1)
   })
 
   it("flatMapNullable", () => {
@@ -303,205 +311,230 @@ describe("Option", () => {
     const x3: X = { a: { b: { c: { d: 1 } } } }
     Util.deepStrictEqual(
       pipe(
-        _.fromNullable(x1.a),
-        _.flatMapNullable((x) => x.b),
-        _.flatMapNullable((x) => x.c),
-        _.flatMapNullable((x) => x.d)
+        Option.fromNullable(x1.a),
+        Option.flatMapNullable((x) => x.b),
+        Option.flatMapNullable((x) => x.c),
+        Option.flatMapNullable((x) => x.d)
       ),
-      _.none()
+      Option.none()
     )
     Util.deepStrictEqual(
       pipe(
-        _.fromNullable(x2.a),
-        _.flatMapNullable((x) => x.b),
-        _.flatMapNullable((x) => x.c),
-        _.flatMapNullable((x) => x.d)
+        Option.fromNullable(x2.a),
+        Option.flatMapNullable((x) => x.b),
+        Option.flatMapNullable((x) => x.c),
+        Option.flatMapNullable((x) => x.d)
       ),
-      _.none()
+      Option.none()
     )
     Util.deepStrictEqual(
       pipe(
-        _.fromNullable(x3.a),
-        _.flatMapNullable((x) => x.b),
-        _.flatMapNullable((x) => x.c),
-        _.flatMapNullable((x) => x.d)
+        Option.fromNullable(x3.a),
+        Option.flatMapNullable((x) => x.b),
+        Option.flatMapNullable((x) => x.c),
+        Option.flatMapNullable((x) => x.d)
       ),
-      _.some(1)
+      Option.some(1)
     )
   })
 
   it("fromNullable", () => {
-    Util.deepStrictEqual(_.fromNullable(2), _.some(2))
-    Util.deepStrictEqual(_.fromNullable(null), _.none())
-    Util.deepStrictEqual(_.fromNullable(undefined), _.none())
+    Util.deepStrictEqual(Option.fromNullable(2), Option.some(2))
+    Util.deepStrictEqual(Option.fromNullable(null), Option.none())
+    Util.deepStrictEqual(Option.fromNullable(undefined), Option.none())
   })
 
   it("liftPredicate", () => {
-    const f = _.liftPredicate(p)
-    Util.deepStrictEqual(f(1), _.none())
-    Util.deepStrictEqual(f(3), _.some(3))
+    const f = Option.liftPredicate(p)
+    Util.deepStrictEqual(f(1), Option.none())
+    Util.deepStrictEqual(f(3), Option.some(3))
 
     type Direction = "asc" | "desc"
-    const parseDirection = _.liftPredicate((s: string): s is Direction => s === "asc" || s === "desc")
-    Util.deepStrictEqual(parseDirection("asc"), _.some("asc"))
-    Util.deepStrictEqual(parseDirection("foo"), _.none())
+    const parseDirection = Option.liftPredicate((s: string): s is Direction => s === "asc" || s === "desc")
+    Util.deepStrictEqual(parseDirection("asc"), Option.some("asc"))
+    Util.deepStrictEqual(parseDirection("foo"), Option.none())
   })
 
   it("containsWith", () => {
-    const containsWith = _.containsWith<number>((self, that) => self % 2 === that % 2)
-    Util.deepStrictEqual(pipe(_.some(2), containsWith(2)), true)
-    Util.deepStrictEqual(pipe(_.some(4), containsWith(4)), true)
-    Util.deepStrictEqual(pipe(_.some(1), containsWith(3)), true)
+    const containsWith = Option.containsWith<number>((self, that) => self % 2 === that % 2)
+    Util.deepStrictEqual(pipe(Option.some(2), containsWith(2)), true)
+    Util.deepStrictEqual(pipe(Option.some(4), containsWith(4)), true)
+    Util.deepStrictEqual(pipe(Option.some(1), containsWith(3)), true)
 
-    Util.deepStrictEqual(pipe(_.none(), containsWith(2)), false)
-    Util.deepStrictEqual(pipe(_.some(2), containsWith(1)), false)
+    Util.deepStrictEqual(pipe(Option.none(), containsWith(2)), false)
+    Util.deepStrictEqual(pipe(Option.some(2), containsWith(1)), false)
   })
 
   it("contains", () => {
-    Util.deepStrictEqual(pipe(_.none(), _.contains(2)), false)
-    Util.deepStrictEqual(pipe(_.some(2), _.contains(2)), true)
-    Util.deepStrictEqual(pipe(_.some(2), _.contains(1)), false)
+    Util.deepStrictEqual(pipe(Option.none(), Option.contains(2)), false)
+    Util.deepStrictEqual(pipe(Option.some(2), Option.contains(2)), true)
+    Util.deepStrictEqual(pipe(Option.some(2), Option.contains(1)), false)
   })
 
   it("isNone", () => {
-    Util.deepStrictEqual(_.isNone(_.none()), true)
-    Util.deepStrictEqual(_.isNone(_.some(1)), false)
+    Util.deepStrictEqual(Option.isNone(Option.none()), true)
+    Util.deepStrictEqual(Option.isNone(Option.some(1)), false)
   })
 
   it("isSome", () => {
-    Util.deepStrictEqual(_.isSome(_.none()), false)
-    Util.deepStrictEqual(_.isSome(_.some(1)), true)
+    Util.deepStrictEqual(Option.isSome(Option.none()), false)
+    Util.deepStrictEqual(Option.isSome(Option.some(1)), true)
   })
 
   it("exists", () => {
     const predicate = (a: number) => a === 2
-    Util.deepStrictEqual(pipe(_.none(), _.exists(predicate)), false)
-    Util.deepStrictEqual(pipe(_.some(1), _.exists(predicate)), false)
-    Util.deepStrictEqual(pipe(_.some(2), _.exists(predicate)), true)
-  })
-
-  it("do notation", () => {
-    Util.deepStrictEqual(
-      pipe(
-        _.some(1),
-        _.bindTo("a"),
-        _.bind("b", () => _.some("b")),
-        _.let("c", () => true)
-      ),
-      _.some({ a: 1, b: "b", c: true })
-    )
+    Util.deepStrictEqual(pipe(Option.none(), Option.exists(predicate)), false)
+    Util.deepStrictEqual(pipe(Option.some(1), Option.exists(predicate)), false)
+    Util.deepStrictEqual(pipe(Option.some(2), Option.exists(predicate)), true)
   })
 
   it("liftNullable", () => {
-    const f = _.liftNullable((n: number) => (n > 0 ? n : null))
-    Util.deepStrictEqual(f(1), _.some(1))
-    Util.deepStrictEqual(f(-1), _.none())
+    const f = Option.liftNullable((n: number) => (n > 0 ? n : null))
+    Util.deepStrictEqual(f(1), Option.some(1))
+    Util.deepStrictEqual(f(-1), Option.none())
   })
 
   it("liftThrowable", () => {
-    const parse = _.liftThrowable(JSON.parse)
-    Util.deepStrictEqual(parse("1"), _.some(1))
-    Util.deepStrictEqual(parse(""), _.none())
+    const parse = Option.liftThrowable(JSON.parse)
+    Util.deepStrictEqual(parse("1"), Option.some(1))
+    Util.deepStrictEqual(parse(""), Option.none())
   })
 
   it("tap", () => {
-    Util.deepStrictEqual(_.tap(_.none(), () => _.none()), _.none())
-    Util.deepStrictEqual(_.tap(_.some(1), () => _.none()), _.none())
-    Util.deepStrictEqual(_.tap(_.none(), (n) => _.some(n * 2)), _.none())
-    Util.deepStrictEqual(_.tap(_.some(1), (n) => _.some(n * 2)), _.some(1))
+    Util.deepStrictEqual(Option.tap(Option.none(), () => Option.none()), Option.none())
+    Util.deepStrictEqual(Option.tap(Option.some(1), () => Option.none()), Option.none())
+    Util.deepStrictEqual(Option.tap(Option.none(), (n) => Option.some(n * 2)), Option.none())
+    Util.deepStrictEqual(Option.tap(Option.some(1), (n) => Option.some(n * 2)), Option.some(1))
   })
 
   it("guard", () => {
     Util.deepStrictEqual(
       pipe(
-        _.Do,
-        _.bind("x", () => _.some("a")),
-        _.bind("y", () => _.some("a")),
-        _.filter(({ x, y }) => x === y)
+        Option.Do,
+        Option.bind("x", () => Option.some("a")),
+        Option.bind("y", () => Option.some("a")),
+        Option.filter(({ x, y }) => x === y)
       ),
-      _.some({ x: "a", y: "a" })
+      Option.some({ x: "a", y: "a" })
     )
     Util.deepStrictEqual(
       pipe(
-        _.Do,
-        _.bind("x", () => _.some("a")),
-        _.bind("y", () => _.some("b")),
-        _.filter(({ x, y }) => x === y)
+        Option.Do,
+        Option.bind("x", () => Option.some("a")),
+        Option.bind("y", () => Option.some("b")),
+        Option.filter(({ x, y }) => x === y)
       ),
-      _.none()
+      Option.none()
     )
   })
 
   it("zipWith", () => {
-    expect(pipe(_.none(), _.zipWith(_.some(2), (a, b) => a + b))).toEqual(_.none())
-    expect(pipe(_.some(1), _.zipWith(_.none(), (a, b) => a + b))).toEqual(_.none())
-    expect(pipe(_.some(1), _.zipWith(_.some(2), (a, b) => a + b))).toEqual(_.some(3))
+    expect(pipe(Option.none(), Option.zipWith(Option.some(2), (a, b) => a + b))).toEqual(Option.none())
+    expect(pipe(Option.some(1), Option.zipWith(Option.none(), (a, b) => a + b))).toEqual(Option.none())
+    expect(pipe(Option.some(1), Option.zipWith(Option.some(2), (a, b) => a + b))).toEqual(Option.some(3))
   })
 
   it("ap", () => {
-    expect(pipe(_.some((a: number) => (b: number) => a + b), _.ap(_.none()), _.ap(_.some(2)))).toEqual(_.none())
-    expect(pipe(_.some((a: number) => (b: number) => a + b), _.ap(_.some(1)), _.ap(_.none()))).toEqual(_.none())
-    expect(pipe(_.some((a: number) => (b: number) => a + b), _.ap(_.some(1)), _.ap(_.some(2)))).toEqual(_.some(3))
+    expect(pipe(Option.some((a: number) => (b: number) => a + b), Option.ap(Option.none()), Option.ap(Option.some(2))))
+      .toEqual(Option.none())
+    expect(pipe(Option.some((a: number) => (b: number) => a + b), Option.ap(Option.some(1)), Option.ap(Option.none())))
+      .toEqual(Option.none())
+    expect(pipe(Option.some((a: number) => (b: number) => a + b), Option.ap(Option.some(1)), Option.ap(Option.some(2))))
+      .toEqual(Option.some(3))
   })
 
   it("reduceCompact", () => {
-    const sumCompact = _.reduceCompact(0, N.sum)
+    const sumCompact = Option.reduceCompact(0, N.sum)
     expect(sumCompact([])).toEqual(0)
-    expect(sumCompact([_.some(2), _.some(3)])).toEqual(5)
-    expect(sumCompact([_.some(2), _.none(), _.some(3)])).toEqual(5)
+    expect(sumCompact([Option.some(2), Option.some(3)])).toEqual(5)
+    expect(sumCompact([Option.some(2), Option.none(), Option.some(3)])).toEqual(5)
   })
 
   it("getEquivalence", () => {
-    const isEquivalent = _.getEquivalence(N.Equivalence)
-    expect(isEquivalent(_.none(), _.none())).toEqual(true)
-    expect(isEquivalent(_.none(), _.some(1))).toEqual(false)
-    expect(isEquivalent(_.some(1), _.none())).toEqual(false)
-    expect(isEquivalent(_.some(2), _.some(1))).toEqual(false)
-    expect(isEquivalent(_.some(1), _.some(2))).toEqual(false)
-    expect(isEquivalent(_.some(2), _.some(2))).toEqual(true)
+    const isEquivalent = Option.getEquivalence(N.Equivalence)
+    expect(isEquivalent(Option.none(), Option.none())).toEqual(true)
+    expect(isEquivalent(Option.none(), Option.some(1))).toEqual(false)
+    expect(isEquivalent(Option.some(1), Option.none())).toEqual(false)
+    expect(isEquivalent(Option.some(2), Option.some(1))).toEqual(false)
+    expect(isEquivalent(Option.some(1), Option.some(2))).toEqual(false)
+    expect(isEquivalent(Option.some(2), Option.some(2))).toEqual(true)
   })
 
   it("all/ tuple", () => {
-    assertType<_.Option<[number, string]>>(_.all([_.some(1), _.some("hello")]))
-    assert.deepStrictEqual(_.all([]), _.some([]))
-    assert.deepStrictEqual(_.all([_.some(1), _.some("hello")]), _.some([1, "hello"]))
-    assert.deepStrictEqual(_.all([_.some(1), _.none()]), _.none())
+    assertType<Option.Option<[number, string]>>(Option.all([Option.some(1), Option.some("hello")]))
+    assert.deepStrictEqual(Option.all([]), Option.some([]))
+    assert.deepStrictEqual(Option.all([Option.some(1), Option.some("hello")]), Option.some([1, "hello"]))
+    assert.deepStrictEqual(Option.all([Option.some(1), Option.none()]), Option.none())
   })
 
   it("all/ iterable", () => {
-    assertType<_.Option<Array<number>>>(_.all([_.some(1), _.some(2)]))
-    assertType<_.Option<Array<number>>>(_.all(new Set([_.some(1), _.some(2)])))
+    assertType<Option.Option<Array<number>>>(Option.all([Option.some(1), Option.some(2)]))
+    assertType<Option.Option<Array<number>>>(Option.all(new Set([Option.some(1), Option.some(2)])))
 
-    Util.deepStrictEqual(_.all([]), _.some([]))
-    Util.deepStrictEqual(_.all([_.none()]), _.none())
-    Util.deepStrictEqual(_.all([_.some(1), _.some(2)]), _.some([1, 2]))
-    Util.deepStrictEqual(_.all(new Set([_.some(1), _.some(2)])), _.some([1, 2]))
-    Util.deepStrictEqual(_.all([_.some(1), _.none()]), _.none())
+    Util.deepStrictEqual(Option.all([]), Option.some([]))
+    Util.deepStrictEqual(Option.all([Option.none()]), Option.none())
+    Util.deepStrictEqual(Option.all([Option.some(1), Option.some(2)]), Option.some([1, 2]))
+    Util.deepStrictEqual(Option.all(new Set([Option.some(1), Option.some(2)])), Option.some([1, 2]))
+    Util.deepStrictEqual(Option.all([Option.some(1), Option.none()]), Option.none())
   })
 
   it("all/ struct", () => {
-    assertType<_.Option<{ a: number; b: string }>>(_.all({ a: _.some(1), b: _.some("hello") }))
-    assert.deepStrictEqual(_.all({ a: _.some(1), b: _.some("hello") }), _.some({ a: 1, b: "hello" }))
-    assert.deepStrictEqual(_.all({ a: _.some(1), b: _.none() }), _.none())
+    assertType<Option.Option<{ a: number; b: string }>>(Option.all({ a: Option.some(1), b: Option.some("hello") }))
+    assert.deepStrictEqual(
+      Option.all({ a: Option.some(1), b: Option.some("hello") }),
+      Option.some({ a: 1, b: "hello" })
+    )
+    assert.deepStrictEqual(Option.all({ a: Option.some(1), b: Option.none() }), Option.none())
   })
 
   it(".pipe()", () => {
-    expect(_.some(1).pipe(_.map((n) => n + 1))).toEqual(_.some(2))
+    expect(Option.some(1).pipe(Option.map((n) => n + 1))).toEqual(Option.some(2))
   })
 
   it("lift2", () => {
-    const f = _.lift2((a: number, b: number): number => a + b)
-    expect(f(_.none(), _.none())).toStrictEqual(_.none())
-    expect(f(_.some(1), _.none())).toStrictEqual(_.none())
-    expect(f(_.none(), _.some(2))).toStrictEqual(_.none())
-    expect(f(_.some(1), _.some(2))).toStrictEqual(_.some(3))
+    const f = Option.lift2((a: number, b: number): number => a + b)
+    expect(f(Option.none(), Option.none())).toStrictEqual(Option.none())
+    expect(f(Option.some(1), Option.none())).toStrictEqual(Option.none())
+    expect(f(Option.none(), Option.some(2))).toStrictEqual(Option.none())
+    expect(f(Option.some(1), Option.some(2))).toStrictEqual(Option.some(3))
   })
 
   it("vitest equality", () => {
-    expect(_.some(2)).toStrictEqual(_.some(2))
-    expect(_.none()).toStrictEqual(_.none())
+    expect(Option.some(2)).toStrictEqual(Option.some(2))
+    expect(Option.none()).toStrictEqual(Option.none())
 
-    expect(_.some(2)).not.toStrictEqual(_.some(1))
-    expect(_.none()).not.toStrictEqual(_.some(1))
+    expect(Option.some(2)).not.toStrictEqual(Option.some(1))
+    expect(Option.none()).not.toStrictEqual(Option.some(1))
+  })
+
+  describe("do notation", () => {
+    it("Do", () => {
+      expectSome(Option.Do, {})
+    })
+
+    it("bindTo", () => {
+      expectSome(pipe(Option.some(1), Option.bindTo("a")), { a: 1 })
+      expectNone(pipe(Option.none(), Option.bindTo("a")))
+    })
+
+    it("bind", () => {
+      expectSome(pipe(Option.some(1), Option.bindTo("a"), Option.bind("b", ({ a }) => Option.some(a + 1))), {
+        a: 1,
+        b: 2
+      })
+      expectNone(
+        pipe(Option.some(1), Option.bindTo("a"), Option.bind("b", () => Option.none()))
+      )
+      expectNone(
+        pipe(Option.none(), Option.bindTo("a"), Option.bind("b", () => Option.some(2)))
+      )
+    })
+
+    it("let", () => {
+      expectSome(pipe(Option.some(1), Option.bindTo("a"), Option.let("b", ({ a }) => a + 1)), { a: 1, b: 2 })
+      expectNone(
+        pipe(Option.none(), Option.bindTo("a"), Option.let("b", () => 2))
+      )
+    })
   })
 })

--- a/packages/effect/test/Stream/do-notation.test.ts
+++ b/packages/effect/test/Stream/do-notation.test.ts
@@ -1,0 +1,49 @@
+import * as Util from "effect-test/util"
+import * as Chunk from "effect/Chunk"
+import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import * as Stream from "effect/Stream"
+import { describe, it } from "vitest"
+
+const expectRight = <R, L>(s: Stream.Stream<R, L>, expected: R) => {
+  Util.deepStrictEqual(Chunk.toArray(Effect.runSync(Stream.runCollect(Stream.either(s)))), [Either.right(expected)])
+}
+
+const expectLeft = <R, L>(s: Stream.Stream<R, L>, expected: L) => {
+  Util.deepStrictEqual(Chunk.toArray(Effect.runSync(Stream.runCollect(Stream.either(s)))), [Either.left(expected)])
+}
+
+describe("do notation", () => {
+  it("Do", () => {
+    expectRight(Stream.Do, {})
+  })
+
+  it("bindTo", () => {
+    expectRight(pipe(Stream.succeed(1), Stream.bindTo("a")), { a: 1 })
+    expectLeft(pipe(Stream.fail("left"), Stream.bindTo("a")), "left")
+  })
+
+  it("bind", () => {
+    expectRight(pipe(Stream.succeed(1), Stream.bindTo("a"), Stream.bind("b", ({ a }) => Stream.succeed(a + 1))), {
+      a: 1,
+      b: 2
+    })
+    expectLeft(
+      pipe(Stream.succeed(1), Stream.bindTo("a"), Stream.bind("b", () => Stream.fail("left"))),
+      "left"
+    )
+    expectLeft(
+      pipe(Stream.fail("left"), Stream.bindTo("a"), Stream.bind("b", () => Stream.succeed(2))),
+      "left"
+    )
+  })
+
+  it("let", () => {
+    expectRight(pipe(Stream.succeed(1), Stream.bindTo("a"), Stream.let("b", ({ a }) => a + 1)), { a: 1, b: 2 })
+    expectLeft(
+      pipe(Stream.fail("left"), Stream.bindTo("a"), Stream.let("b", () => 2)),
+      "left"
+    )
+  })
+})


### PR DESCRIPTION
The purpose of this PR is to avoid code duplication currently present in the modules:
- `Effect`
- `Either`
- `Option`
- `Stream`

and to pave the way for PR https://github.com/Effect-TS/effect/pull/2678
