### PR TITLE
Allow use of the URL object with libSQL

### DIFF
--- a/.changeset/big-hairs-give.md
+++ b/.changeset/big-hairs-give.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-libsql": patch
+---
+
+Allow use of the URL object with libSQL

--- a/packages/sql-libsql/src/LibsqlClient.ts
+++ b/packages/sql-libsql/src/LibsqlClient.ts
@@ -80,13 +80,13 @@ export declare namespace LibsqlClientConfig {
      *
      * https://github.com/libsql/libsql-client-ts#supported-urls
      */
-    readonly url: string
+    readonly url: string | URL
     /** Authentication token for the database. */
     readonly authToken?: string | undefined
     /** Encryption key for the database. */
     readonly encryptionKey?: string | undefined
     /** URL of a remote server to synchronize database with. */
-    readonly syncUrl?: string | undefined
+    readonly syncUrl?: string | URL | undefined
     /** Sync interval in seconds. */
     readonly syncInterval?: number | undefined
     /** Enables or disables TLS for `libsql:` URLs.
@@ -225,7 +225,11 @@ export const make = (
       ? new LibsqlConnectionImpl(options.liveClient)
       : yield* Effect.map(
         Effect.acquireRelease(
-          Effect.sync(() => Libsql.createClient(options as Libsql.Config)),
+          Effect.sync(() =>
+            Libsql.createClient(
+              { ...options, url: options.url.toString(), syncUrl: options.syncUrl?.toString() } as Libsql.Config
+            )
+          ),
           (sdk) => Effect.sync(() => sdk.close())
         ),
         (sdk) => new LibsqlConnectionImpl(sdk)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allows URL objects to be in `sql-libsql`, so that it's compatible with `Config.url()`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
