### PR TITLE
Add support for obtaining raw SQL query results from the underlying SQL client

### DIFF
--- a/.changeset/metal-geese-move.md
+++ b/.changeset/metal-geese-move.md
@@ -1,0 +1,59 @@
+---
+"@effect/sql-sqlite-react-native": minor
+"@effect/sql-sqlite-node": minor
+"@effect/sql-sqlite-wasm": minor
+"@effect/sql-sqlite-bun": minor
+"@effect/sql-mysql2": minor
+"@effect/sql-mssql": minor
+"@effect/sql-d1": minor
+"@effect/sql-pg": minor
+"@effect/sql": minor
+---
+
+Add support for executing raw SQL queries with the underlying SQL client.
+
+This is primarily useful when the SQL client returns special results for certain
+query types.
+
+For example, because MySQL does not support the `RETURNING` clause, the `mysql2`
+client will return a [`ResultSetHeader`](https://sidorares.github.io/node-mysql2/docs/documentation/typescript-examples#resultsetheader)
+for `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` operations.
+
+To gain access to the raw results of a query, you can use the `.raw` property on
+the `Statement`:
+
+```ts
+import * as Effect from "effect/Effect"
+import * as SqlClient from "@effect/sql/SqlClient"
+import * as MysqlClient from "@effect/sql/MysqlClient"
+
+const DatabaseLive = MysqlClient.layer({
+  database: Config.succeed("database"),
+  username: Config.succeed("root"),
+  password: Config.succeed(Redacted.make("password")),
+})
+
+const program = Effect.gen(function*() {
+  const sql = yield* SqlClient.SqlClient
+
+  const result = yield* sql`INSERT INTO usernames VALUES ("Bob")`.raw
+
+  console.log(result)
+  /**
+   * ResultSetHeader {
+   *   fieldCount: 0,
+   *   affectedRows: 1,
+   *   insertId: 0,
+   *   info: '',
+   *   serverStatus: 2,
+   *   warningStatus: 0,
+   *   changedRows: 0
+   * }
+   */
+})
+
+program.pipe(
+  Effect.provide(DatabaseLive),
+  Effect.runPromise
+)
+```

--- a/packages/sql-mssql/src/MssqlClient.ts
+++ b/packages/sql-mssql/src/MssqlClient.ts
@@ -260,13 +260,16 @@ export const make = (
         execute(sql, params) {
           return run(sql, params)
         },
+        executeRaw(sql, params) {
+          return run(sql, params, false)
+        },
         executeWithoutTransform(sql, params) {
           return run(sql, params, false)
         },
         executeValues(sql, params) {
           return run(sql, params, true, true)
         },
-        executeRaw(sql, params) {
+        executeUnprepared(sql, params) {
           return run(sql, params)
         },
         executeStream() {

--- a/packages/sql-mysql2/src/MysqlClient.ts
+++ b/packages/sql-mysql2/src/MysqlClient.ts
@@ -89,7 +89,7 @@ export const make = (
     class ConnectionImpl implements Connection {
       constructor(private readonly conn: Mysql.PoolConnection | Mysql.Pool) {}
 
-      private runUnprepared(
+      private runRaw(
         sql: string,
         values?: ReadonlyArray<any>,
         rowsAsArray = false,
@@ -117,7 +117,7 @@ export const make = (
         rowsAsArray = false,
         method: "execute" | "query" = "execute"
       ) {
-        return this.runUnprepared(sql, values, rowsAsArray, method).pipe(
+        return this.runRaw(sql, values, rowsAsArray, method).pipe(
           Effect.map((results) => {
             if (transform && !rowsAsArray && options.transformResultNames) {
               return transformRows(results as ReadonlyArray<any>)
@@ -131,7 +131,7 @@ export const make = (
         return this.run(sql, params)
       }
       executeRaw(sql: string, params: ReadonlyArray<Statement.Primitive>) {
-        return this.runUnprepared(sql, params, true)
+        return this.runRaw(sql, params, true)
       }
       executeWithoutTransform(sql: string, params: ReadonlyArray<Statement.Primitive>) {
         return this.run(sql, params, false)

--- a/packages/sql-pg/src/PgClient.ts
+++ b/packages/sql-pg/src/PgClient.ts
@@ -192,13 +192,16 @@ export const make = (
       execute(sql: string, params: ReadonlyArray<Primitive>) {
         return this.runTransform(this.pg.unsafe(sql, params as any))
       }
+      executeRaw(sql: string, params: ReadonlyArray<Primitive>) {
+        return this.run(this.pg.unsafe(sql, params as any))
+      }
       executeWithoutTransform(sql: string, params: ReadonlyArray<Primitive>) {
         return this.run(this.pg.unsafe(sql, params as any))
       }
       executeValues(sql: string, params: ReadonlyArray<Primitive>) {
         return this.run(this.pg.unsafe(sql, params as any).values())
       }
-      executeRaw(sql: string, params?: ReadonlyArray<Primitive>) {
+      executeUnprepared(sql: string, params?: ReadonlyArray<Primitive>) {
         return this.runTransform(this.pg.unsafe(sql, params as any))
       }
       executeStream(sql: string, params: ReadonlyArray<Primitive>) {

--- a/packages/sql-sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql-sqlite-bun/src/SqliteClient.ts
@@ -120,13 +120,16 @@ export const make = (
         execute(sql, params) {
           return runTransform(sql, params)
         },
+        executeRaw(sql, params) {
+          return run(sql, params)
+        },
         executeValues(sql, params) {
           return runValues(sql, params)
         },
         executeWithoutTransform(sql, params) {
           return run(sql, params)
         },
-        executeRaw(sql, params) {
+        executeUnprepared(sql, params) {
           return runTransform(sql, params)
         },
         executeStream(_sql, _params) {

--- a/packages/sql-sqlite-node/src/SqliteClient.ts
+++ b/packages/sql-sqlite-node/src/SqliteClient.ts
@@ -136,7 +136,7 @@ export const make = (
         params: ReadonlyArray<Statement.Primitive> = []
       ) => Effect.flatMap(prepareCache.get(sql), (s) => runStatement(s, params))
 
-      const runRaw = (
+      const runUnprepared = (
         sql: string,
         params: ReadonlyArray<Statement.Primitive> = []
       ) => Effect.map(runStatement(db.prepare(sql), params), transformRows)
@@ -172,14 +172,17 @@ export const make = (
         execute(sql, params) {
           return runTransform(sql, params)
         },
+        executeRaw(sql, params) {
+          return run(sql, params)
+        },
         executeValues(sql, params) {
           return runValues(sql, params)
         },
         executeWithoutTransform(sql, params) {
           return run(sql, params)
         },
-        executeRaw(sql, params) {
-          return runRaw(sql, params)
+        executeUnprepared(sql, params) {
+          return runUnprepared(sql, params)
         },
         executeStream(_sql, _params) {
           return Effect.dieMessage("executeStream not implemented")

--- a/packages/sql-sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql-sqlite-react-native/src/SqliteClient.ts
@@ -149,6 +149,9 @@ export const make = (
         execute(sql, params) {
           return runTransform(sql, params)
         },
+        executeRaw(sql, params) {
+          return run(sql, params)
+        },
         executeValues(sql, params) {
           return Effect.map(run(sql, params), (results) => {
             if (results.length === 0) {
@@ -161,7 +164,7 @@ export const make = (
         executeWithoutTransform(sql, params) {
           return run(sql, params)
         },
-        executeRaw(sql, params) {
+        executeUnprepared(sql, params) {
           return runTransform(sql, params)
         },
         executeStream() {

--- a/packages/sql-sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql-sqlite-wasm/src/SqliteClient.ts
@@ -132,13 +132,16 @@ export const make = (
         execute(sql, params) {
           return runTransform(sql, params)
         },
+        executeRaw(sql, params) {
+          return run(sql, params)
+        },
         executeValues(sql, params) {
           return run(sql, params, "array")
         },
         executeWithoutTransform(sql, params) {
           return run(sql, params)
         },
-        executeRaw(sql, params) {
+        executeUnprepared(sql, params) {
           return runTransform(sql, params)
         },
         executeStream() {

--- a/packages/sql/src/SqlConnection.ts
+++ b/packages/sql/src/SqlConnection.ts
@@ -18,6 +18,15 @@ export interface Connection {
     params: ReadonlyArray<Primitive>
   ) => Effect<ReadonlyArray<any>, SqlError>
 
+  /**
+   * Execute the specified SQL query and return the raw results directly from
+   * underlying SQL client.
+   */
+  readonly executeRaw: (
+    sql: string,
+    params: ReadonlyArray<Primitive>
+  ) => Effect<unknown, SqlError>
+
   readonly executeStream: (
     sql: string,
     params: ReadonlyArray<Primitive>
@@ -33,7 +42,7 @@ export interface Connection {
     params: ReadonlyArray<Primitive>
   ) => Effect<ReadonlyArray<ReadonlyArray<Primitive>>, SqlError>
 
-  readonly executeRaw: (
+  readonly executeUnprepared: (
     sql: string,
     params?: ReadonlyArray<Primitive> | undefined
   ) => Effect<ReadonlyArray<any>, SqlError>

--- a/packages/sql/src/Statement.ts
+++ b/packages/sql/src/Statement.ts
@@ -45,6 +45,7 @@ export type Dialect = "sqlite" | "pg" | "mysql" | "mssql"
  * @since 1.0.0
  */
 export interface Statement<A> extends Fragment, Effect<ReadonlyArray<A>, SqlError>, Pipeable {
+  readonly raw: Effect<unknown, SqlError>
   readonly withoutTransform: Effect<ReadonlyArray<A>, SqlError>
   readonly stream: Stream.Stream<A, SqlError>
   readonly values: Effect<ReadonlyArray<ReadonlyArray<Primitive>>, SqlError>

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -133,7 +133,8 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
   get raw(): Effect.Effect<unknown, Error.SqlError> {
     return this.withConnection(
       "executeRaw",
-      (connection, sql, params) => connection.executeRaw(sql, params)
+      (connection, sql, params) => connection.executeRaw(sql, params),
+      true
     )
   }
 

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -130,6 +130,13 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
     )
   }
 
+  get raw(): Effect.Effect<unknown, Error.SqlError> {
+    return this.withConnection(
+      "executeRaw",
+      (connection, sql, params) => connection.executeRaw(sql, params)
+    )
+  }
+
   get stream(): Stream.Stream<A, Error.SqlError> {
     return Stream.unwrapScoped(Effect.flatMap(
       Effect.makeSpanScoped("sql.execute", { kind: "client", captureStackTrace: false }),
@@ -154,7 +161,10 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
   }
 
   get unprepared(): Effect.Effect<ReadonlyArray<A>, Error.SqlError> {
-    return this.withConnection("executeRaw", (connection, sql, params) => connection.executeRaw(sql, params))
+    return this.withConnection(
+      "executeUnprepared",
+      (connection, sql, params) => connection.executeUnprepared(sql, params)
+    )
   }
 
   compile(withoutTransform?: boolean | undefined) {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds support for executing raw SQL queries with the underlying SQL client.

This is primarily useful when the SQL client returns special results for certain query types.

For example, because MySQL does not support the `RETURNING` clause, the `mysql2` client will return a [`ResultSetHeader`](https://sidorares.github.io/node-mysql2/docs/documentation/typescript-examples#resultsetheader) for `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` operations.

To gain access to the raw results of a query, you can use the `.raw` property on the `Statement`:

```ts
import * as Effect from "effect/Effect"
import * as SqlClient from "@effect/sql/SqlClient"
import * as MysqlClient from "@effect/sql/MysqlClient"

const DatabaseLive = MysqlClient.layer({
  database: Config.succeed("database"),
  username: Config.succeed("root"),
  password: Config.succeed(Redacted.make("password")),
})

const program = Effect.gen(function*() {
  const sql = yield* SqlClient.SqlClient

  const result = yield* sql`INSERT INTO usernames VALUES ("Bob")`.raw

  console.log(result)
  /**
   * ResultSetHeader {
   *   fieldCount: 0,
   *   affectedRows: 1,
   *   insertId: 0,
   *   info: '',
   *   serverStatus: 2,
   *   warningStatus: 0,
   *   changedRows: 0
   * }
   */
})

program.pipe(
  Effect.provide(DatabaseLive),
  Effect.runPromise
)
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
