### PR TITLE
Send `SELECT 1` as unprepared statements

### DIFF
--- a/.changeset/selfish-apricots-mix.md
+++ b/.changeset/selfish-apricots-mix.md
@@ -1,0 +1,6 @@
+---
+"@effect/sql-mysql2": patch
+"@effect/sql-mssql": patch
+---
+
+Use an unprepared `SELECT 1` statement to test the DB connection during client initialization instead of a prepared statement.

--- a/packages/sql-mssql/src/MssqlClient.ts
+++ b/packages/sql-mssql/src/MssqlClient.ts
@@ -344,7 +344,7 @@ export const make = (
     })
 
     yield* pool.get.pipe(
-      Effect.tap((connection) => connection.executeRaw("SELECT 1", [])),
+      Effect.tap((connection) => connection.executeUnprepared("SELECT 1", [], undefined)),
       Effect.mapError(({ cause }) => new SqlError({ cause, message: "MssqlClient: Failed to connect" })),
       Effect.scoped,
       Effect.timeoutFail({

--- a/packages/sql-mysql2/src/MysqlClient.ts
+++ b/packages/sql-mysql2/src/MysqlClient.ts
@@ -190,7 +190,7 @@ export const make = (
 
     yield* Effect.acquireRelease(
       Effect.async<void, SqlError>((resume) => {
-        ;(pool as any).execute("SELECT 1", (cause: Error) => {
+        ;(pool as any).query("SELECT 1", (cause: Error) => {
           if (cause) {
             resume(Effect.fail(
               new SqlError({


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Some database proxies out there do not handle prepared statements. Since there is little benefit in preparing the `SELECT 1` statement, this change makes sure that these database connection testing queries are sent unprepared.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
