### PR TITLE
Duration: fix `format` output when the input is zero

### DIFF
--- a/.changeset/many-lemons-rush.md
+++ b/.changeset/many-lemons-rush.md
@@ -1,0 +1,23 @@
+---
+"effect": patch
+---
+
+Duration: fix `format` output when the input is zero.
+
+Before
+
+```ts
+import { Duration } from "effect"
+
+console.log(Duration.format(Duration.zero))
+// Output: ""
+```
+
+After
+
+```ts
+import { Duration } from "effect"
+
+console.log(Duration.format(Duration.zero))
+// Output: "0"
+```

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -821,6 +821,9 @@ export const format = (self: DurationInput): string => {
   if (duration.value._tag === "Infinity") {
     return "Infinity"
   }
+  if (isZero(duration)) {
+    return "0"
+  }
 
   const fragments = parts(duration)
   const pieces = []

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -322,6 +322,7 @@ describe("Duration", () => {
     strictEqual(Duration.format(Duration.days(2)), `2d`)
     strictEqual(Duration.format(Duration.days(2.25)), `2d 6h`)
     strictEqual(Duration.format(Duration.weeks(1)), `7d`)
+    strictEqual(Duration.format(Duration.zero), `0`)
   })
 
   it("format", () => {


### PR DESCRIPTION
Before

```ts
import { Duration } from "effect"

console.log(Duration.format(Duration.zero))
// Output: ""
```

After

```ts
import { Duration } from "effect"

console.log(Duration.format(Duration.zero))
// Output: "0"
```
