### PR TITLE
Platform: add `sync` (fsync)

### DIFF
--- a/.changeset/spicy-pumas-kneel.md
+++ b/.changeset/spicy-pumas-kneel.md
@@ -1,6 +1,6 @@
 ---
-"@effect/platform-node-shared": minor
-"@effect/platform": minor
+"@effect/platform-node-shared": patch
+"@effect/platform": patch
 ---
 
 Addition of the `sync` function to `FileSystem.FileSystem` and `sync` property to `FileSystem.File` representing the `fsync` syscall.

--- a/.changeset/spicy-pumas-kneel.md
+++ b/.changeset/spicy-pumas-kneel.md
@@ -3,4 +3,4 @@
 "@effect/platform": patch
 ---
 
-Addition of the `sync` function to `FileSystem.FileSystem` and `sync` property to `FileSystem.File` representing the `fsync` syscall.
+Addition of `sync` property to `FileSystem.File` representing the `fsync` syscall.

--- a/.changeset/spicy-pumas-kneel.md
+++ b/.changeset/spicy-pumas-kneel.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node-shared": minor
+"@effect/platform": minor
+---
+
+Addition of the `sync` function to `FileSystem.FileSystem` and `sync` property to `FileSystem.File` representing the `fsync` syscall.

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -210,6 +210,12 @@ const makeFile = (() => {
     handleBadArgument("truncate")
   )
 
+  const nodeSync = effectify(
+    NFS.fsync,
+    handleErrnoException("FileSystem", "sync"),
+    handleBadArgument("sync")
+  )
+
   const nodeWriteFactory = (method: string) =>
     effectify(
       NFS.write,
@@ -234,6 +240,10 @@ const makeFile = (() => {
 
     get stat() {
       return Effect.map(nodeStat(this.fd), makeFileInfo)
+    }
+
+    get sync() {
+      return nodeSync(this.fd)
     }
 
     seek(offset: FileSystem.SizeInput, from: FileSystem.SeekMode) {
@@ -498,6 +508,17 @@ const symlink = (() => {
   return (target: string, path: string) => nodeSymlink(target, path)
 })()
 
+// == sync
+
+const sync = (() => {
+  const nodeSync = effectify(
+    NFS.fsync,
+    handleErrnoException("FileSystem", "sync"),
+    handleBadArgument("sync")
+  )
+  return (fd: FileSystem.File.Descriptor) => nodeSync(fd)
+})()
+
 // == truncate
 
 const truncate = (() => {
@@ -615,6 +636,7 @@ const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend),
     rename,
     stat,
     symlink,
+    sync,
     truncate,
     utimes,
     watch(path) {

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -508,17 +508,6 @@ const symlink = (() => {
   return (target: string, path: string) => nodeSymlink(target, path)
 })()
 
-// == sync
-
-const sync = (() => {
-  const nodeSync = effectify(
-    NFS.fsync,
-    handleErrnoException("FileSystem", "sync"),
-    handleBadArgument("sync")
-  )
-  return (fd: FileSystem.File.Descriptor) => nodeSync(fd)
-})()
-
 // == truncate
 
 const truncate = (() => {
@@ -636,7 +625,6 @@ const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend),
     rename,
     stat,
     symlink,
-    sync,
     truncate,
     utimes,
     watch(path) {

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -214,6 +214,13 @@ export interface FileSystem {
     toPath: string
   ) => Effect.Effect<void, PlatformError>
   /**
+   * Synchronize a file's in-memory state with the on-disk state.
+   * This ensures that all file system updates for the file are written to the storage device.
+   */
+  readonly sync: (
+    fd: File.Descriptor
+  ) => Effect.Effect<void, PlatformError>
+  /**
    * Truncate a file to a specified length. If the `length` is not specified,
    * the file will be truncated to length `0`.
    */
@@ -491,6 +498,7 @@ export interface File {
   readonly fd: File.Descriptor
   readonly stat: Effect.Effect<File.Info, PlatformError>
   readonly seek: (offset: SizeInput, from: SeekMode) => Effect.Effect<void>
+  readonly sync: Effect.Effect<void, PlatformError>
   readonly read: (buffer: Uint8Array) => Effect.Effect<Size, PlatformError>
   readonly readAlloc: (size: SizeInput) => Effect.Effect<Option<Uint8Array>, PlatformError>
   readonly truncate: (length?: SizeInput) => Effect.Effect<void, PlatformError>

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -214,13 +214,6 @@ export interface FileSystem {
     toPath: string
   ) => Effect.Effect<void, PlatformError>
   /**
-   * Synchronize a file's in-memory state with the on-disk state.
-   * This ensures that all file system updates for the file are written to the storage device.
-   */
-  readonly sync: (
-    fd: File.Descriptor
-  ) => Effect.Effect<void, PlatformError>
-  /**
    * Truncate a file to a specified length. If the `length` is not specified,
    * the file will be truncated to length `0`.
    */

--- a/packages/platform/src/internal/fileSystem.ts
+++ b/packages/platform/src/internal/fileSystem.ts
@@ -173,6 +173,9 @@ export const makeNoop = (
     symlink(fromPath) {
       return Effect.fail(notFound("symlink", fromPath))
     },
+    sync(fd) {
+      return Effect.fail(notFound("sync", fd.toString()))
+    },
     truncate(path) {
       return Effect.fail(notFound("truncate", path))
     },

--- a/packages/platform/src/internal/fileSystem.ts
+++ b/packages/platform/src/internal/fileSystem.ts
@@ -173,9 +173,6 @@ export const makeNoop = (
     symlink(fromPath) {
       return Effect.fail(notFound("symlink", fromPath))
     },
-    sync(fd) {
-      return Effect.fail(notFound("sync", fd.toString()))
-    },
     truncate(path) {
       return Effect.fail(notFound("truncate", path))
     },


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Addition of `sync` property to `FileSystem.File` representing the `fsync` syscall.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
