### PR TITLE
Add `toString` to `AST.PropertySignature` and `AST.IndexSignature` an…

### DIFF
--- a/.changeset/violet-cats-fetch.md
+++ b/.changeset/violet-cats-fetch.md
@@ -1,0 +1,45 @@
+---
+"@effect/schema": patch
+---
+
+Add `toString` to `AST.PropertySignature` and `AST.IndexSignature` and fix type display for IndexSignature.
+
+**Before the Change**
+
+Previously, when a type mismatch occurred in `Schema.decodeUnknownSync`, the error message displayed for `IndexSignature` was not accurately representing the type used. For example:
+
+```typescript
+import { Schema } from "@effect/schema"
+
+const schema = Schema.Record(Schema.Char, Schema.String)
+
+Schema.decodeUnknownSync(schema)({ a: 1 })
+/*
+throws
+ParseError: { readonly [x: string]: string }
+└─ ["a"]
+   └─ Expected string, actual 1
+*/
+```
+
+This output incorrectly indicated `[x: string]` when the actual index type was `Char`.
+
+**After the Change**
+
+The `toString` implementation now correctly reflects the type used in `IndexSignature`, providing more accurate and informative error messages:
+
+```ts
+import { Schema } from "@effect/schema"
+
+const schema = Schema.Record(Schema.Char, Schema.String)
+
+Schema.decodeUnknownSync(schema)({ a: 1 })
+/*
+throws
+ParseError: { readonly [x: Char]: string }
+└─ ["a"]
+   └─ Expected string, actual 1
+*/
+```
+
+The updated output now correctly displays `{ readonly [x: Char]: string }`, aligning the error messages with the actual data types used in the schema.

--- a/packages/schema/benchmark/toString.ts
+++ b/packages/schema/benchmark/toString.ts
@@ -1,0 +1,45 @@
+import * as ParseResult from "@effect/schema/ParseResult"
+import * as S from "@effect/schema/Schema"
+import * as TreeFormatter from "@effect/schema/TreeFormatter"
+import { Bench } from "tinybench"
+
+/*
+Before
+┌─────────┬─────────────────────────────────┬───────────┬────────────────────┬──────────┬─────────┐
+│ (index) │ Task Name                       │ ops/sec   │ Average Time (ns)  │ Margin   │ Samples │
+├─────────┼─────────────────────────────────┼───────────┼────────────────────┼──────────┼─────────┤
+│ 0       │ 'toString'                      │ '617,892' │ 1618.4039663825793 │ '±0.39%' │ 617893  │
+│ 1       │ 'toJSON'                        │ '301,728' │ 3314.2333451541776 │ '±0.16%' │ 301729  │
+│ 2       │ 'TreeFormatter.formatIssueSync' │ '36,498'  │ 27398.213814076604 │ '±0.18%' │ 36499   │
+└─────────┴─────────────────────────────────┴───────────┴────────────────────┴──────────┴─────────┘
+After:
+*/
+
+const bench = new Bench({ time: 1000 })
+
+const schema = S.Struct({
+  a: S.Literal("a"),
+  b: S.Array(S.String),
+  c: S.Record(S.String, S.Number),
+  d: S.NumberFromString,
+  e: S.Boolean
+})
+
+const result: any = ParseResult.decodeUnknownEither(schema)({ a: "a", b: ["b"], c: { c: "c" }, d: "1", e: true })
+
+// console.log(String(schema.ast))
+
+bench
+  .add("toString", function() {
+    String(schema.ast)
+  })
+  .add("toJSON", function() {
+    schema.ast.toJSON()
+  })
+  .add("TreeFormatter.formatIssueSync", function() {
+    TreeFormatter.formatIssueSync(result.left)
+  })
+
+await bench.run()
+
+console.table(bench.table())

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -1231,6 +1231,13 @@ export class PropertySignature extends OptionalType {
     super(type, isOptional, annotations)
   }
   /**
+   * @since 0.68.18
+   */
+  toString(): string {
+    return (this.isReadonly ? "readonly " : "") + String(this.name) + (this.isOptional ? "?" : "") + ": " +
+      this.type
+  }
+  /**
    * @since 0.67.0
    */
   toJSON(): object {
@@ -1283,6 +1290,12 @@ export class IndexSignature {
     } else {
       throw new Error(errors_.getASTIndexSignatureParameterErrorMessage)
     }
+  }
+  /**
+   * @since 0.68.18
+   */
+  toString(): string {
+    return (this.isReadonly ? "readonly " : "") + `[x: ${this.parameter}]: ${this.type}`
   }
   /**
    * @since 0.67.0
@@ -1369,22 +1382,19 @@ export class TypeLiteral implements Annotated {
   }
 }
 
+const formatIndexSignatures = (iss: ReadonlyArray<IndexSignature>): string => iss.map(String).join("; ")
+
 const formatTypeLiteral = (ast: TypeLiteral): string => {
-  const formattedPropertySignatures = ast.propertySignatures.map((ps) =>
-    (ps.isReadonly ? "readonly " : "") + String(ps.name) + (ps.isOptional ? "?" : "") + ": " + ps.type
-  ).join("; ")
-  if (ast.indexSignatures.length > 0) {
-    const formattedIndexSignatures = ast.indexSignatures.map((is) =>
-      (is.isReadonly ? "readonly " : "") + `[x: ${getParameterBase(is.parameter)}]: ${is.type}`
-    ).join("; ")
-    if (ast.propertySignatures.length > 0) {
-      return `{ ${formattedPropertySignatures}; ${formattedIndexSignatures} }`
+  if (ast.propertySignatures.length > 0) {
+    const pss = ast.propertySignatures.map(String).join("; ")
+    if (ast.indexSignatures.length > 0) {
+      return `{ ${pss}; ${formatIndexSignatures(ast.indexSignatures)} }`
     } else {
-      return `{ ${formattedIndexSignatures} }`
+      return `{ ${pss} }`
     }
   } else {
-    if (ast.propertySignatures.length > 0) {
-      return `{ ${formattedPropertySignatures} }`
+    if (ast.indexSignatures.length > 0) {
+      return `{ ${formatIndexSignatures(ast.indexSignatures)} }`
     } else {
       return "{}"
     }

--- a/packages/schema/test/Schema/ParseOptions-errors.test.ts
+++ b/packages/schema/test/Schema/ParseOptions-errors.test.ts
@@ -140,7 +140,7 @@ describe("`errors` option", () => {
         await Util.expectDecodeUnknownFailure(
           schema,
           { a: 1, b: 2 },
-          `{ readonly [x: string]: number }
+          `{ readonly [x: a string at least 2 character(s) long]: number }
 ├─ ["a"]
 │  └─ is unexpected, expected: a string at least 2 character(s) long
 └─ ["b"]
@@ -278,7 +278,7 @@ describe("`errors` option", () => {
         await Util.expectEncodeFailure(
           schema,
           { aa: "a", bb: "bb" },
-          `{ readonly [x: string]: string }
+          `{ readonly [x: Char]: string }
 ├─ ["aa"]
 │  └─ is unexpected, expected: Char
 └─ ["bb"]

--- a/packages/schema/test/Schema/Record/Record.test.ts
+++ b/packages/schema/test/Schema/Record/Record.test.ts
@@ -325,14 +325,14 @@ describe("record", () => {
       await Util.expectDecodeUnknownFailure(
         schema,
         { "aa": "aa" },
-        `{ readonly [x: string]: number }
+        `{ readonly [x: a string at least 2 character(s) long]: number }
 └─ ["aa"]
    └─ Expected number, actual "aa"`
       )
       await Util.expectDecodeUnknownFailure(
         schema,
         { "a": 1 },
-        `{ readonly [x: string]: number }
+        `{ readonly [x: a string at least 2 character(s) long]: number }
 └─ ["a"]
    └─ is unexpected, expected: a string at least 2 character(s) long`,
         Util.onExcessPropertyError
@@ -377,7 +377,7 @@ describe("record", () => {
       await Util.expectDecodeUnknownFailure(
         schema,
         { "": 1 },
-        `{ readonly [x: string]: number }
+        `{ readonly [x: NonEmpty]: number }
 └─ [""]
    └─ is unexpected, expected: NonEmpty`,
         Util.onExcessPropertyError
@@ -391,7 +391,7 @@ describe("record", () => {
       await Util.expectEncodeFailure(
         schema,
         { aa: "a" },
-        `{ readonly [x: string]: string }
+        `{ readonly [x: Char]: string }
 └─ ["aa"]
    └─ is unexpected, expected: Char`,
         Util.onExcessPropertyError


### PR DESCRIPTION
…d fix type display for IndexSignature

**Before the Change**

Previously, when a type mismatch occurred in `Schema.decodeUnknownSync`, the error message displayed for `IndexSignature` was not accurately representing the type used. For example:

```typescript
import { Schema } from "@effect/schema"

const schema = Schema.Record(Schema.Char, Schema.String)

Schema.decodeUnknownSync(schema)({ a: 1 })
/*
throws
ParseError: { readonly [x: string]: string }
└─ ["a"]
   └─ Expected string, actual 1
*/
```

This output incorrectly indicated `[x: string]` when the actual index type was `Char`.

**After the Change**

The `toString` implementation now correctly reflects the type used in `IndexSignature`, providing more accurate and informative error messages:

```ts
import { Schema } from "@effect/schema"

const schema = Schema.Record(Schema.Char, Schema.String)

Schema.decodeUnknownSync(schema)({ a: 1 })
/*
throws
ParseError: { readonly [x: Char]: string }
└─ ["a"]
   └─ Expected string, actual 1
*/
```

The updated output now correctly displays `{ readonly [x: Char]: string }`, aligning the error messages with the actual data types used in the schema.
