### PR TITLE
added Stream.mergeWithTag

### DIFF
--- a/.changeset/silver-tools-collect.md
+++ b/.changeset/silver-tools-collect.md
@@ -2,7 +2,7 @@
 "effect": patch
 ---
 
-added Stream.mergeStruct
+added Stream.mergeWithTag
 
 Combines a struct of streams into a single stream of tagged values where the tag is the key of the struct.
 
@@ -10,7 +10,7 @@ Combines a struct of streams into a single stream of tagged values where the tag
 import { Stream } from "effect"
 
 // Stream.Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }>
-const stream = Stream.mergeStruct(
+const stream = Stream.mergeWithTag(
   {
     a: Stream.make(0),
     b: Stream.make("")

--- a/.changeset/silver-tools-collect.md
+++ b/.changeset/silver-tools-collect.md
@@ -1,0 +1,20 @@
+---
+"effect": patch
+---
+
+added Stream.mergeStruct
+
+Combines a struct of streams into a single stream of tagged values where the tag is the key of the struct.
+
+```ts
+import { Stream } from "effect"
+
+// Stream.Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }>
+const stream = Stream.mergeStruct(
+  {
+    a: Stream.make(0),
+    b: Stream.make("")
+  },
+  { concurrency: 1 }
+)
+```

--- a/packages/effect/dtslint/Stream.ts
+++ b/packages/effect/dtslint/Stream.ts
@@ -256,7 +256,7 @@ Stream.zipLatestAll(numbers, numbersOrStrings, Stream.fail(new Error("")))
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }, NoSuchElementException, never>
-Stream.mergeStruct({
+Stream.mergeWithTag({
   a: Stream.make(0).pipe(Stream.tap(() => new Cause.NoSuchElementException())),
   b: Stream.make("")
 }, { concurrency: 1 })

--- a/packages/effect/dtslint/Stream.ts
+++ b/packages/effect/dtslint/Stream.ts
@@ -1,6 +1,7 @@
 import { pipe } from "effect/Function"
 import * as Predicate from "effect/Predicate"
 import * as Stream from "effect/Stream"
+import { Cause } from "../src/index.js"
 
 declare const numbers: Stream.Stream<number>
 declare const numbersOrStrings: Stream.Stream<number | string>
@@ -249,3 +250,13 @@ Stream.zipLatestAll(numbers, numbersOrStrings)
 
 // $ExpectType Stream<[number, string | number, never], Error, never>
 Stream.zipLatestAll(numbers, numbersOrStrings, Stream.fail(new Error("")))
+
+// -------------------------------------------------------------------------------------
+// merge
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }, NoSuchElementException, never>
+Stream.mergeStruct({
+  a: Stream.make(0).pipe(Stream.tap(() => new Cause.NoSuchElementException())),
+  b: Stream.make("")
+}, { concurrency: 1 })

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2896,6 +2896,40 @@ export const mergeAll: {
 } = internal.mergeAll
 
 /**
+ * Merges a struct of streams into a single stream of tagged values.
+ * @category combinators
+ * @since 3.8.5
+ *
+ * @example
+ * // Stream.Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }>
+ * const res = mergeStruct({
+ *    a: Stream.make(0),
+ *    b: Stream.make("")
+ * })
+ */
+export const mergeStruct: {
+  <S extends { [k in string]: Stream<any, any, any> }>(
+    streams: S,
+    options: {
+      readonly concurrency: number | "unbounded"
+      readonly bufferSize?: number | undefined
+    }
+  ): Stream<
+    { [K in keyof S]: { _tag: K; value: Stream.Success<S[K]> } }[keyof S],
+    Stream.Error<S[keyof S]>,
+    Stream.Context<S[keyof S]>
+  >
+  (options: {
+    readonly concurrency: number | "unbounded"
+    readonly bufferSize?: number | undefined
+  }): <S extends { [k in string]: Stream<any, any, any> }>(streams: S) => Stream<
+    { [K in keyof S]: { _tag: K; value: Stream.Success<S[K]> } }[keyof S],
+    Stream.Error<S[keyof S]>,
+    Stream.Context<S[keyof S]>
+  >
+} = internal.mergeStruct
+
+/**
  * Merges this stream and the specified stream together to a common element
  * type with the specified mapping functions.
  *

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2901,8 +2901,9 @@ export const mergeAll: {
  * @since 3.8.5
  *
  * @example
+ * import { Stream } from "effect"
  * // Stream.Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }>
- * const res = mergeWithTag({
+ * const res = Stream.mergeWithTag({
  *    a: Stream.make(0),
  *    b: Stream.make("")
  * })

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2906,7 +2906,7 @@ export const mergeAll: {
  * const res = Stream.mergeWithTag({
  *    a: Stream.make(0),
  *    b: Stream.make("")
- * })
+ * }, { concurrency: "unbounded" })
  */
 export const mergeWithTag: {
   <S extends { [k in string]: Stream<any, any, any> }>(

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2902,12 +2902,12 @@ export const mergeAll: {
  *
  * @example
  * // Stream.Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }>
- * const res = mergeStruct({
+ * const res = mergeWithTag({
  *    a: Stream.make(0),
  *    b: Stream.make("")
  * })
  */
-export const mergeStruct: {
+export const mergeWithTag: {
   <S extends { [k in string]: Stream<any, any, any> }>(
     streams: S,
     options: {
@@ -2927,7 +2927,7 @@ export const mergeStruct: {
     Stream.Error<S[keyof S]>,
     Stream.Context<S[keyof S]>
   >
-} = internal.mergeStruct
+} = internal.mergeWithTag
 
 /**
  * Merges this stream and the specified stream together to a common element

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -4108,6 +4108,33 @@ export const mergeAll = dual<
 >((args) => Symbol.iterator in args[0], (streams, options) => flatten(fromIterable(streams), options))
 
 /** @internal */
+export const mergeStruct: {
+  <S extends { [k in string]: Stream.Stream<any, any, any> }>(
+    streams: S,
+    options: {
+      readonly concurrency: number | "unbounded"
+      readonly bufferSize?: number | undefined
+    }
+  ): Stream.Stream<
+    { [K in keyof S]: { _tag: K; value: Stream.Stream.Success<S[K]> } }[keyof S],
+    Stream.Stream.Error<S[keyof S]>,
+    Stream.Stream.Context<S[keyof S]>
+  >
+  (options: {
+    readonly concurrency: number | "unbounded"
+    readonly bufferSize?: number | undefined
+  }): <S extends { [k in string]: Stream.Stream<any, any, any> }>(streams: S) => Stream.Stream<
+    { [K in keyof S]: { _tag: K; value: Stream.Stream.Success<S[K]> } }[keyof S],
+    Stream.Stream.Error<S[keyof S]>,
+    Stream.Stream.Context<S[keyof S]>
+  >
+} = dual(2, (streams, options) => {
+  const keys = Object.keys(streams)
+  const values = keys.map((key) => streams[key].pipe(map((value) => ({ _tag: key, value })))) as any
+  return mergeAll(values, options)
+})
+
+/** @internal */
 export const mergeEither = dual<
   <A2, E2, R2>(
     that: Stream.Stream<A2, E2, R2>

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -4108,7 +4108,7 @@ export const mergeAll = dual<
 >((args) => Symbol.iterator in args[0], (streams, options) => flatten(fromIterable(streams), options))
 
 /** @internal */
-export const mergeStruct: {
+export const mergeWithTag: {
   <S extends { [k in string]: Stream.Stream<any, any, any> }>(
     streams: S,
     options: {

--- a/packages/effect/test/Stream/merging.test.ts
+++ b/packages/effect/test/Stream/merging.test.ts
@@ -38,9 +38,9 @@ describe("Stream", () => {
       assert.deepStrictEqual(Array.from(result), [1])
     }))
 
-  it.effect("mergeStruct", (ctx) =>
+  it.effect("mergeWithTag", (ctx) =>
     Effect.gen(function*() {
-      const stream = Stream.mergeStruct({
+      const stream = Stream.mergeWithTag({
         a: Stream.make(0),
         b: Stream.make("")
       }, { concurrency: 1 })

--- a/packages/effect/test/Stream/merging.test.ts
+++ b/packages/effect/test/Stream/merging.test.ts
@@ -38,6 +38,20 @@ describe("Stream", () => {
       assert.deepStrictEqual(Array.from(result), [1])
     }))
 
+  it.effect("mergeStruct", (ctx) =>
+    Effect.gen(function*() {
+      const stream = Stream.mergeStruct({
+        a: Stream.make(0),
+        b: Stream.make("")
+      }, { concurrency: 1 })
+
+      const res = Chunk.toArray(yield* Stream.runCollect(stream))
+      ctx.expect(res).toEqual([
+        { _tag: "a", value: 0 },
+        { _tag: "b", value: "" }
+      ])
+    }))
+
   it.effect("mergeHaltLeft - terminates as soon as the first stream terminates", () =>
     Effect.gen(function*($) {
       const queue1 = yield* $(Queue.unbounded<number>())


### PR DESCRIPTION
Adds Stream.mergeWithTag

```ts
// Stream.Stream<{ _tag: "a"; value: number; } | { _tag: "b"; value: string; }>
Stream.mergeWithTag({
  a: Stream.make(0),
  b: Stream.make("")
}, { concurrency: "unbounded"  })
```