### PR TITLE
fix: vitest custom tester with toMatchObject (rebase)

### DIFF
--- a/.changeset/forty-lizards-tap.md
+++ b/.changeset/forty-lizards-tap.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Call Equal.equals internally in order inputs were passed.

--- a/.changeset/shiny-crabs-bake.md
+++ b/.changeset/shiny-crabs-bake.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Fix usage of `toMatchObject`.

--- a/packages/effect/src/Equal.ts
+++ b/packages/effect/src/Equal.ts
@@ -44,7 +44,13 @@ function compareBoth(self: unknown, that: unknown): boolean {
   if (selfType === "object" || selfType === "function") {
     if (self !== null && that !== null) {
       if (isEqual(self) && isEqual(that)) {
-        return Hash.hash(self) === Hash.hash(that) && self[symbol](that)
+        if (Hash.hash(self) === Hash.hash(that) && self[symbol](that)) {
+          return true
+        } else {
+          return structuralRegionState.enabled && structuralRegionState.tester
+            ? structuralRegionState.tester(self, that)
+            : false
+        }
       }
     }
     if (structuralRegionState.enabled) {

--- a/packages/effect/src/Hash.ts
+++ b/packages/effect/src/Hash.ts
@@ -36,6 +36,10 @@ export interface Hash {
  * @category hashing
  */
 export const hash: <A>(self: A) => number = <A>(self: A) => {
+  if (structuralRegionState.enabled === true) {
+    return 0
+  }
+
   switch (typeof self) {
     case "number":
       return number(self)
@@ -72,9 +76,6 @@ export const hash: <A>(self: A) => number = <A>(self: A) => {
  * @category hashing
  */
 export const random: <A extends object>(self: A) => number = (self) => {
-  if (structuralRegionState.enabled === true) {
-    return 0
-  }
   if (!randomHashCache.has(self)) {
     randomHashCache.set(self, number(pcgr.integer(Number.MAX_SAFE_INTEGER)))
   }
@@ -171,36 +172,23 @@ export const cached: {
   if (arguments.length === 1) {
     const self = arguments[0] as object
     return function(hash: number) {
-      // @ts-expect-error
-      const original = self[symbol].bind(self)
-      if (structuralRegionState.enabled === false) {
-        Object.defineProperty(self, symbol, {
-          value() {
-            if (structuralRegionState.enabled === true) {
-              return original()
-            }
-            return hash
-          },
-          enumerable: false
-        })
-      }
+      Object.defineProperty(self, symbol, {
+        value() {
+          return hash
+        },
+        enumerable: false
+      })
       return hash
     } as any
   }
   const self = arguments[0] as object
   const hash = arguments[1] as number
-  // @ts-expect-error
-  const original = self[symbol].bind(self)
-  if (structuralRegionState.enabled === false) {
-    Object.defineProperty(self, symbol, {
-      value() {
-        if (structuralRegionState.enabled === true) {
-          return original()
-        }
-        return hash
-      },
-      enumerable: false
-    })
-  }
+  Object.defineProperty(self, symbol, {
+    value() {
+      return hash
+    },
+    enumerable: false
+  })
+
   return hash
 }

--- a/packages/effect/src/internal/either.ts
+++ b/packages/effect/src/internal/either.ts
@@ -34,7 +34,7 @@ const RightProto = Object.assign(Object.create(CommonProto), {
   _tag: "Right",
   _op: "Right",
   [Equal.symbol]<L, R>(this: Either.Right<L, R>, that: unknown): boolean {
-    return isEither(that) && isRight(that) && Equal.equals(that.right, this.right)
+    return isEither(that) && isRight(that) && Equal.equals(this.right, that.right)
   },
   [Hash.symbol]<L, R>(this: Either.Right<L, R>) {
     return Hash.combine(Hash.hash(this._tag))(Hash.hash(this.right))
@@ -52,7 +52,7 @@ const LeftProto = Object.assign(Object.create(CommonProto), {
   _tag: "Left",
   _op: "Left",
   [Equal.symbol]<L, R>(this: Either.Left<L, R>, that: unknown): boolean {
-    return isEither(that) && isLeft(that) && Equal.equals(that.left, this.left)
+    return isEither(that) && isLeft(that) && Equal.equals(this.left, that.left)
   },
   [Hash.symbol]<L, R>(this: Either.Left<L, R>) {
     return Hash.combine(Hash.hash(this._tag))(Hash.hash(this.left))

--- a/packages/effect/src/internal/option.ts
+++ b/packages/effect/src/internal/option.ts
@@ -28,7 +28,7 @@ const SomeProto = Object.assign(Object.create(CommonProto), {
   _tag: "Some",
   _op: "Some",
   [Equal.symbol]<A>(this: Option.Some<A>, that: unknown): boolean {
-    return isOption(that) && isSome(that) && Equal.equals(that.value, this.value)
+    return isOption(that) && isSome(that) && Equal.equals(this.value, that.value)
   },
   [Hash.symbol]<A>(this: Option.Some<A>) {
     return Hash.cached(this, Hash.combine(Hash.hash(this._tag))(Hash.hash(this.value)))

--- a/packages/effect/test/Either.test.ts
+++ b/packages/effect/test/Either.test.ts
@@ -326,16 +326,6 @@ describe("Either", () => {
     Util.deepStrictEqual(pipe(Either.left("a"), Either.orElse(() => Either.left("b"))), Either.left("b"))
   })
 
-  it("vitest equality", () => {
-    expect(Either.right(1)).toStrictEqual(Either.right(1))
-    expect(Either.left(1)).toStrictEqual(Either.left(1))
-
-    expect(Either.right(2)).not.toStrictEqual(Either.right(1))
-    expect(Either.left(2)).not.toStrictEqual(Either.left(1))
-    expect(Either.left(1)).not.toStrictEqual(Either.right(1))
-    expect(Either.left(1)).not.toStrictEqual(Either.right(2))
-  })
-
   describe("do notation", () => {
     it("Do", () => {
       expectRight(Either.Do, {})

--- a/packages/effect/test/Exit.test.ts
+++ b/packages/effect/test/Exit.test.ts
@@ -1,4 +1,3 @@
-import * as Cause from "effect/Cause"
 import * as Exit from "effect/Exit"
 import { describe, expect, it } from "vitest"
 
@@ -73,19 +72,5 @@ describe("Exit", () => {
   }
 }`)
     })
-  })
-
-  it("vitest equality", () => {
-    expect(Exit.succeed(1)).toEqual(Exit.succeed(1))
-    expect(Exit.fail("failure")).toEqual(Exit.fail("failure"))
-    expect(Exit.die("defect")).toEqual(Exit.die("defect"))
-
-    expect(Exit.succeed(1)).not.toEqual(Exit.succeed(2))
-    expect(Exit.fail("failure")).not.toEqual(Exit.fail("failure1"))
-    expect(Exit.die("failure")).not.toEqual(Exit.fail("failure1"))
-    expect(Exit.die("failure")).not.toEqual(Exit.fail("failure1"))
-    expect(Exit.failCause(Cause.sequential(Cause.fail("f1"), Cause.fail("f2")))).not.toEqual(
-      Exit.failCause(Cause.sequential(Cause.fail("f1"), Cause.fail("f3")))
-    )
   })
 })

--- a/packages/effect/test/Option.test.ts
+++ b/packages/effect/test/Option.test.ts
@@ -499,14 +499,6 @@ describe("Option", () => {
     expect(f(Option.some(1), Option.some(2))).toStrictEqual(Option.some(3))
   })
 
-  it("vitest equality", () => {
-    expect(Option.some(2)).toStrictEqual(Option.some(2))
-    expect(Option.none()).toStrictEqual(Option.none())
-
-    expect(Option.some(2)).not.toStrictEqual(Option.some(1))
-    expect(Option.none()).not.toStrictEqual(Option.some(1))
-  })
-
   describe("do notation", () => {
     it("Do", () => {
       expectSome(Option.Do, {})

--- a/packages/schema/test/Schema/Class/Class.test.ts
+++ b/packages/schema/test/Schema/Class/Class.test.ts
@@ -49,7 +49,7 @@ describe("Class", () => {
     const schema = S.suspend(() => string)
     class A extends S.Class<A>("A")({ a: S.optional(schema) }) {}
     const string = S.String
-    await Util.expectDecodeUnknownSuccess(A, { a: "a" })
+    await Util.expectDecodeUnknownSuccess(A, new A({ a: "a" }))
   })
 
   it("should be a Schema", () => {

--- a/packages/schema/test/Schema/Class/extend.test.ts
+++ b/packages/schema/test/Schema/Class/extend.test.ts
@@ -80,7 +80,7 @@ describe("extend", () => {
       S.Struct(fields).pipe(S.filter(({ a, b }) => a === b ? undefined : "a should be equal to b"))
     ) {}
     Util.expectFields(A.fields, { ...baseFields, ...fields })
-    await Util.expectDecodeUnknownSuccess(A, { base: "base", a: 1, b: 1 })
+    await Util.expectDecodeUnknownSuccess(A, new A({ base: "base", a: 1, b: 1 }))
     await Util.expectDecodeUnknownFailure(
       A,
       { base: "base", a: 1, b: 2 },

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @since 1.0.0
  */
-import type { TesterContext } from "@vitest/expect"
+import type { Tester, TesterContext } from "@vitest/expect"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
@@ -25,8 +25,12 @@ const TestEnv = TestEnvironment.TestContext.pipe(
   Layer.provide(Logger.remove(Logger.defaultLogger))
 )
 /** @internal */
-function customTester(this: TesterContext, a: unknown, b: unknown) {
-  return Utils.structuralRegion(() => Equal.equals(a, b), (x, y) => this.equals(x, y))
+function customTester(this: TesterContext, a: unknown, b: unknown, customTesters: Array<Tester>) {
+  if (!Equal.isEqual(a) || !Equal.isEqual(b)) {
+    return undefined
+  }
+
+  return Utils.structuralRegion(() => Equal.equals(a, b), (x, y) => this.equals(x, y, customTesters))
 }
 
 /**

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -24,13 +24,16 @@ export type API = TestAPI<{}>
 const TestEnv = TestEnvironment.TestContext.pipe(
   Layer.provide(Logger.remove(Logger.defaultLogger))
 )
+
 /** @internal */
 function customTester(this: TesterContext, a: unknown, b: unknown, customTesters: Array<Tester>) {
   if (!Equal.isEqual(a) || !Equal.isEqual(b)) {
     return undefined
   }
-
-  return Utils.structuralRegion(() => Equal.equals(a, b), (x, y) => this.equals(x, y, customTesters))
+  return Utils.structuralRegion(
+    () => Equal.equals(a, b),
+    (x, y) => this.equals(x, y, customTesters.filter((t) => t !== customTester))
+  )
 }
 
 /**

--- a/packages/vitest/test/equality-tester.test.ts
+++ b/packages/vitest/test/equality-tester.test.ts
@@ -1,4 +1,5 @@
 import * as Cause from "effect/Cause"
+import * as Data from "effect/Data"
 import * as Either from "effect/Either"
 import * as Exit from "effect/Exit"
 import * as Option from "effect/Option"
@@ -7,6 +8,12 @@ import { describe, expect, it } from "vitest"
 describe("toMatchObject", () => {
   it("plain objects", () => {
     expect({ a: 1, b: 2 }).toMatchObject({ a: 1 })
+  })
+
+  it("Data.struct", () => {
+    const alice = Data.struct({ name: "Alice", age: 30 })
+
+    expect(alice).toMatchObject(Data.struct({ name: "Alice" }))
   })
 
   it("option", () => {

--- a/packages/vitest/test/equality-tester.test.ts
+++ b/packages/vitest/test/equality-tester.test.ts
@@ -1,0 +1,72 @@
+import * as Cause from "effect/Cause"
+import * as Either from "effect/Either"
+import * as Exit from "effect/Exit"
+import * as Option from "effect/Option"
+import { describe, expect, it } from "vitest"
+
+describe("toMatchObject", () => {
+  it("plain objects", () => {
+    expect({ a: 1, b: 2 }).toMatchObject({ a: 1 })
+  })
+
+  it("option", () => {
+    expect(Option.some({ a: 1, b: 2 })).toMatchObject(Option.some({ a: 1 }))
+    expect(Option.none()).toMatchObject(Option.none())
+    expect({ x: Option.some({ a: 1, b: 2 }), y: Option.none() }).toMatchObject({ x: Option.some({ a: 1 }) })
+
+    expect(Option.none()).not.toMatchObject(Option.some({ a: 1 }))
+    expect(Option.some({ b: 1 })).not.toMatchObject(Option.some({ a: 1 }))
+    expect({ x: Option.some({ a: 1, b: 2 }), y: Option.none() }).not.toMatchObject({ x: Option.some({ b: 1 }) })
+    expect({ x: Option.none(), y: Option.none() }).not.toMatchObject({ x: Option.some({}) })
+  })
+
+  it("either", () => {
+    expect(Either.right({ a: 1, b: 2 })).toMatchObject(Either.right({ a: 1 }))
+    expect(Either.left({ a: 1, b: 2 })).toMatchObject(Either.left({ a: 1 }))
+
+    expect(Either.right({ a: 1, b: 2 })).not.toMatchObject(Either.left({ a: 1 }))
+    expect(Either.left({ a: 1, b: 2 })).not.toMatchObject(Either.right({ a: 1 }))
+  })
+
+  it("either", () => {
+    expect(Either.right({ a: 1, b: 2 })).toMatchObject(Either.right({ a: 1 }))
+    expect(Either.left({ a: 1, b: 2 })).toMatchObject(Either.left({ a: 1 }))
+
+    expect(Either.right({ a: 1, b: 2 })).not.toMatchObject(Either.left({ a: 1 }))
+    expect(Either.left({ a: 1, b: 2 })).not.toMatchObject(Either.right({ a: 1 }))
+  })
+})
+
+describe.each(["toStrictEqual", "toEqual"] as const)("%s", (matcher) => {
+  it("either", () => {
+    expect(Either.right(1))[matcher](Either.right(1))
+    expect(Either.left(1))[matcher](Either.left(1))
+
+    expect(Either.right(2)).not[matcher](Either.right(1))
+    expect(Either.left(2)).not[matcher](Either.left(1))
+    expect(Either.left(1)).not[matcher](Either.right(1))
+    expect(Either.left(1)).not[matcher](Either.right(2))
+  })
+
+  it("exit", () => {
+    expect(Exit.succeed(1))[matcher](Exit.succeed(1))
+    expect(Exit.fail("failure"))[matcher](Exit.fail("failure"))
+    expect(Exit.die("defect"))[matcher](Exit.die("defect"))
+
+    expect(Exit.succeed(1)).not[matcher](Exit.succeed(2))
+    expect(Exit.fail("failure")).not[matcher](Exit.fail("failure1"))
+    expect(Exit.die("failure")).not[matcher](Exit.fail("failure1"))
+    expect(Exit.die("failure")).not[matcher](Exit.fail("failure1"))
+    expect(Exit.failCause(Cause.sequential(Cause.fail("f1"), Cause.fail("f2")))).not[matcher](
+      Exit.failCause(Cause.sequential(Cause.fail("f1"), Cause.fail("f3")))
+    )
+  })
+
+  it("option", () => {
+    expect(Option.some(2))[matcher](Option.some(2))
+    expect(Option.none())[matcher](Option.none())
+
+    expect(Option.some(2)).not[matcher](Option.some(1))
+    expect(Option.none()).not[matcher](Option.some(1))
+  })
+})


### PR DESCRIPTION
closes #2688  