### PR TITLE
Align Stream.run public function signatures

### DIFF
--- a/.changeset/twenty-toes-brake.md
+++ b/.changeset/twenty-toes-brake.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Align Stream.run public function signatures

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -3679,7 +3679,7 @@ export const retry: {
 export const run: {
   <A2, A, E2, R2>(
     sink: Sink.Sink<A2, A, unknown, E2, R2>
-  ): <E, R>(self: Stream<A, E, R>) => Effect.Effect<A2, E2 | E, R2 | R>
+  ): <E, R>(self: Stream<A, E, R>) => Effect.Effect<A2, E2 | E, Exclude<R | R2, Scope.Scope>>
   <A, E, R, A2, E2, R2>(
     self: Stream<A, E, R>,
     sink: Sink.Sink<A2, A, unknown, E2, R2>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

I remembered reading something in the Discord about how Scope was removed from the resulting effect of all the non-scoped .run* methods, and yet Stream.run didn't seem to be behaving like this. I reviewed [this commit](https://github.com/Effect-TS/effect/commit/ac71f378f2413e5aa91c95f649ffe898d6a26114) from pr #3190, and it looks to me like one of the function signatures of `Stream.run` was not updated (I couldn't find any others that were missed). The internal signatures are correct as well.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

#3190 
