### PR TITLE
[bugfix] `Layer.retry` and `MetricPolling.retry` signatures

### DIFF
--- a/.changeset/clever-grapes-marry.md
+++ b/.changeset/clever-grapes-marry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix `Layer.retry` and `MetricPolling.retry` signatures

--- a/packages/effect/dtslint/Layer.ts
+++ b/packages/effect/dtslint/Layer.ts
@@ -1,4 +1,5 @@
 import * as Layer from "effect/Layer"
+import * as Schedule from "effect/Schedule"
 
 interface In1 {}
 interface Err1 {}
@@ -46,3 +47,14 @@ Layer.mergeAll(layer1, layer2)
 
 // $ExpectType Layer<Out1 | Out2 | Out3, Err1 | Err2 | Err3, In1 | In2 | In3>
 Layer.mergeAll(layer1, layer2, layer3)
+
+// -------------------------------------------------------------------------------------
+// retry
+// -------------------------------------------------------------------------------------
+
+// $ExpectType Layer<Out1, Err1, In1>
+layer1.pipe(
+  Layer.retry(Schedule.recurs(1))
+)
+// $ExpectType Layer<Out1, Err1, In1>
+Layer.retry(layer1, Schedule.recurs(1))

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -631,7 +631,7 @@ export const fiberRefLocallyScopedWith: <A>(self: FiberRef<A>, value: (_: A) => 
  */
 export const retry: {
   <X, E, RIn2>(
-    schedule: Schedule.Schedule<X, E, RIn2>
+    schedule: Schedule.Schedule<X, NoInfer<E>, RIn2>
   ): <ROut, RIn>(self: Layer<ROut, E, RIn>) => Layer<ROut, E, RIn2 | RIn>
   <ROut, E, RIn, X, RIn2>(
     self: Layer<ROut, E, RIn>,

--- a/packages/effect/src/MetricPolling.ts
+++ b/packages/effect/src/MetricPolling.ts
@@ -109,7 +109,7 @@ export const pollAndUpdate: <Type, In, R, E, Out>(
  */
 export const retry: {
   <X, E, R2>(
-    policy: Schedule.Schedule<X, E, R2>
+    policy: Schedule.Schedule<X, NoInfer<E>, R2>
   ): <Type, In, R, Out>(self: MetricPolling<Type, In, R, E, Out>) => MetricPolling<Type, In, R2 | R, E, Out>
   <Type, In, R, E, Out, X, R2>(
     self: MetricPolling<Type, In, R, E, Out>,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
```ts
declare const LLL: Layer.Layer<1, "eee">

const qwe = LLL.pipe( // => Layer<1, unknown, never> and now  Layer<1, 'eee', never>
  Layer.retry(Schedule.fibonacci("1 seconds"))
)
```
Fixed in the same way as here https://github.com/Effect-TS/effect/blob/main/packages/effect/src/Effect.ts#L4333

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
