### PR TITLE
Fix typo about do notation documentation

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3419,7 +3419,7 @@ export const updateService: {
 // -------------------------------------------------------------------------------------
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -3449,7 +3449,7 @@ export const updateService: {
 export const Do: Effect<{}> = effect.Do
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -3489,7 +3489,7 @@ export const bind: {
 } = effect.bind
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -3535,7 +3535,7 @@ const let_: {
 
 export {
   /**
-   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+   * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
    * Here's how the do simulation works:
    *

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -791,7 +791,7 @@ export const gen: Gen.Gen<EitherTypeLambda, Gen.Adapter<EitherTypeLambda>> = (..
 // -------------------------------------------------------------------------------------
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -821,7 +821,7 @@ export const gen: Gen.Gen<EitherTypeLambda, Gen.Adapter<EitherTypeLambda>> = (..
 export const Do: Either<{}> = right({})
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -861,7 +861,7 @@ export const bind: {
 } = doNotation.bind<EitherTypeLambda>(map, flatMap)
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -907,7 +907,7 @@ const let_: {
 
 export {
   /**
-   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+   * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
    * Here's how the do simulation works:
    *

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -1196,7 +1196,7 @@ export const exists: {
 // -------------------------------------------------------------------------------------
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -1244,7 +1244,7 @@ const let_: {
 
 export {
   /**
-   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+   * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
    * Here's how the do simulation works:
    *
@@ -1277,7 +1277,7 @@ export {
 }
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -1319,7 +1319,7 @@ export const bind: {
 } = doNotation.bind<OptionTypeLambda>(map, flatMap)
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -5676,11 +5676,11 @@ export const zipWithPreviousAndNext: <A, E, R>(
 export const zipWithIndex: <A, E, R>(self: Stream<A, E, R>) => Stream<[A, number], E, R> = internal.zipWithIndex
 
 // -------------------------------------------------------------------------------------
-// Do notation
+// do notation
 // -------------------------------------------------------------------------------------
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -5711,7 +5711,7 @@ export const zipWithIndex: <A, E, R>(self: Stream<A, E, R>) => Stream<[A, number
 export const Do: Stream<{}> = internal.Do
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -5787,7 +5787,7 @@ export const bindEffect: {
 } = _groupBy.bindEffect
 
 /**
- * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+ * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
  *
  * Here's how the do simulation works:
  *
@@ -5834,7 +5834,7 @@ const let_: {
 
 export {
   /**
-   * The "do simulation" in allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
+   * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.
    *
    * Here's how the do simulation works:
    *


### PR DESCRIPTION
Just fixing a typo about the do notation documentation.