### PR TITLE
Fix runtime error in `Struct.evolve` by enhancing compile-time checks, closes #2953

### DIFF
--- a/.changeset/long-dodos-poke.md
+++ b/.changeset/long-dodos-poke.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+made Struct.evolve more strict

--- a/.changeset/long-dodos-poke.md
+++ b/.changeset/long-dodos-poke.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-made Struct.evolve more strict
+Fix runtime error in `Struct.evolve` by enhancing compile-time checks, closes #2953

--- a/packages/effect/dtslint/Struct.ts
+++ b/packages/effect/dtslint/Struct.ts
@@ -25,10 +25,59 @@ declare const optionalStringStruct: {
 // -------------------------------------------------------------------------------------
 
 // $ExpectType { a: boolean; }
-S.evolve({ a: 1 }, { a: (x) => x > 0 })
+S.evolve({ a: 1 }, {
+  a: (
+    n // $ExpectType number
+  ) => n > 0
+})
+
+// $ExpectType { a: boolean; }
+pipe(
+  { a: 1 },
+  S.evolve({
+    a: (
+      n // $ExpectType number
+    ) => n > 0
+  })
+)
 
 // $ExpectType { a: number; b: number; }
-pipe({ a: "a", b: 2 }, S.evolve({ a: (s) => s.length }))
+S.evolve(
+  { a: "a", b: 1 },
+  {
+    a: (
+      s // $ExpectType string
+    ) => s.length
+  }
+)
+
+// $ExpectType { a: number; b: number; }
+pipe(
+  { a: "a", b: 1 },
+  S.evolve({
+    a: (
+      s // $ExpectType string
+    ) => s.length
+  })
+)
+
+// @ts-expect-error
+S.evolve({ a: "a", b: 1 }, { a: (n: number) => n })
+
+// @ts-expect-error
+S.evolve(hole<{ a: "a"; b: 1 }>(), hole<Record<string, string>>())
+
+// @ts-expect-error
+S.evolve(hole<{ a: "a"; b: 1 }>(), hole<Record<string, (s: string) => null>>())
+
+// @ts-expect-error
+pipe({ a: "a", b: 1 }, S.evolve({ a: (n: number) => n }))
+
+// @ts-expect-error
+pipe(hole<{ a: "a"; b: 1 }>(), S.evolve(hole<Record<string, string>>()))
+
+// @ts-expect-error
+pipe(hole<{ a: "a"; b: 1 }>(), S.evolve(hole<Record<string, (s: string) => null>>()))
 
 // -------------------------------------------------------------------------------------
 // get

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -152,7 +152,7 @@ export const evolve: {
   <O, T>(obj: O, t: PartialTransform<O, T>): Transformed<O, T>
 } = dual(
   2,
-<O, T>(obj: O, t: PartialTransform<O, T>): Transformed<O, T> => {
+  <O, T>(obj: O, t: PartialTransform<O, T>): Transformed<O, T> => {
     const out = { ...obj }
     for (const k in t) {
       if (Object.prototype.hasOwnProperty.call(obj, k)) {

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -152,10 +152,7 @@ export const evolve: {
   <O, T>(obj: O, t: PartialTransform<O, T>): Transformed<O, T>
 } = dual(
   2,
-  <O, T extends PartialTransform<O, T>>(
-    obj: O,
-    t: T
-  ): unknown & Transformed<O, T> => {
+<O, T>(obj: O, t: PartialTransform<O, T>): Transformed<O, T> => {
     const out = { ...obj }
     for (const k in t) {
       if (Object.prototype.hasOwnProperty.call(obj, k)) {


### PR DESCRIPTION
Closes #2953