### PR TITLE
Expose success and failure schemas on `TaggedRequestClass` interface,…

### DIFF
--- a/.changeset/young-onions-drum.md
+++ b/.changeset/young-onions-drum.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Expose success and failure schemas on `TaggedRequestClass` interface, closes #3331

--- a/packages/schema/dtslint/TaggedRequest.ts
+++ b/packages/schema/dtslint/TaggedRequest.ts
@@ -1,0 +1,21 @@
+import * as S from "@effect/schema/Schema"
+
+class TRA extends S.TaggedRequest<TRA>()("TRA", {
+  failure: S.String,
+  success: S.Number,
+  payload: {
+    id: S.Number
+  }
+}) {}
+
+// $ExpectType { readonly _tag: tag<"TRA">; readonly id: typeof Number$; }
+TRA.fields
+
+// $ExpectType "TRA"
+TRA._tag
+
+// $ExpectType typeof Number$
+TRA.success
+
+// $ExpectType typeof String$
+TRA.failure

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -7522,7 +7522,9 @@ export interface TaggedRequestClass<
   >
 {
   readonly _tag: Tag
+  /** @since 0.69.1 */
   readonly success: Success
+  /** @since 0.69.1 */
   readonly failure: Failure
 }
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -7522,6 +7522,8 @@ export interface TaggedRequestClass<
   >
 {
   readonly _tag: Tag
+  readonly success: Success
+  readonly failure: Failure
 }
 
 /**
@@ -7557,6 +7559,8 @@ export const TaggedRequest =
       annotations
     }) {
       static _tag = tag
+      static success = options.success
+      static failure = options.failure
       get [serializable_.symbol]() {
         return this.constructor
       }

--- a/packages/schema/test/Schema/Class/TaggedRequest.test.ts
+++ b/packages/schema/test/Schema/Class/TaggedRequest.test.ts
@@ -43,7 +43,7 @@ const IdNumber = S.Number.pipe(
 )
 
 describe("TaggedRequest", () => {
-  it("should expose the fields and the tag", () => {
+  it("should expose the fields, the tag, the success and the failure schema", () => {
     class TRA extends S.TaggedRequest<TRA>()("TRA", {
       failure: S.String,
       success: S.Number,
@@ -56,6 +56,8 @@ describe("TaggedRequest", () => {
       id: S.Number
     })
     expect(TRA._tag).toBe("TRA")
+    expect(TRA.success).toBe(S.Number)
+    expect(TRA.failure).toBe(S.String)
   })
 
   it("should expose the identifier", () => {


### PR DESCRIPTION
… closes #3331
