### PR TITLE
Cookies: `unsafeMakeCookie` and `unsafeSetAll` now throw a more infor…

### DIFF
--- a/.changeset/fuzzy-rockets-wash.md
+++ b/.changeset/fuzzy-rockets-wash.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Cookies: `unsafeMakeCookie` and `unsafeSetAll` now throw a more informative error instead of a generic one

--- a/packages/platform/src/Cookies.ts
+++ b/packages/platform/src/Cookies.ts
@@ -3,7 +3,7 @@
  */
 import * as Duration from "effect/Duration"
 import * as Either from "effect/Either"
-import { dual } from "effect/Function"
+import { dual, identity } from "effect/Function"
 import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
 import { type Pipeable, pipeArguments } from "effect/Pipeable"
@@ -368,7 +368,7 @@ export const unsafeMakeCookie = (
   name: string,
   value: string,
   options?: Cookie["options"] | undefined
-): Cookie => Either.getOrThrow(makeCookie(name, value, options))
+): Cookie => Either.getOrThrowWith(makeCookie(name, value, options), identity)
 
 /**
  * Add a cookie to a Cookies object
@@ -579,7 +579,7 @@ export const unsafeSetAll: {
   (
     self: Cookies,
     cookies: Iterable<readonly [name: string, value: string, options?: Cookie["options"]]>
-  ): Cookies => Either.getOrThrow(setAll(self, cookies))
+  ): Cookies => Either.getOrThrowWith(setAll(self, cookies), identity)
 )
 
 /**

--- a/packages/platform/test/Cookies.test.ts
+++ b/packages/platform/test/Cookies.test.ts
@@ -1,0 +1,24 @@
+import * as Cookies from "@effect/platform/Cookies"
+import { describe, expect, it } from "vitest"
+
+describe("Cookies", () => {
+  it("unsafeMakeCookie", () => {
+    expect(() => Cookies.unsafeMakeCookie("", "value")).toThrow(new Error("InvalidName"))
+    expect(() => Cookies.unsafeMakeCookie("name", "value", { domain: "" })).toThrow(new Error("InvalidDomain"))
+    expect(() => Cookies.unsafeMakeCookie("name", "value", { path: "" })).toThrow(new Error("InvalidPath"))
+    expect(() => Cookies.unsafeMakeCookie("name", "value", { maxAge: Infinity })).toThrow(new Error("InfinityMaxAge"))
+  })
+
+  it("unsafeSetAll", () => {
+    expect(() => Cookies.unsafeSetAll(Cookies.empty, [["", "value"]])).toThrow(new Error("InvalidName"))
+    expect(() => Cookies.unsafeSetAll(Cookies.empty, [["name", "value", { domain: "" }]])).toThrow(
+      new Error("InvalidDomain")
+    )
+    expect(() => Cookies.unsafeSetAll(Cookies.empty, [["name", "value", { path: "" }]])).toThrow(
+      new Error("InvalidPath")
+    )
+    expect(() => Cookies.unsafeSetAll(Cookies.empty, [["name", "value", { maxAge: Infinity }]])).toThrow(
+      new Error("InfinityMaxAge")
+    )
+  })
+})


### PR DESCRIPTION
…mative error instead of a generic one