### PR TITLE
export Random.make taking hashable values as seed

### DIFF
--- a/.changeset/rich-insects-jog.md
+++ b/.changeset/rich-insects-jog.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+export Random.make taking hashable values as seed

--- a/.changeset/rich-insects-jog.md
+++ b/.changeset/rich-insects-jog.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 export Random.make taking hashable values as seed

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -123,7 +123,7 @@ export const Random: Context.Tag<Random, Random> = internal.randomTag
  * Constructs the `Random` service, seeding the pseudo-random number generator
  * with an hash of the specified seed.
  *
- * @since 3.4.9
+ * @since 3.5.0
  * @category constructors
  */
 export const make: <A>(seed: A) => Random = internal.make

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -118,3 +118,12 @@ export const randomWith: <A, E, R>(f: (random: Random) => Effect.Effect<A, E, R>
  * @category context
  */
 export const Random: Context.Tag<Random, Random> = internal.randomTag
+
+/**
+ * Constructs the `Random` service, seeding the pseudo-random number generator
+ * with an hash of the specified seed.
+ *
+ * @since 3.4.9
+ * @category constructors
+ */
+export const make: <A>(seed: A) => Random = internal.make

--- a/packages/effect/src/internal/defaultServices.ts
+++ b/packages/effect/src/internal/defaultServices.ts
@@ -22,7 +22,7 @@ export const liveServices: Context.Context<DefaultServices.DefaultServices> = pi
   Context.empty(),
   Context.add(clock.clockTag, clock.make()),
   Context.add(console_.consoleTag, console_.defaultConsole),
-  Context.add(random.randomTag, random.make((Math.random() * 4294967296) >>> 0)),
+  Context.add(random.randomTag, random.make(Math.random())),
   Context.add(configProvider.configProviderTag, configProvider.fromEnv()),
   Context.add(tracer.tracerTag, tracer.nativeTracer)
 )

--- a/packages/effect/src/internal/random.ts
+++ b/packages/effect/src/internal/random.ts
@@ -2,6 +2,7 @@ import * as Chunk from "../Chunk.js"
 import * as Context from "../Context.js"
 import type * as Effect from "../Effect.js"
 import { pipe } from "../Function.js"
+import * as Hash from "../Hash.js"
 import type * as Random from "../Random.js"
 import * as PCGRandom from "../Utils.js"
 import * as core from "./core.js"
@@ -85,4 +86,4 @@ const swap = <A>(buffer: Array<A>, index1: number, index2: number): Array<A> => 
   return buffer
 }
 
-export const make = (seed: number): Random.Random => new RandomImpl(seed)
+export const make = <A>(seed: A): Random.Random => new RandomImpl(Hash.hash(seed))

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -1,4 +1,4 @@
-import { Array, Chunk, Effect, Random } from "effect"
+import { Array, Chunk, Data, Effect, Random } from "effect"
 import * as it from "effect/test/utils/extend"
 import { assert, describe } from "vitest"
 
@@ -10,4 +10,19 @@ describe("Random", () => {
       assert.isTrue(Chunk.every(end, (n) => n !== undefined))
       assert.deepStrictEqual(start.sort(), Array.fromIterable(end).sort())
     }).pipe(Effect.repeatN(100)))
+
+  it.effect("make", () =>
+    Effect.gen(function*() {
+      const random0 = Random.make("foo")
+      const random1 = Random.make("foo")
+      const random2 = Random.make(Data.struct({ foo: "bar" }))
+      const random3 = Random.make(Data.struct({ foo: "bar" }))
+      const n0 = yield* random0.next
+      const n1 = yield* random1.next
+      const n2 = yield* random2.next
+      const n3 = yield* random3.next
+      assert.strictEqual(n0, n1)
+      assert.strictEqual(n2, n3)
+      assert.notStrictEqual(n0, n2)
+    }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Proposed changes:

- Export `Random.make`
- Allow any hashable value as a seed for `Random.make`, instead of 32-bit integers

These changes enable developers to create instances of the `Random` service with a specified seed.

Use cases:

- For visual tests where the UI data is randomly generated, we use the string "test" as a seed.
- To compute data that should vary daily but remain consistent within the same day, we use a date as a seed.
