### PR TITLE
Introduced `RandomScheduler`

### DIFF
--- a/.changeset/cyan-coats-peel.md
+++ b/.changeset/cyan-coats-peel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Introduced `RandomScheduler`

--- a/.changeset/cyan-coats-peel.md
+++ b/.changeset/cyan-coats-peel.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Introduced `RandomScheduler`

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -249,35 +249,35 @@ export class ControlledScheduler implements Scheduler {
  * `RandomScheduler` can be seeded for reproducibility.
  *
  * @see MixedScheduler
- * @since 3.6.4
+ * @since 3.7.0
  * @category constructors
  */
 export class RandomScheduler implements Scheduler {
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   running = false
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   readonly tasks = new PriorityBuckets()
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   readonly maxNextTickBeforeTimer: number
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   readonly PRNG: Utils.PCGRandom
 
   constructor(
     options?: {
       /**
-       * @since 3.6.4
+       * @since 3.7.0
        */
       readonly seed?: unknown
       /**
-       * @since 3.6.4
+       * @since 3.7.0
        */
       readonly maxNextTickBeforeTimer?: number | undefined
     } | undefined
@@ -287,7 +287,7 @@ export class RandomScheduler implements Scheduler {
   }
 
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   private starveInternal(depth: number) {
     const tasks = this.tasks.buckets
@@ -307,7 +307,7 @@ export class RandomScheduler implements Scheduler {
   }
 
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   private starve(depth = 0) {
     if (depth >= this.maxNextTickBeforeTimer) {
@@ -318,14 +318,14 @@ export class RandomScheduler implements Scheduler {
   }
 
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   shouldYield(fiber: RuntimeFiber<unknown, unknown>) {
     return defaultShouldYield(fiber)
   }
 
   /**
-   * @since 3.6.4
+   * @since 3.7.0
    */
   scheduleTask(task: Task, priority: number) {
     this.tasks.scheduleTask(task, priority)

--- a/packages/effect/test/Effect/scheduler.test.ts
+++ b/packages/effect/test/Effect/scheduler.test.ts
@@ -1,6 +1,12 @@
+import * as Array from "effect/Array"
+import * as Chunk from "effect/Chunk"
 import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Random from "effect/Random"
+import * as Ref from "effect/Ref"
 import * as Scheduler from "effect/Scheduler"
 import * as it from "effect/test/utils/extend"
+import * as fc from "fast-check"
 import { assert, describe } from "vitest"
 
 describe("Effect", () => {
@@ -71,4 +77,79 @@ describe("Effect", () => {
       assert.deepEqual(ps100, [100, 100])
       assert.deepEqual(ps200, [200])
     }))
+
+  describe("RandomScheduler", () => {
+    it.effect("executes randomly", () =>
+      Effect.gen(function*() {
+        const execOrderRef = yield* Ref.make<Array<number>>([])
+
+        const testEffect = (value: number) =>
+          execOrderRef.pipe(
+            Ref.update((x) => {
+              x.push(value)
+              return x
+            })
+          )
+
+        yield* Effect.all(
+          Array.makeBy(6, testEffect),
+          { concurrency: "unbounded" }
+        ).pipe(
+          Effect.withScheduler(new Scheduler.RandomScheduler({ seed: 108 }))
+        )
+
+        const execOrder = yield* Ref.get(execOrderRef)
+
+        assert.deepEqual(execOrder, [0, 5, 2, 4, 3, 1])
+      }))
+
+    it.it("respects priority", () =>
+      fc.assert(fc.asyncProperty(
+        fc.integer(),
+        fc.integer(),
+        fc.integer(),
+        fc.integer({
+          min: 1,
+          max: 5
+        }),
+        (priority1, priority2, priority3, replicateCount) =>
+          Effect.gen(function*() {
+            const execOrderRef = yield* Ref.make<Array<number>>([])
+
+            const createEffectWithPriority = (priority: number) =>
+              Effect.yieldNow().pipe(
+                Effect.andThen(
+                  Ref.update(execOrderRef, (x) => {
+                    x.push(priority)
+                    return x
+                  })
+                ),
+                Effect.withSchedulingPriority(priority)
+              )
+            const priorities = [priority1, priority2, priority3]
+            const testEffects = yield* pipe(
+              priorities,
+              Array.map((x) => createEffectWithPriority(x)),
+              Array.replicate(replicateCount),
+              Array.flatten,
+              Random.shuffle,
+              Effect.andThen(Chunk.toReadonlyArray)
+            )
+
+            yield* Effect.all(testEffects, { concurrency: "unbounded" })
+              .pipe(
+                Effect.withScheduler(new Scheduler.RandomScheduler())
+              )
+
+            const execOrder = yield* Ref.get(execOrderRef)
+
+            assert.equal(
+              execOrder.length,
+              priorities.length * replicateCount
+            )
+
+            assert.deepEqual(execOrder, [...execOrder].sort((a, b) => a - b))
+          }).pipe(Effect.runPromise)
+      )))
+  })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

 Same as `MixedScheduler`, but performs tasks with the same priority randomly
 
 It is useful in scenarios where you want to introduce non-deterministic behavior in task execution while still
 ensuring that higher-priority tasks are generally executed before lower-priority ones.
 Uses a Pseudo-Random Number Generator (PRNG) for selecting the next task to execute within a tasks with the same priority.
 `RandomScheduler` can be seeded for reproducibility.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
