### PR TITLE
JSONSchema: represent `never` as `{ enum: [] }`

### DIFF
--- a/.changeset/purple-pandas-film.md
+++ b/.changeset/purple-pandas-film.md
@@ -1,0 +1,38 @@
+---
+"effect": patch
+---
+
+JSONSchema: represent `never` as `{ enum: [] }`
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Never
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+throws:
+Error: Missing annotation
+details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
+schema (NeverKeyword): never
+*/
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Never
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "enum": [],
+  "title": "never",
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}
+*/
+```

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -424,7 +424,7 @@ const go = (
     case "VoidKeyword":
       return { ...constVoid, ...getJsonSchemaAnnotations(ast) }
     case "NeverKeyword":
-      throw new Error(errors_.getJSONSchemaMissingAnnotationErrorMessage(path, ast))
+      return { enum: [], ...getJsonSchemaAnnotations(ast) }
     case "UnknownKeyword":
       return { ...constUnknown, ...getJsonSchemaAnnotations(ast) }
     case "AnyKeyword":

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -267,15 +267,6 @@ schema (UndefinedKeyword): undefined`
         )
       })
 
-      it("Never", () => {
-        expectError(
-          Schema.Never,
-          `Missing annotation
-details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
-schema (NeverKeyword): never`
-        )
-      })
-
       it("Schema.Literal with a bigint literal", () => {
         expectError(
           Schema.Literal(1n),
@@ -366,6 +357,13 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
     })
   })
 
+  it("Never", () => {
+    expectJsonSchemaAnnotations(Schema.Never, {
+      "enum": [],
+      "title": "never"
+    })
+  })
+
   it("Any", () => {
     expectJsonSchemaAnnotations(Schema.Any, {
       "$id": "/schemas/any",
@@ -384,12 +382,8 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
     const jsonSchema: Root = {
       "$id": "/schemas/object",
       "anyOf": [
-        {
-          "type": "object"
-        },
-        {
-          "type": "array"
-        }
+        { "type": "object" },
+        { "type": "array" }
       ],
       "description": "an object in the TypeScript meaning, i.e. the `object` type",
       "title": "object"
@@ -409,7 +403,6 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
     const schema = Schema.Struct({})
     const jsonSchema: Root = {
       "$id": "/schemas/{}",
-
       "anyOf": [{
         "type": "object"
       }, {


### PR DESCRIPTION
Before

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Never

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
throws:
Error: Missing annotation
details: Generating a JSON Schema for this schema requires a "jsonSchema" annotation
schema (NeverKeyword): never
*/
```

After

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Never

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "enum": [],
  "title": "never",
  "$schema": "http://json-schema.org/draft-07/schema#"
}
*/
```
