### PR TITLE
Change `Config.array` to return `Array` instead of `ReadonlyArray`

### DIFF
--- a/.changeset/clean-frogs-cry.md
+++ b/.changeset/clean-frogs-cry.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Changing the signature of a `Config.array`
+Change `Config.array` to return `Array<A>` instead of `ReadonlyArray<A>`

--- a/.changeset/clean-frogs-cry.md
+++ b/.changeset/clean-frogs-cry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Changing the signature of a `Config.array`

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -110,7 +110,7 @@ export const all: <const Arg extends Iterable<Config<any>> | Record<string, Conf
  * @since 2.0.0
  * @category constructors
  */
-export const array: <A>(config: Config<A>, name?: string) => Config<ReadonlyArray<A>> = internal.array
+export const array: <A>(config: Config<A>, name?: string) => Config<Array<A>> = internal.array
 
 /**
  * Constructs a config for a boolean value.

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -180,8 +180,8 @@ export const boolean = (name?: string): Config.Config<boolean> => {
 }
 
 /** @internal */
-export const array = <A>(config: Config.Config<A>, name?: string): Config.Config<ReadonlyArray<A>> => {
-  return pipe(chunk(config, name), map(Chunk.toReadonlyArray))
+export const array = <A>(config: Config.Config<A>, name?: string): Config.Config<Array<A>> => {
+  return pipe(chunk(config, name), map(Chunk.toArray))
 }
 
 /** @internal */


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Changed the return type by analogy with the `Array` module
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Discord thread https://discord.com/channels/795981131316985866/795983589644304396/1248597048673177601
- Related Issue #
- Closes #
