### PR TITLE
effect: add Stream.filterMapEffectOption function

### DIFF
--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2094,7 +2094,7 @@ export const mapEffect: {
  * const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
  *
  * const result = Stream.make(0, 1, 2, 4).pipe(
- *   Stream.mapEffectFilter(even),
+ *   Stream.filterMapEffectOption(even),
  *   Stream.runCollect,
  *   Effect.runPromise,
  * )
@@ -2103,7 +2103,7 @@ export const mapEffect: {
  * @since 3.3.5
  * @category utils
  */
-export const mapEffectFilter: {
+export const filterMapEffectOption: {
   <A, A2, E2, R2>(
     fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
   ): <E, R>(stream: Stream<A, E, R>) => Stream<A2, E2 | E, R2 | R>
@@ -2111,7 +2111,7 @@ export const mapEffectFilter: {
     stream: Stream<A, E, R>,
     fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
   ): Stream<A2, E2 | E, R2 | R>
-} = _groupBy.mapEffectFilter
+} = _groupBy.filterMapEffectOption
 
 /**
  * Transforms the errors emitted by this stream using `f`.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2088,7 +2088,6 @@ export const mapEffect: {
  * and filters out `None` values
  *
  * @example
- * ```ts
  * import { Effect, Stream, Console } from 'effect';
  *
  * // returns `Some(number)` if the number is even, otherwise `None`
@@ -2100,7 +2099,6 @@ export const mapEffect: {
  *   Effect.runPromise,
  * )
  * // => [0, 2, 4]
- * ```
  *
  * @since 3.3.5
  * @category utils

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2084,6 +2084,38 @@ export const mapEffect: {
 } = _groupBy.mapEffectOptions
 
 /**
+ * Maps over elements of the stream with the specified effectful function
+ * and filters out `None` values
+ *
+ * @example
+ * ```ts
+ * import { Effect, Stream, Console } from 'effect';
+ *
+ * // returns `Some(number)` if the number is even, otherwise `None`
+ * const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
+ *
+ * const result = Stream.make(0, 1, 2, 4).pipe(
+ *   Stream.mapEffectFilter(even),
+ *   Stream.runCollect,
+ *   Effect.runPromise,
+ * )
+ * // => [0, 2, 4]
+ * ```
+ *
+ * @since 3.3.5
+ * @category utils
+ */
+export const mapEffectFilter: {
+  <A, A2, E2, R2>(
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ): <E, R>(stream: Stream<A, E, R>) => Stream<A2, E2 | E, R2 | R>
+  <A, E, R, A2, E2, R2>(
+    stream: Stream<A, E, R>,
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ): Stream<A2, E2 | E, R2 | R>
+} = _groupBy.mapEffectFilter
+
+/**
  * Transforms the errors emitted by this stream using `f`.
  *
  * @since 2.0.0

--- a/packages/effect/src/internal/groupBy.ts
+++ b/packages/effect/src/internal/groupBy.ts
@@ -207,7 +207,7 @@ export const groupBy = dual<
 )
 
 /** @internal */
-export const mapEffectFilter = dual<
+export const filterMapEffectOption = dual<
   <A, A2, E2, R2>(
     fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
   ) => <E, R>(

--- a/packages/effect/src/internal/groupBy.ts
+++ b/packages/effect/src/internal/groupBy.ts
@@ -4,7 +4,7 @@ import * as Chunk from "../Chunk.js"
 import * as Deferred from "../Deferred.js"
 import * as Effect from "../Effect.js"
 import * as Exit from "../Exit.js"
-import { dual, pipe } from "../Function.js"
+import { dual, identity, pipe } from "../Function.js"
 import type * as GroupBy from "../GroupBy.js"
 import * as Option from "../Option.js"
 import { pipeArguments } from "../Pipeable.js"
@@ -205,6 +205,19 @@ export const groupBy = dual<
       )
     )
 )
+
+/** @internal */
+export const mapEffectFilter = dual<
+  <A, A2, E2, R2>(
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ) => <E, R>(
+    stream: Stream.Stream<A, E, R>
+  ) => Stream.Stream<A2, E2 | E, R2 | R>,
+  <A, E, R, A2, E2, R2>(
+    stream: Stream.Stream<A, E, R>,
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ) => Stream.Stream<A2, E2 | E, R2 | R>
+>(2, (s, fn) => stream.filterMap(mapEffectOptions(s, fn), identity))
 
 /** @internal */
 export const mapEffectOptions = dual<

--- a/packages/effect/test/Stream/filtering.test.ts
+++ b/packages/effect/test/Stream/filtering.test.ts
@@ -46,4 +46,14 @@ describe("Stream", () => {
         [Either.right(1), Either.right(2), Either.left("boom")]
       )
     }))
+
+  it.effect("mapEffectFilter", () =>
+    Effect.gen(function*() {
+      const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
+      const result = yield* Stream.make(0, 1, 2, 4).pipe(
+        Stream.mapEffectFilter(even),
+        Stream.runCollect
+      )
+      assert.deepStrictEqual(Array.from(result), [0, 2, 4])
+    }))
 })

--- a/packages/effect/test/Stream/filtering.test.ts
+++ b/packages/effect/test/Stream/filtering.test.ts
@@ -47,11 +47,11 @@ describe("Stream", () => {
       )
     }))
 
-  it.effect("mapEffectFilter", () =>
+  it.effect("filterMapEffectOption", () =>
     Effect.gen(function*() {
       const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
       const result = yield* Stream.make(0, 1, 2, 4).pipe(
-        Stream.mapEffectFilter(even),
+        Stream.filterMapEffectOption(even),
         Stream.runCollect
       )
       assert.deepStrictEqual(Array.from(result), [0, 2, 4])


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a `Stream.mapEffectFilter` function that maps items of a stream effectfully,
and then filters them.

## Related

- Closes #3018
