### PR TITLE
Ensure nested configs can be loaded from env file

### DIFF
--- a/.changeset/late-pants-wash.md
+++ b/.changeset/late-pants-wash.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Ensure that nested configuration values can be properly loaded from an env file

--- a/packages/platform/src/internal/platformConfigProvider.ts
+++ b/packages/platform/src/internal/platformConfigProvider.ts
@@ -17,13 +17,17 @@ import * as Layer from "effect/Layer"
 
 /** @internal */
 export const fromDotEnv = (
-  path: string
+  path: string,
+  config?: Partial<ConfigProvider.ConfigProvider.FromMapConfig>
 ): Effect.Effect<ConfigProvider.ConfigProvider, PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function*() {
     const fs = yield* FileSystem.FileSystem
     const content = yield* fs.readFileString(path)
     const obj = parseDotEnv(content)
-    return ConfigProvider.fromJson(obj)
+    return ConfigProvider.fromMap(
+      new Map(Object.entries(obj)),
+      Object.assign({}, { pathDelim: "_", seqDelim: "," }, config)
+    )
   })
 
 /** @internal */

--- a/packages/platform/test/ConfigProvider.test.ts
+++ b/packages/platform/test/ConfigProvider.test.ts
@@ -1,0 +1,28 @@
+import * as FileSystem from "@effect/platform/FileSystem"
+import * as PlatformConfigProvider from "@effect/platform/PlatformConfigProvider"
+import { assert, describe, it } from "@effect/vitest"
+import * as Config from "effect/Config"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+const ConfigProviderLive = Layer.unwrapEffect(
+  PlatformConfigProvider.fromDotEnv(".env").pipe(
+    Effect.map(Layer.setConfigProvider)
+  )
+)
+
+describe("PlatformConfigProvider", () => {
+  it.effect("should properly load configuration values from an env file", () =>
+    Effect.gen(function*() {
+      const fileSystem = FileSystem.layerNoop({
+        readFileString: () => Effect.succeed("NESTED_CONFIG=nested_config")
+      })
+
+      const result = yield* Config.string("CONFIG").pipe(
+        Config.nested("NESTED"),
+        Effect.provide(Layer.provide(ConfigProviderLive, fileSystem))
+      )
+
+      assert.strictEqual(result, "nested_config")
+    }))
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Prior to this change, `ConfigProvider.json` would treat all nested configuration values as separated by nothing. However, in an `env` file a path and sequence delimiter may exist.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
