### PR TITLE
refactor vitest

### DIFF
--- a/.changeset/lucky-moose-hear.md
+++ b/.changeset/lucky-moose-hear.md
@@ -1,0 +1,30 @@
+---
+"@effect/vitest": minor
+---
+
+Refactor `@effect/vitest` package.
+
+- Clear separation of the public API and internals.
+- Fix type of `scoped`, `live`, `scopedLive` and `effect` objects. Make sure `skip` and `only` are available.
+- Add `each` method to `scoped`, `live`, `scopedLive` and `effect` objects.
+
+Example usage
+
+```ts
+import { expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+it.scoped.skip(
+  "test skipped",
+  () =>
+    Effect.acquireRelease(
+      Effect.die("skipped anyway"),
+      () => Effect.void
+    )
+)
+
+it.effect.each([1, 2, 3])(
+  "effect each %s",
+  (n) => Effect.sync(() => expect(n).toEqual(n))
+)
+```

--- a/packages/effect/test/utils/effect-vitest-link
+++ b/packages/effect/test/utils/effect-vitest-link
@@ -1,0 +1,1 @@
+../../../../packages/vitest/src/

--- a/packages/effect/test/utils/extend.ts
+++ b/packages/effect/test/utils/extend.ts
@@ -1,1 +1,1 @@
-../../../vitest/src/index.ts
+export * from "./effect-vitest-link/index.js"

--- a/packages/vitest/docgen.json
+++ b/packages/vitest/docgen.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/internal/**/*.ts"
+    "src/internal.ts"
   ],
   "examplesCompilerOptions": {
     "noEmit": true,

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -1,206 +1,91 @@
 /**
  * @since 1.0.0
  */
-import type { Tester, TesterContext } from "@vitest/expect"
-import * as Cause from "effect/Cause"
-import * as Duration from "effect/Duration"
-import * as Effect from "effect/Effect"
-import * as Equal from "effect/Equal"
-import * as Exit from "effect/Exit"
-import { pipe } from "effect/Function"
-import * as Layer from "effect/Layer"
-import * as Logger from "effect/Logger"
-import * as Schedule from "effect/Schedule"
+import type * as Duration from "effect/Duration"
+import type * as Effect from "effect/Effect"
 import type * as Scope from "effect/Scope"
-import * as TestEnvironment from "effect/TestContext"
 import type * as TestServices from "effect/TestServices"
-import * as Utils from "effect/Utils"
-import type { TestAPI } from "vitest"
 import * as V from "vitest"
-
-const runTest = <E, A>(effect: Effect.Effect<A, E>) =>
-  Effect.gen(function*() {
-    const exit: Exit.Exit<A, E> = yield* Effect.exit(effect)
-    if (Exit.isSuccess(exit)) {
-      return () => {}
-    } else {
-      const errors = Cause.prettyErrors(exit.cause)
-      for (let i = 1; i < errors.length; i++) {
-        yield* Effect.logError(errors[i])
-      }
-      return () => {
-        throw errors[0]
-      }
-    }
-  }).pipe(Effect.runPromise).then((f) => f())
+import * as internal from "./internal.js"
 
 /**
  * @since 1.0.0
  */
-export type API = TestAPI<{}>
+export type API = V.TestAPI<{}>
 
-const TestEnv = TestEnvironment.TestContext.pipe(
-  Layer.provide(Logger.remove(Logger.defaultLogger))
-)
-
-/** @internal */
-function customTester(this: TesterContext, a: unknown, b: unknown, customTesters: Array<Tester>) {
-  if (!Equal.isEqual(a) || !Equal.isEqual(b)) {
-    return undefined
+/**
+ * @since 1.0.0
+ */
+export namespace Vitest {
+  /**
+   * @since 1.0.0
+   */
+  export interface TestFunction<A, E, R, TestArgs extends Array<any>> {
+    (...args: TestArgs): Effect.Effect<A, E, R>
   }
-  return Utils.structuralRegion(
-    () => Equal.equals(a, b),
-    (x, y) => this.equals(x, y, customTesters.filter((t) => t !== customTester))
-  )
-}
 
-/**
- * @since 1.0.0
- */
-export const addEqualityTesters = () => {
-  V.expect.addEqualityTesters([customTester])
-}
-
-/**
- * @since 1.0.0
- */
-export const effect = (() => {
-  const f = <E, A>(
-    name: string,
-    self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>,
-    timeout: number | V.TestOptions = 5_000
-  ) =>
-    it(
-      name,
-      (c) =>
-        pipe(
-          Effect.suspend(() => self(c)),
-          Effect.provide(TestEnv),
-          runTest
-        ),
-      timeout
-    )
-  return Object.assign(f, {
-    skip: <E, A>(
+  /**
+   * @since 1.0.0
+   */
+  export interface Test<R> {
+    <A, E>(
       name: string,
-      self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>,
-      timeout = 5_000
-    ) =>
-      it.skip(
-        name,
-        (c) =>
-          pipe(
-            Effect.suspend(() => self(c)),
-            Effect.provide(TestEnv),
-            runTest
-          ),
-        timeout
-      ),
-    only: <E, A>(
-      name: string,
-      self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, TestServices.TestServices>,
-      timeout = 5_000
-    ) =>
-      it.only(
-        name,
-        (c) =>
-          pipe(
-            Effect.suspend(() => self(c)),
-            Effect.provide(TestEnv),
-            runTest
-          ),
-        timeout
-      )
-  })
-})()
+      self: TestFunction<A, E, R, [V.TaskContext<V.Test<{}>> & V.TestContext]>,
+      timeout?: number | V.TestOptions
+    ): void
+  }
+
+  /**
+   * @since 1.0.0
+   */
+  export interface Tester<R> extends Vitest.Test<R> {
+    skip: Vitest.Test<R>
+    only: Vitest.Test<R>
+    each: <T>(
+      cases: ReadonlyArray<T>
+    ) => <A, E>(name: string, self: TestFunction<A, E, R, Array<T>>, timeout?: number | V.TestOptions) => void
+  }
+}
+/**
+ * @since 1.0.0
+ */
+export const addEqualityTesters: () => void = internal.addEqualityTesters
 
 /**
  * @since 1.0.0
  */
-export const live = <E, A>(
-  name: string,
-  self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E>,
-  timeout = 5_000
-) =>
-  it(
-    name,
-    (c) =>
-      pipe(
-        Effect.suspend(() => self(c)),
-        runTest
-      ),
-    timeout
-  )
+export const effect: Vitest.Tester<TestServices.TestServices> = internal.effect
 
 /**
  * @since 1.0.0
  */
-export const flakyTest = <A, E, R>(
+export const scoped: Vitest.Tester<TestServices.TestServices | Scope.Scope> = internal.scoped
+
+/**
+ * @since 1.0.0
+ */
+export const live: Vitest.Tester<never> = internal.live
+
+/**
+ * @since 1.0.0
+ */
+export const scopedLive: Vitest.Tester<Scope.Scope> = internal.scopedLive
+
+/**
+ * @since 1.0.0
+ */
+export const flakyTest: <A, E, R>(
   self: Effect.Effect<A, E, R>,
-  timeout: Duration.DurationInput = Duration.seconds(30)
-) =>
-  pipe(
-    Effect.catchAllDefect(self, Effect.fail),
-    Effect.retry(
-      pipe(
-        Schedule.recurs(10),
-        Schedule.compose(Schedule.elapsed),
-        Schedule.whileOutput(Duration.lessThanOrEqualTo(timeout))
-      )
-    ),
-    Effect.orDie
-  )
+  timeout?: Duration.DurationInput
+) => Effect.Effect<A, never, R> = internal.flakyTest
 
-/**
- * @since 1.0.0
- */
-export const scoped = <E, A>(
-  name: string,
-  self: (
-    ctx: V.TaskContext<V.Test<{}>> & V.TestContext
-  ) => Effect.Effect<A, E, Scope.Scope | TestServices.TestServices>,
-  timeout = 5_000
-) =>
-  it(
-    name,
-    (c) =>
-      pipe(
-        Effect.suspend(() => self(c)),
-        Effect.scoped,
-        Effect.provide(TestEnv),
-        runTest
-      ),
-    timeout
-  )
-
-/**
- * @since 1.0.0
- */
-export const scopedLive = <E, A>(
-  name: string,
-  self: (ctx: V.TaskContext<V.Test<{}>> & V.TestContext) => Effect.Effect<A, E, Scope.Scope>,
-  timeout = 5_000
-) =>
-  it(
-    name,
-    (c) =>
-      pipe(
-        Effect.suspend(() => self(c)),
-        Effect.scoped,
-        runTest
-      ),
-    timeout
-  )
-
+/** @ignored */
 const methods = { effect, live, flakyTest, scoped, scopedLive } as const
 
 /**
  * @since 1.0.0
  */
-export const it: API & typeof methods = Object.assign(
-  V.it,
-  methods
-)
+export const it: API & typeof methods = Object.assign(V.it, methods)
 
 /**
  * @since 1.0.0

--- a/packages/vitest/src/internal.ts
+++ b/packages/vitest/src/internal.ts
@@ -1,0 +1,104 @@
+/**
+ * @since 1.0.0
+ */
+import type { Tester, TesterContext } from "@vitest/expect"
+import * as Cause from "effect/Cause"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as Equal from "effect/Equal"
+import * as Exit from "effect/Exit"
+import { flow, identity, pipe } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Logger from "effect/Logger"
+import * as Schedule from "effect/Schedule"
+import type * as Scope from "effect/Scope"
+import * as TestEnvironment from "effect/TestContext"
+import type * as TestServices from "effect/TestServices"
+import * as Utils from "effect/Utils"
+import * as V from "vitest"
+import type * as Vitest from "./index.js"
+
+/** @internal */
+const runTest = <E, A>(effect: Effect.Effect<A, E>) =>
+  Effect.gen(function*() {
+    const exit: Exit.Exit<A, E> = yield* Effect.exit(effect)
+    if (Exit.isSuccess(exit)) {
+      return () => {}
+    } else {
+      const errors = Cause.prettyErrors(exit.cause)
+      for (let i = 1; i < errors.length; i++) {
+        yield* Effect.logError(errors[i])
+      }
+      return () => {
+        throw errors[0]
+      }
+    }
+  }).pipe(Effect.runPromise).then((f) => f())
+
+/** @internal */
+const TestEnv = TestEnvironment.TestContext.pipe(
+  Layer.provide(Logger.remove(Logger.defaultLogger))
+)
+
+/** @internal */
+function customTester(this: TesterContext, a: unknown, b: unknown, customTesters: Array<Tester>) {
+  if (!Equal.isEqual(a) || !Equal.isEqual(b)) {
+    return undefined
+  }
+  return Utils.structuralRegion(
+    () => Equal.equals(a, b),
+    (x, y) => this.equals(x, y, customTesters.filter((t) => t !== customTester))
+  )
+}
+
+/** @internal */
+export const addEqualityTesters = () => {
+  V.expect.addEqualityTesters([customTester])
+}
+
+/** @internal */
+const makeTester = <R>(
+  mapEffect: <A, E>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, never>
+): Vitest.Vitest.Tester<R> => {
+  const run =
+    <A, E, TestArgs extends Array<any>>(self: Vitest.Vitest.TestFunction<A, E, R, TestArgs>) => (...args: TestArgs) =>
+      pipe(Effect.suspend(() => self(...args)), mapEffect, runTest)
+
+  const f: Vitest.Vitest.Test<R> = (name, self, timeout) => V.it(name, run(self), timeout)
+
+  const skip: Vitest.Vitest.Tester<R>["only"] = (name, self, timeout) => V.it.skip(name, run(self), timeout)
+  const only: Vitest.Vitest.Tester<R>["only"] = (name, self, timeout) => V.it.only(name, run(self), timeout)
+  const each: Vitest.Vitest.Tester<R>["each"] = (cases) => (name, self, timeout) =>
+    V.it.each(cases)(name, run(self), timeout)
+
+  return Object.assign(f, { skip, only, each })
+}
+
+/** @internal */
+export const effect = makeTester<TestServices.TestServices>(Effect.provide(TestEnv))
+
+/** @internal */
+export const scoped = makeTester<TestServices.TestServices | Scope.Scope>(flow(Effect.scoped, Effect.provide(TestEnv)))
+
+/** @internal */
+export const live = makeTester<never>(identity)
+
+/** @internal */
+export const scopedLive = makeTester<Scope.Scope>(Effect.scoped)
+
+/** @internal */
+export const flakyTest = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+  timeout: Duration.DurationInput = Duration.seconds(30)
+) =>
+  pipe(
+    Effect.catchAllDefect(self, Effect.fail),
+    Effect.retry(
+      pipe(
+        Schedule.recurs(10),
+        Schedule.compose(Schedule.elapsed),
+        Schedule.whileOutput(Duration.lessThanOrEqualTo(timeout))
+      )
+    ),
+    Effect.orDie
+  )

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+it.live(
+  "live %s",
+  () => Effect.sync(() => expect(1).toEqual(1))
+)
+it.effect(
+  "effect",
+  () => Effect.sync(() => expect(1).toEqual(1))
+)
+it.scoped(
+  "scoped",
+  () => Effect.acquireRelease(Effect.sync(() => expect(1).toEqual(1)), () => Effect.void)
+)
+it.scopedLive(
+  "scopedLive",
+  () => Effect.acquireRelease(Effect.sync(() => expect(1).toEqual(1)), () => Effect.void)
+)
+
+// each
+
+it.live.each([1, 2, 3])(
+  "live each %s",
+  (n) => Effect.sync(() => expect(n).toEqual(n))
+)
+it.effect.each([1, 2, 3])(
+  "effect each %s",
+  (n) => Effect.sync(() => expect(n).toEqual(n))
+)
+it.scoped.each([1, 2, 3])(
+  "scoped each %s",
+  (n) => Effect.acquireRelease(Effect.sync(() => expect(n).toEqual(n)), () => Effect.void)
+)
+it.scopedLive.each([1, 2, 3])(
+  "scopedLive each %s",
+  (n) => Effect.acquireRelease(Effect.sync(() => expect(n).toEqual(n)), () => Effect.void)
+)
+
+// skip
+
+it.live.skip(
+  "live skipped",
+  () => Effect.die("skipped anyway")
+)
+it.effect.skip(
+  "effect skipped",
+  () => Effect.die("skipped anyway")
+)
+it.scoped.skip(
+  "scoped skipped",
+  () => Effect.acquireRelease(Effect.die("skipped anyway"), () => Effect.void)
+)
+it.scopedLive.skip(
+  "scopedLive skipped",
+  () => Effect.acquireRelease(Effect.die("skipped anyway"), () => Effect.void)
+)


### PR DESCRIPTION
Refactor `@effect/vitest` package.

- Clear separation of the public API and internals.
- Fix type of `scoped`, `live`, `scopedLive` and `effect` objects. Make sure `skip` and `only` are available.
- Add `each` method to `scoped`, `live`, `scopedLive` and `effect` objects.
