### PR TITLE
Add support for `TemplateLiteral` parameters in `TemplateLiteral`, cl…

### DIFF
--- a/.changeset/good-pigs-roll.md
+++ b/.changeset/good-pigs-roll.md
@@ -2,4 +2,16 @@
 "effect": patch
 ---
 
-Support template literals in Schema.Config
+Schema: Support template literals in `Schema.Config`.
+
+**Example**
+
+```ts
+import { Schema } from "effect"
+
+// const config: Config<`a${string}`>
+const config = Schema.Config(
+  "A",
+  Schema.TemplateLiteral(Schema.Literal("a"), Schema.String)
+)
+```

--- a/.changeset/rude-impalas-type.md
+++ b/.changeset/rude-impalas-type.md
@@ -1,0 +1,40 @@
+---
+"effect": patch
+---
+
+Schema: Add support for `TemplateLiteral` parameters in `TemplateLiteral`, closes #4166.
+
+This update also adds support for `TemplateLiteral` and `TemplateLiteralParser` parameters in `TemplateLiteralParser`.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteralParser(
+  "<",
+  Schema.TemplateLiteralParser("h", Schema.Literal(1, 2)),
+  ">"
+)
+/*
+throws:
+Error: Unsupported template literal span
+schema (TemplateLiteral): `h${"1" | "2"}`
+*/
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+// Schema<readonly ["<", readonly ["h", 2 | 1], ">"], "<h2>" | "<h1>", never>
+const schema = Schema.TemplateLiteralParser(
+  "<",
+  Schema.TemplateLiteralParser("h", Schema.Literal(1, 2)),
+  ">"
+)
+
+console.log(Schema.decodeUnknownSync(schema)("<h1>"))
+// Output: [ '<', [ 'h', 1 ], '>' ]
+```

--- a/.changeset/shy-carpets-tap.md
+++ b/.changeset/shy-carpets-tap.md
@@ -1,0 +1,47 @@
+---
+"effect": patch
+---
+
+Schema: Fix bug in `TemplateLiteralParser` where unions of numeric literals were not coerced correctly.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteralParser("a", Schema.Literal(1, 2))
+
+console.log(Schema.decodeUnknownSync(schema)("a1"))
+/*
+throws:
+ParseError: (`a${"1" | "2"}` <-> readonly ["a", 1 | 2])
+└─ Type side transformation failure
+   └─ readonly ["a", 1 | 2]
+      └─ [1]
+         └─ 1 | 2
+            ├─ Expected 1, actual "1"
+            └─ Expected 2, actual "1"
+*/
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteralParser("a", Schema.Literal(1, 2))
+
+console.log(Schema.decodeUnknownSync(schema)("a1"))
+// Output: [ 'a', 1 ]
+
+console.log(Schema.decodeUnknownSync(schema)("a2"))
+// Output: [ 'a', 2 ]
+
+console.log(Schema.decodeUnknownSync(schema)("a3"))
+/*
+throws:
+ParseError: (`a${"1" | "2"}` <-> readonly ["a", 1 | 2])
+└─ Encoded side transformation failure
+   └─ Expected `a${"1" | "2"}`, actual "a3"
+*/
+```

--- a/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
@@ -1,103 +1,73 @@
 import type * as array_ from "effect/Array"
-import * as Schema from "effect/Schema"
+import * as S from "effect/Schema"
 import * as AST from "effect/SchemaAST"
 import * as Util from "effect/test/Schema/TestUtils"
 import { describe, expect, it } from "vitest"
 
-type TemplateLiteralParameter = Schema.Schema.AnyNoContext | AST.LiteralValue
+type TemplateLiteralParameter = S.Schema.AnyNoContext | AST.LiteralValue
 
-const expectCapturingPattern = (
+const expectPattern = (
   params: array_.NonEmptyReadonlyArray<TemplateLiteralParameter>,
   expectedPattern: string
 ) => {
-  const ast = Schema.TemplateLiteral(...params).ast as AST.TemplateLiteral
+  const ast = S.TemplateLiteral(...params).ast as AST.TemplateLiteral
   expect(AST.getTemplateLiteralCapturingRegExp(ast).source).toEqual(expectedPattern)
 }
 
 describe("TemplateLiteralParser", () => {
   it("should throw on unsupported template literal spans", () => {
-    expect(() => Schema.TemplateLiteralParser(Schema.Boolean)).toThrow(
+    expect(() => S.TemplateLiteralParser(S.Boolean)).toThrow(
       new Error(`Unsupported template literal span
 schema (BooleanKeyword): boolean`)
     )
 
-    expect(() => Schema.TemplateLiteralParser(Schema.Union(Schema.Boolean, Schema.SymbolFromSelf))).toThrow(
+    expect(() => S.TemplateLiteralParser(S.Union(S.Boolean, S.SymbolFromSelf))).toThrow(
       new Error(`Unsupported template literal span
 schema (Union): boolean | symbol`)
     )
   })
 
-  describe("getTemplateLiteralCapturingRegExp", () => {
-    it(`"a"`, () => {
-      expectCapturingPattern(["a"], "^(a)$")
-    })
-
-    it(`"a" + "b"`, () => {
-      expectCapturingPattern(["a", "b"], "^(a)(b)$")
-    })
-
-    it(`("a" | "b") + "c"`, () => {
-      expectCapturingPattern([Schema.Literal("a", "b"), "c"], "^(a|b)(c)$")
-    })
-
-    it(`("a" | "b) + "c" + ("d" | "e")`, () => {
-      expectCapturingPattern([Schema.Literal("a", "b"), "c", Schema.Literal("d", "e")], "^(a|b)(c)(d|e)$")
-    })
-
-    it(`("a" | "b") + string + ("d" | "e")`, () => {
-      expectCapturingPattern([Schema.Literal("a", "b"), Schema.String, Schema.Literal("d", "e")], "^(a|b)(.*)(d|e)$")
-    })
-
-    it(`"a" + string`, () => {
-      expectCapturingPattern(["a", Schema.String], "^(a)(.*)$")
-    })
-
-    it(`"a" + string + "b"`, () => {
-      expectCapturingPattern(["a", Schema.String, "b"], "^(a)(.*)(b)$")
-    })
-
-    it(`"a" + string + "b" + number`, () => {
-      expectCapturingPattern(
-        ["a", Schema.String, "b", Schema.Number],
-        "^(a)(.*)(b)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$"
-      )
-    })
-
-    it(`"a" + number`, () => {
-      expectCapturingPattern(["a", Schema.Number], "^(a)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$")
-    })
-
-    it(`string + "a"`, () => {
-      expectCapturingPattern([Schema.String, "a"], "^(.*)(a)$")
-    })
-
-    it(`number + "a"`, () => {
-      expectCapturingPattern([Schema.Number, "a"], "^([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)(a)$")
-    })
-
-    it(`(string | 1) + (number | true)`, () => {
-      expectCapturingPattern([
-        Schema.Union(Schema.String, Schema.Literal(1)),
-        Schema.Union(Schema.Number, Schema.Literal(true))
-      ], "^(.*|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$")
-    })
-
-    it(`(("a" | "b") | "c")`, () => {
-      expectCapturingPattern([
-        Schema.Union(Schema.Union(Schema.Literal("a"), Schema.Literal("b")), Schema.Literal("c"))
-      ], "^(a|b|c)$")
-    })
+  it("getTemplateLiteralCapturingRegExp", () => {
+    expectPattern(["a"], "^(a)$")
+    expectPattern(["a", "b"], "^(a)(b)$")
+    expectPattern([S.Literal("a", "b"), "c"], "^(a|b)(c)$")
+    expectPattern([S.Literal("a", "b"), "c", S.Literal("d", "e")], "^(a|b)(c)(d|e)$")
+    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)(.*)(d|e)$")
+    expectPattern(["a", S.String], "^(a)(.*)$")
+    expectPattern(["a", S.String, "b"], "^(a)(.*)(b)$")
+    expectPattern(
+      ["a", S.String, "b", S.Number],
+      "^(a)(.*)(b)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$"
+    )
+    expectPattern(["a", S.Number], "^(a)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$")
+    expectPattern([S.String, "a"], "^(.*)(a)$")
+    expectPattern([S.Number, "a"], "^([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)(a)$")
+    expectPattern([
+      S.Union(S.String, S.Literal(1)),
+      S.Union(S.Number, S.Literal(true))
+    ], "^(.*|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$")
+    expectPattern([S.Union(S.Literal("a", "b"), S.Literal(1, 2))], "^(a|b|1|2)$")
+    expectPattern([
+      "c",
+      S.Union(S.TemplateLiteral("a", S.String, "b"), S.Literal("e")),
+      "d"
+    ], "^(c)(a.*b|e)(d)$")
+    expectPattern(["<", S.TemplateLiteral("h", S.Literal(1, 2)), ">"], "^(<)(h(?:1|2))(>)$")
+    expectPattern(
+      ["-", S.Union(S.TemplateLiteral("a", S.Literal("b", "c")), S.TemplateLiteral("d", S.Literal("e", "f")))],
+      "^(-)(a(?:b|c)|d(?:e|f))$"
+    )
   })
 
   it("should expose the params", () => {
-    const params = ["/", Schema.Int, "/", Schema.String] as const
-    const schema = Schema.TemplateLiteralParser(...params)
+    const params = ["/", S.Int, "/", S.String] as const
+    const schema = S.TemplateLiteralParser(...params)
     expect(schema.params).toStrictEqual(params)
   })
 
   describe("decoding", () => {
     it(`"a"`, async () => {
-      const schema = Schema.TemplateLiteralParser("a")
+      const schema = S.TemplateLiteralParser("a")
 
       await Util.expectDecodeUnknownSuccess(schema, "a", ["a"])
       await Util.expectDecodeUnknownFailure(
@@ -112,7 +82,7 @@ schema (Union): boolean | symbol`)
     })
 
     it(`"a" + "b"`, async () => {
-      const schema = Schema.TemplateLiteralParser("a", "b")
+      const schema = S.TemplateLiteralParser("a", "b")
 
       await Util.expectDecodeUnknownSuccess(schema, "ab", ["a", "b"])
       await Util.expectDecodeUnknownFailure(
@@ -127,7 +97,7 @@ schema (Union): boolean | symbol`)
     })
 
     it(`Int + "a"`, async () => {
-      const schema = Schema.TemplateLiteralParser(Schema.Int, "a")
+      const schema = S.TemplateLiteralParser(S.Int, "a")
 
       await Util.expectDecodeUnknownSuccess(schema, "1a", [1, "a"])
       await Util.expectDecodeUnknownFailure(
@@ -137,9 +107,11 @@ schema (Union): boolean | symbol`)
 └─ Type side transformation failure
    └─ readonly [Int, "a"]
       └─ [0]
-         └─ Int
-            └─ Predicate refinement failure
-               └─ Expected Int, actual 1.1`
+         └─ (NumberFromString <-> Int)
+            └─ Type side transformation failure
+               └─ Int
+                  └─ Predicate refinement failure
+                     └─ Expected Int, actual 1.1`
       )
 
       await Util.expectEncodeSuccess(schema, [1, "a"], "1a")
@@ -150,14 +122,16 @@ schema (Union): boolean | symbol`)
 └─ Type side transformation failure
    └─ readonly [Int, "a"]
       └─ [0]
-         └─ Int
-            └─ Predicate refinement failure
-               └─ Expected Int, actual 1.1`
+         └─ (NumberFromString <-> Int)
+            └─ Type side transformation failure
+               └─ Int
+                  └─ Predicate refinement failure
+                     └─ Expected Int, actual 1.1`
       )
     })
 
     it(`NumberFromString + "a" + NonEmptyString`, async () => {
-      const schema = Schema.TemplateLiteralParser(Schema.NumberFromString, "a", Schema.NonEmptyString)
+      const schema = S.TemplateLiteralParser(S.NumberFromString, "a", S.NonEmptyString)
 
       await Util.expectDecodeUnknownSuccess(schema, "100ab", [100, "a", "b"])
       await Util.expectDecodeUnknownFailure(
@@ -185,30 +159,232 @@ schema (Union): boolean | symbol`)
                └─ Expected NonEmptyString, actual ""`
       )
     })
-  })
 
-  it("1", async () => {
-    const schema = Schema.TemplateLiteralParser(1)
-    await Util.expectDecodeUnknownSuccess(schema, "1", [1])
-  })
+    it("1", async () => {
+      const schema = S.TemplateLiteralParser(1)
+      await Util.expectDecodeUnknownSuccess(schema, "1", [1])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "1a",
+        `(\`1\` <-> readonly [1])
+└─ Encoded side transformation failure
+   └─ Expected \`1\`, actual "1a"`
+      )
+    })
 
-  it("1n", async () => {
-    const schema = Schema.TemplateLiteralParser(1n)
-    await Util.expectDecodeUnknownSuccess(schema, "1", [1n])
-  })
+    it("Literal(1)", async () => {
+      const schema = S.TemplateLiteralParser(S.Literal(1))
+      await Util.expectDecodeUnknownSuccess(schema, "1", [1])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "1a",
+        `(\`1\` <-> readonly [1])
+└─ Encoded side transformation failure
+   └─ Expected \`1\`, actual "1a"`
+      )
+    })
 
-  it("true", async () => {
-    const schema = Schema.TemplateLiteralParser(true)
-    await Util.expectDecodeUnknownSuccess(schema, "true", [true])
-  })
+    it("1n", async () => {
+      const schema = S.TemplateLiteralParser(1n)
+      await Util.expectDecodeUnknownSuccess(schema, "1", [1n])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "1a",
+        `(\`1\` <-> readonly [1n])
+└─ Encoded side transformation failure
+   └─ Expected \`1\`, actual "1a"`
+      )
+    })
 
-  it("false", async () => {
-    const schema = Schema.TemplateLiteralParser(false)
-    await Util.expectDecodeUnknownSuccess(schema, "false", [false])
-  })
+    it("Literal(1n)", async () => {
+      const schema = S.TemplateLiteralParser(S.Literal(1n))
+      await Util.expectDecodeUnknownSuccess(schema, "1", [1n])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "1a",
+        `(\`1\` <-> readonly [1n])
+└─ Encoded side transformation failure
+   └─ Expected \`1\`, actual "1a"`
+      )
+    })
 
-  it("null", async () => {
-    const schema = Schema.TemplateLiteralParser(null)
-    await Util.expectDecodeUnknownSuccess(schema, "null", [null])
+    it("true", async () => {
+      const schema = S.TemplateLiteralParser(true)
+      await Util.expectDecodeUnknownSuccess(schema, "true", [true])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "truea",
+        `(\`true\` <-> readonly [true])
+└─ Encoded side transformation failure
+   └─ Expected \`true\`, actual "truea"`
+      )
+    })
+
+    it("Literal(true)", async () => {
+      const schema = S.TemplateLiteralParser(S.Literal(true))
+      await Util.expectDecodeUnknownSuccess(schema, "true", [true])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "truea",
+        `(\`true\` <-> readonly [true])
+└─ Encoded side transformation failure
+   └─ Expected \`true\`, actual "truea"`
+      )
+    })
+
+    it("false", async () => {
+      const schema = S.TemplateLiteralParser(false)
+      await Util.expectDecodeUnknownSuccess(schema, "false", [false])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "falsea",
+        `(\`false\` <-> readonly [false])
+└─ Encoded side transformation failure
+   └─ Expected \`false\`, actual "falsea"`
+      )
+    })
+
+    it("Literal(false)", async () => {
+      const schema = S.TemplateLiteralParser(S.Literal(false))
+      await Util.expectDecodeUnknownSuccess(schema, "false", [false])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "falsea",
+        `(\`false\` <-> readonly [false])
+└─ Encoded side transformation failure
+   └─ Expected \`false\`, actual "falsea"`
+      )
+    })
+
+    it("null", async () => {
+      const schema = S.TemplateLiteralParser(null)
+      await Util.expectDecodeUnknownSuccess(schema, "null", [null])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "nulla",
+        `(\`null\` <-> readonly [null])
+└─ Encoded side transformation failure
+   └─ Expected \`null\`, actual "nulla"`
+      )
+    })
+
+    it("Literal(null)", async () => {
+      const schema = S.TemplateLiteralParser(S.Literal(null))
+      await Util.expectDecodeUnknownSuccess(schema, "null", [null])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "nulla",
+        `(\`null\` <-> readonly [null])
+└─ Encoded side transformation failure
+   └─ Expected \`null\`, actual "nulla"`
+      )
+    })
+
+    it("1 | 2", async () => {
+      const schema = S.TemplateLiteralParser(S.Literal(1, 2))
+      await Util.expectDecodeUnknownSuccess(schema, "1", [1])
+      await Util.expectDecodeUnknownSuccess(schema, "2", [2])
+    })
+
+    it(`"h" + (1 | 2 | 3)`, async () => {
+      const schema = S.TemplateLiteralParser("h", S.Literal(1, 2, 3))
+      await Util.expectDecodeUnknownSuccess(schema, "h1", ["h", 1])
+    })
+
+    it(`"c" + (\`a\${string}b\`|"e") + "d"`, async () => {
+      const schema = S.TemplateLiteralParser(
+        "c",
+        S.Union(S.TemplateLiteralParser("a", S.NonEmptyString, "b"), S.Literal("e")),
+        "d"
+      )
+      await Util.expectDecodeUnknownSuccess(schema, "ca bd", ["c", ["a", " ", "b"], "d"])
+      await Util.expectDecodeUnknownSuccess(schema, "ced", ["c", "e", "d"])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "cabd",
+        `(\`c\${\`a\${string}b\` | "e"}d\` <-> readonly ["c", (\`a\${string}b\` <-> readonly ["a", NonEmptyString, "b"]) | "e", "d"])
+└─ Type side transformation failure
+   └─ readonly ["c", (\`a\${string}b\` <-> readonly ["a", NonEmptyString, "b"]) | "e", "d"]
+      └─ [1]
+         └─ (\`a\${string}b\` <-> readonly ["a", NonEmptyString, "b"]) | "e"
+            ├─ (\`a\${string}b\` <-> readonly ["a", NonEmptyString, "b"])
+            │  └─ Type side transformation failure
+            │     └─ readonly ["a", NonEmptyString, "b"]
+            │        └─ [1]
+            │           └─ NonEmptyString
+            │              └─ Predicate refinement failure
+            │                 └─ Expected NonEmptyString, actual ""
+            └─ Expected "e", actual "ab"`
+      )
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "ed",
+        `(\`c\${\`a\${string}b\` | "e"}d\` <-> readonly ["c", (\`a\${string}b\` <-> readonly ["a", NonEmptyString, "b"]) | "e", "d"])
+└─ Encoded side transformation failure
+   └─ Expected \`c\${\`a\${string}b\` | "e"}d\`, actual "ed"`
+      )
+    })
+
+    it(`"c" + (\`a\${number}b\`|"e") + "d"`, async () => {
+      const schema = S.TemplateLiteralParser(
+        "c",
+        S.Union(S.TemplateLiteralParser("a", S.Int, "b"), S.Literal("e")),
+        "d"
+      )
+      await Util.expectDecodeUnknownSuccess(schema, "ced", ["c", "e", "d"])
+      await Util.expectDecodeUnknownSuccess(schema, "ca1bd", ["c", ["a", 1, "b"], "d"])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "ca1.1bd",
+        `(\`c\${\`a\${number}b\` | "e"}d\` <-> readonly ["c", (\`a\${number}b\` <-> readonly ["a", Int, "b"]) | "e", "d"])
+└─ Type side transformation failure
+   └─ readonly ["c", (\`a\${number}b\` <-> readonly ["a", Int, "b"]) | "e", "d"]
+      └─ [1]
+         └─ (\`a\${number}b\` <-> readonly ["a", Int, "b"]) | "e"
+            ├─ (\`a\${number}b\` <-> readonly ["a", Int, "b"])
+            │  └─ Type side transformation failure
+            │     └─ readonly ["a", Int, "b"]
+            │        └─ [1]
+            │           └─ (NumberFromString <-> Int)
+            │              └─ Type side transformation failure
+            │                 └─ Int
+            │                    └─ Predicate refinement failure
+            │                       └─ Expected Int, actual 1.1
+            └─ Expected "e", actual "a1.1b"`
+      )
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "ca-bd",
+        `(\`c\${\`a\${number}b\` | "e"}d\` <-> readonly ["c", (\`a\${number}b\` <-> readonly ["a", Int, "b"]) | "e", "d"])
+└─ Encoded side transformation failure
+   └─ Expected \`c\${\`a\${number}b\` | "e"}d\`, actual "ca-bd"`
+      )
+    })
+
+    it("(`<${`h${\"1\" | \"2\"}`}>` <-> readonly [\"<\", `h${\"1\" | \"2\"}`, \">\"])", async () => {
+      const schema = S.TemplateLiteralParser("<", S.TemplateLiteral("h", S.Literal(1, 2)), ">")
+      await Util.expectDecodeUnknownSuccess(schema, "<h1>", ["<", "h1", ">"])
+      await Util.expectDecodeUnknownSuccess(schema, "<h2>", ["<", "h2", ">"])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "<h3>",
+        `(\`<\${\`h\${"1" | "2"}\`}>\` <-> readonly ["<", \`h\${"1" | "2"}\`, ">"])
+└─ Encoded side transformation failure
+   └─ Expected \`<\${\`h\${"1" | "2"}\`}>\`, actual "<h3>"`
+      )
+    })
+
+    it("(`<${`h${\"1\" | \"2\"}`}>` <-> readonly [\"<\", `h${\"1\" | \"2\"}`, \">\"])", async () => {
+      const schema = S.TemplateLiteralParser("<", S.TemplateLiteralParser("h", S.Literal(1, 2)), ">")
+      await Util.expectDecodeUnknownSuccess(schema, "<h1>", ["<", ["h", 1], ">"])
+      await Util.expectDecodeUnknownSuccess(schema, "<h2>", ["<", ["h", 2], ">"])
+      await Util.expectDecodeUnknownFailure(
+        schema,
+        "<h3>",
+        `(\`<\${\`h\${"1" | "2"}\`}>\` <-> readonly ["<", (\`h\${"1" | "2"}\` <-> readonly ["h", 1 | 2]), ">"])
+└─ Encoded side transformation failure
+   └─ Expected \`<\${\`h\${"1" | "2"}\`}>\`, actual "<h3>"`
+      )
+    })
   })
 })


### PR DESCRIPTION
…oses #4166

## Fix 1

Schema: Fix bug in `TemplateLiteralParser` where unions of numeric literals were not coerced correctly.

Before

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteralParser("a", Schema.Literal(1, 2))

console.log(Schema.decodeUnknownSync(schema)("a1"))
/*
throws:
ParseError: (`a${"1" | "2"}` <-> readonly ["a", 1 | 2])
└─ Type side transformation failure
   └─ readonly ["a", 1 | 2]
      └─ [1]
         └─ 1 | 2
            ├─ Expected 1, actual "1"
            └─ Expected 2, actual "1"
*/
```

After

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteralParser("a", Schema.Literal(1, 2))

console.log(Schema.decodeUnknownSync(schema)("a1"))
// Output: [ 'a', 1 ]

console.log(Schema.decodeUnknownSync(schema)("a2"))
// Output: [ 'a', 2 ]

console.log(Schema.decodeUnknownSync(schema)("a3"))
/*
throws:
ParseError: (`a${"1" | "2"}` <-> readonly ["a", 1 | 2])
└─ Encoded side transformation failure
   └─ Expected `a${"1" | "2"}`, actual "a3"
*/
```

## Fix 2

Schema: Add support for `TemplateLiteral` parameters in `TemplateLiteral`, closes #4166.

This update also adds support for `TemplateLiteral` and `TemplateLiteralParser` parameters in `TemplateLiteralParser`.

Before

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteralParser(
  "<",
  Schema.TemplateLiteralParser("h", Schema.Literal(1, 2)),
  ">"
)
/*
throws:
Error: Unsupported template literal span
schema (TemplateLiteral): `h${"1" | "2"}`
*/
```

After

```ts
import { Schema } from "effect"

// Schema<readonly ["<", readonly ["h", 2 | 1], ">"], "<h2>" | "<h1>", never>
const schema = Schema.TemplateLiteralParser(
  "<",
  Schema.TemplateLiteralParser("h", Schema.Literal(1, 2)),
  ">"
)

console.log(Schema.decodeUnknownSync(schema)("<h1>"))
// Output: [ '<', [ 'h', 1 ], '>' ]
```
