### PR TITLE
Fix `sql.update` default arguments

### DIFF
--- a/.changeset/famous-bananas-search.md
+++ b/.changeset/famous-bananas-search.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql": patch
+---
+
+fix `sql.update` default arguments

--- a/packages/sql-pg/test/Client.test.ts
+++ b/packages/sql-pg/test/Client.test.ts
@@ -18,7 +18,7 @@ describe("pg", () => {
     expect(params).toEqual(["Tim", 10])
   })
 
-  it("update helper", () => {
+  it("updateValues helper", () => {
     const [query, params] = compiler.compile(
       sql`UPDATE people SET name = data.name FROM ${
         sql.updateValues(
@@ -31,6 +31,20 @@ describe("pg", () => {
       `UPDATE people SET name = data.name FROM (values ($1),($2)) AS data("name")`
     )
     expect(params).toEqual(["Tim", "John"])
+  })
+
+  it("update helper", () => {
+    let result = compiler.compile(
+      sql`UPDATE people SET ${sql.update({ name: "Tim" })}`
+    )
+    expect(result[0]).toEqual(`UPDATE people SET "name" = $1`)
+    expect(result[1]).toEqual(["Tim"])
+
+    result = compiler.compile(
+      sql`UPDATE people SET ${sql.update({ name: "Tim", age: 10 }, ["age"])}`
+    )
+    expect(result[0]).toEqual(`UPDATE people SET "name" = $1`)
+    expect(result[1]).toEqual(["Tim"])
   })
 
   it("array helper", () => {

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -291,7 +291,7 @@ export const make = (
         )
       },
       update(value: any, omit: any) {
-        return new RecordUpdateHelperSingleImpl(value, omit)
+        return new RecordUpdateHelperSingleImpl(value, omit ?? [])
       },
       updateValues(value: any, alias: any) {
         return new RecordUpdateHelperImpl(value, alias)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
In `@effect/sql`, `Constructor["update"]` implementation is missing default value for `omit?: ReadonlyArray<keyof A>` argument.