### PR TITLE
Made `Ref`, `SynchronizedRef`,`RcRef, and `SubscriptionRef` a subtype of `Effect`

### DIFF
--- a/.changeset/eighty-lobsters-refuse.md
+++ b/.changeset/eighty-lobsters-refuse.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-Make `Ref`, `SynchronizedRed` and `SubscriptionRef` subtype of `Effect`
+Made `Ref`, `SynchronizedRed` and `SubscriptionRef` a subtype of `Effect`

--- a/.changeset/eighty-lobsters-refuse.md
+++ b/.changeset/eighty-lobsters-refuse.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Make `Ref`, `SynchronizedRed` and `SubscriptionRef` subtype of `Effect`

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -1,18 +1,23 @@
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
+import type * as Exit from "effect/Exit"
 import type * as Micro from "effect/Micro"
 import type * as Option from "effect/Option"
+import type * as RcRef from "effect/RcRef"
+import type * as Ref from "effect/Ref"
 import type * as Stream from "effect/Stream"
+import type * as SubscriptionRef from "effect/SubscriptionRef"
+import type * as SynchronizedRef from "effect/SynchronizedRef"
 import * as Unify from "effect/Unify"
 
 // $ExpectType Option<string | number>
-export type option = Unify.Unify<Option.Option<number> | Option.Option<string>>
+export type OptionUnify = Unify.Unify<Option.Option<number> | Option.Option<string>>
 
 // $ExpectType Either<"RA" | "RB", "LA" | "LB">
-export type either = Unify.Unify<Either.Either<"RA", "LA"> | Either.Either<"RB", "LB">>
+export type EitherUnify = Unify.Unify<Either.Either<"RA", "LA"> | Either.Either<"RB", "LB">>
 
 // $ExpectType 0 | Option<string | number> | Either<"RA" | "RB", "LA" | "LB">
-export type both = Unify.Unify<
+export type EitherOptionUnify = Unify.Unify<
   Either.Either<"RA", "LA"> | Either.Either<"RB", "LB"> | Option.Option<number> | Option.Option<string> | 0
 >
 
@@ -26,15 +31,38 @@ Unify.unify(<N>(n: N) => Math.random() > 0 ? Either.right(n) : Either.left("ok")
 Unify.unify(Math.random() > 0 ? Either.right(10) : Either.left("ok"))
 
 // $ExpectType Stream<0 | "a", "b" | 1, "c" | 2>
-export type SU = Unify.Unify<
+export type StreamUnify = Unify.Unify<
   Stream.Stream<0, 1, 2> | Stream.Stream<"a", "b", "c">
 >
 
 // $ExpectType Micro<0 | "a", "b" | 1, "c" | 2>
-export type MU = Unify.Unify<
+export type MicroUnify = Unify.Unify<
   Micro.Micro<0, 1, 2> | Micro.Micro<"a", "b", "c">
 >
 // $ExpectType Effect<0 | "a", "b" | 1, "c" | 2>
-export type EU = Unify.Unify<
+export type EffectUnify = Unify.Unify<
   Effect.Effect<0, 1, 2> | Effect.Effect<"a", "b", "c">
+>
+// $ExpectType Exit<0 | "a", "b" | 1>
+export type ExitUnify = Unify.Unify<
+  | Exit.Exit<0, 1>
+  | Exit.Exit<"a", "b">
+>
+// $ExpectType Ref<"a" | 1>
+export type RefUnify = Unify.Unify<Ref.Ref<1> | Ref.Ref<"a">>
+//          ^?
+// $ExpectType SynchronizedRef<"a" | 1>
+export type SynchronizedRefUnify = Unify.Unify<
+  | SynchronizedRef.SynchronizedRef<1>
+  | SynchronizedRef.SynchronizedRef<"a">
+>
+// $ExpectType SubscriptionRef<"a" | 1>
+export type SubscriptionRefUnify = Unify.Unify<
+  | SubscriptionRef.SubscriptionRef<1>
+  | SubscriptionRef.SubscriptionRef<"a">
+>
+// $ExpectType RcRef<"a" | 1, "b" | 2>
+export type RcRefUnify = Unify.Unify<
+  | RcRef.RcRef<1, 2>
+  | RcRef.RcRef<"a", "b">
 >

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -41,22 +41,22 @@ export type MicroUnify = Unify.Unify<
 >
 // $ExpectType Effect<0 | "a", "b" | 1, "c" | 2>
 export type EffectUnify = Unify.Unify<
-  Effect.Effect<0, 1, 2> | Effect.Effect<"a", "b", "c">
+  | Effect.Effect<0, 1, 2>
+  | Effect.Effect<"a", "b", "c">
 >
 // $ExpectType Exit<0 | "a", "b" | 1>
 export type ExitUnify = Unify.Unify<
   | Exit.Exit<0, 1>
   | Exit.Exit<"a", "b">
 >
-// $ExpectType Ref<"a" | 1>
+// $ExpectType Ref<1> | Ref<"a">
 export type RefUnify = Unify.Unify<Ref.Ref<1> | Ref.Ref<"a">>
-//          ^?
-// $ExpectType SynchronizedRef<"a" | 1>
+// $ExpectType SynchronizedRef<1> | SynchronizedRef<"a">
 export type SynchronizedRefUnify = Unify.Unify<
   | SynchronizedRef.SynchronizedRef<1>
   | SynchronizedRef.SynchronizedRef<"a">
 >
-// $ExpectType SubscriptionRef<"a" | 1>
+// $ExpectType SubscriptionRef<1> | SubscriptionRef<"a">
 export type SubscriptionRefUnify = Unify.Unify<
   | SubscriptionRef.SubscriptionRef<1>
   | SubscriptionRef.SubscriptionRef<"a">

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -66,3 +66,22 @@ export type RcRefUnify = Unify.Unify<
   | RcRef.RcRef<1, 2>
   | RcRef.RcRef<"a", "b">
 >
+
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+export type AllUnify = Unify.Unify<
+  | Either.Either<1, 0>
+  | Either.Either<"A", "E">
+  | Option.Option<number>
+  | Option.Option<string>
+  | Effect.Effect<"A", "E", "R">
+  | Effect.Effect<1, 0, "R1">
+  | Ref.Ref<1>
+  | Ref.Ref<"A">
+  | SynchronizedRef.SynchronizedRef<1>
+  | SynchronizedRef.SynchronizedRef<"A">
+  | SubscriptionRef.SubscriptionRef<1>
+  | SubscriptionRef.SubscriptionRef<"A">
+  | RcRef.RcRef<1, 0>
+  | RcRef.RcRef<"A", "E">
+  | 0
+>

--- a/packages/effect/src/RcRef.ts
+++ b/packages/effect/src/RcRef.ts
@@ -4,9 +4,10 @@
 import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/rcRef.js"
-import { type Pipeable } from "./Pipeable.js"
+import type * as Readable from "./Readable.js"
 import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 3.5.0
@@ -24,10 +25,31 @@ export type TypeId = typeof TypeId
  * @since 3.5.0
  * @category models
  */
-export interface RcRef<out A, out E = never> extends Pipeable {
+export interface RcRef<out A, out E = never>
+  extends Effect.Effect<A, E, Scope.Scope>, Readable.Readable<A, E, Scope.Scope>
+{
   readonly [TypeId]: RcRef.Variance<A, E>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: RcRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: RcRefUnifyIgnore
 }
 
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RcRefUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  RcRef?: () => A[Unify.typeSymbol] extends RcRef<infer A0, infer E0> | infer _ ? RcRef<A0, E0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RcRefUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
+}
 /**
  * @since 3.5.0
  * @category models

--- a/packages/effect/src/Ref.ts
+++ b/packages/effect/src/Ref.ts
@@ -36,8 +36,7 @@ export interface Ref<in out A> extends Ref.Variance<A>, Effect.Effect<A>, Readab
  * @since 3.8.0
  */
 export interface RefUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
-  Ref?: () => A[Unify.typeSymbol] extends Ref<infer A0> | infer _ ? Ref<A0>
-    : never
+  Ref?: () => Extract<A[Unify.typeSymbol], Ref<any>>
 }
 
 /**

--- a/packages/effect/src/Ref.ts
+++ b/packages/effect/src/Ref.ts
@@ -23,7 +23,7 @@ export type RefTypeId = typeof RefTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Ref<in out A> extends Ref.Variance<A>, Readable<A> {
+export interface Ref<in out A> extends Effect.Effect<A>, Ref.Variance<A>, Readable<A> {
   modify<B>(f: (a: A) => readonly [B, A]): Effect.Effect<B>
 }
 

--- a/packages/effect/src/Ref.ts
+++ b/packages/effect/src/Ref.ts
@@ -4,8 +4,9 @@
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/ref.js"
 import type * as Option from "./Option.js"
-import type { Readable } from "./Readable.js"
+import type * as Readable from "./Readable.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -23,8 +24,28 @@ export type RefTypeId = typeof RefTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Ref<in out A> extends Effect.Effect<A>, Ref.Variance<A>, Readable<A> {
+export interface Ref<in out A> extends Ref.Variance<A>, Effect.Effect<A>, Readable.Readable<A> {
   modify<B>(f: (a: A) => readonly [B, A]): Effect.Effect<B>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: RefUnify<this>
+  readonly [Unify.ignoreSymbol]?: RefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RefUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  Ref?: () => A[Unify.typeSymbol] extends Ref<infer A0> | infer _ ? Ref<A0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RefUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -57,8 +57,7 @@ export interface SubscriptionRef<in out A>
 export interface SubscriptionRefUnify<A extends { [Unify.typeSymbol]?: any }>
   extends Synchronized.SynchronizedRefUnify<A>
 {
-  SubscriptionRef?: () => A[Unify.typeSymbol] extends SubscriptionRef<infer A0> | infer _ ? SubscriptionRef<A0>
-    : never
+  SubscriptionRef?: () => Extract<A[Unify.typeSymbol], SubscriptionRef<any>>
 }
 
 /**

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -10,6 +10,7 @@ import type * as Stream from "./Stream.js"
 import type { Subscribable } from "./Subscribable.js"
 import * as Synchronized from "./SynchronizedRef.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -44,6 +45,28 @@ export interface SubscriptionRef<in out A>
    * to that value.
    */
   readonly changes: Stream.Stream<A>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: SubscriptionRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: SubscriptionRefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SubscriptionRefUnify<A extends { [Unify.typeSymbol]?: any }>
+  extends Synchronized.SynchronizedRefUnify<A>
+{
+  SubscriptionRef?: () => A[Unify.typeSymbol] extends SubscriptionRef<infer A0> | infer _ ? SubscriptionRef<A0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SubscriptionRefUnifyIgnore extends Synchronized.SynchronizedRefUnifyIgnore {
+  SynchronizedRef?: true
 }
 
 /**

--- a/packages/effect/src/SynchronizedRef.ts
+++ b/packages/effect/src/SynchronizedRef.ts
@@ -8,6 +8,7 @@ import * as internal from "./internal/synchronizedRef.js"
 import type * as Option from "./Option.js"
 import type * as Ref from "./Ref.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -27,6 +28,26 @@ export type SynchronizedRefTypeId = typeof SynchronizedRefTypeId
  */
 export interface SynchronizedRef<in out A> extends SynchronizedRef.Variance<A>, Ref.Ref<A> {
   modifyEffect<B, E, R>(f: (a: A) => Effect.Effect<readonly [B, A], E, R>): Effect.Effect<B, E, R>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: SynchronizedRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: SynchronizedRefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SynchronizedRefUnify<A extends { [Unify.typeSymbol]?: any }> extends Ref.RefUnify<A> {
+  SynchronizedRef?: () => A[Unify.typeSymbol] extends SynchronizedRef<infer A0> | infer _ ? SynchronizedRef<A0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SynchronizedRefUnifyIgnore extends Ref.RefUnifyIgnore {
+  Ref?: true
 }
 
 /**

--- a/packages/effect/src/SynchronizedRef.ts
+++ b/packages/effect/src/SynchronizedRef.ts
@@ -38,8 +38,7 @@ export interface SynchronizedRef<in out A> extends SynchronizedRef.Variance<A>, 
  * @since 3.8.0
  */
 export interface SynchronizedRefUnify<A extends { [Unify.typeSymbol]?: any }> extends Ref.RefUnify<A> {
-  SynchronizedRef?: () => A[Unify.typeSymbol] extends SynchronizedRef<infer A0> | infer _ ? SynchronizedRef<A0>
-    : never
+  SynchronizedRef?: () => Extract<A[Unify.typeSymbol], SynchronizedRef<any>>
 }
 
 /**

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -574,13 +574,12 @@ export const synchronizedVariance = {
 class SynchronizedImpl<in out A> extends Effectable.Class<A> implements Synchronized.SynchronizedRef<A> {
   readonly [SynchronizedTypeId] = synchronizedVariance
   readonly [internalRef.RefTypeId] = internalRef.refVariance
-  readonly [Readable.TypeId]: Readable.TypeId
+  readonly [Readable.TypeId]: Readable.TypeId = Readable.TypeId
   constructor(
     readonly ref: Ref.Ref<A>,
     readonly withLock: <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
   ) {
     super()
-    this[Readable.TypeId] = Readable.TypeId
     this.get = internalRef.get(this.ref)
   }
   readonly get: Effect.Effect<A>

--- a/packages/effect/src/internal/ref.ts
+++ b/packages/effect/src/internal/ref.ts
@@ -1,8 +1,8 @@
 import type * as Effect from "../Effect.js"
+import * as Effectable from "../Effectable.js"
 import { dual } from "../Function.js"
 import * as MutableRef from "../MutableRef.js"
 import * as Option from "../Option.js"
-import { pipeArguments } from "../Pipeable.js"
 import * as Readable from "../Readable.js"
 import type * as Ref from "../Ref.js"
 import * as core from "./core.js"
@@ -16,10 +16,14 @@ export const refVariance = {
   _A: (_: any) => _
 }
 
-class RefImpl<in out A> implements Ref.Ref<A> {
+class RefImpl<in out A> extends Effectable.Class<A> implements Ref.Ref<A> {
+  commit() {
+    return this.get
+  }
   readonly [RefTypeId] = refVariance
   readonly [Readable.TypeId]: Readable.TypeId
   constructor(readonly ref: MutableRef.MutableRef<A>) {
+    super()
     this[Readable.TypeId] = Readable.TypeId
     this.get = core.sync(() => MutableRef.get(this.ref))
   }
@@ -33,9 +37,6 @@ class RefImpl<in out A> implements Ref.Ref<A> {
       }
       return b
     })
-  }
-  pipe() {
-    return pipeArguments(this, arguments)
   }
 }
 

--- a/packages/effect/src/internal/ref.ts
+++ b/packages/effect/src/internal/ref.ts
@@ -21,10 +21,9 @@ class RefImpl<in out A> extends Effectable.Class<A> implements Ref.Ref<A> {
     return this.get
   }
   readonly [RefTypeId] = refVariance
-  readonly [Readable.TypeId]: Readable.TypeId
+  readonly [Readable.TypeId]: Readable.TypeId = Readable.TypeId
   constructor(readonly ref: MutableRef.MutableRef<A>) {
     super()
-    this[Readable.TypeId] = Readable.TypeId
     this.get = core.sync(() => MutableRef.get(this.ref))
   }
   readonly get: Effect.Effect<A>

--- a/packages/effect/src/internal/subscriptionRef.ts
+++ b/packages/effect/src/internal/subscriptionRef.ts
@@ -27,8 +27,8 @@ const subscriptionRefVariance = {
 
 /** @internal */
 class SubscriptionRefImpl<in out A> extends Effectable.Class<A> implements SubscriptionRef.SubscriptionRef<A> {
-  readonly [Readable.TypeId]: Readable.TypeId
-  readonly [Subscribable.TypeId]: Subscribable.TypeId
+  readonly [Readable.TypeId]: Readable.TypeId = Readable.TypeId
+  readonly [Subscribable.TypeId]: Subscribable.TypeId = Subscribable.TypeId
   readonly [Ref.RefTypeId] = _ref.refVariance
   readonly [Synchronized.SynchronizedRefTypeId] = _circular.synchronizedVariance
   readonly [SubscriptionRefTypeId] = subscriptionRefVariance
@@ -38,9 +38,7 @@ class SubscriptionRefImpl<in out A> extends Effectable.Class<A> implements Subsc
     readonly semaphore: Effect.Semaphore
   ) {
     super()
-    this[Readable.TypeId] = Readable.TypeId
-    this[Subscribable.TypeId] = Subscribable.TypeId
-    this.get = this.ref
+    this.get = Ref.get(this.ref)
   }
   commit() {
     return this.get
@@ -48,7 +46,7 @@ class SubscriptionRefImpl<in out A> extends Effectable.Class<A> implements Subsc
   readonly get: Effect.Effect<A>
   get changes(): Stream<A> {
     return pipe(
-      this.ref,
+      Ref.get(this.ref),
       Effect.flatMap((a) =>
         Effect.map(
           stream.fromPubSub(this.pubsub, { scoped: true }),
@@ -68,7 +66,7 @@ class SubscriptionRefImpl<in out A> extends Effectable.Class<A> implements Subsc
   }
   modifyEffect<B, E, R>(f: (a: A) => Effect.Effect<readonly [B, A], E, R>): Effect.Effect<B, E, R> {
     return pipe(
-      this.ref,
+      Ref.get(this.ref),
       Effect.flatMap(f),
       Effect.flatMap(([b, a]) =>
         pipe(

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -23,14 +23,14 @@ describe("RcRef", () => {
       )
 
       assert.strictEqual(acquired, 0)
-      assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
+      assert.strictEqual(yield* Effect.scoped(ref), "foo")
       assert.strictEqual(acquired, 1)
       assert.strictEqual(released, 1)
 
       const scopeA = yield* Scope.make()
       const scopeB = yield* Scope.make()
-      yield* RcRef.get(ref).pipe(Scope.extend(scopeA))
-      yield* RcRef.get(ref).pipe(Scope.extend(scopeB))
+      yield* ref.pipe(Scope.extend(scopeA))
+      yield* ref.pipe(Scope.extend(scopeB))
       assert.strictEqual(acquired, 2)
       assert.strictEqual(released, 1)
       yield* Scope.close(scopeB, Exit.void)
@@ -41,7 +41,7 @@ describe("RcRef", () => {
       assert.strictEqual(released, 2)
 
       const scopeC = yield* Scope.make()
-      yield* RcRef.get(ref).pipe(Scope.extend(scopeC))
+      yield* ref.pipe(Scope.extend(scopeC))
       assert.strictEqual(acquired, 3)
       assert.strictEqual(released, 2)
 
@@ -49,7 +49,7 @@ describe("RcRef", () => {
       assert.strictEqual(acquired, 3)
       assert.strictEqual(released, 3)
 
-      const exit = yield* RcRef.get(ref).pipe(Effect.scoped, Effect.exit)
+      const exit = yield* ref.get.pipe(Effect.scoped, Effect.exit)
       assert.isTrue(Exit.isInterrupted(exit))
     }))
 

--- a/packages/effect/test/Ref.test.ts
+++ b/packages/effect/test/Ref.test.ts
@@ -56,7 +56,7 @@ describe("Ref", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(current))
       const result1 = yield* $(Ref.getAndUpdate(ref, () => update))
-      const result2 = yield* $(ref)
+      const result2 = yield* ref
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))

--- a/packages/effect/test/Ref.test.ts
+++ b/packages/effect/test/Ref.test.ts
@@ -35,7 +35,7 @@ describe("Ref", () => {
     Effect.gen(function*(_) {
       const ref = yield* _(Ref.make(123))
       assert.isTrue(Readable.isReadable(ref))
-      assert.strictEqual(yield* _(ref.get), 123)
+      assert.strictEqual(yield* ref, 123)
     }))
 
   it.effect("get", () =>
@@ -44,10 +44,11 @@ describe("Ref", () => {
       assert.strictEqual(result, current)
     }))
   it.effect("getAndSet", () =>
-    Effect.gen(function*($) {
-      const ref = yield* $(Ref.make(current))
-      const result1 = yield* $(Ref.getAndSet(ref, update))
-      const result2 = yield* $(Ref.get(ref))
+    Effect.gen(function*() {
+      const ref = yield* Ref.make(current)
+      const result1 = yield* Ref.getAndSet(ref, update)
+
+      const result2 = yield* ref
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))
@@ -55,7 +56,7 @@ describe("Ref", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(current))
       const result1 = yield* $(Ref.getAndUpdate(ref, () => update))
-      const result2 = yield* $(Ref.get(ref))
+      const result2 = yield* $(ref)
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))

--- a/packages/effect/test/Synchronized.test.ts
+++ b/packages/effect/test/Synchronized.test.ts
@@ -40,10 +40,10 @@ describe("SynchronizedRef", () => {
       assert.strictEqual(result, current)
     }))
   it.effect("getAndUpdateEffect - happy path", () =>
-    Effect.gen(function*($) {
-      const ref = yield* $(Synchronized.make(current))
-      const result1 = yield* $(Synchronized.getAndUpdateEffect(ref, () => Effect.succeed(update)))
-      const result2 = yield* $(Synchronized.get(ref))
+    Effect.gen(function*() {
+      const ref = yield* Synchronized.make(current)
+      const result1 = yield* Synchronized.getAndUpdateEffect(ref, () => Effect.succeed(update))
+      const result2 = yield* ref
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))
@@ -77,7 +77,7 @@ describe("SynchronizedRef", () => {
           : isChanged(state)
           ? Option.some(Effect.succeed(Closed))
           : Option.none()))
-      const result3 = yield* $(Synchronized.get(ref))
+      const result3 = yield* ref
       assert.deepStrictEqual(result1, Active)
       assert.deepStrictEqual(result2, Changed)
       assert.deepStrictEqual(result3, Closed)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue https://github.com/Effect-TS/effect/issues/3500
- Closes #
