### PR TITLE
Fix `Effect.repeat` with times option returning wrong value

### DIFF
--- a/.changeset/dull-horses-flash.md
+++ b/.changeset/dull-horses-flash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.repeat` with times option returns wrong value

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -1844,7 +1844,7 @@ export const repeat_combined = dual<{
       }) :
       withWhile
     const withTimes = options.times ?
-      intersect(withUntil, recurs(options.times)) :
+      intersect(withUntil, recurs(options.times)).pipe(map((intersectionPair) => intersectionPair[0])) :
       withUntil
 
     return scheduleDefectRefail(repeat_Effect(self, withTimes))

--- a/packages/effect/test/Effect/repeating.test.ts
+++ b/packages/effect/test/Effect/repeating.test.ts
@@ -140,4 +140,19 @@ describe("Effect", () => {
       const result = yield* $(Ref.get(ref))
       assert.strictEqual(result, 3)
     }))
+
+  it.effect("repeat/times ", () =>
+    Effect.gen(function*($) {
+      const ref = yield* $(Ref.make<Array<number>>([]))
+      const effectResult = yield* $(
+        Ref.updateAndGet(ref, (arr) => {
+          arr.push(arr.length)
+          return arr
+        }),
+        Effect.repeat({ times: 2 })
+      )
+      const result = yield* $(Ref.get(ref))
+      assert.deepStrictEqual(result, [0, 1, 2])
+      assert.deepStrictEqual(effectResult, [0, 1, 2])
+    }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue # https://github.com/Effect-TS/effect/issues/3403
- Closes # https://github.com/Effect-TS/effect/issues/3403
