### PR TITLE
add `onnotice` option to `PgClient`

### DIFF
--- a/.changeset/forty-worms-help.md
+++ b/.changeset/forty-worms-help.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Add `onnotice` option to `PgClient`.

--- a/packages/sql-pg/src/PgClient.ts
+++ b/packages/sql-pg/src/PgClient.ts
@@ -101,6 +101,18 @@ export interface PgClientConfig {
   readonly transformJson?: boolean | undefined
   readonly fetchTypes?: boolean | undefined
   readonly prepare?: boolean | undefined
+  /**
+   * A callback when postgres has a notice, see
+   * [readme](https://github.com/porsager/postgres?tab=readme-ov-file#connection-details).
+   * By default, postgres.js logs these with console.log.
+   * To silence notices, see the following example:
+   * @example
+   * import { PgClient } from "@effect/sql-pg";
+   * import { Config, Layer } from "effect"
+   *
+   * const layer = PgClient.layer({ onnotice: Config.succeed(() => {}) })
+   */
+  readonly onnotice?: (notice: postgres.Notice) => void
   readonly types?: Record<string, postgres.PostgresType> | undefined
 
   readonly debug?: postgres.Options<{}>["debug"] | undefined
@@ -156,6 +168,7 @@ export const make = (
       password: options.password ? Redacted.value(options.password) : undefined,
       fetch_types: options.fetchTypes ?? true,
       prepare: options.prepare ?? true,
+      onnotice: options.onnotice,
       types: options.types,
       debug: options.debug,
       connection: {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Postgres.js logs notices provided by PostgreSQL to `console.log` by default. Exposing this option allows for configuring what to do with the notice. For example, a command like `DROP TABLE IF EXISTS [tablename]` will fire a notice if the table doesn't exist, which causes logs to be noisy.
