### PR TITLE
feat: allow point-free usage of Schema.make constructors

### DIFF
--- a/.changeset/young-guests-live.md
+++ b/.changeset/young-guests-live.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Point-free usage of Schema.make constructors

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -2363,9 +2363,9 @@ const makeTypeLiteralClass = <
 
     static records = [...records] as Records
 
-    static make(
+    static make = (
       props: Types.Simplify<TypeLiteral.Constructor<Fields, Records>>
-    ): Types.Simplify<TypeLiteral.Type<Fields, Records>> {
+    ): Types.Simplify<TypeLiteral.Type<Fields, Records>> => {
       return ParseResult.validateSync(this)(lazilyMergeDefaults(fields, { ...props as any }))
     }
   }
@@ -2528,7 +2528,7 @@ const makeBrandClass = <S extends Schema.Any, B extends string | symbol>(ast: AS
       return makeBrandClass(AST.annotations(this.ast, toASTAnnotations(annotations)))
     }
 
-    static make(a: Brand.Unbranded<Schema.Type<S> & Brand<B>>): Schema.Type<S> & Brand<B> {
+    static make = (a: Brand.Unbranded<Schema.Type<S> & Brand<B>>): Schema.Type<S> & Brand<B> => {
       return ParseResult.validateSync(this)(a)
     }
   }
@@ -2914,7 +2914,7 @@ const makeRefineClass = <From extends Schema.Any, A>(
 
     static filter = filter
 
-    static make(a: Schema.Type<From>): A {
+    static make = (a: Schema.Type<From>): A => {
       return ParseResult.validateSync(this)(a)
     }
   }

--- a/packages/schema/test/TestUtils.ts
+++ b/packages/schema/test/TestUtils.ts
@@ -81,20 +81,26 @@ export const effectify = <A, I>(schema: S.Schema<A, I, never>): S.Schema<A, I, n
   S.make(effectifyAST(schema.ast))
 
 export const expectConstructorSuccess = <A, B>(
-  schema: { readonly make: (a: A) => B },
+  // Destructure to verify that "this" type is bound
+  { make }: { readonly make: (a: A) => B },
   input: A,
   expected: A = input
 ) => {
   try {
-    expect(schema.make(input)).toStrictEqual(expected)
+    expect(make(input)).toStrictEqual(expected)
   } catch (e: any) {
     assert.fail(e.message)
   }
 }
 
-export const expectConstructorFailure = <A, B>(schema: { readonly make: (a: A) => B }, input: A, message: string) => {
+export const expectConstructorFailure = <A, B>(
+  // Destructure to verify that "this" type is bound
+  { make }: { readonly make: (a: A) => B },
+  input: A,
+  message: string
+) => {
   try {
-    schema.make(input)
+    make(input)
     assert.fail("expected to throw an error")
   } catch (e: any) {
     expect(e.message).toStrictEqual(message)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Enables the ability to utilize the various `Schema.make` constructors without worry of capturing the correct `this` context

