### PR TITLE
extend IterableIterator instead of Generator

### DIFF
--- a/.changeset/polite-crews-march.md
+++ b/.changeset/polite-crews-march.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+extend `IterableIterator` instead of `Generator` in `SingleShotGen`

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -106,7 +106,7 @@ export class GenKindImpl<F extends TypeLambda, R, O, E, A> implements GenKind<F,
  * @category constructors
  * @since 2.0.0
  */
-export class SingleShotGen<T, A> implements Generator<T, A> {
+export class SingleShotGen<T, A> implements IterableIterator<T, A> {
   private called = false
 
   constructor(readonly self: T) {}

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -40,7 +40,7 @@ export type GenKindTypeId = typeof GenKindTypeId
 export interface GenKind<F extends TypeLambda, R, O, E, A> extends Variance<F, R, O, E> {
   readonly value: Kind<F, R, O, E, A>
 
-  [Symbol.iterator](): Generator<GenKind<F, R, O, E, A>, A>
+  [Symbol.iterator](): IterableIterator<GenKind<F, R, O, E, A>, A>
 }
 
 /**
@@ -97,7 +97,7 @@ export class GenKindImpl<F extends TypeLambda, R, O, E, A> implements GenKind<F,
   /**
    * @since 2.0.0
    */
-  [Symbol.iterator](): Generator<GenKind<F, R, O, E, A>, A> {
+  [Symbol.iterator](): IterableIterator<GenKind<F, R, O, E, A>, A> {
     return new SingleShotGen<GenKind<F, R, O, E, A>, A>(this as any)
   }
 }
@@ -147,7 +147,7 @@ export class SingleShotGen<T, A> implements IterableIterator<T, A> {
   /**
    * @since 2.0.0
    */
-  [Symbol.iterator](): Generator<T, A> {
+  [Symbol.iterator](): IterableIterator<T, A> {
     return new SingleShotGen<T, A>(this.self)
   }
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Make `SingleShotGen` extend `IterableIterator` instead of `Generator`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #3848 
- Closes #3848
