### PR TITLE
Schema: fix `withDecodingDefault` and `withDefaults` signatures by removing `Exclude<Type, undefined>`

### DIFF
--- a/.changeset/wise-jobs-know.md
+++ b/.changeset/wise-jobs-know.md
@@ -1,0 +1,52 @@
+---
+"effect": patch
+---
+
+Schema: fix `withDecodingDefault` and `withDefaults` signatures by removing `Exclude<Type, undefined>` in the return type.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema1 = Schema.Struct({
+  a: Schema.optional(Schema.String).pipe(
+    Schema.withConstructorDefault(() => undefined) // ok
+  )
+})
+
+console.log(schema1.make({}))
+// Output: { a: undefined }
+
+const schema2 = Schema.Struct({
+  a: Schema.optional(Schema.String).pipe(
+    Schema.withDecodingDefault(() => ""),
+    Schema.withConstructorDefault(() => undefined) // Type Error: Type 'undefined' is not assignable to type 'string'.ts(2322)
+  )
+})
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema1 = Schema.Struct({
+  a: Schema.optional(Schema.String).pipe(
+    Schema.withConstructorDefault(() => undefined) // ok
+  )
+})
+
+console.log(schema1.make({}))
+// Output: { a: undefined }
+
+const schema2 = Schema.Struct({
+  a: Schema.optional(Schema.String).pipe(
+    Schema.withDecodingDefault(() => ""),
+    Schema.withConstructorDefault(() => undefined) // ok
+  )
+})
+
+console.log(schema2.make({}))
+// Output: { a: undefined }
+```

--- a/packages/effect/dtslint/Schema.ts
+++ b/packages/effect/dtslint/Schema.ts
@@ -2646,26 +2646,26 @@ hole<ConstructorParameters<typeof AA>>()
 // withDecodingDefault
 // ---------------------------------------------
 
-// $ExpectType Schema<{ readonly a: string; }, { readonly a?: string | undefined; }, never>
+// $ExpectType Schema<{ readonly a: string | undefined; }, { readonly a?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.String).pipe(S.withDecodingDefault(() => "")) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", string, never, "?:", string | undefined, false, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", string | undefined, never, "?:", string | undefined, false, never>; }>
 S.Struct({ a: S.optional(S.String).pipe(S.withDecodingDefault(() => "")) })
 
 // ---------------------------------------------
 // withDefaults
 // ---------------------------------------------
 
-// $ExpectType Schema<{ readonly a: string; }, { readonly a?: string | undefined; }, never>
+// $ExpectType Schema<{ readonly a: string | undefined; }, { readonly a?: string | undefined; }, never>
 S.asSchema(S.Struct({ a: S.optional(S.String).pipe(S.withDefaults({ decoding: () => "", constructor: () => "" })) }))
 
-// $ExpectType Struct<{ a: PropertySignature<":", string, never, "?:", string | undefined, true, never>; }>
+// $ExpectType Struct<{ a: PropertySignature<":", string | undefined, never, "?:", string | undefined, true, never>; }>
 S.Struct({ a: S.optional(S.String).pipe(S.withDefaults({ decoding: () => "", constructor: () => "" })) })
 
 const make4 =
   S.Struct({ a: S.optional(S.String).pipe(S.withDefaults({ decoding: () => "", constructor: () => "" })) }).make
 
-// $ExpectType void | { readonly a?: string; } | undefined
+// $ExpectType void | { readonly a?: string | undefined; } | undefined
 hole<Parameters<typeof make4>["0"]>()
 
 // ---------------------------------------------

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1915,7 +1915,7 @@ export const withDecodingDefault: {
     R
   >(
     self: PropertySignature<"?:", Type, Key, "?:", Encoded, HasDefault, R>
-  ) => PropertySignature<":", Exclude<Type, undefined>, Key, "?:", Encoded, HasDefault, R>
+  ) => PropertySignature<":", Type, Key, "?:", Encoded, HasDefault, R>
   <
     Type,
     Key extends PropertyKey,
@@ -1925,7 +1925,7 @@ export const withDecodingDefault: {
   >(
     self: PropertySignature<"?:", Type, Key, "?:", Encoded, HasDefault, R>,
     defaultValue: () => Types.NoInfer<Type>
-  ): PropertySignature<":", Exclude<Type, undefined>, Key, "?:", Encoded, HasDefault, R>
+  ): PropertySignature<":", Type, Key, "?:", Encoded, HasDefault, R>
 } = dual(2, <
   Type,
   Key extends PropertyKey,
@@ -1934,10 +1934,10 @@ export const withDecodingDefault: {
 >(
   self: PropertySignature<"?:", Type, Key, "?:", Encoded, boolean, R>,
   defaultValue: () => Types.NoInfer<Type>
-): PropertySignature<":", Exclude<Type, undefined>, Key, "?:", Encoded, true, R> => {
+): PropertySignature<":", Type, Key, "?:", Encoded, true, R> => {
   const ast = self.ast
   switch (ast._tag) {
-    case "PropertySignatureDeclaration":
+    case "PropertySignatureDeclaration": {
       return makePropertySignature(
         new PropertySignatureTransformation(
           new FromPropertySignature(ast.type, ast.isOptional, ast.isReadonly, ast.annotations),
@@ -1946,15 +1946,23 @@ export const withDecodingDefault: {
           identity
         )
       )
-    case "PropertySignatureTransformation":
+    }
+    case "PropertySignatureTransformation": {
       return makePropertySignature(
         new PropertySignatureTransformation(
           ast.from,
-          new ToPropertySignature(ast.to.type, false, ast.to.isReadonly, ast.to.annotations, ast.to.defaultValue),
+          new ToPropertySignature(
+            ast.to.type,
+            false,
+            ast.to.isReadonly,
+            ast.to.annotations,
+            ast.to.defaultValue
+          ),
           (o) => applyDefaultValue(ast.decode(o), defaultValue),
           ast.encode
         )
       )
+    }
   }
 })
 
@@ -1966,15 +1974,15 @@ export const withDecodingDefault: {
  */
 export const withDefaults: {
   <Type>(defaults: {
-    constructor: () => Types.NoInfer<Exclude<Type, undefined>>
     decoding: () => Types.NoInfer<Type>
+    constructor: () => Types.NoInfer<Type>
   }): <
     Key extends PropertyKey,
     Encoded,
     R
   >(
     self: PropertySignature<"?:", Type, Key, "?:", Encoded, boolean, R>
-  ) => PropertySignature<":", Exclude<Type, undefined>, Key, "?:", Encoded, true, R>
+  ) => PropertySignature<":", Type, Key, "?:", Encoded, true, R>
   <
     Type,
     Key extends PropertyKey,
@@ -1983,10 +1991,10 @@ export const withDefaults: {
   >(
     self: PropertySignature<"?:", Type, Key, "?:", Encoded, boolean, R>,
     defaults: {
-      constructor: () => Types.NoInfer<Exclude<Type, undefined>>
       decoding: () => Types.NoInfer<Type>
+      constructor: () => Types.NoInfer<Type>
     }
-  ): PropertySignature<":", Exclude<Type, undefined>, Key, "?:", Encoded, true, R>
+  ): PropertySignature<":", Type, Key, "?:", Encoded, true, R>
 } = dual(2, <
   Type,
   Key extends PropertyKey,
@@ -1995,11 +2003,15 @@ export const withDefaults: {
 >(
   self: PropertySignature<"?:", Type, Key, "?:", Encoded, boolean, R>,
   defaults: {
-    constructor: () => Types.NoInfer<Exclude<Type, undefined>>
     decoding: () => Types.NoInfer<Type>
+    constructor: () => Types.NoInfer<Type>
   }
-): PropertySignature<":", Exclude<Type, undefined>, Key, "?:", Encoded, true, R> =>
-  self.pipe(withDecodingDefault(defaults.decoding), withConstructorDefault(defaults.constructor)))
+): PropertySignature<":", Type, Key, "?:", Encoded, true, R> => {
+  return self.pipe(
+    withDecodingDefault(defaults.decoding),
+    withConstructorDefault(defaults.constructor)
+  )
+})
 
 /**
  * Enhances a property signature by specifying a different key for it in the Encoded type.


### PR DESCRIPTION
Before

```ts
import { Schema } from "effect"

const schema1 = Schema.Struct({
  a: Schema.optional(Schema.String).pipe(
    Schema.withConstructorDefault(() => undefined) // ok
  )
})

console.log(schema1.make({}))
// Output: { a: undefined }

const schema2 = Schema.Struct({
  a: Schema.optional(Schema.String).pipe(
    Schema.withDecodingDefault(() => ""),
    Schema.withConstructorDefault(() => undefined) // Type Error: Type 'undefined' is not assignable to type 'string'.ts(2322)
  )
})
```

After

```ts
import { Schema } from "effect"

const schema1 = Schema.Struct({
  a: Schema.optional(Schema.String).pipe(
    Schema.withConstructorDefault(() => undefined) // ok
  )
})

console.log(schema1.make({}))
// Output: { a: undefined }

const schema2 = Schema.Struct({
  a: Schema.optional(Schema.String).pipe(
    Schema.withDecodingDefault(() => ""),
    Schema.withConstructorDefault(() => undefined) // ok
  )
})

console.log(schema2.make({}))
// Output: { a: undefined }
```
