### PR TITLE
repro for deadlock on worker forkScoped

### DIFF
--- a/packages/platform-node/examples/worker.ts
+++ b/packages/platform-node/examples/worker.ts
@@ -1,18 +1,27 @@
 import { Worker } from "@effect/platform"
 import { NodeRuntime, NodeWorker } from "@effect/platform-node"
-import { Console, Context, Effect, Layer, Stream } from "effect"
+import type { WorkerError } from "@effect/platform/WorkerError"
+import { Console, Context, Effect, Fiber, Layer, Stream } from "effect"
+import type { RuntimeFiber } from "effect/Fiber"
 import * as WT from "node:worker_threads"
 
 interface MyWorkerPool {
   readonly _: unique symbol
 }
-const Pool = Context.GenericTag<MyWorkerPool, Worker.WorkerPool<number, never, number>>("@app/MyWorkerPool")
-const PoolLive = Worker.makePoolLayer(Pool, { size: 3 }).pipe(
+const Pool = Context.GenericTag<MyWorkerPool, RuntimeFiber<Worker.WorkerPool<number, never, number>, WorkerError>>(
+  "@app/MyWorkerPool"
+)
+const PoolLive = Layer.scoped(
+  Pool,
+  Worker.makePool<number, never, number>({ size: 3 }).pipe(
+    Effect.forkScoped // use forkDaemon here to actually receive the error and have the process die
+  )
+).pipe(
   Layer.provide(NodeWorker.layer(() => tsWorker("./worker/range.ts")))
 )
 
 Effect.gen(function*() {
-  const pool = yield* Pool
+  const pool = yield* Fiber.join(yield* Pool)
   yield* Effect.all([
     pool.execute(5).pipe(
       Stream.runForEach((_) => Console.log("worker 1", _))
@@ -24,7 +33,10 @@ Effect.gen(function*() {
       Stream.runForEach((_) => Console.log("worker 3", _))
     )
   ], { concurrency: "inherit" })
-}).pipe(Effect.provide(PoolLive), NodeRuntime.runMain)
+}).pipe(
+  Effect.provide(Layer.mergeAll(PoolLive, Layer.effectDiscard(Effect.die("hello").pipe(Effect.delay(100))))),
+  NodeRuntime.runMain
+)
 
 const tsWorker = (path: string) => {
   const url = new URL(path, import.meta.url)


### PR DESCRIPTION
this is a repro for a deadlock that @schickling is experiencing.

`cd packages/platform-node`
`pnpm tsx examples/worker.ts`

Expected result: 
- worker closes, process exits with "Error: hello"

Observed result:
- worker closes, but nothing happens further

replace `forkScoped` with `forkDaemon`: everything is fine