### PR TITLE
option: make Option.none and Option.some return Some<T> and None<T>

### DIFF
--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -107,7 +107,7 @@ export interface OptionTypeLambda extends TypeLambda {
  * @category constructors
  * @since 2.0.0
  */
-export const none => option.none <A = never>(): None<A>
+export const none = option.none as <A = never>() => None<A>
 
 /**
  * Creates a new `Option` that wraps the given value.

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -107,7 +107,7 @@ export interface OptionTypeLambda extends TypeLambda {
  * @category constructors
  * @since 2.0.0
  */
-export const none = <A = never>(): Option<A> => option.none
+export const none => option.none <A = never>(): None<A>
 
 /**
  * Creates a new `Option` that wraps the given value.
@@ -117,7 +117,7 @@ export const none = <A = never>(): Option<A> => option.none
  * @category constructors
  * @since 2.0.0
  */
-export const some: <A>(value: A) => Option<A> = option.some
+export const some = option.some as <A>(value: A) => Some<A>
 
 /**
  * Checks if a given value is an `Option` value.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
I was trying to use Option in a union where it is expected to be Some in some situations and None in others:

```ts
export interface AnonymousAuthenticationResult {
  readonly kind: 'anonymous';
  readonly user: None<User.User>;
  readonly session: None<Session.Session>;
  readonly workspace: None<Workspace.Workspace>;
}
export interface UserAuthenticationResult {
  readonly kind: 'user';
  readonly user: Some<User.User>;
  readonly session: Some<Session.Session>;
  readonly workspace: Option.Option<Workspace.Workspace>;
}
export interface WorkspaceAuthenticationResult {
  readonly kind: 'workspace';
  readonly user: None<User.User>;
  readonly session: None<Session.Session>;
  readonly workspace: Some<Workspace.Workspace>;
}
export type AuthenticationResult =
  | UserAuthenticationResult
  | WorkspaceAuthenticationResult
  | AnonymousAuthenticationResult;
```

However, since `Option.some` and `Option.none` return `Option<T>`, it becomes non-ergonomic to create these structures, since you have to cast manually to `Some` or `None`

```ts
const authResult: AuthenticationResult = {
  kind: "workspace",
  user: Option.none() as None<User.User>,
  session: Option.none() as None<Session.Session>,
  workspace: Option.some(workspace) as Some<Workspace.Workspace>
};
```

which doesn't make any sense because it is expected that `Option.some` always returns `Some`, and `Option.none` always returns `None`

