### PR TITLE
Ensure help documentation always respects the cli configuration

### DIFF
--- a/.changeset/grumpy-apricots-end.md
+++ b/.changeset/grumpy-apricots-end.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+ensure that the built-in option for displaying the CLI's help documentation always respects `CliConfig.showBuiltIns`

--- a/packages/cli/examples/naval-fate.ts
+++ b/packages/cli/examples/naval-fate.ts
@@ -1,6 +1,7 @@
-import { Args, Command, Options } from "@effect/cli"
+import { Args, CliConfig, Command, Options } from "@effect/cli"
 import { NodeContext, NodeKeyValueStore, NodeRuntime } from "@effect/platform-node"
 import * as Console from "effect/Console"
+import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as NavalFateStore from "./naval-fate/store.js"
@@ -101,6 +102,11 @@ const command = Command.make("naval_fate").pipe(
   ])
 )
 
+const cliContext = Context.make(
+  CliConfig.CliConfig,
+  CliConfig.make({ showBuiltIns: false })
+)
+
 const MainLayer = NavalFateStore.layer.pipe(
   Layer.provide(NodeKeyValueStore.layerFileSystem("naval-fate-store")),
   Layer.merge(NodeContext.layer)
@@ -112,6 +118,7 @@ const cli = Command.run(command, {
 })
 
 Effect.suspend(() => cli(process.argv)).pipe(
+  Effect.provide(cliContext),
   Effect.provide(MainLayer),
   Effect.tapErrorCause(Effect.logError),
   NodeRuntime.runMain

--- a/packages/cli/src/ValidationError.ts
+++ b/packages/cli/src/ValidationError.ts
@@ -1,9 +1,10 @@
 /**
  * @since 1.0.0
  */
-import type { BuiltInOptions } from "./BuiltInOptions.js"
+// import type { BuiltInOptions } from "./BuiltInOptions.js"
 import type { Command } from "./CommandDescriptor.js"
 import type { HelpDoc } from "./HelpDoc.js"
+import type { CommandDescriptor } from "./index.js"
 import * as InternalCommand from "./internal/commandDescriptor.js"
 import * as InternalValidationError from "./internal/validationError.js"
 
@@ -61,7 +62,8 @@ export interface CorrectedFlag extends ValidationError.Proto {
 export interface HelpRequested extends ValidationError.Proto {
   readonly _tag: "HelpRequested"
   readonly error: HelpDoc
-  readonly showHelp: BuiltInOptions
+  readonly command: CommandDescriptor.Command<unknown>
+  // readonly showHelp: BuiltInOptions
 }
 
 /**

--- a/packages/cli/src/ValidationError.ts
+++ b/packages/cli/src/ValidationError.ts
@@ -1,7 +1,6 @@
 /**
  * @since 1.0.0
  */
-// import type { BuiltInOptions } from "./BuiltInOptions.js"
 import type { Command } from "./CommandDescriptor.js"
 import type { HelpDoc } from "./HelpDoc.js"
 import type { CommandDescriptor } from "./index.js"
@@ -63,7 +62,6 @@ export interface HelpRequested extends ValidationError.Proto {
   readonly _tag: "HelpRequested"
   readonly error: HelpDoc
   readonly command: CommandDescriptor.Command<unknown>
-  // readonly showHelp: BuiltInOptions
 }
 
 /**

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -15,6 +15,7 @@ import type * as CliConfig from "../CliConfig.js"
 import type * as Command from "../CommandDescriptor.js"
 import type * as HelpDoc from "../HelpDoc.js"
 import type * as ValidationError from "../ValidationError.js"
+import * as InternalBuiltInOptions from "./builtInOptions.js"
 import * as InternalCliConfig from "./cliConfig.js"
 import * as InternalCommand from "./commandDescriptor.js"
 import * as InternalHelpDoc from "./helpDoc.js"
@@ -90,7 +91,19 @@ export const run = dual<
                   Effect.catchSome((e) =>
                     InternalValidationError.isValidationError(e) &&
                       InternalValidationError.isHelpRequested(e)
-                      ? Option.some(handleBuiltInOption(self, executable, filteredArgs, e.showHelp, execute, config))
+                      ? Option.some(
+                        handleBuiltInOption(
+                          self,
+                          executable,
+                          filteredArgs,
+                          InternalBuiltInOptions.showHelp(
+                            InternalCommand.getUsage(e.command),
+                            InternalCommand.getHelp(e.command, config)
+                          ),
+                          execute,
+                          config
+                        )
+                      )
                       : Option.none()
                   )
                 ),

--- a/packages/cli/src/internal/commandDescriptor.ts
+++ b/packages/cli/src/internal/commandDescriptor.ts
@@ -1368,9 +1368,5 @@ export const helpRequestedError = <A>(
   op._tag = "HelpRequested"
   op.error = InternalHelpDoc.empty
   op.command = command
-  // op.showHelp = InternalBuiltInOptions.showHelp(
-  //   getUsageInternal(command as Instruction),
-  //   getHelpInternal(command as Instruction, config)
-  // )
   return op
 }

--- a/packages/cli/src/internal/commandDescriptor.ts
+++ b/packages/cli/src/internal/commandDescriptor.ts
@@ -1367,9 +1367,10 @@ export const helpRequestedError = <A>(
   const op = Object.create(InternalValidationError.proto)
   op._tag = "HelpRequested"
   op.error = InternalHelpDoc.empty
-  op.showHelp = InternalBuiltInOptions.showHelp(
-    getUsageInternal(command as Instruction),
-    getHelpInternal(command as Instruction, InternalCliConfig.defaultConfig)
-  )
+  op.command = command
+  // op.showHelp = InternalBuiltInOptions.showHelp(
+  //   getUsageInternal(command as Instruction),
+  //   getHelpInternal(command as Instruction, config)
+  // )
   return op
 }

--- a/packages/cli/test/CliApp.test.ts
+++ b/packages/cli/test/CliApp.test.ts
@@ -1,29 +1,83 @@
 import type * as CliApp from "@effect/cli/CliApp"
+import * as CliConfig from "@effect/cli/CliConfig"
 import * as Command from "@effect/cli/Command"
 import * as HelpDoc from "@effect/cli/HelpDoc"
+import * as MockConsole from "@effect/cli/test/services/MockConsole"
 import * as ValidationError from "@effect/cli/ValidationError"
 import { NodeContext } from "@effect/platform-node"
-import { Array, Effect } from "effect"
+import { Array, Console, Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
+
+const MainLive = Effect.gen(function*(_) {
+  const console = yield* _(MockConsole.make)
+  return Layer.mergeAll(
+    Console.setConsole(console),
+    NodeContext.layer
+  )
+}).pipe(Layer.unwrapEffect)
 
 const runEffect = <E, A>(
   self: Effect.Effect<A, E, CliApp.CliApp.Environment>
 ): Promise<A> =>
-  Effect.provide(self, NodeContext.layer).pipe(
+  Effect.provide(self, MainLive).pipe(
     Effect.runPromise
   )
 
 describe("CliApp", () => {
   it("should return an error if excess arguments are provided", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const cli = Command.run(Command.make("foo"), {
         name: "Test",
         version: "1.0.0"
       })
       const args = Array.make("node", "test.js", "--bar")
-      const result = yield* _(Effect.flip(cli(args)))
+      const result = yield* Effect.flip(cli(args))
       expect(result).toEqual(ValidationError.invalidValue(HelpDoc.p(
         "Received unknown argument: '--bar'"
       )))
     }).pipe(runEffect))
+
+  it("should display built-in options in help if `CliConfig.showBuiltIns` is true", () => {
+    const CliConfigLive = CliConfig.layer({
+      showBuiltIns: true // this is the default
+    })
+    return Effect.gen(function*() {
+      const cli = Command.run(Command.make("foo"), {
+        name: "Test",
+        version: "1.0.0"
+      })
+      yield* cli([])
+      const lines = yield* MockConsole.getLines()
+      const output = lines.join("\n")
+      expect(output).toContain("--completions sh | bash | fish | zsh")
+      expect(output).toContain("(-h, --help)")
+      expect(output).toContain("--wizard")
+      expect(output).toContain("--version")
+    }).pipe(
+      Effect.provide(Layer.mergeAll(MainLive, CliConfigLive)),
+      Effect.runPromise
+    )
+  })
+
+  it("should not display built-in options in help if `CliConfig.showBuiltIns` is false", () => {
+    const CliConfigLive = CliConfig.layer({
+      showBuiltIns: false
+    })
+    return Effect.gen(function*() {
+      const cli = Command.run(Command.make("foo"), {
+        name: "Test",
+        version: "1.0.0"
+      })
+      yield* cli([])
+      const lines = yield* MockConsole.getLines()
+      const output = lines.join("\n")
+      expect(output).not.toContain("--completions sh | bash | fish | zsh")
+      expect(output).not.toContain("(-h, --help)")
+      expect(output).not.toContain("--wizard")
+      expect(output).not.toContain("--version")
+    }).pipe(
+      Effect.provide(Layer.mergeAll(MainLive, CliConfigLive)),
+      Effect.runPromise
+    )
+  })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ensures that the built-in option for displaying the CLI's help documentation always respects the `CliConfig.showBuiltIns` option.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #3058
- Closes #3058 
