### PR TITLE
update internal namespace import convention from `_<name>` to `<name>_`

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -26,7 +26,7 @@ import type * as HashMap from "./HashMap.js"
 import type * as HashSet from "./HashSet.js"
 import type { TypeLambda } from "./HKT.js"
 import * as internalCause from "./internal/cause.js"
-import * as _console from "./internal/console.js"
+import * as console_ from "./internal/console.js"
 import { TagProto } from "./internal/context.js"
 import * as effect from "./internal/core-effect.js"
 import * as core from "./internal/core.js"
@@ -35,8 +35,8 @@ import * as circular from "./internal/effect/circular.js"
 import * as fiberRuntime from "./internal/fiberRuntime.js"
 import * as layer from "./internal/layer.js"
 import * as query from "./internal/query.js"
-import * as _runtime from "./internal/runtime.js"
-import * as _schedule from "./internal/schedule.js"
+import * as runtime_ from "./internal/runtime.js"
+import * as schedule_ from "./internal/schedule.js"
 import * as internalTracer from "./internal/tracer.js"
 import type * as Layer from "./Layer.js"
 import type { LogLevel } from "./LogLevel.js"
@@ -2433,7 +2433,7 @@ export const async: <A, E = never, R = never>(
  */
 export const asyncEffect: <A, E, R, R3, E2, R2>(
   register: (callback: (_: Effect<A, E, R>) => void) => Effect<Effect<void, never, R3> | void, E2, R2>
-) => Effect<A, E | E2, R | R2 | R3> = _runtime.asyncEffect
+) => Effect<A, E | E2, R | R2 | R3> = runtime_.asyncEffect
 
 /**
  * Low level constructor that enables for custom stack tracing cutpoints.
@@ -4340,7 +4340,7 @@ export const retry: {
     self: Effect<A, E, R>,
     policy: Schedule.Schedule<B, E, R1>
   ): Effect<A, E, R1 | R>
-} = _schedule.retry_combined
+} = schedule_.retry_combined
 
 /**
  * Retries a failing effect and runs a fallback effect if retries are exhausted.
@@ -4412,7 +4412,7 @@ export const retryOrElse: {
     policy: Schedule.Schedule<A1, NoInfer<E>, R1>,
     orElse: (e: NoInfer<E>, out: A1) => Effect<A2, E2, R2>
   ): Effect<A | A2, E2, R | R1 | R2>
-} = _schedule.retryOrElse_Effect
+} = schedule_.retryOrElse_Effect
 
 const try_: {
   <A, E>(options: { readonly try: LazyArg<A>; readonly catch: (error: unknown) => E }): Effect<A, E>
@@ -6616,7 +6616,7 @@ export const withClock: {
  * @since 2.0.0
  * @category Console
  */
-export const console: Effect<Console> = _console.console
+export const console: Effect<Console> = console_.console
 
 /**
  * Retreives the `Console` service from the context and provides it to the
@@ -6625,7 +6625,7 @@ export const console: Effect<Console> = _console.console
  * @since 2.0.0
  * @category Console
  */
-export const consoleWith: <A, E, R>(f: (console: Console) => Effect<A, E, R>) => Effect<A, E, R> = _console.consoleWith
+export const consoleWith: <A, E, R>(f: (console: Console) => Effect<A, E, R>) => Effect<A, E, R> = console_.consoleWith
 
 /**
  * Sets the implementation of the console service to the specified value and
@@ -6635,7 +6635,7 @@ export const consoleWith: <A, E, R>(f: (console: Console) => Effect<A, E, R>) =>
  * @category Creating Effects
  */
 export const withConsoleScoped: <A extends Console>(console: A) => Effect<void, never, Scope.Scope> =
-  _console.withConsoleScoped
+  console_.withConsoleScoped
 
 /**
  * Executes the specified workflow with the specified implementation of the
@@ -6647,7 +6647,7 @@ export const withConsoleScoped: <A extends Console>(console: A) => Effect<void, 
 export const withConsole: {
   <C extends Console>(console: C): <A, E, R>(effect: Effect<A, E, R>) => Effect<A, E, R>
   <A, E, R, C extends Console>(effect: Effect<A, E, R>, console: C): Effect<A, E, R>
-} = _console.withConsole
+} = console_.withConsole
 
 /**
  * Delays the execution of an effect by a specified `Duration`.
@@ -9862,7 +9862,7 @@ export const repeat: {
     options: O
   ): Repeat.Return<R, E, A, O>
   <A, E, R, B, R1>(self: Effect<A, E, R>, schedule: Schedule.Schedule<B, A, R1>): Effect<B, E, R | R1>
-} = _schedule.repeat_combined
+} = schedule_.repeat_combined
 
 /**
  * Repeats an effect a specified number of times or until the first failure.
@@ -9963,7 +9963,7 @@ export const repeatOrElse: {
     schedule: Schedule.Schedule<B, A, R2>,
     orElse: (error: E, option: Option.Option<B>) => Effect<B, E2, R3>
   ): Effect<B, E2, R | R2 | R3>
-} = _schedule.repeatOrElse_Effect
+} = schedule_.repeatOrElse_Effect
 
 /**
  * Repeats an effect based on a specified schedule.
@@ -9990,7 +9990,7 @@ export const repeatOrElse: {
 export const schedule: {
   <R2, Out>(schedule: Schedule.Schedule<Out, unknown, R2>): <A, E, R>(self: Effect<A, E, R>) => Effect<Out, E, R2 | R>
   <A, E, R, R2, Out>(self: Effect<A, E, R>, schedule: Schedule.Schedule<Out, unknown, R2>): Effect<Out, E, R | R2>
-} = _schedule.schedule_Effect
+} = schedule_.schedule_Effect
 
 /**
  * Runs an effect repeatedly on a new fiber according to a given schedule.
@@ -10053,7 +10053,7 @@ export const scheduleFrom: {
     initial: In,
     schedule: Schedule.Schedule<Out, In, R2>
   ): Effect<Out, E, R | R2>
-} = _schedule.scheduleFrom_Effect
+} = schedule_.scheduleFrom_Effect
 
 /**
  * @since 2.0.0
@@ -11211,7 +11211,7 @@ export const withRandomScoped: <A extends Random.Random>(value: A) => Effect<voi
  * @since 2.0.0
  * @category Runtime
  */
-export const runtime: <R = never>() => Effect<Runtime.Runtime<R>, never, R> = _runtime.runtime
+export const runtime: <R = never>() => Effect<Runtime.Runtime<R>, never, R> = runtime_.runtime
 
 /**
  * Retrieves an effect that succeeds with the current runtime flags, which
@@ -11636,7 +11636,7 @@ export const makeLatch: (open?: boolean | undefined) => Effect<Latch, never, nev
 export const runFork: <A, E>(
   effect: Effect<A, E>,
   options?: Runtime.RunForkOptions
-) => Fiber.RuntimeFiber<A, E> = _runtime.unsafeForkEffect
+) => Fiber.RuntimeFiber<A, E> = runtime_.unsafeForkEffect
 
 /**
  * Executes an effect asynchronously and handles the result using a callback.
@@ -11659,7 +11659,7 @@ export const runFork: <A, E>(
 export const runCallback: <A, E>(
   effect: Effect<A, E>,
   options?: Runtime.RunCallbackOptions<A, E> | undefined
-) => Runtime.Cancel<A, E> = _runtime.unsafeRunEffect
+) => Runtime.Cancel<A, E> = runtime_.unsafeRunEffect
 
 /**
  * Executes an effect and returns the result as a `Promise`.
@@ -11706,7 +11706,7 @@ export const runCallback: <A, E>(
 export const runPromise: <A, E>(
   effect: Effect<A, E, never>,
   options?: { readonly signal?: AbortSignal } | undefined
-) => Promise<A> = _runtime.unsafeRunPromiseEffect
+) => Promise<A> = runtime_.unsafeRunPromiseEffect
 
 /**
  * Runs an effect and returns a `Promise` that resolves to an `Exit`,
@@ -11767,7 +11767,7 @@ export const runPromise: <A, E>(
 export const runPromiseExit: <A, E>(
   effect: Effect<A, E, never>,
   options?: { readonly signal?: AbortSignal } | undefined
-) => Promise<Exit.Exit<A, E>> = _runtime.unsafeRunPromiseExitEffect
+) => Promise<Exit.Exit<A, E>> = runtime_.unsafeRunPromiseExitEffect
 
 /**
  * Executes an effect synchronously, running it immediately and returning the
@@ -11844,7 +11844,7 @@ export const runPromiseExit: <A, E>(
  * @since 2.0.0
  * @category Running Effects
  */
-export const runSync: <A, E>(effect: Effect<A, E>) => A = _runtime.unsafeRunSyncEffect
+export const runSync: <A, E>(effect: Effect<A, E>) => A = runtime_.unsafeRunSyncEffect
 
 /**
  * Runs an effect synchronously and returns the result as an `Exit` type.
@@ -11920,7 +11920,7 @@ export const runSync: <A, E>(effect: Effect<A, E>) => A = _runtime.unsafeRunSync
  * @since 2.0.0
  * @category Running Effects
  */
-export const runSyncExit: <A, E>(effect: Effect<A, E>) => Exit.Exit<A, E> = _runtime.unsafeRunSyncExitEffect
+export const runSyncExit: <A, E>(effect: Effect<A, E>) => Exit.Exit<A, E> = runtime_.unsafeRunSyncExitEffect
 
 /**
  * Combines multiple effects and accumulates both successes and failures.

--- a/packages/effect/src/HashMap.ts
+++ b/packages/effect/src/HashMap.ts
@@ -6,7 +6,7 @@ import type { Equal } from "./Equal.js"
 import type { HashSet } from "./HashSet.js"
 import type { Inspectable } from "./Inspectable.js"
 import * as HM from "./internal/hashMap.js"
-import * as _keySet from "./internal/hashMap/keySet.js"
+import * as keySet_ from "./internal/hashMap/keySet.js"
 import type { Option } from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { NoInfer } from "./Types.js"
@@ -219,7 +219,7 @@ export const keys: <K, V>(self: HashMap<K, V>) => IterableIterator<K> = HM.keys
  * @since 2.0.0
  * @category getter
  */
-export const keySet: <K, V>(self: HashMap<K, V>) => HashSet<K> = _keySet.keySet
+export const keySet: <K, V>(self: HashMap<K, V>) => HashSet<K> = keySet_.keySet
 
 /**
  * Returns an `IterableIterator` of the values within the `HashMap`.

--- a/packages/effect/src/Request.ts
+++ b/packages/effect/src/Request.ts
@@ -8,7 +8,7 @@ import type { DurationInput } from "./Duration.js"
 import type * as Effect from "./Effect.js"
 import type * as Exit from "./Exit.js"
 import type { FiberId } from "./FiberId.js"
-import * as _RequestBlock from "./internal/blockedRequests.js"
+import * as RequestBlock_ from "./internal/blockedRequests.js"
 import * as cache from "./internal/cache.js"
 import * as core from "./internal/core.js"
 import * as fiberRuntime from "./internal/fiberRuntime.js"
@@ -338,10 +338,10 @@ export declare namespace Entry {
  * @since 2.0.0
  * @category guards
  */
-export const isEntry = _RequestBlock.isEntry
+export const isEntry = RequestBlock_.isEntry
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const makeEntry = _RequestBlock.makeEntry
+export const makeEntry = RequestBlock_.makeEntry

--- a/packages/effect/src/RequestBlock.ts
+++ b/packages/effect/src/RequestBlock.ts
@@ -1,7 +1,7 @@
 /**
  * @since 2.0.0
  */
-import * as _RequestBlock from "./internal/blockedRequests.js"
+import * as RequestBlock_ from "./internal/blockedRequests.js"
 import type * as Request from "./Request.js"
 import type * as RequestResolver from "./RequestResolver.js"
 
@@ -82,13 +82,13 @@ export interface Single {
 export const single: <A>(
   dataSource: RequestResolver.RequestResolver<A>,
   blockedRequest: Request.Entry<A>
-) => RequestBlock = _RequestBlock.single
+) => RequestBlock = RequestBlock_.single
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const empty: RequestBlock = _RequestBlock.empty
+export const empty: RequestBlock = RequestBlock_.empty
 
 /**
  * @since 2.0.0
@@ -97,22 +97,22 @@ export const empty: RequestBlock = _RequestBlock.empty
 export const mapRequestResolvers: <A>(
   self: RequestBlock,
   f: (dataSource: RequestResolver.RequestResolver<A>) => RequestResolver.RequestResolver<A>
-) => RequestBlock = _RequestBlock.mapRequestResolvers
+) => RequestBlock = RequestBlock_.mapRequestResolvers
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const parallel: (self: RequestBlock, that: RequestBlock) => RequestBlock = _RequestBlock.par
+export const parallel: (self: RequestBlock, that: RequestBlock) => RequestBlock = RequestBlock_.par
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const reduce: <Z>(self: RequestBlock, reducer: RequestBlock.Reducer<Z>) => Z = _RequestBlock.reduce
+export const reduce: <Z>(self: RequestBlock, reducer: RequestBlock.Reducer<Z>) => Z = RequestBlock_.reduce
 
 /**
  * @since 2.0.0
  * @category constructors
  */
-export const sequential: (self: RequestBlock, that: RequestBlock) => RequestBlock = _RequestBlock.seq
+export const sequential: (self: RequestBlock, that: RequestBlock) => RequestBlock = RequestBlock_.seq

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -13,7 +13,7 @@ import type * as Exit from "./Exit.js"
 import type { LazyArg } from "./Function.js"
 import type * as GroupBy from "./GroupBy.js"
 import type { TypeLambda } from "./HKT.js"
-import * as _groupBy from "./internal/groupBy.js"
+import * as groupBy_ from "./internal/groupBy.js"
 import * as internal from "./internal/stream.js"
 import type * as Layer from "./Layer.js"
 import type * as Option from "./Option.js"
@@ -2287,7 +2287,7 @@ export const groupBy: {
     f: (a: A) => Effect.Effect<readonly [K, V], E2, R2>,
     options?: { readonly bufferSize?: number | undefined } | undefined
   ): GroupBy.GroupBy<K, V, E | E2, R | R2>
-} = _groupBy.groupBy
+} = groupBy_.groupBy
 
 /**
  * Partition a stream using a function and process each stream individually.
@@ -2340,7 +2340,7 @@ export const groupByKey: {
       readonly bufferSize?: number | undefined
     }
   ): GroupBy.GroupBy<K, A, E, R>
-} = _groupBy.groupByKey
+} = groupBy_.groupByKey
 
 /**
  * Partitions the stream with specified `chunkSize`.
@@ -2919,7 +2919,7 @@ export const mapEffect: {
     f: (a: A) => Effect.Effect<A2, E2, R2>,
     options: { readonly key: (a: A) => K; readonly bufferSize?: number | undefined }
   ): Stream<A2, E | E2, R | R2>
-} = _groupBy.mapEffectOptions
+} = groupBy_.mapEffectOptions
 
 /**
  * Transforms the errors emitted by this stream using `f`.
@@ -6263,7 +6263,7 @@ export const bindEffect: {
     f: (_: NoInfer<A>) => Effect.Effect<B, E2, R2>,
     options?: { readonly concurrency?: number | "unbounded" | undefined; readonly unordered?: boolean | undefined }
   ): Stream<{ [K in keyof A | N]: K extends keyof A ? A[K] : B }, E | E2, R | R2>
-} = _groupBy.bindEffect
+} = groupBy_.bindEffect
 
 /**
  * The "do simulation" in Effect allows you to write code in a more declarative style, similar to the "do notation" in other programming languages. It provides a way to define variables and perform operations on them using functions like `bind` and `let`.

--- a/packages/effect/src/internal/channel.ts
+++ b/packages/effect/src/internal/channel.ts
@@ -27,7 +27,7 @@ import * as executor from "./channel/channelExecutor.js"
 import type * as ChannelState from "./channel/channelState.js"
 import * as mergeDecision from "./channel/mergeDecision.js"
 import * as mergeState from "./channel/mergeState.js"
-import * as _mergeStrategy from "./channel/mergeStrategy.js"
+import * as mergeStrategy_ from "./channel/mergeStrategy.js"
 import * as singleProducerAsyncInput from "./channel/singleProducerAsyncInput.js"
 import * as coreEffect from "./core-effect.js"
 import * as core from "./core-stream.js"
@@ -1086,7 +1086,7 @@ export const mergeAllWith = (
   {
     bufferSize = 16,
     concurrency,
-    mergeStrategy = _mergeStrategy.BackPressure()
+    mergeStrategy = mergeStrategy_.BackPressure()
   }: {
     readonly concurrency: number | "unbounded"
     readonly bufferSize?: number | undefined
@@ -1198,7 +1198,7 @@ export const mergeAllWith = (
                   }
                 ),
               onRight: (channel) =>
-                _mergeStrategy.match(mergeStrategy, {
+                mergeStrategy_.match(mergeStrategy, {
                   onBackPressure: () =>
                     Effect.gen(function*() {
                       const latch = yield* Deferred.make<void>()

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -38,7 +38,7 @@ import type * as Scope from "../Scope.js"
 import type * as Tracer from "../Tracer.js"
 import type { NoInfer, NotFunction } from "../Types.js"
 import { internalCall, YieldWrap } from "../Utils.js"
-import * as _blockedRequests from "./blockedRequests.js"
+import * as blockedRequests_ from "./blockedRequests.js"
 import * as internalCause from "./cause.js"
 import * as deferred from "./deferred.js"
 import * as internalDiffer from "./differ.js"
@@ -48,7 +48,7 @@ import type * as FiberRuntime from "./fiberRuntime.js"
 import type * as fiberScope from "./fiberScope.js"
 import * as DeferredOpCodes from "./opCodes/deferred.js"
 import * as OpCodes from "./opCodes/effect.js"
-import * as _runtimeFlags from "./runtimeFlags.js"
+import * as runtimeFlags_ from "./runtimeFlags.js"
 import { SingleShotGen } from "./singleShotGen.js"
 
 // -----------------------------------------------------------------------------
@@ -651,7 +651,7 @@ export const catchSome = dual<
 /* @internal */
 export const checkInterruptible = <A, E, R>(
   f: (isInterruptible: boolean) => Effect.Effect<A, E, R>
-): Effect.Effect<A, E, R> => withFiberRuntime((_, status) => f(_runtimeFlags.interruption(status.runtimeFlags)))
+): Effect.Effect<A, E, R> => withFiberRuntime((_, status) => f(runtimeFlags_.interruption(status.runtimeFlags)))
 
 const spanSymbol = Symbol.for("effect/SpanAnnotation")
 const originalSymbol = Symbol.for("effect/OriginalAnnotation")
@@ -1001,7 +1001,7 @@ export const interruptWith = (fiberId: FiberId.FiberId): Effect.Effect<never> =>
 /* @internal */
 export const interruptible = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> => {
   const effect = new EffectPrimitive(OpCodes.OP_UPDATE_RUNTIME_FLAGS) as any
-  effect.effect_instruction_i0 = RuntimeFlagsPatch.enable(_runtimeFlags.Interruption)
+  effect.effect_instruction_i0 = RuntimeFlagsPatch.enable(runtimeFlags_.Interruption)
   effect.effect_instruction_i1 = () => self
   return effect
 }
@@ -1012,9 +1012,9 @@ export const interruptibleMask = <A, E, R>(
 ): Effect.Effect<A, E, R> =>
   custom(f, function() {
     const effect = new EffectPrimitive(OpCodes.OP_UPDATE_RUNTIME_FLAGS) as any
-    effect.effect_instruction_i0 = RuntimeFlagsPatch.enable(_runtimeFlags.Interruption)
+    effect.effect_instruction_i0 = RuntimeFlagsPatch.enable(runtimeFlags_.Interruption)
     effect.effect_instruction_i1 = (oldFlags: RuntimeFlags.RuntimeFlags) =>
-      _runtimeFlags.interruption(oldFlags)
+      runtimeFlags_.interruption(oldFlags)
         ? internalCall(() => this.effect_instruction_i0(interruptible))
         : internalCall(() => this.effect_instruction_i0(uninterruptible))
     return effect
@@ -1330,7 +1330,7 @@ export const uninterruptible: <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.
   self: Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> => {
   const effect = new EffectPrimitive(OpCodes.OP_UPDATE_RUNTIME_FLAGS) as any
-  effect.effect_instruction_i0 = RuntimeFlagsPatch.disable(_runtimeFlags.Interruption)
+  effect.effect_instruction_i0 = RuntimeFlagsPatch.disable(runtimeFlags_.Interruption)
   effect.effect_instruction_i1 = () => self
   return effect
 }
@@ -1341,9 +1341,9 @@ export const uninterruptibleMask = <A, E, R>(
 ): Effect.Effect<A, E, R> =>
   custom(f, function() {
     const effect = new EffectPrimitive(OpCodes.OP_UPDATE_RUNTIME_FLAGS) as any
-    effect.effect_instruction_i0 = RuntimeFlagsPatch.disable(_runtimeFlags.Interruption)
+    effect.effect_instruction_i0 = RuntimeFlagsPatch.disable(runtimeFlags_.Interruption)
     effect.effect_instruction_i1 = (oldFlags: RuntimeFlags.RuntimeFlags) =>
-      _runtimeFlags.interruption(oldFlags)
+      runtimeFlags_.interruption(oldFlags)
         ? internalCall(() => this.effect_instruction_i0(interruptible))
         : internalCall(() => this.effect_instruction_i0(uninterruptible))
     return effect
@@ -1878,17 +1878,17 @@ export const requestBlockLocally = <A>(
   self: BlockedRequests.RequestBlock,
   ref: FiberRef.FiberRef<A>,
   value: A
-): BlockedRequests.RequestBlock => _blockedRequests.reduce(self, LocallyReducer(ref, value))
+): BlockedRequests.RequestBlock => blockedRequests_.reduce(self, LocallyReducer(ref, value))
 
 const LocallyReducer = <A>(
   ref: FiberRef.FiberRef<A>,
   value: A
 ): BlockedRequests.RequestBlock.Reducer<BlockedRequests.RequestBlock> => ({
-  emptyCase: () => _blockedRequests.empty,
-  parCase: (left, right) => _blockedRequests.par(left, right),
-  seqCase: (left, right) => _blockedRequests.seq(left, right),
+  emptyCase: () => blockedRequests_.empty,
+  parCase: (left, right) => blockedRequests_.par(left, right),
+  seqCase: (left, right) => blockedRequests_.seq(left, right),
   singleCase: (dataSource, blockedRequest) =>
-    _blockedRequests.single(
+    blockedRequests_.single(
       resolverLocally(dataSource, ref, value),
       blockedRequest as any
     )
@@ -1991,8 +1991,8 @@ export const fiberRefUnsafeMakeRuntimeFlags = (
   initial: RuntimeFlags.RuntimeFlags
 ): FiberRef.FiberRef<RuntimeFlags.RuntimeFlags> =>
   fiberRefUnsafeMakePatch(initial, {
-    differ: _runtimeFlags.differ,
-    fork: _runtimeFlags.differ.empty
+    differ: runtimeFlags_.differ,
+    fork: runtimeFlags_.differ.empty
   })
 
 /** @internal */

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -32,7 +32,7 @@ import * as internalFiber from "../fiber.js"
 import * as fiberRuntime from "../fiberRuntime.js"
 import { globalScope } from "../fiberScope.js"
 import * as internalRef from "../ref.js"
-import * as _schedule from "../schedule.js"
+import * as schedule_ from "../schedule.js"
 import * as supervisor from "../supervisor.js"
 
 /** @internal */
@@ -480,7 +480,7 @@ export const scheduleForked = dual<
     self: Effect.Effect<A, E, R>,
     schedule: Schedule.Schedule<Out, unknown, R2>
   ) => Effect.Effect<Fiber.RuntimeFiber<Out, E>, never, R | R2 | Scope.Scope>
->(2, (self, schedule) => pipe(self, _schedule.schedule_Effect(schedule), forkScoped))
+>(2, (self, schedule) => pipe(self, schedule_.schedule_Effect(schedule), forkScoped))
 
 /** @internal */
 export const supervised = dual<

--- a/packages/effect/src/internal/fiberRefs/patch.ts
+++ b/packages/effect/src/internal/fiberRefs/patch.ts
@@ -4,7 +4,7 @@ import type * as FiberId from "../../FiberId.js"
 import type * as FiberRefs from "../../FiberRefs.js"
 import type * as FiberRefsPatch from "../../FiberRefsPatch.js"
 import { dual } from "../../Function.js"
-import * as _fiberRefs from "../fiberRefs.js"
+import * as fiberRefs_ from "../fiberRefs.js"
 
 /** @internal */
 export const OP_EMPTY = "Empty" as const
@@ -111,7 +111,7 @@ export const patch = dual<
         break
       }
       case OP_ADD: {
-        fiberRefs = _fiberRefs.updateAs(fiberRefs, {
+        fiberRefs = fiberRefs_.updateAs(fiberRefs, {
           fiberId,
           fiberRef: head.fiberRef,
           value: head.value
@@ -120,13 +120,13 @@ export const patch = dual<
         break
       }
       case OP_REMOVE: {
-        fiberRefs = _fiberRefs.delete_(fiberRefs, head.fiberRef)
+        fiberRefs = fiberRefs_.delete_(fiberRefs, head.fiberRef)
         patches = tail
         break
       }
       case OP_UPDATE: {
-        const value = _fiberRefs.getOrDefault(fiberRefs, head.fiberRef)
-        fiberRefs = _fiberRefs.updateAs(fiberRefs, {
+        const value = fiberRefs_.getOrDefault(fiberRefs, head.fiberRef)
+        fiberRefs = fiberRefs_.updateAs(fiberRefs, {
           fiberId,
           fiberRef: head.fiberRef,
           value: head.fiberRef.patch(head.patch)(value)

--- a/packages/effect/src/internal/fiberScope.ts
+++ b/packages/effect/src/internal/fiberScope.ts
@@ -3,7 +3,6 @@ import { globalValue } from "../GlobalValue.js"
 import type * as RuntimeFlags from "../RuntimeFlags.js"
 import * as FiberMessage from "./fiberMessage.js"
 import type * as FiberRuntime from "./fiberRuntime.js"
-import * as _runtimeFlags from "./runtimeFlags.js"
 
 /** @internal */
 const FiberScopeSymbolKey = "effect/FiberScope"

--- a/packages/effect/src/internal/layer/circular.ts
+++ b/packages/effect/src/internal/layer/circular.ts
@@ -15,7 +15,7 @@ import * as fiberRuntime from "../fiberRuntime.js"
 import * as layer from "../layer.js"
 import * as runtimeFlags from "../runtimeFlags.js"
 import * as runtimeFlagsPatch from "../runtimeFlagsPatch.js"
-import * as _supervisor from "../supervisor.js"
+import * as supervisor_ from "../supervisor.js"
 import * as tracer from "../tracer.js"
 
 // circular with Logger
@@ -106,7 +106,7 @@ export const addSupervisor = <A>(supervisor: Supervisor.Supervisor<A>): Layer.La
   layer.scopedDiscard(
     fiberRuntime.fiberRefLocallyScopedWith(
       fiberRuntime.currentSupervisor,
-      (current) => new _supervisor.Zip(current, supervisor)
+      (current) => new supervisor_.Zip(current, supervisor)
     )
   )
 

--- a/packages/effect/src/internal/logger-circular.ts
+++ b/packages/effect/src/internal/logger-circular.ts
@@ -4,7 +4,7 @@ import * as HashMap from "../HashMap.js"
 import * as List from "../List.js"
 import type * as Logger from "../Logger.js"
 import * as core from "./core.js"
-import * as _fiberId from "./fiberId.js"
+import * as fiberId_ from "./fiberId.js"
 import * as fiberRefs from "./fiberRefs.js"
 
 /** @internal */
@@ -13,7 +13,7 @@ export const test = dual<
   <Message, Output>(self: Logger.Logger<Message, Output>, input: Message) => Output
 >(2, (self, input) =>
   self.log({
-    fiberId: _fiberId.none,
+    fiberId: fiberId_.none,
     logLevel: core.logLevelInfo,
     message: input,
     cause: Cause.empty,

--- a/packages/effect/src/internal/logger.ts
+++ b/packages/effect/src/internal/logger.ts
@@ -15,7 +15,7 @@ import { pipeArguments } from "../Pipeable.js"
 import * as Cause from "./cause.js"
 import * as defaultServices from "./defaultServices.js"
 import { consoleTag } from "./defaultServices/console.js"
-import * as _fiberId from "./fiberId.js"
+import * as fiberId_ from "./fiberId.js"
 
 /** @internal */
 const LoggerSymbolKey = "effect/Logger"
@@ -170,7 +170,7 @@ export const stringLogger: Logger.Logger<unknown, string> = makeLogger(
     const outputArray = [
       `timestamp=${date.toISOString()}`,
       `level=${logLevel.label}`,
-      `fiber=${_fiberId.threadName(fiberId)}`
+      `fiber=${fiberId_.threadName(fiberId)}`
     ]
 
     let output = outputArray.join(" ")
@@ -240,7 +240,7 @@ export const logfmtLogger = makeLogger<unknown, string>(
     const outputArray = [
       `timestamp=${date.toISOString()}`,
       `level=${logLevel.label}`,
-      `fiber=${_fiberId.threadName(fiberId)}`
+      `fiber=${fiberId_.threadName(fiberId)}`
     ]
 
     let output = outputArray.join(" ")
@@ -328,7 +328,7 @@ export const structuredLogger = makeLogger<unknown, {
       cause: Cause.isEmpty(cause) ? undefined : Cause.pretty(cause, { renderErrorCause: true }),
       annotations: annotationsObj,
       spans: spansObj,
-      fiberId: _fiberId.threadName(fiberId)
+      fiberId: fiberId_.threadName(fiberId)
     }
   }
 )
@@ -460,7 +460,7 @@ const prettyLoggerTty = (options: {
 
       let firstLine = color(`[${options.formatDate(date)}]`, colors.white)
         + ` ${color(logLevel.label, ...logLevelColors[logLevel._tag])}`
-        + ` (${_fiberId.threadName(fiberId)})`
+        + ` (${fiberId_.threadName(fiberId)})`
 
       if (List.isCons(spans)) {
         const now = date.getTime()
@@ -520,7 +520,7 @@ const prettyLoggerBrowser = (options: {
       if (options.colors) {
         firstParams.push("color:gray")
       }
-      firstLine += ` ${color}${logLevel.label}${color} (${_fiberId.threadName(fiberId)})`
+      firstLine += ` ${color}${logLevel.label}${color} (${fiberId_.threadName(fiberId)})`
       if (options.colors) {
         firstParams.push(logLevelStyle[logLevel._tag], "")
       }

--- a/packages/effect/src/internal/metric.ts
+++ b/packages/effect/src/internal/metric.ts
@@ -16,7 +16,7 @@ import type * as MetricRegistry from "../MetricRegistry.js"
 import type * as MetricState from "../MetricState.js"
 import { pipeArguments } from "../Pipeable.js"
 import * as Cause from "./cause.js"
-import * as _effect from "./core-effect.js"
+import * as effect_ from "./core-effect.js"
 import * as core from "./core.js"
 import * as metricBoundaries from "./metric/boundaries.js"
 import * as metricKey from "./metric/key.js"
@@ -411,7 +411,7 @@ export const trackDefectWith = dual<
   ) => Effect.Effect<A, E, R>
 >(3, (self, metric, f) => {
   const updater = (defect: unknown) => update(metric, f(defect))
-  return _effect.tapDefect(self, (cause) => core.forEachSequentialDiscard(Cause.defects(cause), updater))
+  return effect_.tapDefect(self, (cause) => core.forEachSequentialDiscard(Cause.defects(cause), updater))
 })
 
 /* @internal */
@@ -477,7 +477,7 @@ export const trackErrorWith = dual<
   f: (error: In2) => In
 ) => {
   const updater = (error: E): Effect.Effect<void> => update(metric, f(error))
-  return _effect.tapError(self, updater)
+  return effect_.tapError(self, updater)
 })
 
 /* @internal */

--- a/packages/effect/src/internal/reloadable.ts
+++ b/packages/effect/src/internal/reloadable.ts
@@ -7,8 +7,8 @@ import type * as Schedule from "../Schedule.js"
 import * as effect from "./core-effect.js"
 import * as core from "./core.js"
 import * as fiberRuntime from "./fiberRuntime.js"
-import * as _layer from "./layer.js"
-import * as _schedule from "./schedule.js"
+import * as layer_ from "./layer.js"
+import * as schedule_ from "./schedule.js"
 import * as scopedRef from "./scopedRef.js"
 
 /** @internal */
@@ -32,17 +32,17 @@ export const auto = <Out extends Context.Tag<any, any>, E, In, R>(
     readonly schedule: Schedule.Schedule<unknown, unknown, R>
   }
 ): Layer.Layer<Reloadable.Reloadable<Context.Tag.Identifier<Out>>, E, R | In> =>
-  _layer.scoped(
+  layer_.scoped(
     reloadableTag(tag),
     pipe(
-      _layer.build(manual(tag, { layer: options.layer })),
+      layer_.build(manual(tag, { layer: options.layer })),
       core.map(Context.unsafeGet(reloadableTag(tag))),
       core.tap((reloadable) =>
         fiberRuntime.acquireRelease(
           pipe(
             reloadable.reload,
             effect.ignoreLogged,
-            _schedule.schedule_Effect(options.schedule),
+            schedule_.schedule_Effect(options.schedule),
             fiberRuntime.forkDaemon
           ),
           core.interruptFiber
@@ -59,13 +59,13 @@ export const autoFromConfig = <Out extends Context.Tag<any, any>, E, In, R>(
     readonly scheduleFromConfig: (context: Context.Context<In>) => Schedule.Schedule<unknown, unknown, R>
   }
 ): Layer.Layer<Reloadable.Reloadable<Context.Tag.Identifier<Out>>, E, R | In> =>
-  _layer.scoped(
+  layer_.scoped(
     reloadableTag(tag),
     pipe(
       core.context<In>(),
       core.flatMap((env) =>
         pipe(
-          _layer.build(auto(tag, {
+          layer_.build(auto(tag, {
             layer: options.layer,
             schedule: options.scheduleFromConfig(env)
           })),
@@ -91,18 +91,18 @@ export const manual = <Out extends Context.Tag<any, any>, In, E>(
     readonly layer: Layer.Layer<Context.Tag.Identifier<Out>, E, In>
   }
 ): Layer.Layer<Reloadable.Reloadable<Context.Tag.Identifier<Out>>, E, In> =>
-  _layer.scoped(
+  layer_.scoped(
     reloadableTag(tag),
     pipe(
       core.context<In>(),
       core.flatMap((env) =>
         pipe(
-          scopedRef.fromAcquire(pipe(_layer.build(options.layer), core.map(Context.unsafeGet(tag)))),
+          scopedRef.fromAcquire(pipe(layer_.build(options.layer), core.map(Context.unsafeGet(tag)))),
           core.map((ref) => ({
             [ReloadableTypeId]: reloadableVariance,
             scopedRef: ref,
             reload: pipe(
-              scopedRef.set(ref, pipe(_layer.build(options.layer), core.map(Context.unsafeGet(tag)))),
+              scopedRef.set(ref, pipe(layer_.build(options.layer), core.map(Context.unsafeGet(tag)))),
               core.provideContext(env)
             )
           }))

--- a/packages/effect/src/internal/resource.ts
+++ b/packages/effect/src/internal/resource.ts
@@ -6,7 +6,7 @@ import type * as Scope from "../Scope.js"
 import * as core from "./core.js"
 import * as effectable from "./effectable.js"
 import * as fiberRuntime from "./fiberRuntime.js"
-import * as _schedule from "./schedule.js"
+import * as schedule_ from "./schedule.js"
 import * as scopedRef from "./scopedRef.js"
 
 /** @internal */
@@ -42,7 +42,7 @@ export const auto = <A, E, R, Out, R2>(
     fiberRuntime.acquireRelease(
       pipe(
         refresh(manual),
-        _schedule.schedule_Effect(policy),
+        schedule_.schedule_Effect(policy),
         core.interruptible,
         fiberRuntime.forkDaemon
       ),

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -42,7 +42,7 @@ import * as MergeStrategy from "./channel/mergeStrategy.js"
 import * as core from "./core-stream.js"
 import * as doNotation from "./doNotation.js"
 import { RingBuffer } from "./ringBuffer.js"
-import * as _sink from "./sink.js"
+import * as sink_ from "./sink.js"
 import * as DebounceState from "./stream/debounceState.js"
 import * as emit from "./stream/emit.js"
 import * as haltStrategy from "./stream/haltStrategy.js"
@@ -295,7 +295,7 @@ export const aggregateWithinEither = dual<
             Effect.zipRight(
               pipe(
                 handoffConsumer,
-                channel.pipeToOrFail(_sink.toChannel(sink)),
+                channel.pipeToOrFail(sink_.toChannel(sink)),
                 core.collectElements,
                 channel.run,
                 Effect.forkIn(scope)
@@ -424,7 +424,7 @@ export const aggregateWithinEither = dual<
             channel.run,
             Effect.forkIn(scope),
             Effect.zipRight(
-              channel.pipeToOrFail(handoffConsumer, _sink.toChannel(sink)).pipe(
+              channel.pipeToOrFail(handoffConsumer, sink_.toChannel(sink)).pipe(
                 core.collectElements,
                 channel.run,
                 Effect.forkIn(scope),
@@ -3478,7 +3478,7 @@ export const groupedWithin = dual<
     chunkSize: number,
     duration: Duration.DurationInput
   ): Stream.Stream<Chunk.Chunk<A>, E, R> =>
-    aggregateWithin(self, _sink.collectAllN(chunkSize), Schedule.spaced(duration))
+    aggregateWithin(self, sink_.collectAllN(chunkSize), Schedule.spaced(duration))
 )
 
 /** @internal */
@@ -4285,7 +4285,7 @@ export const mergeWith = dual<
 
 /** @internal */
 export const mkString = <E, R>(self: Stream.Stream<string, E, R>): Effect.Effect<string, E, R> =>
-  run(self, _sink.mkString)
+  run(self, sink_.mkString)
 
 /** @internal */
 export const never: Stream.Stream<never> = fromEffect(Effect.never)
@@ -4570,11 +4570,11 @@ export const peel = dual<
       pipe(
         Handoff.make<Signal>(),
         Effect.map((handoff) => {
-          const consumer = _sink.foldSink(_sink.collectLeftover(sink), {
+          const consumer = sink_.foldSink(sink_.collectLeftover(sink), {
             onFailure: (error) =>
-              _sink.zipRight(
-                _sink.fromEffect(Deferred.fail(deferred, error)),
-                _sink.fail(error)
+              sink_.zipRight(
+                sink_.fromEffect(Deferred.fail(deferred, error)),
+                sink_.fail(error)
               ),
             onSuccess: ([z, leftovers]) => {
               const loop: Channel.Channel<Chunk.Chunk<A>, Chunk.Chunk<A>, E | E2, E, void, unknown> = core
@@ -4597,7 +4597,7 @@ export const peel = dual<
                       core.void
                     )
                 })
-              return _sink.fromChannel(
+              return sink_.fromChannel(
                 pipe(
                   core.fromEffect(Deferred.succeed(deferred, z)),
                   channel.zipRight(core.fromEffect(
@@ -4791,7 +4791,7 @@ export const pipeThrough = dual<
     self: Stream.Stream<A, E, R>,
     sink: Sink.Sink<A2, A, L, E2, R2>
   ): Stream.Stream<L, E2 | E, R2 | R> =>
-    new StreamImpl(pipe(toChannel(self), channel.pipeToOrFail(_sink.toChannel(sink))))
+    new StreamImpl(pipe(toChannel(self), channel.pipeToOrFail(sink_.toChannel(sink))))
 )
 
 /** @internal */
@@ -5492,20 +5492,20 @@ export const run = dual<
   sink: Sink.Sink<A2, A, unknown, E2, R2>
 ): Effect.Effect<A2, E2 | E, R | R2> =>
   toChannel(self).pipe(
-    channel.pipeToOrFail(_sink.toChannel(sink)),
+    channel.pipeToOrFail(sink_.toChannel(sink)),
     channel.runDrain
   ))
 
 /** @internal */
 export const runCollect = <A, E, R>(
   self: Stream.Stream<A, E, R>
-): Effect.Effect<Chunk.Chunk<A>, E, R> => run(self, _sink.collectAll())
+): Effect.Effect<Chunk.Chunk<A>, E, R> => run(self, sink_.collectAll())
 
 /** @internal */
-export const runCount = <A, E, R>(self: Stream.Stream<A, E, R>): Effect.Effect<number, E, R> => run(self, _sink.count)
+export const runCount = <A, E, R>(self: Stream.Stream<A, E, R>): Effect.Effect<number, E, R> => run(self, sink_.count)
 
 /** @internal */
-export const runDrain = <A, E, R>(self: Stream.Stream<A, E, R>): Effect.Effect<void, E, R> => run(self, _sink.drain)
+export const runDrain = <A, E, R>(self: Stream.Stream<A, E, R>): Effect.Effect<void, E, R> => run(self, sink_.drain)
 
 /** @internal */
 export const runFold = dual<
@@ -5590,7 +5590,7 @@ export const runFoldWhile = dual<
   s: S,
   cont: Predicate<S>,
   f: (s: S, a: A) => S
-): Effect.Effect<S, E, R> => run(self, _sink.fold(s, cont, f)))
+): Effect.Effect<S, E, R> => run(self, sink_.fold(s, cont, f)))
 
 /** @internal */
 export const runFoldWhileEffect = dual<
@@ -5612,7 +5612,7 @@ export const runFoldWhileEffect = dual<
   s: S,
   cont: Predicate<S>,
   f: (s: S, a: A) => Effect.Effect<S, E2, R2>
-): Effect.Effect<S, E2 | E, R | R2> => run(self, _sink.foldEffect(s, cont, f)))
+): Effect.Effect<S, E2 | E, R | R2> => run(self, sink_.foldEffect(s, cont, f)))
 
 /** @internal */
 export const runFoldWhileScoped = dual<
@@ -5632,7 +5632,7 @@ export const runFoldWhileScoped = dual<
   s: S,
   cont: Predicate<S>,
   f: (s: S, a: A) => S
-): Effect.Effect<S, E, Scope.Scope | R> => pipe(self, runScoped(_sink.fold(s, cont, f))))
+): Effect.Effect<S, E, Scope.Scope | R> => pipe(self, runScoped(sink_.fold(s, cont, f))))
 
 /** @internal */
 export const runFoldWhileScopedEffect = dual<
@@ -5652,7 +5652,7 @@ export const runFoldWhileScopedEffect = dual<
   s: S,
   cont: Predicate<S>,
   f: (s: S, a: A) => Effect.Effect<S, E2, R2>
-): Effect.Effect<S, E2 | E, Scope.Scope | R2 | R> => pipe(self, runScoped(_sink.foldEffect(s, cont, f))))
+): Effect.Effect<S, E2 | E, Scope.Scope | R2 | R> => pipe(self, runScoped(sink_.foldEffect(s, cont, f))))
 
 /** @internal */
 export const runForEach = dual<
@@ -5668,7 +5668,7 @@ export const runForEach = dual<
 >(2, <A, E, R, X, E2, R2>(
   self: Stream.Stream<A, E, R>,
   f: (a: A) => Effect.Effect<X, E2, R2>
-): Effect.Effect<void, E2 | E, R | R2> => run(self, _sink.forEach(f)))
+): Effect.Effect<void, E2 | E, R | R2> => run(self, sink_.forEach(f)))
 
 /** @internal */
 export const runForEachChunk = dual<
@@ -5684,7 +5684,7 @@ export const runForEachChunk = dual<
 >(2, <A, E, R, X, E2, R2>(
   self: Stream.Stream<A, E, R>,
   f: (a: Chunk.Chunk<A>) => Effect.Effect<X, E2, R2>
-): Effect.Effect<void, E2 | E, R | R2> => run(self, _sink.forEachChunk(f)))
+): Effect.Effect<void, E2 | E, R | R2> => run(self, sink_.forEachChunk(f)))
 
 /** @internal */
 export const runForEachChunkScoped = dual<
@@ -5698,7 +5698,7 @@ export const runForEachChunkScoped = dual<
 >(2, <A, E, R, X, E2, R2>(
   self: Stream.Stream<A, E, R>,
   f: (a: Chunk.Chunk<A>) => Effect.Effect<X, E2, R2>
-): Effect.Effect<void, E2 | E, Scope.Scope | R2 | R> => pipe(self, runScoped(_sink.forEachChunk(f))))
+): Effect.Effect<void, E2 | E, Scope.Scope | R2 | R> => pipe(self, runScoped(sink_.forEachChunk(f))))
 
 /** @internal */
 export const runForEachScoped = dual<
@@ -5712,7 +5712,7 @@ export const runForEachScoped = dual<
 >(2, <A, E, R, X, E2, R2>(
   self: Stream.Stream<A, E, R>,
   f: (a: A) => Effect.Effect<X, E2, R2>
-): Effect.Effect<void, E2 | E, R2 | R | Scope.Scope> => pipe(self, runScoped(_sink.forEach(f))))
+): Effect.Effect<void, E2 | E, R2 | R | Scope.Scope> => pipe(self, runScoped(sink_.forEach(f))))
 
 /** @internal */
 export const runForEachWhile = dual<
@@ -5728,7 +5728,7 @@ export const runForEachWhile = dual<
 >(2, <A, E, R, E2, R2>(
   self: Stream.Stream<A, E, R>,
   f: (a: A) => Effect.Effect<boolean, E2, R2>
-): Effect.Effect<void, E2 | E, R | R2> => run(self, _sink.forEachWhile(f)))
+): Effect.Effect<void, E2 | E, R | R2> => run(self, sink_.forEachWhile(f)))
 
 /** @internal */
 export const runForEachWhileScoped = dual<
@@ -5742,12 +5742,12 @@ export const runForEachWhileScoped = dual<
 >(2, <A, E, R, E2, R2>(
   self: Stream.Stream<A, E, R>,
   f: (a: A) => Effect.Effect<boolean, E2, R2>
-): Effect.Effect<void, E2 | E, R2 | R | Scope.Scope> => pipe(self, runScoped(_sink.forEachWhile(f))))
+): Effect.Effect<void, E2 | E, R2 | R | Scope.Scope> => pipe(self, runScoped(sink_.forEachWhile(f))))
 
 /** @internal */
 export const runHead = <A, E, R>(
   self: Stream.Stream<A, E, R>
-): Effect.Effect<Option.Option<A>, E, R> => run(self, _sink.head<A>())
+): Effect.Effect<Option.Option<A>, E, R> => run(self, sink_.head<A>())
 
 /** @internal */
 export const runIntoPubSub = dual<
@@ -5859,7 +5859,7 @@ export const runIntoQueueScoped = dual<
 /** @internal */
 export const runLast = <A, E, R>(
   self: Stream.Stream<A, E, R>
-): Effect.Effect<Option.Option<A>, E, R> => run(self, _sink.last())
+): Effect.Effect<Option.Option<A>, E, R> => run(self, sink_.last())
 
 /** @internal */
 export const runScoped = dual<
@@ -5876,13 +5876,13 @@ export const runScoped = dual<
 ): Effect.Effect<A2, E | E2, R | R2 | Scope.Scope> =>
   pipe(
     toChannel(self),
-    channel.pipeToOrFail(_sink.toChannel(sink)),
+    channel.pipeToOrFail(sink_.toChannel(sink)),
     channel.drain,
     channel.runScoped
   ))
 
 /** @internal */
-export const runSum = <E, R>(self: Stream.Stream<number, E, R>): Effect.Effect<number, E, R> => run(self, _sink.sum)
+export const runSum = <E, R>(self: Stream.Stream<number, E, R>): Effect.Effect<number, E, R> => run(self, sink_.sum)
 
 /** @internal */
 export const scan = dual<
@@ -7190,7 +7190,7 @@ export const transduce = dual<
         })
       const transducer: Channel.Channel<Chunk.Chunk<A2>, Chunk.Chunk<A>, E | E2, never, void, unknown, R | R2> = pipe(
         sink,
-        _sink.toChannel,
+        sink_.toChannel,
         core.collectElements,
         core.flatMap(([leftover, z]) =>
           pipe(

--- a/packages/effect/src/internal/subscriptionRef.ts
+++ b/packages/effect/src/internal/subscriptionRef.ts
@@ -8,8 +8,8 @@ import type { Stream } from "../Stream.js"
 import * as Subscribable from "../Subscribable.js"
 import type * as SubscriptionRef from "../SubscriptionRef.js"
 import * as Synchronized from "../SynchronizedRef.js"
-import * as _circular from "./effect/circular.js"
-import * as _ref from "./ref.js"
+import * as circular_ from "./effect/circular.js"
+import * as ref_ from "./ref.js"
 import * as stream from "./stream.js"
 
 /** @internal */
@@ -29,8 +29,8 @@ const subscriptionRefVariance = {
 class SubscriptionRefImpl<in out A> extends Effectable.Class<A> implements SubscriptionRef.SubscriptionRef<A> {
   readonly [Readable.TypeId]: Readable.TypeId = Readable.TypeId
   readonly [Subscribable.TypeId]: Subscribable.TypeId = Subscribable.TypeId
-  readonly [Ref.RefTypeId] = _ref.refVariance
-  readonly [Synchronized.SynchronizedRefTypeId] = _circular.synchronizedVariance
+  readonly [Ref.RefTypeId] = ref_.refVariance
+  readonly [Synchronized.SynchronizedRefTypeId] = circular_.synchronizedVariance
   readonly [SubscriptionRefTypeId] = subscriptionRefVariance
   constructor(
     readonly ref: Ref.Ref<A>,

--- a/packages/effect/src/internal/synchronizedRef.ts
+++ b/packages/effect/src/internal/synchronizedRef.ts
@@ -3,7 +3,6 @@ import { dual, pipe } from "../Function.js"
 import * as Option from "../Option.js"
 import type * as Synchronized from "../SynchronizedRef.js"
 import * as core from "./core.js"
-import * as _ref from "./ref.js"
 
 /** @internal */
 export const getAndUpdateEffect = dual<


### PR DESCRIPTION
This change avoids conflicts with the `_<name>` pattern, which is intended to be ignored by the linter. Using `<name>_` ensures that unnecessary imports do not go unnoticed.

(2 unnecessary imports found)