### PR TITLE
fix(platform-node): EADDRINUSE error reporting

### DIFF
--- a/.changeset/popular-lions-boil.md
+++ b/.changeset/popular-lions-boil.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Attempt to close a server only if `listen` succeeds. This fixes the error reporting in case a port is already in use.

--- a/.changeset/seven-mayflies-wonder.md
+++ b/.changeset/seven-mayflies-wonder.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+rebuild packages


### PR DESCRIPTION
related issue https://github.com/sukovanej/effect-http/issues/558

With this change, the user will see `listen EADDRINUSE: address already in use :::3000` instead of `Error [ERR_SERVER_NOT_RUNNING]: Server is not running.` in case of an attempt to run the server on a port that's already in use.

The problem was that the `server.close` was called even if the `listen` call was not successful.