### PR TITLE
Calling HashMap constructors with empty entries returns "untouched" empty HashMap

### DIFF
--- a/.changeset/pretty-trees-tickle.md
+++ b/.changeset/pretty-trees-tickle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make `HashMap.make` and `HashMap.fromIterable` return an "untouched" empty `HashMap` when called with an empty iterable

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -191,11 +191,12 @@ export const make = <Entries extends ReadonlyArray<readonly [any, any]>>(
 
 /** @internal */
 export const fromIterable = <K, V>(entries: Iterable<readonly [K, V]>): HM.HashMap<K, V> => {
-  const map = beginMutation(empty<K, V>())
+  const emptyMap = empty<K, V>()
+  const map = beginMutation(emptyMap)
   for (const entry of entries) {
     set(map, entry[0], entry[1])
   }
-  return endMutation(map)
+  return isEmpty(map) ? emptyMap : endMutation(map)
 }
 
 /** @internal */

--- a/packages/effect/test/HashMap.test.ts
+++ b/packages/effect/test/HashMap.test.ts
@@ -59,6 +59,37 @@ describe("HashMap", () => {
 }`)
   })
 
+  it("empty", () => {
+    assert.isTrue(HM.isEmpty(HM.empty()))
+  })
+
+  describe("fromIterable", () => {
+    it("returns an immutable HashMap", () => {
+      const map = HM.fromIterable([[0, "a"]])
+      expect(HM.has(HM.remove(map, 0), 0)).toBe(false)
+      expect(HM.has(map, 0)).toBe(true)
+    })
+    it("returns an untouched empty HashMap", () => {
+      const emptyIterable = new Map().entries()
+      deepStrictEqual(HM.fromIterable([]), HM.empty())
+      deepStrictEqual(HM.fromIterable(emptyIterable), HM.empty())
+    })
+  })
+
+  describe("make", () => {
+    it("returns an immutable HashMap", () => {
+      const map = HM.make([0, "a"])
+      expect(HM.has(HM.remove(map, 0), 0)).toBe(false)
+      expect(HM.has(map, 0)).toBe(true)
+    })
+    it("returns an untouched empty HashMap", () => {
+      const emptyIterable = new Map().entries()
+      deepStrictEqual(HM.make(), HM.empty())
+      deepStrictEqual(HM.make(...[]), HM.empty())
+      deepStrictEqual(HM.make(...emptyIterable), HM.empty())
+    })
+  })
+
   it("toJSON", () => {
     const map = HM.make([0, "a"])
     expect(map.toJSON()).toEqual({ _id: "HashMap", values: [[0, "a"]] })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Make `HashMap.make` and `HashMap.fromIterable` return an "untouched" empty `HashMap` when called with empty entries.

Before this change, the below assertion failed because even when the given `Iterable` is empty, we would create an `HashMap` with one edit.

```typescript
deepStrictEqual(HM.fromIterable([]), HM.empty())
```
![Screenshot 2024-09-25 at 20 54 31](https://github.com/user-attachments/assets/e62ba9dc-bbc2-4549-b425-7bf343e8090b)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
