### PR TITLE
ensure headers are redacted when inspecting http requests & responses

### DIFF
--- a/.changeset/old-spies-knock.md
+++ b/.changeset/old-spies-knock.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+ensure requests & responses have headers redacted when inspecting

--- a/packages/platform-browser/src/internal/httpClient.ts
+++ b/packages/platform-browser/src/internal/httpClient.ts
@@ -314,25 +314,11 @@ class ClientResponseImpl extends IncomingMessageImpl<Error.ResponseError> implem
   }
 
   toJSON(): unknown {
-    let body: unknown
-    try {
-      body = Effect.runSync(this.json)
-    } catch (_) {
-      //
-    }
-    try {
-      body = body ?? Effect.runSync(this.text)
-    } catch (_) {
-      //
-    }
-    return {
+    return IncomingMessage.inspect(this, {
       _id: "@effect/platform/HttpClientResponse",
       request: this.request.toJSON(),
-      status: this.status,
-      headers: this.headers,
-      remoteAddress: this.remoteAddress.toJSON(),
-      body
-    }
+      status: this.status
+    })
   }
 }
 

--- a/packages/platform/src/HttpIncomingMessage.ts
+++ b/packages/platform/src/HttpIncomingMessage.ts
@@ -5,7 +5,7 @@ import * as Effect from "effect/Effect"
 import * as FiberRef from "effect/FiberRef"
 import { dual } from "effect/Function"
 import * as Global from "effect/GlobalValue"
-import type { Inspectable } from "effect/Inspectable"
+import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
 import type * as ParseResult from "effect/ParseResult"
 import * as Schema from "effect/Schema"
@@ -31,7 +31,7 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category models
  */
-export interface HttpIncomingMessage<E> extends Inspectable {
+export interface HttpIncomingMessage<E> extends Inspectable.Inspectable {
   readonly [TypeId]: TypeId
   readonly headers: Headers.Headers
   readonly remoteAddress: Option.Option<string>
@@ -116,7 +116,7 @@ export const inspect = <E>(self: HttpIncomingMessage<E>, that: object): object =
   }
   const obj: any = {
     ...that,
-    headers: self.headers,
+    headers: Inspectable.redact(self.headers),
     remoteAddress: self.remoteAddress.toJSON()
   }
   if (body !== undefined) {

--- a/packages/platform/src/internal/httpClientRequest.ts
+++ b/packages/platform/src/internal/httpClientRequest.ts
@@ -29,7 +29,7 @@ const Proto = {
       url: this.url,
       urlParams: this.urlParams,
       hash: this.hash,
-      headers: this.headers,
+      headers: Inspectable.redact(this.headers),
       body: this.body.toJSON()
     }
   },

--- a/packages/platform/src/internal/httpServerResponse.ts
+++ b/packages/platform/src/internal/httpServerResponse.ts
@@ -75,7 +75,7 @@ class ServerResponseImpl extends Effectable.StructuralClass<ServerResponse.HttpS
       _id: "@effect/platform/HttpServerResponse",
       status: this.status,
       statusText: this.statusText,
-      headers: this.headers,
+      headers: Inspectable.redact(this.headers),
       cookies: this.cookies.toJSON(),
       body: this.body.toJSON()
     }

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -1,13 +1,14 @@
 import {
   Cookies,
   FetchHttpClient,
+  Headers,
   HttpClient,
   HttpClientRequest,
   HttpClientResponse,
   UrlParams
 } from "@effect/platform"
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Either, Inspectable, Ref, Struct } from "effect"
+import { Either, FiberId, FiberRefs, Inspectable, Ref, Struct } from "effect"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
@@ -199,7 +200,15 @@ describe("HttpClient", () => {
       })
     )
 
-    const r = Inspectable.toStringUnknown(request)
+    const fiberRefs = FiberRefs.unsafeMake(
+      new Map([
+        [
+          Headers.currentRedactedNames,
+          [[FiberId.none, ["Authorization"]] as const]
+        ] as const
+      ])
+    )
+    const r = Inspectable.withRedactableContext(fiberRefs, () => Inspectable.toStringUnknown(request))
     const redacted = JSON.parse(r)
 
     assert.deepStrictEqual(redacted, {

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -7,7 +7,7 @@ import {
   UrlParams
 } from "@effect/platform"
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Either, Ref, Struct } from "effect"
+import { Either, Inspectable, Ref, Struct } from "effect"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
@@ -191,4 +191,25 @@ describe("HttpClient", () => {
       )
       assert.deepStrictEqual(response, { id: 1, userId: 1, title: "delectus aut autem", completed: false })
     }).pipe(Effect.provide(JsonPlaceholderLive)))
+
+  it("ClientRequest redacts headers", () => {
+    const request = HttpClientRequest.get(new URL("https://example.com")).pipe(
+      HttpClientRequest.setHeaders({
+        "authorization": "foobar"
+      })
+    )
+
+    const r = Inspectable.toStringUnknown(request)
+    const redacted = JSON.parse(r)
+
+    assert.deepStrictEqual(redacted, {
+      _id: "@effect/platform/HttpClientRequest",
+      method: "GET",
+      url: "https://example.com/",
+      urlParams: [],
+      hash: { _id: "Option", _tag: "None" },
+      headers: { authorization: "<redacted>" },
+      body: { _id: "@effect/platform/HttpBody", _tag: "Empty" }
+    })
+  })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Follow-up #3777 by redacting HttpClientRequest headers

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

Blocking https://github.com/pingdotgg/uploadthing/pull/993

- Related Issue #
- Closes #
