### PR TITLE
Generate JSON Schemas correctly for a schema created by extending two…

### DIFF
--- a/.changeset/warm-ghosts-swim.md
+++ b/.changeset/warm-ghosts-swim.md
@@ -1,0 +1,39 @@
+---
+"@effect/schema": patch
+---
+
+Generate JSON Schemas correctly for a schema created by extending two refinements using the `extend` API, ensuring their JSON Schema annotations are preserved.
+
+Example
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Struct({
+  a: Schema.String
+})
+  .pipe(Schema.filter(() => true, { jsonSchema: { a: 1 } }))
+  .pipe(
+    Schema.extend(
+      Schema.Struct({
+        b: Schema.Number
+      }).pipe(Schema.filter(() => true, { jsonSchema: { b: 2 } }))
+    )
+  )
+
+console.log(JSONSchema.make(schema))
+/*
+{
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: [ 'a', 'b' ],
+  properties: {
+    a: { type: 'string', description: 'a string', title: 'string' },
+    b: { type: 'number', description: 'a number', title: 'number' }
+  },
+  additionalProperties: false,
+  b: 2,
+  a: 1
+}
+*/
+```

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -2915,18 +2915,10 @@ const intersectTypeLiterals = (
   throw new Error(errors_.getSchemaExtendErrorMessage(x, y, path))
 }
 
+const preserveRefinementAnnotations = AST.preserveAnnotations([AST.MessageAnnotationId, AST.JSONSchemaAnnotationId])
+
 const addRefinementToMembers = (refinement: AST.Refinement, asts: ReadonlyArray<AST.AST>): Array<AST.Refinement> =>
-  asts.map((ast) =>
-    new AST.Refinement(
-      ast,
-      refinement.filter,
-      // preserve message annotation
-      option_.match(AST.getMessageAnnotation(refinement), {
-        onNone: () => undefined,
-        onSome: (message) => ({ [AST.MessageAnnotationId]: message })
-      })
-    )
-  )
+  asts.map((ast) => new AST.Refinement(ast, refinement.filter, preserveRefinementAnnotations(refinement)))
 
 const extendAST = (
   x: AST.AST,

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -2158,6 +2158,30 @@ schema (Suspend): <suspended schema>`
       }
     )
   })
+
+  it("should correctly generate JSON Schemas for a schema created by extending two refinements using the `extend` API", () => {
+    expectJSONSchema(
+      Schema.Struct({
+        a: Schema.String
+      }).pipe(Schema.filter(() => true, { jsonSchema: { a: 1 } })).pipe(Schema.extend(
+        Schema.Struct({
+          b: Schema.Number
+        }).pipe(Schema.filter(() => true, { jsonSchema: { b: 2 } }))
+      )),
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        type: "object",
+        required: ["a", "b"],
+        properties: {
+          a: { type: "string", description: "a string", title: "string" },
+          b: { type: "number", description: "a number", title: "number" }
+        },
+        additionalProperties: false,
+        b: 2,
+        a: 1
+      }
+    )
+  })
 })
 
 export const decode = <A>(schema: JSONSchema.JsonSchema7Root): Schema.Schema<A> =>


### PR DESCRIPTION
… refinements using the `extend` API, ensuring their JSON Schema annotations are preserved.
