### PR TITLE
Remove `Omit` from `Class` to align type signatures with runtime beha…

### DIFF
--- a/.changeset/wet-ladybugs-relax.md
+++ b/.changeset/wet-ladybugs-relax.md
@@ -1,0 +1,49 @@
+---
+"effect": patch
+---
+
+Remove `Omit` from the `Class` interface definition to align type signatures with runtime behavior. This fix addresses the issue of being unable to override base class methods in extended classes without encountering type errors, closes #3958
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+class Base extends Schema.Class<Base>("Base")({
+  a: Schema.String
+}) {
+  f() {
+    console.log("base")
+  }
+}
+
+class Extended extends Base.extend<Extended>("Extended")({}) {
+  // Class '{ readonly a: string; } & Omit<Base, "a">' defines instance member property 'f',
+  // but extended class 'Extended' defines it as instance member function.ts(2425)
+  // @ts-expect-error
+  override f() {
+    console.log("extended")
+  }
+}
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+class Base extends Schema.Class<Base>("Base")({
+  a: Schema.String
+}) {
+  f() {
+    console.log("base")
+  }
+}
+
+class Extended extends Base.extend<Extended>("Extended")({}) {
+  // ok
+  override f() {
+    console.log("extended")
+  }
+}
+```

--- a/packages/effect/dtslint/SchemaClass.ts
+++ b/packages/effect/dtslint/SchemaClass.ts
@@ -217,3 +217,87 @@ export class FromRefinement
 export class FromDoubleRefinement extends S.Class<FromDoubleRefinement>("FromDoubleRefinement")(
   S.Struct({ a: S.String }).pipe(S.filter(() => true), S.filter(() => true))
 ) {}
+
+// ---------------------------------------------
+// users can override an instance member property
+// ---------------------------------------------
+
+class OverrideBase1 extends S.Class<OverrideBase1>("OverrideBase1")(S.Struct({
+  a: S.String
+})) {
+  readonly b: number = 1
+}
+
+class OverrideExtended1 extends OverrideBase1.extend<OverrideExtended1>(
+  "OverrideExtended1"
+)({
+  c: S.String
+}) {
+  override readonly b = 2
+}
+
+// $ExpectType 2
+new OverrideExtended1({ a: "a", c: "c" }).b
+
+// ---------------------------------------------
+// users can override an instance member function
+// ---------------------------------------------
+
+class OverrideBase2 extends S.Class<OverrideBase2>("OverrideBase2")(S.Struct({
+  a: S.String
+})) {
+  b(): number {
+    return 1
+  }
+}
+
+class OverrideExtended2 extends OverrideBase2.extend<OverrideExtended2>(
+  "OverrideExtended2"
+)({
+  c: S.String
+}) {
+  override b(): 2 {
+    return 2
+  }
+}
+
+// $ExpectType 2
+new OverrideExtended2({ a: "a", c: "c" }).b()
+
+// ---------------------------------------------
+// users can override a field with an instance member property
+// ---------------------------------------------
+
+class OverrideBase3 extends S.Class<OverrideBase3>("OverrideBase3")(S.Struct({
+  a: S.String
+})) {}
+
+class OverrideExtended3 extends OverrideBase3.extend<OverrideExtended3>(
+  "OverrideExtended3"
+)({
+  c: S.String
+}) {
+  override readonly a = "default"
+}
+
+// $ExpectType "default"
+new OverrideExtended3({ a: "a", c: "c" }).a
+
+// ---------------------------------------------
+// users can't override an instance member property with a field
+// ---------------------------------------------
+
+class OverrideBase4 extends S.Class<OverrideBase4>("OverrideBase4")(S.Struct({
+  a: S.String
+})) {
+  readonly b = 1
+}
+
+class OverrideExtended4 extends OverrideBase4.extend<OverrideExtended4>(
+  "OverrideExtended4"
+)({
+  b: S.Number
+}) {}
+
+// $ExpectType 1
+new OverrideExtended4({ a: "a", b: 2 }).b

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7740,7 +7740,7 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
   new(
     props: RequiredKeys<C> extends never ? void | Simplify<C> : Simplify<C>,
     options?: MakeOptions
-  ): Struct.Type<Fields> & Omit<Inherited, keyof Fields> & Proto
+  ): Struct.Type<Fields> & Inherited & Proto
 
   /** @since 3.10.0 */
   readonly ast: AST.Transformation

--- a/packages/effect/test/Schema/Schema/Class/extend.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/extend.test.ts
@@ -118,4 +118,76 @@ describe("extend", () => {
     expect(b.a()).toEqual("1a")
     expect(b.b()).toEqual("1b")
   })
+
+  it("users can override an instance member property", () => {
+    class OverrideBase1 extends S.Class<OverrideBase1>("OverrideBase1")(S.Struct({
+      a: S.String
+    })) {
+      readonly b: number = 1
+    }
+
+    class OverrideExtended1 extends OverrideBase1.extend<OverrideExtended1>(
+      "OverrideExtended1"
+    )({
+      c: S.String
+    }) {
+      override readonly b = 2
+    }
+
+    expect(new OverrideExtended1({ a: "a", c: "c" }).b).toEqual(2)
+  })
+
+  it("users can override an instance member function", () => {
+    class OverrideBase2 extends S.Class<OverrideBase2>("OverrideBase2")(S.Struct({
+      a: S.String
+    })) {
+      b(): number {
+        return 1
+      }
+    }
+
+    class OverrideExtended2 extends OverrideBase2.extend<OverrideExtended2>(
+      "OverrideExtended2"
+    )({
+      c: S.String
+    }) {
+      override b(): 2 {
+        return 2
+      }
+    }
+
+    expect(new OverrideExtended2({ a: "a", c: "c" }).b()).toEqual(2)
+  })
+
+  it("users can override a field with an instance member property", () => {
+    class OverrideBase3 extends S.Class<OverrideBase3>("OverrideBase3")(S.Struct({
+      a: S.String
+    })) {}
+
+    class OverrideExtended3 extends OverrideBase3.extend<OverrideExtended3>(
+      "OverrideExtended3"
+    )({
+      c: S.String
+    }) {
+      override readonly a = "default"
+    }
+
+    expect(new OverrideExtended3({ a: "a", c: "c" }).a).toEqual("default")
+  })
+
+  it("users can't override an instance member property with a field", () => {
+    class OverrideBase4 extends S.Class<OverrideBase4>("OverrideBase4")(S.Struct({
+      a: S.String
+    })) {
+      readonly b = 1
+    }
+
+    class OverrideExtended4 extends OverrideBase4.extend<OverrideExtended4>(
+      "OverrideExtended4"
+    )({
+      b: S.Number
+    }) {}
+
+    expect(new OverrideExtended4({ a: "a", b: 2 }).b).toEqual(1)
+  })
 })


### PR DESCRIPTION
…vior and fix method overriding issues in extended classes, closes #3958