### PR TITLE
add Schema.headNonEmpty on Schema.NonEmptyArray

### DIFF
--- a/.changeset/violet-spoons-compare.md
+++ b/.changeset/violet-spoons-compare.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Schema.headNonEmpty for Schema.NonEmptyArray

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5911,7 +5911,7 @@ export const head = <A, I, R>(self: Schema<ReadonlyArray<A>, I, R>): SchemaClass
    * Get the first element of a `NonEmptyReadonlyArray`.
    *
    * @category NonEmptyReadonlyArray transformations
-   * @since 3.11.0
+   * @since 3.12.0
    */
   export const headNonEmpty = <A, I, R>(self: Schema<array_.NonEmptyReadonlyArray<A>, I, R>): SchemaClass<A, I, R> => transform(
     self,

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5906,14 +5906,14 @@ export const head = <A, I, R>(self: Schema<ReadonlyArray<A>, I, R>): SchemaClass
     { strict: true, decode: array_.head, encode: option_.match({ onNone: () => [], onSome: array_.of }) }
   )
 
-
-  /**
-   * Get the first element of a `NonEmptyReadonlyArray`.
-   *
-   * @category NonEmptyReadonlyArray transformations
-   * @since 3.12.0
-   */
-  export const headNonEmpty = <A, I, R>(self: Schema<array_.NonEmptyReadonlyArray<A>, I, R>): SchemaClass<A, I, R> => transform(
+/**
+ * Get the first element of a `NonEmptyReadonlyArray`.
+ *
+ * @category NonEmptyReadonlyArray transformations
+ * @since 3.12.0
+ */
+export const headNonEmpty = <A, I, R>(self: Schema<array_.NonEmptyReadonlyArray<A>, I, R>): SchemaClass<A, I, R> =>
+  transform(
     self,
     getNumberIndexedAccess(typeSchema(self)),
     { strict: true, decode: array_.headNonEmpty, encode: array_.of }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5906,6 +5906,19 @@ export const head = <A, I, R>(self: Schema<ReadonlyArray<A>, I, R>): SchemaClass
     { strict: true, decode: array_.head, encode: option_.match({ onNone: () => [], onSome: array_.of }) }
   )
 
+
+  /**
+   * Get the first element of a `NonEmptyReadonlyArray`.
+   *
+   * @category NonEmptyReadonlyArray transformations
+   * @since 3.11.0
+   */
+  export const headNonEmpty = <A, I, R>(self: Schema<array_.NonEmptyReadonlyArray<A>, I, R>): SchemaClass<A, I, R> => transform(
+    self,
+    getNumberIndexedAccess(typeSchema(self)),
+    { strict: true, decode: array_.headNonEmpty, encode: array_.of }
+  )
+
 /**
  * Retrieves the first element of a `ReadonlyArray`.
  *

--- a/packages/effect/test/Schema/Schema/Array/headNonEmpty.test.ts
+++ b/packages/effect/test/Schema/Schema/Array/headNonEmpty.test.ts
@@ -1,0 +1,26 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("headNonEmpty", () => {
+  it("decoding", async () => {
+    const schema = S.headNonEmpty(S.NonEmptyArray(S.NumberFromString))
+    await Util.expectDecodeUnknownSuccess(schema, ["1"], 1)
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      ["a"],
+`(readonly [NumberFromString, ...NumberFromString[]] <-> number | number)
+└─ Encoded side transformation failure
+   └─ readonly [NumberFromString, ...NumberFromString[]]
+      └─ [0]
+         └─ NumberFromString
+            └─ Transformation process failure
+               └─ Expected NumberFromString, actual "a"`
+    )
+  })
+
+  it("encoding", async () => {
+    const schema = S.headNonEmpty(S.NonEmptyArray(S.NumberFromString))
+    await Util.expectEncodeSuccess(schema, 1, ["1"])
+  })
+})

--- a/packages/effect/test/Schema/Schema/Array/headNonEmpty.test.ts
+++ b/packages/effect/test/Schema/Schema/Array/headNonEmpty.test.ts
@@ -9,7 +9,7 @@ describe("headNonEmpty", () => {
     await Util.expectDecodeUnknownFailure(
       schema,
       ["a"],
-`(readonly [NumberFromString, ...NumberFromString[]] <-> number | number)
+      `(readonly [NumberFromString, ...NumberFromString[]] <-> number | number)
 └─ Encoded side transformation failure
    └─ readonly [NumberFromString, ...NumberFromString[]]
       └─ [0]


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

```ts

const mySchema = S.headNonEmpty(S.NonEmptyArray(S.String));

const head = S.decodeUnknownSync(mySchema)(["Hello", "World"]);

// head == "Hello"

```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
