### PR TITLE
Preserve function `length` property in `Effect.fn` / `Effect.fnUntrac…

### DIFF
--- a/.changeset/nice-numbers-hammer.md
+++ b/.changeset/nice-numbers-hammer.md
@@ -1,0 +1,47 @@
+---
+"effect": patch
+---
+
+Preserve function `length` property in `Effect.fn` / `Effect.fnUntraced`, closes #4435
+
+Previously, functions created with `Effect.fn` and `Effect.fnUntraced` always had a `.length` of `0`, regardless of their actual number of parameters. This has been fixed so that the `length` property correctly reflects the expected number of arguments.
+
+**Before**
+
+```ts
+import { Effect } from "effect"
+
+const fn1 = Effect.fn("fn1")(function* (n: number) {
+  return n
+})
+
+console.log(fn1.length)
+// Output: 0 ❌ (incorrect)
+
+const fn2 = Effect.fnUntraced(function* (n: number) {
+  return n
+})
+
+console.log(fn2.length)
+// Output: 0 ❌ (incorrect)
+```
+
+**After**
+
+```ts
+import { Effect } from "effect"
+
+const fn1 = Effect.fn("fn1")(function* (n: number) {
+  return n
+})
+
+console.log(fn1.length)
+// Output: 1 ✅ (correct)
+
+const fn2 = Effect.fnUntraced(function* (n: number) {
+  return n
+})
+
+console.log(fn2.length)
+// Output: 1 ✅ (correct)
+```

--- a/packages/effect/test/Effect/fn.test.ts
+++ b/packages/effect/test/Effect/fn.test.ts
@@ -64,4 +64,30 @@ describe("Effect.fn", () => {
       assertInstanceOf(cause.right.defect, Error)
       strictEqual(cause.right.defect.message, "test2")
     }))
+
+  it("should preserve the function length", () => {
+    const f = function*(n: number) {
+      return n
+    }
+    const fn1 = Effect.fn("fn1")(f)
+    strictEqual(fn1.length, 1)
+    strictEqual(Effect.runSync(fn1(2)), 2)
+    const fn2 = Effect.fn(f)
+    strictEqual(fn2.length, 1)
+    strictEqual(Effect.runSync(fn2(2)), 2)
+  })
+})
+
+describe("Effect.fnUntraced", () => {
+  it("should preserve the function length", () => {
+    const f = function*(n: number) {
+      return n
+    }
+    const fn1 = Effect.fnUntraced(f)
+    strictEqual(fn1.length, 1)
+    strictEqual(Effect.runSync(fn1(2)), 2)
+    const fn2 = Effect.fnUntraced(f, (x) => x)
+    strictEqual(fn2.length, 1)
+    strictEqual(Effect.runSync(fn2(2)), 2)
+  })
 })

--- a/packages/effect/vitest.config.ts
+++ b/packages/effect/vitest.config.ts
@@ -5,7 +5,7 @@ const config: ViteUserConfig = {
   test: {
     coverage: {
       reporter: ["html"],
-      include: ["src/Match.ts", "src/internal/matcher.ts"]
+      include: ["src/Effect.ts"]
     }
   }
 }


### PR DESCRIPTION
…ed`, closes #4435

Previously, functions created with `Effect.fn` and `Effect.fnUntraced` always had a `.length` of `0`, regardless of their actual number of parameters. This has been fixed so that the `length` property correctly reflects the expected number of arguments.

**Before**

```ts
import { Effect } from "effect"

const fn1 = Effect.fn("fn1")(function* (n: number) {
  return n
})

console.log(fn1.length)
// Output: 0 ❌ (incorrect)

const fn2 = Effect.fnUntraced(function* (n: number) {
  return n
})

console.log(fn2.length)
// Output: 0 ❌ (incorrect)
```

**After**

```ts
import { Effect } from "effect"

const fn1 = Effect.fn("fn1")(function* (n: number) {
  return n
})

console.log(fn1.length)
// Output: 1 ✅ (correct)

const fn2 = Effect.fnUntraced(function* (n: number) {
  return n
})

console.log(fn2.length)
// Output: 1 ✅ (correct)
```
