### PR TITLE
docs: fix incorrect usage of PgClient.layer in sql README

### DIFF
--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -33,7 +33,7 @@ Alternatively, you can also create the `SqlLive` layer using the `PgClient.layer
 import { Config } from "effect"
 import { PgClient } from "@effect/sql-pg"
 
-const SqlLive = PgClient.layer({
+const SqlLive = PgClient.layerConfig({
   database: Config.string("DATABASE")
 })
 ```


### PR DESCRIPTION
## Type

- [x] Documentation Update

## Description

Fixes an error in the sql README where `PgClient.layer` was used instead of `PgClient.layerConfig`.

**Change:**
- Replaced `PgClient.layer{` with `PgClient.layerConfig({` to match the correct syntax.

This fix should help new users avoid errors during configuration.
