### PR TITLE
Cron: `unsafeParse` now throws a more informative error instead of a …

### DIFF
--- a/.changeset/lazy-clouds-grin.md
+++ b/.changeset/lazy-clouds-grin.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Cron: `unsafeParse` now throws a more informative error instead of a generic one

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -7,7 +7,7 @@ import type * as DateTime from "./DateTime.js"
 import * as Either from "./Either.js"
 import * as Equal from "./Equal.js"
 import * as equivalence from "./Equivalence.js"
-import { constVoid, dual, pipe } from "./Function.js"
+import { constVoid, dual, identity, pipe } from "./Function.js"
 import * as Hash from "./Hash.js"
 import { format, type Inspectable, NodeInspectSymbol } from "./Inspectable.js"
 import * as dateTime from "./internal/dateTime.js"
@@ -284,28 +284,45 @@ export const parse = (cron: string, tz?: DateTime.TimeZone | string): Either.Eit
 /**
  * Parses a cron expression into a `Cron` instance.
  *
- * Throws on failure.
+ * **Details**
  *
- * @param cron - The cron expression to parse.
+ * This function takes a cron expression as a string and attempts to parse it
+ * into a `Cron` instance. If the expression is valid, the resulting `Cron`
+ * instance will represent the schedule defined by the cron expression.
+ *
+ * If the expression is invalid, the function throws a `ParseError`.
+ *
+ * You can optionally provide a time zone (`tz`) to interpret the cron
+ * expression in a specific time zone. If no time zone is provided, the cron
+ * expression will use the default time zone.
  *
  * @example
  * ```ts
  * import { Cron } from "effect"
  *
  * // At 04:00 on every day-of-month from 8 through 14.
- * assert.deepStrictEqual(Cron.unsafeParse("0 4 8-14 * *"), Cron.make({
- *   minutes: [0],
- *   hours: [4],
- *   days: [8, 9, 10, 11, 12, 13, 14],
- *   months: [],
- *   weekdays: []
- * }))
+ * console.log(Cron.unsafeParse("0 4 8-14 * *"))
+ * // Output:
+ * // {
+ * //   _id: 'Cron',
+ * //   tz: { _id: 'Option', _tag: 'None' },
+ * //   seconds: [ 0 ],
+ * //   minutes: [ 0 ],
+ * //   hours: [ 4 ],
+ * //   days: [
+ * //      8,  9, 10, 11,
+ * //     12, 13, 14
+ * //   ],
+ * //   months: [],
+ * //   weekdays: []
+ * // }
  * ```
  *
  * @since 2.0.0
  * @category constructors
  */
-export const unsafeParse = (cron: string, tz?: DateTime.TimeZone | string): Cron => Either.getOrThrow(parse(cron, tz))
+export const unsafeParse = (cron: string, tz?: DateTime.TimeZone | string): Cron =>
+  Either.getOrThrowWith(parse(cron, tz), identity)
 
 /**
  * Checks if a given `Date` falls within an active `Cron` time window.

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -5,7 +5,7 @@ import * as Equal from "effect/Equal"
 import { identity } from "effect/Function"
 import * as Option from "effect/Option"
 import { assertFalse, assertTrue, deepStrictEqual } from "effect/test/util"
-import { describe, it } from "vitest"
+import { describe, expect, it } from "vitest"
 
 const parse = (input: string, tz?: DateTime.TimeZone | string) => Either.getOrThrowWith(Cron.parse(input, tz), identity)
 const match = (input: Cron.Cron | string, date: DateTime.DateTime.Input) =>
@@ -48,6 +48,11 @@ describe("Cron", () => {
         weekdays: []
       }))
     )
+  })
+
+  it("unsafeParse", () => {
+    expect(() => Cron.unsafeParse("")).toThrow(new Error("Invalid number of segments in cron expression"))
+    expect(() => Cron.unsafeParse("0 0 4 8-14 * *", "")).toThrow(new Error("Invalid time zone in cron expression"))
   })
 
   it("match", () => {


### PR DESCRIPTION
…generic one