### PR TITLE
feat: add `Config.Config.Success`

### DIFF
--- a/.changeset/lucky-poets-guess.md
+++ b/.changeset/lucky-poets-guess.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add `Success` type util for `Config`.

--- a/packages/effect/dtslint/Config.ts
+++ b/packages/effect/dtslint/Config.ts
@@ -1,5 +1,5 @@
 import * as Config from "effect/Config"
-import { pipe } from "effect/Function"
+import { hole, pipe } from "effect/Function"
 
 declare const string: Config.Config<string>
 declare const number: Config.Config<number>
@@ -45,3 +45,18 @@ Config.all(numberRecord)
 
 // $ExpectType Config<{ [x: string]: number; }>
 pipe(numberRecord, Config.all)
+
+// -------------------------------------------------------------------------------------
+// Success
+// -------------------------------------------------------------------------------------
+
+// $ExpectType string
+hole<Config.Config.Success<typeof string>>()
+
+// $ExpectType number
+hole<Config.Config.Success<typeof number>>()
+
+const object = Config.all({ a: string, b: number })
+
+// $ExpectType { a: string; b: number; }
+hole<Config.Config.Success<typeof object>>()

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -52,6 +52,12 @@ export declare namespace Config {
   }
 
   /**
+   * @since 2.5.0
+   * @category models
+   */
+  export type Success<T extends Config<any>> = [T] extends [Config<infer _A>] ? _A : never
+
+  /**
    * @since 2.0.0
    * @category models
    */


### PR DESCRIPTION
I'm aware `Effect.Effect.Success` does effectively the same thing but e.g. in our codebase we ended up creating a custom type util just for to purpose of being specific because when reading the code one doesn't need to do the additional mental step of realising the thing is a config and it works because it extends an Effect type.