### PR TITLE
Carry both call-site and definition site in Effect.fn, auto-trace to anon

### DIFF
--- a/.changeset/quiet-kings-impress.md
+++ b/.changeset/quiet-kings-impress.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add Effect.fnUntraced - an untraced version of Effect.fn

--- a/.changeset/weak-pears-remember.md
+++ b/.changeset/weak-pears-remember.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Carry both call-site and definition site in Effect.fn, auto-trace to anon

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -1106,9 +1106,13 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
         const stack = stackFn()
         if (typeof stack === "string") {
           const locationMatchAll = stack.matchAll(locationRegex)
-          for (const locationMatch of locationMatchAll) {
-            const location = locationMatch ? locationMatch[1] : stack.replace(/^at /, "")
+          let match = false
+          for (const [location] of locationMatchAll) {
+            match = true
             out.push(`    at ${current.name} (${location})`)
+          }
+          if (!match) {
+            out.push(`    at ${current.name} (${stack.replace(/^at /, "")})`)
           }
         } else {
           out.push(`    at ${current.name}`)

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -1073,7 +1073,7 @@ export const prettyErrorMessage = (u: unknown): string => {
   return stringifyCircular(u)
 }
 
-const locationRegex = /\((.*)\)/
+const locationRegex = /\((.*)\)/g
 
 /** @internal */
 export const spanToTrace = globalValue("effect/Tracer/spanToTrace", () => new WeakMap())
@@ -1105,9 +1105,11 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
       if (typeof stackFn === "function") {
         const stack = stackFn()
         if (typeof stack === "string") {
-          const locationMatch = stack.match(locationRegex)
-          const location = locationMatch ? locationMatch[1] : stack.replace(/^at /, "")
-          out.push(`    at ${current.name} (${location})`)
+          const locationMatchAll = stack.matchAll(locationRegex)
+          for (const locationMatch of locationMatchAll) {
+            const location = locationMatch ? locationMatch[1] : stack.replace(/^at /, "")
+            out.push(`    at ${current.name} (${location})`)
+          }
         } else {
           out.push(`    at ${current.name}`)
         }

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -1107,7 +1107,7 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
         if (typeof stack === "string") {
           const locationMatchAll = stack.matchAll(locationRegex)
           let match = false
-          for (const [location] of locationMatchAll) {
+          for (const [, location] of locationMatchAll) {
             match = true
             out.push(`    at ${current.name} (${location})`)
           }

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -1428,13 +1428,23 @@ export const whileLoop = <A, E, R>(
 }
 
 /* @internal */
-export const gen: typeof Effect.gen = function() {
-  const f = arguments.length === 1 ? arguments[0] : arguments[1].bind(arguments[0])
-  return suspend(() => {
+export const fromIterator = <Eff extends YieldWrap<Effect.Effect<any, any, any>>, AEff>(
+  iterator: LazyArg<Iterator<Eff, AEff, never>>
+): Effect.Effect<
+  AEff,
+  [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect.Effect<infer _A, infer E, infer _R>>] ? E : never,
+  [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect.Effect<infer _A, infer _E, infer R>>] ? R : never
+> =>
+  suspend(() => {
     const effect = new EffectPrimitive(OpCodes.OP_ITERATOR) as any
-    effect.effect_instruction_i0 = f(pipe)
+    effect.effect_instruction_i0 = iterator()
     return effect
   })
+
+/* @internal */
+export const gen: typeof Effect.gen = function() {
+  const f = arguments.length === 1 ? arguments[0] : arguments[1].bind(arguments[0])
+  return fromIterator(() => f(pipe))
 }
 
 /* @internal */


### PR DESCRIPTION
The following code:

```ts
import { Cause, Effect, Exit } from "effect"

const f = () => {
  throw new Error("OOO")
}

const program = Effect.fn(function*() {
  f()
})

Effect.runPromiseExit(Effect.scoped(program())).then(Exit.match({
  onSuccess() {},
  onFailure(cause) {
    console.log(Cause.pretty(cause))
  }
}))
```

will print:

```
Error: OOO
    at f (/Users/michaelarnaldi/repositories/effect/scratchpad/exit.ts:4:9)
    at <anonymous> (/Users/michaelarnaldi/repositories/effect/scratchpad/exit.ts:8:3)
    at <anonymous> (/Users/michaelarnaldi/repositories/effect/scratchpad/exit.ts:7:24)
    at <anonymous> (/Users/michaelarnaldi/repositories/effect/scratchpad/exit.ts:11:37)
```