### PR TITLE
Unify CI and Nix to Nodejs `v20.12.2`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: The version of Node.js to install
     required: true
-    default: 20.9.0
+    default: 20.12.2
 
 runs:
   using: composite

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             bun
             corepack
             deno
-            nodejs-slim_22
+            nodejs-slim # Node v20.12.2
           ];
         };
       }

--- a/packages/cluster-workflow/test/DurableExecutionJournal.test.ts
+++ b/packages/cluster-workflow/test/DurableExecutionJournal.test.ts
@@ -88,8 +88,6 @@ describe("DurableExecutionJournal", () => {
         false
       ).pipe(Stream.runCollect)
 
-      console.log(results)
-
       expect(results).toEqual(Chunk.of(DurableExecutionEvent.Attempted("")(0)))
     }).pipe(runTest({ table: "test_read" })))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Unifies CI and the pinned Nixpkgs to utilize `v20.12.2` of NodeJS to avoid discrepancies.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
