### PR TITLE
`Schema.optional`: the `default` option now allows setting a default …

### DIFF
--- a/.changeset/khaki-experts-run.md
+++ b/.changeset/khaki-experts-run.md
@@ -1,0 +1,31 @@
+---
+"@effect/schema": patch
+---
+
+`Schema.optional`: the `default` option now allows setting a default value for **both** the decoding phase and the default constructor. Previously, it only set the decoding default. Closes #2740.
+
+**Example**
+
+```ts
+import { Schema } from "@effect/schema"
+
+const Product = Schema.Struct({
+  name: Schema.String,
+  price: Schema.NumberFromString,
+  quantity: Schema.optional(Schema.NumberFromString, { default: () => 1 })
+})
+
+// Applying defaults in the decoding phase
+console.log(Schema.decodeUnknownSync(Product)({ name: "Laptop", price: "999" })) // { name: 'Laptop', price: 999, quantity: 1 }
+console.log(
+  Schema.decodeUnknownSync(Product)({
+    name: "Laptop",
+    price: "999",
+    quantity: "2"
+  })
+) // { name: 'Laptop', price: 999, quantity: 2 }
+
+// Applying defaults in the constructor
+console.log(Product.make({ name: "Laptop", price: 999 })) // { name: 'Laptop', price: 999, quantity: 1 }
+console.log(Product.make({ name: "Laptop", price: 999, quantity: 2 })) // { name: 'Laptop', price: 999, quantity: 2 }
+```

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -2622,6 +2622,36 @@ console.log(Schema.decodeUnknownSync(Person)({ name: "name", AGE: "18" }))
 
 ### Default Values
 
+The `default` option allows you to set a default value for both the decoding phase and the default constructor.
+
+**Example**
+
+Let's see how default values work in both the decoding and constructing phases, illustrating how the default value is applied when certain properties are not provided.
+
+```ts
+import { Schema } from "@effect/schema"
+
+const Product = Schema.Struct({
+  name: Schema.String,
+  price: Schema.NumberFromString,
+  quantity: Schema.optional(Schema.NumberFromString, { default: () => 1 })
+})
+
+// Applying defaults in the decoding phase
+console.log(Schema.decodeUnknownSync(Product)({ name: "Laptop", price: "999" })) // { name: 'Laptop', price: 999, quantity: 1 }
+console.log(
+  Schema.decodeUnknownSync(Product)({
+    name: "Laptop",
+    price: "999",
+    quantity: "2"
+  })
+) // { name: 'Laptop', price: 999, quantity: 2 }
+
+// Applying defaults in the constructor
+console.log(Product.make({ name: "Laptop", price: 999 })) // { name: 'Laptop', price: 999, quantity: 1 }
+console.log(Product.make({ name: "Laptop", price: 999, quantity: 2 })) // { name: 'Laptop', price: 999, quantity: 2 }
+```
+
 | Combinator | From                                                                   | To                                                                                |
 | ---------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | `optional` | `Schema<A, I, R>`, `{ default: () => A }`                              | `PropertySignature<":", string, never, "?:", string \| undefined, never>`         |

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -653,7 +653,7 @@ S.asSchema(S.Struct({
   c: S.optional(S.Boolean, { exact: true, default: () => false })
 }))
 
-// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", boolean, never, "?:", boolean, false, never>; }>
+// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", boolean, never, "?:", boolean, true, never>; }>
 S.Struct({
   a: S.String,
   b: S.Number,
@@ -667,20 +667,20 @@ S.asSchema(S.Struct({
   c: S.optional(S.NumberFromString, { exact: true, default: () => 0 })
 }))
 
-// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", number, never, "?:", string, false, never>; }>
+// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", number, never, "?:", string, true, never>; }>
 S.Struct({
   a: S.String,
   b: S.Number,
   c: S.optional(S.NumberFromString, { exact: true, default: () => 0 })
 })
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", true, never>; }>
 S.Struct({ a: S.optional(S.Literal("a", "b"), { default: () => "a", exact: true }) })
 
 // $ExpectType Schema<{ readonly a: "a" | "b"; }, { readonly a?: "a" | "b"; }, never>
 S.asSchema(S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, exact: true })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b", true, never>; }>
 S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, exact: true })) })
 
 // ---------------------------------------------
@@ -690,23 +690,33 @@ S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const,
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: boolean; }, { readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { default: () => false }) }))
 
-// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", boolean, never, "?:", boolean | undefined, false, never>; }>
+// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", boolean, never, "?:", boolean | undefined, true, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean, { default: () => false }) })
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c: number; }, { readonly a: string; readonly b: number; readonly c?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { default: () => 0 }) }))
 
-// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", number, never, "?:", string | undefined, false, never>; }>
+// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; c: PropertySignature<":", number, never, "?:", string | undefined, true, never>; }>
 S.Struct({ a: S.String, b: S.Number, c: S.optional(S.NumberFromString, { default: () => 0 }) })
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, true, never>; }>
 S.Struct({ a: S.optional(S.Literal("a", "b"), { default: () => "a" }) })
 
 // $ExpectType Schema<{ readonly a: "a" | "b"; }, { readonly a?: "a" | "b" | undefined; }, never>
 S.asSchema(S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | undefined, true, never>; }>
 S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const })) })
+
+// ---------------------------------------------
+// optional { exact: true, nullable: true, default: () => A }
+// ---------------------------------------------
+
+// $ExpectType Schema<{ readonly a: number; }, { readonly a?: string | null; }, never>
+S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) }))
+
+// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null, true, never>; }>
+S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
 
 // ---------------------------------------------
 // optional { nullable: true, default: () => A }
@@ -715,22 +725,22 @@ S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const 
 // $ExpectType Schema<{ readonly a: number; }, { readonly a?: string | null | undefined; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { nullable: true, default: () => 0 }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null | undefined, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null | undefined, true, never>; }>
 S.Struct({ a: S.optional(S.NumberFromString, { nullable: true, default: () => 0 }) })
 
 // $ExpectType Schema<{ readonly a: number; }, { readonly a?: string | null; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", number, never, "?:", string | null, true, never>; }>
 S.Struct({ a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, true, never>; }>
 S.Struct({ a: S.optional(S.Literal("a", "b"), { default: () => "a", nullable: true }) })
 
 // $ExpectType Schema<{ readonly a: "a" | "b"; }, { readonly a?: "a" | "b" | null | undefined; }, never>
 S.asSchema(S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, nullable: true })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", "a" | "b", never, "?:", "a" | "b" | null | undefined, true, never>; }>
 S.Struct({ a: S.Literal("a", "b").pipe(S.optional({ default: () => "a" as const, nullable: true })) })
 
 // ---------------------------------------------

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1893,7 +1893,7 @@ export const optional: {
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),
-      false,
+      Types.Has<Options, "default">,
       R
     >
   <
@@ -1937,7 +1937,7 @@ export const optional: {
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),
-      false,
+      Types.Has<Options, "default">,
       R
     >
 } = dual((args) => isSchema(args[0]), <A, I, R>(
@@ -1957,19 +1957,25 @@ export const optional: {
   if (isExact) {
     if (defaultValue) {
       if (isNullable) {
-        return optionalToRequired(
-          NullOr(schema),
-          typeSchema(schema),
-          {
-            decode: option_.match({ onNone: defaultValue, onSome: (a) => a === null ? defaultValue() : a }),
-            encode: option_.some
-          }
+        return withConstructorDefault(
+          optionalToRequired(
+            NullOr(schema),
+            typeSchema(schema),
+            {
+              decode: option_.match({ onNone: defaultValue, onSome: (a) => a === null ? defaultValue() : a }),
+              encode: option_.some
+            }
+          ),
+          defaultValue
         )
       } else {
-        return optionalToRequired(
-          schema,
-          typeSchema(schema),
-          { decode: option_.match({ onNone: defaultValue, onSome: identity }), encode: option_.some }
+        return withConstructorDefault(
+          optionalToRequired(
+            schema,
+            typeSchema(schema),
+            { decode: option_.match({ onNone: defaultValue, onSome: identity }), encode: option_.some }
+          ),
+          defaultValue
         )
       }
     } else if (asOption) {
@@ -2000,22 +2006,28 @@ export const optional: {
   } else {
     if (defaultValue) {
       if (isNullable) {
-        return optionalToRequired(
-          NullishOr(schema),
-          typeSchema(schema),
-          {
-            decode: option_.match({ onNone: defaultValue, onSome: (a) => (a == null ? defaultValue() : a) }),
-            encode: option_.some
-          }
+        return withConstructorDefault(
+          optionalToRequired(
+            NullishOr(schema),
+            typeSchema(schema),
+            {
+              decode: option_.match({ onNone: defaultValue, onSome: (a) => (a == null ? defaultValue() : a) }),
+              encode: option_.some
+            }
+          ),
+          defaultValue
         )
       } else {
-        return optionalToRequired(
-          UndefinedOr(schema),
-          typeSchema(schema),
-          {
-            decode: option_.match({ onNone: defaultValue, onSome: (a) => (a === undefined ? defaultValue() : a) }),
-            encode: option_.some
-          }
+        return withConstructorDefault(
+          optionalToRequired(
+            UndefinedOr(schema),
+            typeSchema(schema),
+            {
+              decode: option_.match({ onNone: defaultValue, onSome: (a) => (a === undefined ? defaultValue() : a) }),
+              encode: option_.some
+            }
+          ),
+          defaultValue
         )
       }
     } else if (asOption) {

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -297,6 +297,13 @@ describe("optional APIs", () => {
       await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
       await Util.expectEncodeSuccess(schema, { a: 0 }, { a: "0" })
     })
+
+    it("should apply the default to the default constructor", () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { exact: true, default: () => 0 })
+      })
+      expect(schema.make({})).toStrictEqual({ a: 0 })
+    })
   })
 
   describe("optional > { default: () => A }", () => {
@@ -325,6 +332,13 @@ describe("optional APIs", () => {
 
       await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
       await Util.expectEncodeSuccess(schema, { a: 0 }, { a: "0" })
+    })
+
+    it("should apply the default to the default constructor", () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { default: () => 0 })
+      })
+      expect(schema.make({})).toStrictEqual({ a: 0 })
     })
   })
 
@@ -358,6 +372,13 @@ describe("optional APIs", () => {
       await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
       await Util.expectEncodeSuccess(schema, { a: 0 }, { a: "0" })
     })
+
+    it("should apply the default to the default constructor", () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { nullable: true, default: () => 0 })
+      })
+      expect(schema.make({})).toStrictEqual({ a: 0 })
+    })
   })
 
   describe("optional > { exact: true, nullable: true, default: () => A }", () => {
@@ -386,6 +407,13 @@ describe("optional APIs", () => {
 
       await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
       await Util.expectEncodeSuccess(schema, { a: 0 }, { a: "0" })
+    })
+
+    it("should apply the default to the default constructor", () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { exact: true, nullable: true, default: () => 0 })
+      })
+      expect(schema.make({})).toStrictEqual({ a: 0 })
     })
   })
 })


### PR DESCRIPTION
…value for both the decoding phase and the default constructor, closes #2740

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2740
