### PR TITLE
revert cron schedule regression

### DIFF
--- a/.changeset/ninety-deers-grow.md
+++ b/.changeset/ninety-deers-grow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Revert cron schedule regression

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -433,18 +433,12 @@ export const cron = (expression: string | Cron.Cron): Schedule.Schedule<[number,
       const cron = parsed.right
       const date = new Date(now)
 
+      let next: number
       if (initial && Cron.match(cron, date)) {
-        const next = now
-        const start = beginningOfMinute(next)
-        const end = endOfMinute(next)
-        return core.succeed([
-          [false, [next, start, end]],
-          [start, end],
-          ScheduleDecision.continueWith(Interval.make(start + 60000, end + 60000))
-        ])
+        next = now
       }
 
-      const next = Cron.next(cron, date).getTime()
+      next = Cron.next(cron, date).getTime()
       const start = beginningOfMinute(next)
       const end = endOfMinute(next)
       return core.succeed([

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -572,26 +572,25 @@ describe("Schedule", () => {
       }))
   })
   describe("cron-like scheduling - repeats at point of time (minute of hour, day of week, ...)", () => {
-    it.effect("recur every minute after initial interval using cron", () =>
+    it.effect("recur every second minute using cron", () =>
       Effect.gen(function*($) {
         const ref = yield* $(Ref.make<ReadonlyArray<string>>([]))
         yield* $(TestClock.setTime(new Date(2024, 0, 1, 0, 0, 35).getTime()))
-        const schedule = Schedule.cron("* * * * *")
+        const schedule = Schedule.cron("*/2 * * * *")
         yield* $(
           TestClock.currentTimeMillis,
           Effect.tap((instant) => Ref.update(ref, Array.append(format(instant)))),
           Effect.repeat(schedule),
           Effect.fork
         )
-        yield* $(TestClock.adjust("5 minutes"))
+        yield* $(TestClock.adjust("8 minutes"))
         const result = yield* $(Ref.get(ref))
         const expected = [
           "Mon Jan 01 2024 00:00:35",
-          "Mon Jan 01 2024 00:01:00",
           "Mon Jan 01 2024 00:02:00",
-          "Mon Jan 01 2024 00:03:00",
           "Mon Jan 01 2024 00:04:00",
-          "Mon Jan 01 2024 00:05:00"
+          "Mon Jan 01 2024 00:06:00",
+          "Mon Jan 01 2024 00:08:00"
         ]
         assert.deepStrictEqual(result, expected)
       }))


### PR DESCRIPTION
@tim-smart apologies, the previous "fix" was incorrect and a result of me misinterpreting how the schedule decisions work.