### PR TITLE
add support for string literals to `Schema.TemplateLiteral` and `Temp…

### DIFF
--- a/.changeset/cyan-jokes-report.md
+++ b/.changeset/cyan-jokes-report.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+make the `AST.TemplateLiteral` constructor public

--- a/.changeset/famous-crabs-fetch.md
+++ b/.changeset/famous-crabs-fetch.md
@@ -1,0 +1,33 @@
+---
+"@effect/schema": patch
+---
+
+add support for string literals to `Schema.TemplateLiteral` and `TemplateLiteral` API interface.
+
+Before
+
+```ts
+import { Schema } from "@effect/schema"
+
+// `https://${string}.com` | `https://${string}.net`
+const MyUrl = Schema.TemplateLiteral(
+  Schema.Literal("https://"),
+  Schema.String,
+  Schema.Literal("."),
+  Schema.Literal("com", "net")
+)
+```
+
+Now
+
+```ts
+import { Schema } from "@effect/schema"
+
+// `https://${string}.com` | `https://${string}.net`
+const MyUrl = Schema.TemplateLiteral(
+  "https://",
+  Schema.String,
+  ".",
+  Schema.Literal("com", "net")
+)
+```

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1520,7 +1520,7 @@ console.log(Equivalence.make(schema)("aaa", "abb")) // Output: true
 | `object`                                     |                                          | `S.Object`                                                |
 | `unique symbol`                              |                                          | `S.UniqueSymbolFromSelf`                                  |
 | `"a"`, `1`, `true`                           | type literals                            | `S.Literal("a")`, `S.Literal(1)`, `S.Literal(true)`       |
-| `a${string}`                                 | template literals                        | `S.TemplateLiteral(S.Literal("a"), S.String)`             |
+| `a${string}`                                 | template literals                        | `S.TemplateLiteral("a", S.String)`                        |
 | `{ readonly a: string, readonly b: number }` | structs                                  | `S.Struct({ a: S.String, b: S.Number })`                  |
 | `{ readonly a?: string \| undefined }`       | optional fields                          | `S.Struct({ a: S.optional(S.String) })`                   |
 | `{ readonly a?: string }`                    | optional fields                          | `S.Struct({ a: S.optional(S.String, { exact: true }) })`  |
@@ -1628,18 +1628,23 @@ The `TemplateLiteral` constructor allows you to create a schema for a TypeScript
 ```ts
 import { Schema } from "@effect/schema"
 
-// Schema<`a${string}`>
-Schema.TemplateLiteral(Schema.Literal("a"), Schema.String)
+// TemplateLiteral<`a${string}`>
+Schema.TemplateLiteral("a", Schema.String)
+
+// TemplateLiteral<`https://${string}.com` | `https://${string}.net`>
+Schema.TemplateLiteral(
+  "https://",
+  Schema.String,
+  ".",
+  Schema.Literal("com", "net")
+)
 
 // example from https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
 const EmailLocaleIDs = Schema.Literal("welcome_email", "email_heading")
 const FooterLocaleIDs = Schema.Literal("footer_title", "footer_sendoff")
 
-// Schema<"welcome_email_id" | "email_heading_id" | "footer_title_id" | "footer_sendoff_id">
-Schema.TemplateLiteral(
-  Schema.Union(EmailLocaleIDs, FooterLocaleIDs),
-  Schema.Literal("_id")
-)
+// TemplateLiteral<"welcome_email_id" | "email_heading_id" | "footer_title_id" | "footer_sendoff_id">
+Schema.TemplateLiteral(Schema.Union(EmailLocaleIDs, FooterLocaleIDs), "_id")
 ```
 
 ## Unique Symbols

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1039,7 +1039,7 @@ S.Record(S.SymbolFromSelf, S.String)
 // $ExpectType Schema<{ readonly [x: `a${string}`]: string; }, { readonly [x: `a${string}`]: string; }, never>
 S.asSchema(S.Record(S.TemplateLiteral(S.Literal("a"), S.String), S.String))
 
-// $ExpectType Record$<SchemaClass<`a${string}`, `a${string}`, never>, typeof String$>
+// $ExpectType Record$<TemplateLiteral<`a${string}`>, typeof String$>
 S.Record(S.TemplateLiteral(S.Literal("a"), S.String), S.String)
 
 // $ExpectType Schema<{ readonly [x: string & Brand<"UserId">]: string; }, { readonly [x: string]: string; }, never>
@@ -1185,15 +1185,24 @@ S.instanceOf(Test)
 // TemplateLiteral
 // ---------------------------------------------
 
-// $ExpectType SchemaClass<`a${string}`, `a${string}`, never>
+// @ts-expect-error
+S.TemplateLiteral(1, S.String)
+
+// TemplateLiteral<`a${string}`>
 S.TemplateLiteral(S.Literal("a"), S.String)
+
+// TemplateLiteral<`a${string}`>
+S.TemplateLiteral("a", S.String)
 
 // example from https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
 const EmailLocaleIDs = S.Literal("welcome_email", "email_heading")
 const FooterLocaleIDs = S.Literal("footer_title", "footer_sendoff")
 
-// $ExpectType SchemaClass<"welcome_email_id" | "email_heading_id" | "footer_title_id" | "footer_sendoff_id", "welcome_email_id" | "email_heading_id" | "footer_title_id" | "footer_sendoff_id", never>
+// $ExpectType TemplateLiteral<"welcome_email_id" | "email_heading_id" | "footer_title_id" | "footer_sendoff_id">
 S.TemplateLiteral(S.Union(EmailLocaleIDs, FooterLocaleIDs), S.Literal("_id"))
+
+// $ExpectType TemplateLiteral<"welcome_email_id" | "email_heading_id" | "footer_title_id" | "footer_sendoff_id">
+S.TemplateLiteral(S.Union(EmailLocaleIDs, FooterLocaleIDs), "_id")
 
 // ---------------------------------------------
 // attachPropertySignature

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1015,7 +1015,7 @@ export class TemplateLiteral implements Annotated {
    * @since 0.67.0
    */
   readonly _tag = "TemplateLiteral"
-  private constructor(
+  constructor(
     readonly head: string,
     readonly spans: Arr.NonEmptyReadonlyArray<TemplateLiteralSpan>,
     readonly annotations: Annotations = {}

--- a/packages/schema/test/Schema/TemplateLiteral/TemplateLiteral.test.ts
+++ b/packages/schema/test/Schema/TemplateLiteral/TemplateLiteral.test.ts
@@ -12,34 +12,32 @@ describe("TemplateLiteral", () => {
 
   describe("AST", () => {
     it("a", () => {
-      const schema = S.TemplateLiteral(S.Literal("a"))
-      expect(schema.ast).toEqual(new AST.Literal("a"))
+      const expected = new AST.Literal("a")
+      expect(S.TemplateLiteral(S.Literal("a")).ast).toEqual(expected)
+      expect(S.TemplateLiteral("a").ast).toEqual(expected)
     })
 
     it("a b", () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.Literal(" "), S.Literal("b"))
-      expect(schema.ast).toEqual(
-        new AST.Literal("a b")
-      )
+      const expected = new AST.Literal("a b")
+      expect(S.TemplateLiteral(S.Literal("a"), S.Literal(" "), S.Literal("b")).ast).toEqual(expected)
+      expect(S.TemplateLiteral("a", " ", "b").ast).toEqual(expected)
     })
 
     it("(a | b) c", () => {
-      const schema = S.TemplateLiteral(S.Literal("a", "b"), S.Literal("c"))
-      expect(schema.ast).toEqual(
-        AST.Union.make([new AST.Literal("ac"), new AST.Literal("bc")])
-      )
+      const expected = AST.Union.make([new AST.Literal("ac"), new AST.Literal("bc")])
+      expect(S.TemplateLiteral(S.Literal("a", "b"), S.Literal("c")).ast).toEqual(expected)
+      expect(S.TemplateLiteral(S.Literal("a", "b"), "c").ast).toEqual(expected)
     })
 
     it("(a | b) c (d | e)", () => {
-      const schema = S.TemplateLiteral(S.Literal("a", "b"), S.Literal("c"), S.Literal("d", "e"))
-      expect(schema.ast).toEqual(
-        AST.Union.make([
-          new AST.Literal("acd"),
-          new AST.Literal("ace"),
-          new AST.Literal("bcd"),
-          new AST.Literal("bce")
-        ])
-      )
+      const expected = AST.Union.make([
+        new AST.Literal("acd"),
+        new AST.Literal("ace"),
+        new AST.Literal("bcd"),
+        new AST.Literal("bce")
+      ])
+      expect(S.TemplateLiteral(S.Literal("a", "b"), S.Literal("c"), S.Literal("d", "e")).ast).toEqual(expected)
+      expect(S.TemplateLiteral(S.Literal("a", "b"), "c", S.Literal("d", "e")).ast).toEqual(expected)
     })
 
     it("(a | b) string (d | e)", () => {
@@ -55,24 +53,22 @@ describe("TemplateLiteral", () => {
     })
 
     it("a${string}", () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.String)
-      expect(schema.ast).toEqual(
-        AST.TemplateLiteral.make("a", [new AST.TemplateLiteralSpan(AST.stringKeyword, "")])
-      )
+      const expected = AST.TemplateLiteral.make("a", [new AST.TemplateLiteralSpan(AST.stringKeyword, "")])
+      expect(S.TemplateLiteral(S.Literal("a"), S.String).ast).toEqual(expected)
+      expect(S.TemplateLiteral("a", S.String).ast).toEqual(expected)
     })
 
     it("a${string}b", () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.String, S.Literal("b"))
-      expect(schema.ast).toEqual(
-        AST.TemplateLiteral.make("a", [new AST.TemplateLiteralSpan(AST.stringKeyword, "b")])
-      )
+      const expected = AST.TemplateLiteral.make("a", [new AST.TemplateLiteralSpan(AST.stringKeyword, "b")])
+      expect(S.TemplateLiteral(S.Literal("a"), S.String, S.Literal("b")).ast).toEqual(expected)
+      expect(S.TemplateLiteral("a", S.String, "b").ast).toEqual(expected)
     })
   })
 
-  describe("Decoder", () => {
+  describe("decoding", () => {
     it("a", async () => {
-      const schema = S.TemplateLiteral(S.Literal("a"))
-      await Util.expectDecodeUnknownSuccess(schema, "a", "a")
+      const schema = S.TemplateLiteral("a")
+      await Util.expectDecodeUnknownSuccess(schema, "a")
 
       await Util.expectDecodeUnknownFailure(schema, "ab", `Expected "a", actual "ab"`)
       await Util.expectDecodeUnknownFailure(schema, "", `Expected "a", actual ""`)
@@ -80,23 +76,23 @@ describe("TemplateLiteral", () => {
     })
 
     it("a b", async () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.Literal(" "), S.Literal("b"))
-      await Util.expectDecodeUnknownSuccess(schema, "a b", "a b")
+      const schema = S.TemplateLiteral("a", " ", "b")
+      await Util.expectDecodeUnknownSuccess(schema, "a b")
 
       await Util.expectDecodeUnknownFailure(schema, "a  b", `Expected "a b", actual "a  b"`)
     })
 
     it("[${string}]", async () => {
-      const schema = S.TemplateLiteral(S.Literal("["), S.String, S.Literal("]"))
-      await Util.expectDecodeUnknownSuccess(schema, "[a]", "[a]")
+      const schema = S.TemplateLiteral("[", S.String, "]")
+      await Util.expectDecodeUnknownSuccess(schema, "[a]")
 
       await Util.expectDecodeUnknownFailure(schema, "a", "Expected `[${string}]`, actual \"a\"")
     })
 
     it("a${string}", async () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.String)
-      await Util.expectDecodeUnknownSuccess(schema, "a", "a")
-      await Util.expectDecodeUnknownSuccess(schema, "ab", "ab")
+      const schema = S.TemplateLiteral("a", S.String)
+      await Util.expectDecodeUnknownSuccess(schema, "a")
+      await Util.expectDecodeUnknownSuccess(schema, "ab")
 
       await Util.expectDecodeUnknownFailure(
         schema,
@@ -111,7 +107,7 @@ describe("TemplateLiteral", () => {
     })
 
     it("a${number}", async () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.Number)
+      const schema = S.TemplateLiteral("a", S.Number)
       await Util.expectDecodeUnknownSuccess(schema, "a1")
       await Util.expectDecodeUnknownSuccess(schema, "a1.2")
 
@@ -148,16 +144,16 @@ describe("TemplateLiteral", () => {
 
     it("${string}", async () => {
       const schema = S.TemplateLiteral(S.String)
-      await Util.expectDecodeUnknownSuccess(schema, "a", "a")
-      await Util.expectDecodeUnknownSuccess(schema, "ab", "ab")
-      await Util.expectDecodeUnknownSuccess(schema, "", "")
+      await Util.expectDecodeUnknownSuccess(schema, "a")
+      await Util.expectDecodeUnknownSuccess(schema, "ab")
+      await Util.expectDecodeUnknownSuccess(schema, "")
     })
 
     it("a${string}b", async () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.String, S.Literal("b"))
-      await Util.expectDecodeUnknownSuccess(schema, "ab", "ab")
-      await Util.expectDecodeUnknownSuccess(schema, "acb", "acb")
-      await Util.expectDecodeUnknownSuccess(schema, "abb", "abb")
+      const schema = S.TemplateLiteral("a", S.String, "b")
+      await Util.expectDecodeUnknownSuccess(schema, "ab")
+      await Util.expectDecodeUnknownSuccess(schema, "acb")
+      await Util.expectDecodeUnknownSuccess(schema, "abb")
       await Util.expectDecodeUnknownFailure(
         schema,
         "",
@@ -177,10 +173,10 @@ describe("TemplateLiteral", () => {
     })
 
     it("a${string}b${string}", async () => {
-      const schema = S.TemplateLiteral(S.Literal("a"), S.String, S.Literal("b"), S.String)
-      await Util.expectDecodeUnknownSuccess(schema, "ab", "ab")
-      await Util.expectDecodeUnknownSuccess(schema, "acb", "acb")
-      await Util.expectDecodeUnknownSuccess(schema, "acbd", "acbd")
+      const schema = S.TemplateLiteral("a", S.String, "b", S.String)
+      await Util.expectDecodeUnknownSuccess(schema, "ab")
+      await Util.expectDecodeUnknownSuccess(schema, "acb")
+      await Util.expectDecodeUnknownSuccess(schema, "acbd")
 
       await Util.expectDecodeUnknownFailure(
         schema,
@@ -197,11 +193,11 @@ describe("TemplateLiteral", () => {
     it("https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html", async () => {
       const EmailLocaleIDs = S.Literal("welcome_email", "email_heading")
       const FooterLocaleIDs = S.Literal("footer_title", "footer_sendoff")
-      const schema = S.TemplateLiteral(S.Union(EmailLocaleIDs, FooterLocaleIDs), S.Literal("_id"))
-      await Util.expectDecodeUnknownSuccess(schema, "welcome_email_id", "welcome_email_id")
-      await Util.expectDecodeUnknownSuccess(schema, "email_heading_id", "email_heading_id")
-      await Util.expectDecodeUnknownSuccess(schema, "footer_title_id", "footer_title_id")
-      await Util.expectDecodeUnknownSuccess(schema, "footer_sendoff_id", "footer_sendoff_id")
+      const schema = S.TemplateLiteral(S.Union(EmailLocaleIDs, FooterLocaleIDs), "_id")
+      await Util.expectDecodeUnknownSuccess(schema, "welcome_email_id")
+      await Util.expectDecodeUnknownSuccess(schema, "email_heading_id")
+      await Util.expectDecodeUnknownSuccess(schema, "footer_title_id")
+      await Util.expectDecodeUnknownSuccess(schema, "footer_sendoff_id")
 
       await Util.expectDecodeUnknownFailure(
         schema,


### PR DESCRIPTION
…lateLiteral` API interface

Before

```ts
import { Schema } from "@effect/schema"

// `https://${string}.com` | `https://${string}.net`
const MyUrl = Schema.TemplateLiteral(
  Schema.Literal("https://"),
  Schema.String,
  Schema.Literal("."),
  Schema.Literal("com", "net")
)
```

Now

```ts
import { Schema } from "@effect/schema"

// `https://${string}.com` | `https://${string}.net`
const MyUrl = Schema.TemplateLiteral(
  "https://",
  Schema.String,
  ".",
  Schema.Literal("com", "net")
)
```
