### PR TITLE
Schema: BigDecimal Arbitrary restricted to the range of 0-18

### DIFF
--- a/.changeset/fast-readers-try.md
+++ b/.changeset/fast-readers-try.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Schema.BigDecimal Arbitrary's scale limited to the range 0-18

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7174,7 +7174,8 @@ const bigDecimalPretty = (): pretty_.Pretty<bigDecimal_.BigDecimal> => (val) =>
   `BigDecimal(${bigDecimal_.format(bigDecimal_.normalize(val))})`
 
 const bigDecimalArbitrary = (): LazyArbitrary<bigDecimal_.BigDecimal> => (fc) =>
-  fc.tuple(fc.bigInt(), fc.integer()).map(([value, scale]) => bigDecimal_.make(value, scale))
+  fc.tuple(fc.bigInt(), fc.integer({ min: 0, max: 18 }))
+    .map(([value, scale]) => bigDecimal_.make(value, scale))
 
 /**
  * @category BigDecimal constructors


### PR DESCRIPTION
## Type

- [x] Optimization
- [x] Bug

## Description

In the case of very large scales, the BigDecimal can no longer be formatted into a string, which breaks in the default encoding (if trying to serialize BigDecimal to a string).

this is extremely limting the usecase of the arbitrary as the default Decimal will serialize to a string

Additionally a negative scale is invalid. A decimal cannot have a negative number of decimal points therefore the scale must always be positive or 0 (bug)

