### PR TITLE
add additional duration conversion apis

### DIFF
--- a/.changeset/rich-timers-fix.md
+++ b/.changeset/rich-timers-fix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Added additional `Duration` conversion apis

--- a/.changeset/rich-timers-fix.md
+++ b/.changeset/rich-timers-fix.md
@@ -1,5 +1,11 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
-Added additional `Duration` conversion apis
+Add additional `Duration` conversion apis
+
+- `Duration.toSeconds`
+- `Duration.toMinutes`
+- `Duration.toHours`
+- `Duration.toDays`
+- `Duration.toWeeks`

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -299,7 +299,7 @@ export const toSeconds = (self: DurationInput): number =>
   })
 
 /**
- * @since 3.7.4
+ * @since 3.8.0
  * @category getters
  */
 export const toMinutes = (self: DurationInput): number =>
@@ -309,7 +309,7 @@ export const toMinutes = (self: DurationInput): number =>
   })
 
 /**
- * @since 3.7.4
+ * @since 3.8.0
  * @category getters
  */
 export const toHours = (self: DurationInput): number =>
@@ -319,7 +319,7 @@ export const toHours = (self: DurationInput): number =>
   })
 
 /**
- * @since 3.7.4
+ * @since 3.8.0
  * @category getters
  */
 export const toDays = (self: DurationInput): number =>
@@ -329,7 +329,7 @@ export const toDays = (self: DurationInput): number =>
   })
 
 /**
- * @since 3.7.4
+ * @since 3.8.0
  * @category getters
  */
 export const toWeeks = (self: DurationInput): number =>

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -282,23 +282,61 @@ export const weeks = (weeks: number): Duration => make(weeks * 604_800_000)
  * @since 2.0.0
  * @category getters
  */
-export const toMillis = (self: DurationInput): number => {
-  const _self = decode(self)
-  switch (_self.value._tag) {
-    case "Infinity":
-      return Infinity
-    case "Nanos":
-      return Number(_self.value.nanos) / 1_000_000
-    case "Millis":
-      return _self.value.millis
-  }
-}
+export const toMillis = (self: DurationInput): number =>
+  match(self, {
+    onMillis: (millis) => millis,
+    onNanos: (nanos) => Number(nanos) / 1_000_000
+  })
 
 /**
  * @since 2.0.0
  * @category getters
  */
-export const toSeconds = (self: DurationInput): number => toMillis(self) / 1_000
+export const toSeconds = (self: DurationInput): number =>
+  match(self, {
+    onMillis: (millis) => millis / 1_000,
+    onNanos: (nanos) => Number(nanos) / 1_000_000_000
+  })
+
+/**
+ * @since 3.7.4
+ * @category getters
+ */
+export const toMinutes = (self: DurationInput): number =>
+  match(self, {
+    onMillis: (millis) => millis / 60_000,
+    onNanos: (nanos) => Number(nanos) / 60_000_000_000
+  })
+
+/**
+ * @since 3.7.4
+ * @category getters
+ */
+export const toHours = (self: DurationInput): number =>
+  match(self, {
+    onMillis: (millis) => millis / 3_600_000,
+    onNanos: (nanos) => Number(nanos) / 3_600_000_000_000
+  })
+
+/**
+ * @since 3.7.4
+ * @category getters
+ */
+export const toDays = (self: DurationInput): number =>
+  match(self, {
+    onMillis: (millis) => millis / 86_400_000,
+    onNanos: (nanos) => Number(nanos) / 86_400_000_000_000
+  })
+
+/**
+ * @since 3.7.4
+ * @category getters
+ */
+export const toWeeks = (self: DurationInput): number =>
+  match(self, {
+    onMillis: (millis) => millis / 604_800_000,
+    onNanos: (nanos) => Number(nanos) / 604_800_000_000_000
+  })
 
 /**
  * Get the duration in nanoseconds as a bigint.

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -388,7 +388,7 @@ describe("Duration", () => {
 
   it("toSeconds", () => {
     expect(Duration.millis(1).pipe(Duration.toSeconds)).toBe(0.001)
-    expect(Duration.nanos(1n).pipe(Duration.toSeconds)).toBe(9.999999999999999e-10)
+    expect(Duration.nanos(1n).pipe(Duration.toSeconds)).toBe(1e-9)
     expect(Duration.infinity.pipe(Duration.toSeconds)).toBe(Infinity)
 
     expect(Duration.toSeconds("1 seconds")).toBe(1)


### PR DESCRIPTION
With the recent addition of the `DateTime` module, it's tempting to add some additional duration conversion utilities.