### PR TITLE
refactor(Stream): rename argument names of mergeLeft and mergeRight from self/that to left/right for clarity

### DIFF
--- a/.changeset/stream-merge-left-right.md
+++ b/.changeset/stream-merge-left-right.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+---
+
+refactor(Stream/mergeLeft): rename `self`/`that` argument names to `left`/`right` for clarity
+
+refactor(Stream/mergeRight): rename `self`/`that` argument names to `left`/`right` for clarity

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2232,8 +2232,8 @@ export const mergeEither: {
  * @category utils
  */
 export const mergeLeft: {
-  <A2, E2, R2>(that: Stream<A2, E2, R2>): <A, E, R>(self: Stream<A, E, R>) => Stream<A, E2 | E, R2 | R>
-  <A, E, R, A2, E2, R2>(self: Stream<A, E, R>, that: Stream<A2, E2, R2>): Stream<A, E | E2, R | R2>
+  <AR, ER, RR>(right: Stream<AR, ER, RR>): <AL, EL, RL>(left: Stream<AL, EL, RL>) => Stream<AL, ER | EL, RR | RL>
+  <AL, EL, RL, AR, ER, RR>(left: Stream<AL, EL, RL>, right: Stream<AR, ER, RR>): Stream<AL, EL | ER, RL | RR>
 } = internal.mergeLeft
 
 /**
@@ -2244,8 +2244,8 @@ export const mergeLeft: {
  * @category utils
  */
 export const mergeRight: {
-  <A2, E2, R2>(that: Stream<A2, E2, R2>): <A, E, R>(self: Stream<A, E, R>) => Stream<A2, E2 | E, R2 | R>
-  <A, E, R, A2, E2, R2>(self: Stream<A, E, R>, that: Stream<A2, E2, R2>): Stream<A2, E | E2, R | R2>
+  <AR, ER, RR>(right: Stream<AR, ER, RR>): <AL, EL, RL>(left: Stream<AL, EL, RL>) => Stream<AR, ER | EL, RR | RL>
+  <AL, EL, RL, AR, ER, RR>(left: Stream<AL, EL, RL>, right: Stream<AR, ER, RR>): Stream<AR, EL | ER, RL | RR>
 } = internal.mergeRight
 
 /**

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -3921,36 +3921,36 @@ export const mergeEither = dual<
 
 /** @internal */
 export const mergeLeft = dual<
-  <A2, E2, R2>(
-    that: Stream.Stream<A2, E2, R2>
-  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<A, E2 | E, R2 | R>,
-  <A, E, R, A2, E2, R2>(
-    self: Stream.Stream<A, E, R>,
-    that: Stream.Stream<A2, E2, R2>
-  ) => Stream.Stream<A, E2 | E, R2 | R>
+  <AR, ER, RR>(
+    right: Stream.Stream<AR, ER, RR>
+  ) => <AL, EL, RL>(left: Stream.Stream<AL, EL, RL>) => Stream.Stream<AL, ER | EL, RR | RL>,
+  <AL, EL, RL, AR, ER, RR>(
+    left: Stream.Stream<AL, EL, RL>,
+    right: Stream.Stream<AR, ER, RR>
+  ) => Stream.Stream<AL, ER | EL, RR | RL>
 >(
   2,
-  <A, E, R, A2, E2, R2>(
-    self: Stream.Stream<A, E, R>,
-    that: Stream.Stream<A2, E2, R2>
-  ): Stream.Stream<A, E | E2, R | R2> => pipe(self, merge(drain(that)))
+  <AL, EL, RL, AR, ER, RR>(
+    left: Stream.Stream<AL, EL, RL>,
+    right: Stream.Stream<AR, ER, RR>
+  ): Stream.Stream<AL, EL | ER, RL | RR> => pipe(left, merge(drain(right)))
 )
 
 /** @internal */
 export const mergeRight = dual<
-  <A2, E2, R2>(
-    that: Stream.Stream<A2, E2, R2>
-  ) => <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<A2, E2 | E, R2 | R>,
-  <A, E, R, A2, E2, R2>(
-    self: Stream.Stream<A, E, R>,
-    that: Stream.Stream<A2, E2, R2>
-  ) => Stream.Stream<A2, E2 | E, R2 | R>
+  <AR, ER, RR>(
+    right: Stream.Stream<AR, ER, RR>
+  ) => <AL, EL, RL>(left: Stream.Stream<AL, EL, RL>) => Stream.Stream<AR, ER | EL, RR | RL>,
+  <AL, EL, RL, AR, ER, RR>(
+    left: Stream.Stream<AL, EL, RL>,
+    right: Stream.Stream<AR, ER, RR>
+  ) => Stream.Stream<AR, ER | EL, RR | RL>
 >(
   2,
-  <A, E, R, A2, E2, R2>(
-    self: Stream.Stream<A, E, R>,
-    that: Stream.Stream<A2, E2, R2>
-  ): Stream.Stream<A2, E | E2, R | R2> => pipe(drain(self), merge(that))
+  <AL, EL, RL, AR, ER, RR>(
+    left: Stream.Stream<AL, EL, RL>,
+    right: Stream.Stream<AR, ER, RR>
+  ): Stream.Stream<AR, EL | ER, RL | RR> => pipe(drain(left), merge(right))
 )
 
 /** @internal */


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

In the [documentation for mergeLeft](https://effect-ts.github.io/effect/effect/Stream.ts.html#mergeleft) it is written

> Merges this stream and the specified stream together, discarding the values from the right stream.

But the declaration contains `self` and `that` arg names, so i need to watch generics to understand what is "left" and what is "right", which is an extra mental overhead. I think it's more user friendly to name arguments according to documentation and function name:)

If it will be merged, i will refactor the rest functions with left/right semantic.

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
