### PR TITLE
Schema: improve error messages for invalid transformations

### DIFF
--- a/.changeset/lovely-squids-smell.md
+++ b/.changeset/lovely-squids-smell.md
@@ -1,0 +1,33 @@
+---
+"effect": patch
+---
+
+Schema: improve error messages for invalid transformations
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+Schema.decodeUnknownSync(Schema.NumberFromString)("a")
+/*
+throws:
+ParseError: NumberFromString
+└─ Transformation process failure
+   └─ Expected NumberFromString, actual "a"
+*/
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+Schema.decodeUnknownSync(Schema.NumberFromString)("a")
+/*
+throws:
+ParseError: NumberFromString
+└─ Transformation process failure
+   └─ Unable to decode "a" into a number
+*/
+```

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -574,7 +574,7 @@ describe("Options", () => {
         ValidationError.invalidValue(HelpDoc.p(
           "BigDecimal\n" +
             "└─ Transformation process failure\n" +
-            "   └─ Expected BigDecimal, actual \"abc\""
+            "   └─ Unable to decode \"abc\" into a BigDecimal"
         ))
       )
     }).pipe(runEffect))

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -342,7 +342,7 @@ describe("makeWithOptions", () => {
           }
         }, {
           "NumberFromString": {
-            "description": "a string that will be parsed into a number",
+            "description": "a string to be decoded into a number",
             "type": "string"
           }
         })
@@ -578,7 +578,7 @@ describe("makeWithOptions", () => {
           }
         }, {
           "NumberFromString": {
-            "description": "a string that will be parsed into a number",
+            "description": "a string to be decoded into a number",
             "type": "string"
           }
         })
@@ -2351,7 +2351,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
         "$defs": {
           "NumberFromString": {
             "type": "string",
-            "description": "a string that will be parsed into a number"
+            "description": "a string to be decoded into a number"
           }
         },
         "$ref": "#/$defs/NumberFromString"
@@ -2365,7 +2365,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "$defs": {
             "DateFromString": {
               "type": "string",
-              "description": "a string that will be parsed into a Date"
+              "description": "a string to be decoded into a Date"
             }
           },
           "$ref": "#/$defs/DateFromString"
@@ -2380,7 +2380,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "$defs": {
             "Date": {
               "type": "string",
-              "description": "a string that will be parsed into a Date"
+              "description": "a string to be decoded into a Date"
             }
           },
           "$ref": "#/$defs/Date"
@@ -2429,11 +2429,11 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "$defs": {
             "NumberFromString": {
               "type": "string",
-              "description": "a string that will be parsed into a number"
+              "description": "a string to be decoded into a number"
             }
           },
           "type": "object",
-          "description": "a record that will be parsed into a ReadonlyMap",
+          "description": "a record to be decoded into a ReadonlyMap",
           "required": [],
           "properties": {},
           "patternProperties": {
@@ -2461,11 +2461,11 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "$defs": {
             "NumberFromString": {
               "type": "string",
-              "description": "a string that will be parsed into a number"
+              "description": "a string to be decoded into a number"
             }
           },
           "type": "object",
-          "description": "a record that will be parsed into a Map",
+          "description": "a record to be decoded into a Map",
           "required": [],
           "properties": {},
           "patternProperties": {
@@ -4075,7 +4075,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           const expected = {
             "$defs": {
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               },
               "e4be2cb9-227a-4160-b4a6-d2e3db09eb24": {
@@ -4148,7 +4148,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
                 "type": "array"
               },
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               }
             },
@@ -4163,7 +4163,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
                 "type": "array"
               },
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               }
             },
@@ -4209,7 +4209,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           const expected = {
             "$defs": {
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               },
               "5f699d98-b193-4436-9ac5-145a532a2b4d": {
@@ -4255,7 +4255,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           const expected = {
             "$defs": {
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               },
               "bc516245-69d0-4671-82e1-8629a656e99a": {
@@ -4320,7 +4320,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           const expected = {
             "$defs": {
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               },
               "a9c6e11c-e1a2-482e-9748-e0ce161b926a": {
@@ -4432,7 +4432,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
             "additionalProperties": false,
             "$defs": {
               "NumberFromString": {
-                "description": "a string that will be parsed into a number",
+                "description": "a string to be decoded into a number",
                 "type": "string"
               },
               "1e7880a8-555c-46e9-8b58-500e441134bf": {
@@ -4466,7 +4466,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "$defs": {
             "NumberFromString": {
               "type": "string",
-              "description": "a string that will be parsed into a number"
+              "description": "a string to be decoded into a number"
             }
           },
           "$ref": "#/$defs/NumberFromString"

--- a/packages/effect/test/Schema/Schema/Array/head.test.ts
+++ b/packages/effect/test/Schema/Schema/Array/head.test.ts
@@ -17,7 +17,7 @@ describe("head", () => {
       └─ [0]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Array/headNonEmpty.test.ts
+++ b/packages/effect/test/Schema/Schema/Array/headNonEmpty.test.ts
@@ -15,7 +15,7 @@ describe("headNonEmpty", () => {
       └─ [0]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Array/headOrElse.test.ts
+++ b/packages/effect/test/Schema/Schema/Array/headOrElse.test.ts
@@ -11,7 +11,7 @@ describe("headOrElse", () => {
       [],
       `(ReadonlyArray<NumberFromString> <-> number)
 └─ Transformation process failure
-   └─ Expected (ReadonlyArray<NumberFromString> <-> number), actual []`
+   └─ Unable to retrieve the first element of an empty array`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
@@ -22,7 +22,7 @@ describe("headOrElse", () => {
       └─ [0]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
   })
 
@@ -39,7 +39,7 @@ describe("headOrElse", () => {
       └─ [0]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
 
     const schema2 = S.Array(S.NumberFromString).pipe(S.headOrElse(() => 0))

--- a/packages/effect/test/Schema/Schema/BigDecimal/BigDecimal.test.ts
+++ b/packages/effect/test/Schema/Schema/BigDecimal/BigDecimal.test.ts
@@ -27,7 +27,7 @@ describe("BigDecimal", () => {
       "abc",
       `BigDecimal
 └─ Transformation process failure
-   └─ Expected BigDecimal, actual "abc"`
+   └─ Unable to decode "abc" into a BigDecimal`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/BigInt/BigInt.test.ts
+++ b/packages/effect/test/Schema/Schema/BigInt/BigInt.test.ts
@@ -19,49 +19,49 @@ describe("BigInt", () => {
       "",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual ""`
+   └─ Unable to decode "" into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       " ",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual " "`
+   └─ Unable to decode " " into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "1.2",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual "1.2"`
+   └─ Unable to decode "1.2" into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "1AB",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual "1AB"`
+   └─ Unable to decode "1AB" into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "AB1",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual "AB1"`
+   └─ Unable to decode "AB1" into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual "a"`
+   └─ Unable to decode "a" into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a1",
       `BigInt
 └─ Transformation process failure
-   └─ Expected BigInt, actual "a1"`
+   └─ Unable to decode "a1" into a bigint`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/BigInt/BigIntFromNumber.test.ts
+++ b/packages/effect/test/Schema/Schema/BigInt/BigIntFromNumber.test.ts
@@ -19,28 +19,28 @@ describe("BigIntFromNumber", () => {
       1.2,
       `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigIntFromNumber, actual 1.2`
+   └─ Unable to decode 1.2 into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       NaN,
       `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigIntFromNumber, actual NaN`
+   └─ Unable to decode NaN into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       Infinity,
       `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigIntFromNumber, actual Infinity`
+   └─ Unable to decode Infinity into a bigint`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       -Infinity,
       `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigIntFromNumber, actual -Infinity`
+   └─ Unable to decode -Infinity into a bigint`
     )
   })
 
@@ -52,14 +52,14 @@ describe("BigIntFromNumber", () => {
       BigInt(Number.MAX_SAFE_INTEGER) + 1n,
       `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigIntFromNumber, actual 9007199254740992n`
+   └─ Unable to encode 9007199254740992n into a number`
     )
     await Util.expectEncodeFailure(
       schema,
       BigInt(Number.MIN_SAFE_INTEGER) - 1n,
       `BigIntFromNumber
 └─ Transformation process failure
-   └─ Expected BigIntFromNumber, actual -9007199254740992n`
+   └─ Unable to encode -9007199254740992n into a number`
     )
   })
 })

--- a/packages/effect/test/Schema/Schema/Cause/CauseFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/Cause/CauseFromSelf.test.ts
@@ -33,7 +33,7 @@ describe("CauseFromSelf", () => {
       └─ ["error"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
@@ -47,7 +47,7 @@ describe("CauseFromSelf", () => {
                └─ ["error"]
                   └─ NumberFromString
                      └─ Transformation process failure
-                        └─ Expected NumberFromString, actual "a"`
+                        └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Chunk/ChunkFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/Chunk/ChunkFromSelf.test.ts
@@ -32,7 +32,7 @@ describe("ChunkFromSelf", () => {
    └─ [1]
       └─ NumberFromString
          └─ Transformation process failure
-            └─ Expected NumberFromString, actual "a"`
+            └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Chunk/NonEmptyChunkFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/Chunk/NonEmptyChunkFromSelf.test.ts
@@ -40,7 +40,7 @@ describe("NonEmptyChunkFromSelf", () => {
    └─ [1]
       └─ NumberFromString
          └─ Transformation process failure
-            └─ Expected NumberFromString, actual "a"`
+            └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/DateTime/DateTime.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTime.test.ts
@@ -21,7 +21,7 @@ describe("DateTime.Utc", () => {
       "a",
       `DateTimeUtc
 └─ Transformation process failure
-   └─ Expected DateTimeUtc, actual "a"`
+   └─ Unable to decode "a" into a DateTime.Utc`
     )
   })
 
@@ -45,14 +45,14 @@ describe("DateTime.Zoned", () => {
       "1970-01-01T00:00:00.000Z",
       `DateTimeZoned
 └─ Transformation process failure
-   └─ Expected DateTimeZoned, actual "1970-01-01T00:00:00.000Z"`
+   └─ Unable to decode "1970-01-01T00:00:00.000Z" into a DateTime.Zoned`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a",
       `DateTimeZoned
 └─ Transformation process failure
-   └─ Expected DateTimeZoned, actual "a"`
+   └─ Unable to decode "a" into a DateTime.Zoned`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromDate.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromDate.test.ts
@@ -24,7 +24,7 @@ describe("DateTimeUtcFromDate", () => {
       new Date(NaN),
       `DateTimeUtcFromDate
 └─ Transformation process failure
-   └─ Expected DateTimeUtcFromDate, actual Invalid Date`
+   └─ Unable to decode Invalid Date into a DateTime.Utc`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Either/EitherFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/Either/EitherFromSelf.test.ts
@@ -53,7 +53,7 @@ describe("EitherFromSelf", () => {
       `Either<("true" | "false" <-> boolean), NumberFromString>
 └─ NumberFromString
    └─ Transformation process failure
-      └─ Expected NumberFromString, actual "a"`
+      └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Exit/ExitFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/Exit/ExitFromSelf.test.ts
@@ -38,7 +38,7 @@ describe("ExitFromSelf", () => {
          └─ ["error"]
             └─ NumberFromString
                └─ Transformation process failure
-                  └─ Expected NumberFromString, actual "a"`
+                  └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/HashMap/HashMapFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/HashMap/HashMapFromSelf.test.ts
@@ -34,7 +34,7 @@ describe("HashMapFromSelf", () => {
          └─ [0]
             └─ NumberFromString
                └─ Transformation process failure
-                  └─ Expected NumberFromString, actual "a"`
+                  └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/HashSet/HashSetFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/HashSet/HashSetFromSelf.test.ts
@@ -32,7 +32,7 @@ describe("HashSetFromSelf", () => {
    └─ [0]
       └─ NumberFromString
          └─ Transformation process failure
-            └─ Expected NumberFromString, actual "a"`
+            └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/List/ListFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/List/ListFromSelf.test.ts
@@ -32,7 +32,7 @@ describe("ListFromSelf", () => {
    └─ [1]
       └─ NumberFromString
          └─ Transformation process failure
-            └─ Expected NumberFromString, actual "a"`
+            └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Map/MapFromRecord.test.ts
+++ b/packages/effect/test/Schema/Schema/Map/MapFromRecord.test.ts
@@ -15,14 +15,14 @@ describe("MapFromRecord", () => {
     await Util.expectDecodeUnknownFailure(
       schema,
       null,
-      `(a record that will be parsed into a Map <-> Map<NumberFromString, number>)
+      `(a record to be decoded into a Map <-> Map<NumberFromString, number>)
 └─ Encoded side transformation failure
-   └─ Expected a record that will be parsed into a Map, actual null`
+   └─ Expected a record to be decoded into a Map, actual null`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       { a: "1" },
-      `(a record that will be parsed into a Map <-> Map<NumberFromString, number>)
+      `(a record to be decoded into a Map <-> Map<NumberFromString, number>)
 └─ Type side transformation failure
    └─ Map<NumberFromString, number>
       └─ ReadonlyArray<readonly [NumberFromString, number]>
@@ -31,18 +31,18 @@ describe("MapFromRecord", () => {
                └─ [0]
                   └─ NumberFromString
                      └─ Transformation process failure
-                        └─ Expected NumberFromString, actual "a"`
+                        └─ Unable to decode "a" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       { 1: "a" },
-      `(a record that will be parsed into a Map <-> Map<NumberFromString, number>)
+      `(a record to be decoded into a Map <-> Map<NumberFromString, number>)
 └─ Encoded side transformation failure
-   └─ a record that will be parsed into a Map
+   └─ a record to be decoded into a Map
       └─ ["1"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Number/numberFromString.test.ts
+++ b/packages/effect/test/Schema/Schema/Number/numberFromString.test.ts
@@ -24,42 +24,42 @@ describe("NumberFromString", () => {
       "",
       `NumberFromString
 └─ Transformation process failure
-   └─ Expected NumberFromString, actual ""`
+   └─ Unable to decode "" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       " ",
       `NumberFromString
 └─ Transformation process failure
-   └─ Expected NumberFromString, actual " "`
+   └─ Unable to decode " " into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "1AB",
       `NumberFromString
 └─ Transformation process failure
-   └─ Expected NumberFromString, actual "1AB"`
+   └─ Unable to decode "1AB" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "AB1",
       `NumberFromString
 └─ Transformation process failure
-   └─ Expected NumberFromString, actual "AB1"`
+   └─ Unable to decode "AB1" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a",
       `NumberFromString
 └─ Transformation process failure
-   └─ Expected NumberFromString, actual "a"`
+   └─ Unable to decode "a" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       "a1",
       `NumberFromString
 └─ Transformation process failure
-   └─ Expected NumberFromString, actual "a1"`
+   └─ Unable to decode "a1" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/PropertySignature.test.ts
+++ b/packages/effect/test/Schema/Schema/PropertySignature.test.ts
@@ -124,7 +124,7 @@ describe("PropertySignature", () => {
       └─ ["a"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
 
     await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
@@ -153,7 +153,7 @@ describe("PropertySignature", () => {
       └─ ["a"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
 
     await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })

--- a/packages/effect/test/Schema/Schema/ReadonlyMap/ReadonlyMapFromRecord.test.ts
+++ b/packages/effect/test/Schema/Schema/ReadonlyMap/ReadonlyMapFromRecord.test.ts
@@ -15,14 +15,14 @@ describe("ReadonlyMapFromRecord", () => {
     await Util.expectDecodeUnknownFailure(
       schema,
       null,
-      `(a record that will be parsed into a ReadonlyMap <-> ReadonlyMap<NumberFromString, number>)
+      `(a record to be decoded into a ReadonlyMap <-> ReadonlyMap<NumberFromString, number>)
 └─ Encoded side transformation failure
-   └─ Expected a record that will be parsed into a ReadonlyMap, actual null`
+   └─ Expected a record to be decoded into a ReadonlyMap, actual null`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       { a: "1" },
-      `(a record that will be parsed into a ReadonlyMap <-> ReadonlyMap<NumberFromString, number>)
+      `(a record to be decoded into a ReadonlyMap <-> ReadonlyMap<NumberFromString, number>)
 └─ Type side transformation failure
    └─ ReadonlyMap<NumberFromString, number>
       └─ ReadonlyArray<readonly [NumberFromString, number]>
@@ -31,18 +31,18 @@ describe("ReadonlyMapFromRecord", () => {
                └─ [0]
                   └─ NumberFromString
                      └─ Transformation process failure
-                        └─ Expected NumberFromString, actual "a"`
+                        └─ Unable to decode "a" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema,
       { 1: "a" },
-      `(a record that will be parsed into a ReadonlyMap <-> ReadonlyMap<NumberFromString, number>)
+      `(a record to be decoded into a ReadonlyMap <-> ReadonlyMap<NumberFromString, number>)
 └─ Encoded side transformation failure
-   └─ a record that will be parsed into a ReadonlyMap
+   └─ a record to be decoded into a ReadonlyMap
       └─ ["1"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/ReadonlyMap/ReadonlyMapFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/ReadonlyMap/ReadonlyMapFromSelf.test.ts
@@ -33,7 +33,7 @@ describe("ReadonlyMapFromSelf", () => {
          └─ [0]
             └─ NumberFromString
                └─ Transformation process failure
-                  └─ Expected NumberFromString, actual "a"`
+                  └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/ReadonlySet/ReadonlySetFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/ReadonlySet/ReadonlySetFromSelf.test.ts
@@ -27,7 +27,7 @@ describe("ReadonlySetFromSelf", () => {
    └─ [1]
       └─ NumberFromString
          └─ Transformation process failure
-            └─ Expected NumberFromString, actual "a"`
+            └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/SortedSet/SortedSetFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/SortedSet/SortedSetFromSelf.test.ts
@@ -38,7 +38,7 @@ describe("SortedSetFromSelf", () => {
    └─ [2]
       └─ NumberFromString
          └─ Transformation process failure
-            └─ Expected NumberFromString, actual "a"`
+            └─ Unable to decode "a" into a number`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
@@ -143,7 +143,7 @@ schema (Union): boolean | symbol`)
       └─ [0]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "-"`
+               └─ Unable to decode "-" into a number`
       )
 
       await Util.expectEncodeSuccess(schema, [100, "a", "b"], "100ab")

--- a/packages/effect/test/Schema/Schema/URL/URL.test.ts
+++ b/packages/effect/test/Schema/Schema/URL/URL.test.ts
@@ -25,7 +25,7 @@ describe("URL", () => {
       "123",
       `URL
 └─ Transformation process failure
-   └─ Expected URL, actual "123"`
+   └─ Unable to decode "123" into a URL. Invalid URL`
     )
   })
 

--- a/packages/effect/test/Schema/Schema/Uint8Array/Uint8Array.test.ts
+++ b/packages/effect/test/Schema/Schema/Uint8Array/Uint8Array.test.ts
@@ -20,7 +20,7 @@ describe("Uint8Array > Uint8Array", () => {
       [12354],
       `Uint8Array
 └─ Encoded side transformation failure
-   └─ an array of 8-bit unsigned integers that will be parsed into a Uint8Array
+   └─ an array of 8-bit unsigned integers to be decoded into a Uint8Array
       └─ [0]
          └─ Uint8
             └─ Predicate refinement failure

--- a/packages/effect/test/Schema/Schema/compose.test.ts
+++ b/packages/effect/test/Schema/Schema/compose.test.ts
@@ -20,7 +20,7 @@ describe("compose", async () => {
 └─ Type side transformation failure
    └─ NumberFromString
       └─ Transformation process failure
-         └─ Expected NumberFromString, actual "a"`
+         └─ Unable to decode "a" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema1,
@@ -42,7 +42,7 @@ describe("compose", async () => {
 └─ Type side transformation failure
    └─ NumberFromString
       └─ Transformation process failure
-         └─ Expected NumberFromString, actual "a"`
+         └─ Unable to decode "a" into a number`
     )
     await Util.expectDecodeUnknownFailure(
       schema2,

--- a/packages/effect/test/Schema/Schema/optional.test.ts
+++ b/packages/effect/test/Schema/Schema/optional.test.ts
@@ -38,7 +38,7 @@ describe("optional", () => {
    └─ NumberFromString | undefined
       ├─ NumberFromString
       │  └─ Transformation process failure
-      │     └─ Expected NumberFromString, actual "a"
+      │     └─ Unable to decode "a" into a number
       └─ Expected undefined, actual "a"`
     )
 

--- a/packages/effect/test/Schema/Schema/optionalWith.test.ts
+++ b/packages/effect/test/Schema/Schema/optionalWith.test.ts
@@ -40,7 +40,7 @@ describe("optionalWith", () => {
 └─ ["a"]
    └─ NumberFromString
       └─ Transformation process failure
-         └─ Expected NumberFromString, actual "a"`
+         └─ Unable to decode "a" into a number`
       )
 
       await Util.expectEncodeSuccess(schema, {}, {})
@@ -80,7 +80,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             ├─ Expected null, actual "a"
             └─ Expected undefined, actual "a"`
       )
@@ -122,7 +122,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected null, actual "a"`
       )
 
@@ -149,7 +149,7 @@ describe("optionalWith", () => {
       └─ ["a"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
       )
 
       await Util.expectEncodeSuccess(schema, { a: O.some(1) }, { a: "1" })
@@ -177,7 +177,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected null, actual "a"`
       )
 
@@ -211,7 +211,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected null, actual "a"`
       )
 
@@ -238,7 +238,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected undefined, actual "a"`
       )
 
@@ -268,7 +268,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             ├─ Expected null, actual "a"
             └─ Expected undefined, actual "a"`
       )
@@ -311,7 +311,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected undefined, actual "a"`
       )
 
@@ -341,7 +341,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             ├─ Expected null, actual "a"
             └─ Expected undefined, actual "a"`
       )
@@ -372,7 +372,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             ├─ Expected null, actual "a"
             └─ Expected undefined, actual "a"`
       )
@@ -398,7 +398,7 @@ describe("optionalWith", () => {
       └─ ["a"]
          └─ NumberFromString
             └─ Transformation process failure
-               └─ Expected NumberFromString, actual "a"`
+               └─ Unable to decode "a" into a number`
       )
 
       await Util.expectEncodeSuccess(schema, { a: 1 }, { a: "1" })
@@ -431,7 +431,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected undefined, actual "a"`
       )
 
@@ -466,7 +466,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null | undefined
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             ├─ Expected null, actual "a"
             └─ Expected undefined, actual "a"`
       )
@@ -501,7 +501,7 @@ describe("optionalWith", () => {
          └─ NumberFromString | null
             ├─ NumberFromString
             │  └─ Transformation process failure
-            │     └─ Expected NumberFromString, actual "a"
+            │     └─ Unable to decode "a" into a number
             └─ Expected null, actual "a"`
       )
 

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -507,7 +507,7 @@
       },
       "NumberFromString": {
         "type": "string",
-        "description": "a string that will be parsed into a number"
+        "description": "a string to be decoded into a number"
       },
       "PersistedFile": {
         "format": "binary",
@@ -609,7 +609,7 @@
         "additionalProperties": false
       },
       "DateTimeUtc": {
-        "description": "a string that will be parsed into a DateTime.Utc",
+        "description": "a string to be decoded into a DateTime.Utc",
         "type": "string"
       },
       "UserError": {

--- a/packages/platform/test/OpenApiJsonSchema.test.ts
+++ b/packages/platform/test/OpenApiJsonSchema.test.ts
@@ -47,7 +47,7 @@ describe("OpenApiJsonSchema", () => {
         "type": "integer"
       },
       "NumberFromString": {
-        "description": "a string that will be parsed into a number",
+        "description": "a string to be decoded into a number",
         "type": "string"
       }
     })


### PR DESCRIPTION
**Before**

```ts
import { Schema } from "effect"

Schema.decodeUnknownSync(Schema.NumberFromString)("a")
/*
throws:
ParseError: NumberFromString
└─ Transformation process failure
   └─ Expected NumberFromString, actual "a"
*/
```

**After**

```ts
import { Schema } from "effect"

Schema.decodeUnknownSync(Schema.NumberFromString)("a")
/*
throws:
ParseError: NumberFromString
└─ Transformation process failure
   └─ Unable to decode "a" into a number
*/
```
