### PR TITLE
Fix the behavior of `Schema.TemplateLiteralParser` when the arguments…

### DIFF
--- a/.changeset/modern-beds-compare.md
+++ b/.changeset/modern-beds-compare.md
@@ -1,0 +1,34 @@
+---
+"effect": patch
+---
+
+Fix the behavior of `Schema.TemplateLiteralParser` when the arguments include literals other than string literals.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteralParser(Schema.String, 1)
+
+console.log(Schema.decodeUnknownSync(schema)("a1"))
+/*
+throws
+ParseError: (`${string}1` <-> readonly [string, 1])
+└─ Type side transformation failure
+   └─ readonly [string, 1]
+      └─ [1]
+         └─ Expected 1, actual "1"
+*/
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteralParser(Schema.String, 1)
+
+console.log(Schema.decodeUnknownSync(schema)("a1"))
+// Output: [ 'a', 1 ]
+```

--- a/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
@@ -186,4 +186,29 @@ schema (Union): boolean | symbol`)
       )
     })
   })
+
+  it("1", async () => {
+    const schema = Schema.TemplateLiteralParser(1)
+    await Util.expectDecodeUnknownSuccess(schema, "1", [1])
+  })
+
+  it("1n", async () => {
+    const schema = Schema.TemplateLiteralParser(1n)
+    await Util.expectDecodeUnknownSuccess(schema, "1", [1n])
+  })
+
+  it("true", async () => {
+    const schema = Schema.TemplateLiteralParser(true)
+    await Util.expectDecodeUnknownSuccess(schema, "true", [true])
+  })
+
+  it("false", async () => {
+    const schema = Schema.TemplateLiteralParser(false)
+    await Util.expectDecodeUnknownSuccess(schema, "false", [false])
+  })
+
+  it("null", async () => {
+    const schema = Schema.TemplateLiteralParser(null)
+    await Util.expectDecodeUnknownSuccess(schema, "null", [null])
+  })
 })


### PR DESCRIPTION
… include literals other than string literals

Before

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteralParser(Schema.String, 1)

console.log(Schema.decodeUnknownSync(schema)("a1"))
/*
throws
ParseError: (`${string}1` <-> readonly [string, 1])
└─ Type side transformation failure
   └─ readonly [string, 1]
      └─ [1]
         └─ Expected 1, actual "1"
*/
```

After

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteralParser(Schema.String, 1)

console.log(Schema.decodeUnknownSync(schema)("a1"))
// Output: [ 'a', 1 ]
```
