### PR TITLE
more type safe dual signature, closes #2967

### DIFF
--- a/.changeset/nice-laws-admire.md
+++ b/.changeset/nice-laws-admire.md
@@ -1,0 +1,8 @@
+---
+"@effect/typeclass": minor
+"@effect/platform": minor
+"effect": minor
+"@effect/schema": minor
+---
+
+more type safe `Function.dual` signature

--- a/packages/effect/dtslint/Function.ts
+++ b/packages/effect/dtslint/Function.ts
@@ -1,0 +1,24 @@
+import * as Function from "effect/Function"
+
+// -------------------------------------------------------------------------------------
+// dual
+// -------------------------------------------------------------------------------------
+
+type f_data_first = (a: number, b: number) => number
+type f_data_last = (b: number) => (a: number) => number
+
+const f: f_data_first & f_data_last = Function.dual(2, (a: number, b: number) => a + b)
+// $ExpectType f_data_first & f_data_last
+f
+
+const f_explicit_types = Function.dual<f_data_last, f_data_first>(2, (a: number, b: number) => a + b)
+// $ExpectType f_data_first & f_data_last
+f_explicit_types
+
+const f_no_type = Function.dual(2, (a: number, b: number) => a + b)
+// $ExpectType (a: number, b: number) => number
+f_no_type
+
+// @ts-expect-error
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const f_wrong_impl: f_data_first & f_data_last = Function.dual(2, (a: string, b: string) => a + b)

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -994,9 +994,12 @@ export const findLast: {
   <A, B>(self: Iterable<A>, f: (a: A, i: number) => Option<B>): Option<B>
   <A, B extends A>(self: Iterable<A>, refinement: (a: A, i: number) => a is B): Option<B>
   <A>(self: Iterable<A>, predicate: (a: A, i: number) => boolean): Option<A>
-} = dual(
+} = dual<
+  typeof findLast,
+  <A>(self: Iterable<A>, f: ((a: A, i: number) => boolean) | ((a: A, i: number) => Option<A>)) => Option<A>
+>(
   2,
-  <A>(self: Iterable<A>, f: ((a: A, i: number) => boolean) | ((a: A, i: number) => Option<A>)): Option<A> => {
+  (self, f) => {
     const input = fromIterable(self)
     for (let i = input.length - 1; i >= 0; i--) {
       const a = input[i]
@@ -1680,7 +1683,7 @@ export const splitNonEmptyAt: {
 export const split: {
   (n: number): <A>(self: Iterable<A>) => Array<Array<A>>
   <A>(self: Iterable<A>, n: number): Array<Array<A>>
-} = dual(2, <A>(self: Iterable<A>, n: number) => {
+} = dual<typeof split, <A>(self: Iterable<A>, n: number) => Array<Array<A>>>(2, (self, n) => {
   const input = fromIterable(self)
   return chunksOf(input, Math.ceil(input.length / Math.floor(n)))
 })

--- a/packages/effect/src/Function.ts
+++ b/packages/effect/src/Function.ts
@@ -69,14 +69,22 @@ export const isFunction = (input: unknown): input is Function => typeof input ==
  * @since 2.0.0
  */
 export const dual: {
-  <DataLast extends (...args: Array<any>) => any, DataFirst extends (...args: Array<any>) => any>(
-    arity: Parameters<DataFirst>["length"],
-    body: DataFirst
-  ): DataLast & DataFirst
-  <DataLast extends (...args: Array<any>) => any, DataFirst extends (...args: Array<any>) => any>(
+  <
+    Other extends (...args: ReadonlyArray<any>) => any,
+    Impl extends (...args: ReadonlyArray<any>) => any,
+    Signature extends Impl = Impl & ([Array<any>] extends [Parameters<Other>] ? unknown : Other)
+  >(
+    arity: Parameters<Impl>["length"],
+    body: Impl
+  ): Signature
+  <
+    Other extends (...args: ReadonlyArray<any>) => any,
+    Impl extends (...args: ReadonlyArray<any>) => any,
+    Signature extends Impl = Impl & ([Array<any>] extends [Parameters<Other>] ? unknown : Other)
+  >(
     isDataFirst: (args: IArguments) => boolean,
-    body: DataFirst
-  ): DataLast & DataFirst
+    body: Impl
+  ): Signature
 } = function(arity, body) {
   if (typeof arity === "function") {
     return function() {

--- a/packages/effect/src/Iterable.ts
+++ b/packages/effect/src/Iterable.ts
@@ -376,9 +376,12 @@ export const findFirst: {
   <A, B>(self: Iterable<A>, f: (a: A, i: number) => Option<B>): Option<B>
   <A, B extends A>(self: Iterable<A>, refinement: (a: A, i: number) => a is B): Option<B>
   <A>(self: Iterable<A>, predicate: (a: A, i: number) => boolean): Option<A>
-} = dual(
+} = dual<
+  typeof findFirst,
+  <A>(self: Iterable<A>, f: ((a: A, i: number) => boolean) | ((a: A, i: number) => Option<A>)) => Option<A>
+>(
   2,
-  <A>(self: Iterable<A>, f: ((a: A, i: number) => boolean) | ((a: A, i: number) => Option<A>)): Option<A> => {
+  (self, f) => {
     let i = 0
     for (const a of self) {
       const o = f(a, i)
@@ -410,7 +413,10 @@ export const findLast: {
   <A, B>(self: Iterable<A>, f: (a: A, i: number) => Option<B>): Option<B>
   <A, B extends A>(self: Iterable<A>, refinement: (a: A, i: number) => a is B): Option<B>
   <A>(self: Iterable<A>, predicate: (a: A, i: number) => boolean): Option<A>
-} = dual(
+} = dual<
+  typeof findLast,
+  <A>(self: Iterable<A>, f: ((a: A, i: number) => boolean) | ((a: A, i: number) => Option<A>)) => Option<A>
+>(
   2,
   <A>(self: Iterable<A>, f: ((a: A, i: number) => boolean) | ((a: A, i: number) => Option<A>)): Option<A> => {
     let i = 0
@@ -795,7 +801,10 @@ export const filterMap: {
 export const filterMapWhile: {
   <A, B>(f: (a: A, i: number) => Option<B>): (self: Iterable<A>) => Iterable<B>
   <A, B>(self: Iterable<A>, f: (a: A, i: number) => Option<B>): Iterable<B>
-} = dual(2, <A, B>(self: Iterable<A>, f: (a: A, i: number) => Option<B>) => ({
+} = dual<
+  typeof filterMapWhile,
+  <A, B>(self: Iterable<A>, f: (a: A, i: number) => Option<B>) => Iterable<B>
+>(2, (self, f) => ({
   [Symbol.iterator]() {
     const iterator = self[Symbol.iterator]()
     let i = 0

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -614,7 +614,7 @@ export const map: {
  */
 export const as: {
   <B>(b: B): <X>(self: Option<X>) => Option<B>
-} = dual(2, <X, B>(self: Option<X>, b: B): Option<B> => map(self, () => b))
+} = dual<typeof as, <X, B>(self: Option<X>, b: B) => Option<B>>(2, (self, b) => map(self, () => b))
 
 /**
  * Maps the `Some` value of this `Option` to the `void` constant value.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2703,6 +2703,36 @@ export const mapEffect: {
 } = _groupBy.mapEffectOptions
 
 /**
+ * Maps over elements of the stream with the specified effectful function
+ * and filters out `None` values
+ *
+ * @example
+ * import { Effect, Stream, Console } from 'effect';
+ *
+ * // returns `Some(number)` if the number is even, otherwise `None`
+ * const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
+ *
+ * const result = Stream.make(0, 1, 2, 4).pipe(
+ *   Stream.filterMapEffectOption(even),
+ *   Stream.runCollect,
+ *   Effect.runPromise,
+ * )
+ * // => [0, 2, 4]
+ *
+ * @since 3.3.5
+ * @category utils
+ */
+export const filterMapEffectOption: {
+  <A, A2, E2, R2>(
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ): <E, R>(stream: Stream<A, E, R>) => Stream<A2, E2 | E, R2 | R>
+  <A, E, R, A2, E2, R2>(
+    stream: Stream<A, E, R>,
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ): Stream<A2, E2 | E, R2 | R>
+} = _groupBy.filterMapEffectOption
+
+/**
  * Transforms the errors emitted by this stream using `f`.
  *
  * @since 2.0.0

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -495,10 +495,12 @@ export const andThen: {
   <E2>(f: Cause.Cause<E2>): <E>(self: Cause.Cause<E>) => Cause.Cause<E2>
   <E, E2>(self: Cause.Cause<E>, f: (e: E) => Cause.Cause<E2>): Cause.Cause<E2>
   <E, E2>(self: Cause.Cause<E>, f: Cause.Cause<E2>): Cause.Cause<E2>
-} = dual(
+} = dual<
+  typeof andThen,
+  <E, E2>(self: Cause.Cause<E>, f: ((e: E) => Cause.Cause<E2>) | Cause.Cause<E2>) => Cause.Cause<E2>
+>(
   2,
-  <E, E2>(self: Cause.Cause<E>, f: ((e: E) => Cause.Cause<E2>) | Cause.Cause<E2>): Cause.Cause<E2> =>
-    isFunction(f) ? flatMap(self, f) : flatMap(self, () => f)
+  (self, f) => isFunction(f) ? flatMap(self, f) : flatMap(self, () => f)
 )
 
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1992,7 +1992,18 @@ export const forEach: {
       readonly discard: true
     }
   ): Effect.Effect<void, E, R>
-} = dual((args) => Predicate.isIterable(args[0]), <A, R, E, B>(
+} = dual<
+  typeof forEach,
+  <A, R, E, B>(
+    self: Iterable<A>,
+    f: (a: A, i: number) => Effect.Effect<B, E, R>,
+    options?: {
+      readonly concurrency?: Concurrency | undefined
+      readonly batching?: boolean | "inherit" | undefined
+      readonly discard?: boolean | undefined
+    }
+  ) => Effect.Effect<void, E, R> | Effect.Effect<RA.NonEmptyArray<B>, E, R> | Effect.Effect<Array<B>, E, R>
+>((args) => Predicate.isIterable(args[0]), <A, R, E, B>(
   self: Iterable<A>,
   f: (a: A, i: number) => Effect.Effect<B, E, R>,
   options?: {

--- a/packages/effect/src/internal/groupBy.ts
+++ b/packages/effect/src/internal/groupBy.ts
@@ -4,7 +4,7 @@ import * as Chunk from "../Chunk.js"
 import * as Deferred from "../Deferred.js"
 import * as Effect from "../Effect.js"
 import * as Exit from "../Exit.js"
-import { dual, pipe } from "../Function.js"
+import { dual, identity, pipe } from "../Function.js"
 import type * as GroupBy from "../GroupBy.js"
 import * as Option from "../Option.js"
 import { pipeArguments } from "../Pipeable.js"
@@ -205,6 +205,19 @@ export const groupBy = dual<
       )
     )
 )
+
+/** @internal */
+export const filterMapEffectOption = dual<
+  <A, A2, E2, R2>(
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ) => <E, R>(
+    stream: Stream.Stream<A, E, R>
+  ) => Stream.Stream<A2, E2 | E, R2 | R>,
+  <A, E, R, A2, E2, R2>(
+    stream: Stream.Stream<A, E, R>,
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ) => Stream.Stream<A2, E2 | E, R2 | R>
+>(2, (s, fn) => stream.filterMap(mapEffectOptions(s, fn), identity))
 
 /** @internal */
 export const mapEffectOptions = dual<

--- a/packages/effect/src/internal/hashSet.ts
+++ b/packages/effect/src/internal/hashSet.ts
@@ -280,18 +280,21 @@ export const filter: {
   <A>(predicate: Predicate<NoInfer<A>>): (self: HS.HashSet<A>) => HS.HashSet<A>
   <A, B extends A>(self: HS.HashSet<A>, refinement: Refinement<A, B>): HS.HashSet<B>
   <A>(self: HS.HashSet<A>, predicate: Predicate<A>): HS.HashSet<A>
-} = dual(2, <A>(self: HS.HashSet<A>, f: Predicate<A>) => {
-  return mutate(empty(), (set) => {
-    const iterator = values(self)
-    let next: IteratorResult<A, any>
-    while (!(next = iterator.next()).done) {
-      const value = next.value
-      if (f(value)) {
-        add(set, value)
+} = dual<typeof filter, <A>(self: HS.HashSet<A>, f: Predicate<A>) => HS.HashSet<A>>(
+  2,
+  <A>(self: HS.HashSet<A>, f: Predicate<A>): HS.HashSet<A> => {
+    return mutate(empty(), (set) => {
+      const iterator = values(self)
+      let next: IteratorResult<A, any>
+      while (!(next = iterator.next()).done) {
+        const value = next.value
+        if (f(value)) {
+          add(set, value)
+        }
       }
-    }
-  })
-})
+    })
+  }
+)
 
 /** @internal */
 export const partition: {

--- a/packages/effect/src/internal/stm/tMap.ts
+++ b/packages/effect/src/internal/stm/tMap.ts
@@ -362,7 +362,16 @@ export const removeIf: {
       readonly discard: false
     }
   ): STM.STM<Array<[K, V]>>
-} = dual((args) => isTMap(args[0]), <K, V>(
+} = dual<
+  typeof removeIf,
+  <K, V>(
+    self: TMap.TMap<K, V>,
+    predicate: (key: K, value: V) => boolean,
+    options?: {
+      readonly discard: boolean
+    }
+  ) => STM.STM<Array<[K, V]> | void>
+>((args) => isTMap(args[0]), <K, V>(
   self: TMap.TMap<K, V>,
   predicate: (key: K, value: V) => boolean,
   options?: {

--- a/packages/effect/test/Function.test.ts
+++ b/packages/effect/test/Function.test.ts
@@ -140,7 +140,7 @@ describe("Function", () => {
       deepStrictEqual(f(3, 2), 1)
       deepStrictEqual(Function.pipe(3, f(2)), 1)
       // should ignore excess arguments
-      deepStrictEqual(f.apply(null, [3, 2, 100] as any), 1)
+      deepStrictEqual((f as (self: number, that: number) => number).apply(null, [3, 2, 100] as any), 1)
     })
 
     it("arity: 0", () => {
@@ -169,7 +169,7 @@ describe("Function", () => {
       deepStrictEqual(f(3, 2), 1)
       deepStrictEqual(Function.pipe(3, f(2)), 1)
       // should ignore excess arguments
-      deepStrictEqual(f.apply(null, [3, 2, 100] as any), 1)
+      deepStrictEqual((f as (self: number, that: number) => number).apply(null, [3, 2, 100] as any), 1)
     })
 
     it("arity: 5", () => {
@@ -180,7 +180,13 @@ describe("Function", () => {
       deepStrictEqual(f("_", "a", "b", "c", "d"), "_abcd")
       deepStrictEqual(Function.pipe("_", f("a", "b", "c", "d")), "_abcd")
       // should ignore excess arguments
-      deepStrictEqual(f.apply(null, ["_", "a", "b", "c", "d", "e"] as any), "_abcd")
+      deepStrictEqual(
+        (f as ((self: string, a: string, b: string, c: string, d: string) => string)).apply(
+          null,
+          ["_", "a", "b", "c", "d", "e"] as any
+        ),
+        "_abcd"
+      )
     })
 
     it("arity > 5", () => {
@@ -191,7 +197,13 @@ describe("Function", () => {
       deepStrictEqual(f("_", "a", "b", "c", "d", "e"), "_abcde")
       deepStrictEqual(Function.pipe("_", f("a", "b", "c", "d", "e")), "_abcde")
       // should ignore excess arguments
-      deepStrictEqual(f.apply(null, ["_", "a", "b", "c", "d", "e", "f"] as any), "_abcde")
+      deepStrictEqual(
+        (f as (self: string, a: string, b: string, c: string, d: string, e: string) => string).apply(
+          null,
+          ["_", "a", "b", "c", "d", "e", "f"] as any
+        ),
+        "_abcde"
+      )
     })
   })
 })

--- a/packages/effect/test/Stream/filtering.test.ts
+++ b/packages/effect/test/Stream/filtering.test.ts
@@ -46,4 +46,14 @@ describe("Stream", () => {
         [Either.right(1), Either.right(2), Either.left("boom")]
       )
     }))
+
+  it.effect("filterMapEffectOption", () =>
+    Effect.gen(function*() {
+      const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
+      const result = yield* Stream.make(0, 1, 2, 4).pipe(
+        Stream.filterMapEffectOption(even),
+        Stream.runCollect
+      )
+      assert.deepStrictEqual(Array.from(result), [0, 2, 4])
+    }))
 })

--- a/packages/platform/src/Transferable.ts
+++ b/packages/platform/src/Transferable.ts
@@ -86,9 +86,15 @@ export const schema: {
     self: Schema.Schema<A, I, R>,
     f: (_: I) => Iterable<globalThis.Transferable>
   ): Schema.Schema<A, I, R>
-} = dual(2, <A, I, R>(
-  self: Schema.Schema<A, I, R>,
-  f: (_: I) => Iterable<globalThis.Transferable>
+} = dual<
+  typeof schema,
+  <A, I, R>(
+    self: Schema.Schema<A, I, R>,
+    f: (_: I) => Iterable<globalThis.Transferable>
+  ) => Schema.Schema<A, I, R>
+>(2, (
+  self,
+  f
 ) =>
   Schema.transformOrFail(
     Schema.encodedSchema(self),

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -2246,12 +2246,15 @@ export const optional: {
     self: Schema.All extends S ? "you can't apply optional implicitly, use optional() instead" : S,
     options?: Options
   ): [undefined] extends [Options] ? optional<S> : optionalWithOptions<S, Options>
-} = dual((args) => isSchema(args[0]), (from, options) => {
+} = (dual((args) => isSchema(args[0]), (
+  from,
+  options
+) => {
   // Note: `Schema.All extends S ? "you can't...` is used to prevent the case where `optional` is implicitly applied.
   // For example: `S.String.pipe(S.optional)` would result in `S.String` being inferred as `Schema.All`,
   // which is not the intended behavior. This is mostly an aesthetic consideration, so if it causes issues, we can remove it.
   return new PropertySignatureWithFromImpl(optionalPropertySignatureAST(from, options), from)
-})
+})) as unknown as typeof optional
 
 /**
  * @since 0.67.0
@@ -3073,9 +3076,12 @@ export interface extend<Self extends Schema.Any, That extends Schema.Any> extend
 export const extend: {
   <That extends Schema.Any>(that: That): <Self extends Schema.Any>(self: Self) => extend<Self, That>
   <Self extends Schema.Any, That extends Schema.Any>(self: Self, that: That): extend<Self, That>
-} = dual(
+} = dual<
+  typeof extend,
+  <Self extends Schema.Any, That extends Schema.Any>(self: Self, that: That) => extend<Self, That>
+>(
   2,
-  <Self extends Schema.Any, That extends Schema.Any>(self: Self, that: That) => make(extendAST(self.ast, that.ast, []))
+  (self, that) => make(extendAST(self.ast, that.ast, []))
 )
 
 /**

--- a/packages/typeclass/src/Filterable.ts
+++ b/packages/typeclass/src/Filterable.ts
@@ -103,7 +103,10 @@ export const filter: <F extends TypeLambda>(
     predicate: (a: A) => boolean
   ): Kind<F, R, O, E, B>
 } = <F extends TypeLambda>(Filterable: Filterable<F>) =>
-  dual(
+  dual<
+    ReturnType<typeof filter<F>>,
+    <R, O, E, A>(self: Kind<F, R, O, E, A>, predicate: (a: A) => boolean) => Kind<F, R, O, E, A>
+  >(
     2,
     <R, O, E, A>(self: Kind<F, R, O, E, A>, predicate: (a: A) => boolean): Kind<F, R, O, E, A> =>
       Filterable.filterMap(self, (b) => (predicate(b) ? Option.some(b) : Option.none()))


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ad discussed in #2967, the `dual` type signature could be improved to avoid inferring an `(...args: any[]) => any` function type, which is assignable to  every function signature you define for your dual api, and instead be precise over the implementation signature used. Of course the rest of the type signature would still be unsafe, but that's unavoidable.

This should help prevent errors when the type signature of the implementation used for the `dual` api is different to the one used as the final signature of such dual api.

NOTICE:

There are a couple of tests failing, regarding the schema package, which should not be related to this change. In fact, if you run the tests on the main this pr is based on, those tests keep failing.

This PR should be type level only. I added dtslint tests for the dual signature type checks I did in the first place that brought this change to exist. This should help to assert those cases are preserved in the future.

## Related

- Closes #2967 
