### PR TITLE
fix: respect the default for a text prompt

### DIFF
--- a/.changeset/cool-dogs-behave.md
+++ b/.changeset/cool-dogs-behave.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Respect the `Prompt.TextOptions.default` for a prompt created with `Prompt.text`

--- a/packages/cli/src/internal/prompt/text.ts
+++ b/packages/cli/src/internal/prompt/text.ts
@@ -5,7 +5,6 @@ import * as Optimize from "@effect/printer/Optimize"
 import * as Arr from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
-import * as Predicate from "effect/Predicate"
 import * as Redacted from "effect/Redacted"
 import type * as Prompt from "../../Prompt.js"
 import * as InternalPrompt from "../prompt.js"
@@ -233,10 +232,11 @@ function handleProcess(options: Options) {
       }
       case "enter":
       case "return": {
-        return Effect.match(options.validate(state.value), {
+        const value = state.value.length > 0 ? state.value : options.default
+        return Effect.match(options.validate(value), {
           onFailure: (error) =>
             Action.NextFrame({
-              state: { ...state, error: Option.some(error) }
+              state: { ...state, value, error: Option.some(error) }
             }),
           onSuccess: (value) => Action.Submit({ value })
         })
@@ -266,17 +266,7 @@ function basePrompt(
     ...options
   }
 
-  const state: State = {
-    ...initialState,
-    ...(Predicate.isString(options.default) ?
-      {
-        value: options.default,
-        cursor: options.default.length
-      } :
-      undefined)
-  }
-
-  return InternalPrompt.custom(state, {
+  return InternalPrompt.custom(initialState, {
     render: handleRender(opts),
     process: handleProcess(opts),
     clear: handleClear(opts)

--- a/packages/cli/src/internal/prompt/text.ts
+++ b/packages/cli/src/internal/prompt/text.ts
@@ -5,6 +5,7 @@ import * as Optimize from "@effect/printer/Optimize"
 import * as Arr from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
 import * as Redacted from "effect/Redacted"
 import type * as Prompt from "../../Prompt.js"
 import * as InternalPrompt from "../prompt.js"
@@ -264,7 +265,18 @@ function basePrompt(
     validate: Effect.succeed,
     ...options
   }
-  return InternalPrompt.custom(initialState, {
+
+  const state: State = {
+    ...initialState,
+    ...(Predicate.isString(options.default) ?
+      {
+        value: options.default,
+        cursor: options.default.length
+      } :
+      undefined)
+  }
+
+  return InternalPrompt.custom(state, {
     render: handleRender(opts),
     process: handleProcess(opts),
     clear: handleClear(opts)

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -1,21 +1,15 @@
 import * as Prompt from "@effect/cli/Prompt"
 import * as MockTerminal from "@effect/cli/test/services/MockTerminal"
-import type { Terminal } from "@effect/platform"
-import { Effect } from "effect"
+import type { Terminal } from "@effect/platform/Terminal"
+import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
-import * as Layer from "effect/Layer"
 import { describe, expect, it } from "vitest"
 
 
-const MainLive = Effect.gen(function*(_) {
-  return Layer.mergeAll(
-    MockTerminal.layer,
-  )
-}).pipe(Layer.unwrapEffect)
 
 const runEffect = <E, A>(
-  self: Effect.Effect<A, E, Terminal.Terminal>
-): Promise<A> => Effect.provide(self, MainLive).pipe(Effect.runPromise)
+  self: Effect.Effect<A, E, Terminal>
+): Promise<A> => Effect.provide(self, MockTerminal.layer).pipe(Effect.runPromise)
 
 describe("Prompt", () => {
   describe("text", () => {

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -1,83 +1,54 @@
-import type * as CliApp from "@effect/cli/CliApp"
-import * as Command from "@effect/cli/Command"
 import * as Prompt from "@effect/cli/Prompt"
 import * as MockConsole from "@effect/cli/test/services/MockConsole"
 import * as MockTerminal from "@effect/cli/test/services/MockTerminal"
-import {} from "@effect/platform"
+import { } from "@effect/platform"
 import { Array, Effect } from "effect"
 import * as Console from "effect/Console"
 import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
 import { describe, expect, it } from "vitest"
+import { Terminal } from "../../platform/src/Terminal.js"
 
 const MainLive = Effect.gen(function*(_) {
   const console = yield* _(MockConsole.make)
   return Layer.mergeAll(
     Console.setConsole(console),
-    MockTerminal.layer
+    MockTerminal.layer,
   )
 }).pipe(Layer.unwrapEffect)
 
 const runEffect = <E, A>(
-  self: Effect.Effect<A, E, CliApp.CliApp.Environment>
+  self: Effect.Effect<A, E, Terminal>
 ): Promise<A> => Effect.provide(self, MainLive).pipe(Effect.runPromise)
 
 describe("Prompt", () => {
   describe("text", () => {
-    it("should return an empty string when `default` on `Prompt.TextOptions` is not provided", () =>
-      Effect.gen(function*(_) {
+    it("should use the prompt value when no default is provided", () =>
+      Effect.gen(function*() {
         const prompt = Prompt.text({
-          message: "This should not have a default"
+          message: "This does not have a default",
         })
 
-        const command = Command.prompt(
-          "prompt-command",
-          prompt,
-          (value) =>
-            Console.log(
-              `Prompt value: "${value}"`
-            )
-        )
-
-        const cli = Command.run(command, {
-          name: "Default Value App",
-          version: "0.0.1"
-        })
-
-        const fiber = yield* _(Effect.fork(cli([])))
-        yield* _(MockTerminal.inputKey("Enter"))
-        yield* _(Fiber.join(fiber))
-        const lines = yield* _(MockConsole.getLines({ stripAnsi: true }))
-        const result = Array.some(lines, (line) => line.includes("Prompt value: \"\""))
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+        const lines = yield* MockConsole.getLines({ stripAnsi: true })
+        const result = Array.some(lines, (line) => line.includes("? This does not have a default › "))
         expect(result).toBe(true)
       }).pipe(runEffect))
 
-    it("should respect the `default` property on `Prompt.TextOptions`", () =>
-      Effect.gen(function*(_) {
+    it("should use the default value when the default is provided", () =>
+      Effect.gen(function*() {
         const prompt = Prompt.text({
           message: "This should have a default",
           default: "default-value"
         })
 
-        const command = Command.prompt(
-          "prompt-command",
-          prompt,
-          (value) =>
-            Console.log(
-              `Prompt value: "${value}"`
-            )
-        )
-
-        const cli = Command.run(command, {
-          name: "Default Value App",
-          version: "0.0.1"
-        })
-
-        const fiber = yield* _(Effect.fork(cli([])))
-        yield* _(MockTerminal.inputKey("Enter"))
-        yield* _(Fiber.join(fiber))
-        const lines = yield* _(MockConsole.getLines({ stripAnsi: true }))
-        const result = Array.some(lines, (line) => line.includes("Prompt value: \"default-value\""))
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+        const lines = yield* MockConsole.getLines({ stripAnsi: true })
+        const result = Array.some(lines, (line) => line.includes("? This should have a default › default-value"))
         expect(result).toBe(true)
       }).pipe(runEffect))
   })

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -1,0 +1,84 @@
+import type * as CliApp from "@effect/cli/CliApp"
+import * as Command from "@effect/cli/Command"
+import * as Prompt from "@effect/cli/Prompt"
+import * as MockConsole from "@effect/cli/test/services/MockConsole"
+import * as MockTerminal from "@effect/cli/test/services/MockTerminal"
+import {} from "@effect/platform"
+import { Array, Effect } from "effect"
+import * as Console from "effect/Console"
+import * as Fiber from "effect/Fiber"
+import * as Layer from "effect/Layer"
+import { describe, expect, it } from "vitest"
+
+const MainLive = Effect.gen(function*(_) {
+  const console = yield* _(MockConsole.make)
+  return Layer.mergeAll(
+    Console.setConsole(console),
+    MockTerminal.layer
+  )
+}).pipe(Layer.unwrapEffect)
+
+const runEffect = <E, A>(
+  self: Effect.Effect<A, E, CliApp.CliApp.Environment>
+): Promise<A> => Effect.provide(self, MainLive).pipe(Effect.runPromise)
+
+describe("Prompt", () => {
+  describe("text", () => {
+    it("should return an empty string when `default` on `Prompt.TextOptions` is not provided", () =>
+      Effect.gen(function*(_) {
+        const prompt = Prompt.text({
+          message: "This should not have a default"
+        })
+
+        const command = Command.prompt(
+          "prompt-command",
+          prompt,
+          (value) =>
+            Console.log(
+              `Prompt value: "${value}"`
+            )
+        )
+
+        const cli = Command.run(command, {
+          name: "Default Value App",
+          version: "0.0.1"
+        })
+
+        const fiber = yield* _(Effect.fork(cli([])))
+        yield* _(MockTerminal.inputKey("Enter"))
+        yield* _(Fiber.join(fiber))
+        const lines = yield* _(MockConsole.getLines({ stripAnsi: true }))
+        const result = Array.some(lines, (line) => line.includes("Prompt value: \"\""))
+        expect(result).toBe(true)
+      }).pipe(runEffect))
+
+    it("should respect the `default` property on `Prompt.TextOptions`", () =>
+      Effect.gen(function*(_) {
+        const prompt = Prompt.text({
+          message: "This should have a default",
+          default: "default-value"
+        })
+
+        const command = Command.prompt(
+          "prompt-command",
+          prompt,
+          (value) =>
+            Console.log(
+              `Prompt value: "${value}"`
+            )
+        )
+
+        const cli = Command.run(command, {
+          name: "Default Value App",
+          version: "0.0.1"
+        })
+
+        const fiber = yield* _(Effect.fork(cli([])))
+        yield* _(MockTerminal.inputKey("Enter"))
+        yield* _(Fiber.join(fiber))
+        const lines = yield* _(MockConsole.getLines({ stripAnsi: true }))
+        const result = Array.some(lines, (line) => line.includes("Prompt value: \"default-value\""))
+        expect(result).toBe(true)
+      }).pipe(runEffect))
+  })
+})

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -5,8 +5,6 @@ import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
 import { describe, expect, it } from "vitest"
 
-
-
 const runEffect = <E, A>(
   self: Effect.Effect<A, E, Terminal>
 ): Promise<A> => Effect.provide(self, MockTerminal.layer).pipe(Effect.runPromise)
@@ -16,14 +14,14 @@ describe("Prompt", () => {
     it("should use the prompt value when no default is provided", () =>
       Effect.gen(function*() {
         const prompt = Prompt.text({
-          message: "This does not have a default",
+          message: "This does not have a default"
         })
 
         const fiber = yield* Effect.fork(prompt)
         yield* MockTerminal.inputKey("enter")
         const result = yield* Fiber.join(fiber)
 
-        expect(result).toBe('')
+        expect(result).toBe("")
       }).pipe(runEffect))
 
     it("should use the default value when the default is provided", () =>
@@ -32,12 +30,12 @@ describe("Prompt", () => {
           message: "This should have a default",
           default: "default-value"
         })
-        
+
         const fiber = yield* Effect.fork(prompt)
         yield* MockTerminal.inputKey("enter")
         const result = yield* Fiber.join(fiber)
 
-        expect(result).toBe('default-value')
+        expect(result).toBe("default-value")
       }).pipe(runEffect))
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR respects the default value passed in when creating a 

### Example
```ts
const prompt = Prompt.text({
  message: "This is a prompt with a default value",
  default: "default-value", // <-- This value does not populate before this PR
});
```


> [!WARNING]  
> I attempted to model the `Wizard` tests, but could not get the `Enter` key to effect the program exit.

## Related

- Closes #3465 
