### PR TITLE
incorrect type declaration in LibsqlClient.layer

### DIFF
--- a/.changeset/light-carrots-teach.md
+++ b/.changeset/light-carrots-teach.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fixed incorrect type declaration in LibsqlClient.layer

--- a/packages/sql-libsql/src/LibsqlClient.ts
+++ b/packages/sql-libsql/src/LibsqlClient.ts
@@ -316,7 +316,7 @@ export const layerConfig = (
  */
 export const layer = (
   config: LibsqlClientConfig
-): Layer.Layer<LibsqlClient | Client.SqlClient, ConfigError> =>
+): Layer.Layer<LibsqlClient | Client.SqlClient> =>
   Layer.scopedContext(
     Effect.map(make(config), (client) =>
       Context.make(LibsqlClient, client).pipe(


### PR DESCRIPTION
This is incorrect. I think it's left over from when layer became layerConfig

Removing the declaration reveals the real type. 

<img width="1045" alt="Screenshot 2024-12-23 at 3 20 18 PM" src="https://github.com/user-attachments/assets/690d0ed9-e02c-4dc1-9053-f3fdcfdac8af" />
