### PR TITLE
fix effect vitest layer

### DIFF
--- a/.changeset/six-ghosts-pull.md
+++ b/.changeset/six-ghosts-pull.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Fix @effect.vitest layer method not running tests in some cases

--- a/packages/vitest/src/internal.ts
+++ b/packages/vitest/src/internal.ts
@@ -227,7 +227,7 @@ export const layer = <R, E>(layer_: Layer.Layer<R, E>, options?: {
     return args[0](makeIt(V.it))
   }
 
-  return V.describe(args[0], (it) => {
+  return V.describe(args[0], () => {
     V.beforeAll(
       () => runPromise()(Effect.asVoid(runtimeEffect)),
       options?.timeout ? Duration.toMillis(options.timeout) : undefined
@@ -236,7 +236,7 @@ export const layer = <R, E>(layer_: Layer.Layer<R, E>, options?: {
       () => runPromise()(Scope.close(scope, Exit.void)),
       options?.timeout ? Duration.toMillis(options.timeout) : undefined
     )
-    return args[1](makeIt(it))
+    return args[1](makeIt(V.it))
   })
 }
 

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -182,6 +182,16 @@ describe("layer", () => {
         yield* Fiber.join(fiber)
       }))
   })
+
+  layer(Foo.Live)("with a name", (it) => {
+    describe("with a nested describe", () => {
+      it.effect("adds context", () =>
+        Effect.gen(function*() {
+          const foo = yield* Foo
+          expect(foo).toEqual("foo")
+        }))
+    })
+  })
 })
 
 // property testing

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -191,6 +191,11 @@ describe("layer", () => {
           expect(foo).toEqual("foo")
         }))
     })
+    it.effect("adds context", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        expect(foo).toEqual("foo")
+      }))
   })
 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
This fixes the fact that vitest does not finds the tests nested in a `describe` inside a named `layer()`
I believe the issue was introduced in this P.R.: https://github.com/Effect-TS/effect/pull/4254

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #4339
