### PR TITLE
JSONSchema: handle the `nullable` keyword for OpenAPI target, closes #4075

### DIFF
--- a/.changeset/perfect-trains-cough.md
+++ b/.changeset/perfect-trains-cough.md
@@ -2,23 +2,29 @@
 "effect": patch
 ---
 
-JSONSchema: handle empty native enums.
+JSONSchema: ignore never members in unions.
 
 Before
 
 ```ts
 import { JSONSchema, Schema } from "effect"
 
-enum Empty {}
-
-const schema = Schema.Enums(Empty)
+const schema = Schema.Union(Schema.String, Schema.Never)
 
 console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
 /*
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$comment": "/schemas/enums",
-  "anyOf": [] // <= invalid schema!
+  "anyOf": [
+    {
+      "type": "string"
+    },
+    {
+      "$id": "/schemas/never",
+      "not": {},
+      "title": "never"
+    }
+  ]
 }
 */
 ```
@@ -28,16 +34,13 @@ After
 ```ts
 import { JSONSchema, Schema } from "effect"
 
-enum Empty {}
-
-const schema = Schema.Enums(Empty)
+const schema = Schema.Union(Schema.String, Schema.Never)
 
 console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
 /*
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "/schemas/never",
-  "not": {}
+  "type": "string"
 }
 */
 ```

--- a/.changeset/red-mice-march.md
+++ b/.changeset/red-mice-march.md
@@ -1,0 +1,48 @@
+---
+"@effect/platform": patch
+"effect": patch
+---
+
+JSONSchema: handle the `nullable` keyword for OpenAPI target, closes #4075.
+
+Before
+
+```ts
+import { OpenApiJsonSchema } from "@effect/platform"
+import { Schema } from "effect"
+
+const schema = Schema.NullOr(Schema.String)
+
+console.log(JSON.stringify(OpenApiJsonSchema.make(schema), null, 2))
+/*
+{
+  "anyOf": [
+    {
+      "type": "string"
+    },
+    {
+      "enum": [
+        null
+      ]
+    }
+  ]
+}
+*/
+```
+
+After
+
+```ts
+import { OpenApiJsonSchema } from "@effect/platform"
+import { Schema } from "effect"
+
+const schema = Schema.NullOr(Schema.String)
+
+console.log(JSON.stringify(OpenApiJsonSchema.make(schema), null, 2))
+/*
+{
+  "type": "string",
+  "nullable": true
+}
+*/
+```

--- a/.changeset/tall-chicken-arrive.md
+++ b/.changeset/tall-chicken-arrive.md
@@ -3,7 +3,7 @@
 "effect": patch
 ---
 
-add `type` for homogeneous enum schemas, closes #4127
+JSONSchema: add `type` for homogeneous enum schemas, closes #4127
 
 Before
 

--- a/.changeset/ten-insects-wonder.md
+++ b/.changeset/ten-insects-wonder.md
@@ -1,0 +1,54 @@
+---
+"@effect/platform": patch
+"effect": patch
+---
+
+JSONSchema: use `{ "type": "null" }` to represent the `null` literal
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.NullOr(Schema.String)
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "anyOf": [
+    {
+      "type": "string"
+    },
+    {
+      "enum": [
+        null
+      ]
+    }
+  ]
+}
+*/
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.NullOr(Schema.String)
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "anyOf": [
+    {
+      "type": "string"
+    },
+    {
+      "type": "null"
+    }
+  ]
+}
+*/
+```

--- a/.changeset/wild-months-pay.md
+++ b/.changeset/wild-months-pay.md
@@ -1,0 +1,43 @@
+---
+"effect": patch
+---
+
+Handle empty native enums.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+enum Empty {}
+
+const schema = Schema.Enums(Empty)
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "/schemas/enums",
+  "anyOf": [] // <= invalid schema!
+}
+*/
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+enum Empty {}
+
+const schema = Schema.Enums(Empty)
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/schemas/never",
+  "not": {}
+}
+*/
+```

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -1787,6 +1787,15 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
   })
 
   describe("Union", () => {
+    it("should ignore never members", () => {
+      expectJSONSchemaAnnotations(Schema.Union(Schema.String, Schema.Never), {
+        "type": "string"
+      })
+      expectJSONSchemaAnnotations(Schema.Union(Schema.String, Schema.Union(Schema.Never, Schema.Never)), {
+        "type": "string"
+      })
+    })
+
     it("string | JsonNumber", () => {
       expectJSONSchemaAnnotations(Schema.Union(Schema.String, JsonNumber), {
         "anyOf": [
@@ -3508,7 +3517,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
       )
     })
 
-    it.skip("UndefinedOr(Undefined)", () => {
+    it("UndefinedOr(Undefined)", () => {
       expectJSONSchemaAnnotations(
         Schema.Struct({
           a: Schema.UndefinedOr(Schema.Undefined)

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -680,6 +680,32 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
   })
 
   describe("Enums", () => {
+    it("empty enum", () => {
+      enum Empty {}
+      const jsonSchema = expectJSONSchema(Schema.Enums(Empty), {
+        "$id": "/schemas/never",
+        "not": {}
+      })
+      const validate = getAjvValidate(jsonSchema)
+      expect(validate(1)).toEqual(false)
+    })
+
+    it("single enum", () => {
+      enum Fruits {
+        Apple
+      }
+      expectJSONSchemaAnnotations(Schema.Enums(Fruits), {
+        "$comment": "/schemas/enums",
+        "anyOf": [
+          {
+            "type": "number",
+            "title": "Apple",
+            "enum": [0]
+          }
+        ]
+      })
+    })
+
     it("numeric enums", () => {
       enum Fruits {
         Apple,

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -128,13 +128,37 @@ describe("makeWithOptions", () => {
           expectJSONSchemaAnnotations(schema, { "type": "null" })
         })
 
-        it("NullOr", () => {
+        it("NullOr(String)", () => {
           const schema = Schema.NullOr(Schema.String)
           expectJSONSchemaAnnotations(schema, {
             "anyOf": [
               { "type": "string" },
               { "type": "null" }
             ]
+          })
+        })
+
+        it("NullOr(Any)", () => {
+          const schema = Schema.NullOr(Schema.Any)
+          expectJSONSchemaAnnotations(schema, {
+            "$id": "/schemas/any",
+            "title": "any"
+          })
+        })
+
+        it("NullOr(Unknown)", () => {
+          const schema = Schema.NullOr(Schema.Unknown)
+          expectJSONSchemaAnnotations(schema, {
+            "$id": "/schemas/unknown",
+            "title": "unknown"
+          })
+        })
+
+        it("NullOr(Void)", () => {
+          const schema = Schema.NullOr(Schema.Void)
+          expectJSONSchemaAnnotations(schema, {
+            "$id": "/schemas/void",
+            "title": "void"
           })
         })
 
@@ -166,6 +190,26 @@ describe("makeWithOptions", () => {
             ]
           })
         })
+
+        it("Nested nullable unions", () => {
+          const schema = Schema.Union(Schema.NullOr(Schema.String), Schema.Literal("a", null))
+          expectJSONSchemaAnnotations(schema, {
+            "anyOf": [
+              {
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "null" }
+                ]
+              },
+              {
+                "anyOf": [
+                  { "type": "string", "enum": ["a"] },
+                  { "type": "null" }
+                ]
+              }
+            ]
+          })
+        })
       })
 
       it("parseJson handling", () => {
@@ -191,13 +235,37 @@ describe("makeWithOptions", () => {
           expectJSONSchema2019(schema, { "type": "null" }, {})
         })
 
-        it("NullOr", () => {
+        it("NullOr(String)", () => {
           const schema = Schema.NullOr(Schema.String)
           expectJSONSchema2019(schema, {
             "anyOf": [
               { "type": "string" },
               { "type": "null" }
             ]
+          }, {})
+        })
+
+        it("NullOr(Any)", () => {
+          const schema = Schema.NullOr(Schema.Any)
+          expectJSONSchema2019(schema, {
+            "$id": "/schemas/any",
+            "title": "any"
+          }, {})
+        })
+
+        it("NullOr(Unknown)", () => {
+          const schema = Schema.NullOr(Schema.Unknown)
+          expectJSONSchema2019(schema, {
+            "$id": "/schemas/unknown",
+            "title": "unknown"
+          }, {})
+        })
+
+        it("NullOr(Void)", () => {
+          const schema = Schema.NullOr(Schema.Void)
+          expectJSONSchema2019(schema, {
+            "$id": "/schemas/void",
+            "title": "void"
           }, {})
         })
 
@@ -225,6 +293,26 @@ describe("makeWithOptions", () => {
               {
                 "type": "null",
                 "description": "mydescription"
+              }
+            ]
+          }, {})
+        })
+
+        it("Nested nullable unions", () => {
+          const schema = Schema.Union(Schema.NullOr(Schema.String), Schema.Literal("a", null))
+          expectJSONSchema2019(schema, {
+            "anyOf": [
+              {
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "null" }
+                ]
+              },
+              {
+                "anyOf": [
+                  { "type": "string", "enum": ["a"] },
+                  { "type": "null" }
+                ]
               }
             ]
           }, {})
@@ -268,7 +356,7 @@ describe("makeWithOptions", () => {
           expectJSONSchemaOpenApi31(schema, { "enum": [null] }, {})
         })
 
-        it.skip("NullOr", () => {
+        it("NullOr(String)", () => {
           const schema = Schema.NullOr(Schema.String)
           expectJSONSchemaOpenApi31(schema, {
             "type": "string",
@@ -276,7 +364,145 @@ describe("makeWithOptions", () => {
           }, {})
         })
 
-        it.skip("Literal | null", () => {
+        it("NullOr(Any)", () => {
+          const schema = Schema.NullOr(Schema.Any)
+          expectJSONSchemaOpenApi31(schema, {
+            "$id": "/schemas/any",
+            "title": "any"
+          }, {})
+        })
+
+        it("NullOr(Unknown)", () => {
+          const schema = Schema.NullOr(Schema.Unknown)
+          expectJSONSchemaOpenApi31(schema, {
+            "$id": "/schemas/unknown",
+            "title": "unknown"
+          }, {})
+        })
+
+        it("NullOr(Void)", () => {
+          const schema = Schema.NullOr(Schema.Void)
+          expectJSONSchemaOpenApi31(schema, {
+            "$id": "/schemas/void",
+            "title": "void"
+          }, {})
+        })
+
+        it("NullOr(Object)", () => {
+          const schema = Schema.NullOr(Schema.Object)
+          expectJSONSchemaOpenApi31(schema, {
+            "$id": "/schemas/object",
+            "anyOf": [
+              { "type": "object" },
+              { "type": "array" }
+            ],
+            "description": "an object in the TypeScript meaning, i.e. the `object` type",
+            "nullable": true,
+            "title": "object"
+          }, {})
+        })
+
+        it("NullOr(Struct({}))", () => {
+          const schema = Schema.NullOr(Schema.Struct({}))
+          expectJSONSchemaOpenApi31(schema, {
+            "$id": "/schemas/{}",
+            "anyOf": [
+              { "type": "object" },
+              { "type": "array" }
+            ],
+            "nullable": true
+          }, {})
+        })
+
+        it("NullOr(Ref)", () => {
+          const schema = Schema.NullOr(
+            Schema.String.annotations({ identifier: "b812aaa1-cfe1-4dda-8c9c-360bfa6cb855" })
+          )
+          expectJSONSchemaOpenApi31(schema, {
+            "$ref": "#/$defs/b812aaa1-cfe1-4dda-8c9c-360bfa6cb855",
+            "nullable": true
+          }, {
+            "b812aaa1-cfe1-4dda-8c9c-360bfa6cb855": {
+              "type": "string"
+            }
+          })
+        })
+
+        it("NullOr(Number)", () => {
+          const schema = Schema.NullOr(Schema.Number)
+          expectJSONSchemaOpenApi31(schema, {
+            "type": "number",
+            "nullable": true
+          }, {})
+        })
+
+        it("NullOr(Int)", () => {
+          const schema = Schema.NullOr(Schema.Int)
+          expectJSONSchemaOpenApi31(schema, {
+            "$ref": "#/$defs/Int",
+            "nullable": true
+          }, {
+            "Int": {
+              "description": "an integer",
+              "title": "Int",
+              "type": "integer"
+            }
+          })
+        })
+
+        it("NullOr(Boolean)", () => {
+          const schema = Schema.NullOr(Schema.Boolean)
+          expectJSONSchemaOpenApi31(schema, {
+            "type": "boolean",
+            "nullable": true
+          }, {})
+        })
+
+        it("NullOr(Array)", () => {
+          const schema = Schema.NullOr(Schema.Array(Schema.String))
+          expectJSONSchemaOpenApi31(schema, {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }, {})
+        })
+
+        it("NullOr(Enum)", () => {
+          enum Fruits {
+            Apple,
+            Banana
+          }
+          const schema = Schema.NullOr(Schema.Enums(Fruits))
+          expectJSONSchemaOpenApi31(schema, {
+            "$comment": "/schemas/enums",
+            "anyOf": [
+              {
+                "type": "number",
+                "title": "Apple",
+                "enum": [0]
+              },
+              {
+                "type": "number",
+                "title": "Banana",
+                "enum": [1]
+              }
+            ],
+            "nullable": true
+          }, {})
+        })
+
+        it("NullOr(Literal)", () => {
+          const schema = Schema.NullOr(Schema.Literal("a"))
+          expectJSONSchemaOpenApi31(schema, {
+            "type": "string",
+            "enum": ["a"],
+            "nullable": true
+          }, {})
+        })
+
+        it("Literal | null", () => {
           const schema = Schema.Literal("a", null)
           expectJSONSchemaOpenApi31(schema, {
             "type": "string",
@@ -285,12 +511,46 @@ describe("makeWithOptions", () => {
           }, {})
         })
 
-        it.skip("Literal | null(with description)", () => {
+        it("Literal | null(with description)", () => {
           const schema = Schema.Union(Schema.Literal("a"), Schema.Null.annotations({ description: "mydescription" }))
           expectJSONSchemaOpenApi31(schema, {
-            "type": "string",
-            "enum": ["a"],
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["a"]
+              },
+              {
+                "description": "mydescription",
+                "enum": [null]
+              }
+            ]
+          }, {})
+        })
+
+        it("Nested nullable unions", () => {
+          const schema = Schema.Union(Schema.NullOr(Schema.String), Schema.Literal("a", null))
+          expectJSONSchemaOpenApi31(schema, {
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "string",
+                "enum": ["a"]
+              }
+            ],
             "nullable": true
+          }, {})
+        })
+
+        it("NullOr(Struct({ a: String }))", () => {
+          const schema = Schema.NullOr(Schema.Struct({ a: Schema.String }))
+          expectJSONSchemaOpenApi31(schema, {
+            "additionalProperties": false,
+            "nullable": true,
+            "properties": {
+              "a": { "type": "string" }
+            },
+            "required": ["a"],
+            "type": "object"
           }, {})
         })
       })
@@ -1788,10 +2048,10 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
 
   describe("Union", () => {
     it("should ignore never members", () => {
-      expectJSONSchemaAnnotations(Schema.Union(Schema.String, Schema.Never), {
+      expectJSONSchema(Schema.Union(Schema.String, Schema.Never), {
         "type": "string"
       })
-      expectJSONSchemaAnnotations(Schema.Union(Schema.String, Schema.Union(Schema.Never, Schema.Never)), {
+      expectJSONSchema(Schema.Union(Schema.String, Schema.Union(Schema.Never, Schema.Never)), {
         "type": "string"
       })
     })

--- a/packages/platform/src/OpenApiJsonSchema.ts
+++ b/packages/platform/src/OpenApiJsonSchema.ts
@@ -23,6 +23,7 @@ export interface Annotations {
 export interface Never extends Annotations {
   $id: "/schemas/never"
   not: {}
+  nullable?: boolean
 }
 
 /**
@@ -59,6 +60,7 @@ export interface AnyObject extends Annotations {
     { type: "object" },
     { type: "array" }
   ]
+  nullable?: boolean
 }
 
 /**
@@ -71,6 +73,7 @@ export interface Empty extends Annotations {
     { type: "object" },
     { type: "array" }
   ]
+  nullable?: boolean
 }
 
 /**
@@ -79,6 +82,7 @@ export interface Empty extends Annotations {
  */
 export interface Ref extends Annotations {
   $ref: string
+  nullable?: boolean
 }
 
 /**
@@ -98,6 +102,7 @@ export interface String extends Annotations {
     maxLength?: number
     pattern?: string
   }>
+  nullable?: boolean
 }
 
 /**
@@ -118,6 +123,7 @@ export interface Numeric extends Annotations {
     exclusiveMaximum?: number
     multipleOf?: number
   }>
+  nullable?: boolean
 }
 
 /**
@@ -142,6 +148,7 @@ export interface Integer extends Numeric {
  */
 export interface Boolean extends Annotations {
   type: "boolean"
+  nullable?: boolean
 }
 
 /**
@@ -154,6 +161,7 @@ export interface Array extends Annotations {
   minItems?: number
   maxItems?: number
   additionalItems?: JsonSchema | boolean
+  nullable?: boolean
 }
 
 /**
@@ -163,6 +171,7 @@ export interface Array extends Annotations {
 export interface Enum extends Annotations {
   type?: "string" | "number" | "boolean"
   enum: globalThis.Array<string | number | boolean | null>
+  nullable?: boolean
 }
 
 /**
@@ -176,6 +185,7 @@ export interface Enums extends Annotations {
     title: string
     enum: [string | number]
   }>
+  nullable?: boolean
 }
 
 /**
@@ -184,6 +194,7 @@ export interface Enums extends Annotations {
  */
 export interface AnyOf extends Annotations {
   anyOf: globalThis.Array<JsonSchema>
+  nullable?: boolean
 }
 
 /**
@@ -197,6 +208,7 @@ export interface Object extends Annotations {
   additionalProperties?: boolean | JsonSchema
   patternProperties?: Record<string, JsonSchema>
   propertyNames?: JsonSchema
+  nullable?: boolean
 }
 
 /**

--- a/packages/platform/src/OpenApiJsonSchema.ts
+++ b/packages/platform/src/OpenApiJsonSchema.ts
@@ -4,7 +4,6 @@
 import * as JSONSchema from "effect/JSONSchema"
 import * as Record from "effect/Record"
 import type * as Schema from "effect/Schema"
-import type * as AST from "effect/SchemaAST"
 
 /**
  * @category model
@@ -163,7 +162,7 @@ export interface Array extends Annotations {
  */
 export interface Enum extends Annotations {
   type?: "string" | "number" | "boolean"
-  enum: globalThis.Array<AST.LiteralValue>
+  enum: globalThis.Array<string | number | boolean | null>
 }
 
 /**
@@ -256,14 +255,15 @@ export const make = <A, I, R>(schema: Schema.Schema<A, I, R>): Root => {
  * @since 1.0.0
  */
 export const makeWithDefs = <A, I, R>(schema: Schema.Schema<A, I, R>, options: {
-  readonly defs: Record<string, JsonSchema>
+  readonly defs: Record<string, any>
   readonly defsPath?: string
   readonly topLevelReferenceStrategy?: "skip" | "keep"
 }): JsonSchema => {
-  return JSONSchema.fromAST(schema.ast, {
+  const jsonSchema = JSONSchema.fromAST(schema.ast, {
     definitions: options.defs,
     definitionPath: options.defsPath ?? "#/components/schemas/",
     target: "openApi3.1",
     topLevelReferenceStrategy: options.topLevelReferenceStrategy ?? "keep"
   })
+  return jsonSchema as JsonSchema
 }


### PR DESCRIPTION
Before

```ts
import { OpenApiJsonSchema } from "@effect/platform"
import { Schema } from "effect"

const schema = Schema.NullOr(Schema.String)

console.log(JSON.stringify(OpenApiJsonSchema.make(schema), null, 2))
/*
{
  "anyOf": [
    {
      "type": "string"
    },
    {
      "enum": [
        null
      ]
    }
  ]
}
*/
```

After

```ts
import { OpenApiJsonSchema } from "@effect/platform"
import { Schema } from "effect"

const schema = Schema.NullOr(Schema.String)

console.log(JSON.stringify(OpenApiJsonSchema.make(schema), null, 2))
/*
{
  "type": "string",
  "nullable": true
}
*/
```
