### PR TITLE
Add onNoneEncoding to schema.optional

### DIFF
--- a/.changeset/chilled-owls-tap.md
+++ b/.changeset/chilled-owls-tap.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Add onNoneEncoding for Schema.optional used with {as: "Option"}

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -4,6 +4,7 @@ import * as S from "@effect/schema/Schema"
 import * as Brand from "effect/Brand"
 import { hole, identity, pipe } from "effect/Function"
 import * as N from "effect/Number"
+import * as Option from "effect/Option"
 import * as Str from "effect/String"
 import type { Simplify } from "effect/Types"
 
@@ -606,17 +607,39 @@ S.asSchema(S.Struct({ a: S.String.pipe(S.optional({ exact: true })) }))
 S.Struct({ a: S.String.pipe(S.optional({ exact: true })) })
 
 // ---------------------------------------------
-// optional()
+// optional - Errors
 // ---------------------------------------------
 
 // @ts-expect-error
 S.optional(S.String, { as: "Option", default: () => "" })
 
 // @ts-expect-error
+S.optional(S.String, { as: "Option", exact: true, onNoneEncoding: () => Option.some(null) })
+
+// @ts-expect-error
+S.String.pipe(S.optional({ as: "Option", exact: true, onNoneEncoding: () => Option.some(null) }))
+
+// @ts-expect-error
+S.optional(S.String, { as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) })
+
+// @ts-expect-error
+S.String.pipe(S.optional({ as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) }))
+
+// @ts-expect-error
+S.optional(S.String, { as: "Option", nullable: true, onNoneEncoding: () => Option.some(1) })
+
+// @ts-expect-error
+S.String.pipe(S.optional({ as: "Option", nullable: true, onNoneEncoding: () => Option.some(1) }))
+
+// @ts-expect-error
 S.optional(S.String, { as: null })
 
 // @ts-expect-error
 S.optional(S.String, { default: null })
+
+// ---------------------------------------------
+// optional()
+// ---------------------------------------------
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, { readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean) }))

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -623,6 +623,12 @@ S.String.pipe(S.optional({ as: "Option", exact: true, onNoneEncoding: () => Opti
 S.optional(S.String, { as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) })
 
 // @ts-expect-error
+S.optional(S.String, { as: "Option", onNoneEncoding: () => Option.some(null) })
+
+// @ts-expect-error
+S.String.pipe(S.optional({ as: "Option", onNoneEncoding: () => Option.some(null) }))
+
+// @ts-expect-error
 S.String.pipe(S.optional({ as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) }))
 
 // @ts-expect-error

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1871,7 +1871,14 @@ export const optional: {
       readonly as: "Option"
       readonly default?: never
       readonly exact?: true
-      readonly nullable?: true
+      readonly nullable?: never
+      readonly onNoneEncoding?: undefined
+    } | {
+      readonly as: "Option"
+      readonly default?: never
+      readonly exact?: true
+      readonly nullable: true
+      readonly onNoneEncoding?: null | undefined
     } | undefined
   >(
     options?: Options
@@ -1889,7 +1896,7 @@ export const optional: {
       | (Types.Has<Options, "as"> extends true ? option_.Option<A> : A)
       | (Types.Has<Options, "as" | "default" | "exact"> extends true ? never : undefined),
       never,
-      "?:",
+      Types.Has<Options, "onNoneEncoding"> extends true ? ":" : "?:",
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),
@@ -1914,7 +1921,14 @@ export const optional: {
       readonly as: "Option"
       readonly default?: never
       readonly exact?: true
-      readonly nullable?: true
+      readonly nullable?: never
+      readonly onNoneEncoding?: undefined
+    } | {
+      readonly as: "Option"
+      readonly default?: never
+      readonly exact?: true
+      readonly nullable: true
+      readonly onNoneEncoding?: null | undefined
     } | undefined
   >(
     schema: Schema<A, I, R>,
@@ -1933,7 +1947,7 @@ export const optional: {
       | (Types.Has<Options, "as"> extends true ? option_.Option<A> : A)
       | (Types.Has<Options, "as" | "default" | "exact"> extends true ? never : undefined),
       never,
-      "?:",
+      Types.Has<Options, "onNoneEncoding"> extends true ? ":" : "?:",
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1872,13 +1872,13 @@ export const optional: {
       readonly default?: never
       readonly exact?: never
       readonly nullable?: never
-      readonly onNoneEncoding?: undefined
+      readonly onNoneEncoding?: option_.Option<undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact?: never
       readonly nullable: true
-      readonly onNoneEncoding?: null | undefined
+      readonly onNoneEncoding?: option_.Option<null | undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
@@ -1890,7 +1890,7 @@ export const optional: {
       readonly default?: never
       readonly exact: true
       readonly nullable: true
-      readonly onNoneEncoding?: null
+      readonly onNoneEncoding?: option_.Option<null>
     } | undefined
   >(
     options?: Options
@@ -1934,13 +1934,13 @@ export const optional: {
       readonly default?: never
       readonly exact?: never
       readonly nullable?: never
-      readonly onNoneEncoding?: undefined
+      readonly onNoneEncoding?: option_.Option<undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact?: never
       readonly nullable: true
-      readonly onNoneEncoding?: null | undefined
+      readonly onNoneEncoding?: option_.Option<null | undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
@@ -1952,7 +1952,7 @@ export const optional: {
       readonly default?: never
       readonly exact: true
       readonly nullable: true
-      readonly onNoneEncoding?: null
+      readonly onNoneEncoding?: option_.Option<null>
     } | undefined
   >(
     schema: Schema<A, I, R>,
@@ -1985,13 +1985,14 @@ export const optional: {
     readonly default?: () => A
     readonly nullable?: true
     readonly as?: "Option"
-    readonly onNoneEncoding?: null | undefined
+    readonly onNoneEncoding?: option_.Option<null | undefined>
   }
 ): PropertySignature<any, any, never, any, any, boolean, any> => {
   const isExact = options?.exact
   const defaultValue = options?.default
   const isNullable = options?.nullable
   const asOption = options?.as == "Option"
+  const onNoneEncoding = options?.onNoneEncoding ?? option_.none()
 
   if (isExact) {
     if (defaultValue) {
@@ -2024,12 +2025,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter(Predicate.isNotNull<A | null>),
-            encode: (t) => {
-              if ("onNoneEncoding" in options) {
-                return option_.orElse(t, () => option_.some(options.onNoneEncoding as null))
-              }
-              return t
-            }
+            encode: option_.orElse(() => onNoneEncoding as option_.Option<null>)
           }
         )
       } else {
@@ -2084,12 +2080,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter<A | null | undefined, A>((a): a is A => a != null),
-            encode: (t) => {
-              if ("onNoneEncoding" in options) {
-                return option_.orElse(t, () => option_.some(options.onNoneEncoding))
-              }
-              return t
-            }
+            encode: option_.orElse(() => onNoneEncoding)
           }
         )
       } else {
@@ -2098,12 +2089,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter(Predicate.isNotUndefined<A | undefined>),
-            encode: (t) => {
-              if ("onNoneEncoding" in options) {
-                return option_.orElse(t, () => option_.some(options.onNoneEncoding as undefined))
-              }
-              return t
-            }
+            encode: option_.orElse(() => onNoneEncoding as option_.Option<undefined>)
           }
         )
       }

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1971,7 +1971,7 @@ export const optional: {
       | (Types.Has<Options, "as"> extends true ? option_.Option<A> : A)
       | (Types.Has<Options, "as" | "default" | "exact"> extends true ? never : undefined),
       never,
-      Types.Has<Options, "onNoneEncoding"> extends true ? ":" : "?:",
+      "?:",
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1872,25 +1872,25 @@ export const optional: {
       readonly default?: never
       readonly exact?: never
       readonly nullable?: never
-      readonly onNoneEncoding?: option_.Option<undefined>
+      readonly onNoneEncoding?: () => option_.Option<undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact?: never
       readonly nullable: true
-      readonly onNoneEncoding?: option_.Option<null | undefined>
+      readonly onNoneEncoding?: () => option_.Option<null | undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact: true
       readonly nullable?: never
-      readonly onNoneEncoding?: never
+      readonly onNoneEncoding?: () => never
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact: true
       readonly nullable: true
-      readonly onNoneEncoding?: option_.Option<null>
+      readonly onNoneEncoding?: () => option_.Option<null>
     } | undefined
   >(
     options?: Options
@@ -1934,25 +1934,25 @@ export const optional: {
       readonly default?: never
       readonly exact?: never
       readonly nullable?: never
-      readonly onNoneEncoding?: option_.Option<undefined>
+      readonly onNoneEncoding?: () => option_.Option<undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact?: never
       readonly nullable: true
-      readonly onNoneEncoding?: option_.Option<null | undefined>
+      readonly onNoneEncoding?: () => option_.Option<null | undefined>
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact: true
       readonly nullable?: never
-      readonly onNoneEncoding?: never
+      readonly onNoneEncoding?: () => never
     } | {
       readonly as: "Option"
       readonly default?: never
       readonly exact: true
       readonly nullable: true
-      readonly onNoneEncoding?: option_.Option<null>
+      readonly onNoneEncoding?: () => option_.Option<null>
     } | undefined
   >(
     schema: Schema<A, I, R>,
@@ -1985,14 +1985,14 @@ export const optional: {
     readonly default?: () => A
     readonly nullable?: true
     readonly as?: "Option"
-    readonly onNoneEncoding?: option_.Option<null | undefined>
+    readonly onNoneEncoding?: () => option_.Option<null | undefined>
   }
 ): PropertySignature<any, any, never, any, any, boolean, any> => {
   const isExact = options?.exact
   const defaultValue = options?.default
   const isNullable = options?.nullable
   const asOption = options?.as == "Option"
-  const onNoneEncoding = options?.onNoneEncoding ?? option_.none()
+  const onNoneEncoding = options?.onNoneEncoding ?? option_.none
 
   if (isExact) {
     if (defaultValue) {
@@ -2025,7 +2025,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter(Predicate.isNotNull<A | null>),
-            encode: option_.orElse(() => onNoneEncoding as option_.Option<null>)
+            encode: option_.orElse(onNoneEncoding as () => option_.Option<null>)
           }
         )
       } else {
@@ -2080,7 +2080,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter<A | null | undefined, A>((a): a is A => a != null),
-            encode: option_.orElse(() => onNoneEncoding)
+            encode: option_.orElse(onNoneEncoding)
           }
         )
       } else {
@@ -2089,7 +2089,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter(Predicate.isNotUndefined<A | undefined>),
-            encode: option_.orElse(() => onNoneEncoding as option_.Option<undefined>)
+            encode: option_.orElse(onNoneEncoding as () => option_.Option<undefined>)
           }
         )
       }

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1870,15 +1870,27 @@ export const optional: {
     } | {
       readonly as: "Option"
       readonly default?: never
-      readonly exact?: true
+      readonly exact?: never
       readonly nullable?: never
       readonly onNoneEncoding?: undefined
     } | {
       readonly as: "Option"
       readonly default?: never
-      readonly exact?: true
+      readonly exact?: never
       readonly nullable: true
       readonly onNoneEncoding?: null | undefined
+    } | {
+      readonly as: "Option"
+      readonly default?: never
+      readonly exact: true
+      readonly nullable?: never
+      readonly onNoneEncoding?: never
+    } | {
+      readonly as: "Option"
+      readonly default?: never
+      readonly exact: true
+      readonly nullable: true
+      readonly onNoneEncoding?: null
     } | undefined
   >(
     options?: Options
@@ -1920,15 +1932,27 @@ export const optional: {
     } | {
       readonly as: "Option"
       readonly default?: never
-      readonly exact?: true
+      readonly exact?: never
       readonly nullable?: never
       readonly onNoneEncoding?: undefined
     } | {
       readonly as: "Option"
       readonly default?: never
-      readonly exact?: true
+      readonly exact?: never
       readonly nullable: true
       readonly onNoneEncoding?: null | undefined
+    } | {
+      readonly as: "Option"
+      readonly default?: never
+      readonly exact: true
+      readonly nullable?: never
+      readonly onNoneEncoding?: never
+    } | {
+      readonly as: "Option"
+      readonly default?: never
+      readonly exact: true
+      readonly nullable: true
+      readonly onNoneEncoding?: null
     } | undefined
   >(
     schema: Schema<A, I, R>,
@@ -1998,7 +2022,15 @@ export const optional: {
         return optionalToRequired(
           NullOr(schema),
           OptionFromSelf(typeSchema(schema)),
-          { decode: option_.filter(Predicate.isNotNull<A | null>), encode: identity }
+          {
+            decode: option_.filter(Predicate.isNotNull<A | null>),
+            encode: (t) => {
+              if ("onNoneEncoding" in options) {
+                return option_.orElse(t, () => option_.some(options.onNoneEncoding as null))
+              }
+              return t
+            }
+          }
         )
       } else {
         return optionalToRequired(

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1985,14 +1985,14 @@ export const optional: {
     readonly default?: () => A
     readonly nullable?: true
     readonly as?: "Option"
-    readonly onNoneEncoding?: () => option_.Option<null | undefined>
+    readonly onNoneEncoding?: () => option_.Option<never>
   }
 ): PropertySignature<any, any, never, any, any, boolean, any> => {
   const isExact = options?.exact
   const defaultValue = options?.default
   const isNullable = options?.nullable
   const asOption = options?.as == "Option"
-  const onNoneEncoding = options?.onNoneEncoding ?? option_.none
+  const asOptionEncode = options?.onNoneEncoding ? option_.orElse(options.onNoneEncoding) : identity
 
   if (isExact) {
     if (defaultValue) {
@@ -2025,7 +2025,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter(Predicate.isNotNull<A | null>),
-            encode: option_.orElse(onNoneEncoding as () => option_.Option<null>)
+            encode: asOptionEncode
           }
         )
       } else {
@@ -2080,7 +2080,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter<A | null | undefined, A>((a): a is A => a != null),
-            encode: option_.orElse(onNoneEncoding)
+            encode: asOptionEncode
           }
         )
       } else {
@@ -2089,7 +2089,7 @@ export const optional: {
           OptionFromSelf(typeSchema(schema)),
           {
             decode: option_.filter(Predicate.isNotUndefined<A | undefined>),
-            encode: option_.orElse(onNoneEncoding as () => option_.Option<undefined>)
+            encode: asOptionEncode
           }
         )
       }

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1884,7 +1884,7 @@ export const optional: {
       readonly default?: never
       readonly exact: true
       readonly nullable?: never
-      readonly onNoneEncoding?: () => never
+      readonly onNoneEncoding?: never
     } | {
       readonly as: "Option"
       readonly default?: never
@@ -1946,7 +1946,7 @@ export const optional: {
       readonly default?: never
       readonly exact: true
       readonly nullable?: never
-      readonly onNoneEncoding?: () => never
+      readonly onNoneEncoding?: never
     } | {
       readonly as: "Option"
       readonly default?: never

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1908,7 +1908,7 @@ export const optional: {
       | (Types.Has<Options, "as"> extends true ? option_.Option<A> : A)
       | (Types.Has<Options, "as" | "default" | "exact"> extends true ? never : undefined),
       never,
-      Types.Has<Options, "onNoneEncoding"> extends true ? ":" : "?:",
+      "?:",
       | I
       | (Types.Has<Options, "nullable"> extends true ? null : never)
       | (Types.Has<Options, "exact"> extends true ? never : undefined),

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -212,10 +212,15 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optionalToOption > { exact: true, nullable: true, as: "Option", onNoneEncoding: O.some(null) }`, () => {
+  describe(`optionalToOption > { exact: true, nullable: true, as: "Option", onNoneEncoding: () => O.some(null) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { exact: true, nullable: true, as: "Option", onNoneEncoding: O.some(null) })
+        a: S.optional(S.NumberFromString, {
+          exact: true,
+          nullable: true,
+          as: "Option",
+          onNoneEncoding: () => O.some(null)
+        })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: null }, { a: O.none() })
@@ -306,10 +311,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optional > { as: "Option", onNoneEncoding: O.some(undefined) }`, () => {
+  describe(`optional > { as: "Option", onNoneEncoding: () => O.some(undefined) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { as: "Option", onNoneEncoding: O.some(undefined) })
+        a: S.optional(S.NumberFromString, { as: "Option", onNoneEncoding: () => O.some(undefined) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
@@ -352,10 +357,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: O.some(undefined) }`, () => {
+  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: () => O.some(undefined) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: O.some(undefined) })
+        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: () => O.some(undefined) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
@@ -386,10 +391,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: O.some(null) }`, () => {
+  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: () => O.some(null) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: O.some(null) })
+        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: () => O.some(null) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -212,10 +212,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optionalToOption > { exact: true, nullable: true, as: "Option", onNoneEncoding: null }`, () => {
+  describe(`optionalToOption > { exact: true, nullable: true, as: "Option", onNoneEncoding: O.some(null) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { exact: true, nullable: true, as: "Option", onNoneEncoding: null })
+        a: S.optional(S.NumberFromString, { exact: true, nullable: true, as: "Option", onNoneEncoding: O.some(null) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: null }, { a: O.none() })
@@ -306,10 +306,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optional > { as: "Option", onNoneEncoding: undefined }`, () => {
+  describe(`optional > { as: "Option", onNoneEncoding: O.some(undefined) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { as: "Option", onNoneEncoding: undefined })
+        a: S.optional(S.NumberFromString, { as: "Option", onNoneEncoding: O.some(undefined) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
@@ -352,10 +352,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: undefined }`, () => {
+  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: O.some(undefined) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: undefined })
+        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: O.some(undefined) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
@@ -386,10 +386,10 @@ describe("optional APIs", () => {
     })
   })
 
-  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: null }`, () => {
+  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: O.some(null) }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({
-        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: null })
+        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: O.some(null) })
       })
       await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
       await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -275,6 +275,120 @@ describe("optional APIs", () => {
     })
   })
 
+  describe(`optional > { as: "Option", onNoneEncoding: undefined }`, () => {
+    it("decoding / encoding", async () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { as: "Option", onNoneEncoding: undefined })
+      })
+      await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: O.some(1) })
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        { a: null },
+        `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ NumberFromString | undefined
+            ├─ Union member
+            │  └─ NumberFromString
+            │     └─ Encoded side transformation failure
+            │        └─ Expected a string, actual null
+            └─ Union member
+               └─ Expected undefined, actual null`
+      )
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        {
+          a: "a"
+        },
+        `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ NumberFromString | undefined
+            ├─ Union member
+            │  └─ NumberFromString
+            │     └─ Transformation process failure
+            │        └─ Expected NumberFromString, actual "a"
+            └─ Union member
+               └─ Expected undefined, actual "a"`
+      )
+
+      await Util.expectEncodeSuccess(schema, { a: O.some(1) }, { a: "1" })
+      await Util.expectEncodeSuccess(schema, { a: O.none() }, { a: undefined })
+    })
+  })
+
+  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: undefined }`, () => {
+    it("decoding / encoding", async () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: undefined })
+      })
+      await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: null }, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: O.some(1) })
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        {
+          a: "a"
+        },
+        `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ NumberFromString | null | undefined
+            ├─ Union member
+            │  └─ NumberFromString
+            │     └─ Transformation process failure
+            │        └─ Expected NumberFromString, actual "a"
+            ├─ Union member
+            │  └─ Expected null, actual "a"
+            └─ Union member
+               └─ Expected undefined, actual "a"`
+      )
+
+      await Util.expectEncodeSuccess(schema, { a: O.some(1) }, { a: "1" })
+      await Util.expectEncodeSuccess(schema, { a: O.none() }, { a: undefined })
+    })
+  })
+
+  describe(`optional > { nullable: true, as: "Option", onNoneEncoding: null }`, () => {
+    it("decoding / encoding", async () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { nullable: true, as: "Option", onNoneEncoding: null })
+      })
+      await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: null }, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: O.some(1) })
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        {
+          a: "a"
+        },
+        `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ NumberFromString | null | undefined
+            ├─ Union member
+            │  └─ NumberFromString
+            │     └─ Transformation process failure
+            │        └─ Expected NumberFromString, actual "a"
+            ├─ Union member
+            │  └─ Expected null, actual "a"
+            └─ Union member
+               └─ Expected undefined, actual "a"`
+      )
+
+      await Util.expectEncodeSuccess(schema, { a: O.some(1) }, { a: "1" })
+      await Util.expectEncodeSuccess(schema, { a: O.none() }, { a: null })
+    })
+  })
+
   describe("optional > { exact: true, default: () => A }", () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -212,6 +212,37 @@ describe("optional APIs", () => {
     })
   })
 
+  describe(`optionalToOption > { exact: true, nullable: true, as: "Option", onNoneEncoding: null }`, () => {
+    it("decoding / encoding", async () => {
+      const schema = S.Struct({
+        a: S.optional(S.NumberFromString, { exact: true, nullable: true, as: "Option", onNoneEncoding: null })
+      })
+      await Util.expectDecodeUnknownSuccess(schema, {}, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: null }, { a: O.none() })
+      await Util.expectDecodeUnknownSuccess(schema, { a: "1" }, { a: O.some(1) })
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        {
+          a: "a"
+        },
+        `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ NumberFromString | null
+            ├─ Union member
+            │  └─ NumberFromString
+            │     └─ Transformation process failure
+            │        └─ Expected NumberFromString, actual "a"
+            └─ Union member
+               └─ Expected null, actual "a"`
+      )
+
+      await Util.expectEncodeSuccess(schema, { a: O.some(1) }, { a: "1" })
+      await Util.expectEncodeSuccess(schema, { a: O.none() }, { a: null })
+    })
+  })
+
   describe(`optional > { as: "Option" }`, () => {
     it("decoding / encoding", async () => {
       const schema = S.Struct({ a: S.optional(S.NumberFromString, { as: "Option" }) })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
This adds `onNoneEncoding` option to `schema.optiona` when used with `{as: "Option"}`. I took inspiration from `OptionFromNullishOr`

Without `onNoneEncoding`, the prop gets removed from the containing Struct
```typescript
const schema = S.Struct({
  a: S.optional(S.String, { as: "Option")
})
S.encode(schema)({ a: O.none() }) // => {}
```

With `onNoneEncoding`, the prop is kept with the value being the value of `onNoneEncoding`
```typescript
const schema = S.Struct({
  a: S.optional(S.String, { as: "Option", onNoneEncoding: undefined })
})
S.encode(schema)({ a: O.none() }) // => { a: undefined }
```
## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

N/A