### PR TITLE
allow setting a custom Redacted.toString

### DIFF
--- a/.changeset/short-monkeys-compete.md
+++ b/.changeset/short-monkeys-compete.md
@@ -1,0 +1,13 @@
+---
+"effect": minor
+---
+
+allow users to provide a custom name for Redacted values on creation
+
+```ts
+Redacted.make("1234567890", "API_KEY")
+```
+
+example logged output:
+
+level=INFO msg="permission granted" user=Perry token=API_KEY

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -65,12 +65,12 @@ export const isRedacted: (u: unknown) => u is Redacted<unknown> = redacted_.isRe
  * @example
  * import { Redacted } from "effect"
  *
- * const API_KEY = Redacted.make("1234567890")
+ * const API_KEY = Redacted.make("1234567890", "API_KEY")
  *
  * @since 3.3.0
  * @category constructors
  */
-export const make: <A>(value: A) => Redacted<A> = redacted_.make
+export const make: <A>(value: A, str?: string) => Redacted<A> = redacted_.make
 
 /**
  * Retrieves the original value from a `Redacted` instance. Use this function

--- a/packages/effect/src/internal/redacted.ts
+++ b/packages/effect/src/internal/redacted.ts
@@ -48,17 +48,16 @@ export const isRedacted = (u: unknown): u is Redacted.Redacted<unknown> => hasPr
 export const make = <T>(value: T, str = "<redacted>"): Redacted.Redacted<T> => {
   const redacted = Object.create({
     ...proto,
-      toString() {
-        return str
-      },
-      toJSON() {
-        return str
-      },
-      [NodeInspectSymbol]() {
-        return str
-      },
+    toString() {
+      return str
+    },
+    toJSON() {
+      return str
+    },
+    [NodeInspectSymbol]() {
+      return str
     }
-  )
+  })
   redactedRegistry.set(redacted, value)
   return redacted
 }

--- a/packages/effect/src/internal/redacted.ts
+++ b/packages/effect/src/internal/redacted.ts
@@ -29,15 +29,6 @@ export const proto = {
   pipe() {
     return pipeArguments(this, arguments)
   },
-  toString() {
-    return "<redacted>"
-  },
-  toJSON() {
-    return "<redacted>"
-  },
-  [NodeInspectSymbol]() {
-    return "<redacted>"
-  },
   [Hash.symbol]<T>(this: Redacted.Redacted<T>): number {
     return pipe(
       Hash.hash(RedactedSymbolKey),
@@ -54,8 +45,20 @@ export const proto = {
 export const isRedacted = (u: unknown): u is Redacted.Redacted<unknown> => hasProperty(u, RedactedTypeId)
 
 /** @internal */
-export const make = <T>(value: T): Redacted.Redacted<T> => {
-  const redacted = Object.create(proto)
+export const make = <T>(value: T, str = "<redacted>"): Redacted.Redacted<T> => {
+  const redacted = Object.create({
+    ...proto,
+      toString() {
+        return str
+      },
+      toJSON() {
+        return str
+      },
+      [NodeInspectSymbol]() {
+        return str
+      },
+    }
+  )
   redactedRegistry.set(redacted, value)
   return redacted
 }

--- a/packages/effect/test/Redacted.test.ts
+++ b/packages/effect/test/Redacted.test.ts
@@ -29,9 +29,19 @@ describe("Redacted", () => {
     assert.strictEqual(`${redacted}`, "<redacted>")
   })
 
+  it("toString - custom string", () => {
+    const redacted = Redacted.make("redacted", "API_KEY")
+    assert.strictEqual(`${redacted}`, "API_KEY")
+  })
+
   it("toJSON", () => {
     const redacted = Redacted.make("redacted")
     assert.strictEqual(JSON.stringify(redacted), "\"<redacted>\"")
+  })
+
+  it("toJSON - custom string", () => {
+    const redacted = Redacted.make("redacted", "API_KEY")
+    assert.strictEqual(JSON.stringify(redacted), "\"API_KEY\"")
   })
 
   it("unsafeWipe", () => {

--- a/packages/platform/test/Headers.test.ts
+++ b/packages/platform/test/Headers.test.ts
@@ -111,7 +111,7 @@ describe("Headers", () => {
 
       assert.deepEqual(redacted, {
         "content-type": "application/json",
-        "authorization": Redacted.make("some secret"),
+        "authorization": redacted.authorization,
         "x-api-key": "some-key"
       })
       assert.strictEqual(Redacted.value(redacted.authorization as Redacted.Redacted), "Bearer some-token")
@@ -128,8 +128,8 @@ describe("Headers", () => {
 
       assert.deepEqual(redacted, {
         "content-type": "application/json",
-        "authorization": Redacted.make("some secret"),
-        "x-api-key": Redacted.make("some secret")
+        "authorization": redacted.authorization,
+        "x-api-key": redacted["x-api-key"]
       })
       assert.strictEqual(Redacted.value(redacted.authorization as Redacted.Redacted), "Bearer some-token")
       assert.strictEqual(Redacted.value(redacted["x-api-key"] as Redacted.Redacted), "some-key")
@@ -146,8 +146,8 @@ describe("Headers", () => {
 
       assert.deepEqual(redacted, {
         "authorization": "Bearer some-token",
-        "sec-ret": Redacted.make("some"),
-        "sec-ret-2": Redacted.make("some")
+        "sec-ret": redacted["sec-ret"],
+        "sec-ret-2": redacted["sec-ret-2"]
       })
     })
   })


### PR DESCRIPTION
Allow setting a custom string when creating redacted values e.g. "REDACTED_TOKEN" which is logged as:

`level=INFO msg="permission granted" user=Perry token=REDACTED_TOKEN`

```ts
Redacted.make("abc", "REDACTED_TOKEN")
```

This is useful for keeping tract of redacted values between log statements and is a feature provided by a few other logging libraries. 