### PR TITLE
Schema: Fix bug where calling `withDecodingDefault` after `withConstr…

### DIFF
--- a/.changeset/strange-ducks-applaud.md
+++ b/.changeset/strange-ducks-applaud.md
@@ -1,0 +1,43 @@
+---
+"effect": patch
+---
+
+Schema: Fix bug where calling `withDecodingDefault` after `withConstructorDefault` removed the constructor default.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.optional(Schema.Number).pipe(
+    Schema.withConstructorDefault(() => 0),
+    Schema.withDecodingDefault(() => 1)
+  )
+})
+
+console.log(schema.make())
+// Output: { a: undefined }
+
+console.log(schema.make({}))
+// Output: { a: undefined }
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.optional(Schema.Number).pipe(
+    Schema.withConstructorDefault(() => 0),
+    Schema.withDecodingDefault(() => 1)
+  )
+})
+
+console.log(schema.make())
+// Output: { a: 0 }
+
+console.log(schema.make({}))
+// Output: { a: 0 }
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1940,8 +1940,8 @@ export const withDecodingDefault: {
     case "PropertySignatureDeclaration":
       return makePropertySignature(
         new PropertySignatureTransformation(
-          ast,
-          new ToPropertySignature(AST.typeAST(ast.type), false, true, {}, undefined),
+          new FromPropertySignature(ast.type, ast.isOptional, ast.isReadonly, ast.annotations),
+          new ToPropertySignature(AST.typeAST(ast.type), false, true, {}, ast.defaultValue),
           (o) => applyDefaultValue(o, defaultValue),
           identity
         )

--- a/packages/effect/test/Schema/Schema/Struct/make.test.ts
+++ b/packages/effect/test/Schema/Schema/Struct/make.test.ts
@@ -115,4 +115,11 @@ describe("make", () => {
     Util.expectConstructorSuccess(schema, { [b]: 2 }, { a: "", [b]: 2 })
     Util.expectConstructorSuccess(schema, {}, { a: "", [b]: 0 })
   })
+
+  it("withConstructorDefault + withDecodingDefault", () => {
+    const schema = S.Struct({
+      a: S.optional(S.Number).pipe(S.withConstructorDefault(() => 0), S.withDecodingDefault(() => 1))
+    })
+    Util.expectConstructorSuccess(schema, {}, { a: 0 })
+  })
 })


### PR DESCRIPTION
…uctorDefault` removed the constructor default.

Before

```ts
import { Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.optional(Schema.Number).pipe(
    Schema.withConstructorDefault(() => 0),
    Schema.withDecodingDefault(() => 1)
  )
})

console.log(schema.make())
// Output: { a: undefined }

console.log(schema.make({}))
// Output: { a: undefined }
```

After

```ts
import { Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.optional(Schema.Number).pipe(
    Schema.withConstructorDefault(() => 0),
    Schema.withDecodingDefault(() => 1)
  )
})

console.log(schema.make())
// Output: { a: 0 }

console.log(schema.make({}))
// Output: { a: 0 }
```
