### PR TITLE
add description annotation to the encoded part of NumberFromString

### DIFF
--- a/.changeset/fresh-terms-drop.md
+++ b/.changeset/fresh-terms-drop.md
@@ -1,0 +1,38 @@
+---
+"@effect/schema": patch
+---
+
+Add description annotation to the encoded part of NumberFromString.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.NumberFromString
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string"
+}
+*/
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "@effect/schema"
+
+const schema = Schema.NumberFromString
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "description": "a string that will be parsed into a number"
+}
+*/
+```

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -14,8 +14,8 @@
             "name": "id",
             "in": "path",
             "schema": {
-              "description": "a number",
-              "title": "number",
+              "description": "a string that will be parsed into a number",
+              "title": "string",
               "type": "string"
             },
             "required": true
@@ -282,8 +282,8 @@
             "name": "id",
             "in": "path",
             "schema": {
-              "description": "a number",
-              "title": "number",
+              "description": "a string that will be parsed into a number",
+              "title": "string",
               "type": "string"
             },
             "required": true
@@ -558,8 +558,8 @@
             "name": "page",
             "in": "header",
             "schema": {
-              "description": "a number",
-              "title": "number",
+              "description": "a string that will be parsed into a number",
+              "title": "string",
               "type": "string"
             },
             "required": false

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -1867,8 +1867,8 @@ schema (Suspend): <suspended schema>`
           "properties": {
             "a": {
               "type": "string",
-              description: "a number",
-              title: "number"
+              description: "a string that will be parsed into a number",
+              title: "string"
             }
           },
           "additionalProperties": false
@@ -2067,8 +2067,8 @@ schema (Suspend): <suspended schema>`
               contentMediaType: "application/json",
               contentSchema: {
                 type: "string",
-                description: "a number",
-                title: "number"
+                description: "a string that will be parsed into a number",
+                title: "string"
               },
               type: "string"
             }
@@ -2116,8 +2116,8 @@ schema (Suspend): <suspended schema>`
         properties: {},
         "patternProperties": {
           "": {
-            description: "a number",
-            title: "number",
+            description: "a string that will be parsed into a number",
+            title: "string",
             type: "string"
           }
         },
@@ -2143,8 +2143,8 @@ schema (Suspend): <suspended schema>`
         properties: {},
         "patternProperties": {
           "": {
-            description: "a number",
-            title: "number",
+            description: "a string that will be parsed into a number",
+            title: "string",
             type: "string"
           }
         },

--- a/packages/schema/src/Schema.ts
+++ b/packages/schema/src/Schema.ts
@@ -4909,7 +4909,9 @@ export const parseNumber = <A extends string, I, R>(
  * @category number constructors
  * @since 0.67.0
  */
-export class NumberFromString extends parseNumber(String$).annotations({ identifier: "NumberFromString" }) {}
+export class NumberFromString extends parseNumber(String$.annotations({
+  description: "a string that will be parsed into a number"
+})).annotations({ identifier: "NumberFromString" }) {}
 
 /**
  * @category number constructors

--- a/packages/schema/test/JSONSchema.test.ts
+++ b/packages/schema/test/JSONSchema.test.ts
@@ -246,6 +246,14 @@ schema (Declaration): DateFromSelf`
     })
   })
 
+  it("NumberFromString", () => {
+    expectJSONSchema(Schema.NumberFromString, {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "description": "a string that will be parsed into a number"
+    }, false)
+  })
+
   describe("Literal", () => {
     it("Null", () => {
       expectJSONSchema(Schema.Null, {
@@ -1952,7 +1960,8 @@ schema (Suspend): <suspended schema>`
           ],
           "properties": {
             "a": {
-              "type": "string"
+              "type": "string",
+              "description": "a string that will be parsed into a number"
             }
           },
           "additionalProperties": false
@@ -2151,7 +2160,12 @@ schema (Suspend): <suspended schema>`
         "$schema": "http://json-schema.org/draft-07/schema#",
         type: "object",
         required: ["a"],
-        properties: { a: { type: "string" } },
+        properties: {
+          a: {
+            "type": "string",
+            "description": "a string that will be parsed into a number"
+          }
+        },
         additionalProperties: false
       },
       false
@@ -2194,7 +2208,10 @@ schema (Suspend): <suspended schema>`
         required: [],
         properties: {},
         "patternProperties": {
-          "": { type: "string" }
+          "": {
+            "type": "string",
+            "description": "a string that will be parsed into a number"
+          }
         },
         "propertyNames": {
           "description": "a string at least 2 character(s) long",
@@ -2217,7 +2234,10 @@ schema (Suspend): <suspended schema>`
         required: [],
         properties: {},
         "patternProperties": {
-          "": { type: "string" }
+          "": {
+            "type": "string",
+            "description": "a string that will be parsed into a number"
+          }
         },
         "propertyNames": {
           "description": "a string at least 2 character(s) long",


### PR DESCRIPTION
Before

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.NumberFromString

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "string"
}
*/
```

After

```ts
import { JSONSchema, Schema } from "@effect/schema"

const schema = Schema.NumberFromString

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "string",
  "description": "a string that will be parsed into a number"
}
*/
```
