### PR TITLE
Add `prepare` and `types` to `PgClientConfig`

### DIFF
--- a/.changeset/gentle-goats-begin.md
+++ b/.changeset/gentle-goats-begin.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+add `prepare` and `types` to `PgClientConfig`

--- a/packages/sql-pg/src/Client.ts
+++ b/packages/sql-pg/src/Client.ts
@@ -60,6 +60,7 @@ export interface PgClientConfig {
   readonly transformQueryNames?: ((str: string) => string) | undefined
   readonly transformJson?: boolean | undefined
   readonly fetchTypes?: boolean | undefined
+  readonly prepare?: boolean | undefined
 
   readonly debug?: postgres.Options<{}>["debug"] | undefined
 }
@@ -112,6 +113,7 @@ export const make = (
       username: options.username,
       password: options.password ? Secret.value(options.password) : undefined,
       fetch_types: options.fetchTypes ?? true,
+      prepare: options.prepare ?? true,
       debug: options.debug
     }
 

--- a/packages/sql-pg/src/Client.ts
+++ b/packages/sql-pg/src/Client.ts
@@ -61,6 +61,7 @@ export interface PgClientConfig {
   readonly transformJson?: boolean | undefined
   readonly fetchTypes?: boolean | undefined
   readonly prepare?: boolean | undefined
+  readonly types?: Record<string, postgres.PostgresType> | undefined
 
   readonly debug?: postgres.Options<{}>["debug"] | undefined
 }
@@ -114,6 +115,7 @@ export const make = (
       password: options.password ? Secret.value(options.password) : undefined,
       fetch_types: options.fetchTypes ?? true,
       prepare: options.prepare ?? true,
+      types: options.types,
       debug: options.debug
     }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds `prepare` and `types` to `PgClientConfig` in `@effect/sql-pg`. These options are forwarded to the underlying Postgres.js client. See Postgres.js [options](https://github.com/porsager/postgres?tab=readme-ov-file#all-postgres-options) and [custom types](https://github.com/porsager/postgres?tab=readme-ov-file#custom-types) documentation.

Motivation:
- `prepare`: When connecting to Supabase from serverless environments such as AWS Lambda, it is [recommended](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler:~:text=Some%20session%2Dbased%20Postgres%20features%20such%20as%20prepared%20statements%20are%20not%20available%20with%20this%20option) to set `prepare: false`
- `types`: This option enables overriding the [default Postgres.js data transformations](https://github.com/porsager/postgres/blob/cc688c6/src/types.js#L28). Our specific use case involves disabling the default Postgres.js transformation of `string` to `Date` for `timestamptz` and similar types, preferring instead to handle transformations using schemas. The change allows the to use of `Schema.Date` rather than `Schema.DateFromSelf` in our schemas.

As discussed on [Discord](https://discord.com/channels/795981131316985866/1234886828025184387) the `types` option might be redundant: devs have two ways to express data transformations, schemas and now `types`.
A possible alternative is to override the timestamp transformation without exposing `types`. However, `@effect/sql-*` clients currently do not standardize underlying client types, not sure it this alternative align with the existing design.
Drizzle uses a similar approach, disabling the default Postgres.js timestamp transformation and introducing a `{ mode: "string" | "date" }` option as detailed in [DrizzleORM v0.30.0 release](https://orm.drizzle.team/learn/latest-releases/drizzle-orm-v0300).

