### PR TITLE
Special case `S.parseJson` to generate JSON Schemas by targeting the …

### DIFF
--- a/.changeset/rude-meals-dream.md
+++ b/.changeset/rude-meals-dream.md
@@ -1,0 +1,57 @@
+---
+"@effect/schema": patch
+---
+
+Special case `S.parseJson` to generate JSON Schemas by targeting the "to" side of transformations, closes #3086
+
+Resolved an issue where `JSONSchema.make` improperly generated JSON Schemas for schemas defined with `S.parseJson(<real schema>)`. Previously, invoking `JSONSchema.make` on these transformed schemas produced a JSON Schema corresponding to a string type rather than the underlying real schema.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.parseJson(
+  Schema.Struct({
+    a: Schema.parseJson(Schema.NumberFromString)
+  })
+)
+
+console.log(JSONSchema.make(schema))
+/*
+{
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  '$ref': '#/$defs/JsonString',
+  '$defs': {
+    JsonString: {
+      type: 'string',
+      description: 'a JSON string',
+      title: 'JsonString'
+    }
+  }
+}
+*/
+```
+
+Now
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.parseJson(
+  Schema.Struct({
+    a: Schema.parseJson(Schema.NumberFromString)
+  })
+)
+
+console.log(JSONSchema.make(schema))
+/*
+{
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: [ 'a' ],
+  properties: { a: { type: 'string', description: 'a string', title: 'string' } },
+  additionalProperties: false
+}
+*/
+```

--- a/.changeset/rude-meals-dream.md
+++ b/.changeset/rude-meals-dream.md
@@ -11,9 +11,10 @@ Before
 ```ts
 import { JSONSchema, Schema } from "@effect/schema"
 
+// Define a schema that parses a JSON string into a structured object
 const schema = Schema.parseJson(
   Schema.Struct({
-    a: Schema.parseJson(Schema.NumberFromString)
+    a: Schema.parseJson(Schema.NumberFromString) // Nested parsing from JSON string to number
   })
 )
 
@@ -38,9 +39,10 @@ Now
 ```ts
 import { JSONSchema, Schema } from "@effect/schema"
 
+// Define a schema that parses a JSON string into a structured object
 const schema = Schema.parseJson(
   Schema.Struct({
-    a: Schema.parseJson(Schema.NumberFromString)
+    a: Schema.parseJson(Schema.NumberFromString) // Nested parsing from JSON string to number
   })
 )
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1781,6 +1781,34 @@ the default would be:
 */
 ```
 
+### Understanding `Schema.parseJson` in JSON Schema Generation
+
+When utilizing `Schema.parseJson` within the `@effect/schema` library, JSON Schema generation follows a specialized approach. Instead of merely generating a JSON Schema for a string—which would be the default output representing the "from" side of the transformation defined by `Schema.parseJson`—it specifically generates the JSON Schema for the actual schema provided as an argument.
+
+**Example of Generating JSON Schema with `Schema.parseJson`**
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+// Define a schema that parses a JSON string into a structured object
+const schema = Schema.parseJson(
+  Schema.Struct({
+    a: Schema.parseJson(Schema.NumberFromString) // Nested parsing from JSON string to number
+  })
+)
+
+console.log(JSONSchema.make(schema))
+/*
+{
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: [ 'a' ],
+  properties: { a: { type: 'string', description: 'a string', title: 'string' } },
+  additionalProperties: false
+}
+*/
+```
+
 ## Generating Equivalences
 
 The `make` function, which is part of the `@effect/schema/Equivalence` module, allows you to generate an [Equivalence](https://effect-ts.github.io/effect/schema/Equivalence.ts.html) based on a schema definition:

--- a/packages/schema/src/internal/filters.ts
+++ b/packages/schema/src/internal/filters.ts
@@ -84,3 +84,6 @@ export const MaxItemsTypeId: Schema.MaxItemsTypeId = Symbol.for(
 export const ItemsCountTypeId: Schema.ItemsCountTypeId = Symbol.for(
   "@effect/schema/TypeId/ItemsCount"
 ) as Schema.ItemsCountTypeId
+
+/** @internal */
+export const ParseJsonTypeId: unique symbol = Symbol.for("@effect/schema/TypeId/ParseJson")

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -2142,6 +2142,21 @@ schema (Suspend): <suspended schema>`
       })
     })
   })
+
+  it(`should correctly generate JSON Schemas by targeting the "to" side of transformations from S.parseJson`, () => {
+    expectJSONSchema(
+      Schema.parseJson(Schema.Struct({
+        a: Schema.parseJson(Schema.NumberFromString)
+      })),
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        type: "object",
+        required: ["a"],
+        properties: { a: { type: "string", description: "a string", title: "string" } },
+        additionalProperties: false
+      }
+    )
+  })
 })
 
 export const decode = <A>(schema: JSONSchema.JsonSchema7Root): Schema.Schema<A> =>

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -2145,8 +2145,9 @@ schema (Suspend): <suspended schema>`
 
   it(`should correctly generate JSON Schemas by targeting the "to" side of transformations from S.parseJson`, () => {
     expectJSONSchema(
+      // Define a schema that parses a JSON string into a structured object
       Schema.parseJson(Schema.Struct({
-        a: Schema.parseJson(Schema.NumberFromString)
+        a: Schema.parseJson(Schema.NumberFromString) // Nested parsing from JSON string to number
       })),
       {
         "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
…"to" side of transformations, closes #3086

Resolved an issue where `JSONSchema.make` improperly generated JSON Schemas for schemas defined with `S.parseJson(<real schema>)`. Previously, invoking `JSONSchema.make` on these transformed schemas produced a JSON Schema corresponding to a string type rather than the underlying real schema.

Before

```ts
import { JSONSchema, Schema } from "@effect/schema"

// Define a schema that parses a JSON string into a structured object
const schema = Schema.parseJson(
  Schema.Struct({
    a: Schema.parseJson(Schema.NumberFromString) // Nested parsing from JSON string to number
  })
)

console.log(JSONSchema.make(schema))
/*
{
  '$schema': 'http://json-schema.org/draft-07/schema#',
  '$ref': '#/$defs/JsonString',
  '$defs': {
    JsonString: {
      type: 'string',
      description: 'a JSON string',
      title: 'JsonString'
    }
  }
}
*/
```

Now

```ts
import { JSONSchema, Schema } from "@effect/schema"

// Define a schema that parses a JSON string into a structured object
const schema = Schema.parseJson(
  Schema.Struct({
    a: Schema.parseJson(Schema.NumberFromString) // Nested parsing from JSON string to number
  })
)

console.log(JSONSchema.make(schema))
/*
{
  '$schema': 'http://json-schema.org/draft-07/schema#',
  type: 'object',
  required: [ 'a' ],
  properties: { a: { type: 'string', description: 'a string', title: 'string' } },
  additionalProperties: false
}
*/
```
