### PR TITLE
Fix placeholder count in `@effect/sql` helpers

### DIFF
--- a/.changeset/tall-houses-grab.md
+++ b/.changeset/tall-houses-grab.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql": patch
+---
+
+fix placeholder count in sql helpers

--- a/packages/sql-pg/test/Client.test.ts
+++ b/packages/sql-pg/test/Client.test.ts
@@ -183,4 +183,21 @@ describe("pg", () => {
     assert.lengthOf(params, 3)
     expect((params[2] as any).type).toEqual(1022)
   })
+
+  it("update fragments", () => {
+    const now = new Date()
+    const [query, params] = sql`UPDATE people SET json = data.json FROM ${
+      sql.updateValues(
+        [{ json: sql.json({ a: 1 }) }, { json: sql.json({ b: 1 }) }],
+        "data"
+      )
+    } WHERE created_at > ${now}`.compile()
+    assert.strictEqual(
+      query,
+      `UPDATE people SET json = data.json FROM (values ($1),($2)) AS data("json") WHERE created_at > $3`
+    )
+    assert.lengthOf(params, 3)
+    expect((params[0] as any).type).toEqual(3802)
+    expect((params[1] as any).type).toEqual(3802)
+  })
 })

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -470,6 +470,7 @@ class CompilerImpl implements Statement.Compiler {
     const binds: Array<Statement.Primitive> = []
     let placeholderCount = 0
     const placeholder = () => this.parameterPlaceholder(++placeholderCount)
+    const placeholderNoIncrement = () => this.parameterPlaceholder(placeholderCount)
 
     for (let i = 0; i < len; i++) {
       const segment = segments[i]
@@ -511,7 +512,7 @@ class CompilerImpl implements Statement.Compiler {
                 segment.value.length
               ),
               segment.value.map((record) =>
-                keys.map((key) => extractPrimitive(record[key], this.onCustom, placeholder))
+                keys.map((key) => extractPrimitive(record[key], this.onCustom, placeholderNoIncrement))
               )
             )
             sql += s
@@ -535,7 +536,7 @@ class CompilerImpl implements Statement.Compiler {
                   extractPrimitive(
                     segment.value[i]?.[keys[j]] ?? null,
                     this.onCustom,
-                    placeholder
+                    placeholderNoIncrement
                   )
                 )
               }
@@ -556,7 +557,7 @@ class CompilerImpl implements Statement.Compiler {
                 extractPrimitive(
                   segment.value[key],
                   this.onCustom,
-                  placeholder
+                  placeholderNoIncrement
                 )
               )
             )
@@ -574,7 +575,7 @@ class CompilerImpl implements Statement.Compiler {
                 extractPrimitive(
                   segment.value[keys[i]],
                   this.onCustom,
-                  placeholder
+                  placeholderNoIncrement
                 )
               )
             }
@@ -592,7 +593,7 @@ class CompilerImpl implements Statement.Compiler {
             segment.alias,
             generateColumns(keys, this.onIdentifier),
             segment.value.map((record) =>
-              keys.map((key) => extractPrimitive(record?.[key], this.onCustom, placeholder))
+              keys.map((key) => extractPrimitive(record?.[key], this.onCustom, placeholderNoIncrement))
             )
           )
           sql += s


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

```
sql`UPDATE people SET json = data.json FROM ${
  sql.updateValues(
    [{ json: sql.json({ a: 1 }) }, { json: sql.json({ b: 1 }) }],
    "data"
  )
} WHERE created_at > ${now}`
```

compiles to 

```
UPDATE people SET json = data.json FROM (values ($1)($2)) AS data("json") WHERE created_at > $5
```

instead of 

```
UPDATE people SET json = data.json FROM (values ($1)($2)) AS data("json") WHERE created_at > $3
```

For each value in the array, the placeholder counts in incremented by `sql.updateValues` and by `sql.json`. The problem occurs when passing custom types to any sql helper.