### PR TITLE
fix typo (`isExact` -> `exact`) and make internal `toASTAnnotations` more general

### DIFF
--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -710,7 +710,7 @@ export const validate = <A, I, R>(
   getEffect(AST.typeAST(schema.ast), true, options)
 
 /**
- * By default the option `isExact` is set to `true`.
+ * By default the option `exact` is set to `true`.
  *
  * @category validation
  * @since 0.67.0
@@ -722,7 +722,7 @@ export const is = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: AST.ParseO
 }
 
 /**
- * By default the option `isExact` is set to `true`.
+ * By default the option `exact` is set to `true`.
  *
  * @category validation
  * @since 0.67.0

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -119,8 +119,12 @@ const variance = {
   _R: (_: never) => _
 }
 
+interface AllAnnotations<A, TypeParameters extends ReadonlyArray<any>>
+  extends Annotations.Schema<A, TypeParameters>, PropertySignature.Annotations<A>
+{}
+
 const toASTAnnotations = <A, TypeParameters extends ReadonlyArray<any>>(
-  annotations?: Annotations.Schema<A, TypeParameters>
+  annotations?: AllAnnotations<A, TypeParameters>
 ): AST.Annotations => {
   if (!annotations) {
     return {}

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -326,7 +326,7 @@ export const typeSchema = <A, I, R>(schema: Schema<A, I, R>): SchemaClass<A> => 
 /* c8 ignore start */
 export {
   /**
-   * By default the option `isExact` is set to `true`.
+   * By default the option `exact` is set to `true`.
    *
    * @category validation
    * @since 0.67.0
@@ -373,7 +373,7 @@ export {
    */
   encodeUnknownSync,
   /**
-   * By default the option `isExact` is set to `true`.
+   * By default the option `exact` is set to `true`.
    *
    * @category validation
    * @since 0.67.0


### PR DESCRIPTION
- fix typo (`isExact` -> `exact`)
- internal: make `toASTAnnotations` more general
