### PR TITLE
`OpenApi.Transform` annotation

### DIFF
--- a/.changeset/chilly-jars-sing.md
+++ b/.changeset/chilly-jars-sing.md
@@ -1,0 +1,21 @@
+---
+"@effect/platform": patch
+---
+
+`OpenApi.Transform` annotation has been added
+
+This customization point allows you to transform the generated specification in an arbitrary way
+
+```ts
+class Api extends HttpApi.empty
+  .annotateContext(OpenApi.annotations({
+    title: "API",
+    summary: "test api summary",
+    transform: (openApiSpec) => ({
+      ...openApiSpec,
+      tags: [...openApiSpec.tags ?? [], {
+        name: "Tag from OpenApi.Transform annotation"
+      }]
+    })
+  }))
+```

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -304,7 +304,16 @@ class Api extends HttpApi.empty
   .addHttpApi(AnotherApi)
   .add(UsersApi.prefix("/users"))
   .addError(GlobalError, { status: 413 })
-  .annotateContext(OpenApi.annotations({ title: "API", summary: "test api summary" }))
+  .annotateContext(OpenApi.annotations({
+    title: "API",
+    summary: "test api summary",
+    transform: (openApiSpec) => ({
+      ...openApiSpec,
+      tags: [...openApiSpec.tags ?? [], {
+        name: "Tag from OpenApi.Transform annotation"
+      }]
+    })
+  }))
   .annotate(
     HttpApi.AdditionalSchemas,
     [

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -422,6 +422,9 @@
     },
     {
       "name": "Users API"
+    },
+    {
+      "name": "Tag from OpenApi.Transform annotation"
     }
   ],
   "components": {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`OpenApi.Transform` annotation has been added

This customization point allows you to transform the generated specification in an arbitrary way

```ts
class Api extends HttpApi.empty
  .annotateContext(OpenApi.annotations({
    title: "API",
    summary: "test api summary",
    transform: (openApiSpec) => ({
      ...openApiSpec,
      tags: [...openApiSpec.tags ?? [], {
        name: "Tag from OpenApi.Transform annotation"
      }]
    })
  }))
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue https://github.com/Effect-TS/effect/issues/3952 
   this particular case is solved with the help of `AdditionalSchemas` annotation, but `OpenApi.Transform` can be useful in some unpredictable cases
- Closes #
