### PR TITLE
`pick`: do not return a `ComposeTransformation` if none of the picked…

### DIFF
--- a/.changeset/nine-chairs-tell.md
+++ b/.changeset/nine-chairs-tell.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+`pick`: do not return a `ComposeTransformation` if none of the picked keys are related to a property signature transformation, closes #2743

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -2045,13 +2045,13 @@ export const pick = (ast: AST, keys: ReadonlyArray<PropertyKey>): TypeLiteral | 
             fromKeys.push(k)
           }
         }
-        return new Transformation(
-          pick(ast.from, fromKeys),
-          pick(ast.to, keys),
-          Arr.isNonEmptyReadonlyArray(ts) ?
+        return Arr.isNonEmptyReadonlyArray(ts) ?
+          new Transformation(
+            pick(ast.from, fromKeys),
+            pick(ast.to, keys),
             new TypeLiteralTransformation(ts)
-            : composeTransformation
-        )
+          ) :
+          pick(ast.from, fromKeys)
       }
       case "FinalTransformation": {
         const annotation = getSurrogateAnnotation(ast)

--- a/packages/schema/test/AST/pick.test.ts
+++ b/packages/schema/test/AST/pick.test.ts
@@ -20,20 +20,24 @@ describe("pick", () => {
     })
 
     describe("TypeLiteralTransformation", () => {
-      it("picking keys with PropertySignatureTransformations", async () => {
+      it("picking keys with associated PropertySignatureTransformations", async () => {
         const schema = S.Struct({ a: S.optional(S.NumberFromString, { default: () => 0 }), b: S.Number })
-        const ast = schema.pipe(S.pick("a")).ast as AST.Transformation
+        const pick = schema.pipe(S.pick("a"))
+        const ast = pick.ast as AST.Transformation
         expect(ast.from).toStrictEqual(S.Struct({ a: S.optional(S.NumberFromString) }).ast)
         expect(ast.to).toStrictEqual(S.Struct({ a: S.Number }).ast)
         expect(ast.transformation).toStrictEqual((schema.ast as AST.Transformation).transformation)
+        expect(() => pick.pipe(S.extend(S.Struct({ c: S.Boolean })))).not.Throw()
       })
 
-      it("picking keys without PropertySignatureTransformations", async () => {
+      it("picking keys without associated PropertySignatureTransformations", async () => {
         const schema = S.Struct({ a: S.optional(S.NumberFromString, { default: () => 0 }), b: S.NumberFromString })
-        const ast = schema.pipe(S.pick("b")).ast as AST.TypeLiteral
+        const pick = schema.pipe(S.pick("b"))
+        const ast = pick.ast as AST.TypeLiteral
         expect(ast.propertySignatures).toStrictEqual([
           new AST.PropertySignature("b", S.NumberFromString.ast, false, true)
         ])
+        expect(() => pick.pipe(S.extend(S.Struct({ c: S.Boolean })))).not.Throw()
       })
     })
 

--- a/packages/schema/test/AST/pick.test.ts
+++ b/packages/schema/test/AST/pick.test.ts
@@ -1,4 +1,4 @@
-import type * as AST from "@effect/schema/AST"
+import * as AST from "@effect/schema/AST"
 import * as S from "@effect/schema/Schema"
 import { describe, expect, it } from "vitest"
 
@@ -19,12 +19,22 @@ describe("pick", () => {
       expect(ast).toStrictEqual(S.compose(S.Struct({ a: S.NumberFromString }), S.Struct({ a: S.Number })).ast)
     })
 
-    it("TypeLiteralTransformation", async () => {
-      const schema = S.Struct({ a: S.optional(S.NumberFromString, { default: () => 0 }), b: S.Number })
-      const ast = schema.pipe(S.pick("a")).ast as AST.Transformation
-      expect(ast.from).toStrictEqual(S.Struct({ a: S.optional(S.NumberFromString) }).ast)
-      expect(ast.to).toStrictEqual(S.Struct({ a: S.Number }).ast)
-      expect(ast.transformation).toStrictEqual((schema.ast as AST.Transformation).transformation)
+    describe("TypeLiteralTransformation", () => {
+      it("picking keys with PropertySignatureTransformations", async () => {
+        const schema = S.Struct({ a: S.optional(S.NumberFromString, { default: () => 0 }), b: S.Number })
+        const ast = schema.pipe(S.pick("a")).ast as AST.Transformation
+        expect(ast.from).toStrictEqual(S.Struct({ a: S.optional(S.NumberFromString) }).ast)
+        expect(ast.to).toStrictEqual(S.Struct({ a: S.Number }).ast)
+        expect(ast.transformation).toStrictEqual((schema.ast as AST.Transformation).transformation)
+      })
+
+      it("picking keys without PropertySignatureTransformations", async () => {
+        const schema = S.Struct({ a: S.optional(S.NumberFromString, { default: () => 0 }), b: S.NumberFromString })
+        const ast = schema.pipe(S.pick("b")).ast as AST.TypeLiteral
+        expect(ast.propertySignatures).toStrictEqual([
+          new AST.PropertySignature("b", S.NumberFromString.ast, false, true)
+        ])
+      })
     })
 
     it("with SurrogateAnnotation", async () => {


### PR DESCRIPTION
… keys are related to a property signature transformation, closes #2743

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2743
