### PR TITLE
http api param inherits description from schema #4046

### DIFF
--- a/.changeset/empty-beans-complain.md
+++ b/.changeset/empty-beans-complain.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+http api param inherits description from schema

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -81,7 +81,8 @@ describe("HttpApi", () => {
       Effect.gen(function*() {
         const client = yield* HttpApiClient.make(Api)
         const users = yield* client.users.list({
-          headers: { page: 1 }
+          headers: { page: 1 },
+          urlParams: {}
         })
         const user = users[0]
         assert.deepStrictEqual(
@@ -150,7 +151,7 @@ describe("HttpApi", () => {
   it.effect("handler level context", () =>
     Effect.gen(function*() {
       const client = yield* HttpApiClient.make(Api)
-      const users = yield* client.users.list({ headers: { page: 1 } })
+      const users = yield* client.users.list({ headers: { page: 1 }, urlParams: {} })
       const user = users[0]
       assert.strictEqual(user.name, "page 1")
       assert.deepStrictEqual(user.createdAt, DateTime.unsafeMake(0))
@@ -206,7 +207,7 @@ describe("HttpApi", () => {
   it.effect("client withResponse", () =>
     Effect.gen(function*() {
       const client = yield* HttpApiClient.make(Api)
-      const [users, response] = yield* client.users.list({ headers: { page: 1 }, withResponse: true })
+      const [users, response] = yield* client.users.list({ headers: { page: 1 }, urlParams: {}, withResponse: true })
       assert.strictEqual(users[0].name, "page 1")
       assert.strictEqual(response.status, 200)
     }).pipe(Effect.provide(HttpLive)))
@@ -329,6 +330,9 @@ class UsersApi extends HttpApiGroup.make("users")
         page: Schema.NumberFromString.pipe(
           Schema.optionalWith({ default: () => 1 })
         )
+      }))
+      .setUrlParams(Schema.Struct({
+        query: Schema.optional(Schema.String).annotations({ description: "search query" })
       }))
       .addSuccess(Schema.Array(User))
       .addError(NoStatusError)

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -289,6 +289,16 @@
               "$ref": "#/components/schemas/NumberFromString"
             },
             "required": false
+          },
+          {
+            "description": "search query",
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "description": "search query",
+              "type": "string"
+            }
           }
         ],
         "security": [

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -294,7 +294,7 @@
             "description": "search query",
             "in": "query",
             "name": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "description": "search query",
               "type": "string"

--- a/packages/platform/src/OpenApi.ts
+++ b/packages/platform/src/OpenApi.ts
@@ -299,7 +299,8 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
               name,
               in: "path",
               schema: jsonSchema,
-              required: schema.required.includes(name)
+              required: schema.required.includes(name),
+              ...(jsonSchema.description ? { description: jsonSchema.description } : {})
             })
           })
         }
@@ -312,7 +313,8 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
               name,
               in: "query",
               schema: jsonSchema,
-              required: schema.required.includes(name)
+              required: schema.required.includes(name),
+              ...(jsonSchema.description ? { description: jsonSchema.description } : {})
             })
           })
         }
@@ -325,7 +327,8 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
               name,
               in: "header",
               schema: jsonSchema,
-              required: schema.required.includes(name)
+              required: schema.required.includes(name),
+              ...(jsonSchema.description ? { description: jsonSchema.description } : {})
             })
           })
         }
@@ -338,7 +341,8 @@ export const fromApi = <A extends HttpApi.HttpApi.Any>(self: A): OpenAPISpec => 
               name,
               in: "query",
               schema: jsonSchema,
-              required: schema.required.includes(name)
+              required: schema.required.includes(name),
+              ...(jsonSchema.description ? { description: jsonSchema.description } : {})
             })
           })
         }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

adds option to render parameter (header, urlQuery, path) description in swagger 

<!--
Please add a brief summary/description of the pull request here.
-->


<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

implements part of this issue:

- Related Issue #4046
