### PR TITLE
Introducing Customizable Parsing Behavior at the Schema Level, closes…

### DIFF
--- a/.changeset/honest-monkeys-smile.md
+++ b/.changeset/honest-monkeys-smile.md
@@ -1,0 +1,52 @@
+---
+"@effect/schema": patch
+---
+
+Introducing Customizable Parsing Behavior at the Schema Level, closes #3027
+
+With this latest update, developers can now set specific parse options for each schema using the `parseOptions` annotation. This flexibility allows for precise parsing behaviors across different levels of your schema hierarchy, giving you the ability to override settings in parent schemas and propagate settings to nested schemas as needed.
+
+Here's how you can leverage this new feature:
+
+```ts
+import { Schema } from "@effect/schema"
+import { Either } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.Struct({
+    b: Schema.String,
+    c: Schema.String
+  }).annotations({
+    title: "first error only",
+    parseOptions: { errors: "first" } // Only the first error in this sub-schema is reported
+  }),
+  d: Schema.String
+}).annotations({
+  title: "all errors",
+  parseOptions: { errors: "all" } // All errors in the main schema are reported
+})
+
+const result = Schema.decodeUnknownEither(schema)(
+  { a: {} },
+  { errors: "first" }
+)
+if (Either.isLeft(result)) {
+  console.log(result.left.message)
+}
+/*
+all errors
+├─ ["d"]
+│  └─ is missing
+└─ ["a"]
+   └─ first error only
+      └─ ["b"]
+         └─ is missing
+*/
+```
+
+**Detailed Output Explanation:**
+
+In this example:
+
+- The main schema is configured to display all errors. Hence, you will see errors related to both the `d` field (since it's missing) and any errors from the `a` subschema.
+- The subschema (`a`) is set to display only the first error. Although both `b` and `c` fields are missing, only the first missing field (`b`) is reported.

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -223,6 +223,12 @@ export type ParseIssueTitleAnnotation = (issue: ParseIssue) => string | undefine
  */
 export const ParseIssueTitleAnnotationId = Symbol.for("@effect/schema/annotation/ParseIssueTitle")
 
+/**
+ * @category annotations
+ * @since 0.68.3
+ */
+export const ParseOptionsAnnotationId = Symbol.for("@effect/schema/annotation/ParseOptions")
+
 /** @internal */
 export const SurrogateAnnotationId = Symbol.for("@effect/schema/annotation/Surrogate")
 
@@ -354,6 +360,12 @@ export const getBatchingAnnotation = getAnnotation<BatchingAnnotation>(BatchingA
  * @since 0.67.0
  */
 export const getParseIssueTitleAnnotation = getAnnotation<ParseIssueTitleAnnotation>(ParseIssueTitleAnnotationId)
+
+/**
+ * @category annotations
+ * @since 0.68.3
+ */
+export const getParseOptionsAnnotation = getAnnotation<ParseOptions>(ParseOptionsAnnotationId)
 
 /** @internal */
 export const getSurrogateAnnotation = getAnnotation<SurrogateAnnotation>(SurrogateAnnotationId)

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -171,6 +171,7 @@ const toASTAnnotations = <A, TypeParameters extends ReadonlyArray<any>>(
   move("concurrency", AST.ConcurrencyAnnotationId)
   move("batching", AST.BatchingAnnotationId)
   move("parseIssueTitle", AST.ParseIssueTitleAnnotationId)
+  move("parseOptions", AST.ParseOptionsAnnotationId)
 
   return out
 }
@@ -3620,6 +3621,7 @@ export declare namespace Annotations {
     readonly concurrency?: AST.ConcurrencyAnnotation
     readonly batching?: AST.BatchingAnnotation
     readonly parseIssueTitle?: AST.ParseIssueTitleAnnotation
+    readonly parseOptions?: AST.ParseOptions
   }
 
   /**

--- a/packages/schema/test/ParseResult.test.ts
+++ b/packages/schema/test/ParseResult.test.ts
@@ -199,20 +199,26 @@ describe("ParseIssue.actual", () => {
     expect(Either.isEither(P.encode(S.String)("a")))
   })
 
-  it("mergeParseOptions", () => {
-    expect(P.mergeParseOptions(undefined, undefined)).toStrictEqual(undefined)
-    expect(P.mergeParseOptions({}, undefined)).toStrictEqual({})
-    expect(P.mergeParseOptions(undefined, {})).toStrictEqual({})
-    expect(P.mergeParseOptions({ errors: undefined }, undefined)).toStrictEqual({ errors: undefined })
-    expect(P.mergeParseOptions(undefined, { errors: undefined })).toStrictEqual({ errors: undefined })
-    expect(P.mergeParseOptions({ errors: "all" }, { errors: "first" })).toStrictEqual({
+  it("mergeInternalOptions", () => {
+    expect(P.mergeInternalOptions(undefined, undefined)).toStrictEqual(undefined)
+    expect(P.mergeInternalOptions({}, undefined)).toStrictEqual({})
+    expect(P.mergeInternalOptions(undefined, {})).toStrictEqual({})
+    expect(P.mergeInternalOptions({ errors: undefined }, undefined)).toStrictEqual({ errors: undefined })
+    expect(P.mergeInternalOptions(undefined, { errors: undefined })).toStrictEqual({ errors: undefined })
+    expect(P.mergeInternalOptions({ errors: "all" }, { errors: "first" })).toStrictEqual({
       errors: "first"
     })
-    expect(P.mergeParseOptions({ onExcessProperty: "ignore" }, { onExcessProperty: "error" })).toStrictEqual({
+    expect(P.mergeInternalOptions({ onExcessProperty: "ignore" }, { onExcessProperty: "error" })).toStrictEqual({
       onExcessProperty: "error"
     })
-    expect(P.mergeParseOptions({}, { exact: false })).toStrictEqual({ exact: false })
-    expect(P.mergeParseOptions({ exact: true }, { exact: false })).toStrictEqual({ exact: false })
+    expect(P.mergeInternalOptions({}, { exact: false })).toStrictEqual({ exact: false })
+    expect(P.mergeInternalOptions({ exact: true }, { exact: false })).toStrictEqual({ exact: false })
+
+    expect(P.mergeInternalOptions({ isEffectAllowed: true }, {})).toStrictEqual({ isEffectAllowed: true })
+    expect(P.mergeInternalOptions({}, { isEffectAllowed: true })).toStrictEqual({ isEffectAllowed: true })
+    expect(P.mergeInternalOptions({ isEffectAllowed: false }, { isEffectAllowed: true })).toStrictEqual({
+      isEffectAllowed: true
+    })
   })
 
   it("asserts", () => {

--- a/packages/schema/test/Schema/ParseOptionsAnnotation.test.ts
+++ b/packages/schema/test/Schema/ParseOptionsAnnotation.test.ts
@@ -1,0 +1,52 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/TestUtils"
+import { describe, it } from "vitest"
+
+const String = S.transform(S.NonEmpty, S.String, { decode: (s) => s, encode: (s) => s }).annotations({
+  identifier: "string"
+})
+
+describe("ParseOptionsAnnotation", () => {
+  it("nested structs", async () => {
+    const schema = S.Struct({
+      a: S.Struct({
+        b: String,
+        c: String
+      }).annotations({ parseOptions: { errors: "first" } }),
+      d: String
+    }).annotations({ parseOptions: { errors: "all" } })
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      { a: {} },
+      `{ readonly a: { readonly b: string; readonly c: string }; readonly d: string }
+├─ ["a"]
+│  └─ { readonly b: string; readonly c: string }
+│     └─ ["b"]
+│        └─ is missing
+└─ ["d"]
+   └─ is missing`,
+      { errors: "first" }
+    )
+
+    await Util.expectEncodeFailure(
+      schema,
+      { a: { b: "", c: "" }, d: "" },
+      `{ readonly a: { readonly b: string; readonly c: string }; readonly d: string }
+├─ ["a"]
+│  └─ { readonly b: string; readonly c: string }
+│     └─ ["b"]
+│        └─ string
+│           └─ Encoded side transformation failure
+│              └─ NonEmpty
+│                 └─ Predicate refinement failure
+│                    └─ Expected NonEmpty, actual ""
+└─ ["d"]
+   └─ string
+      └─ Encoded side transformation failure
+         └─ NonEmpty
+            └─ Predicate refinement failure
+               └─ Expected NonEmpty, actual ""`,
+      { errors: "first" }
+    )
+  })
+})


### PR DESCRIPTION
… #3027

With this latest update, developers can now set specific parse options for each schema using the `parseOptions` annotation. This flexibility allows for precise parsing behaviors across different levels of your schema hierarchy, giving you the ability to override settings in parent schemas and propagate settings to nested schemas as needed.

Here's how you can leverage this new feature:

```ts
import { Schema } from "@effect/schema"
import { Either } from "effect"

const schema = Schema.Struct({
  a: Schema.Struct({
    b: Schema.String,
    c: Schema.String
  }).annotations({
    title: "first error only",
    parseOptions: { errors: "first" } // Only the first error in this sub-schema is reported
  }),
  d: Schema.String
}).annotations({
  title: "all errors",
  parseOptions: { errors: "all" } // All errors in the main schema are reported
})

const result = Schema.decodeUnknownEither(schema)(
  { a: {} },
  { errors: "first" }
)
if (Either.isLeft(result)) {
  console.log(result.left.message)
}
/*
all errors
├─ ["d"]
│  └─ is missing
└─ ["a"]
   └─ first error only
      └─ ["b"]
         └─ is missing
*/
```

**Detailed Output Explanation:**

In this example:

- The main schema is configured to display all errors. Hence, you will see errors related to both the `d` field (since it's missing) and any errors from the `a` subschema.
- The subschema (`a`) is set to display only the first error. Although both `b` and `c` fields are missing, only the first missing field (`b`) is reported.
