### PR TITLE
docs: Bring e/sql docs up to date after recent module reorg.

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -17,12 +17,10 @@ const SqlLive = PgClient.layer({
 const program = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient
 
-  const people = yield* _(
-    sql<{
-      readonly id: number
-      readonly name: string
-    }>`SELECT id, name FROM people`
-  )
+  const people = yield* sql<{
+    readonly id: number
+    readonly name: string
+  }>`SELECT id, name FROM people`
 
   yield* Effect.log(`Got ${people.length} results!`)
 })
@@ -258,10 +256,10 @@ export const make = (names: string[], cursor: Date) =>
 
 ```ts
 import { Effect } from "effect"
-import { SqlClient } from '@effect/sql'
+import { SqlClient } from "@effect/sql"
 
 export const make = (names: string[], afterCursor: Date, beforeCursor: Date) =>
-  Effect.gen(function* _) {
+  Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
 
     const statement = sql`SELECT * FROM people WHERE ${sql.or([

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -81,15 +81,15 @@ Or you can rename the `sqlfx_migrations` table to `effect_sql_migrations`.
 
 #### The resolver & schema apis have moved
 
-- `sql.resolver` -> `Sql.SqlResolver.ordered`
-- `sql.resolverVoid` -> `Sql.SqlResolver.void`
-- `sql.resolverId` -> `Sql.SqlResolver.findById`
-- `sql.resolverIdMany` -> `Sql.SqlResolver.grouped`
+- `sql.resolver` -> `SqlResolver.ordered`
+- `sql.resolverVoid` -> `SqlResolver.void`
+- `sql.resolverId` -> `SqlResolver.findById`
+- `sql.resolverIdMany` -> `SqlResolver.grouped`
 - `sql.resolverSingle*` has been removed in favour of using the `effect/Cache` module with the schema apis
-- `sql.schema` -> `Sql.SqlShema.findAll`
-- `sql.schemaSingle` -> `Sql.SqlSchema.single`
-- `sql.schemaSingleOption` -> `Sql.SqlSchema.findOne`
-- `sql.schemaVoid` -> `Sql.SqlSchema.void`
+- `sql.schema` -> `SqlSchema.findAll`
+- `sql.schemaSingle` -> `SqlSchema.single`
+- `sql.schemaSingleOption` -> `SqlSchema.findOne`
+- `sql.schemaVoid` -> `SqlSchema.void`
 
 #### The array helper has moved
 

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -198,7 +198,7 @@ export const make = (limit: number) =>
 ### Unsafe interpolation
 
 ```ts
-import { Effect } from "effect/Effect"
+import { Effect } from "effect"
 import { SqlClient } from "@effect/sql"
 
 type OrderBy = "id" | "created_at" | "updated_at"

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -6,7 +6,6 @@ A SQL toolkit for Effect.
 
 ```ts
 import { Config, Effect, Struct, pipe } from "effect"
-import * as Sql from "@effect/sql"
 import { PgClient } from "@effect/sql-pg"
 import { SqlClient } from "@effect/sql"
 

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -37,9 +37,9 @@ For example, to create the client Layer, instead of:
 
 ```ts
 import { Config } from "effect"
-import * as Pg from "@sqlfx/pg"
+import { PgClient } from "@sqlfx/pg"
 
-const SqlLive = Pg.makeLayer({
+const SqlLive = PgClient.makeLayer({
   database: Config.succeed("effect_pg_dev")
 })
 ```
@@ -198,7 +198,7 @@ export const make = (limit: number) =>
 ### Unsafe interpolation
 
 ```ts
-import * as Effect from "effect/Effect"
+import { Effect } from "effect/Effect"
 import { SqlClient } from "@effect/sql"
 
 type OrderBy = "id" | "created_at" | "updated_at"


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

Simply updating the `e/sql` docs to reflect the recent move of namespaces.

I realised I used some variations of imports. I thought it could be useful for people to know. Happy to stick to a consistent blessed import style if required though, just let me know.

## Related
This is the follow on from #3035

- Related Issue #3035 
