### PR TITLE
Add `Either.transposeOption`

### DIFF
--- a/.changeset/quiet-tables-listen.md
+++ b/.changeset/quiet-tables-listen.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Either.transposeOption

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -9,6 +9,7 @@ import type { TypeLambda } from "./HKT.js"
 import type { Inspectable } from "./Inspectable.js"
 import * as doNotation from "./internal/doNotation.js"
 import * as either from "./internal/either.js"
+import * as option_ from "./internal/option.js"
 import type { Option } from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
@@ -965,4 +966,39 @@ export {
    * @since 2.0.0
    */
   let_ as let
+}
+
+/**
+ * Converts an `Option` of an `Either` into an `Either` of an `Option`.
+ *
+ * **Details**
+ *
+ * This function transforms an `Option<Either<A, E>>` into an
+ * `Either<Option<A>, E>`. If the `Option` is `None`, the resulting `Either`
+ * will be a `Right` with a `None` value. If the `Option` is `Some`, the
+ * inner `Either` will be executed, and its result wrapped in a `Some`.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Either, Option } from "effect"
+ *
+ * //      ┌─── Option<Either<number, never>>
+ * //      ▼
+ * const maybe = Option.some(Either.right(42))
+ *
+ * //      ┌─── Either<Option<number>, never, never>
+ * //      ▼
+ * const result = Either.transposeOption(maybe)
+ *
+ * console.log(Effect.runSync(result))
+ * // Output: { _id: 'Option', _tag: 'Some', value: 42 }
+ * ```
+ *
+ * @since 3.14.0
+ * @category Optional Wrapping & Unwrapping
+ */
+export const transposeOption = <A = never, E = never>(
+  self: Option<Either<A, E>>
+): Either<Option<A>, E> => {
+  return option_.isNone(self) ? right(option_.none) : map(self.value, option_.some)
 }

--- a/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
+++ b/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
 import * as Option from "effect/Option"
 
 describe("Effect", () => {
@@ -13,6 +14,22 @@ describe("Effect", () => {
     it.effect("Some", () =>
       Effect.gen(function*() {
         const result = yield* Effect.transposeOption(Option.some(Effect.succeed(42)))
+        assert.deepStrictEqual(result, Option.some(42))
+      }))
+  })
+})
+
+describe("Either", () => {
+  describe("transposeOption", () => {
+    it.effect("None", () =>
+      Effect.gen(function*() {
+        const result = yield* Either.transposeOption(Option.none())
+        assert.ok(Option.isNone(result))
+      }))
+
+    it.effect("Some", () =>
+      Effect.gen(function*() {
+        const result = yield* Either.transposeOption(Option.some(Either.right(42)))
         assert.deepStrictEqual(result, Option.some(42))
       }))
   })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
Ports the recent `Effect.transposeOption` to `Either`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
