### PR TITLE
Harmonize Schema.OptionFromNullishOr signature

### DIFF
--- a/.changeset/fifty-beans-hope.md
+++ b/.changeset/fifty-beans-hope.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Harmonize OptionFromNullishOr signature

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1944,10 +1944,10 @@ S.OptionFromUndefinedOr(S.NumberFromString)
 // ---------------------------------------------
 
 // $ExpectType Schema<Option<number>, string | null | undefined, never>
-S.asSchema(S.OptionFromNullishOr(S.NumberFromString, null))
+S.asSchema(S.OptionFromNullishOr(S.NumberFromString, { onNoneEncoding: () => null }))
 
 // $ExpectType OptionFromNullishOr<typeof NumberFromString>
-S.OptionFromNullishOr(S.NumberFromString, undefined)
+S.OptionFromNullishOr(S.NumberFromString, { onNoneEncoding: () => undefined })
 
 // ---------------------------------------------
 // EitherFromSelf

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -5606,13 +5606,13 @@ export interface OptionFromNullishOr<Value extends Schema.Any> extends
  */
 export const OptionFromNullishOr = <Value extends Schema.Any>(
   value: Value,
-  onNoneEncoding: null | undefined
+  options: { onNoneEncoding: () => null | undefined }
 ): OptionFromNullishOr<Value> => {
   const value_ = asSchema(value)
   return transform(
     NullishOr(value_),
     OptionFromSelf(typeSchema(value_)),
-    { decode: option_.fromNullable, encode: onNoneEncoding === null ? option_.getOrNull : option_.getOrUndefined }
+    { decode: option_.fromNullable, encode: option_.getOrElse(options.onNoneEncoding) }
   )
 }
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -5606,7 +5606,7 @@ export interface OptionFromNullishOr<Value extends Schema.Any> extends
  */
 export const OptionFromNullishOr = <Value extends Schema.Any>(
   value: Value,
-  options: { onNoneEncoding: () => null | undefined }
+  options: { onNoneEncoding: LazyArg<null | undefined> }
 ): OptionFromNullishOr<Value> => {
   const value_ = asSchema(value)
   return transform(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
This harmonizes the second argument of `Schema.OptionFromNullishOr` with the rest of the code base:
- Make the second argument a named argument
- Make onNoneEncoding a lasy argument

This follows [this discussion](https://discordapp.com/channels/795981131316985866/1242189617352937524/1242365827395747943) and this [P.R. comment](https://github.com/Effect-TS/effect/pull/2772#issuecomment-2118882488).


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
N/A
