### PR TITLE
New methods `extractAll` and `extractSchema` to `UrlParams` (added `Schema.BooleanFromString`)

### DIFF
--- a/.changeset/nervous-months-camp.md
+++ b/.changeset/nervous-months-camp.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform": minor
+"effect": minor
+---
+
+New methods `extractAll` and `extractSchema` to `UrlParams` (added `Schema.BooleanFromString`).

--- a/.changeset/nervous-months-camp.md
+++ b/.changeset/nervous-months-camp.md
@@ -1,5 +1,5 @@
 ---
-"@effect/platform": minor
+"@effect/platform": patch
 "effect": minor
 ---
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -9246,6 +9246,19 @@ export class BooleanFromUnknown extends transform(
 ).annotations({ identifier: "BooleanFromUnknown" }) {}
 
 /**
+ * Converts an `string` value into its corresponding `boolean`
+ * ("true" as `true` and "false" as `false`).
+ *
+ * @category boolean constructors
+ * @since 3.10.0
+ */
+export class BooleanFromString extends transform(
+  String$,
+  Boolean$,
+  { strict: true, decode: (value) => value === "true", encode: (value) => value.toString() }
+).annotations({ identifier: "BooleanFromString" }) {}
+
+/**
  * @category Config validations
  * @since 3.10.0
  */

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -9249,13 +9249,13 @@ export class BooleanFromUnknown extends transform(
  * Converts an `string` value into its corresponding `boolean`
  * ("true" as `true` and "false" as `false`).
  *
- * @category boolean constructors
- * @since 3.10.0
+ * @category boolean transformations
+ * @since 3.11.0
  */
 export class BooleanFromString extends transform(
-  String$,
+  Literal("true", "false"),
   Boolean$,
-  { strict: true, decode: (value) => value === "true", encode: (value) => value.toString() }
+  { strict: true, decode: (value) => value === "true", encode: (value) => value ? "true" : "false" }
 ).annotations({ identifier: "BooleanFromString" }) {}
 
 /**

--- a/packages/effect/test/Schema/Schema/Boolean/BooleanFromString.test.ts
+++ b/packages/effect/test/Schema/Schema/Boolean/BooleanFromString.test.ts
@@ -1,0 +1,16 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("BooleanFromString", () => {
+  const schema = S.BooleanFromString
+  it("decoding", async () => {
+    await Util.expectDecodeUnknownSuccess(schema, "true", true)
+    await Util.expectDecodeUnknownSuccess(schema, "false", false)
+  })
+
+  it("encoding", async () => {
+    await Util.expectEncodeSuccess(schema, true, "true")
+    await Util.expectEncodeSuccess(schema, false, "false")
+  })
+})

--- a/packages/effect/test/Schema/Schema/Boolean/BooleanFromString.test.ts
+++ b/packages/effect/test/Schema/Schema/Boolean/BooleanFromString.test.ts
@@ -7,6 +7,15 @@ describe("BooleanFromString", () => {
   it("decoding", async () => {
     await Util.expectDecodeUnknownSuccess(schema, "true", true)
     await Util.expectDecodeUnknownSuccess(schema, "false", false)
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      "a",
+      `BooleanFromString
+└─ Encoded side transformation failure
+   └─ "true" | "false"
+      ├─ Expected "true", actual "a"
+      └─ Expected "false", actual "a"`
+    )
   })
 
   it("encoding", async () => {

--- a/packages/platform/src/UrlParams.ts
+++ b/packages/platform/src/UrlParams.ts
@@ -94,6 +94,7 @@ export const getAll: {
  *
  * const urlParams = UrlParams.fromInput({ a: 1, b: true, c: "string", e: [1, 2, 3] })
  * const result = UrlParams.extractAll(urlParams)
+ *
  * assert.deepStrictEqual(
  *   result,
  *   { "a": "1", "b": "true", "c": "string", "e": ["1", "2", "3"] }
@@ -264,6 +265,22 @@ export const schemaJson = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: Pa
 }
 
 /**
+ * Extract schema from all key-value pairs in the given `UrlParams`.
+ *
+ * @example
+ * import { UrlParams } from "@effect/platform"
+ *
+ * const urlParams = UrlParams.fromInput({ "a": [10, "string"], "b": false })
+ * const result = yield* UrlParams.extractSchema(Schema.Struct({
+ *   a: Schema.Tuple(Schema.NumberFromString, Schema.String),
+ *   b: Schema.BooleanFromString
+ * }))(urlParams)
+ *
+ * assert.deepStrictEqual(result, {
+ *   a: [10, "string"],
+ *   b: false
+ * })
+ *
  * @since 1.0.0
  * @category schema
  */

--- a/packages/platform/src/UrlParams.ts
+++ b/packages/platform/src/UrlParams.ts
@@ -85,6 +85,39 @@ export const getAll: {
 )
 
 /**
+ * Builds a `Record` containing all the key-value pairs in the given `UrlParams`
+ * as `string` (if only one value for a key) or a `NonEmptyArray<string>`
+ * (when more than one value for a key)
+ *
+ * @example
+ * import { UrlParams } from "@effect/platform"
+ *
+ * const urlParams = UrlParams.fromInput({ a: 1, b: true, c: "string", e: [1, 2, 3] })
+ * const result = UrlParams.extractAll(urlParams)
+ * assert.deepStrictEqual(
+ *   result,
+ *   { "a": "1", "b": "true", "c": "string", "e": ["1", "2", "3"] }
+ * )
+ *
+ * @since 1.0.0
+ * @category combinators
+ */
+export const extractAll = (self: UrlParams): Record<string, string | Arr.NonEmptyArray<string>> => {
+  const out: Record<string, string | Arr.NonEmptyArray<string>> = {}
+  for (const [k, value] of self) {
+    const curr = out[k]
+    if (curr === undefined) {
+      out[k] = value
+    } else if (typeof curr === "string") {
+      out[k] = [curr, value]
+    } else {
+      curr.push(value)
+    }
+  }
+  return out
+}
+
+/**
  * @since 1.0.0
  * @category combinators
  */
@@ -229,3 +262,14 @@ export const schemaJson = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: Pa
     (self: UrlParams, field: string) => Effect.Effect<A, ParseResult.ParseError, R>
   >(2, (self, field) => parse(Option.getOrElse(getLast(self, field), () => "")))
 }
+
+/**
+ * @since 1.0.0
+ * @category schema
+ */
+export const extractSchema =
+  <A, I, R>(schema: Schema.Schema<A, I, R>, options?: ParseOptions | undefined) =>
+  (self: UrlParams): Effect.Effect<A, ParseResult.ParseError, R> => {
+    const parse = Schema.decodeUnknown(schema, options)
+    return parse(extractAll(self))
+  }

--- a/packages/platform/test/UrlParams.test.ts
+++ b/packages/platform/test/UrlParams.test.ts
@@ -1,6 +1,6 @@
 import * as UrlParams from "@effect/platform/UrlParams"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Option } from "effect"
+import { Effect, Option, Schema } from "effect"
 
 describe("UrlParams", () => {
   describe("makeUrl", () => {
@@ -83,5 +83,62 @@ describe("UrlParams", () => {
         ]
       )
     })
+  })
+
+  describe("extractAll", () => {
+    it("works when empty", () => {
+      assert.deepStrictEqual(
+        UrlParams.extractAll(UrlParams.empty),
+        {}
+      )
+    })
+
+    it("builds non empty array from same keys", () => {
+      assert.deepStrictEqual(
+        UrlParams.extractAll(UrlParams.fromInput({ "a": [10, "string", false] })),
+        { a: ["10", "string", "false"] }
+      )
+    })
+
+    it("works with non-strings", () => {
+      const urlParams = UrlParams.fromInput({ a: 1, b: true, c: "string", e: [1, 2, 3] })
+      const result = UrlParams.extractAll(urlParams)
+      assert.deepStrictEqual(
+        result,
+        { "a": "1", "b": "true", "c": "string", "e": ["1", "2", "3"] }
+      )
+    })
+  })
+
+  describe("extractSchema", () => {
+    it.effect("works when empty", () =>
+      Effect.gen(function*() {
+        const result = yield* UrlParams.extractSchema(Schema.Struct({}))(UrlParams.empty)
+        assert.deepStrictEqual(result, {})
+      }))
+
+    it.effect("parse original values", () =>
+      Effect.gen(function*() {
+        const urlParams = UrlParams.fromInput({ "a": [10, "string", false] })
+        const result = yield* UrlParams.extractSchema(Schema.Struct({
+          a: Schema.Tuple(Schema.NumberFromString, Schema.String, Schema.BooleanFromString)
+        }))(urlParams)
+        assert.deepStrictEqual(result, {
+          a: [10, "string", false]
+        })
+      }))
+
+    it.effect("parse multiple keys", () =>
+      Effect.gen(function*() {
+        const urlParams = UrlParams.fromInput({ "a": [10, "string"], "b": false })
+        const result = yield* UrlParams.extractSchema(Schema.Struct({
+          a: Schema.Tuple(Schema.NumberFromString, Schema.String),
+          b: Schema.BooleanFromString
+        }))(urlParams)
+        assert.deepStrictEqual(result, {
+          a: [10, "string"],
+          b: false
+        })
+      }))
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Added `extractAll` and `extractSchema` to `UrlParams`. They allow to extract all key-value pairs from `UrlParams` and validate them using a given `Schema`.

```ts
const urlParams = UrlParams.fromInput({ a: 1, b: true, c: "string", e: [1, 2, 3] })
const result = UrlParams.extractAll(urlParams)
assert.deepStrictEqual(
  result,
  { "a": "1", "b": "true", "c": "string", "e": ["1", "2", "3"] }
)
```

```ts
Effect.gen(function*() {
  const urlParams = UrlParams.fromInput({ "a": [10, "string"], "b": false })
  const result = yield* UrlParams.extractSchema(Schema.Struct({
    a: Schema.Tuple(Schema.NumberFromString, Schema.String),
    b: Schema.BooleanFromString
  }))(urlParams)

  assert.deepStrictEqual(result, {
    a: [10, "string"],
    b: false
  })
}))
```

The PR also added a new `Schema.BooleanFromString` to `Schema`.

## Motivation
When using `searchParams` from frameworks like `next`, I often need to validate the correct shape using a `Schema`. The params have this type:

```ts
type SearchParamsNext = Promise<{ [key: string]: string | string[] | undefined }>;
```

Using `fromInput` + `extractSchema` allows to make sure that the params are valid (or handle a `ParseError` otherwise).