### PR TITLE
Add the missing dependency on @effect/experimental to @effect/sql-X

### DIFF
--- a/.changeset/happy-ligers-wonder.md
+++ b/.changeset/happy-ligers-wonder.md
@@ -1,0 +1,14 @@
+---
+"@effect/sql-sqlite-react-native": patch
+"@effect/sql-sqlite-node": patch
+"@effect/sql-sqlite-wasm": patch
+"@effect/sql-clickhouse": patch
+"@effect/sql-sqlite-bun": patch
+"@effect/sql-libsql": patch
+"@effect/sql-mysql2": patch
+"@effect/sql-mssql": patch
+"@effect/sql-d1": patch
+"@effect/sql-pg": patch
+---
+
+Add the missing dependency on @effect/experimental to @effect/sql-X

--- a/packages/sql-clickhouse/package.json
+++ b/packages/sql-clickhouse/package.json
@@ -39,12 +39,14 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/platform-node": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/platform-node": "workspace:^",
     "@effect/sql": "workspace:^",

--- a/packages/sql-d1/package.json
+++ b/packages/sql-d1/package.json
@@ -43,12 +43,14 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^",
     "miniflare": "^3.20240806.0"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-libsql/package.json
+++ b/packages/sql-libsql/package.json
@@ -41,12 +41,14 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^",
     "testcontainers": "^10.11.0"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-mssql/package.json
+++ b/packages/sql-mssql/package.json
@@ -39,11 +39,13 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-mysql2/package.json
+++ b/packages/sql-mysql2/package.json
@@ -39,12 +39,14 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "@testcontainers/mysql": "^10.11.0",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-pg/package.json
+++ b/packages/sql-pg/package.json
@@ -39,12 +39,14 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "@testcontainers/postgresql": "^10.11.0",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-sqlite-bun/package.json
+++ b/packages/sql-sqlite-bun/package.json
@@ -42,12 +42,14 @@
     "@opentelemetry/semantic-conventions": "^1.25.1"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "@types/bun": "^1.1.13",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-sqlite-node/package.json
+++ b/packages/sql-sqlite-node/package.json
@@ -39,12 +39,14 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "@types/better-sqlite3": "^7.6.11",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/sql": "workspace:^",
     "effect": "workspace:^"

--- a/packages/sql-sqlite-react-native/package.json
+++ b/packages/sql-sqlite-react-native/package.json
@@ -39,11 +39,13 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/sql": "workspace:^",
     "@op-engineering/op-sqlite": "7.1.0",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/sql": "workspace:^",
     "@op-engineering/op-sqlite": "7.1.0",
     "effect": "workspace:^"

--- a/packages/sql-sqlite-wasm/package.json
+++ b/packages/sql-sqlite-wasm/package.json
@@ -38,11 +38,13 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/sql": "workspace:^",
     "@effect/wa-sqlite": "^0.1.2",
     "effect": "workspace:^"
   },
   "peerDependencies": {
+    "@effect/experimental": "workspace:^",
     "@effect/sql": "workspace:^",
     "@effect/wa-sqlite": "^0.1.2",
     "effect": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,9 @@ importers:
         specifier: ^1.25.1
         version: 1.25.1
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -611,6 +614,9 @@ importers:
         specifier: ^1.24.1
         version: 1.25.1
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -685,6 +691,9 @@ importers:
         specifier: ^1.25.1
         version: 1.25.1
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -708,6 +717,9 @@ importers:
         specifier: ^18.3.0
         version: 18.3.0
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -728,6 +740,9 @@ importers:
         specifier: ^3.11.0
         version: 3.11.0
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -751,6 +766,9 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -771,6 +789,9 @@ importers:
         specifier: ^1.25.1
         version: 1.25.1
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -794,6 +815,9 @@ importers:
         specifier: ^11.1.2
         version: 11.1.2
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/platform':
         specifier: workspace:^
         version: link:../platform/dist
@@ -814,6 +838,9 @@ importers:
         specifier: ^1.25.1
         version: 1.25.1
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/sql':
         specifier: workspace:^
         version: link:../sql/dist
@@ -831,6 +858,9 @@ importers:
         specifier: ^1.25.1
         version: 1.25.1
     devDependencies:
+      '@effect/experimental':
+        specifier: workspace:^
+        version: link:../experimental/dist
       '@effect/sql':
         specifier: workspace:^
         version: link:../sql/dist
@@ -5473,7 +5503,6 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.6:


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Most of @effect/sql-X packages started to adopt @effect/experimental as a new dependency in #4021, but didn't have it set in package.json.

For my case, this leads to issues when they are being used in Deno.

This PR fixes that by adding the missing dependency.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- #4021

