### PR TITLE
use Array.partitionMap for Effect.partitionMap

### DIFF
--- a/.changeset/nine-windows-smoke.md
+++ b/.changeset/nine-windows-smoke.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+improve the performance of Effect.partitionMap

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -1198,25 +1198,10 @@ export const orDieWith: {
 )
 
 /* @internal */
-export const partitionMap = <A, A1, A2>(
+export const partitionMap: <A, A1, A2>(
   elements: Iterable<A>,
   f: (a: A) => Either.Either<A2, A1>
-): [left: Array<A1>, right: Array<A2>] =>
-  Arr.fromIterable(elements).reduceRight(
-    ([lefts, rights], current) => {
-      const either = f(current)
-      switch (either._tag) {
-        case "Left": {
-          return [[either.left, ...lefts], rights]
-        }
-        case "Right": {
-          return [lefts, [either.right, ...rights]]
-        }
-      }
-    },
-    [Arr.empty<A1>(), Arr.empty<A2>()]
-  )
-
+) => [left: Array<A1>, right: Array<A2>] = Arr.partitionMap
 /* @internal */
 export const runtimeFlags: Effect.Effect<RuntimeFlags.RuntimeFlags> = withFiberRuntime((_, status) =>
   succeed(status.runtimeFlags)

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1769,7 +1769,7 @@ const allValidate = (
     readonly mode?: "default" | "validate" | "either" | undefined
   }
 ) => {
-  const eitherEffects: Array<Effect.Effect<unknown, never, Either.Either<unknown, unknown>>> = []
+  const eitherEffects: Array<Effect.Effect<Either.Either<unknown, unknown>, never, unknown>> = []
   for (const effect of effects) {
     eitherEffects.push(core.either(effect))
   }
@@ -1818,7 +1818,7 @@ const allEither = (
     readonly mode?: "default" | "validate" | "either" | undefined
   }
 ) => {
-  const eitherEffects: Array<Effect.Effect<unknown, never, Either.Either<unknown, unknown>>> = []
+  const eitherEffects: Array<Effect.Effect<Either.Either<unknown, unknown>, never, unknown>> = []
   for (const effect of effects) {
     eitherEffects.push(core.either(effect))
   }


### PR DESCRIPTION
- perf: alias Effect.partitionMap to Array.partitionMap
- fix: reverse type from R,E,A to A,E,R

aiming to fix #3503

`Array.partitionMap` is identical to `Effect.partitionMap` except that the former is mutative on the intermediate array
