### PR TITLE
render json schema containing union with null as nullable attribute for openapi #4075

### DIFF
--- a/.changeset/quiet-suns-melt.md
+++ b/.changeset/quiet-suns-melt.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform": patch
+"effect": patch
+---
+
+render json schema containing union with null as nullable attribute for openapi #4075

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -2,7 +2,6 @@
  * @since 3.10.0
  */
 
-import * as Either from "./Either.js"
 import * as errors_ from "./internal/schema/errors.js"
 import * as Option from "./Option.js"
 import * as Predicate from "./Predicate.js"
@@ -637,62 +636,54 @@ const go = (
       return { ...output, ...getJsonSchemaAnnotations(ast) }
     }
     case "Union": {
-      const NonNullable = {}
-
-      type UnionOrSingleSchema = Either.Either<[{ nullable: true } | {}, Array<AST.AST>], JsonSchema7>
-
-      // https://swagger.io/docs/specification/v3_0/data-models/data-types/#null
-      const renderAsOpenApi = (): UnionOrSingleSchema => {
-        const [containsNull, restAstTypes] = ast.types.reduce<[boolean, Array<AST.AST>]>(
-          (prev, current) =>
-            current._tag === "Literal" && current.literal === null
-              ? [true, prev[1]]
-              : [prev[0], [...prev[1], current]],
-          [false, []]
-        )
-
-        const nullable = containsNull ? { nullable: true } : NonNullable
-        if (restAstTypes.length === 1) {
-          return Either.left({
-            ...go(restAstTypes[0], $defs, true, path, options),
-            ...nullable,
-            ...getASTJsonSchemaAnnotations(restAstTypes[0])
-          } as JsonSchema7)
-        }
-        return Either.right([nullable, restAstTypes] as const)
-      }
-
-      const unionOrSingleSchema: UnionOrSingleSchema = options.target === "openApi3.1"
-        ? renderAsOpenApi()
-        : Either.right([NonNullable, [...ast.types]])
-
-      return unionOrSingleSchema.pipe(Either.map(([nullable, astTypes]) => {
-        const anyOf: Array<JsonSchema7> = []
-        for (const type of astTypes) {
-          const schema = go(type, $defs, true, path, options)
-          if ("enum" in schema) {
-            if (Object.keys(schema).length > 1) {
-              anyOf.push(schema)
-            } else {
-              const last = anyOf[anyOf.length - 1]
-              if (last !== undefined && isEnumOnly(last)) {
-                for (const e of schema.enum) {
-                  last.enum.push(e)
-                }
-              } else {
-                anyOf.push(schema)
-              }
-            }
+      let types = ast.types
+      const nullable: { nullable?: boolean } = {}
+      if (options.target === "openApi3.1") {
+        const restAstTypes = []
+        for (const type of ast.types) {
+          if (type._tag === "Literal" && type.literal === null) {
+            nullable.nullable = true
           } else {
-            anyOf.push(schema)
+            restAstTypes.push(type)
           }
         }
-        if (anyOf.length === 1 && isEnumOnly(anyOf[0])) {
-          return { enum: anyOf[0].enum, ...getJsonSchemaAnnotations(ast), ...nullable } as JsonSchema7
-        } else {
-          return { anyOf, ...getJsonSchemaAnnotations(ast), ...nullable } as JsonSchema7
+        if (nullable.nullable === true) {
+          if (restAstTypes.length === 1) {
+            return {
+              ...go(restAstTypes[0], $defs, handleIdentifier, path, options),
+              ...nullable,
+              ...getJsonSchemaAnnotations(ast)
+            }
+          }
+          types = restAstTypes as any
         }
-      })).pipe(Either.merge)
+      }
+
+      const anyOf: Array<JsonSchema7> = []
+      for (const type of types) {
+        const schema = go(type, $defs, true, path, options)
+        if ("enum" in schema) {
+          if (Object.keys(schema).length > 1) {
+            anyOf.push(schema)
+          } else {
+            const last = anyOf[anyOf.length - 1]
+            if (last !== undefined && isEnumOnly(last)) {
+              for (const e of schema.enum) {
+                last.enum.push(e)
+              }
+            } else {
+              anyOf.push(schema)
+            }
+          }
+        } else {
+          anyOf.push(schema)
+        }
+      }
+      if (anyOf.length === 1 && isEnumOnly(anyOf[0])) {
+        return { enum: anyOf[0].enum, ...nullable, ...getJsonSchemaAnnotations(ast) }
+      } else {
+        return { anyOf, ...nullable, ...getJsonSchemaAnnotations(ast) }
+      }
     }
     case "Enums": {
       return {

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -2,6 +2,8 @@ import * as OpenApiJsonSchema from "@effect/platform/OpenApiJsonSchema"
 import * as Schema from "effect/Schema"
 import { describe, expect, it } from "vitest"
 
+type NullableCase = [string, Schema.Schema.Any, object]
+
 describe("OpenApiJsonSchema", () => {
   it("default options", () => {
     const schema = Schema.Struct({
@@ -51,5 +53,24 @@ describe("OpenApiJsonSchema", () => {
         "type": "string"
       }
     })
+  })
+  it.for<NullableCase>([
+    ["union of 2 types", Schema.NullOr(Schema.Union(Schema.String, Schema.Number)), {
+      anyOf: [{
+        type: "string"
+      }, {
+        type: "number"
+      }],
+      nullable: true
+    }],
+    ["only one simple type", Schema.NullOr(Schema.String), {
+      type: "string",
+      nullable: true
+    }],
+    ["only null", Schema.Null, { enum: [null] }]
+  ])("nullable case: %s", ([_name, schema, expected]) => {
+    const defs: Record<string, OpenApiJsonSchema.JsonSchema> = {}
+    const jsonSchema = OpenApiJsonSchema.makeWithDefs(schema, { defs })
+    expect(jsonSchema).toStrictEqual(expected)
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

renders schemas of unions with null as nullable.

For example, schema Schema.NullOr(Schema.String)

will render as:
```
{
   type: "string",
   nullable: true
}
```

instead of union of null literal

applicable only when the schema target is openapi

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->


- closes #4075
