### PR TITLE
Fix following relative locations

### DIFF
--- a/.changeset/tiny-onions-change.md
+++ b/.changeset/tiny-onions-change.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix following relative locations

--- a/packages/platform/src/internal/httpClient.ts
+++ b/packages/platform/src/internal/httpClient.ts
@@ -711,7 +711,7 @@ export const followRedirects = dual<
               ? loop(
                 internalRequest.setUrl(
                   request,
-                  response.headers.location
+                  new URL(response.headers.location, response.request.url)
                 ),
                 redirects + 1
               )

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -221,4 +221,20 @@ describe("HttpClient", () => {
       body: { _id: "@effect/platform/HttpBody", _tag: "Empty" }
     })
   })
+
+  it("followRedirects", () =>
+    Effect.gen(function*(_) {
+      const defaultClient = yield* HttpClient.HttpClient
+      const client = defaultClient.pipe(HttpClient.followRedirects())
+
+      const response = yield* _(
+        client.get("https://google.com/"),
+        Effect.scoped
+      )
+      expect(response.request.url).toBe("https://www.google.com/")
+    }).pipe(
+      Effect.provide(FetchHttpClient.layer),
+      Effect.provideService(FetchHttpClient.RequestInit, { redirect: "manual" }),
+      Effect.runPromise
+    ))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `Location` header on a response can be relative; currently, it throws a `TypeError: Invalid URL`.

I added a basic test for the general case. As these tests are making real requests I've not covered this specific case. (It feels like there should be a way to not make real requests, or at least make them to a locally-running server.)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
