### PR TITLE
fix(sql): mysql migrator

### DIFF
--- a/.changeset/gold-beers-approve.md
+++ b/.changeset/gold-beers-approve.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql": patch
+---
+
+fix sql mysql migrator

--- a/packages/sql/src/Migrator.ts
+++ b/packages/sql/src/Migrator.ts
@@ -191,7 +191,7 @@ export const make = <RD = never>({
     const run = Effect.gen(function*(_) {
       yield* sql.onDialect({
         mssql: () => Effect.void,
-        mysql: () => sql`LOCK TABLE ${sql(table)} IN ACCESS EXCLUSIVE MODE`,
+        mysql: () => Effect.void,
         pg: () => sql`LOCK TABLE ${sql(table)} IN ACCESS EXCLUSIVE MODE`,
         sqlite: () => Effect.void
       })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

MySQL does not support `IN ACCESS EXCLUSIVE MODE`. It does support locking, but seeing as there is currently no unlock step, I've simply removed the statement.

- Related Issue #
- Closes #
