### PR TITLE
make Fiber subtype of Effect

### DIFF
--- a/.changeset/seven-lamps-nail.md
+++ b/.changeset/seven-lamps-nail.md
@@ -1,0 +1,16 @@
+---
+"effect": minor
+---
+
+The `Fiber<A, E>` is now a subtype of `Effect<A, E>`. This change removes the need for explicit call `Fiber.join`.
+
+```typescript
+import { Effect, Fiber } from "effect"
+
+Effect.gen(function*() {
+  const fiber = yield* Effect.fork(Effect.succeed(1))
+
+  const oldWay = yield* Fiber.join(fiber)
+  const now = yield* fiber
+}))
+```

--- a/packages/effect/dtslint/Unify.ts
+++ b/packages/effect/dtslint/Unify.ts
@@ -2,6 +2,7 @@ import type * as Deferred from "effect/Deferred"
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import type * as Exit from "effect/Exit"
+import type * as Fiber from "effect/Fiber"
 import type * as FiberRef from "effect/FiberRef"
 import type * as Micro from "effect/Micro"
 import type * as Option from "effect/Option"
@@ -78,8 +79,18 @@ export type FiberRefUnify = Unify.Unify<
   | FiberRef.FiberRef<1>
   | FiberRef.FiberRef<"a">
 >
+// $ExpectType Fiber<"a" | 1, "b" | 2>
+export type FiberUnify = Unify.Unify<
+  | Fiber.Fiber<1, 2>
+  | Fiber.Fiber<"a", "b">
+>
+// $ExpectType RuntimeFiber<"a" | 1, "b" | 2>
+export type RuntimeFiberUnify = Unify.Unify<
+  | Fiber.RuntimeFiber<1, 2>
+  | Fiber.RuntimeFiber<"a", "b">
+>
 
-// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | FiberRef<12> | FiberRef<"a2"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
+// $ExpectType 0 | Option<string | number> | Ref<1> | SynchronizedRef<1> | SubscriptionRef<1> | Deferred<1, 2> | Deferred<"a", "b"> | Fiber<"a" | 1, "b" | 2> | RuntimeFiber<"a" | 1, "b" | 2> | Ref<"A"> | SynchronizedRef<"A"> | SubscriptionRef<"A"> | FiberRef<12> | FiberRef<"a2"> | Either<1 | "A", 0 | "E"> | Effect<1 | "A", 0 | "E", "R" | "R1"> | RcRef<1 | "A", 0 | "E">
 export type AllUnify = Unify.Unify<
   | Either.Either<1, 0>
   | Either.Either<"A", "E">
@@ -99,5 +110,9 @@ export type AllUnify = Unify.Unify<
   | Deferred.Deferred<"a", "b">
   | FiberRef.FiberRef<12>
   | FiberRef.FiberRef<"a2">
+  | Fiber.Fiber<1, 2>
+  | Fiber.Fiber<"a", "b">
+  | Fiber.RuntimeFiber<1, 2>
+  | Fiber.RuntimeFiber<"a", "b">
   | 0
 >

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -18,13 +18,13 @@ import * as internal from "./internal/fiber.js"
 import * as fiberRuntime from "./internal/fiberRuntime.js"
 import type * as Option from "./Option.js"
 import type * as order from "./Order.js"
-import type { Pipeable } from "./Pipeable.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
 import type { Scheduler } from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type { Supervisor } from "./Supervisor.js"
 import type { AnySpan, Tracer } from "./Tracer.js"
 import type * as Types from "./Types.js"
+import type * as Unify from "./Unify.js"
 
 /**
  * @since 2.0.0
@@ -62,7 +62,7 @@ export type RuntimeFiberTypeId = typeof RuntimeFiberTypeId
  * @since 2.0.0
  * @category models
  */
-export interface Fiber<out A, out E = never> extends Fiber.Variance<A, E>, Pipeable {
+export interface Fiber<out A, out E = never> extends Effect.Effect<A, E>, Fiber.Variance<A, E> {
   /**
    * The identity of the fiber.
    */
@@ -97,6 +97,26 @@ export interface Fiber<out A, out E = never> extends Fiber.Variance<A, E>, Pipea
    * resume immediately. Otherwise, the effect will resume when the fiber exits.
    */
   interruptAsFork(fiberId: FiberId.FiberId): Effect.Effect<void>
+
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: FiberUnify<this>
+  readonly [Unify.ignoreSymbol]?: FiberUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface FiberUnify<A extends { [Unify.typeSymbol]?: any }> extends Effect.EffectUnify<A> {
+  Fiber?: () => A[Unify.typeSymbol] extends Fiber<infer A0, infer E0> | infer _ ? Fiber<A0, E0> : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface FiberUnifyIgnore extends Effect.EffectUnifyIgnore {
+  Effect?: true
 }
 
 /**
@@ -190,6 +210,27 @@ export interface RuntimeFiber<out A, out E = never> extends Fiber<A, E>, Fiber.R
    * Gets the current supervisor
    */
   get currentSupervisor(): Supervisor<unknown>
+
+  readonly [Unify.typeSymbol]?: unknown
+  readonly [Unify.unifySymbol]?: RuntimeFiberUnify<this>
+  readonly [Unify.ignoreSymbol]?: RuntimeFiberUnifyIgnore
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RuntimeFiberUnify<A extends { [Unify.typeSymbol]?: any }> extends FiberUnify<A> {
+  RuntimeFiber?: () => A[Unify.typeSymbol] extends RuntimeFiber<infer A0, infer E0> | infer _ ? RuntimeFiber<A0, E0>
+    : never
+}
+
+/**
+ * @category models
+ * @since 3.8.0
+ */
+export interface RuntimeFiberUnifyIgnore extends FiberUnifyIgnore {
+  Fiber?: true
 }
 
 /**

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -665,6 +665,10 @@ export const zipWithFiber = dual<
     f: (a: A, b: B) => C
   ) => Fiber.Fiber<C, E | E2>
 >(3, (self, that, f) => ({
+  ...Effectable.CommitPrototype,
+  commit() {
+    return internalFiber.join(this)
+  },
   [internalFiber.FiberTypeId]: internalFiber.fiberVariance,
   id: () => pipe(self.id(), FiberId.getOrElse(that.id())),
   await: pipe(

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -226,4 +226,10 @@ describe("Fiber", () => {
       const result = yield* $(Fiber.join(Fiber.all(fibers)), Effect.asVoid)
       assert.isUndefined(result)
     }), 10000)
+  it.effect("is subtype of Effect", () =>
+    Effect.gen(function*() {
+      const fiber = yield* Effect.fork(Effect.succeed(1))
+      const fiberResult = yield* fiber
+      assert(1 === fiberResult)
+    }))
 })


### PR DESCRIPTION
rebase fixes

add changeset

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The `Fiber<A, E>` is now a subtype of `Effect<A, E>`. This change removes the need for explicit call `Fiber.join`.

```typescript
import { Effect, Fiber } from "effect"

Effect.gen(function*() {
  const fiber = yield* Effect.fork(Effect.succeed(1))

  const oldWay = yield* Fiber.join(fiber)
  const now = yield* fiber
}))
```
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
