### PR TITLE
Allow `Schema.TemplateLiteral` to handle strings with linebreaks, clo…

### DIFF
--- a/.changeset/green-scissors-pull.md
+++ b/.changeset/green-scissors-pull.md
@@ -1,0 +1,58 @@
+---
+"effect": patch
+---
+
+Fix: Correct `Arbitrary.make` to support nested `TemplateLiteral`s.
+
+Previously, `Arbitrary.make` did not properly handle nested `TemplateLiteral` schemas, resulting in incorrect or empty outputs. This fix ensures that nested template literals are processed correctly, producing valid arbitrary values.
+
+**Before**
+
+```ts
+import { Arbitrary, FastCheck, Schema as S } from "effect"
+
+const schema = S.TemplateLiteral(
+  "<",
+  S.TemplateLiteral("h", S.Literal(1, 2)),
+  ">"
+)
+
+const arb = Arbitrary.make(schema)
+
+console.log(FastCheck.sample(arb, { numRuns: 10 }))
+/*
+Output:
+[
+  '<>', '<>', '<>',
+  '<>', '<>', '<>',
+  '<>', '<>', '<>',
+  '<>'
+]
+*/
+```
+
+**After**
+
+```ts
+import { Arbitrary, FastCheck, Schema as S } from "effect"
+
+const schema = S.TemplateLiteral(
+  "<",
+  S.TemplateLiteral("h", S.Literal(1, 2)),
+  ">"
+)
+
+const arb = Arbitrary.make(schema)
+
+console.log(FastCheck.sample(arb, { numRuns: 10 }))
+/*
+Output:
+[
+  '<h2>', '<h2>',
+  '<h2>', '<h2>',
+  '<h2>', '<h1>',
+  '<h2>', '<h1>',
+  '<h1>', '<h1>'
+]
+*/
+```

--- a/.changeset/lucky-mice-sing.md
+++ b/.changeset/lucky-mice-sing.md
@@ -1,0 +1,31 @@
+---
+"effect": patch
+---
+
+Fix: Allow `Schema.TemplateLiteral` to handle strings with linebreaks, closes #4251.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteral("a: ", Schema.String)
+
+console.log(Schema.decodeSync(schema)("a: b \n c"))
+// throws: ParseError: Expected `a: ${string}`, actual "a: b \n c"
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.TemplateLiteral("a: ", Schema.String)
+
+console.log(Schema.decodeSync(schema)("a: b \n c"))
+/*
+Output:
+a: b
+ c
+*/
+```

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2092,7 +2092,7 @@ export const annotations = (ast: AST, a: Annotations): AST => {
  */
 export const keyof = (ast: AST): AST => Union.unify(_keyof(ast))
 
-const STRING_KEYWORD_PATTERN = ".*"
+const STRING_KEYWORD_PATTERN = "[\\s\\S]*" // any string, including newlines
 const NUMBER_KEYWORD_PATTERN = "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
 
 const getTemplateLiteralSpanTypePattern = (type: TemplateLiteralSpanType, capture: boolean): string => {

--- a/packages/effect/test/Schema/Arbitrary/Arbitrary.test.ts
+++ b/packages/effect/test/Schema/Arbitrary/Arbitrary.test.ts
@@ -193,6 +193,18 @@ schema (NeverKeyword): never`)
       const schema = S.TemplateLiteral(S.Literal("a"), S.String, S.Literal("b"))
       expectValidArbitrary(schema)
     })
+
+    it("https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html", async () => {
+      const EmailLocaleIDs = S.Literal("welcome_email", "email_heading")
+      const FooterLocaleIDs = S.Literal("footer_title", "footer_sendoff")
+      const schema = S.TemplateLiteral(S.Union(EmailLocaleIDs, FooterLocaleIDs), "_id")
+      expectValidArbitrary(schema)
+    })
+
+    it("< + h + (1|2) + >", async () => {
+      const schema = S.TemplateLiteral("<", S.TemplateLiteral("h", S.Literal(1, 2)), ">")
+      expectValidArbitrary(schema)
+    })
   })
 
   describe("Enums", () => {

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -2038,7 +2038,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "": { "type": "number" }
         },
         "propertyNames": {
-          "pattern": "^.*-.*$",
+          "pattern": "^[\\s\\S]*-[\\s\\S]*$",
           "type": "string"
         }
       }

--- a/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
@@ -32,26 +32,26 @@ schema (Union): boolean | symbol`)
     expectPattern(["a", "b"], "^(a)(b)$")
     expectPattern([S.Literal("a", "b"), "c"], "^(a|b)(c)$")
     expectPattern([S.Literal("a", "b"), "c", S.Literal("d", "e")], "^(a|b)(c)(d|e)$")
-    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)(.*)(d|e)$")
-    expectPattern(["a", S.String], "^(a)(.*)$")
-    expectPattern(["a", S.String, "b"], "^(a)(.*)(b)$")
+    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)([\\s\\S]*)(d|e)$")
+    expectPattern(["a", S.String], "^(a)([\\s\\S]*)$")
+    expectPattern(["a", S.String, "b"], "^(a)([\\s\\S]*)(b)$")
     expectPattern(
       ["a", S.String, "b", S.Number],
-      "^(a)(.*)(b)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$"
+      "^(a)([\\s\\S]*)(b)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$"
     )
     expectPattern(["a", S.Number], "^(a)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$")
-    expectPattern([S.String, "a"], "^(.*)(a)$")
+    expectPattern([S.String, "a"], "^([\\s\\S]*)(a)$")
     expectPattern([S.Number, "a"], "^([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)(a)$")
     expectPattern([
       S.Union(S.String, S.Literal(1)),
       S.Union(S.Number, S.Literal(true))
-    ], "^(.*|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$")
+    ], "^([\\s\\S]*|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$")
     expectPattern([S.Union(S.Literal("a", "b"), S.Literal(1, 2))], "^(a|b|1|2)$")
     expectPattern([
       "c",
       S.Union(S.TemplateLiteral("a", S.String, "b"), S.Literal("e")),
       "d"
-    ], "^(c)(a.*b|e)(d)$")
+    ], "^(c)(a[\\s\\S]*b|e)(d)$")
     expectPattern(["<", S.TemplateLiteral("h", S.Literal(1, 2)), ">"], "^(<)(h(?:1|2))(>)$")
     expectPattern(
       ["-", S.Union(S.TemplateLiteral("a", S.Literal("b", "c")), S.TemplateLiteral("d", S.Literal("e", "f")))],


### PR DESCRIPTION
…ses #4251

## Fix 1

Fix: Allow `Schema.TemplateLiteral` to handle strings with linebreaks, closes #4251.

**Before**

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteral("a: ", Schema.String)

console.log(Schema.decodeSync(schema)("a: b \n c"))
// throws: ParseError: Expected `a: ${string}`, actual "a: b \n c"
```

**After**

```ts
import { Schema } from "effect"

const schema = Schema.TemplateLiteral("a: ", Schema.String)

console.log(Schema.decodeSync(schema)("a: b \n c"))
/*
Output:
a: b
 c
*/
```

## Fix 2

Fix: Correct `Arbitrary.make` to support nested `TemplateLiteral`s.

Previously, `Arbitrary.make` did not properly handle nested `TemplateLiteral` schemas, resulting in incorrect or empty outputs. This fix ensures that nested template literals are processed correctly, producing valid arbitrary values.

**Before**

```ts
import { Arbitrary, FastCheck, Schema as S } from "effect"

const schema = S.TemplateLiteral(
  "<",
  S.TemplateLiteral("h", S.Literal(1, 2)),
  ">"
)

const arb = Arbitrary.make(schema)

console.log(FastCheck.sample(arb, { numRuns: 10 }))
/*
Output:
[
  '<>', '<>', '<>',
  '<>', '<>', '<>',
  '<>', '<>', '<>',
  '<>'
]
*/
```

**After**

```ts
import { Arbitrary, FastCheck, Schema as S } from "effect"

const schema = S.TemplateLiteral(
  "<",
  S.TemplateLiteral("h", S.Literal(1, 2)),
  ">"
)

const arb = Arbitrary.make(schema)

console.log(FastCheck.sample(arb, { numRuns: 10 }))
/*
Output:
[
  '<h2>', '<h2>',
  '<h2>', '<h2>',
  '<h2>', '<h1>',
  '<h2>', '<h1>',
  '<h1>', '<h1>'
]
*/
```
