### PR TITLE
remove push trigger from snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,15 +1,12 @@
 name: Snapshot
-
 on:
   pull_request:
-    branches: [main, next-minor, next-major]
-  push:
     branches: [main, next-minor, next-major]
 
 jobs:
   snapshot:
     name: Snapshot
-    if: ${{ github.repository_owner == 'Effect-Ts' && github.event.pull_request }}
+    if: github.repository_owner == 'Effect-Ts'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
If we want to also publish snapshot for `main` we can do that, but then we need to set the condition differently (basically skip the commenting steps, but not the entire job)