### PR TITLE
fix(platform): http client body stream runtime

### DIFF
--- a/.changeset/bright-apricots-sit.md
+++ b/.changeset/bright-apricots-sit.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Stream.toReadableStreamEffect.

--- a/.changeset/bright-apricots-sit.md
+++ b/.changeset/bright-apricots-sit.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-Add Stream.toReadableStreamEffect.
+Add Stream.toReadableStreamEffect / .toReadableStreamRuntime

--- a/.changeset/seven-cougars-jump.md
+++ b/.changeset/seven-cougars-jump.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Run client request stream with a current runtime.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -22,6 +22,7 @@ import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
 import type * as PubSub from "./PubSub.js"
 import type * as Queue from "./Queue.js"
+import type { Runtime } from "./Runtime.js"
 import type * as Schedule from "./Schedule.js"
 import type * as Scope from "./Scope.js"
 import type * as Sink from "./Sink.js"
@@ -3859,7 +3860,7 @@ export const toQueueOfElements: {
  * @since 2.0.0
  * @category destructors
  */
-export const toReadableStream: <A, E>(source: Stream<A, E>) => ReadableStream<A> = internal.toReadableStream
+export const toReadableStream: <A, E>(self: Stream<A, E>) => ReadableStream<A> = internal.toReadableStream
 
 /**
  * Converts the stream to a `Effect<ReadableStream>`.
@@ -3869,8 +3870,26 @@ export const toReadableStream: <A, E>(source: Stream<A, E>) => ReadableStream<A>
  * @since 2.0.0
  * @category destructors
  */
-export const toReadableStreamEffect: <A, E, R>(source: Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R> =
+export const toReadableStreamEffect: <A, E, R>(self: Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R> =
   internal.toReadableStreamEffect
+
+/**
+ * Converts the stream to a `ReadableStream` using the provided runtime.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream.
+ *
+ * @since 2.0.0
+ * @category destructors
+ */
+export const toReadableStreamRuntime: {
+  <XR>(
+    runtime: Runtime<XR>
+  ): <A, E, R extends XR>(self: Stream<A, E, R>) => ReadableStream<A>
+  <A, E, XR, R extends XR>(
+    self: Stream<A, E, R>,
+    runtime: Runtime<XR>
+  ): ReadableStream<A>
+} = internal.toReadableStreamRuntime
 
 /**
  * Applies the transducer to the stream and emits its outputs.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -3862,6 +3862,17 @@ export const toQueueOfElements: {
 export const toReadableStream: <A, E>(source: Stream<A, E>) => ReadableStream<A> = internal.toReadableStream
 
 /**
+ * Converts the stream to a `Effect<ReadableStream>`.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream.
+ *
+ * @since 2.0.0
+ * @category destructors
+ */
+export const toReadableStreamEffect: <A, E, R>(source: Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R> =
+  internal.toReadableStreamEffect
+
+/**
  * Applies the transducer to the stream and emits its outputs.
  *
  * @since 2.0.0

--- a/packages/platform-bun/src/internal/http/server.ts
+++ b/packages/platform-bun/src/internal/http/server.ts
@@ -27,6 +27,7 @@ import * as Inspectable from "effect/Inspectable"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import type { ReadonlyRecord } from "effect/Record"
+import type * as Runtime from "effect/Runtime"
 import type * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import { Readable } from "node:stream"
@@ -73,25 +74,27 @@ export const make = (
     return Server.make({
       address: { _tag: "TcpAddress", port: server.port, hostname: server.hostname },
       serve(httpApp, middleware) {
-        const app = App.toHandled(httpApp, (request, exit) =>
-          Effect.sync(() => {
-            const impl = request as ServerRequestImpl
-            if (exit._tag === "Success") {
-              impl.resolve(makeResponse(request, exit.value))
-            } else if (Cause.isInterruptedOnly(exit.cause)) {
-              impl.resolve(
-                new Response(undefined, {
-                  status: impl.source.signal.aborted ? 499 : 503
-                })
-              )
-            } else {
-              impl.reject(Cause.pretty(exit.cause))
-            }
-          }), middleware)
-
         return pipe(
           FiberSet.makeRuntime<never>(),
-          Effect.flatMap((runFork) =>
+          Effect.bindTo("runFork"),
+          Effect.bind("runtime", () => Effect.runtime<never>()),
+          Effect.let("app", ({ runtime }) =>
+            App.toHandled(httpApp, (request, exit) =>
+              Effect.sync(() => {
+                const impl = request as ServerRequestImpl
+                if (exit._tag === "Success") {
+                  impl.resolve(makeResponse(request, exit.value, runtime))
+                } else if (Cause.isInterruptedOnly(exit.cause)) {
+                  impl.resolve(
+                    new Response(undefined, {
+                      status: impl.source.signal.aborted ? 499 : 503
+                    })
+                  )
+                } else {
+                  impl.reject(Cause.pretty(exit.cause))
+                }
+              }), middleware)),
+          Effect.flatMap(({ app, runFork }) =>
             Effect.async<never>((_) => {
               function handler(request: Request, server: BunServer) {
                 return new Promise<Response>((resolve, reject) => {
@@ -121,7 +124,11 @@ export const make = (
     })
   })
 
-const makeResponse = (request: ServerRequest.ServerRequest, response: ServerResponse.ServerResponse): Response => {
+const makeResponse = (
+  request: ServerRequest.ServerRequest,
+  response: ServerResponse.ServerResponse,
+  runtime: Runtime.Runtime<never>
+): Response => {
   const fields: {
     headers: globalThis.Headers
     status?: number
@@ -157,7 +164,10 @@ const makeResponse = (request: ServerRequest.ServerRequest, response: ServerResp
       return new Response(body.formData as any, fields)
     }
     case "Stream": {
-      return new Response(Stream.toReadableStream(body.stream), fields)
+      return new Response(
+        Stream.toReadableStreamRuntime(body.stream, runtime),
+        fields
+      )
     }
   }
 }

--- a/packages/platform/src/Http/ServerResponse.ts
+++ b/packages/platform/src/Http/ServerResponse.ts
@@ -165,7 +165,7 @@ export const formData: (body: FormData, options?: Options.WithContent | undefine
  * @since 1.0.0
  * @category constructors
  */
-export const stream: (body: Stream.Stream<Uint8Array, unknown>, options?: Options | undefined) => ServerResponse =
+export const stream: <E>(body: Stream.Stream<Uint8Array, E, never>, options?: Options | undefined) => ServerResponse =
   internal.stream
 
 /**

--- a/packages/platform/src/internal/http/client.ts
+++ b/packages/platform/src/internal/http/client.ts
@@ -222,23 +222,23 @@ export const fetch: Client.Client.Default = makeDefault((request, url, signal, f
       (response) => internalResponse.fromWeb(request, response)
     )
   if (Method.hasBody(request.method)) {
-    return send(convertBody(request.body))
+    return Effect.flatMap(convertBody(request.body), send)
   }
   return send(undefined)
 })
 
-const convertBody = (body: Body.Body): BodyInit | undefined => {
+const convertBody = (body: Body.Body): Effect.Effect<BodyInit | undefined> => {
   switch (body._tag) {
     case "Empty":
-      return undefined
+      return Effect.succeed(undefined)
     case "Raw":
-      return body.body as any
+      return Effect.succeed(body.body as any)
     case "Uint8Array":
-      return body.body
+      return Effect.succeed(body.body)
     case "FormData":
-      return body.formData
+      return Effect.succeed(body.formData)
     case "Stream":
-      return Stream.toReadableStream(body.stream)
+      return Stream.toReadableStreamEffect(body.stream)
   }
 }
 

--- a/packages/platform/src/internal/http/serverResponse.ts
+++ b/packages/platform/src/internal/http/serverResponse.ts
@@ -258,8 +258,8 @@ export const formData = (
   )
 
 /** @internal */
-export const stream = (
-  body: Stream.Stream<Uint8Array, unknown>,
+export const stream = <E>(
+  body: Stream.Stream<Uint8Array, E>,
   options?: ServerResponse.Options | undefined
 ): ServerResponse.ServerResponse =>
   new ServerResponseImpl(


### PR DESCRIPTION
Run the stream passed to `HttpClient.request.streamBody` within the current runtime instead of the default one.
