### PR TITLE
The `minItems` filter now checks for an invalid argument (`n < 1`) an…

### DIFF
--- a/.changeset/unlucky-flowers-suffer.md
+++ b/.changeset/unlucky-flowers-suffer.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+The `minItems` filter now checks for an invalid argument (`n < 1`) and, when valid, refines the type to `NonEmptyReadonlyArray<A>`.

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -2547,3 +2547,16 @@ S.asSchema(
 
 // $ExpectType Struct<{ a: PropertySignature<"?:", string, never, ":", string, false, "a">; }>
 S.Struct({ a: S.requiredToOptional(aContext, S.String, { decode: Option.some, encode: Option.getOrElse(() => "") }) })
+
+// ---------------------------------------------
+// minItems
+// ---------------------------------------------
+
+// $ExpectType Schema<readonly [string, ...string[]], readonly string[], never>
+S.asSchema(S.Array(S.String).pipe(S.minItems(1)))
+
+// $ExpectType refine<readonly [string, ...string[]], Schema<readonly string[], readonly string[], never>>
+S.Array(S.String).pipe(S.minItems(1))
+
+// $ExpectType Schema<readonly string[], readonly string[], never>
+S.Array(S.String).pipe(S.minItems(1)).from

--- a/packages/schema/test/Schema/Array/minItems.test.ts
+++ b/packages/schema/test/Schema/Array/minItems.test.ts
@@ -1,10 +1,16 @@
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/TestUtils"
-import { describe, it } from "vitest"
+import { describe, expect, it } from "vitest"
 
 describe("minItems", () => {
-  const schema = S.Array(S.Number).pipe(S.minItems(2))
+  it("should throw for invalid argument", () => {
+    expect(() => S.Array(S.Number).pipe(S.minItems(-1))).toThrowError(
+      new Error("minItems: Expected an integer greater than or equal to 1, actual -1")
+    )
+  })
+
   it("decoding", async () => {
+    const schema = S.Array(S.Number).pipe(S.minItems(2))
     await Util.expectDecodeUnknownFailure(
       schema,
       [1],


### PR DESCRIPTION
…d, when valid, refines the type to `NonEmptyReadonlyArray<A>`.
