### PR TITLE
Add `Array.pad`

### DIFF
--- a/.changeset/tall-vans-appear.md
+++ b/.changeset/tall-vans-appear.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Array.pad function

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1759,6 +1759,40 @@ export const copy: {
 } = (<A>(self: ReadonlyArray<A>): Array<A> => self.slice()) as any
 
 /**
+ * Pads an array.
+ * Returns a new array of length `n` with the elements of `array` followed by `fill` elements if `array` is shorter than `n`.
+ * If `array` is longer than `n`, the returned array will be a slice of `array` containing the `n` first elements of `array`.
+ * If `n` is less than or equal to 0, the returned array will be an empty array.
+ *
+ * @example
+ * import { Array } from "effect"
+ *
+ * const arr = [1, 2, 3]
+ * const result = Array.pad(arr, 6, 0)
+ * assert.deepStrictEqual(result, [1, 2, 3, 0, 0, 0])
+ *
+ * @since 3.8.4
+ *
+ */
+export const pad: {
+  <A, T>(
+    n: number,
+    fill: T
+  ): (
+    self: Array<A>
+  ) => Array<A | T>
+  <A, T>(self: Array<A>, n: number, fill: T): Array<A | T>
+} = dual(3, <A, T>(self: Array<A>, n: number, fill: T): Array<A | T> => {
+  if (self.length >= n) {
+    return take(self, n)
+  }
+  return appendAll(
+    self,
+    makeBy(n - self.length, () => fill)
+  )
+})
+
+/**
  * Splits an `Iterable` into length-`n` pieces. The last piece will be shorter if `n` does not evenly divide the length of
  * the `Iterable`. Note that `chunksOf(n)([])` is `[]`, not `[[]]`. This is intentional, and is consistent with a recursive
  * definition of `chunksOf`; it satisfies the property that

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1772,7 +1772,6 @@ export const copy: {
  * assert.deepStrictEqual(result, [1, 2, 3, 0, 0, 0])
  *
  * @since 3.8.4
- *
  */
 export const pad: {
   <A, T>(

--- a/packages/effect/test/Array.test.ts
+++ b/packages/effect/test/Array.test.ts
@@ -1084,6 +1084,14 @@ describe("ReadonlyArray", () => {
     deepStrictEqual(pipe([1, 2, 3], RA.chop((as) => [as[0] * 2, as.slice(1)])), [2, 4, 6])
   })
 
+  it("pad", () => {
+    deepStrictEqual(pipe([], RA.pad(0, 0)), [])
+    deepStrictEqual(pipe([1, 2, 3], RA.pad(0, 0)), [])
+    deepStrictEqual(pipe([1, 2, 3], RA.pad(2, 0)), [1, 2])
+    deepStrictEqual(pipe([1, 2, 3], RA.pad(6, 0)), [1, 2, 3, 0, 0, 0])
+    deepStrictEqual(pipe([1, 2, 3], RA.pad(-2, 0)), [])
+  })
+
   describe("chunksOf", () => {
     it("should split a `ReadonlyArray` into length-n pieces", () => {
       deepStrictEqual(RA.chunksOf(2)([1, 2, 3, 4, 5]), [[1, 2], [3, 4], [5]])


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a small utility function to the Array module: `pad`:

```typescript
import { Array } from "effect"

const result = Array.pad([1, 2], 4, 8)
assert.deepStrictEqual(result, [1, 2, 8, 8])
``` 
