### PR TITLE
Schema: Correct `BigInt` and `BigIntFromNumber` identifier annotation…

### DIFF
--- a/.changeset/quick-cobras-smash.md
+++ b/.changeset/quick-cobras-smash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Schema: Correct `BigInt` and `BigIntFromNumber` identifier annotations to follow naming conventions

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5415,7 +5415,7 @@ class BigInt$ extends transformOrFail(
     decode: (s, _, ast) => ParseResult.fromOption(bigInt_.fromString(s), () => new ParseResult.Type(ast, s)),
     encode: (n) => ParseResult.succeed(String(n))
   }
-).annotations({ identifier: "bigint" }) {}
+).annotations({ identifier: "BigInt" }) {}
 
 export {
   /**
@@ -5513,7 +5513,7 @@ export class BigIntFromNumber extends transformOrFail(
       ),
     encode: (b, _, ast) => ParseResult.fromOption(bigInt_.toNumber(b), () => new ParseResult.Type(ast, b))
   }
-).annotations({ identifier: "BigintFromNumber" }) {}
+).annotations({ identifier: "BigIntFromNumber" }) {}
 
 const redactedArbitrary = <A>(value: LazyArbitrary<A>): LazyArbitrary<redacted_.Redacted<A>> => (fc) =>
   value(fc).map(redacted_.make)

--- a/packages/effect/test/Schema/Schema/BigInt/BigInt.test.ts
+++ b/packages/effect/test/Schema/Schema/BigInt/BigInt.test.ts
@@ -17,51 +17,51 @@ describe("BigInt", () => {
     await Util.expectDecodeUnknownFailure(
       schema,
       "",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual ""`
+   └─ Expected BigInt, actual ""`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       " ",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual " "`
+   └─ Expected BigInt, actual " "`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "1.2",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual "1.2"`
+   └─ Expected BigInt, actual "1.2"`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "1AB",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual "1AB"`
+   └─ Expected BigInt, actual "1AB"`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "AB1",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual "AB1"`
+   └─ Expected BigInt, actual "AB1"`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual "a"`
+   └─ Expected BigInt, actual "a"`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a1",
-      `bigint
+      `BigInt
 └─ Transformation process failure
-   └─ Expected bigint, actual "a1"`
+   └─ Expected BigInt, actual "a1"`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/BigInt/BigIntFromNumber.test.ts
+++ b/packages/effect/test/Schema/Schema/BigInt/BigIntFromNumber.test.ts
@@ -17,30 +17,30 @@ describe("BigIntFromNumber", () => {
     await Util.expectDecodeUnknownFailure(
       schema,
       1.2,
-      `BigintFromNumber
+      `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigintFromNumber, actual 1.2`
+   └─ Expected BigIntFromNumber, actual 1.2`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       NaN,
-      `BigintFromNumber
+      `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigintFromNumber, actual NaN`
+   └─ Expected BigIntFromNumber, actual NaN`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       Infinity,
-      `BigintFromNumber
+      `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigintFromNumber, actual Infinity`
+   └─ Expected BigIntFromNumber, actual Infinity`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       -Infinity,
-      `BigintFromNumber
+      `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigintFromNumber, actual -Infinity`
+   └─ Expected BigIntFromNumber, actual -Infinity`
     )
   })
 
@@ -50,16 +50,16 @@ describe("BigIntFromNumber", () => {
     await Util.expectEncodeFailure(
       schema,
       BigInt(Number.MAX_SAFE_INTEGER) + 1n,
-      `BigintFromNumber
+      `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigintFromNumber, actual 9007199254740992n`
+   └─ Expected BigIntFromNumber, actual 9007199254740992n`
     )
     await Util.expectEncodeFailure(
       schema,
       BigInt(Number.MIN_SAFE_INTEGER) - 1n,
-      `BigintFromNumber
+      `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigintFromNumber, actual -9007199254740992n`
+   └─ Expected BigIntFromNumber, actual -9007199254740992n`
     )
   })
 })


### PR DESCRIPTION
…s to follow naming conventions
