### PR TITLE
Add `Tuple.map`

### DIFF
--- a/.changeset/strong-pans-flash.md
+++ b/.changeset/strong-pans-flash.md
@@ -1,0 +1,19 @@
+---
+"effect": minor
+---
+
+`Tuple.map` transforms each element of tuple using the given function, treating tuple homomorphically
+
+```ts
+import { pipe, Tuple } from "effect"
+
+const result = pipe(
+  //  ^? [string, string, string]
+  ["a", 1, false] as const,
+  T.map((el) => {
+    //^? "a" | 1 | false
+    return el.toString().toUppercase()
+  })
+)
+assert.deepStrictEqual(result, ["A", "1", "FALSE"])
+```

--- a/packages/effect/dtslint/Tuple.ts
+++ b/packages/effect/dtslint/Tuple.ts
@@ -75,3 +75,10 @@ pipe(
     return false as const
   })
 )
+
+// $ExpectType [false, false, false]
+T.map(["a", 1, false], (x) => {
+  // $ExpectType string | number | boolean
+  x
+  return false as const
+})

--- a/packages/effect/dtslint/Tuple.ts
+++ b/packages/effect/dtslint/Tuple.ts
@@ -60,3 +60,18 @@ pipe(hole<Array<number>>(), T.at(1))
 
 // $ExpectType number
 pipe(hole<Array<number>>(), T.at(-1))
+
+// -------------------------------------------------------------------------------------
+// map
+// -------------------------------------------------------------------------------------
+
+// $ExpectType [false, false, false]
+pipe(
+  T.make("a", 1),
+  T.appendElement(true),
+  T.map((x) => {
+    // $ExpectType string | number | boolean
+    x
+    return false as const
+  })
+)

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -73,7 +73,7 @@ export const getSecond = <L, R>(self: readonly [L, R]): R => self[1]
  *
  * const result = pipe(
  *   ["a", 1, false] as const,
- *   T.map((el) => el.toString().toUppercase())
+ *   Tuple.map((el) => el.toString().toUpperCase())
  * )
  * assert.deepStrictEqual(result, ['A', '1', 'FALSE'])
  *

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -7,6 +7,7 @@ import * as Equivalence from "./Equivalence.js"
 import { dual } from "./Function.js"
 import type { TypeLambda } from "./HKT.js"
 import * as order from "./Order.js"
+import type { TupleOf } from "./Types.js"
 
 /**
  * @category type lambdas
@@ -60,6 +61,40 @@ export const getFirst = <L, R>(self: readonly [L, R]): L => self[0]
  * @since 2.0.0
  */
 export const getSecond = <L, R>(self: readonly [L, R]): R => self[1]
+
+/**
+ * Transforms each element of tuple using the given function, treating tuple homomorphically
+ *
+ * @param self - A tuple.
+ * @param f - The function to transform elements of the tuple.
+ *
+ * @example
+ * import { pipe, Tuple } from "effect"
+ *
+ * const result = pipe(
+ *   ["a", 1, false] as const,
+ *   T.map((el) => el.toString().toUppercase())
+ * )
+ * assert.deepStrictEqual(result, ['A', '1', 'FALSE'])
+ *
+ * @category mapping
+ * @since 3.9.0
+ */
+export const map: {
+  <T extends ReadonlyArray<any> | [], B>(
+    fn: (element: T[number]) => B
+  ): (self: T) => TupleOf<T["length"], B>
+  <B, T extends ReadonlyArray<any> | []>(
+    self: T,
+    fn: (element: T[number]) => B
+  ): TupleOf<T["length"], B>
+} = dual(
+  2,
+  <N extends number, A, B>(
+    self: TupleOf<N, A>,
+    fn: (element: A) => B
+  ): TupleOf<N, B> => self.map((element) => fn(element)) as TupleOf<N, B>
+)
 
 /**
  * Transforms both elements of a tuple using the given functions.

--- a/packages/effect/test/Tuple.test.ts
+++ b/packages/effect/test/Tuple.test.ts
@@ -31,6 +31,10 @@ describe("Tuple", () => {
     })).toEqual(["a!", 2])
   })
 
+  it("map", () => {
+    expect(T.map(["a", 1, false], (x) => x.toString().toUpperCase())).toEqual(["A", "1", "FALSE"])
+  })
+
   it("swap", () => {
     expect(T.swap(T.make("a", 1))).toEqual([1, "a"])
   })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Tuple.map` transforms each element of tuple using the given function, treating tuple homomorphically

```ts
import { pipe, Tuple } from "effect"

const result = pipe(
  //  ^? [string, string, string]
  ["a", 1, false] as const,
  T.map((el) => {
    //   ^? "a" | 1 | false
    return el.toString().toUppercase()
  })
)
assert.deepStrictEqual(result, ["A", "1", "FALSE"])
```

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
