### PR TITLE
fix(Stream): align .empty to behave like .make with no arguments

### DIFF
--- a/.changeset/rare-eagles-think.md
+++ b/.changeset/rare-eagles-think.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Align behavior of `Stream.empty` to act like `Stream.make()` to fix behavior with `NodeStream.toReadable`

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -2405,7 +2405,7 @@ export const either = <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<Eit
   pipe(self, map(Either.right), catchAll((error) => make(Either.left(error))))
 
 /** @internal */
-export const empty: Stream.Stream<never> = new StreamImpl(core.write(Chunk.empty()))
+export const empty: Stream.Stream<never> = new StreamImpl(core.void)
 
 /** @internal */
 export const ensuring = dual<


### PR DESCRIPTION
fixes: #3542 

I don't know the history of why `Channel` prefers a `void` over an empty `Chunk`, but this was the smallest change to fix the bug described in the issue