### PR TITLE
add `cause` in errors thrown by `asserts`, closes #2729

### DIFF
--- a/.changeset/fifty-clocks-fail.md
+++ b/.changeset/fifty-clocks-fail.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+add `cause` in errors thrown by `asserts`, closes #2729

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -731,7 +731,7 @@ export const asserts = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.P
       isExact: true
     }) as any
     if (Either.isLeft(result)) {
-      throw new Error(TreeFormatter.formatIssueSync(result.left))
+      throw new Error(TreeFormatter.formatIssueSync(result.left), { cause: result.left })
     }
   }
 }

--- a/packages/schema/test/Schema/asserts.test.ts
+++ b/packages/schema/test/Schema/asserts.test.ts
@@ -11,6 +11,15 @@ const expectAssertsFailure = <A, I>(schema: S.Schema<A, I>, input: unknown, mess
 }
 
 describe("asserts", () => {
+  it("the returned error should include a cause", () => {
+    const asserts: (u: unknown) => asserts u is string = S.asserts(S.String)
+    try {
+      asserts(1)
+    } catch (e: any) {
+      expect(e.cause).exist
+    }
+  })
+
   it("should respect outer/inner options", () => {
     const schema = S.Struct({ a: Util.NumberFromChar })
     const input = { a: 1, b: "b" }

--- a/packages/schema/test/Schema/decodeUnknownSync.test.ts
+++ b/packages/schema/test/Schema/decodeUnknownSync.test.ts
@@ -3,6 +3,14 @@ import * as Util from "@effect/schema/test/TestUtils"
 import { describe, expect, it } from "vitest"
 
 describe("decodeUnknownSync", () => {
+  it("the returned error should include a cause", () => {
+    try {
+      S.decodeUnknownSync(S.String)(1)
+    } catch (e: any) {
+      expect(e.cause).exist
+    }
+  })
+
   it("should throw on async", () => {
     expect(() => S.decodeUnknownSync(Util.AsyncString)("a")).toThrow(
       new Error(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2729
