### PR TITLE
Equivalence: Fixed a bug related to discriminated tuples

### DIFF
--- a/.changeset/tender-dots-rescue.md
+++ b/.changeset/tender-dots-rescue.md
@@ -1,0 +1,25 @@
+---
+"@effect/schema": patch
+---
+
+Equivalence: Fixed a bug related to discriminated tuples.
+
+Example:
+
+The following equivalence check was incorrectly returning `false`:
+
+```ts
+import * as E from "@effect/schema/Equivalence"
+import * as S from "@effect/schema/Schema"
+
+// Union of discriminated tuples
+const schema = S.Union(
+  S.Tuple(S.Literal("a"), S.String),
+  S.Tuple(S.Literal("b"), S.Number)
+)
+
+const equivalence = E.make(schema)
+
+console.log(equivalence(["a", "x"], ["a", "x"]))
+// false
+```

--- a/packages/schema/src/Equivalence.ts
+++ b/packages/schema/src/Equivalence.ts
@@ -6,7 +6,6 @@ import * as Arr from "effect/Array"
 import * as Equal from "effect/Equal"
 import * as Equivalence from "effect/Equivalence"
 import * as Option from "effect/Option"
-import * as Predicate from "effect/Predicate"
 import * as AST from "./AST.js"
 import * as errors_ from "./internal/errors.js"
 import * as util_ from "./internal/util.js"
@@ -189,7 +188,7 @@ const go = (ast: AST.AST, path: ReadonlyArray<PropertyKey>): Equivalence.Equival
       const len = ownKeys.length
       return Equivalence.make((a, b) => {
         let candidates: Array<AST.AST> = []
-        if (len > 0 && Predicate.isRecord(a)) {
+        if (len > 0 && isRecordOrArray(a)) {
           for (let i = 0; i < len; i++) {
             const name = ownKeys[i]
             const buckets = searchTree.keys[name].buckets
@@ -218,3 +217,6 @@ const go = (ast: AST.AST, path: ReadonlyArray<PropertyKey>): Equivalence.Equival
     }
   }
 }
+
+const isRecordOrArray = (input: unknown): input is { [x: PropertyKey]: unknown } =>
+  typeof input === "object" && input !== null

--- a/packages/schema/test/Equivalence.test.ts
+++ b/packages/schema/test/Equivalence.test.ts
@@ -316,6 +316,22 @@ schema (NeverKeyword): never`)
       expect(equivalence({ tag: "b", b: 1 }, { tag: "b", b: 2 })).toBe(false)
       expect(equivalence({ tag: "a", a: "a" }, { tag: "b", b: 1 })).toBe(false)
     })
+
+    it("discriminated tuples", () => {
+      const schema = S.Union(
+        S.Tuple(S.Literal("a"), S.String),
+        S.Tuple(S.Literal("b"), S.Number)
+      )
+      const equivalence = E.make(schema)
+
+      expect(equivalence(["a", "x"], ["a", "x"])).toBe(true)
+      expect(equivalence(["a", "x"], ["a", "y"])).toBe(false)
+
+      expect(equivalence(["b", 1], ["b", 1])).toBe(true)
+      expect(equivalence(["b", 1], ["b", 2])).toBe(false)
+
+      expect(equivalence(["a", "x"], ["b", 1])).toBe(false)
+    })
   })
 
   describe("tuple", () => {


### PR DESCRIPTION
Example:

The following equivalence check was incorrectly returning `false`:

```ts
import * as E from "@effect/schema/Equivalence"
import * as S from "@effect/schema/Schema"

// Union of discriminated tuples
const schema = S.Union(
  S.Tuple(S.Literal("a"), S.String),
  S.Tuple(S.Literal("b"), S.Number)
)

const equivalence = E.make(schema)

console.log(equivalence(["a", "x"], ["a", "x"]))
// false
```
