### PR TITLE
`@effect/sql-libsql` allow either a pre-built client or configuration options

### DIFF
--- a/.changeset/dull-pumas-bow.md
+++ b/.changeset/dull-pumas-bow.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-libsql": minor
+---
+
+allow client instance to be passed in to LibsqlClient

--- a/.changeset/dull-pumas-bow.md
+++ b/.changeset/dull-pumas-bow.md
@@ -1,5 +1,5 @@
 ---
-"@effect/sql-libsql": minor
+"@effect/sql-libsql": patch
 ---
 
 allow client instance to be passed in to LibsqlClient

--- a/packages/sql-libsql/test/util.ts
+++ b/packages/sql-libsql/test/util.ts
@@ -23,7 +23,8 @@ export class LibsqlContainer extends Context.Tag("test/LibsqlContainer")<
     Effect.gen(function*() {
       const container = yield* LibsqlContainer
       return LibsqlClient.layer({
-        url: Config.succeed(`http://localhost:${container.getMappedPort(8080)}`)
+        url: Config.succeed(`http://localhost:${container.getMappedPort(8080)}`),
+        _tag: Config.succeed("Config")
       })
     })
   ).pipe(Layer.provide(this.Live))

--- a/packages/sql-libsql/test/util.ts
+++ b/packages/sql-libsql/test/util.ts
@@ -23,8 +23,7 @@ export class LibsqlContainer extends Context.Tag("test/LibsqlContainer")<
     Effect.gen(function*() {
       const container = yield* LibsqlContainer
       return LibsqlClient.layer({
-        url: Config.succeed(`http://localhost:${container.getMappedPort(8080)}`),
-        _tag: Config.succeed("Config")
+        url: Config.succeed(`http://localhost:${container.getMappedPort(8080)}`)
       })
     })
   ).pipe(Layer.provide(this.Live))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR allows for a developer to provide _either_ a set of configuration options, as currently implemented, _or_ a client instance itself. It uses a discriminated union to detect what was passed in.

**Why?**

Libsql/Turso allows you to connect to either a cloud hosted or a local "embedded" replica, and provides ["read-your-writes semantics"](https://docs.turso.tech/features/embedded-replicas/introduction#read-your-writes) meaning that the client library tracks replication frames and ensures that the connection that wrote to the DB will immediately be able to read back that same data.

This depends on using the _same_ client instance. However, at the moment the client which is built inside of `@effect/sql-libsql` is not accessible outside. There are use cases, however, where it is desirable to use the client in other parts of the system outside of `@effect/sql`, but still guarantee that the entire application is reading from the same connection. The most important use case is when using the [`batch` API](https://docs.turso.tech/sdk/ts/reference#batch-transactions), a pattern not supported by `@effect/sql`, which allows you to commit an entire unit of work at once, by sending a set of SQL statements which will be executed as a transaction, without the overhead of opening an interactive transaction and sending commands one by one, with [the latency that entails](https://turso.tech/blog/batches-in-sqlite-838e0961).

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
