### PR TITLE
`Secret` generalization

### DIFF
--- a/.changeset/stale-crabs-sneeze.md
+++ b/.changeset/stale-crabs-sneeze.md
@@ -25,4 +25,7 @@
 "@effect/sql": patch
 ---
 
-The secret has been generalized to work with any data
+The `Secret` has been generalized to work with any data
+Added the necessary schemas `SecretFromString` and `SecretFromSelf`
+Now the `Secret` implements `Pipeable`
+The tests were placed in a separate module

--- a/.changeset/stale-crabs-sneeze.md
+++ b/.changeset/stale-crabs-sneeze.md
@@ -1,0 +1,28 @@
+---
+"effect": major
+"@effect/sql-sqlite-react-native": patch
+"@effect/platform-node-shared": patch
+"@effect/platform-browser": patch
+"@effect/sql-sqlite-node": patch
+"@effect/sql-sqlite-wasm": patch
+"@effect/sql-sqlite-bun": patch
+"@effect/opentelemetry": patch
+"@effect/platform-node": patch
+"@effect/experimental": patch
+"@effect/platform-bun": patch
+"@effect/printer-ansi": patch
+"@effect/sql-mysql2": patch
+"@effect/sql-mssql": patch
+"@effect/typeclass": patch
+"@effect/platform": patch
+"@effect/rpc-http": patch
+"@effect/printer": patch
+"@effect/schema": patch
+"@effect/sql-pg": patch
+"@effect/vitest": patch
+"@effect/cli": patch
+"@effect/rpc": patch
+"@effect/sql": patch
+---
+
+The secret has been generalized to work with any data

--- a/packages/cli/src/Args.ts
+++ b/packages/cli/src/Args.ts
@@ -384,7 +384,7 @@ export const repeated: <A>(self: Args<A>) => Args<Array<A>> = InternalArgs.repea
  * @since 1.0.0
  * @category constructors
  */
-export const secret: (config?: Args.BaseArgsConfig) => Args<Secret> = InternalArgs.secret
+export const secret: (config?: Args.BaseArgsConfig) => Args<Secret<string>> = InternalArgs.secret
 
 /**
  * Creates a text argument.

--- a/packages/cli/src/Options.ts
+++ b/packages/cli/src/Options.ts
@@ -311,7 +311,7 @@ export const none: Options<void> = InternalOptions.none
  * @since 1.0.0
  * @category constructors
  */
-export const secret: (name: string) => Options<Secret> = InternalOptions.secret
+export const secret: (name: string) => Options<Secret<string>> = InternalOptions.secret
 
 /**
  * @since 1.0.0

--- a/packages/cli/src/Prompt.ts
+++ b/packages/cli/src/Prompt.ts
@@ -423,7 +423,7 @@ export const float: (options: Prompt.FloatOptions) => Prompt<number> = InternalN
  * @since 1.0.0
  * @category constructors
  */
-export const hidden: (options: Prompt.TextOptions) => Prompt<Secret> = InternalTextPrompt.hidden
+export const hidden: (options: Prompt.TextOptions) => Prompt<Secret<string>> = InternalTextPrompt.hidden
 
 /**
  * @since 1.0.0
@@ -450,7 +450,7 @@ export const map: {
  * @since 1.0.0
  * @category constructors
  */
-export const password: (options: Prompt.TextOptions) => Prompt<Secret> = InternalTextPrompt.password
+export const password: (options: Prompt.TextOptions) => Prompt<Secret<string>> = InternalTextPrompt.password
 
 /**
  * Executes the specified `Prompt`.

--- a/packages/cli/src/internal/args.ts
+++ b/packages/cli/src/internal/args.ts
@@ -269,7 +269,7 @@ export const path = (config?: Args.Args.PathArgsConfig): Args.Args<string> =>
 /** @internal */
 export const secret = (
   config?: Args.Args.BaseArgsConfig
-): Args.Args<Secret.Secret> => makeSingle(Option.fromNullable(config?.name), InternalPrimitive.secret)
+): Args.Args<Secret.Secret<string>> => makeSingle(Option.fromNullable(config?.name), InternalPrimitive.secret)
 
 /** @internal */
 export const text = (config?: Args.Args.BaseArgsConfig): Args.Args<string> =>

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -376,7 +376,7 @@ export const none: Options.Options<void> = (() => {
 })()
 
 /** @internal */
-export const secret = (name: string): Options.Options<Secret.Secret> =>
+export const secret = (name: string): Options.Options<Secret.Secret<string>> =>
   makeSingle(name, Arr.empty(), InternalPrimitive.secret)
 
 /** @internal */

--- a/packages/cli/src/internal/primitive.ts
+++ b/packages/cli/src/internal/primitive.ts
@@ -193,7 +193,7 @@ export const path = (
 }
 
 /** @internal */
-export const secret: Primitive.Primitive<EffectSecret.Secret> = (() => {
+export const secret: Primitive.Primitive<EffectSecret.Secret<string>> = (() => {
   const op = Object.create(proto)
   op._tag = "Secret"
   return op
@@ -446,7 +446,7 @@ const validateInternal = (
     }
     case "Secret": {
       return attempt(value, getTypeNameInternal(self), Schema.decodeUnknown(Schema.String)).pipe(
-        Effect.map((value) => EffectSecret.fromString(value))
+        Effect.map((value) => EffectSecret.make(value))
       )
     }
     case "Text": {

--- a/packages/cli/src/internal/prompt/text.ts
+++ b/packages/cli/src/internal/prompt/text.ts
@@ -297,12 +297,12 @@ const basePrompt = (
 }
 
 /** @internal */
-export const hidden = (options: Prompt.Prompt.TextOptions): Prompt.Prompt<Secret.Secret> =>
-  basePrompt(options, "hidden").pipe(InternalPrompt.map(Secret.fromString))
+export const hidden = (options: Prompt.Prompt.TextOptions): Prompt.Prompt<Secret.Secret<string>> =>
+  basePrompt(options, "hidden").pipe(InternalPrompt.map(Secret.make))
 
 /** @internal */
-export const password = (options: Prompt.Prompt.TextOptions): Prompt.Prompt<Secret.Secret> =>
-  basePrompt(options, "password").pipe(InternalPrompt.map(Secret.fromString))
+export const password = (options: Prompt.Prompt.TextOptions): Prompt.Prompt<Secret.Secret<string>> =>
+  basePrompt(options, "password").pipe(InternalPrompt.map(Secret.make))
 
 /** @internal */
 export const text = (options: Prompt.Prompt.TextOptions): Prompt.Prompt<string> => basePrompt(options, "text")

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -333,7 +333,7 @@ export const repeat: <A>(self: Config<A>) => Config<Array<A>> = internal.repeat
  * @since 2.0.0
  * @category constructors
  */
-export const secret: (name?: string) => Config<Secret.Secret> = internal.secret
+export const secret: (name?: string) => Config<Secret.Secret<string>> = internal.secret
 
 /**
  * Constructs a config for a sequence of values.

--- a/packages/effect/src/Secret.ts
+++ b/packages/effect/src/Secret.ts
@@ -3,6 +3,8 @@
  */
 import type * as Equal from "./Equal.js"
 import * as InternalSecret from "./internal/secret.js"
+import type { Pipeable } from "./Pipeable.js"
+import type { Covariant } from "./Types.js"
 
 /**
  * @since 2.0.0
@@ -20,9 +22,7 @@ export type SecretTypeId = typeof SecretTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Secret extends Secret.Proto, Equal.Equal {
-  /** @internal */
-  readonly raw: Array<number>
+export interface Secret<out A> extends Secret.Variance<A>, Equal.Equal, Pipeable {
 }
 
 /**
@@ -30,46 +30,42 @@ export interface Secret extends Secret.Proto, Equal.Equal {
  */
 export declare namespace Secret {
   /**
-   * @since 2.0.0
+   * @since 4.0.0
    * @category models
    */
-  export interface Proto {
-    readonly [SecretTypeId]: SecretTypeId
+  export interface Variance<out A> {
+    readonly [SecretTypeId]: {
+      readonly _A: Covariant<A>
+    }
   }
+
+  /**
+   * @since 4.0.0
+   * @category type-level
+   */
+  export type Value<T extends Secret<any>> = [T] extends [Secret<infer _A>] ? _A : never
 }
 
 /**
- * @since 2.0.0
+ * @since 4.0.0
  * @category refinements
  */
-export const isSecret: (u: unknown) => u is Secret = InternalSecret.isSecret
+export const isSecret: (u: unknown) => u is Secret<unknown> = InternalSecret.isSecret
 
 /**
- * @since 2.0.0
+ * @since 4.0.0
  * @category constructors
  */
-export const make: (bytes: Array<number>) => Secret = InternalSecret.make
+export const make: <T>(value: T) => Secret<T> = InternalSecret.make
 
 /**
- * @since 2.0.0
- * @category constructors
- */
-export const fromIterable: (iterable: Iterable<string>) => Secret = InternalSecret.fromIterable
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const fromString: (text: string) => Secret = InternalSecret.fromString
-
-/**
- * @since 2.0.0
+ * @since 4.0.0
  * @category getters
  */
-export const value: (self: Secret) => string = InternalSecret.value
+export const value: <T>(self: Secret<T>) => T = InternalSecret.value
 
 /**
- * @since 2.0.0
+ * @since 4.0.0
  * @category unsafe
  */
-export const unsafeWipe: (self: Secret) => void = InternalSecret.unsafeWipe
+export const unsafeWipe: <T>(self: Secret<T>) => void = InternalSecret.unsafeWipe

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -413,10 +413,10 @@ export const repeat = <A>(self: Config.Config<A>): Config.Config<Array<A>> => {
 }
 
 /** @internal */
-export const secret = (name?: string): Config.Config<Secret.Secret> => {
+export const secret = (name?: string): Config.Config<Secret.Secret<string>> => {
   const config = primitive(
     "a secret property",
-    (text) => Either.right(InternalSecret.fromString(text))
+    (text) => Either.right(InternalSecret.make(text))
   )
   return name === undefined ? config : nested(config, name)
 }

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -1,16 +1,13 @@
-import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import * as ConfigError from "effect/ConfigError"
 import * as ConfigProvider from "effect/ConfigProvider"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
-import * as Equal from "effect/Equal"
 import * as Exit from "effect/Exit"
 import { pipe } from "effect/Function"
 import * as HashSet from "effect/HashSet"
 import * as LogLevel from "effect/LogLevel"
 import * as Option from "effect/Option"
-import * as Secret from "effect/Secret"
 import { assert, describe, expect, it } from "vitest"
 
 const assertFailure = <A>(
@@ -461,52 +458,6 @@ describe("Config", () => {
         config,
         [["NUMBER", "1"], ["BOOL", "value"]],
         ConfigError.InvalidData(["BOOL"], "Expected a boolean value but received value")
-      )
-    })
-  })
-
-  describe("Secret", () => {
-    describe("Config.secret", () => {
-      it("name = undefined", () => {
-        const config = Config.array(Config.secret(), "ITEMS")
-        assertSuccess(config, [["ITEMS", "a"]], [Secret.fromString("a")])
-      })
-
-      it("name != undefined", () => {
-        const config = Config.secret("SECRET")
-        assertSuccess(config, [["SECRET", "a"]], Secret.fromString("a"))
-      })
-    })
-
-    it("chunk constructor", () => {
-      const secret = Secret.fromIterable(Chunk.fromIterable("secret".split("")))
-      assert.isTrue(Equal.equals(secret, Secret.fromString("secret")))
-    })
-
-    it("value", () => {
-      const secret = Secret.fromIterable(Chunk.fromIterable("secret".split("")))
-      const value = Secret.value(secret)
-      assert.strictEqual(value, "secret")
-    })
-
-    it("toString", () => {
-      const secret = Secret.fromString("secret")
-      assert.strictEqual(`${secret}`, "Secret(<redacted>)")
-    })
-
-    it("toJSON", () => {
-      const secret = Secret.fromString("secret")
-      assert.strictEqual(JSON.stringify(secret), "\"<redacted>\"")
-    })
-
-    it("wipe", () => {
-      const secret = Secret.fromString("secret")
-      Secret.unsafeWipe(secret)
-      assert.isTrue(
-        Equal.equals(
-          Secret.value(secret),
-          Array.from({ length: "secret".length }, () => String.fromCharCode(0)).join("")
-        )
       )
     })
   })

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -799,7 +799,7 @@ describe("ConfigProvider", () => {
       const value = "Hello, World!"
       const configProvider = ConfigProvider.fromMap(new Map([["greeting", value]]))
       const result = yield* $(configProvider.load(Config.secret("greeting")))
-      assert.deepStrictEqual(result, Secret.make(value.split("").map((c) => c.charCodeAt(0))))
+      assert.deepStrictEqual(result, Secret.make(value))
     }))
 
   it.effect("snakeCase", () =>

--- a/packages/effect/test/Secret.test.ts
+++ b/packages/effect/test/Secret.test.ts
@@ -1,0 +1,83 @@
+import * as Chunk from "effect/Chunk"
+import * as Config from "effect/Config"
+import * as ConfigProvider from "effect/ConfigProvider"
+import * as Effect from "effect/Effect"
+import * as Equal from "effect/Equal"
+import * as Exit from "effect/Exit"
+import * as Hash from "effect/Hash"
+import * as Secret from "effect/Secret"
+import { assert, describe, expect, it } from "vitest"
+
+const assertSuccess = <A>(
+  config: Config.Config<A>,
+  map: ReadonlyArray<readonly [string, string]>,
+  a: A
+) => {
+  const configProvider = ConfigProvider.fromMap(new Map(map))
+  const result = Effect.runSync(Effect.exit(configProvider.load(config)))
+  expect(result).toStrictEqual(Exit.succeed(a))
+}
+
+describe("Secret", () => {
+  describe("Config.secret", () => {
+    it("name = undefined", () => {
+      const config = Config.array(Config.secret(), "ITEMS")
+      assertSuccess(config, [["ITEMS", "a"]], [Secret.make("a")])
+    })
+
+    it("name != undefined", () => {
+      const config = Config.secret("SECRET")
+      assertSuccess(config, [["SECRET", "a"]], Secret.make("a"))
+    })
+  })
+
+  it("chunk constructor", () => {
+    const secret = Secret.make(Chunk.fromIterable("secret".split("")))
+    assert.isTrue(Equal.equals(secret, Secret.make(Chunk.fromIterable("secret".split("")))))
+  })
+
+  it("value", () => {
+    const secret = Secret.make(Chunk.fromIterable("secret".split("")))
+    const value = Secret.value(secret)
+    assert.isTrue(Equal.equals(value, Chunk.fromIterable("secret".split(""))))
+    // assert.strictEqual(value, Chunk.fromIterable("secret".split("")))
+  })
+
+  it("pipe", () => {
+    const value = { asd: 123 }
+    const secret = Secret.make(value)
+    const extractedValue = secret.pipe(Secret.value)
+    assert.strictEqual(value, extractedValue)
+  })
+
+  it("toString", () => {
+    const secret = Secret.make("secret")
+    assert.strictEqual(`${secret}`, "Secret(<redacted>)")
+  })
+
+  it("toJSON", () => {
+    const secret = Secret.make("secret")
+    assert.strictEqual(JSON.stringify(secret), "\"<redacted>\"")
+  })
+
+  it("wipe", () => {
+    const secret = Secret.make("secret")
+    Secret.unsafeWipe(secret)
+    assert.isTrue(
+      Equal.equals(
+        Secret.value(secret),
+        undefined
+      )
+    )
+  })
+
+  it("Equal", () => {
+    assert.isTrue(Equal.equals(Secret.make(1), Secret.make(1)))
+    assert.isFalse(Equal.equals(Secret.make(1), Secret.make(2)))
+  })
+
+  it("Hash", () => {
+    assert.strictEqual(Hash.hash(Secret.make(1)), Hash.hash(Secret.make(1)))
+    assert.notStrictEqual(Hash.hash(Secret.make(1)), Hash.hash(Secret.make(2)))
+  })
+})

--- a/packages/platform/src/Http/Headers.ts
+++ b/packages/platform/src/Http/Headers.ts
@@ -205,22 +205,27 @@ export const remove: {
  * @category combinators
  */
 export const redact: {
-  (key: string | RegExp | ReadonlyArray<string | RegExp>): (self: Headers) => Record<string, string | Secret.Secret>
-  (self: Headers, key: string | RegExp | ReadonlyArray<string | RegExp>): Record<string, string | Secret.Secret>
+  (
+    key: string | RegExp | ReadonlyArray<string | RegExp>
+  ): (self: Headers) => Record<string, string | Secret.Secret<string>>
+  (self: Headers, key: string | RegExp | ReadonlyArray<string | RegExp>): Record<string, string | Secret.Secret<string>>
 } = dual(
   2,
-  (self: Headers, key: string | RegExp | ReadonlyArray<string | RegExp>): Record<string, string | Secret.Secret> => {
-    const out: Record<string, string | Secret.Secret> = { ...self }
+  (
+    self: Headers,
+    key: string | RegExp | ReadonlyArray<string | RegExp>
+  ): Record<string, string | Secret.Secret<string>> => {
+    const out: Record<string, string | Secret.Secret<string>> = { ...self }
     const modify = (key: string | RegExp) => {
       if (typeof key === "string") {
         const k = key.toLowerCase()
         if (k in self) {
-          out[k] = Secret.fromString(self[k])
+          out[k] = Secret.make(self[k])
         }
       } else {
         for (const name in self) {
           if (key.test(name)) {
-            out[name] = Secret.fromString(self[name])
+            out[name] = Secret.make(self[name])
           }
         }
       }

--- a/packages/platform/test/Http/Headers.test.ts
+++ b/packages/platform/test/Http/Headers.test.ts
@@ -15,10 +15,10 @@ describe("Headers", () => {
 
       assert.deepEqual(redacted, {
         "content-type": "application/json",
-        "authorization": Secret.fromString("some secret"),
+        "authorization": Secret.make("some secret"),
         "x-api-key": "some-key"
       })
-      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
+      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret<string>), "Bearer some-token")
     })
 
     it("multiple keys", () => {
@@ -32,11 +32,11 @@ describe("Headers", () => {
 
       assert.deepEqual(redacted, {
         "content-type": "application/json",
-        "authorization": Secret.fromString("some secret"),
-        "x-api-key": Secret.fromString("some secret")
+        "authorization": Secret.make("some secret"),
+        "x-api-key": Secret.make("some secret")
       })
-      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret), "Bearer some-token")
-      assert.strictEqual(Secret.value(redacted["x-api-key"] as Secret.Secret), "some-key")
+      assert.strictEqual(Secret.value(redacted.authorization as Secret.Secret<string>), "Bearer some-token")
+      assert.strictEqual(Secret.value(redacted["x-api-key"] as Secret.Secret<string>), "some-key")
     })
 
     it("RegExp", () => {
@@ -50,8 +50,8 @@ describe("Headers", () => {
 
       assert.deepEqual(redacted, {
         "authorization": "Bearer some-token",
-        "sec-ret": Secret.fromString("some"),
-        "sec-ret-2": Secret.fromString("some")
+        "sec-ret": Secret.make("some"),
+        "sec-ret-2": Secret.make("some")
       })
     })
   })

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1596,16 +1596,16 @@ S.DurationFromNanos
 // Secret
 // ---------------------------------------------
 
-// $ExpectType Schema<Secret, string, never>
+// $ExpectType Schema<Secret<string>, string, never>
 S.asSchema(S.SecretFromString)
 
-// $ExpectType typeof Secret
+// $ExpectType typeof SecretFromString
 S.SecretFromString
 
 // $ExpectType Schema<Secret<number>, Secret<number>, never>
 S.asSchema(S.SecretFromSelf(S.Number))
 
-// $ExpectType S.SecretFromSelf<typeof S.Number>
+// $ExpectType SecretFromSelf<typeof Number$>
 S.SecretFromSelf(S.Number)
 
 // ---------------------------------------------

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1597,16 +1597,16 @@ S.DurationFromNanos
 // ---------------------------------------------
 
 // $ExpectType Schema<Secret, string, never>
-S.asSchema(S.Secret)
+S.asSchema(S.SecretFromString)
 
 // $ExpectType typeof Secret
-S.Secret
+S.SecretFromString
 
-// $ExpectType Schema<Secret, Secret, never>
-S.asSchema(S.SecretFromSelf)
+// $ExpectType Schema<Secret<number>, Secret<number>, never>
+S.asSchema(S.SecretFromSelf(S.Number))
 
-// $ExpectType typeof SecretFromSelf
-S.SecretFromSelf
+// $ExpectType S.SecretFromSelf<typeof S.Number>
+S.SecretFromSelf(S.Number)
 
 // ---------------------------------------------
 // propertySignature

--- a/packages/schema/test/Schema/Secret/Secret.test.ts
+++ b/packages/schema/test/Schema/Secret/Secret.test.ts
@@ -3,21 +3,21 @@ import * as Util from "@effect/schema/test/TestUtils"
 import { Secret } from "effect"
 import { describe, it } from "vitest"
 
-describe("Secret", () => {
-  const schema = S.Secret
+describe("SecretFromString", () => {
+  const schema = S.SecretFromString
 
   it("property tests", () => {
     Util.roundtrip(schema)
   })
 
   it("decoding", () => {
-    Util.expectDecodeUnknownSuccess(schema, "keep me safe", Secret.fromString("keep me safe"))
+    Util.expectDecodeUnknownSuccess(schema, "keep me safe", Secret.make("keep me safe"))
   })
 
   it("encoding", () => {
     Util.expectEncodeSuccess(
       schema,
-      Secret.fromString("keep me safe"),
+      Secret.make("keep me safe"),
       "keep me safe"
     )
   })

--- a/packages/schema/test/Schema/Secret/SecretFromSelf.test.ts
+++ b/packages/schema/test/Schema/Secret/SecretFromSelf.test.ts
@@ -5,7 +5,9 @@ import { Secret } from "effect"
 import { describe, expect, it } from "vitest"
 
 describe("SecretFromSelf", () => {
-  const schema = S.SecretFromSelf
+  const schema = S.SecretFromSelf(S.Struct({
+    coord: S.Tuple(S.Number, S.String)
+  }))
 
   it("property tests", () => {
     Util.roundtrip(schema)
@@ -14,21 +16,21 @@ describe("SecretFromSelf", () => {
   it("decoding", () => {
     Util.expectDecodeUnknownSuccess(
       schema,
-      Secret.fromString("keep me safe"),
-      Secret.fromString("keep me safe")
+      Secret.make({ coord: [23.33, "keep me safe"] as const }),
+      Secret.make({ coord: [23.33, "keep me safe"] as const })
     )
   })
 
   it("encoding", () => {
     Util.expectEncodeSuccess(
       schema,
-      Secret.fromString("keep me safe"),
-      Secret.fromString("keep me safe")
+      Secret.make({ coord: [23.33, "keep me safe"] as const }),
+      Secret.make({ coord: [23.33, "keep me safe"] as const })
     )
   })
 
   it("Pretty", () => {
     const pretty = Pretty.make(schema)
-    expect(pretty(Secret.fromString("keep me safe"))).toEqual(`Secret(<redacted>)`)
+    expect(pretty(Secret.make({ coord: [23.33, "keep me safe"] as const }))).toEqual(`Secret(<redacted>)`)
   })
 })

--- a/packages/sql-mssql/examples/migrations.ts
+++ b/packages/sql-mssql/examples/migrations.ts
@@ -89,7 +89,7 @@ const SqlLive = Mssql.migrator.layer({
       database: Config.succeed("msdb"),
       server: Config.succeed("localhost"),
       username: Config.succeed("sa"),
-      password: Config.succeed(Secret.fromString("Sq1Fx_password")),
+      password: Config.succeed(Secret.make("Sq1Fx_password")),
       transformQueryNames: Config.succeed(String.camelToSnake),
       transformResultNames: Config.succeed(String.snakeToCamel)
     })

--- a/packages/sql-mssql/src/Client.ts
+++ b/packages/sql-mssql/src/Client.ts
@@ -81,7 +81,7 @@ export interface MssqlClientConfig {
   readonly authType?: string | undefined
   readonly database?: string | undefined
   readonly username?: string | undefined
-  readonly password?: Secret.Secret | undefined
+  readonly password?: Secret.Secret<string> | undefined
   readonly connectTimeout?: Duration.DurationInput | undefined
 
   readonly minConnections?: number | undefined

--- a/packages/sql-mysql2/examples/statement-transform.ts
+++ b/packages/sql-mysql2/examples/statement-transform.ts
@@ -22,7 +22,7 @@ const SqlTracingLive = Sql.statement.setTransformer((prev, sql, refs, span) => {
 const EnvLive = Mysql.client.layer({
   database: Config.succeed("effect_dev"),
   username: Config.succeed("effect"),
-  password: Config.succeed(Secret.fromString("password")),
+  password: Config.succeed(Secret.make("password")),
   transformQueryNames: Config.succeed(String.camelToSnake),
   transformResultNames: Config.succeed(String.snakeToCamel)
 }).pipe(

--- a/packages/sql-mysql2/src/Client.ts
+++ b/packages/sql-mysql2/src/Client.ts
@@ -54,13 +54,13 @@ export interface MysqlClientConfig {
   /**
    * Connection URI. Setting this will override the other connection options
    */
-  readonly url?: Secret.Secret
+  readonly url?: Secret.Secret<string>
 
   readonly host?: string
   readonly port?: number
   readonly database?: string
   readonly username?: string
-  readonly password?: Secret.Secret
+  readonly password?: Secret.Secret<string>
 
   readonly maxConnections?: number
   readonly connectionTTL?: Duration.DurationInput

--- a/packages/sql-pg/src/Client.ts
+++ b/packages/sql-pg/src/Client.ts
@@ -54,7 +54,7 @@ export const PgClient = Context.GenericTag<PgClient>("@effect/sql-pg/Client")
  * @since 1.0.0
  */
 export interface PgClientConfig {
-  readonly url?: Secret.Secret | undefined
+  readonly url?: Secret.Secret<string> | undefined
 
   readonly host?: string | undefined
   readonly port?: number | undefined
@@ -62,7 +62,7 @@ export interface PgClientConfig {
   readonly ssl?: boolean | undefined
   readonly database?: string | undefined
   readonly username?: string | undefined
-  readonly password?: Secret.Secret | undefined
+  readonly password?: Secret.Secret<string> | undefined
 
   readonly idleTimeout?: Duration.DurationInput | undefined
   readonly connectTimeout?: Duration.DurationInput | undefined
@@ -212,7 +212,7 @@ export const make = (
           host: client.options.host[0] ?? undefined,
           port: client.options.port[0] ?? undefined,
           username: client.options.user,
-          password: client.options.pass ? Secret.fromString(client.options.pass) : undefined,
+          password: client.options.pass ? Secret.make(client.options.pass) : undefined,
           database: client.options.database
         },
         json: (_: unknown) => PgJson(_),


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I wanted to protect any type of data from accidental logging - for example coordinates, amounts of money ...

The `Secret` has been generalized to work with any data
Added the necessary schemas `SecretFromString` and `SecretFromSelf`
Now the `Secret` implements `Pipeable`
The tests were placed in a separate module

I'm not sure if it was possible to do this with backward compatibility support

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
