### PR TITLE
Make `Option.liftPredicate` dual

### DIFF
--- a/.changeset/fair-turkeys-float.md
+++ b/.changeset/fair-turkeys-float.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make Option.liftPredicate dual

--- a/.changeset/fair-turkeys-float.md
+++ b/.changeset/fair-turkeys-float.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Make Option.liftPredicate dual

--- a/packages/effect/dtslint/Option.ts
+++ b/packages/effect/dtslint/Option.ts
@@ -16,6 +16,7 @@ declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
 // $ExpectType Option<string>
 pipe(pimitiveNumerOrString, Option.liftPredicate(Predicate.isString))
 
+// $ExpectType Option<number>
 pipe(
   pimitiveNumerOrString,
   Option.liftPredicate(
@@ -39,6 +40,31 @@ pipe(
       _n // $ExpectType number
     ) => true
   )
+)
+
+// $ExpectType Option<string>
+Option.liftPredicate(pimitiveNumerOrString, Predicate.isString)
+
+// $ExpectType Option<number>
+Option.liftPredicate(
+  pimitiveNumerOrString,
+  (
+    n // $ExpectType string | number
+  ): n is number => typeof n === "number"
+)
+
+// $ExpectType Option<string | number>
+Option.liftPredicate(pimitiveNumerOrString, predicateNumbersOrStrings)
+
+// $ExpectType Option<number>
+Option.liftPredicate(pimitiveNumber, predicateNumbersOrStrings)
+
+// $ExpectType Option<number>
+Option.liftPredicate(
+  pimitiveNumber,
+  (
+    _n // $ExpectType number
+  ) => true
 )
 
 // -------------------------------------------------------------------------------------

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1115,7 +1115,18 @@ export const lift2 = <A, B, C>(f: (a: A, b: B) => C): {
 export const liftPredicate: { // Note: I intentionally avoid using the NoInfer pattern here.
   <A, B extends A>(refinement: Refinement<A, B>): (a: A) => Option<B>
   <B extends A, A = B>(predicate: Predicate<A>): (b: B) => Option<B>
-} = <B extends A, A = B>(predicate: Predicate<A>) => (b: B): Option<B> => predicate(b) ? some(b) : none()
+  <A, B extends A>(
+    self: A,
+    refinement: Refinement<A, B>
+  ): Option<B>
+  <B extends A, A = B>(
+    self: B,
+    predicate: Predicate<A>
+  ): Option<B>
+} = dual(
+  2,
+  <B extends A, A = B>(b: B, predicate: Predicate<A>): Option<B> => predicate(b) ? some(b) : none()
+)
 
 /**
  * Returns a function that checks if a `Option` contains a given value using a provided `isEquivalent` function.

--- a/packages/effect/test/Option.test.ts
+++ b/packages/effect/test/Option.test.ts
@@ -350,14 +350,17 @@ describe("Option", () => {
   })
 
   it("liftPredicate", () => {
-    const f = Option.liftPredicate(p)
-    Util.deepStrictEqual(f(1), Option.none())
-    Util.deepStrictEqual(f(3), Option.some(3))
+    Util.deepStrictEqual(pipe(1, Option.liftPredicate(p)), Option.none())
+    Util.deepStrictEqual(pipe(3, Option.liftPredicate(p)), Option.some(3))
+    Util.deepStrictEqual(Option.liftPredicate(1, p), Option.none())
+    Util.deepStrictEqual(Option.liftPredicate(3, p), Option.some(3))
 
     type Direction = "asc" | "desc"
-    const parseDirection = Option.liftPredicate((s: string): s is Direction => s === "asc" || s === "desc")
-    Util.deepStrictEqual(parseDirection("asc"), Option.some("asc"))
-    Util.deepStrictEqual(parseDirection("foo"), Option.none())
+    const isDirection = (s: string): s is Direction => s === "asc" || s === "desc"
+    Util.deepStrictEqual(pipe("asc", Option.liftPredicate(isDirection)), Option.some("asc"))
+    Util.deepStrictEqual(pipe("foo", Option.liftPredicate(isDirection)), Option.none())
+    Util.deepStrictEqual(Option.liftPredicate("asc", isDirection), Option.some("asc"))
+    Util.deepStrictEqual(Option.liftPredicate("foo", isDirection), Option.none())
   })
 
   it("containsWith", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Make `Option.liftPredicate` dual to be able to use a data-first version when wanted

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

N/A
