### PR TITLE
Schema: move type-level fields (e.g., Type, Encoded) in the Schema im…

### DIFF
--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -102,10 +102,6 @@ export interface SchemaClass<A, I = A, R = never> extends AnnotableClass<SchemaC
  */
 export const make = <A, I = A, R = never>(ast: AST.AST): SchemaClass<A, I, R> => (class SchemaClass {
   [TypeId] = variance
-  static Type: A
-  static Encoded: I
-  static Context: R
-  static [TypeId] = variance
   static ast = ast
   static annotations(annotations: Annotations.GenericSchema<A>) {
     return make<A, I, R>(mergeSchemaAnnotations(this.ast, annotations))
@@ -116,6 +112,10 @@ export const make = <A, I = A, R = never>(ast: AST.AST): SchemaClass<A, I, R> =>
   static toString() {
     return String(ast)
   }
+  static Type: A
+  static Encoded: I
+  static Context: R
+  static [TypeId] = variance
 })
 
 const variance = {


### PR DESCRIPTION
…plementation lower in the structure to avoid displaying them at the top during console logging

```ts
import { Schema } from "effect"

console.log(Schema.String.annotations({}))
/*
Output:
[class SchemaClass] {
  ast: StringKeyword {
    _tag: 'StringKeyword',
    annotations: {
      [Symbol(effect/annotation/Title)]: 'string',
      [Symbol(effect/annotation/Description)]: 'a string'
    }
  },
  Type: undefined,
  Encoded: undefined,
  Context: undefined,
  [Symbol(effect/Schema)]: { _A: [Function: _A], _I: [Function: _I], _R: [Function: _R] }
}
*/
```