### PR TITLE
chore: add `references` for type test projects

### DIFF
--- a/packages/effect/dtslint/tsconfig.json
+++ b/packages/effect/dtslint/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "include": ["."],
+  "references": [
+    { "path": "../tsconfig.src.json" },
+  ],
   "compilerOptions": {
     "incremental": false,
     "composite": false,

--- a/packages/platform/dtslint/tsconfig.json
+++ b/packages/platform/dtslint/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "include": ["."],
+  "references": [
+    { "path": "../tsconfig.src.json" },
+  ],
   "compilerOptions": {
     "incremental": false,
     "composite": false,

--- a/packages/typeclass/dtslint/tsconfig.json
+++ b/packages/typeclass/dtslint/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "include": ["."],
+  "references": [
+    { "path": "../tsconfig.src.json" },
+  ],
   "compilerOptions": {
     "incremental": false,
     "composite": false,

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://tstyche.org/schemas/config.json",
+  "checkSourceFiles": true,
+  "rejectAnyType": true,
+  "testFileMatch": [
+    "packages/*/dtslint/**/*.tst.*"
+  ]
+}


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR adds `references` for type test projects (their `tsconfig.json` files).

I was trying out TSTyche’s `checkSourceFiles` option and noticed few errors. For example, `packages/effect/tsconfig.src.json` has `types: ["node"]` set or `packages/platform/tsconfig.src.json` has `exactOptionalPropertyTypes: false` set, but these options were ignored while checking `effect` or `@effect/platform` source files. Seems like package were not treated as separate projects. Adding `references` solves the problem.

The `checkSourceFiles` option will be enable by default in the next major TSTyche release. That is why I wanted to try it out.

## Context

To retrieve type information TSTyche wraps around language service, which allows opening / checking files one by one. Even if two test files belong to the same project / program, this approach allows reporting errors only in a single test file. The problem is that source files are not checked. That is why the option was added.

Another aspect: language service handles `references`. In contrary `tsc --noEmit` can’t do that.