### PR TITLE
`Deferred` is subtype of `Effect`

### DIFF
--- a/.changeset/gorgeous-toes-help.md
+++ b/.changeset/gorgeous-toes-help.md
@@ -1,0 +1,16 @@
+---
+"effect": minor
+---
+
+The `Deferred<A>` is now a subtype of `Effect<A>`. This change simplifies handling of deferred values, removing the need for explicit call `Deffer.await`.
+
+```typescript
+import { Effect, Deferred } from "effect"
+
+Effect.gen(function* () {
+  const deferred = yield* Deferred.make<string>()
+
+  const before = yield* Deferred.await(deferred)
+  const after = yield* deferred
+})
+```

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -1,3 +1,4 @@
+import type * as Deferred from "effect/Deferred"
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import type * as Micro from "effect/Micro"
@@ -35,6 +36,55 @@ export type MU = Unify.Unify<
   Micro.Micro<0, 1, 2> | Micro.Micro<"a", "b", "c">
 >
 // $ExpectType Effect<0 | "a", "b" | 1, "c" | 2>
-export type EU = Unify.Unify<
-  Effect.Effect<0, 1, 2> | Effect.Effect<"a", "b", "c">
+export type EffectUnify = Unify.Unify<
+  | Effect.Effect<0, 1, 2>
+  | Effect.Effect<"a", "b", "c">
+>
+// $ExpectType Exit<0 | "a", "b" | 1>
+export type ExitUnify = Unify.Unify<
+  | Exit.Exit<0, 1>
+  | Exit.Exit<"a", "b">
+>
+// $ExpectType Ref<1> | Ref<"a">
+export type RefUnify = Unify.Unify<Ref.Ref<1> | Ref.Ref<"a">>
+// $ExpectType SynchronizedRef<1> | SynchronizedRef<"a">
+export type SynchronizedRefUnify = Unify.Unify<
+  | SynchronizedRef.SynchronizedRef<1>
+  | SynchronizedRef.SynchronizedRef<"a">
+>
+// $ExpectType SubscriptionRef<1> | SubscriptionRef<"a">
+export type SubscriptionRefUnify = Unify.Unify<
+  | SubscriptionRef.SubscriptionRef<1>
+  | SubscriptionRef.SubscriptionRef<"a">
+>
+// $ExpectType RcRef<"a" | 1, "b" | 2>
+export type RcRefUnify = Unify.Unify<
+  | RcRef.RcRef<1, 2>
+  | RcRef.RcRef<"a", "b">
+>
+// $ExpectType Deferred<1, 2> | Deferred<"a", "b">
+export type DeferredUnify = Unify.Unify<
+  | Deferred.Deferred<1, 2>
+  | Deferred.Deferred<"a", "b">
+>
+
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+export type AllUnify = Unify.Unify<
+  | Either.Either<1, 0>
+  | Either.Either<"A", "E">
+  | Option.Option<number>
+  | Option.Option<string>
+  | Effect.Effect<"A", "E", "R">
+  | Effect.Effect<1, 0, "R1">
+  | Ref.Ref<1>
+  | Ref.Ref<"A">
+  | SynchronizedRef.SynchronizedRef<1>
+  | SynchronizedRef.SynchronizedRef<"A">
+  | SubscriptionRef.SubscriptionRef<1>
+  | SubscriptionRef.SubscriptionRef<"A">
+  | RcRef.RcRef<1, 0>
+  | RcRef.RcRef<"A", "E">
+  | Deferred.Deferred<1, 2>
+  | Deferred.Deferred<"a", "b">
+  | 0
 >

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -10,8 +10,8 @@ import * as core from "./internal/core.js"
 import * as internal from "./internal/deferred.js"
 import type * as MutableRef from "./MutableRef.js"
 import type * as Option from "./Option.js"
-import type { Pipeable } from "./Pipeable.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -37,11 +37,30 @@ export type DeferredTypeId = typeof DeferredTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Deferred<in out A, in out E = never> extends Deferred.Variance<A, E>, Pipeable {
+export interface Deferred<in out A, in out E = never> extends Effect.Effect<A, E>, Deferred.Variance<A, E> {
   /** @internal */
   readonly state: MutableRef.MutableRef<internal.State<A, E>>
   /** @internal */
   readonly blockingOn: FiberId.FiberId
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: DeferredUnify<this>
+  readonly [Unify.ignoreSymbol]?: DeferredUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface DeferredUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  Deferred?: () => Extract<A[Unify.typeSymbol], Deferred<any>>
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface DeferredUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -43,7 +43,7 @@ import * as _blockedRequests from "./blockedRequests.js"
 import * as internalCause from "./cause.js"
 import * as deferred from "./deferred.js"
 import * as internalDiffer from "./differ.js"
-import { effectVariance, StructuralCommitPrototype } from "./effectable.js"
+import { CommitPrototype, effectVariance, StructuralCommitPrototype } from "./effectable.js"
 import { getBugErrorMessage } from "./errors.js"
 import type * as FiberRuntime from "./fiberRuntime.js"
 import type * as fiberScope from "./fiberScope.js"
@@ -2788,14 +2788,18 @@ const exitCollectAllInternal = <A, E>(
 // -----------------------------------------------------------------------------
 
 /** @internal */
-export const deferredUnsafeMake = <A, E = never>(fiberId: FiberId.FiberId): Deferred.Deferred<A, E> => ({
-  [deferred.DeferredTypeId]: deferred.deferredVariance,
-  state: MutableRef.make(deferred.pending([])),
-  blockingOn: fiberId,
-  pipe() {
-    return pipeArguments(this, arguments)
+export const deferredUnsafeMake = <A, E = never>(fiberId: FiberId.FiberId): Deferred.Deferred<A, E> => {
+  const _deferred = {
+    ...CommitPrototype,
+    [deferred.DeferredTypeId]: deferred.deferredVariance,
+    state: MutableRef.make(deferred.pending<A, E>([])),
+    commit() {
+      return deferredAwait(this)
+    },
+    blockingOn: fiberId
   }
-})
+  return _deferred
+}
 
 /* @internal */
 export const deferredMake = <A, E = never>(): Effect.Effect<Deferred.Deferred<A, E>> =>

--- a/packages/effect/test/Deferred.test.ts
+++ b/packages/effect/test/Deferred.test.ts
@@ -157,4 +157,14 @@ describe("Deferred", () => {
       )
       assert.isTrue(Exit.isInterrupted(result))
     }))
+  it.effect("is subtype of Effect", () =>
+    Effect.gen(function*() {
+      const deferred = yield* Deferred.make<number>()
+      const ref = yield* Ref.make(13)
+      yield* Deferred.complete(deferred, Ref.updateAndGet(ref, (n) => n + 1))
+      const result1 = yield* deferred
+      const result2 = yield* deferred
+      assert.strictEqual(result1, 14)
+      assert.strictEqual(result2, 14)
+    }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `Deferred<A>` is now a subtype of `Effect<A>`. This change simplifies handling of deferred values, removing the need for explicit call `Deferred.await`.

```typescript
import { Effect, Deferred } from "effect"

Effect.gen(function* () {
  const deferred = yield* Deferred.make<string>()

  const before = yield* Deferred.await(deferred)
  const after = yield* deferred
})
```


<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
