### PR TITLE
Class API: avoid access before initialization when creating a class w…

### DIFF
--- a/.changeset/wild-shoes-rest.md
+++ b/.changeset/wild-shoes-rest.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Class API: avoid access before initialization when creating a class with suspended props, closes #2709

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -6499,7 +6499,6 @@ const makeClass = ({ Base, annotations, fields, fromSchema, identifier, kind, ta
 }): any => {
   const classSymbol = Symbol.for(`@effect/schema/${kind}/${identifier}`)
   const schema = fromSchema ?? Struct(fields)
-  const validate = ParseResult.validateSync(schema)
   const from = option_.match(AST.getTitleAnnotation(schema.ast), {
     onNone: () => schema.annotations({ title: `${identifier} (Encoded side)` }),
     onSome: () => schema
@@ -6514,7 +6513,7 @@ const makeClass = ({ Base, annotations, fields, fromSchema, identifier, kind, ta
         props = { ...props, ...tag }
       }
       if (disableValidation !== true) {
-        props = validate(props)
+        props = ParseResult.validateSync(schema)(props)
       }
       super(props, true)
     }

--- a/packages/schema/test/Schema/Class/Class.test.ts
+++ b/packages/schema/test/Schema/Class/Class.test.ts
@@ -126,6 +126,12 @@ class PersonWithTransformFrom extends Person.transformOrFailFrom<PersonWithTrans
 
 describe("Class APIs", () => {
   describe("Class", () => {
+    it("suspend before initialization", async () => {
+      class A extends S.Class<A>("A")({ a: S.optional(S.suspend(() => string)) }) {}
+      const string = S.String
+      await Util.expectDecodeUnknownSuccess(A, new A({ a: "a" }))
+    })
+
     it("should be a Schema", () => {
       class A extends S.Class<A>("A")({ a: S.String }) {}
       expect(S.isSchema(A)).toEqual(true)


### PR DESCRIPTION
…ith suspended props, closes #2709

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2709
