### PR TITLE
Fix template literal parser throw on string literals

### DIFF
--- a/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
@@ -20,6 +20,80 @@ schema (SymbolKeyword): symbol`)
     expect(schema.params).toStrictEqual(params)
   })
 
+  describe("string literal based schemas", () => {
+    it("decoding", async () => {
+      const schema = Schema.TemplateLiteralParser("foo")
+      await Util.expectDecodeUnknownSuccess(schema, "foo", ["foo"])
+    })
+
+    it("encoding", async () => {
+      const schema = Schema.TemplateLiteralParser("foo")
+      await Util.expectEncodeSuccess(schema, ["foo"], "foo")
+    })
+  })
+
+  describe("literal based schemas", () => {
+    it("decoding", async () => {
+      const schema = Schema.TemplateLiteralParser(Schema.Literal("foo"))
+      await Util.expectDecodeUnknownSuccess(schema, "foo", ["foo"])
+    })
+
+    it("encoding", async () => {
+      const schema = Schema.TemplateLiteralParser(Schema.Literal("foo"))
+      await Util.expectEncodeSuccess(schema, ["foo"], "foo")
+    })
+  })
+
+  describe("literal union based schemas", () => {
+    it("decoding", async () => {
+      const schema = Schema.TemplateLiteralParser(Schema.Literal("foo", "bar"))
+      await Util.expectDecodeUnknownSuccess(schema, "foo", ["foo"])
+      await Util.expectDecodeUnknownSuccess(schema, "bar", ["bar"])
+    })
+
+    it("encoding", async () => {
+      const schema = Schema.TemplateLiteralParser(Schema.Literal("foo", "bar"))
+      await Util.expectEncodeSuccess(schema, ["foo"], "foo")
+      await Util.expectEncodeSuccess(schema, ["bar"], "bar")
+    })
+  })
+
+  describe("union of literals based schemas", () => {
+    it("decoding", async () => {
+      const schema = Schema.TemplateLiteralParser(Schema.Union(Schema.Literal("foo")))
+      await Util.expectDecodeUnknownSuccess(schema, "foo", ["foo"])
+    })
+
+    it("encoding", async () => {
+      const schema = Schema.TemplateLiteralParser(Schema.Union(Schema.Literal("foo")))
+      await Util.expectEncodeSuccess(schema, ["foo"], "foo")
+    })
+  })
+
+  describe("complex literal schemas", () => {
+    it("decoding", async () => {
+      const schema = Schema.TemplateLiteralParser(
+        Schema.Union(Schema.Literal("foo", "bar"), Schema.Literal("baz")),
+        "cux"
+      )
+
+      await Util.expectDecodeUnknownSuccess(schema, "foocux", ["foo", "cux"])
+      await Util.expectDecodeUnknownSuccess(schema, "barcux", ["bar", "cux"])
+      await Util.expectDecodeUnknownSuccess(schema, "bazcux", ["baz", "cux"])
+    })
+
+    it("encoding", async () => {
+      const schema = Schema.TemplateLiteralParser(
+        Schema.Union(Schema.Literal("foo", "bar"), Schema.Literal("baz")),
+        "cux"
+      )
+
+      await Util.expectEncodeSuccess(schema, ["foo", "cux"], "foocux")
+      await Util.expectEncodeSuccess(schema, ["bar", "cux"], "barcux")
+      await Util.expectEncodeSuccess(schema, ["baz", "cux"], "bazcux")
+    })
+  })
+
   describe("number based schemas", () => {
     it("decoding", async () => {
       const schema = Schema.TemplateLiteralParser(Schema.Int, "a")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix:

```ts
Schema.TemplateLiteralParser('asd')
```

...resulting in:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'replace')
    at Object.escape (./node_modules/effect/dist/cjs/RegExp.js:45:33)
    at Object.getTemplateLiteralCapturingRegExp (./node_modules/effect/dist/cjs/SchemaAST.js:1718:27)
    at Object.TemplateLiteralParser (./node_modules/effect/dist/cjs/Schema.js:492:18)
```
