### PR TITLE
Optimize JSON Schema output for homogeneous tuples (such as non empty…

### DIFF
--- a/.changeset/tender-nails-work.md
+++ b/.changeset/tender-nails-work.md
@@ -1,0 +1,7 @@
+---
+"@effect/schema": patch
+---
+
+Optimize JSON Schema output for homogeneous tuples (such as non empty arrays).
+
+This change corrects the JSON Schema generation for `S.NonEmptyArray` to eliminate redundant schema definitions. Previously, the element schema was unnecessarily duplicated under both `items` and `additionalItems`.

--- a/packages/schema/src/JSONSchema.ts
+++ b/packages/schema/src/JSONSchema.ts
@@ -385,7 +385,6 @@ const go = (
     case "SymbolKeyword":
       throw new Error(errors_.getJSONSchemaMissingAnnotationErrorMessage(path, ast))
     case "TupleType": {
-      const len = ast.elements.length
       const elements = ast.elements.map((e, i) =>
         merge(
           go(e.type, $defs, true, path.concat(i)),
@@ -402,6 +401,7 @@ const go = (
       // ---------------------------------------------
       // handle elements
       // ---------------------------------------------
+      const len = ast.elements.length
       if (len > 0) {
         output.minItems = len - ast.elements.filter((element) => element.isOptional).length
         output.items = elements
@@ -409,18 +409,20 @@ const go = (
       // ---------------------------------------------
       // handle rest element
       // ---------------------------------------------
-      if (rest.length > 0) {
+      const restLength = rest.length
+      if (restLength > 0) {
         const head = rest[0]
-        if (len > 0) {
-          output.additionalItems = head
-        } else {
+        const isHomogeneous = restLength === 1 && ast.elements.every((e) => e.type === ast.rest[0].type)
+        if (len === 0 || isHomogeneous) {
           output.items = head
+        } else {
+          output.additionalItems = head
         }
 
         // ---------------------------------------------
         // handle post rest elements
         // ---------------------------------------------
-        if (rest.length > 1) {
+        if (restLength > 1) {
           throw new Error(errors_.getJSONSchemaUnsupportedPostRestElementsErrorMessage(path))
         }
       } else {

--- a/packages/schema/src/JSONSchema.ts
+++ b/packages/schema/src/JSONSchema.ts
@@ -413,7 +413,7 @@ const go = (
       if (restLength > 0) {
         const head = rest[0]
         const isHomogeneous = restLength === 1 && ast.elements.every((e) => e.type === ast.rest[0].type)
-        if (len === 0 || isHomogeneous) {
+        if (isHomogeneous) {
           output.items = head
         } else {
           output.additionalItems = head

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -2140,6 +2140,18 @@ schema (Suspend): <suspended schema>`
       }
     )
   })
+
+  it("NonEmptyArray", () => {
+    expectJSONSchema(
+      Schema.NonEmptyArray(Schema.String),
+      {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        type: "array",
+        minItems: 1,
+        items: { type: "string" }
+      }
+    )
+  })
 })
 
 export const decode = <A>(schema: JSONSchema.JsonSchema7Root): Schema.Schema<A> =>


### PR DESCRIPTION
… arrays)

This change corrects the JSON Schema generation for `S.NonEmptyArray` to eliminate redundant schema definitions. Previously, the element schema was unnecessarily duplicated under both `items` and `additionalItems`.
