### PR TITLE
Preserve `MissingMessageAnnotation`s on property signature declaratio…

### DIFF
--- a/.changeset/lovely-berries-dream.md
+++ b/.changeset/lovely-berries-dream.md
@@ -1,0 +1,73 @@
+---
+"effect": patch
+---
+
+Preserve `MissingMessageAnnotation`s on property signature declarations when another field is a property signature transformation.
+
+Before
+
+```ts
+import { Console, Effect, ParseResult, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.String).annotations({
+    missingMessage: () => "message1"
+  }),
+  b: Schema.propertySignature(Schema.String)
+    .annotations({ missingMessage: () => "message2" })
+    .pipe(Schema.fromKey("c")), // <= transformation
+  d: Schema.propertySignature(Schema.String).annotations({
+    missingMessage: () => "message3"
+  })
+})
+
+Effect.runPromiseExit(
+  Schema.decodeUnknown(schema, { errors: "all" })({}).pipe(
+    Effect.tapError((error) =>
+      Console.log(ParseResult.ArrayFormatter.formatErrorSync(error))
+    )
+  )
+)
+/*
+Output:
+[
+  { _tag: 'Missing', path: [ 'a' ], message: 'is missing' }, // <= wrong
+  { _tag: 'Missing', path: [ 'c' ], message: 'message2' },
+  { _tag: 'Missing', path: [ 'd' ], message: 'is missing' } // <= wrong
+]
+*/
+```
+
+After
+
+```ts
+import { Console, Effect, ParseResult, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.String).annotations({
+    missingMessage: () => "message1"
+  }),
+  b: Schema.propertySignature(Schema.String)
+    .annotations({ missingMessage: () => "message2" })
+    .pipe(Schema.fromKey("c")), // <= transformation
+  d: Schema.propertySignature(Schema.String).annotations({
+    missingMessage: () => "message3"
+  })
+})
+
+Effect.runPromiseExit(
+  Schema.decodeUnknown(schema, { errors: "all" })({}).pipe(
+    Effect.tapError((error) =>
+      Console.log(ParseResult.ArrayFormatter.formatErrorSync(error))
+    )
+  )
+)
+/*
+Output:
+[
+  { _tag: 'Missing', path: [ 'a' ], message: 'message1' },
+  { _tag: 'Missing', path: [ 'c' ], message: 'message2' },
+  { _tag: 'Missing', path: [ 'd' ], message: 'message3' }
+]
+*/
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2559,6 +2559,8 @@ export interface TypeLiteral<
   ): Simplify<TypeLiteral.Type<Fields, Records>>
 }
 
+const preserveMissingMessageAnnotation = AST.whiteListAnnotations([AST.MissingMessageAnnotationId])
+
 const getDefaultTypeLiteralAST = <
   Fields extends Struct.Fields,
   const Records extends IndexSignature.Records
@@ -2579,7 +2581,7 @@ const getDefaultTypeLiteralAST = <
             const type = ast.type
             const isOptional = ast.isOptional
             const toAnnotations = ast.annotations
-            from.push(new AST.PropertySignature(key, type, isOptional, true))
+            from.push(new AST.PropertySignature(key, type, isOptional, true, preserveMissingMessageAnnotation(ast)))
             to.push(new AST.PropertySignature(key, AST.typeAST(type), isOptional, true, toAnnotations))
             pss.push(
               new AST.PropertySignature(key, type, isOptional, true, toAnnotations)

--- a/packages/effect/test/Schema/ParseResultFormatter.test.ts
+++ b/packages/effect/test/Schema/ParseResultFormatter.test.ts
@@ -141,26 +141,60 @@ describe("ParseResultFormatter", () => {
     })
 
     describe("missing message", () => {
-      it("Struct", async () => {
-        const schema = S.Struct({
-          a: S.propertySignature(S.String).annotations({
-            description: "my description",
-            missingMessage: () => "my missing message"
+      describe("Struct", () => {
+        it("PropertySignatureDeclaration", async () => {
+          const schema = S.Struct({
+            a: S.propertySignature(S.String).annotations({
+              missingMessage: () => "a80b642a-729f-4676-ba6a-235964afd52b"
+            })
           })
-        })
-        const input = {}
-        await Util.expectDecodeUnknownFailure(
-          schema,
-          input,
-          `{ readonly a: string }
+          const input = {}
+          await Util.expectDecodeUnknownFailure(
+            schema,
+            input,
+            `{ readonly a: string }
 └─ ["a"]
-   └─ my missing message`
-        )
-        expectIssues(schema, input, [{
-          _tag: "Missing",
-          path: ["a"],
-          message: "my missing message"
-        }])
+   └─ a80b642a-729f-4676-ba6a-235964afd52b`
+          )
+          expectIssues(schema, input, [{
+            _tag: "Missing",
+            path: ["a"],
+            message: "a80b642a-729f-4676-ba6a-235964afd52b"
+          }])
+        })
+
+        it("PropertySignatureDeclaration + PropertySignatureTransformation", async () => {
+          const schema = S.Struct({
+            a: S.propertySignature(S.String).annotations({
+              missingMessage: () => "1ff9f37a-1f50-4ee2-906d-e824067d4cf7"
+            }),
+            b: S.propertySignature(S.String).annotations({
+              missingMessage: () => "132f0e48-ae12-4bbb-8473-3dd433de2eb0"
+            }).pipe(S.fromKey("c"))
+          })
+          const input = {}
+          await Util.expectDecodeUnknownFailure(
+            schema,
+            input,
+            `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      ├─ ["a"]
+      │  └─ 1ff9f37a-1f50-4ee2-906d-e824067d4cf7
+      └─ ["c"]
+         └─ 132f0e48-ae12-4bbb-8473-3dd433de2eb0`,
+            Util.allErrors
+          )
+          expectIssues(schema, input, [{
+            _tag: "Missing",
+            path: ["a"],
+            message: "1ff9f37a-1f50-4ee2-906d-e824067d4cf7"
+          }, {
+            _tag: "Missing",
+            path: ["c"],
+            message: "132f0e48-ae12-4bbb-8473-3dd433de2eb0"
+          }])
+        })
       })
 
       describe("Tuple", () => {


### PR DESCRIPTION
…ns when another field is a property signature transformation, closes #4079

Before

```ts
import { Console, Effect, ParseResult, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.String).annotations({
    missingMessage: () => "message1"
  }),
  b: Schema.propertySignature(Schema.String)
    .annotations({ missingMessage: () => "message2" })
    .pipe(Schema.fromKey("c")), // <= transformation
  d: Schema.propertySignature(Schema.String).annotations({
    missingMessage: () => "message3"
  })
})

Effect.runPromiseExit(
  Schema.decodeUnknown(schema, { errors: "all" })({}).pipe(
    Effect.tapError((error) =>
      Console.log(ParseResult.ArrayFormatter.formatErrorSync(error))
    )
  )
)
/*
Output:
[
  { _tag: 'Missing', path: [ 'a' ], message: 'is missing' }, // <= wrong
  { _tag: 'Missing', path: [ 'c' ], message: 'message2' },
  { _tag: 'Missing', path: [ 'd' ], message: 'is missing' } // <= wrong
]
*/
```

After

```ts
import { Console, Effect, ParseResult, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.String).annotations({
    missingMessage: () => "message1"
  }),
  b: Schema.propertySignature(Schema.String)
    .annotations({ missingMessage: () => "message2" })
    .pipe(Schema.fromKey("c")), // <= transformation
  d: Schema.propertySignature(Schema.String).annotations({
    missingMessage: () => "message3"
  })
})

Effect.runPromiseExit(
  Schema.decodeUnknown(schema, { errors: "all" })({}).pipe(
    Effect.tapError((error) =>
      Console.log(ParseResult.ArrayFormatter.formatErrorSync(error))
    )
  )
)
/*
Output:
[
  { _tag: 'Missing', path: [ 'a' ], message: 'message1' },
  { _tag: 'Missing', path: [ 'c' ], message: 'message2' },
  { _tag: 'Missing', path: [ 'd' ], message: 'message3' }
]
*/
```
