### PR TITLE
ensure fiber is properly cleared in FiberHandle.unsafeSet

### DIFF
--- a/.changeset/nice-ligers-notice.md
+++ b/.changeset/nice-ligers-notice.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+ensure fiber is properly cleared in FiberHandle.unsafeSet

--- a/packages/effect/src/FiberHandle.ts
+++ b/packages/effect/src/FiberHandle.ts
@@ -184,7 +184,7 @@ export const unsafeSet: {
       return
     }
     self.state.fiber.unsafeInterruptAsFork(options?.interruptAs ?? FiberId.none)
-    self.state.fiber === undefined
+    self.state.fiber = undefined
   }
 
   ;(fiber as FiberRuntime<unknown, unknown>).setFiberRef(FiberRef.unhandledErrorLogLevel, Option.none())


### PR DESCRIPTION
This was caught by this TS experiment I'm running: https://github.com/microsoft/TypeScript/pull/59559 . I believe this to be the correct change :P