### PR TITLE
add Logger.withLeveledConsole

### DIFF
--- a/.changeset/calm-houses-brake.md
+++ b/.changeset/calm-houses-brake.md
@@ -1,0 +1,20 @@
+---
+"effect": minor
+---
+
+add `Logger.withLeveledConsole`
+
+In browsers and different platforms, `console.error` renders differently than `console.info`. This helps to distinguish between different levels of logging. `Logger.withLeveledConsole` takes any logger and calls the respective `Console` method based on the log level. For instance, `Effect.logError` will call `Console.error` and `Effect.logInfo` will call `Console.info`.
+
+To use it, you can replace the default logger with a `Logger.withLeveledConsole` logger:
+
+```ts
+import { Logger, Effect } from "effect"
+
+const loggerLayer = Logger.withLeveledConsole(Logger.stringLogger)
+
+Effect.gen(function* () {
+  yield* Effect.logError("an error")
+  yield* Effect.logInfo("an info")
+}).pipe(Effect.provide(loggerLayer))
+```

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -242,6 +242,12 @@ export const withConsoleLog: <M, O>(self: Logger<M, O>) => Logger<M, void> = fib
  * @since 2.0.0
  * @category console
  */
+export const withLeveledConsole: <M, O>(self: Logger<M, O>) => Logger<M, void> = fiberRuntime.loggerWithLeveledLog
+
+/**
+ * @since 2.0.0
+ * @category console
+ */
 export const withConsoleError: <M, O>(self: Logger<M, O>) => Logger<M, void> = fiberRuntime.loggerWithConsoleError
 
 /**

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -245,7 +245,10 @@ export const withConsoleLog: <M, O>(self: Logger<M, O>) => Logger<M, void> = fib
  * @example
  * import { Logger, Effect } from "effect"
  *
- * const loggerLayer = Logger.withLeveledConsole(Logger.stringLogger)
+ * const loggerLayer = Logger.replace(
+ *   Logger.defaultLogger,
+ *   Logger.withLeveledConsole(Logger.stringLogger),
+ * )
  *
  * Effect.gen(function* () {
  *   yield* Effect.logError("an error")

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -239,6 +239,19 @@ export const batched: {
 export const withConsoleLog: <M, O>(self: Logger<M, O>) => Logger<M, void> = fiberRuntime.loggerWithConsoleLog
 
 /**
+ * Takes a `Logger<M, O>` and returns a logger that calls the respective `Console` method
+ * based on the log level.
+ *
+ * @example
+ * import { Logger, Effect } from "effect"
+ *
+ * const loggerLayer = Logger.withLeveledConsole(Logger.stringLogger)
+ *
+ * Effect.gen(function* () {
+ *   yield* Effect.logError("an error")
+ *   yield* Effect.logInfo("an info")
+ * }).pipe(Effect.provide(loggerLayer))
+ *
  * @since 2.0.0
  * @category console
  */

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -252,7 +252,7 @@ export const withConsoleLog: <M, O>(self: Logger<M, O>) => Logger<M, void> = fib
  *   yield* Effect.logInfo("an info")
  * }).pipe(Effect.provide(loggerLayer))
  *
- * @since 2.0.0
+ * @since 3.8.0
  * @category console
  */
 export const withLeveledConsole: <M, O>(self: Logger<M, O>) => Logger<M, void> = fiberRuntime.loggerWithLeveledLog

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1401,6 +1401,23 @@ export const loggerWithConsoleLog = <M, O>(self: Logger<M, O>): Logger<M, void> 
   })
 
 /** @internal */
+export const loggerWithLeveledLog = <M, O>(self: Logger<M, O>): Logger<M, void> =>
+  internalLogger.makeLogger((opts) => {
+    const services = FiberRefs.getOrDefault(opts.context, defaultServices.currentServices)
+    const unsafeLogger = Context.get(services, consoleTag).unsafe
+    const levels: Partial<Record<LogLevel.LogLevel["_tag"], (v: unknown) => void>> = {
+      All: unsafeLogger.log,
+      Info: unsafeLogger.info,
+      Debug: unsafeLogger.debug,
+      Error: unsafeLogger.error,
+      Fatal: unsafeLogger.error,
+      Trace: unsafeLogger.trace,
+      Warning: unsafeLogger.warn
+    }
+    levels[opts.logLevel._tag]?.(self.log(opts))
+  })
+
+/** @internal */
 export const loggerWithConsoleError = <M, O>(self: Logger<M, O>): Logger<M, void> =>
   internalLogger.makeLogger((opts) => {
     const services = FiberRefs.getOrDefault(opts.context, defaultServices.currentServices)

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1405,16 +1405,21 @@ export const loggerWithLeveledLog = <M, O>(self: Logger<M, O>): Logger<M, void> 
   internalLogger.makeLogger((opts) => {
     const services = FiberRefs.getOrDefault(opts.context, defaultServices.currentServices)
     const unsafeLogger = Context.get(services, consoleTag).unsafe
-    const levels: Partial<Record<LogLevel.LogLevel["_tag"], (v: unknown) => void>> = {
-      All: unsafeLogger.log,
-      Info: unsafeLogger.info,
-      Debug: unsafeLogger.debug,
-      Error: unsafeLogger.error,
-      Fatal: unsafeLogger.error,
-      Trace: unsafeLogger.trace,
-      Warning: unsafeLogger.warn
+    switch (opts.logLevel._tag) {
+      case "Debug":
+        return unsafeLogger.debug(self.log(opts))
+      case "Info":
+        return unsafeLogger.info(self.log(opts))
+      case "Trace":
+        return unsafeLogger.trace(self.log(opts))
+      case "Warning":
+        return unsafeLogger.warn(self.log(opts))
+      case "Error":
+      case "Fatal":
+        return unsafeLogger.error(self.log(opts))
+      default:
+        return unsafeLogger.log(self.log(opts))
     }
-    levels[opts.logLevel._tag]?.(self.log(opts))
   })
 
 /** @internal */


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In browsers and different platforms, `console.error` renders differently than `console.info`. This helps to distinguish between different levels of logging. `Logger.withLeveledConsole` takes any logger and calls the respective `Console` method based on the log level. For instance, `Effect.logError` will call `Console.error` and `Effect.logInfo` will call `Console.info`.

To use it, you can replace the default logger with a `Logger.withLeveledConsole` logger:

```ts
import { Logger, Effect } from "effect"

const loggerLayer = Logger.withLeveledConsole(Logger.stringLogger)

Effect.gen(function* () {
  yield* Effect.logError("an error")
  yield* Effect.logInfo("an info")
}).pipe(Effect.provide(loggerLayer))
```


## Related

- Related Issue #
- Closes #
