### PR TITLE
Prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "singleQuote": false,
+  "trailingComma": "none",
+  "semi": false,
+  "printWidth": 120,
+  "endOfLine": "auto"
+}


### PR DESCRIPTION
I have not provided documentation because this is not a public update, and I'm not sure if users should know about it.

I noticed that Effect uses Prettier, but its default configuration is very different from the ESLint configuration. Effect is a pretty large codebase, and it takes forever to `run lint-fix` on my M1 Pro MacBook. Prettier works very fast, so I use `Prettier => Run on save` in my WebStorm. However, it incorrectly reformats the code, leading to ESLint errors and red underlines all over my new code in the editor, which distracts me from contributing.

I implemented a Prettier configuration that is aligned as closely as possible with the ESLint configuration.