### PR TITLE
add node modules directory to `clean` script

### DIFF
--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -3,7 +3,7 @@ import * as Fs from "node:fs"
 
 const dirs = [".", ...Glob.sync("packages/*/")]
 dirs.forEach((pkg) => {
-  const files = [".tsbuildinfo", "docs", "build", "dist", "coverage"]
+  const files = [".tsbuildinfo", "docs", "build", "dist", "coverage", "node_modules"]
 
   files.forEach((file) => {
     if (pkg === "." && file === "docs") {


### PR DESCRIPTION
I regularly need this when I come back to the repository after 1 or 2 weeks. Sometimes `pnpm` fails to properly fix up the node modules directory after an update to dependencies or the pnpm version(?) it seems.