### PR TITLE
increase max-old-space-size manually for tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Test
         run: pnpm vitest --shard ${{ matrix.shard }}
         if: matrix.runtime == 'Node'
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
       - name: Test
         run: bun vitest --shard ${{ matrix.shard }}
         if: matrix.runtime == 'Bun'


### PR DESCRIPTION
There's no mention in the docs of any gc & memory issues with fork pooling (which we use [default]) but I found some user reports that this had a positive impact. The GitHub hosted CI runners have 16gb of available memory so going with 8 for the old-space size should be fine.

Not sure if this helps with the random test failures. But it's worth a shot.

It should also be possible to more specifically set this in vitest config (`poolOptions`), but it should also be forwarded from the parent node options.

It's hard to tell whether the memory issue lies in the main process or the forked child processes for test isolation. It's probably more likely that it's the forks though. But whether it's a random memory leak within our test suite itself (seems unlikely because it so randomly appears in different locations) or with ESM module caches or sth. like that is still unclear to me.