### PR TITLE
Allow ignoring empty lines when unpacking Ndjson

### DIFF
--- a/.changeset/pink-buses-sleep.md
+++ b/.changeset/pink-buses-sleep.md
@@ -1,0 +1,5 @@
+---
+"@effect/experimental": patch
+---
+
+allow unpacking newline delimited JSON to ignore empty lines

--- a/.changeset/slimy-shrimps-change.md
+++ b/.changeset/slimy-shrimps-change.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+expose `Channel.isChannel`

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -187,6 +187,20 @@ export interface ChannelException<out E> {
 }
 
 /**
+ * @since 3.5.4
+ * @category refinements
+ */
+export const isChannel: (u: unknown) => u is Channel<
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown
+> = core.isChannel
+
+/**
  * @since 2.0.0
  * @category constructors
  */

--- a/packages/experimental/src/Ndjson.ts
+++ b/packages/experimental/src/Ndjson.ts
@@ -8,7 +8,7 @@ import type * as Cause from "effect/Cause"
 import * as Channel from "effect/Channel"
 import * as Chunk from "effect/Chunk"
 import * as Effect from "effect/Effect"
-import { dual, pipe } from "effect/Function"
+import { constTrue, dual, pipe } from "effect/Function"
 
 /**
  * @since 1.0.0
@@ -31,6 +31,34 @@ const encoder = new TextEncoder()
 export class NdjsonError extends RefailError(NdjsonErrorTypeId, "NdjsonError")<{
   readonly reason: "Pack" | "Unpack"
 }> {}
+
+/**
+ * Represents a set of options which can be used to control how the newline
+ * delimited JSON is handled.
+ *
+ * @since 1.0.0
+ * @category models
+ */
+export interface NdjsonOptions {
+  /**
+   * Whether or not the newline delimited JSON parser should ignore empty lines.
+   *
+   * Defaults to `false`.
+   *
+   * From the [newline delimited JSON spec](https://github.com/ndjson/ndjson-spec):
+   * ```text
+   * The parser MAY silently ignore empty lines, e.g. \n\n. This behavior MUST
+   * be documented and SHOULD be configurable by the user of the parser.
+   * ```
+   *
+   * @since 1.0.0
+   */
+  readonly ignoreEmptyLines?: boolean
+}
+
+const defaultOptions: NdjsonOptions = {
+  ignoreEmptyLines: false
+}
 
 /**
  * @since 1.0.0
@@ -108,7 +136,7 @@ export const packSchema = <A, I, R>(
  * @since 1.0.0
  * @category constructors
  */
-export const unpack = <IE = never, Done = unknown>(): Channel.Channel<
+export const unpack = <IE = never, Done = unknown>(options?: NdjsonOptions): Channel.Channel<
   Chunk.Chunk<unknown>,
   Chunk.Chunk<Uint8Array>,
   IE | NdjsonError,
@@ -117,6 +145,7 @@ export const unpack = <IE = never, Done = unknown>(): Channel.Channel<
   Done
 > =>
   Channel.suspend(() => {
+    const opts = { ...defaultOptions, ...options }
     const decoder = new TextDecoder()
     const loop: Channel.Channel<Chunk.Chunk<string>, Chunk.Chunk<Uint8Array>, IE, IE, Done, Done, never> = Channel
       .readWithCause({
@@ -128,9 +157,10 @@ export const unpack = <IE = never, Done = unknown>(): Channel.Channel<
         onFailure: (cause) => Channel.failCause(cause),
         onDone: (_) => Channel.succeed(_)
       })
+    const filter = opts.ignoreEmptyLines ? (line: string) => line.length > 0 : constTrue
     return Channel.mapOutEffect(Channel.pipeTo(loop, Channel.splitLines()), (chunk) =>
       Effect.try({
-        try: () => Chunk.map(chunk, (_) => JSON.parse(_)),
+        try: () => chunk.pipe(Chunk.filter(filter), Chunk.map((_) => JSON.parse(_))),
         catch: (error) => new NdjsonError({ reason: "Unpack", error })
       }))
   })
@@ -142,7 +172,7 @@ export const unpack = <IE = never, Done = unknown>(): Channel.Channel<
 export const unpackSchema = <A, I, R>(
   schema: Schema.Schema<A, I, R>
 ) =>
-<IE = never, Done = unknown>(): Channel.Channel<
+<IE = never, Done = unknown>(options?: NdjsonOptions): Channel.Channel<
   Chunk.Chunk<A>,
   Chunk.Chunk<Uint8Array>,
   NdjsonError | ParseError | IE,
@@ -152,20 +182,26 @@ export const unpackSchema = <A, I, R>(
   R
 > => {
   const parse = Schema.decodeUnknown(Schema.ChunkFromSelf(schema))
-  return Channel.mapOutEffect(unpack<IE, Done>(), parse)
+  return Channel.mapOutEffect(unpack<IE, Done>(options), parse)
 }
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const duplex = <R, IE, OE, OutDone, InDone>(
-  self: Channel.Channel<Chunk.Chunk<Uint8Array>, Chunk.Chunk<Uint8Array>, OE, IE | NdjsonError, OutDone, InDone, R>
-): Channel.Channel<Chunk.Chunk<unknown>, Chunk.Chunk<unknown>, NdjsonError | OE, IE, OutDone, InDone, R> =>
+export const duplex = dual<
+  (options?: NdjsonOptions) => <R, IE, OE, OutDone, InDone>(
+    self: Channel.Channel<Chunk.Chunk<Uint8Array>, Chunk.Chunk<Uint8Array>, OE, IE | NdjsonError, OutDone, InDone, R>
+  ) => Channel.Channel<Chunk.Chunk<unknown>, Chunk.Chunk<unknown>, NdjsonError | OE, IE, OutDone, InDone, R>,
+  <R, IE, OE, OutDone, InDone>(
+    self: Channel.Channel<Chunk.Chunk<Uint8Array>, Chunk.Chunk<Uint8Array>, OE, IE | NdjsonError, OutDone, InDone, R>,
+    options?: NdjsonOptions
+  ) => Channel.Channel<Chunk.Chunk<unknown>, Chunk.Chunk<unknown>, NdjsonError | OE, IE, OutDone, InDone, R>
+>((args) => Channel.isChannel(args[0]), (self, options) =>
   Channel.pipeTo(
     Channel.pipeTo(pack(), self),
-    unpack()
-  )
+    unpack(options)
+  ))
 
 /**
  * @since 1.0.0
@@ -173,7 +209,7 @@ export const duplex = <R, IE, OE, OutDone, InDone>(
  */
 export const duplexSchema = dual<
   <IA, II, IR, OA, OI, OR>(
-    options: {
+    options: Partial<NdjsonOptions> & {
       readonly inputSchema: Schema.Schema<IA, II, IR>
       readonly outputSchema: Schema.Schema<OA, OI, OR>
     }
@@ -206,7 +242,7 @@ export const duplexSchema = dual<
       InDone,
       R
     >,
-    options: {
+    options: Partial<NdjsonOptions> & {
       readonly inputSchema: Schema.Schema<IA, II, IR>
       readonly outputSchema: Schema.Schema<OA, OI, OR>
     }
@@ -229,7 +265,7 @@ export const duplexSchema = dual<
     InDone,
     R
   >,
-  options: {
+  options: Partial<NdjsonOptions> & {
     readonly inputSchema: Schema.Schema<IA, II, IR>
     readonly outputSchema: Schema.Schema<OA, OI, OR>
   }
@@ -242,11 +278,12 @@ export const duplexSchema = dual<
   InDone,
   R | IR | OR
 > => {
-  const pack = packSchema(options.inputSchema)
-  const unpack = unpackSchema(options.outputSchema)
+  const { inputSchema, outputSchema, ...opts } = options
+  const pack = packSchema(inputSchema)
+  const unpack = unpackSchema(outputSchema)
   return pipe(
     pack<InErr, InDone>(),
     Channel.pipeTo(self),
-    Channel.pipeTo(unpack())
+    Channel.pipeTo(unpack(opts))
   )
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds an option to ignore empty lines when unpacking newline delimited JSON.

From the [NDJSON](https://discord.com/channels/795981131316985866/1262401172778647562/1262545122516799559) spec:

> The parser MAY silently ignore empty lines, e.g. \n\n. This behavior MUST be documented and SHOULD be configurable by the user of the parser.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #3258 
- Closes #3258 
