### PR TITLE
Add `pick` and `omit` members to `Struct` interface, closes #3152

### DIFF
--- a/.changeset/fluffy-balloons-obey.md
+++ b/.changeset/fluffy-balloons-obey.md
@@ -1,0 +1,39 @@
+---
+"@effect/schema": patch
+---
+
+Add `pick` and `omit` static functions to `Struct` interface, closes #3152.
+
+**pick**
+
+The `pick` static function available in each struct schema can be used to create a new `Struct` by selecting particular properties from an existing `Struct`.
+
+```ts
+import { Schema } from "@effect/schema"
+
+const MyStruct = Schema.Struct({
+  a: Schema.String,
+  b: Schema.Number,
+  c: Schema.Boolean
+})
+
+// Schema.Struct<{ a: typeof Schema.String; c: typeof Schema.Boolean; }>
+const PickedSchema = MyStruct.pick("a", "c")
+```
+
+**omit**
+
+The `omit` static function available in each struct schema can be used to create a new `Struct` by excluding particular properties from an existing `Struct`.
+
+```ts
+import { Schema } from "@effect/schema"
+
+const MyStruct = Schema.Struct({
+  a: Schema.String,
+  b: Schema.Number,
+  c: Schema.Boolean
+})
+
+// Schema.Struct<{ a: typeof Schema.String; c: typeof Schema.Boolean; }>
+const PickedSchema = MyStruct.omit("b")
+```

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -3818,38 +3818,66 @@ Error: Expected MyData (an instance of MyData), actual {"name":"name"}
 
 ## pick
 
-The `pick` operation is used to select specific properties from a schema.
+The `pick` static function available in each struct schema can be used to create a new `Struct` by selecting particular properties from an existing `Struct`.
 
 ```ts
 import { Schema } from "@effect/schema"
 
-// Schema<{ readonly a: string; }>
-Schema.Struct({ a: Schema.String, b: Schema.Number, c: Schema.Boolean }).pipe(
-  Schema.pick("a")
+const MyStruct = Schema.Struct({
+  a: Schema.String,
+  b: Schema.Number,
+  c: Schema.Boolean
+})
+
+// Schema.Struct<{ a: typeof Schema.String; c: typeof Schema.Boolean; }>
+const PickedSchema = MyStruct.pick("a", "c")
+```
+
+The `Schema.pick` function can be applied more broadly beyond just `Struct` types, such as with unions of schemas. However it returns a generic `SchemaClass`.
+
+**Example: Picking from a Union**
+
+```ts
+import { Schema } from "@effect/schema"
+
+const MyUnion = Schema.Union(
+  Schema.Struct({ a: Schema.String, b: Schema.String, c: Schema.String }),
+  Schema.Struct({ a: Schema.Number, b: Schema.Number, d: Schema.Number })
 )
 
-// Schema<{ readonly a: string; readonly c: boolean; }>
-Schema.Struct({ a: Schema.String, b: Schema.Number, c: Schema.Boolean }).pipe(
-  Schema.pick("a", "c")
-)
+// Schema.SchemaClass<{ readonly a: string | number; readonly b: string | number }>
+const PickedSchema = MyUnion.pipe(Schema.pick("a", "b"))
 ```
 
 ## omit
 
-The `omit` operation is employed to exclude certain properties from a schema.
+The `omit` static function available in each struct schema can be used to create a new `Struct` by excluding particular properties from an existing `Struct`.
 
 ```ts
 import { Schema } from "@effect/schema"
 
-// Schema<{ readonly b: number; readonly c: boolean; }>
-Schema.Struct({ a: Schema.String, b: Schema.Number, c: Schema.Boolean }).pipe(
-  Schema.omit("a")
+const MyStruct = Schema.Struct({
+  a: Schema.String,
+  b: Schema.Number,
+  c: Schema.Boolean
+})
+
+// Schema.Struct<{ a: typeof Schema.String; c: typeof Schema.Boolean; }>
+const PickedSchema = MyStruct.omit("b")
+```
+
+The `Schema.omit` function can be applied more broadly beyond just `Struct` types, such as with unions of schemas. However it returns a generic `SchemaClass`.
+
+```ts
+import { Schema } from "@effect/schema"
+
+const MyUnion = Schema.Union(
+  Schema.Struct({ a: Schema.String, b: Schema.String, c: Schema.String }),
+  Schema.Struct({ a: Schema.Number, b: Schema.Number, d: Schema.Number })
 )
 
-// Schema<{ readonly b: number; }>
-Schema.Struct({ a: Schema.String, b: Schema.Number, c: Schema.Boolean }).pipe(
-  Schema.omit("a", "c")
-)
+// Schema.SchemaClass<{ readonly a: string | number }>
+const PickedSchema = MyUnion.pipe(Schema.omit("b"))
 ```
 
 ## partial

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -813,6 +813,19 @@ pipe(
 )
 
 // ---------------------------------------------
+// Struct.pick
+// ---------------------------------------------
+
+// @ts-expect-error
+S.Struct({ a: S.String }).pick("c")
+
+// @ts-expect-error
+S.Struct({ a: S.propertySignature(S.String).pipe(S.fromKey("c")) }).pick("c")
+
+// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; }>
+S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).pick("a", "b")
+
+// ---------------------------------------------
 // omit
 // ---------------------------------------------
 
@@ -847,6 +860,22 @@ pipe(
   }),
   S.omit("c")
 )
+
+// ---------------------------------------------
+// Struct.omit
+// ---------------------------------------------
+
+// @ts-expect-error
+S.Struct({ a: S.String }).omit("c")
+
+// @ts-expect-error
+S.Struct({ a: S.propertySignature(S.String).pipe(S.fromKey("c")) }).omit("c")
+
+// $ExpectType Struct<{ a: typeof String$; b: typeof Number$; }>
+S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).omit("c")
+
+// $ExpectType Struct<{ a: typeof Number$; }>
+S.Struct({ a: S.Number, b: S.Number.pipe(S.propertySignature, S.fromKey("c")) }).omit("b")
 
 // ---------------------------------------------
 // brand

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -36,6 +36,7 @@ import * as redacted_ from "effect/Redacted"
 import * as Request from "effect/Request"
 import * as sortedSet_ from "effect/SortedSet"
 import * as string_ from "effect/String"
+import * as struct_ from "effect/Struct"
 import type * as Types from "effect/Types"
 import type { LazyArbitrary } from "./Arbitrary.js"
 import * as arbitrary_ from "./Arbitrary.js"
@@ -2565,6 +2566,14 @@ const makeTypeLiteralClass = <
         ? propsWithDefaults
         : ParseResult.validateSync(this)(propsWithDefaults)
     }
+
+    static pick(...keys: Array<keyof Fields>): Struct<Simplify<Pick<Fields, typeof keys[number]>>> {
+      return Struct(struct_.pick(fields, ...keys) as any)
+    }
+
+    static omit(...keys: Array<keyof Fields>): Struct<Simplify<Omit<Fields, typeof keys[number]>>> {
+      return Struct(struct_.omit(fields, ...keys) as any)
+    }
   }
 }
 
@@ -2574,6 +2583,10 @@ const makeTypeLiteralClass = <
  */
 export interface Struct<Fields extends Struct.Fields> extends TypeLiteral<Fields, []> {
   annotations(annotations: Annotations.Schema<Simplify<Struct.Type<Fields>>>): Struct<Fields>
+  /** @since 0.68.17 */
+  pick<Keys extends ReadonlyArray<keyof Fields>>(...keys: Keys): Struct<Simplify<Pick<Fields, Keys[number]>>>
+  /** @since 0.68.17 */
+  omit<Keys extends ReadonlyArray<keyof Fields>>(...keys: Keys): Struct<Simplify<Omit<Fields, Keys[number]>>>
 }
 
 /**

--- a/packages/schema/test/Schema/Struct/omit.test.ts
+++ b/packages/schema/test/Schema/Struct/omit.test.ts
@@ -1,0 +1,9 @@
+import * as S from "@effect/schema/Schema"
+import { describe, expect, it } from "vitest"
+
+describe("omit", () => {
+  it("should work", () => {
+    const schema = S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).omit("c")
+    expect(schema.fields).toStrictEqual({ a: S.String, b: S.Number })
+  })
+})

--- a/packages/schema/test/Schema/Struct/pick.test.ts
+++ b/packages/schema/test/Schema/Struct/pick.test.ts
@@ -1,0 +1,9 @@
+import * as S from "@effect/schema/Schema"
+import { describe, expect, it } from "vitest"
+
+describe("pick", () => {
+  it("should work", () => {
+    const schema = S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).pick("a", "b")
+    expect(schema.fields).toStrictEqual({ a: S.String, b: S.Number })
+  })
+})


### PR DESCRIPTION
**pick**

The `pick` static function available in each struct schema can be used to create a new `Struct` by selecting particular properties from an existing `Struct`.

```ts
import { Schema } from "@effect/schema"

const MyStruct = Schema.Struct({
  a: Schema.String,
  b: Schema.Number,
  c: Schema.Boolean
})

// Schema.Struct<{ a: typeof Schema.String; c: typeof Schema.Boolean; }>
const PickedSchema = MyStruct.pick("a", "c")
```

**omit**

The `omit` static function available in each struct schema can be used to create a new `Struct` by excluding particular properties from an existing `Struct`.

```ts
import { Schema } from "@effect/schema"

const MyStruct = Schema.Struct({
  a: Schema.String,
  b: Schema.Number,
  c: Schema.Boolean
})

// Schema.Struct<{ a: typeof Schema.String; c: typeof Schema.Boolean; }>
const PickedSchema = MyStruct.omit("b")
```
