### PR TITLE
Introduce `NonEmptyString`

### DIFF
--- a/.changeset/perfect-houses-do.md
+++ b/.changeset/perfect-houses-do.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Introduce `NonEmptyString`

--- a/packages/effect/dtslint/String.ts
+++ b/packages/effect/dtslint/String.ts
@@ -93,3 +93,15 @@ export type TrimNewLinesAndTabs = S.Trim<NewLinesAndTabs>
 
 // $ExpectType "foo"
 export type TrimCarriageReturns = S.Trim<CarriageReturns>
+
+// -----------------------------------------------------------------------------
+// NonEmptyString
+// -----------------------------------------------------------------------------
+
+function testNonEmptyString(_nes: S.NonEmptyString) {}
+
+// @ts-expect-error
+testNonEmptyString("")
+testNonEmptyString(" ")
+testNonEmptyString("1")
+testNonEmptyString("s")

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2703,6 +2703,36 @@ export const mapEffect: {
 } = _groupBy.mapEffectOptions
 
 /**
+ * Maps over elements of the stream with the specified effectful function
+ * and filters out `None` values
+ *
+ * @example
+ * import { Effect, Stream, Console } from 'effect';
+ *
+ * // returns `Some(number)` if the number is even, otherwise `None`
+ * const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
+ *
+ * const result = Stream.make(0, 1, 2, 4).pipe(
+ *   Stream.filterMapEffectOption(even),
+ *   Stream.runCollect,
+ *   Effect.runPromise,
+ * )
+ * // => [0, 2, 4]
+ *
+ * @since 3.3.5
+ * @category utils
+ */
+export const filterMapEffectOption: {
+  <A, A2, E2, R2>(
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ): <E, R>(stream: Stream<A, E, R>) => Stream<A2, E2 | E, R2 | R>
+  <A, E, R, A2, E2, R2>(
+    stream: Stream<A, E, R>,
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ): Stream<A2, E2 | E, R2 | R>
+} = _groupBy.filterMapEffectOption
+
+/**
  * Transforms the errors emitted by this stream using `f`.
  *
  * @since 2.0.0

--- a/packages/effect/src/String.ts
+++ b/packages/effect/src/String.ts
@@ -164,7 +164,11 @@ export const trim = <A extends string>(self: A): Trim<A> => self.trim() as Trim<
 /**
  * @since 2.0.0
  */
-export type TrimStart<A extends string> = A extends `${" " | "\n" | "\t" | "\r"}${infer B}` ? TrimStart<B> : A
+export type TrimStart<A extends string> = A extends ` ${infer B}` ? TrimStart<B>
+  : A extends `\n${infer B}` ? TrimStart<B>
+  : A extends `\t${infer B}` ? TrimStart<B>
+  : A extends `\r${infer B}` ? TrimStart<B>
+  : A
 
 /**
  * @example
@@ -179,8 +183,11 @@ export const trimStart = <A extends string>(self: A): TrimStart<A> => self.trimS
 /**
  * @since 2.0.0
  */
-export type TrimEnd<A extends string> = A extends `${infer B}${" " | "\n" | "\t" | "\r"}` ? TrimEnd<B> : A
-
+export type TrimEnd<A extends string> = A extends `${infer B} ` ? TrimEnd<B>
+  : A extends `${infer B}\n` ? TrimEnd<B>
+  : A extends `${infer B}\t` ? TrimEnd<B>
+  : A extends `${infer B}\r` ? TrimEnd<B>
+  : A
 /**
  * @example
  * import { String } from "effect"
@@ -618,9 +625,6 @@ export const stripMargin = (self: string): string => stripMarginWith(self, "|")
  * @since 2.0.0
  */
 export const snakeToCamel = <S extends string>(self: S): MatchNonEmpty<S, EmptyString, NonEmptyString> => {
-  if (self === empty) {
-    return empty as any
-  }
   let str = self[0]
   for (let i = 1; i < self.length; i++) {
     str += self[i] === "_" ? self[++i].toUpperCase() : self[i]
@@ -632,12 +636,9 @@ export const snakeToCamel = <S extends string>(self: S): MatchNonEmpty<S, EmptyS
  * @since 2.0.0
  */
 export const snakeToPascal = <S extends string>(self: S): MatchNonEmpty<S, EmptyString, NonEmptyString> => {
-  if (self === empty) {
-    return empty as any
-  }
   let str = self[0].toUpperCase()
   for (let i = 1; i < self.length; i++) {
-    str += self[i] === "_" ? self[++i]?.toUpperCase() ?? "_" : self[i]
+    str += self[i] === "_" ? self[++i].toUpperCase() : self[i]
   }
   return str as any
 }

--- a/packages/effect/src/internal/groupBy.ts
+++ b/packages/effect/src/internal/groupBy.ts
@@ -4,7 +4,7 @@ import * as Chunk from "../Chunk.js"
 import * as Deferred from "../Deferred.js"
 import * as Effect from "../Effect.js"
 import * as Exit from "../Exit.js"
-import { dual, pipe } from "../Function.js"
+import { dual, identity, pipe } from "../Function.js"
 import type * as GroupBy from "../GroupBy.js"
 import * as Option from "../Option.js"
 import { pipeArguments } from "../Pipeable.js"
@@ -205,6 +205,19 @@ export const groupBy = dual<
       )
     )
 )
+
+/** @internal */
+export const filterMapEffectOption = dual<
+  <A, A2, E2, R2>(
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ) => <E, R>(
+    stream: Stream.Stream<A, E, R>
+  ) => Stream.Stream<A2, E2 | E, R2 | R>,
+  <A, E, R, A2, E2, R2>(
+    stream: Stream.Stream<A, E, R>,
+    fn: (a: A) => Effect.Effect<Option.Option<A2>, E2, R2>
+  ) => Stream.Stream<A2, E2 | E, R2 | R>
+>(2, (s, fn) => stream.filterMap(mapEffectOptions(s, fn), identity))
 
 /** @internal */
 export const mapEffectOptions = dual<

--- a/packages/effect/test/Stream/filtering.test.ts
+++ b/packages/effect/test/Stream/filtering.test.ts
@@ -46,4 +46,14 @@ describe("Stream", () => {
         [Either.right(1), Either.right(2), Either.left("boom")]
       )
     }))
+
+  it.effect("filterMapEffectOption", () =>
+    Effect.gen(function*() {
+      const even = (a: number) => a % 2 === 0 ? Effect.succeedSome(a) : Effect.succeedNone
+      const result = yield* Stream.make(0, 1, 2, 4).pipe(
+        Stream.filterMapEffectOption(even),
+        Stream.runCollect
+      )
+      assert.deepStrictEqual(Array.from(result), [0, 2, 4])
+    }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- introduce `type NonEmptyString = '${any}${string}'`
- preserve `NonEmptyString` in functions

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
