### PR TITLE
add getAlternativeMonoid

### DIFF
--- a/.changeset/odd-bananas-trade.md
+++ b/.changeset/odd-bananas-trade.md
@@ -1,0 +1,5 @@
+---
+"@effect/typeclass": minor
+---
+
+add getAlternativeMonoid

--- a/packages/typeclass/src/Alternative.ts
+++ b/packages/typeclass/src/Alternative.ts
@@ -1,12 +1,36 @@
 /**
  * @since 0.24.0
  */
-import type { TypeLambda } from "effect/HKT"
+import type { Kind, TypeLambda } from "effect/HKT"
+import type { Applicative } from "./Applicative.js"
 import type { Coproduct } from "./Coproduct.js"
+import * as monoid from "./Monoid.js"
 import type { SemiAlternative } from "./SemiAlternative.js"
+import * as semiApplicative from "./SemiApplicative.js"
+import * as semigroup from "./Semigroup.js"
 
 /**
  * @category type class
  * @since 0.24.0
  */
-export interface Alternative<F extends TypeLambda> extends SemiAlternative<F>, Coproduct<F> {}
+export interface Alternative<F extends TypeLambda> extends Applicative<F>, SemiAlternative<F>, Coproduct<F> {}
+
+/**
+ * @category lifting
+ * @since 0.30.0
+ */
+export const getAlternativeMonoid = <F extends TypeLambda>(
+  F: Alternative<F>
+) => {
+  const f = semiApplicative.getSemigroup(F)
+  return <R, O, E, A>(S: semigroup.Semigroup<A>) => {
+    const SF = f<A, R, O, E>(S)
+    return monoid.fromSemigroup(
+      semigroup.make(
+        (first: Kind<F, R, O, E, A>, second: Kind<F, R, O, E, A>) =>
+          F.coproduct(SF.combine(first, second), F.coproduct(first, second))
+      ),
+      F.zero()
+    )
+  }
+}

--- a/packages/typeclass/src/data/Option.ts
+++ b/packages/typeclass/src/data/Option.ts
@@ -224,6 +224,10 @@ export const SemiAlternative: semiAlternative.SemiAlternative<Option.OptionTypeL
 export const Alternative: alternative.Alternative<Option.OptionTypeLambda> = {
   map,
   imap,
+  of,
+  product,
+  productMany,
+  productAll,
   coproduct,
   coproductMany,
   coproductAll,

--- a/packages/typeclass/test/Alternative.test.ts
+++ b/packages/typeclass/test/Alternative.test.ts
@@ -1,0 +1,17 @@
+import * as alternative from "@effect/typeclass/Alternative"
+import * as NumberInstances from "@effect/typeclass/data/Number"
+import * as OptionInstances from "@effect/typeclass/data/Option"
+import * as Option from "effect/Option"
+import { describe, it } from "vitest"
+import * as Util from "./util.js"
+
+describe.concurrent("Alternative", () => {
+  it("getAlternativeMonoid", () => {
+    const liftMonoid = alternative.getAlternativeMonoid(OptionInstances.Alternative)
+    const M = liftMonoid(NumberInstances.MonoidSum)
+    Util.deepStrictEqual(M.combine(Option.some(1), Option.some(2)), Option.some(3))
+    Util.deepStrictEqual(M.combine(Option.some(1), Option.none()), Option.some(1))
+    Util.deepStrictEqual(M.combine(Option.none(), Option.some(2)), Option.some(2))
+    Util.deepStrictEqual(M.combine(Option.none(), Option.none()), Option.none())
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the `getAlternativeMonoid` combinator for constructing monoid instances from alternative instances. It combines inner values using a provided semigroup, defaulting to the non-empty value when one side is empty.