### PR TITLE
relax constraints for members within a union from `Schema.Any` to `Sc…

### DIFF
--- a/.changeset/grumpy-zebras-battle.md
+++ b/.changeset/grumpy-zebras-battle.md
@@ -1,0 +1,13 @@
+---
+"@effect/schema": minor
+---
+
+Updates the constraints for members within a union from the more restrictive `Schema.Any` to the more inclusive `Schema.All`, closes #3587.
+
+Involved APIs:
+
+- `Schema.Union`
+- `Schema.UndefinedOr`
+- `Schema.NullOr`
+- `Schema.NullishOr`
+- `Schema.optional`

--- a/.changeset/grumpy-zebras-battle.md
+++ b/.changeset/grumpy-zebras-battle.md
@@ -1,13 +1,14 @@
 ---
-"@effect/schema": minor
+"@effect/schema": patch
 ---
 
 Updates the constraints for members within a union from the more restrictive `Schema.Any` to the more inclusive `Schema.All`, closes #3587.
 
-Involved APIs:
+Affected APIs include:
 
 - `Schema.Union`
 - `Schema.UndefinedOr`
 - `Schema.NullOr`
 - `Schema.NullishOr`
 - `Schema.optional`
+- `AST.Union.make` now retains duplicate members and no longer eliminates the `neverKeyword`.

--- a/.changeset/grumpy-zebras-battle.md
+++ b/.changeset/grumpy-zebras-battle.md
@@ -1,5 +1,5 @@
 ---
-"@effect/schema": patch
+"@effect/schema": minor
 ---
 
 Updates the constraints for members within a union from the more restrictive `Schema.Any` to the more inclusive `Schema.All`, closes #3587.

--- a/packages/schema/dtslint/Schema.ts
+++ b/packages/schema/dtslint/Schema.ts
@@ -305,6 +305,9 @@ S.NullOr(S.NumberFromString)
 // Union
 // ---------------------------------------------
 
+// $ExpectType Union<[typeof String$, typeof Never]>
+S.Union(S.String, S.Never)
+
 // $ExpectType Union<[typeof String$, typeof Number$]>
 S.Union(S.String, S.Number).annotations({})
 
@@ -507,6 +510,9 @@ S.asSchema(S.Struct({ a: neverAnyPropertySignature }))
 // ---------------------------------------------
 // optional
 // ---------------------------------------------
+
+// $ExpectType optional<typeof Never>
+S.optional(S.Never)
 
 // $ExpectType Schema<{ readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, { readonly a: string; readonly b: number; readonly c?: boolean | undefined; }, never>
 S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optional(S.Boolean) }))
@@ -2683,3 +2689,24 @@ S.asSchema(S.TemplateLiteralParser("/", S.Int, "/", S.Literal("a", "b")))
 
 // $ExpectType TemplateLiteralParser<["/", typeof Int, "/", Literal<["a", "b"]>]>
 S.TemplateLiteralParser("/", S.Int, "/", S.Literal("a", "b"))
+
+// ---------------------------------------------
+// UndefinedOr
+// ---------------------------------------------
+
+// $ExpectType UndefinedOr<typeof Never>
+S.UndefinedOr(S.Never)
+
+// ---------------------------------------------
+// NullOr
+// ---------------------------------------------
+
+// $ExpectType NullOr<typeof Never>
+S.NullOr(S.Never)
+
+// ---------------------------------------------
+// NullishOr
+// ---------------------------------------------
+
+// $ExpectType NullishOr<typeof Never>
+S.NullishOr(S.Never)

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -1110,10 +1110,10 @@ export interface Union<Members extends ReadonlyArray<Schema.All>> extends
   annotations(annotations: Annotations.Schema<Schema.Type<Members[number]>>): Union<Members>
 }
 
-const getDefaultUnionAST = <Members extends ReadonlyArray<Schema.All>>(members: Members) =>
-  AST.Union.members(members.map((m) => m.ast))
+const getDefaultUnionAST = <Members extends AST.Members<Schema.All>>(members: Members): AST.AST =>
+  AST.Union.make(members.map((m) => m.ast))
 
-const makeUnionClass = <Members extends ReadonlyArray<Schema.All>>(
+const makeUnionClass = <Members extends AST.Members<Schema.All>>(
   members: Members,
   ast: AST.AST = getDefaultUnionAST(members)
 ): Union<Members> =>
@@ -1124,7 +1124,7 @@ const makeUnionClass = <Members extends ReadonlyArray<Schema.All>>(
       return makeUnionClass(this.members, mergeSchemaAnnotations(this.ast, annotations))
     }
 
-    static members = [...members] as any as Members
+    static members = [...members]
   }
 
 /**
@@ -1139,14 +1139,11 @@ export function Union<Members extends ReadonlyArray<Schema.All>>(
 ): Schema<Schema.Type<Members[number]>, Schema.Encoded<Members[number]>, Schema.Context<Members[number]>>
 export function Union<Members extends ReadonlyArray<Schema.All>>(
   ...members: Members
-):
-  | Schema<Schema.Type<Members[number]>, Schema.Encoded<Members[number]>, Schema.Context<Members[number]>>
-  | typeof Never
-{
+) {
   return AST.isMembers(members)
     ? makeUnionClass(members)
     : array_.isNonEmptyReadonlyArray(members)
-    ? members[0] as any
+    ? members[0]
     : Never
 }
 

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -830,7 +830,7 @@ export const TemplateLiteralParser = <Params extends array_.NonEmptyReadonlyArra
       encodedSchemas.push(encoded)
       typeSchemas.push(p)
     } else {
-      const literal = Literal(p as AST.LiteralValue)
+      const literal = Literal(p)
       encodedSchemas.push(literal)
       typeSchemas.push(literal)
     }
@@ -1098,7 +1098,7 @@ export {
  * @category api interface
  * @since 0.67.0
  */
-export interface Union<Members extends ReadonlyArray<Schema.Any>> extends
+export interface Union<Members extends ReadonlyArray<Schema.All>> extends
   AnnotableClass<
     Union<Members>,
     Schema.Type<Members[number]>,
@@ -1110,10 +1110,10 @@ export interface Union<Members extends ReadonlyArray<Schema.Any>> extends
   annotations(annotations: Annotations.Schema<Schema.Type<Members[number]>>): Union<Members>
 }
 
-const getDefaultUnionAST = <Members extends ReadonlyArray<Schema.Any>>(members: Members) =>
+const getDefaultUnionAST = <Members extends ReadonlyArray<Schema.All>>(members: Members) =>
   AST.Union.members(members.map((m) => m.ast))
 
-const makeUnionClass = <Members extends ReadonlyArray<Schema.Any>>(
+const makeUnionClass = <Members extends ReadonlyArray<Schema.All>>(
   members: Members,
   ast: AST.AST = getDefaultUnionAST(members)
 ): Union<Members> =>
@@ -1131,13 +1131,13 @@ const makeUnionClass = <Members extends ReadonlyArray<Schema.Any>>(
  * @category combinators
  * @since 0.67.0
  */
-export function Union<Members extends AST.Members<Schema.Any>>(...members: Members): Union<Members>
-export function Union<Member extends Schema.Any>(member: Member): Member
+export function Union<Members extends AST.Members<Schema.All>>(...members: Members): Union<Members>
+export function Union<Member extends Schema.All>(member: Member): Member
 export function Union(): typeof Never
-export function Union<Members extends ReadonlyArray<Schema.Any>>(
+export function Union<Members extends ReadonlyArray<Schema.All>>(
   ...members: Members
 ): Schema<Schema.Type<Members[number]>, Schema.Encoded<Members[number]>, Schema.Context<Members[number]>>
-export function Union<Members extends ReadonlyArray<Schema.Any>>(
+export function Union<Members extends ReadonlyArray<Schema.All>>(
   ...members: Members
 ):
   | Schema<Schema.Type<Members[number]>, Schema.Encoded<Members[number]>, Schema.Context<Members[number]>>
@@ -1154,7 +1154,7 @@ export function Union<Members extends ReadonlyArray<Schema.Any>>(
  * @category api interface
  * @since 0.67.0
  */
-export interface NullOr<S extends Schema.Any> extends Union<[S, typeof Null]> {
+export interface NullOr<S extends Schema.All> extends Union<[S, typeof Null]> {
   annotations(annotations: Annotations.Schema<Schema.Type<S> | null>): NullOr<S>
 }
 
@@ -1162,13 +1162,13 @@ export interface NullOr<S extends Schema.Any> extends Union<[S, typeof Null]> {
  * @category combinators
  * @since 0.67.0
  */
-export const NullOr = <S extends Schema.Any>(self: S): NullOr<S> => Union(self, Null)
+export const NullOr = <S extends Schema.All>(self: S): NullOr<S> => Union(self, Null)
 
 /**
  * @category api interface
  * @since 0.67.0
  */
-export interface UndefinedOr<S extends Schema.Any> extends Union<[S, typeof Undefined]> {
+export interface UndefinedOr<S extends Schema.All> extends Union<[S, typeof Undefined]> {
   annotations(annotations: Annotations.Schema<Schema.Type<S> | undefined>): UndefinedOr<S>
 }
 
@@ -1176,13 +1176,13 @@ export interface UndefinedOr<S extends Schema.Any> extends Union<[S, typeof Unde
  * @category combinators
  * @since 0.67.0
  */
-export const UndefinedOr = <S extends Schema.Any>(self: S): UndefinedOr<S> => Union(self, Undefined)
+export const UndefinedOr = <S extends Schema.All>(self: S): UndefinedOr<S> => Union(self, Undefined)
 
 /**
  * @category api interface
  * @since 0.67.0
  */
-export interface NullishOr<S extends Schema.Any> extends Union<[S, typeof Null, typeof Undefined]> {
+export interface NullishOr<S extends Schema.All> extends Union<[S, typeof Null, typeof Undefined]> {
   annotations(annotations: Annotations.Schema<Schema.Type<S> | null | undefined>): NullishOr<S>
 }
 
@@ -1190,7 +1190,7 @@ export interface NullishOr<S extends Schema.Any> extends Union<[S, typeof Null, 
  * @category combinators
  * @since 0.67.0
  */
-export const NullishOr = <S extends Schema.Any>(self: S): NullishOr<S> => Union(self, Null, Undefined)
+export const NullishOr = <S extends Schema.All>(self: S): NullishOr<S> => Union(self, Null, Undefined)
 
 /**
  * @category combinators
@@ -2351,11 +2351,12 @@ const optionalPropertySignatureAST = <A, I, R>(
  * @category PropertySignature
  * @since 0.69.0
  */
-export const optional = <S extends Schema.Any>(self: S): optional<S> =>
-  new PropertySignatureWithFromImpl(
-    new PropertySignatureDeclaration(UndefinedOr(self).ast, true, true, {}, undefined),
-    self
-  )
+export const optional = <S extends Schema.All>(self: S): optional<S> => {
+  const ast = self.ast === AST.undefinedKeyword || self.ast === AST.neverKeyword
+    ? AST.undefinedKeyword
+    : UndefinedOr(self).ast
+  return new PropertySignatureWithFromImpl(new PropertySignatureDeclaration(ast, true, true, {}, undefined), self)
+}
 
 /**
  * @category PropertySignature

--- a/packages/schema/test/AST/Union.test.ts
+++ b/packages/schema/test/AST/Union.test.ts
@@ -8,20 +8,20 @@ describe("AST.Union", () => {
     expect(asts.length).toBe(4)
   })
 
-  it("make should remove never from members", () => {
-    expect(AST.Union.make([AST.neverKeyword, AST.neverKeyword])).toEqual(
+  it("unify should remove never from members", () => {
+    expect(AST.Union.unify([AST.neverKeyword, AST.neverKeyword])).toEqual(
       AST.neverKeyword
     )
-    expect(AST.Union.make([AST.neverKeyword, AST.stringKeyword])).toEqual(AST.stringKeyword)
-    expect(AST.Union.make([AST.stringKeyword, AST.neverKeyword])).toEqual(AST.stringKeyword)
+    expect(AST.Union.unify([AST.neverKeyword, AST.stringKeyword])).toEqual(AST.stringKeyword)
+    expect(AST.Union.unify([AST.stringKeyword, AST.neverKeyword])).toEqual(AST.stringKeyword)
     expect(
-      AST.Union.make([
+      AST.Union.unify([
         AST.neverKeyword,
         AST.stringKeyword,
         AST.neverKeyword,
         AST.numberKeyword
       ])
-    ).toEqual(AST.Union.make([AST.stringKeyword, AST.numberKeyword]))
+    ).toEqual(AST.Union.unify([AST.stringKeyword, AST.numberKeyword]))
   })
 
   it("toString() should support suspended schemas", () => {

--- a/packages/schema/test/Schema/optional.test.ts
+++ b/packages/schema/test/Schema/optional.test.ts
@@ -8,6 +8,16 @@ describe("optional", () => {
     expect(schema.from).toStrictEqual(S.String)
   })
 
+  it("if the input is Schema.Undefined should not duplicate the schema", () => {
+    const schema = S.optional(S.Undefined)
+    expect((schema.ast as any as S.PropertySignatureDeclaration).type).toStrictEqual(S.Undefined.ast)
+  })
+
+  it("if the input is Schema.Never should include the input in the schema", () => {
+    const schema = S.optional(S.Never)
+    expect((schema.ast as any as S.PropertySignatureDeclaration).type).toStrictEqual(S.Undefined.ast)
+  })
+
   it("should expose a from property after an annotations call", () => {
     const schema = S.optional(S.String).annotations({})
     expect(schema.from).toStrictEqual(S.String)
@@ -35,5 +45,23 @@ describe("optional", () => {
     await Util.expectEncodeSuccess(schema, {}, {})
     await Util.expectEncodeSuccess(schema, { a: undefined }, { a: undefined })
     await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
+  })
+
+  it("Schema.Never as input", async () => {
+    const schema = S.Struct({
+      a: S.optional(S.Never)
+    })
+    await Util.expectDecodeUnknownSuccess(schema, {}, {})
+    await Util.expectDecodeUnknownSuccess(schema, { a: undefined }, { a: undefined })
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      { a: "a" },
+      `{ readonly a?: undefined }
+└─ ["a"]
+   └─ Expected undefined, actual "a"`
+    )
+
+    await Util.expectEncodeSuccess(schema, {}, {})
+    await Util.expectEncodeSuccess(schema, { a: undefined }, { a: undefined })
   })
 })


### PR DESCRIPTION
…hema.All`, closes #3587
