### PR TITLE
Add support for symbols in the `Issue` definition within `platform/HttpApiError`

### DIFF
--- a/.changeset/two-lies-end.md
+++ b/.changeset/two-lies-end.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Relocate the `Issue` definition from `platform/HttpApiError` to `Schema` (renamed as `ArrayFormatterIssue`).

--- a/.changeset/young-trains-jam.md
+++ b/.changeset/young-trains-jam.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Add support for symbols in the `Issue` definition within `platform/HttpApiError`.

--- a/packages/effect/src/ParseResult.ts
+++ b/packages/effect/src/ParseResult.ts
@@ -1935,12 +1935,25 @@ const formatTree = (
 }
 
 /**
+ * Represents an issue returned by the {@link ArrayFormatter} formatter.
+ *
  * @category model
  * @since 3.10.0
  */
 export interface ArrayFormatterIssue {
+  /**
+   * The tag identifying the type of parse issue.
+   */
   readonly _tag: ParseIssue["_tag"]
+
+  /**
+   * The path to the property where the issue occurred.
+   */
   readonly path: ReadonlyArray<PropertyKey>
+
+  /**
+   * A descriptive message explaining the issue.
+   */
   readonly message: string
 }
 

--- a/packages/effect/test/Schema/Schema/ArrayFormatterIssue/ArrayFormatterIssue.test.ts
+++ b/packages/effect/test/Schema/Schema/ArrayFormatterIssue/ArrayFormatterIssue.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("ArrayFormatterIssue", () => {
+  const schema = S.ArrayFormatterIssue
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/PropertyKey/PropertyKey.test.ts
+++ b/packages/effect/test/Schema/Schema/PropertyKey/PropertyKey.test.ts
@@ -1,0 +1,16 @@
+import * as Schema from "effect/Schema"
+import { describe, expect, it } from "vitest"
+
+describe("PropertyKey", () => {
+  it("should handle symbol, string, and number", () => {
+    const encodeSync = Schema.encodeSync(Schema.PropertyKey)
+    const decodeSync = Schema.decodeSync(Schema.PropertyKey)
+    const expectRoundtrip = (pk: PropertyKey) => {
+      expect(decodeSync(encodeSync(pk))).toStrictEqual(pk)
+    }
+
+    expectRoundtrip("path")
+    expectRoundtrip(1)
+    expectRoundtrip(Symbol.for("symbol"))
+  })
+})

--- a/packages/effect/test/Schema/TestUtils.ts
+++ b/packages/effect/test/Schema/TestUtils.ts
@@ -13,9 +13,6 @@ import * as AST from "effect/SchemaAST"
 import * as fc from "fast-check"
 import { assert, expect } from "vitest"
 
-const doEffectify = true
-const doRoundtrip = false
-
 export const sleep = Effect.sleep(Duration.millis(10))
 
 const effectifyDecode = <R>(
@@ -124,7 +121,7 @@ export const expectArbitrary = <A, I>(schema: S.Schema<A, I, never>, n: number =
 }
 
 export const roundtrip = <A, I>(schema: S.Schema<A, I, never>, params?: Parameters<typeof fc.assert>[1]) => {
-  if (!doRoundtrip) {
+  if (true as boolean) {
     return
   }
   const arb = A.makeLazy(schema)
@@ -146,7 +143,7 @@ export const roundtrip = <A, I>(schema: S.Schema<A, I, never>, params?: Paramete
     }),
     params
   )
-  if (doEffectify) {
+  if (true as boolean) {
     const effectSchema = effectify(schema)
     const encode = S.encode(effectSchema)
     const decode = S.decode(effectSchema)

--- a/packages/platform-node/test/fixtures/openapi.json
+++ b/packages/platform-node/test/fixtures/openapi.json
@@ -531,52 +531,73 @@
           "issues": {
             "type": "array",
             "items": {
-              "type": "object",
-              "required": ["_tag", "path", "message"],
-              "properties": {
-                "_tag": {
-                  "type": "string",
-                  "enum": [
-                    "Pointer",
-                    "Unexpected",
-                    "Missing",
-                    "Composite",
-                    "Refinement",
-                    "Transformation",
-                    "Type",
-                    "Forbidden"
-                  ]
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ]
-                  }
-                },
-                "message": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/components/schemas/Issue"
             }
           },
-          "message": {
-            "type": "string"
-          },
+          "message": { "type": "string" },
           "_tag": {
             "type": "string",
-            "enum": ["HttpApiDecodeError"]
+            "enum": [
+              "HttpApiDecodeError"
+            ]
           }
         },
         "additionalProperties": false,
         "description": "The request did not match the expected schema"
+      },
+      "Issue": {
+        "type": "object",
+        "description": "Represents an error encountered while parsing a value to match the schema",
+        "required": ["_tag", "path", "message"],
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "description": "The tag identifying the type of parse issue",
+            "enum": [
+              "Pointer",
+              "Unexpected",
+              "Missing",
+              "Composite",
+              "Refinement",
+              "Transformation",
+              "Type",
+              "Forbidden"
+            ]
+          },
+          "path": {
+            "type": "array",
+            "description": "The path to the property where the issue occurred",
+            "items": {
+              "$ref": "#/components/schemas/PropertyKey"
+            }
+          },
+          "message": {
+            "type": "string",
+            "description": "A descriptive message explaining the issue"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PropertyKey": {
+        "anyOf": [
+          { "type": "string" },
+          { "type": "number" },
+          {
+            "additionalProperties": false,
+            "description": "an object to be decoded into a globally shared symbol",
+            "properties": {
+              "_tag": {
+                "enum": [
+                  "symbol"
+                ],
+                "type": "string"
+              },
+              "key": { "type": "string" }
+            },
+            "required": ["_tag", "key"],
+            "type": "object"
+          }
+        ]
       },
       "GlobalError": {
         "type": "object",

--- a/packages/platform/src/HttpApiError.ts
+++ b/packages/platform/src/HttpApiError.ts
@@ -2,7 +2,6 @@
  * @since 1.0.0
  */
 import * as Effect from "effect/Effect"
-import { identity } from "effect/Function"
 import * as ParseResult from "effect/ParseResult"
 import * as Schema from "effect/Schema"
 import * as HttpApiSchema from "./HttpApiSchema.js"
@@ -23,60 +22,10 @@ export type TypeId = typeof TypeId
  * @since 1.0.0
  * @category schemas
  */
-export interface Issue extends
-  Schema.Struct<
-    {
-      _tag: Schema.Literal<
-        ["Pointer", "Unexpected", "Missing", "Composite", "Refinement", "Transformation", "Type", "Forbidden"]
-      >
-      path: PropertyKeysNoSymbol
-      message: typeof Schema.String
-    }
-  >
-{}
-
-/**
- * @since 1.0.0
- * @category schemas
- */
-export interface PropertyKeysNoSymbol extends
-  Schema.transform<
-    Schema.Array$<Schema.Union<[typeof Schema.String, typeof Schema.Number]>>,
-    Schema.Array$<Schema.Union<[typeof Schema.SymbolFromSelf, typeof Schema.String, typeof Schema.Number]>>
-  >
-{}
-
-/**
- * @since 1.0.0
- * @category schemas
- */
-export const PropertyKeysNoSymbol: PropertyKeysNoSymbol = Schema.transform(
-  Schema.Array(Schema.Union(Schema.String, Schema.Number)),
-  Schema.Array(Schema.Union(Schema.SymbolFromSelf, Schema.String, Schema.Number)),
-  {
-    decode: identity,
-    encode: (items) => items.filter((item) => typeof item !== "symbol")
-  }
-)
-
-/**
- * @since 1.0.0
- * @category schemas
- */
-export const Issue: Issue = Schema.Struct({
-  _tag: Schema.Literal(
-    "Pointer",
-    "Unexpected",
-    "Missing",
-    "Composite",
-    "Refinement",
-    "Transformation",
-    "Type",
-    "Forbidden"
-  ),
-  path: PropertyKeysNoSymbol,
-  message: Schema.String
-})
+export class Issue extends Schema.ArrayFormatterIssue.annotations({
+  identifier: "Issue",
+  description: "Represents an error encountered while parsing a value to match the schema"
+}) {}
 
 /**
  * @since 1.0.0

--- a/packages/platform/test/HttpApiError.test.ts
+++ b/packages/platform/test/HttpApiError.test.ts
@@ -1,0 +1,21 @@
+import * as HttpApiError from "@effect/platform/HttpApiError"
+import * as Schema from "effect/Schema"
+import { describe, expect, it } from "vitest"
+
+describe("HttpApiError", () => {
+  describe("Issue schema", () => {
+    it("path should handle symbol, string, and number", () => {
+      const encodeSync = Schema.encodeSync(HttpApiError.Issue)
+      const decodeSync = Schema.decodeSync(HttpApiError.Issue)
+      const expectRoundtrip = (issue: typeof HttpApiError.Issue.Type) => {
+        expect(decodeSync(encodeSync(issue))).toStrictEqual(issue)
+      }
+
+      expectRoundtrip({
+        _tag: "Pointer",
+        path: ["path", 1, Symbol.for("symbol")],
+        message: "message"
+      })
+    })
+  })
+})

--- a/packages/platform/test/OpenApi.test.ts
+++ b/packages/platform/test/OpenApi.test.ts
@@ -46,31 +46,7 @@ const getSpec = (options: Options): OpenApi.OpenAPISpec => {
             "issues": {
               "type": "array",
               "items": {
-                "type": "object",
-                "required": ["_tag", "path", "message"],
-                "properties": {
-                  "_tag": {
-                    "type": "string",
-                    "enum": [
-                      "Pointer",
-                      "Unexpected",
-                      "Missing",
-                      "Composite",
-                      "Refinement",
-                      "Transformation",
-                      "Type",
-                      "Forbidden"
-                    ]
-                  },
-                  "path": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [{ "type": "string" }, { "type": "number" }]
-                    }
-                  },
-                  "message": { "type": "string" }
-                },
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Issue"
               }
             },
             "message": { "type": "string" },
@@ -83,6 +59,60 @@ const getSpec = (options: Options): OpenApi.OpenAPISpec => {
           },
           "additionalProperties": false,
           "description": "The request did not match the expected schema"
+        },
+        "Issue": {
+          "type": "object",
+          "description": "Represents an error encountered while parsing a value to match the schema",
+          "required": ["_tag", "path", "message"],
+          "properties": {
+            "_tag": {
+              "type": "string",
+              "description": "The tag identifying the type of parse issue",
+              "enum": [
+                "Pointer",
+                "Unexpected",
+                "Missing",
+                "Composite",
+                "Refinement",
+                "Transformation",
+                "Type",
+                "Forbidden"
+              ]
+            },
+            "path": {
+              "type": "array",
+              "description": "The path to the property where the issue occurred",
+              "items": {
+                "$ref": "#/components/schemas/PropertyKey"
+              }
+            },
+            "message": {
+              "type": "string",
+              "description": "A descriptive message explaining the issue"
+            }
+          },
+          "additionalProperties": false
+        },
+        "PropertyKey": {
+          "anyOf": [
+            { "type": "string" },
+            { "type": "number" },
+            {
+              "additionalProperties": false,
+              "description": "an object to be decoded into a globally shared symbol",
+              "properties": {
+                "_tag": {
+                  "enum": [
+                    "symbol"
+                  ],
+                  "type": "string"
+                },
+                "key": { "type": "string" }
+              },
+              "required": ["_tag", "key"],
+              "type": "object"
+            }
+          ]
         },
         ...options.schemas
       },


### PR DESCRIPTION
Also: Relocate the `Issue` definition from `platform/HttpApiError` to `Schema` (renamed as `ArrayFormatterIssue`).