### PR TITLE
Use non-enumerable properties for mutable fields of `DateTime` objects

### DIFF
--- a/.changeset/fuzzy-lemons-turn.md
+++ b/.changeset/fuzzy-lemons-turn.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use cache instead of mutable fields for `DateTime` objects.

--- a/.changeset/fuzzy-lemons-turn.md
+++ b/.changeset/fuzzy-lemons-turn.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Use cache instead of mutable fields for `DateTime` objects.
+Use non-enumerable properties for mutable fields of `DateTime` objects.

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -43,6 +43,7 @@ export type DateTime = Utc | Zoned
 export interface Utc extends DateTime.Proto {
   readonly _tag: "Utc"
   readonly epochMillis: number
+  partsUtc: DateTime.PartsWithWeekday | undefined
 }
 
 /**
@@ -53,6 +54,9 @@ export interface Zoned extends DateTime.Proto {
   readonly _tag: "Zoned"
   readonly epochMillis: number
   readonly zone: TimeZone
+  adjustedEpochMillis: number | undefined
+  partsAdjusted: DateTime.PartsWithWeekday | undefined
+  partsUtc: DateTime.PartsWithWeekday | undefined
 }
 
 /**

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -43,8 +43,6 @@ export type DateTime = Utc | Zoned
 export interface Utc extends DateTime.Proto {
   readonly _tag: "Utc"
   readonly epochMillis: number
-  /** @internal */
-  partsUtc: DateTime.PartsWithWeekday
 }
 
 /**
@@ -55,12 +53,6 @@ export interface Zoned extends DateTime.Proto {
   readonly _tag: "Zoned"
   readonly epochMillis: number
   readonly zone: TimeZone
-  /** @internal */
-  adjustedEpochMillis?: number
-  /** @internal */
-  partsAdjusted?: DateTime.PartsWithWeekday
-  /** @internal */
-  partsUtc?: DateTime.PartsWithWeekday
 }
 
 /**

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -121,6 +121,12 @@ const ProtoTimeZoneOffset = {
 }
 
 /** @internal */
+const partsUtcCache = globalValue(
+  "effect/DateTime/partsUtcCache",
+  () => new WeakMap<object, DateTime.DateTime.PartsWithWeekday>()
+)
+
+/** @internal */
 export const makeZonedProto = (
   epochMillis: number,
   zone: DateTime.TimeZone,
@@ -129,7 +135,7 @@ export const makeZonedProto = (
   const self = Object.create(ProtoZoned)
   self.epochMillis = epochMillis
   self.zone = zone
-  self.partsUtc = partsUtc
+  if (partsUtc) partsUtcCache.set(self, partsUtc)
   return self
 }
 
@@ -235,7 +241,7 @@ export const unsafeMakeZoned = (input: DateTime.DateTime.Input, options?: {
     zone = parsedZone.value
   }
   if (options?.adjustForTimeZone !== true) {
-    return makeZonedProto(self.epochMillis, zone, self.partsUtc)
+    return makeZonedProto(self.epochMillis, zone, partsUtcCache.get(self))
   }
   return makeZonedFromAdjusted(self.epochMillis, zone)
 }
@@ -289,7 +295,7 @@ export const setZone: {
 }): DateTime.Zoned =>
   options?.adjustForTimeZone === true
     ? makeZonedFromAdjusted(self.epochMillis, zone)
-    : makeZonedProto(self.epochMillis, zone, self.partsUtc))
+    : makeZonedProto(self.epochMillis, zone, partsUtcCache.get(self)))
 
 /** @internal */
 export const setZoneOffset: {
@@ -511,14 +517,24 @@ export const unsafeIsPast = (self: DateTime.DateTime): boolean => greaterThan(un
 export const toDateUtc = (self: DateTime.DateTime): Date => new Date(self.epochMillis)
 
 /** @internal */
+const adjustedEpochMillisCache = globalValue(
+  "effect/DateTime/adjustedEpochMillisCache",
+  () => new WeakMap<object, number>()
+)
+
+/** @internal */
 export const toDate = (self: DateTime.DateTime): Date => {
   if (self._tag === "Utc") {
     return new Date(self.epochMillis)
   } else if (self.zone._tag === "Offset") {
     return new Date(self.epochMillis + self.zone.offset)
-  } else if (self.adjustedEpochMillis !== undefined) {
-    return new Date(self.adjustedEpochMillis)
   }
+
+  const adjustedEpochMillis = adjustedEpochMillisCache.get(self)
+  if (adjustedEpochMillis !== undefined) {
+    return new Date(adjustedEpochMillis)
+  }
+
   const parts = self.zone.format.formatToParts(self.epochMillis).filter((_) => _.type !== "literal")
   const date = new Date(0)
   date.setUTCFullYear(
@@ -532,7 +548,7 @@ export const toDate = (self: DateTime.DateTime): Date => {
     Number(parts[5].value),
     Number(parts[6].value)
   )
-  self.adjustedEpochMillis = date.getTime()
+  adjustedEpochMillisCache.set(self, date.getTime())
   return date
 }
 
@@ -578,23 +594,32 @@ const dateToParts = (date: Date): DateTime.DateTime.PartsWithWeekday => ({
 })
 
 /** @internal */
+const partsAdjustedCache = globalValue(
+  "effect/DateTime/partsAdjustedCache",
+  () => new WeakMap<object, DateTime.DateTime.PartsWithWeekday>()
+)
+
+/** @internal */
 export const toParts = (self: DateTime.DateTime): DateTime.DateTime.PartsWithWeekday => {
   if (self._tag === "Utc") {
     return toPartsUtc(self)
-  } else if (self.partsAdjusted !== undefined) {
-    return self.partsAdjusted
   }
-  self.partsAdjusted = withDate(self, dateToParts)
-  return self.partsAdjusted
+  let partsAdjusted = partsAdjustedCache.get(self)
+  if (partsAdjusted === undefined) {
+    partsAdjusted = withDate(self, dateToParts)
+    partsAdjustedCache.set(self, partsAdjusted)
+  }
+  return partsAdjusted
 }
 
 /** @internal */
 export const toPartsUtc = (self: DateTime.DateTime): DateTime.DateTime.PartsWithWeekday => {
-  if (self.partsUtc !== undefined) {
-    return self.partsUtc
+  let partsUtc = partsUtcCache.get(self)
+  if (partsUtc === undefined) {
+    partsUtc = withDateUtc(self, dateToParts)
+    partsUtcCache.set(self, partsUtc)
   }
-  self.partsUtc = withDateUtc(self, dateToParts)
-  return self.partsUtc
+  return partsUtc
 }
 
 /** @internal */

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -405,6 +405,14 @@ describe("DateTime", () => {
       }))
   })
 
+  it("parts equality", () => {
+    const d1 = DateTime.unsafeMake("2025-01-01")
+    const d2 = DateTime.unsafeMake("2025-01-01")
+    assert.deepStrictEqual(d1, d2)
+    DateTime.toPartsUtc(d2)
+    assert.deepStrictEqual(d1, d2)
+  })
+
   // doesnt work in CI
   it.skip("unsafeMakeZoned no options", () => {
     const date = new Date("2024-07-21T20:12:34.112Z")


### PR DESCRIPTION
Calling `DateTime.toPartsUtc` causes a mutation on the datetime object which results in an unexpected behaviour in tests.

```ts
  it("test", () => {
    const d1 = DateTime.unsafeMake("2025-01-01")
    const d2 = DateTime.unsafeMake("2025-01-01")
    assert.deepStrictEqual(d1, d2) // OK
    DateTime.toPartsUtc(d2)
    assert.deepStrictEqual(d1, d2) // BOOM!
  })
```