### PR TITLE
move ManagedRuntime.TypeId to fix circular imports

### DIFF
--- a/.changeset/silly-glasses-deliver.md
+++ b/.changeset/silly-glasses-deliver.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
-Create managedRuntime/circular.ts
+move ManagedRuntime.TypeId to fix circular imports

--- a/.changeset/silly-glasses-deliver.md
+++ b/.changeset/silly-glasses-deliver.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Create managedRuntime/circular.ts

--- a/packages/effect/src/ManagedRuntime.ts
+++ b/packages/effect/src/ManagedRuntime.ts
@@ -5,6 +5,7 @@ import type * as Effect from "./Effect.js"
 import type * as Exit from "./Exit.js"
 import type * as Fiber from "./Fiber.js"
 import * as internal from "./internal/managedRuntime.js"
+import * as circular from "./internal/managedRuntime/circular.js"
 import type * as Layer from "./Layer.js"
 import type * as Runtime from "./Runtime.js"
 import type * as Unify from "./Unify.js"
@@ -13,7 +14,7 @@ import type * as Unify from "./Unify.js"
  * @since 3.9.0
  * @category symbol
  */
-export const TypeId: unique symbol = internal.TypeId as TypeId
+export const TypeId: unique symbol = circular.TypeId as TypeId
 
 /**
  * @since 3.9.0

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -24,6 +24,7 @@ import * as effect from "./core-effect.js"
 import * as core from "./core.js"
 import * as circular from "./effect/circular.js"
 import * as fiberRuntime from "./fiberRuntime.js"
+import * as circularManagedRuntime from "./managedRuntime/circular.js"
 import * as EffectOpCodes from "./opCodes/effect.js"
 import * as OpCodes from "./opCodes/layer.js"
 import * as ref from "./ref.js"
@@ -1289,8 +1290,6 @@ const provideSomeRuntime = dual<
   )
 })
 
-const ManagedRuntimeTypeId: ManagedRuntime.TypeId = Symbol.for("effect/ManagedRuntime") as ManagedRuntime.TypeId
-
 /** @internal */
 export const effect_provide = dual<
   {
@@ -1339,7 +1338,7 @@ export const effect_provide = dual<
       return provideSomeLayer(self, source as Layer.Layer<ROut, any, any>)
     } else if (Context.isContext(source)) {
       return core.provideSomeContext(self, source)
-    } else if (ManagedRuntimeTypeId in source) {
+    } else if (circularManagedRuntime.TypeId in source) {
       return core.flatMap(
         (source as ManagedRuntime.ManagedRuntime<ROut, any>).runtimeEffect,
         (rt) => provideSomeRuntime(self, rt)

--- a/packages/effect/src/internal/managedRuntime.ts
+++ b/packages/effect/src/internal/managedRuntime.ts
@@ -12,6 +12,7 @@ import * as effect from "./core-effect.js"
 import * as core from "./core.js"
 import * as fiberRuntime from "./fiberRuntime.js"
 import * as internalLayer from "./layer.js"
+import * as circular from "./managedRuntime/circular.js"
 import * as internalRuntime from "./runtime.js"
 
 interface ManagedRuntimeImpl<R, E> extends M.ManagedRuntime<R, E> {
@@ -20,10 +21,7 @@ interface ManagedRuntimeImpl<R, E> extends M.ManagedRuntime<R, E> {
 }
 
 /** @internal */
-export const TypeId: M.TypeId = Symbol.for("effect/ManagedRuntime") as M.TypeId
-
-/** @internal */
-export const isManagedRuntime = (u: unknown): u is M.ManagedRuntime<unknown, unknown> => hasProperty(u, TypeId)
+export const isManagedRuntime = (u: unknown): u is M.ManagedRuntime<unknown, unknown> => hasProperty(u, circular.TypeId)
 
 function provide<R, ER, A, E>(
   managed: ManagedRuntimeImpl<R, ER>,
@@ -42,7 +40,7 @@ function provide<R, ER, A, E>(
 
 const ManagedRuntimeProto = {
   ...Effectable.CommitPrototype,
-  [TypeId]: TypeId,
+  [circular.TypeId]: circular.TypeId,
   pipe() {
     return pipeArguments(this, arguments)
   },

--- a/packages/effect/src/internal/managedRuntime/circular.ts
+++ b/packages/effect/src/internal/managedRuntime/circular.ts
@@ -1,0 +1,6 @@
+import type * as M from "../../ManagedRuntime.js"
+
+// circular with Layer
+
+/** @internal */
+export const TypeId: M.TypeId = Symbol.for("effect/ManagedRuntime") as M.TypeId


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now, there is two typeId definitions for `effect/ManagedRuntime`, one in layer and one in managedRuntime. If you change one of them then everything still type-checks, but it would not be correct. Would this be an appropriate solution? Didn't make a public MemoMap file because I didn't think it warranted changing the public Layer file 

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
