### PR TITLE
Fix handling of `exact` option overrides in `AST.ParseOptions` and im…

### DIFF
--- a/.changeset/orange-ants-marry.md
+++ b/.changeset/orange-ants-marry.md
@@ -1,0 +1,7 @@
+---
+"@effect/schema": patch
+---
+
+- Fix handling of `exact` option overrides in `AST.ParseOptions`
+  This commit resolves a bug affecting the `exact` option within `AST.ParseOptions`. Previously, the implementation failed to correctly incorporate overrides for the `exact` setting, resulting in the parser not respecting the specified behavior in extended configurations.
+- Improve error messaging in `Pretty.make` for unmatched union schemas

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1744,7 +1744,7 @@ export interface ParseOptions {
    *
    * @since 0.67.24
    */
-  readonly exact?: boolean
+  readonly exact?: boolean | undefined
 }
 
 /**

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -457,9 +457,16 @@ export const mergeParseOptions = (
   if (options === undefined) {
     return overrideOptions
   }
-  const out: Mutable<AST.ParseOptions> = {}
-  out.errors = overrideOptions.errors ?? options.errors
-  out.onExcessProperty = overrideOptions.onExcessProperty ?? options.onExcessProperty
+  const out: Mutable<AST.ParseOptions> = { ...options }
+  if (overrideOptions.errors !== undefined) {
+    out.errors = overrideOptions.errors
+  }
+  if (overrideOptions.onExcessProperty !== undefined) {
+    out.onExcessProperty = overrideOptions.onExcessProperty
+  }
+  if (overrideOptions.exact !== undefined) {
+    out.exact = overrideOptions.exact
+  }
   return out
 }
 

--- a/packages/schema/src/Pretty.ts
+++ b/packages/schema/src/Pretty.ts
@@ -186,6 +186,9 @@ export const match: AST.Match<Pretty<any>> = {
     const types = ast.types.map((ast) => [ParseResult.is({ ast } as any), go(ast, path)] as const)
     return (a) => {
       const index = types.findIndex(([is]) => is(a))
+      if (index === -1) {
+        throw new Error(errors_.getPrettyNoMatchingSchemaErrorMessage(a, path, ast))
+      }
       return types[index][1](a)
     }
   },

--- a/packages/schema/src/internal/errors.ts
+++ b/packages/schema/src/internal/errors.ts
@@ -126,6 +126,13 @@ export const getPrettyMissingAnnotationErrorMessage = (
 /** @internal */
 export const getPrettyNeverErrorMessage = "Cannot pretty print a `never` value"
 
+/** @internal */
+export const getPrettyNoMatchingSchemaErrorMessage = (
+  actual: unknown,
+  path: ReadonlyArray<PropertyKey>,
+  ast: AST.AST
+) => getErrorMessage("Unexpected Error", `Cannot find a matching schema for ${util_.formatUnknown(actual)}`, path, ast)
+
 // ---------------------------------------------
 // Schema
 // ---------------------------------------------

--- a/packages/schema/test/ParseResult.test.ts
+++ b/packages/schema/test/ParseResult.test.ts
@@ -206,13 +206,13 @@ describe("ParseIssue.actual", () => {
     expect(P.mergeParseOptions({ errors: undefined }, undefined)).toStrictEqual({ errors: undefined })
     expect(P.mergeParseOptions(undefined, { errors: undefined })).toStrictEqual({ errors: undefined })
     expect(P.mergeParseOptions({ errors: "all" }, { errors: "first" })).toStrictEqual({
-      errors: "first",
-      onExcessProperty: undefined
+      errors: "first"
     })
     expect(P.mergeParseOptions({ onExcessProperty: "ignore" }, { onExcessProperty: "error" })).toStrictEqual({
-      onExcessProperty: "error",
-      errors: undefined
+      onExcessProperty: "error"
     })
+    expect(P.mergeParseOptions({}, { exact: false })).toStrictEqual({ exact: false })
+    expect(P.mergeParseOptions({ exact: true }, { exact: false })).toStrictEqual({ exact: false })
   })
 
   it("asserts", () => {

--- a/packages/schema/test/Pretty.test.ts
+++ b/packages/schema/test/Pretty.test.ts
@@ -535,4 +535,16 @@ schema (Declaration): <declaration schema>`)
       expectHook(S.NumberFromString)
     })
   })
+
+  it("no matching schema error", () => {
+    const A = S.Struct({ a: S.optional(S.String, { exact: true }) })
+    const schema = S.Union(A, S.Number)
+    const x: {} = { a: undefined }
+    const input: typeof A.Type = x
+    expect(() => Pretty.make(schema)(input)).toThrow(
+      new Error(`Unexpected Error
+details: Cannot find a matching schema for {"a":undefined}
+schema (Union): { readonly a?: string } | number`)
+    )
+  })
 })


### PR DESCRIPTION
…prove error messaging in `Pretty.make` for unmatched union schemas

- Fix handling of `exact` option overrides in `AST.ParseOptions`
  This commit resolves a bug affecting the `exact` option within `AST.ParseOptions`. Previously, the implementation failed to correctly incorporate overrides for the `exact` setting, resulting in the parser not respecting the specified behavior in extended configurations.
- Improve error messaging in `Pretty.make` for unmatched union schemas
