### PR TITLE
upgrade undici to 7.x and expose re-exports in Undici module

### DIFF
--- a/.changeset/serious-eels-rule.md
+++ b/.changeset/serious-eels-rule.md
@@ -2,4 +2,4 @@
 "@effect/platform-node": minor
 ---
 
-upgrade undici to 7.x and move to peerDependencies
+upgrade undici to 7.x and expose re-exports in Undici module

--- a/.changeset/serious-eels-rule.md
+++ b/.changeset/serious-eels-rule.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Use Undici 7

--- a/.changeset/serious-eels-rule.md
+++ b/.changeset/serious-eels-rule.md
@@ -1,5 +1,5 @@
 ---
-"@effect/platform-node": patch
+"@effect/platform-node": minor
 ---
 
-Use Undici 7
+upgrade undici to 7.x and move to peerDependencies

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -46,17 +46,18 @@
   "dependencies": {
     "@effect/platform-node-shared": "workspace:^",
     "mime": "^3.0.0",
-    "undici": "^7.1.0",
     "ws": "^8.18.0"
   },
   "peerDependencies": {
     "@effect/platform": "workspace:^",
-    "effect": "workspace:^"
+    "effect": "workspace:^",
+    "undici": "^7.1.0"
   },
   "devDependencies": {
     "@effect/platform": "workspace:^",
     "@types/mime": "^3.0.4",
     "@types/ws": "^8.5.12",
-    "effect": "workspace:^"
+    "effect": "workspace:^",
+    "undici": "^7.1.0"
   }
 }

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -46,18 +46,17 @@
   "dependencies": {
     "@effect/platform-node-shared": "workspace:^",
     "mime": "^3.0.0",
+    "undici": "^7.1.0",
     "ws": "^8.18.0"
   },
   "peerDependencies": {
     "@effect/platform": "workspace:^",
-    "effect": "workspace:^",
-    "undici": "^7.1.0"
+    "effect": "workspace:^"
   },
   "devDependencies": {
     "@effect/platform": "workspace:^",
     "@types/mime": "^3.0.4",
     "@types/ws": "^8.5.12",
-    "effect": "workspace:^",
-    "undici": "^7.1.0"
+    "effect": "workspace:^"
   }
 }

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@effect/platform-node-shared": "workspace:^",
     "mime": "^3.0.0",
-    "undici": "^6.19.7",
+    "undici": "^7.1.0",
     "ws": "^8.18.0"
   },
   "peerDependencies": {

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -8,9 +8,9 @@ import type * as Layer from "effect/Layer"
 import type * as Scope from "effect/Scope"
 import type * as Http from "node:http"
 import type * as Https from "node:https"
-import type * as Undici from "undici"
 import * as internal from "./internal/httpClient.js"
 import * as internalUndici from "./internal/httpClientUndici.js"
+import type * as Undici from "./Undici.js"
 
 /**
  * @since 1.0.0

--- a/packages/platform-node/src/Undici.ts
+++ b/packages/platform-node/src/Undici.ts
@@ -1,0 +1,9 @@
+/**
+ * @since 1.0.0
+ */
+
+/**
+ * @since 1.0.0
+ * @category undici
+ */
+export * from "undici"

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -82,3 +82,8 @@ export * as NodeWorker from "./NodeWorker.js"
  * @since 1.0.0
  */
 export * as NodeWorkerRunner from "./NodeWorkerRunner.js"
+
+/**
+ * @since 1.0.0
+ */
+export * as Undici from "./Undici.js"

--- a/packages/platform-node/src/internal/httpClientUndici.ts
+++ b/packages/platform-node/src/internal/httpClientUndici.ts
@@ -15,9 +15,9 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import type * as Scope from "effect/Scope"
 import type * as Stream from "effect/Stream"
-import * as Undici from "undici"
 import type * as NodeClient from "../NodeHttpClient.js"
 import * as NodeStream from "../NodeStream.js"
+import * as Undici from "../Undici.js"
 
 /** @internal */
 export const Dispatcher = Context.GenericTag<NodeClient.Dispatcher, Undici.Dispatcher>(

--- a/packages/platform-node/src/internal/httpClientUndici.ts
+++ b/packages/platform-node/src/internal/httpClientUndici.ts
@@ -58,8 +58,7 @@ export const make = (dispatcher: Undici.Dispatcher): Client.HttpClient =>
               body,
               // leave timeouts to Effect.timeout etc
               headersTimeout: 60 * 60 * 1000,
-              bodyTimeout: 0,
-              throwOnError: false
+              bodyTimeout: 0
             }),
           catch: (cause) =>
             new Error.RequestError({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,9 +467,6 @@ importers:
       mime:
         specifier: ^3.0.0
         version: 3.0.0
-      undici:
-        specifier: ^7.1.0
-        version: 7.1.0
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -486,6 +483,9 @@ importers:
       effect:
         specifier: workspace:^
         version: link:../effect/dist
+      undici:
+        specifier: ^7.1.0
+        version: 7.1.0
     publishDirectory: dist
 
   packages/platform-node-shared:
@@ -5523,7 +5523,6 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.6:
@@ -6928,6 +6927,7 @@ packages:
 
   sudo-prompt@9.2.1:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       mime:
         specifier: ^3.0.0
         version: 3.0.0
+      undici:
+        specifier: ^7.1.0
+        version: 7.1.0
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -483,9 +486,6 @@ importers:
       effect:
         specifier: workspace:^
         version: link:../effect/dist
-      undici:
-        specifier: ^7.1.0
-        version: 7.1.0
     publishDirectory: dist
 
   packages/platform-node-shared:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,8 +468,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       undici:
-        specifier: ^6.19.7
-        version: 6.19.7
+        specifier: ^7.1.0
+        version: 7.1.0
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -7196,9 +7196,9 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  undici@6.19.7:
-    resolution: {integrity: sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==}
-    engines: {node: '>=18.17'}
+  undici@7.1.0:
+    resolution: {integrity: sha512-3+mdX2R31khuLCm2mKExSlMdJsfol7bJkIMH80tdXA74W34rT1jKemUTlYR7WY3TqsV4wfOgpatWmmB2Jl1+5g==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -15537,7 +15537,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@6.19.7: {}
+  undici@7.1.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

https://github.com/nodejs/undici/releases/tag/v7.0.0

I could only find 1 change to match (removal of `throwOnError`).

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
