### PR TITLE
`Data.Error#fromCause` constructor

### DIFF
--- a/.changeset/breezy-dogs-press.md
+++ b/.changeset/breezy-dogs-press.md
@@ -1,0 +1,29 @@
+---
+"effect": minor
+---
+
+`Data.Error#fromCause` and `Data.TaggedError#fromCause` have been added
+`fromCause` takes all constructor options except property with name 'cause'
+and returns function which accept specified type of cause (unknown by default) and created an instantiate the error
+Basically, it is sugar for `(cause) => new MyError({ props: 1, cause })`
+
+```ts
+import { Data } from "Effect"
+
+class MyError extends Data.TaggedError("MyError") {}
+
+class MySecondError extends Data.TaggedError("MySecondError")<{
+  prop: number
+  cause: MyError
+}> {}
+
+MyError.fromCause() // (cause: unknown) => MyError
+MySecondError.fromCause({ prop: 2 }) // (cause: MyError) => MySecondError
+
+Effect.try({
+  try: () => {
+    throw new Error("External Error")
+  },
+  catch: MyError.fromCause()
+}).pipe(Effect.mapError(MySecondError.fromCause({ prop: 2 })))
+```

--- a/packages/effect/dtslint/Data.ts
+++ b/packages/effect/dtslint/Data.ts
@@ -212,6 +212,12 @@ class MyTaggedError extends Data.TaggedError("Foo")<{
 }> {}
 class VoidTaggedError extends Data.TaggedError("Foo") {}
 
+// $ExpectType (cause: unknown) => MyTaggedError
+const myFromCause = MyTaggedError.fromCause({ a: 2 })
+
+// $ExpectType MyTaggedError
+myFromCause(2)
+
 const myTaggedError1 = new MyTaggedError({ message: "Oh no!", a: 1 })
 
 // test optional props
@@ -224,3 +230,21 @@ myTaggedError1.message = "a"
 
 // $ExpectType [args?: void]
 export type VoidTaggedErrorParams = ConstructorParameters<typeof VoidTaggedError>
+
+class MyTaggedWithKnownCauseError extends Data.TaggedError("MyTaggedWithKnownCauseError")<{
+  cause: number
+}> {}
+
+// $ExpectType (cause: number) => MyTaggedWithKnownCauseError
+const myTaggedWithKnownCauseErrorFromCause = MyTaggedWithKnownCauseError.fromCause()
+
+// $ExpectType MyTaggedWithKnownCauseError
+myTaggedWithKnownCauseErrorFromCause(2)
+
+class MyTaggedWithKnownCauseInheritedError extends MyTaggedWithKnownCauseError {}
+
+// $ExpectType (cause: number) => MyTaggedWithKnownCauseInheritedError
+const myTaggedWithKnownCauseInheritedErrorFromCause = MyTaggedWithKnownCauseInheritedError.fromCause()
+
+// $ExpectType MyTaggedWithKnownCauseInheritedError
+myTaggedWithKnownCauseInheritedErrorFromCause(2)

--- a/packages/effect/test/Data.test.ts
+++ b/packages/effect/test/Data.test.ts
@@ -285,12 +285,45 @@ describe("Data", () => {
       const e = new MyError({ message: "Oh no!", a: 1, cause: "Boom" })
       assert.deepStrictEqual(e.toJSON(), { message: "Oh no!", a: 1, cause: "Boom" })
     })
+
+    it("fromCause", () => {
+      class MyError extends Data.Error<{ message: string; a: number; cause: string }> {}
+      const e = MyError.fromCause({ message: "Oh no!", a: 1 })("Boom")
+      assert.instanceOf(e, MyError)
+      assert.deepStrictEqual(e.toJSON(), { message: "Oh no!", a: 1, cause: "Boom" })
+    })
   })
 
   describe("TaggedError", () => {
     it("toJSON includes all args", () => {
       class MyError extends Data.TaggedError("MyError")<{ message: string; a: number; cause: string }> {}
       const e = new MyError({ message: "Oh no!", a: 1, cause: "Boom" })
+      assert.deepStrictEqual(e.toJSON(), {
+        _tag: "MyError",
+        message: "Oh no!",
+        a: 1,
+        cause: "Boom"
+      })
+    })
+    it("fromCause", () => {
+      class MyError extends Data.TaggedError("MyError")<{ message: string; a: number; cause: string }> {}
+      const e = MyError.fromCause({ message: "Oh no!", a: 1 })("Boom")
+      assert.instanceOf(e, MyError)
+      assert.deepStrictEqual(e.toJSON(), {
+        _tag: "MyError",
+        message: "Oh no!",
+        a: 1,
+        cause: "Boom"
+      })
+    })
+    it("fromCause inherits", () => {
+      class MyError extends Data.TaggedError("MyError")<{ message: string; a: number; cause: string }> {}
+
+      class MyError2 extends MyError {}
+
+      const e = MyError2.fromCause({ message: "Oh no!", a: 1 })("Boom")
+      assert.instanceOf(e, MyError)
+      assert.instanceOf(e, MyError2)
       assert.deepStrictEqual(e.toJSON(), {
         _tag: "MyError",
         message: "Oh no!",


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Data.Error#fromCause` and `Data.TaggedError#fromCause` have been added
`fromCause` takes all constructor options except property with name 'cause' and returns function which accepts specified type of cause (unknown by default) and creates an instance of the error.
Basically, it is convenient sugar for `(cause) => new MyError({ props: 1, cause })`.

```ts
import { Data } from "Effect"

class MyError extends Data.Error {}

class MySecondError extends Data.TaggedError("MySecondError")<{
  prop: number
  cause: MyError
}> {}

MyError.fromCause() // (cause: unknown) => MyError
MySecondError.fromCause({ prop: 2 }) // (cause: MyError) => MySecondError

Effect.try({
  try: () => {
    throw new Error("External Error")
  },
  catch: MyError.fromCause()
}).pipe(
  Effect.mapError(
    MySecondError.fromCause({ prop: 2 })
  )
)
```
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
