### PR TITLE
Fix cli options repeated order

### DIFF
--- a/.changeset/tasty-flies-call.md
+++ b/.changeset/tasty-flies-call.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Repeated options can now be parsed independend of the order of the arguments

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1833,29 +1833,44 @@ const parseCommandLine = (
       let optionName: string | undefined = undefined
       let values = Arr.empty<string>()
       let leftover = args as ReadonlyArray<string>
+      let unparsed = Arr.empty<string>()
       while (Arr.isNonEmptyReadonlyArray(leftover)) {
         const name = Arr.headNonEmpty(leftover)
         const normalizedName = InternalCliConfig.normalizeCase(config, name)
-        if (leftover.length >= 2 && Arr.contains(normalizedNames, normalizedName)) {
+
+        if (Arr.contains(normalizedNames, normalizedName)) {
           if (optionName === undefined) {
             optionName = name
           }
           const value = leftover[1]
           if (value !== undefined && value.length > 0) {
             values = Arr.append(values, value.trim())
-            leftover = leftover.slice(2)
-            continue
           }
-          break
         } else {
-          break
+          unparsed = Arr.appendAll(unparsed, leftover.slice(0, 2))
         }
+        leftover = leftover.slice(2)
+
+        // if (leftover.length >= 2 && Arr.contains(normalizedNames, normalizedName)) {
+        //   if (optionName === undefined) {
+        //     optionName = name
+        //   }
+        //   const value = leftover[1]
+        //   if (value !== undefined && value.length > 0) {
+        //     values = Arr.append(values, value.trim())
+        //     leftover = leftover.slice(2)
+        //     continue
+        //   }
+        //   break
+        // } else {
+        //   break
+        // }
       }
       const parsed = Option.fromNullable(optionName).pipe(
         Option.orElse(() => Option.some(self.argumentOption.fullName)),
         Option.map((name) => ({ name, values }))
       )
-      return Effect.succeed<ParsedCommandLine>({ parsed, leftover })
+      return Effect.succeed<ParsedCommandLine>({ parsed, leftover: unparsed })
     }
   }
 }

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -492,14 +492,20 @@ describe("Options", () => {
       const args2 = ["--foo", "1", "--foo", "2", "--foo", "3"]
       const args3 = ["--foo", "v2"]
       const args4 = ["--foo", "1", "--foo", "v2", "--foo", "3"]
+      const args5 = ["--foo", "1", "-d", "--foo", "2"]
+      const args6 = ["--foo", "1", "-f", "firstName", "--foo", "2"]
       const result1 = yield* _(process(option, [], CliConfig.defaultConfig))
       const result2 = yield* _(process(option, args2, CliConfig.defaultConfig))
       const result3 = yield* _(Effect.flip(process(option, args3, CliConfig.defaultConfig)))
       const result4 = yield* _(Effect.flip(process(option, args4, CliConfig.defaultConfig)))
+      const result5 = yield* _(process(option, args5, CliConfig.defaultConfig))
+      const result6 = yield* _(process(option, args6, CliConfig.defaultConfig))
       expect(result1).toEqual([Array.empty(), []])
       expect(result2).toEqual([Array.empty(), [1, 2, 3]])
       expect(result3).toEqual(ValidationError.invalidValue(HelpDoc.p("'v2' is not a integer")))
       expect(result4).toEqual(ValidationError.invalidValue(HelpDoc.p("'v2' is not a integer")))
+      expect(result5).toEqual([["-d"], [1, 2]])
+      expect(result6).toEqual([["-f", "firstName"], [1, 2]])
     }).pipe(runEffect))
 
   it("atLeast", () =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Fixes the issue that order off given options matters when using repeated Options in @effect/cli.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #3729
