### PR TITLE
Updated zod to schema comparison: added mention of Schema.URL

### DIFF
--- a/schema/comparisons.md
+++ b/schema/comparisons.md
@@ -221,7 +221,7 @@ S.String.pipe(S.maxLength(5))
 S.String.pipe(S.minLength(5))
 S.String.pipe(S.length(5))
 // S.string().email() // No equivalent
-// S.string().url() // No equivalent
+S.URL
 // S.string().emoji() // No equivalent
 S.UUID
 // S.string().nanoid() // No equivalent


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

`schema/comparisons.md` said that there is no alternative in `Effect` to `zod`'s `z.string().url()`, while @KhraksMamtsov added support in #3889