### PR TITLE
Add default utf-8 charset to node file responses

### DIFF
--- a/.changeset/tough-buttons-brake.md
+++ b/.changeset/tough-buttons-brake.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+add default utf-8 charset to content type of node platform file responses

--- a/packages/platform-node/src/internal/httpPlatform.ts
+++ b/packages/platform-node/src/internal/httpPlatform.ts
@@ -9,14 +9,28 @@ import * as Fs from "node:fs"
 import { Readable } from "node:stream"
 import * as FileSystem from "../NodeFileSystem.js"
 
+const getMimeTypeWithCharset = (path: string, charset = "utf-8") => {
+  const mimeType = Mime.getType(path)
+
+  if (mimeType) {
+    // in case of non-text types,
+    // the charset should be ignored by the client
+    return `${mimeType};charset=${charset}`
+  }
+
+  return null
+}
+
 /** @internal */
 export const make = Platform.make({
   fileResponse(path, status, statusText, headers, start, end, contentLength) {
     const stream = Fs.createReadStream(path, { start, end })
+
     return ServerResponse.raw(stream, {
       headers: {
         ...headers,
-        "content-type": headers["content-type"] ?? Mime.getType(path) ?? "application/octet-stream",
+        "content-type": headers["content-type"]
+          ?? getMimeTypeWithCharset(path) ?? "application/octet-stream",
         "content-length": contentLength.toString()
       },
       status,
@@ -28,7 +42,8 @@ export const make = Platform.make({
       headers: Headers.merge(
         headers,
         Headers.unsafeFromRecord({
-          "content-type": headers["content-type"] ?? Mime.getType(file.name) ?? "application/octet-stream",
+          "content-type": headers["content-type"]
+            ?? getMimeTypeWithCharset(file.name) ?? "application/octet-stream",
           "content-length": file.size.toString()
         })
       ),

--- a/packages/platform-node/test/HttpServer.test.ts
+++ b/packages/platform-node/test/HttpServer.test.ts
@@ -66,7 +66,7 @@ describe("HttpServer", () => {
             const file = part[0]
             assert(typeof file !== "string")
             expect(file.path.endsWith("/test.txt")).toEqual(true)
-            expect(file.contentType).toEqual("text/plain")
+            expect(file.contentType).toEqual("text/plain;charset=utf-8")
             return yield* HttpServerResponse.json({ ok: "file" in formData })
           })
         ),
@@ -247,7 +247,7 @@ describe("HttpServer", () => {
       const client = yield* HttpClient.HttpClient
       const res = yield* client.get("/").pipe(Effect.scoped)
       expect(res.status).toEqual(200)
-      expect(res.headers["content-type"]).toEqual("text/plain")
+      expect(res.headers["content-type"]).toEqual("text/plain;charset=utf-8")
       expect(res.headers["content-length"]).toEqual("27")
       expect(res.headers.etag).toEqual("\"etag\"")
       const text = yield* res.text
@@ -278,7 +278,7 @@ describe("HttpServer", () => {
       const client = yield* HttpClient.HttpClient
       const res = yield* client.get("/").pipe(Effect.scoped)
       expect(res.status).toEqual(200)
-      expect(res.headers["content-type"]).toEqual("text/plain")
+      expect(res.headers["content-type"]).toEqual("text/plain;charset=utf-8")
       expect(res.headers["content-length"]).toEqual("4")
       expect(res.headers["last-modified"]).toEqual(now.toUTCString())
       expect(res.headers.etag).toEqual("W/\"etag\"")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed that by default the node platform `HttpServerResponse.file` sets just e.g. "text/html" as the content type, which prevents e.g. some browsers from displaying emojis correctly.

To be clear [specification](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5) doesn't specify any behavior.

As per chatgpt, we should be able to safely add a default charset attribute with any content type coming from the "mime" package, the client should just ignore it in case of non-textual responses.

This is my proposition to correct this problem.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
