### PR TITLE
Schema: align the `make` constructor of structs with the behavior of …

### DIFF
--- a/.changeset/swift-sloths-taste.md
+++ b/.changeset/swift-sloths-taste.md
@@ -1,0 +1,35 @@
+---
+"effect": patch
+---
+
+Schema: align the `make` constructor of structs with the behavior of the Class API constructors when all fields have a default.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.Number).pipe(
+    Schema.withConstructorDefault(() => 0)
+  )
+})
+
+// TypeScript error: Expected 1-2 arguments, but got 0.ts(2554)
+console.log(schema.make())
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.Number).pipe(
+    Schema.withConstructorDefault(() => 0)
+  )
+})
+
+console.log(schema.make())
+// Output: { a: 0 }
+```

--- a/packages/effect/dtslint/Schema.ts
+++ b/packages/effect/dtslint/Schema.ts
@@ -2603,7 +2603,7 @@ const make3 = S.Struct({
   a: S.withConstructorDefault(S.propertySignature(S.String), () => "")
 }).make
 
-// $ExpectType { readonly a?: string; }
+// $ExpectType void | { readonly a?: string; } | undefined
 hole<Parameters<typeof make3>["0"]>()
 
 class AA extends S.Class<AA>("AA")({
@@ -2638,7 +2638,7 @@ S.Struct({ a: S.optional(S.String).pipe(S.withDefaults({ decoding: () => "", con
 const make4 =
   S.Struct({ a: S.optional(S.String).pipe(S.withDefaults({ decoding: () => "", constructor: () => "" })) }).make
 
-// $ExpectType { readonly a?: string; }
+// $ExpectType void | { readonly a?: string; } | undefined
 hole<Parameters<typeof make4>["0"]>()
 
 // ---------------------------------------------

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2563,7 +2563,9 @@ export interface TypeLiteral<
     annotations: Annotations.Schema<Simplify<TypeLiteral.Type<Fields, Records>>>
   ): TypeLiteral<Fields, Records>
   make(
-    props: Simplify<TypeLiteral.Constructor<Fields, Records>>,
+    props: RequiredKeys<TypeLiteral.Constructor<Fields, Records>> extends never
+      ? void | Simplify<TypeLiteral.Constructor<Fields, Records>>
+      : Simplify<TypeLiteral.Constructor<Fields, Records>>,
     options?: MakeOptions
   ): Simplify<TypeLiteral.Type<Fields, Records>>
 }

--- a/packages/effect/test/Schema/Schema/Class/Class.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/Class.test.ts
@@ -156,11 +156,15 @@ describe("Class", () => {
     it("should accept void if the Class has no fields", () => {
       class A extends S.Class<A>("A")({}) {}
       expect({ ...new A() }).toStrictEqual({})
+      expect({ ...new A(undefined) }).toStrictEqual({})
       expect({ ...new A(undefined, true) }).toStrictEqual({})
+      expect({ ...new A(undefined, false) }).toStrictEqual({})
       expect({ ...new A({}) }).toStrictEqual({})
 
       expect({ ...A.make() }).toStrictEqual({})
+      expect({ ...A.make(undefined) }).toStrictEqual({})
       expect({ ...A.make(undefined, true) }).toStrictEqual({})
+      expect({ ...A.make(undefined, false) }).toStrictEqual({})
       expect({ ...A.make({}) }).toStrictEqual({})
     })
 
@@ -170,10 +174,14 @@ describe("Class", () => {
       }) {}
       expect({ ...new A() }).toStrictEqual({ a: "" })
       expect({ ...new A(undefined) }).toStrictEqual({ a: "" })
+      expect({ ...new A(undefined, true) }).toStrictEqual({ a: "" })
+      expect({ ...new A(undefined, false) }).toStrictEqual({ a: "" })
       expect({ ...new A({}) }).toStrictEqual({ a: "" })
 
       expect({ ...A.make() }).toStrictEqual({ a: "" })
       expect({ ...A.make(undefined) }).toStrictEqual({ a: "" })
+      expect({ ...A.make(undefined, true) }).toStrictEqual({ a: "" })
+      expect({ ...A.make(undefined, false) }).toStrictEqual({ a: "" })
       expect({ ...A.make({}) }).toStrictEqual({ a: "" })
     })
   })

--- a/packages/effect/test/Schema/Schema/Class/Class.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/Class.test.ts
@@ -74,95 +74,108 @@ describe("Class", () => {
     expect((A.ast as AST.Transformation).to.annotations[AST.IdentifierAnnotationId]).toEqual("MyName")
   })
 
-  it("should be a constructor", () => {
-    class A extends S.Class<A>("A")({ a: S.String }) {}
-    const instance = new A({ a: "a" })
-    expect(instance.a).toStrictEqual("a")
-    expect(instance instanceof A).toBe(true)
-  })
+  describe("constructor", () => {
+    it("should be a constructor", () => {
+      class A extends S.Class<A>("A")({ a: S.String }) {}
+      const instance = new A({ a: "a" })
+      expect(instance.a).toStrictEqual("a")
+      expect(instance instanceof A).toBe(true)
+    })
 
-  it("the constructor should validate the input by default", () => {
-    class A extends S.Class<A>("A")({ a: S.NonEmptyString }) {}
-    expect(() => new A({ a: "" })).toThrow(
-      new Error(`A (Constructor)
+    it("should validate the input by default", () => {
+      class A extends S.Class<A>("A")({ a: S.NonEmptyString }) {}
+      expect(() => new A({ a: "" })).toThrow(
+        new Error(`A (Constructor)
 └─ ["a"]
    └─ NonEmptyString
       └─ Predicate refinement failure
          └─ Expected NonEmptyString, actual ""`)
-    )
-    expect(() => A.make({ a: "" })).toThrow(
-      new Error(`A (Constructor)
+      )
+      expect(() => A.make({ a: "" })).toThrow(
+        new Error(`A (Constructor)
 └─ ["a"]
    └─ NonEmptyString
       └─ Predicate refinement failure
          └─ Expected NonEmptyString, actual ""`)
-    )
-  })
+      )
+    })
 
-  it("the constructor validation can be disabled", () => {
-    class A extends S.Class<A>("A")({ a: S.NonEmptyString }) {}
-    expect(new A({ a: "" }, true).a).toStrictEqual("")
-    expect(new A({ a: "" }, { disableValidation: true }).a).toStrictEqual("")
+    it("validation can be disabled", () => {
+      class A extends S.Class<A>("A")({ a: S.NonEmptyString }) {}
+      expect(new A({ a: "" }, true).a).toStrictEqual("")
+      expect(new A({ a: "" }, { disableValidation: true }).a).toStrictEqual("")
 
-    expect(A.make({ a: "" }, true).a).toStrictEqual("")
-    expect(A.make({ a: "" }, { disableValidation: true }).a).toStrictEqual("")
-  })
+      expect(A.make({ a: "" }, true).a).toStrictEqual("")
+      expect(A.make({ a: "" }, { disableValidation: true }).a).toStrictEqual("")
+    })
 
-  it("the constructor should support defaults", () => {
-    const b = Symbol.for("b")
-    class A extends S.Class<A>("A")({
-      a: S.propertySignature(S.String).pipe(S.withConstructorDefault(() => "")),
-      [b]: S.propertySignature(S.Number).pipe(S.withConstructorDefault(() => 1))
-    }) {}
-    expect({ ...new A({ a: "a", [b]: 2 }) }).toStrictEqual({ a: "a", [b]: 2 })
-    expect({ ...new A({ a: "a" }) }).toStrictEqual({ a: "a", [b]: 1 })
-    expect({ ...new A({ [b]: 2 }) }).toStrictEqual({ a: "", [b]: 2 })
-    expect({ ...new A({}) }).toStrictEqual({ a: "", [b]: 1 })
+    it("should support defaults", () => {
+      const b = Symbol.for("b")
+      class A extends S.Class<A>("A")({
+        a: S.propertySignature(S.String).pipe(S.withConstructorDefault(() => "")),
+        [b]: S.propertySignature(S.Number).pipe(S.withConstructorDefault(() => 1))
+      }) {}
+      expect({ ...new A({ a: "a", [b]: 2 }) }).toStrictEqual({ a: "a", [b]: 2 })
+      expect({ ...new A({ a: "a" }) }).toStrictEqual({ a: "a", [b]: 1 })
+      expect({ ...new A({ [b]: 2 }) }).toStrictEqual({ a: "", [b]: 2 })
+      expect({ ...new A({}) }).toStrictEqual({ a: "", [b]: 1 })
 
-    expect({ ...A.make({ a: "a", [b]: 2 }) }).toStrictEqual({ a: "a", [b]: 2 })
-    expect({ ...A.make({ a: "a" }) }).toStrictEqual({ a: "a", [b]: 1 })
-    expect({ ...A.make({ [b]: 2 }) }).toStrictEqual({ a: "", [b]: 2 })
-    expect({ ...A.make({}) }).toStrictEqual({ a: "", [b]: 1 })
-  })
+      expect({ ...A.make({ a: "a", [b]: 2 }) }).toStrictEqual({ a: "a", [b]: 2 })
+      expect({ ...A.make({ a: "a" }) }).toStrictEqual({ a: "a", [b]: 1 })
+      expect({ ...A.make({ [b]: 2 }) }).toStrictEqual({ a: "", [b]: 2 })
+      expect({ ...A.make({}) }).toStrictEqual({ a: "", [b]: 1 })
+    })
 
-  it("the constructor should support lazy defaults", () => {
-    let i = 0
-    class A extends S.Class<A>("A")({
-      a: S.propertySignature(S.Number).pipe(S.withConstructorDefault(() => ++i))
-    }) {}
-    expect({ ...new A({}) }).toStrictEqual({ a: 1 })
-    expect({ ...new A({}) }).toStrictEqual({ a: 2 })
-    new A({ a: 10 })
-    expect({ ...new A({}) }).toStrictEqual({ a: 3 })
+    it("should support lazy defaults", () => {
+      let i = 0
+      class A extends S.Class<A>("A")({
+        a: S.propertySignature(S.Number).pipe(S.withConstructorDefault(() => ++i))
+      }) {}
+      expect({ ...new A({}) }).toStrictEqual({ a: 1 })
+      expect({ ...new A({}) }).toStrictEqual({ a: 2 })
+      new A({ a: 10 })
+      expect({ ...new A({}) }).toStrictEqual({ a: 3 })
 
-    expect({ ...A.make({}) }).toStrictEqual({ a: 4 })
-    expect({ ...A.make({}) }).toStrictEqual({ a: 5 })
-    new A({ a: 10 })
-    expect({ ...A.make({}) }).toStrictEqual({ a: 6 })
-  })
+      expect({ ...A.make({}) }).toStrictEqual({ a: 4 })
+      expect({ ...A.make({}) }).toStrictEqual({ a: 5 })
+      new A({ a: 10 })
+      expect({ ...A.make({}) }).toStrictEqual({ a: 6 })
+    })
 
-  it("a Class with no fields should have a void constructor", () => {
-    class A extends S.Class<A>("A")({}) {}
-    expect({ ...new A() }).toStrictEqual({})
-    expect({ ...new A(undefined, true) }).toStrictEqual({})
-    expect({ ...new A({}) }).toStrictEqual({})
+    it("should treat `undefined` as missing field", () => {
+      class A extends S.Class<A>("A")({
+        a: S.propertySignature(S.UndefinedOr(S.String)).pipe(S.withConstructorDefault(() => ""))
+      }) {}
+      expect({ ...new A({}) }).toStrictEqual({ a: "" })
+      expect({ ...new A({ a: undefined }) }).toStrictEqual({ a: "" })
 
-    expect({ ...A.make() }).toStrictEqual({})
-    expect({ ...A.make(undefined, true) }).toStrictEqual({})
-    expect({ ...A.make({}) }).toStrictEqual({})
-  })
+      expect({ ...A.make({}) }).toStrictEqual({ a: "" })
+      expect({ ...A.make({ a: undefined }) }).toStrictEqual({ a: "" })
+    })
 
-  it("a Class with all defaulted fields should have a void constructor", () => {
-    class A extends S.Class<A>("A")({
-      a: S.String.pipe(S.propertySignature, S.withConstructorDefault(() => ""))
-    }) {}
-    expect({ ...new A() }).toStrictEqual({ a: "" })
-    expect({ ...new A(undefined) }).toStrictEqual({ a: "" })
-    expect({ ...new A({}) }).toStrictEqual({ a: "" })
+    it("should accept void if the Class has no fields", () => {
+      class A extends S.Class<A>("A")({}) {}
+      expect({ ...new A() }).toStrictEqual({})
+      expect({ ...new A(undefined, true) }).toStrictEqual({})
+      expect({ ...new A({}) }).toStrictEqual({})
 
-    expect({ ...A.make() }).toStrictEqual({ a: "" })
-    expect({ ...A.make(undefined) }).toStrictEqual({ a: "" })
-    expect({ ...A.make({}) }).toStrictEqual({ a: "" })
+      expect({ ...A.make() }).toStrictEqual({})
+      expect({ ...A.make(undefined, true) }).toStrictEqual({})
+      expect({ ...A.make({}) }).toStrictEqual({})
+    })
+
+    it("should accept void if the Class has all the fields with a default", () => {
+      class A extends S.Class<A>("A")({
+        a: S.String.pipe(S.propertySignature, S.withConstructorDefault(() => ""))
+      }) {}
+      expect({ ...new A() }).toStrictEqual({ a: "" })
+      expect({ ...new A(undefined) }).toStrictEqual({ a: "" })
+      expect({ ...new A({}) }).toStrictEqual({ a: "" })
+
+      expect({ ...A.make() }).toStrictEqual({ a: "" })
+      expect({ ...A.make(undefined) }).toStrictEqual({ a: "" })
+      expect({ ...A.make({}) }).toStrictEqual({ a: "" })
+    })
   })
 
   it("should support methods", () => {

--- a/packages/effect/test/Schema/Schema/Struct/make.test.ts
+++ b/packages/effect/test/Schema/Schema/Struct/make.test.ts
@@ -3,6 +3,44 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { describe, expect, it } from "vitest"
 
 describe("make", () => {
+  it("required fields", () => {
+    const schema = S.Struct({ a: S.String })
+    Util.expectConstructorSuccess(schema, { a: "a" })
+  })
+
+  it("optional fields", () => {
+    const schema = S.Struct({ a: S.optional(S.String) })
+    Util.expectConstructorSuccess(schema, { a: "a" })
+    Util.expectConstructorSuccess(schema, {})
+  })
+
+  it("should validate the input by default", () => {
+    const schema = S.Struct({ a: S.NonEmptyString })
+    Util.expectConstructorFailure(
+      schema,
+      { a: "" },
+      `{ readonly a: NonEmptyString }
+└─ ["a"]
+   └─ NonEmptyString
+      └─ Predicate refinement failure
+         └─ Expected NonEmptyString, actual ""`
+    )
+  })
+
+  it("validation can be disabled", () => {
+    const schema = S.Struct({ a: S.NonEmptyString })
+    expect(schema.make({ a: "" }, true)).toStrictEqual({ a: "" })
+    expect(schema.make({ a: "" }, { disableValidation: true })).toStrictEqual({ a: "" })
+  })
+
+  it("should support defaults", () => {
+    const schema = S.Struct({
+      a: S.propertySignature(S.Number).pipe(S.withConstructorDefault(() => 0))
+    })
+    expect(schema.make({})).toStrictEqual({ a: 0 })
+    expect(schema.make({ a: 1 })).toStrictEqual({ a: 1 })
+  })
+
   it("should support lazy defaults", () => {
     let i = 0
     const schema = S.Struct({
@@ -14,15 +52,28 @@ describe("make", () => {
     expect(schema.make({})).toStrictEqual({ a: 3 })
   })
 
-  it("required fields", () => {
-    const schema = S.Struct({ a: S.String })
-    Util.expectConstructorSuccess(schema, { a: "a" })
+  it("should treat `undefined` as missing field", () => {
+    const schema = S.Struct({
+      a: S.propertySignature(S.UndefinedOr(S.Number)).pipe(S.withConstructorDefault(() => 0))
+    })
+    expect(schema.make({})).toStrictEqual({ a: 0 })
+    expect(schema.make({ a: undefined })).toStrictEqual({ a: 0 })
   })
 
-  it("optional fields", () => {
-    const schema = S.Struct({ a: S.optional(S.String) })
-    Util.expectConstructorSuccess(schema, { a: "a" })
-    Util.expectConstructorSuccess(schema, {})
+  it("should accept void if the struct has no fields", () => {
+    const schema = S.Struct({})
+    expect(schema.make({})).toStrictEqual({})
+    expect(schema.make(undefined)).toStrictEqual({})
+    expect(schema.make()).toStrictEqual({})
+  })
+
+  it("should accept void if the Class has all the fields with a default", () => {
+    const schema = S.Struct({
+      a: S.propertySignature(S.Number).pipe(S.withConstructorDefault(() => 0))
+    })
+    expect(schema.make({})).toStrictEqual({ a: 0 })
+    expect(schema.make(undefined)).toStrictEqual({ a: 0 })
+    expect(schema.make()).toStrictEqual({ a: 0 })
   })
 
   it("props declarations with defaults (data last)", () => {
@@ -59,24 +110,5 @@ describe("make", () => {
     Util.expectConstructorSuccess(schema, { a: "a" }, { a: "a", [b]: 0 })
     Util.expectConstructorSuccess(schema, { [b]: 2 }, { a: "", [b]: 2 })
     Util.expectConstructorSuccess(schema, {}, { a: "", [b]: 0 })
-  })
-
-  it("the constructor should validate the input by default", () => {
-    const schema = S.Struct({ a: S.NonEmptyString })
-    Util.expectConstructorFailure(
-      schema,
-      { a: "" },
-      `{ readonly a: NonEmptyString }
-└─ ["a"]
-   └─ NonEmptyString
-      └─ Predicate refinement failure
-         └─ Expected NonEmptyString, actual ""`
-    )
-  })
-
-  it("the constructor validation can be disabled", () => {
-    const schema = S.Struct({ a: S.NonEmptyString })
-    expect(schema.make({ a: "" }, true)).toStrictEqual({ a: "" })
-    expect(schema.make({ a: "" }, { disableValidation: true })).toStrictEqual({ a: "" })
   })
 })

--- a/packages/effect/test/Schema/Schema/Struct/make.test.ts
+++ b/packages/effect/test/Schema/Schema/Struct/make.test.ts
@@ -64,6 +64,8 @@ describe("make", () => {
     const schema = S.Struct({})
     expect(schema.make({})).toStrictEqual({})
     expect(schema.make(undefined)).toStrictEqual({})
+    expect(schema.make(undefined, true)).toStrictEqual({})
+    expect(schema.make(undefined, false)).toStrictEqual({})
     expect(schema.make()).toStrictEqual({})
   })
 
@@ -73,6 +75,8 @@ describe("make", () => {
     })
     expect(schema.make({})).toStrictEqual({ a: 0 })
     expect(schema.make(undefined)).toStrictEqual({ a: 0 })
+    expect(schema.make(undefined, true)).toStrictEqual({ a: 0 })
+    expect(schema.make(undefined, false)).toStrictEqual({ a: 0 })
     expect(schema.make()).toStrictEqual({ a: 0 })
   })
 


### PR DESCRIPTION
…the Class API constructors when all fields have a default

Before

```ts
import { Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.Number).pipe(
    Schema.withConstructorDefault(() => 0)
  )
})

// TypeScript error: Expected 1-2 arguments, but got 0.ts(2554)
console.log(schema.make())
```

After

```ts
import { Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.Number).pipe(
    Schema.withConstructorDefault(() => 0)
  )
})

console.log(schema.make())
// Output: { a: 0 }
```
