### PR TITLE
fix: ManagedRuntime.Context to work when Context is of type never, cl…

### DIFF
--- a/.changeset/slow-drinks-behave.md
+++ b/.changeset/slow-drinks-behave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix: ManagedRuntime.Context to work when Context is of type never

--- a/packages/effect/src/ManagedRuntime.ts
+++ b/packages/effect/src/ManagedRuntime.ts
@@ -40,7 +40,8 @@ export declare namespace ManagedRuntime {
    * @category type-level
    * @since 3.4.0
    */
-  export type Context<T extends ManagedRuntime<any, any>> = [T] extends [ManagedRuntime<infer R, infer _E>] ? R : never
+  export type Context<T extends ManagedRuntime<never, any>> = [T] extends [ManagedRuntime<infer R, infer _E>] ? R
+    : never
   /**
    * @category type-level
    * @since 3.4.0


### PR DESCRIPTION
…oses #4218

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Using `ManagedRuntime.ManagedRuntime.Context` with an empty layer doesn't seem to be working at the type level. The type of managed runtime context must be never when used with empty layers and infer the requirements correctly when layers are composed. This patch fixes it.

https://effect.website/play/#7fb6c6a4fd99

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #4218 
