### PR TITLE
Adds `withClickhouseSettings` to `@effect/sql-clickhouse`

### DIFF
--- a/.changeset/four-lions-heal.md
+++ b/.changeset/four-lions-heal.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-clickhouse": minor
+---
+
+Exposes clickhouse_settings parameter

--- a/packages/sql-clickhouse/examples/basic.ts
+++ b/packages/sql-clickhouse/examples/basic.ts
@@ -33,7 +33,10 @@ Effect.gen(function*() {
 
   yield* sql`SELECT * FROM clickhouse_js_example_cloud_table ORDER BY id`.stream.pipe(
     Stream.runForEach(Effect.log),
-    sql.withQueryId("select")
+    sql.withQueryId("select"),
+    sql.withClickhouseSettings({
+      log_comment: "Some comment to be stored in the query log"
+    })
   )
 }).pipe(
   Effect.provide(ClickhouseLive),

--- a/packages/sql-clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql-clickhouse/src/ClickhouseClient.ts
@@ -53,6 +53,15 @@ export interface ClickhouseClient extends Client.SqlClient {
     (queryId: string): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
     <A, E, R>(effect: Effect.Effect<A, E, R>, queryId: string): Effect.Effect<A, E, R>
   }
+  readonly withClickhouseSettings: {
+    (
+      settings: Clickhouse.BaseQueryParams["clickhouse_settings"]
+    ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+    <A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+      settings: Clickhouse.BaseQueryParams["clickhouse_settings"]
+    ): Effect.Effect<A, E, R>
+  }
 }
 
 /**
@@ -106,13 +115,15 @@ export const make = (
           const method = fiber.getFiberRef(currentClientMethod)
           return Effect.async<Clickhouse.ResultSet<"JSON"> | Clickhouse.CommandResult, SqlError>((resume) => {
             const queryId = fiber.getFiberRef(currentQueryId) ?? Crypto.randomUUID()
+            const settings = fiber.getFiberRef(currentClickhouseSettings) ?? {}
             const controller = new AbortController()
             if (method === "command") {
               this.conn.command({
                 query: sql,
                 query_params: paramsObj,
                 abort_signal: controller.signal,
-                query_id: queryId
+                query_id: queryId,
+                clickhouse_settings: settings
               }).then(
                 (result) => resume(Effect.succeed(result)),
                 (cause) => resume(Effect.fail(new SqlError({ cause, message: "Failed to execute statement" })))
@@ -123,6 +134,7 @@ export const make = (
                 query_params: paramsObj,
                 abort_signal: controller.signal,
                 query_id: queryId,
+                clickhouse_settings: settings,
                 format
               }).then(
                 (result) => resume(Effect.succeed(result)),
@@ -231,28 +243,36 @@ export const make = (
           readonly values: Clickhouse.InsertValues<Readable, T>
           readonly format?: Clickhouse.DataFormat
         }) {
-          return FiberRef.getWith(currentQueryId, (queryId_) =>
-            Effect.async<Clickhouse.InsertResult, SqlError>((resume) => {
-              const queryId = queryId_ ?? Crypto.randomUUID()
-              const controller = new AbortController()
-              client.insert({
-                format: "JSONEachRow",
-                ...options,
-                abort_signal: controller.signal,
-                query_id: queryId
-              }).then(
-                (result) =>
-                  resume(Effect.succeed(result)),
-                (cause) => resume(Effect.fail(new SqlError({ cause, message: "Failed to insert data" })))
-              )
-              return Effect.suspend(() => {
-                controller.abort()
-                return Effect.promise(() => client.command({ query: `KILL QUERY WHERE query_id = '${queryId}'` }))
-              })
-            }))
+          return FiberRef.getWith(currentClickhouseSettings, (settings_) =>
+            FiberRef.getWith(currentQueryId, (queryId_) =>
+              Effect.async<Clickhouse.InsertResult, SqlError>((resume) => {
+                const queryId = queryId_ ?? Crypto.randomUUID()
+                const settings = settings_ ?? {}
+                const controller = new AbortController()
+                client.insert({
+                  format: "JSONEachRow",
+                  ...options,
+                  abort_signal: controller.signal,
+                  query_id: queryId,
+                  clickhouse_settings: settings
+                }).then(
+                  (result) =>
+                    resume(Effect.succeed(result)),
+                  (cause) => resume(Effect.fail(new SqlError({ cause, message: "Failed to insert data" })))
+                )
+                return Effect.suspend(() => {
+                  controller.abort()
+                  return Effect.promise(() => client.command({ query: `KILL QUERY WHERE query_id = '${queryId}'` }))
+                })
+              })))
         },
         withQueryId: dual(2, <A, E, R>(effect: Effect.Effect<A, E, R>, queryId: string) =>
-          Effect.locally(effect, currentQueryId, queryId))
+          Effect.locally(effect, currentQueryId, queryId)),
+        withClickhouseSettings: dual(
+          2,
+          <A, E, R>(effect: Effect.Effect<A, E, R>, settings: Clickhouse.BaseQueryParams["clickhouse_settings"]) =>
+            Effect.locally(effect, currentClickhouseSettings, settings)
+        )
       }
     )
   })
@@ -273,6 +293,17 @@ export const currentClientMethod: FiberRef.FiberRef<"query" | "command" | "inser
 export const currentQueryId: FiberRef.FiberRef<string | undefined> = globalValue(
   "@effect/sql-clickhouse/ClickhouseClient/currentQueryId",
   () => FiberRef.unsafeMake<string | undefined>(undefined)
+)
+
+/**
+ * @category fiber refs
+ * @since 1.0.0
+ */
+export const currentClickhouseSettings: FiberRef.FiberRef<
+  Clickhouse.BaseQueryParams["clickhouse_settings"] | undefined
+> = globalValue(
+  "@effect/sql-clickhouse/ClickhouseClient/currentClickhouseSettings",
+  () => FiberRef.unsafeMake<Clickhouse.BaseQueryParams["clickhouse_settings"] | undefined>(undefined)
 )
 
 /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
Adds the `.withClickhouseSettings` method to `@effect/sql-clickhouse` following the pattern for `.withQueryId` to allow the caller to set per-query settings, like adding a "log_comment" to be stored in the query_log. 

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue https://github.com/Effect-TS/effect/pull/3760/commits/e48be4b2a55b8da55f13ad9ec893e2c8bdfd9843

