### PR TITLE
Preserve Span on Interruption

### DIFF
--- a/.changeset/eighty-lobsters-refuse.md
+++ b/.changeset/eighty-lobsters-refuse.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Made `Ref`, `SynchronizedRed` and `SubscriptionRef` a subtype of `Effect`

--- a/.changeset/gorgeous-toes-help.md
+++ b/.changeset/gorgeous-toes-help.md
@@ -1,0 +1,16 @@
+---
+"effect": minor
+---
+
+The `Deferred<A>` is now a subtype of `Effect<A>`. This change simplifies handling of deferred values, removing the need for explicit call `Deffer.await`.
+
+```typescript
+import { Effect, Deferred } from "effect"
+
+Effect.gen(function* () {
+  const deferred = yield* Deferred.make<string>()
+
+  const before = yield* Deferred.await(deferred)
+  const after = yield* deferred
+})
+```

--- a/.changeset/honest-cups-wash.md
+++ b/.changeset/honest-cups-wash.md
@@ -1,0 +1,6 @@
+---
+"effect": minor
+"@effect/platform": patch
+---
+
+add Logger.prettyLoggerDefault, to prevent duplicate pretty loggers

--- a/.changeset/quick-roses-warn.md
+++ b/.changeset/quick-roses-warn.md
@@ -1,0 +1,6 @@
+---
+"effect": minor
+"@effect/cli": patch
+---
+
+Add Number.round

--- a/.changeset/seven-lamps-nail.md
+++ b/.changeset/seven-lamps-nail.md
@@ -1,0 +1,16 @@
+---
+"effect": minor
+---
+
+The `Fiber<A, E>` is now a subtype of `Effect<A, E>`. This change removes the need for explicit call `Fiber.join`.
+
+```typescript
+import { Effect, Fiber } from "effect"
+
+Effect.gen(function*() {
+  const fiber = yield* Effect.fork(Effect.succeed(1))
+
+  const oldWay = yield* Fiber.join(fiber)
+  const now = yield* fiber
+}))
+```

--- a/.changeset/stream-share.md
+++ b/.changeset/stream-share.md
@@ -1,0 +1,10 @@
+---
+"effect": minor
+---
+
+add `Stream.share` api
+
+The `Stream.share` api is a ref counted variant of the broadcast apis.
+
+It allows you to share a stream between multiple consumers, and will close the
+upstream when the last consumer ends.

--- a/.changeset/tender-foxes-walk.md
+++ b/.changeset/tender-foxes-walk.md
@@ -1,0 +1,87 @@
+---
+"@effect/platform-browser": minor
+"@effect/platform-node": minor
+"@effect/platform-bun": minor
+"@effect/platform": minor
+"@effect/rpc-http": minor
+---
+
+refactor /platform HttpClient
+
+#### HttpClient.fetch removed
+
+The `HttpClient.fetch` client implementation has been removed. Instead, you can
+access a `HttpClient` using the corresponding `Context.Tag`.
+
+```ts
+import { FetchHttpClient, HttpClient } from "@effect/platform"
+import { Effect } from "effect"
+
+Effect.gen(function* () {
+  const client = yield* HttpClient.HttpClient
+
+  // make a get request
+  yield* client.get("https://jsonplaceholder.typicode.com/todos/1")
+}).pipe(
+  Effect.scoped,
+  // the fetch client has been moved to the `FetchHttpClient` module
+  Effect.provide(FetchHttpClient.layer)
+)
+```
+
+#### `HttpClient` interface now uses methods
+
+Instead of being a function that returns the response, the `HttpClient`
+interface now uses methods to make requests.
+
+Some shorthand methods have been added to the `HttpClient` interface to make
+less complex requests easier.
+
+```ts
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest
+} from "@effect/platform"
+import { Effect } from "effect"
+
+Effect.gen(function* () {
+  const client = yield* HttpClient.HttpClient
+
+  // make a get request
+  yield* client.get("https://jsonplaceholder.typicode.com/todos/1")
+  // make a post request
+  yield* client.post("https://jsonplaceholder.typicode.com/todos")
+
+  // execute a request instance
+  yield* client.execute(
+    HttpClientRequest.get("https://jsonplaceholder.typicode.com/todos/1")
+  )
+})
+```
+
+#### Scoped `HttpClientResponse` helpers removed
+
+The `HttpClientResponse` helpers that also eliminated the `Scope` have been removed.
+
+Instead, you can use the `HttpClientResponse` methods directly, and explicitly
+add a `Effect.scoped` to the pipeline.
+
+```ts
+import { FetchHttpClient, HttpClient } from "@effect/platform"
+import { Effect } from "effect"
+
+Effect.gen(function* () {
+  const client = yield* HttpClient.HttpClient
+
+  yield* client.get("https://jsonplaceholder.typicode.com/todos/1").pipe(
+    Effect.flatMap((response) => response.json),
+    Effect.scoped // eliminate the `Scope`
+  )
+})
+```
+
+#### Some apis have been renamed
+
+Including the `HttpClientRequest` body apis, which is to make them more
+discoverable.

--- a/.changeset/tricky-spoons-wait.md
+++ b/.changeset/tricky-spoons-wait.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Preserve Span on Interruption

--- a/.changeset/twelve-dingos-destroy.md
+++ b/.changeset/twelve-dingos-destroy.md
@@ -1,0 +1,6 @@
+---
+"@effect/opentelemetry": minor
+"effect": minor
+---
+
+Cache some fiber references in the runtime to optimize reading in hot-paths

--- a/.changeset/violet-suns-chew.md
+++ b/.changeset/violet-suns-chew.md
@@ -1,0 +1,26 @@
+---
+"effect": minor
+---
+
+Added `RcMap.keys` and `MutableHashMap.keys`.
+
+These functions allow you to get a list of keys currently stored in the underlying hash map.
+
+```ts
+const map = MutableHashMap.make([["a", "a"], ["b", "b"], ["c", "c"]])
+const keys = MutableHashMap.keys(map) // ["a", "b", "c"]
+```
+
+```ts
+Effect.gen(function* () {
+  const map = yield* RcMap.make({
+    lookup: (key) => Effect.succeed(key)
+  })
+
+  yield* RcMap.get(map, "a")
+  yield* RcMap.get(map, "b")
+  yield* RcMap.get(map, "c")
+
+  const keys = yield* RcMap.keys(map) // ["a", "b", "c"]
+})
+```

--- a/.changeset/wise-kiwis-tan.md
+++ b/.changeset/wise-kiwis-tan.md
@@ -1,0 +1,16 @@
+---
+"effect": minor
+---
+
+The `FiberRef<A>` is now a subtype of `Effect<A>`. This change simplifies handling of deferred values, removing the need for explicit call `FiberRef.get`.
+
+```typescript
+import { Effect, FiberRef } from "effect"
+
+Effect.gen(function* () {
+  const fiberRef = yield* FiberRef.make("value")
+
+  const before = yield* FiberRef.get(fiberRef)
+  const after = yield* fiberRef
+})
+```

--- a/packages/cli/src/internal/prompt/number.ts
+++ b/packages/cli/src/internal/prompt/number.ts
@@ -5,6 +5,7 @@ import * as Optimize from "@effect/printer/Optimize"
 import * as Schema from "@effect/schema/Schema"
 import * as Arr from "effect/Array"
 import * as Effect from "effect/Effect"
+import * as EffectNumber from "effect/Number"
 import * as Option from "effect/Option"
 import type * as Prompt from "../../Prompt.js"
 import * as InternalPrompt from "../prompt.js"
@@ -18,11 +19,6 @@ interface State {
   readonly cursor: number
   readonly value: string
   readonly error: Option.Option<string>
-}
-
-const round = (number: number, precision: number) => {
-  const factor = Math.pow(10, precision)
-  return Math.round(number * factor) / factor
 }
 
 const parseInt = Schema.NumberFromString.pipe(
@@ -352,7 +348,7 @@ function handleProcessFloat(options: FloatOptions) {
             })),
           onSuccess: (n) =>
             Effect.flatMap(
-              Effect.sync(() => round(n, options.precision)),
+              Effect.sync(() => EffectNumber.round(n, options.precision)),
               (rounded) =>
                 Effect.match(options.validate(rounded), {
                   onFailure: (error) =>

--- a/packages/cluster-node/examples/sample-shard.ts
+++ b/packages/cluster-node/examples/sample-shard.ts
@@ -62,25 +62,33 @@ const liveLayer = Sharding.registerEntity(
   Layer.provide(HttpLive),
   Layer.provideMerge(Sharding.live),
   Layer.provide(StorageFile.storageFile),
-  Layer.provide(PodsRpc.podsRpc<never>((podAddress) =>
-    HttpRpcResolver.make<ShardingServiceRpc.ShardingServiceRpc>(
-      HttpClient.fetchOk.pipe(
-        HttpClient.mapRequest(
-          HttpClientRequest.prependUrl(`http://${podAddress.host}:${podAddress.port}/api/rest`)
-        )
-      )
-    ).pipe(RpcResolver.toClient)
-  )),
-  Layer.provide(ShardManagerClientRpc.shardManagerClientRpc(
-    (shardManagerUri) =>
+  Layer.provide(Layer.unwrapEffect(Effect.gen(function*() {
+    const client = yield* HttpClient.HttpClient
+    return PodsRpc.podsRpc<never>((podAddress) =>
       HttpRpcResolver.make<ShardingServiceRpc.ShardingServiceRpc>(
-        HttpClient.fetchOk.pipe(
+        client.pipe(
+          HttpClient.filterStatusOk,
           HttpClient.mapRequest(
-            HttpClientRequest.prependUrl(shardManagerUri)
+            HttpClientRequest.prependUrl(`http://${podAddress.host}:${podAddress.port}/api/rest`)
           )
         )
       ).pipe(RpcResolver.toClient)
-  )),
+    )
+  }))),
+  Layer.provide(Layer.unwrapEffect(Effect.gen(function*() {
+    const client = yield* HttpClient.HttpClient
+    return ShardManagerClientRpc.shardManagerClientRpc(
+      (shardManagerUri) =>
+        HttpRpcResolver.make<ShardingServiceRpc.ShardingServiceRpc>(
+          client.pipe(
+            HttpClient.filterStatusOk,
+            HttpClient.mapRequest(
+              HttpClientRequest.prependUrl(shardManagerUri)
+            )
+          )
+        ).pipe(RpcResolver.toClient)
+    )
+  }))),
   Layer.provide(Serialization.json),
   Layer.provide(NodeHttpClient.layerUndici),
   Layer.provide(ShardingConfig.fromConfig)

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -2,6 +2,7 @@ import type * as Deferred from "effect/Deferred"
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import type * as Exit from "effect/Exit"
+import type * as Fiber from "effect/Fiber"
 import type * as FiberRef from "effect/FiberRef"
 import type * as Micro from "effect/Micro"
 import type * as Option from "effect/Option"
@@ -78,8 +79,18 @@ export type FiberRefUnify = Unify.Unify<
   | FiberRef.FiberRef<1>
   | FiberRef.FiberRef<"a">
 >
+// $ExpectType Fiber<"a" | 1, "b" | 2>
+export type FiberUnify = Unify.Unify<
+  | Fiber.Fiber<1, 2>
+  | Fiber.Fiber<"a", "b">
+>
+// $ExpectType RuntimeFiber<"a" | 1, "b" | 2>
+export type RuntimeFiberUnify = Unify.Unify<
+  | Fiber.RuntimeFiber<1, 2>
+  | Fiber.RuntimeFiber<"a", "b">
+>
 
-// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | FiberRef<12> | FiberRef<"a2"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Fiber<"a" | 1, "b" | 2> | RuntimeFiber<"a" | 1, "b" | 2> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | FiberRef<12> | FiberRef<"a2"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
 export type AllUnify = Unify.Unify<
   | Either.Either<1, 0>
   | Either.Either<"A", "E">
@@ -99,5 +110,9 @@ export type AllUnify = Unify.Unify<
   | Deferred.Deferred<"a", "b">
   | FiberRef.FiberRef<12>
   | FiberRef.FiberRef<"a2">
+  | Fiber.Fiber<1, 2>
+  | Fiber.Fiber<"a", "b">
+  | Fiber.RuntimeFiber<1, 2>
+  | Fiber.RuntimeFiber<"a", "b">
   | 0
 >

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -1,18 +1,23 @@
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
+import type * as Exit from "effect/Exit"
 import type * as Micro from "effect/Micro"
 import type * as Option from "effect/Option"
+import type * as RcRef from "effect/RcRef"
+import type * as Ref from "effect/Ref"
 import type * as Stream from "effect/Stream"
+import type * as SubscriptionRef from "effect/SubscriptionRef"
+import type * as SynchronizedRef from "effect/SynchronizedRef"
 import * as Unify from "effect/Unify"
 
 // $ExpectType Option<string | number>
-export type option = Unify.Unify<Option.Option<number> | Option.Option<string>>
+export type OptionUnify = Unify.Unify<Option.Option<number> | Option.Option<string>>
 
 // $ExpectType Either<"RA" | "RB", "LA" | "LB">
-export type either = Unify.Unify<Either.Either<"RA", "LA"> | Either.Either<"RB", "LB">>
+export type EitherUnify = Unify.Unify<Either.Either<"RA", "LA"> | Either.Either<"RB", "LB">>
 
 // $ExpectType 0 | Option<string | number> | Either<"RA" | "RB", "LA" | "LB">
-export type both = Unify.Unify<
+export type EitherOptionUnify = Unify.Unify<
   Either.Either<"RA", "LA"> | Either.Either<"RB", "LB"> | Option.Option<number> | Option.Option<string> | 0
 >
 
@@ -26,15 +31,57 @@ Unify.unify(<N>(n: N) => Math.random() > 0 ? Either.right(n) : Either.left("ok")
 Unify.unify(Math.random() > 0 ? Either.right(10) : Either.left("ok"))
 
 // $ExpectType Stream<0 | "a", "b" | 1, "c" | 2>
-export type SU = Unify.Unify<
+export type StreamUnify = Unify.Unify<
   Stream.Stream<0, 1, 2> | Stream.Stream<"a", "b", "c">
 >
 
 // $ExpectType Micro<0 | "a", "b" | 1, "c" | 2>
-export type MU = Unify.Unify<
+export type MicroUnify = Unify.Unify<
   Micro.Micro<0, 1, 2> | Micro.Micro<"a", "b", "c">
 >
 // $ExpectType Effect<0 | "a", "b" | 1, "c" | 2>
-export type EU = Unify.Unify<
-  Effect.Effect<0, 1, 2> | Effect.Effect<"a", "b", "c">
+export type EffectUnify = Unify.Unify<
+  | Effect.Effect<0, 1, 2>
+  | Effect.Effect<"a", "b", "c">
+>
+// $ExpectType Exit<0 | "a", "b" | 1>
+export type ExitUnify = Unify.Unify<
+  | Exit.Exit<0, 1>
+  | Exit.Exit<"a", "b">
+>
+// $ExpectType Ref<1> | Ref<"a">
+export type RefUnify = Unify.Unify<Ref.Ref<1> | Ref.Ref<"a">>
+// $ExpectType SynchronizedRef<1> | SynchronizedRef<"a">
+export type SynchronizedRefUnify = Unify.Unify<
+  | SynchronizedRef.SynchronizedRef<1>
+  | SynchronizedRef.SynchronizedRef<"a">
+>
+// $ExpectType SubscriptionRef<1> | SubscriptionRef<"a">
+export type SubscriptionRefUnify = Unify.Unify<
+  | SubscriptionRef.SubscriptionRef<1>
+  | SubscriptionRef.SubscriptionRef<"a">
+>
+// $ExpectType RcRef<"a" | 1, "b" | 2>
+export type RcRefUnify = Unify.Unify<
+  | RcRef.RcRef<1, 2>
+  | RcRef.RcRef<"a", "b">
+>
+
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+export type AllUnify = Unify.Unify<
+  | Either.Either<1, 0>
+  | Either.Either<"A", "E">
+  | Option.Option<number>
+  | Option.Option<string>
+  | Effect.Effect<"A", "E", "R">
+  | Effect.Effect<1, 0, "R1">
+  | Ref.Ref<1>
+  | Ref.Ref<"A">
+  | SynchronizedRef.SynchronizedRef<1>
+  | SynchronizedRef.SynchronizedRef<"A">
+  | SubscriptionRef.SubscriptionRef<1>
+  | SubscriptionRef.SubscriptionRef<"A">
+  | RcRef.RcRef<1, 0>
+  | RcRef.RcRef<"A", "E">
+  | 0
 >

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -1,3 +1,4 @@
+import type * as Deferred from "effect/Deferred"
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import type * as Exit from "effect/Exit"
@@ -66,8 +67,13 @@ export type RcRefUnify = Unify.Unify<
   | RcRef.RcRef<1, 2>
   | RcRef.RcRef<"a", "b">
 >
+// $ExpectType Deferred<1, 2> | Deferred<"a", "b">
+export type DeferredUnify = Unify.Unify<
+  | Deferred.Deferred<1, 2>
+  | Deferred.Deferred<"a", "b">
+>
 
-// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
 export type AllUnify = Unify.Unify<
   | Either.Either<1, 0>
   | Either.Either<"A", "E">
@@ -83,5 +89,7 @@ export type AllUnify = Unify.Unify<
   | SubscriptionRef.SubscriptionRef<"A">
   | RcRef.RcRef<1, 0>
   | RcRef.RcRef<"A", "E">
+  | Deferred.Deferred<1, 2>
+  | Deferred.Deferred<"a", "b">
   | 0
 >

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -2,6 +2,7 @@ import type * as Deferred from "effect/Deferred"
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import type * as Exit from "effect/Exit"
+import type * as FiberRef from "effect/FiberRef"
 import type * as Micro from "effect/Micro"
 import type * as Option from "effect/Option"
 import type * as RcRef from "effect/RcRef"
@@ -72,8 +73,13 @@ export type DeferredUnify = Unify.Unify<
   | Deferred.Deferred<1, 2>
   | Deferred.Deferred<"a", "b">
 >
+// $ExpectType FiberRef<1> | FiberRef<"a">
+export type FiberRefUnify = Unify.Unify<
+  | FiberRef.FiberRef<1>
+  | FiberRef.FiberRef<"a">
+>
 
-// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | FiberRef<12> | FiberRef<"a2"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
 export type AllUnify = Unify.Unify<
   | Either.Either<1, 0>
   | Either.Either<"A", "E">
@@ -91,5 +97,7 @@ export type AllUnify = Unify.Unify<
   | RcRef.RcRef<"A", "E">
   | Deferred.Deferred<1, 2>
   | Deferred.Deferred<"a", "b">
+  | FiberRef.FiberRef<12>
+  | FiberRef.FiberRef<"a2">
   | 0
 >

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -10,8 +10,8 @@ import * as core from "./internal/core.js"
 import * as internal from "./internal/deferred.js"
 import type * as MutableRef from "./MutableRef.js"
 import type * as Option from "./Option.js"
-import type { Pipeable } from "./Pipeable.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -37,11 +37,30 @@ export type DeferredTypeId = typeof DeferredTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Deferred<in out A, in out E = never> extends Deferred.Variance<A, E>, Pipeable {
+export interface Deferred<in out A, in out E = never> extends Effect.Effect<A, E>, Deferred.Variance<A, E> {
   /** @internal */
   readonly state: MutableRef.MutableRef<internal.State<A, E>>
   /** @internal */
   readonly blockingOn: FiberId.FiberId
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: DeferredUnify<this>
+  readonly [Unify.ignoreSymbol]?: DeferredUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface DeferredUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  Deferred?: () => Extract<A[Unify.typeSymbol], Deferred<any>>
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface DeferredUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -2,6 +2,8 @@
  * @since 2.0.0
  */
 import type * as Cause from "./Cause.js"
+import type { Context } from "./Context.js"
+import type { DefaultServices } from "./DefaultServices.js"
 import type * as Effect from "./Effect.js"
 import type * as Either from "./Either.js"
 import type * as Exit from "./Exit.js"
@@ -18,7 +20,10 @@ import type * as Option from "./Option.js"
 import type * as order from "./Order.js"
 import type { Pipeable } from "./Pipeable.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
+import type { Scheduler } from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
+import type { Supervisor } from "./Supervisor.js"
+import type { AnySpan, Tracer } from "./Tracer.js"
 import type * as Types from "./Types.js"
 
 /**
@@ -155,6 +160,36 @@ export interface RuntimeFiber<out A, out E = never> extends Fiber<A, E>, Fiber.R
    * resume immediately. Otherwise, the effect will resume when the fiber exits.
    */
   unsafeInterruptAsFork(fiberId: FiberId.FiberId): void
+
+  /**
+   * Gets the current context
+   */
+  get currentContext(): Context<never>
+
+  /**
+   * Gets the current context
+   */
+  get currentDefaultServices(): Context<DefaultServices>
+
+  /**
+   * Gets the current scheduler
+   */
+  get currentScheduler(): Scheduler
+
+  /**
+   * Gets the current tracer
+   */
+  get currentTracer(): Tracer
+
+  /**
+   * Gets the current span
+   */
+  get currentSpan(): AnySpan | undefined
+
+  /**
+   * Gets the current supervisor
+   */
+  get currentSupervisor(): Supervisor<unknown>
 }
 
 /**

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -18,13 +18,13 @@ import * as internal from "./internal/fiber.js"
 import * as fiberRuntime from "./internal/fiberRuntime.js"
 import type * as Option from "./Option.js"
 import type * as order from "./Order.js"
-import type { Pipeable } from "./Pipeable.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
 import type { Scheduler } from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type { Supervisor } from "./Supervisor.js"
 import type { AnySpan, Tracer } from "./Tracer.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -62,7 +62,7 @@ export type RuntimeFiberTypeId = typeof RuntimeFiberTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Fiber<out A, out E = never> extends Fiber.Variance<A, E>, Pipeable {
+export interface Fiber<out A, out E = never> extends Effect.Effect<A, E>, Fiber.Variance<A, E> {
   /**
    * The identity of the fiber.
    */
@@ -97,6 +97,26 @@ export interface Fiber<out A, out E = never> extends Fiber.Variance<A, E>, Pipea
    * resume immediately. Otherwise, the effect will resume when the fiber exits.
    */
   interruptAsFork(fiberId: FiberId.FiberId): Effect.Effect<void>
+
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: FiberUnify<this>
+  readonly [Unify.ignoreSymbol]?: FiberUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface FiberUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  Fiber?: () => A[Unify.typeSymbol] extends Fiber<infer A0, infer E0> | infer _ ? Fiber<A0, E0> : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface FiberUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**
@@ -190,6 +210,27 @@ export interface RuntimeFiber<out A, out E = never> extends Fiber<A, E>, Fiber.R
    * Gets the current supervisor
    */
   get currentSupervisor(): Supervisor<unknown>
+
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: RuntimeFiberUnify<this>
+  readonly [Unify.ignoreSymbol]?: RuntimeFiberUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RuntimeFiberUnify<A extends { [Unify.typeSymbol]?: any }> extends FiberUnify<A> {
+  RuntimeFiber?: () => A[Unify.typeSymbol] extends RuntimeFiber<infer A0, infer E0> | infer _ ? RuntimeFiber<A0, E0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RuntimeFiberUnifyIgnore extends FiberUnifyIgnore {
+  Fiber?: true
 }
 
 /**

--- a/packages/effect/src/FiberRef.ts
+++ b/packages/effect/src/FiberRef.ts
@@ -18,7 +18,6 @@ import type * as LogLevel from "./LogLevel.js"
 import type * as LogSpan from "./LogSpan.js"
 import type * as MetricLabel from "./MetricLabel.js"
 import type * as Option from "./Option.js"
-import type { Pipeable } from "./Pipeable.js"
 import type * as Request from "./Request.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
 import * as Scheduler from "./Scheduler.js"
@@ -26,6 +25,7 @@ import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -43,7 +43,7 @@ export type FiberRefTypeId = typeof FiberRefTypeId
  * @since 2.0.0
  * @category model
  */
-export interface FiberRef<in out A> extends Variance<A>, Pipeable {
+export interface FiberRef<in out A> extends Effect.Effect<A>, Variance<A> {
   /** @internal */
   readonly initial: A
   /** @internal */
@@ -56,6 +56,25 @@ export interface FiberRef<in out A> extends Variance<A>, Pipeable {
   readonly fork: unknown
   /** @internal */
   join(oldValue: A, newValue: A): A
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: FiberRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: FiberRefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface FiberRefUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  FiberRef?: () => Extract<A[Unify.typeSymbol], FiberRef<any>>
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface FiberRefUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -476,6 +476,14 @@ export const prettyLogger: (
 ) => Logger<unknown, void> = internal.prettyLogger
 
 /**
+ * A default version of the pretty logger.
+ *
+ * @since 3.8.0
+ * @category constructors
+ */
+export const prettyLoggerDefault: Logger<unknown, void> = internal.prettyLoggerDefault
+
+/**
  * The structured logger provides detailed log outputs, structured in a way that
  * retains comprehensive traceability of the events, suitable for deeper
  * analysis and troubleshooting.

--- a/packages/effect/src/MutableHashMap.ts
+++ b/packages/effect/src/MutableHashMap.ts
@@ -159,6 +159,18 @@ export const get: {
   return getFromBucket(self, bucket, key)
 })
 
+/**
+ * @since 3.8.0
+ * @category elements
+ */
+export const keys = <K, V>(self: MutableHashMap<K, V>): Array<K> => {
+  const keys: Array<K> = []
+  for (const [key] of self) {
+    keys.push(key)
+  }
+  return keys
+}
+
 const getFromBucket = <K, V>(
   self: MutableHashMap<K, V>,
   bucket: NonEmptyArray<readonly [K & Equal.Equal, V]>,

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -492,3 +492,26 @@ export const parse = (s: string): Option<number> => {
     ? option.none
     : option.some(n)
 }
+
+/**
+ * Returns the number rounded with the given precision.
+ *
+ * @param self - The number to round
+ * @param precision - The precision
+ *
+ * @example
+ * import { round } from "effect/Number"
+ *
+ * assert.deepStrictEqual(round(1.1234, 2), 1.12)
+ * assert.deepStrictEqual(round(1.567, 2), 1.57)
+ *
+ * @category math
+ * @since 3.8.0
+ */
+export const round: {
+  (precision: number): (self: number) => number
+  (self: number, precision: number): number
+} = dual(2, (self: number, precision: number): number => {
+  const factor = Math.pow(10, precision)
+  return Math.round(self * factor) / factor
+})

--- a/packages/effect/src/RcMap.ts
+++ b/packages/effect/src/RcMap.ts
@@ -101,3 +101,9 @@ export const get: {
   <K>(key: K): <A, E>(self: RcMap<K, A, E>) => Effect.Effect<A, E, Scope.Scope>
   <K, A, E>(self: RcMap<K, A, E>, key: K): Effect.Effect<A, E, Scope.Scope>
 } = internal.get
+
+/**
+ * @since 3.8.0
+ * @category combinators
+ */
+export const keys: <K, A, E>(self: RcMap<K, A, E>) => Effect.Effect<Array<K>, E> = internal.keys

--- a/packages/effect/src/RcRef.ts
+++ b/packages/effect/src/RcRef.ts
@@ -4,9 +4,10 @@
 import type * as Duration from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/rcRef.js"
-import { type Pipeable } from "./Pipeable.js"
+import type * as Readable from "./Readable.js"
 import type * as Scope from "./Scope.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 3.5.0
@@ -24,10 +25,31 @@ export type TypeId = typeof TypeId
  * @since 3.5.0
  * @category models
  */
-export interface RcRef<out A, out E = never> extends Pipeable {
+export interface RcRef<out A, out E = never>
+  extends Effect.Effect<A, E, Scope.Scope>, Readable.Readable<A, E, Scope.Scope>
+{
   readonly [TypeId]: RcRef.Variance<A, E>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: RcRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: RcRefUnifyIgnore
 }
 
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RcRefUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  RcRef?: () => A[Unify.typeSymbol] extends RcRef<infer A0, infer E0> | infer _ ? RcRef<A0, E0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RcRefUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
+}
 /**
  * @since 3.5.0
  * @category models

--- a/packages/effect/src/Ref.ts
+++ b/packages/effect/src/Ref.ts
@@ -4,8 +4,9 @@
 import type * as Effect from "./Effect.js"
 import * as internal from "./internal/ref.js"
 import type * as Option from "./Option.js"
-import type { Readable } from "./Readable.js"
+import type * as Readable from "./Readable.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -23,8 +24,27 @@ export type RefTypeId = typeof RefTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Ref<in out A> extends Ref.Variance<A>, Readable<A> {
+export interface Ref<in out A> extends Ref.Variance<A>, Effect.Effect<A>, Readable.Readable<A> {
   modify<B>(f: (a: A) => readonly [B, A]): Effect.Effect<B>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: RefUnify<this>
+  readonly [Unify.ignoreSymbol]?: RefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RefUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  Ref?: () => Extract<A[Unify.typeSymbol], Ref<any>>
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RefUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -550,6 +550,42 @@ export const broadcast: {
 } = internal.broadcast
 
 /**
+ * Returns a new Stream that multicasts the original Stream, subscribing to it as soon as the first consumer subscribes.
+ * As long as there is at least one consumer, the upstream will continue running and emitting data.
+ * When all consumers have exited, the upstream will be finalized.
+ *
+ * @since 3.8.0
+ * @category utils
+ */
+export const share: {
+  <A, E>(
+    config: {
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+      readonly idleTimeToLive?: Duration.DurationInput | undefined
+    } | {
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+      readonly idleTimeToLive?: Duration.DurationInput | undefined
+    }
+  ): <R>(self: Stream<A, E, R>) => Effect.Effect<Stream<A, E>, never, R | Scope.Scope>
+  <A, E, R>(
+    self: Stream<A, E, R>,
+    config: {
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+      readonly idleTimeToLive?: Duration.DurationInput | undefined
+    } | {
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+      readonly idleTimeToLive?: Duration.DurationInput | undefined
+    }
+  ): Effect.Effect<Stream<A, E>, never, R | Scope.Scope>
+} = internal.share
+
+/**
  * Fan out the stream, producing a dynamic number of streams that have the
  * same elements as this stream. The driver stream will only ever advance the
  * `maximumLag` chunks before the slowest downstream stream.

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -10,6 +10,7 @@ import type * as Stream from "./Stream.js"
 import type { Subscribable } from "./Subscribable.js"
 import * as Synchronized from "./SynchronizedRef.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -44,6 +45,27 @@ export interface SubscriptionRef<in out A>
    * to that value.
    */
   readonly changes: Stream.Stream<A>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: SubscriptionRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: SubscriptionRefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SubscriptionRefUnify<A extends { [Unify.typeSymbol]?: any }>
+  extends Synchronized.SynchronizedRefUnify<A>
+{
+  SubscriptionRef?: () => Extract<A[Unify.typeSymbol], SubscriptionRef<any>>
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SubscriptionRefUnifyIgnore extends Synchronized.SynchronizedRefUnifyIgnore {
+  SynchronizedRef?: true
 }
 
 /**

--- a/packages/effect/src/SynchronizedRef.ts
+++ b/packages/effect/src/SynchronizedRef.ts
@@ -8,6 +8,7 @@ import * as internal from "./internal/synchronizedRef.js"
 import type * as Option from "./Option.js"
 import type * as Ref from "./Ref.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -27,6 +28,25 @@ export type SynchronizedRefTypeId = typeof SynchronizedRefTypeId
  */
 export interface SynchronizedRef<in out A> extends SynchronizedRef.Variance<A>, Ref.Ref<A> {
   modifyEffect<B, E, R>(f: (a: A) => Effect.Effect<readonly [B, A], E, R>): Effect.Effect<B, E, R>
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: SynchronizedRefUnify<this>
+  readonly [Unify.ignoreSymbol]?: SynchronizedRefUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SynchronizedRefUnify<A extends { [Unify.typeSymbol]?: any }> extends Ref.RefUnify<A> {
+  SynchronizedRef?: () => Extract<A[Unify.typeSymbol], SynchronizedRef<any>>
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface SynchronizedRefUnifyIgnore extends Ref.RefUnifyIgnore {
+  Ref?: true
 }
 
 /**

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -1135,7 +1135,8 @@ export const prettyErrors = <E>(cause: Cause.Cause<E>): Array<PrettyError> =>
     interruptCase: (_, fiberId) => {
       const limit = Error.stackTraceLimit
       Error.stackTraceLimit = 0
-      const err = new Error(`Fiber Interrupted by: ${internalFiberId.threadName(fiberId)}`)
+      const threadName = internalFiberId.threadName(fiberId)
+      const err = new Error(threadName.length > 0 ? `Fiber Interrupted by: ${threadName}` : "Fiber Interrupted")
       err.name = "InterruptedException"
       Error.stackTraceLimit = limit
       delete err.stack

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -16,6 +16,7 @@ import { hasProperty, isFunction } from "../Predicate.js"
 import type { AnySpan, Span } from "../Tracer.js"
 import type { NoInfer } from "../Types.js"
 import { getBugErrorMessage } from "./errors.js"
+import * as internalFiberId from "./fiberId.js"
 import * as OpCodes from "./opCodes/cause.js"
 
 // -----------------------------------------------------------------------------
@@ -973,9 +974,6 @@ export const reduceWithContext = dual<
 export const pretty = <E>(cause: Cause.Cause<E>, options?: {
   readonly renderErrorCause?: boolean | undefined
 }): string => {
-  if (isInterruptedOnly(cause)) {
-    return "All fibers interrupted without errors."
-  }
   return prettyErrors<E>(cause).map(function(e) {
     if (options?.renderErrorCause !== true || e.cause === undefined) {
       return e.stack
@@ -1134,7 +1132,19 @@ export const prettyErrors = <E>(cause: Cause.Cause<E>): Array<PrettyError> =>
     failCase: (_, error) => {
       return [new PrettyError(error)]
     },
-    interruptCase: () => [],
+    interruptCase: (_, fiberId) => {
+      const limit = Error.stackTraceLimit
+      Error.stackTraceLimit = 0
+      const err = new Error(`Fiber Interrupted by: ${internalFiberId.threadName(fiberId)}`)
+      err.name = "InterruptedException"
+      Error.stackTraceLimit = limit
+      delete err.stack
+      if (spanSymbol in fiberId) {
+        // @ts-expect-error
+        err[spanSymbol] = fiberId[spanSymbol]
+      }
+      return [new PrettyError(err)]
+    },
     parallelCase: (_, l, r) => [...l, ...r],
     sequentialCase: (_, l, r) => [...l, ...r]
   })

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -675,7 +675,7 @@ export const originalInstance = <E>(obj: E): E => {
 }
 
 /* @internal */
-const capture = <E>(obj: E & object, span: Option.Option<Tracer.Span>): E => {
+export const capture = <E>(obj: E & object, span: Option.Option<Tracer.Span>): E => {
   if (Option.isSome(span)) {
     return new Proxy(obj, {
       has(target, p) {

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -1955,18 +1955,22 @@ export const fiberRefUnsafeMakePatch = <Value, Patch>(
     readonly fork: Patch
     readonly join?: ((oldV: Value, newV: Value) => Value) | undefined
   }
-): FiberRef.FiberRef<Value> => ({
-  [FiberRefTypeId]: fiberRefVariance,
-  initial,
-  diff: (oldValue, newValue) => options.differ.diff(oldValue, newValue),
-  combine: (first, second) => options.differ.combine(first as Patch, second as Patch),
-  patch: (patch) => (oldValue) => options.differ.patch(patch as Patch, oldValue),
-  fork: options.fork,
-  join: options.join ?? ((_, n) => n),
-  pipe() {
-    return pipeArguments(this, arguments)
+): FiberRef.FiberRef<Value> => {
+  const _fiberRef = {
+    ...CommitPrototype,
+    [FiberRefTypeId]: fiberRefVariance,
+    initial,
+    commit() {
+      return fiberRefGet(this)
+    },
+    diff: (oldValue: Value, newValue: Value) => options.differ.diff(oldValue, newValue),
+    combine: (first: Patch, second: Patch) => options.differ.combine(first, second),
+    patch: (patch: Patch) => (oldValue: Value) => options.differ.patch(patch, oldValue),
+    fork: options.fork,
+    join: options.join ?? ((_, n) => n)
   }
-})
+  return _fiberRef
+}
 
 /** @internal */
 export const fiberRefUnsafeMakeRuntimeFlags = (

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -1005,7 +1005,11 @@ export const interrupt: Effect.Effect<never> = flatMap(fiberId, (fiberId) => int
 
 /* @internal */
 export const interruptWith = (fiberId: FiberId.FiberId): Effect.Effect<never> =>
-  failCause(internalCause.interrupt(fiberId))
+  withFiberRuntime((fiber) =>
+    failCause(internalCause.interrupt(
+      capture(fiberId, currentSpanFromFiber(fiber))
+    ))
+  )
 
 /* @internal */
 export const interruptible = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> => {

--- a/packages/effect/src/internal/defaultServices.ts
+++ b/packages/effect/src/internal/defaultServices.ts
@@ -48,8 +48,13 @@ export const sleep = (duration: Duration.DurationInput): Effect.Effect<void> => 
 }
 
 /** @internal */
+export const defaultServicesWith = <A, E, R>(
+  f: (services: Context.Context<DefaultServices.DefaultServices>) => Effect.Effect<A, E, R>
+) => core.withFiberRuntime<A, E, R>((fiber) => f(fiber.currentDefaultServices))
+
+/** @internal */
 export const clockWith = <A, E, R>(f: (clock: Clock.Clock) => Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  core.fiberRefGetWith(currentServices, (services) => f(Context.get(services, clock.clockTag)))
+  defaultServicesWith((services) => f(services.unsafeMap.get(clock.clockTag.key)))
 
 /** @internal */
 export const currentTimeMillis: Effect.Effect<number> = clockWith((clock) => clock.currentTimeMillis)
@@ -83,10 +88,7 @@ export const withConfigProvider = dual<
 export const configProviderWith = <A, E, R>(
   f: (configProvider: ConfigProvider.ConfigProvider) => Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> =>
-  core.fiberRefGetWith(
-    currentServices,
-    (services) => f(Context.get(services, configProvider.configProviderTag))
-  )
+  defaultServicesWith((services) => f(services.unsafeMap.get(configProvider.configProviderTag.key)))
 
 /** @internal */
 export const config = <A>(config: Config.Config<A>) => configProviderWith((_) => _.load(config))
@@ -98,10 +100,7 @@ export const configOrDie = <A>(config: Config.Config<A>) => core.orDie(configPro
 
 /** @internal */
 export const randomWith = <A, E, R>(f: (random: Random.Random) => Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  core.fiberRefGetWith(
-    currentServices,
-    (services) => f(Context.get(services, random.randomTag))
-  )
+  defaultServicesWith((services) => f(services.unsafeMap.get(random.randomTag.key)))
 
 /** @internal */
 export const withRandom = dual<
@@ -151,7 +150,7 @@ export const choice = <Self extends Iterable<unknown>>(
 
 /** @internal */
 export const tracerWith = <A, E, R>(f: (tracer: Tracer.Tracer) => Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  core.fiberRefGetWith(currentServices, (services) => f(Context.get(services, tracer.tracerTag)))
+  defaultServicesWith((services) => f(services.unsafeMap.get(tracer.tracerTag.key)))
 
 /** @internal */
 export const withTracer = dual<

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -665,6 +665,10 @@ export const zipWithFiber = dual<
     f: (a: A, b: B) => C
   ) => Fiber.Fiber<C, E | E2>
 >(3, (self, that, f) => ({
+  ...Effectable.CommitPrototype,
+  commit() {
+    return internalFiber.join(this)
+  },
   [internalFiber.FiberTypeId]: internalFiber.fiberVariance,
   id: () => pipe(self.id(), FiberId.getOrElse(that.id())),
   await: pipe(

--- a/packages/effect/src/internal/fiberRefs.ts
+++ b/packages/effect/src/internal/fiberRefs.ts
@@ -33,8 +33,7 @@ export class FiberRefsImpl implements FiberRefs.FiberRefs {
       FiberRef.FiberRef<any>,
       Arr.NonEmptyReadonlyArray<readonly [FiberId.Single, any]>
     >
-  ) {
-  }
+  ) {}
   pipe() {
     return pipeArguments(this, arguments)
   }

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1426,7 +1426,7 @@ export const logFmtLogger: Logger<unknown, void> = globalValue(
 /** @internal */
 export const prettyLogger: Logger<unknown, void> = globalValue(
   Symbol.for("effect/Logger/prettyLogger"),
-  () => internalLogger.prettyLogger()
+  () => internalLogger.prettyLoggerDefault
 )
 
 /** @internal */

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -1270,17 +1270,17 @@ const provideSomeRuntime = dual<
       const oldContext = fiber.getFiberRef(core.currentContext)
       const oldRefs = fiber.getFiberRefs()
       const newRefs = FiberRefsPatch.patch(fiber.id(), oldRefs)(patchRefs)
-      const oldFlags = fiber._runtimeFlags
+      const oldFlags = fiber.currentRuntimeFlags
       const newFlags = runtimeFlags.patch(patchFlags)(oldFlags)
       const rollbackRefs = FiberRefsPatch.diff(newRefs, oldRefs)
       const rollbackFlags = runtimeFlags.diff(newFlags, oldFlags)
       fiber.setFiberRefs(newRefs)
-      fiber._runtimeFlags = newFlags
+      fiber.currentRuntimeFlags = newFlags
       return fiberRuntime.ensuring(
         core.provideSomeContext(restore(self), Context.merge(oldContext, rt.context)),
         core.withFiberRuntime((fiber) => {
           fiber.setFiberRefs(FiberRefsPatch.patch(fiber.id(), fiber.getFiberRefs())(rollbackRefs))
-          fiber._runtimeFlags = runtimeFlags.patch(rollbackFlags)(fiber._runtimeFlags)
+          fiber.currentRuntimeFlags = runtimeFlags.patch(rollbackFlags)(fiber.currentRuntimeFlags)
           return core.void
         })
       )

--- a/packages/effect/src/internal/logger.ts
+++ b/packages/effect/src/internal/logger.ts
@@ -3,6 +3,7 @@ import * as Context from "../Context.js"
 import * as FiberRefs from "../FiberRefs.js"
 import type { LazyArg } from "../Function.js"
 import { constVoid, dual, pipe } from "../Function.js"
+import { globalValue } from "../GlobalValue.js"
 import * as HashMap from "../HashMap.js"
 import * as Inspectable from "../Inspectable.js"
 import * as List from "../List.js"
@@ -570,3 +571,6 @@ const prettyLoggerBrowser = (options: {
     }
   )
 }
+
+/** @internal */
+export const prettyLoggerDefault = globalValue("effect/Logger/prettyLoggerDefault", () => prettyLogger())

--- a/packages/effect/src/internal/managedRuntime.ts
+++ b/packages/effect/src/internal/managedRuntime.ts
@@ -26,7 +26,7 @@ function provide<R, ER, A, E>(
     (rt) =>
       core.withFiberRuntime((fiber) => {
         fiber.setFiberRefs(rt.fiberRefs)
-        fiber._runtimeFlags = rt.runtimeFlags
+        fiber.currentRuntimeFlags = rt.runtimeFlags
         return core.provideContext(effect, rt.context)
       })
   )

--- a/packages/effect/src/internal/rcMap.ts
+++ b/packages/effect/src/internal/rcMap.ts
@@ -211,3 +211,11 @@ export const get: {
     )
   }
 )
+
+/** @internal */
+export const keys = <K, A, E>(self: RcMap.RcMap<K, A, E>): Effect<Array<K>> => {
+  const impl = self as RcMapImpl<K, A, E>
+  return core.suspend(() =>
+    impl.state._tag === "Closed" ? core.interrupt : core.succeed(MutableHashMap.keys(impl.state.map))
+  )
+}

--- a/packages/effect/src/internal/ref.ts
+++ b/packages/effect/src/internal/ref.ts
@@ -1,8 +1,8 @@
 import type * as Effect from "../Effect.js"
+import * as Effectable from "../Effectable.js"
 import { dual } from "../Function.js"
 import * as MutableRef from "../MutableRef.js"
 import * as Option from "../Option.js"
-import { pipeArguments } from "../Pipeable.js"
 import * as Readable from "../Readable.js"
 import type * as Ref from "../Ref.js"
 import * as core from "./core.js"
@@ -16,11 +16,14 @@ export const refVariance = {
   _A: (_: any) => _
 }
 
-class RefImpl<in out A> implements Ref.Ref<A> {
+class RefImpl<in out A> extends Effectable.Class<A> implements Ref.Ref<A> {
+  commit() {
+    return this.get
+  }
   readonly [RefTypeId] = refVariance
-  readonly [Readable.TypeId]: Readable.TypeId
+  readonly [Readable.TypeId]: Readable.TypeId = Readable.TypeId
   constructor(readonly ref: MutableRef.MutableRef<A>) {
-    this[Readable.TypeId] = Readable.TypeId
+    super()
     this.get = core.sync(() => MutableRef.get(this.ref))
   }
   readonly get: Effect.Effect<A>
@@ -33,9 +36,6 @@ class RefImpl<in out A> implements Ref.Ref<A> {
       }
       return b
     })
-  }
-  pipe() {
-    return pipeArguments(this, arguments)
   }
 }
 

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -74,7 +74,7 @@ export const unsafeFork = <R>(runtime: Runtime.Runtime<R>) =>
     )
   }
 
-  const supervisor = fiberRuntime._supervisor
+  const supervisor = fiberRuntime.currentSupervisor
 
   // we can compare by reference here as _supervisor.none is wrapped with globalValue
   if (supervisor !== _supervisor.none) {

--- a/packages/effect/src/internal/subscriptionRef.ts
+++ b/packages/effect/src/internal/subscriptionRef.ts
@@ -1,6 +1,6 @@
 import * as Effect from "../Effect.js"
+import * as Effectable from "../Effectable.js"
 import { dual, pipe } from "../Function.js"
-import { pipeArguments } from "../Pipeable.js"
 import * as PubSub from "../PubSub.js"
 import * as Readable from "../Readable.js"
 import * as Ref from "../Ref.js"
@@ -26,9 +26,9 @@ const subscriptionRefVariance = {
 }
 
 /** @internal */
-class SubscriptionRefImpl<in out A> implements SubscriptionRef.SubscriptionRef<A> {
-  readonly [Readable.TypeId]: Readable.TypeId
-  readonly [Subscribable.TypeId]: Subscribable.TypeId
+class SubscriptionRefImpl<in out A> extends Effectable.Class<A> implements SubscriptionRef.SubscriptionRef<A> {
+  readonly [Readable.TypeId]: Readable.TypeId = Readable.TypeId
+  readonly [Subscribable.TypeId]: Subscribable.TypeId = Subscribable.TypeId
   readonly [Ref.RefTypeId] = _ref.refVariance
   readonly [Synchronized.SynchronizedRefTypeId] = _circular.synchronizedVariance
   readonly [SubscriptionRefTypeId] = subscriptionRefVariance
@@ -37,12 +37,11 @@ class SubscriptionRefImpl<in out A> implements SubscriptionRef.SubscriptionRef<A
     readonly pubsub: PubSub.PubSub<A>,
     readonly semaphore: Effect.Semaphore
   ) {
-    this[Readable.TypeId] = Readable.TypeId
-    this[Subscribable.TypeId] = Subscribable.TypeId
+    super()
     this.get = Ref.get(this.ref)
   }
-  pipe() {
-    return pipeArguments(this, arguments)
+  commit() {
+    return this.get
   }
   readonly get: Effect.Effect<A>
   get changes(): Stream<A> {

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -48,7 +48,7 @@ describe("Cause", () => {
 
   describe("pretty", () => {
     it("Empty", () => {
-      expect(Cause.pretty(Cause.empty)).toEqual("All fibers interrupted without errors.")
+      expect(Cause.pretty(Cause.empty)).toEqual("")
     })
 
     it("Fail", () => {
@@ -84,12 +84,12 @@ describe("Cause", () => {
     })
 
     it("Interrupt", () => {
-      expect(Cause.pretty(Cause.interrupt(FiberId.none))).toEqual("All fibers interrupted without errors.")
+      expect(Cause.pretty(Cause.interrupt(FiberId.none))).toEqual("InterruptedException: Fiber Interrupted")
       expect(Cause.pretty(Cause.interrupt(FiberId.runtime(1, 0)))).toEqual(
-        "All fibers interrupted without errors."
+        "InterruptedException: Fiber Interrupted by: #1"
       )
       expect(Cause.pretty(Cause.interrupt(FiberId.composite(FiberId.none, FiberId.runtime(1, 0))))).toEqual(
-        "All fibers interrupted without errors."
+        "InterruptedException: Fiber Interrupted by: #1"
       )
     })
   })
@@ -202,7 +202,7 @@ describe("Cause", () => {
 
   describe("toString", () => {
     it("Empty", () => {
-      expect(String(Cause.empty)).toEqual(`All fibers interrupted without errors.`)
+      expect(String(Cause.empty)).toEqual(``)
     })
 
     it("Fail", () => {
@@ -214,10 +214,10 @@ describe("Cause", () => {
     })
 
     it("Interrupt", () => {
-      expect(String(Cause.interrupt(FiberId.none))).toEqual(`All fibers interrupted without errors.`)
-      expect(String(Cause.interrupt(FiberId.runtime(1, 0)))).toEqual(`All fibers interrupted without errors.`)
+      expect(String(Cause.interrupt(FiberId.none))).toEqual(`InterruptedException: Fiber Interrupted`)
+      expect(String(Cause.interrupt(FiberId.runtime(1, 0)))).toEqual(`InterruptedException: Fiber Interrupted by: #1`)
       expect(String(Cause.interrupt(FiberId.composite(FiberId.none, FiberId.runtime(1, 0))))).toEqual(
-        `All fibers interrupted without errors.`
+        `InterruptedException: Fiber Interrupted by: #1`
       )
     })
 

--- a/packages/effect/test/Deferred.test.ts
+++ b/packages/effect/test/Deferred.test.ts
@@ -157,4 +157,14 @@ describe("Deferred", () => {
       )
       assert.isTrue(Exit.isInterrupted(result))
     }))
+  it.effect("is subtype of Effect", () =>
+    Effect.gen(function*() {
+      const deferred = yield* Deferred.make<number>()
+      const ref = yield* Ref.make(13)
+      yield* Deferred.complete(deferred, Ref.updateAndGet(ref, (n) => n + 1))
+      const result1 = yield* deferred
+      const result2 = yield* deferred
+      assert.strictEqual(result1, 14)
+      assert.strictEqual(result2, 14)
+    }))
 })

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -226,4 +226,10 @@ describe("Fiber", () => {
       const result = yield* $(Fiber.join(Fiber.all(fibers)), Effect.asVoid)
       assert.isUndefined(result)
     }), 10000)
+  it.effect("is subtype of Effect", () =>
+    Effect.gen(function*() {
+      const fiber = yield* Effect.fork(Effect.succeed(1))
+      const fiberResult = yield* fiber
+      assert(1 === fiberResult)
+    }))
 })

--- a/packages/effect/test/FiberRef.test.ts
+++ b/packages/effect/test/FiberRef.test.ts
@@ -361,4 +361,10 @@ describe("FiberRef", () => {
       const result = yield* $(Deferred.await(deferred))
       assert.isTrue(result)
     }))
+  it.scoped("is subtype of Effect", () =>
+    Effect.gen(function*() {
+      const fiberRef = yield* FiberRef.make(initial)
+      const result = yield* fiberRef
+      assert.strictEqual(result, initial)
+    }))
 })

--- a/packages/effect/test/MutableHashMap.test.ts
+++ b/packages/effect/test/MutableHashMap.test.ts
@@ -174,6 +174,19 @@ describe("MutableHashMap", () => {
     )
   })
 
+  it("keys", () => {
+    const map = pipe(
+      HM.empty<Key, Value>(),
+      HM.set(key(0, 0), value(0, 0)),
+      HM.set(key(1, 1), value(1, 1))
+    )
+
+    expect(HM.keys(map)).toStrictEqual([
+      key(0, 0),
+      key(1, 1)
+    ])
+  })
+
   it("modifyAt", () => {
     const map = pipe(
       HM.empty<Key, Value>(),

--- a/packages/effect/test/Number.test.ts
+++ b/packages/effect/test/Number.test.ts
@@ -135,4 +135,13 @@ describe("Number", () => {
     assert.deepStrictEqual(Number.parse("42"), Option.some(42))
     assert.deepStrictEqual(Number.parse("a"), Option.none())
   })
+
+  it("round", () => {
+    assert.deepStrictEqual(Number.round(1.1234, 2), 1.12)
+    assert.deepStrictEqual(Number.round(2)(1.1234), 1.12)
+    assert.deepStrictEqual(Number.round(0)(1.1234), 1)
+    assert.deepStrictEqual(Number.round(0)(1.1234), 1)
+    assert.deepStrictEqual(Number.round(1.567, 2), 1.57)
+    assert.deepStrictEqual(Number.round(2)(1.567), 1.57)
+  })
 })

--- a/packages/effect/test/RcMap.test.ts
+++ b/packages/effect/test/RcMap.test.ts
@@ -124,4 +124,17 @@ describe("RcMap", () => {
       // no failure means a hit
       assert.strictEqual(yield* RcMap.get(map, new Key({ id: 1 })), 1)
     }))
+
+  it.scoped("keys lookup", () =>
+    Effect.gen(function*() {
+      const map = yield* RcMap.make({
+        lookup: (key: string) => Effect.succeed(key)
+      })
+
+      yield* RcMap.get(map, "foo")
+      yield* RcMap.get(map, "bar")
+      yield* RcMap.get(map, "baz")
+
+      assert.deepStrictEqual(yield* RcMap.keys(map), ["foo", "bar", "baz"])
+    }))
 })

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -23,14 +23,14 @@ describe("RcRef", () => {
       )
 
       assert.strictEqual(acquired, 0)
-      assert.strictEqual(yield* Effect.scoped(RcRef.get(ref)), "foo")
+      assert.strictEqual(yield* Effect.scoped(ref), "foo")
       assert.strictEqual(acquired, 1)
       assert.strictEqual(released, 1)
 
       const scopeA = yield* Scope.make()
       const scopeB = yield* Scope.make()
-      yield* RcRef.get(ref).pipe(Scope.extend(scopeA))
-      yield* RcRef.get(ref).pipe(Scope.extend(scopeB))
+      yield* ref.pipe(Scope.extend(scopeA))
+      yield* ref.pipe(Scope.extend(scopeB))
       assert.strictEqual(acquired, 2)
       assert.strictEqual(released, 1)
       yield* Scope.close(scopeB, Exit.void)
@@ -41,7 +41,7 @@ describe("RcRef", () => {
       assert.strictEqual(released, 2)
 
       const scopeC = yield* Scope.make()
-      yield* RcRef.get(ref).pipe(Scope.extend(scopeC))
+      yield* ref.pipe(Scope.extend(scopeC))
       assert.strictEqual(acquired, 3)
       assert.strictEqual(released, 2)
 
@@ -49,7 +49,7 @@ describe("RcRef", () => {
       assert.strictEqual(acquired, 3)
       assert.strictEqual(released, 3)
 
-      const exit = yield* RcRef.get(ref).pipe(Effect.scoped, Effect.exit)
+      const exit = yield* ref.get.pipe(Effect.scoped, Effect.exit)
       assert.isTrue(Exit.isInterrupted(exit))
     }))
 

--- a/packages/effect/test/Ref.test.ts
+++ b/packages/effect/test/Ref.test.ts
@@ -35,7 +35,7 @@ describe("Ref", () => {
     Effect.gen(function*(_) {
       const ref = yield* _(Ref.make(123))
       assert.isTrue(Readable.isReadable(ref))
-      assert.strictEqual(yield* _(ref.get), 123)
+      assert.strictEqual(yield* ref, 123)
     }))
 
   it.effect("get", () =>
@@ -44,10 +44,11 @@ describe("Ref", () => {
       assert.strictEqual(result, current)
     }))
   it.effect("getAndSet", () =>
-    Effect.gen(function*($) {
-      const ref = yield* $(Ref.make(current))
-      const result1 = yield* $(Ref.getAndSet(ref, update))
-      const result2 = yield* $(Ref.get(ref))
+    Effect.gen(function*() {
+      const ref = yield* Ref.make(current)
+      const result1 = yield* Ref.getAndSet(ref, update)
+
+      const result2 = yield* ref
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))
@@ -55,7 +56,7 @@ describe("Ref", () => {
     Effect.gen(function*($) {
       const ref = yield* $(Ref.make(current))
       const result1 = yield* $(Ref.getAndUpdate(ref, () => update))
-      const result2 = yield* $(Ref.get(ref))
+      const result2 = yield* ref
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))

--- a/packages/effect/test/Synchronized.test.ts
+++ b/packages/effect/test/Synchronized.test.ts
@@ -40,10 +40,10 @@ describe("SynchronizedRef", () => {
       assert.strictEqual(result, current)
     }))
   it.effect("getAndUpdateEffect - happy path", () =>
-    Effect.gen(function*($) {
-      const ref = yield* $(Synchronized.make(current))
-      const result1 = yield* $(Synchronized.getAndUpdateEffect(ref, () => Effect.succeed(update)))
-      const result2 = yield* $(Synchronized.get(ref))
+    Effect.gen(function*() {
+      const ref = yield* Synchronized.make(current)
+      const result1 = yield* Synchronized.getAndUpdateEffect(ref, () => Effect.succeed(update))
+      const result2 = yield* ref
       assert.strictEqual(result1, current)
       assert.strictEqual(result2, update)
     }))
@@ -77,7 +77,7 @@ describe("SynchronizedRef", () => {
           : isChanged(state)
           ? Option.some(Effect.succeed(Closed))
           : Option.none()))
-      const result3 = yield* $(Synchronized.get(ref))
+      const result3 = yield* ref
       assert.deepStrictEqual(result1, Active)
       assert.deepStrictEqual(result2, Changed)
       assert.deepStrictEqual(result3, Closed)

--- a/packages/opentelemetry/src/internal/tracer.ts
+++ b/packages/opentelemetry/src/internal/tracer.ts
@@ -3,7 +3,6 @@ import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import type { Exit } from "effect/Exit"
-import * as FiberRef from "effect/FiberRef"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as EffectTracer from "effect/Tracer"
@@ -143,9 +142,7 @@ export const make = Effect.map(Tracer, (tracer) =>
       )
     },
     context(execution, fiber) {
-      const currentSpan = fiber.getFiberRef(FiberRef.currentContext).unsafeMap.get(EffectTracer.ParentSpan.key) as
-        | EffectTracer.AnySpan
-        | undefined
+      const currentSpan = fiber.currentSpan
 
       if (currentSpan === undefined) {
         return execution()

--- a/packages/platform-browser/src/BrowserHttpClient.ts
+++ b/packages/platform-browser/src/BrowserHttpClient.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 import type * as HttpClient from "@effect/platform/HttpClient"
+import * as Context from "effect/Context"
 import type { Effect } from "effect/Effect"
 import type * as FiberRef from "effect/FiberRef"
 import type { LazyArg } from "effect/Function"
@@ -10,22 +11,18 @@ import * as internal from "./internal/httpClient.js"
 
 /**
  * @since 1.0.0
- * @category clients
- */
-export const xmlHttpRequest: HttpClient.HttpClient.Default = internal.makeXMLHttpRequest
-
-/**
- * @since 1.0.0
  * @category layers
  */
-export const layerXMLHttpRequest: Layer.Layer<HttpClient.HttpClient.Default, never, never> =
-  internal.layerXMLHttpRequest
+export const layerXMLHttpRequest: Layer.Layer<HttpClient.HttpClient.Service> = internal.layerXMLHttpRequest
 
 /**
  * @since 1.0.0
- * @category fiber refs
+ * @category tags
  */
-export const currentXMLHttpRequest: FiberRef.FiberRef<LazyArg<XMLHttpRequest>> = internal.currentXMLHttpRequest
+export class XMLHttpRequest extends Context.Tag(internal.xhrTagKey)<
+  XMLHttpRequest,
+  LazyArg<globalThis.XMLHttpRequest>
+>() {}
 
 /**
  * @since 1.0.0

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -46,7 +46,7 @@ export const layer: (
  * @category layers
  */
 export const layerTest: Layer.Layer<
-  | HttpClient.HttpClient.Default
+  | HttpClient.HttpClient.Service
   | Server.HttpServer
   | Platform.HttpPlatform
   | Etag.Generator

--- a/packages/platform-bun/src/internal/httpServer.ts
+++ b/packages/platform-bun/src/internal/httpServer.ts
@@ -2,10 +2,10 @@
 import * as MultipartNode from "@effect/platform-node-shared/NodeMultipart"
 import * as Cookies from "@effect/platform/Cookies"
 import * as Etag from "@effect/platform/Etag"
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient"
 import type * as FileSystem from "@effect/platform/FileSystem"
 import * as Headers from "@effect/platform/Headers"
 import * as App from "@effect/platform/HttpApp"
-import * as HttpClient from "@effect/platform/HttpClient"
 import * as IncomingMessage from "@effect/platform/HttpIncomingMessage"
 import type { HttpMethod } from "@effect/platform/HttpMethod"
 import * as Server from "@effect/platform/HttpServer"
@@ -180,11 +180,8 @@ export const layer = (
 
 /** @internal */
 export const layerTest = Server.layerTestClient.pipe(
-  Layer.provide(Layer.succeed(
-    HttpClient.HttpClient,
-    HttpClient.fetch.pipe(
-      HttpClient.transformResponse(HttpClient.withFetchOptions({ keepalive: false }))
-    )
+  Layer.provide(FetchHttpClient.layer.pipe(
+    Layer.provide(Layer.succeed(FetchHttpClient.RequestInit, { keepalive: false }))
   )),
   Layer.provideMerge(layer({ port: 0 }))
 )

--- a/packages/platform-node/examples/api.ts
+++ b/packages/platform-node/examples/api.ts
@@ -1,4 +1,5 @@
 import {
+  FetchHttpClient,
   HttpApi,
   HttpApiBuilder,
   HttpApiClient,
@@ -7,7 +8,6 @@ import {
   HttpApiSchema,
   HttpApiSecurity,
   HttpApiSwagger,
-  HttpClient,
   HttpMiddleware,
   HttpServer,
   OpenApi
@@ -173,6 +173,6 @@ Effect.gen(function*() {
   const binary = yield* client.users.binary()
   console.log("binary", binary)
 }).pipe(
-  Effect.provide(HttpClient.layer),
+  Effect.provide(FetchHttpClient.layer),
   NodeRuntime.runMain
 )

--- a/packages/platform-node/examples/http-client.ts
+++ b/packages/platform-node/examples/http-client.ts
@@ -14,7 +14,7 @@ class Todo extends Schema.Class<Todo>("Todo")({
   title: Schema.String,
   completed: Schema.Boolean
 }) {
-  static decodeResponse = HttpClientResponse.schemaBodyJsonScoped(Todo)
+  static decodeResponse = HttpClientResponse.schemaBodyJson(Todo)
 }
 
 const TodoWithoutId = Schema.Struct(Todo.fields).pipe(Schema.omit("id"))
@@ -34,14 +34,15 @@ const makeTodoService = Effect.gen(function*() {
     HttpClient.mapRequest(HttpClientRequest.prependUrl("https://jsonplaceholder.typicode.com"))
   )
 
-  const addTodoWithoutIdBody = HttpClientRequest.schemaBody(TodoWithoutId)
+  const addTodoWithoutIdBody = HttpClientRequest.schemaBodyJson(TodoWithoutId)
   const create = (todo: TodoWithoutId) =>
     addTodoWithoutIdBody(
       HttpClientRequest.post("/todos"),
       todo
     ).pipe(
-      Effect.flatMap(clientWithBaseUrl),
-      Todo.decodeResponse
+      Effect.flatMap(clientWithBaseUrl.execute),
+      Effect.flatMap(Todo.decodeResponse),
+      Effect.scoped
     )
 
   return TodoService.of({ create })

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -2,9 +2,8 @@
  * @since 1.0.0
  */
 import type * as Client from "@effect/platform/HttpClient"
-import type * as Context from "effect/Context"
+import * as Context from "effect/Context"
 import type * as Effect from "effect/Effect"
-import type * as FiberRef from "effect/FiberRef"
 import type * as Layer from "effect/Layer"
 import type * as Scope from "effect/Scope"
 import type * as Http from "node:http"
@@ -64,19 +63,19 @@ export const makeAgentLayer: (options?: Https.AgentOptions) => Layer.Layer<HttpA
  * @since 1.0.0
  * @category constructors
  */
-export const make: Effect.Effect<Client.HttpClient.Default, never, HttpAgent> = internal.make
+export const make: Effect.Effect<Client.HttpClient.Service, never, HttpAgent> = internal.make
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layer: Layer.Layer<Client.HttpClient.Default> = internal.layer
+export const layer: Layer.Layer<Client.HttpClient.Service> = internal.layer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerWithoutAgent: Layer.Layer<Client.HttpClient.Default, never, HttpAgent> = internal.layerWithoutAgent
+export const layerWithoutAgent: Layer.Layer<Client.HttpClient.Service, never, HttpAgent> = internal.layerWithoutAgent
 
 /**
  * @since 1.0.0
@@ -114,35 +113,26 @@ export const dispatcherLayerGlobal: Layer.Layer<Dispatcher> = internalUndici.dis
  * @since 1.0.0
  * @category undici
  */
-export const currentUndiciOptions: FiberRef.FiberRef<Partial<Undici.Dispatcher.RequestOptions>> =
-  internalUndici.currentUndiciOptions
-
-/**
- * @since 1.0.0
- * @category undici
- */
-export const withUndiciOptions: {
-  (
-    options: Partial<Undici.Dispatcher.RequestOptions>
-  ): <R, E, A>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <R, E, A>(effect: Effect.Effect<A, E, R>, options: Partial<Undici.Dispatcher.RequestOptions>): Effect.Effect<A, E, R>
-} = internalUndici.withUndiciOptions
+export class UndiciRequestOptions extends Context.Tag(internalUndici.undiciOptionsTagKey)<
+  UndiciRequestOptions,
+  Undici.Dispatcher.RequestOptions
+>() {}
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const makeUndici: (dispatcher: Undici.Dispatcher) => Client.HttpClient.Default = internalUndici.make
+export const makeUndici: (dispatcher: Undici.Dispatcher) => Client.HttpClient.Service = internalUndici.make
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerUndici: Layer.Layer<Client.HttpClient.Default> = internalUndici.layer
+export const layerUndici: Layer.Layer<Client.HttpClient.Service> = internalUndici.layer
 
 /**
  * @since 1.0.0
  * @category layers
  */
-export const layerUndiciWithoutDispatcher: Layer.Layer<Client.HttpClient.Default, never, Dispatcher> =
+export const layerUndiciWithoutDispatcher: Layer.Layer<Client.HttpClient.Service, never, Dispatcher> =
   internalUndici.layerWithoutDispatcher

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -105,7 +105,7 @@ export const layerConfig: (
  * @category layers
  */
 export const layerTest: Layer.Layer<
-  | HttpClient.HttpClient.Default
+  | HttpClient.HttpClient.Service
   | Server.HttpServer
   | Platform.HttpPlatform
   | Etag.Generator

--- a/packages/platform-node/src/internal/httpClient.ts
+++ b/packages/platform-node/src/internal/httpClient.ts
@@ -54,8 +54,8 @@ export const makeAgentLayer = (options?: Https.AgentOptions): Layer.Layer<NodeCl
 /** @internal */
 export const agentLayer = makeAgentLayer()
 
-const fromAgent = (agent: NodeClient.HttpAgent): Client.HttpClient.Default =>
-  Client.makeDefault((request, url, signal) => {
+const fromAgent = (agent: NodeClient.HttpAgent): Client.HttpClient.Service =>
+  Client.makeService((request, url, signal) => {
     const nodeRequest = url.protocol === "https:" ?
       Https.request(url, {
         agent: agent.https,
@@ -254,7 +254,7 @@ class ClientResponseImpl extends HttpIncomingMessageImpl<Error.ResponseError>
 export const make = Effect.map(HttpAgent, fromAgent)
 
 /** @internal */
-export const layerWithoutAgent = Layer.effect(Client.HttpClient, make)
+export const layerWithoutAgent = Client.layerMergedContext(make)
 
 /** @internal */
 export const layer = Layer.provide(layerWithoutAgent, agentLayer)

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -103,7 +103,7 @@ describe("HttpApi", () => {
     it.scoped("class level annotations", () =>
       Effect.gen(function*() {
         const response = yield* HttpClientRequest.post("/users").pipe(
-          HttpClientRequest.unsafeJsonBody({ name: "boom" })
+          HttpClientRequest.bodyUnsafeJson({ name: "boom" })
         )
         assert.strictEqual(response.status, 400)
       }).pipe(Effect.provide(HttpLive)))

--- a/packages/platform/src/FetchHttpClient.ts
+++ b/packages/platform/src/FetchHttpClient.ts
@@ -1,0 +1,25 @@
+/**
+ * @since 1.0.0
+ */
+import * as Context from "effect/Context"
+import type * as Layer from "effect/Layer"
+import type { HttpClient } from "./HttpClient.js"
+import * as internal from "./internal/fetchHttpClient.js"
+
+/**
+ * @since 1.0.0
+ * @category tags
+ */
+export class Fetch extends Context.Tag(internal.fetchTagKey)<Fetch, typeof globalThis.fetch>() {}
+
+/**
+ * @since 1.0.0
+ * @category tags
+ */
+export class RequestInit extends Context.Tag(internal.requestInitTagKey)<RequestInit, globalThis.RequestInit>() {}
+
+/**
+ * @since 1.0.0
+ * @category layers
+ */
+export const layer: Layer.Layer<HttpClient.Service> = internal.layer

--- a/packages/platform/src/HttpClientRequest.ts
+++ b/packages/platform/src/HttpClientRequest.ts
@@ -36,7 +36,7 @@ export type TypeId = typeof TypeId
  * @category models
  */
 export interface HttpClientRequest
-  extends Effect.Effect<HttpClientResponse, HttpClientError, HttpClient.Default | Scope>, Inspectable
+  extends Effect.Effect<HttpClientResponse, HttpClientError, HttpClient.Service | Scope>, Inspectable
 {
   readonly [TypeId]: TypeId
   readonly method: HttpMethod
@@ -301,73 +301,73 @@ export const setBody: {
  * @since 1.0.0
  * @category combinators
  */
-export const uint8ArrayBody: {
+export const bodyUint8Array: {
   (body: Uint8Array, contentType?: string): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, body: Uint8Array, contentType?: string): HttpClientRequest
-} = internal.uint8ArrayBody
+} = internal.bodyUint8Array
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const textBody: {
+export const bodyText: {
   (body: string, contentType?: string): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, body: string, contentType?: string): HttpClientRequest
-} = internal.textBody
+} = internal.bodyText
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const jsonBody: {
+export const bodyJson: {
   (body: unknown): (self: HttpClientRequest) => Effect.Effect<HttpClientRequest, Body.HttpBodyError>
   (self: HttpClientRequest, body: unknown): Effect.Effect<HttpClientRequest, Body.HttpBodyError>
-} = internal.jsonBody
+} = internal.bodyJson
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const unsafeJsonBody: {
+export const bodyUnsafeJson: {
   (body: unknown): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, body: unknown): HttpClientRequest
-} = internal.unsafeJsonBody
+} = internal.bodyUnsafeJson
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const schemaBody: <A, I, R>(
+export const schemaBodyJson: <A, I, R>(
   schema: Schema.Schema<A, I, R>,
   options?: ParseOptions | undefined
 ) => {
   (body: A): (self: HttpClientRequest) => Effect.Effect<HttpClientRequest, Body.HttpBodyError, R>
   (self: HttpClientRequest, body: A): Effect.Effect<HttpClientRequest, Body.HttpBodyError, R>
-} = internal.schemaBody
+} = internal.schemaBodyJson
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const urlParamsBody: {
+export const bodyUrlParams: {
   (input: UrlParams.Input): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, input: UrlParams.Input): HttpClientRequest
-} = internal.urlParamsBody
+} = internal.bodyUrlParams
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const formDataBody: {
+export const bodyFormData: {
   (body: FormData): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, body: FormData): HttpClientRequest
-} = internal.formDataBody
+} = internal.bodyFormData
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const streamBody: {
+export const bodyStream: {
   (
     body: Stream.Stream<Uint8Array, unknown>,
     options?: { readonly contentType?: string | undefined; readonly contentLength?: number | undefined } | undefined
@@ -377,13 +377,13 @@ export const streamBody: {
     body: Stream.Stream<Uint8Array, unknown>,
     options?: { readonly contentType?: string | undefined; readonly contentLength?: number | undefined } | undefined
   ): HttpClientRequest
-} = internal.streamBody
+} = internal.bodyStream
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const fileBody: {
+export const bodyFile: {
   (
     path: string,
     options?: FileSystem.StreamOptions & { readonly contentType?: string }
@@ -393,13 +393,13 @@ export const fileBody: {
     path: string,
     options?: FileSystem.StreamOptions & { readonly contentType?: string }
   ): Effect.Effect<HttpClientRequest, PlatformError.PlatformError, FileSystem.FileSystem>
-} = internal.fileBody
+} = internal.bodyFile
 
 /**
  * @since 1.0.0
  * @category combinators
  */
-export const fileWebBody: {
+export const bodyFileWeb: {
   (file: Body.HttpBody.FileLike): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, file: Body.HttpBody.FileLike): HttpClientRequest
-} = internal.fileWebBody
+} = internal.bodyFileWeb

--- a/packages/platform/src/HttpClientResponse.ts
+++ b/packages/platform/src/HttpClientResponse.ts
@@ -7,12 +7,12 @@ import type * as Schema from "@effect/schema/Schema"
 import type * as Effect from "effect/Effect"
 import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
+import type { Unify } from "effect/Unify"
 import type * as Cookies from "./Cookies.js"
 import type * as Error from "./HttpClientError.js"
 import type * as ClientRequest from "./HttpClientRequest.js"
 import type * as IncomingMessage from "./HttpIncomingMessage.js"
 import * as internal from "./internal/httpClientResponse.js"
-import type * as UrlParams from "./UrlParams.js"
 
 export {
   /**
@@ -24,27 +24,12 @@ export {
    * @since 1.0.0
    * @category schema
    */
-  schemaBodyJsonScoped,
-  /**
-   * @since 1.0.0
-   * @category schema
-   */
   schemaBodyUrlParams,
   /**
    * @since 1.0.0
    * @category schema
    */
-  schemaBodyUrlParamsScoped,
-  /**
-   * @since 1.0.0
-   * @category schema
-   */
-  schemaHeaders,
-  /**
-   * @since 1.0.0
-   * @category schema
-   */
-  schemaHeadersScoped
+  schemaHeaders
 } from "./HttpIncomingMessage.js"
 
 /**
@@ -115,102 +100,9 @@ export const schemaNoBody: <
  * @since 1.0.0
  * @category accessors
  */
-export const arrayBuffer: <E, R>(
-  effect: Effect.Effect<HttpClientResponse, E, R>
-) => Effect.Effect<ArrayBuffer, Error.ResponseError | E, Exclude<R, Scope.Scope>> = internal.arrayBuffer
-
-/**
- * @since 1.0.0
- * @category accessors
- */
-export const formData: <E, R>(
-  effect: Effect.Effect<HttpClientResponse, E, R>
-) => Effect.Effect<FormData, Error.ResponseError | E, Exclude<R, Scope.Scope>> = internal.formData
-
-/**
- * @since 1.0.0
- * @category accessors
- */
-export const json: <E, R>(
-  effect: Effect.Effect<HttpClientResponse, E, R>
-) => Effect.Effect<unknown, Error.ResponseError | E, Exclude<R, Scope.Scope>> = internal.json
-
-const void_: <E, R>(
-  effect: Effect.Effect<HttpClientResponse, E, R>
-) => Effect.Effect<void, E, Exclude<R, Scope.Scope>> = internal.void_
-export {
-  /**
-   * @since 1.0.0
-   * @category accessors
-   */
-  void_ as void
-}
-
-/**
- * @since 1.0.0
- * @category accessors
- */
 export const stream: <E, R>(
   effect: Effect.Effect<HttpClientResponse, E, R>
 ) => Stream.Stream<Uint8Array, Error.ResponseError | E, Exclude<R, Scope.Scope>> = internal.stream
-
-/**
- * @since 1.0.0
- * @category accessors
- */
-export const text: <E, R>(
-  effect: Effect.Effect<HttpClientResponse, E, R>
-) => Effect.Effect<string, Error.ResponseError | E, Exclude<R, Scope.Scope>> = internal.text
-
-/**
- * @since 1.0.0
- * @category accessors
- */
-export const urlParamsBody: <E, R>(
-  effect: Effect.Effect<HttpClientResponse, E, R>
-) => Effect.Effect<UrlParams.UrlParams, Error.ResponseError | E, Exclude<R, Scope.Scope>> = internal.urlParamsBody
-
-/**
- * @since 1.0.0
- * @category schema
- */
-export const schemaJsonScoped: <
-  R,
-  I extends {
-    readonly status?: number | undefined
-    readonly headers?: Readonly<Record<string, string>> | undefined
-    readonly body?: unknown
-  },
-  A
->(
-  schema: Schema.Schema<A, I, R>,
-  options?: ParseOptions | undefined
-) => <E, R2>(
-  effect: Effect.Effect<HttpClientResponse, E, R2>
-) => Effect.Effect<
-  A,
-  E | Error.ResponseError | ParseResult.ParseError,
-  Exclude<R, Scope.Scope> | Exclude<R2, Scope.Scope>
-> = internal.schemaJsonScoped
-
-/**
- * @since 1.0.0
- * @category schema
- */
-export const schemaNoBodyScoped: <
-  R,
-  I extends {
-    readonly status?: number | undefined
-    readonly headers?: Readonly<Record<string, string>> | undefined
-  },
-  A
->(
-  schema: Schema.Schema<A, I, R>,
-  options?: ParseOptions | undefined
-) => <E, R2>(
-  effect: Effect.Effect<HttpClientResponse, E, R2>
-) => Effect.Effect<A, E | ParseResult.ParseError, Exclude<R, Scope.Scope> | Exclude<R2, Scope.Scope>> =
-  internal.schemaNoBodyScoped
 
 /**
  * @since 1.0.0
@@ -226,7 +118,7 @@ export const matchStatus: {
       readonly "5xx"?: (_: HttpClientResponse) => any
       readonly orElse: (_: HttpClientResponse) => any
     }
-  >(cases: Cases): (self: HttpClientResponse) => Cases[keyof Cases] extends (_: any) => infer R ? R : never
+  >(cases: Cases): (self: HttpClientResponse) => Cases[keyof Cases] extends (_: any) => infer R ? Unify<R> : never
   <
     const Cases extends {
       readonly [status: number]: (_: HttpClientResponse) => any
@@ -236,55 +128,5 @@ export const matchStatus: {
       readonly "5xx"?: (_: HttpClientResponse) => any
       readonly orElse: (_: HttpClientResponse) => any
     }
-  >(self: HttpClientResponse, cases: Cases): Cases[keyof Cases] extends (_: any) => infer R ? R : never
+  >(self: HttpClientResponse, cases: Cases): Cases[keyof Cases] extends (_: any) => infer R ? Unify<R> : never
 } = internal.matchStatus
-
-/**
- * @since 1.0.0
- * @category pattern matching
- */
-export const matchStatusScoped: {
-  <
-    const Cases extends {
-      readonly [status: number]: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "2xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "3xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "4xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "5xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly orElse: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-    }
-  >(
-    cases: Cases
-  ): <E, R>(
-    self: Effect.Effect<HttpClientResponse, E, R>
-  ) => Effect.Effect<
-    Cases[keyof Cases] extends (_: any) => Effect.Effect<infer _A, infer _E, infer _R> ? _A : never,
-    E | (Cases[keyof Cases] extends (_: any) => Effect.Effect<infer _A, infer _E, infer _R> ? _E : never),
-    Exclude<
-      R | (Cases[keyof Cases] extends (_: any) => Effect.Effect<infer _A, infer _E, infer _R> ? _R : never),
-      Scope.Scope
-    >
-  >
-  <
-    E,
-    R,
-    const Cases extends {
-      readonly [status: number]: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "2xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "3xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "4xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly "5xx"?: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-      readonly orElse: (_: HttpClientResponse) => Effect.Effect<any, any, any>
-    }
-  >(
-    self: Effect.Effect<HttpClientResponse, E, R>,
-    cases: Cases
-  ): Effect.Effect<
-    Cases[keyof Cases] extends (_: any) => Effect.Effect<infer _A, infer _E, infer _R> ? _A : never,
-    E | (Cases[keyof Cases] extends (_: any) => Effect.Effect<infer _A, infer _E, infer _R> ? _E : never),
-    Exclude<
-      R | (Cases[keyof Cases] extends (_: any) => Effect.Effect<infer _A, infer _E, infer _R> ? _R : never),
-      Scope.Scope
-    >
-  >
-} = internal.matchStatusScoped

--- a/packages/platform/src/HttpIncomingMessage.ts
+++ b/packages/platform/src/HttpIncomingMessage.ts
@@ -10,7 +10,6 @@ import { dual } from "effect/Function"
 import * as Global from "effect/GlobalValue"
 import type { Inspectable } from "effect/Inspectable"
 import * as Option from "effect/Option"
-import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
 import * as FileSystem from "./FileSystem.js"
 import type * as Headers from "./Headers.js"
@@ -57,18 +56,6 @@ export const schemaBodyJson = <A, I, R>(schema: Schema.Schema<A, I, R>, options?
  * @since 1.0.0
  * @category schema
  */
-export const schemaBodyJsonScoped = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: ParseOptions | undefined) => {
-  const decode = schemaBodyJson(schema, options)
-  return <E, E2, R2>(
-    effect: Effect.Effect<HttpIncomingMessage<E>, E2, R2>
-  ): Effect.Effect<A, ParseResult.ParseError | E | E2, Exclude<R, Scope.Scope> | Exclude<R2, Scope.Scope>> =>
-    Effect.scoped(Effect.flatMap(effect, decode))
-}
-
-/**
- * @since 1.0.0
- * @category schema
- */
 export const schemaBodyUrlParams = <A, I extends Readonly<Record<string, string | undefined>>, R>(
   schema: Schema.Schema<A, I, R>,
   options?: ParseOptions | undefined
@@ -82,42 +69,12 @@ export const schemaBodyUrlParams = <A, I extends Readonly<Record<string, string 
  * @since 1.0.0
  * @category schema
  */
-export const schemaBodyUrlParamsScoped = <A, I extends Readonly<Record<string, string | undefined>>, R>(
-  schema: Schema.Schema<A, I, R>,
-  options?: ParseOptions | undefined
-) => {
-  const decode = schemaBodyUrlParams(schema, options)
-  return <E, E2, R2>(
-    effect: Effect.Effect<HttpIncomingMessage<E>, E2, R2>
-  ): Effect.Effect<A, ParseResult.ParseError | E | E2, Exclude<R, Scope.Scope> | Exclude<R2, Scope.Scope>> =>
-    Effect.scoped(Effect.flatMap(effect, decode))
-}
-
-/**
- * @since 1.0.0
- * @category schema
- */
 export const schemaHeaders = <A, I extends Readonly<Record<string, string | undefined>>, R>(
   schema: Schema.Schema<A, I, R>,
   options?: ParseOptions | undefined
 ) => {
   const parse = Schema.decodeUnknown(schema, options)
   return <E>(self: HttpIncomingMessage<E>): Effect.Effect<A, ParseResult.ParseError, R> => parse(self.headers)
-}
-
-/**
- * @since 1.0.0
- * @category schema
- */
-export const schemaHeadersScoped = <A, I extends Readonly<Record<string, string | undefined>>, R>(
-  schema: Schema.Schema<A, I, R>,
-  options?: ParseOptions | undefined
-) => {
-  const decode = schemaHeaders(schema, options)
-  return <E, E2, R2>(
-    effect: Effect.Effect<HttpIncomingMessage<E>, E2, R2>
-  ): Effect.Effect<A, ParseResult.ParseError | E2, Exclude<R, Scope.Scope> | Exclude<R2, Scope.Scope>> =>
-    Effect.scoped(Effect.flatMap(effect, decode))
 }
 
 /**

--- a/packages/platform/src/HttpServer.ts
+++ b/packages/platform/src/HttpServer.ts
@@ -201,5 +201,5 @@ export const withLogAddress: <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.Lay
  * @since 1.0.0
  * @category layers
  */
-export const layerTestClient: Layer.Layer<Client.HttpClient.Default, never, Client.HttpClient.Default | HttpServer> =
+export const layerTestClient: Layer.Layer<Client.HttpClient.Service, never, Client.HttpClient.Service | HttpServer> =
   internal.layerTestClient

--- a/packages/platform/src/Runtime.ts
+++ b/packages/platform/src/Runtime.ts
@@ -63,7 +63,7 @@ const addPrettyLogger = (refs: FiberRefs.FiberRefs, fiberId: FiberId.Runtime) =>
     fiberRef: FiberRef.currentLoggers,
     value: loggers.pipe(
       HashSet.remove(Logger.defaultLogger),
-      HashSet.add(Logger.prettyLogger())
+      HashSet.add(Logger.prettyLoggerDefault)
     )
   })
 }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -31,6 +31,11 @@ export * as Etag from "./Etag.js"
 /**
  * @since 1.0.0
  */
+export * as FetchHttpClient from "./FetchHttpClient.js"
+
+/**
+ * @since 1.0.0
+ */
 export * as FileSystem from "./FileSystem.js"
 
 /**

--- a/packages/platform/src/internal/fetchHttpClient.ts
+++ b/packages/platform/src/internal/fetchHttpClient.ts
@@ -1,0 +1,56 @@
+import * as Effect from "effect/Effect"
+import * as FiberRef from "effect/FiberRef"
+import * as Stream from "effect/Stream"
+import type * as Client from "../HttpClient.js"
+import * as Error from "../HttpClientError.js"
+import * as Method from "../HttpMethod.js"
+import * as client from "./httpClient.js"
+import * as internalResponse from "./httpClientResponse.js"
+
+/** @internal */
+export const fetchTagKey = "@effect/platform/FetchHttpClient/Fetch"
+/** @internal */
+export const requestInitTagKey = "@effect/platform/FetchHttpClient/FetchOptions"
+
+const fetch: Client.HttpClient.Service = client.makeService((request, url, signal, fiber) => {
+  const context = fiber.getFiberRef(FiberRef.currentContext)
+  const fetch: typeof globalThis.fetch = context.unsafeMap.get(fetchTagKey) ?? globalThis.fetch
+  const options: RequestInit = context.unsafeMap.get(requestInitTagKey) ?? {}
+  const headers = new globalThis.Headers(request.headers)
+  const send = (body: BodyInit | undefined) =>
+    Effect.map(
+      Effect.tryPromise({
+        try: () =>
+          fetch(url, {
+            ...options,
+            method: request.method,
+            headers,
+            body,
+            duplex: request.body._tag === "Stream" ? "half" : undefined,
+            signal
+          } as any),
+        catch: (cause) =>
+          new Error.RequestError({
+            request,
+            reason: "Transport",
+            cause
+          })
+      }),
+      (response) => internalResponse.fromWeb(request, response)
+    )
+  if (Method.hasBody(request.method)) {
+    switch (request.body._tag) {
+      case "Raw":
+      case "Uint8Array":
+        return send(request.body.body as any)
+      case "FormData":
+        return send(request.body.formData)
+      case "Stream":
+        return Effect.flatMap(Stream.toReadableStreamEffect(request.body.stream), send)
+    }
+  }
+  return send(undefined)
+})
+
+/** @internal */
+export const layer = client.layerMergedContext(Effect.succeed(fetch))

--- a/packages/platform/src/internal/httpClientRequest.ts
+++ b/packages/platform/src/internal/httpClientRequest.ts
@@ -21,14 +21,14 @@ import * as internalBody from "./httpBody.js"
 export const TypeId: ClientRequest.TypeId = Symbol.for("@effect/platform/HttpClientRequest") as ClientRequest.TypeId
 
 /** @internal */
-export const clientTag = Context.GenericTag<HttpClient.Default>("@effect/platform/HttpClient")
+export const clientTag = Context.GenericTag<HttpClient.Service>("@effect/platform/HttpClient")
 
 const Proto = {
   [TypeId]: TypeId,
   ...Effectable.CommitPrototype,
   ...Inspectable.BaseProto,
   commit(this: ClientRequest.HttpClientRequest) {
-    return Effect.flatMap(clientTag, (client) => client(this))
+    return Effect.flatMap(clientTag, (client) => client.execute(this))
   },
   toJSON(this: ClientRequest.HttpClientRequest): unknown {
     return {
@@ -393,7 +393,7 @@ export const setBody = dual<
 })
 
 /** @internal */
-export const uint8ArrayBody = dual<
+export const bodyUint8Array = dual<
   (
     body: Uint8Array,
     contentType?: string
@@ -405,7 +405,7 @@ export const uint8ArrayBody = dual<
 )
 
 /** @internal */
-export const textBody = dual<
+export const bodyText = dual<
   (body: string, contentType?: string) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
   (self: ClientRequest.HttpClientRequest, body: string, contentType?: string) => ClientRequest.HttpClientRequest
 >(
@@ -414,7 +414,7 @@ export const textBody = dual<
 )
 
 /** @internal */
-export const jsonBody = dual<
+export const bodyJson = dual<
   (
     body: unknown
   ) => (self: ClientRequest.HttpClientRequest) => Effect.Effect<ClientRequest.HttpClientRequest, Body.HttpBodyError>,
@@ -425,13 +425,13 @@ export const jsonBody = dual<
 >(2, (self, body) => Effect.map(internalBody.json(body), (body) => setBody(self, body)))
 
 /** @internal */
-export const unsafeJsonBody = dual<
+export const bodyUnsafeJson = dual<
   (body: unknown) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
   (self: ClientRequest.HttpClientRequest, body: unknown) => ClientRequest.HttpClientRequest
 >(2, (self, body) => setBody(self, internalBody.unsafeJson(body)))
 
 /** @internal */
-export const fileBody = dual<
+export const bodyFile = dual<
   (
     path: string,
     options?: FileSystem.StreamOptions & { readonly contentType?: string }
@@ -449,13 +449,13 @@ export const fileBody = dual<
 )
 
 /** @internal */
-export const fileWebBody = dual<
+export const bodyFileWeb = dual<
   (file: Body.HttpBody.FileLike) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
   (self: ClientRequest.HttpClientRequest, file: Body.HttpBody.FileLike) => ClientRequest.HttpClientRequest
 >(2, (self, file) => setBody(self, internalBody.fileWeb(file)))
 
 /** @internal */
-export const schemaBody = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: ParseOptions | undefined): {
+export const schemaBodyJson = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: ParseOptions | undefined): {
   (
     body: A
   ): (self: ClientRequest.HttpClientRequest) => Effect.Effect<ClientRequest.HttpClientRequest, Body.HttpBodyError, R>
@@ -479,7 +479,7 @@ export const schemaBody = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: Pa
 }
 
 /** @internal */
-export const urlParamsBody = dual<
+export const bodyUrlParams = dual<
   (input: UrlParams.Input) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
   (self: ClientRequest.HttpClientRequest, input: UrlParams.Input) => ClientRequest.HttpClientRequest
 >(2, (self, body) =>
@@ -492,13 +492,13 @@ export const urlParamsBody = dual<
   ))
 
 /** @internal */
-export const formDataBody = dual<
+export const bodyFormData = dual<
   (body: FormData) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
   (self: ClientRequest.HttpClientRequest, body: FormData) => ClientRequest.HttpClientRequest
 >(2, (self, body) => setBody(self, internalBody.formData(body)))
 
 /** @internal */
-export const streamBody = dual<
+export const bodyStream = dual<
   (
     body: Stream.Stream<Uint8Array, unknown>,
     options?: {

--- a/packages/platform/src/internal/httpServerError.ts
+++ b/packages/platform/src/internal/httpServerError.ts
@@ -1,5 +1,6 @@
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
+import * as Equal from "effect/Equal"
 import type * as Exit from "effect/Exit"
 import * as FiberId from "effect/FiberId"
 import { globalValue } from "effect/GlobalValue"
@@ -46,7 +47,7 @@ export const causeResponse = <E>(
           if (acc[1]._tag !== "Empty") {
             return Option.none()
           }
-          const response = cause.fiberId === clientAbortFiberId ? clientAbortError : serverAbortError
+          const response = Equal.equals(cause.fiberId, clientAbortFiberId) ? clientAbortError : serverAbortError
           return Option.some([Effect.succeed(response), cause] as const)
         }
         default: {

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -1,4 +1,11 @@
-import { Cookies, HttpClient, HttpClientRequest, HttpClientResponse, UrlParams } from "@effect/platform"
+import {
+  Cookies,
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  UrlParams
+} from "@effect/platform"
 import * as Schema from "@effect/schema/Schema"
 import { assert, describe, expect, it } from "@effect/vitest"
 import { Either, Ref } from "effect"
@@ -25,7 +32,8 @@ const makeJsonPlaceholder = Effect.gen(function*(_) {
     HttpClient.mapRequest(HttpClientRequest.prependUrl("https://jsonplaceholder.typicode.com"))
   )
   const todoClient = client.pipe(
-    HttpClient.mapEffectScoped(HttpClientResponse.schemaBodyJson(Todo))
+    HttpClient.mapEffect(HttpClientResponse.schemaBodyJson(Todo)),
+    HttpClient.scoped
   )
   const createTodo = HttpClient.schemaFunction(
     todoClient,
@@ -40,27 +48,28 @@ const makeJsonPlaceholder = Effect.gen(function*(_) {
 interface JsonPlaceholder extends Effect.Effect.Success<typeof makeJsonPlaceholder> {}
 const JsonPlaceholder = Context.GenericTag<JsonPlaceholder>("test/JsonPlaceholder")
 const JsonPlaceholderLive = Layer.effect(JsonPlaceholder, makeJsonPlaceholder)
-  .pipe(Layer.provide(HttpClient.layer))
+  .pipe(Layer.provide(FetchHttpClient.layer))
 
 describe("HttpClient", () => {
   it("google", () =>
     Effect.gen(function*(_) {
       const response = yield* _(
         HttpClientRequest.get("https://www.google.com/"),
-        HttpClient.fetchOk,
         Effect.flatMap((_) => _.text),
         Effect.scoped
       )
       expect(response).toContain("Google")
-    }).pipe(Effect.runPromise))
+    }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
 
   it("google withCookiesRef", () =>
     Effect.gen(function*(_) {
       const ref = yield* _(Ref.make(Cookies.empty))
-      const client = HttpClient.withCookiesRef(HttpClient.fetchOk, ref)
+      const client = (yield* HttpClient.HttpClient).pipe(
+        HttpClient.withCookiesRef(ref)
+      )
       yield* _(
         HttpClientRequest.get("https://www.google.com/"),
-        client,
+        client.execute,
         Effect.scoped
       )
       const cookieHeader = yield* _(Ref.get(ref), Effect.map(Cookies.toCookieHeader))
@@ -72,27 +81,26 @@ describe("HttpClient", () => {
               assert.strictEqual(req.headers.cookie, cookieHeader)
             })
           )
-        ),
+        ).execute,
         Effect.scoped
       )
-    }).pipe(Effect.runPromise))
+    }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
 
   it("google stream", () =>
     Effect.gen(function*(_) {
       const response = yield* _(
         HttpClientRequest.get(new URL("https://www.google.com/")),
-        HttpClient.fetchOk,
         Effect.map((_) => _.stream),
         Stream.unwrapScoped,
         Stream.runFold("", (a, b) => a + new TextDecoder().decode(b))
       )
       expect(response).toContain("Google")
-    }).pipe(Effect.runPromise))
+    }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
 
   it("jsonplaceholder", () =>
-    Effect.gen(function*(_) {
-      const jp = yield* _(JsonPlaceholder)
-      const response = yield* _(HttpClientRequest.get("/todos/1"), jp.todoClient)
+    Effect.gen(function*() {
+      const jp = yield* JsonPlaceholder
+      const response = yield* jp.todoClient.get("/todos/1")
       expect(response.id).toBe(1)
     }).pipe(Effect.provide(JsonPlaceholderLive), Effect.runPromise))
 
@@ -110,30 +118,32 @@ describe("HttpClient", () => {
   it("jsonplaceholder schemaJson", () =>
     Effect.gen(function*(_) {
       const jp = yield* _(JsonPlaceholder)
-      const client = HttpClient.mapEffectScoped(jp.client, HttpClientResponse.schemaJson(OkTodo)).pipe(
+      const client = HttpClient.mapEffect(jp.client, HttpClientResponse.schemaJson(OkTodo)).pipe(
+        HttpClient.scoped,
         HttpClient.map((_) => _.body)
       )
-      const response = yield* _(HttpClientRequest.get("/todos/1"), client)
+      const response = yield* client.get("/todos/1")
       expect(response.id).toBe(1)
     }).pipe(Effect.provide(JsonPlaceholderLive), Effect.runPromise))
 
   it("request processing order", () =>
-    Effect.gen(function*(_) {
-      const defaultClient = yield* _(HttpClient.HttpClient)
+    Effect.gen(function*() {
+      const defaultClient = yield* HttpClient.HttpClient
       const client = defaultClient.pipe(
         HttpClient.mapRequest(HttpClientRequest.prependUrl("jsonplaceholder.typicode.com")),
         HttpClient.mapRequest(HttpClientRequest.prependUrl("https://"))
       )
       const todoClient = client.pipe(
-        HttpClient.mapEffectScoped(HttpClientResponse.schemaBodyJson(Todo))
+        HttpClient.mapEffect(HttpClientResponse.schemaBodyJson(Todo)),
+        HttpClient.scoped
       )
-      const response = yield* _(HttpClientRequest.get("/todos/1"), todoClient)
+      const response = yield* todoClient.get("/todos/1")
       expect(response.id).toBe(1)
-    }).pipe(Effect.provide(HttpClient.layer), Effect.runPromise))
+    }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
 
   it("streamBody accesses the current runtime", () =>
-    Effect.gen(function*(_) {
-      const defaultClient = yield* _(HttpClient.HttpClient)
+    Effect.gen(function*() {
+      const defaultClient = yield* HttpClient.HttpClient
 
       const requestStream = Stream.fromIterable(["hello", "world"]).pipe(
         Stream.tap((_) => Effect.log(_)),
@@ -144,14 +154,14 @@ describe("HttpClient", () => {
       const logger = Logger.make(({ message }) => logs.push(message))
 
       yield* HttpClientRequest.post("https://jsonplaceholder.typicode.com").pipe(
-        HttpClientRequest.streamBody(requestStream),
-        defaultClient,
+        HttpClientRequest.bodyStream(requestStream),
+        defaultClient.execute,
         Effect.provide(Logger.replace(Logger.defaultLogger, logger)),
         Effect.scoped
       )
 
       expect(logs).toEqual([["hello"], ["world"]])
-    }).pipe(Effect.provide(HttpClient.layer), Effect.runPromise))
+    }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
 
   it("ClientRequest parses URL instances", () => {
     const request = HttpClientRequest.get(new URL("https://example.com/?foo=bar#hash")).pipe(
@@ -164,16 +174,18 @@ describe("HttpClient", () => {
     )
   })
 
-  it.effect("matchStatusScoped", () =>
+  it.effect("matchStatus", () =>
     Effect.gen(function*() {
       const jp = yield* JsonPlaceholder
-      const response = yield* HttpClientRequest.get("/todos/1").pipe(
-        jp.client,
-        HttpClientResponse.matchStatusScoped({
-          "2xx": HttpClientResponse.schemaBodyJson(Todo),
-          404: () => Effect.fail("not found"),
-          orElse: () => Effect.fail("boom")
-        })
+      const response = yield* jp.client.get("/todos/1").pipe(
+        Effect.flatMap(
+          HttpClientResponse.matchStatus({
+            "2xx": HttpClientResponse.schemaBodyJson(Todo),
+            404: () => Effect.fail("not found"),
+            orElse: () => Effect.fail("boom")
+          })
+        ),
+        Effect.scoped
       )
       assert.deepStrictEqual(response, { id: 1, userId: 1, title: "delectus aut autem", completed: false })
     }).pipe(Effect.provide(JsonPlaceholderLive)))

--- a/packages/rpc-http/examples/client.ts
+++ b/packages/rpc-http/examples/client.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpClientRequest } from "@effect/platform"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform"
 import { RpcResolver } from "@effect/rpc"
 import { HttpRpcResolver } from "@effect/rpc-http"
 import { Console, Effect, Stream } from "effect"
@@ -6,16 +6,24 @@ import type { UserRouter } from "./router.js"
 import { GetUser, GetUserIds } from "./schema.js"
 
 // Create the client
-const client = HttpRpcResolver.make<UserRouter>(
-  HttpClient.fetchOk.pipe(
-    HttpClient.mapRequest(HttpClientRequest.prependUrl("http://localhost:3000/rpc"))
-  )
-).pipe(RpcResolver.toClient)
+const makeClient = Effect.gen(function*() {
+  const client = yield* HttpClient.HttpClient
+  return HttpRpcResolver.make<UserRouter>(
+    client.pipe(
+      HttpClient.mapRequest(HttpClientRequest.prependUrl("http://localhost:3000/rpc"))
+    )
+  ).pipe(RpcResolver.toClient)
+})
 
 // Use the client
-client(new GetUserIds()).pipe(
-  Stream.runCollect,
-  Effect.flatMap(Effect.forEach((id) => client(new GetUser({ id })), { batching: true })),
-  Effect.tap(Console.log),
+Effect.gen(function*() {
+  const client = yield* makeClient
+  yield* client(new GetUserIds()).pipe(
+    Stream.runCollect,
+    Effect.flatMap(Effect.forEach((id) => client(new GetUser({ id })), { batching: true })),
+    Effect.tap(Console.log)
+  )
+}).pipe(
+  Effect.provide(FetchHttpClient.layer),
   Effect.runFork
 )


### PR DESCRIPTION
The following code:

```ts
import { Effect, Fiber } from "effect"

const program = Effect.gen(function*() {
  const fiber = yield* Effect.fork(
    Effect.uninterruptibleMask((restore) =>
      restore(
        Effect.sleep("1 second").pipe(
          Effect.withSpan("sleep")
        )
      ).pipe(
        Effect.tapErrorCause((cause) => Effect.logError("Got cause:", cause))
      )
    )
  )

  yield* Effect.sleep("250 millis")
  yield* Fiber.interrupt(fiber)
  yield* Fiber.await(fiber)
  yield* Effect.logInfo("Done")
})

Effect.runFork(program)
```

now prints:

```ts
michaelarnaldi@Michaels-MacBook-Pro effect % pnpm tsx scratchpad/interrupt-span.ts 
timestamp=2024-09-09T15:43:01.173Z level=ERROR fiber=#1 message="Got cause:" cause="InterruptedException: Fiber Interrupted by: #0
    at sleep (/Users/michaelarnaldi/repositories/effect/scratchpad/interrupt-span.ts:8:18)"
timestamp=2024-09-09T15:43:01.175Z level=INFO fiber=#0 message=Done
michaelarnaldi@Michaels-MacBook-Pro effect % 
```

I am not too sure this is a wanted & helpful feature, up for discussion