### PR TITLE
Implement Effect.Service and allow multiple layers to be provided in Effect.provide

### DIFF
--- a/.changeset/old-ways-accept.md
+++ b/.changeset/old-ways-accept.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Support providing an array of layers via Effect.provide

--- a/.changeset/old-ways-accept.md
+++ b/.changeset/old-ways-accept.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-Support providing an array of layers via Effect.provide
+Support providing an array of layers via Effect.provide and Layer.provide

--- a/.changeset/twelve-dots-enjoy.md
+++ b/.changeset/twelve-dots-enjoy.md
@@ -1,0 +1,54 @@
+---
+"effect": minor
+---
+
+Implement Effect.Service as a Tag and Layer with Opaque Type.
+
+Namely the following is now possible:
+
+```ts
+import * as Effect from "effect/Effect"
+import * as it from "effect/test/utils/extend"
+import { describe, expect } from "vitest"
+
+class Prefix extends Effect.Service<Prefix>()("Prefix", {
+  sync: () => ({
+    prefix: "PRE"
+  })
+}) {}
+
+class Postfix extends Effect.Service<Postfix>()("Postfix", {
+  sync: () => ({
+    postfix: "POST"
+  })
+}) {}
+
+const messages: Array<string> = []
+
+class Logger extends Effect.Service<Logger>()("Logger", {
+  effect: Effect.gen(function* () {
+    const { prefix } = yield* Prefix
+    const { postfix } = yield* Postfix
+    return {
+      info: (message: string) =>
+        Effect.sync(() => messages.push(`[${prefix}][${message}][${postfix}]`))
+    }
+  }),
+  dependencies: [Prefix, Postfix]
+}) {}
+
+describe("Effect", () => {
+  it.effect("Service correctly wires dependencies", () =>
+    Effect.gen(function* () {
+      const { _tag } = yield* Logger
+      expect(_tag).toEqual("Logger")
+      yield* Logger.info("Ok")
+      expect(messages).toEqual(["[PRE][Ok][POST]"])
+      const { prefix } = yield* Prefix
+      expect(prefix).toEqual("PRE")
+      const { postfix } = yield* Postfix
+      expect(postfix).toEqual("POST")
+    }).pipe(Effect.provide([Logger, Prefix, Postfix]))
+  )
+})
+```

--- a/.changeset/twelve-dots-enjoy.md
+++ b/.changeset/twelve-dots-enjoy.md
@@ -7,10 +7,6 @@ Implement Effect.Service as a Tag and Layer with Opaque Type.
 Namely the following is now possible:
 
 ```ts
-import * as Effect from "effect/Effect"
-import * as it from "effect/test/utils/extend"
-import { describe, expect } from "vitest"
-
 class Prefix extends Effect.Service<Prefix>()("Prefix", {
   sync: () => ({
     prefix: "PRE"
@@ -26,15 +22,18 @@ class Postfix extends Effect.Service<Postfix>()("Postfix", {
 const messages: Array<string> = []
 
 class Logger extends Effect.Service<Logger>()("Logger", {
+  accessors: true,
   effect: Effect.gen(function* () {
     const { prefix } = yield* Prefix
     const { postfix } = yield* Postfix
     return {
       info: (message: string) =>
-        Effect.sync(() => messages.push(`[${prefix}][${message}][${postfix}]`))
+        Effect.sync(() => {
+          messages.push(`[${prefix}][${message}][${postfix}]`)
+        })
     }
   }),
-  dependencies: [Prefix, Postfix]
+  dependencies: [Prefix.Default, Postfix.Default]
 }) {}
 
 describe("Effect", () => {
@@ -48,7 +47,7 @@ describe("Effect", () => {
       expect(prefix).toEqual("PRE")
       const { postfix } = yield* Postfix
       expect(postfix).toEqual("POST")
-    }).pipe(Effect.provide([Logger, Prefix, Postfix]))
+    }).pipe(Effect.provide([Logger.Default, Prefix.Default, Postfix.Default]))
   )
 })
 ```

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -29,7 +29,6 @@ export type TagTypeId = typeof TagTypeId
  * @category models
  */
 export interface Tag<in out Id, in out Value> extends Pipeable, Inspectable {
-  readonly _tag: "Tag"
   readonly _op: "Tag"
   readonly Service: Value
   readonly Identifier: Id

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -37,8 +37,8 @@ export interface Tag<in out Id, in out Value> extends Pipeable, Inspectable {
     readonly _Service: Types.Invariant<Value>
     readonly _Identifier: Types.Invariant<Id>
   }
-  of(self: Value): Value
-  context(self: Value): Context<Id>
+  of<V extends Value>(self: V): Value
+  context<V extends Value>(self: V): Context<Id>
   readonly stack?: string | undefined
   readonly key: string
   [Unify.typeSymbol]?: unknown

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -37,8 +37,8 @@ export interface Tag<in out Id, in out Value> extends Pipeable, Inspectable {
     readonly _Service: Types.Invariant<Value>
     readonly _Identifier: Types.Invariant<Id>
   }
-  of<V extends Value>(self: V): Value
-  context<V extends Value>(self: V): Context<Id>
+  of(self: Value): Value
+  context(self: Value): Context<Id>
   readonly stack?: string | undefined
   readonly key: string
   [Unify.typeSymbol]?: unknown
@@ -85,13 +85,13 @@ export declare namespace Tag {
   /**
    * @since 2.0.0
    */
-  export type Service<T extends Tag<any, any> | TagClassShape<any, any>> = T extends Tag<any, infer A> ? A
+  export type Service<T extends Tag<any, any> | TagClassShape<any, any>> = T extends Tag<any, any> ? T["Service"]
     : T extends TagClassShape<any, infer A> ? A
     : never
   /**
    * @since 2.0.0
    */
-  export type Identifier<T extends Tag<any, any> | TagClassShape<any, any>> = T extends Tag<infer A, any> ? A
+  export type Identifier<T extends Tag<any, any> | TagClassShape<any, any>> = T extends Tag<any, any> ? T["Identifier"]
     : T extends TagClassShape<any, any> ? T
     : never
 }

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -57,7 +57,7 @@ import * as Scheduler from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
-import type { Concurrency, Contravariant, Covariant, NoExtraKeys, NoInfer, NotFunction } from "./Types.js"
+import type { Concurrency, Contravariant, Covariant, NoExcessProperties, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 import type { YieldWrap } from "./Utils.js"
 
@@ -6336,21 +6336,21 @@ export const Service: <Self>() => {
   <
     const Key extends string,
     const Make extends
-      | NoExtraKeys<{
+      | NoExcessProperties<{
         readonly scoped: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
       }, Make>
-      | NoExtraKeys<{
+      | NoExcessProperties<{
         readonly effect: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
       }, Make>
-      | NoExtraKeys<{
+      | NoExcessProperties<{
         readonly sync: LazyArg<Service.AllowedType<Key, Make["accessors"]>>
         readonly accessors?: boolean
       }, Make>
-      | NoExtraKeys<{
+      | NoExcessProperties<{
         readonly succeed: Service.AllowedType<Key, Make["accessors"]>
         readonly accessors?: boolean
       }, Make>

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6514,16 +6514,16 @@ export const Service: {
   <Self>(): {
     <
       const Id extends string,
-      Maker extends (Service.Maker<Service.ProhibitedType> & { proxy?: true }) | (Service.Maker<{}> & { proxy: false })
+      Maker extends (Service.Maker<Service.ProhibitedType> & { proxy: true }) | (Service.Maker<{}> & { proxy?: false })
     >(
       id: Id,
       maker: Maker
-    ): Service.ReturnWithMaker<Self, Id, Maker, Maker extends { proxy: false } ? false : true>
+    ): Service.ReturnWithMaker<Self, Id, Maker, Maker extends { proxy: true } ? true : false>
   }
 } = function() {
   return function() {
     const [id, maker] = arguments
-    const proxy = "proxy" in maker ? maker["proxy"] : true
+    const proxy = "proxy" in maker ? maker["proxy"] : false
     const limit = Error.stackTraceLimit
     Error.stackTraceLimit = 2
     const creationError = new Error()

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2,7 +2,6 @@
  * @since 2.0.0
  */
 import type * as RA from "./Array.js"
-import type { BrandTypeId } from "./Brand.js"
 import type * as Cause from "./Cause.js"
 import type * as Chunk from "./Chunk.js"
 import type * as Clock from "./Clock.js"
@@ -6334,6 +6333,7 @@ export const Tag: <const Id extends string>(id: Id) => <
 /**
  * @since 3.9.0
  * @category context
+ * @experimental might be up for breaking changes
  */
 export const Service: <Self>() => {
   <
@@ -6344,28 +6344,28 @@ export const Service: <Self>() => {
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [BrandTypeId]: never
+        readonly ಠ_ಠ: never
       }
       | {
         readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [BrandTypeId]: never
+        readonly ಠ_ಠ: never
       }
       | {
         readonly sync: LazyArg<Service.AllowedType<Key, Make>>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [BrandTypeId]: never
+        readonly ಠ_ಠ: never
       }
       | {
         readonly succeed: Service.AllowedType<Key, Make>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [BrandTypeId]: never
+        readonly ಠ_ಠ: never
       }
   >(
     key: Key,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6522,10 +6522,12 @@ export declare namespace Service {
   export interface ProhibitedType {
     Service?: `property "Service" is forbidden`
     Identifier?: `property "Identifier" is forbidden`
-    Layer?: `property "Layer" is forbidden`
+    Default?: `property "Default" is forbidden`
+    DefaultWithoutDependencies?: `property "DefaultWithoutDependencies" is forbidden`
     _op_layer?: `property "_op_layer" is forbidden`
     _op?: `property "_op" is forbidden`
     of?: `property "of" is forbidden`
+    make?: `property "make" is forbidden`
     context?: `property "context" is forbidden`
     key?: `property "key" is forbidden`
     stack?: `property "stack" is forbidden`

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6235,12 +6235,13 @@ export declare namespace Tag {
     Service?: `property "Service" is forbidden`
     Identifier?: `property "Identifier" is forbidden`
     _op?: `property "_op" is forbidden`
-    _tag?: `property "_tag" is forbidden`
     of?: `property "of" is forbidden`
     context?: `property "context" is forbidden`
     key?: `property "key" is forbidden`
     stack?: `property "stack" is forbidden`
     name?: `property "name" is forbidden`
+    pipe?: `property "pipe" is forbidden`
+    use?: `property "use" is forbidden`
   }
 
   /**
@@ -6347,6 +6348,7 @@ export declare namespace Service {
     stack?: `property "stack" is forbidden`
     name?: `property "name" is forbidden`
     pipe?: `property "pipe" is forbidden`
+    use?: `property "use" is forbidden`
   }
 
   /**
@@ -6404,19 +6406,18 @@ export declare namespace Service {
    * @since 2.0.0
    * @category models
    */
-  export type Return<Self, Id extends string, Type, Proxy extends boolean> =
+  export type Return<Self, Id extends string, Type, Proxy extends boolean, T = Type & { readonly _tag: Id }> =
     & TagClass<Self, Id, Type>
-    & (Proxy extends true ? (Type extends Record<PropertyKey, any> ? {
+    & (Proxy extends true ? (T extends Record<PropertyKey, any> ? {
           [
-            k in keyof Type as Type[k] extends ((...args: [...infer Args]) => infer Ret)
-              ? ((...args: Readonly<Args>) => Ret) extends Type[k] ? k : never
+            k in keyof T as T[k] extends ((...args: [...infer Args]) => infer Ret)
+              ? ((...args: Readonly<Args>) => Ret) extends T[k] ? k : never
               : k
-          ]: Type[k] extends (...args: [...infer Args]) => Effect<infer A, infer E, infer R>
+          ]: T[k] extends (...args: [...infer Args]) => Effect<infer A, infer E, infer R>
             ? (...args: Readonly<Args>) => Effect<A, E, Self | R>
-            : Type[k] extends (...args: [...infer Args]) => infer A ?
-              (...args: Readonly<Args>) => Effect<A, never, Self>
-            : Type[k] extends Effect<infer A, infer E, infer R> ? Effect<A, E, Self | R>
-            : Effect<Type[k], never, Self>
+            : T[k] extends (...args: [...infer Args]) => infer A ? (...args: Readonly<Args>) => Effect<A, never, Self>
+            : T[k] extends Effect<infer A, infer E, infer R> ? Effect<A, E, Self | R>
+            : Effect<T[k], never, Self>
         } :
         {}) :
       {})

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6353,38 +6353,38 @@ export declare namespace Service {
    * @since 2.0.0
    * @category models
    */
-  export type AllowedType = Record<PropertyKey, any> & ProhibitedType
+  export type AllowedType<P> = Record<PropertyKey, any> & P
 
   /**
    * @since 2.0.0
    * @category models
    */
-  export type Maker = {
-    effect: Effect<AllowedType, any, any>
+  export type Maker<P> = {
+    effect: Effect<AllowedType<P>, any, any>
     dependencies?: never
   } | {
-    effect: Effect<AllowedType, any, any>
+    effect: Effect<AllowedType<P>, any, any>
     dependencies: []
   } | {
-    effect: Effect<AllowedType, any, any>
+    effect: Effect<AllowedType<P>, any, any>
     dependencies: [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]
   } | {
-    scoped: Effect<AllowedType, any, any>
+    scoped: Effect<AllowedType<P>, any, any>
     dependencies?: never
   } | {
-    scoped: Effect<AllowedType, any, any>
+    scoped: Effect<AllowedType<P>, any, any>
     dependencies: []
   } | {
-    scoped: Effect<AllowedType, any, any>
+    scoped: Effect<AllowedType<P>, any, any>
     dependencies: [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]
   } | {
-    sync: () => AllowedType
+    sync: () => AllowedType<P>
     dependencies?: never
   } | {
-    sync: () => AllowedType
+    sync: () => AllowedType<P>
     dependencies: [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]
   } | {
-    sync: () => AllowedType
+    sync: () => AllowedType<P>
     dependencies: []
   }
 
@@ -6404,37 +6404,40 @@ export declare namespace Service {
    * @since 2.0.0
    * @category models
    */
-  export type Return<Self, Id extends string, Type extends AllowedType> =
+  export type Return<Self, Id extends string, Type, Proxy extends boolean> =
     & TagClass<Self, Id, Type>
-    & (Type extends Record<PropertyKey, any> ? {
-        [
-          k in keyof Type as Type[k] extends ((...args: [...infer Args]) => infer Ret)
-            ? ((...args: Readonly<Args>) => Ret) extends Type[k] ? k : never
-            : k
-        ]: Type[k] extends (...args: [...infer Args]) => Effect<infer A, infer E, infer R>
-          ? (...args: Readonly<Args>) => Effect<A, E, Self | R>
-          : Type[k] extends (...args: [...infer Args]) => infer A ? (...args: Readonly<Args>) => Effect<A, never, Self>
-          : Type[k] extends Effect<infer A, infer E, infer R> ? Effect<A, E, Self | R>
-          : Effect<Type[k], never, Self>
+    & (Proxy extends true ? (Type extends Record<PropertyKey, any> ? {
+          [
+            k in keyof Type as Type[k] extends ((...args: [...infer Args]) => infer Ret)
+              ? ((...args: Readonly<Args>) => Ret) extends Type[k] ? k : never
+              : k
+          ]: Type[k] extends (...args: [...infer Args]) => Effect<infer A, infer E, infer R>
+            ? (...args: Readonly<Args>) => Effect<A, E, Self | R>
+            : Type[k] extends (...args: [...infer Args]) => infer A ?
+              (...args: Readonly<Args>) => Effect<A, never, Self>
+            : Type[k] extends Effect<infer A, infer E, infer R> ? Effect<A, E, Self | R>
+            : Effect<Type[k], never, Self>
+        } :
+        {}) :
+      {})
+    & (Proxy extends true ? {
+        use: <X>(
+          body: (_: Type) => X
+        ) => X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
       } :
       {})
-    & {
-      use: <X>(
-        body: (_: Type) => X
-      ) => X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
-    }
 
   /**
    * @since 2.0.0
    * @category models
    */
-  export type ReturnWithMaker<Self, Id extends string, Maker extends Service.Maker> =
+  export type ReturnWithMaker<Self, Id extends string, Maker, Proxy extends boolean> =
     & {}
     & Maker extends {
-    scoped: Effect<infer Type extends AllowedType, infer E, infer R>
+    scoped: Effect<infer Type, infer E, infer R>
     dependencies: infer Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]
   } ?
-      & Return<Self, Id, Type>
+      & Return<Self, Id, Type, Proxy>
       & Layer.Layer<
         Self,
         E | { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
@@ -6443,21 +6446,21 @@ export declare namespace Service {
       >
       & { readonly Layer: Layer.Layer<Self, E, Exclude<R, Scope.Scope>> }
     : Maker extends {
-      scoped: Effect<infer Type extends AllowedType, infer E, infer R>
-    } ? Return<Self, Id, Type> & Layer.Layer<Self, E, Exclude<R, Scope.Scope>> & {
+      scoped: Effect<infer Type, infer E, infer R>
+    } ? Return<Self, Id, Type, Proxy> & Layer.Layer<Self, E, Exclude<R, Scope.Scope>> & {
         readonly Layer: Layer.Layer<Self, E, Exclude<R, Scope.Scope>>
       }
     : Maker extends {
-      scoped: Effect<infer Type extends AllowedType, infer E, infer R>
+      scoped: Effect<infer Type, infer E, infer R>
       dependencies: []
-    } ? Return<Self, Id, Type> & Layer.Layer<Self, E, Exclude<R, Scope.Scope>> & {
+    } ? Return<Self, Id, Type, Proxy> & Layer.Layer<Self, E, Exclude<R, Scope.Scope>> & {
         readonly Layer: Layer.Layer<Self, E, Exclude<R, Scope.Scope>>
       }
     : Maker extends {
-      effect: Effect<infer Type extends AllowedType, infer E, infer R>
+      effect: Effect<infer Type, infer E, infer R>
       dependencies: infer Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]
     } ?
-        & Return<Self, Id, Type>
+        & Return<Self, Id, Type, Proxy>
         & Layer.Layer<
           Self,
           E | { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
@@ -6466,21 +6469,21 @@ export declare namespace Service {
         >
         & { readonly Layer: Layer.Layer<Self, E, Exclude<R, Scope.Scope>> }
     : Maker extends {
-      effect: Effect<infer Type extends AllowedType, infer E, infer R>
-    } ? Return<Self, Id, Type> & Layer.Layer<Self, E, R> & {
+      effect: Effect<infer Type, infer E, infer R>
+    } ? Return<Self, Id, Type, Proxy> & Layer.Layer<Self, E, R> & {
         readonly Layer: Layer.Layer<Self, E, R>
       }
     : Maker extends {
-      effect: Effect<infer Type extends AllowedType, infer E, infer R>
+      effect: Effect<infer Type, infer E, infer R>
       dependencies: []
-    } ? Return<Self, Id, Type> & Layer.Layer<Self, E, R> & {
+    } ? Return<Self, Id, Type, Proxy> & Layer.Layer<Self, E, R> & {
         readonly Layer: Layer.Layer<Self, E, R>
       }
     : Maker extends {
-      sync: () => infer Type extends AllowedType
+      sync: () => infer Type
       dependencies: infer Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]
     } ?
-        & Return<Self, Id, Type>
+        & Return<Self, Id, Type, Proxy>
         & Layer.Layer<
           Self,
           { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
@@ -6490,14 +6493,14 @@ export declare namespace Service {
           readonly Layer: Layer.Layer<Self, never, never>
         }
     : Maker extends {
-      sync: () => infer Type extends AllowedType
+      sync: () => infer Type
       dependencies: []
-    } ? Service.Return<Self, Id, Type> & Layer.Layer<Self, never, never> & {
+    } ? Service.Return<Self, Id, Type, Proxy> & Layer.Layer<Self, never, never> & {
         readonly Layer: Layer.Layer<Self, never, never>
       }
     : Maker extends {
-      sync: () => infer Type extends AllowedType
-    } ? Return<Self, Id, Type> & Layer.Layer<Self, never, never> & {
+      sync: () => infer Type
+    } ? Return<Self, Id, Type, Proxy> & Layer.Layer<Self, never, never> & {
         readonly Layer: Layer.Layer<Self, never, never>
       }
     : never
@@ -6508,13 +6511,19 @@ export declare namespace Service {
  * @category constructors
  */
 export const Service: {
-  <Self>(): <const Id extends string, Maker extends Service.Maker>(
-    id: Id,
-    maker: Maker
-  ) => Service.ReturnWithMaker<Self, Id, Maker>
+  <Self>(): {
+    <
+      const Id extends string,
+      Maker extends (Service.Maker<Service.ProhibitedType> & { proxy?: true }) | (Service.Maker<{}> & { proxy: false })
+    >(
+      id: Id,
+      maker: Maker
+    ): Service.ReturnWithMaker<Self, Id, Maker, Maker extends { proxy: false } ? false : true>
+  }
 } = function() {
   return function() {
     const [id, maker] = arguments
+    const proxy = "proxy" in maker ? maker["proxy"] : true
     const limit = Error.stackTraceLimit
     Error.stackTraceLimit = 2
     const creationError = new Error()
@@ -6581,7 +6590,9 @@ export const Service: {
       Object.assign(TagClass, live)
       Object.assign(TagClass, layer.proto)
     }
-
+    if (proxy === false) {
+      return TagClass
+    }
     const cache = new Map()
     const done = new Proxy(TagClass, {
       get(_target: any, prop: any, _receiver) {

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -57,7 +57,7 @@ import * as Scheduler from "./Scheduler.js"
 import type * as Scope from "./Scope.js"
 import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
-import type { Concurrency, Contravariant, Covariant, NoInfer, NotFunction } from "./Types.js"
+import type { Concurrency, Contravariant, Covariant, NoExtraKeys, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
 import type { YieldWrap } from "./Utils.js"
 
@@ -6335,21 +6335,25 @@ export const Tag: <const Id extends string>(id: Id) => <
 export const Service: <Self>() => {
   <
     const Key extends string,
-    const Make extends {
-      readonly scoped: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
-      readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
-      readonly accessors?: boolean
-    } | {
-      readonly effect: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
-      readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
-      readonly accessors?: boolean
-    } | {
-      readonly sync: LazyArg<Service.AllowedType<Key, Make["accessors"]>>
-      readonly accessors?: boolean
-    } | {
-      readonly succeed: Service.AllowedType<Key, Make["accessors"]>
-      readonly accessors?: boolean
-    }
+    const Make extends
+      | NoExtraKeys<{
+        readonly scoped: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
+        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+        readonly accessors?: boolean
+      }, Make>
+      | NoExtraKeys<{
+        readonly effect: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
+        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+        readonly accessors?: boolean
+      }, Make>
+      | NoExtraKeys<{
+        readonly sync: LazyArg<Service.AllowedType<Key, Make["accessors"]>>
+        readonly accessors?: boolean
+      }, Make>
+      | NoExtraKeys<{
+        readonly succeed: Service.AllowedType<Key, Make["accessors"]>
+        readonly accessors?: boolean
+      }, Make>
   >(
     key: Key,
     make: Make

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6337,21 +6337,21 @@ export const Service: <Self>() => {
     const Key extends string,
     const Make extends
       | NoExcessProperties<{
-        readonly scoped: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
+        readonly scoped: Effect<Service.AllowedType<Key, Make>, any, any>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
       }, Make>
       | NoExcessProperties<{
-        readonly effect: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
+        readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
       }, Make>
       | NoExcessProperties<{
-        readonly sync: LazyArg<Service.AllowedType<Key, Make["accessors"]>>
+        readonly sync: LazyArg<Service.AllowedType<Key, Make>>
         readonly accessors?: boolean
       }, Make>
       | NoExcessProperties<{
-        readonly succeed: Service.AllowedType<Key, Make["accessors"]>
+        readonly succeed: Service.AllowedType<Key, Make>
         readonly accessors?: boolean
       }, Make>
   >(
@@ -6474,13 +6474,18 @@ export declare namespace Service {
     name?: `property "name" is forbidden`
     pipe?: `property "pipe" is forbidden`
     use?: `property "use" is forbidden`
+    _tag?: `property "_tag" is forbidden`
   }
 
   /**
    * @since 3.9.0
    */
-  export type AllowedType<Key extends string, Accessors extends boolean | undefined> = [Accessors] extends [true]
-    ? Record<PropertyKey, any> & ProhibitedType & { readonly _tag?: Key }
+  export type AllowedType<Key extends string, Make> = MakeAccessors<Make> extends true ?
+      & Record<PropertyKey, any>
+      & {
+        readonly [K in Extract<keyof MakeService<Make>, keyof ProhibitedType>]: K extends "_tag" ? Key
+          : ProhibitedType[K]
+      }
     : Record<PropertyKey, any> & { readonly _tag?: Key }
 
   /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6436,12 +6436,16 @@ export const Service: <Self>() => {
     }
 
     TagClass.prototype._tag = id
-    TagClass.make = function(service: any) {
-      return new this(service)
-    }
-    TagClass.use = function(body: (_: any) => any) {
-      return core.andThen(this, body)
-    }
+    Object.defineProperty(TagClass, "make", {
+      get() {
+        return (service: any) => new this(service)
+      }
+    })
+    Object.defineProperty(TagClass, "use", {
+      get() {
+        return (body: any) => core.andThen(this, body)
+      }
+    })
     TagClass.key = id
 
     Object.setPrototypeOf(TagClass, {
@@ -6554,10 +6558,10 @@ export declare namespace Service {
       new(_: MakeService<Make>): MakeService<Make> & {
         readonly _tag: Key
       }
-      use<X>(
+      readonly use: <X>(
         body: (_: Self) => X
-      ): X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
-      make(_: MakeService<Make>): Self
+      ) => X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
+      readonly make: (_: MakeService<Make>) => Self
     }
     & Context.Tag<Self, Self>
     & (MakeAccessors<Make> extends true ? Tag.Proxy<Self, MakeService<Make>> : {})

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6395,7 +6395,7 @@ export declare namespace Service {
    * @category models
    */
   export interface TagClass<Self, Id, Type> extends Context.Tag<Self, Self> {
-    of(_: Pick<Self, (keyof Type) & (keyof Self)>): Self
+    make(_: Type): Self
 
     new(_: never): Type & {
       readonly _tag: Id

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6554,10 +6554,10 @@ export declare namespace Service {
       new(_: MakeService<Make>): MakeService<Make> & {
         readonly _tag: Key
       }
-      readonly use: <X>(
+      use<X>(
         body: (_: Self) => X
-      ) => X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
-      readonly make: (_: MakeService<Make>) => Self
+      ): X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
+      make(_: MakeService<Make>): Self
     }
     & Context.Tag<Self, Self>
     & (MakeAccessors<Make> extends true ? Tag.Proxy<Self, MakeService<Make>> : {})

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6393,7 +6393,7 @@ export declare namespace Service {
    * @category models
    */
   export interface TagClass<Self, Id, Type> extends Context.Tag<Self, Self> {
-    of<V extends Pick<Self, (keyof Type) & (keyof Self)>>(_: V): Self
+    of(_: Pick<Self, (keyof Type) & (keyof Self)>): Self
 
     new(_: never): Type & {
       readonly _tag: Id

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6330,6 +6330,8 @@ export const Tag: <const Id extends string>(id: Id) => <
     return makeTagProxy(TagClass as any)
   }
 
+declare const phantom: unique symbol
+
 /**
  * @since 3.9.0
  * @category context
@@ -6341,22 +6343,22 @@ export const Service: <Self>() => {
       | NoExcessProperties<{
         readonly scoped: Effect<Service.AllowedType<Key, Make>, any, any>
         /** @deprecated */
-        readonly phantom: never
+        readonly [phantom]: never
       }, Make>
       | NoExcessProperties<{
         readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
         /** @deprecated */
-        readonly phantom: never
+        readonly [phantom]: never
       }, Make>
       | NoExcessProperties<{
         readonly sync: LazyArg<Service.AllowedType<Key, Make>>
         /** @deprecated */
-        readonly phantom: never
+        readonly [phantom]: never
       }, Make>
       | NoExcessProperties<{
         readonly succeed: Service.AllowedType<Key, Make>
         /** @deprecated */
-        readonly phantom: never
+        readonly [phantom]: never
       }, Make>
   >(
     key: Key,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6336,18 +6336,18 @@ export const Service: <Self>() => {
   <
     const Key extends string,
     const Make extends {
-      readonly scoped: Effect<Service.AllowedType<Make["accessors"]>, any, any>
+      readonly scoped: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
       readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
       readonly accessors?: boolean
     } | {
-      readonly effect: Effect<Service.AllowedType<Make["accessors"]>, any, any>
+      readonly effect: Effect<Service.AllowedType<Key, Make["accessors"]>, any, any>
       readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
       readonly accessors?: boolean
     } | {
-      readonly sync: LazyArg<Service.AllowedType<Make["accessors"]>>
+      readonly sync: LazyArg<Service.AllowedType<Key, Make["accessors"]>>
       readonly accessors?: boolean
     } | {
-      readonly succeed: Service.AllowedType<Make["accessors"]>
+      readonly succeed: Service.AllowedType<Key, Make["accessors"]>
       readonly accessors?: boolean
     }
   >(
@@ -6442,7 +6442,6 @@ export declare namespace Service {
     Layer?: `property "Layer" is forbidden`
     _op_layer?: `property "_op_layer" is forbidden`
     _op?: `property "_op" is forbidden`
-    _tag?: `property "_tag" is forbidden`
     of?: `property "of" is forbidden`
     context?: `property "context" is forbidden`
     key?: `property "key" is forbidden`
@@ -6455,9 +6454,9 @@ export declare namespace Service {
   /**
    * @since 3.9.0
    */
-  export type AllowedType<Accessors extends boolean | undefined> = [Accessors] extends [true]
-    ? Record<PropertyKey, any> & ProhibitedType
-    : any
+  export type AllowedType<Key extends string, Accessors extends boolean | undefined> = [Accessors] extends [true]
+    ? Record<PropertyKey, any> & ProhibitedType & { readonly _tag?: Key }
+    : Record<PropertyKey, any> & { readonly _tag?: Key }
 
   /**
    * @since 3.9.0

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2,6 +2,7 @@
  * @since 2.0.0
  */
 import type * as RA from "./Array.js"
+import type { BrandTypeId } from "./Brand.js"
 import type * as Cause from "./Cause.js"
 import type * as Chunk from "./Chunk.js"
 import type * as Clock from "./Clock.js"
@@ -6330,8 +6331,6 @@ export const Tag: <const Id extends string>(id: Id) => <
     return makeTagProxy(TagClass as any)
   }
 
-declare const phantom: unique symbol
-
 /**
  * @since 3.9.0
  * @category context
@@ -6345,28 +6344,28 @@ export const Service: <Self>() => {
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [phantom]: never
+        readonly [BrandTypeId]: never
       }
       | {
         readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [phantom]: never
+        readonly [BrandTypeId]: never
       }
       | {
         readonly sync: LazyArg<Service.AllowedType<Key, Make>>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [phantom]: never
+        readonly [BrandTypeId]: never
       }
       | {
         readonly succeed: Service.AllowedType<Key, Make>
         readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
         readonly accessors?: boolean
         /** @deprecated */
-        readonly [phantom]: never
+        readonly [BrandTypeId]: never
       }
   >(
     key: Key,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6340,26 +6340,34 @@ export const Service: <Self>() => {
   <
     const Key extends string,
     const Make extends
-      | NoExcessProperties<{
+      | {
         readonly scoped: Effect<Service.AllowedType<Key, Make>, any, any>
+        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+        readonly accessors?: boolean
         /** @deprecated */
         readonly [phantom]: never
-      }, Make>
-      | NoExcessProperties<{
+      }
+      | {
         readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
+        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+        readonly accessors?: boolean
         /** @deprecated */
         readonly [phantom]: never
-      }, Make>
-      | NoExcessProperties<{
+      }
+      | {
         readonly sync: LazyArg<Service.AllowedType<Key, Make>>
+        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+        readonly accessors?: boolean
         /** @deprecated */
         readonly [phantom]: never
-      }, Make>
-      | NoExcessProperties<{
+      }
+      | {
         readonly succeed: Service.AllowedType<Key, Make>
+        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+        readonly accessors?: boolean
         /** @deprecated */
         readonly [phantom]: never
-      }, Make>
+      }
   >(
     key: Key,
     make: Make

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6393,7 +6393,7 @@ export declare namespace Service {
    * @category models
    */
   export interface TagClass<Self, Id, Type> extends Context.Tag<Self, Self> {
-    readonly of: (_: Pick<Self, (keyof Type) & (keyof Self)>) => Self
+    of<V extends Pick<Self, (keyof Type) & (keyof Self)>>(_: V): Self
 
     new(_: never): Type & {
       readonly _tag: Id

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6458,10 +6458,7 @@ export const Service: <Self>() => {
     })
     TagClass.key = id
 
-    Object.setPrototypeOf(TagClass, {
-      ...layer.proto,
-      ...TagProto
-    })
+    Object.assign(TagClass, TagProto)
 
     Object.defineProperty(TagClass, "stack", {
       get() {
@@ -6509,13 +6506,6 @@ export const Service: <Self>() => {
         }
       })
     }
-
-    Object.assign(
-      TagClass,
-      layer.suspend(function(this: any) {
-        return this.Default
-      })
-    )
 
     return proxy === true ? makeTagProxy(TagClass) : TagClass
   }
@@ -6575,12 +6565,6 @@ export declare namespace Service {
     }
     & Context.Tag<Self, Self>
     & (MakeAccessors<Make> extends true ? Tag.Proxy<Self, MakeService<Make>> : {})
-    & Layer.Layer<
-      Self,
-      MakeError<Make> | MakeDepsE<Make>,
-      | Exclude<MakeContext<Make>, MakeDepsOut<Make>>
-      | MakeDepsIn<Make>
-    >
     & (MakeDeps<Make> extends never ? {
         readonly Default: Layer.Layer<Self, MakeError<Make>, MakeContext<Make>>
       } :

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6340,22 +6340,68 @@ export const Service: <Self>() => {
     const Make extends
       | NoExcessProperties<{
         readonly scoped: Effect<Service.AllowedType<Key, Make>, any, any>
-        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
-        readonly accessors?: boolean
+        /** @deprecated */
+        readonly phantom: never
       }, Make>
       | NoExcessProperties<{
         readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
-        readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
-        readonly accessors?: boolean
+        /** @deprecated */
+        readonly phantom: never
       }, Make>
       | NoExcessProperties<{
         readonly sync: LazyArg<Service.AllowedType<Key, Make>>
-        readonly accessors?: boolean
+        /** @deprecated */
+        readonly phantom: never
       }, Make>
       | NoExcessProperties<{
         readonly succeed: Service.AllowedType<Key, Make>
-        readonly accessors?: boolean
+        /** @deprecated */
+        readonly phantom: never
       }, Make>
+  >(
+    key: Key,
+    make: Make
+  ): Service.Class<Self, Key, Make>
+  <
+    const Key extends string,
+    const Make extends NoExcessProperties<{
+      readonly scoped: Effect<Service.AllowedType<Key, Make>, any, any>
+      readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+      readonly accessors?: boolean
+    }, Make>
+  >(
+    key: Key,
+    make: Make
+  ): Service.Class<Self, Key, Make>
+  <
+    const Key extends string,
+    const Make extends NoExcessProperties<{
+      readonly effect: Effect<Service.AllowedType<Key, Make>, any, any>
+      readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+      readonly accessors?: boolean
+    }, Make>
+  >(
+    key: Key,
+    make: Make
+  ): Service.Class<Self, Key, Make>
+  <
+    const Key extends string,
+    const Make extends NoExcessProperties<{
+      readonly sync: LazyArg<Service.AllowedType<Key, Make>>
+      readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+      readonly accessors?: boolean
+    }, Make>
+  >(
+    key: Key,
+    make: Make
+  ): Service.Class<Self, Key, Make>
+  <
+    const Key extends string,
+    const Make extends NoExcessProperties<{
+      readonly succeed: Service.AllowedType<Key, Make>
+      readonly dependencies?: ReadonlyArray<Layer.Layer.Any>
+      readonly accessors?: boolean
+    }, Make>
   >(
     key: Key,
     make: Make
@@ -6514,7 +6560,6 @@ export declare namespace Service {
       readonly make: (_: MakeService<Make>) => Self
     }
     & Context.Tag<Self, Self>
-    & Layer.Layer<Self, MakeError<Make>, MakeContext<Make>>
     & (MakeAccessors<Make> extends true ? Tag.Proxy<Self, MakeService<Make>> : {})
     & Layer.Layer<
       Self,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6467,7 +6467,7 @@ export const Service: <Self>() => {
     } else if ("scoped" in maker) {
       Object.defineProperty(TagClass, layerName, {
         get(this: any) {
-          return layerCache ??= layer.scoped(TagClass, map(maker.effect, (_) => new this(_)))
+          return layerCache ??= layer.scoped(TagClass, map(maker.scoped, (_) => new this(_)))
         }
       })
     } else if ("sync" in maker) {

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -81,7 +81,11 @@ export declare namespace Layer {
    * @category type-level
    */
   export interface Any {
-    readonly [LayerTypeId]: any
+    readonly [LayerTypeId]: {
+      readonly _ROut: any
+      readonly _E: any
+      readonly _RIn: any
+    }
   }
   /**
    * @since 2.0.0

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -77,22 +77,29 @@ export declare namespace Layer {
     }
   }
   /**
+   * @since 3.9.0
+   * @category type-level
+   */
+  export interface Any {
+    readonly [LayerTypeId]: any
+  }
+  /**
    * @since 2.0.0
    * @category type-level
    */
-  export type Context<T extends Layer<never, any, any>> = [T] extends [Layer<infer _ROut, infer _E, infer _RIn>] ? _RIn
+  export type Context<T extends Any> = [T] extends [Layer<infer _ROut, infer _E, infer _RIn>] ? _RIn
     : never
   /**
    * @since 2.0.0
    * @category type-level
    */
-  export type Error<T extends Layer<never, any, any>> = [T] extends [Layer<infer _ROut, infer _E, infer _RIn>] ? _E
+  export type Error<T extends Any> = [T] extends [Layer<infer _ROut, infer _E, infer _RIn>] ? _E
     : never
   /**
    * @since 2.0.0
    * @category type-level
    */
-  export type Success<T extends Layer<never, any, any>> = [T] extends [Layer<infer _ROut, infer _E, infer _RIn>] ? _ROut
+  export type Success<T extends Any> = [T] extends [Layer<infer _ROut, infer _E, infer _RIn>] ? _ROut
     : never
 }
 

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -844,12 +844,31 @@ export const toRuntimeWithMemoMap: {
  */
 export const provide: {
   <RIn, E, ROut>(
-    self: Layer<ROut, E, RIn>
-  ): <RIn2, E2, ROut2>(that: Layer<ROut2, E2, RIn2>) => Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>
+    that: Layer<ROut, E, RIn>
+  ): <RIn2, E2, ROut2>(self: Layer<ROut2, E2, RIn2>) => Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>
+  <const Layers extends [Layer.Any, ...Array<Layer.Any>]>(
+    that: Layers
+  ): <A, E, R>(
+    self: Layer<A, E, R>
+  ) => Layer<
+    A,
+    E | { [k in keyof Layers]: Layer.Error<Layers[k]> }[number],
+    | { [k in keyof Layers]: Layer.Context<Layers[k]> }[number]
+    | Exclude<R, { [k in keyof Layers]: Layer.Success<Layers[k]> }[number]>
+  >
   <RIn2, E2, ROut2, RIn, E, ROut>(
-    that: Layer<ROut2, E2, RIn2>,
-    self: Layer<ROut, E, RIn>
-  ): Layer<ROut2, E2 | E, RIn | Exclude<RIn2, ROut>>
+    self: Layer<ROut2, E2, RIn2>,
+    that: Layer<ROut, E, RIn>
+  ): Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>
+  <A, E, R, const Layers extends [Layer.Any, ...Array<Layer.Any>]>(
+    self: Layer<A, E, R>,
+    that: Layers
+  ): Layer<
+    A,
+    E | { [k in keyof Layers]: Layer.Error<Layers[k]> }[number],
+    | { [k in keyof Layers]: Layer.Context<Layers[k]> }[number]
+    | Exclude<R, { [k in keyof Layers]: Layer.Success<Layers[k]> }[number]>
+  >
 } = internal.provide
 
 /**

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -319,4 +319,4 @@ export type NotFunction<T> = T extends Function ? never : T
 /**
  * @since 3.9.0
  */
-export type NoExtraKeys<T, U> = T & { readonly [K in Exclude<keyof U, keyof T>]: never }
+export type NoExcessProperties<T, U> = T & { readonly [K in Exclude<keyof U, keyof T>]: never }

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -255,6 +255,18 @@ export type NoInfer<A> = [A][A extends any ? 0 : never]
 export type Invariant<A> = (_: A) => A
 
 /**
+ * @since 3.9.0
+ * @category models
+ */
+export declare namespace Invariant {
+  /**
+   * @since 3.9.0
+   * @category models
+   */
+  export type Type<A> = A extends Invariant<infer U> ? U : never
+}
+
+/**
  * Covariant helper.
  *
  * @since 2.0.0
@@ -263,12 +275,36 @@ export type Invariant<A> = (_: A) => A
 export type Covariant<A> = (_: never) => A
 
 /**
+ * @since 3.9.0
+ * @category models
+ */
+export declare namespace Covariant {
+  /**
+   * @since 3.9.0
+   * @category models
+   */
+  export type Type<A> = A extends Covariant<infer U> ? U : never
+}
+
+/**
  * Contravariant helper.
  *
  * @since 2.0.0
  * @category models
  */
 export type Contravariant<A> = (_: A) => void
+
+/**
+ * @since 3.9.0
+ * @category models
+ */
+export declare namespace Contravariant {
+  /**
+   * @since 3.9.0
+   * @category models
+   */
+  export type Type<A> = A extends Contravariant<infer U> ? U : never
+}
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -315,3 +315,8 @@ export type MatchRecord<S, onTrue, onFalse> = {} extends S ? onTrue : onFalse
  * @since 2.0.0
  */
 export type NotFunction<T> = T extends Function ? never : T
+
+/**
+ * @since 3.9.0
+ */
+export type NoExtraKeys<T, U> = T & { readonly [K in Exclude<keyof U, keyof T>]: never }

--- a/packages/effect/src/internal/context.ts
+++ b/packages/effect/src/internal/context.ts
@@ -25,7 +25,6 @@ export const STMTypeId: STM.STMTypeId = Symbol.for(
 /** @internal */
 export const TagProto: any = {
   ...EffectPrototype,
-  _tag: "Tag",
   _op: "Tag",
   [STMTypeId]: effectVariance,
   [TagTypeId]: {

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -51,7 +51,7 @@ const layerVariance = {
 }
 
 /** @internal */
-const proto = {
+export const proto = {
   [LayerTypeId]: layerVariance,
   pipe() {
     return pipeArguments(this, arguments)
@@ -81,7 +81,7 @@ export type Primitive =
 
 /** @internal */
 export type Op<Tag extends string, Body = {}> = Layer.Layer<unknown, unknown, unknown> & Body & {
-  readonly _tag: Tag
+  readonly _op_layer: Tag
 }
 
 /** @internal */
@@ -167,7 +167,7 @@ export const isLayer = (u: unknown): u is Layer.Layer<unknown, unknown, unknown>
 
 /** @internal */
 export const isFresh = <RIn, E, ROut>(self: Layer.Layer<ROut, E, RIn>): boolean => {
-  return (self as Primitive)._tag === OpCodes.OP_FRESH
+  return (self as Primitive)._op_layer === OpCodes.OP_FRESH
 }
 
 // -----------------------------------------------------------------------------
@@ -358,7 +358,7 @@ const makeBuilder = <RIn, E, ROut>(
   inMemoMap = false
 ): Effect.Effect<(memoMap: Layer.MemoMap) => Effect.Effect<Context.Context<ROut>, E, RIn>> => {
   const op = self as Primitive
-  switch (op._tag) {
+  switch (op._op_layer) {
     case "Locally": {
       return core.sync(() => (memoMap: Layer.MemoMap) => op.f(memoMap.getOrElseMemoize(op.self, scope)))
     }
@@ -489,7 +489,7 @@ export const extendScope = <RIn, E, ROut>(
   self: Layer.Layer<ROut, E, RIn>
 ): Layer.Layer<ROut, E, RIn | Scope.Scope> => {
   const extendScope = Object.create(proto)
-  extendScope._tag = OpCodes.OP_EXTEND_SCOPE
+  extendScope._op_layer = OpCodes.OP_EXTEND_SCOPE
   extendScope.layer = self
   return extendScope
 }
@@ -535,7 +535,7 @@ export const flatten = dual<
 /** @internal */
 export const fresh = <A, E, R>(self: Layer.Layer<A, E, R>): Layer.Layer<A, E, R> => {
   const fresh = Object.create(proto)
-  fresh._tag = OpCodes.OP_FRESH
+  fresh._op_layer = OpCodes.OP_FRESH
   fresh.layer = self
   return fresh
 }
@@ -567,7 +567,7 @@ export function fromEffectContext<A, E, R>(
   effect: Effect.Effect<Context.Context<A>, E, R>
 ): Layer.Layer<A, E, R> {
   const fromEffect = Object.create(proto)
-  fromEffect._tag = OpCodes.OP_FROM_EFFECT
+  fromEffect._op_layer = OpCodes.OP_FROM_EFFECT
   fromEffect.effect = effect
   return fromEffect
 }
@@ -589,7 +589,7 @@ export const locallyEffect = dual<
   ) => Layer.Layer<ROut2, E2, RIn2>
 >(2, (self, f) => {
   const locally = Object.create(proto)
-  locally._tag = "Locally"
+  locally._op_layer = "Locally"
   locally.self = self
   locally.f = f
   return locally
@@ -660,7 +660,7 @@ export const matchCause = dual<
   ) => Layer.Layer<A2 & A3, E2 | E3, R | R2 | R3>
 >(2, (self, { onFailure, onSuccess }) => {
   const fold = Object.create(proto)
-  fold._tag = OpCodes.OP_FOLD
+  fold._op_layer = OpCodes.OP_FOLD
   fold.layer = self
   fold.failureK = onFailure
   fold.successK = onSuccess
@@ -868,7 +868,7 @@ export const scopedContext = <A, E, R>(
   effect: Effect.Effect<Context.Context<A>, E, R>
 ): Layer.Layer<A, E, Exclude<R, Scope.Scope>> => {
   const scoped = Object.create(proto)
-  scoped._tag = OpCodes.OP_SCOPED
+  scoped._op_layer = OpCodes.OP_SCOPED
   scoped.effect = effect
   return scoped
 }
@@ -922,7 +922,7 @@ export const suspend = <RIn, E, ROut>(
   evaluate: LazyArg<Layer.Layer<ROut, E, RIn>>
 ): Layer.Layer<ROut, E, RIn> => {
   const suspend = Object.create(proto)
-  suspend._tag = OpCodes.OP_SUSPEND
+  suspend._op_layer = OpCodes.OP_SUSPEND
   suspend.evaluate = evaluate
   return suspend
 }
@@ -1041,9 +1041,9 @@ export const provide = dual<
 ) =>
   suspend(() => {
     const provideTo = Object.create(proto)
-    provideTo._tag = OpCodes.OP_PROVIDE
+    provideTo._op_layer = OpCodes.OP_PROVIDE
     provideTo.first = Object.create(proto, {
-      _tag: { value: OpCodes.OP_PROVIDE_MERGE, enumerable: true },
+      _op_layer: { value: OpCodes.OP_PROVIDE_MERGE, enumerable: true },
       first: { value: context<Exclude<RIn2, ROut>>(), enumerable: true },
       second: { value: self },
       zipK: { value: (a: Context.Context<ROut>, b: Context.Context<ROut2>) => pipe(a, Context.merge(b)) }
@@ -1065,7 +1065,7 @@ export const provideMerge = dual<
   ) => Layer.Layer<ROut | ROut2, E2 | E, RIn | Exclude<RIn2, ROut>>
 >(2, <RIn2, E2, ROut2, RIn, E, ROut>(that: Layer.Layer<ROut2, E2, RIn2>, self: Layer.Layer<ROut, E, RIn>) => {
   const zipWith = Object.create(proto)
-  zipWith._tag = OpCodes.OP_PROVIDE_MERGE
+  zipWith._op_layer = OpCodes.OP_PROVIDE_MERGE
   zipWith.first = self
   zipWith.second = provide(that, self)
   zipWith.zipK = (a: Context.Context<ROut>, b: Context.Context<ROut2>): Context.Context<ROut | ROut2> => {
@@ -1088,7 +1088,7 @@ export const zipWith = dual<
 >(3, (self, that, f) =>
   suspend(() => {
     const zipWith = Object.create(proto)
-    zipWith._tag = OpCodes.OP_ZIP_WITH
+    zipWith._op_layer = OpCodes.OP_ZIP_WITH
     zipWith.first = self
     zipWith.second = that
     zipWith.zipK = f
@@ -1293,6 +1293,16 @@ const provideSomeRuntime = dual<
 /** @internal */
 export const effect_provide = dual<
   {
+    <const Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]>(
+      layers: Layers
+    ): <A, E, R>(
+      self: Effect.Effect<A, E, R>
+    ) => Effect.Effect<
+      A,
+      E | { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
+      | { [k in keyof Layers]: Layer.Layer.Context<Layers[k]> }[number]
+      | Exclude<R, { [k in keyof Layers]: Layer.Layer.Success<Layers[k]> }[number]>
+    >
     <ROut, E2, RIn>(
       layer: Layer.Layer<ROut, E2, RIn>
     ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | E2, RIn | Exclude<R, ROut>>
@@ -1307,6 +1317,15 @@ export const effect_provide = dual<
     ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | E2, Exclude<R, R2>>
   },
   {
+    <A, E, R, const Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]>(
+      self: Effect.Effect<A, E, R>,
+      layers: Layers
+    ): Effect.Effect<
+      A,
+      E | { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
+      | { [k in keyof Layers]: Layer.Layer.Context<Layers[k]> }[number]
+      | Exclude<R, { [k in keyof Layers]: Layer.Layer.Success<Layers[k]> }[number]>
+    >
     <A, E, R, ROut, E2, RIn>(
       self: Effect.Effect<A, E, R>,
       layer: Layer.Layer<ROut, E2, RIn>
@@ -1333,8 +1352,12 @@ export const effect_provide = dual<
       | Context.Context<ROut>
       | Runtime.Runtime<ROut>
       | ManagedRuntime.ManagedRuntime<ROut, any>
+      | Array<Layer.Layer<any, any, any>>
   ): Effect.Effect<any, any, Exclude<R, ROut>> => {
-    if (isLayer(source)) {
+    if (Array.isArray(source)) {
+      // @ts-expect-error
+      return provideSomeLayer(self, mergeAll(...source))
+    } else if (isLayer(source)) {
       return provideSomeLayer(self, source as Layer.Layer<ROut, any, any>)
     } else if (Context.isContext(source)) {
       return core.provideSomeContext(self, source)

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -1026,29 +1026,52 @@ export const toRuntimeWithMemoMap = dual<
 
 /** @internal */
 export const provide = dual<
-  <RIn, E, ROut>(
-    self: Layer.Layer<ROut, E, RIn>
-  ) => <RIn2, E2, ROut2>(
-    that: Layer.Layer<ROut2, E2, RIn2>
-  ) => Layer.Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>,
-  <RIn2, E2, ROut2, RIn, E, ROut>(
-    that: Layer.Layer<ROut2, E2, RIn2>,
-    self: Layer.Layer<ROut, E, RIn>
-  ) => Layer.Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>
->(2, <RIn2, E2, ROut2, RIn, E, ROut>(
-  that: Layer.Layer<ROut2, E2, RIn2>,
-  self: Layer.Layer<ROut, E, RIn>
+  {
+    <RIn, E, ROut>(
+      that: Layer.Layer<ROut, E, RIn>
+    ): <RIn2, E2, ROut2>(
+      self: Layer.Layer<ROut2, E2, RIn2>
+    ) => Layer.Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>
+    <const Layers extends [Layer.Layer.Any, ...Array<Layer.Layer.Any>]>(
+      that: Layers
+    ): <A, E, R>(
+      self: Layer.Layer<A, E, R>
+    ) => Layer.Layer<
+      A,
+      E | { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
+      | { [k in keyof Layers]: Layer.Layer.Context<Layers[k]> }[number]
+      | Exclude<R, { [k in keyof Layers]: Layer.Layer.Success<Layers[k]> }[number]>
+    >
+  },
+  {
+    <RIn2, E2, ROut2, RIn, E, ROut>(
+      self: Layer.Layer<ROut2, E2, RIn2>,
+      that: Layer.Layer<ROut, E, RIn>
+    ): Layer.Layer<ROut2, E | E2, RIn | Exclude<RIn2, ROut>>
+    <A, E, R, const Layers extends [Layer.Layer.Any, ...Array<Layer.Layer.Any>]>(
+      self: Layer.Layer<A, E, R>,
+      that: Layers
+    ): Layer.Layer<
+      A,
+      E | { [k in keyof Layers]: Layer.Layer.Error<Layers[k]> }[number],
+      | { [k in keyof Layers]: Layer.Layer.Context<Layers[k]> }[number]
+      | Exclude<R, { [k in keyof Layers]: Layer.Layer.Success<Layers[k]> }[number]>
+    >
+  }
+>(2, (
+  self: Layer.Layer.Any,
+  that: Layer.Layer.Any | ReadonlyArray<Layer.Layer.Any>
 ) =>
   suspend(() => {
     const provideTo = Object.create(proto)
     provideTo._op_layer = OpCodes.OP_PROVIDE
     provideTo.first = Object.create(proto, {
       _op_layer: { value: OpCodes.OP_PROVIDE_MERGE, enumerable: true },
-      first: { value: context<Exclude<RIn2, ROut>>(), enumerable: true },
-      second: { value: self },
-      zipK: { value: (a: Context.Context<ROut>, b: Context.Context<ROut2>) => pipe(a, Context.merge(b)) }
+      first: { value: context(), enumerable: true },
+      second: { value: Array.isArray(that) ? mergeAll(...that as any) : that },
+      zipK: { value: (a: Context.Context<any>, b: Context.Context<any>) => pipe(a, Context.merge(b)) }
     })
-    provideTo.second = that
+    provideTo.second = self
     return provideTo
   }))
 

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -1293,7 +1293,7 @@ const provideSomeRuntime = dual<
 /** @internal */
 export const effect_provide = dual<
   {
-    <const Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]>(
+    <const Layers extends [Layer.Layer.Any, ...Array<Layer.Layer.Any>]>(
       layers: Layers
     ): <A, E, R>(
       self: Effect.Effect<A, E, R>
@@ -1317,7 +1317,7 @@ export const effect_provide = dual<
     ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | E2, Exclude<R, R2>>
   },
   {
-    <A, E, R, const Layers extends [Layer.Layer<any, any, any>, ...Array<Layer.Layer<any, any, any>>]>(
+    <A, E, R, const Layers extends [Layer.Layer.Any, ...Array<Layer.Layer.Any>]>(
       self: Effect.Effect<A, E, R>,
       layers: Layers
     ): Effect.Effect<
@@ -1352,7 +1352,7 @@ export const effect_provide = dual<
       | Context.Context<ROut>
       | Runtime.Runtime<ROut>
       | ManagedRuntime.ManagedRuntime<ROut, any>
-      | Array<Layer.Layer<any, any, any>>
+      | Array<Layer.Layer.Any>
   ): Effect.Effect<any, any, Exclude<R, ROut>> => {
     if (Array.isArray(source)) {
       // @ts-expect-error

--- a/packages/effect/src/internal/stm/core.ts
+++ b/packages/effect/src/internal/stm/core.ts
@@ -56,7 +56,7 @@ export type Primitive =
 
 /** @internal */
 type Op<Tag extends string, Body = {}> = STM.STM<never> & Body & {
-  readonly _tag: OP_COMMIT
+  readonly _op: OP_COMMIT
   readonly effect_instruction_i0: Tag
 }
 
@@ -150,7 +150,6 @@ const stmVariance = {
 
 /** @internal */
 class STMPrimitive implements STM.STM<any, any, any> {
-  public _tag = OP_COMMIT
   public _op = OP_COMMIT
   public effect_instruction_i1: any = undefined
   public effect_instruction_i2: any = undefined;
@@ -481,7 +480,7 @@ export class STMDriver<in out R, out E, out A> {
       try {
         const current = curr
         if (current) {
-          switch (current._tag) {
+          switch (current._op) {
             case "Tag": {
               curr = effect((_, __, env) => Context.unsafeGet(env, current)) as Primitive
               break

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -51,8 +51,7 @@ class Scoped extends Effect.Service<Scoped>()("Scoped", {
     }
   }),
   dependencies: [Prefix, Postfix]
-}) {
-}
+}) {}
 
 describe("Effect.Service", () => {
   it("make is a function", () => {

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -17,6 +17,7 @@ class Postfix extends Effect.Service<Postfix>()("Postfix", {
 const messages: Array<string> = []
 
 class Logger extends Effect.Service<Logger>()("Logger", {
+  proxy: true,
   effect: Effect.gen(function*() {
     const { prefix } = yield* Prefix
     const { postfix } = yield* Postfix

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -1,0 +1,44 @@
+import * as Effect from "effect/Effect"
+import * as it from "effect/test/utils/extend"
+import { describe, expect } from "vitest"
+
+class Prefix extends Effect.Service<Prefix>()("Prefix", {
+  sync: () => ({
+    prefix: "PRE"
+  })
+}) {}
+
+class Postfix extends Effect.Service<Postfix>()("Postfix", {
+  sync: () => ({
+    postfix: "POST"
+  })
+}) {}
+
+const messages: Array<string> = []
+
+class Logger extends Effect.Service<Logger>()("Logger", {
+  effect: Effect.gen(function*() {
+    const { prefix } = yield* Prefix
+    const { postfix } = yield* Postfix
+    return {
+      info: (message: string) => Effect.sync(() => messages.push(`[${prefix}][${message}][${postfix}]`))
+    }
+  }),
+  dependencies: [Prefix, Postfix]
+}) {}
+
+describe("Effect", () => {
+  it.effect("Service correctly wires dependencies", () =>
+    Effect.gen(function*() {
+      const { _tag } = yield* Logger
+      expect(_tag).toEqual("Logger")
+      yield* Logger.info("Ok")
+      expect(messages).toEqual(["[PRE][Ok][POST]"])
+      const { prefix } = yield* Prefix
+      expect(prefix).toEqual("PRE")
+      const { postfix } = yield* Postfix
+      expect(postfix).toEqual("POST")
+    }).pipe(
+      Effect.provide([Logger, Prefix, Postfix])
+    ))
+})

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -84,4 +84,25 @@ describe("Effect.Service", () => {
       expect(time).toStrictEqual(time2)
     }).pipe(Effect.provide(Time))
   })
+
+  it.effect("patrick", () =>
+    Effect.gen(function*() {
+      class TimeLive {
+        #now: Date | undefined
+        constructor(now?: Date) {
+          this.#now = now
+        }
+
+        get now() {
+          return this.#now ||= new Date()
+        } // others omitted
+      }
+      abstract class Time extends Effect.Service<Time>()("Time", {
+        effect: Effect.sync(() => new TimeLive()),
+        accessors: true
+      }) {
+      }
+
+      expect(yield* Time.use((_) => _.now).pipe(Effect.provide(Time))).toBeInstanceOf(Date) // undefined, not Date
+    }))
 })

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -31,7 +31,7 @@ class Logger extends Effect.Service<Logger>()("Logger", {
   }),
   dependencies: [Prefix, Postfix]
 }) {
-  static Test = Layer.succeed(this, this.of({ info: () => Effect.void }))
+  static Test = Layer.succeed(this, Logger.make({ info: () => Effect.void }))
 }
 
 describe("Effect", () => {

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
 import * as it from "effect/test/utils/extend"
 import { describe, expect } from "vitest"
 
@@ -22,11 +23,16 @@ class Logger extends Effect.Service<Logger>()("Logger", {
     const { prefix } = yield* Prefix
     const { postfix } = yield* Postfix
     return {
-      info: (message: string) => Effect.sync(() => messages.push(`[${prefix}][${message}][${postfix}]`))
+      info: (message: string) =>
+        Effect.sync(() => {
+          messages.push(`[${prefix}][${message}][${postfix}]`)
+        })
     }
   }),
   dependencies: [Prefix, Postfix]
-}) {}
+}) {
+  static Test = Layer.succeed(this, this.of({ info: () => Effect.void }))
+}
 
 describe("Effect", () => {
   it.effect("Service correctly wires dependencies", () =>

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -5,13 +5,15 @@ import { describe, expect } from "vitest"
 
 class Prefix extends Effect.Service<Prefix>()("Prefix", {
   sync: () => ({
-    prefix: "PRE"
+    prefix: "PRE",
+    key: "test"
   })
 }) {}
 
 class Postfix extends Effect.Service<Postfix>()("Postfix", {
   sync: () => ({
-    postfix: "POST"
+    postfix: "POST",
+    key: ""
   })
 }) {}
 

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import { describe, expect, it } from "effect/test/utils/extend"
@@ -54,6 +55,9 @@ class Scoped extends Effect.Service<Scoped>()("Scoped", {
 }
 
 describe("Effect.Service", () => {
+  it("make is a function", () => {
+    expect(pipe({ prefix: "OK" }, Prefix.make)).toBeInstanceOf(Prefix)
+  })
   it("tags are both layers and tags", () => {
     expect(Layer.isLayer(Logger)).toBe(true)
     expect(Context.isTag(Logger)).toBe(true)

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -49,7 +49,7 @@ describe("Effect.Service", () => {
 
   it.effect("inherits prototype", () => {
     class Time extends Effect.Service<Time>()("Time", {
-      sync: () => ({ time: new Date() }),
+      sync: () => ({}),
       accessors: true
     }) {
       #now: Date | undefined
@@ -59,9 +59,29 @@ describe("Effect.Service", () => {
     }
     return Effect.gen(function*() {
       const time = yield* Time.use((_) => _.now)
-      const accessed = yield* Time.time
       expect(time).toBeInstanceOf(Date)
-      expect(accessed).toStrictEqual(time)
+    }).pipe(Effect.provide(Time))
+  })
+
+  it.effect("support values with prototype", () => {
+    class DateTest {
+      #now: Date | undefined
+      get now() {
+        return this.#now ||= new Date()
+      }
+    }
+    class Time extends Effect.Service<Time>()("Time", {
+      sync: () => new DateTest(),
+      accessors: true
+    }) {
+      get now2() {
+        return this.now
+      }
+    }
+    return Effect.gen(function*() {
+      const time = yield* Time.use((_) => _.now)
+      const time2 = yield* Time.use((_) => _.now2)
+      expect(time).toStrictEqual(time2)
     }).pipe(Effect.provide(Time))
   })
 })

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -1,3 +1,4 @@
+import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import { describe, expect, it } from "effect/test/utils/extend"
@@ -35,6 +36,11 @@ class Logger extends Effect.Service<Logger>()("Logger", {
 }
 
 describe("Effect.Service", () => {
+  it("tags are both layers and tags", () => {
+    expect(Layer.isLayer(Logger)).toBe(true)
+    expect(Context.isTag(Logger)).toBe(true)
+  })
+
   it.effect("correctly wires dependencies", () =>
     Effect.gen(function*() {
       yield* Logger.info("Ok")
@@ -43,6 +49,7 @@ describe("Effect.Service", () => {
       expect(prefix).toEqual("PRE")
       const { postfix } = yield* Postfix
       expect(postfix).toEqual("POST")
+      expect(yield* Prefix.use((_) => _._tag)).toBe("Prefix")
     }).pipe(
       Effect.provide([Logger, Prefix, Postfix])
     ))
@@ -120,7 +127,15 @@ describe("Effect.Service", () => {
       const map = yield* MapThing.use((_) => _.set("a", 1)).pipe(
         Effect.provide(MapThing)
       )
+
       expect(map).toBeInstanceOf(MapThing)
       expect(map).toBeInstanceOf(Map)
+
+      const map2 = yield* MapThing.set("a", 1).pipe(
+        Effect.provide(MapThing)
+      )
+
+      expect(map2).toBeInstanceOf(MapThing)
+      expect(map2).toBeInstanceOf(Map)
     }))
 })

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -20,7 +20,7 @@ class Postfix extends Effect.Service<Postfix>()("Postfix", {
 const messages: Array<string> = []
 
 class Logger extends Effect.Service<Logger>()("Logger", {
-  withAccessors: true,
+  accessors: true,
   effect: Effect.gen(function*() {
     const { prefix } = yield* Prefix
     const { postfix } = yield* Postfix
@@ -31,9 +31,9 @@ class Logger extends Effect.Service<Logger>()("Logger", {
         })
     }
   }),
-  dependencies: [Prefix.Live, Postfix.Live]
+  dependencies: [Prefix, Postfix]
 }) {
-  static Test = Layer.succeed(this, Logger.of({ info: () => Effect.void }))
+  static Test = Layer.succeed(this, new Logger({ info: () => Effect.void }))
 }
 
 describe("Effect", () => {
@@ -46,6 +46,6 @@ describe("Effect", () => {
       const { postfix } = yield* Postfix
       expect(postfix).toEqual("POST")
     }).pipe(
-      Effect.provide([Logger.Live, Prefix.Live, Postfix.Live])
+      Effect.provide([Logger, Prefix, Postfix])
     ))
 })

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -4,15 +4,14 @@ import { describe, expect, it } from "effect/test/utils/extend"
 
 class Prefix extends Effect.Service<Prefix>()("Prefix", {
   sync: () => ({
-    prefix: "PRE",
-    key: "test"
+    prefix: "PRE"
   })
 }) {}
 
 class Postfix extends Effect.Service<Postfix>()("Postfix", {
+  accessors: true,
   sync: () => ({
-    postfix: "POST",
-    key: ""
+    postfix: "POST"
   })
 }) {}
 
@@ -53,12 +52,13 @@ describe("Effect.Service", () => {
       sync: () => ({ time: new Date() }),
       accessors: true
     }) {
-      get foo() {
-        return this.time
+      #now: Date | undefined
+      get now() {
+        return this.#now ||= new Date()
       }
     }
     return Effect.gen(function*() {
-      const time = yield* Time.use((_) => _.foo)
+      const time = yield* Time.use((_) => _.now)
       const accessed = yield* Time.time
       expect(time).toBeInstanceOf(Date)
       expect(accessed).toStrictEqual(time)


### PR DESCRIPTION
Namely the following is now possible:

```ts
class Prefix extends Effect.Service<Prefix>()("Prefix", {
  sync: () => ({
    prefix: "PRE"
  })
}) {}

class Postfix extends Effect.Service<Postfix>()("Postfix", {
  sync: () => ({
    postfix: "POST"
  })
}) {}

const messages: Array<string> = []

class Logger extends Effect.Service<Logger>()("Logger", {
  accessors: true,
  effect: Effect.gen(function* () {
    const { prefix } = yield* Prefix
    const { postfix } = yield* Postfix
    return {
      info: (message: string) =>
        Effect.sync(() => {
          messages.push(`[${prefix}][${message}][${postfix}]`)
        })
    }
  }),
  dependencies: [Prefix.Default, Postfix.Default]
}) {}

describe("Effect", () => {
  it.effect("Service correctly wires dependencies", () =>
    Effect.gen(function* () {
      const { _tag } = yield* Logger
      expect(_tag).toEqual("Logger")
      yield* Logger.info("Ok")
      expect(messages).toEqual(["[PRE][Ok][POST]"])
      const { prefix } = yield* Prefix
      expect(prefix).toEqual("PRE")
      const { postfix } = yield* Postfix
      expect(postfix).toEqual("POST")
    }).pipe(Effect.provide([Logger.Default, Prefix.Default, Postfix.Default]))
  )
})
```
