### PR TITLE
don't reconstruct either in ParseResult.go

### DIFF
--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -1461,7 +1461,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
                   } else {
                     return Effect.flatMap(Effect.either(pr), (t) => {
                       if (Either.isRight(t)) {
-                        state.finalResult = t;
+                        state.finalResult = t
                       } else {
                         state.es.push([nk, t.left])
                       }

--- a/packages/schema/src/ParseResult.ts
+++ b/packages/schema/src/ParseResult.ts
@@ -1444,7 +1444,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
           const eu = !queue || queue.length === 0 ? eitherOrUndefined(pr) : undefined
           if (eu) {
             if (Either.isRight(eu)) {
-              return Either.right(eu.right)
+              return eu
             } else {
               es.push([stepKey++, eu.left])
             }
@@ -1461,7 +1461,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
                   } else {
                     return Effect.flatMap(Effect.either(pr), (t) => {
                       if (Either.isRight(t)) {
-                        state.finalResult = Either.right(t.right)
+                        state.finalResult = t;
                       } else {
                         state.es.push([nk, t.left])
                       }


### PR DESCRIPTION
I ran across this and it didn't make any sense. 