### PR TITLE
Remove reference to non-existent function

### DIFF
--- a/.changeset/perfect-berries-give.md
+++ b/.changeset/perfect-berries-give.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove reference to non-existent function

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -264,8 +264,6 @@ export const isRight: <R, L>(self: Either<R, L>) => self is Right<L, R> = either
 /**
  * Converts a `Either` to an `Option` discarding the `Left`.
  *
- * Alias of {@link toOption}.
- *
  * @example
  * ```ts
  * import { Either, Option } from "effect"


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Can't see anything to suggest that `Either.toOption` ever existed.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
