### PR TITLE
refactor: Alternative Effect.Service suggestion

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6342,9 +6342,10 @@ type SupportDependencies = Record<
 export const Service: <Self>() => {
   <
     const Key extends string,
-    Dependencies extends SupportDependencies,
+    const Dependencies extends SupportDependencies,
     const Make extends
       | {
+        readonly dependencies: Dependencies
         readonly scoped: (
           deps: Service.MakeDepsM<{ dependencies: Dependencies }>
         ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6353,6 +6354,7 @@ export const Service: <Self>() => {
         readonly ಠ_ಠ: never
       }
       | {
+        readonly dependencies: Dependencies
         readonly effect: (
           deps: Service.MakeDepsM<{ dependencies: Dependencies }>
         ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6361,12 +6363,16 @@ export const Service: <Self>() => {
         readonly ಠ_ಠ: never
       }
       | {
-        readonly sync: (deps: Service.MakeDepsM<{ dependencies: Dependencies }>) => Service.AllowedType<Key, Make>
+        readonly dependencies: Dependencies
+        readonly sync: (
+          deps: Service.MakeDepsM<{ dependencies: Dependencies }>
+        ) => Service.AllowedType<Key, Make>
         readonly accessors?: boolean
         /** @deprecated */
         readonly ಠ_ಠ: never
       }
       | {
+        readonly dependencies: Dependencies
         readonly succeed: Service.AllowedType<Key, Make>
         readonly accessors?: boolean
         /** @deprecated */
@@ -6374,13 +6380,13 @@ export const Service: <Self>() => {
       }
   >(
     key: Key,
-    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
+  ): Service.Class<Self, Key, Make>
   <
     const Key extends string,
-    Dependencies extends SupportDependencies,
+    const Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
+      readonly dependencies: Dependencies
       readonly scoped: (
         deps: Service.MakeDepsM<{ dependencies: Dependencies }>
       ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6388,13 +6394,13 @@ export const Service: <Self>() => {
     }, Make>
   >(
     key: Key,
-    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
+  ): Service.Class<Self, Key, Make>
   <
     const Key extends string,
-    Dependencies extends SupportDependencies,
+    const Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
+      readonly dependencies: Dependencies
       readonly effect: (
         deps: Service.MakeDepsM<{ dependencies: Dependencies }>
       ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6402,33 +6408,32 @@ export const Service: <Self>() => {
     }, Make>
   >(
     key: Key,
-    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
+  ): Service.Class<Self, Key, Make>
   <
     const Key extends string,
-    Dependencies extends SupportDependencies,
+    const Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
+      readonly dependencies: Dependencies
       readonly sync: (deps: Service.MakeDepsM<{ dependencies: Dependencies }>) => Service.AllowedType<Key, Make>
       readonly accessors?: boolean
     }, Make>
   >(
     key: Key,
-    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
+  ): Service.Class<Self, Key, Make>
   <
     const Key extends string,
     Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
+      readonly dependencies: Dependencies
       readonly succeed: Service.AllowedType<Key, Make>
       readonly accessors?: boolean
     }, Make>
   >(
     key: Key,
-    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
+  ): Service.Class<Self, Key, Make>
 } = function() {
   return function() {
     const [id, dependencies, maker] = arguments

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6342,10 +6342,9 @@ type SupportDependencies = Record<
 export const Service: <Self>() => {
   <
     const Key extends string,
-    const Dependencies extends SupportDependencies,
+    Dependencies extends SupportDependencies,
     const Make extends
       | {
-        readonly dependencies: Dependencies
         readonly scoped: (
           deps: Service.MakeDepsM<{ dependencies: Dependencies }>
         ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6354,7 +6353,6 @@ export const Service: <Self>() => {
         readonly ಠ_ಠ: never
       }
       | {
-        readonly dependencies: Dependencies
         readonly effect: (
           deps: Service.MakeDepsM<{ dependencies: Dependencies }>
         ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6363,16 +6361,12 @@ export const Service: <Self>() => {
         readonly ಠ_ಠ: never
       }
       | {
-        readonly dependencies: Dependencies
-        readonly sync: (
-          deps: Service.MakeDepsM<{ dependencies: Dependencies }>
-        ) => Service.AllowedType<Key, Make>
+        readonly sync: (deps: Service.MakeDepsM<{ dependencies: Dependencies }>) => Service.AllowedType<Key, Make>
         readonly accessors?: boolean
         /** @deprecated */
         readonly ಠ_ಠ: never
       }
       | {
-        readonly dependencies: Dependencies
         readonly succeed: Service.AllowedType<Key, Make>
         readonly accessors?: boolean
         /** @deprecated */
@@ -6380,13 +6374,13 @@ export const Service: <Self>() => {
       }
   >(
     key: Key,
+    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make>
+  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
   <
     const Key extends string,
-    const Dependencies extends SupportDependencies,
+    Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
-      readonly dependencies: Dependencies
       readonly scoped: (
         deps: Service.MakeDepsM<{ dependencies: Dependencies }>
       ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6394,13 +6388,13 @@ export const Service: <Self>() => {
     }, Make>
   >(
     key: Key,
+    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make>
+  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
   <
     const Key extends string,
-    const Dependencies extends SupportDependencies,
+    Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
-      readonly dependencies: Dependencies
       readonly effect: (
         deps: Service.MakeDepsM<{ dependencies: Dependencies }>
       ) => Effect<Service.AllowedType<Key, Make>, any, any>
@@ -6408,32 +6402,33 @@ export const Service: <Self>() => {
     }, Make>
   >(
     key: Key,
+    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make>
+  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
   <
     const Key extends string,
-    const Dependencies extends SupportDependencies,
+    Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
-      readonly dependencies: Dependencies
       readonly sync: (deps: Service.MakeDepsM<{ dependencies: Dependencies }>) => Service.AllowedType<Key, Make>
       readonly accessors?: boolean
     }, Make>
   >(
     key: Key,
+    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make>
+  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
   <
     const Key extends string,
     Dependencies extends SupportDependencies,
     const Make extends NoExcessProperties<{
-      readonly dependencies: Dependencies
       readonly succeed: Service.AllowedType<Key, Make>
       readonly accessors?: boolean
     }, Make>
   >(
     key: Key,
+    dependencies: Dependencies,
     make: Make
-  ): Service.Class<Self, Key, Make>
+  ): Service.Class<Self, Key, Make & { dependencies: Dependencies }>
 } = function() {
   return function() {
     const [id, dependencies, maker] = arguments

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6605,8 +6605,9 @@ export declare namespace Service {
   /**
    * @since 3.9.0
    */
-  export type MakeService<Make> = Make extends { readonly effect: Effect<infer _A, infer _E, infer _R> } ? _A
-    : Make extends { readonly scoped: Effect<infer _A, infer _E, infer _R> } ? _A
+  export type MakeService<Make> = Make extends
+    { readonly effect: (deps: any) => Effect<infer _A, infer _E, infer _R> } ? _A
+    : Make extends { readonly scoped: (deps: any) => Effect<infer _A, infer _E, infer _R> } ? _A
     : Make extends { readonly sync: (deps: any) => infer A } ? A
     : Make extends { readonly succeed: infer A } ? A
     : never
@@ -6614,15 +6615,17 @@ export declare namespace Service {
   /**
    * @since 3.9.0
    */
-  export type MakeError<Make> = Make extends { readonly effect: Effect<infer _A, infer _E, infer _R> } ? _E
-    : Make extends { readonly scoped: Effect<infer _A, infer _E, infer _R> } ? _E
+  export type MakeError<Make> = Make extends { readonly effect: (deps: any) => Effect<infer _A, infer _E, infer _R> } ?
+    _E
+    : Make extends { readonly scoped: (deps: any) => Effect<infer _A, infer _E, infer _R> } ? _E
     : never
 
   /**
    * @since 3.9.0
    */
-  export type MakeContext<Make> = Make extends { readonly effect: Effect<infer _A, infer _E, infer _R> } ? _R
-    : Make extends { readonly scoped: Effect<infer _A, infer _E, infer _R> } ? Exclude<_R, Scope.Scope>
+  export type MakeContext<Make> = Make extends
+    { readonly effect: (deps: any) => Effect<infer _A, infer _E, infer _R> } ? _R
+    : Make extends { readonly scoped: (deps: any) => Effect<infer _A, infer _E, infer _R> } ? Exclude<_R, Scope.Scope>
     : never
 
   type Values<T> = T[keyof T]

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -5,13 +5,15 @@ import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import { describe, expect, it } from "effect/test/utils/extend"
 
-class Prefix extends Effect.Service<Prefix>()("Prefix", {}, {
+class Prefix extends Effect.Service<Prefix>()("Prefix", {
+  dependencies: {},
   sync: () => ({
     prefix: "PRE"
   })
 }) {}
 
-class Postfix extends Effect.Service<Postfix>()("Postfix", {}, {
+class Postfix extends Effect.Service<Postfix>()("Postfix", {
+  dependencies: {},
   sync: () => ({
     postfix: "POST"
   })
@@ -20,10 +22,10 @@ class Postfix extends Effect.Service<Postfix>()("Postfix", {}, {
 const messages: Array<string> = []
 
 class Logger extends Effect.Service<Logger>()("Logger", {
-  Postfix,
-  Prefix,
-  Something: Layer.empty
-}, {
+  dependencies: {
+    Prefix,
+    Postfix
+  },
   accessors: true,
   sync: ({ postfix: { postfix }, prefix: { prefix } }) => ({
     info: (message: string) =>
@@ -36,10 +38,11 @@ class Logger extends Effect.Service<Logger>()("Logger", {
 }
 
 class Scoped extends Effect.Service<Scoped>()("Scoped", {
-  Prefix,
-  Postfix
-}, {
   accessors: true,
+  dependencies: {
+    Prefix,
+    Postfix
+  },
   scoped: ({ postfix, prefix }) =>
     Effect.gen(function*() {
       yield* Scope.Scope

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -25,10 +25,10 @@ class Logger extends Effect.Service<Logger>()("Logger", {
   Something: Layer.empty
 }, {
   accessors: true,
-  sync: ({ postfix: { postfix }, prefix: { prefix } }) => ({
+  sync: ({ postfix, prefix }) => ({
     info: (message: string) =>
       Effect.sync(() => {
-        messages.push(`[${prefix}][${message}][${postfix}]`)
+        messages.push(`[${prefix.prefix}][${message}][${postfix.postfix}]`)
       })
   })
 }) {

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -21,8 +21,7 @@ const messages: Array<string> = []
 
 class Logger extends Effect.Service<Logger>()("Logger", {
   Postfix,
-  Prefix,
-  Something: Layer.empty
+  Prefix
 }, {
   accessors: true,
   sync: ({ postfix, prefix }) => ({

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -19,10 +19,7 @@ class Postfix extends Effect.Service<Postfix>()("Postfix", {}, {
 
 const messages: Array<string> = []
 
-class Logger extends Effect.Service<Logger>()("Logger", {
-  Postfix,
-  Prefix
-}, {
+class Logger extends Effect.Service<Logger>()("Logger", { Postfix, Prefix }, {
   accessors: true,
   sync: ({ postfix, prefix }) => ({
     info: (message: string) =>
@@ -34,10 +31,7 @@ class Logger extends Effect.Service<Logger>()("Logger", {
   static Test = Layer.succeed(this, new Logger({ info: () => Effect.void }))
 }
 
-class Scoped extends Effect.Service<Scoped>()("Scoped", {
-  Prefix,
-  Postfix
-}, {
+class Scoped extends Effect.Service<Scoped>()("Scoped", { Prefix, Postfix }, {
   accessors: true,
   scoped: ({ postfix, prefix }) =>
     Effect.gen(function*() {

--- a/packages/effect/test/Effect/service.test.ts
+++ b/packages/effect/test/Effect/service.test.ts
@@ -5,15 +5,13 @@ import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import { describe, expect, it } from "effect/test/utils/extend"
 
-class Prefix extends Effect.Service<Prefix>()("Prefix", {
-  dependencies: {},
+class Prefix extends Effect.Service<Prefix>()("Prefix", {}, {
   sync: () => ({
     prefix: "PRE"
   })
 }) {}
 
-class Postfix extends Effect.Service<Postfix>()("Postfix", {
-  dependencies: {},
+class Postfix extends Effect.Service<Postfix>()("Postfix", {}, {
   sync: () => ({
     postfix: "POST"
   })
@@ -22,10 +20,10 @@ class Postfix extends Effect.Service<Postfix>()("Postfix", {
 const messages: Array<string> = []
 
 class Logger extends Effect.Service<Logger>()("Logger", {
-  dependencies: {
-    Prefix,
-    Postfix
-  },
+  Postfix,
+  Prefix,
+  Something: Layer.empty
+}, {
   accessors: true,
   sync: ({ postfix: { postfix }, prefix: { prefix } }) => ({
     info: (message: string) =>
@@ -38,11 +36,10 @@ class Logger extends Effect.Service<Logger>()("Logger", {
 }
 
 class Scoped extends Effect.Service<Scoped>()("Scoped", {
+  Prefix,
+  Postfix
+}, {
   accessors: true,
-  dependencies: {
-    Prefix,
-    Postfix
-  },
   scoped: ({ postfix, prefix }) =>
     Effect.gen(function*() {
       yield* Scope.Scope


### PR DESCRIPTION
since we combine tags and default layers, we can go one step further and grab and pass the dependent services to the constructors.

NOTE: api is not yet finished, I would suggest we have overloads without dependencies as second argument.

at least I couldn't make it work to infer the dependencies and provide them within the same options object.