### PR TITLE
Avoid "Cannot access 'ParentSpan' before initialization" error during…

### DIFF
--- a/.changeset/dull-elephants-knock.md
+++ b/.changeset/dull-elephants-knock.md
@@ -1,0 +1,5 @@
+---
+"@effect/experimental": patch
+---
+
+Avoid "Cannot access 'ParentSpan' before initialization" error during module initialization

--- a/packages/experimental/src/DevTools/Domain.ts
+++ b/packages/experimental/src/DevTools/Domain.ts
@@ -64,7 +64,11 @@ export const Span: Schema.Schema<Span, SpanFrom> = Schema.Struct({
   sampled: Schema.Boolean,
   attributes: Schema.ReadonlyMap({ key: Schema.String, value: Schema.Unknown }),
   status: SpanStatus,
-  parent: Schema.Option(Schema.suspend(() => ParentSpan))
+  parent: Schema.Option(
+    Schema.suspend(() => ParentSpan)
+      // add a title annotation to avoid "Cannot access 'ParentSpan' before initialization" error during module initialization
+      .annotations({ title: "ParentSpan" })
+  )
 })
 
 /**


### PR DESCRIPTION
… module initialization

**Reproduction steps**

Run the following code with the debugger, ensuring the "Caught Exception" checkbox is selected:

```ts
import "@effect/experimental"
```

<img width="797" alt="Screenshot 2024-11-30 at 15 59 53" src="https://github.com/user-attachments/assets/94fe1868-0a08-4fa0-a0ac-515cb444e92d">

