### PR TITLE
Enhance JSON Schema Support for Refinements in Record Parameters

### DIFF
--- a/.changeset/dirty-cows-sin.md
+++ b/.changeset/dirty-cows-sin.md
@@ -1,0 +1,53 @@
+---
+"@effect/schema": patch
+---
+
+Enhance JSON Schema Support for Refinements in Record Parameters.
+
+Enhanced `JSONSchema.make` to properly support refinements as record parameters. Previously, using refinements with `Schema.Record` resulted in errors when generating JSON schemas.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Record(
+  Schema.String.pipe(Schema.minLength(1)),
+  Schema.Number
+)
+
+console.log(JSONSchema.make(schema))
+/*
+throws
+Error: Unsupported index signature parameter
+schema (Refinement): a string at least 1 character(s) long
+*/
+```
+
+Now
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Record(
+  Schema.String.pipe(Schema.minLength(1)),
+  Schema.Number
+)
+
+console.log(JSONSchema.make(schema))
+/*
+Output:
+{
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: [],
+  properties: {},
+  patternProperties: { '': { type: 'number' } },
+  propertyNames: {
+    type: 'string',
+    description: 'a string at least 1 character(s) long',
+    minLength: 1
+  }
+}
+*/
+```

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -21,9 +21,9 @@ type Json =
   | JsonArray
   | JsonObject
 
-const doProperty = false
+const doProperty = true
 
-const ajvOptions = { strictTuples: false, allowUnionTypes: true, allowMatchingProperties: true }
+const ajvOptions = { allowMatchingProperties: true }
 
 const propertyType = <A, I>(schema: Schema.Schema<A, I>, options?: {
   params?: fc.Parameters<[I]>


### PR DESCRIPTION
Enhanced `JSONSchema.make` to properly support refinements as record parameters. Previously, using refinements with `Schema.Record` resulted in errors when generating JSON schemas.

Before

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.Record(
  Schema.String.pipe(Schema.minLength(1)),
  Schema.Number
)

console.log(JSONSchema.make(schema))
/*
throws
Error: Unsupported index signature parameter
schema (Refinement): a string at least 1 character(s) long
*/
```

Now

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.Record(Schema.String.pipe(Schema.minLength(1)), Schema.Number)

console.log(JSONSchema.make(schema))
/*
Output:
{
  '$schema': 'http://json-schema.org/draft-07/schema#',
  type: 'object',
  required: [],
  properties: {},
  patternProperties: { '': { type: 'number' } },
  propertyNames: {
    type: 'string',
    description: 'a string at least 1 character(s) long',
    minLength: 1
  }
}
*/
```