### PR TITLE
Add `{ once: true }` to all `"abort"` event listeners for `AbortContr…

### DIFF
--- a/.changeset/silver-taxis-cover.md
+++ b/.changeset/silver-taxis-cover.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-browser": patch
+"@effect/platform-bun": patch
+"@effect/platform": patch
+"effect": patch
+---
+
+Add `{ once: true }` to all `"abort"` event listeners for `AbortController` to automatically remove handlers after execution

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -290,7 +290,7 @@ export const unsafeRunPromiseExit = <R>(runtime: Runtime.Runtime<R>) =>
       } else {
         options.signal.addEventListener("abort", () => {
           fiber.unsafeInterruptAsFork(fiber.id())
-        })
+        }, { once: true })
       }
     }
   })

--- a/packages/effect/test/Effect/promise.test.ts
+++ b/packages/effect/test/Effect/promise.test.ts
@@ -28,7 +28,7 @@ describe("Effect", () => {
     const effect = Effect.promise<void>((signal) => {
       signal.addEventListener("abort", () => {
         aborted = true
-      })
+      }, { once: true })
       return new Promise((resolve) => {
         setTimeout(() => {
           resolve()

--- a/packages/effect/test/Effect/tryPromise.test.ts
+++ b/packages/effect/test/Effect/tryPromise.test.ts
@@ -47,7 +47,7 @@ describe("Effect", () => {
     const effect = Effect.tryPromise<void>((signal) => {
       signal.addEventListener("abort", () => {
         aborted = true
-      })
+      }, { once: true })
       return new Promise((resolve) => {
         setTimeout(() => {
           resolve()
@@ -70,7 +70,7 @@ describe("Effect", () => {
       try: (signal) => {
         signal.addEventListener("abort", () => {
           aborted = true
-        })
+        }, { once: true })
         return new Promise((resolve) => {
           setTimeout(() => {
             resolve()

--- a/packages/platform-browser/src/internal/http/client.ts
+++ b/packages/platform-browser/src/internal/http/client.ts
@@ -43,7 +43,7 @@ export const makeXMLHttpRequest = Client.makeDefault((request, url, signal, fibe
     signal.addEventListener("abort", () => {
       xhr.abort()
       xhr.onreadystatechange = null
-    })
+    }, { once: true })
     xhr.open(request.method, url.toString(), true)
     xhr.responseType = fiber.getFiberRef(currentXHRResponseType)
     Object.entries(request.headers).forEach(([k, v]) => {

--- a/packages/platform-bun/src/internal/http/server.ts
+++ b/packages/platform-bun/src/internal/http/server.ts
@@ -102,7 +102,7 @@ export const make = (
                   ))
                   request.signal.addEventListener("abort", () => {
                     runFork(fiber.interruptAsFork(Error.clientAbortFiberId))
-                  })
+                  }, { once: true })
                 })
               }
               handlerStack.push(handler)

--- a/packages/platform/src/Http/App.ts
+++ b/packages/platform/src/Http/App.ts
@@ -155,7 +155,7 @@ export const toWebHandlerRuntime = <R>(runtime: Runtime.Runtime<R>) => {
         const fiber = run(Effect.provideService(handled, ServerRequest.ServerRequest, req))
         request.signal.addEventListener("abort", () => {
           fiber.unsafeInterruptAsFork(ServerError.clientAbortFiberId)
-        })
+        }, { once: true })
       })
   }
 }


### PR DESCRIPTION
…oller` to automatically remove handlers after execution

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
