### PR TITLE
fix print to stdout of cli (#1812)

### DIFF
--- a/.changeset/lazy-keys-wait.md
+++ b/.changeset/lazy-keys-wait.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+in case of error let cli print to stderr instead of stdout (#1812)

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -129,7 +129,7 @@ const splitExecutable = <A>(self: CliApp.CliApp<A>, args: ReadonlyArray<string>)
   return [`${runtime} ${script}`, optionsAndArgs]
 }
 
-const printDocs = (error: HelpDoc.HelpDoc): Effect.Effect<void> => Console.log(InternalHelpDoc.toAnsiText(error))
+const printDocs = (error: HelpDoc.HelpDoc): Effect.Effect<void> => Console.error(InternalHelpDoc.toAnsiText(error))
 
 // TODO: move to `/platform`
 const isQuitException = (u: unknown): u is Terminal.QuitException =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updates the CLI Package: The error message for invalid commands will be printed out to stderr instead of stdout, as indicated by the related issue below.

## Related

- Closes #1812 
