### PR TITLE
add support for unions to `rename`, closes #2904

### DIFF
--- a/.changeset/fifty-impalas-cheer.md
+++ b/.changeset/fifty-impalas-cheer.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+add support for unions to `rename`, closes #2904

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -2624,6 +2624,8 @@ export const rename = (ast: AST, mapping: { readonly [K in PropertyKey]?: Proper
         new TypeLiteralTransformation(propertySignatureTransformations)
       )
     }
+    case "Union":
+      return Union.make(ast.types.map((ast) => rename(ast, mapping)))
     case "Suspend":
       return new Suspend(() => rename(ast.f(), mapping))
     case "Transformation":

--- a/packages/schema/test/Schema/rename.test.ts
+++ b/packages/schema/test/Schema/rename.test.ts
@@ -96,4 +96,25 @@ describe("rename", () => {
     await Util.expectDecodeUnknownSuccess(renamed, { a: "a", b: "1" }, { c: "a", b: 1 })
     await Util.expectEncodeSuccess(renamed, { c: "a", b: 1 }, { a: "a", b: "1" })
   })
+
+  it("union", async () => {
+    const A = S.Struct({
+      ab: S.Number
+    })
+
+    const B = S.Struct({
+      ab: S.Null
+    })
+
+    const schema = S.Union(
+      A.pipe(S.attachPropertySignature("kind", "A")),
+      B.pipe(S.attachPropertySignature("kind", "B"))
+    )
+    const renamed = schema.pipe(S.rename({ ab: "c" }))
+    await Util.expectDecodeUnknownSuccess(renamed, { ab: 1 }, { kind: "A", c: 1 })
+    await Util.expectDecodeUnknownSuccess(renamed, { ab: null }, { kind: "B", c: null })
+
+    await Util.expectEncodeSuccess(renamed, { kind: "A", c: 1 }, { ab: 1 })
+    await Util.expectEncodeSuccess(renamed, { kind: "B", c: null }, { ab: null })
+  })
 })


### PR DESCRIPTION
## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #2904
