### PR TITLE
Allow passing fast-check parameters to prop function

### DIFF
--- a/.changeset/four-ghosts-decide.md
+++ b/.changeset/four-ghosts-decide.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Update fast-check to latest version

--- a/.changeset/hot-jeans-kiss.md
+++ b/.changeset/hot-jeans-kiss.md
@@ -1,0 +1,20 @@
+---
+"@effect/vitest": patch
+---
+
+Allow passing fast-check parameters to prop function
+
+```ts
+it.effect.prop(
+  "adds context",
+  [realNumber],
+  ([num]) =>
+    Effect.gen(function* () {
+      const foo = yield* Foo
+      expect(foo).toEqual("foo")
+      return num === num
+    }),
+  {},
+  { numRuns: 200 }
+)
+```

--- a/.changeset/hot-jeans-kiss.md
+++ b/.changeset/hot-jeans-kiss.md
@@ -14,7 +14,6 @@ it.effect.prop(
       expect(foo).toEqual("foo")
       return num === num
     }),
-  {},
-  { numRuns: 200 }
+  { fastCheck: { numRuns: 200 } }
 )
 ```

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
-    "fast-check": "^3.21.0",
+    "fast-check": "^3.23.1",
     "glob": "^11.0.0",
     "jscodeshift": "^0.16.1",
     "madge": "^8.0.0",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -50,6 +50,6 @@
     "zod": "^3.23.5"
   },
   "dependencies": {
-    "fast-check": "^3.21.0"
+    "fast-check": "^3.23.1"
   }
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -3,6 +3,7 @@
  */
 import type * as Duration from "effect/Duration"
 import type * as Effect from "effect/Effect"
+import type * as FC from "effect/FastCheck"
 import type * as Layer from "effect/Layer"
 import type * as Schema from "effect/Schema"
 import type * as Scope from "effect/Scope"
@@ -66,7 +67,8 @@ export namespace Vitest {
         R,
         [{ [K in keyof S]: Schema.Schema.Type<S[K]> }, V.TaskContext<V.RunnerTestCase<{}>> & V.TestContext]
       >,
-      timeout?: number | V.TestOptions
+      timeout?: number | V.TestOptions,
+      check?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }>
     ) => void
   }
 
@@ -99,7 +101,8 @@ export namespace Vitest {
         schemas: { [K in keyof S]: Schema.Schema.Type<S[K]> },
         ctx: V.TaskContext<V.RunnerTestCase<{}>> & V.TestContext
       ) => void,
-      timeout?: number | V.TestOptions
+      timeout?: number | V.TestOptions,
+      check?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }>
     ) => void
   }
 }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -67,8 +67,7 @@ export namespace Vitest {
         R,
         [{ [K in keyof S]: Schema.Schema.Type<S[K]> }, V.TaskContext<V.RunnerTestCase<{}>> & V.TestContext]
       >,
-      timeout?: number | V.TestOptions,
-      check?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }>
+      timeout?: number | V.TestOptions & { fastCheck?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }> }
     ) => void
   }
 
@@ -101,8 +100,7 @@ export namespace Vitest {
         schemas: { [K in keyof S]: Schema.Schema.Type<S[K]> },
         ctx: V.TaskContext<V.RunnerTestCase<{}>> & V.TestContext
       ) => void,
-      timeout?: number | V.TestOptions,
-      check?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }>
+      timeout?: number | V.TestOptions & { fastCheck?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }> }
     ) => void
   }
 }
@@ -198,7 +196,7 @@ export const prop: <const S extends Vitest.SchemaObj>(
     schemas: { [K in keyof S]: Schema.Schema.Type<S[K]> },
     ctx: V.TaskContext<V.RunnerTestCase<{}>> & V.TestContext
   ) => void,
-  timeout?: number | V.TestOptions
+  timeout?: number | V.TestOptions & { fastCheck?: FC.Parameters<{ [K in keyof S]: Schema.Schema.Type<S[K]> }> }
 ) => void = internal.prop
 
 /**

--- a/packages/vitest/src/internal.ts
+++ b/packages/vitest/src/internal.ts
@@ -97,13 +97,13 @@ const makeTester = <R>(
       (args, ctx) => run(ctx, [args], self) as any
     )
 
-  const prop: Vitest.Vitest.Tester<R>["prop"] = (name, schemaObj, self, timeout) => {
+  const prop: Vitest.Vitest.Tester<R>["prop"] = (name, schemaObj, self, timeout, check) => {
     if (Array.isArray(schemaObj)) {
       const arbs = schemaObj.map((schema) => Arbitrary.make(schema))
       return V.it(
         name,
         // @ts-ignore
-        (ctx) => fc.assert(fc.asyncProperty(...arbs, (...as) => run(ctx, [as as any, ctx], self))),
+        (ctx) => fc.assert(fc.asyncProperty(...arbs, (...as) => run(ctx, [as as any, ctx], self)), check),
         timeout
       )
     }
@@ -118,7 +118,7 @@ const makeTester = <R>(
     return V.it(
       name,
       // @ts-ignore
-      (ctx) => fc.assert(fc.asyncProperty(arbs, (...as) => run(ctx, [as[0] as any, ctx], self))),
+      (ctx) => fc.assert(fc.asyncProperty(arbs, (...as) => run(ctx, [as[0] as any, ctx], self)), check),
       timeout
     )
   }
@@ -126,13 +126,13 @@ const makeTester = <R>(
   return Object.assign(f, { skip, skipIf, runIf, only, each, prop })
 }
 
-export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeout) => {
+export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeout, check) => {
   if (Array.isArray(schemaObj)) {
     const arbs = schemaObj.map((schema) => Arbitrary.make(schema))
     return V.it(
       name,
       // @ts-ignore
-      (ctx) => fc.assert(fc.property(...arbs, (...as) => self(as, ctx))),
+      (ctx) => fc.assert(fc.property(...arbs, (...as) => self(as, ctx)), check),
       timeout
     )
   }
@@ -147,7 +147,7 @@ export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeo
   return V.it(
     name,
     // @ts-ignore
-    (ctx) => fc.assert(fc.property(arbs, (...as) => self(as[0], ctx))),
+    (ctx) => fc.assert(fc.property(arbs, (...as) => self(as[0], ctx)), check),
     timeout
   )
 }

--- a/packages/vitest/src/internal.ts
+++ b/packages/vitest/src/internal.ts
@@ -12,6 +12,7 @@ import * as Fiber from "effect/Fiber"
 import { flow, identity, pipe } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Logger from "effect/Logger"
+import { isObject } from "effect/Predicate"
 import * as Schedule from "effect/Schedule"
 import * as Scope from "effect/Scope"
 import * as TestEnvironment from "effect/TestContext"
@@ -97,13 +98,18 @@ const makeTester = <R>(
       (args, ctx) => run(ctx, [args], self) as any
     )
 
-  const prop: Vitest.Vitest.Tester<R>["prop"] = (name, schemaObj, self, timeout, check) => {
+  const prop: Vitest.Vitest.Tester<R>["prop"] = (name, schemaObj, self, timeout) => {
     if (Array.isArray(schemaObj)) {
       const arbs = schemaObj.map((schema) => Arbitrary.make(schema))
       return V.it(
         name,
-        // @ts-ignore
-        (ctx) => fc.assert(fc.asyncProperty(...arbs, (...as) => run(ctx, [as as any, ctx], self)), check),
+        (ctx) =>
+          // @ts-ignore
+          fc.assert(
+            // @ts-ignore
+            fc.asyncProperty(...arbs, (...as) => run(ctx, [as as any, ctx], self)),
+            isObject(timeout) ? timeout?.fastCheck : {}
+          ),
         timeout
       )
     }
@@ -117,8 +123,14 @@ const makeTester = <R>(
 
     return V.it(
       name,
-      // @ts-ignore
-      (ctx) => fc.assert(fc.asyncProperty(arbs, (...as) => run(ctx, [as[0] as any, ctx], self)), check),
+      (ctx) =>
+        // @ts-ignore
+        fc.assert(
+          fc.asyncProperty(arbs, (...as) =>
+            // @ts-ignore
+            run(ctx, [as[0] as any, ctx], self)),
+          isObject(timeout) ? timeout?.fastCheck : {}
+        ),
       timeout
     )
   }
@@ -126,13 +138,13 @@ const makeTester = <R>(
   return Object.assign(f, { skip, skipIf, runIf, only, each, prop })
 }
 
-export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeout, check) => {
+export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeout) => {
   if (Array.isArray(schemaObj)) {
     const arbs = schemaObj.map((schema) => Arbitrary.make(schema))
     return V.it(
       name,
       // @ts-ignore
-      (ctx) => fc.assert(fc.property(...arbs, (...as) => self(as, ctx)), check),
+      (ctx) => fc.assert(fc.property(...arbs, (...as) => self(as, ctx)), isObject(timeout) ? timeout?.fastCheck : {}),
       timeout
     )
   }

--- a/packages/vitest/test/advent-of-pbt-2024/day-1.test.ts
+++ b/packages/vitest/test/advent-of-pbt-2024/day-1.test.ts
@@ -29,6 +29,5 @@ it.prop(
       if (prev.name > curr.name) throw new Error("Invalid on name")
     }
   },
-  { fails: true },
-  { seed: 1485455336, path: "352:3:7:9:9:13:12:11", endOnFailure: true }
+  { fails: true, fastCheck: { seed: 1485455336, path: "352:3:7:9:9:13:12:11", endOnFailure: true } }
 )

--- a/packages/vitest/test/advent-of-pbt-2024/day-1.test.ts
+++ b/packages/vitest/test/advent-of-pbt-2024/day-1.test.ts
@@ -1,0 +1,34 @@
+import { it } from "@effect/vitest"
+import { Schema } from "effect"
+
+const Letter = Schema.Struct({
+  name: Schema.String.pipe(
+    Schema.minLength(1),
+    Schema.filter((s) => s.match(/^[a-z]+$/) !== null)
+  ),
+  age: Schema.Int.pipe(
+    Schema.between(1, 77)
+  )
+})
+
+function sortLetters(letters: ReadonlyArray<Schema.Schema.Type<typeof Letter>>) {
+  const clonedLetters = [...letters]
+  return clonedLetters.sort((la, lb) => la.age - lb.age || la.name.codePointAt(0)! - lb.name.codePointAt(0)!)
+}
+
+it.prop(
+  "day #1: should properly sort letters",
+  [Schema.Array(Letter)],
+  ([unsortedLetters]) => {
+    const letters = sortLetters(unsortedLetters)
+    for (let i = 1; i < letters.length; ++i) {
+      const prev = letters[i - 1]
+      const curr = letters[i]
+      if (prev.age < curr.age) continue // properly ordered
+      if (prev.age > curr.age) throw new Error("Invalid on age")
+      if (prev.name > curr.name) throw new Error("Invalid on name")
+    }
+  },
+  { fails: true },
+  { seed: 1485455336, path: "352:3:7:9:9:13:12:11", endOnFailure: true }
+)

--- a/packages/vitest/test/advent-of-pbt-2024/day-1.test.ts
+++ b/packages/vitest/test/advent-of-pbt-2024/day-1.test.ts
@@ -1,7 +1,7 @@
 import { it } from "@effect/vitest"
 import { Schema } from "effect"
 
-const Letter = Schema.Struct({
+class Letter extends Schema.Class<Letter>("Letter")({
   name: Schema.String.pipe(
     Schema.minLength(1),
     Schema.filter((s) => s.match(/^[a-z]+$/) !== null)
@@ -9,16 +9,18 @@ const Letter = Schema.Struct({
   age: Schema.Int.pipe(
     Schema.between(1, 77)
   )
-})
+}) {
+  static Array = Schema.Array(this)
+}
 
-function sortLetters(letters: ReadonlyArray<Schema.Schema.Type<typeof Letter>>) {
+function sortLetters(letters: Schema.Schema.Type<typeof Letter.Array>) {
   const clonedLetters = [...letters]
   return clonedLetters.sort((la, lb) => la.age - lb.age || la.name.codePointAt(0)! - lb.name.codePointAt(0)!)
 }
 
 it.prop(
   "day #1: should properly sort letters",
-  [Schema.Array(Letter)],
+  [Letter.Array],
   ([unsortedLetters]) => {
     const letters = sortLetters(unsortedLetters)
     for (let i = 1; i < letters.length; ++i) {

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -147,12 +147,18 @@ layer(Foo.Live)("layer", (it) => {
         }))
     })
 
-    it.effect.prop("adds context", [realNumber], ([num]) =>
-      Effect.gen(function*() {
-        const foo = yield* Foo
-        expect(foo).toEqual("foo")
-        return num === num
-      }))
+    it.effect.prop(
+      "adds context",
+      [realNumber],
+      ([num]) =>
+        Effect.gen(function*() {
+          const foo = yield* Foo
+          expect(foo).toEqual("foo")
+          return num === num
+        }),
+      {},
+      { numRuns: 200 }
+    )
   })
 })
 

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -156,8 +156,7 @@ layer(Foo.Live)("layer", (it) => {
           expect(foo).toEqual("foo")
           return num === num
         }),
-      {},
-      { numRuns: 200 }
+      { fastCheck: { numRuns: 200 } }
     )
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(eslint@9.9.1)
       fast-check:
-        specifier: ^3.21.0
-        version: 3.21.0
+        specifier: ^3.23.1
+        version: 3.23.1
       glob:
         specifier: ^11.0.0
         version: 11.0.0
@@ -303,8 +303,8 @@ importers:
   packages/effect:
     dependencies:
       fast-check:
-        specifier: ^3.21.0
-        version: 3.21.0
+        specifier: ^3.23.1
+        version: 3.23.1
     devDependencies:
       '@types/jscodeshift':
         specifier: ^0.11.11
@@ -4660,8 +4660,8 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
-  fast-check@3.21.0:
-    resolution: {integrity: sha512-QpmbiqRFRZ+SIlBJh6xi5d/PgXciUc/xWKc4Vi2RWEHHIRx6oM3f0fWNna++zP9VB5HUBTObUK9gTKQP3vVcrQ==}
+  fast-check@3.23.1:
+    resolution: {integrity: sha512-u/MudsoQEgBUZgR5N1v87vEgybeVYus9VnDVaIkxkkGP2jt54naghQ3PCQHJiogS8U/GavZCUPFfx3Xkp+NaHw==}
     engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
@@ -12547,7 +12547,7 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  fast-check@3.21.0:
+  fast-check@3.23.1:
     dependencies:
       pure-rand: 6.1.0
 


### PR DESCRIPTION
```ts
it.effect.prop(
  "adds context",
  [realNumber],
  ([num]) =>
    Effect.gen(function* () {
      const foo = yield* Foo
      expect(foo).toEqual("foo")
      return num === num
    }),
  {},
  { numRuns: 200 }
)
```