### PR TITLE
Fix CLI -h to display default values (#4400)

### DIFF
--- a/.changeset/quiet-boats-smile.md
+++ b/.changeset/quiet-boats-smile.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Fix CLI help output to correctly display default values

--- a/packages/cli/src/internal/args.ts
+++ b/packages/cli/src/internal/args.ts
@@ -8,9 +8,11 @@ import * as Console from "effect/Console"
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import { dual, pipe } from "effect/Function"
+import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
 import * as ParseResult from "effect/ParseResult"
 import { pipeArguments } from "effect/Pipeable"
+import * as Predicate from "effect/Predicate"
 import type * as Redacted from "effect/Redacted"
 import * as Ref from "effect/Ref"
 import type * as Schema from "effect/Schema"
@@ -536,7 +538,11 @@ const getHelpInternal = (self: Instruction): HelpDoc.HelpDoc => {
           const optionalDescription = Option.isOption(self.fallback)
             ? Option.match(self.fallback, {
               onNone: () => InternalHelpDoc.p("This setting is optional."),
-              onSome: () => InternalHelpDoc.p(`This setting is optional. Defaults to: ${self.fallback}`)
+              onSome: (fallbackValue) => {
+                const inspectableValue = Predicate.isObject(fallbackValue) ? fallbackValue : String(fallbackValue)
+                const displayValue = Inspectable.toStringUnknown(inspectableValue, 0)
+                return InternalHelpDoc.p(`This setting is optional. Defaults to: ${displayValue}`)
+              }
             })
             : InternalHelpDoc.p("This setting is optional.")
           return [span, InternalHelpDoc.sequence(block, optionalDescription)]

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -9,6 +9,7 @@ import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import { dual, pipe } from "effect/Function"
 import * as HashMap from "effect/HashMap"
+import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
 import * as Order from "effect/Order"
 import * as ParseResult from "effect/ParseResult"
@@ -791,7 +792,11 @@ const getHelpInternal = (self: Instruction): HelpDoc.HelpDoc => {
           const optionalDescription = Option.isOption(self.fallback)
             ? Option.match(self.fallback, {
               onNone: () => InternalHelpDoc.p("This setting is optional."),
-              onSome: () => InternalHelpDoc.p(`This setting is optional. Defaults to: ${self.fallback}`)
+              onSome: (fallbackValue) => {
+                const inspectableValue = Predicate.isObject(fallbackValue) ? fallbackValue : String(fallbackValue)
+                const displayValue = Inspectable.toStringUnknown(inspectableValue, 0)
+                return InternalHelpDoc.p(`This setting is optional. Defaults to: ${displayValue}`)
+              }
             })
             : InternalHelpDoc.p("This setting is optional.")
           return [span, InternalHelpDoc.sequence(block, optionalDescription)]

--- a/packages/cli/test/Args.test.ts
+++ b/packages/cli/test/Args.test.ts
@@ -172,4 +172,32 @@ describe("Args", () => {
       )
       expect(result).toEqual([Array.empty(), Array.of(content)])
     }).pipe(runEffect))
+
+  it("displays default value in help when default wrapped in Option.Some (primitive)", () =>
+    Effect.gen(function*(_) {
+      const option = Args.withDefault(Args.integer({ name: "value" }), Option.some(123))
+      const helpDoc = Args.getHelp(option)
+      yield* _(
+        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-primitive"))
+      )
+    }).pipe(runEffect))
+
+  it("displays default value in help when default wrapped in Option.Some (object)", () =>
+    Effect.gen(function*(_) {
+      const defaultObject = { key: "value", number: 456 }
+      const option = Args.withDefault(Args.text({ name: "config" }), Option.some(defaultObject))
+      const helpDoc = Args.getHelp(option)
+      yield* _(
+        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-object"))
+      )
+    }).pipe(runEffect))
+
+  it("displays no default value in help when default is not Option.Some", () =>
+    Effect.gen(function*(_) {
+      const option = Args.withDefault(Args.text({ name: "name" }), Option.none())
+      const helpDoc = Args.getHelp(option)
+      yield* _(
+        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-no-default"))
+      )
+    }).pipe(runEffect))
 })

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -705,4 +705,32 @@ describe("Options", () => {
       const content = yield* _(fs.readFileString(jsonPath), Effect.map(JSON.parse))
       assert.deepStrictEqual(result, [[], content])
     }).pipe(runEffect))
+
+  it("displays default value in help when default wrapped in Option.Some (primitive)", () =>
+    Effect.gen(function*(_) {
+      const option = Options.withDefault(Options.integer("value"), Option.some(123))
+      const helpDoc = Options.getHelp(option)
+      yield* _(
+        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/options-default-primitive"))
+      )
+    }).pipe(runEffect))
+
+  it("displays default value in help when default wrapped in Option.Some (object)", () =>
+    Effect.gen(function*(_) {
+      const defaultObject = { key: "value", number: 456 }
+      const option = Options.withDefault(Options.text("config"), Option.some(defaultObject))
+      const helpDoc = Options.getHelp(option)
+      yield* _(
+        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/options-default-object"))
+      )
+    }).pipe(runEffect))
+
+  it("displays no default value in help when default is not Option.Some", () =>
+    Effect.gen(function*(_) {
+      const option = Options.withDefault(Options.text("name"), Option.none())
+      const helpDoc = Options.getHelp(option)
+      yield* _(
+        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/options-no-default"))
+      )
+    }).pipe(runEffect))
 })

--- a/packages/cli/test/snapshots/help-output/args-default-object
+++ b/packages/cli/test/snapshots/help-output/args-default-object
@@ -1,0 +1,31 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Weak",
+        "value": {
+          "_tag": "Text",
+          "value": "<config>",
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "A user-defined piece of text.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: {"key":"value","number":456}",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/args-default-primitive
+++ b/packages/cli/test/snapshots/help-output/args-default-primitive
@@ -1,0 +1,31 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Weak",
+        "value": {
+          "_tag": "Text",
+          "value": "<value>",
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "An integer.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: 123",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/args-no-default
+++ b/packages/cli/test/snapshots/help-output/args-no-default
@@ -1,0 +1,31 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Weak",
+        "value": {
+          "_tag": "Text",
+          "value": "<name>",
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "A user-defined piece of text.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional.",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/options-default-object
+++ b/packages/cli/test/snapshots/help-output/options-default-object
@@ -1,0 +1,42 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Text",
+          "value": "--config",
+        },
+        "right": {
+          "_tag": "Sequence",
+          "left": {
+            "_tag": "Text",
+            "value": " ",
+          },
+          "right": {
+            "_tag": "Text",
+            "value": "text",
+          },
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "A user-defined piece of text.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: {"key":"value","number":456}",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/options-default-primitive
+++ b/packages/cli/test/snapshots/help-output/options-default-primitive
@@ -1,0 +1,42 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Text",
+          "value": "--value",
+        },
+        "right": {
+          "_tag": "Sequence",
+          "left": {
+            "_tag": "Text",
+            "value": " ",
+          },
+          "right": {
+            "_tag": "Text",
+            "value": "integer",
+          },
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "An integer.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: 123",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/options-no-default
+++ b/packages/cli/test/snapshots/help-output/options-no-default
@@ -1,0 +1,42 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Text",
+          "value": "--name",
+        },
+        "right": {
+          "_tag": "Sequence",
+          "left": {
+            "_tag": "Text",
+            "value": " ",
+          },
+          "right": {
+            "_tag": "Text",
+            "value": "text",
+          },
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "A user-defined piece of text.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional.",
+          },
+        },
+      },
+    ],
+  ],
+}


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

`Args` and `Options` in `@effect/cli` did not correctly display default values in the help output when `withDefault` was used. If the fallback value was wrapped in `Option.some`, the internal object details were printed instead of the expected default value.

Fix attempted is:
- Coerce primitive fallback values to strings for proper display.
- Serialize non-primitive fallback values to (compact-style) JSON using the `effect/Inspectable` module.
- This ensures that both `Args` and `Options` display expected default values in their help output.

A few basic test cases were added for both `Args` and `Options`. Snapshots used due to deep partial object matching getting messy without custom matchers. (Unless I missed something.)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #4400 
