### PR TITLE
fix internal cutpoint name preservation

### DIFF
--- a/.changeset/strange-carrots-punch.md
+++ b/.changeset/strange-carrots-punch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix internal cutpoint name preservation

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -803,10 +803,3 @@ const tracingFunction = (name: string) => {
  * @category tracing
  */
 export const internalCall = tracingFunction("effect_internal_function")
-
-/**
- * @since 3.2.2
- * @status experimental
- * @category tracing
- */
-export const internalCallGenerator = tracingFunction("effect_internal_generator")

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -786,9 +786,15 @@ export const structuralRegion = <A>(body: () => A, tester?: (a: unknown, b: unkn
 }
 
 const tracingFunction = (name: string) => {
-  const internalCall = <A>(body: () => A): A => body()
-  Object.defineProperty(internalCall, "name", { value: name })
-  return internalCall
+  class Wrap {
+    [name]<A>(body: () => A) {
+      return body()
+    }
+  }
+  const wrap = new Wrap()
+  return function<A>(fn: () => A): A {
+    return (wrap as any)[name](fn)
+  }
 }
 
 /**
@@ -796,11 +802,11 @@ const tracingFunction = (name: string) => {
  * @status experimental
  * @category tracing
  */
-export const effect_internal_function = tracingFunction("effect_internal_function")
+export const internalCall = tracingFunction("effect_internal_function")
 
 /**
  * @since 3.2.2
  * @status experimental
  * @category tracing
  */
-export const effect_internal_generator = tracingFunction("effect_internal_generator")
+export const internalCallGenerator = tracingFunction("effect_internal_generator")

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -786,14 +786,13 @@ export const structuralRegion = <A>(body: () => A, tester?: (a: unknown, b: unkn
 }
 
 const tracingFunction = (name: string) => {
-  class Wrap {
+  const wrap = {
     [name]<A>(body: () => A) {
       return body()
     }
   }
-  const wrap = new Wrap()
   return function<A>(fn: () => A): A {
-    return (wrap as any)[name](fn)
+    return wrap[name](fn)
   }
 }
 

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -1061,12 +1061,10 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
   const lines = stack.split("\n")
 
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i].includes("effect_internal_function")) {
-      out.pop()
+    if (lines[i].includes("Generator.next")) {
       break
     }
-    if (lines[i].includes("effect_internal_generator")) {
-      out.pop()
+    if (lines[i].includes("effect_internal_function")) {
       out.pop()
       break
     }

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -1,4 +1,4 @@
-import { internalCall, internalCallGenerator } from "effect/Utils"
+import { internalCall } from "effect/Utils"
 import * as Arr from "../Array.js"
 import type * as Cause from "../Cause.js"
 import * as Chunk from "../Chunk.js"
@@ -772,7 +772,7 @@ export const gen: typeof Effect.gen = function() {
   }
   return core.suspend(() => {
     const iterator = f(pipe)
-    const state = internalCallGenerator(() => iterator.next())
+    const state = internalCall(() => iterator.next())
     const run = (
       state: IteratorYieldResult<any> | IteratorReturnResult<any>
     ): Effect.Effect<any, any, any> => {
@@ -780,7 +780,7 @@ export const gen: typeof Effect.gen = function() {
         ? core.succeed(state.value)
         : core.flatMap(
           yieldWrapGet(state.value) as any,
-          (val: any) => run(internalCallGenerator(() => iterator.next(val)))
+          (val: any) => run(internalCall(() => iterator.next(val)))
         ))
     }
     return run(state)

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -1,4 +1,4 @@
-import { effect_internal_function, effect_internal_generator } from "effect/Utils"
+import { internalCall, internalCallGenerator } from "effect/Utils"
 import * as Arr from "../Array.js"
 import type * as Cause from "../Cause.js"
 import * as Chunk from "../Chunk.js"
@@ -772,7 +772,7 @@ export const gen: typeof Effect.gen = function() {
   }
   return core.suspend(() => {
     const iterator = f(pipe)
-    const state = effect_internal_generator(() => iterator.next())
+    const state = internalCallGenerator(() => iterator.next())
     const run = (
       state: IteratorYieldResult<any> | IteratorReturnResult<any>
     ): Effect.Effect<any, any, any> => {
@@ -780,7 +780,7 @@ export const gen: typeof Effect.gen = function() {
         ? core.succeed(state.value)
         : core.flatMap(
           yieldWrapGet(state.value) as any,
-          (val: any) => run(effect_internal_generator(() => iterator.next(val)))
+          (val: any) => run(internalCallGenerator(() => iterator.next(val)))
         ))
     }
     return run(state)
@@ -2185,7 +2185,7 @@ export const functionWithSpan = <Args extends Array<any>, Ret extends Effect.Eff
         ? options.options.apply(null, arguments as any)
         : options.options
       return withSpan(
-        core.suspend(() => effect_internal_function(() => options.body.apply(this, arguments as any))),
+        core.suspend(() => internalCall(() => options.body.apply(this, arguments as any))),
         opts.name,
         {
           ...opts,

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -1,4 +1,4 @@
-import { effect_internal_function } from "effect/Utils"
+import { internalCall } from "effect/Utils"
 import * as Arr from "../Array.js"
 import type * as Cause from "../Cause.js"
 import * as Chunk from "../Chunk.js"
@@ -534,9 +534,9 @@ export const async = <A, E = never, R = never>(
     let controllerRef: AbortController | void = undefined
     if (this.effect_instruction_i0.length !== 1) {
       controllerRef = new AbortController()
-      cancelerRef = effect_internal_function(() => this.effect_instruction_i0(proxyResume, controllerRef!.signal))
+      cancelerRef = internalCall(() => this.effect_instruction_i0(proxyResume, controllerRef!.signal))
     } else {
-      cancelerRef = effect_internal_function(() => (this.effect_instruction_i0 as any)(proxyResume))
+      cancelerRef = internalCall(() => (this.effect_instruction_i0 as any)(proxyResume))
     }
     return (cancelerRef || controllerRef) ?
       onInterrupt(effect, (_) => {
@@ -1007,8 +1007,8 @@ export const interruptibleMask = <A, E, R>(
     effect.effect_instruction_i0 = RuntimeFlagsPatch.enable(_runtimeFlags.Interruption)
     effect.effect_instruction_i1 = (oldFlags: RuntimeFlags.RuntimeFlags) =>
       _runtimeFlags.interruption(oldFlags)
-        ? effect_internal_function(() => this.effect_instruction_i0(interruptible))
-        : effect_internal_function(() => this.effect_instruction_i0(uninterruptible))
+        ? internalCall(() => this.effect_instruction_i0(interruptible))
+        : internalCall(() => this.effect_instruction_i0(uninterruptible))
     return effect
   })
 
@@ -1323,8 +1323,8 @@ export const uninterruptibleMask = <A, E, R>(
     effect.effect_instruction_i0 = RuntimeFlagsPatch.disable(_runtimeFlags.Interruption)
     effect.effect_instruction_i1 = (oldFlags: RuntimeFlags.RuntimeFlags) =>
       _runtimeFlags.interruption(oldFlags)
-        ? effect_internal_function(() => this.effect_instruction_i0(interruptible))
-        : effect_internal_function(() => this.effect_instruction_i0(uninterruptible))
+        ? internalCall(() => this.effect_instruction_i0(interruptible))
+        : internalCall(() => this.effect_instruction_i0(uninterruptible))
     return effect
   })
 

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1,4 +1,4 @@
-import { effect_internal_function } from "effect/Utils"
+import { internalCall } from "effect/Utils"
 import * as RA from "../Array.js"
 import * as Boolean from "../Boolean.js"
 import type * as Cause from "../Cause.js"
@@ -147,7 +147,7 @@ const contOpSuccess = {
     cont: core.OnSuccess,
     value: unknown
   ) => {
-    return effect_internal_function(() => cont.effect_instruction_i1(value))
+    return internalCall(() => cont.effect_instruction_i1(value))
   },
   ["OnStep"]: (
     _: FiberRuntime<any, any>,
@@ -161,7 +161,7 @@ const contOpSuccess = {
     cont: core.OnSuccessAndFailure,
     value: unknown
   ) => {
-    return effect_internal_function(() => cont.effect_instruction_i2(value))
+    return internalCall(() => cont.effect_instruction_i2(value))
   },
   [OpCodes.OP_REVERT_FLAGS]: (
     self: FiberRuntime<any, any>,
@@ -180,10 +180,10 @@ const contOpSuccess = {
     cont: core.While,
     value: unknown
   ) => {
-    effect_internal_function(() => cont.effect_instruction_i2(value))
-    if (effect_internal_function(() => cont.effect_instruction_i0())) {
+    internalCall(() => cont.effect_instruction_i2(value))
+    if (internalCall(() => cont.effect_instruction_i0())) {
       self.pushStack(cont)
-      return effect_internal_function(() => cont.effect_instruction_i1())
+      return internalCall(() => cont.effect_instruction_i1())
     } else {
       return core.void
     }
@@ -1074,7 +1074,7 @@ export class FiberRuntime<in out A, in out E = never> implements Fiber.RuntimeFi
   }
 
   [OpCodes.OP_SYNC](op: core.Primitive & { _op: OpCodes.OP_SYNC }) {
-    const value = effect_internal_function(() => op.effect_instruction_i0())
+    const value = internalCall(() => op.effect_instruction_i0())
     const cont = this.getNextSuccessCont()
     if (cont !== undefined) {
       if (!(cont._op in contOpSuccess)) {
@@ -1113,7 +1113,7 @@ export class FiberRuntime<in out A, in out E = never> implements Fiber.RuntimeFi
         case OpCodes.OP_ON_FAILURE:
         case OpCodes.OP_ON_SUCCESS_AND_FAILURE: {
           if (!(_runtimeFlags.interruptible(this._runtimeFlags) && this.isInterrupted())) {
-            return effect_internal_function(() => cont.effect_instruction_i1(cause))
+            return internalCall(() => cont.effect_instruction_i1(cause))
           } else {
             return core.exitFailCause(internalCause.stripFailures(cause))
           }
@@ -1144,7 +1144,7 @@ export class FiberRuntime<in out A, in out E = never> implements Fiber.RuntimeFi
   }
 
   [OpCodes.OP_WITH_RUNTIME](op: core.Primitive & { _op: OpCodes.OP_WITH_RUNTIME }) {
-    return effect_internal_function(() =>
+    return internalCall(() =>
       op.effect_instruction_i0(
         this as FiberRuntime<unknown, unknown>,
         FiberStatus.running(this._runtimeFlags) as FiberStatus.Running
@@ -1210,7 +1210,7 @@ export class FiberRuntime<in out A, in out E = never> implements Fiber.RuntimeFi
         // Since we updated the flags, we need to revert them
         const revertFlags = _runtimeFlags.diff(newRuntimeFlags, oldRuntimeFlags)
         this.pushStack(new core.RevertFlags(revertFlags, op))
-        return effect_internal_function(() => op.effect_instruction_i1!(oldRuntimeFlags))
+        return internalCall(() => op.effect_instruction_i1!(oldRuntimeFlags))
       } else {
         return core.exitVoid
       }
@@ -1262,7 +1262,7 @@ export class FiberRuntime<in out A, in out E = never> implements Fiber.RuntimeFi
   }
 
   [OpCodes.OP_COMMIT](op: core.Primitive & { _op: OpCodes.OP_COMMIT }) {
-    return effect_internal_function(() => op.commit())
+    return internalCall(() => op.commit())
   }
 
   /**

--- a/packages/effect/src/internal/stm/core.ts
+++ b/packages/effect/src/internal/stm/core.ts
@@ -1,4 +1,4 @@
-import { effect_internal_function } from "effect/Utils"
+import { internalCall } from "effect/Utils"
 import * as Cause from "../../Cause.js"
 import * as Context from "../../Context.js"
 import * as Effect from "../../Effect.js"
@@ -505,17 +505,17 @@ export class STMDriver<in out R, out E, out A> {
             case "Commit": {
               switch (current.effect_instruction_i0) {
                 case OpCodes.OP_DIE: {
-                  exit = TExit.die(effect_internal_function(() => current.effect_instruction_i1()))
+                  exit = TExit.die(internalCall(() => current.effect_instruction_i1()))
                   break
                 }
                 case OpCodes.OP_FAIL: {
                   const cont = this.nextFailure()
                   if (cont === undefined) {
-                    exit = TExit.fail(effect_internal_function(() => current.effect_instruction_i1()))
+                    exit = TExit.fail(internalCall(() => current.effect_instruction_i1()))
                   } else {
-                    curr = effect_internal_function(() =>
+                    curr = internalCall(() =>
                       cont.effect_instruction_i2(
-                        effect_internal_function(() => current.effect_instruction_i1())
+                        internalCall(() => current.effect_instruction_i1())
                       ) as Primitive
                     )
                   }
@@ -526,7 +526,7 @@ export class STMDriver<in out R, out E, out A> {
                   if (cont === undefined) {
                     exit = TExit.retry
                   } else {
-                    curr = effect_internal_function(() => cont.effect_instruction_i2() as Primitive)
+                    curr = internalCall(() => cont.effect_instruction_i2() as Primitive)
                   }
                   break
                 }
@@ -535,7 +535,7 @@ export class STMDriver<in out R, out E, out A> {
                   break
                 }
                 case OpCodes.OP_WITH_STM_RUNTIME: {
-                  curr = effect_internal_function(() =>
+                  curr = internalCall(() =>
                     current.effect_instruction_i1(this as STMDriver<unknown, unknown, unknown>) as Primitive
                   )
                   break
@@ -549,7 +549,7 @@ export class STMDriver<in out R, out E, out A> {
                 }
                 case OpCodes.OP_PROVIDE: {
                   const env = this.env
-                  this.env = effect_internal_function(() => current.effect_instruction_i2(env))
+                  this.env = internalCall(() => current.effect_instruction_i2(env))
                   curr = pipe(
                     current.effect_instruction_i1,
                     ensuring(sync(() => (this.env = env)))
@@ -562,17 +562,17 @@ export class STMDriver<in out R, out E, out A> {
                   if (cont === undefined) {
                     exit = TExit.succeed(value)
                   } else {
-                    curr = effect_internal_function(() => cont.effect_instruction_i2(value) as Primitive)
+                    curr = internalCall(() => cont.effect_instruction_i2(value) as Primitive)
                   }
                   break
                 }
                 case OpCodes.OP_SYNC: {
-                  const value = effect_internal_function(() => current.effect_instruction_i1())
+                  const value = internalCall(() => current.effect_instruction_i1())
                   const cont = this.nextSuccess()
                   if (cont === undefined) {
                     exit = TExit.succeed(value)
                   } else {
-                    curr = effect_internal_function(() => cont.effect_instruction_i2(value) as Primitive)
+                    curr = internalCall(() => cont.effect_instruction_i2(value) as Primitive)
                   }
                   break
                 }


### PR DESCRIPTION
This was the only thing that worked across these environments:

Playground:
<img width="839" alt="image" src="https://github.com/Effect-TS/effect/assets/40680/32774bff-d852-4406-88cb-a7a6b16b9cfb">

tsx esm:
<img width="781" alt="image" src="https://github.com/Effect-TS/effect/assets/40680/43cb32c5-6e25-448f-8eb8-2cad20dbcaf8">

tsx cjs:
<img width="773" alt="image" src="https://github.com/Effect-TS/effect/assets/40680/32c67c98-7ea4-44a5-90bd-1c3d5f40163b">

Browser:
<img width="608" alt="image" src="https://github.com/Effect-TS/effect/assets/40680/28b68f82-c638-4efa-85d7-6fbdec64bab1">