### PR TITLE
Add `make` constructor to `Class`-based APIs, closes #3042

### DIFF
--- a/.changeset/empty-apricots-enjoy.md
+++ b/.changeset/empty-apricots-enjoy.md
@@ -1,0 +1,29 @@
+---
+"@effect/schema": patch
+---
+
+Add `make` constructor to `Class`-based APIs, closes #3042
+
+Introduced a `make` constructor to class-based APIs to facilitate easier instantiation of classes. This method allows developers to create instances of a class without directly using the `new` keyword.
+
+**Example**
+
+```ts
+import { Schema } from "@effect/schema"
+
+class MyClass extends Schema.Class<MyClass>("MyClass")({
+  someField: Schema.String
+}) {
+  someMethod() {
+    return this.someField + "bar"
+  }
+}
+
+// Create an instance of MyClass using the make constructor
+const instance = MyClass.make({ someField: "foo" }) // same as new MyClass({ someField: "foo" })
+
+// Outputs to console to demonstrate that the instance is correctly created
+console.log(instance instanceof MyClass) // true
+console.log(instance.someField) // "foo"
+console.log(instance.someMethod()) // "foobar"
+```

--- a/packages/schema/dtslint/Class.ts
+++ b/packages/schema/dtslint/Class.ts
@@ -12,7 +12,11 @@ hole<ConstructorParameters<typeof NoFields>>()
 
 new NoFields()
 
+NoFields.make()
+
 new NoFields({})
+
+NoFields.make({})
 
 // ---------------------------------------------
 // A class with all fields with a default should permit an empty argument in the constructor.
@@ -27,7 +31,11 @@ hole<ConstructorParameters<typeof AllDefaultedFields>>()
 
 new AllDefaultedFields()
 
+AllDefaultedFields.make()
+
 new AllDefaultedFields({})
+
+AllDefaultedFields.make({})
 
 // ---------------------------------------------
 // test Context

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -6944,6 +6944,8 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
     options?: MakeOptions
   ): Struct.Type<Fields> & Omit<Inherited, keyof Fields> & Proto
 
+  make<Args extends Array<any>, X>(this: { new(...args: Args): X }, ...args: Args): X
+
   annotations(annotations: Annotations.Schema<Self>): SchemaClass<Self, Simplify<I>, R>
 
   readonly fields: { readonly [K in keyof Fields]: Fields[K] }
@@ -7417,6 +7419,10 @@ const makeClass = ({ Base, annotations, fields, identifier, kind, schema, toStri
     // ----------------
     // Class interface
     // ----------------
+
+    static make(...args: Array<any>) {
+      return new this(...args)
+    }
 
     static fields = { ...fields }
 

--- a/packages/schema/test/Schema/Class/Class.test.ts
+++ b/packages/schema/test/Schema/Class/Class.test.ts
@@ -89,12 +89,22 @@ describe("Class", () => {
       └─ Predicate refinement failure
          └─ Expected NonEmpty, actual ""`)
     )
+    expect(() => A.make({ a: "" })).toThrow(
+      new Error(`A (Constructor)
+└─ ["a"]
+   └─ NonEmpty
+      └─ Predicate refinement failure
+         └─ Expected NonEmpty, actual ""`)
+    )
   })
 
   it("the constructor validation can be disabled", () => {
     class A extends S.Class<A>("A")({ a: S.NonEmpty }) {}
     expect(new A({ a: "" }, true).a).toStrictEqual("")
     expect(new A({ a: "" }, { disableValidation: true }).a).toStrictEqual("")
+
+    expect(A.make({ a: "" }, true).a).toStrictEqual("")
+    expect(A.make({ a: "" }, { disableValidation: true }).a).toStrictEqual("")
   })
 
   it("the constructor should support defaults", () => {
@@ -107,6 +117,11 @@ describe("Class", () => {
     expect({ ...new A({ a: "a" }) }).toStrictEqual({ a: "a", [b]: 1 })
     expect({ ...new A({ [b]: 2 }) }).toStrictEqual({ a: "", [b]: 2 })
     expect({ ...new A({}) }).toStrictEqual({ a: "", [b]: 1 })
+
+    expect({ ...A.make({ a: "a", [b]: 2 }) }).toStrictEqual({ a: "a", [b]: 2 })
+    expect({ ...A.make({ a: "a" }) }).toStrictEqual({ a: "a", [b]: 1 })
+    expect({ ...A.make({ [b]: 2 }) }).toStrictEqual({ a: "", [b]: 2 })
+    expect({ ...A.make({}) }).toStrictEqual({ a: "", [b]: 1 })
   })
 
   it("the constructor should support lazy defaults", () => {
@@ -118,6 +133,11 @@ describe("Class", () => {
     expect({ ...new A({}) }).toStrictEqual({ a: 2 })
     new A({ a: 10 })
     expect({ ...new A({}) }).toStrictEqual({ a: 3 })
+
+    expect({ ...A.make({}) }).toStrictEqual({ a: 4 })
+    expect({ ...A.make({}) }).toStrictEqual({ a: 5 })
+    new A({ a: 10 })
+    expect({ ...A.make({}) }).toStrictEqual({ a: 6 })
   })
 
   it("a Class with no fields should have a void constructor", () => {
@@ -125,6 +145,10 @@ describe("Class", () => {
     expect({ ...new A() }).toStrictEqual({})
     expect({ ...new A(undefined, true) }).toStrictEqual({})
     expect({ ...new A({}) }).toStrictEqual({})
+
+    expect({ ...A.make() }).toStrictEqual({})
+    expect({ ...A.make(undefined, true) }).toStrictEqual({})
+    expect({ ...A.make({}) }).toStrictEqual({})
   })
 
   it("a Class with all defaulted fields should have a void constructor", () => {
@@ -134,6 +158,10 @@ describe("Class", () => {
     expect({ ...new A() }).toStrictEqual({ a: "" })
     expect({ ...new A(undefined) }).toStrictEqual({ a: "" })
     expect({ ...new A({}) }).toStrictEqual({ a: "" })
+
+    expect({ ...A.make() }).toStrictEqual({ a: "" })
+    expect({ ...A.make(undefined) }).toStrictEqual({ a: "" })
+    expect({ ...A.make({}) }).toStrictEqual({ a: "" })
   })
 
   it("should support methods", () => {
@@ -436,5 +464,18 @@ details: Duplicate key "a"`)
   it("arbitrary", () => {
     class A extends S.Class<A>("A")({ a: S.String }) {}
     Util.expectArbitrary(A)
+  })
+
+  it("should expose a make constructor", () => {
+    class A extends S.Class<A>("A")({
+      n: S.NumberFromString
+    }) {
+      a() {
+        return this.n + "a"
+      }
+    }
+    const a = A.make({ n: 1 })
+    expect(a instanceof A).toEqual(true)
+    expect(a.a()).toEqual("1a")
   })
 })

--- a/packages/schema/test/Schema/Class/TaggedClass.test.ts
+++ b/packages/schema/test/Schema/Class/TaggedClass.test.ts
@@ -220,4 +220,18 @@ details: Duplicate key "_tag"`)
     expect(person._tag).toEqual("TaggedPerson")
     expect(person.upperName).toEqual("JOHN")
   })
+
+  it("should expose a make constructor", () => {
+    class TA extends S.TaggedClass<TA>()("TA", {
+      n: S.NumberFromString
+    }) {
+      a() {
+        return this.n + "a"
+      }
+    }
+    const ta = TA.make({ n: 1 })
+    expect(ta instanceof TA).toEqual(true)
+    expect(ta._tag).toEqual("TA")
+    expect(ta.a()).toEqual("1a")
+  })
 })

--- a/packages/schema/test/Schema/Class/TaggedError.test.ts
+++ b/packages/schema/test/Schema/Class/TaggedError.test.ts
@@ -87,4 +87,18 @@ describe("TaggedError", () => {
     expect(err._tag).toEqual("MyError")
     expect(err.id).toEqual(1)
   })
+
+  it("should expose a make constructor", () => {
+    class A extends S.TaggedError<A>()("A", {
+      n: S.NumberFromString
+    }) {
+      a() {
+        return this.n + "a"
+      }
+    }
+    const a = A.make({ n: 1 })
+    expect(a instanceof A).toEqual(true)
+    expect(a._tag).toEqual("A")
+    expect(a.a()).toEqual("1a")
+  })
 })

--- a/packages/schema/test/Schema/Class/TaggedRequest.test.ts
+++ b/packages/schema/test/Schema/Class/TaggedRequest.test.ts
@@ -159,4 +159,18 @@ describe("TaggedRequest", () => {
       Exit.fail("fail")
     )
   })
+
+  it("should expose a make constructor", () => {
+    class TRA extends S.TaggedRequest<TRA>()("TRA", S.String, S.Number, {
+      n: S.NumberFromString
+    }) {
+      a() {
+        return this.n + "a"
+      }
+    }
+    const tra = TRA.make({ n: 1 })
+    expect(tra instanceof TRA).toEqual(true)
+    expect(tra._tag).toEqual("TRA")
+    expect(tra.a()).toEqual("1a")
+  })
 })

--- a/packages/schema/test/Schema/Class/extend.test.ts
+++ b/packages/schema/test/Schema/Class/extend.test.ts
@@ -107,4 +107,25 @@ describe("extend", () => {
          └─ is missing`
     )
   })
+
+  it("should expose a make constructor", () => {
+    class A extends S.Class<A>("A")({
+      n: S.NumberFromString
+    }) {
+      a() {
+        return this.n + "a"
+      }
+    }
+    class B extends A.extend<B>("B")({
+      c: S.String
+    }) {
+      b() {
+        return this.n + "b"
+      }
+    }
+    const b = B.make({ n: 1, c: "c" })
+    expect(b instanceof B).toEqual(true)
+    expect(b.a()).toEqual("1a")
+    expect(b.b()).toEqual("1b")
+  })
 })

--- a/packages/schema/test/Schema/Class/transformOrFail.test.ts
+++ b/packages/schema/test/Schema/Class/transformOrFail.test.ts
@@ -32,7 +32,11 @@ class PersonWithTransform extends Person.transformOrFail<PersonWithTransform>("P
         ParseResult.fail(new ParseResult.Type(ast, input)) :
         ParseResult.succeed(input)
   }
-) {}
+) {
+  a() {
+    return this.id + "a"
+  }
+}
 
 describe("transformOrFail", () => {
   it("transformOrFail", async () => {
@@ -79,5 +83,11 @@ describe("transformOrFail", () => {
   }
 }}`
     )
+  })
+
+  it("should expose a make constructor", () => {
+    const instance = PersonWithTransform.make({ id: 2, name: "John", thing: Option.some({ id: 1 }) })
+    expect(instance instanceof PersonWithTransform).toEqual(true)
+    expect(instance.a()).toEqual("2a")
   })
 })

--- a/packages/schema/test/Schema/Class/transformOrFailFrom.test.ts
+++ b/packages/schema/test/Schema/Class/transformOrFailFrom.test.ts
@@ -32,7 +32,11 @@ class PersonWithTransformFrom extends Person.transformOrFailFrom<PersonWithTrans
         ParseResult.fail(new ParseResult.Type(ast, input)) :
         ParseResult.succeed(input)
   }
-) {}
+) {
+  a() {
+    return this.id + "a"
+  }
+}
 
 describe("", () => {
   it("transformOrFailFrom", async () => {
@@ -73,5 +77,11 @@ describe("", () => {
       └─ Transformation process failure
          └─ Expected PersonWithTransformFrom (Encoded side), actual {"id":2,"name":"John","thing":{"id":1}}`
     )
+  })
+
+  it("should expose a make constructor", () => {
+    const instance = PersonWithTransformFrom.make({ id: 2, name: "John", thing: Option.some({ id: 1 }) })
+    expect(instance instanceof PersonWithTransformFrom).toEqual(true)
+    expect(instance.a()).toEqual("2a")
   })
 })


### PR DESCRIPTION
Introduced a `make` constructor to class-based APIs to facilitate easier instantiation of classes. This method allows developers to create instances of a class without directly using the `new` keyword.

**Example**

```ts
import { Schema } from "@effect/schema"

class MyClass extends Schema.Class<MyClass>("MyClass")({
  someField: Schema.String
}) {
  someMethod() {
    return this.someField + "bar"
  }
}

// Create an instance of MyClass using the make constructor
const instance = MyClass.make({ someField: "foo" }) // same as new MyClass({ someField: "foo" })

// Outputs to console to demonstrate that the instance is correctly created
console.log(instance instanceof MyClass) // true
console.log(instance.someField) // "foo"
console.log(instance.someMethod()) // "foobar"
```
