### PR TITLE
Remove unnecessary `===` comparison in `getEquivalence` functions

### DIFF
--- a/.changeset/tasty-toys-wave.md
+++ b/.changeset/tasty-toys-wave.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Remove unnecessary `===` comparison in `getEquivalence` functions
+
+In some `getEquivalence` functions that use `make`, there is an unnecessary `===` comparison. The `make` function already handles this comparison.

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -290,10 +290,9 @@ export const getEquivalence = <R, L>({ left, right }: {
   left: Equivalence.Equivalence<L>
 }): Equivalence.Equivalence<Either<R, L>> =>
   Equivalence.make((x, y) =>
-    x === y ||
-    (isLeft(x) ?
+    isLeft(x) ?
       isLeft(y) && left(x.left, y.left) :
-      isRight(y) && right(x.right, y.right))
+      isRight(y) && right(x.right, y.right)
   )
 
 /**

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1057,7 +1057,7 @@ export const filter: {
  * @since 2.0.0
  */
 export const getEquivalence = <A>(isEquivalent: Equivalence.Equivalence<A>): Equivalence.Equivalence<Option<A>> =>
-  Equivalence.make((x, y) => x === y || (isNone(x) ? isNone(y) : isNone(y) ? false : isEquivalent(x.value, y.value)))
+  Equivalence.make((x, y) => isNone(x) ? isNone(y) : isNone(y) ? false : isEquivalent(x.value, y.value))
 
 /**
  * The `Order` instance allows `Option` values to be compared with

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -130,4 +130,4 @@ export const unsafeWipe: <A>(self: Redacted<A>) => boolean = redacted_.unsafeWip
  * @since 3.3.0
  */
 export const getEquivalence = <A>(isEquivalent: Equivalence.Equivalence<A>): Equivalence.Equivalence<Redacted<A>> =>
-  Equivalence.make((x, y) => x === y || (isEquivalent(value(x), value(y))))
+  Equivalence.make((x, y) => isEquivalent(value(x), value(y)))


### PR DESCRIPTION
In some `getEquivalence` functions that use `make`, there is an unnecessary `===` comparison. The `make` function already handles this comparison.
