### PR TITLE
Improve pattern handling by merging multiple patterns into a union, c…

### DIFF
--- a/.changeset/cool-parrots-draw.md
+++ b/.changeset/cool-parrots-draw.md
@@ -1,0 +1,26 @@
+---
+"effect": patch
+---
+
+Improve pattern handling by merging multiple patterns into a union, closes #4243.
+
+Previously, the algorithm always prioritized the first pattern when multiple patterns were encountered.
+
+This fix introduces a merging strategy that combines patterns into a union (e.g., `(?:${pattern1})|(?:${pattern2})`). By doing so, all patterns have an equal chance to generate values when using `FastCheck.stringMatching`.
+
+**Example**
+
+```ts
+import { Arbitrary, FastCheck, Schema } from "effect"
+
+// /^[^A-Z]*$/ (given by Lowercase) + /^0x[0-9a-f]{40}$/
+const schema = Schema.Lowercase.pipe(Schema.pattern(/^0x[0-9a-f]{40}$/))
+
+const arb = Arbitrary.make(schema)
+
+// Before this fix, the first pattern would always dominate,
+// making it impossible to generate values
+const sample = FastCheck.sample(arb, { numRuns: 100 })
+
+console.log(sample)
+```

--- a/packages/effect/src/Arbitrary.ts
+++ b/packages/effect/src/Arbitrary.ts
@@ -452,7 +452,7 @@ export const toOp = (
       return new Succeed((fc) => fc.constant(null).chain(() => get()(fc)))
     }
     case "Transformation":
-      return new Succeed(go(ast.to, ctx, path))
+      return toOp(ast.to, ctx, path)
   }
 }
 
@@ -577,6 +577,16 @@ const getOr = (a: boolean | undefined, b: boolean | undefined): boolean | undefi
   return a === undefined ? b : b === undefined ? a : a || b
 }
 
+function mergePattern(pattern1: string | undefined, pattern2: string | undefined): string | undefined {
+  if (pattern1 === undefined) {
+    return pattern2
+  }
+  if (pattern2 === undefined) {
+    return pattern1
+  }
+  return `(?:${pattern1})|(?:${pattern2})`
+}
+
 const merge = (c1: Config, c2: Constraints | undefined): Config => {
   if (c2) {
     switch (c1._tag) {
@@ -585,7 +595,7 @@ const merge = (c1: Config, c2: Constraints | undefined): Config => {
           return makeStringConstraints({
             minLength: getMax(c1.constraints.minLength, c2.constraints.minLength),
             maxLength: getMin(c1.constraints.maxLength, c2.constraints.maxLength),
-            pattern: c1.pattern ?? c2.pattern
+            pattern: mergePattern(c1.pattern, c2.pattern)
           })
         }
         break

--- a/packages/effect/test/Schema/Arbitrary/Arbitrary.test.ts
+++ b/packages/effect/test/Schema/Arbitrary/Arbitrary.test.ts
@@ -634,6 +634,17 @@ details: Generating an Arbitrary for this schema requires at least one enum`)
         expectConstraints(schema, Arbitrary.makeStringConstraints({ minLength: 1, pattern: regex.source }))
         expectValidArbitrary(schema)
       })
+
+      it("pattern + pattern", () => {
+        const regexp1 = /^[^A-Z]*$/
+        const regexp2 = /^0x[0-9a-f]{40}$/
+        const schema = S.String.pipe(S.pattern(regexp1), S.pattern(regexp2))
+        expectConstraints(
+          schema,
+          Arbitrary.makeStringConstraints({ pattern: `(?:${regexp1.source})|(?:${regexp2.source})` })
+        )
+        expectValidArbitrary(schema)
+      })
     })
 
     describe("number filters", () => {


### PR DESCRIPTION
…loses #4243

Previously, the algorithm always prioritized the first pattern when multiple patterns were encountered.

This fix introduces a merging strategy that combines patterns into a union (e.g., `(?:${pattern1})|(?:${pattern2})`). By doing so, all patterns have an equal chance to generate values when using `FastCheck.stringMatching`.

**Example**

```ts
import { Arbitrary, FastCheck, Schema } from "effect"

// /^[^A-Z]*$/ (given by Lowercase) + /^0x[0-9a-f]{40}$/
const schema = Schema.Lowercase.pipe(Schema.pattern(/^0x[0-9a-f]{40}$/))

const arb = Arbitrary.make(schema)

// Before this fix, the first pattern would always dominate,
// making it impossible to generate values
const sample = FastCheck.sample(arb, { numRuns: 100 })

console.log(sample)
```
