### PR TITLE
Add `Effect.whenLogLevel`

### DIFF
--- a/.changeset/dirty-ways-dress.md
+++ b/.changeset/dirty-ways-dress.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.whenLogLevel`, which conditionally executes an effect if the specified log level is enabled

--- a/.changeset/dirty-ways-dress.md
+++ b/.changeset/dirty-ways-dress.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Add `Effect.whenLogLevel`, which conditionally executes an effect if the specified log level is enabled

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -10904,7 +10904,7 @@ export const withUnhandledErrorLogLevel: {
 export const whenLogLevel: {
   (level: LogLevel): <A, E, R>(self: Effect<A, E, R>) => Effect<Option.Option<A>, E, R>
   <A, E, R>(self: Effect<A, E, R>, level: LogLevel): Effect<Option.Option<A>, E, R>
-} = effect.whenLogLevel;
+} = effect.whenLogLevel
 
 /**
  * Converts an effect's failure into a fiber termination, removing the error

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -10871,6 +10871,42 @@ export const withUnhandledErrorLogLevel: {
 } = core.withUnhandledErrorLogLevel
 
 /**
+ * Conditionally executes an effect based on the specified log level and currently enabled log level.
+ *
+ * **Details**
+ *
+ * This function runs the provided effect only if the specified log level is
+ * enabled. If the log level is enabled, the effect is executed and its result
+ * is wrapped in `Some`. If the log level is not enabled, the effect is not
+ * executed and `None` is returned.
+ *
+ * This function is useful for conditionally executing logging-related effects
+ * or other operations that depend on the current log level configuration.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Logger, LogLevel } from "effect"
+ *
+ * const program = Effect.gen(function* () {
+ *   yield* Effect.whenLogLevel(Effect.logTrace("message1"), LogLevel.Trace); // returns `None`
+ *   yield* Effect.whenLogLevel(Effect.logDebug("message2"), LogLevel.Debug); // returns `Some`
+ * }).pipe(Logger.withMinimumLogLevel(LogLevel.Debug));
+ *
+ * // Effect.runFork(program)
+ * // timestamp=... level=DEBUG fiber=#0 message=message2
+ * ```
+ *
+ * @see {@link FiberRef.minimumLogLevel} to retrieve the current minimum log level.
+ *
+ * @since 3.13.0
+ * @category Logging
+ */
+export const whenLogLevel: {
+  (level: LogLevel): <A, E, R>(self: Effect<A, E, R>) => Effect<Option.Option<A>, E, R>
+  <A, E, R>(self: Effect<A, E, R>, level: LogLevel): Effect<Option.Option<A>, E, R>
+} = effect.whenLogLevel;
+
+/**
  * Converts an effect's failure into a fiber termination, removing the error
  * from the effect's type.
  *

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -39,7 +39,7 @@ import * as runtime_ from "./internal/runtime.js"
 import * as schedule_ from "./internal/schedule.js"
 import * as internalTracer from "./internal/tracer.js"
 import type * as Layer from "./Layer.js"
-import type { LogLevel } from "./LogLevel.js"
+import type * as LogLevel from "./LogLevel.js"
 import type * as ManagedRuntime from "./ManagedRuntime.js"
 import type * as Metric from "./Metric.js"
 import type * as MetricLabel from "./MetricLabel.js"
@@ -10572,7 +10572,7 @@ export const log: (...message: ReadonlyArray<any>) => Effect<void, never, never>
  * @category Logging
  */
 export const logWithLevel = (
-  level: LogLevel,
+  level: LogLevel.LogLevel,
   ...message: ReadonlyArray<any>
 ): Effect<void> => effect.logWithLevel(level)(...message)
 
@@ -10866,8 +10866,8 @@ export const logAnnotations: Effect<HashMap.HashMap<string, unknown>> = effect.l
  * @category Logging
  */
 export const withUnhandledErrorLogLevel: {
-  (level: Option.Option<LogLevel>): <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, R>
-  <A, E, R>(self: Effect<A, E, R>, level: Option.Option<LogLevel>): Effect<A, E, R>
+  (level: Option.Option<LogLevel.LogLevel>): <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, R>
+  <A, E, R>(self: Effect<A, E, R>, level: Option.Option<LogLevel.LogLevel>): Effect<A, E, R>
 } = core.withUnhandledErrorLogLevel
 
 /**
@@ -10902,9 +10902,9 @@ export const withUnhandledErrorLogLevel: {
  * @category Logging
  */
 export const whenLogLevel: {
-  (level: LogLevel): <A, E, R>(self: Effect<A, E, R>) => Effect<Option.Option<A>, E, R>
-  <A, E, R>(self: Effect<A, E, R>, level: LogLevel): Effect<Option.Option<A>, E, R>
-} = effect.whenLogLevel
+  (level: LogLevel.LogLevel | LogLevel.Literal): <A, E, R>(self: Effect<A, E, R>) => Effect<Option.Option<A>, E, R>
+  <A, E, R>(self: Effect<A, E, R>, level: LogLevel.LogLevel | LogLevel.Literal): Effect<Option.Option<A>, E, R>
+} = fiberRuntime.whenLogLevel
 
 /**
  * Converts an effect's failure into a fiber termination, removing the error

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -950,8 +950,13 @@ export const logAnnotations: Effect.Effect<HashMap.HashMap<string, unknown>> = c
 
 /** @internal */
 export const whenLogLevel = dual<
-  (level: LogLevel.LogLevel | LogLevel.Literal) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<Option.Option<A>, E, R>,
-  <A, E, R>(effect: Effect.Effect<A, E, R>, level: LogLevel.LogLevel | LogLevel.Literal) => Effect.Effect<Option.Option<A>, E, R>
+  (
+    level: LogLevel.LogLevel | LogLevel.Literal
+  ) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<Option.Option<A>, E, R>,
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+    level: LogLevel.LogLevel | LogLevel.Literal
+  ) => Effect.Effect<Option.Option<A>, E, R>
 >(2, (effect, level) => {
   const requiredLogLevel = typeof level === "string" ? LogLevel.fromLiteral(level) : level
 

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -35,7 +35,6 @@ import * as core from "./core.js"
 import * as defaultServices from "./defaultServices.js"
 import * as doNotation from "./doNotation.js"
 import * as fiberRefsPatch from "./fiberRefs/patch.js"
-import * as fiberRuntime from "./fiberRuntime.js"
 import type { FiberRuntime } from "./fiberRuntime.js"
 import * as metricLabel from "./metric/label.js"
 import * as runtimeFlags from "./runtimeFlags.js"
@@ -948,30 +947,6 @@ export const logAnnotations: Effect.Effect<HashMap.HashMap<string, unknown>> = c
   .fiberRefGet(
     core.currentLogAnnotations
   )
-
-/** @internal */
-export const whenLogLevel = dual<
-  (
-    level: LogLevel.LogLevel | LogLevel.Literal
-  ) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<Option.Option<A>, E, R>,
-  <A, E, R>(
-    effect: Effect.Effect<A, E, R>,
-    level: LogLevel.LogLevel | LogLevel.Literal
-  ) => Effect.Effect<Option.Option<A>, E, R>
->(2, (effect, level) => {
-  const requiredLogLevel = typeof level === "string" ? LogLevel.fromLiteral(level) : level
-
-  return core.withFiberRuntime((fiberState) => {
-    const minimumLogLevel = fiberState.getFiberRef(fiberRuntime.currentMinimumLogLevel)
-
-    // Imitate the behaviour of `FiberRuntime.log`
-    if (LogLevel.greaterThan(minimumLogLevel, requiredLogLevel)) {
-      return core.succeed(Option.none())
-    }
-
-    return core.map(effect, Option.some)
-  })
-})
 
 /* @internal */
 export const loop: {

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -953,14 +953,14 @@ export const whenLogLevel = dual<
   (level: LogLevel.LogLevel) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<Option.Option<A>, E, R>,
   <A, E, R>(effect: Effect.Effect<A, E, R>, level: LogLevel.LogLevel) => Effect.Effect<Option.Option<A>, E, R>
 >(2, (effect, level) => {
-   return core.withFiberRuntime((fiberState) => {
-     const currentLogLevel = FiberRef.currentMinimumLogLevel.pipe(fiberState.getFiberRef);
+  return core.withFiberRuntime((fiberState) => {
+    const currentLogLevel = FiberRef.currentMinimumLogLevel.pipe(fiberState.getFiberRef)
 
-     const levelEnabled = LogLevel.lessThanEqual(currentLogLevel, level);
+    const levelEnabled = LogLevel.lessThanEqual(currentLogLevel, level)
 
-     return levelEnabled ? core.map(effect, Option.some) : core.succeed(Option.none());
-   })
-});
+    return levelEnabled ? core.map(effect, Option.some) : core.succeed(Option.none())
+  })
+})
 
 /* @internal */
 export const loop: {

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -8,7 +8,7 @@ import type * as Effect from "../Effect.js"
 import type { Exit } from "../Exit.js"
 import type * as Fiber from "../Fiber.js"
 import type * as FiberId from "../FiberId.js"
-import * as FiberRef from "../FiberRef.js"
+import type * as FiberRef from "../FiberRef.js"
 import * as FiberRefs from "../FiberRefs.js"
 import type * as FiberRefsPatch from "../FiberRefsPatch.js"
 import type { LazyArg } from "../Function.js"
@@ -35,6 +35,7 @@ import * as core from "./core.js"
 import * as defaultServices from "./defaultServices.js"
 import * as doNotation from "./doNotation.js"
 import * as fiberRefsPatch from "./fiberRefs/patch.js"
+import * as fiberRuntime from "./fiberRuntime.js"
 import type { FiberRuntime } from "./fiberRuntime.js"
 import * as metricLabel from "./metric/label.js"
 import * as runtimeFlags from "./runtimeFlags.js"
@@ -961,7 +962,7 @@ export const whenLogLevel = dual<
   const requiredLogLevel = typeof level === "string" ? LogLevel.fromLiteral(level) : level
 
   return core.withFiberRuntime((fiberState) => {
-    const minimumLogLevel = fiberState.getFiberRef(FiberRef.currentMinimumLogLevel)
+    const minimumLogLevel = fiberState.getFiberRef(fiberRuntime.currentMinimumLogLevel)
 
     // Imitate the behaviour of `FiberRuntime.log`
     if (LogLevel.greaterThan(minimumLogLevel, requiredLogLevel)) {

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1631,6 +1631,30 @@ export const annotateLogsScoped: {
   )
 }
 
+/** @internal */
+export const whenLogLevel = dual<
+  (
+    level: LogLevel.LogLevel | LogLevel.Literal
+  ) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<Option.Option<A>, E, R>,
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+    level: LogLevel.LogLevel | LogLevel.Literal
+  ) => Effect.Effect<Option.Option<A>, E, R>
+>(2, (effect, level) => {
+  const requiredLogLevel = typeof level === "string" ? LogLevel.fromLiteral(level) : level
+
+  return core.withFiberRuntime((fiberState) => {
+    const minimumLogLevel = fiberState.getFiberRef(currentMinimumLogLevel)
+
+    // Imitate the behaviour of `FiberRuntime.log`
+    if (LogLevel.greaterThan(minimumLogLevel, requiredLogLevel)) {
+      return core.succeed(Option.none())
+    }
+
+    return core.map(effect, Option.some)
+  })
+})
+
 // circular with Effect
 
 /* @internal */


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is the result from the following Discord discussion: https://discord.com/channels/795981131316985866/1332442902629978132, it implements a new function `Effect.whenLogLevel`, for which the specified effect is only executed whenever the log level is enabled.

I am unsure if the return type here is okay, currently it permits the effect to return a value, and wrap the return value in `Option.Option`. The other possibility would be to simply say the return must be (like for `Effect.tap`) to be `void`. I could imagine scenarios in which it could be helpful to get the return value, but also feel like that it could be abused in a sense, 95% of usecases would likely just `yield*` without considering the return value (but one could for example use the return value to determine if other diagnostics should be generated, etc.)

## Related

- Discord discussion: https://discord.com/channels/795981131316985866/1332442902629978132
- Related Rust feature: https://docs.rs/tracing/latest/tracing/macro.enabled.html
