### PR TITLE
Add HttpClient.tapError

### DIFF
--- a/.changeset/popular-squids-love.md
+++ b/.changeset/popular-squids-love.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Add HttpClient.tapError

--- a/packages/platform/src/HttpClient.ts
+++ b/packages/platform/src/HttpClient.ts
@@ -557,7 +557,7 @@ export const tap: {
  */
 export const tapError: {
   <_, E, E2, R2>(
-    f: (e: E) => Effect.Effect<_, E2, R2>
+    f: (e: NoInfer<E>) => Effect.Effect<_, E2, R2>
   ): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | E2, R | R2>
   <E, R, _, E2, R2>(
     self: HttpClient.With<E, R>,

--- a/packages/platform/src/HttpClient.ts
+++ b/packages/platform/src/HttpClient.ts
@@ -558,10 +558,10 @@ export const tap: {
 export const tapError: {
   <_, E, E2, R2>(
     f: (e: NoInfer<E>) => Effect.Effect<_, E2, R2>
-  ): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | E2, R | R2>
+  ): <R>(self: HttpClient.With<E, R>) => HttpClient.With<E | E2, R | R2>
   <E, R, _, E2, R2>(
     self: HttpClient.With<E, R>,
-    f: (e: E) => Effect.Effect<_, E2, R2>
+    f: (e: NoInfer<E>) => Effect.Effect<_, E2, R2>
   ): HttpClient.With<E | E2, R | R2>
 } = internal.tapError
 

--- a/packages/platform/src/HttpClient.ts
+++ b/packages/platform/src/HttpClient.ts
@@ -550,6 +550,22 @@ export const tap: {
 } = internal.tap
 
 /**
+ * Performs an additional effect after an unsuccessful request.
+ *
+ * @since 1.0.0
+ * @category mapping & sequencing
+ */
+export const tapError: {
+  <_, E, E2, R2>(
+    f: (e: E) => Effect.Effect<_, E2, R2>
+  ): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | E2, R | R2>
+  <E, R, _, E2, R2>(
+    self: HttpClient.With<E, R>,
+    f: (e: E) => Effect.Effect<_, E2, R2>
+  ): HttpClient.With<E | E2, R | R2>
+} = internal.tapError
+
+/**
  * Performs an additional effect on the request before sending it.
  *
  * @since 1.0.0

--- a/packages/platform/src/internal/httpClient.ts
+++ b/packages/platform/src/internal/httpClient.ts
@@ -622,6 +622,17 @@ export const tap = dual<
 >(2, (self, f) => transformResponse(self, Effect.tap(f)))
 
 /** @internal */
+export const tapError = dual<
+  <_, E, E2, R2>(
+    f: (e: E) => Effect.Effect<_, E2, R2>
+  ) => <R>(self: Client.HttpClient.With<E, R>) => Client.HttpClient.With<E | E2, R | R2>,
+  <E, R, _, E2, R2>(
+    self: Client.HttpClient.With<E, R>,
+    f: (e: E) => Effect.Effect<_, E2, R2>
+  ) => Client.HttpClient.With<E | E2, R | R2>
+>(2, (self, f) => transformResponse(self, Effect.tapError(f)))
+
+/** @internal */
 export const tapRequest = dual<
   <_, E2, R2>(
     f: (a: ClientRequest.HttpClientRequest) => Effect.Effect<_, E2, R2>

--- a/packages/platform/src/internal/httpClient.ts
+++ b/packages/platform/src/internal/httpClient.ts
@@ -624,11 +624,11 @@ export const tap = dual<
 /** @internal */
 export const tapError = dual<
   <_, E, E2, R2>(
-    f: (e: E) => Effect.Effect<_, E2, R2>
+    f: (e: NoInfer<E>) => Effect.Effect<_, E2, R2>
   ) => <R>(self: Client.HttpClient.With<E, R>) => Client.HttpClient.With<E | E2, R | R2>,
   <E, R, _, E2, R2>(
     self: Client.HttpClient.With<E, R>,
-    f: (e: E) => Effect.Effect<_, E2, R2>
+    f: (e: NoInfer<E>) => Effect.Effect<_, E2, R2>
   ) => Client.HttpClient.With<E | E2, R | R2>
 >(2, (self, f) => transformResponse(self, Effect.tapError(f)))
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `tapError` to match `tap` on `HttpClient`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
