### PR TITLE
Add a Config constructor : `Config.stringNonEmpty `

### DIFF
--- a/.changeset/hot-dogs-mix.md
+++ b/.changeset/hot-dogs-mix.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-New constructor Config.nonEmptyString
+New constructor Config.stringNonEmpty

--- a/.changeset/hot-dogs-mix.md
+++ b/.changeset/hot-dogs-mix.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+New constructor Config.nonEmptyString

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -370,7 +370,7 @@ export const string: (name?: string) => Config<string> = internal.string
 /**
  * Constructs a config for a non-empty string value.
  *
- * @since ??
+ * @since 3.7.0
  * @category constructors
  */
 export const nonEmptyString: (name?: string) => Config<string> = internal.nonEmptyString

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -373,7 +373,7 @@ export const string: (name?: string) => Config<string> = internal.string
  * @since 3.7.0
  * @category constructors
  */
-export const nonEmptyString: (name?: string) => Config<string> = internal.nonEmptyString
+export const stringNonEmpty: (name?: string) => Config<string> = internal.stringNonEmpty
 
 /**
  * Constructs a config which contains the specified value.

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -368,6 +368,14 @@ export const hashSet: <A>(config: Config<A>, name?: string) => Config<HashSet.Ha
 export const string: (name?: string) => Config<string> = internal.string
 
 /**
+ * Constructs a config for a non-empty string value.
+ *
+ * @since ??
+ * @category constructors
+ */
+export const nonEmptyString: (name?: string) => Config<string> = internal.nonEmptyString
+
+/**
  * Constructs a config which contains the specified value.
  *
  * @since 2.0.0

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -451,7 +451,7 @@ export const string = (name?: string): Config.Config<string> => {
 export const stringNonEmpty = (name?: string): Config.Config<string> => {
   const config = primitive(
     "a non-empty text property",
-    Either.liftPredicate((text) => text.length > 0, () => configError.InvalidData([], "Expected a non-empty string"))
+    Either.liftPredicate((text) => text.length > 0, () => configError.MissingData([], "Expected a non-empty string"))
   )
 
   return name === undefined ? config : nested(config, name)

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -448,7 +448,7 @@ export const string = (name?: string): Config.Config<string> => {
 }
 
 /** @internal */
-export const nonEmptyString = (name?: string): Config.Config<string> => {
+export const stringNonEmpty = (name?: string): Config.Config<string> => {
   const config = primitive(
     "a non-empty text property",
     Either.liftPredicate((text) => text.length > 0, () => configError.InvalidData([], "Expected a non-empty string"))

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -448,6 +448,16 @@ export const string = (name?: string): Config.Config<string> => {
 }
 
 /** @internal */
+export const nonEmptyString = (name?: string): Config.Config<string> => {
+  const config = primitive(
+    "a non-empty text property",
+    Either.liftPredicate((text) => text.length > 0, () => configError.InvalidData([], "Expected a non-empty string"))
+  )
+
+  return name === undefined ? config : nested(config, name)
+}
+
+/** @internal */
 export const all = <const Arg extends Iterable<Config.Config<any>> | Record<string, Config.Config<any>>>(
   arg: Arg
 ): Config.Config<

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -70,7 +70,7 @@ describe("Config", () => {
     it("name = undefined", () => {
       const config = Config.array(Config.stringNonEmpty(), "ITEMS")
       assertSuccess(config, [["ITEMS", "foo"]], ["foo"])
-      assertFailure(config, [["ITEMS", ""]], ConfigError.InvalidData(["ITEMS"], "Expected a non-empty string"))
+      assertFailure(config, [["ITEMS", ""]], ConfigError.MissingData(["ITEMS"], "Expected a non-empty string"))
     })
 
     it("name != undefined", () => {
@@ -80,7 +80,7 @@ describe("Config", () => {
       assertFailure(
         config,
         [["NON_EMPTY_STRING", ""]],
-        ConfigError.InvalidData(["NON_EMPTY_STRING"], "Expected a non-empty string")
+        ConfigError.MissingData(["NON_EMPTY_STRING"], "Expected a non-empty string")
       )
     })
   })

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -66,15 +66,15 @@ describe("Config", () => {
     })
   })
 
-  describe("nonEmptyString", () => {
+  describe("stringNonEmpty", () => {
     it("name = undefined", () => {
-      const config = Config.array(Config.nonEmptyString(), "ITEMS")
+      const config = Config.array(Config.stringNonEmpty(), "ITEMS")
       assertSuccess(config, [["ITEMS", "foo"]], ["foo"])
       assertFailure(config, [["ITEMS", ""]], ConfigError.InvalidData(["ITEMS"], "Expected a non-empty string"))
     })
 
     it("name != undefined", () => {
-      const config = Config.nonEmptyString("NON_EMPTY_STRING")
+      const config = Config.stringNonEmpty("NON_EMPTY_STRING")
       assertSuccess(config, [["NON_EMPTY_STRING", "foo"]], "foo")
       assertSuccess(config, [["NON_EMPTY_STRING", " "]], " ")
       assertFailure(

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -66,6 +66,25 @@ describe("Config", () => {
     })
   })
 
+  describe("nonEmptyString", () => {
+    it("name = undefined", () => {
+      const config = Config.array(Config.nonEmptyString(), "ITEMS")
+      assertSuccess(config, [["ITEMS", "foo"]], ["foo"])
+      assertFailure(config, [["ITEMS", ""]], ConfigError.InvalidData(["ITEMS"], "Expected a non-empty string"))
+    })
+
+    it("name != undefined", () => {
+      const config = Config.nonEmptyString("NON_EMPTY_STRING")
+      assertSuccess(config, [["NON_EMPTY_STRING", "foo"]], "foo")
+      assertSuccess(config, [["NON_EMPTY_STRING", " "]], " ")
+      assertFailure(
+        config,
+        [["NON_EMPTY_STRING", ""]],
+        ConfigError.InvalidData(["NON_EMPTY_STRING"], "Expected a non-empty string")
+      )
+    })
+  })
+
   describe("number", () => {
     it("name = undefined", () => {
       const config = Config.array(Config.number(), "ITEMS")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added a new constructor to config.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #3515
- Closes #3515
