### PR TITLE
Stable filters now generate multiple errors when 'errors = all', clos…

### DIFF
--- a/.changeset/chilly-ducks-repair.md
+++ b/.changeset/chilly-ducks-repair.md
@@ -1,0 +1,43 @@
+---
+"@effect/schema": patch
+---
+
+Stable filters such as `minItems`, `maxItems`, and `itemsCount` now generate multiple errors when the 'errors' option is set to 'all', closes #3633
+
+**Example:**
+
+```ts
+import { ArrayFormatter, Schema } from "@effect/schema"
+
+const schema = Schema.Struct({
+  tags: Schema.Array(Schema.String.pipe(Schema.minLength(2))).pipe(
+    Schema.minItems(3)
+  )
+})
+
+const invalidData = { tags: ["AB", "B"] }
+
+const either = Schema.decodeUnknownEither(schema, { errors: "all" })(
+  invalidData
+)
+if (either._tag === "Left") {
+  console.log(ArrayFormatter.formatErrorSync(either.left))
+  /*
+  Output:
+  [
+    {
+      _tag: 'Type',
+      path: [ 'tags', 1 ],
+      message: 'Expected a string at least 2 character(s) long, actual "B"'
+    },
+    {
+      _tag: 'Type',
+      path: [ 'tags' ],
+      message: 'Expected an array of at least 3 items, actual ["AB","B"]'
+    }
+  ]
+  */
+}
+```
+
+Previously, only the issue related to the `[ 'tags', 1 ]` path was reported.

--- a/packages/schema/src/AST.ts
+++ b/packages/schema/src/AST.ts
@@ -259,7 +259,13 @@ export type SurrogateAnnotation = AST
 /** @internal */
 export const StableFilterAnnotationId = Symbol.for("@effect/schema/annotation/StableFilter")
 
-/** @internal */
+/**
+ * A stable filter consistently applies fixed validation rules, such as
+ * 'minItems', 'maxItems', and 'itemsCount', to ensure array length complies
+ * with set criteria regardless of the input data's content.
+ *
+ * @internal
+ */
 export type StableFilterAnnotation = boolean
 
 /**
@@ -389,6 +395,10 @@ export const getDecodingFallbackAnnotation = getAnnotation<DecodingFallbackAnnot
 export const getSurrogateAnnotation = getAnnotation<SurrogateAnnotation>(SurrogateAnnotationId)
 
 const getStableFilterAnnotation = getAnnotation<StableFilterAnnotation>(StableFilterAnnotationId)
+
+/** @internal */
+export const hasStableFilter = (annotated: Annotated) =>
+  Option.exists(getStableFilterAnnotation(annotated), (b) => b === true)
 
 const JSONIdentifierAnnotationId = Symbol.for("@effect/schema/annotation/JSONIdentifier")
 
@@ -2552,11 +2562,8 @@ const encodedAST_ = (ast: AST, isBound: boolean): AST => {
         if (from === ast.from) {
           return ast
         }
-        if (!isTransformation(ast.from)) {
-          const annotations = getStableFilterAnnotation(ast)
-          if (Option.isSome(annotations) && annotations.value === true) {
-            return new Refinement(from, ast.filter)
-          }
+        if (!isTransformation(ast.from) && hasStableFilter(ast)) {
+          return new Refinement(from, ast.filter)
         }
       }
       return from

--- a/packages/schema/test/Schema/filter.test.ts
+++ b/packages/schema/test/Schema/filter.test.ts
@@ -227,4 +227,41 @@ describe("filter", () => {
       )
     })
   })
+
+  it("stable filters (such as `minItems`, `maxItems`, and `itemsCount`) should generate multiple errors when the 'errors' option is set to 'all'", async () => {
+    const schema = S.Struct({
+      tags: S.Array(S.String.pipe(S.minLength(2))).pipe(S.minItems(3))
+    })
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      { tags: ["AB", "B"] },
+      `{ readonly tags: an array of at least 3 items }
+└─ ["tags"]
+   └─ an array of at least 3 items
+      ├─ an array of at least 3 items
+      │  └─ From side refinement failure
+      │     └─ ReadonlyArray<a string at least 2 character(s) long>
+      │        └─ [1]
+      │           └─ a string at least 2 character(s) long
+      │              └─ Predicate refinement failure
+      │                 └─ Expected a string at least 2 character(s) long, actual "B"
+      └─ an array of at least 3 items
+         └─ Predicate refinement failure
+            └─ Expected an array of at least 3 items, actual ["AB","B"]`,
+      Util.allErrors
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      { tags: ["AB", "B"] },
+      `{ readonly tags: an array of at least 3 items }
+└─ ["tags"]
+   └─ an array of at least 3 items
+      └─ From side refinement failure
+         └─ ReadonlyArray<a string at least 2 character(s) long>
+            └─ [1]
+               └─ a string at least 2 character(s) long
+                  └─ Predicate refinement failure
+                     └─ Expected a string at least 2 character(s) long, actual "B"`
+    )
+  })
 })


### PR DESCRIPTION
…es #3633
