### PR TITLE
"format" property in `JSONSchema` and `OpenApiSpec`

### DIFF
--- a/.changeset/small-swans-juggle.md
+++ b/.changeset/small-swans-juggle.md
@@ -3,6 +3,9 @@
 "@effect/platform": patch
 ---
 
-- `JsonSchema` interfaces have been updated
-- added tests that confirm that the field `"format"` is reflected in the final `JSONSchema` and `OpenApi` spec.
-- updated `UUID` schema
+- JSONSchema module
+  - add `format?: string` optional field to `JsonSchema7String` interface
+- Schema module
+  - add custom json schema annotation to `UUID` schema including `format: "uuid"`
+- OpenApiJsonSchema module
+  - add `format?: string` optional field to `String` and ` Numeric` interfaces

--- a/.changeset/small-swans-juggle.md
+++ b/.changeset/small-swans-juggle.md
@@ -1,0 +1,8 @@
+---
+"effect": minor
+"@effect/platform": patch
+---
+
+- `JsonSchema` interfaces have been updated
+- added tests that confirm that the field `"format"` is reflected in the final `JSONSchema` and `OpenApi` spec.
+- updated `UUID` schema

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -97,7 +97,6 @@ export interface JsonSchema7Numeric extends JsonSchemaAnnotations {
   exclusiveMinimum?: number
   maximum?: number
   exclusiveMaximum?: number
-  format?: string
 }
 
 /**

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -85,6 +85,7 @@ export interface JsonSchema7String extends JsonSchemaAnnotations {
   minLength?: number
   maxLength?: number
   pattern?: string
+  format?: string
 }
 
 /**
@@ -96,6 +97,7 @@ export interface JsonSchema7Numeric extends JsonSchemaAnnotations {
   exclusiveMinimum?: number
   maximum?: number
   exclusiveMaximum?: number
+  format?: string
 }
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4525,6 +4525,10 @@ export class UUID extends String$.pipe(
     schemaId: UUIDSchemaId,
     identifier: "UUID",
     title: "UUID",
+    jsonSchema: {
+      format: "uuid",
+      pattern: uuidRegexp.source
+    },
     description: "a Universally Unique Identifier",
     arbitrary: (): LazyArbitrary<string> => (fc) => fc.uuid()
   })

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -1805,11 +1805,16 @@ schema (Suspend): <suspended schema>`
     it("String", () => {
       expectJSONSchema(
         Schema.String.annotations({
-          jsonSchema: { "type": "custom JSON Schema", "description": "description" }
+          jsonSchema: {
+            "type": "custom JSON Schema",
+            "description": "description",
+            "format": "uuid"
+          }
         }),
         {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "custom JSON Schema",
+          "format": "uuid",
           "description": "description"
         },
         false
@@ -1878,6 +1883,20 @@ schema (Suspend): <suspended schema>`
         {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "custom JSON Schema"
+        },
+        false
+      )
+    })
+    it("UUID", () => {
+      expectJSONSchema(
+        Schema.UUID,
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "description": "a Universally Unique Identifier",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "title": "UUID",
+          "type": "string",
+          "format": "uuid"
         },
         false
       )

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -200,6 +200,7 @@ class NoStatusError extends Schema.TaggedClass<NoStatusError>()("NoStatusError",
 
 class User extends Schema.Class<User>("User")({
   id: Schema.Int,
+  uuid: Schema.optional(Schema.UUID),
   name: Schema.String,
   createdAt: Schema.DateTimeUtc
 }) {}

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -8,7 +8,9 @@
   "paths": {
     "/groups/{id}": {
       "get": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "operationId": "groups.findById",
         "parameters": [
           {
@@ -60,7 +62,9 @@
     },
     "/groups": {
       "post": {
-        "tags": ["groups"],
+        "tags": [
+          "groups"
+        ],
         "operationId": "groups.create",
         "parameters": [],
         "security": [],
@@ -104,7 +108,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -120,7 +126,9 @@
     },
     "/users/{id}": {
       "get": {
-        "tags": ["Users API"],
+        "tags": [
+          "Users API"
+        ],
         "operationId": "users.findById",
         "parameters": [
           {
@@ -173,7 +181,9 @@
     },
     "/users": {
       "post": {
-        "tags": ["Users API"],
+        "tags": [
+          "Users API"
+        ],
         "operationId": "users.create",
         "parameters": [
           {
@@ -234,9 +244,18 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
+                    "type": "string"
+                  },
+                  "uuid": {
+                    "description": "a Universally Unique Identifier",
+                    "format": "uuid",
+                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                    "title": "UUID",
                     "type": "string"
                   }
                 },
@@ -318,7 +337,9 @@
     },
     "/users/upload": {
       "post": {
-        "tags": ["Users API"],
+        "tags": [
+          "Users API"
+        ],
         "operationId": "users.upload",
         "parameters": [],
         "security": [
@@ -333,7 +354,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["contentType", "length"],
+                  "required": [
+                    "contentType",
+                    "length"
+                  ],
                   "properties": {
                     "contentType": {
                       "type": "string"
@@ -375,7 +399,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "array",
@@ -409,7 +435,10 @@
     "schemas": {
       "Group": {
         "type": "object",
-        "required": ["id", "name"],
+        "required": [
+          "id",
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -430,13 +459,21 @@
       },
       "HttpApiDecodeError": {
         "type": "object",
-        "required": ["issues", "message", "_tag"],
+        "required": [
+          "issues",
+          "message",
+          "_tag"
+        ],
         "properties": {
           "issues": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["_tag", "path", "message"],
+              "required": [
+                "_tag",
+                "path",
+                "message"
+              ],
               "properties": {
                 "_tag": {
                   "enum": [
@@ -474,7 +511,9 @@
             "type": "string"
           },
           "_tag": {
-            "enum": ["HttpApiDecodeError"]
+            "enum": [
+              "HttpApiDecodeError"
+            ]
           }
         },
         "additionalProperties": false,
@@ -483,10 +522,14 @@
       },
       "GlobalError": {
         "type": "object",
-        "required": ["_tag"],
+        "required": [
+          "_tag"
+        ],
         "properties": {
           "_tag": {
-            "enum": ["GlobalError"]
+            "enum": [
+              "GlobalError"
+            ]
           }
         },
         "additionalProperties": false,
@@ -495,7 +538,11 @@
       },
       "User": {
         "type": "object",
-        "required": ["id", "name", "createdAt"],
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -503,6 +550,13 @@
             "title": "Int"
           },
           "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "description": "a Universally Unique Identifier",
+            "format": "uuid",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            "title": "UUID",
             "type": "string"
           },
           "createdAt": {
@@ -519,10 +573,14 @@
       },
       "UserError": {
         "type": "object",
-        "required": ["_tag"],
+        "required": [
+          "_tag"
+        ],
         "properties": {
           "_tag": {
-            "enum": ["UserError"]
+            "enum": [
+              "UserError"
+            ]
           }
         },
         "additionalProperties": false,
@@ -531,10 +589,14 @@
       },
       "NoStatusError": {
         "type": "object",
-        "required": ["_tag"],
+        "required": [
+          "_tag"
+        ],
         "properties": {
           "_tag": {
-            "enum": ["NoStatusError"]
+            "enum": [
+              "NoStatusError"
+            ]
           }
         },
         "additionalProperties": false,

--- a/packages/platform/src/OpenApiJsonSchema.ts
+++ b/packages/platform/src/OpenApiJsonSchema.ts
@@ -85,6 +85,7 @@ export interface String extends Annotations {
   minLength?: number
   maxLength?: number
   pattern?: string
+  format?: string
   contentEncoding?: string
   contentMediaType?: string
   contentSchema?: JsonSchema
@@ -99,6 +100,7 @@ export interface Numeric extends Annotations {
   exclusiveMinimum?: number
   maximum?: number
   exclusiveMaximum?: number
+  format?: string
 }
 
 /**

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -1823,11 +1823,20 @@ schema (Suspend): <suspended schema>`
     })
 
     it("refinement", () => {
-      expectJSONSchema(Schema.Int.annotations({ jsonSchema: { "type": "custom JSON Schema" } }), {
-        "description": "an integer",
-        "title": "Int",
-        "type": "custom JSON Schema"
-      }, false)
+      expectJSONSchema(
+        Schema.Int.annotations({
+          jsonSchema: {
+            "format": "int32",
+            "type": "custom JSON Schema"
+          }
+        }),
+        {
+          "description": "an integer",
+          "title": "Int",
+          "type": "custom JSON Schema"
+        },
+        false
+      )
     })
 
     it("transformation", () => {

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -1832,6 +1832,7 @@ schema (Suspend): <suspended schema>`
         }),
         {
           "description": "an integer",
+          "format": "int32",
           "title": "Int",
           "type": "custom JSON Schema"
         },

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -1718,10 +1718,11 @@ schema (Suspend): <suspended schema>`
     it("String", () => {
       expectJSONSchema(
         Schema.String.annotations({
-          jsonSchema: { "type": "custom JSON Schema", "description": "description" }
+          jsonSchema: { "type": "custom JSON Schema", "format": "uuid", "description": "description" }
         }),
         {
           "type": "custom JSON Schema",
+          "format": "uuid",
           "description": "description"
         },
         false


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- `JsonSchema` interfaces have been updated
- added tests that confirm that the field `"format"` is reflected in the final `JSONSchema` and `OpenApi` spec.
- updated `UUID` schema

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
