### PR TITLE
Chunk tests

### DIFF
--- a/.changeset/dull-zoos-fly.md
+++ b/.changeset/dull-zoos-fly.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Added tests for `Chunk.toArray` and `Chunk.toReadonlyArray` with use cases in the `pipe`

--- a/packages/effect/dtslint/Chunk.ts
+++ b/packages/effect/dtslint/Chunk.ts
@@ -495,15 +495,27 @@ pipe(nonEmptyNumbers, Chunk.reverse)
 // $ExpectType string[]
 Chunk.toArray(hole<Chunk.Chunk<string>>())
 
+// $ExpectType string[]
+pipe(hole<Chunk.Chunk<string>>(), Chunk.toArray)
+
 // $ExpectType [string, ...string[]]
 Chunk.toArray(hole<Chunk.NonEmptyChunk<string>>())
 
+// $ExpectType string[]
+pipe(hole<Chunk.NonEmptyChunk<string>>(), Chunk.toArray)
+
 // -------------------------------------------------------------------------------------
-// toArray
+// toReadonlyArray
 // -------------------------------------------------------------------------------------
 
 // $ExpectType readonly string[]
 Chunk.toReadonlyArray(hole<Chunk.Chunk<string>>())
 
+// $ExpectType string[]
+pipe(hole<Chunk.Chunk<string>>(), Chunk.toReadonlyArray)
+
 // $ExpectType readonly [string, ...string[]]
 Chunk.toReadonlyArray(hole<Chunk.NonEmptyChunk<string>>())
+
+// $ExpectType readonly [string, ...string[]]
+pipe(hole<Chunk.NonEmptyChunk<string>>(), Chunk.toReadonlyArray)

--- a/packages/effect/dtslint/Chunk.ts
+++ b/packages/effect/dtslint/Chunk.ts
@@ -501,7 +501,7 @@ pipe(hole<Chunk.Chunk<string>>(), Chunk.toArray)
 // $ExpectType [string, ...string[]]
 Chunk.toArray(hole<Chunk.NonEmptyChunk<string>>())
 
-// $ExpectType string[]
+// $ExpectType [string, ...string[]]
 pipe(hole<Chunk.NonEmptyChunk<string>>(), Chunk.toArray)
 
 // -------------------------------------------------------------------------------------
@@ -511,7 +511,7 @@ pipe(hole<Chunk.NonEmptyChunk<string>>(), Chunk.toArray)
 // $ExpectType readonly string[]
 Chunk.toReadonlyArray(hole<Chunk.Chunk<string>>())
 
-// $ExpectType string[]
+// $ExpectType readonly string[]
 pipe(hole<Chunk.Chunk<string>>(), Chunk.toReadonlyArray)
 
 // $ExpectType readonly [string, ...string[]]


### PR DESCRIPTION
Added tests for `Chunk.toArray` and `Chunk.toReadonlyArray` with use cases in the `pipe`

Because I noticed that the implementation with function overloads doesn't support tacit usage

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
