### PR TITLE
upgrade to typescript 5.7 (and latest dtslint)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.9.1",
     "@types/jscodeshift": "^0.11.11",
-    "@types/node": "^22.5.4",
+    "@types/node": "^22.9.3",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "@vitest/browser": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@edge-runtime/vm": "^4.0.0",
     "@effect/build-utils": "^0.7.7",
     "@effect/docgen": "^0.4.4",
-    "@effect/dtslint": "^0.1.1",
+    "@effect/dtslint": "^0.1.2",
     "@effect/eslint-plugin": "^0.2.0",
     "@effect/language-service": "^0.1.0",
     "@eslint/compat": "1.1.1",
@@ -77,7 +77,7 @@
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "tsx": "^4.17.0",
-    "typescript": "^5.6.2",
+    "typescript": "^5.7.2",
     "vite": "^5.4.0",
     "vitest": "^2.1.4"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,6 @@
     "@effect/printer": "workspace:^",
     "@effect/printer-ansi": "workspace:^",
     "@types/ini": "^4.1.1",
-    "@types/node": "^22.5.4",
     "effect": "workspace:^"
   },
   "effect": {

--- a/packages/cluster-node/package.json
+++ b/packages/cluster-node/package.json
@@ -35,7 +35,6 @@
     "@effect/platform-node": "workspace:^",
     "@effect/rpc": "workspace:^",
     "@effect/rpc-http": "workspace:^",
-    "@types/node": "^22.5.4",
     "effect": "workspace:^"
   }
 }

--- a/packages/effect/dtslint/Predicate.ts
+++ b/packages/effect/dtslint/Predicate.ts
@@ -152,8 +152,12 @@ unknowns.filter(Predicate.isError)
 // isUint8Array
 // -------------------------------------------------------------------------------------
 
-// $ExpectType Uint8Array[]
-unknowns.filter(Predicate.isUint8Array)
+// TODO: Re-enable this test when the minimum TypeScript version used by @effect/dtslint is 5.7.2
+// This test has been disabled because it is not possible to test it
+// after upgrading to TypeScript 5.7.2. For versions less than 5.7.2,
+// the inferred type is just `Uint8Array[]`.
+// // $ExpectType Uint8Array<ArrayBufferLike>[]
+// unknowns.filter(Predicate.isUint8Array)
 
 // -------------------------------------------------------------------------------------
 // isDate

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@types/jscodeshift": "^0.11.11",
-    "@types/node": "^22.5.4",
     "ajv": "^8.17.1",
     "ast-types": "^0.14.2",
     "jscodeshift": "^0.16.1",

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@effect/platform": "workspace:^",
-    "bun-types": "1.1.22",
+    "bun-types": "1.1.36",
     "effect": "workspace:^"
   }
 }

--- a/packages/platform-node-shared/package.json
+++ b/packages/platform-node-shared/package.json
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@effect/platform": "workspace:^",
-    "@types/node": "^22.5.4",
     "@types/tar": "^6.1.12",
     "effect": "workspace:^",
     "tar": "^6"

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -56,7 +56,6 @@
   "devDependencies": {
     "@effect/platform": "workspace:^",
     "@types/mime": "^3.0.4",
-    "@types/node": "^22.5.4",
     "@types/ws": "^8.5.12",
     "effect": "workspace:^"
   }

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -18,7 +18,7 @@ import {
 import { NodeHttpServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
 import { Context, DateTime, Effect, Layer, Redacted, Ref, Schema, Struct } from "effect"
-import OpenApiFixture from "./fixtures/openapi.json"
+import OpenApiFixture from "./fixtures/openapi.json" with { type: "json" }
 
 describe("HttpApi", () => {
   describe("payload", () => {

--- a/packages/sql-clickhouse/package.json
+++ b/packages/sql-clickhouse/package.json
@@ -42,7 +42,6 @@
     "@effect/platform": "workspace:^",
     "@effect/platform-node": "workspace:^",
     "@effect/sql": "workspace:^",
-    "@types/node": "^22.5.4",
     "effect": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/sql-pg/package.json
+++ b/packages/sql-pg/package.json
@@ -42,7 +42,6 @@
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "@testcontainers/postgresql": "^10.11.0",
-    "@types/node": "^22.5.4",
     "effect": "workspace:^"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 0.11.11
       '@types/node':
         specifier: ^22.5.4
-        version: 22.5.4
+        version: 22.9.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.16.0
         version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint@9.9.1)(typescript@5.7.2)
@@ -91,16 +91,16 @@ importers:
         version: 7.16.1(eslint@9.9.1)(typescript@5.7.2)
       '@vitest/browser':
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
+        version: 2.1.4(@types/node@22.9.3)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4)
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))
+        version: 2.1.4(@vitest/browser@2.1.4(@types/node@22.9.3)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0))
       '@vitest/expect':
         specifier: ^2.1.4
         version: 2.1.4
       '@vitest/web-worker':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))
+        version: 2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0))
       ast-types:
         specifier: ^0.14.2
         version: 0.14.2
@@ -154,10 +154,10 @@ importers:
         version: 5.7.2
       vite:
         specifier: ^5.4.0
-        version: 5.4.0(@types/node@22.5.4)(terser@5.36.0)
+        version: 5.4.0(@types/node@22.9.3)(terser@5.36.0)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
+        version: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
 
   packages/ai/ai:
     devDependencies:
@@ -362,7 +362,7 @@ importers:
         version: 3.0.13
       vitest-websocket-mock:
         specifier: ^0.4.0
-        version: 0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0))
+        version: 0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0))
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -875,7 +875,7 @@ importers:
         version: link:../effect/dist
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)
+        version: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
     publishDirectory: dist
 
 packages:
@@ -3289,8 +3289,8 @@ packages:
   '@types/node@22.5.4':
     resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
 
-  '@types/node@22.8.2':
-    resolution: {integrity: sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==}
+  '@types/node@22.9.3':
+    resolution: {integrity: sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5480,7 +5480,6 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.6:
@@ -9907,23 +9906,16 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@inquirer/confirm@5.0.1(@types/node@22.5.4)':
+  '@inquirer/confirm@5.0.1(@types/node@22.9.3)':
     dependencies:
-      '@inquirer/core': 10.0.1(@types/node@22.5.4)
-      '@inquirer/type': 3.0.0(@types/node@22.5.4)
-      '@types/node': 22.5.4
+      '@inquirer/core': 10.0.1(@types/node@22.9.3)
+      '@inquirer/type': 3.0.0(@types/node@22.9.3)
+      '@types/node': 22.9.3
 
-  '@inquirer/confirm@5.0.1(@types/node@22.8.2)':
-    dependencies:
-      '@inquirer/core': 10.0.1(@types/node@22.8.2)
-      '@inquirer/type': 3.0.0(@types/node@22.8.2)
-      '@types/node': 22.8.2
-    optional: true
-
-  '@inquirer/core@10.0.1(@types/node@22.5.4)':
+  '@inquirer/core@10.0.1(@types/node@22.9.3)':
     dependencies:
       '@inquirer/figures': 1.0.7
-      '@inquirer/type': 3.0.0(@types/node@22.5.4)
+      '@inquirer/type': 3.0.0(@types/node@22.9.3)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -9933,32 +9925,12 @@ snapshots:
       yoctocolors-cjs: 2.1.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@inquirer/core@10.0.1(@types/node@22.8.2)':
-    dependencies:
-      '@inquirer/figures': 1.0.7
-      '@inquirer/type': 3.0.0(@types/node@22.8.2)
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@inquirer/figures@1.0.7': {}
 
-  '@inquirer/type@3.0.0(@types/node@22.5.4)':
+  '@inquirer/type@3.0.0(@types/node@22.9.3)':
     dependencies:
-      '@types/node': 22.5.4
-
-  '@inquirer/type@3.0.0(@types/node@22.8.2)':
-    dependencies:
-      '@types/node': 22.8.2
-    optional: true
+      '@types/node': 22.9.3
 
   '@ioredis/commands@1.2.0': {}
 
@@ -9991,7 +9963,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -10002,7 +9974,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -10035,7 +10007,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     optional: true
@@ -10045,7 +10017,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -10193,7 +10165,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -10840,11 +10812,11 @@ snapshots:
 
   '@types/better-sqlite3@7.6.10':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
 
   '@types/better-sqlite3@7.6.11':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
 
   '@types/cookie@0.6.0': {}
 
@@ -10852,13 +10824,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       '@types/ssh2': 1.15.1
 
   '@types/dockerode@3.3.31':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       '@types/ssh2': 1.15.1
 
   '@types/eslint@8.56.10':
@@ -10873,11 +10845,11 @@ snapshots:
   '@types/glob@7.1.3':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
 
   '@types/ini@4.1.1': {}
 
@@ -10914,13 +10886,13 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
 
   '@types/node@22.5.4':
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.8.2':
+  '@types/node@22.9.3':
     dependencies:
       undici-types: 6.19.8
 
@@ -10928,23 +10900,23 @@ snapshots:
 
   '@types/readable-stream@4.0.15':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       safe-buffer: 5.1.2
 
   '@types/semver@7.5.8': {}
 
   '@types/ssh2-streams@0.1.12':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       '@types/ssh2-streams': 0.1.12
 
   '@types/ssh2@1.15.1':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
 
   '@types/stack-utils@2.0.3': {}
 
@@ -10952,7 +10924,7 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       minipass: 4.2.8
 
   '@types/tough-cookie@4.0.5': {}
@@ -10961,7 +10933,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -11076,17 +11048,17 @@ snapshots:
       '@typescript-eslint/types': 7.16.1
       eslint-visitor-keys: 3.4.3
 
-  '@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)':
+  '@vitest/browser@2.1.4(@types/node@22.9.3)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))
       '@vitest/utils': 2.1.4
       magic-string: 0.30.12
-      msw: 2.5.2(@types/node@22.5.4)(typescript@5.7.2)
+      msw: 2.5.2(@types/node@22.9.3)(typescript@5.7.2)
       sirv: 3.0.0
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.46.0
@@ -11097,17 +11069,17 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@2.1.4(@types/node@22.8.2)(playwright@1.48.2)(typescript@5.7.2)(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))(vitest@2.1.4)':
+  '@vitest/browser@2.1.4(@types/node@22.9.3)(playwright@1.48.2)(typescript@5.7.2)(vite@5.4.10(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(vite@5.4.10(@types/node@22.9.3)(terser@5.36.0))
       '@vitest/utils': 2.1.4
       magic-string: 0.30.12
-      msw: 2.5.2(@types/node@22.8.2)(typescript@5.7.2)
+      msw: 2.5.2(@types/node@22.9.3)(typescript@5.7.2)
       sirv: 3.0.0
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.48.2
@@ -11119,7 +11091,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@2.1.4(@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))':
+  '@vitest/coverage-v8@2.1.4(@vitest/browser@2.1.4(@types/node@22.9.3)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -11133,9 +11105,9 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
     optionalDependencies:
-      '@vitest/browser': 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
+      '@vitest/browser': 2.1.4(@types/node@22.9.3)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -11146,32 +11118,23 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))':
+  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      msw: 2.5.2(@types/node@22.5.4)(typescript@5.7.2)
-      vite: 5.4.0(@types/node@22.5.4)(terser@5.36.0)
+      msw: 2.5.2(@types/node@22.9.3)(typescript@5.7.2)
+      vite: 5.4.0(@types/node@22.9.3)(terser@5.36.0)
 
-  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.0(@types/node@22.8.2)(terser@5.36.0))':
+  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(vite@5.4.10(@types/node@22.9.3)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      msw: 2.5.2(@types/node@22.8.2)(typescript@5.7.2)
-      vite: 5.4.0(@types/node@22.8.2)(terser@5.36.0)
-
-  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))':
-    dependencies:
-      '@vitest/spy': 2.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.12
-    optionalDependencies:
-      msw: 2.5.2(@types/node@22.8.2)(typescript@5.7.2)
-      vite: 5.4.10(@types/node@22.8.2)(terser@5.36.0)
+      msw: 2.5.2(@types/node@22.9.3)(typescript@5.7.2)
+      vite: 5.4.10(@types/node@22.9.3)(terser@5.36.0)
     optional: true
 
   '@vitest/pretty-format@2.1.4':
@@ -11199,10 +11162,10 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/web-worker@2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))':
+  '@vitest/web-worker@2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0))':
     dependencies:
       debug: 4.3.7
-      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11654,12 +11617,12 @@ snapshots:
 
   bun-types@1.1.22:
     dependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       '@types/ws': 8.5.12
 
   bun-types@1.1.33:
     dependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       '@types/ws': 8.5.12
     optional: true
 
@@ -11753,7 +11716,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11762,7 +11725,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -12362,7 +12325,7 @@ snapshots:
       '@types/glob': 7.1.3
       '@types/js-yaml': 3.12.5
       '@types/lodash': 4.17.7
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       dedent: 1.5.3
       eslint-plugin-markdown: 4.0.1(eslint@9.9.1)
       expect: 29.7.0
@@ -13232,7 +13195,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -13242,7 +13205,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13276,7 +13239,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -13284,7 +13247,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -13301,7 +13264,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14042,12 +14005,12 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
-  msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2):
+  msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.0.1(@types/node@22.5.4)
+      '@inquirer/confirm': 5.0.1(@types/node@22.9.3)
       '@mswjs/interceptors': 0.36.6
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0
@@ -14065,31 +14028,6 @@ snapshots:
       typescript: 5.7.2
     transitivePeerDependencies:
       - '@types/node'
-
-  msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2):
-    dependencies:
-      '@bundled-es-modules/cookie': 2.0.0
-      '@bundled-es-modules/statuses': 1.0.1
-      '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.0.1(@types/node@22.8.2)
-      '@mswjs/interceptors': 0.36.6
-      '@open-draft/until': 2.1.0
-      '@types/cookie': 0.6.0
-      '@types/statuses': 2.0.5
-      chalk: 4.1.2
-      graphql: 16.9.0
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      strict-event-emitter: 0.5.1
-      type-fest: 4.26.1
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   multipasta@0.2.5: {}
 
@@ -14568,7 +14506,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       long: 5.2.3
 
   pseudomap@1.0.2: {}
@@ -15285,7 +15223,7 @@ snapshots:
       '@azure/identity': 4.4.1
       '@azure/keyvault-keys': 4.8.0
       '@js-joda/core': 5.6.3
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       bl: 6.0.14
       iconv-lite: 0.6.3
       js-md4: 0.3.2
@@ -15597,12 +15535,12 @@ snapshots:
   vary@1.1.2:
     optional: true
 
-  vite-node@2.1.4(@types/node@22.5.4)(terser@5.36.0):
+  vite-node@2.1.4(@types/node@22.9.3)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.0(@types/node@22.5.4)(terser@5.36.0)
+      vite: 5.4.0(@types/node@22.9.3)(terser@5.36.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15614,64 +15552,37 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.4(@types/node@22.8.2)(terser@5.36.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.7
-      pathe: 1.1.2
-      vite: 5.4.0(@types/node@22.8.2)(terser@5.36.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@5.4.0(@types/node@22.5.4)(terser@5.36.0):
+  vite@5.4.0(@types/node@22.9.3)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.41
       rollup: 4.20.0
     optionalDependencies:
-      '@types/node': 22.5.4
+      '@types/node': 22.9.3
       fsevents: 2.3.3
       terser: 5.36.0
 
-  vite@5.4.0(@types/node@22.8.2)(terser@5.36.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.41
-      rollup: 4.20.0
-    optionalDependencies:
-      '@types/node': 22.8.2
-      fsevents: 2.3.3
-      terser: 5.36.0
-
-  vite@5.4.10(@types/node@22.8.2)(terser@5.36.0):
+  vite@5.4.10(@types/node@22.9.3)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.2
     optionalDependencies:
-      '@types/node': 22.8.2
+      '@types/node': 22.9.3
       fsevents: 2.3.3
       terser: 5.36.0
     optional: true
 
-  vitest-websocket-mock@0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)):
+  vitest-websocket-mock@0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)):
     dependencies:
       '@vitest/utils': 2.1.4
       mock-socket: 9.3.1
-      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0)
 
-  vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0):
+  vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -15687,13 +15598,13 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@22.5.4)(terser@5.36.0)
-      vite-node: 2.1.4(@types/node@22.5.4)(terser@5.36.0)
+      vite: 5.4.0(@types/node@22.9.3)(terser@5.36.0)
+      vite-node: 2.1.4(@types/node@22.9.3)(terser@5.36.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 4.0.1
-      '@types/node': 22.5.4
-      '@vitest/browser': 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
+      '@types/node': 22.9.3
+      '@vitest/browser': 2.1.4(@types/node@22.9.3)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4)
       happy-dom: 15.7.4
     transitivePeerDependencies:
       - less
@@ -15706,10 +15617,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0):
+  vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.9.3)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.0(@types/node@22.8.2)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.9.3)(typescript@5.7.2))(vite@5.4.0(@types/node@22.9.3)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -15725,13 +15636,13 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@22.8.2)(terser@5.36.0)
-      vite-node: 2.1.4(@types/node@22.8.2)(terser@5.36.0)
+      vite: 5.4.0(@types/node@22.9.3)(terser@5.36.0)
+      vite-node: 2.1.4(@types/node@22.9.3)(terser@5.36.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 4.0.3
-      '@types/node': 22.8.2
-      '@vitest/browser': 2.1.4(@types/node@22.8.2)(playwright@1.48.2)(typescript@5.7.2)(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))(vitest@2.1.4)
+      '@types/node': 22.9.3
+      '@vitest/browser': 2.1.4(@types/node@22.9.3)(playwright@1.48.2)(typescript@5.7.2)(vite@5.4.10(@types/node@22.9.3)(terser@5.36.0))(vitest@2.1.4)
       happy-dom: 15.7.4
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,10 +58,10 @@ importers:
         version: 0.7.7
       '@effect/docgen':
         specifier: ^0.4.4
-        version: 0.4.4(tsx@4.17.0)(typescript@5.6.2)
+        version: 0.4.4(tsx@4.17.0)(typescript@5.7.2)
       '@effect/dtslint':
-        specifier: ^0.1.1
-        version: 0.1.1(typescript@5.6.2)
+        specifier: ^0.1.2
+        version: 0.1.2(typescript@5.7.2)
       '@effect/eslint-plugin':
         specifier: ^0.2.0
         version: 0.2.0
@@ -85,22 +85,22 @@ importers:
         version: 22.5.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.16.0
-        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint@9.9.1)(typescript@5.6.2)
+        version: 7.16.1(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint@9.9.1)(typescript@5.7.2)
       '@typescript-eslint/parser':
         specifier: ^7.16.0
-        version: 7.16.1(eslint@9.9.1)(typescript@5.6.2)
+        version: 7.16.1(eslint@9.9.1)(typescript@5.7.2)
       '@vitest/browser':
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.6.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
+        version: 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
       '@vitest/coverage-v8':
         specifier: ^2.1.4
-        version: 2.1.4(@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.6.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0))
+        version: 2.1.4(@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))
       '@vitest/expect':
         specifier: ^2.1.4
         version: 2.1.4
       '@vitest/web-worker':
         specifier: ^2.1.4
-        version: 2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0))
+        version: 2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))
       ast-types:
         specifier: ^0.14.2
         version: 0.14.2
@@ -112,13 +112,13 @@ importers:
         version: 9.9.1
       eslint-import-resolver-typescript:
         specifier: ^3.6.3
-        version: 3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1)
+        version: 3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1)
       eslint-plugin-codegen:
         specifier: ^0.28.0
         version: 0.28.0(eslint@9.9.1)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.30.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.1)
+        version: 2.30.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.1)
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@9.9.1)
@@ -136,7 +136,7 @@ importers:
         version: 0.16.1(@babel/preset-env@7.26.0(@babel/core@7.25.2))
       madge:
         specifier: ^8.0.0
-        version: 8.0.0(typescript@5.6.2)
+        version: 8.0.0(typescript@5.7.2)
       playwright:
         specifier: ^1.46.0
         version: 1.46.0
@@ -150,14 +150,14 @@ importers:
         specifier: ^4.17.0
         version: 4.17.0
       typescript:
-        specifier: ^5.6.2
-        version: 5.6.2
+        specifier: ^5.7.2
+        version: 5.7.2
       vite:
         specifier: ^5.4.0
         version: 5.4.0(@types/node@22.5.4)(terser@5.36.0)
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0)
+        version: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
 
   packages/ai/ai:
     devDependencies:
@@ -362,7 +362,7 @@ importers:
         version: 3.0.13
       vitest-websocket-mock:
         specifier: ^0.4.0
-        version: 0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(terser@5.36.0))
+        version: 0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0))
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -875,7 +875,7 @@ importers:
         version: link:../effect/dist
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(terser@5.36.0)
+        version: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)
     publishDirectory: dist
 
 packages:
@@ -2037,8 +2037,8 @@ packages:
       tsx: ^4.1.0
       typescript: ^5.2.2
 
-  '@effect/dtslint@0.1.1':
-    resolution: {integrity: sha512-/xbyEjxt31JsBp5YlJiRPlBz01tOgkk2NTgYJFYNS9OoH1x2xaiwMrzJFjg3/6S+D7D2Tqi7jKQTRXTQSSW8AA==}
+  '@effect/dtslint@0.1.2':
+    resolution: {integrity: sha512-fTEN3N2JccgKoF2rlpEi1zQciD0Jl87SBI08sUSdpK3qxcOWUXRxDx+Le5W9wrumzYBwqTdHOsC/EaZRAPvSfg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -5104,10 +5104,6 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.14.0:
-    resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
-    engines: {node: '>= 0.4'}
-
   is-core-module@2.15.1:
     resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
     engines: {node: '>= 0.4'}
@@ -5484,6 +5480,7 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.6:
@@ -7138,13 +7135,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7524,11 +7516,11 @@ snapshots:
 
   '@azure/abort-controller@1.1.0':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/abort-controller@2.1.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/core-auth@1.7.2':
     dependencies:
@@ -7544,7 +7536,7 @@ snapshots:
       '@azure/core-tracing': 1.1.2
       '@azure/core-util': 1.9.2
       '@azure/logger': 1.1.4
-      tslib: 2.6.3
+      tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7561,11 +7553,11 @@ snapshots:
       '@azure/abort-controller': 2.1.2
       '@azure/core-util': 1.9.2
       '@azure/logger': 1.1.4
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/core-paging@1.6.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/core-rest-pipeline@1.16.3':
     dependencies:
@@ -7576,18 +7568,18 @@ snapshots:
       '@azure/logger': 1.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
-      tslib: 2.6.3
+      tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
 
   '@azure/core-tracing@1.1.2':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/core-util@1.9.2':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/identity@4.4.1':
     dependencies:
@@ -7626,7 +7618,7 @@ snapshots:
 
   '@azure/logger@1.1.4':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.0
 
   '@azure/msal-browser@3.20.0':
     dependencies:
@@ -9693,20 +9685,20 @@ snapshots:
 
   '@effect/build-utils@0.7.7': {}
 
-  '@effect/docgen@0.4.4(tsx@4.17.0)(typescript@5.6.2)':
+  '@effect/docgen@0.4.4(tsx@4.17.0)(typescript@5.7.2)':
     dependencies:
       '@effect/markdown-toc': 0.1.0
       doctrine: 3.0.0
       glob: 10.4.5
       prettier: 3.3.3
       tsx: 4.17.0
-      typescript: 5.6.2
+      typescript: 5.7.2
 
-  '@effect/dtslint@0.1.1(typescript@5.6.2)':
+  '@effect/dtslint@0.1.2(typescript@5.7.2)':
     dependencies:
       fs-extra: 11.2.0
-      tslint: 6.1.3(typescript@5.6.2)
-      typescript: 5.6.2
+      tslint: 6.1.3(typescript@5.7.2)
+      typescript: 5.7.2
 
   '@effect/eslint-plugin@0.2.0':
     dependencies:
@@ -10982,34 +10974,34 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint@9.9.1)(typescript@5.6.2)':
+  '@typescript-eslint/eslint-plugin@7.16.1(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint@9.9.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.16.1(eslint@9.9.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@9.9.1)(typescript@5.7.2)
       '@typescript-eslint/scope-manager': 7.16.1
-      '@typescript-eslint/type-utils': 7.16.1(eslint@9.9.1)(typescript@5.6.2)
-      '@typescript-eslint/utils': 7.16.1(eslint@9.9.1)(typescript@5.6.2)
+      '@typescript-eslint/type-utils': 7.16.1(eslint@9.9.1)(typescript@5.7.2)
+      '@typescript-eslint/utils': 7.16.1(eslint@9.9.1)(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 7.16.1
       eslint: 9.9.1
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.2)
+      ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2)':
+  '@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.16.1
       '@typescript-eslint/types': 7.16.1
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.7.2)
       '@typescript-eslint/visitor-keys': 7.16.1
       debug: 4.3.5
       eslint: 9.9.1
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11018,15 +11010,15 @@ snapshots:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
 
-  '@typescript-eslint/type-utils@7.16.1(eslint@9.9.1)(typescript@5.6.2)':
+  '@typescript-eslint/type-utils@7.16.1(eslint@9.9.1)(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.6.2)
-      '@typescript-eslint/utils': 7.16.1(eslint@9.9.1)(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.7.2)
+      '@typescript-eslint/utils': 7.16.1(eslint@9.9.1)(typescript@5.7.2)
       debug: 4.3.5
       eslint: 9.9.1
-      ts-api-utils: 1.3.0(typescript@5.6.2)
+      ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11034,7 +11026,7 @@ snapshots:
 
   '@typescript-eslint/types@7.16.1': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.2)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -11042,13 +11034,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.6.2)
+      tsutils: 3.21.0(typescript@5.7.2)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.6.2)':
+  '@typescript-eslint/typescript-estree@7.16.1(typescript@5.7.2)':
     dependencies:
       '@typescript-eslint/types': 7.16.1
       '@typescript-eslint/visitor-keys': 7.16.1
@@ -11057,18 +11049,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.2)
+      ts-api-utils: 1.3.0(typescript@5.7.2)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.16.1(eslint@9.9.1)(typescript@5.6.2)':
+  '@typescript-eslint/utils@7.16.1(eslint@9.9.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.1)
       '@typescript-eslint/scope-manager': 7.16.1
       '@typescript-eslint/types': 7.16.1
-      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 7.16.1(typescript@5.7.2)
       eslint: 9.9.1
     transitivePeerDependencies:
       - supports-color
@@ -11084,17 +11076,17 @@ snapshots:
       '@typescript-eslint/types': 7.16.1
       eslint-visitor-keys: 3.4.3
 
-  '@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.6.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)':
+  '@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))
       '@vitest/utils': 2.1.4
       magic-string: 0.30.12
-      msw: 2.5.2(@types/node@22.5.4)(typescript@5.6.2)
+      msw: 2.5.2(@types/node@22.5.4)(typescript@5.7.2)
       sirv: 3.0.0
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.46.0
@@ -11105,17 +11097,17 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@2.1.4(@types/node@22.8.2)(playwright@1.48.2)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))(vitest@2.1.4)':
+  '@vitest/browser@2.1.4(@types/node@22.8.2)(playwright@1.48.2)(typescript@5.7.2)(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))(vitest@2.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))
       '@vitest/utils': 2.1.4
       magic-string: 0.30.12
-      msw: 2.5.2(@types/node@22.8.2)(typescript@5.6.3)
+      msw: 2.5.2(@types/node@22.8.2)(typescript@5.7.2)
       sirv: 3.0.0
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.48.2
@@ -11127,7 +11119,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@2.1.4(@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.6.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0))':
+  '@vitest/coverage-v8@2.1.4(@vitest/browser@2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4))(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -11141,9 +11133,9 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
     optionalDependencies:
-      '@vitest/browser': 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.6.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
+      '@vitest/browser': 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -11154,31 +11146,31 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))':
+  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      msw: 2.5.2(@types/node@22.5.4)(typescript@5.6.2)
+      msw: 2.5.2(@types/node@22.5.4)(typescript@5.7.2)
       vite: 5.4.0(@types/node@22.5.4)(terser@5.36.0)
 
-  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(vite@5.4.0(@types/node@22.8.2)(terser@5.36.0))':
+  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.0(@types/node@22.8.2)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      msw: 2.5.2(@types/node@22.8.2)(typescript@5.6.3)
+      msw: 2.5.2(@types/node@22.8.2)(typescript@5.7.2)
       vite: 5.4.0(@types/node@22.8.2)(terser@5.36.0)
 
-  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))':
+  '@vitest/mocker@2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      msw: 2.5.2(@types/node@22.8.2)(typescript@5.6.3)
+      msw: 2.5.2(@types/node@22.8.2)(typescript@5.7.2)
       vite: 5.4.10(@types/node@22.8.2)(terser@5.36.0)
     optional: true
 
@@ -11207,10 +11199,10 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/web-worker@2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0))':
+  '@vitest/web-worker@2.1.4(vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0))':
     dependencies:
       debug: 4.3.7
-      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12006,7 +11998,7 @@ snapshots:
       commander: 10.0.1
       filing-cabinet: 4.2.0
       precinct: 11.0.5
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12058,10 +12050,10 @@ snapshots:
 
   detective-typescript@11.2.0:
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.2)
       ast-module-types: 5.0.0
       node-source-walk: 6.0.2
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12328,33 +12320,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 9.9.1
-      eslint-module-utils: 2.9.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1))(eslint@9.9.1)
+      eslint-module-utils: 2.9.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1))(eslint@9.9.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.0
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.9.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1))(eslint@9.9.1):
+  eslint-module-utils@2.9.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1))(eslint@9.9.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.16.1(eslint@9.9.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@9.9.1)(typescript@5.7.2)
       eslint: 9.9.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12386,7 +12378,7 @@ snapshots:
       - eslint
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.1):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -12397,7 +12389,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.9.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.9.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1))(eslint@9.9.1)
+      eslint-module-utils: 2.9.0(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.16.1(eslint@9.9.1)(typescript@5.7.2))(eslint-plugin-import@2.30.0)(eslint@9.9.1))(eslint@9.9.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -12408,7 +12400,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.16.1(eslint@9.9.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 7.16.1(eslint@9.9.1)(typescript@5.7.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -12608,7 +12600,7 @@ snapshots:
       sass-lookup: 5.0.1
       stylus-lookup: 5.0.1
       tsconfig-paths: 4.2.0
-      typescript: 5.6.2
+      typescript: 5.7.2
 
   fill-range@2.2.4:
     dependencies:
@@ -13060,10 +13052,6 @@ snapshots:
       semver: 7.6.3
 
   is-callable@1.2.7: {}
-
-  is-core-module@2.14.0:
-    dependencies:
-      hasown: 2.0.2
 
   is-core-module@2.15.1:
     dependencies:
@@ -13665,7 +13653,7 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  madge@8.0.0(typescript@5.6.2):
+  madge@8.0.0(typescript@5.7.2):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
@@ -13680,7 +13668,7 @@ snapshots:
       ts-graphviz: 2.1.2
       walkdir: 0.4.1
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14054,7 +14042,7 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
-  msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2):
+  msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
@@ -14074,11 +14062,11 @@ snapshots:
       type-fest: 4.26.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3):
+  msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
@@ -14098,7 +14086,7 @@ snapshots:
       type-fest: 4.26.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.7.2
     transitivePeerDependencies:
       - '@types/node'
     optional: true
@@ -14365,7 +14353,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.0
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -14844,7 +14832,7 @@ snapshots:
 
   resolve@1.22.8:
     dependencies:
-      is-core-module: 2.14.0
+      is-core-module: 2.15.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -15414,9 +15402,9 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-api-utils@1.3.0(typescript@5.6.2):
+  ts-api-utils@1.3.0(typescript@5.7.2):
     dependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
 
   ts-graphviz@2.1.2:
     dependencies:
@@ -15444,9 +15432,9 @@ snapshots:
 
   tslib@2.8.0: {}
 
-  tslint@6.1.3(typescript@5.6.2):
+  tslint@6.1.3(typescript@5.7.2):
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.0
       builtin-modules: 1.1.1
       chalk: 2.4.2
       commander: 2.20.3
@@ -15458,18 +15446,18 @@ snapshots:
       resolve: 1.22.8
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@5.6.2)
-      typescript: 5.6.2
+      tsutils: 2.29.0(typescript@5.7.2)
+      typescript: 5.7.2
 
-  tsutils@2.29.0(typescript@5.6.2):
+  tsutils@2.29.0(typescript@5.7.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.6.2
+      typescript: 5.7.2
 
-  tsutils@3.21.0(typescript@5.6.2):
+  tsutils@3.21.0(typescript@5.7.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.6.2
+      typescript: 5.7.2
 
   tsx@4.17.0:
     dependencies:
@@ -15534,10 +15522,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.6.2: {}
-
-  typescript@5.6.3:
-    optional: true
+  typescript@5.7.2: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -15677,16 +15662,16 @@ snapshots:
       terser: 5.36.0
     optional: true
 
-  vitest-websocket-mock@0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(terser@5.36.0)):
+  vitest-websocket-mock@0.4.0(vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)):
     dependencies:
       '@vitest/utils': 2.1.4
       mock-socket: 9.3.1
-      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(terser@5.36.0)
+      vitest: 2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0)
 
-  vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(terser@5.36.0):
+  vitest@2.1.4(@edge-runtime/vm@4.0.1)(@types/node@22.5.4)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.6.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.5.4)(typescript@5.7.2))(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -15708,7 +15693,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 4.0.1
       '@types/node': 22.5.4
-      '@vitest/browser': 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.6.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
+      '@vitest/browser': 2.1.4(@types/node@22.5.4)(playwright@1.46.0)(typescript@5.7.2)(vite@5.4.0(@types/node@22.5.4)(terser@5.36.0))(vitest@2.1.4)
       happy-dom: 15.7.4
     transitivePeerDependencies:
       - less
@@ -15721,10 +15706,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(terser@5.36.0):
+  vitest@2.1.4(@edge-runtime/vm@4.0.3)(@types/node@22.8.2)(@vitest/browser@2.1.4)(happy-dom@15.7.4)(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.6.3))(vite@5.4.0(@types/node@22.8.2)(terser@5.36.0))
+      '@vitest/mocker': 2.1.4(msw@2.5.2(@types/node@22.8.2)(typescript@5.7.2))(vite@5.4.0(@types/node@22.8.2)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.4
       '@vitest/runner': 2.1.4
       '@vitest/snapshot': 2.1.4
@@ -15746,7 +15731,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 4.0.3
       '@types/node': 22.8.2
-      '@vitest/browser': 2.1.4(@types/node@22.8.2)(playwright@1.48.2)(typescript@5.6.3)(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))(vitest@2.1.4)
+      '@vitest/browser': 2.1.4(@types/node@22.8.2)(playwright@1.48.2)(typescript@5.7.2)(vite@5.4.10(@types/node@22.8.2)(terser@5.36.0))(vitest@2.1.4)
       happy-dom: 15.7.4
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,8 +459,8 @@ importers:
         specifier: workspace:^
         version: link:../platform/dist
       bun-types:
-        specifier: 1.1.22
-        version: 1.1.22
+        specifier: 1.1.36
+        version: 1.1.36
       effect:
         specifier: workspace:^
         version: link:../effect/dist
@@ -654,7 +654,7 @@ importers:
         version: 10.11.0
       drizzle-orm:
         specifier: ^0.31.0
-        version: 0.31.4(@cloudflare/workers-types@4.20241022.0)(@libsql/client@0.14.0)(@op-engineering/op-sqlite@9.2.6(react-native@0.76.0(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.0)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.5.0)(bun-types@1.1.33)(kysely@0.27.4)(mysql2@3.11.3)(postgres@3.4.5)(react@18.3.1)
+        version: 0.31.4(@cloudflare/workers-types@4.20241022.0)(@libsql/client@0.14.0)(@op-engineering/op-sqlite@9.2.6(react-native@0.76.0(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.0)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.5.0)(bun-types@1.1.36)(kysely@0.27.4)(mysql2@3.11.3)(postgres@3.4.5)(react@18.3.1)
       effect:
         specifier: workspace:^
         version: link:../effect/dist
@@ -3809,8 +3809,8 @@ packages:
   bun-types@1.1.22:
     resolution: {integrity: sha512-PBgj4pQd+1WZJ8kWCho7D6i1RMS9/6WkiRikIfqYFzFomfyWZET32Wy83xK2zmF9HiKXd2+bjtVahJ6546oraA==}
 
-  bun-types@1.1.33:
-    resolution: {integrity: sha512-SOMt3HeI34EyXoAsMxs5qY+e8cjQOn9v1BQl/ZUy1BsOYYuSPBSRVBYE5DjauqY1bOAWGFAjVu9G9pSmCe1bVw==}
+  bun-types@1.1.36:
+    resolution: {integrity: sha512-4hALpWAzRKw7xXDH7MW3MPFn5aIsHcwD5QXUWQfEjATuTp6zONRhav7ThnStqeeRP1QkB/oQa8hRk9OAB0hi8w==}
 
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
@@ -5480,6 +5480,7 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.6:
@@ -11620,11 +11621,10 @@ snapshots:
       '@types/node': 22.9.3
       '@types/ws': 8.5.12
 
-  bun-types@1.1.33:
+  bun-types@1.1.36:
     dependencies:
       '@types/node': 22.9.3
       '@types/ws': 8.5.12
-    optional: true
 
   byline@5.0.0: {}
 
@@ -12063,7 +12063,7 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  drizzle-orm@0.31.4(@cloudflare/workers-types@4.20241022.0)(@libsql/client@0.14.0)(@op-engineering/op-sqlite@9.2.6(react-native@0.76.0(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.0)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.5.0)(bun-types@1.1.33)(kysely@0.27.4)(mysql2@3.11.3)(postgres@3.4.5)(react@18.3.1):
+  drizzle-orm@0.31.4(@cloudflare/workers-types@4.20241022.0)(@libsql/client@0.14.0)(@op-engineering/op-sqlite@9.2.6(react-native@0.76.0(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.0.0)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.11)(better-sqlite3@11.5.0)(bun-types@1.1.36)(kysely@0.27.4)(mysql2@3.11.3)(postgres@3.4.5)(react@18.3.1):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20241022.0
       '@libsql/client': 0.14.0
@@ -12071,7 +12071,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.11
       better-sqlite3: 11.5.0
-      bun-types: 1.1.33
+      bun-types: 1.1.36
       kysely: 0.27.4
       mysql2: 3.11.3
       postgres: 3.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,6 @@ importers:
       '@types/ini':
         specifier: ^4.1.1
         version: 4.1.1
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       effect:
         specifier: workspace:^
         version: link:../effect/dist
@@ -277,9 +274,6 @@ importers:
       '@effect/rpc-http':
         specifier: workspace:^
         version: link:../rpc-http/dist
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       effect:
         specifier: workspace:^
         version: link:../effect/dist
@@ -316,9 +310,6 @@ importers:
       '@types/jscodeshift':
         specifier: ^0.11.11
         version: 0.11.11
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -327,7 +318,7 @@ importers:
         version: 0.14.2
       jscodeshift:
         specifier: ^0.16.1
-        version: 0.16.1(@babel/preset-env@7.26.0(@babel/core@7.26.0))
+        version: 0.16.1(@babel/preset-env@7.26.0(@babel/core@7.25.2))
       tinybench:
         specifier: ^2.9.0
         version: 2.9.0
@@ -487,9 +478,6 @@ importers:
       '@types/mime':
         specifier: ^3.0.4
         version: 3.0.4
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       '@types/ws':
         specifier: ^8.5.12
         version: 8.5.12
@@ -510,9 +498,6 @@ importers:
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       '@types/tar':
         specifier: ^6.1.12
         version: 6.1.13
@@ -610,9 +595,6 @@ importers:
       '@effect/sql':
         specifier: workspace:^
         version: link:../sql/dist
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       effect:
         specifier: workspace:^
         version: link:../effect/dist
@@ -776,9 +758,6 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^10.11.0
         version: 10.11.0
-      '@types/node':
-        specifier: ^22.5.4
-        version: 22.5.4
       effect:
         specifier: workspace:^
         version: link:../effect/dist
@@ -3285,9 +3264,6 @@ packages:
 
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
-
-  '@types/node@22.5.4':
-    resolution: {integrity: sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==}
 
   '@types/node@22.9.3':
     resolution: {integrity: sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==}
@@ -10889,10 +10865,6 @@ snapshots:
     dependencies:
       '@types/node': 22.9.3
 
-  '@types/node@22.5.4':
-    dependencies:
-      undici-types: 6.19.8
-
   '@types/node@22.9.3':
     dependencies:
       undici-types: 6.19.8
@@ -13336,32 +13308,6 @@ snapshots:
       write-file-atomic: 5.0.1
     optionalDependencies:
       '@babel/preset-env': 7.26.0(@babel/core@7.25.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  jscodeshift@0.16.1(@babel/preset-env@7.26.0(@babel/core@7.26.0)):
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/parser': 7.24.8
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.25.2)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.25.2)
-      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.25.2)
-      '@babel/preset-flow': 7.24.7(@babel/core@7.25.2)
-      '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
-      '@babel/register': 7.24.6(@babel/core@7.25.2)
-      chalk: 4.1.2
-      flow-parser: 0.239.1
-      graceful-fs: 4.2.11
-      micromatch: 4.0.7
-      neo-async: 2.6.2
-      node-dir: 0.1.17
-      recast: 0.23.9
-      temp: 0.9.4
-      write-file-atomic: 5.0.1
-    optionalDependencies:
-      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
**Fixes**

- Add import attribute: https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#validated-json-imports-in---module-nodenext
- update `@types/node`: https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/#typedarrays-are-now-generic-over-arraybufferlike