### PR TITLE
feat(Stream): add Stream.onStart api

### DIFF
--- a/.changeset/stream-on-start.md
+++ b/.changeset/stream-on-start.md
@@ -2,13 +2,13 @@
 "effect": minor
 ---
 
-Implement `Stream.tapStart` that adds an effect to be executed at the start of the stream.
+Implement `Stream.onStart` that adds an effect to be executed at the start of the stream.
 
 ```ts
 import { Console, Effect, Stream } from "effect";
 
 const stream = Stream.make(1, 2, 3).pipe(
-  Stream.tapStart(Console.log("Stream started")),
+  Stream.onStart(Console.log("Stream started")),
   Stream.map((n) => n * 2),
   Stream.tap((n) => Console.log(`after mapping: ${n}`))
 ) 

--- a/.changeset/stream-tap-start.md
+++ b/.changeset/stream-tap-start.md
@@ -1,0 +1,22 @@
+---
+"effect": minor
+---
+
+Implement `Stream.tapStart` that adds an effect to be executed at the start of the stream.
+
+```ts
+import { Console, Effect, Stream } from "effect";
+
+const stream = Stream.make(1, 2, 3).pipe(
+  Stream.tapStart(Console.log("Stream started")),
+  Stream.map((n) => n * 2),
+  Stream.tap((n) => Console.log(`after mapping: ${n}`))
+) 
+
+Effect. runPromise(Stream. runCollect(stream)).then(console. log) 
+// Stream started 
+// after mapping: 2 
+// after mapping: 4 
+// after mapping: 6 
+// { _id: 'Chunk', values: [ 2, 4, 6 ] }
+```

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2919,6 +2919,38 @@ export const onDone: {
 } = internal.onDone
 
 /**
+ * Adds an effect to be executed at the start of the stream.
+ *
+ * @example
+ * import { Console, Effect, Stream } from "effect"
+ *
+ * const stream = Stream.make(1, 2, 3).pipe(
+ *   Stream.onStart(Console.log("Stream started")),
+ *   Stream.map((n) => n * 2),
+ *   Stream.tap((n) => Console.log(`after mapping: ${n}`))
+ * )
+ *
+ * // Effect.runPromise(Stream.runCollect(stream)).then(console.log)
+ * // Stream started
+ * // after mapping: 2
+ * // after mapping: 4
+ * // after mapping: 6
+ * // { _id: 'Chunk', values: [ 2, 4, 6 ] }
+ *
+ * @since 3.6.0
+ * @category sequencing
+ */
+export const onStart: {
+  <_, E2, R2>(
+    effect: Effect.Effect<_, E2, R2>
+  ): <A, E, R>(self: Stream<A, E, R>) => Stream<A, E2 | E, R2 | R>
+  <A, E, R, _, E2, R2>(
+    self: Stream<A, E, R>,
+    effect: Effect.Effect<_, E2, R2>
+  ): Stream<A, E | E2, R | R2>
+} = internal.onStart
+
+/**
  * Translates any failure into a stream termination, making the stream
  * infallible and all failures unchecked.
  *
@@ -4535,38 +4567,6 @@ export const tapSink: {
   <A, E2, R2>(sink: Sink.Sink<unknown, A, unknown, E2, R2>): <E, R>(self: Stream<A, E, R>) => Stream<A, E2 | E, R2 | R>
   <A, E, R, E2, R2>(self: Stream<A, E, R>, sink: Sink.Sink<unknown, A, unknown, E2, R2>): Stream<A, E | E2, R | R2>
 } = internal.tapSink
-
-/**
- * Adds an effect to be executed at the start of the stream.
- *
- * @example
- * import { Console, Effect, Stream } from "effect"
- *
- * const stream = Stream.make(1, 2, 3).pipe(
- *   Stream.tapStart(Console.log("Stream started")),
- *   Stream.map((n) => n * 2),
- *   Stream.tap((n) => Console.log(`after mapping: ${n}`))
- * )
- *
- * // Effect.runPromise(Stream.runCollect(stream)).then(console.log)
- * // Stream started
- * // after mapping: 2
- * // after mapping: 4
- * // after mapping: 6
- * // { _id: 'Chunk', values: [ 2, 4, 6 ] }
- *
- * @since 3.6.0
- * @category sequencing
- */
-export const tapStart: {
-  <_, E2, R2>(
-    effect: Effect.Effect<_, E2, R2>
-  ): <A, E, R>(self: Stream<A, E, R>) => Stream<A, E2 | E, R2 | R>
-  <A, E, R, _, E2, R2>(
-    self: Stream<A, E, R>,
-    effect: Effect.Effect<_, E2, R2>
-  ): Stream<A, E | E2, R | R2>
-} = internal.tapStart
 
 /**
  * Delays the chunks of this stream according to the given bandwidth

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4537,6 +4537,38 @@ export const tapSink: {
 } = internal.tapSink
 
 /**
+ * Adds an effect to be executed at the start of the stream.
+ *
+ * @example
+ * import { Console, Effect, Stream } from "effect"
+ *
+ * const stream = Stream.make(1, 2, 3).pipe(
+ *   Stream.tapStart(Console.log("Stream started")),
+ *   Stream.map((n) => n * 2),
+ *   Stream.tap((n) => Console.log(`after mapping: ${n}`))
+ * )
+ *
+ * // Effect.runPromise(Stream.runCollect(stream)).then(console.log)
+ * // Stream started
+ * // after mapping: 2
+ * // after mapping: 4
+ * // after mapping: 6
+ * // { _id: 'Chunk', values: [ 2, 4, 6 ] }
+ *
+ * @since 3.6.0
+ * @category sequencing
+ */
+export const tapStart: {
+  <_, E2, R2>(
+    effect: Effect.Effect<_, E2, R2>
+  ): <A, E, R>(self: Stream<A, E, R>) => Stream<A, E2 | E, R2 | R>
+  <A, E, R, _, E2, R2>(
+    self: Stream<A, E, R>,
+    effect: Effect.Effect<_, E2, R2>
+  ): Stream<A, E | E2, R | R2>
+} = internal.tapStart
+
+/**
  * Delays the chunks of this stream according to the given bandwidth
  * parameters using the token bucket algorithm. Allows for burst in the
  * processing of elements by allowing the token bucket to accumulate tokens up

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -6208,7 +6208,7 @@ export const tapStart: {
   <A, E, R, _, E2, R2>(
     self: Stream.Stream<A, E, R>,
     effect: Effect.Effect<_, E2, R2>
-  ): Stream.Stream<A, E | E2, R | R2> => concat(drain(fromEffect(effect)), self)
+  ): Stream.Stream<A, E | E2, R | R2> => unwrap(Effect.as(effect, self))
 )
 
 /** @internal */

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -6195,6 +6195,23 @@ export const tap: {
 )
 
 /** @internal */
+export const tapStart: {
+  <_, E2, R2>(
+    effect: Effect.Effect<_, E2, R2>
+  ): <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<A, E2 | E, R2 | R>
+  <A, E, R, _, E2, R2>(
+    self: Stream.Stream<A, E, R>,
+    effect: Effect.Effect<_, E2, R2>
+  ): Stream.Stream<A, E | E2, R | R2>
+} = dual(
+  2,
+  <A, E, R, _, E2, R2>(
+    self: Stream.Stream<A, E, R>,
+    effect: Effect.Effect<_, E2, R2>
+  ): Stream.Stream<A, E | E2, R | R2> => concat(drain(fromEffect(effect)), self)
+)
+
+/** @internal */
 export const tapBoth: {
   <E, X1, E2, R2, A, X2, E3, R3>(
     options: {

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -4155,6 +4155,23 @@ export const onDone = dual<
 )
 
 /** @internal */
+export const onStart: {
+  <_, E2, R2>(
+    effect: Effect.Effect<_, E2, R2>
+  ): <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<A, E2 | E, R2 | R>
+  <A, E, R, _, E2, R2>(
+    self: Stream.Stream<A, E, R>,
+    effect: Effect.Effect<_, E2, R2>
+  ): Stream.Stream<A, E | E2, R | R2>
+} = dual(
+  2,
+  <A, E, R, _, E2, R2>(
+    self: Stream.Stream<A, E, R>,
+    effect: Effect.Effect<_, E2, R2>
+  ): Stream.Stream<A, E | E2, R | R2> => unwrap(Effect.as(effect, self))
+)
+
+/** @internal */
 export const orDie = <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<A, never, R> =>
   pipe(self, orDieWith(identity))
 
@@ -6192,23 +6209,6 @@ export const tap: {
     self: Stream.Stream<A, E, R>,
     f: (a: NoInfer<A>) => Effect.Effect<X, E2, R2>
   ): Stream.Stream<A, E | E2, R | R2> => mapEffectSequential(self, (a) => Effect.as(f(a), a))
-)
-
-/** @internal */
-export const tapStart: {
-  <_, E2, R2>(
-    effect: Effect.Effect<_, E2, R2>
-  ): <A, E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<A, E2 | E, R2 | R>
-  <A, E, R, _, E2, R2>(
-    self: Stream.Stream<A, E, R>,
-    effect: Effect.Effect<_, E2, R2>
-  ): Stream.Stream<A, E | E2, R | R2>
-} = dual(
-  2,
-  <A, E, R, _, E2, R2>(
-    self: Stream.Stream<A, E, R>,
-    effect: Effect.Effect<_, E2, R2>
-  ): Stream.Stream<A, E | E2, R | R2> => unwrap(Effect.as(effect, self))
 )
 
 /** @internal */

--- a/packages/effect/test/Stream/lifecycle.test.ts
+++ b/packages/effect/test/Stream/lifecycle.test.ts
@@ -1,0 +1,18 @@
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+import * as it from "effect/test/utils/extend"
+import { assert, describe } from "vitest"
+
+describe("Stream", () => {
+  it.effect("onStart", () =>
+    Effect.gen(function*($) {
+      let counter = 0
+      const result = yield* $(
+        Stream.make(1, 1),
+        Stream.onStart(Effect.sync(() => counter++)),
+        Stream.runCollect
+      )
+      assert.strictEqual(counter, 1)
+      assert.deepStrictEqual(Array.from(result), [1, 1])
+    }))
+})

--- a/packages/effect/test/Stream/tapping.test.ts
+++ b/packages/effect/test/Stream/tapping.test.ts
@@ -97,7 +97,11 @@ describe("Stream", () => {
       const result = yield* $(
         Stream.make(1, 2, 3),
         Stream.tapBoth({
-          onSuccess: (n) => pipe(Effect.fail("error"), Effect.when(() => n === 3)),
+          onSuccess: (n) =>
+            pipe(
+              Effect.fail("error"),
+              Effect.when(() => n === 3)
+            ),
           onFailure: () => Effect.void
         }),
         Stream.either,
@@ -183,5 +187,17 @@ describe("Stream", () => {
       )
       const result = yield* $(Ref.get(ref))
       assert.strictEqual(result, 6)
+    }))
+
+  it.effect("tapStart", () =>
+    Effect.gen(function*($) {
+      let counter = 0
+      const result = yield* $(
+        Stream.make(1, 1),
+        Stream.tapStart(Effect.sync(() => counter++)),
+        Stream.runCollect
+      )
+      assert.strictEqual(counter, 1)
+      assert.deepStrictEqual(Array.from(result), [1, 1])
     }))
 })

--- a/packages/effect/test/Stream/tapping.test.ts
+++ b/packages/effect/test/Stream/tapping.test.ts
@@ -188,16 +188,4 @@ describe("Stream", () => {
       const result = yield* $(Ref.get(ref))
       assert.strictEqual(result, 6)
     }))
-
-  it.effect("tapStart", () =>
-    Effect.gen(function*($) {
-      let counter = 0
-      const result = yield* $(
-        Stream.make(1, 1),
-        Stream.tapStart(Effect.sync(() => counter++)),
-        Stream.runCollect
-      )
-      assert.strictEqual(counter, 1)
-      assert.deepStrictEqual(Array.from(result), [1, 1])
-    }))
 })


### PR DESCRIPTION
Not sure about name, maybe it should be `tapSubscribe`?

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


Implement `Stream.tapStart` that adds an effect to be executed at the start of the stream.

```ts
import { Console, Effect, Stream } from "effect";

const stream = Stream.make(1, 2, 3).pipe(
  Stream.tapStart(Console.log("Stream started")),
  Stream.map((n) => n * 2),
  Stream.tap((n) => Console.log(`after mapping: ${n}`))
) 

Effect. runPromise(Stream. runCollect(stream)).then(console. log) 
// Stream started 
// after mapping: 2 
// after mapping: 4 
// after mapping: 6 
// { _id: 'Chunk', values: [ 2, 4, 6 ] }
```
