### PR TITLE
add the literals as their own example when using Schema.Literal

### DIFF
--- a/.changeset/old-radios-unite.md
+++ b/.changeset/old-radios-unite.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+sets the literals themselves as the example annotation when using Schema.Literal

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -604,10 +604,11 @@ const makeLiteralClass = <Literals extends array_.NonEmptyReadonlyArray<AST.Lite
 ): Literal<Literals> =>
   class LiteralClass extends make<Literals[number]>(ast) {
     static override annotations(annotations: Annotations.Schema<Literals[number]>): Literal<Literals> {
-      return makeLiteralClass(this.literals, mergeSchemaAnnotations(this.ast, annotations))
+      return makeLiteralClass(this.literals, mergeSchemaAnnotations(this.ast, { ...annotations, examples: literals }))
     }
     static literals = [...literals] as Literals
   }
+  
 
 /**
  * @category constructors

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -428,7 +428,7 @@ schema (Declaration): DateFromSelf`
         {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "anyOf": [
-            { "enum": [true], "description": "description" },
+            { "enum": [true], "description": "description", examples: [true] },
             {
               "type": "string"
             },
@@ -448,7 +448,7 @@ schema (Declaration): DateFromSelf`
         {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "anyOf": [
-            { "enum": [true], "description": "description" },
+            { "enum": [true], "description": "description", examples: [true] },
             {
               "type": "string"
             },
@@ -469,11 +469,13 @@ schema (Declaration): DateFromSelf`
           "anyOf": [
             {
               "enum": ["foo"],
-              "description": "I'm a foo"
+              "description": "I'm a foo",
+              "examples": ["foo"]
             },
             {
               "enum": ["bar"],
-              "description": "I'm a bar"
+              "description": "I'm a bar",
+              "examples": ["bar"]
             }
           ]
         }
@@ -497,11 +499,13 @@ schema (Declaration): DateFromSelf`
           "$defs": {
             "bar": {
               "enum": ["bar"],
-              "description": "I'm a bar"
+              "description": "I'm a bar",
+              "examples": ["bar"]
             },
             "foo": {
               "enum": ["foo"],
-              "description": "I'm a foo"
+              "description": "I'm a foo",
+              "examples": ["foo"]
             }
           },
           "anyOf": [

--- a/packages/effect/test/Schema/Schema/Literal/Literal.test.ts
+++ b/packages/effect/test/Schema/Schema/Literal/Literal.test.ts
@@ -8,7 +8,8 @@ describe("Literal", () => {
     const schema = S.Literal(1).annotations({ identifier: "X" }).annotations({ title: "Y" })
     expect(schema.ast.annotations).toStrictEqual({
       [AST.IdentifierAnnotationId]: "X",
-      [AST.TitleAnnotationId]: "Y"
+      [AST.TitleAnnotationId]: "Y",
+      [AST.ExamplesAnnotationId]: [1]
     })
   })
 
@@ -29,7 +30,10 @@ describe("Literal", () => {
 
   it("should return the literal interface when using the .annotations() method", () => {
     const schema = S.Literal("a", "b").annotations({ identifier: "literal test" })
-    expect(schema.ast.annotations).toStrictEqual({ [AST.IdentifierAnnotationId]: "literal test" })
+    expect(schema.ast.annotations).toStrictEqual({
+      [AST.IdentifierAnnotationId]: "literal test",
+      [AST.ExamplesAnnotationId]: ["a", "b"]
+    })
     expect(schema.literals).toStrictEqual(["a", "b"])
   })
 

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -390,11 +390,11 @@ schema (Declaration): DateFromSelf`
         ),
         {
           "anyOf": [
-            { "enum": [true], "description": "description" },
+            { "enum": [true], "description": "description", examples: [true] },
             {
               "type": "string"
             },
-            { "enum": [1] }
+            { "enum": [1], examples: [1] }
           ]
         }
       )
@@ -409,11 +409,11 @@ schema (Declaration): DateFromSelf`
         ),
         {
           "anyOf": [
-            { "enum": [true], "description": "description" },
+            { "enum": [true], "description": "description", examples: [true] },
             {
               "type": "string"
             },
-            { "enum": [1, 2] }
+            { "enum": [1, 2], examples: [1, 2] }
           ]
         }
       )
@@ -429,11 +429,13 @@ schema (Declaration): DateFromSelf`
           "anyOf": [
             {
               "enum": ["foo"],
-              "description": "I'm a foo"
+              "description": "I'm a foo",
+              "examples": ["foo"]
             },
             {
               "enum": ["bar"],
-              "description": "I'm a bar"
+              "description": "I'm a bar",
+              "examples": ["bar"]
             }
           ]
         }
@@ -445,11 +447,13 @@ schema (Declaration): DateFromSelf`
         Schema.Union(
           Schema.Literal("foo").annotations({
             description: "I'm a foo",
-            identifier: "foo"
+            identifier: "foo",
+            examples: ["foo"]
           }),
           Schema.Literal("bar").annotations({
             description: "I'm a bar",
-            identifier: "bar"
+            identifier: "bar",
+            examples: ["bar"]
           })
         ),
         {

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -394,7 +394,7 @@ schema (Declaration): DateFromSelf`
             {
               "type": "string"
             },
-            { "enum": [1], examples: [1] }
+            { "enum": [1] }
           ]
         }
       )
@@ -413,7 +413,7 @@ schema (Declaration): DateFromSelf`
             {
               "type": "string"
             },
-            { "enum": [1, 2], examples: [1, 2] }
+            { "enum": [1, 2] }
           ]
         }
       )
@@ -448,23 +448,23 @@ schema (Declaration): DateFromSelf`
           Schema.Literal("foo").annotations({
             description: "I'm a foo",
             identifier: "foo",
-            examples: ["foo"]
           }),
           Schema.Literal("bar").annotations({
             description: "I'm a bar",
             identifier: "bar",
-            examples: ["bar"]
           })
         ),
         {
           "$defs": {
             "bar": {
               "enum": ["bar"],
+              "examples": ["bar"],
               "description": "I'm a bar"
             },
             "foo": {
               "enum": ["foo"],
-              "description": "I'm a foo"
+              "description": "I'm a foo",
+              "examples": ["foo"]
             }
           },
           "anyOf": [


### PR DESCRIPTION
It would be convenient if Schema.Literal set the examples annotation to the literals themselves.

```ts
import { Schema } from "effect";

export class Currency extends Schema.Literal("USD", "EUR").annotations({
  title: "Currency",
  examples: ["USD", "EUR"], // now set automatically
}) {}
``` 