### PR TITLE
Add number round

### DIFF
--- a/.changeset/quick-roses-warn.md
+++ b/.changeset/quick-roses-warn.md
@@ -1,0 +1,6 @@
+---
+"effect": minor
+"@effect/cli": patch
+---
+
+Add Number.round

--- a/packages/cli/src/internal/prompt/number.ts
+++ b/packages/cli/src/internal/prompt/number.ts
@@ -5,6 +5,7 @@ import * as Optimize from "@effect/printer/Optimize"
 import * as Schema from "@effect/schema/Schema"
 import * as Arr from "effect/Array"
 import * as Effect from "effect/Effect"
+import * as EffectNumber from "effect/Number"
 import * as Option from "effect/Option"
 import type * as Prompt from "../../Prompt.js"
 import * as InternalPrompt from "../prompt.js"
@@ -18,11 +19,6 @@ interface State {
   readonly cursor: number
   readonly value: string
   readonly error: Option.Option<string>
-}
-
-const round = (number: number, precision: number) => {
-  const factor = Math.pow(10, precision)
-  return Math.round(number * factor) / factor
 }
 
 const parseInt = Schema.NumberFromString.pipe(
@@ -352,7 +348,7 @@ function handleProcessFloat(options: FloatOptions) {
             })),
           onSuccess: (n) =>
             Effect.flatMap(
-              Effect.sync(() => round(n, options.precision)),
+              Effect.sync(() => EffectNumber.round(n, options.precision)),
               (rounded) =>
                 Effect.match(options.validate(rounded), {
                   onFailure: (error) =>

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -502,8 +502,8 @@ export const parse = (s: string): Option<number> => {
  * @example
  * import { round } from "effect/Number"
  *
- * assert.deepStrictEqual(round(5,1234, 2), 5.12)
- * assert.deepStrictEqual(nextPow2(17), 32)
+ * assert.deepStrictEqual(round(1.1234, 2), 1.12)
+ * assert.deepStrictEqual(round(1.567, 2), 1.57)
  *
  * @category math
  * @since 3.8.0

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -492,3 +492,26 @@ export const parse = (s: string): Option<number> => {
     ? option.none
     : option.some(n)
 }
+
+/**
+ * Returns the number rounded with the given precision.
+ *
+ * @param self - The number to round
+ * @param precision - The precision
+ *
+ * @example
+ * import { round } from "effect/Number"
+ *
+ * assert.deepStrictEqual(round(5,1234, 2), 5.12)
+ * assert.deepStrictEqual(nextPow2(17), 32)
+ *
+ * @category math
+ * @since 3.8.0
+ */
+export const round: {
+  (precision: number): (self: number) => number
+  (self: number, precision: number): number
+} = dual(2, (self: number, precision: number): number => {
+  const factor = Math.pow(10, precision)
+  return Math.round(self * factor) / factor
+})

--- a/packages/effect/test/Number.test.ts
+++ b/packages/effect/test/Number.test.ts
@@ -135,4 +135,13 @@ describe("Number", () => {
     assert.deepStrictEqual(Number.parse("42"), Option.some(42))
     assert.deepStrictEqual(Number.parse("a"), Option.none())
   })
+
+  it("round", () => {
+    assert.deepStrictEqual(Number.round(1.1234, 2), 1.12)
+    assert.deepStrictEqual(Number.round(2)(1.1234), 1.12)
+    assert.deepStrictEqual(Number.round(0)(1.1234), 1)
+    assert.deepStrictEqual(Number.round(0)(1.1234), 1)
+    assert.deepStrictEqual(Number.round(1.567, 2), 1.57)
+    assert.deepStrictEqual(Number.round(2)(1.567), 1.57)
+  })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds `Number.round` method to which you can pass a precision.
`* assert.deepStrictEqual(round(5,1234, 2), 5.12)`


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
