### PR TITLE
fix `Config.integer` & `Config.number`

### DIFF
--- a/.changeset/many-cows-dress.md
+++ b/.changeset/many-cows-dress.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Config.integer`

--- a/.changeset/many-cows-dress.md
+++ b/.changeset/many-cows-dress.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Config.integer`
+Fix `Config.integer` & `Config.number`

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -243,8 +243,8 @@ export const integer = (name?: string): Config.Config<number> => {
   const config = primitive(
     "an integer property",
     (text) => {
-      const result = Number.parseInt(text, 10)
-      if (Number.isNaN(result)) {
+      const result = Number(text)
+      if (!Number.isInteger(result)) {
         return Either.left(
           configError.InvalidData(
             [],
@@ -424,12 +424,11 @@ export const secret = (name?: string): Config.Config<Secret.Secret> => {
 }
 
 /** @internal */
-export const redacted = (name?: string): Config.Config<Redacted.Redacted> => {
-  const config = primitive(
-    "a redacted property",
-    (text) => Either.right(redacted_.make(text))
-  )
-  return name === undefined ? config : nested(config, name)
+export const redacted = <A>(
+  nameOrConfig?: string | Config.Config<A>
+): Config.Config<Redacted.Redacted<A | string>> => {
+  const config: Config.Config<A | string> = isConfig(nameOrConfig) ? nameOrConfig : string(nameOrConfig)
+  return map(config, redacted_.make)
 }
 
 /** @internal */

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -424,11 +424,12 @@ export const secret = (name?: string): Config.Config<Secret.Secret> => {
 }
 
 /** @internal */
-export const redacted = <A>(
-  nameOrConfig?: string | Config.Config<A>
-): Config.Config<Redacted.Redacted<A | string>> => {
-  const config: Config.Config<A | string> = isConfig(nameOrConfig) ? nameOrConfig : string(nameOrConfig)
-  return map(config, redacted_.make)
+export const redacted = (name?: string): Config.Config<Redacted.Redacted> => {
+  const config = primitive(
+    "a redacted property",
+    (text) => Either.right(redacted_.make(text))
+  )
+  return name === undefined ? config : nested(config, name)
 }
 
 /** @internal */

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -223,7 +223,7 @@ export const number = (name?: string): Config.Config<number> => {
   const config = primitive(
     "a number property",
     (text) => {
-      const result = Number.parseFloat(text)
+      const result = Number(text)
       if (Number.isNaN(result)) {
         return Either.left(
           configError.InvalidData(

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -295,6 +295,12 @@ describe("Config", () => {
       assertSuccess(config, [["key", "1"]], 1)
       assertFailure(
         config,
+        [["key", "1.2"]],
+        // available data but not an integer
+        ConfigError.InvalidData(["key"], "Expected an integer value but received 1.2")
+      )
+      assertFailure(
+        config,
         [["key", "value"]],
         // available data but not an integer
         ConfigError.InvalidData(["key"], "Expected an integer value but received value")

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -91,6 +91,11 @@ describe("Config", () => {
       assertSuccess(config, [["ITEMS", "1"]], [1])
       assertFailure(
         config,
+        [["ITEMS", "123qq"]],
+        ConfigError.InvalidData(["ITEMS"], "Expected a number value but received 123qq")
+      )
+      assertFailure(
+        config,
         [["ITEMS", "value"]],
         ConfigError.InvalidData(["ITEMS"], "Expected a number value but received value")
       )


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

right now `Config.integer` uses `Number.parseInt` to parse a string - which doesn't seem strict enough in such scenarios
```
Config.integer('1.2') -> 1 - defect is expected
Config.integer('1e2') -> 1 - 100 is good enough)
Config.number('123qq') -> 123, but defect is expected
```
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
