### PR TITLE
ensure makeZonedFromString supports 00:00 offset

### DIFF
--- a/.changeset/selfish-plants-flow.md
+++ b/.changeset/selfish-plants-flow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix `DateTime.makeZonedFromString` for 0 offset

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -562,7 +562,7 @@ export const makeZonedFromString = (input: string): Option.Option<Zoned> => {
   const match = zonedStringRegex.exec(input)
   if (match === null) {
     const offset = parseOffset(input)
-    return offset ? makeZoned(input, { timeZone: offset }) : Option.none()
+    return offset !== null ? makeZoned(input, { timeZone: offset }) : Option.none()
   }
   const [, isoString, timeZone] = match
   return makeZoned(isoString, { timeZone })

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -387,6 +387,13 @@ describe("DateTime", () => {
         assert.strictEqual(dt.toJSON(), "2024-07-21T08:12:34.112Z")
       }))
 
+    it.effect("only offset with 00:00", () =>
+      Effect.gen(function*() {
+        const dt = yield* DateTime.makeZonedFromString("2024-07-21T20:12:34.112546348+00:00")
+        assert.strictEqual(dt.zone._tag, "Offset")
+        assert.strictEqual(dt.toJSON(), "2024-07-21T20:12:34.112Z")
+      }))
+
     it.effect("roundtrip", () =>
       Effect.gen(function*() {
         const dt = yield* DateTime.makeZonedFromString("2024-07-21T20:12:34.112546348+12:00[Pacific/Auckland]").pipe(


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently `effect/DateTime::makeZonedFromString()` doesn't parse dates with `00:00` offset.
Fixed in order to allow zero offset.
