### PR TITLE
Schema: Enforce Finite Durations in `DurationFromNanos`

### DIFF
--- a/.changeset/metal-jobs-fix.md
+++ b/.changeset/metal-jobs-fix.md
@@ -1,0 +1,18 @@
+---
+"effect": patch
+---
+
+Schema: Enforce Finite Durations in `DurationFromNanos`.
+
+This update ensures that `DurationFromNanos` only accepts finite durations. Previously, the schema did not explicitly enforce this constraint.
+
+A filter has been added to validate that the duration is finite.
+
+```diff
+DurationFromSelf
++.pipe(
++  filter((duration) => duration_.isFinite(duration), {
++    description: "a finite duration"
++  })
+)
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5679,7 +5679,7 @@ export class DurationFromSelf extends declare(
  */
 export class DurationFromNanos extends transformOrFail(
   NonNegativeBigIntFromSelf.annotations({ description: "a bigint to be decoded into a Duration" }),
-  DurationFromSelf,
+  DurationFromSelf.pipe(filter((duration) => duration_.isFinite(duration), { description: "a finite duration" })),
   {
     strict: true,
     decode: (nanos) => ParseResult.succeed(duration_.nanos(nanos)),
@@ -5687,7 +5687,7 @@ export class DurationFromNanos extends transformOrFail(
       option_.match(duration_.toNanos(duration), {
         onNone: () =>
           ParseResult.fail(new ParseResult.Type(ast, duration, `Unable to encode ${duration} into a bigint`)),
-        onSome: (val) => ParseResult.succeed(val)
+        onSome: (nanos) => ParseResult.succeed(nanos)
       })
   }
 ).annotations({ identifier: "DurationFromNanos" }) {}

--- a/packages/effect/test/Schema/Schema/Duration/DurationFromNanos.test.ts
+++ b/packages/effect/test/Schema/Schema/Duration/DurationFromNanos.test.ts
@@ -6,7 +6,7 @@ import { describe, it } from "vitest"
 describe("DurationFromNanos", () => {
   const schema = S.DurationFromNanos
 
-  it.todo("test roundtrip consistency", () => {
+  it("test roundtrip consistency", () => {
     Util.assertions.testRoundtripConsistency(schema)
   })
 
@@ -22,8 +22,10 @@ describe("DurationFromNanos", () => {
       schema,
       Duration.infinity,
       `DurationFromNanos
-└─ Transformation process failure
-   └─ Unable to encode Duration(Infinity) into a bigint`
+└─ Type side transformation failure
+   └─ a finite duration
+      └─ Predicate refinement failure
+         └─ Expected a finite duration, actual Duration(Infinity)`
     )
   })
 })


### PR DESCRIPTION
This update ensures that `DurationFromNanos` only accepts finite durations. Previously, the schema did not explicitly enforce this constraint.

A filter has been added to validate that the duration is finite.

```diff
DurationFromSelf
+.pipe(
+  filter((duration) => duration_.isFinite(duration), {
+    description: "a finite duration"
+  })
)
```
