### PR TITLE
Support native arbitraries in @effect/vitest

### DIFF
--- a/.changeset/shiny-timers-agree.md
+++ b/.changeset/shiny-timers-agree.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": minor
+---
+
+Support native arbitraries in @effect/vitest

--- a/packages/vitest/src/internal.ts
+++ b/packages/vitest/src/internal.ts
@@ -13,6 +13,7 @@ import { flow, identity, pipe } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Logger from "effect/Logger"
 import * as Schedule from "effect/Schedule"
+import * as Schema from "effect/Schema"
 import * as Scope from "effect/Scope"
 import * as TestEnvironment from "effect/TestContext"
 import type * as TestServices from "effect/TestServices"
@@ -97,9 +98,9 @@ const makeTester = <R>(
       (args, ctx) => run(ctx, [args], self) as any
     )
 
-  const prop: Vitest.Vitest.Tester<R>["prop"] = (name, schemaObj, self, timeout) => {
-    if (Array.isArray(schemaObj)) {
-      const arbs = schemaObj.map((schema) => Arbitrary.make(schema))
+  const prop: Vitest.Vitest.Tester<R>["prop"] = (name, arbitraries, self, timeout) => {
+    if (Array.isArray(arbitraries)) {
+      const arbs = arbitraries.map((arbitrary) => Schema.isSchema(arbitrary) ? Arbitrary.make(arbitrary) : arbitrary)
       return V.it(
         name,
         // @ts-ignore
@@ -109,8 +110,8 @@ const makeTester = <R>(
     }
 
     const arbs = fc.record(
-      Object.keys(schemaObj).reduce(function(result, key) {
-        result[key] = Arbitrary.make(schemaObj[key])
+      Object.keys(arbitraries).reduce(function(result, key) {
+        result[key] = Schema.isSchema(arbitraries[key]) ? Arbitrary.make(arbitraries[key]) : arbitraries[key]
         return result
       }, {} as Record<string, fc.Arbitrary<any>>)
     )
@@ -126,9 +127,9 @@ const makeTester = <R>(
   return Object.assign(f, { skip, skipIf, runIf, only, each, prop })
 }
 
-export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeout) => {
-  if (Array.isArray(schemaObj)) {
-    const arbs = schemaObj.map((schema) => Arbitrary.make(schema))
+export const prop: Vitest.Vitest.Methods["prop"] = (name, arbitraries, self, timeout) => {
+  if (Array.isArray(arbitraries)) {
+    const arbs = arbitraries.map((arbitrary) => Schema.isSchema(arbitrary) ? Arbitrary.make(arbitrary) : arbitrary)
     return V.it(
       name,
       // @ts-ignore
@@ -138,8 +139,8 @@ export const prop: Vitest.Vitest.Methods["prop"] = (name, schemaObj, self, timeo
   }
 
   const arbs = fc.record(
-    Object.keys(schemaObj).reduce(function(result, key) {
-      result[key] = Arbitrary.make(schemaObj[key])
+    Object.keys(arbitraries).reduce(function(result, key) {
+      result[key] = Schema.isSchema(arbitraries[key]) ? Arbitrary.make(arbitraries[key]) : arbitraries[key]
       return result
     }, {} as Record<string, fc.Arbitrary<any>>)
   )

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it, layer } from "@effect/vitest"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, FastCheck, Layer, Schema } from "effect"
 
 it.live(
   "live %s",
@@ -160,17 +160,31 @@ layer(Foo.Live)("layer", (it) => {
 
 const realNumber = Schema.Finite.pipe(Schema.nonNaN())
 
-it.prop("symmetry", [realNumber, realNumber], ([a, b]) => a + b === b + a)
+it.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) => a + b === b + a)
 
-it.effect.prop("symmetry", [realNumber, realNumber], ([a, b]) =>
+it.prop(
+  "symmetry with object",
+  { a: realNumber, b: FastCheck.integer() },
+  ({ a, b }) => a + b === b + a
+)
+
+it.effect.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) =>
   Effect.gen(function*() {
     yield* Effect.void
+
+    return a + b === b + a
+  }))
+
+it.effect.prop("symmetry with object", { a: realNumber, b: FastCheck.integer() }, ({ a, b }) =>
+  Effect.gen(function*() {
+    yield* Effect.void
+
     return a + b === b + a
   }))
 
 it.scoped.prop(
   "should detect the substring",
-  { a: Schema.String, b: Schema.String, c: Schema.String },
+  { a: Schema.String, b: Schema.String, c: FastCheck.string() },
   ({ a, b, c }) =>
     Effect.gen(function*() {
       yield* Effect.scope


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're looking at migrating to `@effect/vitest` but currently it requires all arbitraries to be `Schema`s. This change allows them to be existing fast-check arbitraries, which will make adoption easier.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
