### PR TITLE
Accept TLS options for SSL configuration of PgClient

### DIFF
--- a/.changeset/nervous-starfishes-wave.md
+++ b/.changeset/nervous-starfishes-wave.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+accept tls options for ssl configuration of PgClient

--- a/packages/sql-pg/src/PgClient.ts
+++ b/packages/sql-pg/src/PgClient.ts
@@ -18,6 +18,7 @@ import * as Redacted from "effect/Redacted"
 import type { Scope } from "effect/Scope"
 import * as Stream from "effect/Stream"
 import type * as NodeStream from "node:stream"
+import type { ConnectionOptions } from "node:tls"
 import postgres from "postgres"
 
 /**
@@ -61,7 +62,7 @@ export interface PgClientConfig {
   readonly host?: string | undefined
   readonly port?: number | undefined
   readonly path?: string | undefined
-  readonly ssl?: boolean | undefined
+  readonly ssl?: boolean | ConnectionOptions | undefined
   readonly database?: string | undefined
   readonly username?: string | undefined
   readonly password?: Redacted.Redacted | undefined


### PR DESCRIPTION
the PgClient should be able to accept a TLS connection object instead of a boolean for the `ssl` prop