### PR TITLE
Schema: expose property signature schemas

### DIFF
--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -6,3 +6,4 @@ Schema
 
 - add `PropertySignatureWithSchema` interface (with a `schema` property exposed)
 - `propertySignature` now returns `PropertySignatureWithSchema`
+- `S.optional(schema)` now returns `PropertySignatureWithSchema`

--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -4,7 +4,7 @@
 
 Schema
 
-- add `PropertySignatureFrom` interface (with a `from` property exposed)
-- add `propertySignature` API interface
-- now `optional` extends `PropertySignatureWithSchema`
-- now `optionalWithOptions` extends `PropertySignatureWithSchema`
+- add `PropertySignatureFrom` interface extending `PropertySignature` with a `from` property
+- add `propertySignature` API interface extending `PropertySignatureFrom`
+- now `optional` extends `PropertySignatureFrom`
+- now `optionalWithOptions` extends `PropertySignatureFrom`

--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -4,6 +4,6 @@
 
 Schema
 
-- add `propertySignature` API interface with a `from` property
+- add `propertySignature` API interface (with a `from` property)
 - extend `optional` API interface with a `from` property
 - extend `optionalWithOptions` API interface with a `from` property

--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -5,5 +5,6 @@
 Schema
 
 - add `PropertySignatureWithSchema` interface (with a `schema` property exposed)
-- `propertySignature` now returns `PropertySignatureWithSchema`
-- `S.optional(schema)` now returns `PropertySignatureWithSchema`
+- add `propertySignature` API interface
+- now `optional` extends `PropertySignatureWithSchema`
+- now `optionalWithOptions` extends `PropertySignatureWithSchema`

--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -4,7 +4,6 @@
 
 Schema
 
-- add `PropertySignatureFrom` interface extending `PropertySignature` with a `from` property
-- add `propertySignature` API interface extending `PropertySignatureFrom`
-- now `optional` extends `PropertySignatureFrom`
-- now `optionalWithOptions` extends `PropertySignatureFrom`
+- add `propertySignature` API interface with a `from` property
+- extend `optional` API interface with a `from` property
+- extend `optionalWithOptions` API interface with a `from` property

--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -4,7 +4,7 @@
 
 Schema
 
-- add `PropertySignatureWithSchema` interface (with a `schema` property exposed)
+- add `PropertySignatureFrom` interface (with a `from` property exposed)
 - add `propertySignature` API interface
 - now `optional` extends `PropertySignatureWithSchema`
 - now `optionalWithOptions` extends `PropertySignatureWithSchema`

--- a/.changeset/cold-schools-know.md
+++ b/.changeset/cold-schools-know.md
@@ -1,0 +1,8 @@
+---
+"@effect/schema": patch
+---
+
+Schema
+
+- add `PropertySignatureWithSchema` interface (with a `schema` property exposed)
+- `propertySignature` now returns `PropertySignatureWithSchema`

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -164,8 +164,11 @@ S.NonEmptyArray(aContext)
 // propertySignatureDeclaration
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<":", string, never, ":", string, false, "aContext">
+// $ExpectType PropertySignatureWithSchema<aContext, ":", string, never, ":", string, false, "aContext">
 S.propertySignature(aContext)
+
+// $ExpectType PropertySignatureWithSchema<aContext, ":", string, never, ":", string, false, "aContext">
+S.propertySignature(aContext).annotations({})
 
 // ---------------------------------------------
 // optionalToOptional

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -164,10 +164,10 @@ S.NonEmptyArray(aContext)
 // propertySignatureDeclaration
 // ---------------------------------------------
 
-// $ExpectType PropertySignatureWithSchema<aContext, ":", string, never, ":", string, false, "aContext">
+// $ExpectType propertySignature<aContext>
 S.propertySignature(aContext)
 
-// $ExpectType PropertySignatureWithSchema<aContext, ":", string, never, ":", string, false, "aContext">
+// $ExpectType propertySignature<aContext>
 S.propertySignature(aContext).annotations({})
 
 // ---------------------------------------------

--- a/packages/schema/dtslint/PropertySignature.ts
+++ b/packages/schema/dtslint/PropertySignature.ts
@@ -1,8 +1,12 @@
 import { Schema } from "@effect/schema"
 
 const schema = Schema.Struct({
-  a: Schema.propertySignature(Schema.String).annotations({})
+  a: Schema.propertySignature(Schema.String).annotations({}),
+  b: Schema.optional(Schema.Number).annotations({})
 })
 
 // $ExpectType typeof String$
 schema.fields.a.schema
+
+// $ExpectType typeof Number$
+schema.fields.b.schema

--- a/packages/schema/dtslint/PropertySignature.ts
+++ b/packages/schema/dtslint/PropertySignature.ts
@@ -1,0 +1,8 @@
+import { Schema } from "@effect/schema"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.String).annotations({})
+})
+
+// $ExpectType typeof String$
+schema.fields.a.schema

--- a/packages/schema/dtslint/PropertySignature.ts
+++ b/packages/schema/dtslint/PropertySignature.ts
@@ -1,8 +1,18 @@
 import { Schema } from "@effect/schema"
 
+// $ExpectType propertySignature<typeof String$>
+const A = Schema.propertySignature(Schema.String).annotations({})
+
+// $ExpectType optional<typeof Number$>
+const B = Schema.optional(Schema.Number).annotations({})
+
+// $ExpectType optionalWithOptions<typeof Boolean$, { exact: true; }>
+const C = Schema.optional(Schema.Boolean, { exact: true }).annotations({})
+
 const schema = Schema.Struct({
-  a: Schema.propertySignature(Schema.String).annotations({}),
-  b: Schema.optional(Schema.Number).annotations({})
+  a: A,
+  b: B,
+  c: C
 })
 
 // $ExpectType typeof String$
@@ -10,3 +20,6 @@ schema.fields.a.schema
 
 // $ExpectType typeof Number$
 schema.fields.b.schema
+
+// $ExpectType typeof Boolean$
+schema.fields.c.schema

--- a/packages/schema/dtslint/PropertySignature.ts
+++ b/packages/schema/dtslint/PropertySignature.ts
@@ -1,18 +1,27 @@
 import { Schema } from "@effect/schema"
 
 // $ExpectType propertySignature<typeof String$>
-const A = Schema.propertySignature(Schema.String).annotations({})
+const A = Schema.propertySignature(Schema.String)
+
+// $ExpectType propertySignature<typeof String$>
+const AA = A.annotations({})
 
 // $ExpectType optional<typeof Number$>
-const B = Schema.optional(Schema.Number).annotations({})
+const B = Schema.optional(Schema.Number)
+
+// $ExpectType optional<typeof Number$>
+const BB = B.annotations({})
 
 // $ExpectType optionalWithOptions<typeof Boolean$, { exact: true; }>
-const C = Schema.optional(Schema.Boolean, { exact: true }).annotations({})
+const C = Schema.optional(Schema.Boolean, { exact: true })
+
+// $ExpectType optionalWithOptions<typeof Boolean$, { exact: true; }>
+const CC = C.annotations({})
 
 const schema = Schema.Struct({
-  a: A,
-  b: B,
-  c: C
+  a: AA,
+  b: BB,
+  c: CC
 })
 
 // $ExpectType typeof String$

--- a/packages/schema/dtslint/PropertySignature.ts
+++ b/packages/schema/dtslint/PropertySignature.ts
@@ -16,10 +16,10 @@ const schema = Schema.Struct({
 })
 
 // $ExpectType typeof String$
-schema.fields.a.schema
+schema.fields.a.from
 
 // $ExpectType typeof Number$
-schema.fields.b.schema
+schema.fields.b.from
 
 // $ExpectType typeof Boolean$
-schema.fields.c.schema
+schema.fields.c.from

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1622,7 +1622,7 @@ S.propertySignature(S.String).annotations({})
 // PropertySignature .annotations({}) method
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<"?:", string | undefined, never, "?:", string | undefined, false, never>
+// $ExpectType PropertySignatureWithSchema<typeof String$, "?:", string | undefined, never, "?:", string | undefined, false, never>
 S.optional(S.String).annotations({})
 
 // ---------------------------------------------

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1612,15 +1612,18 @@ S.SecretFromSelf
 // propertySignature
 // ---------------------------------------------
 
-// $ExpectType PropertySignature<":", string, never, ":", string, false, never>
-S.propertySignature(S.String).annotations({ description: "description" })
+// $ExpectType PropertySignatureWithSchema<typeof String$, ":", string, never, ":", string, false, never>
+S.propertySignature(S.String)
+
+// $ExpectType PropertySignatureWithSchema<typeof String$, ":", string, never, ":", string, false, never>
+S.propertySignature(S.String).annotations({})
 
 // ---------------------------------------------
 // PropertySignature .annotations({}) method
 // ---------------------------------------------
 
 // $ExpectType PropertySignature<"?:", string | undefined, never, "?:", string | undefined, false, never>
-S.optional(S.String).annotations({ description: "description" })
+S.optional(S.String).annotations({})
 
 // ---------------------------------------------
 // Pluck

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1612,17 +1612,17 @@ S.SecretFromSelf
 // propertySignature
 // ---------------------------------------------
 
-// $ExpectType PropertySignatureWithSchema<typeof String$, ":", string, never, ":", string, false, never>
+// $ExpectType propertySignature<typeof String$>
 S.propertySignature(S.String)
 
-// $ExpectType PropertySignatureWithSchema<typeof String$, ":", string, never, ":", string, false, never>
+// $ExpectType propertySignature<typeof String$>
 S.propertySignature(S.String).annotations({})
 
 // ---------------------------------------------
 // PropertySignature .annotations({}) method
 // ---------------------------------------------
 
-// $ExpectType PropertySignatureWithSchema<typeof String$, "?:", string | undefined, never, "?:", string | undefined, false, never>
+// $ExpectType optional<typeof String$>
 S.optional(S.String).annotations({})
 
 // ---------------------------------------------

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1994,7 +1994,8 @@ export type OptionalOptions<A> = {
  * @since 1.0.0
  */
 export interface optional<S extends Schema.All> extends
-  PropertySignature<
+  PropertySignatureWithSchema<
+    S,
     "?:",
     Schema.Type<S> | undefined,
     never,
@@ -2159,8 +2160,9 @@ export const optional: {
           { decode: option_.filter(Predicate.isNotNull<A | null | undefined>), encode: identity }
         )
       } else {
-        return makePropertySignature(
-          new PropertySignatureDeclaration(UndefinedOr(schema).ast, true, true, {}, undefined)
+        return makePropertySignatureWithSchema(
+          new PropertySignatureDeclaration(UndefinedOr(schema).ast, true, true, {}, undefined),
+          schema
         )
       }
     }

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1606,7 +1606,7 @@ class PropertySignatureFromImpl<
   }
 }
 
-const makePropertySignatureWithSchema = <
+const makePropertySignatureFrom = <
   From extends Schema.All,
   TypeToken extends PropertySignature.Token,
   Type,
@@ -1622,17 +1622,8 @@ const makePropertySignatureWithSchema = <
  * @category API interface
  * @since 1.0.0
  */
-export interface propertySignature<S extends Schema.All> extends
-  PropertySignatureFrom<
-    S,
-    PropertySignature.GetToken<false>,
-    Schema.Type<S>,
-    never,
-    PropertySignature.GetToken<false>,
-    Schema.Encoded<S>,
-    false,
-    Schema.Context<S>
-  >
+export interface propertySignature<S extends Schema.All>
+  extends PropertySignatureFrom<S, ":", Schema.Type<S>, never, ":", Schema.Encoded<S>, false, Schema.Context<S>>
 {
   annotations(annotations: PropertySignature.Annotations<Schema.Type<S>>): propertySignature<S>
 }
@@ -1646,7 +1637,7 @@ export interface propertySignature<S extends Schema.All> extends
 export const propertySignature = <S extends Schema.All>(
   self: S
 ): propertySignature<S> =>
-  makePropertySignatureWithSchema(new PropertySignatureDeclaration(self.ast, false, true, {}, undefined), self)
+  makePropertySignatureFrom(new PropertySignatureDeclaration(self.ast, false, true, {}, undefined), self)
 
 /**
  * Enhances a property signature with a default constructor value.
@@ -2085,7 +2076,7 @@ export const optional: {
   if (isExact) {
     if (defaultValue) {
       if (isNullable) {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           withConstructorDefault(
             optionalToRequired(
               NullOr(schema),
@@ -2100,7 +2091,7 @@ export const optional: {
           schema
         )
       } else {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           withConstructorDefault(
             optionalToRequired(
               schema,
@@ -2114,7 +2105,7 @@ export const optional: {
       }
     } else if (asOption) {
       if (isNullable) {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           optionalToRequired(
             NullOr(schema),
             OptionFromSelf(typeSchema(schema)),
@@ -2126,7 +2117,7 @@ export const optional: {
           schema
         )
       } else {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           optionalToRequired(
             schema,
             OptionFromSelf(typeSchema(schema)),
@@ -2137,7 +2128,7 @@ export const optional: {
       }
     } else {
       if (isNullable) {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           optionalToOptional(
             NullOr(schema),
             typeSchema(schema),
@@ -2146,7 +2137,7 @@ export const optional: {
           schema
         )
       } else {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           new PropertySignatureDeclaration(schema.ast, true, true, {}, undefined),
           schema
         )
@@ -2155,7 +2146,7 @@ export const optional: {
   } else {
     if (defaultValue) {
       if (isNullable) {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           withConstructorDefault(
             optionalToRequired(
               NullishOr(schema),
@@ -2170,7 +2161,7 @@ export const optional: {
           schema
         )
       } else {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           withConstructorDefault(
             optionalToRequired(
               UndefinedOr(schema),
@@ -2187,7 +2178,7 @@ export const optional: {
       }
     } else if (asOption) {
       if (isNullable) {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           optionalToRequired(
             NullishOr(schema),
             OptionFromSelf(typeSchema(schema)),
@@ -2199,7 +2190,7 @@ export const optional: {
           schema
         )
       } else {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           optionalToRequired(
             UndefinedOr(schema),
             OptionFromSelf(typeSchema(schema)),
@@ -2213,7 +2204,7 @@ export const optional: {
       }
     } else {
       if (isNullable) {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           optionalToOptional(
             NullishOr(schema),
             UndefinedOr(typeSchema(schema)),
@@ -2222,7 +2213,7 @@ export const optional: {
           schema
         )
       } else {
-        return makePropertySignatureWithSchema(
+        return makePropertySignatureFrom(
           new PropertySignatureDeclaration(UndefinedOr(schema).ast, true, true, {}, undefined),
           schema
         )

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1561,26 +1561,6 @@ export const makePropertySignature = <
 >(ast: PropertySignature.AST) =>
   new PropertySignatureImpl<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>(ast)
 
-/**
- * @category PropertySignature
- * @since 1.0.0
- */
-export interface PropertySignatureFrom<
-  From extends Schema.All,
-  TypeToken extends PropertySignature.Token,
-  Type,
-  Key extends PropertyKey,
-  EncodedToken extends PropertySignature.Token,
-  Encoded,
-  HasDefault extends boolean = false,
-  R = never
-> extends PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
-  readonly from: From
-  annotations(
-    annotations: PropertySignature.Annotations<Type>
-  ): PropertySignatureFrom<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
-}
-
 class PropertySignatureFromImpl<
   From extends Schema.All,
   TypeToken extends PropertySignature.Token,
@@ -1590,15 +1570,13 @@ class PropertySignatureFromImpl<
   Encoded,
   HasDefault extends boolean = false,
   R = never
-> extends PropertySignatureImpl<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
-  implements PropertySignatureFrom<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
-{
+> extends PropertySignatureImpl<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
   constructor(ast: PropertySignature.AST, readonly from: From) {
     super(ast)
   }
   annotations(
     annotations: PropertySignature.Annotations<Type>
-  ): PropertySignatureFrom<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
+  ): PropertySignatureFromImpl<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
     return new PropertySignatureFromImpl(
       propertySignatureAnnotations_(this.ast, toASTAnnotations(annotations)),
       this.from
@@ -1623,8 +1601,9 @@ const makePropertySignatureFrom = <
  * @since 1.0.0
  */
 export interface propertySignature<S extends Schema.All>
-  extends PropertySignatureFrom<S, ":", Schema.Type<S>, never, ":", Schema.Encoded<S>, false, Schema.Context<S>>
+  extends PropertySignature<":", Schema.Type<S>, never, ":", Schema.Encoded<S>, false, Schema.Context<S>>
 {
+  readonly from: S
   annotations(annotations: PropertySignature.Annotations<Schema.Type<S>>): propertySignature<S>
 }
 
@@ -2004,8 +1983,7 @@ export type OptionalOptions<A> = {
  * @since 1.0.0
  */
 export interface optional<S extends Schema.All> extends
-  PropertySignatureFrom<
-    S,
+  PropertySignature<
     "?:",
     Schema.Type<S> | undefined,
     never,
@@ -2015,6 +1993,7 @@ export interface optional<S extends Schema.All> extends
     Schema.Context<S>
   >
 {
+  readonly from: S
   annotations(annotations: PropertySignature.Annotations<Schema.Type<S> | undefined>): optional<S>
 }
 
@@ -2023,8 +2002,7 @@ export interface optional<S extends Schema.All> extends
  * @since 1.0.0
  */
 export interface optionalWithOptions<S extends Schema.All, Options> extends
-  PropertySignatureFrom<
-    S,
+  PropertySignature<
     Types.Has<Options, "as" | "default"> extends true ? ":" : "?:",
     | (Types.Has<Options, "as"> extends true ? option_.Option<Schema.Type<S>> : Schema.Type<S>)
     | (Types.Has<Options, "as" | "default" | "exact"> extends true ? never : undefined),
@@ -2037,6 +2015,7 @@ export interface optionalWithOptions<S extends Schema.All, Options> extends
     Schema.Context<S>
   >
 {
+  readonly from: S
   annotations(
     annotations: PropertySignature.Annotations<
       | (Types.Has<Options, "as"> extends true ? option_.Option<Schema.Type<S>> : Schema.Type<S>)

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1565,8 +1565,8 @@ export const makePropertySignature = <
  * @category PropertySignature
  * @since 1.0.0
  */
-export interface PropertySignatureWithSchema<
-  S extends Schema.All,
+export interface PropertySignatureFrom<
+  From extends Schema.All,
   TypeToken extends PropertySignature.Token,
   Type,
   Key extends PropertyKey,
@@ -1575,14 +1575,14 @@ export interface PropertySignatureWithSchema<
   HasDefault extends boolean = false,
   R = never
 > extends PropertySignature<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
-  readonly schema: S
+  readonly from: From
   annotations(
     annotations: PropertySignature.Annotations<Type>
-  ): PropertySignatureWithSchema<S, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
+  ): PropertySignatureFrom<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
 }
 
-class PropertySignatureWithSchemaImpl<
-  S extends Schema.All,
+class PropertySignatureFromImpl<
+  From extends Schema.All,
   TypeToken extends PropertySignature.Token,
   Type,
   Key extends PropertyKey,
@@ -1591,23 +1591,23 @@ class PropertySignatureWithSchemaImpl<
   HasDefault extends boolean = false,
   R = never
 > extends PropertySignatureImpl<TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
-  implements PropertySignatureWithSchema<S, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
+  implements PropertySignatureFrom<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>
 {
-  constructor(ast: PropertySignature.AST, readonly schema: S) {
+  constructor(ast: PropertySignature.AST, readonly from: From) {
     super(ast)
   }
   annotations(
     annotations: PropertySignature.Annotations<Type>
-  ): PropertySignatureWithSchema<S, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
-    return new PropertySignatureWithSchemaImpl(
+  ): PropertySignatureFrom<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R> {
+    return new PropertySignatureFromImpl(
       propertySignatureAnnotations_(this.ast, toASTAnnotations(annotations)),
-      this.schema
+      this.from
     )
   }
 }
 
 const makePropertySignatureWithSchema = <
-  S extends Schema.All,
+  From extends Schema.All,
   TypeToken extends PropertySignature.Token,
   Type,
   Key extends PropertyKey,
@@ -1615,15 +1615,15 @@ const makePropertySignatureWithSchema = <
   Encoded,
   HasDefault extends boolean = false,
   R = never
->(ast: PropertySignature.AST, schema: S) =>
-  new PropertySignatureWithSchemaImpl<S, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>(ast, schema)
+>(ast: PropertySignature.AST, from: From) =>
+  new PropertySignatureFromImpl<From, TypeToken, Type, Key, EncodedToken, Encoded, HasDefault, R>(ast, from)
 
 /**
  * @category API interface
  * @since 1.0.0
  */
 export interface propertySignature<S extends Schema.All> extends
-  PropertySignatureWithSchema<
+  PropertySignatureFrom<
     S,
     PropertySignature.GetToken<false>,
     Schema.Type<S>,
@@ -2013,7 +2013,7 @@ export type OptionalOptions<A> = {
  * @since 1.0.0
  */
 export interface optional<S extends Schema.All> extends
-  PropertySignatureWithSchema<
+  PropertySignatureFrom<
     S,
     "?:",
     Schema.Type<S> | undefined,
@@ -2032,7 +2032,7 @@ export interface optional<S extends Schema.All> extends
  * @since 1.0.0
  */
 export interface optionalWithOptions<S extends Schema.All, Options> extends
-  PropertySignatureWithSchema<
+  PropertySignatureFrom<
     S,
     Types.Has<Options, "as" | "default"> extends true ? ":" : "?:",
     | (Types.Has<Options, "as"> extends true ? option_.Option<Schema.Type<S>> : Schema.Type<S>)

--- a/packages/schema/test/Schema/PropertySignature.test.ts
+++ b/packages/schema/test/Schema/PropertySignature.test.ts
@@ -6,7 +6,17 @@ import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
 describe("PropertySignature", () => {
+  it("should expose the schema", () => {
+    const schema = S.propertySignature(S.String)
+    expect(schema.schema).toStrictEqual(S.String)
+  })
+
   describe("annotations", () => {
+    it("should expose the schema", () => {
+      const schema = S.propertySignature(S.String).annotations({})
+      expect(schema.schema).toStrictEqual(S.String)
+    })
+
     it("propertySignature(S.string)", () => {
       const schema = S.Struct({
         a: S.propertySignature(S.String).annotations({ description: "a description" }).annotations({ title: "a title" })

--- a/packages/schema/test/Schema/PropertySignature.test.ts
+++ b/packages/schema/test/Schema/PropertySignature.test.ts
@@ -6,17 +6,17 @@ import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
 describe("PropertySignature", () => {
-  it("propertySignature should expose the schema", () => {
+  it("should expose a from property", () => {
     const schema = S.propertySignature(S.String)
-    expect(schema.schema).toStrictEqual(S.String)
+    expect(schema.from).toStrictEqual(S.String)
+  })
+
+  it("should expose a from property after an annotations call", () => {
+    const schema = S.propertySignature(S.String).annotations({})
+    expect(schema.from).toStrictEqual(S.String)
   })
 
   describe("annotations", () => {
-    it("should expose the schema", () => {
-      const schema = S.propertySignature(S.String).annotations({})
-      expect(schema.schema).toStrictEqual(S.String)
-    })
-
     it("propertySignature(S.string)", () => {
       const schema = S.Struct({
         a: S.propertySignature(S.String).annotations({ description: "a description" }).annotations({ title: "a title" })

--- a/packages/schema/test/Schema/PropertySignature.test.ts
+++ b/packages/schema/test/Schema/PropertySignature.test.ts
@@ -6,7 +6,7 @@ import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 
 describe("PropertySignature", () => {
-  it("should expose the schema", () => {
+  it("propertySignature should expose the schema", () => {
     const schema = S.propertySignature(S.String)
     expect(schema.schema).toStrictEqual(S.String)
   })

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -17,6 +17,16 @@ describe("optional APIs", () => {
   })
 
   describe("optional > { exact: true }", () => {
+    it("should expose a from property", () => {
+      const schema = S.optional(S.String, { exact: true })
+      expect(schema.from).toStrictEqual(S.String)
+    })
+
+    it("should expose a from property after an annotations call", () => {
+      const schema = S.optional(S.String, { exact: true }).annotations({})
+      expect(schema.from).toStrictEqual(S.String)
+    })
+
     it("decoding / encoding", async () => {
       const schema = S.Struct({
         a: S.optional(S.NumberFromString, { exact: true })
@@ -51,9 +61,14 @@ describe("optional APIs", () => {
   })
 
   describe("optional", () => {
-    it("should expose the schema", () => {
+    it("should expose a from property", () => {
       const schema = S.optional(S.String)
-      expect(schema.schema).toStrictEqual(S.String)
+      expect(schema.from).toStrictEqual(S.String)
+    })
+
+    it("should expose a from property after an annotations call", () => {
+      const schema = S.optional(S.String).annotations({})
+      expect(schema.from).toStrictEqual(S.String)
     })
 
     it("decoding / encoding", async () => {

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -51,6 +51,11 @@ describe("optional APIs", () => {
   })
 
   describe("optional", () => {
+    it("should expose the schema", () => {
+      const schema = S.optional(S.String)
+      expect(schema.schema).toStrictEqual(S.String)
+    })
+
     it("decoding / encoding", async () => {
       const schema = S.Struct({
         a: S.optional(S.NumberFromString)


### PR DESCRIPTION
- add `propertySignature` API interface (with a `from` property)
- extend `optional` API interface with a `from` property
- extend `optionalWithOptions` API interface with a `from` property
