### PR TITLE
Add `Either.liftPredicate`

### DIFF
--- a/.changeset/two-bananas-mix.md
+++ b/.changeset/two-bananas-mix.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Add Either.liftPredicate

--- a/.changeset/two-bananas-mix.md
+++ b/.changeset/two-bananas-mix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add Either.liftPredicate

--- a/packages/effect/dtslint/Either.ts
+++ b/packages/effect/dtslint/Either.ts
@@ -111,6 +111,80 @@ string$string.pipe(Either.andThen(string$number))
 string$string.pipe(Either.andThen(() => string$number))
 
 // -------------------------------------------------------------------------------------
+// liftPredicate
+// -------------------------------------------------------------------------------------
+
+declare const primitiveNumber: number
+declare const primitiveNumberOrString: string | number
+declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
+
+// $ExpectType Either<string, "b">
+pipe(
+  primitiveNumberOrString,
+  Either.liftPredicate(Predicate.isString, (
+    _s // $ExpectType string | number
+  ) => "b" as const)
+)
+
+// $ExpectType Either<string, "b">
+Either.liftPredicate(primitiveNumberOrString, Predicate.isString, (
+  _s // $ExpectType string | number
+) => "b" as const)
+
+// $ExpectType Either<number, "b">
+pipe(
+  primitiveNumberOrString,
+  Either.liftPredicate(
+    (
+      n // $ExpectType string | number
+    ): n is number => typeof n === "number",
+    (
+      _s // $ExpectType string | number
+    ) => "b" as const
+  )
+)
+
+// $ExpectType Either<number, "b">
+Either.liftPredicate(
+  primitiveNumberOrString,
+  (
+    n // $ExpectType string | number
+  ): n is number => typeof n === "number",
+  (
+    _s // $ExpectType string | number
+  ) => "b" as const
+)
+
+// $ExpectType Either<string | number, "b">
+pipe(
+  primitiveNumberOrString,
+  Either.liftPredicate(predicateNumbersOrStrings, (
+    _s // $ExpectType string | number
+  ) => "b" as const)
+)
+
+// $ExpectType Either<number, "b">
+pipe(
+  primitiveNumber,
+  Either.liftPredicate(predicateNumbersOrStrings, (
+    _s // $ExpectType number
+  ) => "b" as const)
+)
+
+// $ExpectType Either<number, "b">
+pipe(
+  primitiveNumber,
+  Either.liftPredicate(
+    (
+      _n // $ExpectType number
+    ) => true,
+    (
+      _s // $ExpectType number
+    ) => "b" as const
+  )
+)
+
+// -------------------------------------------------------------------------------------
 // filterOrLeft
 // -------------------------------------------------------------------------------------
 

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -421,24 +421,24 @@ export const match: {
  */
 export const liftPredicate: {
   <A, B extends A, E>(refinement: Refinement<NoInfer<A>, B>, orLeftWith: (a: NoInfer<A>) => E): (a: A) => Either<B, E>
-  <A, E, B = A>(
+  <A, E>(
     predicate: Predicate<NoInfer<A>>,
     orLeftWith: (a: NoInfer<A>) => E
-  ): (x: A) => Either<B, E>
+  ): (a: A) => Either<A, E>
   <A, E, B extends A>(
     self: A,
     refinement: Refinement<A, B>,
     orLeftWith: (a: A) => E
   ): Either<B, E>
-  <A, E, B = A>(
+  <A, E>(
     self: A,
     predicate: Predicate<A>,
     orLeftWith: (a: A) => E
-  ): Either<B, E>
+  ): Either<A, E>
 } = dual(
   3,
-  <A, E, B extends A>(x: B, predicate: Predicate<A>, orLeftWith: (a: A) => E) =>
-    predicate(x) ? right(x) : left(orLeftWith(x))
+  <A, E>(a: A, predicate: Predicate<A>, orLeftWith: (a: A) => E): Either<A, E> =>
+    predicate(a) ? right(a) : left(orLeftWith(a))
 )
 
 /**

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -417,7 +417,7 @@ export const match: {
  * )
  *
  * @category lifting
- * @since 2.0.0
+ * @since 3.2.8
  */
 export const liftPredicate: {
   <A, B extends A, E>(refinement: Refinement<NoInfer<A>, B>, orLeftWith: (a: NoInfer<A>) => E): (a: A) => Either<B, E>

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -417,7 +417,7 @@ export const match: {
  * )
  *
  * @category lifting
- * @since 3.2.8
+ * @since 3.4.0
  */
 export const liftPredicate: {
   <A, B extends A, E>(refinement: Refinement<NoInfer<A>, B>, orLeftWith: (a: NoInfer<A>) => E): (a: A) => Either<B, E>

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -432,8 +432,8 @@ export const liftPredicate: {
   ): Either<B, E>
   <A, E>(
     self: A,
-    predicate: Predicate<A>,
-    orLeftWith: (a: A) => E
+    predicate: Predicate<NoInfer<A>>,
+    orLeftWith: (a: NoInfer<A>) => E
   ): Either<A, E>
 } = dual(
   3,

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -391,6 +391,57 @@ export const match: {
 )
 
 /**
+ * Transforms a `Predicate` function into a `Right` of the input value if the predicate returns `true`
+ * or `Left` of the result of the provided function if the predicate returns false
+ *
+ * @param predicate - A `Predicate` function that takes in a value of type `A` and returns a boolean.
+ *
+ * @example
+ * import { pipe, Either } from "effect"
+ *
+ * const isPositive = (n: number): boolean => n > 0
+ *
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     1,
+ *     Either.liftPredicate(isPositive, n => `${n} is not positive`)
+ *   ),
+ *   Either.right(1)
+ * )
+ * assert.deepStrictEqual(
+ *   pipe(
+ *     0,
+ *     Either.liftPredicate(isPositive, n => `${n} is not positive`)
+ *   ),
+ *   Either.left("0 is not positive")
+ * )
+ *
+ * @category lifting
+ * @since 2.0.0
+ */
+export const liftPredicate: {
+  <A, B extends A, E>(refinement: Refinement<NoInfer<A>, B>, orLeftWith: (a: NoInfer<A>) => E): (a: A) => Either<B, E>
+  <A, E, B = A>(
+    predicate: Predicate<NoInfer<A>>,
+    orLeftWith: (a: NoInfer<A>) => E
+  ): (x: A) => Either<B, E>
+  <A, E, B extends A>(
+    self: A,
+    refinement: Refinement<A, B>,
+    orLeftWith: (a: A) => E
+  ): Either<B, E>
+  <A, E, B = A>(
+    self: A,
+    predicate: Predicate<A>,
+    orLeftWith: (a: A) => E
+  ): Either<B, E>
+} = dual(
+  3,
+  <A, E, B extends A>(x: B, predicate: Predicate<A>, orLeftWith: (a: A) => E) =>
+    predicate(x) ? right(x) : left(orLeftWith(x))
+)
+
+/**
  * Filter the right value with the provided function.
  * If the predicate fails, set the left value with the result of the provided function.
  *

--- a/packages/effect/test/Either.test.ts
+++ b/packages/effect/test/Either.test.ts
@@ -169,6 +169,47 @@ describe("Either", () => {
     Util.deepStrictEqual(Either.flip(Either.left("b")), Either.right("b"))
   })
 
+  it("liftPredicate", () => {
+    const isPositivePredicate = (n: number) => n > 0
+    const onPositivePredicateError = (n: number) => `${n} is not positive`
+    const isNumberRefinement = (n: string | number): n is number => typeof n === "number"
+    const onNumberRefinementError = (n: string | number) => `${n} is not a number`
+
+    Util.deepStrictEqual(
+      pipe(1, Either.liftPredicate(isPositivePredicate, onPositivePredicateError)),
+      Either.right(1)
+    )
+    Util.deepStrictEqual(
+      pipe(-1, Either.liftPredicate(isPositivePredicate, onPositivePredicateError)),
+      Either.left(`-1 is not positive`)
+    )
+    Util.deepStrictEqual(
+      pipe(1, Either.liftPredicate(isNumberRefinement, onNumberRefinementError)),
+      Either.right(1)
+    )
+    Util.deepStrictEqual(
+      pipe("string", Either.liftPredicate(isNumberRefinement, onNumberRefinementError)),
+      Either.left(`string is not a number`)
+    )
+
+    Util.deepStrictEqual(
+      Either.liftPredicate(1, isPositivePredicate, onPositivePredicateError),
+      Either.right(1)
+    )
+    Util.deepStrictEqual(
+      Either.liftPredicate(-1, isPositivePredicate, onPositivePredicateError),
+      Either.left(`-1 is not positive`)
+    )
+    Util.deepStrictEqual(
+      Either.liftPredicate(1, isNumberRefinement, onNumberRefinementError),
+      Either.right(1)
+    )
+    Util.deepStrictEqual(
+      Either.liftPredicate("string", isNumberRefinement, onNumberRefinementError),
+      Either.left(`string is not a number`)
+    )
+  })
+
   it("filterOrLeft", () => {
     Util.deepStrictEqual(Either.filterOrLeft(Either.right(1), (n) => n > 0, () => "a"), Either.right(1))
     Util.deepStrictEqual(Either.filterOrLeft(Either.right(1), (n) => n > 1, () => "a"), Either.left("a"))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Add `Either.liftPredicate`. In my current project we were missing it so we created a custom helper for it, but I found out in the Discord that other people would like it to be implemented (see thread [here](https://discord.com/channels/795981131316985866/1022125411485896708/1241130231666970744)). So I figured it could be an opportunity to contribute here!

I took inspiration from `Option.fromPredicate` but I went a bit further and made `Either.liftPredicate` dual

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

N/A
