### PR TITLE
Add `refineTypeId` unique symbol to the `refine` interface to ensure …

### DIFF
--- a/packages/schema/test/Schema/Class/Class.test.ts
+++ b/packages/schema/test/Schema/Class/Class.test.ts
@@ -330,14 +330,6 @@ details: Duplicate key "a"`)
     )
   })
 
-  it("should accept a simple object as argument", () => {
-    const fields = { a: S.String, b: S.Number }
-    class A extends S.Class<A>("A")({ fields }) {}
-    Util.expectFields(A.fields, fields)
-    class B extends S.Class<B>("B")({ from: { fields } }) {}
-    Util.expectFields(B.fields, fields)
-  })
-
   it("should accept a Struct as argument", () => {
     const fields = { a: S.String, b: S.Number }
     class A extends S.Class<A>("A")(S.Struct(fields)) {}

--- a/packages/schema/test/Schema/Class/TaggedClass.test.ts
+++ b/packages/schema/test/Schema/Class/TaggedClass.test.ts
@@ -49,14 +49,6 @@ details: Duplicate key "_tag"`)
     )
   })
 
-  it("should accept a simple object as argument", () => {
-    const fields = { a: S.String, b: S.Number }
-    class A extends S.TaggedClass<A>()("A", { fields }) {}
-    Util.expectFields(A.fields, { _tag: S.getClassTag("A"), ...fields })
-    class B extends S.TaggedClass<B>()("B", { from: { fields } }) {}
-    Util.expectFields(B.fields, { _tag: S.getClassTag("B"), ...fields })
-  })
-
   it("should accept a Struct as argument", () => {
     const fields = { a: S.String, b: S.Number }
     class A extends S.TaggedClass<A>()("A", S.Struct(fields)) {}

--- a/packages/schema/test/Schema/Class/TaggedError.test.ts
+++ b/packages/schema/test/Schema/Class/TaggedError.test.ts
@@ -11,14 +11,6 @@ describe("TaggedError", () => {
     expect(TE._tag).toBe("TE")
   })
 
-  it("should accept a simple object as argument", () => {
-    const fields = { a: S.String, b: S.Number }
-    class A extends S.TaggedError<A>()("A", { fields }) {}
-    Util.expectFields(A.fields, { _tag: S.getClassTag("A"), ...fields })
-    class B extends S.TaggedError<B>()("B", { from: { fields } }) {}
-    Util.expectFields(B.fields, { _tag: S.getClassTag("B"), ...fields })
-  })
-
   it("should accept a Struct as argument", () => {
     const fields = { a: S.String, b: S.Number }
     class A extends S.TaggedError<A>()("A", S.Struct(fields)) {}

--- a/packages/schema/test/Schema/Class/extend.test.ts
+++ b/packages/schema/test/Schema/Class/extend.test.ts
@@ -53,16 +53,6 @@ describe("extend", () => {
     expect(person.nick).toEqual("Joe")
   })
 
-  it("should accept a simple object as argument", () => {
-    const baseFields = { base: S.String }
-    class Base extends S.Class<Base>("Base")(baseFields) {}
-    const fields = { a: S.String, b: S.Number }
-    class A extends Base.extend<A>("A")({ fields }) {}
-    Util.expectFields(A.fields, { ...baseFields, ...fields })
-    class B extends Base.extend<B>("B")({ from: { fields } }) {}
-    Util.expectFields(B.fields, { ...baseFields, ...fields })
-  })
-
   it("should accept a Struct as argument", () => {
     const baseFields = { base: S.String }
     class Base extends S.Class<Base>("Base")(baseFields) {}


### PR DESCRIPTION
…correct inference of `Fields` in the Class APIs, closes #3063

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #3063
