### PR TITLE
Fix broken basic auth base64 decoding

### DIFF
--- a/.changeset/new-squids-exercise.md
+++ b/.changeset/new-squids-exercise.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fixed handling of basic auth header values

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -971,7 +971,7 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
         password: Redacted.make("")
       } as any
       return HttpServerRequest.HttpServerRequest.pipe(
-        Effect.flatMap((request) => Encoding.decodeBase64String(request.headers.authorization ?? "")),
+        Effect.flatMap((request) => Encoding.decodeBase64String(request.headers.authorization?.split(" ")[1] ?? "")),
         Effect.match({
           onFailure: () => empty,
           onSuccess: (header) => {

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -930,6 +930,7 @@ export const middlewareOpenApi = (
   )
 
 const bearerLen = `Bearer `.length
+const basicLen = `Basic `.length
 
 /**
  * @since 1.0.0
@@ -971,7 +972,7 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
         password: Redacted.make("")
       } as any
       return HttpServerRequest.HttpServerRequest.pipe(
-        Effect.flatMap((request) => Encoding.decodeBase64String(request.headers.authorization?.split(" ")[1] ?? "")),
+        Effect.flatMap((request) => Encoding.decodeBase64String((request.headers.authorization ?? "").slice(basicLen))),
         Effect.match({
           onFailure: () => empty,
           onSuccess: (header) => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Basic auth isn't working for the `HttpApiSecurity` as it is currently trying to base 64 decode the whole header which includes the `basic` word resulting in the parsed security credentials to always be empty.

I've quickly added this fix via Github so haven't written any tests or ran it locally but applying this patch to my compiled Effect node_modules fixes the bug. 

Please feel free to commit on-top of this, add tests or close in favour of another solution. 

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue: Haven't made one
- Closes N/A
