### PR TITLE
improve UnknownException error messages

### DIFF
--- a/.changeset/long-terms-sing.md
+++ b/.changeset/long-terms-sing.md
@@ -2,8 +2,24 @@
 "effect": patch
 ---
 
-Restore `UnknownException` error message handling behavior, closes #4221.
+Improve `UnknownException` error messages
 
-1. Default to "An unknown error occurred" if no message is provided.
-2. **Use the `message` property from the cause, if it exists and is a string**.
-3. Prioritize a provided custom message over the inherited or default message.
+`UnknownException` error messages now include the name of the Effect api that
+created the error.
+
+```ts
+import { Effect } from "effect"
+
+Effect.tryPromise(() => Promise.reject(new Error("The operation failed"))).pipe(
+  Effect.catchAllCause(Effect.logError),
+  Effect.runFork
+)
+
+// timestamp=2025-01-21T00:41:03.403Z level=ERROR fiber=#0 cause="UnknownException: An unknown error occurred in Effect.tryPromise
+//     at fail (.../effect/packages/effect/src/internal/core-effect.ts:1654:19)
+//     at <anonymous> (.../effect/packages/effect/src/internal/core-effect.ts:1674:26) {
+//   [cause]: Error: The operation failed
+//       at <anonymous> (.../effect/scratchpad/error.ts:4:24)
+//       at .../effect/packages/effect/src/internal/core-effect.ts:1671:7
+// }"
+```

--- a/.changeset/long-terms-sing.md
+++ b/.changeset/long-terms-sing.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Restore `UnknownException` error message handling behavior, closes #4221.
+
+1. Default to "An unknown error occurred" if no message is provided.
+2. **Use the `message` property from the cause, if it exists and is a string**.
+3. Prioritize a provided custom message over the inherited or default message.

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -913,8 +913,33 @@ export const isRuntimeException: (u: unknown) => u is RuntimeException = core.is
 export const TimeoutException: new(message?: string | undefined) => TimeoutException = core.TimeoutException
 
 /**
- * Represents a checked exception which occurs when an unknown error is thrown, such as
- * from a rejected promise.
+ * Creates an instance of `UnknownException`, an error object used to handle
+ * unknown errors such as those from rejected promises.
+ *
+ * **Details**
+ *
+ * This function constructs an `UnknownException` with flexible behavior for
+ * managing the error message:
+ *
+ * 1. If no `message` is provided, it defaults to `"An unknown error occurred"`.
+ * 2. If the `error` (cause) has a `message` property and the value is a string,
+ *    the message from the cause is used as the error's message.
+ * 3. If a `message` argument is explicitly provided, it takes precedence over
+ *    the inherited message or the default.
+ *
+ * Additionally, the `error` argument is passed as the `cause` to the `super`
+ * constructor, ensuring that the original cause is preserved in the error chain
+ * for debugging purposes.
+ *
+ * The `error` argument is always stored in the `error` property of the
+ * `UnknownException` instance for reference, regardless of its type.
+ *
+ * **When to Use**
+ *
+ * Use this function when you need to handle unexpected or unknown errors in
+ * your application, particularly when the source of the error might not provide
+ * a clear message. This is useful for wrapping generic errors thrown from
+ * promises or external APIs.
  *
  * @since 2.0.0
  * @category errors

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -919,20 +919,19 @@ export const TimeoutException: new(message?: string | undefined) => TimeoutExcep
  * **Details**
  *
  * This function constructs an `UnknownException` with flexible behavior for
- * managing the error message:
+ * managing the error message and cause.
  *
- * 1. If no `message` is provided, it defaults to `"An unknown error occurred"`.
- * 2. If the `error` (cause) has a `message` property and the value is a string,
- *    the message from the cause is used as the error's message.
- * 3. If a `message` argument is explicitly provided, it takes precedence over
- *    the inherited message or the default.
- *
- * Additionally, the `error` argument is passed as the `cause` to the `super`
+ * The required `error` argument is passed as the `cause` to the global `Error`
  * constructor, ensuring that the original cause is preserved in the error chain
- * for debugging purposes.
+ * for debugging purposes. This ensures that the origin stack trace is
+ * preserved.
  *
  * The `error` argument is always stored in the `error` property of the
  * `UnknownException` instance for reference, regardless of its type.
+ *
+ * Additionally, if you provide a `message` argument, it is used as the error
+ * message. If no `message` is provided, the error message defaults to `"An
+ * unknown error occurred"`.
  *
  * **When to Use**
  *

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -28,7 +28,7 @@ import type * as MetricLabel from "../MetricLabel.js"
 import * as MutableRef from "../MutableRef.js"
 import * as Option from "../Option.js"
 import { pipeArguments } from "../Pipeable.js"
-import { hasProperty, isObject, isPromiseLike, type Predicate, type Refinement } from "../Predicate.js"
+import { hasProperty, isObject, isPromiseLike, isString, type Predicate, type Refinement } from "../Predicate.js"
 import type * as Request from "../Request.js"
 import type * as BlockedRequests from "../RequestBlock.js"
 import type * as RequestResolver from "../RequestResolver.js"
@@ -2346,7 +2346,11 @@ export const UnknownException: new(cause: unknown, message?: string | undefined)
       readonly _tag = "UnknownException"
       readonly error: unknown
       constructor(readonly cause: unknown, message?: string) {
-        super(message ?? "An unknown error occurred", { cause })
+        super(
+          message ??
+            (hasProperty(cause, "message") && isString(cause.message) ? cause.message : "An unknown error occurred"),
+          { cause }
+        )
         this.error = cause
       }
     }

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -28,7 +28,7 @@ import type * as MetricLabel from "../MetricLabel.js"
 import * as MutableRef from "../MutableRef.js"
 import * as Option from "../Option.js"
 import { pipeArguments } from "../Pipeable.js"
-import { hasProperty, isObject, isPromiseLike, isString, type Predicate, type Refinement } from "../Predicate.js"
+import { hasProperty, isObject, isPromiseLike, type Predicate, type Refinement } from "../Predicate.js"
 import type * as Request from "../Request.js"
 import type * as BlockedRequests from "../RequestBlock.js"
 import type * as RequestResolver from "../RequestResolver.js"
@@ -797,7 +797,8 @@ export const andThen: {
       return b
     } else if (isPromiseLike(b)) {
       return unsafeAsync<any, Cause.UnknownException>((resume) => {
-        b.then((a) => resume(succeed(a)), (e) => resume(fail(new UnknownException(e))))
+        b.then((a) => resume(succeed(a)), (e) =>
+          resume(fail(new UnknownException(e, "An unknown error occurred in Effect.andThen"))))
       })
     }
     return succeed(b)
@@ -1281,7 +1282,8 @@ export const tap = dual<
         return as(b, a)
       } else if (isPromiseLike(b)) {
         return unsafeAsync<any, Cause.UnknownException>((resume) => {
-          b.then((_) => resume(succeed(a)), (e) => resume(fail(new UnknownException(e))))
+          b.then((_) => resume(succeed(a)), (e) =>
+            resume(fail(new UnknownException(e, "An unknown error occurred in Effect.tap"))))
         })
       }
       return succeed(a)
@@ -2208,7 +2210,10 @@ export const YieldableError: new(message?: string, options?: ErrorOptions) => Ca
       return fail(this)
     }
     toJSON() {
-      return { ...this }
+      const obj = { ...this }
+      if (this.message) obj.message = this.message
+      if (this.cause) obj.cause = this.cause
+      return obj
     }
     [NodeInspectSymbol]() {
       if (this.toString !== globalThis.Error.prototype.toString) {
@@ -2345,12 +2350,8 @@ export const UnknownException: new(cause: unknown, message?: string | undefined)
     class UnknownException extends YieldableError {
       readonly _tag = "UnknownException"
       readonly error: unknown
-      constructor(readonly cause: unknown, message?: string) {
-        super(
-          message ??
-            (hasProperty(cause, "message") && isString(cause.message) ? cause.message : "An unknown error occurred"),
-          { cause }
-        )
+      constructor(cause: unknown, message?: string) {
+        super(message ?? "An unknown error occurred", { cause })
         this.error = cause
       }
     }

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -406,11 +406,6 @@ describe("Cause", () => {
       expect(err1.message).toEqual("An unknown error occurred")
     })
 
-    it("inherits the message from the provided cause if possible", () => {
-      const err1 = new Cause.UnknownException(new Error("my error"))
-      expect(err1.message).toEqual("my error")
-    })
-
     it("accepts a custom override message", () => {
       const err1 = new Cause.UnknownException(new Error("my error"), "my message")
       expect(err1.message).toEqual("my message")

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -381,4 +381,37 @@ describe("Cause", () => {
       assert.isTrue(Equal.equals(stripped, Option.none()))
     })
   })
+
+  describe("UnknownException", () => {
+    it("should have an `error` property", () => {
+      const err1 = new Cause.UnknownException("my message")
+      expect(err1.error).toEqual("my message")
+      const err2 = new Cause.UnknownException(new Error("my error"))
+      expect(err2.error).toBeInstanceOf(Error)
+      expect((err2.error as Error).message).toEqual("my error")
+    })
+
+    it("should have a `cause` property", () => {
+      const err1 = new Cause.UnknownException("my message")
+      expect(err1.cause).toEqual("my message")
+      const err2 = new Cause.UnknownException(new Error("my error"))
+      expect(err2.cause).toBeInstanceOf(Error)
+      expect((err2.cause as Error).message).toEqual("my error")
+    })
+
+    it("should set a default message", () => {
+      const err1 = new Cause.UnknownException("my message")
+      expect(err1.message).toEqual("An unknown error occurred")
+    })
+
+    it("should inherit the message from the cause", () => {
+      const err1 = new Cause.UnknownException(new Error("my error"))
+      expect(err1.message).toEqual("my error")
+    })
+
+    it("should accept an override message", () => {
+      const err1 = new Cause.UnknownException(new Error("my error"), "my message")
+      expect(err1.message).toEqual("my message")
+    })
+  })
 })


### PR DESCRIPTION
Behavior:

1. Default to "An unknown error occurred" if no message is provided.
2. **Use the `message` property from the cause, if it exists and is a string**.
3. Prioritize a provided custom message over the inherited or default message.

@mikearnaldi @tim-smart It seems the regression was introduced in this PR: https://github.com/Effect-TS/effect/pull/3295. I restored the previous code that inherits the message from the provided cause when possible and added tests for the `UnknownException` constructor.
