### PR TITLE
Fix error message display for composite errors when `overwrite = false`

### DIFF
--- a/.changeset/breezy-houses-cover.md
+++ b/.changeset/breezy-houses-cover.md
@@ -1,0 +1,25 @@
+---
+"@effect/schema": patch
+---
+
+Fix error message display for composite errors when `overwrite = false`
+
+This commit resolves an issue where the custom message for a struct (or tuple or union) was displayed regardless of whether the validation error was related to the entire struct or just a specific part of it. Previously, users would see the custom error message even when the error only concerned a particular field within the struct and the flag `overwrite` was not set to `true`.
+
+```ts
+import { Schema, TreeFormatter } from "@effect/schema"
+import { Either } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.String
+}).annotations({ message: () => "custom message" })
+
+const res = Schema.decodeUnknownEither(schema)({ a: null })
+if (Either.isLeft(res)) {
+  console.log(TreeFormatter.formatErrorSync(res.left))
+  // before: custom message
+  // now: { readonly a: string }
+  //      └─ ["a"]
+  //         └─ Expected string, actual null
+}
+```

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -78,9 +78,7 @@ export const TypeAnnotationId = Symbol.for("@effect/schema/annotation/Type")
  * @category annotations
  * @since 0.67.0
  */
-export type MessageAnnotation = (
-  issue: ParseIssue
-) => string | Effect<string> | {
+export type MessageAnnotation = (issue: ParseIssue) => string | Effect<string> | {
   readonly message: string | Effect<string>
   readonly override: boolean
 }

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -5711,7 +5711,10 @@ const optionParse =
     option_.isOption(u) ?
       option_.isNone(u) ?
         ParseResult.succeed(option_.none())
-        : ParseResult.map(decodeUnknown(u.value, options), option_.some)
+        : ParseResult.mapBoth(decodeUnknown(u.value, options), {
+          onFailure: (e) => new ParseResult.Composite(ast, u, e),
+          onSuccess: option_.some
+        })
       : ParseResult.fail(new ParseResult.Type(ast, u))
 
 /**

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4990,7 +4990,7 @@ export class BigIntFromNumber extends transformOrFail(
 const redactedArbitrary = <A>(value: LazyArbitrary<A>): LazyArbitrary<redacted_.Redacted<A>> => (fc) =>
   value(fc).map((x) => redacted_.make(x))
 
-const redactedParse = <R, A>(
+const redactedParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<A, R>
 ): ParseResult.DeclarationDecodeUnknown<redacted_.Redacted<A>, R> =>
 (u, options, ast) =>
@@ -5706,7 +5706,7 @@ const optionPretty = <A>(value: pretty_.Pretty<A>): pretty_.Pretty<option_.Optio
   })
 
 const optionParse =
-  <R, A>(decodeUnknown: ParseResult.DecodeUnknown<A, R>): ParseResult.DeclarationDecodeUnknown<option_.Option<A>, R> =>
+  <A, R>(decodeUnknown: ParseResult.DecodeUnknown<A, R>): ParseResult.DeclarationDecodeUnknown<option_.Option<A>, R> =>
   (u, options, ast) =>
     option_.isOption(u) ?
       option_.isNone(u) ?
@@ -6257,7 +6257,7 @@ const readonlySetEquivalence = <A>(
   return Equivalence.make((a, b) => arrayEquivalence(Array.from(a.values()), Array.from(b.values())))
 }
 
-const readonlySetParse = <R, A>(
+const readonlySetParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<ReadonlyArray<A>, R>
 ): ParseResult.DeclarationDecodeUnknown<ReadonlySet<A>, R> =>
 (u, options, ast) =>
@@ -6723,7 +6723,7 @@ const chunkArbitrary = <A>(item: LazyArbitrary<A>): LazyArbitrary<chunk_.Chunk<A
 const chunkPretty = <A>(item: pretty_.Pretty<A>): pretty_.Pretty<chunk_.Chunk<A>> => (c) =>
   `Chunk(${chunk_.toReadonlyArray(c).map(item).join(", ")})`
 
-const chunkParse = <R, A>(
+const chunkParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<ReadonlyArray<A>, R>
 ): ParseResult.DeclarationDecodeUnknown<chunk_.Chunk<A>, R> =>
 (u, options, ast) =>
@@ -6814,7 +6814,7 @@ const nonEmptyChunkArbitrary = <A>(item: LazyArbitrary<A>): LazyArbitrary<chunk_
 const nonEmptyChunkPretty = <A>(item: pretty_.Pretty<A>): pretty_.Pretty<chunk_.NonEmptyChunk<A>> => (c) =>
   `NonEmptyChunk(${chunk_.toReadonlyArray(c).map(item).join(", ")})`
 
-const nonEmptyChunkParse = <R, A>(
+const nonEmptyChunkParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<array_.NonEmptyReadonlyArray<A>, R>
 ): ParseResult.DeclarationDecodeUnknown<chunk_.NonEmptyChunk<A>, R> =>
 (u, options, ast) =>
@@ -7758,7 +7758,7 @@ const causePretty = <E>(error: pretty_.Pretty<E>): pretty_.Pretty<cause_.Cause<E
   return f(cause)
 }
 
-const causeParse = <R, A>(
+const causeParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<CauseEncoded<A>, R>
 ): ParseResult.DeclarationDecodeUnknown<cause_.Cause<A>, R> =>
 (u, options, ast) =>
@@ -8092,7 +8092,7 @@ const hashSetEquivalence = <A>(
   return Equivalence.make((a, b) => arrayEquivalence(Array.from(a), Array.from(b)))
 }
 
-const hashSetParse = <R, A>(
+const hashSetParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<ReadonlyArray<A>, R>
 ): ParseResult.DeclarationDecodeUnknown<hashSet_.HashSet<A>, R> =>
 (u, options, ast) =>
@@ -8281,7 +8281,7 @@ const listEquivalence = <A>(
   return Equivalence.make((a, b) => arrayEquivalence(Array.from(a), Array.from(b)))
 }
 
-const listParse = <R, A>(
+const listParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<ReadonlyArray<A>, R>
 ): ParseResult.DeclarationDecodeUnknown<list_.List<A>, R> =>
 (u, options, ast) =>
@@ -8360,7 +8360,7 @@ const sortedSetArbitrary =
 const sortedSetPretty = <A>(item: pretty_.Pretty<A>): pretty_.Pretty<sortedSet_.SortedSet<A>> => (set) =>
   `new SortedSet([${Array.from(sortedSet_.values(set)).map((a) => item(a)).join(", ")}])`
 
-const sortedSetParse = <R, A>(
+const sortedSetParse = <A, R>(
   decodeUnknown: ParseResult.DecodeUnknown<ReadonlyArray<A>, R>,
   ord: Order.Order<A>
 ): ParseResult.DeclarationDecodeUnknown<sortedSet_.SortedSet<A>, R> =>

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -5948,8 +5948,16 @@ const eitherParse = <RR, R, LR, L>(
 (u, options, ast) =>
   either_.isEither(u) ?
     either_.match(u, {
-      onLeft: (left) => ParseResult.map(decodeUnknownLeft(left, options), either_.left),
-      onRight: (right) => ParseResult.map(parseRight(right, options), either_.right)
+      onLeft: (left) =>
+        ParseResult.mapBoth(decodeUnknownLeft(left, options), {
+          onFailure: (e) => new ParseResult.Composite(ast, u, e),
+          onSuccess: either_.left
+        }),
+      onRight: (right) =>
+        ParseResult.mapBoth(parseRight(right, options), {
+          onFailure: (e) => new ParseResult.Composite(ast, u, e),
+          onSuccess: either_.right
+        })
     })
     : ParseResult.fail(new ParseResult.Type(ast, u))
 
@@ -7974,8 +7982,16 @@ const exitParse = <A, R, E, ER>(
 (u, options, ast) =>
   exit_.isExit(u) ?
     exit_.match(u, {
-      onFailure: (cause) => ParseResult.map(decodeUnknownCause(cause, options), exit_.failCause),
-      onSuccess: (value) => ParseResult.map(decodeUnknownValue(value, options), exit_.succeed)
+      onFailure: (cause) =>
+        ParseResult.mapBoth(decodeUnknownCause(cause, options), {
+          onFailure: (e) => new ParseResult.Composite(ast, u, e),
+          onSuccess: exit_.failCause
+        }),
+      onSuccess: (value) =>
+        ParseResult.mapBoth(decodeUnknownValue(value, options), {
+          onFailure: (e) => new ParseResult.Composite(ast, u, e),
+          onSuccess: exit_.succeed
+        })
     })
     : ParseResult.fail(new ParseResult.Type(ast, u))
 

--- a/packages/schema/src/TreeFormatter.ts
+++ b/packages/schema/src/TreeFormatter.ts
@@ -135,14 +135,15 @@ export const getMessage: (
     Effect.catchAll(() =>
       Effect.flatMap(current, (current) => {
         if (
-          !current.override && (
-            (issue._tag === "Refinement" && issue.kind !== "Predicate") ||
-            (issue._tag === "Transformation" && issue.kind !== "Transformation")
+          current.override || (
+            (issue._tag !== "Composite") &&
+            (issue._tag !== "Refinement" || issue.kind === "Predicate") &&
+            (issue._tag !== "Transformation" || issue.kind === "Transformation")
           )
         ) {
-          return Option.none()
+          return Effect.succeed(current.message)
         }
-        return Effect.succeed(current.message)
+        return Option.none()
       })
     )
   )

--- a/packages/schema/test/Schema/Either/EitherFromSelf.test.ts
+++ b/packages/schema/test/Schema/Either/EitherFromSelf.test.ts
@@ -28,9 +28,33 @@ describe("EitherFromSelf", () => {
   })
 
   it("decoding", async () => {
-    const schema = S.EitherFromSelf({ left: S.String, right: S.NumberFromString })
-    await Util.expectDecodeUnknownSuccess(schema, E.left("a"), E.left("a"))
-    await Util.expectDecodeUnknownSuccess(schema, E.right("1"), E.right(1))
+    const schema = S.EitherFromSelf({ left: S.NumberFromString, right: Util.BooleanFromLiteral })
+    await Util.expectDecodeUnknownSuccess(schema, E.left("1"), E.left(1))
+    await Util.expectDecodeUnknownSuccess(schema, E.right("true"), E.right(true))
+
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      null,
+      `Expected Either<("true" | "false" <-> boolean), NumberFromString>, actual null`
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      E.right(""),
+      `Either<("true" | "false" <-> boolean), NumberFromString>
+└─ ("true" | "false" <-> boolean)
+   └─ Encoded side transformation failure
+      └─ "true" | "false"
+         ├─ Expected "true", actual ""
+         └─ Expected "false", actual ""`
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      E.left("a"),
+      `Either<("true" | "false" <-> boolean), NumberFromString>
+└─ NumberFromString
+   └─ Transformation process failure
+      └─ Expected NumberFromString, actual "a"`
+    )
   })
 
   it("pretty", () => {

--- a/packages/schema/test/Schema/Exit/ExitFromSelf.test.ts
+++ b/packages/schema/test/Schema/Exit/ExitFromSelf.test.ts
@@ -1,9 +1,44 @@
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/TestUtils"
+import * as E from "effect/Exit"
 import { describe, it } from "vitest"
 
 describe("ExitFromSelf", () => {
   it("arbitrary", () => {
     Util.expectArbitrary(S.ExitFromSelf({ failure: S.String, success: S.Number }))
+  })
+
+  it("decoding", async () => {
+    const schema = S.ExitFromSelf({ failure: S.NumberFromString, success: Util.BooleanFromLiteral })
+    await Util.expectDecodeUnknownSuccess(schema, E.fail("1"), E.fail(1))
+    await Util.expectDecodeUnknownSuccess(schema, E.succeed("true"), E.succeed(true))
+
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      null,
+      `Expected Exit<("true" | "false" <-> boolean), NumberFromString>, actual null`
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      E.succeed(""),
+      `Exit<("true" | "false" <-> boolean), NumberFromString>
+└─ ("true" | "false" <-> boolean)
+   └─ Encoded side transformation failure
+      └─ "true" | "false"
+         ├─ Expected "true", actual ""
+         └─ Expected "false", actual ""`
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      E.fail("a"),
+      `Exit<("true" | "false" <-> boolean), NumberFromString>
+└─ Cause<NumberFromString>
+   └─ CauseEncoded<NumberFromString>
+      └─ { readonly _tag: "Fail"; readonly error: NumberFromString }
+         └─ ["error"]
+            └─ NumberFromString
+               └─ Transformation process failure
+                  └─ Expected NumberFromString, actual "a"`
+    )
   })
 })

--- a/packages/schema/test/TestUtils.ts
+++ b/packages/schema/test/TestUtils.ts
@@ -361,3 +361,8 @@ export const expectAssertsFailure = <A, I>(
 ) => {
   expect(() => S.asserts(schema, options)(input)).toThrow(new Error(message))
 }
+
+export const BooleanFromLiteral = S.transform(S.Literal("true", "false"), S.Boolean, {
+  decode: (l) => l === "true",
+  encode: (b) => b ? "true" : "false"
+})


### PR DESCRIPTION
This commit resolves an issue where the custom message for a struct (or tuple or union) was displayed regardless of whether the validation error was related to the entire struct or just a specific part of it. Previously, users would see the custom error message even when the error only concerned a particular field within the struct and the flag `overwrite` was not set to `true`.

```ts
import { Schema, TreeFormatter } from "@effect/schema"
import { Either } from "effect"

const schema = Schema.Struct({
  a: Schema.String
}).annotations({ message: () => "custom message" })

const res = Schema.decodeUnknownEither(schema)({ a: null })
if (Either.isLeft(res)) {
  console.log(TreeFormatter.formatErrorSync(res.left))
  // before: custom message
  // now: { readonly a: string }
  //      └─ ["a"]
  //         └─ Expected string, actual null
}
```
