### PR TITLE
allow Stream.split to use refinement for better type inference

### DIFF
--- a/.changeset/warm-meals-pretend.md
+++ b/.changeset/warm-meals-pretend.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
 Allow Stream.split to use refinement for better type inference

--- a/.changeset/warm-meals-pretend.md
+++ b/.changeset/warm-meals-pretend.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Allow Stream.split to use refinement for better type inference

--- a/packages/effect/dtslint/Stream.ts
+++ b/packages/effect/dtslint/Stream.ts
@@ -177,7 +177,7 @@ Stream.dropUntil(numbersOrStrings, Predicate.isNumber)
 pipe(numbersOrStrings, Stream.dropUntil(Predicate.isNumber))
 
 // -------------------------------------------------------------------------------------
-// splitWhere
+// split
 // -------------------------------------------------------------------------------------
 
 // $ExpectType Stream<Chunk<number>, never, never>
@@ -186,10 +186,10 @@ Stream.split(numbers, predicateNumbersOrStrings)
 // $ExpectType Stream<Chunk<number>, never, never>
 pipe(numbers, Stream.split(predicateNumbersOrStrings))
 
-// $ExpectType Stream<Chunk<string | number>, never, never>
+// $ExpectType Stream<Chunk<string>, never, never>
 Stream.split(numbersOrStrings, Predicate.isNumber)
 
-// $ExpectType Stream<Chunk<string | number>, never, never>
+// $ExpectType Stream<Chunk<string>, never, never>
 pipe(numbersOrStrings, Stream.split(Predicate.isNumber))
 
 // -------------------------------------------------------------------------------------

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4567,10 +4567,10 @@ export const someOrFail: {
  */
 export const split: {
   <A, B extends A>(
-    refinement: Refinement<A, B>
+    refinement: Refinement<NoInfer<A>, B>
   ): <E, R>(self: Stream<A, E, R>) => Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
-  <A, E, R, B extends A>(self: Stream<A, E, R>, refinement: Refinement<A, B>): Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
   <A>(predicate: Predicate<NoInfer<A>>): <E, R>(self: Stream<A, E, R>) => Stream<Chunk.Chunk<A>, E, R>
+  <A, E, R, B extends A>(self: Stream<A, E, R>, refinement: Refinement<A, B>): Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
   <A, E, R>(self: Stream<A, E, R>, predicate: Predicate<A>): Stream<Chunk.Chunk<A>, E, R>
 } = internal.split
 

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -4548,7 +4548,7 @@ export const someOrFail: {
 } = internal.someOrFail
 
 /**
- * Splits elements based on a predicate.
+ * Splits elements based on a predicate or refinement.
  *
  * ```ts
  * import * as Stream from "./Stream"
@@ -4566,6 +4566,10 @@ export const someOrFail: {
  * @category utils
  */
 export const split: {
+  <A, B extends A>(
+    refinement: Refinement<A, B>
+  ): <E, R>(self: Stream<A, E, R>) => Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
+  <A, E, R, B extends A>(self: Stream<A, E, R>, refinement: Refinement<A, B>): Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
   <A>(predicate: Predicate<NoInfer<A>>): <E, R>(self: Stream<A, E, R>) => Stream<Chunk.Chunk<A>, E, R>
   <A, E, R>(self: Stream<A, E, R>, predicate: Predicate<A>): Stream<Chunk.Chunk<A>, E, R>
 } = internal.split

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -6189,44 +6189,59 @@ export const slidingSize = dual<
 )
 
 /** @internal */
-export const split = dual<
-  <A>(predicate: Predicate<NoInfer<A>>) => <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Chunk.Chunk<A>, E, R>,
-  <A, E, R>(self: Stream.Stream<A, E, R>, predicate: Predicate<A>) => Stream.Stream<Chunk.Chunk<A>, E, R>
->(2, <A, E, R>(self: Stream.Stream<A, E, R>, predicate: Predicate<A>): Stream.Stream<Chunk.Chunk<A>, E, R> => {
-  const split = (
-    leftovers: Chunk.Chunk<A>,
-    input: Chunk.Chunk<A>
-  ): Channel.Channel<Chunk.Chunk<Chunk.Chunk<A>>, Chunk.Chunk<A>, E, E, unknown, unknown, R> => {
-    const [chunk, remaining] = pipe(leftovers, Chunk.appendAll(input), Chunk.splitWhere(predicate))
-    if (Chunk.isEmpty(chunk) || Chunk.isEmpty(remaining)) {
-      return loop(pipe(chunk, Chunk.appendAll(pipe(remaining, Chunk.drop(1)))))
-    }
-    return pipe(
-      core.write(Chunk.of(chunk)),
-      core.flatMap(() => split(Chunk.empty(), pipe(remaining, Chunk.drop(1))))
-    )
-  }
-  const loop = (
-    leftovers: Chunk.Chunk<A>
-  ): Channel.Channel<Chunk.Chunk<Chunk.Chunk<A>>, Chunk.Chunk<A>, E, E, unknown, unknown, R> =>
-    core.readWith({
-      onInput: (input: Chunk.Chunk<A>) => split(leftovers, input),
-      onFailure: core.fail,
-      onDone: () => {
-        if (Chunk.isEmpty(leftovers)) {
-          return core.void
-        }
-        if (Option.isNone(pipe(leftovers, Chunk.findFirst(predicate)))) {
-          return channel.zipRight(core.write(Chunk.of(leftovers)), core.void)
-        }
-        return channel.zipRight(
-          split(Chunk.empty(), leftovers),
-          core.void
-        )
+export const split: {
+  <A, B extends A>(
+    refinement: Refinement<NoInfer<A>, B>
+  ): <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
+  <A, E, R, B extends A>(
+    self: Stream.Stream<A, E, R>,
+    refinement: Refinement<A, B>
+  ): Stream.Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
+  <A>(
+    predicate: Predicate<NoInfer<A>>
+  ): <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Chunk.Chunk<A>, E, R>
+  <A, E, R>(self: Stream.Stream<A, E, R>, predicate: Predicate<A>): Stream.Stream<Chunk.Chunk<A>, E, R>
+} = dual(
+  2,
+  <A, B extends A, E, R>(
+    self: Stream.Stream<A, E, R>,
+    refinement: Refinement<A, B>
+  ): Stream.Stream<Chunk.Chunk<Exclude<A, B>>, E, R> => {
+    const split = (
+      leftovers: Chunk.Chunk<A>,
+      input: Chunk.Chunk<A>
+    ): Channel.Channel<Chunk.Chunk<Chunk.Chunk<A>>, Chunk.Chunk<A>, E, E, unknown, unknown, R> => {
+      const [chunk, remaining] = pipe(leftovers, Chunk.appendAll(input), Chunk.splitWhere(refinement))
+      if (Chunk.isEmpty(chunk) || Chunk.isEmpty(remaining)) {
+        return loop(pipe(chunk, Chunk.appendAll(pipe(remaining, Chunk.drop(1)))))
       }
-    })
-  return new StreamImpl(pipe(toChannel(self), core.pipeTo(loop(Chunk.empty()))))
-})
+      return pipe(
+        core.write(Chunk.of(chunk)),
+        core.flatMap(() => split(Chunk.empty(), pipe(remaining, Chunk.drop(1))))
+      )
+    }
+    const loop = (
+      leftovers: Chunk.Chunk<A>
+    ): Channel.Channel<Chunk.Chunk<Chunk.Chunk<A>>, Chunk.Chunk<A>, E, E, unknown, unknown, R> =>
+      core.readWith({
+        onInput: (input: Chunk.Chunk<A>) => split(leftovers, input),
+        onFailure: core.fail,
+        onDone: () => {
+          if (Chunk.isEmpty(leftovers)) {
+            return core.void
+          }
+          if (Option.isNone(pipe(leftovers, Chunk.findFirst(refinement)))) {
+            return channel.zipRight(core.write(Chunk.of(leftovers)), core.void)
+          }
+          return channel.zipRight(
+            split(Chunk.empty(), leftovers),
+            core.void
+          )
+        }
+      })
+    return new StreamImpl(pipe(toChannel(self), core.pipeTo(loop(Chunk.empty()))))
+  }
+)
 
 /** @internal */
 export const splitOnChunk = dual<

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -6193,25 +6193,25 @@ export const split: {
   <A, B extends A>(
     refinement: Refinement<NoInfer<A>, B>
   ): <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
+  <A>(
+    predicate: Predicate<NoInfer<A>>
+  ): <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Chunk.Chunk<A>, E, R>
   <A, E, R, B extends A>(
     self: Stream.Stream<A, E, R>,
     refinement: Refinement<A, B>
   ): Stream.Stream<Chunk.Chunk<Exclude<A, B>>, E, R>
-  <A>(
-    predicate: Predicate<NoInfer<A>>
-  ): <E, R>(self: Stream.Stream<A, E, R>) => Stream.Stream<Chunk.Chunk<A>, E, R>
   <A, E, R>(self: Stream.Stream<A, E, R>, predicate: Predicate<A>): Stream.Stream<Chunk.Chunk<A>, E, R>
 } = dual(
   2,
-  <A, B extends A, E, R>(
+  <A, E, R>(
     self: Stream.Stream<A, E, R>,
-    refinement: Refinement<A, B>
-  ): Stream.Stream<Chunk.Chunk<Exclude<A, B>>, E, R> => {
+    predicate: Predicate<A>
+  ): Stream.Stream<Chunk.Chunk<A>, E, R> => {
     const split = (
       leftovers: Chunk.Chunk<A>,
       input: Chunk.Chunk<A>
     ): Channel.Channel<Chunk.Chunk<Chunk.Chunk<A>>, Chunk.Chunk<A>, E, E, unknown, unknown, R> => {
-      const [chunk, remaining] = pipe(leftovers, Chunk.appendAll(input), Chunk.splitWhere(refinement))
+      const [chunk, remaining] = pipe(leftovers, Chunk.appendAll(input), Chunk.splitWhere(predicate))
       if (Chunk.isEmpty(chunk) || Chunk.isEmpty(remaining)) {
         return loop(pipe(chunk, Chunk.appendAll(pipe(remaining, Chunk.drop(1)))))
       }
@@ -6230,7 +6230,7 @@ export const split: {
           if (Chunk.isEmpty(leftovers)) {
             return core.void
           }
-          if (Option.isNone(pipe(leftovers, Chunk.findFirst(refinement)))) {
+          if (Option.isNone(pipe(leftovers, Chunk.findFirst(predicate)))) {
             return channel.zipRight(core.write(Chunk.of(leftovers)), core.void)
           }
           return channel.zipRight(

--- a/packages/effect/test/Stream/splitting.test.ts
+++ b/packages/effect/test/Stream/splitting.test.ts
@@ -90,17 +90,6 @@ describe("Stream", () => {
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
-  it.effect("split - should infer proper types from refinement", () =>
-    Effect.gen(function*($) {
-      const stream = Stream.make(1, "2", 3)
-      const result = yield* $(
-        stream,
-        Stream.split((a: number | string): a is string => typeof a === "string"),
-        Stream.runCollect<Chunk.Chunk<number>, never, never>
-      )
-      assert.deepStrictEqual(Array.from(result).map((chunk) => Array.from(chunk)), [[1], [3]])
-    }))
-
   it.effect("splitOnChunk - consecutive delimiter yields empty Chunk", () =>
     Effect.gen(function*($) {
       const input = Stream.make(

--- a/packages/effect/test/Stream/splitting.test.ts
+++ b/packages/effect/test/Stream/splitting.test.ts
@@ -90,6 +90,17 @@ describe("Stream", () => {
       assert.deepStrictEqual(Array.from(result), [])
     }))
 
+  it.effect("split - should infer proper types from refinement", () =>
+    Effect.gen(function*($) {
+      const stream = Stream.make(1, "2", 3)
+      const result = yield* $(
+        stream,
+        Stream.split((a: number | string): a is string => typeof a === "string"),
+        Stream.runCollect<Chunk.Chunk<number>, never, never>
+      )
+      assert.deepStrictEqual(Array.from(result).map((chunk) => Array.from(chunk)), [[1], [3]])
+    }))
+
   it.effect("splitOnChunk - consecutive delimiter yields empty Chunk", () =>
     Effect.gen(function*($) {
       const input = Stream.make(


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allows `Stream.split()` to take a `Refinement<A, B>` such that the resulting type is  `Stream<Chunk.Chunk<Exclude<A, B>>, E, R>`.

## Related

- Related Issue #3863 
- Closes #3863 
