### PR TITLE
Preserve `Array.modify` and `Array.modifyOption` non emptiness

### DIFF
--- a/.changeset/curvy-cats-smoke.md
+++ b/.changeset/curvy-cats-smoke.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+preserve `Array.modify` `Array.modifyOption` non emptiness

--- a/packages/effect/dtslint/Array.ts
+++ b/packages/effect/dtslint/Array.ts
@@ -1400,30 +1400,40 @@ pipe(new Set([1, 2] as const), Array.replaceOption(0, "a" as const))
 
 // $ExpectType string[]
 Array.modify([], 0, () => "a")
-// $ExpectType Option<string[]>
-Array.modifyOption([], 0, () => "a")
 
 // $ExpectType ("a" | 1 | 2)[]
 Array.modify(new Set([1, 2] as const), 0, () => "a" as const)
-// $ExpectType Option<("a" | 1 | 2)[]>
-Array.modifyOption(new Set([1, 2] as const), 0, () => "a" as const)
 
 // $ExpectType [number | string, ...(number | string)[]]
 Array.modify(Array.of(1), 0, (n) => n.toString())
-// $ExpectType Option<[number | string, ...(number | string)[]]>
-Array.modifyOption(Array.of(1), 0, (n) => n.toString())
 
 // $ExpectType string[]
 pipe([], Array.modify(0, () => "a"))
-// $ExpectType Option<string[]>
-pipe([], Array.modifyOption(0, () => "a"))
 
 // $ExpectType ("a" | 1 | 2)[]
 pipe(new Set([1, 2] as const), Array.modify(0, () => "a" as const))
-// $ExpectType Option<("a" | 1 | 2)[]>
-pipe(new Set([1, 2] as const), Array.modifyOption(0, () => "a" as const))
 
 // $ExpectType [number | "a", ...(number | "a")[]]
 pipe(Array.of(1), Array.modify(0, () => "a" as const))
+
+// -------------------------------------------------------------------------------------
+// modifyOption
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Option<string[]>
+Array.modifyOption([], 0, () => "a")
+
+// $ExpectType Option<("a" | 1 | 2)[]>
+Array.modifyOption(new Set([1, 2] as const), 0, () => "a" as const)
+
+// $ExpectType Option<[number | string, ...(number | string)[]]>
+Array.modifyOption(Array.of(1), 0, (n) => n.toString())
+
+// $ExpectType Option<string[]>
+pipe([], Array.modifyOption(0, () => "a"))
+
+// $ExpectType Option<("a" | 1 | 2)[]>
+pipe(new Set([1, 2] as const), Array.modifyOption(0, () => "a" as const))
+
 // $ExpectType Option<[number | "a", ...(number | "a")[]]>
 pipe(Array.of(1), Array.modifyOption(0, () => "a" as const))

--- a/packages/effect/dtslint/Array.ts
+++ b/packages/effect/dtslint/Array.ts
@@ -1356,3 +1356,37 @@ pipe(new Set([1, 2] as const), Array.replace(0, "a" as const))
 
 // $ExpectType [number | "a", ...(number | "a")[]]
 pipe(Array.of(1), Array.replace(0, "a" as const))
+
+// -------------------------------------------------------------------------------------
+// modify
+// -------------------------------------------------------------------------------------
+
+// $ExpectType string[]
+Array.modify([], 0, () => "a")
+// $ExpectType Option<string[]>
+Array.modifyOption([], 0, () => "a")
+
+// $ExpectType ("a" | 1 | 2)[]
+Array.modify(new Set([1, 2] as const), 0, () => "a" as const)
+// $ExpectType Option<("a" | 1 | 2)[]>
+Array.modifyOption(new Set([1, 2] as const), 0, () => "a" as const)
+
+// $ExpectType [number | "a", ...(number | "a")[]]
+Array.modify(Array.of(1), 0, () => "a" as const)
+// $ExpectType Option<[number | "a", ...(number | "a")[]]>
+Array.modifyOption(Array.of(1), 0, () => "a" as const)
+
+// $ExpectType string[]
+pipe([], Array.modify(0, () => "a"))
+// $ExpectType Option<string[]>
+pipe([], Array.modifyOption(0, () => "a"))
+
+// $ExpectType ("a" | 1 | 2)[]
+pipe(new Set([1, 2] as const), Array.modify(0, () => "a" as const))
+// $ExpectType Option<("a" | 1 | 2)[]>
+pipe(new Set([1, 2] as const), Array.modifyOption(0, () => "a" as const))
+
+// $ExpectType [number | "a", ...(number | "a")[]]
+pipe(Array.of(1), Array.modify(0, () => "a" as const))
+// $ExpectType Option<[number | "a", ...(number | "a")[]]>
+pipe(Array.of(1), Array.modifyOption(0, () => "a" as const))

--- a/packages/effect/dtslint/Array.ts
+++ b/packages/effect/dtslint/Array.ts
@@ -1371,10 +1371,10 @@ Array.modify(new Set([1, 2] as const), 0, () => "a" as const)
 // $ExpectType Option<("a" | 1 | 2)[]>
 Array.modifyOption(new Set([1, 2] as const), 0, () => "a" as const)
 
-// $ExpectType [number | "a", ...(number | "a")[]]
-Array.modify(Array.of(1), 0, () => "a" as const)
-// $ExpectType Option<[number | "a", ...(number | "a")[]]>
-Array.modifyOption(Array.of(1), 0, () => "a" as const)
+// $ExpectType [number | string, ...(number | string)[]]
+Array.modify(Array.of(1), 0, (n) => n.toString())
+// $ExpectType Option<[number | string, ...(number | string)[]]>
+Array.modifyOption(Array.of(1), 0, (n) => n.toString())
 
 // $ExpectType string[]
 pipe([], Array.modify(0, () => "a"))

--- a/packages/effect/dtslint/Array.ts
+++ b/packages/effect/dtslint/Array.ts
@@ -1399,41 +1399,108 @@ pipe(new Set([1, 2] as const), Array.replaceOption(0, "a" as const))
 // -------------------------------------------------------------------------------------
 
 // $ExpectType string[]
-Array.modify([], 0, () => "a")
-
-// $ExpectType ("a" | 1 | 2)[]
-Array.modify(new Set([1, 2] as const), 0, () => "a" as const)
-
-// $ExpectType [number | string, ...(number | string)[]]
-Array.modify(Array.of(1), 0, (n) => n.toString())
-
-// $ExpectType string[]
-pipe([], Array.modify(0, () => "a"))
-
-// $ExpectType ("a" | 1 | 2)[]
-pipe(new Set([1, 2] as const), Array.modify(0, () => "a" as const))
+Array.modify([], 0, (
+  _n // $ExpectType never
+) => "a")
+// $ExpectType (string | number)[]
+Array.modify(numbers, 0, (
+  _n // $ExpectType number
+) => "a")
 
 // $ExpectType [number | "a", ...(number | "a")[]]
-pipe(Array.of(1), Array.modify(0, () => "a" as const))
+Array.modify(nonEmptyNumbers, 0, (
+  _n // $ExpectType number
+) => "a" as const)
+
+// $ExpectType ("a" | 1 | 2)[]
+Array.modify(new Set([1, 2] as const), 0, (
+  _n // $ExpectType 1 | 2
+) => "a" as const)
+
+// $ExpectType string[]
+pipe(
+  [],
+  Array.modify(0, (
+    _n // $ExpectType never
+  ) => "a")
+)
+
+// $ExpectType (string | number)[]
+pipe(
+  numbers,
+  Array.modify(0, (
+    _n // $ExpectType number
+  ) => "a")
+)
+
+// $ExpectType [number | "a", ...(number | "a")[]]
+pipe(
+  nonEmptyNumbers,
+  Array.modify(0, (
+    _n // $ExpectType number
+  ) => "a" as const)
+)
+
+// $ExpectType ("a" | 1 | 2)[]
+pipe(
+  new Set([1, 2] as const),
+  Array.modify(0, (
+    _n // $ExpectType 1 | 2
+  ) => "a" as const)
+)
 
 // -------------------------------------------------------------------------------------
 // modifyOption
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Option<string[]>
-Array.modifyOption([], 0, () => "a")
+Array.modifyOption([], 0, (
+  _n // $ExpectType never
+) => "a")
 
-// $ExpectType Option<("a" | 1 | 2)[]>
-Array.modifyOption(new Set([1, 2] as const), 0, () => "a" as const)
-
-// $ExpectType Option<[number | string, ...(number | string)[]]>
-Array.modifyOption(Array.of(1), 0, (n) => n.toString())
-
-// $ExpectType Option<string[]>
-pipe([], Array.modifyOption(0, () => "a"))
-
-// $ExpectType Option<("a" | 1 | 2)[]>
-pipe(new Set([1, 2] as const), Array.modifyOption(0, () => "a" as const))
+// $ExpectType Option<(string | number)[]>
+Array.modifyOption(numbers, 0, (
+  _n // $ExpectType number
+) => "a")
 
 // $ExpectType Option<[number | "a", ...(number | "a")[]]>
-pipe(Array.of(1), Array.modifyOption(0, () => "a" as const))
+Array.modifyOption(nonEmptyNumbers, 0, (
+  _n // $ExpectType number
+) => "a" as const)
+
+// $ExpectType Option<("a" | 1 | 2)[]>
+Array.modifyOption(new Set([1, 2] as const), 0, (
+  _n // $ExpectType 1 | 2
+) => "a" as const)
+
+// $ExpectType Option<string[]>
+pipe(
+  [],
+  Array.modifyOption(0, (
+    _n // $ExpectType never
+  ) => "a")
+)
+
+// $ExpectType Option<(string | number)[]>
+pipe(
+  numbers,
+  Array.modifyOption(0, (
+    _n // $ExpectType number
+  ) => "a")
+)
+
+// $ExpectType Option<[number | "a", ...(number | "a")[]]>
+pipe(
+  nonEmptyNumbers,
+  Array.modifyOption(0, (
+    _n // $ExpectType number
+  ) => "a" as const)
+)
+
+// $ExpectType Option<("a" | 1 | 2)[]>
+pipe(
+  new Set([1, 2] as const),
+  Array.modifyOption(0, (
+    _n // $ExpectType 1 | 2
+  ) => "a" as const)
+)

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1109,10 +1109,10 @@ export const replaceOption: {
  * @since 2.0.0
  */
 export const modify: {
-  <A, B>(
+  <A, B, S extends Iterable<A> = Iterable<A>>(
     i: number,
-    f: (a: A) => B
-  ): <S extends Iterable<A> = Iterable<A>>(self: S) => ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>
+    f: (a: ReadonlyArray.Infer<S>) => B
+  ): (self: S) => ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>
   <A, B, S extends Iterable<A> = Iterable<A>>(
     self: S,
     i: number,
@@ -1141,10 +1141,10 @@ export const modify: {
  * @since 2.0.0
  */
 export const modifyOption: {
-  <A, B>(
+  <A, B, S extends Iterable<A> = Iterable<A>>(
     i: number,
-    f: (a: A) => B
-  ): <S extends Iterable<A> = Iterable<A>>(self: S) => Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
+    f: (a: ReadonlyArray.Infer<S>) => B
+  ): (self: S) => Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
   <A, B, S extends Iterable<A> = Iterable<A>>(
     self: S,
     i: number,

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1095,8 +1095,6 @@ export const replaceOption: {
   <A, B>(self: Iterable<A>, i: number, b: B): Option<Array<A | B>> => modifyOption(self, i, () => b)
 )
 
-type TypeOfIterable<T extends Iterable<any>> = T extends Iterable<infer A> ? A : never
-
 /**
  * Apply a function to the element at the specified index, creating a new `Array`,
  * or return a copy of the input if the index is out of bounds.
@@ -1118,7 +1116,7 @@ export const modify: {
   <A, B, S extends Iterable<A> = Iterable<A>>(
     self: S,
     i: number,
-    f: (a: TypeOfIterable<S>) => B
+    f: (a: ReadonlyArray.Infer<S>) => B
   ): ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>
 } = dual(
   3,
@@ -1150,7 +1148,7 @@ export const modifyOption: {
   <A, B, S extends Iterable<A> = Iterable<A>>(
     self: S,
     i: number,
-    f: (a: TypeOfIterable<S>) => B
+    f: (a: ReadonlyArray.Infer<S>) => B
   ): Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
 } = dual(3, <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Option<Array<A | B>> => {
   const out = Array.from(self)

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1097,6 +1097,8 @@ export const replaceOption: {
   <A, B>(self: Iterable<A>, i: number, b: B): Option<Array<A | B>> => modifyOption(self, i, () => b)
 )
 
+type TypeOfIterable<T extends Iterable<any>> = T extends Iterable<infer A> ? A : never
+
 /**
  * Apply a function to the element at the specified index, creating a new `Array`,
  * or return a copy of the input if the index is out of bounds.
@@ -1118,7 +1120,7 @@ export const modify: {
   <A, B, S extends Iterable<A> = Iterable<A>>(
     self: S,
     i: number,
-    f: (a: A) => B
+    f: (a: TypeOfIterable<S>) => B
   ): ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>
 } = dual(
   3,
@@ -1150,7 +1152,7 @@ export const modifyOption: {
   <A, B, S extends Iterable<A> = Iterable<A>>(
     self: S,
     i: number,
-    f: (a: A) => B
+    f: (a: TypeOfIterable<S>) => B
   ): Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
 } = dual(3, <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Option<Array<A | B>> => {
   const out = Array.from(self)

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1111,8 +1111,15 @@ export const replaceOption: {
  * @since 2.0.0
  */
 export const modify: {
-  <A, B>(i: number, f: (a: A) => B): (self: Iterable<A>) => Array<A | B>
-  <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Array<A | B>
+  <A, B>(
+    i: number,
+    f: (a: A) => B
+  ): <S extends Iterable<A> = Iterable<A>>(self: S) => ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>
+  <A, B, S extends Iterable<A> = Iterable<A>>(
+    self: S,
+    i: number,
+    f: (a: A) => B
+  ): ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>
 } = dual(
   3,
   <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Array<A | B> =>
@@ -1136,8 +1143,15 @@ export const modify: {
  * @since 2.0.0
  */
 export const modifyOption: {
-  <A, B>(i: number, f: (a: A) => B): (self: Iterable<A>) => Option<Array<A | B>>
-  <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Option<Array<A | B>>
+  <A, B>(
+    i: number,
+    f: (a: A) => B
+  ): <S extends Iterable<A> = Iterable<A>>(self: S) => Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
+  <A, B, S extends Iterable<A> = Iterable<A>>(
+    self: S,
+    i: number,
+    f: (a: A) => B
+  ): Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
 } = dual(3, <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Option<Array<A | B>> => {
   const out = Array.from(self)
   if (isOutOfBound(i, out)) {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Same as https://github.com/Effect-TS/effect/pull/3491 but for modify functions
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
