### PR TITLE
Replace Postgres.js parsed options in `PgClient.config`

### DIFF
--- a/.changeset/pretty-cobras-buy.md
+++ b/.changeset/pretty-cobras-buy.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Replace Postgres.js parsed options in `PgClient.config`

--- a/packages/sql-pg/src/Client.ts
+++ b/packages/sql-pg/src/Client.ts
@@ -207,7 +207,14 @@ export const make = (
       }),
       {
         [TypeId]: TypeId as TypeId,
-        config: options,
+        config: {
+          ...options,
+          host: client.options.host[0] ?? undefined,
+          port: client.options.port[0] ?? undefined,
+          username: client.options.user,
+          password: client.options.pass ? Secret.fromString(client.options.pass) : undefined,
+          database: client.options.database
+        },
         json: (_: unknown) => PgJson(_),
         array: (_: ReadonlyArray<Primitive>) => PgArray(_)
       }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This PR replaces the connection-related values in `PgClient.config` with the corresponding values parsed by Postgres.js from the connection string (`postgresql://postgres:postgres@127.0.0.1:5432/postgres`) and the connection parameters (`{ host: "127.0.0.1", port: "5432", ... }`).

Currently, the connection string is ignored by the `Migrator` in `@effect/sql-pg`, only connection parameters are passed to pg_dump. This PR addresses the issue.

In Postgres.js values specified in the connection string are overwritten by connection parameters.
In pg_dump values specified in the connection string overwrite connection parameters.
This solutions ensures the Postgres.js and pg_dump connections are consistent, by using the values computed by Postgres.js for both tools.