### PR TITLE
add `NonEmptyTrimmedString`, `OptionFromNonEmptyTrimmedString`, close…

### DIFF
--- a/.changeset/tough-sheep-travel.md
+++ b/.changeset/tough-sheep-travel.md
@@ -1,0 +1,27 @@
+---
+"@effect/schema": patch
+---
+
+- add `NonEmptyTrimmedString`
+
+  **Example**
+
+  ```ts
+  import { Schema } from "@effect/schema"
+
+  console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)("")) // Option.none()
+  console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)(" a ")) // Option.none()
+  console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)("a")) // Option.some("a")
+  ```
+
+- add `OptionFromNonEmptyTrimmedString`, closes #3335
+
+  **Example**
+
+  ```ts
+  import { Schema } from "@effect/schema"
+
+  console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("")) // Option.none()
+  console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)(" a ")) // Option.some("a")
+  console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("a")) // Option.some("a")
+  ```

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -6927,6 +6927,25 @@ console.log(encode(Option.none())) // undefined
 console.log(encode(Option.some(1))) // "1"
 ```
 
+### OptionFromNonEmptyTrimmedString
+
+- **Decoding**
+
+  - `s` is converted to `Option.some(s)`, if `s.trim().length > 0`.
+  - `Option.none()` otherwise.
+
+- **Encoding**
+  - `Option.none()` is converted to `""`.
+  - `Option.some(s)` is converted to `s`.
+
+```ts
+import { Schema } from "@effect/schema"
+
+console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("")) // Option.none()
+console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)(" a ")) // Option.some("a")
+console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("a")) // Option.some("a")
+```
+
 ## Either
 
 ### Either

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4280,6 +4280,24 @@ export class Trimmed extends String$.pipe(
 ) {}
 
 /**
+ * Useful for validating strings that must contain meaningful characters without
+ * leading or trailing whitespace.
+ *
+ * @example
+ * import { Schema } from "@effect/schema"
+ *
+ * console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)("")) // Option.none()
+ * console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)(" a ")) // Option.none()
+ * console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)("a")) // Option.some("a")
+ *
+ * @category string constructors
+ * @since 0.69.2
+ */
+export class NonEmptyTrimmedString extends Trimmed.pipe(
+  nonEmptyString({ identifier: "NonEmptyTrimmedString", title: "NonEmptyTrimmedString" })
+) {}
+
+/**
  * This schema allows removing whitespaces from the beginning and end of a string.
  *
  * @category string transformations
@@ -6113,6 +6131,30 @@ export const OptionFromUndefinedOr = <Value extends Schema.Any>(
     encode: option_.getOrUndefined
   })
 }
+
+/**
+ * Transforms strings into an Option type, effectively filtering out empty or
+ * whitespace-only strings by trimming them and checking their length. Returns
+ * `none` for invalid inputs and `some` for valid non-empty strings.
+ *
+ * @example
+ * import { Schema } from "@effect/schema"
+ *
+ * console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("")) // Option.none()
+ * console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)(" a ")) // Option.some("a")
+ * console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("a")) // Option.some("a")
+ *
+ * @category Option transformations
+ * @since 0.69.2
+ */
+export const OptionFromNonEmptyTrimmedString = transform(String$, OptionFromSelf(NonEmptyTrimmedString), {
+  strict: true,
+  decode: (s) => {
+    const out = s.trim()
+    return out.length === 0 ? option_.none() : option_.some(out)
+  },
+  encode: option_.getOrElse(() => "")
+})
 
 /**
  * @category Either utils

--- a/packages/schema/test/Schema/Option/OptionFromNonEmptyTrimmedString.test.ts
+++ b/packages/schema/test/Schema/Option/OptionFromNonEmptyTrimmedString.test.ts
@@ -1,0 +1,43 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/TestUtils"
+import * as O from "effect/Option"
+import { describe, it } from "vitest"
+
+describe("OptionFromNonEmptyTrimmedString", () => {
+  it("property tests", () => {
+    Util.roundtrip(S.OptionFromNonEmptyTrimmedString)
+  })
+
+  it("decoding", async () => {
+    const schema = S.OptionFromNonEmptyTrimmedString
+    await Util.expectDecodeUnknownSuccess(schema, "", O.none())
+    await Util.expectDecodeUnknownSuccess(schema, "a", O.some("a"))
+    await Util.expectDecodeUnknownSuccess(schema, " ", O.none())
+    await Util.expectDecodeUnknownSuccess(schema, " a ", O.some("a"))
+
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      null,
+      `(string <-> Option<NonEmptyTrimmedString>)
+└─ Encoded side transformation failure
+   └─ Expected string, actual null`
+    )
+  })
+
+  it("encoding", async () => {
+    const schema = S.OptionFromNonEmptyTrimmedString
+    await Util.expectEncodeSuccess(schema, O.none(), "")
+    await Util.expectEncodeSuccess(schema, O.some("a"), "a")
+
+    await Util.expectEncodeFailure(
+      schema,
+      O.some(""),
+      `(string <-> Option<NonEmptyTrimmedString>)
+└─ Type side transformation failure
+   └─ Option<NonEmptyTrimmedString>
+      └─ NonEmptyTrimmedString
+         └─ Predicate refinement failure
+            └─ Expected NonEmptyTrimmedString, actual ""`
+    )
+  })
+})

--- a/packages/schema/test/Schema/String/NonEmptyTrimmedString.test.ts
+++ b/packages/schema/test/Schema/String/NonEmptyTrimmedString.test.ts
@@ -1,0 +1,58 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/TestUtils"
+import { describe, it } from "vitest"
+
+describe("NonEmptyTrimmedString", () => {
+  it("property tests", () => {
+    const schema = S.NonEmptyTrimmedString
+    Util.roundtrip(schema)
+  })
+
+  it("decoding", async () => {
+    const schema = S.NonEmptyTrimmedString
+    await Util.expectDecodeUnknownSuccess(schema, "a", "a")
+
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      " ",
+      `NonEmptyTrimmedString
+└─ From side refinement failure
+   └─ Trimmed
+      └─ Predicate refinement failure
+         └─ Expected Trimmed, actual " "`
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      " a ",
+      `NonEmptyTrimmedString
+└─ From side refinement failure
+   └─ Trimmed
+      └─ Predicate refinement failure
+         └─ Expected Trimmed, actual " a "`
+    )
+  })
+
+  it("encoding", async () => {
+    const schema = S.NonEmptyTrimmedString
+    await Util.expectEncodeSuccess(schema, "a", "a")
+
+    await Util.expectEncodeFailure(
+      schema,
+      " ",
+      `NonEmptyTrimmedString
+└─ From side refinement failure
+   └─ Trimmed
+      └─ Predicate refinement failure
+         └─ Expected Trimmed, actual " "`
+    )
+    await Util.expectEncodeFailure(
+      schema,
+      " a ",
+      `NonEmptyTrimmedString
+└─ From side refinement failure
+   └─ Trimmed
+      └─ Predicate refinement failure
+         └─ Expected Trimmed, actual " a "`
+    )
+  })
+})


### PR DESCRIPTION
…s #3335

- add `NonEmptyTrimmedString`

  **Example**

  ```ts
  import { Schema } from "@effect/schema"

  console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)("")) // Option.none()
  console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)(" a ")) // Option.none()
  console.log(Schema.decodeOption(Schema.NonEmptyTrimmedString)("a")) // Option.some("a")
  ```

- add `OptionFromNonEmptyTrimmedString`, closes #3335

  **Example**

  ```ts
  import { Schema } from "@effect/schema"

  console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("")) // Option.none()
  console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)(" a ")) // Option.some("a")
  console.log(Schema.decodeSync(Schema.OptionFromNonEmptyTrimmedString)("a")) // Option.some("a")
  ```
