### PR TITLE
Avoid eager read of the stack when captured by a span

### DIFF
--- a/.changeset/gorgeous-ties-tan.md
+++ b/.changeset/gorgeous-ties-tan.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Avoid eager read of the stack when captured by a span

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -5,6 +5,7 @@ import type * as Context from "./Context.js"
 import type * as Effect from "./Effect.js"
 import type * as Exit from "./Exit.js"
 import type * as Fiber from "./Fiber.js"
+import type { LazyArg } from "./Function.js"
 import * as defaultServices from "./internal/defaultServices.js"
 import * as internal from "./internal/tracer.js"
 import type * as Option from "./Option.js"
@@ -92,7 +93,7 @@ export interface SpanOptions {
   readonly root?: boolean | undefined
   readonly context?: Context.Context<never> | undefined
   readonly kind?: SpanKind | undefined
-  readonly captureStackTrace?: boolean | string | undefined
+  readonly captureStackTrace?: boolean | LazyArg<string | undefined> | undefined
 }
 
 /**

--- a/packages/effect/src/internal/tracer.ts
+++ b/packages/effect/src/internal/tracer.ts
@@ -118,12 +118,20 @@ export const addSpanStackTrace = (options: Tracer.SpanOptions | undefined): Trac
   Error.stackTraceLimit = 3
   const traceError = new Error()
   Error.stackTraceLimit = limit
-  if (traceError.stack === undefined) {
-    return { ...options, captureStackTrace: false }
+  let cache: false | string = false
+  return {
+    ...options,
+    captureStackTrace: () => {
+      if (cache !== false) {
+        return cache
+      }
+      if (traceError.stack !== undefined) {
+        const stack = traceError.stack.split("\n")
+        if (stack[3] !== undefined) {
+          cache = stack[3].trim()
+          return cache
+        }
+      }
+    }
   }
-  const stack = traceError.stack.split("\n")
-  if (!stack[3]) {
-    return { ...options, captureStackTrace: false }
-  }
-  return { ...options, captureStackTrace: stack[3].trim() }
 }


### PR DESCRIPTION
This is technically breaking but I'm of the opinion that the previous behaviour is a bug