### PR TITLE
Add jsdoc-examples for class-based APIs

### DIFF
--- a/.changeset/tough-plants-approve.md
+++ b/.changeset/tough-plants-approve.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+jsdoc-examples for class-based APIs have been added, e.g. `Schema.TaggedError`, `Effect.Service` and others

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -393,6 +393,16 @@ export const omit: <Services, S extends Array<ValidTagsById<Services>>>(
   internal.omit
 
 /**
+ * @example
+ * import { Context, Layer } from "effect"
+ *
+ * class MyTag extends Context.Tag("MyTag")<
+ *  MyTag,
+ *  { readonly myNum: number }
+ * >() {
+ *  static Live = Layer.succeed(this, { myNum: 108 })
+ * }
+ *
  * @since 2.0.0
  * @category constructors
  */

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6538,6 +6538,16 @@ const makeTagProxy = (TagClass: Context.Tag<any, any> & Record<PropertyKey, any>
 }
 
 /**
+ * @example
+ * import { Effect, Layer } from "effect"
+ *
+ * class MapTag extends Effect.Tag("MapTag")<MapTag, Map<string, string>>() {
+ *  static Live = Layer.effect(
+ *    this,
+ *    Effect.sync(() => new Map())
+ *  )
+ * }
+ *
  * @since 2.0.0
  * @category context
  */
@@ -6573,6 +6583,27 @@ export const Tag: <const Id extends string>(id: Id) => <
   }
 
 /**
+ * @example
+ * import { Effect } from 'effect';
+ *
+ * class Prefix extends Effect.Service<Prefix>()("Prefix", {
+ *  sync: () => ({ prefix: "PRE" })
+ * }) {}
+ *
+ * class Logger extends Effect.Service<Logger>()("Logger", {
+ *  accessors: true,
+ *  effect: Effect.gen(function* () {
+ *    const { prefix } = yield* Prefix
+ *    return {
+ *      info: (message: string) =>
+ *        Effect.sync(() => {
+ *          messages.push(`[${prefix}][${message}]`)
+ *        })
+ *    }
+ *  }),
+ *  dependencies: [Prefix.Default]
+ * }) {}
+ *
  * @since 3.9.0
  * @category context
  * @experimental might be up for breaking changes

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6597,7 +6597,7 @@ export const Tag: <const Id extends string>(id: Id) => <
  *    return {
  *      info: (message: string) =>
  *        Effect.sync(() => {
- *          messages.push(`[${prefix}][${message}]`)
+ *          console.log(`[${prefix}][${message}]`)
  *        })
  *    }
  *  }),

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7752,6 +7752,26 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
 
   readonly identifier: string
 
+  /**
+   * @example
+   * import { Schema } from "effect"
+   *
+   * class MyClass extends Schema.Class<MyClass>("MyClass")({
+   *  myField: Schema.String
+   * }) {
+   *  myMethod() {
+   *    return this.myField + "my"
+   *  }
+   * }
+   *
+   * class NextClass extends MyClass.extend<NextClass>("NextClass")({
+   *  nextField: Schema.Number
+   * }) {
+   *  nextMethod() {
+   *    return this.myMethod() + this.myField + this.nextField
+   *  }
+   * }
+   */
   extend<Extended = never>(identifier: string): <newFields extends Struct.Fields>(
     fields: newFields | HasFields<newFields>,
     annotations?: Annotations.Schema<Extended>
@@ -7766,6 +7786,33 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
       Proto
     >
 
+  /**
+   * @example
+   * import { Effect, Schema } from "effect"
+   *
+   * class MyClass extends Schema.Class<MyClass>("MyClass")({
+   *   myField: Schema.String
+   * }) {
+   *   myMethod() {
+   *     return this.myField + "my"
+   *   }
+   * }
+   *
+   * class NextClass extends MyClass.transformOrFail<NextClass>("NextClass")({
+   *   nextField: Schema.Number
+   * }, {
+   *   decode: (i) =>
+   *     Effect.succeed({
+   *       myField: i.myField,
+   *       nextField: i.myField.length
+   *     }),
+   *   encode: (a) => Effect.succeed({ myField: a.myField })
+   * }) {
+   *   nextMethod() {
+   *     return this.myMethod() + this.myField + this.nextField
+   *   }
+   * }
+   */
   transformOrFail<Transformed = never>(identifier: string): <
     newFields extends Struct.Fields,
     R2,
@@ -7796,6 +7843,33 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
       Proto
     >
 
+  /**
+   * @example
+   * import { Effect, Schema } from "effect"
+   *
+   * class MyClass extends Schema.Class<MyClass>("MyClass")({
+   *   myField: Schema.String
+   * }) {
+   *   myMethod() {
+   *     return this.myField + "my"
+   *   }
+   * }
+   *
+   * class NextClass extends MyClass.transformOrFailFrom<NextClass>("NextClass")({
+   *   nextField: Schema.Number
+   * }, {
+   *   decode: (i) =>
+   *     Effect.succeed({
+   *       myField: i.myField,
+   *       nextField: i.myField.length
+   *     }),
+   *   encode: (a) => Effect.succeed({ myField: a.myField })
+   * }) {
+   *   nextMethod() {
+   *     return this.myMethod() + this.myField + this.nextField
+   *   }
+   * }
+   */
   transformOrFailFrom<Transformed = never>(identifier: string): <
     newFields extends Struct.Fields,
     R2,
@@ -7846,6 +7920,17 @@ const getFieldsFromFieldsOr = <Fields extends Struct.Fields>(fieldsOr: Fields | 
   isFields(fieldsOr) ? fieldsOr : getFields(fieldsOr)
 
 /**
+ * @example
+ * import { Schema } from "effect"
+ *
+ * class MyClass extends Schema.Class<MyClass>("MyClass")({
+ *  someField: Schema.String
+ * }) {
+ *  someMethod() {
+ *    return this.someField + "bar"
+ *  }
+ * }
+ *
  * @category classes
  * @since 3.10.0
  */
@@ -7895,6 +7980,13 @@ export interface TaggedClass<Self, Tag extends string, Fields extends Struct.Fie
 }
 
 /**
+ * @example
+ * import { Schema } from "effect"
+ *
+ * class MyClass extends Schema.TaggedClass<MyClass>()("MyClass", {
+ *  a: S.String
+ * }) {}
+ *
  * @category classes
  * @since 3.10.0
  */
@@ -7941,6 +8033,21 @@ export interface TaggedErrorClass<Self, Tag extends string, Fields extends Struc
 }
 
 /**
+ * @example
+ * import { Schema } from "effect"
+ *
+ * class MyError extends Schema.TaggedError<MyError>("MyError")(
+ *   "MyError",
+ *   {
+ *     module: Schema.String,
+ *     method: Schema.String,
+ *     description: Schema.String
+ *   }
+ * ) {
+ *   get message(): string {
+ *     return `${this.module}.${this.method}: ${this.description}`
+ *   }
+ * }
  * @category classes
  * @since 3.10.0
  */
@@ -9609,6 +9716,13 @@ export interface TaggedRequestClass<
 }
 
 /**
+ * @example
+ * class MyRequest extends Schema.TaggedRequest<MyRequest>("MyRequest")("MyRequest", {
+ *  failure: Schema.String,
+ *  success: Schema.Number,
+ *  payload: { id: Schema.String }
+ * }) {}
+ *
  * @category classes
  * @since 3.10.0
  */

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7983,7 +7983,7 @@ export interface TaggedClass<Self, Tag extends string, Fields extends Struct.Fie
  * @example
  * import { Schema } from "effect"
  *
- * class MyClass extends Schema.TaggedClass<MyClass>()("MyClass", {
+ * class MyClass extends Schema.TaggedClass<MyClass>("MyClass")("MyClass", {
  *  a: S.String
  * }) {}
  *

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7984,7 +7984,7 @@ export interface TaggedClass<Self, Tag extends string, Fields extends Struct.Fie
  * import { Schema } from "effect"
  *
  * class MyClass extends Schema.TaggedClass<MyClass>("MyClass")("MyClass", {
- *  a: S.String
+ *  a: Schema.String
  * }) {}
  *
  * @category classes
@@ -9717,6 +9717,8 @@ export interface TaggedRequestClass<
 
 /**
  * @example
+ * import { Schema } from "effect"
+ *
  * class MyRequest extends Schema.TaggedRequest<MyRequest>("MyRequest")("MyRequest", {
  *  failure: Schema.String,
  *  success: Schema.Number,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
added examples to jsdoc for the class-based API - each time it makes it difficult to figure out how it should be filled in
Moreover, they are all different from each other


<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
