### PR TITLE
Enhance `TagClass` and `ReferenceClass` to enforce `key` type narrowi…

### DIFF
--- a/.changeset/rotten-islands-arrive.md
+++ b/.changeset/rotten-islands-arrive.md
@@ -1,0 +1,30 @@
+---
+"effect": patch
+---
+
+Enhance `TagClass` and `ReferenceClass` to enforce `key` type narrowing, closes #4409.
+
+The `key` property in `TagClass` and `ReferenceClass` now correctly retains its specific string value, just like in `Effect.Service`
+
+```ts
+import { Context, Effect } from "effect"
+
+// -------------------------------------------------------------------------------------
+// `key` field
+// -------------------------------------------------------------------------------------
+
+class A extends Effect.Service<A>()("A", { succeed: { a: "value" } }) {}
+
+// $ExpectType "A"
+A.key
+
+class B extends Context.Tag("B")<B, { a: "value" }>() {}
+
+// $ExpectType "B"
+B.key
+
+class C extends Context.Reference<C>()("C", { defaultValue: () => 0 }) {}
+
+// $ExpectType "C"
+C.key
+```

--- a/packages/effect/dtslint/Context.ts
+++ b/packages/effect/dtslint/Context.ts
@@ -1,0 +1,20 @@
+import { Context, Effect } from "effect"
+
+// -------------------------------------------------------------------------------------
+// `key` field
+// -------------------------------------------------------------------------------------
+
+class A extends Effect.Service<A>()("A", { succeed: { a: "value" } }) {}
+
+// $ExpectType "A"
+A.key
+
+class B extends Context.Tag("B")<B, { a: "value" }>() {}
+
+// $ExpectType "B"
+B.key
+
+class C extends Context.Reference<C>()("C", { defaultValue: () => 0 }) {}
+
+// $ExpectType "C"
+C.key

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -87,20 +87,24 @@ export interface TagClassShape<Id, Shape> {
   readonly Id: Id
 }
 
+// TODO(4.0): move key narrowing to the Tag interface
 /**
  * @since 2.0.0
  * @category models
  */
-export interface TagClass<Self, Id, Type> extends Tag<Self, Type> {
+export interface TagClass<Self, Id extends string, Type> extends Tag<Self, Type> {
   new(_: never): TagClassShape<Id, Type>
+  readonly key: Id
 }
 
+// TODO(4.0): move key narrowing to the Reference interface
 /**
  * @since 3.11.0
  * @category models
  */
-export interface ReferenceClass<Self, Id, Type> extends Reference<Self, Type> {
+export interface ReferenceClass<Self, Id extends string, Type> extends Reference<Self, Type> {
   new(_: never): TagClassShape<Id, Type>
+  readonly key: Id
 }
 
 /**


### PR DESCRIPTION
…ng, closes #4409 