### PR TITLE
Ensure `QuitException` terminates command-line processing

### DIFF
--- a/.changeset/thirty-nails-breathe.md
+++ b/.changeset/thirty-nails-breathe.md
@@ -1,0 +1,8 @@
+---
+"@effect/cli": patch
+---
+
+Ensure `QuitException` terminates command-line processing.
+
+A `QuitException` raised by a `Prompt` that is executing as a fallback for a CLI option will terminate processing of the command line.
+

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -13,6 +13,7 @@ import * as HashMap from "effect/HashMap"
 import * as Option from "effect/Option"
 import * as Order from "effect/Order"
 import { pipeArguments } from "effect/Pipeable"
+import * as Predicate from "effect/Predicate"
 import type * as Redacted from "effect/Redacted"
 import * as Ref from "effect/Ref"
 import type * as Secret from "effect/Secret"
@@ -1347,7 +1348,12 @@ const parseInternal = (
       return parseInternal(self.options as Instruction, args, config).pipe(
         Effect.catchTag(
           "MissingValue",
-          (e) => Effect.mapError(self.effect, () => e)
+          (e) =>
+            self.effect.pipe(Effect.catchAll((e2) =>
+              Predicate.isTagged(e2, "QuitException")
+                ? Effect.die(e2)
+                : Effect.fail(e)
+            ))
         )
       )
     }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR ensures that a `QuitException` raised by a `Prompt` that is executing as a fallback for a CLI option will terminate processing of the command line.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
