### PR TITLE
`HttpApiClient.group` & `HttpApiClient.endpoint`

### DIFF
--- a/.changeset/chilled-mangos-sparkle.md
+++ b/.changeset/chilled-mangos-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform": patch
+---
+
+`HttpApiClient.group` & `HttpApiClient.endpoint` have been added
+This makes it possible to create `HttpApiClient` for some part of the `HttpApi`
+This eliminates the need to provide all the dependencies for the entire `HttpApi` - but only those necessary for its specific part to work

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -24,18 +24,42 @@ describe("HttpApi", () => {
   describe("payload", () => {
     it.effect("is decoded / encoded", () =>
       Effect.gen(function*() {
+        const expected = new User({
+          id: 123,
+          name: "Joe",
+          createdAt: DateTime.unsafeMake(0)
+        })
         const client = yield* HttpApiClient.make(Api)
-        const user = yield* client.users.create({
+        const clientUsersGroup = yield* HttpApiClient.group(Api, "users")
+        const clientUsersEndpointCreate = yield* HttpApiClient.endpoint(
+          Api,
+          "users",
+          "create"
+        )
+
+        const apiClientUser = yield* client.users.create({
           urlParams: { id: 123 },
           payload: { name: "Joe" }
         })
         assert.deepStrictEqual(
-          user,
-          new User({
-            id: 123,
-            name: "Joe",
-            createdAt: DateTime.unsafeMake(0)
-          })
+          apiClientUser,
+          expected
+        )
+        const groupClientUser = yield* clientUsersGroup.create({
+          urlParams: { id: 123 },
+          payload: { name: "Joe" }
+        })
+        assert.deepStrictEqual(
+          groupClientUser,
+          expected
+        )
+        const endpointClientUser = yield* clientUsersEndpointCreate({
+          urlParams: { id: 123 },
+          payload: { name: "Joe" }
+        })
+        assert.deepStrictEqual(
+          endpointClientUser,
+          expected
         )
       }).pipe(Effect.provide(HttpLive)))
 

--- a/packages/platform/dtslint/HttpApiClient.ts
+++ b/packages/platform/dtslint/HttpApiClient.ts
@@ -1,0 +1,127 @@
+import { HttpApi, HttpApiClient, HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware } from "@effect/platform"
+import type { Schema } from "effect"
+import { Effect } from "effect"
+
+declare const ApiError: Schema.Schema<"ApiError", "ApiErrorEncoded", "ApiErrorR">
+
+declare const Group1Error: Schema.Schema<"Group1Error", "Group1ErrorEncoded", "Group1ErrorR">
+declare const EndpointAError: Schema.Schema<"EndpointAError", "EndpointAErrorEncoded", "EndpointAErrorR">
+declare const EndpointASuccess: Schema.Schema<"EndpointASuccess", "EndpointASuccessEncoded", "EndpointASuccessR">
+declare const EndpointBError: Schema.Schema<"EndpointBError", "EndpointBErrorEncoded", "EndpointBErrorR">
+declare const EndpointBSuccess: Schema.Schema<"EndpointBSuccess", "EndpointBSuccessEncoded", "EndpointBSuccessR">
+
+declare const EndpointASecurityError: Schema.Schema<
+  "EndpointASecurityError",
+  "EndpointASecurityErrorEncoded",
+  "EndpointASecurityErrorR"
+>
+class EndpointASecurity extends HttpApiMiddleware.Tag<EndpointASecurity>()("EndpointASecurity", {
+  failure: EndpointASecurityError
+}) {}
+declare const EndpointBSecurityError: Schema.Schema<
+  "EndpointBSecurityError",
+  "EndpointBSecurityErrorEncoded",
+  "EndpointBSecurityErrorR"
+>
+class EndpointBSecurity extends HttpApiMiddleware.Tag<EndpointBSecurity>()("EndpointBSecurity", {
+  failure: EndpointBSecurityError
+}) {}
+declare const Group1SecurityError: Schema.Schema<
+  "Group1SecurityError",
+  "Group1SecurityErrorEncoded",
+  "Group1SecurityErrorR"
+>
+class Group1Security extends HttpApiMiddleware.Tag<Group1Security>()("Group1Security", {
+  failure: Group1SecurityError
+}) {}
+declare const ApiSecurityError: Schema.Schema<
+  "ApiSecurityError",
+  "ApiSecurityErrorEncoded",
+  "ApiSecurityErrorR"
+>
+class ApiSecurity extends HttpApiMiddleware.Tag<ApiSecurity>()("ApiSecurity", {
+  failure: ApiSecurityError
+}) {}
+
+const EndpointA = HttpApiEndpoint.post("EndpointA", "/endpoint_a")
+  .middleware(EndpointASecurity)
+  .addError(EndpointAError)
+  .addSuccess(EndpointASuccess)
+const EndpointB = HttpApiEndpoint.post("EndpointB", "/endpoint_b")
+  .middleware(EndpointBSecurity)
+  .addError(EndpointBError)
+  .addSuccess(EndpointBSuccess)
+
+const Group1 = HttpApiGroup.make("Group1")
+  .middleware(Group1Security)
+  .addError(Group1Error)
+  .add(EndpointA)
+  .add(EndpointB)
+
+declare const Group2Error: Schema.Schema<"Group2Error", "Group2ErrorEncoded", "Group2ErrorR">
+declare const EndpointCError: Schema.Schema<"EndpointCError", "EndpointCErrorEncoded", "EndpointCErrorR">
+declare const EndpointCSuccess: Schema.Schema<"EndpointCSuccess", "EndpointCSuccessEncoded", "EndpointCSuccessR">
+
+const EndpointC = HttpApiEndpoint.post("EndpointC", "/endpoint_c")
+  .addError(EndpointCError)
+  .addSuccess(EndpointCSuccess)
+const Group2 = HttpApiGroup.make("Group2")
+  .addError(Group2Error)
+  .add(EndpointC)
+
+const TestApi = HttpApi.empty
+  .middleware(ApiSecurity)
+  .addError(ApiError)
+  .add(Group1)
+  .add(Group2)
+
+// -------------------------------------------------------------------------------------
+// HttpApiClient.endpoint
+// -------------------------------------------------------------------------------------
+
+Effect.gen(function*() {
+  const clientEndpointEffect = HttpApiClient.endpoint(TestApi, "Group1", "EndpointA")
+  // $ExpectType never
+  type _clientEndpointEffectError = Effect.Effect.Error<typeof clientEndpointEffect>
+  // $ExpectType "ApiErrorR" | "Group1ErrorR" | "EndpointAErrorR" | "EndpointASuccessR" | "EndpointASecurityErrorR" | "Group1SecurityErrorR" | "ApiSecurityErrorR" | HttpClient<HttpClientError, Scope>
+  type _clientEndpointEffectContext = Effect.Effect.Context<typeof clientEndpointEffect>
+
+  const clientEndpoint = yield* clientEndpointEffect
+
+  // $ExpectType Effect<"EndpointASuccess", "ApiError" | "Group1Error" | "EndpointAError" | "EndpointASecurityError" | "Group1SecurityError" | "ApiSecurityError" | HttpApiDecodeError | HttpClientError, never>
+  const _endpointCall = clientEndpoint({ withResponse: false })
+})
+
+// -------------------------------------------------------------------------------------
+// HttpApiClient.group
+// -------------------------------------------------------------------------------------
+
+Effect.gen(function*() {
+  const clientGroupEffect = HttpApiClient.group(TestApi, "Group1")
+  // $ExpectType never
+  type _clientGroupEffectError = Effect.Effect.Error<typeof clientGroupEffect>
+  // $ExpectType "ApiErrorR" | "Group1ErrorR" | "EndpointAErrorR" | "EndpointASuccessR" | "EndpointBErrorR" | "EndpointBSuccessR" | "EndpointASecurityErrorR" | "EndpointBSecurityErrorR" | "Group1SecurityErrorR" | "ApiSecurityErrorR" | HttpClient<HttpClientError, Scope>
+  type _clientGroupEffectContext = Effect.Effect.Context<typeof clientGroupEffect>
+
+  const clientGroup = yield* clientGroupEffect
+
+  // $ExpectType Effect<"EndpointASuccess", "ApiError" | "Group1Error" | "EndpointAError" | "EndpointASecurityError" | "Group1SecurityError" | "ApiSecurityError" | HttpApiDecodeError | HttpClientError, never>
+  const _endpointCall = clientGroup.EndpointA({ withResponse: false })
+})
+
+// -------------------------------------------------------------------------------------
+// HttpApiClient.make
+// -------------------------------------------------------------------------------------
+
+Effect.gen(function*() {
+  const clientApiEffect = HttpApiClient.make(TestApi)
+  // $ExpectType never
+  type _clientApiEffectError = Effect.Effect.Error<typeof clientApiEffect>
+  // $ExpectType "ApiErrorR" | "Group1ErrorR" | "EndpointAErrorR" | "EndpointASuccessR" | "EndpointBErrorR" | "EndpointBSuccessR" | "EndpointASecurityErrorR" | "EndpointBSecurityErrorR" | "Group1SecurityErrorR" | "ApiSecurityErrorR" | "Group2ErrorR" | "EndpointCErrorR" | "EndpointCSuccessR" | HttpClient<HttpClientError, Scope>
+  type _clientApiEffectContext = Effect.Effect.Context<typeof clientApiEffect>
+
+  const clientApi = yield* clientApiEffect
+
+  // $ExpectType Effect<"EndpointASuccess", "ApiError" | "Group1Error" | "EndpointAError" | "EndpointASecurityError" | "Group1SecurityError" | "ApiSecurityError" | HttpApiDecodeError | HttpClientError, never>
+  const _endpointCall = clientApi.Group1.EndpointA({ withResponse: false })
+})

--- a/packages/platform/src/HttpApi.ts
+++ b/packages/platform/src/HttpApi.ts
@@ -269,6 +269,10 @@ export const empty: HttpApi<never, HttpApiDecodeError> = makeProto({
 export const reflect = <Groups extends HttpApiGroup.HttpApiGroup.Any, Error, R>(
   self: HttpApi<Groups, Error, R>,
   options: {
+    readonly predicate?: Predicate.Predicate<{
+      readonly endpoint: HttpApiEndpoint.HttpApiEndpoint.AnyWithProps
+      readonly group: HttpApiGroup.HttpApiGroup.AnyWithProps
+    }>
     readonly onGroup: (options: {
       readonly group: HttpApiGroup.HttpApiGroup.AnyWithProps
       readonly mergedAnnotations: Context.Context<never>
@@ -294,6 +298,13 @@ export const reflect = <Groups extends HttpApiGroup.HttpApiGroup.Any, Error, R>(
     })
     const endpoints = Object.values(group.endpoints) as Iterable<HttpApiEndpoint.HttpApiEndpoint<string, HttpMethod>>
     for (const endpoint of endpoints) {
+      if (
+        options.predicate && !options.predicate({
+          endpoint,
+          group
+        } as any)
+      ) continue
+
       const errors = extractMembers(endpoint.errorSchema.ast, groupErrors, HttpApiSchema.getStatusErrorAST)
       options.onEndpoint({
         group,

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -439,7 +439,7 @@ export const group = <
   HttpApiGroup.ApiGroup<Name>,
   Handlers.Error<Return>,
   | Handlers.Context<Return>
-  | HttpApiGroup.HttpApiGroup.MiddlewareContextWithName<Groups, Name>
+  | HttpApiGroup.HttpApiGroup.MiddlewareWithName<Groups, Name>
 > =>
   Router.use((router) =>
     Effect.gen(function*() {

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -439,7 +439,7 @@ export const group = <
   HttpApiGroup.ApiGroup<Name>,
   Handlers.Error<Return>,
   | Handlers.Context<Return>
-  | HttpApiGroup.HttpApiGroup.ContextWithName<Groups, Name>
+  | HttpApiGroup.HttpApiGroup.MiddlewareContextWithName<Groups, Name>
 > =>
   Router.use((router) =>
     Effect.gen(function*() {

--- a/packages/platform/src/HttpApiClient.ts
+++ b/packages/platform/src/HttpApiClient.ts
@@ -354,9 +354,7 @@ export const endpoint = <
     | ApiR
     | HttpApiGroup.Context<HttpApiGroup.WithName<Groups, GroupName>>
     | HttpApiEndpoint.ContextWithName<HttpApiGroup.EndpointsWithName<Groups, GroupName>, EndpointName>
-    | HttpApiEndpoint.ErrorContext<
-      HttpApiEndpoint.WithName<HttpApiGroup.EndpointsWithName<Groups, GroupName>, EndpointName>
-    >
+    | HttpApiEndpoint.ErrorContextWithName<HttpApiGroup.EndpointsWithName<Groups, GroupName>, EndpointName>
   >
   | HttpClient.HttpClient
 > =>

--- a/packages/platform/src/HttpApiEndpoint.ts
+++ b/packages/platform/src/HttpApiEndpoint.ts
@@ -518,6 +518,12 @@ export declare namespace HttpApiEndpoint {
    * @since 1.0.0
    * @category models
    */
+  export type ErrorContextWithName<Endpoints extends Any, Name extends string> = ErrorContext<WithName<Endpoints, Name>>
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
   export type ExcludeProvided<Endpoints extends Any, Name extends string, R> = Exclude<
     R,
     | HttpRouter.HttpRouter.DefaultServices

--- a/packages/platform/src/HttpApiGroup.ts
+++ b/packages/platform/src/HttpApiGroup.ts
@@ -221,7 +221,7 @@ export declare namespace HttpApiGroup {
    * @since 1.0.0
    * @category models
    */
-  export type Provides<Group extends Any> = HttpApiMiddleware.HttpApiMiddleware.ExtractProvides<Context<Group>>
+  export type Provides<Group extends Any> = HttpApiMiddleware.HttpApiMiddleware.ExtractProvides<Middleware<Group>>
 
   /**
    * @since 1.0.0
@@ -242,7 +242,7 @@ export declare namespace HttpApiGroup {
    * @since 1.0.0
    * @category models
    */
-  export type MiddlewareContext<Group> = Group extends
+  export type Middleware<Group> = Group extends
     HttpApiGroup<infer _Name, infer _Endpoints, infer _Error, infer _R, infer _TopLevel> ?
     HttpApiMiddleware.HttpApiMiddleware.Only<_R> :
     never
@@ -277,7 +277,7 @@ export declare namespace HttpApiGroup {
    * @since 1.0.0
    * @category models
    */
-  export type MiddlewareContextWithName<Group extends Any, Name extends string> = MiddlewareContext<
+  export type MiddlewareWithName<Group extends Any, Name extends string> = Middleware<
     WithName<Group, Name>
   >
 }

--- a/packages/platform/src/HttpApiGroup.ts
+++ b/packages/platform/src/HttpApiGroup.ts
@@ -235,6 +235,15 @@ export declare namespace HttpApiGroup {
    */
   export type Context<Group> = Group extends
     HttpApiGroup<infer _Name, infer _Endpoints, infer _Error, infer _R, infer _TopLevel> ?
+    HttpApiMiddleware.HttpApiMiddleware.Without<_R> :
+    never
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
+  export type MiddlewareContext<Group> = Group extends
+    HttpApiGroup<infer _Name, infer _Endpoints, infer _Error, infer _R, infer _TopLevel> ?
     HttpApiMiddleware.HttpApiMiddleware.Only<_R> :
     never
 
@@ -263,6 +272,14 @@ export declare namespace HttpApiGroup {
    * @category models
    */
   export type ContextWithName<Group extends Any, Name extends string> = Context<WithName<Group, Name>>
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
+  export type MiddlewareContextWithName<Group extends Any, Name extends string> = MiddlewareContext<
+    WithName<Group, Name>
+  >
 }
 
 const Proto = {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`HttpApiClient.group` & `HttpApiClient.endpoint` have been added
This makes it possible to create `HttpApiClient` for some part of the `HttpApi`
This eliminates the need to provide all the dependencies for the entire `HttpApi` - but only those necessary for its specific part to work

- ~~I do not know how to avoid duplication in the runtime part (besides passing other hooks inside the `make` function)- if there are ideas, I will be glad to implement them~~
- renamed the `HttpApiGroup.ContextWithName` & `HttpApiGroup.Context` in the `HttpApiGroup.MiddlewareContextWithName` & `HttpApiGroup.Middleware` - it seems to be a more accurate naming
- `HttpApiGroup.ContextWithName` & `HttpApiGroup.Context` now return context without middlewares



## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
