### PR TITLE
fix the type signature of `use` in Effect.Service

### DIFF
--- a/.changeset/perfect-buckets-battle.md
+++ b/.changeset/perfect-buckets-battle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix the type signature of `use` in Effect.Service

--- a/packages/effect/dtslint/Effect.ts
+++ b/packages/effect/dtslint/Effect.ts
@@ -1341,3 +1341,12 @@ hole<
     }>
   >
 >()
+
+// $ExpectType { a: () => Effect<1, UnknownException, "R">; }
+hole<
+  Simplify<
+    Effect.Tag.Proxy<"R", {
+      a: () => Promise<1>
+    }>
+  >
+>()

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6834,7 +6834,9 @@ export declare namespace Service {
       }
       readonly use: <X>(
         body: (_: Self) => X
-      ) => X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
+      ) => [X] extends [Effect<infer A, infer E, infer R>] ? Effect<A, E, R | Self>
+        : [X] extends [PromiseLike<infer A>] ? Effect<A, Cause.UnknownException, Self>
+        : Effect<X, never, Self>
       readonly make: (_: MakeService<Make>) => Self
     }
     & Context.Tag<Self, Self>

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6502,6 +6502,8 @@ export declare namespace Tag {
         : k
     ]: Type[k] extends (...args: infer Args extends ReadonlyArray<any>) => Effect<infer A, infer E, infer R> ?
       (...args: Readonly<Args>) => Effect<A, E, Self | R>
+      : Type[k] extends (...args: infer Args extends ReadonlyArray<any>) => Promise<infer A> ?
+        (...args: Readonly<Args>) => Effect<A, Cause.UnknownException, Self>
       : Type[k] extends (...args: infer Args extends ReadonlyArray<any>) => infer A ?
         (...args: Readonly<Args>) => Effect<A, never, Self>
       : Type[k] extends Effect<infer A, infer E, infer R> ? Effect<A, E, Self | R>
@@ -6560,7 +6562,9 @@ export const Tag: <const Id extends string>(id: Id) => <
   & {
     use: <X>(
       body: (_: Type) => X
-    ) => X extends Effect<infer A, infer E, infer R> ? Effect<A, E, R | Self> : Effect<X, never, Self>
+    ) => [X] extends [Effect<infer A, infer E, infer R>] ? Effect<A, E, R | Self>
+      : [X] extends [PromiseLike<infer A>] ? Effect<A, Cause.UnknownException, Self>
+      : Effect<X, never, Self>
   } = (id) => () => {
     const limit = Error.stackTraceLimit
     Error.stackTraceLimit = 2


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Fixing an incorrect type signature for the `use` method. This brings the type signature of `use` in line with `Effect.andThen`.