### PR TITLE
Schema: Replace the `TimeZoneFromSelf` interface with a class definit…

### DIFF
--- a/.changeset/wet-dodos-carry.md
+++ b/.changeset/wet-dodos-carry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Schema: Replace the `TimeZoneFromSelf` interface with a class definition and fix the arbitraries for `DateTimeUtcFromSelf` and `DateTimeZonedFromSelf` (`fc.date({ noInvalidDate: true })`).

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6516,7 +6516,8 @@ export class DateTimeUtcFromSelf extends declare(
     identifier: "DateTimeUtcFromSelf",
     description: "a DateTime.Utc instance",
     pretty: (): pretty_.Pretty<dateTime.Utc> => (dateTime) => dateTime.toString(),
-    arbitrary: (): LazyArbitrary<dateTime.Utc> => (fc) => fc.date().map((date) => dateTime.unsafeFromDate(date)),
+    arbitrary: (): LazyArbitrary<dateTime.Utc> => (fc) =>
+      fc.date({ noInvalidDate: true }).map((date) => dateTime.unsafeFromDate(date)),
     equivalence: () => dateTime.Equivalence
   }
 ) {}
@@ -6646,18 +6647,10 @@ export class TimeZoneNamed extends transformOrFail(
 ).annotations({ identifier: "TimeZoneNamed" }) {}
 
 /**
- * @category api interface
- * @since 3.10.0
- */
-export interface TimeZoneFromSelf extends Union<[typeof TimeZoneOffsetFromSelf, typeof TimeZoneNamedFromSelf]> {
-  annotations(annotations: Annotations.Schema<dateTime.TimeZone>): TimeZoneFromSelf
-}
-
-/**
  * @category TimeZone constructors
  * @since 3.10.0
  */
-export const TimeZoneFromSelf: TimeZoneFromSelf = Union(TimeZoneOffsetFromSelf, TimeZoneNamedFromSelf)
+export class TimeZoneFromSelf extends Union(TimeZoneOffsetFromSelf, TimeZoneNamedFromSelf) {}
 
 /**
  * Defines a schema that attempts to convert a `string` to a `TimeZone` using the `DateTime.zoneFromString` constructor.
@@ -6699,7 +6692,9 @@ export class DateTimeZonedFromSelf extends declare(
     description: "a DateTime.Zoned instance",
     pretty: (): pretty_.Pretty<dateTime.Zoned> => (dateTime) => dateTime.toString(),
     arbitrary: (): LazyArbitrary<dateTime.Zoned> => (fc) =>
-      fc.date().chain((date) => timeZoneArbitrary(fc).map((timeZone) => dateTime.unsafeMakeZoned(date, { timeZone }))),
+      fc.date({ noInvalidDate: true }).chain((date) =>
+        timeZoneArbitrary(fc).map((timeZone) => dateTime.unsafeMakeZoned(date, { timeZone }))
+      ),
     equivalence: () => dateTime.Equivalence
   }
 ) {}

--- a/packages/effect/test/Schema/Arbitrary/Arbitrary.test.ts
+++ b/packages/effect/test/Schema/Arbitrary/Arbitrary.test.ts
@@ -926,4 +926,22 @@ details: Generating an Arbitrary for this schema requires at least one enum`)
       expectHook(S.NumberFromString)
     })
   })
+
+  describe("DateTime", () => {
+    it("DateTimeUtcFromSelf", () => {
+      expectValidArbitrary(S.DateTimeUtcFromSelf)
+    })
+
+    it("TimeZoneOffsetFromSelf", () => {
+      expectValidArbitrary(S.TimeZoneOffsetFromSelf)
+    })
+
+    it("TimeZoneNamedFromSelf", () => {
+      expectValidArbitrary(S.TimeZoneNamedFromSelf)
+    })
+
+    it("DateTimeZonedFromSelf", () => {
+      expectValidArbitrary(S.DateTimeZonedFromSelf)
+    })
+  })
 })

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeUtc.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeUtc.test.ts
@@ -1,0 +1,31 @@
+import { DateTime } from "effect"
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("DateTimeUtc", () => {
+  const schema = S.DateTimeUtc
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+
+  it("decoding", async () => {
+    await Util.expectDecodeUnknownSuccess(
+      schema,
+      "1970-01-01T00:00:00.000Z",
+      DateTime.unsafeMake(0)
+    )
+    await Util.expectDecodeUnknownFailure(
+      schema,
+      "a",
+      `DateTimeUtc
+└─ Transformation process failure
+   └─ Unable to decode "a" into a DateTime.Utc`
+    )
+  })
+
+  it("encoding", async () => {
+    await Util.expectEncodeSuccess(schema, DateTime.unsafeMake(0), "1970-01-01T00:00:00.000Z")
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromDate.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromDate.test.ts
@@ -4,23 +4,29 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { describe, expect, it } from "vitest"
 
 describe("DateTimeUtcFromDate", () => {
+  const schema = S.DateTimeUtcFromDate
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+
   it("decoding", async () => {
-    await Util.expectDecodeUnknownSuccess(S.DateTimeUtcFromDate, new Date(0), DateTime.unsafeMake(0))
+    await Util.expectDecodeUnknownSuccess(schema, new Date(0), DateTime.unsafeMake(0))
     await Util.expectDecodeUnknownSuccess(
-      S.DateTimeUtcFromDate,
+      schema,
       new Date("2024-12-06T00:00:00Z"),
       DateTime.unsafeMake({ day: 6, month: 12, year: 2024, hour: 0, minute: 0, second: 0, millisecond: 0 })
     )
 
     await Util.expectDecodeUnknownFailure(
-      S.DateTimeUtcFromDate,
+      schema,
       null,
       `DateTimeUtcFromDate
 └─ Encoded side transformation failure
    └─ Expected DateFromSelf, actual null`
     )
     await Util.expectDecodeUnknownFailure(
-      S.DateTimeUtcFromDate,
+      schema,
       new Date(NaN),
       `DateTimeUtcFromDate
 └─ Transformation process failure
@@ -29,9 +35,9 @@ describe("DateTimeUtcFromDate", () => {
   })
 
   it("encoding", async () => {
-    await Util.expectEncodeSuccess(S.DateTimeUtcFromDate, DateTime.unsafeMake(0), new Date(0))
+    await Util.expectEncodeSuccess(schema, DateTime.unsafeMake(0), new Date(0))
     expect(
-      S.encodeSync(S.DateTimeUtcFromDate)(
+      S.encodeSync(schema)(
         DateTime.unsafeMake({ day: 6, month: 12, year: 2024, hour: 0, minute: 0, second: 0, millisecond: 0 })
       )
     ).toStrictEqual(new Date("2024-12-06T00:00:00Z"))

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromNumber.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromNumber.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("DateTimeUtcFromNumber", () => {
+  const schema = S.DateTimeUtcFromNumber
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeUtcFromSelf.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("DateTimeUtcFromSelf", () => {
+  const schema = S.DateTimeUtcFromSelf
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeZoned.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeZoned.test.ts
@@ -3,34 +3,7 @@ import * as S from "effect/Schema"
 import * as Util from "effect/test/Schema/TestUtils"
 import { describe, it } from "vitest"
 
-describe("DateTime.Utc", () => {
-  const schema = S.DateTimeUtc
-
-  it("property tests", () => {
-    Util.roundtrip(schema)
-  })
-
-  it("decoding", async () => {
-    await Util.expectDecodeUnknownSuccess(
-      schema,
-      "1970-01-01T00:00:00.000Z",
-      DateTime.unsafeMake(0)
-    )
-    await Util.expectDecodeUnknownFailure(
-      schema,
-      "a",
-      `DateTimeUtc
-└─ Transformation process failure
-   └─ Unable to decode "a" into a DateTime.Utc`
-    )
-  })
-
-  it("encoding", async () => {
-    await Util.expectEncodeSuccess(schema, DateTime.unsafeMake(0), "1970-01-01T00:00:00.000Z")
-  })
-})
-
-describe("DateTime.Zoned", () => {
+describe("DateTimeZoned", () => {
   const schema = S.DateTimeZoned
   const dt = DateTime.unsafeMakeZoned(0, { timeZone: "Europe/London" })
 

--- a/packages/effect/test/Schema/Schema/DateTime/DateTimeZonedFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/DateTimeZonedFromSelf.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("DateTimeZonedFromSelf", () => {
+  const schema = S.DateTimeZonedFromSelf
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/TimeZone.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/TimeZone.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("TimeZone", () => {
+  const schema = S.TimeZone
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/TimeZoneFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/TimeZoneFromSelf.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("TimeZoneFromSelf", () => {
+  const schema = S.TimeZoneFromSelf
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/TimeZoneNamed.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/TimeZoneNamed.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("TimeZoneNamed", () => {
+  const schema = S.TimeZoneNamed
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/TimeZoneNamedFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/TimeZoneNamedFromSelf.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("TimeZoneNamedFromSelf", () => {
+  const schema = S.TimeZoneNamedFromSelf
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/TimeZoneOffset.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/TimeZoneOffset.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("TimeZoneOffset", () => {
+  const schema = S.TimeZoneOffset
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/Schema/DateTime/TimeZoneOffsetFromSelf.test.ts
+++ b/packages/effect/test/Schema/Schema/DateTime/TimeZoneOffsetFromSelf.test.ts
@@ -1,0 +1,11 @@
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+import { describe, it } from "vitest"
+
+describe("TimeZoneOffsetFromSelf", () => {
+  const schema = S.TimeZoneOffsetFromSelf
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+})

--- a/packages/effect/test/Schema/TestUtils.ts
+++ b/packages/effect/test/Schema/TestUtils.ts
@@ -221,10 +221,8 @@ export const X3 = S.transform(
   { strict: true, decode: (s) => s + s + s, encode: (s) => s.substring(0, s.length / 3) }
 )
 
-const doProperty = true
-
 export const expectValidArbitrary = <A, I>(schema: S.Schema<A, I, never>, params?: fc.Parameters<[A]>) => {
-  if (!doProperty) {
+  if (false as boolean) {
     return
   }
   const arb = A.makeLazy(schema)(fc)


### PR DESCRIPTION
…ion and fix the arbitraries for `DateTimeUtcFromSelf` and `DateTimeZonedFromSelf` (`fc.date({ noInvalidDate: true })`).