### PR TITLE
Automatically wire active span from opentelemetry api

### DIFF
--- a/.changeset/friendly-teachers-kneel.md
+++ b/.changeset/friendly-teachers-kneel.md
@@ -1,0 +1,6 @@
+---
+"@effect/opentelemetry": minor
+"effect": minor
+---
+
+Automatically wire active span from opentelemetry api

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -34,6 +34,7 @@ export interface Tracer {
     kind: SpanKind
   ): Span
   context<X>(f: () => X, fiber: Fiber.RuntimeFiber<any, any>): X
+  getActiveSpan?(): Option.Option<AnySpan>
 }
 
 /**

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -2067,11 +2067,15 @@ export const unsafeMakeSpan = <XA, XE>(
   const annotationsFromEnv = FiberRefs.get(fiberRefs, core.currentTracerSpanAnnotations)
   const linksFromEnv = FiberRefs.get(fiberRefs, core.currentTracerSpanLinks)
 
-  const parent = options.parent
+  let parent = options.parent
     ? Option.some(options.parent)
     : options.root
     ? Option.none()
     : Context.getOption(context, internalTracer.spanTag)
+
+  if (parent._tag === "None" && !(options.root === true) && tracer.getActiveSpan !== undefined) {
+    parent = tracer.getActiveSpan()
+  }
 
   const links = linksFromEnv._tag === "Some" ?
     options.links !== undefined ?

--- a/packages/opentelemetry/src/internal/tracer.ts
+++ b/packages/opentelemetry/src/internal/tracer.ts
@@ -153,6 +153,14 @@ export const make = Effect.map(Tracer, (tracer) =>
         populateContext(OtelApi.context.active(), currentSpan),
         execution
       )
+    },
+    getActiveSpan() {
+      const activeSpan = OtelApi.trace.getActiveSpan()
+      if (!activeSpan) {
+        return Option.none()
+      }
+      const span = makeExternalSpan(activeSpan.spanContext())
+      return Option.some(span)
     }
   }))
 


### PR DESCRIPTION
`getActiveSpan` is set to optional to avoid breaking changes, discord discussion: https://discord.com/channels/795981131316985866/911666033885061240/1291311027144888383