### PR TITLE
Renders the default for all `Prompt` types that accepts `TextOptions`.

### DIFF
--- a/.changeset/late-apricots-thank.md
+++ b/.changeset/late-apricots-thank.md
@@ -1,0 +1,9 @@
+---
+"@effect/cli": patch
+---
+
+Renders the default for all `Prompt` types that accepts `TextOptions`.
+
+- The default value will be rendered as ghost text for `Prompt.text` and `Prompt.list`.
+- The default value will be rendered as redacted ghost text for `Prompt.password`.
+- The default value will remain hidden for `Prompt.hidden`.

--- a/packages/cli/src/internal/prompt/text.ts
+++ b/packages/cli/src/internal/prompt/text.ts
@@ -66,17 +66,19 @@ function renderInput(nextState: State, options: Options, submitted: boolean) {
   const text = getValue(nextState, options)
 
   const annotation = Option.match(nextState.error, {
-    onNone: () => Match.value(submitted)
-    .pipe(
-      Match.when(true, () => Ansi.green),
-      Match.orElse(() => Match.value(nextState.value).pipe(
-        Match.when('', () => Ansi.blackBright),
-        Match.orElse(() => Ansi.combine(Ansi.underlined, Ansi.cyanBright))
-      ))
-    ),
+    onNone: () =>
+      Match.value(submitted)
+        .pipe(
+          Match.when(true, () => Ansi.green),
+          Match.orElse(() =>
+            Match.value(nextState.value).pipe(
+              Match.when("", () => Ansi.blackBright),
+              Match.orElse(() => Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+            )
+          )
+        ),
     onSome: () => Ansi.red
   })
-
 
   switch (options.type) {
     case "hidden": {
@@ -259,7 +261,7 @@ function handleProcess(options: Options) {
       }
       case "enter":
       case "return": {
-        const value = getValue(state, options)   
+        const value = getValue(state, options)
         return Effect.match(options.validate(value), {
           onFailure: (error) =>
             Action.NextFrame({
@@ -269,7 +271,7 @@ function handleProcess(options: Options) {
         })
       }
       case "tab": {
-        return processTab(state, options);
+        return processTab(state, options)
       }
       default: {
         const value = Option.getOrElse(input.input, () => "")

--- a/packages/cli/src/internal/prompt/text.ts
+++ b/packages/cli/src/internal/prompt/text.ts
@@ -4,7 +4,6 @@ import * as Doc from "@effect/printer-ansi/AnsiDoc"
 import * as Optimize from "@effect/printer/Optimize"
 import * as Arr from "effect/Array"
 import * as Effect from "effect/Effect"
-import * as Match from "effect/Match"
 import * as Option from "effect/Option"
 import * as Redacted from "effect/Redacted"
 import type * as Prompt from "../../Prompt.js"
@@ -66,17 +65,17 @@ function renderInput(nextState: State, options: Options, submitted: boolean) {
   const text = getValue(nextState, options)
 
   const annotation = Option.match(nextState.error, {
-    onNone: () =>
-      Match.value(submitted)
-        .pipe(
-          Match.when(true, () => Ansi.green),
-          Match.orElse(() =>
-            Match.value(nextState.value).pipe(
-              Match.when("", () => Ansi.blackBright),
-              Match.orElse(() => Ansi.combine(Ansi.underlined, Ansi.cyanBright))
-            )
-          )
-        ),
+    onNone: () => {
+      if (submitted) {
+        return Ansi.white
+      }
+
+      if (nextState.value.length === 0) {
+        return Ansi.blackBright
+      }
+
+      return Ansi.combine(Ansi.underlined, Ansi.cyanBright)
+    },
     onSome: () => Ansi.red
   })
 

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -1,5 +1,4 @@
 import type * as CliApp from "@effect/cli/CliApp"
-import * as Command from "@effect/cli/Command"
 import * as Prompt from "@effect/cli/Prompt"
 import * as MockConsole from "@effect/cli/test/services/MockConsole"
 import * as MockTerminal from "@effect/cli/test/services/MockTerminal"
@@ -63,12 +62,7 @@ describe("Prompt", () => {
           default: "default-value"
         })
 
-        const cli = Command.prompt("test-command", prompt, () => Effect.void).pipe(Command.run({
-          name: "Test",
-          version: "1.0.0"
-        }))
-
-        const fiber = yield* Effect.fork(cli([]))
+        const fiber = yield* Effect.fork(prompt)
 
         yield* MockTerminal.inputKey("enter")
         yield* Fiber.join(fiber)
@@ -106,12 +100,7 @@ describe("Prompt", () => {
           default: "default-value"
         })
 
-        const cli = Command.prompt("test-command", prompt, () => Effect.void).pipe(Command.run({
-          name: "Test",
-          version: "1.0.0"
-        }))
-
-        const fiber = yield* Effect.fork(cli([]))
+        const fiber = yield* Effect.fork(prompt)
 
         yield* MockTerminal.inputKey("tab")
         yield* MockTerminal.inputKey("enter")
@@ -180,12 +169,7 @@ describe("Prompt", () => {
           default: "default-value"
         })
 
-        const cli = Command.prompt("test-command", prompt, () => Effect.void).pipe(Command.run({
-          name: "Test",
-          version: "1.0.0"
-        }))
-
-        const fiber = yield* Effect.fork(cli([]))
+        const fiber = yield* Effect.fork(prompt)
 
         yield* MockTerminal.inputKey("enter")
         yield* Fiber.join(fiber)
@@ -237,12 +221,7 @@ describe("Prompt", () => {
           default: "default-value"
         })
 
-        const cli = Command.prompt("test-command", prompt, () => Effect.void).pipe(Command.run({
-          name: "Test",
-          version: "1.0.0"
-        }))
-
-        const fiber = yield* Effect.fork(cli([]))
+        const fiber = yield* Effect.fork(prompt)
 
         yield* MockTerminal.inputKey("enter")
         yield* Fiber.join(fiber)
@@ -309,12 +288,7 @@ describe("Prompt", () => {
           default: "default-value"
         })
 
-        const cli = Command.prompt("test-command", prompt, () => Effect.void).pipe(Command.run({
-          name: "Test",
-          version: "1.0.0"
-        }))
-
-        const fiber = yield* Effect.fork(cli([]))
+        const fiber = yield* Effect.fork(prompt)
 
         yield* MockTerminal.inputKey("enter")
         yield* Fiber.join(fiber)

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -3,6 +3,7 @@ import * as MockTerminal from "@effect/cli/test/services/MockTerminal"
 import type { Terminal } from "@effect/platform/Terminal"
 import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
+import * as Redacted from "effect/Redacted"
 import { describe, expect, it } from "vitest"
 
 const runEffect = <E, A>(
@@ -36,6 +37,93 @@ describe("Prompt", () => {
         const result = yield* Fiber.join(fiber)
 
         expect(result).toBe("default-value")
+      }).pipe(runEffect))
+  })
+
+  describe("hidden", () => {
+    it("should use the prompt value when no default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.hidden({
+          message: "This does not have a default"
+        })
+
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        const result = yield* Fiber.join(fiber)
+
+        expect(result).toEqual(Redacted.make(""))
+      }).pipe(runEffect))
+
+    it("should use the default value when the default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.hidden({
+          message: "This should have a default",
+          default: "default-value"
+        })
+
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        const result = yield* Fiber.join(fiber)
+
+        expect(result).toEqual(Redacted.make("default-value"))
+      }).pipe(runEffect))
+  })
+
+  describe("list", () => {
+    it("should use the prompt value when no default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.list({
+          message: "This does not have a default"
+        })
+
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        const result = yield* Fiber.join(fiber)
+
+        expect(result).toEqual([''])
+      }).pipe(runEffect))
+
+    it("should use the default value when the default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.list({
+          message: "This should have a default",
+          default: "default-value"
+        })
+
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        const result = yield* Fiber.join(fiber)
+
+        expect(result).toEqual(["default-value"])
+      }).pipe(runEffect))
+  })
+
+  describe("password", () => {
+    it("should use the prompt value when no default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.password({
+          message: "This does not have a default"
+        })
+
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        const result = yield* Fiber.join(fiber)
+
+        expect(result).toEqual(Redacted.make(""))
+      }).pipe(runEffect))
+
+    it("should use the default value when the default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.password({
+          message: "This should have a default",
+          default: "default-value"
+        })
+
+        const fiber = yield* Effect.fork(prompt)
+        yield* MockTerminal.inputKey("enter")
+        const result = yield* Fiber.join(fiber)
+
+        expect(result).toEqual(Redacted.make("default-value"))
       }).pipe(runEffect))
   })
 })

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -1,14 +1,31 @@
+import type * as CliApp from "@effect/cli/CliApp"
+import * as Command from "@effect/cli/Command"
 import * as Prompt from "@effect/cli/Prompt"
+import * as MockConsole from "@effect/cli/test/services/MockConsole"
 import * as MockTerminal from "@effect/cli/test/services/MockTerminal"
-import type { Terminal } from "@effect/platform/Terminal"
+import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import * as Ansi from "@effect/printer-ansi/Ansi"
+import * as Doc from "@effect/printer-ansi/AnsiDoc"
+import * as Console from "effect/Console"
 import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
+import * as Layer from "effect/Layer"
 import * as Redacted from "effect/Redacted"
 import { describe, expect, it } from "vitest"
 
+const MainLive = Effect.gen(function*(_) {
+  const console = yield* _(MockConsole.make)
+  return Layer.mergeAll(
+    Console.setConsole(console),
+    NodeFileSystem.layer,
+    MockTerminal.layer,
+    NodePath.layer
+  )
+}).pipe(Layer.unwrapEffect)
+
 const runEffect = <E, A>(
-  self: Effect.Effect<A, E, Terminal>
-): Promise<A> => Effect.provide(self, MockTerminal.layer).pipe(Effect.runPromise)
+  self: Effect.Effect<A, E, CliApp.CliApp.Environment>
+): Promise<A> => Effect.provide(self, MainLive).pipe(Effect.runPromise)
 
 describe("Prompt", () => {
   describe("text", () => {
@@ -37,6 +54,37 @@ describe("Prompt", () => {
         const result = yield* Fiber.join(fiber)
 
         expect(result).toBe("default-value")
+      }).pipe(runEffect))
+
+    it("should render the default value when the default is provided", () =>
+      Effect.gen(function*() {
+        const prompt = Prompt.text({
+          message: "Test Prompt",
+          default: "default-value"
+        })
+
+        const cli = Command.prompt("test-command", prompt, () => Effect.void).pipe(Command.run({
+          name: "Test",
+          version: "1.0.0"
+        }))
+
+        const fiber = yield* Effect.fork(cli([]))
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+        const lines = yield* MockConsole.getLines()
+
+        const [line1, , line2] = lines.filter(Boolean)
+
+        expect(line1).toContain(
+          Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
+            style: "pretty"
+          }))
+        )
+        expect(line2).toContain(
+          Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
+            style: "pretty"
+          }))
+        )
       }).pipe(runEffect))
   })
 
@@ -80,7 +128,7 @@ describe("Prompt", () => {
         yield* MockTerminal.inputKey("enter")
         const result = yield* Fiber.join(fiber)
 
-        expect(result).toEqual([''])
+        expect(result).toEqual([""])
       }).pipe(runEffect))
 
     it("should use the default value when the default is provided", () =>

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -73,7 +73,7 @@ describe("Prompt", () => {
           style: "pretty"
         }))
 
-        const submittedValue = Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
+        const submittedValue = Doc.annotate(Doc.text("default-value"), Ansi.white).pipe(Doc.render({
           style: "pretty"
         }))
 
@@ -232,7 +232,7 @@ describe("Prompt", () => {
           style: "pretty"
         }))
 
-        const submittedValue = Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
+        const submittedValue = Doc.annotate(Doc.text("default-value"), Ansi.white).pipe(Doc.render({
           style: "pretty"
         }))
 
@@ -300,7 +300,7 @@ describe("Prompt", () => {
           style: "pretty"
         }))
 
-        const submittedValue = Doc.annotate(Doc.text(redactedValue), Ansi.green).pipe(Doc.render({
+        const submittedValue = Doc.annotate(Doc.text(redactedValue), Ansi.white).pipe(Doc.render({
           style: "pretty"
         }))
 

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -321,7 +321,7 @@ describe("Prompt", () => {
 
         const lines = yield* MockConsole.getLines()
 
-        const redactedValue = Array.from("default-value", () => "*").join("")
+        const redactedValue = "*".repeat("default-value".length)
         const unsubmittedValue = Doc.annotate(Doc.text(redactedValue), Ansi.blackBright).pipe(Doc.render({
           style: "pretty"
         }))

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -75,27 +75,27 @@ describe("Prompt", () => {
 
         const lines = yield* MockConsole.getLines()
 
-        const uncommittedValue = Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
+        const unsubmittedValue = Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
           style: "pretty"
         }))
 
-        const committedValue = Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
+        const submittedValue = Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
           style: "pretty"
         }))
 
         expect(lines).toEqual(
           expect.arrayContaining([
             expect.stringContaining(
-              uncommittedValue
+              unsubmittedValue
             ),
             expect.stringContaining(
-              committedValue
+              submittedValue
             )
           ])
         )
 
-        expect(lines.findIndex((line) => line.includes(uncommittedValue))).toBeLessThan(
-          lines.findIndex((line) => line.includes(committedValue))
+        expect(lines.findIndex((line) => line.includes(unsubmittedValue))).toBeLessThan(
+          lines.findIndex((line) => line.includes(submittedValue))
         )
       }).pipe(runEffect))
 
@@ -119,7 +119,7 @@ describe("Prompt", () => {
 
         const lines = yield* MockConsole.getLines()
 
-        const uncommittedValue = Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
+        const unsubmittedValue = Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
           style: "pretty"
         }))
 
@@ -131,7 +131,7 @@ describe("Prompt", () => {
         expect(lines).toEqual(
           expect.arrayContaining([
             expect.stringContaining(
-              uncommittedValue
+              unsubmittedValue
             ),
             expect.stringContaining(
               enteredValue
@@ -139,7 +139,7 @@ describe("Prompt", () => {
           ])
         )
 
-        expect(lines.findIndex((line) => line.includes(uncommittedValue))).toBeLessThan(
+        expect(lines.findIndex((line) => line.includes(unsubmittedValue))).toBeLessThan(
           lines.findIndex((line) => line.includes(enteredValue))
         )
       }).pipe(runEffect))
@@ -249,27 +249,27 @@ describe("Prompt", () => {
 
         const lines = yield* MockConsole.getLines()
 
-        const uncommittedValue = Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
+        const unsubmittedValue = Doc.annotate(Doc.text("default-value"), Ansi.blackBright).pipe(Doc.render({
           style: "pretty"
         }))
 
-        const committedValue = Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
+        const submittedValue = Doc.annotate(Doc.text("default-value"), Ansi.green).pipe(Doc.render({
           style: "pretty"
         }))
 
         expect(lines).toEqual(
           expect.arrayContaining([
             expect.stringContaining(
-              uncommittedValue
+              unsubmittedValue
             ),
             expect.stringContaining(
-              committedValue
+              submittedValue
             )
           ])
         )
 
-        expect(lines.findIndex((line) => line.includes(uncommittedValue))).toBeLessThan(
-          lines.findIndex((line) => line.includes(committedValue))
+        expect(lines.findIndex((line) => line.includes(unsubmittedValue))).toBeLessThan(
+          lines.findIndex((line) => line.includes(submittedValue))
         )
       }).pipe(runEffect))
   })
@@ -322,27 +322,27 @@ describe("Prompt", () => {
         const lines = yield* MockConsole.getLines()
 
         const redactedValue = Array.from("default-value", () => "*").join("")
-        const uncommittedValue = Doc.annotate(Doc.text(redactedValue), Ansi.blackBright).pipe(Doc.render({
+        const unsubmittedValue = Doc.annotate(Doc.text(redactedValue), Ansi.blackBright).pipe(Doc.render({
           style: "pretty"
         }))
 
-        const committedValue = Doc.annotate(Doc.text(redactedValue), Ansi.green).pipe(Doc.render({
+        const submittedValue = Doc.annotate(Doc.text(redactedValue), Ansi.green).pipe(Doc.render({
           style: "pretty"
         }))
 
         expect(lines).toEqual(
           expect.arrayContaining([
             expect.stringContaining(
-              uncommittedValue
+              unsubmittedValue
             ),
             expect.stringContaining(
-              committedValue
+              submittedValue
             )
           ])
         )
 
-        expect(lines.findIndex((line) => line.includes(uncommittedValue))).toBeLessThan(
-          lines.findIndex((line) => line.includes(committedValue))
+        expect(lines.findIndex((line) => line.includes(unsubmittedValue))).toBeLessThan(
+          lines.findIndex((line) => line.includes(submittedValue))
         )
       }).pipe(runEffect))
   })

--- a/packages/cli/test/Prompt.test.ts
+++ b/packages/cli/test/Prompt.test.ts
@@ -12,8 +12,8 @@ import * as Layer from "effect/Layer"
 import * as Redacted from "effect/Redacted"
 import { describe, expect, it } from "vitest"
 
-const MainLive = Effect.gen(function*(_) {
-  const console = yield* _(MockConsole.make)
+const MainLive = Effect.gen(function*() {
+  const console = yield* MockConsole.make
   return Layer.mergeAll(
     Console.setConsole(console),
     NodeFileSystem.layer,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR renders all `Prompt` types that accepts `TextOptions`.

1. Intially, the text is rendered in a muted fashion.
2. When the user hits the tab key the value is accepted and rendered in cyan.
3. Finally, the user can edit the entered text or hit enter to submit the text.

https://github.com/user-attachments/assets/ca381dcb-40dc-46ce-b147-fdfda15debec

