### PR TITLE
Fix `TemplateLiteral` and `TemplateLiteralParser` encoded type infere…

### DIFF
--- a/packages/effect/dtslint/Schema.ts
+++ b/packages/effect/dtslint/Schema.ts
@@ -1270,6 +1270,9 @@ S.TemplateLiteral("a", S.Number.pipe(S.brand("MyBrand")))
 // $ExpectType TemplateLiteral<`a${number & Brand<"MyBrand">}`>
 S.TemplateLiteral(S.Literal("a"), S.Number.pipe(S.brand("MyBrand")))
 
+// $ExpectType TemplateLiteral<`a${string}` | `a${number}`>
+S.TemplateLiteral("a", S.Union(S.Number, S.String))
+
 // ---------------------------------------------
 // attachPropertySignature
 // ---------------------------------------------
@@ -2868,6 +2871,9 @@ S.asSchema(S.TemplateLiteralParser(S.NumberFromString, "a", S.NonEmptyString))
 
 // $ExpectType Schema<readonly ["/", number, "/", "a" | "b"], `/${number}/a` | `/${number}/b`, never>
 S.asSchema(S.TemplateLiteralParser("/", S.Int, "/", S.Literal("a", "b")))
+
+// $ExpectType Schema<readonly ["a", string | number], `a${string}` | `a${number}`, never>
+S.asSchema(S.TemplateLiteralParser("a", S.Union(S.Number, S.String)))
 
 // ---------------------------------------------
 // UndefinedOr

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -689,11 +689,16 @@ const makeEnumsClass = <A extends EnumsDefinition>(
  */
 export const Enums = <A extends EnumsDefinition>(enums: A): Enums<A> => makeEnumsClass(enums)
 
-type GetTemplateLiteralType<Params> = Params extends [infer Head, ...infer Tail] ?
-  Head extends AST.LiteralValue ? `${Head}${GetTemplateLiteralType<Tail>}` :
-  Head extends Schema<infer A extends AST.LiteralValue, infer _I> ? `${A}${GetTemplateLiteralType<Tail>}` :
-  never :
-  ``
+type AppendType<
+  Template extends string,
+  Next
+> = Next extends AST.LiteralValue ? `${Template}${Next}`
+  : Next extends Schema<infer A extends AST.LiteralValue, infer _I, infer _R> ? `${Template}${A}`
+  : never
+
+type GetTemplateLiteralType<Params> = Params extends [...infer Init, infer Last] ?
+  AppendType<GetTemplateLiteralType<Init>, Last>
+  : ``
 
 /**
  * @category API interface
@@ -762,12 +767,16 @@ type GetTemplateLiteralParserType<Params> = Params extends [infer Head, ...infer
   ]
   : []
 
-type GetTemplateLiteralParserEncoded<Params> = Params extends [infer Head, ...infer Tail] ?
-  Head extends AST.LiteralValue ? `${Head}${GetTemplateLiteralParserEncoded<Tail>}` :
-  Head extends Schema<infer _A, infer I extends AST.LiteralValue, infer _R> ?
-    `${I}${GetTemplateLiteralParserEncoded<Tail>}` :
-  never :
-  ``
+type AppendEncoded<
+  Template extends string,
+  Next
+> = Next extends AST.LiteralValue ? `${Template}${Next}`
+  : Next extends Schema<infer _A, infer I extends AST.LiteralValue, infer _R> ? `${Template}${I}`
+  : never
+
+type GetTemplateLiteralParserEncoded<Params> = Params extends [...infer Init, infer Last] ?
+  AppendEncoded<GetTemplateLiteralParserEncoded<Init>, Last>
+  : ``
 
 /**
  * @category API interface


### PR DESCRIPTION
…nce when the parameters include a union of `string | number`

Before:

```ts
import { Schema as S } from "effect"

// const x: S.Schema<readonly ["/", string | number], `/${string}`, never>
const x = S.asSchema(
  S.TemplateLiteralParser("/", S.Union(S.Number, S.String))
)

// const y: S.Schema<`/${string}`, `/${string}`, never>
const y = S.asSchema(S.TemplateLiteral("/", S.Union(S.Number, S.String)))
```

After:

```ts
import { Schema as S } from "effect"

// const x: S.Schema<readonly ["/", string | number], `/${string}` | `/${number}`, never>
const x = S.asSchema(S.TemplateLiteralParser("/", S.Union(S.Number, S.String)))

// const y: S.Schema<`/${string}` | `/${number}`, `/${string}` | `/${number}`, never>
const y = S.asSchema(S.TemplateLiteral("/", S.Union(S.Number, S.String)))
```