### PR TITLE
Make it easy to convert a DateTime.Zoned to a DateTime.Utc

### DIFF
--- a/.changeset/sixty-mice-occur.md
+++ b/.changeset/sixty-mice-occur.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Make it easy to convert a DateTime.Zoned to a DateTime.Utc

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -438,6 +438,23 @@ export const unsafeNow: LazyArg<Utc> = Internal.unsafeNow
 // =============================================================================
 
 /**
+ * For a `DateTime` returns a new `DateTime.Utc`.
+ *
+ * @since 3.13.0
+ * @category time zones
+ * @example
+ * ```ts
+ * import { DateTime } from "effect"
+ *
+ * const now = DateTime.unsafeMakeZoned({ year: 2024 }, { timeZone: "Europe/London" })
+ *
+ * // set as UTC
+ * const utc: DateTime.Utc = DateTime.toUtc(now)
+ * ```
+ */
+export const toUtc: (self: DateTime) => Utc = Internal.toUtc
+
+/**
  * Set the time zone of a `DateTime`, returning a new `DateTime.Zoned`.
  *
  * @since 3.6.0

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -307,6 +307,9 @@ export const unsafeNow: LazyArg<DateTime.Utc> = () => makeUtc(Date.now())
 // =============================================================================
 
 /** @internal */
+export const toUtc = (self: DateTime.DateTime): DateTime.Utc => makeUtc(self.epochMillis)
+
+/** @internal */
 export const setZone: {
   (zone: DateTime.TimeZone, options?: {
     readonly adjustForTimeZone?: boolean | undefined

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -421,4 +421,21 @@ describe("DateTime", () => {
     const dt = DateTime.unsafeMakeZoned(date)
     deepStrictEqual(dt.zone, DateTime.zoneMakeOffset(60 * 60 * 1000))
   })
+
+  describe("toUtc", () => {
+    it.effect("with a Utc", () =>
+      Effect.gen(function*() {
+        const dt = DateTime.unsafeMake("2024-01-01T01:00:00")
+        strictEqual(dt.toJSON(), "2024-01-01T01:00:00.000Z")
+      }))
+
+    it.effect("with a Zoned", () =>
+      Effect.gen(function*() {
+        const dt = DateTime.unsafeMakeZoned("2024-01-01T01:00:00Z", {
+          timeZone: "Pacific/Auckland",
+          adjustForTimeZone: true
+        })
+        strictEqual(dt.toJSON(), "2023-12-31T12:00:00.000Z")
+      }))
+  })
 })

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -445,7 +445,7 @@ const HttpUsersLive = HttpApiBuilder.group(
               new User({
                 id: 1,
                 name: `page ${_.headers.page}`,
-                createdAt: DateTime.unsafeMake(now.epochMillis)
+                createdAt: DateTime.toUtc(now)
               })
             ]))
         .handle("upload", (_) =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Turning a `Utc` into a `Zoned` with `setZone` is currently possible, but not vice versa.

I did wonder about calling it `removeZone`, but `toUtc` is probably clearer.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #4364
