### PR TITLE
interrupt effect when test finishes

### DIFF
--- a/.changeset/wild-sheep-pay.md
+++ b/.changeset/wild-sheep-pay.md
@@ -1,0 +1,32 @@
+---
+"@effect/vitest": patch
+---
+
+Interrupt an effect when a test finishes. This ensures allocated resources
+will be correctly released even if the test times out.
+
+```ts
+import { it } from "@effect/vitest"
+import { Console, Effect, Layer } from "effect"
+
+class Database extends Effect.Tag("Database")<Database, {}>() {
+  static readonly test = Layer.scoped(
+    Database,
+    Effect.acquireRelease(
+      Effect.as(Console.log("database setup"), Database.of({})),
+      () => Console.log("database teardown")
+    )
+  )
+}
+
+it.live(
+  "testing with closable resources",
+  () =>
+    Effect.gen(function* () {
+      const database = yield* Database
+      // performing some time consuming operations
+      yield* Effect.sleep("500 millis")
+    }).pipe(Effect.provide(Database.test)),
+  { timeout: 100 }
+)
+```

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -65,3 +65,22 @@ it.effect.skipIf(false)("effect skipIf (false)", () => Effect.sync(() => expect(
 
 it.effect.runIf(true)("effect runIf (true)", () => Effect.sync(() => expect(1).toEqual(1)))
 it.effect.runIf(false)("effect runIf (false)", () => Effect.die("not run anyway"))
+
+// The following test is expected to fail because it simulates a test timeout.
+// Be aware that eventual "failure" of the test is only logged out.
+it.scopedLive("interrupts on timeout", (ctx) =>
+  Effect.gen(function*() {
+    let acquired = false
+
+    ctx.onTestFailed(() => {
+      if (acquired) {
+        console.error("'effect is interrupted on timeout' @effect/vitest test failed")
+      }
+    })
+
+    yield* Effect.acquireRelease(
+      Effect.sync(() => acquired = true),
+      () => Effect.sync(() => acquired = false)
+    )
+    yield* Effect.sleep(1000)
+  }), { timeout: 100, fails: true })


### PR DESCRIPTION
Note: the `onTestFinished` is not invoked in case of SIGINT. I don't think we can / should do something about it in here, I'll check what can be done on the vitest side.