### PR TITLE
Layer.ts jsdoc - grammar fix

### DIFF
--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -280,7 +280,7 @@ export const effect: {
 } = internal.fromEffect
 
 /**
- * Constructs a layer from the specified effect discarding it's output.
+ * Constructs a layer from the specified effect, discarding its output.
  *
  * @since 2.0.0
  * @category constructors


### PR DESCRIPTION
`it's` is a contraction of `it is`;  `its` is the possessive.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Fixed minor grammar issue in JSdoc block for `Layer.effectDiscard`.
