### PR TITLE
ensure the uniqueness of the parameters at the type level

### DIFF
--- a/.changeset/large-walls-camp.md
+++ b/.changeset/large-walls-camp.md
@@ -1,0 +1,17 @@
+---
+"@effect/platform": patch
+---
+
+Ensure the uniqueness of the parameters at the type level
+
+```ts
+import { HttpApiEndpoint, HttpApiSchema } from "@effect/platform"
+import { Schema } from "effect"
+
+HttpApiEndpoint.get(
+  "test"
+)`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
+  // @ts-expect-error: Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'
+  HttpApiSchema.param("id", Schema.NumberFromString)
+}`
+```

--- a/packages/platform/dtslint/HttpApiEndpoint.ts
+++ b/packages/platform/dtslint/HttpApiEndpoint.ts
@@ -1,0 +1,6 @@
+import { HttpApiEndpoint, HttpApiSchema } from "@effect/platform"
+import { Schema } from "effect"
+
+HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
+  // @ts-expect-error: Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'
+  HttpApiSchema.param("id", Schema.NumberFromString)}`

--- a/packages/platform/src/HttpApiEndpoint.ts
+++ b/packages/platform/src/HttpApiEndpoint.ts
@@ -575,6 +575,25 @@ export declare namespace HttpApiEndpoint {
    * @since 1.0.0
    * @category models
    */
+  export type ValidateParams<
+    Schemas extends ReadonlyArray<HttpApiSchema.AnyString>,
+    Prev extends HttpApiSchema.AnyString = never
+  > = Schemas extends [
+    infer Head extends HttpApiSchema.AnyString,
+    ...infer Tail extends ReadonlyArray<HttpApiSchema.AnyString>
+  ] ? [
+      Head extends HttpApiSchema.Param<infer _Name, infer _S>
+        ? HttpApiSchema.Param<_Name, any> extends Prev ? `Duplicate param :${_Name}`
+        : Head :
+        Head,
+      ...ValidateParams<Tail, Prev | Head>
+    ]
+    : Schemas
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
   export type AddError<Endpoint extends Any, E, R> = Endpoint extends HttpApiEndpoint<
     infer _Name,
     infer _Method,
@@ -657,7 +676,7 @@ export declare namespace HttpApiEndpoint {
     const Schemas extends ReadonlyArray<HttpApiSchema.AnyString>
   >(
     segments: TemplateStringsArray,
-    ...schemas: Schemas
+    ...schemas: ValidateParams<Schemas>
   ) => HttpApiEndpoint<
     Name,
     Method,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ensure the uniqueness of the parameters at the type level

```ts
import { HttpApiEndpoint, HttpApiSchema } from "@effect/platform"
import { Schema } from "effect"

HttpApiEndpoint.get(
  "test"
)`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
  // @ts-expect-error: Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'
  HttpApiSchema.param("id", Schema.NumberFromString)
}`
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
