### PR TITLE
Add queuing strategy option for Stream.toReadableStream

### DIFF
--- a/.changeset/empty-islands-pump.md
+++ b/.changeset/empty-islands-pump.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Add queuing strategy option for Stream.toReadableStream

--- a/.changeset/empty-islands-pump.md
+++ b/.changeset/empty-islands-pump.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add queuing strategy option for Stream.toReadableStream

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -3860,7 +3860,17 @@ export const toQueueOfElements: {
  * @since 2.0.0
  * @category destructors
  */
-export const toReadableStream: <A, E>(self: Stream<A, E>) => ReadableStream<A> = internal.toReadableStream
+export const toReadableStream: {
+  <A>(
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ): <A, E>(
+    self: Stream<A, E>
+  ) => ReadableStream<A>
+  <A, E>(
+    self: Stream<A, E>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ): ReadableStream<A>
+} = internal.toReadableStream
 
 /**
  * Converts the stream to a `Effect<ReadableStream>`.
@@ -3870,8 +3880,17 @@ export const toReadableStream: <A, E>(self: Stream<A, E>) => ReadableStream<A> =
  * @since 2.0.0
  * @category destructors
  */
-export const toReadableStreamEffect: <A, E, R>(self: Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R> =
-  internal.toReadableStreamEffect
+export const toReadableStreamEffect: {
+  <A>(
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ): <A, E, R>(
+    self: Stream<A, E, R>
+  ) => Effect.Effect<ReadableStream<A>, never, R>
+  <A, E, R>(
+    self: Stream<A, E, R>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ): Effect.Effect<ReadableStream<A>, never, R>
+} = internal.toReadableStreamEffect
 
 /**
  * Converts the stream to a `ReadableStream` using the provided runtime.
@@ -3882,12 +3901,14 @@ export const toReadableStreamEffect: <A, E, R>(self: Stream<A, E, R>) => Effect.
  * @category destructors
  */
 export const toReadableStreamRuntime: {
-  <XR>(
-    runtime: Runtime<XR>
+  <A, XR>(
+    runtime: Runtime<XR>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
   ): <A, E, R extends XR>(self: Stream<A, E, R>) => ReadableStream<A>
   <A, E, XR, R extends XR>(
     self: Stream<A, E, R>,
-    runtime: Runtime<XR>
+    runtime: Runtime<XR>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
   ): ReadableStream<A>
 } = internal.toReadableStreamRuntime
 

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -3863,7 +3863,7 @@ export const toQueueOfElements: {
 export const toReadableStream: {
   <A>(
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
-  ): <A, E>(
+  ): <E>(
     self: Stream<A, E>
   ) => ReadableStream<A>
   <A, E>(
@@ -3883,7 +3883,7 @@ export const toReadableStream: {
 export const toReadableStreamEffect: {
   <A>(
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
-  ): <A, E, R>(
+  ): <E, R>(
     self: Stream<A, E, R>
   ) => Effect.Effect<ReadableStream<A>, never, R>
   <A, E, R>(
@@ -3904,7 +3904,7 @@ export const toReadableStreamRuntime: {
   <A, XR>(
     runtime: Runtime<XR>,
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
-  ): <A, E, R extends XR>(self: Stream<A, E, R>) => ReadableStream<A>
+  ): <E, R extends XR>(self: Stream<A, E, R>) => ReadableStream<A>
   <A, E, XR, R extends XR>(
     self: Stream<A, E, R>,
     runtime: Runtime<XR>,

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -6542,63 +6542,103 @@ export const toQueueOfElements = dual<
   ))
 
 /** @internal */
-export const toReadableStream = <A, E>(self: Stream.Stream<A, E>) =>
-  toReadableStreamRuntime(self, Runtime.defaultRuntime)
+export const toReadableStream = dual<
+  <A>(
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => <A, E>(self: Stream.Stream<A, E>) => ReadableStream<A>,
+  <A, E>(
+    self: Stream.Stream<A, E>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => ReadableStream<A>
+>(
+  (args) => isStream(args[0]),
+  <A, E>(
+    self: Stream.Stream<A, E>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => toReadableStreamRuntime(self, Runtime.defaultRuntime, options)
+)
 
 /** @internal */
-export const toReadableStreamEffect = <A, E, R>(self: Stream.Stream<A, E, R>) =>
-  Effect.map(Effect.runtime<R>(), (runtime) => toReadableStreamRuntime(self, runtime))
+export const toReadableStreamEffect = dual<
+  <A>(
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R>,
+  <A, E, R>(
+    self: Stream.Stream<A, E, R>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => Effect.Effect<ReadableStream<A>, never, R>
+>(
+  (args) => isStream(args[0]),
+  <A, E, R>(
+    self: Stream.Stream<A, E, R>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => Effect.map(Effect.runtime<R>(), (runtime) => toReadableStreamRuntime(self, runtime, options))
+)
 
 /** @internal */
 export const toReadableStreamRuntime = dual<
-  <XR>(runtime: Runtime.Runtime<XR>) => <A, E, R extends XR>(self: Stream.Stream<A, E, R>) => ReadableStream<A>,
-  <A, E, XR, R extends XR>(self: Stream.Stream<A, E, R>, runtime: Runtime.Runtime<XR>) => ReadableStream<A>
->(2, <A, E, XR, R extends XR>(self: Stream.Stream<A, E, R>, runtime: Runtime.Runtime<XR>): ReadableStream<A> => {
-  const runSync = Runtime.runSync(runtime)
-  const runFork = Runtime.runFork(runtime)
+  <A, XR>(
+    runtime: Runtime.Runtime<XR>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => <A, E, R extends XR>(self: Stream.Stream<A, E, R>) => ReadableStream<A>,
+  <A, E, XR, R extends XR>(
+    self: Stream.Stream<A, E, R>,
+    runtime: Runtime.Runtime<XR>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ) => ReadableStream<A>
+>(
+  (args) => isStream(args[0]),
+  <A, E, XR, R extends XR>(
+    self: Stream.Stream<A, E, R>,
+    runtime: Runtime.Runtime<XR>,
+    options?: { readonly strategy?: QueuingStrategy<A> | undefined }
+  ): ReadableStream<A> => {
+    const runSync = Runtime.runSync(runtime)
+    const runFork = Runtime.runFork(runtime)
 
-  let pull: Effect.Effect<void, never, R>
-  let scope: Scope.CloseableScope
-  return new ReadableStream<A>({
-    start(controller) {
-      scope = runSync(Scope.make())
-      pull = pipe(
-        toPull(self),
-        Scope.extend(scope),
-        runSync,
-        Effect.tap((chunk) =>
-          Effect.sync(() => {
-            Chunk.map(chunk, (a) => {
-              controller.enqueue(a)
-            })
-          })
-        ),
-        Effect.tapErrorCause(() => Scope.close(scope, Exit.void)),
-        Effect.catchTags({
-          "None": () =>
+    let pull: Effect.Effect<void, never, R>
+    let scope: Scope.CloseableScope
+    return new ReadableStream<A>({
+      start(controller) {
+        scope = runSync(Scope.make())
+        pull = pipe(
+          toPull(self),
+          Scope.extend(scope),
+          runSync,
+          Effect.tap((chunk) =>
             Effect.sync(() => {
-              controller.close()
-            }),
-          "Some": (error) =>
-            Effect.sync(() => {
-              controller.error(error.value)
+              Chunk.map(chunk, (a) => {
+                controller.enqueue(a)
+              })
             })
-        }),
-        Effect.asVoid
-      )
-    },
-    pull() {
-      return new Promise<void>((resolve) => {
-        runFork(pull, { scope }).addObserver((_) => resolve())
-      })
-    },
-    cancel() {
-      return new Promise<void>((resolve) => {
-        runFork(Scope.close(scope, Exit.void)).addObserver((_) => resolve())
-      })
-    }
-  })
-})
+          ),
+          Effect.tapErrorCause(() => Scope.close(scope, Exit.void)),
+          Effect.catchTags({
+            "None": () =>
+              Effect.sync(() => {
+                controller.close()
+              }),
+            "Some": (error) =>
+              Effect.sync(() => {
+                controller.error(error.value)
+              })
+          }),
+          Effect.asVoid
+        )
+      },
+      pull() {
+        return new Promise<void>((resolve) => {
+          runFork(pull, { scope }).addObserver((_) => resolve())
+        })
+      },
+      cancel() {
+        return new Promise<void>((resolve) => {
+          runFork(Scope.close(scope, Exit.void)).addObserver((_) => resolve())
+        })
+      }
+    }, options?.strategy)
+  }
+)
 
 /** @internal */
 export const transduce = dual<

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -6545,7 +6545,7 @@ export const toQueueOfElements = dual<
 export const toReadableStream = dual<
   <A>(
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
-  ) => <A, E>(self: Stream.Stream<A, E>) => ReadableStream<A>,
+  ) => <E>(self: Stream.Stream<A, E>) => ReadableStream<A>,
   <A, E>(
     self: Stream.Stream<A, E>,
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
@@ -6562,7 +6562,7 @@ export const toReadableStream = dual<
 export const toReadableStreamEffect = dual<
   <A>(
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
-  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R>,
+  ) => <E, R>(self: Stream.Stream<A, E, R>) => Effect.Effect<ReadableStream<A>, never, R>,
   <A, E, R>(
     self: Stream.Stream<A, E, R>,
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
@@ -6580,7 +6580,7 @@ export const toReadableStreamRuntime = dual<
   <A, XR>(
     runtime: Runtime.Runtime<XR>,
     options?: { readonly strategy?: QueuingStrategy<A> | undefined }
-  ) => <A, E, R extends XR>(self: Stream.Stream<A, E, R>) => ReadableStream<A>,
+  ) => <E, R extends XR>(self: Stream.Stream<A, E, R>) => ReadableStream<A>,
   <A, E, XR, R extends XR>(
     self: Stream.Stream<A, E, R>,
     runtime: Runtime.Runtime<XR>,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Adds a "strategy" option to
- `Stream.toReadableStream`
- `Stream.toReadableStreamEffect`
- `Stream.toReadableStreamRuntime`

This allows configuring the queuing strategy of the underlying ReadableStream.

```ts

// Default queuing strategy
stream.pipe(Stream.toReadableStream)

// Custom queuing strategies
stream.pipe(Stream.toReadableStream({ strategy: { highWaterMark: 2 } }))
stream.pipe(Stream.toReadableStream({ strategy: new CountQueuingStrategy({ highWaterMark: 2 }) }))

```

The name "strategy" was chosen to align with the Streams spec and TypeScript lib types.

References:
- https://streams.spec.whatwg.org/#rs-prototype
- https://github.com/microsoft/TypeScript/blob/af3a61fe4487a92d59f9479aa4249d897b91af14/src/lib/dom.generated.d.ts#L18794-L18799

Note the diff for this PR shows many lines changed in `toReadableStreamRuntime`, these are mostly formatting changes incurred by the extra level of indentation from the expanded signature. The main real changes there are:
- the `ReadableStream` constructor receives a second argument passed down via `options?.strategy`
- the first argument of `dual()` has been changed from an arity of `2` to an `isStream` predicate matching other configurable stream functions 



## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2840
