### PR TITLE
Avoid creation of subarray view in Base64.decode

### DIFF
--- a/.changeset/sharp-insects-kneel.md
+++ b/.changeset/sharp-insects-kneel.md
@@ -1,0 +1,11 @@
+---
+"effect": patch
+---
+
+Optimized `Base64.decode` by not capturing the padding characters in the underlying array buffer.
+
+Previously, the implementation first captured the padding characters in the underlying array buffer and
+then returned a new subarray view of the buffer with the padding characters removed.
+
+By not capturing the padding characters, we avoid the creation of another typed array instance for the
+subarray view.

--- a/packages/effect/src/internal/encoding/base64.ts
+++ b/packages/effect/src/internal/encoding/base64.ts
@@ -53,7 +53,7 @@ export const decode = (str: string): Either.Either<Uint8Array, Encoding.DecodeEx
 
   try {
     const missingOctets = stripped.endsWith("==") ? 2 : stripped.endsWith("=") ? 1 : 0
-    const result = new Uint8Array(3 * (length / 4))
+    const result = new Uint8Array(3 * (length / 4) - missingOctets)
     for (let i = 0, j = 0; i < length; i += 4, j += 3) {
       const buffer = getBase64Code(stripped.charCodeAt(i)) << 18 |
         getBase64Code(stripped.charCodeAt(i + 1)) << 12 |
@@ -65,7 +65,7 @@ export const decode = (str: string): Either.Either<Uint8Array, Encoding.DecodeEx
       result[j + 2] = buffer & 0xff
     }
 
-    return Either.right(result.subarray(0, result.length - missingOctets))
+    return Either.right(result)
   } catch (e) {
     return Either.left(
       DecodeException(stripped, e instanceof Error ? e.message : "Invalid input")


### PR DESCRIPTION
@tim-smart It likely doesn't matter much but while we are here ... The outcome is the same but we avoid the creation of an additional typed array instance for the subarray view.