### PR TITLE
feat: allow equals sign in aliased parameter values.

### DIFF
--- a/.changeset/kind-cups-bow.md
+++ b/.changeset/kind-cups-bow.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Allow using the equals (`=`) character inside aliased key value params.

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1144,6 +1144,9 @@ const toParseableInstruction = (self: Instruction): Array<ParseableInstruction> 
   }
 }
 
+/** @internal */
+const keyValueSplitter = new RegExp('=(.*)')
+
 const parseInternal = (
   self: Instruction,
   args: HashMap.HashMap<string, ReadonlyArray<string>>,
@@ -1193,7 +1196,7 @@ const parseInternal = (
       const extractKeyValue = (
         value: string
       ): Effect.Effect<[string, string], ValidationError.ValidationError> => {
-        const split = value.trim().split(/=(.*)/, 2)
+        const split = value.trim().split(keyValueSplitter, 2)
         if (Arr.isNonEmptyReadonlyArray(split) && split.length === 2 && split[1] !== "") {
           return Effect.succeed(split as unknown as [string, string])
         }

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1193,9 +1193,8 @@ const parseInternal = (
       const extractKeyValue = (
         value: string
       ): Effect.Effect<[string, string], ValidationError.ValidationError> => {
-        const splits = Arr.splitWhere(value.trim(), s => s === "=").map(s => s.join(''))
-        if (Arr.isNonEmptyReadonlyArray(splits) && splits.length === 2 && splits[1] !== "=") {
-          const split = [splits[0], splits[1].slice(1)]
+        const split = value.trim().split(/=(.*)/, 2)
+        if (Arr.isNonEmptyReadonlyArray(split) && split.length === 2 && split[1] !== "") {
           return Effect.succeed(split as unknown as [string, string])
         }
         const error = InternalHelpDoc.p(`Expected a key/value pair but received '${value}'`)

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1145,7 +1145,7 @@ const toParseableInstruction = (self: Instruction): Array<ParseableInstruction> 
 }
 
 /** @internal */
-const keyValueSplitter = new RegExp('=(.*)')
+const keyValueSplitter = /=(.*)/
 
 const parseInternal = (
   self: Instruction,

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1193,8 +1193,9 @@ const parseInternal = (
       const extractKeyValue = (
         value: string
       ): Effect.Effect<[string, string], ValidationError.ValidationError> => {
-        const split = value.trim().split("=", 1)
-        if (Arr.isNonEmptyReadonlyArray(split) && split.length === 2 && split[1] !== "") {
+        const splits = Arr.splitWhere(value.trim(), s => s === "=").map(s => s.join(''))
+        if (Arr.isNonEmptyReadonlyArray(splits) && splits.length === 2 && splits[1] !== "=") {
+          const split = [splits[0], splits[1].slice(1)]
           return Effect.succeed(split as unknown as [string, string])
         }
         const error = InternalHelpDoc.p(`Expected a key/value pair but received '${value}'`)

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1193,7 +1193,7 @@ const parseInternal = (
       const extractKeyValue = (
         value: string
       ): Effect.Effect<[string, string], ValidationError.ValidationError> => {
-        const split = value.trim().split("=")
+        const split = value.trim().split("=", 1)
         if (Arr.isNonEmptyReadonlyArray(split) && split.length === 2 && split[1] !== "") {
           return Effect.succeed(split as unknown as [string, string])
         }

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -420,6 +420,14 @@ describe("Options", () => {
       const result = yield* _(process(defs, args, CliConfig.defaultConfig))
       expect(result).toEqual([["--verbose"], HashMap.make(["key1", "v1"], ["key2", "v2=vv"])])
     }).pipe(runEffect))
+  
+  it("keyValueMap - validates key/values with equals in aliased longer value", () =>
+    Effect.gen(function*(_) {
+      const args = Array.make("-d", "key1=v1", "key2=v2=1+1", "--verbose")
+      const result = yield* _(process(defs, args, CliConfig.defaultConfig))
+      console.log(result)
+      expect(result).toEqual([["--verbose"], HashMap.make(["key1", "v1"], ["key2", "v2=1+1"])])
+    }).pipe(runEffect))
 
   it("keyValueMap - validate should keep non-key-value parameters that follow the key-value pairs (each preceded by alias -d)", () =>
     Effect.gen(function*(_) {

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -420,7 +420,7 @@ describe("Options", () => {
       const result = yield* _(process(defs, args, CliConfig.defaultConfig))
       expect(result).toEqual([["--verbose"], HashMap.make(["key1", "v1"], ["key2", "v2=vv"])])
     }).pipe(runEffect))
-  
+
   it("keyValueMap - validates key/values with equals in aliased longer value", () =>
     Effect.gen(function*(_) {
       const args = Array.make("-d", "key1=v1", "key2=v2=1+1", "--verbose")

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -414,6 +414,13 @@ describe("Options", () => {
       expect(result).toEqual([["--verbose"], HashMap.make(["key1", "v1"], ["key2", "v2"])])
     }).pipe(runEffect))
 
+  it("keyValueMap - validates key/values with equals in alias value", () =>
+    Effect.gen(function*(_) {
+      const args = Array.make("-d", "key1=v1", "key2=v2=vv", "--verbose")
+      const result = yield* _(process(defs, args, CliConfig.defaultConfig))
+      expect(result).toEqual([["--verbose"], HashMap.make(["key1", "v1"], ["key2", "v2=vv"])])
+    }).pipe(runEffect))
+
   it("keyValueMap - validate should keep non-key-value parameters that follow the key-value pairs (each preceded by alias -d)", () =>
     Effect.gen(function*(_) {
       const args = Array.make(

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -425,7 +425,6 @@ describe("Options", () => {
     Effect.gen(function*(_) {
       const args = Array.make("-d", "key1=v1", "key2=v2=1+1", "--verbose")
       const result = yield* _(process(defs, args, CliConfig.defaultConfig))
-      console.log(result)
       expect(result).toEqual([["--verbose"], HashMap.make(["key1", "v1"], ["key2", "v2=1+1"])])
     }).pipe(runEffect))
 


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Proposal to allow aliased parameter values to contain an equals sign. for example, something like: `-c formula=x=1+1`

An alternative could be to have a way to escape the value, though that opens a shell can of worms.

Opening this as a draft as a way to get comments before I go and dig into the failing tests this causes. (I realise some may disagree with this change)

Here's an example with a better description:

Say you have a field `formula` you would like to hold a string that contains an equals character. As per the example above, the formula could be `x=x+1`. The desired outcome would be the equivalent of this ts: ` const formula = "x=x+1"`.

This case is articulated in the test I believe, though I could be wrong :)

Cheers!