### PR TITLE
Support union of parameters in functions in `Effect.Tag.Proxy` type

### DIFF
--- a/.changeset/four-items-itch.md
+++ b/.changeset/four-items-itch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Support union of parameters in functions in `Effect.Tag.Proxy` type

--- a/packages/effect/dtslint/Effect.ts
+++ b/packages/effect/dtslint/Effect.ts
@@ -5,6 +5,7 @@ import { hole, pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as Schedule from "effect/Schedule"
+import type { Simplify } from "../src/Types.js"
 
 declare const string: Effect.Effect<string, "err-1", "dep-1">
 declare const number: Effect.Effect<number, "err-2", "dep-2">
@@ -1288,3 +1289,55 @@ pipe(
   nonEmptyReadonlyStrings,
   Effect.mapAccum(0, (s, a, i) => Effect.succeed([s + i, a]))
 )
+
+// -------------------------------------------------------------------------------------
+// Tag.Proxy
+// -------------------------------------------------------------------------------------
+
+// $ExpectType {}
+hole<Simplify<Effect.Tag.Proxy<"R", {}>>>()
+
+// $ExpectType { a: () => Effect<1, never, "R">; }
+hole<
+  Simplify<
+    Effect.Tag.Proxy<"R", {
+      a: () => 1
+    }>
+  >
+>()
+
+// $ExpectType { a: (...args: readonly number[]) => Effect<void, never, "R">; }
+hole<
+  Simplify<
+    Effect.Tag.Proxy<"R", {
+      a: (...args: ReadonlyArray<number>) => void
+    }>
+  >
+>()
+
+// $ExpectType { a: (...args: Readonly<[1] | [2, 3]>) => Effect<void, never, "R">; }
+hole<
+  Simplify<
+    Effect.Tag.Proxy<"R", {
+      a: (...args: [1] | [2, 3]) => void
+    }>
+  >
+>()
+
+// $ExpectType { a: (...args: Readonly<[1] | [2, 3]>) => Effect<1, 2, 3 | "R">; }
+hole<
+  Simplify<
+    Effect.Tag.Proxy<"R", {
+      a: (...args: [1] | [2, 3]) => Effect.Effect<1, 2, 3>
+    }>
+  >
+>()
+
+// $ExpectType { a: Effect<[1, "no"], never, "R">; }
+hole<
+  Simplify<
+    Effect.Tag.Proxy<"R", {
+      a: 1
+    }>
+  >
+>()

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6497,14 +6497,19 @@ export declare namespace Tag {
    */
   export type Proxy<Self, Type> = {
     [
-      k in keyof Type as Type[k] extends ((...args: [...infer Args]) => infer Ret) ?
+      k in keyof Type as Type[k] extends ((...args: infer Args extends ReadonlyArray<any>) => infer Ret) ?
         ((...args: Readonly<Args>) => Ret) extends Type[k] ? k : never
         : k
-    ]: Type[k] extends (...args: [...infer Args]) => Effect<infer A, infer E, infer R> ?
+    ]: Type[k] extends (...args: infer Args extends ReadonlyArray<any>) => Effect<infer A, infer E, infer R> ?
       (...args: Readonly<Args>) => Effect<A, E, Self | R>
-      : Type[k] extends (...args: [...infer Args]) => infer A ? (...args: Readonly<Args>) => Effect<A, never, Self>
+      : Type[k] extends (...args: infer Args extends ReadonlyArray<any>) => infer A ?
+        (...args: Readonly<Args>) => Effect<A, never, Self>
       : Type[k] extends Effect<infer A, infer E, infer R> ? Effect<A, E, Self | R>
-      : Effect<Type[k], never, Self>
+      : Effect<
+        Type[k] extends (...args: infer Args extends ReadonlyArray<any>) => any ? [Type[k], Args] : [Type[k], "no"],
+        never,
+        Self
+      >
   }
 }
 

--- a/packages/effect/test/Effect/environment.test.ts
+++ b/packages/effect/test/Effect/environment.test.ts
@@ -27,6 +27,9 @@ class DemoTag extends Effect.Tag("DemoTag")<DemoTag, {
   readonly getNumbers: () => Array<number>
   readonly strings: Array<string>
   readonly fn: (...args: ReadonlyArray<string>) => Array<string>
+  readonly fnParamsUnion: (
+    ...args: ReadonlyArray<string> | [number] | [false, true]
+  ) => ReadonlyArray<string> | [number] | [false, true]
   readonly fnGen: <S>(s: S) => Array<S>
 }>() {
 }
@@ -69,28 +72,32 @@ describe("Effect", () => {
         getNumbers: () => [0, 1],
         strings: ["a", "b"],
         fn: (...args) => Array.from(args),
-        fnGen: (s) => [s]
+        fnGen: (s) => [s],
+        fnParamsUnion: (..._args) => _args
       })))
   })
   it.effect("effect tag", () =>
     Effect.gen(function*($) {
-      const [n, s, z] = yield* $(Effect.all([
+      const [n, s, z, zUnion] = yield* $(Effect.all([
         DemoTag.getNumbers(),
         DemoTag.strings,
-        DemoTag.fn("a", "b", "c")
+        DemoTag.fn("a", "b", "c"),
+        DemoTag.fnParamsUnion(1)
       ]))
       const s2 = yield* $(DemoTag.pipe(Effect.map((_) => _.strings)))
       const s3 = yield* $(DemoTag.use((_) => _.fnGen("hello")))
       expect(n).toEqual([0, 1])
       expect(s).toEqual(["a", "b"])
       expect(z).toEqual(["a", "b", "c"])
+      expect(zUnion).toEqual([1])
       expect(s2).toEqual(["a", "b"])
       expect(s3).toEqual(["hello"])
     }).pipe(Effect.provideService(DemoTag, {
       getNumbers: () => [0, 1],
       strings: ["a", "b"],
       fn: (...args) => Array.from(args),
-      fnGen: (s) => [s]
+      fnGen: (s) => [s],
+      fnParamsUnion: (..._args) => _args
     })))
   it.effect("effect tag with primitives", () =>
     Effect.gen(function*($) {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Problem
```ts
class DemoTag extends Effect.Tag("DemoTag")<DemoTag, {
  readonly fnParamsUnion: (
    ...args: ReadonlyArray<string> | [number] | [false, true]
  ) => number
}>() {
}

DemoTag.fnParamsUnion //  Property 'fnParamsUnion' does not exist on type 'typeof DemoTag'.ts(2339)
```

Fix: 
`[...infer Args]` => `infer Args extends ReadonlyArray<any>`

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
