### PR TITLE
Fix WebSdk.layer not infering properly due to R and A type args being swapped

### DIFF
--- a/.changeset/hip-needles-smile.md
+++ b/.changeset/hip-needles-smile.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Fix WebSdk.layer not properly infering when passing an evaluate argument of type Effect

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -66,7 +66,7 @@ export const layerTracerProvider = (
  */
 export const layer: {
   (evaluate: LazyArg<Configuration>): Layer.Layer<Resource.Resource>
-  <R, E>(evaluate: Effect.Effect<Configuration, E, R>): Layer.Layer<Resource.Resource, E, R>
+  <E, R>(evaluate: Effect.Effect<Configuration, E, R>): Layer.Layer<Resource.Resource, E, R>
 } = (
   evaluate: LazyArg<Configuration> | Effect.Effect<Configuration, any, any>
 ): Layer.Layer<Resource.Resource> =>

--- a/packages/opentelemetry/src/WebSdk.ts
+++ b/packages/opentelemetry/src/WebSdk.ts
@@ -66,9 +66,9 @@ export const layerTracerProvider = (
  */
 export const layer: {
   (evaluate: LazyArg<Configuration>): Layer.Layer<Resource.Resource>
-  <R, E>(evaluate: Effect.Effect<R, E, Configuration>): Layer.Layer<Resource.Resource, E, R>
+  <R, E>(evaluate: Effect.Effect<Configuration, E, R>): Layer.Layer<Resource.Resource, E, R>
 } = (
-  evaluate: LazyArg<Configuration> | Effect.Effect<any, any, Configuration>
+  evaluate: LazyArg<Configuration> | Effect.Effect<Configuration, any, any>
 ): Layer.Layer<Resource.Resource> =>
   Layer.unwrapEffect(
     Effect.map(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

It looks like `R` and `A` type arguments were not swapped during the major breaking change of the Effect API a few moons ago.
This PR fixes this in `WebSdk.layer` so that inference isn't broken when building a layer when using an Effect.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
