### PR TITLE
Allow the transformation created by the Class API to be annotated on …

### DIFF
--- a/.changeset/angry-tools-lie.md
+++ b/.changeset/angry-tools-lie.md
@@ -1,0 +1,46 @@
+---
+"effect": patch
+---
+
+Allow the transformation created by the Class API to be annotated on all its components: the type side, the transformation itself, and the encoded side.
+
+**Example**
+
+```ts
+import { Schema, SchemaAST } from "effect"
+
+class A extends Schema.Class<A>("A")(
+  {
+    a: Schema.NonEmptyString
+  },
+  [
+    { identifier: "TypeID" }, // annotations for the type side
+    { identifier: "TransformationID" }, // annotations for the the transformation itself
+    { identifier: "EncodedID" } // annotations for the the encoded side
+  ]
+) {}
+
+console.log(SchemaAST.getIdentifierAnnotation(A.ast.to)) // Some("TypeID")
+console.log(SchemaAST.getIdentifierAnnotation(A.ast)) // Some("TransformationID")
+console.log(SchemaAST.getIdentifierAnnotation(A.ast.from)) // Some("EncodedID")
+
+A.make({ a: "" })
+/*
+ParseError: TypeID
+└─ ["a"]
+   └─ NonEmptyString
+      └─ Predicate refinement failure
+         └─ Expected NonEmptyString, actual ""
+*/
+
+Schema.encodeSync(A)({ a: "" })
+/*
+ParseError: TransformationID
+└─ Type side transformation failure
+   └─ TypeID
+      └─ ["a"]
+         └─ NonEmptyString
+            └─ Predicate refinement failure
+               └─ Expected NonEmptyString, actual ""
+*/
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8292,6 +8292,8 @@ const makeClass = <Fields extends Struct.Fields>(
 
   const transformationSurrogate = schema.annotations({
     [AST.JSONIdentifierAnnotationId]: identifier,
+    ...encodedAnnotations,
+    ...typeAnnotations,
     ...transformationAnnotations
   })
 

--- a/packages/effect/test/Schema/Schema/Class/Class.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/Class.test.ts
@@ -596,6 +596,7 @@ details: Duplicate key "a"`)
             },
             "TransformationID": {
               "additionalProperties": false,
+              "description": "TypeDescription",
               "properties": {
                 "a": {
                   "$ref": "#/$defs/NonEmptyString"

--- a/packages/effect/test/Schema/Schema/Class/extend.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/extend.test.ts
@@ -1,4 +1,4 @@
-import * as S from "effect/Schema"
+import { JSONSchema, Option, Schema as S, SchemaAST as AST } from "effect"
 import * as Util from "effect/test/Schema/TestUtils"
 import { describe, expect, it } from "vitest"
 
@@ -189,5 +189,133 @@ describe("extend", () => {
     }) {}
 
     expect(new OverrideExtended4({ a: "a", b: 2 }).b).toEqual(1)
+  })
+
+  describe("should support annotations when declaring the Class", () => {
+    it("single argument", async () => {
+      class A extends S.Class<A>("A")({
+        a: S.NonEmptyString
+      }) {}
+      class B extends A.extend<B>("B")({
+        b: S.NonEmptyString
+      }, { title: "mytitle" }) {}
+
+      expect(B.ast.to.annotations[AST.TitleAnnotationId]).toEqual("mytitle")
+
+      await Util.expectEncodeFailure(
+        B,
+        { a: "a", b: "" },
+        `(B (Encoded side) <-> B)
+└─ Type side transformation failure
+   └─ mytitle
+      └─ ["b"]
+         └─ NonEmptyString
+            └─ Predicate refinement failure
+               └─ Expected NonEmptyString, actual ""`
+      )
+    })
+
+    it("tuple argument", async () => {
+      class A extends S.Class<A>("A")({
+        a: S.NonEmptyString
+      }) {}
+      class B extends A.extend<B>("B")({
+        b: S.NonEmptyString
+      }, [
+        { identifier: "TypeID", description: "TypeDescription" },
+        { identifier: "TransformationID" },
+        { identifier: "EncodedID" }
+      ]) {}
+      expect(AST.getIdentifierAnnotation(B.ast.to)).toEqual(Option.some("TypeID"))
+      expect(AST.getIdentifierAnnotation(B.ast)).toEqual(Option.some("TransformationID"))
+      expect(AST.getIdentifierAnnotation(B.ast.from)).toEqual(Option.some("EncodedID"))
+
+      await Util.expectDecodeUnknownFailure(
+        B,
+        {},
+        `TransformationID
+└─ Encoded side transformation failure
+   └─ EncodedID
+      └─ ["a"]
+         └─ is missing`
+      )
+
+      await Util.expectEncodeFailure(
+        B,
+        { a: "a", b: "" },
+        `TransformationID
+└─ Type side transformation failure
+   └─ TypeID
+      └─ ["b"]
+         └─ NonEmptyString
+            └─ Predicate refinement failure
+               └─ Expected NonEmptyString, actual ""`
+      )
+
+      const ctor = { make: B.make.bind(B) }
+
+      Util.expectConstructorFailure(
+        ctor,
+        null,
+        `TypeID
+└─ ["a"]
+   └─ is missing`
+      )
+
+      expect(JSONSchema.make(S.typeSchema(B))).toStrictEqual({
+        "$defs": {
+          "NonEmptyString": {
+            "description": "a non empty string",
+            "minLength": 1,
+            "title": "NonEmptyString",
+            "type": "string"
+          },
+          "TypeID": {
+            "additionalProperties": false,
+            "description": "TypeDescription",
+            "properties": {
+              "a": {
+                "$ref": "#/$defs/NonEmptyString"
+              },
+              "b": {
+                "$ref": "#/$defs/NonEmptyString"
+              }
+            },
+            "required": ["a", "b"],
+            "type": "object"
+          }
+        },
+        "$ref": "#/$defs/TypeID",
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      })
+
+      expect(JSONSchema.make(B)).toStrictEqual(
+        {
+          "$defs": {
+            "NonEmptyString": {
+              "description": "a non empty string",
+              "minLength": 1,
+              "title": "NonEmptyString",
+              "type": "string"
+            },
+            "TransformationID": {
+              "additionalProperties": false,
+              "properties": {
+                "a": {
+                  "$ref": "#/$defs/NonEmptyString"
+                },
+                "b": {
+                  "$ref": "#/$defs/NonEmptyString"
+                }
+              },
+              "required": ["a", "b"],
+              "type": "object"
+            }
+          },
+          "$ref": "#/$defs/TransformationID",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      )
+    })
   })
 })

--- a/packages/effect/test/Schema/Schema/Class/extend.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/extend.test.ts
@@ -300,6 +300,7 @@ describe("extend", () => {
             },
             "TransformationID": {
               "additionalProperties": false,
+              "description": "TypeDescription",
               "properties": {
                 "a": {
                   "$ref": "#/$defs/NonEmptyString"


### PR DESCRIPTION
…all its components: the type side, the transformation itself, and the encoded side, closes #4089

**Example**

```ts
import { Schema, SchemaAST } from "effect"

class A extends Schema.Class<A>("A")(
  {
    a: Schema.NonEmptyString
  },
  [
    { identifier: "TypeID" }, // annotations for the type side
    { identifier: "TransformationID" }, // annotations for the the transformation itself
    { identifier: "EncodedID" } // annotations for the the encoded side
  ]
) {}

console.log(SchemaAST.getIdentifierAnnotation(A.ast.to)) // Some("TypeID")
console.log(SchemaAST.getIdentifierAnnotation(A.ast)) // Some("TransformationID")
console.log(SchemaAST.getIdentifierAnnotation(A.ast.from)) // Some("EncodedID")

A.make({ a: "" })
/*
ParseError: TypeID
└─ ["a"]
   └─ NonEmptyString
      └─ Predicate refinement failure
         └─ Expected NonEmptyString, actual ""
*/

Schema.encodeSync(A)({ a: "" })
/*
ParseError: TransformationID
└─ Type side transformation failure
   └─ TypeID
      └─ ["a"]
         └─ NonEmptyString
            └─ Predicate refinement failure
               └─ Expected NonEmptyString, actual ""
*/
```
