### PR TITLE
add missing `encoding` argument to `Command.streamLines`

### DIFF
--- a/.changeset/strange-dolls-sit.md
+++ b/.changeset/strange-dolls-sit.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+add missing `encoding` argument to `Command.streamLines`

--- a/packages/platform/src/Command.ts
+++ b/packages/platform/src/Command.ts
@@ -153,9 +153,9 @@ export const feed: {
 /**
  * Flatten this command to a non-empty array of standard commands.
  *
- * * For a `StandardCommand`, this simply returns a `1` element array
- * * For a `PipedCommand`, all commands in the pipe will be extracted out into
- *   a array from left to right
+ * For a `StandardCommand`, this simply returns a `1` element array
+ * For a `PipedCommand`, all commands in the pipe will be extracted out into
+ * a array from left to right
  *
  * @since 1.0.0
  * @category combinators
@@ -169,10 +169,8 @@ export const flatten: (self: Command) => NonEmptyReadonlyArray<StandardCommand> 
  * @since 1.0.0
  * @category execution
  */
-export const lines: (
-  command: Command,
-  encoding?: string
-) => Effect<Array<string>, PlatformError, CommandExecutor> = internal.lines
+export const lines: (command: Command, encoding?: string) => Effect<Array<string>, PlatformError, CommandExecutor> =
+  internal.lines
 
 /**
  * Create a command with the specified process name and an optional list of
@@ -235,7 +233,8 @@ export const stream: (command: Command) => Stream<Uint8Array, PlatformError, Com
  * @since 1.0.0
  * @category execution
  */
-export const streamLines: (command: Command) => Stream<string, PlatformError, CommandExecutor> = internal.streamLines
+export const streamLines: (command: Command, encoding?: string) => Stream<string, PlatformError, CommandExecutor> =
+  internal.streamLines
 
 /**
  * Runs the command returning the entire output as a string with the

--- a/packages/platform/src/internal/command.ts
+++ b/packages/platform/src/internal/command.ts
@@ -241,13 +241,14 @@ export const start = (
 export const stream = (
   command: Command.Command
 ): Stream.Stream<Uint8Array, PlatformError, CommandExecutor.CommandExecutor> =>
-  Stream.flatMap(commandExecutor.CommandExecutor, (process) => process.stream(command))
+  Stream.flatMap(commandExecutor.CommandExecutor, (executor) => executor.stream(command))
 
 /** @internal */
 export const streamLines = (
-  command: Command.Command
+  command: Command.Command,
+  encoding?: string
 ): Stream.Stream<string, PlatformError, CommandExecutor.CommandExecutor> =>
-  Stream.flatMap(commandExecutor.CommandExecutor, (process) => process.streamLines(command))
+  Stream.flatMap(commandExecutor.CommandExecutor, (executor) => executor.streamLines(command, encoding))
 
 /** @internal */
 export const string = dual<


### PR DESCRIPTION
The JSDoc documentation states:

> Runs the command returning the output as an stream of lines with the specified encoding.

However, no encoding parameter is actually accepted.