### PR TITLE
OpenApi spec securitySchema keys fix

### DIFF
--- a/.changeset/tender-spoons-play.md
+++ b/.changeset/tender-spoons-play.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+A bug related to the format of the security schema keys has been fixed. According to the OpenAPI specification, it must match the regular expression` ^[a-zA-Z0-9.-_]+$`

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -21,7 +21,7 @@
         ],
         "security": [
           {
-            "Authorization/cookie": []
+            "cookie": []
           }
         ],
         "responses": {
@@ -96,7 +96,7 @@
         ],
         "security": [
           {
-            "Authorization/cookie": []
+            "cookie": []
           }
         ],
         "responses": {
@@ -153,7 +153,7 @@
         "parameters": [],
         "security": [
           {
-            "Authorization/cookie": []
+            "cookie": []
           }
         ],
         "responses": {
@@ -242,7 +242,7 @@
         ],
         "security": [
           {
-            "Authorization/cookie": []
+            "cookie": []
           }
         ],
         "responses": {
@@ -538,7 +538,7 @@
       }
     },
     "securitySchemes": {
-      "Authorization/cookie": {
+      "cookie": {
         "type": "apiKey",
         "name": "token",
         "in": "cookie"

--- a/packages/platform/src/OpenApi.ts
+++ b/packages/platform/src/OpenApi.ts
@@ -149,7 +149,7 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
     name: string,
     security: HttpApiSecurity
   ): string {
-    const id = `${tag.key}/${name}`
+    const id = `${tag.key}_${name}`
     if (spec.components!.securitySchemes![id]) {
       return id
     }

--- a/packages/platform/src/OpenApi.ts
+++ b/packages/platform/src/OpenApi.ts
@@ -145,17 +145,14 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
     })
   }
   function registerSecurity(
-    tag: HttpApiMiddleware.TagClassSecurityAny,
     name: string,
     security: HttpApiSecurity
-  ): string {
-    const id = `${tag.key}_${name}`
-    if (spec.components!.securitySchemes![id]) {
-      return id
+  ) {
+    if (spec.components!.securitySchemes![name]) {
+      return
     }
     const scheme = makeSecurityScheme(security)
-    spec.components!.securitySchemes![id] = scheme
-    return id
+    spec.components!.securitySchemes![name] = scheme
   }
   Option.map(Context.getOption(api.annotations, Description), (description) => {
     spec.info.description = description
@@ -174,10 +171,8 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
       return
     }
     for (const [name, security] of Object.entries(middleware.security)) {
-      const id = registerSecurity(middleware, name, security)
-      spec.security!.push({
-        [id]: []
-      })
+      registerSecurity(name, security)
+      spec.security!.push({ [name]: [] })
     }
   })
   HttpApi.reflect(api as any, {
@@ -221,10 +216,8 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
           return
         }
         for (const [name, security] of Object.entries(middleware.security)) {
-          const id = registerSecurity(middleware, name, security)
-          op.security!.push({
-            [id]: []
-          })
+          registerSecurity(name, security)
+          op.security!.push({ [name]: [] })
         }
       })
       endpoint.payloadSchema.pipe(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
A bug related to the format of the security schema keys has been fixed. According to the OpenAPI specification, it must match the regular expression` ^[a-zA-Z0-9.-_]+$`

https://swagger.io/specification/#:~:text=All%20the%20fixed%20fields%20declared%20above%20are%20objects%20that%20MUST%20use%20keys%20that%20match%20the%20regular%20expression%3A%20%5E%5Ba%2DzA%2DZ0%2D9%5C.%5C%2D_%5D%2B%24.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
