### PR TITLE
Fix: Correct Handling of JSON Schema Annotations in Refinements

### DIFF
--- a/.changeset/neat-spoons-cheer.md
+++ b/.changeset/neat-spoons-cheer.md
@@ -1,0 +1,41 @@
+---
+"@effect/schema": patch
+---
+
+Fix: Correct Handling of JSON Schema Annotations in Refinements
+
+Fixes an issue where the JSON schema annotation set by a refinement after a transformation was mistakenly interpreted as an override annotation. This caused the output to be incorrect, as the annotations were not applied as intended.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Trim.pipe(Schema.nonEmpty())
+
+const jsonSchema = JSONSchema.make(schema)
+console.log(JSON.stringify(jsonSchema, null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "minLength": 1
+}
+*/
+```
+
+Now
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Trim.pipe(Schema.nonEmpty())
+
+const jsonSchema = JSONSchema.make(schema)
+console.log(JSON.stringify(jsonSchema, null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string"
+}
+*/
+```

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -1866,12 +1866,57 @@ schema (Suspend): <suspended schema>`
       }, false)
     })
 
-    it("refinement of a transformation", () => {
+    it("refinement of a transformation with an override annotation", () => {
       expectJSONSchema(Schema.Date.annotations({ jsonSchema: { type: "string", format: "date-time" } }), {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "format": "date-time",
         "type": "string"
       }, false)
+      expectJSONSchema(
+        Schema.Date.annotations({
+          jsonSchema: { oneOf: [{ type: "object" }, { type: "array" }] }
+        }),
+        { "$schema": "http://json-schema.org/draft-07/schema#", oneOf: [{ type: "object" }, { type: "array" }] },
+        false
+      )
+      expectJSONSchema(
+        Schema.Date.annotations({
+          jsonSchema: { anyOf: [{ type: "object" }, { type: "array" }] }
+        }),
+        { "$schema": "http://json-schema.org/draft-07/schema#", anyOf: [{ type: "object" }, { type: "array" }] },
+        false
+      )
+      expectJSONSchema(Schema.Date.annotations({ jsonSchema: { $ref: "x" } }), {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        $ref: "x"
+      }, false)
+      expectJSONSchema(Schema.Date.annotations({ jsonSchema: { const: 1 } }), {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        const: 1
+      }, false)
+      expectJSONSchema(Schema.Date.annotations({ jsonSchema: { enum: [1] } }), {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        enum: [1]
+      }, false)
+    })
+
+    it("refinement of a transformation without an override annotation", () => {
+      expectJSONSchema(Schema.Trim.pipe(Schema.nonEmpty()), {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "string"
+      }, false)
+      expectJSONSchema(Schema.Trim.pipe(Schema.nonEmpty({ jsonSchema: { title: "Description" } })), {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "string"
+      }, false)
+      expectJSONSchema(
+        Schema.Trim.pipe(Schema.nonEmpty()).annotations({ jsonSchema: { title: "Description" } }),
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "string"
+        },
+        false
+      )
     })
   })
 


### PR DESCRIPTION
Fixes an issue where the JSON schema annotation set by a refinement after a transformation was mistakenly interpreted as an override annotation. This caused the output to be incorrect, as the annotations were not applied as intended.

Before

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.Trim.pipe(Schema.nonEmpty())

const jsonSchema = JSONSchema.make(schema)
console.log(JSON.stringify(jsonSchema, null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "minLength": 1
}
*/
```

Now

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.Trim.pipe(Schema.nonEmpty())

const jsonSchema = JSONSchema.make(schema)
console.log(JSON.stringify(jsonSchema, null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "string"
}
*/
```
