### PR TITLE
Schema: update `pluck` type signature to respect optional fields

### DIFF
--- a/.changeset/two-shrimps-love.md
+++ b/.changeset/two-shrimps-love.md
@@ -1,0 +1,35 @@
+---
+"effect": patch
+---
+
+Schema: update `pluck` type signature to respect optional fields.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+const schema1 = Schema.Struct({ a: Schema.optional(Schema.String) })
+
+/*
+const schema2: Schema.Schema<string | undefined, {
+    readonly a: string | undefined;
+}, never>
+*/
+const schema2 = Schema.pluck(schema1, "a")
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+const schema1 = Schema.Struct({ a: Schema.optional(Schema.String) })
+
+/*
+const schema2: Schema.Schema<string | undefined, {
+    readonly a?: string | undefined;
+}, never>
+*/
+const schema2 = Schema.pluck(schema1, "a")
+```

--- a/packages/effect/dtslint/Schema.ts
+++ b/packages/effect/dtslint/Schema.ts
@@ -1821,7 +1821,7 @@ S.propertySignature(S.String).annotations({})
 S.optional(S.String).annotations({})
 
 // ---------------------------------------------
-// Pluck
+// pluck
 // ---------------------------------------------
 
 // @ts-expect-error
@@ -1832,6 +1832,18 @@ S.pluck(S.Struct({ a: S.String, b: S.Number }), "a")
 
 // $ExpectType Schema<string, { readonly a: string; }, never>
 pipe(S.Struct({ a: S.String, b: S.Number }), S.pluck("a"))
+
+// $ExpectType Schema<string | undefined, { readonly a?: string | undefined; }, never>
+S.pluck(S.Struct({ a: S.optional(S.String), b: S.Number }), "a")
+
+// $ExpectType Schema<string | undefined, { readonly a?: string | undefined; }, never>
+pipe(S.Struct({ a: S.optional(S.String), b: S.Number }), S.pluck("a"))
+
+// $ExpectType Schema<string | undefined, { readonly a?: string; }, never>
+S.pluck(S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number }), "a")
+
+// $ExpectType Schema<string | undefined, { readonly a?: string; }, never>
+pipe(S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number }), S.pluck("a"))
 
 // ---------------------------------------------
 // Head

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2919,11 +2919,11 @@ export const omit = <A, I, Keys extends ReadonlyArray<keyof A & keyof I>>(...key
 export const pluck: {
   <A, I, K extends keyof A & keyof I>(
     key: K
-  ): <R>(schema: Schema<A, I, R>) => Schema<A[K], { readonly [P in K]: I[P] }, R>
+  ): <R>(schema: Schema<A, I, R>) => Schema<A[K], Simplify<Pick<I, K>>, R>
   <A, I, R, K extends keyof A & keyof I>(
     schema: Schema<A, I, R>,
     key: K
-  ): Schema<A[K], { readonly [P in K]: I[P] }, R>
+  ): Schema<A[K], Simplify<Pick<I, K>>, R>
 } = dual(
   2,
   <A, I, R, K extends keyof A & keyof I>(

--- a/packages/effect/test/Schema/Schema/pluck.test.ts
+++ b/packages/effect/test/Schema/Schema/pluck.test.ts
@@ -94,17 +94,17 @@ describe("pluck", () => {
     })
   })
 
-  it.todo("struct with optional key", async () => {
+  it("struct with optional key", async () => {
     const origin = S.Struct({ a: S.optional(S.String) })
     const schema = S.pluck(origin, "a")
     await Util.assertions.encoding.succeed(schema, undefined, { a: undefined })
     await Util.assertions.encoding.succeed(schema, "a", { a: "a" })
   })
 
-  it.todo("struct with exact optional key", async () => {
+  it("struct with exact optional key", async () => {
     const origin = S.Struct({ a: S.optionalWith(S.String, { exact: true }) })
     const schema = S.pluck(origin, "a")
-    await Util.assertions.encoding.succeed(schema, undefined, { a: undefined })
+    await Util.assertions.encoding.succeed(schema, undefined, {})
     await Util.assertions.encoding.succeed(schema, "a", { a: "a" })
   })
 })


### PR DESCRIPTION
**Before**

```ts
import { Schema } from "effect"

const schema1 = Schema.Struct({ a: Schema.optional(Schema.String) })

/*
const schema2: Schema.Schema<string | undefined, {
    readonly a: string | undefined;
}, never>
*/
const schema2 = Schema.pluck(schema1, "a")
```

**After**

```ts
import { Schema } from "effect"

const schema1 = Schema.Struct({ a: Schema.optional(Schema.String) })

/*
const schema2: Schema.Schema<string | undefined, {
    readonly a?: string | undefined;
}, never>
*/
const schema2 = Schema.pluck(schema1, "a")
```
