### PR TITLE
feat(Stream): implement share() operator

### DIFF
--- a/.changeset/large-moose-beam.md
+++ b/.changeset/large-moose-beam.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+feat(Stream): implement flexible `share()` operator

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -3387,6 +3387,9 @@ export const scoped: <A, E, R>(effect: Effect.Effect<A, E, R>) => Stream<A, E, E
  * or Queue to be used for sharing the stream elements.
  *
  * @example
+ *
+ * import {Stream, Effect, StreamEmit, PubSub, Chunk} from 'effect';
+ *
  * const intervalStream = (intervalMs: number) => Stream.async((emit: StreamEmit.Emit<never, never, number, void>) => {
  *     let i = 0
  *     const intervalPointer = setInterval(() => {
@@ -3397,7 +3400,7 @@ export const scoped: <A, E, R>(effect: Effect.Effect<A, E, R>) => Stream<A, E, E
  * });
  *
  * const program = Effect.gen(function* () {
- *     const sharedStream = yield* intervalStream(0).pipe(share({
+ *     const sharedStream = yield* intervalStream(0).pipe(Stream.share({
  *         connector: PubSub.unbounded()
  *     }));
  *     const streamMax3 = sharedStream.pipe(Stream.take(3))
@@ -3418,18 +3421,21 @@ export const scoped: <A, E, R>(effect: Effect.Effect<A, E, R>) => Stream<A, E, E
  * // origin 2
  * // s1 2
  * // s2 2
+ *
+ * @since 3.4.0
+ * @category utils
  */
 export const share: {
   <A, E>(options: {
     readonly connector: Effect.Effect<
       PubSub.PubSub<Take.Take<A, E>> | Queue.Queue<Take.Take<A, E>>
     >
-  }): <R>(self: Stream.Stream<A, E, R>) => Effect.Effect<Stream.Stream<A, E>, never, Scope.Scope | R>
-  <A, E, R>(self: Stream.Stream<A, E, R>, options: {
+  }): <R>(self: Stream<A, E, R>) => Effect.Effect<Stream<A, E>, never, Scope.Scope | R>
+  <A, E, R>(self: Stream<A, E, R>, options: {
     readonly connector: Effect.Effect<
       PubSub.PubSub<Take.Take<A, E>> | Queue.Queue<Take.Take<A, E>>
     >
-  }): Effect.Effect<Stream.Stream<A, E>, never, Scope.Scope | R>
+  }): Effect.Effect<Stream<A, E>, never, Scope.Scope | R>
 } = internal.share
 
 /**

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -5694,16 +5694,16 @@ export const share = dual<
   return Effect.acquireRelease(options.connector, (queue) => Queue.shutdown(queue)).pipe(
     Effect.tap((pubSubOrQueue) => {
       if ("subscribe" in pubSubOrQueue) {
-        return Effect.forkScoped(Stream.runIntoPubSubScoped(self, pubSubOrQueue))
+        return Effect.forkScoped(runIntoPubSubScoped(self, pubSubOrQueue))
       } else {
-        return Effect.forkScoped(Stream.runIntoQueueScoped(self, pubSubOrQueue))
+        return Effect.forkScoped(runIntoQueueScoped(self, pubSubOrQueue))
       }
     }),
     Effect.map((pubSubOrQueue) => {
       if ("subscribe" in pubSubOrQueue) {
-        return Stream.flattenTake(Stream.fromPubSub(pubSubOrQueue))
+        return flattenTake(fromPubSub(pubSubOrQueue))
       }
-      return Stream.flattenTake(Stream.fromQueue(pubSubOrQueue))
+      return flattenTake(fromQueue(pubSubOrQueue))
     })
   )
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A `share()` operator, that accepts any `PubSub` or `Queue`. FMPOV eliminates the need of `broadcast*` family operators, while being even more flexible than them.

Along with my another PR https://github.com/Effect-TS/effect/pull/2940 for replayable PubSub will allow to create replayable streams

```ts
declare const someResourcefulStream: Stream<string>;
const sharedResourcefulReplayableStream = someResourcefulStream.pipe(share(
  connector: PubSub.unbounded(10)
))
```
## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
