### PR TITLE
Implement Struct.keys as a typed alternative to Object.keys

### DIFF
--- a/.changeset/lovely-buckets-sip.md
+++ b/.changeset/lovely-buckets-sip.md
@@ -1,0 +1,19 @@
+---
+"effect": minor
+---
+
+Implement Struct.keys as a typed alternative to Object.keys
+
+```ts
+import { Struct } from "effect"
+
+const symbol: unique symbol = Symbol()
+
+const value = {
+  a: 1,
+  b: 2,
+  [symbol]: 3
+}
+
+const keys: Array<"a" | "b"> = Struct.keys(value)
+```

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -179,3 +179,25 @@ export const evolve: {
 export const get =
   <K extends PropertyKey>(key: K) => <S extends { [P in K]?: any }>(s: S): MatchRecord<S, S[K] | undefined, S[K]> =>
     s[key]
+
+/**
+ * Retrieves the object keys that are strings in a typed manner
+ *
+ * @example
+ * import { Struct } from "effect"
+ *
+ * const symbol: unique symbol = Symbol()
+ *
+ * const value = {
+ *   a: 1,
+ *   b: 2,
+ *   [symbol]: 3
+ * }
+ *
+ * const keys: Array<"a" | "b"> = Struct.keys(value)
+ *
+ * assert.deepStrictEqual(keys, ["a", "b"])
+ *
+ * @since 3.6.0
+ */
+export const keys = <T extends {}>(o: T): Array<(keyof T) & string> => Object.keys(o) as Array<(keyof T) & string>


### PR DESCRIPTION
Allows for use cases such as:

```ts
import * as S from "@effect/schema/Schema"
import { Struct } from "effect"

export const Version = S.String.pipe(
  S.pattern(/^\d+\.\d+\.\d+$/) // Ensure "<major>.<minor>.<patch>" and no leading or trailing
)

export const Email = S.String.pipe(
  S.pattern(
    /^(?!\.)(?!.*\.\.)([A-Z0-9_+-.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i
  )
)
export const Entity = S.Struct({
  id: S.UUID,
  version: Version
})
export class Creator extends S.Class<Creator>("creator")({
  ...Entity.fields,
  createdAt: S.Date,
  communicationChannels: S.Array(S.String),
  email: Email,
  platforms: S.Array(S.String)
}) {}

////// Usecase
export const UseCaseCreateCreator = S.Struct(
  Struct.omit(Creator.fields, ...Struct.keys(Entity.fields))
)
```