### PR TITLE
JSON Schema: change default behavior for property signatures containi…

### DIFF
--- a/.changeset/fuzzy-news-travel.md
+++ b/.changeset/fuzzy-news-travel.md
@@ -1,0 +1,65 @@
+---
+"@effect/schema": patch
+---
+
+JSON Schema: change default behavior for property signatures containing `undefined`
+
+Changed the default behavior when encountering a required property signature whose type contains `undefined`. Instead of raising an exception, `undefined` is now pruned and **the field is set as optional**.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Struct({
+  a: Schema.NullishOr(Schema.Number)
+})
+
+const jsonSchema = JSONSchema.make(schema)
+console.log(JSON.stringify(jsonSchema, null, 2))
+/*
+throws
+Error: Missing annotation
+at path: ["a"]
+details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
+schema (UndefinedKeyword): undefined
+*/
+```
+
+Now
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.Struct({
+  a: Schema.NullishOr(Schema.Number)
+})
+
+const jsonSchema = JSONSchema.make(schema)
+console.log(JSON.stringify(jsonSchema, null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [], // <=== empty
+  "properties": {
+    "a": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "null": {
+      "const": null
+    }
+  }
+}
+*/
+```

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -791,35 +791,63 @@ details: Cannot encode Symbol(@effect/schema/test/a) key to JSON Schema`
       )
     })
 
-    it("should prune `UndefinedKeyword` if the property signature is marked as optional and contains a union that includes `UndefinedKeyword`", () => {
-      expectJSONSchema(
-        Schema.Struct({
-          a: Schema.optional(Schema.String)
-        }),
-        {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "a": {
-              "type": "string"
-            }
-          },
-          "required": [],
-          "additionalProperties": false
-        }
-      )
-    })
+    describe("pruning undefined", () => {
+      it("with an annotation the property should remain required", () => {
+        expectJSONSchema(
+          Schema.Struct({
+            a: Schema.UndefinedOr(Schema.String).annotations({ jsonSchema: { "type": "number" } })
+          }),
+          {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": ["a"],
+            "properties": {
+              "a": {
+                "type": "number"
+              }
+            },
+            "additionalProperties": false
+          }
+        )
+      })
 
-    it("should raise an error if the property signature is not marked as optional and contains a union that includes `UndefinedKeyword`", () => {
-      expectError(
-        Schema.Struct({
-          a: Schema.UndefinedOr(Schema.String)
-        }),
-        `Missing annotation
-at path: ["a"]
-details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
-schema (UndefinedKeyword): undefined`
-      )
+      it("should prune `UndefinedKeyword` from an optional property signature", () => {
+        expectJSONSchema(
+          Schema.Struct({
+            a: Schema.optional(Schema.String)
+          }),
+          {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "additionalProperties": false
+          }
+        )
+      })
+
+      it("should prune `UndefinedKeyword` from a required property signature type and make the property optional by default", () => {
+        expectJSONSchema(
+          Schema.Struct({
+            a: Schema.UndefinedOr(Schema.String)
+          }),
+          {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [],
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        )
+      })
     })
   })
 


### PR DESCRIPTION
…ng `undefined`

Changed the default behavior when encountering a required property signature whose type contains `undefined`. Instead of raising an exception, `undefined` is now pruned and **the field is set as optional**.

Before

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.Struct({
  a: Schema.NullishOr(Schema.Number)
})

const jsonSchema = JSONSchema.make(schema)
console.log(JSON.stringify(jsonSchema, null, 2))
/*
throws
Error: Missing annotation
at path: ["a"]
details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
schema (UndefinedKeyword): undefined
*/
```

Now

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.Struct({
  a: Schema.NullishOr(Schema.Number)
})

const jsonSchema = JSONSchema.make(schema)
console.log(JSON.stringify(jsonSchema, null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [], // <=== empty
  "properties": {
    "a": {
      "anyOf": [
        {
          "type": "number"
        },
        {
          "$ref": "#/$defs/null"
        }
      ]
    }
  },
  "additionalProperties": false,
  "$defs": {
    "null": {
      "const": null
    }
  }
}
*/
```
