### PR TITLE
Schema: Add Support for Infinity in Duration

### DIFF
--- a/.changeset/cyan-ravens-grab.md
+++ b/.changeset/cyan-ravens-grab.md
@@ -1,0 +1,68 @@
+---
+"effect": patch
+---
+
+Schema: Enhance error messages for discriminated unions.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Union(
+  Schema.Tuple(Schema.Literal(-1), Schema.Literal(0)).annotations({
+    identifier: "A"
+  }),
+  Schema.Tuple(Schema.NonNegativeInt, Schema.NonNegativeInt).annotations({
+    identifier: "B"
+  })
+).annotations({ identifier: "AB" })
+
+Schema.decodeUnknownSync(schema)([-500, 0])
+/*
+throws:
+ParseError: AB
+├─ { readonly 0: -1 }
+│  └─ ["0"]
+│     └─ Expected -1, actual -500
+└─ B
+   └─ [0]
+      └─ NonNegativeInt
+         └─ From side refinement failure
+            └─ NonNegative
+               └─ Predicate refinement failure
+                  └─ Expected a non-negative number, actual -500
+*/
+```
+
+**After**
+
+```diff
+import { Schema } from "effect"
+
+const schema = Schema.Union(
+  Schema.Tuple(Schema.Literal(-1), Schema.Literal(0)).annotations({
+    identifier: "A"
+  }),
+  Schema.Tuple(Schema.NonNegativeInt, Schema.NonNegativeInt).annotations({
+    identifier: "B"
+  })
+).annotations({ identifier: "AB" })
+
+Schema.decodeUnknownSync(schema)([-500, 0])
+/*
+throws:
+ParseError: AB
+-├─ { readonly 0: -1 }
++├─ A
+│  └─ ["0"]
+│     └─ Expected -1, actual -500
+└─ B
+   └─ [0]
+      └─ NonNegativeInt
+         └─ From side refinement failure
+            └─ NonNegative
+               └─ Predicate refinement failure
+                  └─ Expected a non-negative number, actual -500
+*/
+```

--- a/.changeset/tough-tables-heal.md
+++ b/.changeset/tough-tables-heal.md
@@ -1,0 +1,38 @@
+---
+"effect": patch
+---
+
+Schema: Add Support for Infinity in `Duration`.
+
+This update adds support for encoding `Duration.infinity` in `Schema.Duration`.
+
+**Before**
+
+Attempting to encode `Duration.infinity` resulted in a `ParseError` due to the lack of support for `Infinity` in `Schema.Duration`:
+
+```ts
+import { Duration, Schema } from "effect"
+
+console.log(Schema.encodeUnknownSync(Schema.Duration)(Duration.infinity))
+/*
+throws:
+ParseError: Duration
+└─ Encoded side transformation failure
+   └─ HRTime
+      └─ [0]
+         └─ NonNegativeInt
+            └─ Predicate refinement failure
+               └─ Expected an integer, actual Infinity
+*/
+```
+
+**After**
+
+The updated behavior successfully encodes `Duration.infinity` as `[ -1, 0 ]`:
+
+```ts
+import { Duration, Schema } from "effect"
+
+console.log(Schema.encodeUnknownSync(Schema.Duration)(Duration.infinity))
+// Output: [ -1, 0 ]
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5726,6 +5726,11 @@ const FiniteHRTime = Tuple(
 
 const InfiniteHRTime = Tuple(Literal(-1), Literal(0)).annotations({ identifier: "InfiniteHRTime" })
 
+const HRTime: Schema<readonly [seconds: number, nanos: number]> = Union(FiniteHRTime, InfiniteHRTime).annotations({
+  identifier: "HRTime",
+  description: "a tuple of seconds and nanos to be decoded into a Duration"
+})
+
 /**
  * A schema that transforms a `[number, number]` tuple into a `Duration`.
  *
@@ -5735,10 +5740,7 @@ const InfiniteHRTime = Tuple(Literal(-1), Literal(0)).annotations({ identifier: 
  * @since 3.10.0
  */
 export class Duration extends transform(
-  Union(FiniteHRTime, InfiniteHRTime).annotations({
-    identifier: "HRTime",
-    description: "a tuple of seconds and nanos to be decoded into a Duration"
-  }),
+  HRTime,
   DurationFromSelf,
   {
     strict: true,

--- a/packages/effect/test/Schema/ParseResult.test.ts
+++ b/packages/effect/test/Schema/ParseResult.test.ts
@@ -331,7 +331,8 @@ describe("ParseIssue.actual", () => {
     it("primitive + primitive", () => {
       expect(P.getSearchTree([S.String.ast, S.Number.ast], true)).toEqual({
         keys: {},
-        otherwise: [S.String.ast, S.Number.ast]
+        otherwise: [S.String.ast, S.Number.ast],
+        candidates: []
       })
     })
 
@@ -344,10 +345,12 @@ describe("ParseIssue.actual", () => {
               buckets: {
                 a: [a.ast]
               },
-              literals: [new AST.Literal("a")]
+              literals: [new AST.Literal("a")],
+              candidates: [a.ast]
             }
           },
-          otherwise: [S.Number.ast]
+          otherwise: [S.Number.ast],
+          candidates: [a.ast]
         }
       )
     })
@@ -362,10 +365,12 @@ describe("ParseIssue.actual", () => {
               a: [a.ast],
               b: [b.ast]
             },
-            literals: [new AST.Literal("a"), new AST.Literal("b")]
+            literals: [new AST.Literal("a"), new AST.Literal("b")],
+            candidates: [a.ast, b.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [a.ast, b.ast]
       })
     })
 
@@ -380,16 +385,19 @@ describe("ParseIssue.actual", () => {
             buckets: {
               A: [A.ast]
             },
-            literals: [new AST.Literal("A")]
+            literals: [new AST.Literal("A")],
+            candidates: [A.ast]
           },
           b: {
             buckets: {
               B: [B.ast]
             },
-            literals: [new AST.Literal("B")]
+            literals: [new AST.Literal("B")],
+            candidates: [B.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [A.ast, B.ast]
       })
     })
 
@@ -404,16 +412,19 @@ describe("ParseIssue.actual", () => {
             buckets: {
               A: [A.ast]
             },
-            literals: [new AST.Literal("A")]
+            literals: [new AST.Literal("A")],
+            candidates: [A.ast]
           },
           _tag2: {
             buckets: {
               A2: [B.ast]
             },
-            literals: [new AST.Literal("A2")]
+            literals: [new AST.Literal("A2")],
+            candidates: [B.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [A.ast, B.ast]
       })
     })
 
@@ -429,10 +440,12 @@ describe("ParseIssue.actual", () => {
               a: [a.ast],
               b: [b.ast]
             },
-            literals: [new AST.Literal("a"), new AST.Literal("b")]
+            literals: [new AST.Literal("a"), new AST.Literal("b")],
+            candidates: [a.ast, b.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [a.ast, b.ast]
       })
     })
 
@@ -447,16 +460,19 @@ describe("ParseIssue.actual", () => {
             buckets: {
               a: [a.ast]
             },
-            literals: [new AST.Literal("a")]
+            literals: [new AST.Literal("a")],
+            candidates: [a.ast]
           },
           1: {
             buckets: {
               b: [b.ast]
             },
-            literals: [new AST.Literal("b")]
+            literals: [new AST.Literal("b")],
+            candidates: [b.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [a.ast, b.ast]
       })
     })
 
@@ -471,16 +487,19 @@ describe("ParseIssue.actual", () => {
             buckets: {
               a: [a.ast]
             },
-            literals: [new AST.Literal("a")]
+            literals: [new AST.Literal("a")],
+            candidates: [a.ast]
           },
           1: {
             buckets: {
               c: [b.ast]
             },
-            literals: [new AST.Literal("c")]
+            literals: [new AST.Literal("c")],
+            candidates: [b.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [a.ast, b.ast]
       })
     })
 
@@ -500,27 +519,34 @@ describe("ParseIssue.actual", () => {
             buckets: {
               catA: [a.ast]
             },
-            literals: [new AST.Literal("catA")]
+            literals: [new AST.Literal("catA")],
+            candidates: [a.ast]
           },
           tag: {
             buckets: {
               b: [b.ast],
               c: [c.ast]
             },
-            literals: [new AST.Literal("b"), new AST.Literal("c")]
+            literals: [new AST.Literal("b"), new AST.Literal("c")],
+            candidates: [b.ast, c.ast]
           }
         },
-        otherwise: []
+        otherwise: [],
+        candidates: [a.ast, b.ast, c.ast]
       })
     })
 
     it("big union", () => {
+      const a = S.Struct({ type: S.Literal("a"), value: S.String })
+      const b = S.Struct({ type: S.Literal("b"), value: S.String })
+      const c = S.Struct({ type: S.Literal("c"), value: S.String })
+      const n = S.Struct({ type: S.Literal(null), value: S.String })
       const schema = S.Union(
-        S.Struct({ type: S.Literal("a"), value: S.String }),
-        S.Struct({ type: S.Literal("b"), value: S.String }),
-        S.Struct({ type: S.Literal("c"), value: S.String }),
+        a,
+        b,
+        c,
         S.Struct({ type: S.String, value: S.String }),
-        S.Struct({ type: S.Literal(null), value: S.String }),
+        n,
         S.Struct({ type: S.Undefined, value: S.String }),
         S.Struct({ type: S.Literal("d", "e"), value: S.String }),
         S.Struct({ type: S.Struct({ nested: S.String }), value: S.String }),
@@ -531,17 +557,18 @@ describe("ParseIssue.actual", () => {
         keys: {
           type: {
             buckets: {
-              a: [S.Struct({ type: S.Literal("a"), value: S.String }).ast],
-              b: [S.Struct({ type: S.Literal("b"), value: S.String }).ast],
-              c: [S.Struct({ type: S.Literal("c"), value: S.String }).ast],
-              null: [S.Struct({ type: S.Literal(null), value: S.String }).ast]
+              a: [a.ast],
+              b: [b.ast],
+              c: [c.ast],
+              null: [n.ast]
             },
             literals: [
               new AST.Literal("a"),
               new AST.Literal("b"),
               new AST.Literal("c"),
               new AST.Literal(null)
-            ]
+            ],
+            candidates: [a.ast, b.ast, c.ast, n.ast]
           }
         },
         otherwise: [
@@ -550,6 +577,12 @@ describe("ParseIssue.actual", () => {
           S.Struct({ type: S.Literal("d", "e"), value: S.String }).ast,
           S.Struct({ type: S.Struct({ nested: S.String }), value: S.String }).ast,
           S.Struct({ type: S.Array(S.Number), value: S.String }).ast
+        ],
+        candidates: [
+          a.ast,
+          b.ast,
+          c.ast,
+          n.ast
         ]
       })
     })
@@ -565,7 +598,8 @@ describe("ParseIssue.actual", () => {
       const types = (schema.ast as AST.Union).types
       expect(P.getSearchTree(types, true)).toEqual({
         keys: {},
-        otherwise: [ab.ast, AB.ast]
+        otherwise: [ab.ast, AB.ast],
+        candidates: []
       })
     })
   })

--- a/packages/effect/test/Schema/Schema/Duration/Duration.test.ts
+++ b/packages/effect/test/Schema/Schema/Duration/Duration.test.ts
@@ -11,6 +11,7 @@ describe("Duration", () => {
   })
 
   it("decoding", async () => {
+    await Util.assertions.decoding.succeed(schema, [-1, 0], Duration.infinity)
     await Util.assertions.decoding.succeed(schema, [555, 123456789], Duration.nanos(555123456789n))
     await Util.assertions.decoding.fail(
       schema,
@@ -18,12 +19,16 @@ describe("Duration", () => {
       `Duration
 └─ Encoded side transformation failure
    └─ HRTime
-      └─ [0]
-         └─ NonNegativeInt
-            └─ From side refinement failure
-               └─ NonNegative
-                  └─ Predicate refinement failure
-                     └─ Expected a non-negative number, actual -500`
+      ├─ InfiniteHRTime
+      │  └─ ["0"]
+      │     └─ Expected -1, actual -500
+      └─ FiniteHRTime
+         └─ [0]
+            └─ NonNegativeInt
+               └─ From side refinement failure
+                  └─ NonNegative
+                     └─ Predicate refinement failure
+                        └─ Expected a non-negative number, actual -500`
     )
     await Util.assertions.decoding.fail(
       schema,
@@ -31,30 +36,39 @@ describe("Duration", () => {
       `Duration
 └─ Encoded side transformation failure
    └─ HRTime
-      └─ [1]
-         └─ NonNegativeInt
-            └─ From side refinement failure
-               └─ NonNegative
-                  └─ Predicate refinement failure
-                     └─ Expected a non-negative number, actual -123`
+      ├─ InfiniteHRTime
+      │  └─ ["0"]
+      │     └─ Expected -1, actual 0
+      └─ FiniteHRTime
+         └─ [1]
+            └─ NonNegativeInt
+               └─ From side refinement failure
+                  └─ NonNegative
+                     └─ Predicate refinement failure
+                        └─ Expected a non-negative number, actual -123`
     )
     await Util.assertions.decoding.fail(
       schema,
       123,
       `Duration
 └─ Encoded side transformation failure
-   └─ Expected HRTime, actual 123`
+   └─ HRTime
+      ├─ Expected InfiniteHRTime, actual 123
+      └─ Expected FiniteHRTime, actual 123`
     )
     await Util.assertions.decoding.fail(
       schema,
       123n,
       `Duration
 └─ Encoded side transformation failure
-   └─ Expected HRTime, actual 123n`
+   └─ HRTime
+      ├─ Expected InfiniteHRTime, actual 123n
+      └─ Expected FiniteHRTime, actual 123n`
     )
   })
 
   it("encoding", async () => {
+    await Util.assertions.encoding.succeed(schema, Duration.infinity, [-1, 0])
     await Util.assertions.encoding.succeed(schema, Duration.seconds(5), [5, 0])
     await Util.assertions.encoding.succeed(schema, Duration.millis(123456789), [123456, 789000000])
     await Util.assertions.encoding.succeed(schema, Duration.nanos(555123456789n), [555, 123456789])

--- a/packages/effect/test/Schema/Schema/Duration/DurationFromMillis.test.ts
+++ b/packages/effect/test/Schema/Schema/Duration/DurationFromMillis.test.ts
@@ -11,12 +11,14 @@ describe("DurationFromMillis", () => {
   })
 
   it("decoding", async () => {
+    await Util.assertions.decoding.succeed(schema, Infinity, Duration.infinity)
     await Util.assertions.decoding.succeed(schema, 0, Duration.millis(0))
     await Util.assertions.decoding.succeed(schema, 1000, Duration.seconds(1))
     await Util.assertions.decoding.succeed(schema, 60 * 1000, Duration.minutes(1))
   })
 
   it("encoding", async () => {
+    await Util.assertions.encoding.succeed(schema, Duration.infinity, Infinity)
     await Util.assertions.encoding.succeed(schema, Duration.seconds(5), 5000)
     await Util.assertions.encoding.succeed(schema, Duration.millis(5000), 5000)
     await Util.assertions.encoding.succeed(schema, Duration.nanos(5000n), 0.005)

--- a/packages/effect/test/Schema/Schema/Union/Union.test.ts
+++ b/packages/effect/test/Schema/Schema/Union/Union.test.ts
@@ -4,7 +4,7 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { describe, expect, it } from "vitest"
 
 describe("Union", () => {
-  it("annotations()", () => {
+  it("should allow annotations to be applied", () => {
     const schema = S.Union(S.String, S.Number).annotations({ identifier: "X" }).annotations({ title: "Y" })
     expect(schema.ast.annotations).toStrictEqual({
       [AST.IdentifierAnnotationId]: "X",
@@ -12,254 +12,296 @@ describe("Union", () => {
     })
   })
 
-  it("should expose the members", () => {
+  it("should expose the union members", () => {
     const schema = S.Union(S.String, S.Number)
     expect(schema.members).toStrictEqual([S.String, S.Number])
   })
 
+  it("should return a `Never` schema when no members are provided", async () => {
+    const schema = S.Union()
+    await Util.assertions.decoding.fail(schema, 1, "Expected never, actual 1")
+  })
+
   describe("decoding", () => {
-    it("should use identifier annotations to generate a more informative error message when an incorrect data type is provided", async () => {
+    it("should use identifier annotations to generate informative error messages", async () => {
       const schema = S.Union(
-        S.Struct({ a: S.String }).annotations({ identifier: "MyDataType1" }),
-        S.Struct({ a: S.String }).annotations({ identifier: "MyDataType2" })
+        S.Struct({ a: S.String }).annotations({ identifier: "ID1" }),
+        S.Struct({ a: S.String }).annotations({ identifier: "ID2" })
       )
       await Util.assertions.decoding.fail(
         schema,
         null,
-        `MyDataType1 | MyDataType2
-├─ Expected MyDataType1, actual null
-└─ Expected MyDataType2, actual null`
+        `ID1 | ID2
+├─ Expected ID1, actual null
+└─ Expected ID2, actual null`
       )
     })
 
-    it("empty union", async () => {
-      const schema = S.Union()
-      await Util.assertions.decoding.fail(schema, 1, "Expected never, actual 1")
-    })
-
-    it("discriminated structs", async () => {
-      const schema = S.Union(
-        S.Struct({ a: S.Literal(1), c: S.String }),
-        S.Struct({ b: S.Literal(2), d: S.Number })
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        null,
-        `Expected { readonly a: 1; readonly c: string } | { readonly b: 2; readonly d: number }, actual null`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        {},
-        `{ readonly a: 1; readonly c: string } | { readonly b: 2; readonly d: number }
-├─ { readonly a: 1 }
+    describe("discriminated unions", () => {
+      describe("structs", () => {
+        it("should handle discriminators for each struct", async () => {
+          const schema = S.Union(
+            S.Struct({ a: S.Literal(1), c: S.String }).annotations({ identifier: "ID1" }),
+            S.Struct({ b: S.Literal(2), d: S.Number }).annotations({ identifier: "ID2" })
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            null,
+            `Expected ID1 | ID2, actual null`
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            {},
+            `ID1 | ID2
+├─ ID1
 │  └─ ["a"]
 │     └─ is missing
-└─ { readonly b: 2 }
+└─ ID2
    └─ ["b"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        { a: null },
-        `{ readonly a: 1; readonly c: string } | { readonly b: 2; readonly d: number }
-├─ { readonly a: 1 }
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            { a: null },
+            `ID1 | ID2
+├─ ID1
 │  └─ ["a"]
 │     └─ Expected 1, actual null
-└─ { readonly b: 2 }
+└─ ID2
    └─ ["b"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        { b: 3 },
-        `{ readonly a: 1; readonly c: string } | { readonly b: 2; readonly d: number }
-├─ { readonly a: 1 }
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            { b: 3 },
+            `ID1 | ID2
+├─ ID1
 │  └─ ["a"]
 │     └─ is missing
-└─ { readonly b: 2 }
+└─ ID2
    └─ ["b"]
       └─ Expected 2, actual 3`
-      )
-    })
+          )
+        })
 
-    it("discriminated structs with multiple tags", async () => {
-      const schema = S.Union(
-        S.Struct({ category: S.Literal("catA"), tag: S.Literal("a") }),
-        S.Struct({ category: S.Literal("catA"), tag: S.Literal("b") }),
-        S.Struct({ category: S.Literal("catA"), tag: S.Literal("c") })
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        null,
-        `Expected { readonly category: "catA"; readonly tag: "a" } | { readonly category: "catA"; readonly tag: "b" } | { readonly category: "catA"; readonly tag: "c" }, actual null`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        {},
-        `{ readonly category: "catA"; readonly tag: "a" } | { readonly category: "catA"; readonly tag: "b" } | { readonly category: "catA"; readonly tag: "c" }
-├─ { readonly category: "catA" }
+        it("should handle structs with multiple discriminators", async () => {
+          const schema = S.Union(
+            S.Struct({ category: S.Literal("catA"), tag: S.Literal("a") }).annotations({ identifier: "IDa" }),
+            S.Struct({ category: S.Literal("catA"), tag: S.Literal("b") }).annotations({ identifier: "IDb" }),
+            S.Struct({ category: S.Literal("catA"), tag: S.Literal("c") }).annotations({ identifier: "IDc" })
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            null,
+            `Expected IDa | IDb | IDc, actual null`
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            {},
+            `IDa | IDb | IDc
+├─ IDa
 │  └─ ["category"]
 │     └─ is missing
-└─ { readonly tag: "b" | "c" }
+└─ IDb | IDc
    └─ ["tag"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        { category: null },
-        `{ readonly category: "catA"; readonly tag: "a" } | { readonly category: "catA"; readonly tag: "b" } | { readonly category: "catA"; readonly tag: "c" }
-├─ { readonly category: "catA" }
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            { category: null },
+            `IDa | IDb | IDc
+├─ IDa
 │  └─ ["category"]
 │     └─ Expected "catA", actual null
-└─ { readonly tag: "b" | "c" }
+└─ IDb | IDc
    └─ ["tag"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        { tag: "d" },
-        `{ readonly category: "catA"; readonly tag: "a" } | { readonly category: "catA"; readonly tag: "b" } | { readonly category: "catA"; readonly tag: "c" }
-├─ { readonly category: "catA" }
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            { tag: "d" },
+            `IDa | IDb | IDc
+├─ IDa
 │  └─ ["category"]
 │     └─ is missing
-└─ { readonly tag: "b" | "c" }
+└─ IDb | IDc
    └─ ["tag"]
       └─ Expected "b" | "c", actual "d"`
-      )
-    })
+          )
+        })
 
-    it("nested unions", async () => {
-      const a = S.Struct({ _tag: S.Literal("a") }).annotations({ identifier: "a" })
-      const b = S.Struct({ _tag: S.Literal("b") }).annotations({ identifier: "b" })
-      const A = S.Struct({ a: S.Literal("A"), c: S.String }).annotations({ identifier: "A" })
-      const B = S.Struct({ b: S.Literal("B"), d: S.Number }).annotations({ identifier: "B" })
-      const ab = S.Union(a, b).annotations({ identifier: "ab" })
-      const AB = S.Union(A, B).annotations({ identifier: "AB" })
-      const schema = S.Union(ab, AB)
-      await Util.assertions.decoding.succeed(schema, { _tag: "a" })
-      await Util.assertions.decoding.succeed(schema, { _tag: "b" })
-      await Util.assertions.decoding.succeed(schema, { a: "A", c: "c" })
-      await Util.assertions.decoding.succeed(schema, { b: "B", d: 1 })
-      await Util.assertions.decoding.fail(
-        schema,
-        {},
-        `ab | AB
-├─ ab
+        it("should handle nested unions", async () => {
+          const a = S.Struct({ _tag: S.Literal("a") }).annotations({ identifier: "IDa" })
+          const b = S.Struct({ _tag: S.Literal("b") }).annotations({ identifier: "IDb" })
+          const A = S.Struct({ a: S.Literal("A"), c: S.String }).annotations({ identifier: "IDA" })
+          const B = S.Struct({ b: S.Literal("B"), d: S.Number }).annotations({ identifier: "IDB" })
+          const ab = S.Union(a, b).annotations({ identifier: "IDab" })
+          const AB = S.Union(A, B).annotations({ identifier: "IDAB" })
+          const schema = S.Union(ab, AB)
+          await Util.assertions.decoding.succeed(schema, { _tag: "a" })
+          await Util.assertions.decoding.succeed(schema, { _tag: "b" })
+          await Util.assertions.decoding.succeed(schema, { a: "A", c: "c" })
+          await Util.assertions.decoding.succeed(schema, { b: "B", d: 1 })
+          await Util.assertions.decoding.fail(
+            schema,
+            {},
+            `IDab | IDAB
+├─ IDab
 │  └─ { readonly _tag: "a" | "b" }
 │     └─ ["_tag"]
 │        └─ is missing
-└─ AB
-   ├─ { readonly a: "A" }
+└─ IDAB
+   ├─ IDA
    │  └─ ["a"]
    │     └─ is missing
-   └─ { readonly b: "B" }
+   └─ IDB
       └─ ["b"]
          └─ is missing`
-      )
-    })
+          )
+        })
+      })
 
-    it("discriminated tuples", async () => {
-      const schema = S.Union(
-        S.Tuple(S.Literal("a"), S.String),
-        S.Tuple(S.Literal("b"), S.Number)
-      ).annotations({ identifier: "MyUnion" })
+      describe("tuples", () => {
+        it("should handle discriminators for each tuple", async () => {
+          const schema = S.Union(
+            S.Tuple(S.Literal("a"), S.String),
+            S.Tuple(S.Literal("b"), S.Number)
+          ).annotations({ identifier: "ID" })
 
-      await Util.assertions.decoding.succeed(schema, ["a", "s"])
-      await Util.assertions.decoding.succeed(schema, ["b", 1])
+          await Util.assertions.decoding.succeed(schema, ["a", "s"])
+          await Util.assertions.decoding.succeed(schema, ["b", 1])
 
-      await Util.assertions.decoding.fail(schema, null, `Expected MyUnion, actual null`)
-      await Util.assertions.decoding.fail(
-        schema,
-        [],
-        `MyUnion
+          await Util.assertions.decoding.fail(schema, null, `Expected ID, actual null`)
+          await Util.assertions.decoding.fail(
+            schema,
+            [],
+            `ID
 └─ { readonly 0: "a" | "b" }
    └─ ["0"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        ["c"],
-        `MyUnion
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            ["c"],
+            `ID
 └─ { readonly 0: "a" | "b" }
    └─ ["0"]
       └─ Expected "a" | "b", actual "c"`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        ["a", 0],
-        `MyUnion
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            ["a", 0],
+            `ID
 └─ readonly ["a", string]
    └─ [1]
       └─ Expected string, actual 0`
-      )
-    })
+          )
+        })
 
-    it("discriminated tuples with multiple tags", async () => {
-      const schema = S.Union(
-        S.Tuple(S.Literal("a"), S.Literal("b"), S.String),
-        S.Tuple(S.Literal("a"), S.Literal("c"), S.Number),
-        S.Tuple(S.Literal("a"), S.Literal("d"), S.Boolean)
-      ).annotations({ identifier: "MyUnion" })
+        it("should handle tuples with multiple discriminators", async () => {
+          const schema = S.Union(
+            S.Tuple(S.Literal("catA"), S.Literal("a"), S.String).annotations({ identifier: "IDa" }),
+            S.Tuple(S.Literal("catA"), S.Literal("b"), S.Number).annotations({ identifier: "IDb" }),
+            S.Tuple(S.Literal("catA"), S.Literal("c"), S.Boolean).annotations({ identifier: "IDc" })
+          ).annotations({ identifier: "ID" })
 
-      await Util.assertions.decoding.succeed(schema, ["a", "b", "s"])
-      await Util.assertions.decoding.succeed(schema, ["a", "c", 1])
+          await Util.assertions.decoding.succeed(schema, ["catA", "a", "s"])
+          await Util.assertions.decoding.succeed(schema, ["catA", "b", 1])
+          await Util.assertions.decoding.succeed(schema, ["catA", "c", true])
 
-      await Util.assertions.decoding.fail(schema, null, `Expected MyUnion, actual null`)
-      await Util.assertions.decoding.fail(
-        schema,
-        [],
-        `MyUnion
-├─ { readonly 0: "a" }
+          await Util.assertions.decoding.fail(schema, null, `Expected ID, actual null`)
+          await Util.assertions.decoding.fail(
+            schema,
+            [],
+            `ID
+├─ IDa
 │  └─ ["0"]
 │     └─ is missing
-└─ { readonly 1: "c" | "d" }
+└─ IDb | IDc
    └─ ["1"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        ["c"],
-        `MyUnion
-├─ { readonly 0: "a" }
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            ["catB"],
+            `ID
+├─ IDa
 │  └─ ["0"]
-│     └─ Expected "a", actual "c"
-└─ { readonly 1: "c" | "d" }
+│     └─ Expected "catA", actual "catB"
+└─ IDb | IDc
    └─ ["1"]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        ["a", "c"],
-        `MyUnion
-├─ readonly ["a", "b", string]
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            ["catA", "c"],
+            `ID
+├─ IDa
 │  └─ [2]
 │     └─ is missing
-└─ readonly ["a", "c", number]
+└─ IDc
    └─ [2]
       └─ is missing`
-      )
-      await Util.assertions.decoding.fail(
-        schema,
-        ["a", "b", 0],
-        `MyUnion
-├─ { readonly 1: "c" | "d" }
+          )
+          await Util.assertions.decoding.fail(
+            schema,
+            ["catA", "a", 0],
+            `ID
+├─ IDb | IDc
 │  └─ ["1"]
-│     └─ Expected "c" | "d", actual "b"
-└─ readonly ["a", "b", string]
+│     └─ Expected "b" | "c", actual "a"
+└─ IDa
    └─ [2]
       └─ Expected string, actual 0`
-      )
+          )
+        })
+
+        it("should handle discriminated tuple + tuple", async () => {
+          const schema = S.Union(
+            S.Tuple(S.Literal(-1), S.Literal(0)).annotations({ identifier: "ID1" }),
+            S.Tuple(S.NonNegativeInt, S.NonNegativeInt).annotations({ identifier: "ID2" })
+          ).annotations({ identifier: "ID" })
+
+          await Util.assertions.decoding.fail(
+            schema,
+            null,
+            `ID
+├─ Expected ID1, actual null
+└─ Expected ID2, actual null`
+          )
+        })
+
+        it("should handle 2 discriminated tuples + a tuple", async () => {
+          const schema = S.Union(
+            S.Tuple(S.Literal(-1), S.Literal(0)).annotations({ identifier: "ID1" }),
+            S.Tuple(S.Literal(1), S.Literal(0)).annotations({ identifier: "ID2" }),
+            S.Tuple(S.NonNegativeInt, S.NonNegativeInt).annotations({ identifier: "ID3" })
+          ).annotations({ identifier: "ID" })
+
+          await Util.assertions.decoding.fail(
+            schema,
+            [],
+            `ID
+├─ ID1 | ID2
+│  └─ ["0"]
+│     └─ is missing
+└─ ID3
+   └─ [0]
+      └─ is missing`
+          )
+        })
+      })
     })
   })
 
   describe("encoding", () => {
-    it("union", async () => {
+    it("should encode all members", async () => {
       const schema = S.Union(S.String, Util.NumberFromChar)
       await Util.assertions.encoding.succeed(schema, "a", "a")
       await Util.assertions.encoding.succeed(schema, 1, "1")
     })
 
-    it("union/ exact optional property signatures", async () => {
+    it("should handle members with exact optional property signatures", async () => {
       const ab = S.Struct({ a: S.String, b: S.optionalWith(S.Number, { exact: true }) })
       const ac = S.Struct({ a: S.String, c: S.optionalWith(S.Number, { exact: true }) })
       const schema = S.Union(ab, ac)


### PR DESCRIPTION
## Fix 1

Schema: Add Support for Infinity in `Duration`.

This update adds support for encoding `Duration.infinity` in `Schema.Duration`.

**Before**

Attempting to encode `Duration.infinity` resulted in a `ParseError` due to the lack of support for `Infinity` in `Schema.Duration`:

```ts
import { Duration, Schema } from "effect"

console.log(Schema.encodeUnknownSync(Schema.Duration)(Duration.infinity))
/*
throws:
ParseError: Duration
└─ Encoded side transformation failure
   └─ HRTime
      └─ [0]
         └─ NonNegativeInt
            └─ Predicate refinement failure
               └─ Expected an integer, actual Infinity
*/
```

**After**

The updated behavior successfully encodes `Duration.infinity` as `[ -1, 0 ]`:

```ts
import { Duration, Schema } from "effect"

console.log(Schema.encodeUnknownSync(Schema.Duration)(Duration.infinity))
// Output: [ -1, 0 ]
```


## Fix 2

Schema: Enhance error messages for discriminated unions.

**Before**

```ts
import { Schema } from "effect"

const schema = Schema.Union(
  Schema.Tuple(Schema.Literal(-1), Schema.Literal(0)).annotations({
    identifier: "A"
  }),
  Schema.Tuple(Schema.NonNegativeInt, Schema.NonNegativeInt).annotations({
    identifier: "B"
  })
).annotations({ identifier: "AB" })

Schema.decodeUnknownSync(schema)([-500, 0])
/*
throws:
ParseError: AB
├─ { readonly 0: -1 }
│  └─ ["0"]
│     └─ Expected -1, actual -500
└─ B
   └─ [0]
      └─ NonNegativeInt
         └─ From side refinement failure
            └─ NonNegative
               └─ Predicate refinement failure
                  └─ Expected a non-negative number, actual -500
*/
```

**After**

```diff
import { Schema } from "effect"

const schema = Schema.Union(
  Schema.Tuple(Schema.Literal(-1), Schema.Literal(0)).annotations({
    identifier: "A"
  }),
  Schema.Tuple(Schema.NonNegativeInt, Schema.NonNegativeInt).annotations({
    identifier: "B"
  })
).annotations({ identifier: "AB" })

Schema.decodeUnknownSync(schema)([-500, 0])
/*
throws:
ParseError: AB
-├─ { readonly 0: -1 }
+├─ A
│  └─ ["0"]
│     └─ Expected -1, actual -500
└─ B
   └─ [0]
      └─ NonNegativeInt
         └─ From side refinement failure
            └─ NonNegative
               └─ Predicate refinement failure
                  └─ Expected a non-negative number, actual -500
*/
```
