### PR TITLE
Expose `exact` option for strict decoding on missing properties, clos…

### DIFF
--- a/.changeset/smart-lemons-stare.md
+++ b/.changeset/smart-lemons-stare.md
@@ -1,0 +1,12 @@
+---
+"@effect/schema": patch
+---
+
+Expose `exact` option for strict decoding on missing properties, closes #2993
+
+This commit addresses an issue where users encountered unexpected decoding behaviors, specifically regarding how undefined values and missing properties are handled. The default behavior of the `@effect/schema` library treats missing properties as `undefined` during decoding, which can lead to confusion when stricter validation is expected.
+
+Changes:
+
+- Exposed an internal configuration option `exțact` (default: `false`), which when set to `true`, enforces strict decoding that will error on missing properties instead of treating them as `undefined`.
+- Updated documentation to clearly outline the default and strict decoding behaviors, providing users with guidance on how to enable strict validation.

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1636,16 +1636,69 @@ export const isRefinement: (ast: AST) => ast is Refinement<AST> = createASTGuard
  * @since 0.67.0
  */
 export interface ParseOptions {
-  /** default "first" */
+  /**
+   * The `errors` option allows you to receive all parsing errors when
+   * attempting to parse a value using a schema. By default only the first error
+   * is returned, but by setting the `errors` option to `"all"`, you can receive
+   * all errors that occurred during the parsing process. This can be useful for
+   * debugging or for providing more comprehensive error messages to the user.
+   *
+   * default: "first"
+   *
+   * @since 0.67.0
+   */
   readonly errors?: "first" | "all" | undefined
-  /** default "ignore" */
+  /**
+   * When using a `Schema` to parse a value, by default any properties that are
+   * not specified in the `Schema` will be stripped out from the output. This is
+   * because the `Schema` is expecting a specific shape for the parsed value,
+   * and any excess properties do not conform to that shape.
+   *
+   * However, you can use the `onExcessProperty` option (default value:
+   * `"ignore"`) to trigger a parsing error. This can be particularly useful in
+   * cases where you need to detect and handle potential errors or unexpected
+   * values.
+   *
+   * If you want to allow excess properties to remain, you can use
+   * `onExcessProperty` set to `"preserve"`.
+   *
+   * default: "ignore"
+   *
+   * @since 0.67.0
+   */
   readonly onExcessProperty?: "ignore" | "error" | "preserve" | undefined
   /**
-   * default "none"
+   * The `propertyOrder` option provides control over the order of object fields
+   * in the output. This feature is particularly useful when the sequence of
+   * keys is important for the consuming processes or when maintaining the input
+   * order enhances readability and usability.
+   *
+   * By default, the `propertyOrder` option is set to `"none"`. This means that
+   * the internal system decides the order of keys to optimize parsing speed.
+   * The order of keys in this mode should not be considered stable, and it's
+   * recommended not to rely on key ordering as it may change in future updates
+   * without notice.
+   *
+   * Setting `propertyOrder` to `"original"` ensures that the keys are ordered
+   * as they appear in the input during the decoding/encoding process.
+   *
+   * default: "none"
    *
    * @since 0.67.20
    */
   readonly propertyOrder?: "none" | "original" | undefined
+  /**
+   * Handles missing properties in data structures. By default, missing
+   * properties are treated as if present with an `undefined` value. To treat
+   * missing properties as errors, set the `exact` option to `true`. This
+   * setting is already enabled by default for `is` and `asserts` functions,
+   * treating absent properties strictly unless overridden.
+   *
+   * default: false
+   *
+   * @since 0.67.24
+   */
+  readonly exact?: boolean
 }
 
 /**

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -710,16 +710,20 @@ export const validate = <A, I, R>(
   getEffect(AST.typeAST(schema.ast), true, options)
 
 /**
+ * By default the option `isExact` is set to `true`.
+ *
  * @category validation
  * @since 0.67.0
  */
 export const is = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseOptions) => {
   const parser = goMemo(AST.typeAST(schema.ast), true)
   return (u: unknown, overrideOptions?: AST.ParseOptions | number): u is A =>
-    Either.isRight(parser(u, { ...mergeParseOptions(options, overrideOptions), isExact: true }) as any)
+    Either.isRight(parser(u, { exact: true, ...mergeParseOptions(options, overrideOptions) }) as any)
 }
 
 /**
+ * By default the option `isExact` is set to `true`.
+ *
  * @category validation
  * @since 0.67.0
  */
@@ -727,8 +731,8 @@ export const asserts = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.P
   const parser = goMemo(AST.typeAST(schema.ast), true)
   return (u: unknown, overrideOptions?: AST.ParseOptions): asserts u is A => {
     const result: Either.Either<any, ParseIssue> = parser(u, {
-      ...mergeParseOptions(options, overrideOptions),
-      isExact: true
+      exact: true,
+      ...mergeParseOptions(options, overrideOptions)
     }) as any
     if (Either.isLeft(result)) {
       throw new Error(TreeFormatter.formatIssueSync(result.left), { cause: result.left })
@@ -783,8 +787,6 @@ export const encode: <A, I, R>(
 
 interface InternalOptions extends AST.ParseOptions {
   readonly isEffectAllowed?: boolean
-  // `isExact = false` means that missing keys are treated as undefined values (`{ key: undefined }`)
-  readonly isExact?: boolean
 }
 
 interface Parser {
@@ -1218,7 +1220,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
           | Array<(state: State) => Effect.Effect<void, ParseIssue, any>>
           | undefined = undefined
 
-        const isExact = options?.isExact === true
+        const isExact = options?.exact === true
         for (let i = 0; i < propertySignatures.length; i++) {
           const ps = propertySignatures[i][1]
           const name = ps.name

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -326,6 +326,8 @@ export const typeSchema = <A, I, R>(schema: Schema<A, I, R>): SchemaClass<A> => 
 /* c8 ignore start */
 export {
   /**
+   * By default the option `isExact` is set to `true`.
+   *
    * @category validation
    * @since 0.67.0
    */
@@ -371,6 +373,8 @@ export {
    */
   encodeUnknownSync,
   /**
+   * By default the option `isExact` is set to `true`.
+   *
    * @category validation
    * @since 0.67.0
    */

--- a/packages/schema/test/Schema/ParseOptions-exact.test.ts
+++ b/packages/schema/test/Schema/ParseOptions-exact.test.ts
@@ -1,0 +1,54 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/TestUtils"
+import { describe, expect, it } from "vitest"
+
+describe("`exact` option", () => {
+  describe("decoding", () => {
+    it("false (default)", async () => {
+      const schema = S.Struct({ a: S.Unknown })
+      await Util.expectDecodeUnknownSuccess(schema, {}, { a: undefined })
+    })
+
+    it("true", async () => {
+      const schema = S.Struct({ a: S.Unknown })
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        {},
+        `{ readonly a: unknown }
+└─ ["a"]
+   └─ is missing`,
+        { exact: true }
+      )
+    })
+  })
+
+  describe("is", () => {
+    it("true (default)", async () => {
+      const schema = S.Struct({ a: S.Unknown })
+      expect(S.is(schema)({})).toBe(false)
+    })
+
+    it("false", async () => {
+      const schema = S.Struct({ a: S.Unknown })
+      expect(S.is(schema)({}, { exact: false })).toBe(true)
+    })
+  })
+
+  describe("asserts", () => {
+    it("true (default)", async () => {
+      const schema = S.Struct({ a: S.Unknown })
+      Util.expectAssertsFailure(
+        schema,
+        {},
+        `{ readonly a: unknown }
+└─ ["a"]
+   └─ is missing`
+      )
+    })
+
+    it("false", async () => {
+      const schema = S.Struct({ a: S.Unknown })
+      Util.expectAssertsSuccess(schema, {}, { exact: false })
+    })
+  })
+})

--- a/packages/schema/test/Schema/asserts.test.ts
+++ b/packages/schema/test/Schema/asserts.test.ts
@@ -2,14 +2,6 @@ import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/TestUtils"
 import { describe, expect, it } from "vitest"
 
-const expectAssertsSuccess = <A, I>(schema: S.Schema<A, I>, input: unknown) => {
-  expect(S.asserts(schema)(input)).toEqual(undefined)
-}
-
-const expectAssertsFailure = <A, I>(schema: S.Schema<A, I>, input: unknown, message: string) => {
-  expect(() => S.asserts(schema)(input)).toThrow(new Error(message))
-}
-
 describe("asserts", () => {
   it("the returned error should include a cause", () => {
     const asserts: (u: unknown) => asserts u is string = S.asserts(S.String)
@@ -40,8 +32,8 @@ describe("asserts", () => {
   describe("struct", () => {
     it("required property signature", () => {
       const schema = S.Struct({ a: Util.NumberFromChar })
-      expectAssertsSuccess(schema, { a: 1 })
-      expectAssertsFailure(
+      Util.expectAssertsSuccess(schema, { a: 1 })
+      Util.expectAssertsFailure(
         schema,
         { a: null },
         `{ readonly a: number }
@@ -52,19 +44,19 @@ describe("asserts", () => {
 
     it("required property signature with undefined", () => {
       const schema = S.Struct({ a: S.Union(S.Number, S.Undefined) })
-      expectAssertsSuccess(schema, { a: 1 })
-      expectAssertsSuccess(schema, { a: undefined })
-      expectAssertsSuccess(schema, { a: 1, b: "b" })
+      Util.expectAssertsSuccess(schema, { a: 1 })
+      Util.expectAssertsSuccess(schema, { a: undefined })
+      Util.expectAssertsSuccess(schema, { a: 1, b: "b" })
 
-      expectAssertsFailure(
+      Util.expectAssertsFailure(
         schema,
         {},
         `{ readonly a: number | undefined }
 └─ ["a"]
    └─ is missing`
       )
-      expectAssertsFailure(schema, null, `Expected { readonly a: number | undefined }, actual null`)
-      expectAssertsFailure(
+      Util.expectAssertsFailure(schema, null, `Expected { readonly a: number | undefined }, actual null`)
+      Util.expectAssertsFailure(
         schema,
         { a: "a" },
         `{ readonly a: number | undefined }

--- a/packages/schema/test/TestUtils.ts
+++ b/packages/schema/test/TestUtils.ts
@@ -348,3 +348,16 @@ export const expectFields = (f1: S.Struct.Fields, f2: S.Struct.Fields) => {
   const ks2 = Reflect.ownKeys(f2).sort().map((k) => [k, f2[k].ast.toString()])
   expect(ks1).toStrictEqual(ks2)
 }
+
+export const expectAssertsSuccess = <A, I>(schema: S.Schema<A, I>, input: unknown, options?: ParseOptions) => {
+  expect(S.asserts(schema, options)(input)).toEqual(undefined)
+}
+
+export const expectAssertsFailure = <A, I>(
+  schema: S.Schema<A, I>,
+  input: unknown,
+  message: string,
+  options?: ParseOptions
+) => {
+  expect(() => S.asserts(schema, options)(input)).toThrow(new Error(message))
+}


### PR DESCRIPTION
…es #2993

This commit addresses an issue where users encountered unexpected decoding behaviors, specifically regarding how undefined values and missing properties are handled. The default behavior of the `@effect/schema` library treats missing properties as `undefined` during decoding, which can lead to confusion when stricter validation is expected.

Changes:

- Exposed an internal configuration option `exțact` (default: `false`), which when set to `true`, enforces strict decoding that will error on missing properties instead of treating them as `undefined`.
- Updated documentation to clearly outline the default and strict decoding behaviors, providing users with guidance on how to enable strict validation.
