### PR TITLE
Improving Predicate Usability of `Schema.is`

### DIFF
--- a/.changeset/light-cobras-hope.md
+++ b/.changeset/light-cobras-hope.md
@@ -1,0 +1,55 @@
+---
+"@effect/schema": patch
+---
+
+Improving Predicate Usability of `Schema.is`
+
+Before this update, the `Schema.is(mySchema)` function couldn't be easily used as a predicate or refinement in common array methods like `filter` or `find`. This was because the function's signature was:
+
+```ts
+(value: unknown, overrideOptions?: AST.ParseOptions) => value is A
+```
+
+Meanwhile, the function expected by methods like `filter` has the following signature:
+
+```ts
+(value: unknown, index: number) => value is A
+```
+
+To make `Schema.is` compatible with these array methods, we've adjusted the function's signature to accept `number` as a possible value for the second parameter, in which case it is ignored:
+
+```diff
+-(value: unknown, overrideOptions?: AST.ParseOptions) => value is A
++(value: unknown, overrideOptions?: AST.ParseOptions | number) => value is A
+```
+
+Here's a practical example comparing the behavior before and after the change:
+
+**Before:**
+
+```ts
+import { Schema } from "@effect/schema"
+
+declare const array: Array<string | number>
+
+/*
+Throws an error:
+No overload matches this call.
+...
+Types of parameters 'overrideOptions' and 'index' are incompatible.
+*/
+const strings = array.filter(Schema.is(Schema.String))
+```
+
+**Now:**
+
+```ts
+import { Schema } from "@effect/schema"
+
+declare const array: Array<string | number>
+
+// const strings: string[]
+const strings = array.filter(Schema.is(Schema.String))
+```
+
+Note that the result has been correctly narrowed to `string[]`.

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -2395,3 +2395,13 @@ export const AsSchemaTest2 = <X extends S.Schema.All>(
   domainEvent.expectedVersion // $ExpectType number
   domainEvent.props // $ExpectType Type<X>
 }
+
+// ---------------------------------------------
+// Schema.is
+// ---------------------------------------------
+
+// $ExpectType string[]
+hole<Array<string | number>>().filter(S.is(S.String))
+
+// $ExpectType string | undefined
+hole<Array<string | number>>().find(S.is(S.String))

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -471,18 +471,18 @@ export type DeclarationDecodeUnknown<Out, R> = (
 
 /** @internal */
 export const mergeParseOptions = (
-  a: AST.ParseOptions | undefined,
-  b: AST.ParseOptions | undefined
+  options: AST.ParseOptions | undefined,
+  overrideOptions: AST.ParseOptions | number | undefined
 ): AST.ParseOptions | undefined => {
-  if (a === undefined) {
-    return b
+  if (overrideOptions === undefined || Predicate.isNumber(overrideOptions)) {
+    return options
   }
-  if (b === undefined) {
-    return a
+  if (options === undefined) {
+    return overrideOptions
   }
   const out: Mutable<AST.ParseOptions> = {}
-  out.errors = b.errors ?? a.errors
-  out.onExcessProperty = b.onExcessProperty ?? a.onExcessProperty
+  out.errors = overrideOptions.errors ?? options.errors
+  out.onExcessProperty = overrideOptions.onExcessProperty ?? options.onExcessProperty
   return out
 }
 
@@ -715,7 +715,7 @@ export const validate = <A, I, R>(
  */
 export const is = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseOptions) => {
   const parser = goMemo(AST.typeAST(schema.ast), true)
-  return (u: unknown, overrideOptions?: AST.ParseOptions): u is A =>
+  return (u: unknown, overrideOptions?: AST.ParseOptions | number): u is A =>
     Either.isRight(parser(u, { ...mergeParseOptions(options, overrideOptions), isExact: true }) as any)
 }
 


### PR DESCRIPTION
Before this update, the `Schema.is(mySchema)` function couldn't be easily used as a predicate or refinement in common array methods like `filter` or `find`. This was because the function's signature was:

```ts
(value: unknown, overrideOptions?: AST.ParseOptions) => value is A
```

Meanwhile, the function expected by methods like `filter` has the following signature:

```ts
(value: unknown, index: number) => value is A
```

To make `Schema.is` compatible with these array methods, we've adjusted the function's signature to accept `number` as a possible value for the second parameter, in which case it is ignored:

```diff
-(value: unknown, overrideOptions?: AST.ParseOptions) => value is A
+(value: unknown, overrideOptions?: AST.ParseOptions | number) => value is A
```

Here's a practical example comparing the behavior before and after the change:

**Before:**

```ts
import { Schema } from "@effect/schema"

declare const array: Array<string | number>

/*
Throws an error:
No overload matches this call.
...
Types of parameters 'overrideOptions' and 'index' are incompatible.
*/
const strings = array.filter(Schema.is(Schema.String))
```

**Now:**

```ts
import { Schema } from "@effect/schema"

declare const array: Array<string | number>

// const strings: string[]
const strings = array.filter(Schema.is(Schema.String))
```

Note that the result has been correctly narrowed to `string[]`.
