### PR TITLE
Fix return types for `attachPropertySignature` function

### DIFF
--- a/.changeset/beige-eyes-sleep.md
+++ b/.changeset/beige-eyes-sleep.md
@@ -1,0 +1,7 @@
+---
+"@effect/schema": patch
+---
+
+Fix return types for `attachPropertySignature` function.
+
+This commit addresses an inconsistency in the return types between the curried and non-curried versions of the `attachPropertySignature` function. Previously, the curried version returned a `Schema`, while the non-curried version returned a `SchemaClass`.

--- a/packages/schema/dtslint/Context.ts
+++ b/packages/schema/dtslint/Context.ts
@@ -320,8 +320,11 @@ S.transform(aContext, bContext, { decode: () => 1, encode: () => "" })
 // attachPropertySignature
 // ---------------------------------------------
 
-// $ExpectType Schema<{ readonly a: string; readonly _tag: "A"; }, { readonly a: string; }, "aContext">
+// $ExpectType SchemaClass<{ readonly a: string; readonly _tag: "A"; }, { readonly a: string; }, "aContext">
 S.Struct({ a: aContext }).pipe(S.attachPropertySignature("_tag", "A"))
+
+// $ExpectType SchemaClass<{ readonly a: string; readonly _tag: "A"; }, { readonly a: string; }, "aContext">
+S.attachPropertySignature(S.Struct({ a: aContext }), "_tag", "A")
 
 // ---------------------------------------------
 // annotations (method)

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -1204,18 +1204,24 @@ S.TemplateLiteral(S.Union(EmailLocaleIDs, FooterLocaleIDs), "_id")
 // attachPropertySignature
 // ---------------------------------------------
 
-// $ExpectType Schema<{ readonly radius: number; readonly kind: "circle"; }, { readonly radius: number; }, never>
+// $ExpectType SchemaClass<{ readonly radius: number; readonly kind: "circle"; }, { readonly radius: number; }, never>
 pipe(S.Struct({ radius: S.Number }), S.attachPropertySignature("kind", "circle"))
 
-// $ExpectType Schema<{ readonly radius: number; readonly kind: "circle"; }, { readonly radius: string; }, never>
+// $ExpectType SchemaClass<{ readonly radius: number; readonly kind: "circle"; }, { readonly radius: string; }, never>
 pipe(S.Struct({ radius: S.NumberFromString }), S.attachPropertySignature("kind", "circle"))
+
+// $ExpectType SchemaClass<{ readonly radius: number; readonly kind: "circle"; }, { readonly radius: number; }, never>
+S.attachPropertySignature(S.Struct({ radius: S.Number }), "kind", "circle")
+
+// $ExpectType SchemaClass<{ readonly radius: number; readonly kind: "circle"; }, { readonly radius: string; }, never>
+S.attachPropertySignature(S.Struct({ radius: S.NumberFromString }), "kind", "circle")
 
 const taggedStruct = <Name extends AST.LiteralValue | symbol, Fields extends S.Struct.Fields>(
   name: Name,
   fields: Fields
 ) => S.Struct(fields).pipe(S.attachPropertySignature("_tag", name))
 
-// $ExpectType Schema<{ readonly a: string; readonly _tag: "A"; }, { readonly a: string; }, never>
+// $ExpectType SchemaClass<{ readonly a: string; readonly _tag: "A"; }, { readonly a: string; }, never>
 taggedStruct("A", { a: S.String })
 
 // ---------------------------------------------

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -3763,7 +3763,7 @@ export const attachPropertySignature: {
     annotations?: Annotations.Schema<Simplify<A & { readonly [k in K]: V }>>
   ): <I, R>(
     schema: SchemaClass<A, I, R>
-  ) => Schema<Simplify<A & { readonly [k in K]: V }>, I, R>
+  ) => SchemaClass<Simplify<A & { readonly [k in K]: V }>, I, R>
   <A, I, R, K extends PropertyKey, V extends AST.LiteralValue | symbol>(
     schema: Schema<A, I, R>,
     key: K,


### PR DESCRIPTION
This commit addresses an inconsistency in the return types between the curried and non-curried versions of the `attachPropertySignature` function. Previously, the curried version returned a `Schema`, while the non-curried version returned a `SchemaClass`.
