### PR TITLE
Add hashmap tovalues

### DIFF
--- a/.changeset/three-bees-attack.md
+++ b/.changeset/three-bees-attack.md
@@ -1,5 +1,5 @@
 ---
-"effect": major
+"effect": minor
 ---
 
 Add HashMap.toValues getter

--- a/.changeset/three-bees-attack.md
+++ b/.changeset/three-bees-attack.md
@@ -1,0 +1,5 @@
+---
+"effect": major
+---
+
+Add HashMap.toValues getter

--- a/packages/effect/src/HashMap.ts
+++ b/packages/effect/src/HashMap.ts
@@ -230,6 +230,14 @@ export const keySet: <K, V>(self: HashMap<K, V>) => HashSet<K> = keySet_.keySet
 export const values: <K, V>(self: HashMap<K, V>) => IterableIterator<V> = HM.values
 
 /**
+ * Returns an `Array` of the values within the `HashMap`.
+ *
+ * @since 3.13.0
+ * @category getters
+ */
+export const toValues = <K, V>(self: HashMap<K, V>): Array<V> => Array.from(values(self))
+
+/**
  * Returns an `IterableIterator` of the entries within the `HashMap`.
  *
  * @since 2.0.0

--- a/packages/effect/src/internal/keyedPool.ts
+++ b/packages/effect/src/internal/keyedPool.ts
@@ -174,7 +174,7 @@ const makeImpl = <K, A, E, R>(
           }
         })
       const activePools: Effect.Effect<Array<Pool.Pool<A, E>>> = core.suspend(() =>
-        core.forEachSequential(Array.from(HashMap.values(MutableRef.get(map))), (value) => {
+        core.forEachSequential(HashMap.toValues(MutableRef.get(map)), (value) => {
           switch (value._tag) {
             case "Complete": {
               return core.succeed(value.pool)

--- a/packages/effect/test/HashMap.test.ts
+++ b/packages/effect/test/HashMap.test.ts
@@ -395,6 +395,13 @@ describe("HashMap", () => {
     deepStrictEqual(result, [value("a"), value("b")])
   })
 
+  it("toValues", () => {
+    const map = HM.make([key(0), value("a")], [key(1), value("b")])
+    const result = HM.toValues(map)
+
+    deepStrictEqual(result, [value("a"), value("b")])
+  })
+
   it("entries", () => {
     const map = HM.make([key(0), value("a")], [key(1), value("b")])
     const result = Array.from(HM.entries(map))

--- a/packages/effect/test/utils/cache/WatchableLookup.ts
+++ b/packages/effect/test/utils/cache/WatchableLookup.ts
@@ -101,7 +101,7 @@ export const makeEffect = <Key, Value, Error = never>(
       const assertAllCleaned = () =>
         Effect.flatMap(createdResources(), (resources) =>
           resourcesCleaned(
-            Chunk.flatten(Chunk.unsafeFromArray(Array.from(HashMap.values(resources))))
+            Chunk.flatten(Chunk.unsafeFromArray(HashMap.toValues(resources)))
           ))
       const assertAllCleanedForKey = (key: Key) =>
         Effect.flatMap(createdResources(), (resources) =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds `HashMap.toValues()` that returns the values of a HashMap as an array instead of as an iterator like is the case for `HashMap.values()`

I took inspiration from `entries` vs `toEntries` for the naming. I don't know if there's another convention for this.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
