### PR TITLE
Improve annotation retrieval from `Class` APIs, closes #3348

### DIFF
--- a/.changeset/loud-colts-joke.md
+++ b/.changeset/loud-colts-joke.md
@@ -1,0 +1,23 @@
+---
+"@effect/schema": patch
+---
+
+Improve annotation retrieval from `Class` APIs, closes #3348.
+
+Previously, accessing annotations such as `identifier` and `title` required explicit casting of the `ast` field to `AST.Transformation`.
+This update refines the type definitions to reflect that `ast` is always an `AST.Transformation`, eliminating the need for casting and simplifying client code.
+
+```ts
+import { AST, Schema } from "@effect/schema"
+
+class Person extends Schema.Class<Person>("Person")(
+  {
+    name: Schema.String,
+    age: Schema.Number
+  },
+  { description: "my description" }
+) {}
+
+console.log(AST.getDescriptionAnnotation(Person.ast.to))
+// { _id: 'Option', _tag: 'Some', value: 'my description' }
+```

--- a/packages/schema/dtslint/Class.ts
+++ b/packages/schema/dtslint/Class.ts
@@ -61,6 +61,11 @@ checkForConflicts({ from: S.Struct({ a: S.String }).pipe(S.filter(() => true), S
 
 class NoFields extends S.Class<NoFields>("NoFields")({}) {}
 
+// the ast should be a AST.Transformation
+
+// $ExpectType Transformation
+NoFields.ast
+
 // $ExpectType [props?: void | {}, options?: MakeOptions | undefined]
 hole<ConstructorParameters<typeof NoFields>>()
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -7208,6 +7208,9 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
     options?: MakeOptions
   ): Struct.Type<Fields> & Omit<Inherited, keyof Fields> & Proto
 
+  /** @since 0.69.3 */
+  readonly ast: AST.Transformation
+
   make<Args extends Array<any>, X>(this: { new(...args: Args): X }, ...args: Args): X
 
   annotations(annotations: Annotations.Schema<Self>): SchemaClass<Self, Simplify<I>, R>


### PR DESCRIPTION
Previously, accessing annotations such as `identifier` and `title` required explicit casting of the `ast` field to `AST.Transformation`.
This update refines the type definitions to reflect that `ast` is always an `AST.Transformation`, eliminating the need for casting and simplifying client code.

```ts
import { AST, Schema } from "@effect/schema"

class Person extends Schema.Class<Person>("Person")(
  {
    name: Schema.String,
    age: Schema.Number
  },
  { description: "my description" }
) {}

console.log(AST.getDescriptionAnnotation(Person.ast.to))
// { _id: 'Option', _tag: 'Some', value: 'my description' }
```
