### PR TITLE
Implement Effect.fn to define traced functions

### DIFF
--- a/.changeset/spicy-adults-hug.md
+++ b/.changeset/spicy-adults-hug.md
@@ -1,0 +1,17 @@
+---
+"effect": minor
+---
+
+Implement Effect.fn to define traced functions.
+
+```ts
+import { Effect } from "effect"
+
+const logExample = Effect.fn("example")(function* <N extends number>(n: N) {
+  yield* Effect.annotateCurrentSpan("n", n)
+  yield* Effect.logInfo(`got: ${n}`)
+  yield* Effect.fail(new Error())
+}, Effect.delay("1 second"))
+
+Effect.runFork(logExample(100).pipe(Effect.catchAllCause(Effect.logError)))
+```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -70,6 +70,7 @@ export default [
       ],
 
       "no-unused-vars": "off",
+      "require-yield": "off",
       "prefer-rest-params": "off",
       "prefer-spread": "off",
       "import/first": "error",

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7192,7 +7192,10 @@ export namespace fn {
  */
 export const fn: (
   name: string,
-  options?: Omit<FunctionWithSpanOptions, "name">
+  options?: {
+    readonly options?: Omit<FunctionWithSpanOptions, "name">
+    readonly captureStackTrace?: boolean | undefined
+  }
 ) => fn.Gen & fn.NonGen = (name, options) =>
 // @ts-ignore
 (body: Function, ...pipeables: Array<any>) => {
@@ -7224,11 +7227,9 @@ export const fn: (
       }
       return res
     }
-    let opts: any
-    if (options) {
-      opts = { captureStackTrace, ...options }
-    } else {
-      opts = { captureStackTrace }
+    let opts: any = options?.captureStackTrace === false ? {} : { captureStackTrace }
+    if (options?.options) {
+      opts = { ...opts, ...options.options }
     }
     return withSpan(
       core.suspend(() => res(...args)),

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7164,7 +7164,9 @@ export namespace fn {
 }
 
 /**
- * Creates a function that returns an Effect which is automatically traced with a span.
+ * Creates a function that returns an Effect which is automatically traced with a span pointing to the call site.
+ *
+ * The function can be created both using a generator function that can yield effects or using a normal function.
  *
  * @since 3.11.0
  * @category function
@@ -7172,7 +7174,7 @@ export namespace fn {
  * @example
  * import { Effect } from "effect"
  *
- * const logExample = Effect.fn("example")(
+ * const logExample = Effect.fn("logExample")(
  *   function*<N extends number>(n: N) {
  *     yield* Effect.annotateCurrentSpan("n", n)
  *     yield* Effect.logInfo(`got: ${n}`)

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7192,10 +7192,7 @@ export namespace fn {
  */
 export const fn: (
   name: string,
-  options?: {
-    readonly options?: Omit<FunctionWithSpanOptions, "name">
-    readonly captureStackTrace?: boolean | undefined
-  }
+  options?: Tracer.SpanOptions
 ) => fn.Gen & fn.NonGen = (name, options) =>
 // @ts-ignore
 (body: Function, ...pipeables: Array<any>) => {
@@ -7227,10 +7224,7 @@ export const fn: (
       }
       return res
     }
-    let opts: any = options?.captureStackTrace === false ? {} : { captureStackTrace }
-    if (options?.options) {
-      opts = { ...opts, ...options.options }
-    }
+    const opts: any = (options && "captureStackTrace" in options) ? options : { captureStackTrace, ...options }
     return withSpan(
       core.suspend(() => res(...args)),
       name,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -59,7 +59,7 @@ import type * as Supervisor from "./Supervisor.js"
 import type * as Tracer from "./Tracer.js"
 import type { Concurrency, Contravariant, Covariant, NoExcessProperties, NoInfer, NotFunction } from "./Types.js"
 import type * as Unify from "./Unify.js"
-import { internalCall, type YieldWrap } from "./Utils.js"
+import { internalCall, isGeneratorFunction, type YieldWrap } from "./Utils.js"
 
 // -------------------------------------------------------------------------------------
 // models
@@ -6927,6 +6927,240 @@ export namespace fn {
     [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect<infer _A, infer E, infer _R>>] ? E : never,
     [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect<infer _A, infer _E, infer R>>] ? R : never
   >
+
+  /**
+   * @since 3.11.0
+   * @category models
+   */
+  export type Gen = {
+    <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>>(
+      body: (...args: Args) => Generator<Eff, AEff, never>
+    ): (...args: Args) => fn.FnEffect<AEff, Eff>
+    <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>, A extends Effect<any, any, any>>(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A
+    ): (...args: Args) => A
+    <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>, A, B extends Effect<any, any, any>>(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B
+    ): (...args: Args) => B
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C
+    ): (...args: Args) => C
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C,
+      D extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C,
+      d: (_: C) => D
+    ): (...args: Args) => D
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C,
+      D,
+      E extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C,
+      d: (_: C) => D,
+      e: (_: D) => E
+    ): (...args: Args) => E
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C,
+      D,
+      E,
+      F extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C,
+      d: (_: C) => D,
+      e: (_: D) => E,
+      f: (_: E) => F
+    ): (...args: Args) => F
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C,
+      D,
+      E,
+      F,
+      G extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C,
+      d: (_: C) => D,
+      e: (_: D) => E,
+      f: (_: E) => F,
+      g: (_: F) => G
+    ): (...args: Args) => G
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C,
+      D,
+      E,
+      F,
+      G,
+      H extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C,
+      d: (_: C) => D,
+      e: (_: D) => E,
+      f: (_: E) => F,
+      g: (_: F) => G,
+      h: (_: G) => H
+    ): (...args: Args) => H
+    <
+      Eff extends YieldWrap<Effect<any, any, any>>,
+      AEff,
+      Args extends Array<any>,
+      A,
+      B,
+      C,
+      D,
+      E,
+      F,
+      G,
+      H,
+      I extends Effect<any, any, any>
+    >(
+      body: (...args: Args) => Generator<Eff, AEff, never>,
+      a: (_: fn.FnEffect<AEff, Eff>) => A,
+      b: (_: A) => B,
+      c: (_: B) => C,
+      d: (_: C) => D,
+      e: (_: D) => E,
+      f: (_: E) => F,
+      g: (_: F) => G,
+      h: (_: G) => H,
+      i: (_: H) => I
+    ): (...args: Args) => I
+  }
+
+  /**
+   * @since 3.11.0
+   * @category models
+   */
+  export type NonGen = {
+    <Eff extends Effect<any, any, any>, Args extends Array<any>>(
+      body: (...args: Args) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, D, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => D,
+      d: (_: D) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, D, E, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => D,
+      d: (_: D) => E,
+      e: (_: E) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, D, E, F, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => D,
+      d: (_: D) => E,
+      e: (_: E) => F,
+      f: (_: E) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, D, E, F, G, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => D,
+      d: (_: D) => E,
+      e: (_: E) => F,
+      f: (_: E) => G,
+      g: (_: G) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, D, E, F, G, H, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => D,
+      d: (_: D) => E,
+      e: (_: E) => F,
+      f: (_: E) => G,
+      g: (_: G) => H,
+      h: (_: H) => Eff
+    ): (...args: Args) => Eff
+    <Eff extends Effect<any, any, any>, A, B, C, D, E, F, G, H, I, Args extends Array<any>>(
+      body: (...args: Args) => A,
+      a: (_: A) => B,
+      b: (_: B) => C,
+      c: (_: C) => D,
+      d: (_: D) => E,
+      e: (_: E) => F,
+      f: (_: E) => G,
+      g: (_: G) => H,
+      h: (_: H) => I,
+      i: (_: H) => Eff
+    ): (...args: Args) => Eff
+  }
 }
 
 /**
@@ -6957,20 +7191,9 @@ export namespace fn {
 export const fn: (
   name: string,
   options?: Omit<FunctionWithSpanOptions, "name">
-) => {
-  <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>>(
-    body: (...args: Args) => Generator<Eff, AEff, never>
-  ): (...args: Args) => fn.FnEffect<AEff, Eff>
-  <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>, A extends Effect<any, any, any>>(
-    body: (...args: Args) => Generator<Eff, AEff, never>,
-    a: (_: fn.FnEffect<AEff, Eff>) => A
-  ): (...args: Args) => A
-  <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>, A, B extends Effect<any, any, any>>(
-    body: (...args: Args) => Generator<Eff, AEff, never>,
-    a: (_: fn.FnEffect<AEff, Eff>) => A,
-    b: (_: A) => B
-  ): (...args: Args) => A
-} = (name, options) => (body: Function, ...pipeables: Array<any>) => {
+) => fn.Gen & fn.NonGen = (name, options) =>
+// @ts-ignore
+(body: Function, ...pipeables: Array<any>) => {
   return function(...args: Array<any>) {
     const limit = Error.stackTraceLimit
     Error.stackTraceLimit = 2
@@ -6991,7 +7214,9 @@ export const fn: (
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
     const res = (...args: Array<any>) => {
-      let res = gen(() => internalCall(() => body.apply(self, args)))
+      let res = isGeneratorFunction(body)
+        ? gen(() => internalCall(() => body.apply(self, args)))
+        : body.apply(self, args)
       for (const x of pipeables) {
         res = x(res)
       }

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7226,18 +7226,14 @@ export const fn: (
         effect = x(effect)
       }
     } catch (error) {
-      effect = fnError ?
-        failCause(internalCause.sequential(
+      effect = fnError
+        ? failCause(internalCause.sequential(
           internalCause.die(fnError),
           internalCause.die(error)
-        )) :
-        die(error)
+        ))
+        : die(error)
     }
     const opts: any = (options && "captureStackTrace" in options) ? options : { captureStackTrace, ...options }
-    return withSpan(
-      effect,
-      name,
-      opts
-    )
+    return withSpan(effect, name, opts)
   }
 }

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -791,3 +791,11 @@ const tracingFunction = (name: string) => {
  * @category tracing
  */
 export const internalCall = tracingFunction("effect_internal_function")
+
+const genConstructor = (function*() {}).constructor
+
+/**
+ * @since 3.11.0
+ */
+export const isGeneratorFunction = (u: unknown): u is (...args: Array<any>) => Generator<any, any, any> =>
+  isObject(u) && u.constructor === genConstructor

--- a/packages/effect/test/Effect/fn.test.ts
+++ b/packages/effect/test/Effect/fn.test.ts
@@ -1,0 +1,62 @@
+import { Cause, Effect } from "effect"
+import { assert, describe, it } from "effect/test/utils/extend"
+
+describe("Effect.fn", () => {
+  it.effect("catches defects in the function", () =>
+    Effect.gen(function*() {
+      let caught: Cause.Cause<never> | undefined
+      const fn = Effect.fn("test")(
+        (): Effect.Effect<void> => {
+          throw new Error("test")
+        },
+        Effect.tapErrorCause((cause) => {
+          caught = cause
+          return Effect.void
+        })
+      )
+      const cause = yield* fn().pipe(
+        Effect.sandbox,
+        Effect.flip
+      )
+      assert(Cause.isDieType(cause))
+      assert.isTrue(cause.defect instanceof Error && cause.defect.message === "test")
+      assert.strictEqual(caught, cause)
+    }))
+
+  it.effect("catches defects in pipeline", () =>
+    Effect.gen(function*() {
+      const fn = Effect.fn("test")(
+        () => Effect.void,
+        (_): Effect.Effect<void> => {
+          throw new Error("test")
+        }
+      )
+      const cause = yield* fn().pipe(
+        Effect.sandbox,
+        Effect.flip
+      )
+      assert(Cause.isDieType(cause))
+      assert.isTrue(cause.defect instanceof Error && cause.defect.message === "test")
+    }))
+
+  it.effect("catches defects in both fn & pipeline", () =>
+    Effect.gen(function*() {
+      const fn = Effect.fn("test")(
+        (): Effect.Effect<void> => {
+          throw new Error("test")
+        },
+        (_): Effect.Effect<void> => {
+          throw new Error("test2")
+        }
+      )
+      const cause = yield* fn().pipe(
+        Effect.sandbox,
+        Effect.flip
+      )
+      assert(Cause.isSequentialType(cause))
+      assert(Cause.isDieType(cause.left))
+      assert(Cause.isDieType(cause.right))
+      assert.isTrue(cause.left.defect instanceof Error && cause.left.defect.message === "test")
+      assert.isTrue(cause.right.defect instanceof Error && cause.right.defect.message === "test2")
+    }))
+})


### PR DESCRIPTION
Allows:

```ts
import { Effect } from "effect"

const logExample = Effect.fn("logExample")(
  function*<N extends number>(n: N) {
    yield* Effect.annotateCurrentSpan("n", n)
    yield* Effect.logInfo(`got: ${n}`)
    yield* Effect.fail(new Error())
  },
  Effect.delay("1 second")
)

Effect.runFork(
  logExample(100).pipe(
    Effect.catchAllCause(Effect.logError)
  )
)
```