### PR TITLE
add support for `Refinement`s to `Predicate.or`, closes #3243

### DIFF
--- a/.changeset/wet-snakes-mate.md
+++ b/.changeset/wet-snakes-mate.md
@@ -1,0 +1,12 @@
+---
+"effect": patch
+---
+
+add support for `Refinement`s to `Predicate.or`, closes #3243
+
+```ts
+import { Predicate } from "effect"
+
+// Refinement<unknown, string | number>
+const isStringOrNumber = Predicate.or(Predicate.isString, Predicate.isNumber)
+```

--- a/packages/effect/dtslint/Predicate.ts
+++ b/packages/effect/dtslint/Predicate.ts
@@ -1,4 +1,4 @@
-import { pipe } from "effect/Function"
+import { hole, pipe } from "effect/Function"
 import * as Predicate from "effect/Predicate"
 
 declare const u: unknown
@@ -255,3 +255,19 @@ pipe(hasa, Predicate.and(hasb))
 
 // $ExpectType Refinement<unknown, { a: unknown; } & { b: unknown; }>
 Predicate.and(hasa, hasb)
+
+// -------------------------------------------------------------------------------------
+// or
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Predicate<number>
+pipe(hole<Predicate.Predicate<number>>(), Predicate.or(hole<Predicate.Predicate<number>>()))
+
+// $ExpectType Predicate<number>
+Predicate.or(hole<Predicate.Predicate<number>>(), hole<Predicate.Predicate<number>>())
+
+// $ExpectType Refinement<unknown, string | number>
+pipe(Predicate.isString, Predicate.or(Predicate.isNumber))
+
+// $ExpectType Refinement<unknown, string | number>
+Predicate.or(Predicate.isString, Predicate.isNumber)

--- a/packages/effect/src/Predicate.ts
+++ b/packages/effect/src/Predicate.ts
@@ -750,6 +750,8 @@ export const not = <A>(self: Predicate<A>): Predicate<A> => (a) => !self(a)
  * @since 2.0.0
  */
 export const or: {
+  <A, C extends A>(that: Refinement<A, C>): <B extends A>(self: Refinement<A, B>) => Refinement<A, B | C>
+  <A, B extends A, C extends A>(self: Refinement<A, B>, that: Refinement<A, C>): Refinement<A, B | C>
   <A>(that: Predicate<A>): (self: Predicate<A>) => Predicate<A>
   <A>(self: Predicate<A>, that: Predicate<A>): Predicate<A>
 } = dual(2, <A>(self: Predicate<A>, that: Predicate<A>): Predicate<A> => (a) => self(a) || that(a))


### PR DESCRIPTION
```ts
import { Predicate } from "effect"

// Refinement<unknown, string | number>
const isStringOrNumber = Predicate.or(Predicate.isString, Predicate.isNumber)
```
