### PR TITLE
Schema: more precise return types when transformations are involved

### DIFF
--- a/.changeset/real-needles-learn.md
+++ b/.changeset/real-needles-learn.md
@@ -1,0 +1,52 @@
+---
+"effect": patch
+---
+
+Schema: more precise return types when transformations are involved.
+
+- `Chunk`
+- `NonEmptyChunk`
+- `Redacted`
+- `Option`
+- `OptionFromNullOr`
+- `OptionFromUndefinedOr`
+- `OptionFromNullishOr`
+- `Either`
+- `EitherFromUnion`
+- `ReadonlyMap`
+- `Map`
+- `HashMap`
+- `ReadonlySet`
+- `Set`
+- `HashSet`
+- `List`
+- `Cause`
+- `Exit`
+- `SortedSet`
+- `head`
+- `headNonEmpty`
+- `headOrElse`
+
+**Example** (with `Schema.Chunk`)
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Chunk(Schema.Number)
+
+// Property 'from' does not exist on type 'Chunk<typeof Number$>'
+schema.from
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Chunk(Schema.Number)
+
+// Schema.Array$<typeof Schema.Number>
+schema.from
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -50,19 +50,229 @@ describe("Schema", () => {
     })
   })
 
-  it("Schema.Encoded", () => {
-    expect<S.Schema.Encoded<typeof S.Never>>().type.toBe<never>()
-    expect<S.Schema.Encoded<typeof S.NumberFromString>>().type.toBe<string>()
-  })
+  describe("Type Level Helpers", () => {
+    it("Schema.Encoded", () => {
+      expect<S.Schema.Encoded<typeof S.Never>>().type.toBe<never>()
+      expect<S.Schema.Encoded<typeof S.NumberFromString>>().type.toBe<string>()
+    })
 
-  it("Schema.Type", () => {
-    expect<S.Schema.Type<typeof S.Never>>().type.toBe<never>()
-    expect<S.Schema.Type<typeof S.NumberFromString>>().type.toBe<number>()
-  })
+    it("Schema.Type", () => {
+      expect<S.Schema.Type<typeof S.Never>>().type.toBe<never>()
+      expect<S.Schema.Type<typeof S.NumberFromString>>().type.toBe<number>()
+    })
 
-  it("Schema.Context", () => {
-    expect<S.Schema.Context<typeof S.Never>>().type.toBe<never>()
-    expect<S.Schema.Context<S.Schema<number, string, "ctx">>>().type.toBe<"ctx">()
+    it("Schema.Context", () => {
+      expect<S.Schema.Context<typeof S.Never>>().type.toBe<never>()
+      expect<S.Schema.Context<S.Schema<number, string, "ctx">>>().type.toBe<"ctx">()
+    })
+
+    it("Struct.Type", () => {
+      const _StructTypeTest1 = <S extends S.Schema.Any>(input: S.Struct.Type<{ s: S }>) => {
+        expect(input).type.toBe<S.Struct.Type<{ s: S }>>()
+        input
+      }
+      expect(hole<Types.Simplify<S.Struct.Type<{}>>>()).type.toBe<{}>()
+      expect(hole<Types.Simplify<S.Struct.Type<{ a: S.Schema<number, string> }>>>()).type.toBe<{ readonly a: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, never, ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, never, "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, "c", ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, "c", "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, never, ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b?: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, never, "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b?: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, "c", ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b?: number }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Type<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, "c", "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: number; readonly b?: number }>()
+    })
+
+    it("Struct.Encoded", () => {
+      expect(hole<Types.Simplify<S.Struct.Encoded<{}>>>()).type.toBe<{}>()
+      expect(hole<Types.Simplify<S.Struct.Encoded<{ a: S.Schema<number, string> }>>>()).type.toBe<
+        { readonly a: string }
+      >()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, never, ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly b: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, never, "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly b?: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, "c", ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly c: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<":", number, "c", "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly c?: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, never, ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly b: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, never, "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly b?: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, "c", ":", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly c: string }>()
+      expect(hole<
+        Types.Simplify<
+          S.Struct.Encoded<{
+            a: S.Schema<number, string>
+            b: S.PropertySignature<"?:", number, "c", "?:", string, false, "context">
+          }>
+        >
+      >()).type.toBe<{ readonly a: string; readonly c?: string }>()
+    })
+
+    it("Struct.Constructor", () => {
+      expect(
+        hole<
+          S.Struct.Constructor<{
+            a: S.PropertySignature<":", string, never, ":", string, true>
+            b: typeof S.Number
+            c: S.PropertySignature<":", boolean, never, ":", boolean, true>
+          }>
+        >()
+      ).type.toBe<{ readonly a?: string } & { readonly b: number } & { readonly c?: boolean }>()
+    })
+
+    it("TupleType.Type", () => {
+      expect(hole<S.TupleType.Type<[], []>>()).type.toBe<readonly []>()
+      expect(hole<S.TupleType.Type<[typeof S.NumberFromString], []>>()).type.toBe<readonly [number]>()
+      expect(hole<S.TupleType.Type<[], [typeof S.NumberFromString]>>()).type.toBe<ReadonlyArray<number>>()
+      expect(hole<S.TupleType.Type<[typeof S.NumberFromString], [typeof S.NumberFromString]>>()).type.toBe<
+        readonly [number, ...Array<number>]
+      >()
+      expect(
+        hole<S.TupleType.Type<[typeof S.NumberFromString], [typeof S.NumberFromString, typeof S.NumberFromString]>>()
+      ).type.toBe<readonly [number, ...Array<number>, number]>()
+      expect(
+        hole<S.TupleType.Type<[typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">], []>>()
+      ).type.toBe<readonly [number, number?]>()
+      expect(
+        hole<
+          S.TupleType.Type<
+            [typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">],
+            [typeof S.NumberFromString]
+          >
+        >()
+      ).type.toBe<readonly [number, number?, ...Array<number>]>()
+    })
+
+    it("TupleType.Encoded", () => {
+      expect(hole<S.TupleType.Encoded<[], []>>()).type.toBe<readonly []>()
+      expect(hole<S.TupleType.Encoded<[typeof S.NumberFromString], []>>()).type.toBe<readonly [string]>()
+      expect(hole<S.TupleType.Encoded<[], [typeof S.NumberFromString]>>()).type.toBe<ReadonlyArray<string>>()
+      expect(hole<S.TupleType.Encoded<[typeof S.NumberFromString], [typeof S.NumberFromString]>>()).type.toBe<
+        readonly [string, ...Array<string>]
+      >()
+      expect(
+        hole<S.TupleType.Encoded<[typeof S.NumberFromString], [typeof S.NumberFromString, typeof S.NumberFromString]>>()
+      ).type.toBe<readonly [string, ...Array<string>, string]>()
+      expect(
+        hole<S.TupleType.Encoded<[typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">], []>>()
+      ).type.toBe<readonly [string, string?]>()
+      expect(
+        hole<
+          S.TupleType.Encoded<
+            [typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">],
+            [typeof S.NumberFromString]
+          >
+        >()
+      ).type.toBe<readonly [string, string?, ...Array<string>]>()
+    })
+
+    it("TupleType.Context", () => {
+      expect(
+        hole<S.Schema.Context<S.TupleType<[typeof aContext], [typeof bContext, typeof cContext]>>>()
+      ).type.toBe<"a" | "b" | "c">()
+    })
   })
 
   it("annotations", () => {
@@ -74,11 +284,11 @@ describe("Schema", () => {
     interface AnnotatedString extends S.Annotable<AnnotatedString, string> {}
     const AnnotatedString = hole<AnnotatedString>()
 
-    expect(hole<S.Schema<string>>().pipe(S.annotations({}))).type.toBe<S.Schema<string, string>>()
+    expect(hole<S.Schema<string>>().pipe(S.annotations({}))).type.toBe<S.Schema<string>>()
     expect(AnnotatedString.pipe(S.annotations({}))).type.toBe<AnnotatedString>()
 
     expect(S.Number.pipe(S.int(), S.brand("Int"), S.annotations({})))
-      .type.toBe<S.brand<S.filter<S.Schema<number, number>>, "Int">>()
+      .type.toBe<S.brand<S.filter<S.Schema<number>>, "Int">>()
     expect(S.Struct({ a: AnnotatedString }).pipe(S.annotations({}))).type.toBe<S.Struct<{ a: AnnotatedString }>>()
     expect(A.pipe(S.annotations({}))).type.toBe<S.SchemaClass<A, { readonly a: string }>>()
     expect(S.Number.pipe(S.int(), S.brand("Int")).make(1)).type.toBe<number & Brand.Brand<"Int">>()
@@ -91,10 +301,10 @@ describe("Schema", () => {
     expect(S.asSchema(S.Undefined)).type.toBe<S.Schema<undefined, undefined>>()
     expect(S.Undefined).type.toBe<typeof S.Undefined>()
 
-    expect(S.asSchema(S.String)).type.toBe<S.Schema<string, string>>()
+    expect(S.asSchema(S.String)).type.toBe<S.Schema<string>>()
     expect(S.String).type.toBe<typeof S.String>()
 
-    expect(S.asSchema(S.Number)).type.toBe<S.Schema<number, number>>()
+    expect(S.asSchema(S.Number)).type.toBe<S.Schema<number>>()
     expect(S.Number).type.toBe<typeof S.Number>()
 
     expect(S.asSchema(S.Boolean)).type.toBe<S.Schema<boolean, boolean>>()
@@ -122,7 +332,7 @@ describe("Schema", () => {
     expect(S.Object).type.toBe<typeof S.Object>()
   })
 
-  it("literals", () => {
+  it("Literal", () => {
     expect(S.asSchema(S.Null)).type.toBe<S.Schema<null, null>>()
     expect(S.Null).type.toBe<typeof S.Null>()
 
@@ -142,26 +352,6 @@ describe("Schema", () => {
     expect(S.Literal("A", "B")).type.toBe<S.Literal<["A", "B"]>>()
     expect(S.Literal("A", "B").literals).type.toBe<readonly ["A", "B"]>()
     expect(S.Literal("A", "B").annotations({})).type.toBe<S.Literal<["A", "B"]>>()
-  })
-
-  it("String", () => {
-    expect(pipe(S.String, S.maxLength(5))).type.toBe<S.filter<S.Schema<string, string>>>()
-    expect(pipe(S.String, S.minLength(5))).type.toBe<S.filter<S.Schema<string, string>>>()
-    expect(pipe(S.String, S.length(5))).type.toBe<S.filter<S.Schema<string, string>>>()
-    expect(pipe(S.String, S.pattern(/a/))).type.toBe<S.filter<S.Schema<string, string>>>()
-    expect(pipe(S.String, S.startsWith("a"))).type.toBe<S.filter<S.Schema<string, string>>>()
-    expect(pipe(S.String, S.endsWith("a"))).type.toBe<S.filter<S.Schema<string, string>>>()
-    expect(pipe(S.String, S.includes("a"))).type.toBe<S.filter<S.Schema<string, string>>>()
-  })
-
-  it("Number", () => {
-    expect(pipe(S.Number, S.greaterThan(5))).type.toBe<S.filter<S.Schema<number, number>>>()
-    expect(pipe(S.Number, S.greaterThanOrEqualTo(5))).type.toBe<S.filter<S.Schema<number, number>>>()
-    expect(pipe(S.Number, S.lessThan(5))).type.toBe<S.filter<S.Schema<number, number>>>()
-    expect(pipe(S.Number, S.lessThanOrEqualTo(5))).type.toBe<S.filter<S.Schema<number, number>>>()
-    expect(pipe(S.Number, S.int())).type.toBe<S.filter<S.Schema<number, number>>>()
-    expect(pipe(S.Number, S.nonNaN())).type.toBe<S.filter<S.Schema<number, number>>>()
-    expect(pipe(S.Number, S.finite())).type.toBe<S.filter<S.Schema<number, number>>>()
   })
 
   describe("Enums", () => {
@@ -185,7 +375,16 @@ describe("Schema", () => {
     })
   })
 
+  it("UndefinedOr", () => {
+    expect(S.UndefinedOr(S.Never)).type.toBe<S.UndefinedOr<typeof S.Never>>()
+  })
+
+  it("NullishOr", () => {
+    expect(S.NullishOr(S.Never)).type.toBe<S.NullishOr<typeof S.Never>>()
+  })
+
   it("NullOr", () => {
+    expect(S.NullOr(S.Never)).type.toBe<S.NullOr<typeof S.Never>>()
     expect(S.asSchema(S.NullOr(S.String))).type.toBe<S.Schema<string | null, string | null>>()
     expect(S.NullOr(S.String)).type.toBe<S.NullOr<typeof S.String>>()
     expect(S.asSchema(S.NullOr(S.NumberFromString))).type.toBe<S.Schema<number | null, string | null>>()
@@ -352,632 +551,671 @@ describe("Schema", () => {
     expect(S.Struct({ a: S.String.pipe(S.optional) })).type.toBe<S.Struct<{ a: S.optional<typeof S.String> }>>()
   })
 
-  it("optionalWith { exact: true }", () => {
-    expect(
-      S.asSchema(S.Struct({ a: S.optionalWith(S.Never, { exact: true }) }))
-    ).type.toBe<S.Schema<{ readonly a?: never }, { readonly a?: never }>>()
-    expect(S.Struct({ a: S.optionalWith(S.Never, { exact: true }) }))
-      .type.toBe<S.Struct<{ a: S.optionalWith<typeof S.Never, { exact: true }> }>>()
-    expect(
-      S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { exact: true }) }))
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c?: boolean },
-        { readonly a: string; readonly b: number; readonly c?: boolean },
-        never
-      >
-    >()
-    expect(
-      S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { exact: true }) }))
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c?: number },
-        { readonly a: string; readonly b: number; readonly c?: string },
-        never
-      >
-    >()
-    expect(S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ exact: true })) }))
-      .type.toBe<S.Struct<{ a: S.optionalWith<S.Literal<["a", "b"]>, { exact: true }> }>>()
-  })
-
-  it("optionalWith - Errors", () => {
-    // @ts-expect-error
-    S.optionalWith(S.String, { as: "Option", default: () => "" })
-    // @ts-expect-error
-    S.optionalWith(S.String, { as: "Option", exact: true, onNoneEncoding: () => Option.some(null) })
-    // @ts-expect-error
-    S.String.pipe(S.optionalWith({ as: "Option", exact: true, onNoneEncoding: () => Option.some(null) }))
-    // @ts-expect-error
-    S.optionalWith(S.String, { as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) })
-    // @ts-expect-error
-    S.optionalWith(S.String, { as: "Option", onNoneEncoding: () => Option.some(null) })
-    // @ts-expect-error
-    S.String.pipe(S.optionalWith({ as: "Option", onNoneEncoding: () => Option.some(null) }))
-    // @ts-expect-error
-    S.String.pipe(S.optionalWith({ as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) }))
-    // @ts-expect-error
-    S.optionalWith(S.String, { as: "Option", nullable: true, onNoneEncoding: () => Option.some(1) })
-    // @ts-expect-error
-    S.String.pipe(S.optionalWith({ as: "Option", nullable: true, onNoneEncoding: () => Option.some(1) }))
-    // @ts-expect-error
-    S.optionalWith(S.String, { as: null })
-    // @ts-expect-error
-    S.optionalWith(S.String, { default: null })
-  })
-
-  it("optionalWith used in a generic context", () => {
-    type TypeWithValue<Value extends S.Schema.Any> = { value: S.optionalWith<Value, { nullable: true }> }
-    const makeTypeWithValue = <Value extends S.Schema.Any>(value: Value): TypeWithValue<Value> => ({
-      value: S.optionalWith(value, { nullable: true })
+  describe("optionalWith", () => {
+    it("{ exact: true }", () => {
+      expect(
+        S.asSchema(S.Struct({ a: S.optionalWith(S.Never, { exact: true }) }))
+      ).type.toBe<S.Schema<{ readonly a?: never }, { readonly a?: never }>>()
+      expect(S.Struct({ a: S.optionalWith(S.Never, { exact: true }) }))
+        .type.toBe<S.Struct<{ a: S.optionalWith<typeof S.Never, { exact: true }> }>>()
+      expect(
+        S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { exact: true }) }))
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c?: boolean },
+          { readonly a: string; readonly b: number; readonly c?: boolean },
+          never
+        >
+      >()
+      expect(
+        S.asSchema(S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { exact: true }) }))
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c?: number },
+          { readonly a: string; readonly b: number; readonly c?: string },
+          never
+        >
+      >()
+      expect(S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ exact: true })) }))
+        .type.toBe<S.Struct<{ a: S.optionalWith<S.Literal<["a", "b"]>, { exact: true }> }>>()
     })
-    expect(makeTypeWithValue(S.String)).type.toBe<TypeWithValue<typeof S.String>>()
-  })
 
-  it("optionalWith { exact: true, default: () => A }", () => {
-    expect(
-      S.asSchema(
+    it("Type Level Errors", () => {
+      // @ts-expect-error
+      S.optionalWith(S.String, { as: "Option", default: () => "" })
+      // @ts-expect-error
+      S.optionalWith(S.String, { as: "Option", exact: true, onNoneEncoding: () => Option.some(null) })
+      // @ts-expect-error
+      S.String.pipe(S.optionalWith({ as: "Option", exact: true, onNoneEncoding: () => Option.some(null) }))
+      // @ts-expect-error
+      S.optionalWith(S.String, { as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) })
+      // @ts-expect-error
+      S.optionalWith(S.String, { as: "Option", onNoneEncoding: () => Option.some(null) })
+      // @ts-expect-error
+      S.String.pipe(S.optionalWith({ as: "Option", onNoneEncoding: () => Option.some(null) }))
+      // @ts-expect-error
+      S.String.pipe(S.optionalWith({ as: "Option", exact: true, nullable: true, onNoneEncoding: () => Option.some(1) }))
+      // @ts-expect-error
+      S.optionalWith(S.String, { as: "Option", nullable: true, onNoneEncoding: () => Option.some(1) })
+      // @ts-expect-error
+      S.String.pipe(S.optionalWith({ as: "Option", nullable: true, onNoneEncoding: () => Option.some(1) }))
+      // @ts-expect-error
+      S.optionalWith(S.String, { as: null })
+      // @ts-expect-error
+      S.optionalWith(S.String, { default: null })
+    })
+
+    it("used in a generic context", () => {
+      type TypeWithValue<Value extends S.Schema.Any> = { value: S.optionalWith<Value, { nullable: true }> }
+      const makeTypeWithValue = <Value extends S.Schema.Any>(value: Value): TypeWithValue<Value> => ({
+        value: S.optionalWith(value, { nullable: true })
+      })
+      expect(makeTypeWithValue(S.String)).type.toBe<TypeWithValue<typeof S.String>>()
+    })
+
+    it("{ exact: true, default: () => A }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({
+            a: S.String,
+            b: S.Number,
+            c: S.optionalWith(S.Boolean, { exact: true, default: () => false })
+          })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: boolean },
+          { readonly a: string; readonly b: number; readonly c?: boolean },
+          never
+        >
+      >()
+
+      expect(
         S.Struct({
           a: S.String,
           b: S.Number,
           c: S.optionalWith(S.Boolean, { exact: true, default: () => false })
         })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: boolean },
-        { readonly a: string; readonly b: number; readonly c?: boolean },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.Boolean, { exact: true; default: () => false }>
+        }>
+      >()
 
-    expect(
-      S.Struct({
-        a: S.String,
-        b: S.Number,
-        c: S.optionalWith(S.Boolean, { exact: true, default: () => false })
-      })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.Boolean, { exact: true; default: () => false }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({
+            a: S.String,
+            b: S.Number,
+            c: S.optionalWith(S.NumberFromString, { exact: true, default: () => 0 })
+          })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: number },
+          { readonly a: string; readonly b: number; readonly c?: string },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({
           a: S.String,
           b: S.Number,
           c: S.optionalWith(S.NumberFromString, { exact: true, default: () => 0 })
         })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: number },
-        { readonly a: string; readonly b: number; readonly c?: string },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.NumberFromString, { exact: true; default: () => number }>
+        }>
+      >()
 
-    expect(
-      S.Struct({
-        a: S.String,
-        b: S.Number,
-        c: S.optionalWith(S.NumberFromString, { exact: true, default: () => 0 })
-      })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.NumberFromString, { exact: true; default: () => number }>
-      }>
-    >()
+      expect(
+        S.Struct({ a: S.optionalWith(S.Literal("a", "b"), { default: () => "a", exact: true }) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; exact: true }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.optionalWith(S.Literal("a", "b"), { default: () => "a", exact: true }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; exact: true }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a", exact: true })) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: "a" | "b" },
+          { readonly a?: "a" | "b" },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a", exact: true })) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: "a" | "b" },
-        { readonly a?: "a" | "b" },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; exact: true }>
+        }>
+      >()
+    })
 
-    expect(
-      S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a", exact: true })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; exact: true }>
-      }>
-    >()
-  })
+    it("{ default: () => A }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { default: () => false }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: boolean },
+          { readonly a: string; readonly b: number; readonly c?: boolean | undefined },
+          never
+        >
+      >()
 
-  it("optionalWith { default: () => A }", () => {
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { default: () => false }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: boolean },
-        { readonly a: string; readonly b: number; readonly c?: boolean | undefined },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.Boolean, { default: () => false }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { default: () => false }) })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.Boolean, { default: () => false }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { default: () => 0 }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: number },
+          { readonly a: string; readonly b: number; readonly c?: string | undefined },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { default: () => 0 }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: number },
-        { readonly a: string; readonly b: number; readonly c?: string | undefined },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.NumberFromString, { default: () => number }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { default: () => 0 }) })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.NumberFromString, { default: () => number }>
-      }>
-    >()
+      expect(
+        S.Struct({ a: S.optionalWith(S.Literal("a", "b"), { default: () => "a" }) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a" }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.optionalWith(S.Literal("a", "b"), { default: () => "a" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a" }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a" })) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: "a" | "b" },
+          { readonly a?: "a" | "b" | undefined },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a" })) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: "a" | "b" },
-        { readonly a?: "a" | "b" | undefined },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a" }>
+        }>
+      >()
+    })
 
-    expect(
-      S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a" })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a" }>
-      }>
-    >()
-  })
+    it("{ exact: true, nullable: true, default: () => A }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: number },
+          { readonly a?: string | null },
+          never
+        >
+      >()
 
-  it("optionalWith { exact: true, nullable: true, default: () => A }", () => {
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: number },
-        { readonly a?: string | null },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.NumberFromString, { exact: true; nullable: true; default: () => number }>
+        }>
+      >()
+    })
 
-    expect(
-      S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.NumberFromString, { exact: true; nullable: true; default: () => number }>
-      }>
-    >()
-  })
+    it("{ nullable: true, default: () => A }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.optionalWith(S.NumberFromString, { nullable: true, default: () => 0 }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: number },
+          { readonly a?: string | null | undefined },
+          never
+        >
+      >()
 
-  it("optionalWith { nullable: true, default: () => A }", () => {
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.optionalWith(S.NumberFromString, { nullable: true, default: () => 0 }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: number },
-        { readonly a?: string | null | undefined },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.NumberFromString, { nullable: true; default: () => number }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.optionalWith(S.NumberFromString, { nullable: true, default: () => 0 }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.NumberFromString, { nullable: true; default: () => number }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: number },
+          { readonly a?: string | null },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: number },
-        { readonly a?: string | null },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.NumberFromString, { exact: true; nullable: true; default: () => number }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, default: () => 0 }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.NumberFromString, { exact: true; nullable: true; default: () => number }>
-      }>
-    >()
+      expect(
+        S.Struct({ a: S.optionalWith(S.Literal("a", "b"), { default: () => "a", nullable: true }) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; nullable: true }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.optionalWith(S.Literal("a", "b"), { default: () => "a", nullable: true }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; nullable: true }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a", nullable: true })) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: "a" | "b" },
+          { readonly a?: "a" | "b" | null | undefined },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a", nullable: true })) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: "a" | "b" },
-        { readonly a?: "a" | "b" | null | undefined },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; nullable: true }>
+        }>
+      >()
+    })
 
-    expect(
-      S.Struct({ a: S.Literal("a", "b").pipe(S.optionalWith({ default: () => "a", nullable: true })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<S.Literal<["a", "b"]>, { default: () => "a"; nullable: true }>
-      }>
-    >()
-  })
+    it("{ exact: true, as: 'Option' }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { exact: true, as: "Option" }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: Option.Option<boolean> },
+          { readonly a: string; readonly b: number; readonly c?: boolean },
+          never
+        >
+      >()
 
-  it("optionalWith { exact: true, as: 'Option' }", () => {
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { exact: true, as: "Option" }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: Option.Option<boolean> },
-        { readonly a: string; readonly b: number; readonly c?: boolean },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.Boolean, { exact: true; as: "Option" }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { exact: true, as: "Option" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.Boolean, { exact: true; as: "Option" }>
-      }>
-    >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { exact: true, as: "Option" }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: Option.Option<number> },
+          { readonly a: string; readonly b: number; readonly c?: string },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(
+      expect(
         S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { exact: true, as: "Option" }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: Option.Option<number> },
-        { readonly a: string; readonly b: number; readonly c?: string },
-        never
-      >
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.NumberFromString, { exact: true; as: "Option" }>
+        }>
+      >()
 
-    expect(
-      S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { exact: true, as: "Option" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.NumberFromString, { exact: true; as: "Option" }>
-      }>
-    >()
+      expect(
+        S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, as: "Option" })) }))
+      ).type.toBe<
+        S.Schema<
+          { readonly a: Option.Option<string> },
+          { readonly a?: string },
+          never
+        >
+      >()
 
-    expect(
-      S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, as: "Option" })) }))
-    ).type.toBe<
-      S.Schema<
-        { readonly a: Option.Option<string> },
-        { readonly a?: string },
-        never
-      >
-    >()
+      expect(
+        S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, as: "Option" })) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.String, { exact: true; as: "Option" }>
+        }>
+      >()
+    })
 
-    expect(
-      S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, as: "Option" })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.String, { exact: true; as: "Option" }>
-      }>
-    >()
-  })
-
-  it("optionalWith { as: 'Option' }", () => {
-    expect(
-      S.asSchema(
+    it("{ as: 'Option' }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { as: "Option" }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: Option.Option<boolean> },
+          { readonly a: string; readonly b: number; readonly c?: boolean | undefined },
+          never
+        >
+      >()
+      expect(
         S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { as: "Option" }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: Option.Option<boolean> },
-        { readonly a: string; readonly b: number; readonly c?: boolean | undefined },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.Boolean, { as: "Option" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.Boolean, { as: "Option" }>
-      }>
-    >()
-    expect(
-      S.asSchema(
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.Boolean, { as: "Option" }>
+        }>
+      >()
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { as: "Option" }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: string; readonly b: number; readonly c: Option.Option<number> },
+          { readonly a: string; readonly b: number; readonly c?: string | undefined },
+          never
+        >
+      >()
+      expect(
         S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { as: "Option" }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: string; readonly b: number; readonly c: Option.Option<number> },
-        { readonly a: string; readonly b: number; readonly c?: string | undefined },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.String, b: S.Number, c: S.optionalWith(S.NumberFromString, { as: "Option" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: typeof S.String
-        b: typeof S.Number
-        c: S.optionalWith<typeof S.NumberFromString, { as: "Option" }>
-      }>
-    >()
-    expect(
-      S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ as: "Option" })) }))
-    ).type.toBe<
-      S.Schema<
-        { readonly a: Option.Option<string> },
-        { readonly a?: string | undefined },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.String.pipe(S.optionalWith({ as: "Option" })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.String, { as: "Option" }>
-      }>
-    >()
-  })
+      ).type.toBe<
+        S.Struct<{
+          a: typeof S.String
+          b: typeof S.Number
+          c: S.optionalWith<typeof S.NumberFromString, { as: "Option" }>
+        }>
+      >()
+      expect(
+        S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ as: "Option" })) }))
+      ).type.toBe<
+        S.Schema<
+          { readonly a: Option.Option<string> },
+          { readonly a?: string | undefined },
+          never
+        >
+      >()
+      expect(
+        S.Struct({ a: S.String.pipe(S.optionalWith({ as: "Option" })) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.String, { as: "Option" }>
+        }>
+      >()
+    })
 
-  it("optionalWith { nullable: true, as: 'Option' }", () => {
-    expect(
-      S.asSchema(
+    it("{ nullable: true, as: 'Option' }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.optionalWith(S.NumberFromString, { nullable: true, as: "Option" }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: Option.Option<number> },
+          { readonly a?: string | null | undefined },
+          never
+        >
+      >()
+      expect(
         S.Struct({ a: S.optionalWith(S.NumberFromString, { nullable: true, as: "Option" }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: Option.Option<number> },
-        { readonly a?: string | null | undefined },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.optionalWith(S.NumberFromString, { nullable: true, as: "Option" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.NumberFromString, { nullable: true; as: "Option" }>
-      }>
-    >()
-    expect(
-      S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ nullable: true, as: "Option" })) }))
-    ).type.toBe<
-      S.Schema<
-        { readonly a: Option.Option<string> },
-        { readonly a?: string | null | undefined },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.String.pipe(S.optionalWith({ nullable: true, as: "Option" })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.String, { nullable: true; as: "Option" }>
-      }>
-    >()
-  })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.NumberFromString, { nullable: true; as: "Option" }>
+        }>
+      >()
+      expect(
+        S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ nullable: true, as: "Option" })) }))
+      ).type.toBe<
+        S.Schema<
+          { readonly a: Option.Option<string> },
+          { readonly a?: string | null | undefined },
+          never
+        >
+      >()
+      expect(
+        S.Struct({ a: S.String.pipe(S.optionalWith({ nullable: true, as: "Option" })) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.String, { nullable: true; as: "Option" }>
+        }>
+      >()
+    })
 
-  it("optionalWith { exact: true, nullable: true, as: 'Option' }", () => {
-    expect(
-      S.asSchema(
+    it("{ exact: true, nullable: true, as: 'Option' }", () => {
+      expect(
+        S.asSchema(
+          S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, as: "Option" }) })
+        )
+      ).type.toBe<
+        S.Schema<
+          { readonly a: Option.Option<number> },
+          { readonly a?: string | null },
+          never
+        >
+      >()
+      expect(
         S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, as: "Option" }) })
-      )
-    ).type.toBe<
-      S.Schema<
-        { readonly a: Option.Option<number> },
-        { readonly a?: string | null },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.optionalWith(S.NumberFromString, { exact: true, nullable: true, as: "Option" }) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.NumberFromString, { exact: true; nullable: true; as: "Option" }>
-      }>
-    >()
-    expect(
-      S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, nullable: true, as: "Option" })) }))
-    ).type.toBe<
-      S.Schema<
-        { readonly a: Option.Option<string> },
-        { readonly a?: string | null },
-        never
-      >
-    >()
-    expect(
-      S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, nullable: true, as: "Option" })) })
-    ).type.toBe<
-      S.Struct<{
-        a: S.optionalWith<typeof S.String, { exact: true; nullable: true; as: "Option" }>
-      }>
-    >()
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.NumberFromString, { exact: true; nullable: true; as: "Option" }>
+        }>
+      >()
+      expect(
+        S.asSchema(S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, nullable: true, as: "Option" })) }))
+      ).type.toBe<
+        S.Schema<
+          { readonly a: Option.Option<string> },
+          { readonly a?: string | null },
+          never
+        >
+      >()
+      expect(
+        S.Struct({ a: S.String.pipe(S.optionalWith({ exact: true, nullable: true, as: "Option" })) })
+      ).type.toBe<
+        S.Struct<{
+          a: S.optionalWith<typeof S.String, { exact: true; nullable: true; as: "Option" }>
+        }>
+      >()
+    })
   })
 
-  it("pick", () => {
-    // @ts-expect-error
-    pipe(S.Struct({ a: S.propertySignature(S.Number).pipe(S.fromKey("c")) }), S.pick("a"))
-    expect(
-      pipe(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }), S.pick("a", "b"))
-    ).type.toBe<
-      S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: number }>
-    >()
-    expect(
-      pipe(S.Struct({ a: S.String, b: S.NumberFromString, c: S.Boolean }), S.pick("a", "b"))
-    ).type.toBe<
-      S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: string }>
-    >()
+  describe("pick", () => {
+    it("required fields", () => {
+      // @ts-expect-error
+      pipe(S.Struct({ a: S.propertySignature(S.Number).pipe(S.fromKey("c")) }), S.pick("a"))
+      expect(
+        pipe(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }), S.pick("a", "b"))
+      ).type.toBe<
+        S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: number }>
+      >()
+      expect(
+        pipe(S.Struct({ a: S.String, b: S.NumberFromString, c: S.Boolean }), S.pick("a", "b"))
+      ).type.toBe<
+        S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: string }>
+      >()
+    })
+
+    it("optional fields", () => {
+      expect(
+        pipe(
+          S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number, c: S.Boolean }),
+          S.pick("a", "b")
+        )
+      ).type.toBe<
+        S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: number }>
+      >()
+      expect(
+        pipe(
+          S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.NumberFromString, c: S.Boolean }),
+          S.pick("a", "b")
+        )
+      ).type.toBe<
+        S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: string }>
+      >()
+      expect(
+        pipe(
+          S.Struct({
+            a: S.optionalWith(S.String, { exact: true, default: () => "" }),
+            b: S.NumberFromString,
+            c: S.Boolean
+          }),
+          S.pick("a", "b")
+        )
+      ).type.toBe<
+        S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a?: string; readonly b: string }>
+      >()
+    })
   })
 
-  it("pick - optionalWith", () => {
-    expect(
-      pipe(
-        S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number, c: S.Boolean }),
-        S.pick("a", "b")
-      )
-    ).type.toBe<
-      S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: number }>
-    >()
-    expect(
-      pipe(
-        S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.NumberFromString, c: S.Boolean }),
-        S.pick("a", "b")
-      )
-    ).type.toBe<
-      S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: string }>
-    >()
-    expect(
-      pipe(
-        S.Struct({
-          a: S.optionalWith(S.String, { exact: true, default: () => "" }),
-          b: S.NumberFromString,
-          c: S.Boolean
-        }),
-        S.pick("a", "b")
-      )
-    ).type.toBe<
-      S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a?: string; readonly b: string }>
-    >()
+  describe("omit", () => {
+    it("required fields", () => {
+      // @ts-expect-error
+      pipe(S.Struct({ a: S.propertySignature(S.Number).pipe(S.fromKey("c")) }), S.omit("a"))
+      expect(
+        pipe(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }), S.omit("c"))
+      ).type.toBe<
+        S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: number }>
+      >()
+      expect(
+        pipe(S.Struct({ a: S.String, b: S.NumberFromString, c: S.Boolean }), S.omit("c"))
+      ).type.toBe<
+        S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: string }>
+      >()
+    })
+
+    it("optional fields", () => {
+      expect(
+        pipe(
+          S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number, c: S.Boolean }),
+          S.omit("c")
+        )
+      ).type.toBe<
+        S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: number }>
+      >()
+      expect(
+        pipe(
+          S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.NumberFromString, c: S.Boolean }),
+          S.omit("c")
+        )
+      ).type.toBe<
+        S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: string }>
+      >()
+      expect(
+        pipe(
+          S.Struct({
+            a: S.optionalWith(S.String, { exact: true, default: () => "" }),
+            b: S.NumberFromString,
+            c: S.Boolean
+          }),
+          S.omit("c")
+        )
+      ).type.toBe<
+        S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a?: string; readonly b: string }>
+      >()
+    })
   })
 
-  it("Struct.pick", () => {
-    // @ts-expect-error
-    S.Struct({ a: S.String }).pick("c")
-    // @ts-expect-error
-    S.Struct({ a: S.propertySignature(S.String).pipe(S.fromKey("c")) }).pick("c")
+  describe("Struct Static Methods", () => {
+    it("make", () => {
+      const make1 = S.Struct({
+        a: S.propertySignature(S.String).pipe(S.withConstructorDefault(() => "")),
+        b: S.Number,
+        c: S.propertySignature(S.Boolean).pipe(S.withConstructorDefault(() => true))
+      }).make
+      expect(hole<Parameters<typeof make1>[0]>()).type.toBe<
+        { readonly a?: string; readonly b: number; readonly c?: boolean }
+      >()
+      const make2 = S.Struct({
+        a: S.withConstructorDefault(S.propertySignature(S.String), () => ""),
+        b: S.Number,
+        c: S.withConstructorDefault(S.propertySignature(S.Boolean), () => true)
+      }).make
+      expect(hole<Parameters<typeof make2>[0]>()).type.toBe<
+        { readonly a?: string; readonly b: number; readonly c?: boolean }
+      >()
+      const make3 = S.Struct({
+        a: S.withConstructorDefault(S.propertySignature(S.String), () => "")
+      }).make
+      expect(hole<Parameters<typeof make3>[0]>()).type.toBe<void | { readonly a?: string } | undefined>()
+      class AA extends S.Class<AA>("AA")({
+        a: S.propertySignature(S.String).pipe(S.withConstructorDefault(() => "")),
+        b: S.Number,
+        c: S.propertySignature(S.Boolean).pipe(S.withConstructorDefault(() => true))
+      }) {}
+      expect(hole<ConstructorParameters<typeof AA>>()).type.toBe<
+        [props: { readonly a?: string; readonly b: number; readonly c?: boolean }, options?: S.MakeOptions | undefined]
+      >()
+    })
 
-    expect(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).pick("a", "b"))
-      .type.toBe<S.Struct<{ a: typeof S.String; b: typeof S.Number }>>()
-  })
+    it("pick", () => {
+      // @ts-expect-error
+      S.Struct({ a: S.String }).pick("c")
+      // @ts-expect-error
+      S.Struct({ a: S.propertySignature(S.String).pipe(S.fromKey("c")) }).pick("c")
 
-  it("omit", () => {
-    // @ts-expect-error
-    pipe(S.Struct({ a: S.propertySignature(S.Number).pipe(S.fromKey("c")) }), S.omit("a"))
-    expect(
-      pipe(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }), S.omit("c"))
-    ).type.toBe<
-      S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: number }>
-    >()
-    expect(
-      pipe(S.Struct({ a: S.String, b: S.NumberFromString, c: S.Boolean }), S.omit("c"))
-    ).type.toBe<
-      S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a: string; readonly b: string }>
-    >()
-  })
+      expect(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).pick("a", "b"))
+        .type.toBe<S.Struct<{ a: typeof S.String; b: typeof S.Number }>>()
+    })
 
-  it("omit - optionalWith", () => {
-    expect(
-      pipe(
-        S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number, c: S.Boolean }),
-        S.omit("c")
-      )
-    ).type.toBe<
-      S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: number }>
-    >()
-    expect(
-      pipe(
-        S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.NumberFromString, c: S.Boolean }),
-        S.omit("c")
-      )
-    ).type.toBe<
-      S.SchemaClass<{ readonly a?: string; readonly b: number }, { readonly a?: string; readonly b: string }>
-    >()
-    expect(
-      pipe(
-        S.Struct({
-          a: S.optionalWith(S.String, { exact: true, default: () => "" }),
-          b: S.NumberFromString,
-          c: S.Boolean
-        }),
-        S.omit("c")
-      )
-    ).type.toBe<
-      S.SchemaClass<{ readonly a: string; readonly b: number }, { readonly a?: string; readonly b: string }>
-    >()
-  })
+    it("omit", () => {
+      // @ts-expect-error
+      S.Struct({ a: S.String }).omit("c")
+      // @ts-expect-error
+      S.Struct({ a: S.propertySignature(S.String).pipe(S.fromKey("c")) }).omit("c")
 
-  it("Struct.omit", () => {
-    // @ts-expect-error
-    S.Struct({ a: S.String }).omit("c")
-    // @ts-expect-error
-    S.Struct({ a: S.propertySignature(S.String).pipe(S.fromKey("c")) }).omit("c")
-
-    expect(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).omit("c"))
-      .type.toBe<S.Struct<{ a: typeof S.String; b: typeof S.Number }>>()
-    expect(S.Struct({ a: S.Number, b: S.Number.pipe(S.propertySignature, S.fromKey("c")) }).omit("b"))
-      .type.toBe<S.Struct<{ a: typeof S.Number }>>()
+      expect(S.Struct({ a: S.String, b: S.Number, c: S.Boolean }).omit("c"))
+        .type.toBe<S.Struct<{ a: typeof S.String; b: typeof S.Number }>>()
+      expect(S.Struct({ a: S.Number, b: S.Number.pipe(S.propertySignature, S.fromKey("c")) }).omit("b"))
+        .type.toBe<S.Struct<{ a: typeof S.Number }>>()
+    })
   })
 
   it("brand", () => {
@@ -986,7 +1224,7 @@ describe("Schema", () => {
     expect(S.asSchema(pipe(S.Number, S.int(), S.brand("Int"))).annotations({}))
       .type.toBe<S.Schema<number & Brand.Brand<"Int">, number>>()
     expect(pipe(S.Number, S.int(), S.brand("Int")))
-      .type.toBe<S.brand<S.filter<S.Schema<number, number>>, "Int">>()
+      .type.toBe<S.brand<S.filter<S.Schema<number>>, "Int">>()
     expect(S.asSchema(pipe(S.NumberFromString, S.int(), S.brand("Int"))))
       .type.toBe<S.Schema<number & Brand.Brand<"Int">, string>>()
     expect(pipe(S.NumberFromString, S.int(), S.brand("Int")))
@@ -1076,10 +1314,10 @@ describe("Schema", () => {
     >()
   })
 
-  it("Records", () => {
-    expect(S.asSchema(S.Record({ key: S.String, value: S.String }).key)).type.toBe<S.Schema<string, string>>()
+  it("Record", () => {
+    expect(S.asSchema(S.Record({ key: S.String, value: S.String }).key)).type.toBe<S.Schema<string>>()
     expect(S.Record({ key: S.String, value: S.String }).key).type.toBe<typeof S.String>()
-    expect(S.asSchema(S.Record({ key: S.String, value: S.String }).value)).type.toBe<S.Schema<string, string>>()
+    expect(S.asSchema(S.Record({ key: S.String, value: S.String }).value)).type.toBe<S.Schema<string>>()
     expect(S.Record({ key: S.String, value: S.String }).value).type.toBe<typeof S.String>()
     expect(S.asSchema(S.Record({ key: S.String, value: S.String })))
       .type.toBe<
@@ -1109,7 +1347,7 @@ describe("Schema", () => {
       >
     >()
     expect(S.Record({ key: pipe(S.String, S.minLength(2)), value: S.String }))
-      .type.toBe<S.Record$<S.filter<S.Schema<string, string>>, typeof S.String>>()
+      .type.toBe<S.Record$<S.filter<S.Schema<string>>, typeof S.String>>()
     expect(S.asSchema(S.Record({ key: S.Union(S.Literal("a"), S.Literal("b")), value: S.String })))
       .type.toBe<
       S.Schema<
@@ -1335,7 +1573,7 @@ describe("Schema", () => {
     S.Struct({ a: S.String, b: S.Number }).pipe(S.rename({ a: "c", d: "e" }))
   })
 
-  it("InstanceOf", () => {
+  it("instanceOf", () => {
     class Test {
       constructor(readonly name: string) {}
     }
@@ -1473,104 +1711,6 @@ describe("Schema", () => {
     >()
   })
 
-  it("filter", () => {
-    S.String.pipe(S.filter((s, options, ast) => {
-      expect(s).type.toBe<string>()
-      expect(options).type.toBe<SchemaAST.ParseOptions>()
-      expect(ast).type.toBe<SchemaAST.Refinement>()
-      return undefined
-    }))
-    const predicateFilter1 = (u: unknown): boolean => typeof u === "string"
-    const FromFilter = S.Union(S.String, S.Number)
-    expect(pipe(FromFilter, S.filter(predicateFilter1)))
-      .type.toBe<S.filter<S.Union<[typeof S.String, typeof S.Number]>>>()
-    const FromRefinement = S.Struct({
-      a: S.optionalWith(S.String, { exact: true }),
-      b: S.optionalWith(S.Number, { exact: true })
-    })
-    expect(pipe(FromRefinement, S.filter(S.is(S.Struct({ b: S.Number })))))
-      .type.toBe<
-      S.refine<
-        { readonly a?: string; readonly b?: number } & { readonly b: number },
-        S.Schema<unknown, { readonly a?: string; readonly b?: number }>
-      >
-    >()
-    const LiteralFilter = S.Literal("a", "b")
-    const predicateFilter2 = (u: unknown): u is "a" => typeof u === "string" && u === "a"
-    expect(pipe(LiteralFilter, S.filter(predicateFilter2)))
-      .type.toBe<S.refine<"a", S.Schema<unknown, "a" | "b">>>()
-    expect(pipe(LiteralFilter, S.filter(S.is(S.Literal("a")))))
-      .type.toBe<S.refine<"a", S.Schema<unknown, "a" | "b">>>()
-    expect(pipe(LiteralFilter, S.filter(S.is(S.Literal("c")))))
-      .type.toBe<S.refine<never, S.Schema<unknown, "a" | "b">>>()
-    const UnionFilter = hole<
-      S.Schema<
-        { readonly a: string } | { readonly b: string },
-        { readonly a: string } | { readonly b: string },
-        never
-      >
-    >()
-    expect(pipe(UnionFilter, S.filter(S.is(S.Struct({ b: S.String })))))
-      .type.toBe<
-      S.refine<
-        ({ readonly a: string } | { readonly b: string }) & { readonly b: string },
-        S.Schema<unknown, { readonly a: string } | { readonly b: string }>
-      >
-    >()
-    expect(pipe(S.Number, S.filter((n): n is number & Brand.Brand<"MyNumber"> => n > 0)))
-      .type.toBe<S.refine<number & Brand.Brand<"MyNumber">, S.Schema<number, number>>>()
-    // annotations
-    pipe(
-      S.String,
-      S.filter(
-        (s) => {
-          expect(s).type.toBe<string>()
-          return true
-        },
-        {
-          arbitrary: (from, ctx) => (fc) => {
-            expect(from).type.toBe<Arbitrary.LazyArbitrary<string>>()
-            expect(ctx).type.toBe<Arbitrary.ArbitraryGenerationContext>()
-            return fc.string()
-          },
-          pretty: (from) => (s) => {
-            expect(from).type.toBe<Pretty.Pretty<string>>()
-            expect(s).type.toBe<string>()
-            return s
-          },
-          equivalence: (from) => (a, b) => {
-            expect(from).type.toBe<Equivalence.Equivalence<string>>()
-            expect(a).type.toBe<string>()
-            expect(b).type.toBe<string>()
-            return true
-          }
-        }
-      )
-    )
-    pipe(
-      S.String,
-      S.filter((s) => {
-        expect(s).type.toBe<string>()
-        return true
-      })
-    ).annotations({
-      arbitrary: (...x) => (fc) => {
-        expect(x).type.toBe<Array<any>>()
-        return fc.string()
-      },
-      pretty: (...x) => (s) => {
-        expect(x).type.toBe<Array<any>>()
-        return s
-      },
-      equivalence: (...x) => (a, b) => {
-        expect(x).type.toBe<Array<any>>()
-        expect(a).type.toBe<string>()
-        expect(b).type.toBe<string>()
-        return true
-      }
-    })
-  })
-
   it("filterEffect", () => {
     expect(
       S.String.pipe(S.filterEffect((s) => {
@@ -1639,7 +1779,7 @@ describe("Schema", () => {
       .type.toBe<S.SchemaClass<number, string>>()
   })
 
-  it("FromBrand", () => {
+  it("fromBrand", () => {
     type Eur = number & Brand.Brand<"Eur">
     const Eur = Brand.nominal<Eur>()
     expect(S.Number.pipe(S.fromBrand(Eur)))
@@ -1648,7 +1788,7 @@ describe("Schema", () => {
 
   it("mutable", () => {
     expect(S.asSchema(S.mutable(S.String)))
-      .type.toBe<S.Schema<string, string>>()
+      .type.toBe<S.Schema<string>>()
     S.mutable(S.String)
     expect(S.asSchema(S.mutable(S.Struct({ a: S.Number }))))
       .type.toBe<S.Schema<{ a: number }, { a: number }>>()
@@ -1817,37 +1957,6 @@ describe("Schema", () => {
     expect(S.transformLiterals(...pairs)).type.toBe<S.Schema<"a" | "b", 0 | 1>>()
   })
 
-  it("BigDecimal", () => {
-    expect(S.asSchema(S.BigDecimal)).type.toBe<S.Schema<BigDecimal.BigDecimal, string>>()
-    expect(S.asSchema(S.BigDecimalFromSelf)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
-    expect(S.asSchema(S.BigDecimalFromNumber)).type.toBe<S.Schema<BigDecimal.BigDecimal, number>>()
-  })
-
-  it("Duration", () => {
-    expect(S.asSchema(S.Duration))
-      .type.toBe<S.Schema<Duration.Duration, S.DurationEncoded | readonly [seconds: number, nanos: number]>>()
-  })
-
-  it("DurationFromSelf", () => {
-    expect(S.asSchema(S.DurationFromSelf)).type.toBe<S.Schema<Duration.Duration>>()
-  })
-
-  it("DurationFromMillis", () => {
-    expect(S.asSchema(S.DurationFromMillis)).type.toBe<S.Schema<Duration.Duration, number>>()
-  })
-
-  it("DurationFromNanos", () => {
-    expect(S.asSchema(S.DurationFromNanos)).type.toBe<S.Schema<Duration.Duration, bigint>>()
-  })
-
-  it("Redacted", () => {
-    expect(S.asSchema(S.Redacted(S.NumberFromString))).type.toBe<S.Schema<Redacted.Redacted<number>, string>>()
-    expect(S.Redacted(S.NumberFromString)).type.toBe<S.Redacted<typeof S.NumberFromString>>()
-    expect(S.asSchema(S.RedactedFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<Redacted.Redacted<number>, Redacted.Redacted<string>>>()
-    expect(S.RedactedFromSelf(S.NumberFromString)).type.toBe<S.RedactedFromSelf<typeof S.NumberFromString>>()
-  })
-
   it("propertySignature", () => {
     expect(S.propertySignature(S.String)).type.toBe<S.propertySignature<typeof S.String>>()
     expect(S.propertySignature(S.String).annotations({})).type.toBe<S.propertySignature<typeof S.String>>()
@@ -1874,12 +1983,48 @@ describe("Schema", () => {
       .type.toBe<S.Schema<string | undefined, { readonly a?: string }>>()
   })
 
-  it("Head", () => {
-    expect(S.head(S.Array(S.Number))).type.toBe<S.SchemaClass<Option.Option<number>, ReadonlyArray<number>>>()
+  it("head", () => {
+    const schema = S.head(S.Array(S.Number))
+    expect(schema).type.toBe<
+      S.transform<
+        S.Schema<ReadonlyArray<number>>,
+        S.OptionFromSelf<S.SchemaClass<number>>
+      >
+    >()
+    expect(schema.annotations({})).type.toBe<
+      S.transform<
+        S.Schema<ReadonlyArray<number>>,
+        S.OptionFromSelf<S.SchemaClass<number>>
+      >
+    >()
+    expect(schema.from).type.toBe<S.Schema<ReadonlyArray<number>>>()
+    expect(schema.to).type.toBe<S.OptionFromSelf<S.SchemaClass<number>>>()
   })
 
-  it("HeadOrElse", () => {
-    expect(S.headOrElse(S.Array(S.Number))).type.toBe<S.SchemaClass<number, ReadonlyArray<number>>>()
+  it("headNonEmpty", () => {
+    const schema = S.headNonEmpty(S.NonEmptyArray(S.Number))
+    expect(schema).type.toBe<
+      S.transform<
+        S.Schema<readonly [number, ...Array<number>]>,
+        S.SchemaClass<number>
+      >
+    >()
+    expect(schema.annotations({})).type.toBe<
+      S.transform<
+        S.Schema<readonly [number, ...Array<number>]>,
+        S.SchemaClass<number>
+      >
+    >()
+    expect(schema.from).type.toBe<S.Schema<readonly [number, ...Array<number>]>>()
+    expect(schema.to).type.toBe<S.SchemaClass<number>>()
+  })
+
+  it("headOrElse", () => {
+    const schema = S.headOrElse(S.Array(S.Number))
+    expect(schema).type.toBe<S.transform<S.Schema<ReadonlyArray<number>>, S.SchemaClass<number>>>()
+    expect(schema.annotations({})).type.toBe<S.transform<S.Schema<ReadonlyArray<number>>, S.SchemaClass<number>>>()
+    expect(schema.from).type.toBe<S.Schema<ReadonlyArray<number>>>()
+    expect(schema.to).type.toBe<S.SchemaClass<number>>()
   })
 
   it("TaggedClass", () => {
@@ -1946,459 +2091,6 @@ describe("Schema", () => {
     >()
   })
 
-  it("Struct.Type", () => {
-    const _StructTypeTest1 = <S extends S.Schema.Any>(input: S.Struct.Type<{ s: S }>) => {
-      expect(input).type.toBe<S.Struct.Type<{ s: S }>>()
-      input
-    }
-    expect(hole<Types.Simplify<S.Struct.Type<{}>>>()).type.toBe<{}>()
-    expect(hole<Types.Simplify<S.Struct.Type<{ a: S.Schema<number, string> }>>>()).type.toBe<{ readonly a: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, never, ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, never, "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, "c", ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, "c", "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, never, ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b?: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, never, "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b?: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, "c", ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b?: number }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Type<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, "c", "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: number; readonly b?: number }>()
-  })
-
-  it("Struct.Encoded", () => {
-    expect(hole<Types.Simplify<S.Struct.Encoded<{}>>>()).type.toBe<{}>()
-    expect(hole<Types.Simplify<S.Struct.Encoded<{ a: S.Schema<number, string> }>>>()).type.toBe<
-      { readonly a: string }
-    >()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, never, ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly b: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, never, "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly b?: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, "c", ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly c: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<":", number, "c", "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly c?: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, never, ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly b: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, never, "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly b?: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, "c", ":", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly c: string }>()
-    expect(hole<
-      Types.Simplify<
-        S.Struct.Encoded<{
-          a: S.Schema<number, string>
-          b: S.PropertySignature<"?:", number, "c", "?:", string, false, "context">
-        }>
-      >
-    >()).type.toBe<{ readonly a: string; readonly c?: string }>()
-  })
-
-  it("OptionFromSelf", () => {
-    expect(S.asSchema(S.OptionFromSelf(S.Number)))
-      .type.toBe<S.Schema<Option.Option<number>, Option.Option<number>>>()
-    expect(S.OptionFromSelf(S.Number)).type.toBe<S.OptionFromSelf<typeof S.Number>>()
-    expect(S.asSchema(S.OptionFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<Option.Option<number>, Option.Option<string>>>()
-    expect(S.OptionFromSelf(S.NumberFromString)).type.toBe<S.OptionFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("Option", () => {
-    expect(S.asSchema(S.Option(S.Number)))
-      .type.toBe<S.Schema<Option.Option<number>, S.OptionEncoded<number>>>()
-    expect(S.Option(S.Number)).type.toBe<S.Option<typeof S.Number>>()
-    expect(S.asSchema(S.Option(S.NumberFromString)))
-      .type.toBe<S.Schema<Option.Option<number>, S.OptionEncoded<string>>>()
-    expect(S.Option(S.NumberFromString)).type.toBe<S.Option<typeof S.NumberFromString>>()
-  })
-
-  it("OptionFromNullOr", () => {
-    expect(S.asSchema(S.OptionFromNullOr(S.Number)))
-      .type.toBe<S.Schema<Option.Option<number>, number | null>>()
-    expect(S.OptionFromNullOr(S.Number)).type.toBe<S.OptionFromNullOr<typeof S.Number>>()
-    expect(S.asSchema(S.OptionFromNullOr(S.NumberFromString)))
-      .type.toBe<S.Schema<Option.Option<number>, string | null>>()
-    expect(S.OptionFromNullOr(S.NumberFromString)).type.toBe<S.OptionFromNullOr<typeof S.NumberFromString>>()
-  })
-
-  it("OptionFromUndefinedOr", () => {
-    expect(S.asSchema(S.OptionFromUndefinedOr(S.NumberFromString)))
-      .type.toBe<S.Schema<Option.Option<number>, string | undefined>>()
-    expect(S.OptionFromUndefinedOr(S.NumberFromString)).type.toBe<S.OptionFromUndefinedOr<typeof S.NumberFromString>>()
-  })
-
-  it("OptionFromNullishOr", () => {
-    expect(S.asSchema(S.OptionFromNullishOr(S.NumberFromString, null)))
-      .type.toBe<S.Schema<Option.Option<number>, string | null | undefined>>()
-    expect(S.OptionFromNullishOr(S.NumberFromString, undefined)).type.toBe<
-      S.OptionFromNullishOr<typeof S.NumberFromString>
-    >()
-  })
-
-  it("EitherFromSelf", () => {
-    expect(
-      S.asSchema(S.EitherFromSelf({ right: S.NumberFromString, left: S.String }))
-    ).type.toBe<S.Schema<Either.Either<number, string>, Either.Either<string, string>>>()
-    expect(S.EitherFromSelf({ right: S.NumberFromString, left: S.String })).type.toBe<
-      S.EitherFromSelf<typeof S.NumberFromString, typeof S.String>
-    >()
-    expect(S.EitherFromSelf({ right: S.String, left: S.Never })).type.toBe<
-      S.EitherFromSelf<typeof S.String, typeof S.Never>
-    >()
-    expect(S.EitherFromSelf({ right: S.Never, left: S.String })).type.toBe<
-      S.EitherFromSelf<typeof S.Never, typeof S.String>
-    >()
-  })
-
-  it("Either", () => {
-    expect(S.asSchema(S.Either({ right: S.NumberFromString, left: S.String })))
-      .type.toBe<S.Schema<Either.Either<number, string>, S.EitherEncoded<string, string>>>()
-    expect(S.Either({ right: S.NumberFromString, left: S.String })).type.toBe<
-      S.Either<typeof S.NumberFromString, typeof S.String>
-    >()
-    expect(S.Either({ right: S.String, left: S.Never })).type.toBe<S.Either<typeof S.String, typeof S.Never>>()
-    expect(S.Either({ right: S.Never, left: S.String })).type.toBe<S.Either<typeof S.Never, typeof S.String>>()
-  })
-
-  it("EitherFromUnion", () => {
-    expect(
-      S.asSchema(S.EitherFromUnion({ right: S.NumberFromString, left: S.Boolean }))
-    ).type.toBe<S.Schema<Either.Either<number, boolean>, string | boolean>>()
-    expect(S.EitherFromUnion({ right: S.NumberFromString, left: S.Boolean })).type.toBe<
-      S.EitherFromUnion<typeof S.NumberFromString, typeof S.Boolean>
-    >()
-    expect(S.EitherFromUnion({ right: S.String, left: S.Never })).type.toBe<
-      S.EitherFromUnion<typeof S.String, typeof S.Never>
-    >()
-    expect(S.EitherFromUnion({ right: S.Never, left: S.String })).type.toBe<
-      S.EitherFromUnion<typeof S.Never, typeof S.String>
-    >()
-  })
-
-  it("ReadonlyMapFromSelf", () => {
-    expect(
-      S.asSchema(S.ReadonlyMapFromSelf({ key: S.NumberFromString, value: S.String }))
-    ).type.toBe<S.Schema<ReadonlyMap<number, string>, ReadonlyMap<string, string>>>()
-    expect(S.ReadonlyMapFromSelf({ key: S.NumberFromString, value: S.String })).type.toBe<
-      S.ReadonlyMapFromSelf<typeof S.NumberFromString, typeof S.String>
-    >()
-  })
-
-  it("MapFromSelf", () => {
-    expect(
-      S.asSchema(S.MapFromSelf({ key: S.NumberFromString, value: S.String }))
-    ).type.toBe<S.Schema<Map<number, string>, ReadonlyMap<string, string>>>()
-    expect(S.MapFromSelf({ key: S.NumberFromString, value: S.String })).type.toBe<
-      S.MapFromSelf<typeof S.NumberFromString, typeof S.String>
-    >()
-  })
-
-  it("ReadonlyMap", () => {
-    expect(
-      S.asSchema(S.ReadonlyMap({ key: S.NumberFromString, value: S.String }))
-    ).type.toBe<
-      S.Schema<ReadonlyMap<number, string>, ReadonlyArray<readonly [string, string]>>
-    >()
-    expect(S.ReadonlyMap({ key: S.NumberFromString, value: S.String }))
-      .type.toBe<S.ReadonlyMap$<typeof S.NumberFromString, typeof S.String>>()
-  })
-
-  it("Map", () => {
-    expect(
-      S.asSchema(S.Map({ key: S.NumberFromString, value: S.String }))
-    ).type.toBe<
-      S.Schema<Map<number, string>, ReadonlyArray<readonly [string, string]>>
-    >()
-    expect(S.Map({ key: S.NumberFromString, value: S.String }))
-      .type.toBe<S.Map$<typeof S.NumberFromString, typeof S.String>>()
-  })
-
-  it("HashMapFromSelf", () => {
-    expect(
-      S.asSchema(S.HashMapFromSelf({ key: S.NumberFromString, value: S.String }))
-    ).type.toBe<S.Schema<HashMap.HashMap<number, string>, HashMap.HashMap<string, string>>>()
-    expect(S.HashMapFromSelf({ key: S.NumberFromString, value: S.String })).type.toBe<
-      S.HashMapFromSelf<typeof S.NumberFromString, typeof S.String>
-    >()
-  })
-
-  it("HashMap", () => {
-    expect(
-      S.asSchema(S.HashMap({ key: S.NumberFromString, value: S.String }))
-    ).type.toBe<
-      S.Schema<HashMap.HashMap<number, string>, ReadonlyArray<readonly [string, string]>>
-    >()
-    expect(S.HashMap({ key: S.NumberFromString, value: S.String }))
-      .type.toBe<S.HashMap<typeof S.NumberFromString, typeof S.String>>()
-  })
-
-  it("ReadonlySetFromSelf", () => {
-    expect(S.asSchema(S.ReadonlySetFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<ReadonlySet<number>, ReadonlySet<string>>>()
-    expect(S.ReadonlySetFromSelf(S.NumberFromString)).type.toBe<S.ReadonlySetFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("SetFromSelf", () => {
-    expect(S.asSchema(S.SetFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<Set<number>, ReadonlySet<string>>>()
-    expect(S.SetFromSelf(S.NumberFromString)).type.toBe<S.SetFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("ReadonlySet", () => {
-    expect(S.asSchema(S.ReadonlySet(S.NumberFromString)))
-      .type.toBe<S.Schema<ReadonlySet<number>, ReadonlyArray<string>>>()
-    expect(S.ReadonlySet(S.NumberFromString))
-      .type.toBe<S.ReadonlySet$<typeof S.NumberFromString>>()
-  })
-
-  it("Set", () => {
-    expect(S.asSchema(S.Set(S.NumberFromString)))
-      .type.toBe<S.Schema<Set<number>, ReadonlyArray<string>>>()
-    expect(S.Set(S.NumberFromString))
-      .type.toBe<S.Set$<typeof S.NumberFromString>>()
-  })
-
-  it("HashSetFromSelf", () => {
-    expect(S.asSchema(S.HashSetFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<HashSet.HashSet<number>, HashSet.HashSet<string>>>()
-    expect(S.HashSetFromSelf(S.NumberFromString)).type.toBe<S.HashSetFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("HashSet", () => {
-    expect(S.asSchema(S.HashSet(S.NumberFromString)))
-      .type.toBe<S.Schema<HashSet.HashSet<number>, ReadonlyArray<string>>>()
-    expect(S.HashSet(S.NumberFromString))
-      .type.toBe<S.HashSet<typeof S.NumberFromString>>()
-  })
-
-  it("ChunkFromSelf", () => {
-    expect(S.asSchema(S.ChunkFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<Chunk.Chunk<number>, Chunk.Chunk<string>>>()
-    expect(S.ChunkFromSelf(S.NumberFromString)).type.toBe<S.ChunkFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("Chunk", () => {
-    expect(S.asSchema(S.Chunk(S.NumberFromString)))
-      .type.toBe<S.Schema<Chunk.Chunk<number>, ReadonlyArray<string>>>()
-    expect(S.Chunk(S.NumberFromString))
-      .type.toBe<S.Chunk<typeof S.NumberFromString>>()
-  })
-
-  it("NonEmptyChunkFromSelf", () => {
-    expect(S.asSchema(S.NonEmptyChunkFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<Chunk.NonEmptyChunk<number>, Chunk.NonEmptyChunk<string>>>()
-    expect(S.NonEmptyChunkFromSelf(S.NumberFromString)).type.toBe<S.NonEmptyChunkFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("NonEmptyChunk", () => {
-    expect(S.asSchema(S.NonEmptyChunk(S.NumberFromString)))
-      .type.toBe<S.Schema<Chunk.NonEmptyChunk<number>, readonly [string, ...Array<string>]>>()
-    expect(S.NonEmptyChunk(S.NumberFromString))
-      .type.toBe<S.NonEmptyChunk<typeof S.NumberFromString>>()
-  })
-
-  it("ListFromSelf", () => {
-    expect(S.asSchema(S.ListFromSelf(S.NumberFromString)))
-      .type.toBe<S.Schema<List.List<number>, List.List<string>>>()
-    expect(S.ListFromSelf(S.NumberFromString)).type.toBe<S.ListFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("List", () => {
-    expect(S.asSchema(S.List(S.NumberFromString)))
-      .type.toBe<S.Schema<List.List<number>, ReadonlyArray<string>>>()
-    expect(S.List(S.NumberFromString))
-      .type.toBe<S.List<typeof S.NumberFromString>>()
-  })
-
-  it("ExitFromSelf", () => {
-    expect(
-      S.asSchema(S.ExitFromSelf({ success: S.Number, failure: S.String, defect: S.Unknown }))
-    ).type.toBe<S.Schema<Exit.Exit<number, string>, Exit.Exit<number, string>>>()
-    expect(S.ExitFromSelf({ success: S.Number, failure: S.String, defect: S.Unknown })).type.toBe<
-      S.ExitFromSelf<typeof S.Number, typeof S.String, typeof S.Unknown>
-    >()
-    expect(
-      S.asSchema(
-        S.ExitFromSelf({ success: S.Number, failure: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })
-      )
-    ).type.toBe<S.Schema<Exit.Exit<number, string>, Exit.Exit<number, string>, "a">>()
-    expect(
-      S.ExitFromSelf({ success: S.Number, failure: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })
-    ).type.toBe<S.ExitFromSelf<typeof S.Number, typeof S.String, S.Schema<unknown, unknown, "a">>>()
-    expect(
-      S.asSchema(
-        S.Struct({
-          a: S.ExitFromSelf({
-            success: S.Number,
-            failure: S.String,
-            defect: S.Unknown
-          })
-        })
-      )
-    ).type.toBe<
-      S.Schema<{ readonly a: Exit.Exit<number, string> }, { readonly a: Exit.Exit<number, string> }>
-    >()
-  })
-
-  it("Exit", () => {
-    expect(S.asSchema(S.Exit({ success: S.Number, failure: S.String, defect: S.Defect })))
-      .type.toBe<S.Schema<Exit.Exit<number, string>, S.ExitEncoded<number, string, unknown>>>()
-    expect(S.Exit({ success: S.Number, failure: S.String, defect: S.Defect })).type.toBe<
-      S.Exit<typeof S.Number, typeof S.String, S.Defect>
-    >()
-    expect(
-      S.asSchema(
-        S.Exit({ success: S.Number, failure: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })
-      )
-    ).type.toBe<S.Schema<Exit.Exit<number, string>, S.ExitEncoded<number, string, unknown>, "a">>()
-    expect(
-      S.Exit({ success: S.Number, failure: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })
-    ).type.toBe<S.Exit<typeof S.Number, typeof S.String, S.Schema<unknown, unknown, "a">>>()
-    expect(
-      S.asSchema(
-        S.Struct({
-          a: S.Exit({ success: S.Number, failure: S.String, defect: S.Defect })
-        })
-      )
-    ).type.toBe<
-      S.Schema<{ readonly a: Exit.Exit<number, string> }, { readonly a: S.ExitEncoded<number, string, unknown> }>
-    >()
-  })
-
-  it("CauseFromSelf", () => {
-    expect(S.asSchema(S.CauseFromSelf({ error: S.String, defect: S.Unknown })))
-      .type.toBe<S.Schema<Cause.Cause<string>, Cause.Cause<string>>>()
-    expect(S.CauseFromSelf({ error: S.String, defect: S.Unknown })).type.toBe<
-      S.CauseFromSelf<typeof S.String, typeof S.Unknown>
-    >()
-    expect(
-      S.asSchema(S.CauseFromSelf({ error: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() }))
-    ).type.toBe<S.Schema<Cause.Cause<string>, Cause.Cause<string>, "a">>()
-    expect(S.CauseFromSelf({ error: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })).type.toBe<
-      S.CauseFromSelf<typeof S.String, S.Schema<unknown, unknown, "a">>
-    >()
-    expect(
-      S.asSchema(
-        S.Struct({ a: S.CauseFromSelf({ error: S.String, defect: S.Unknown }) })
-      )
-    ).type.toBe<S.Schema<{ readonly a: Cause.Cause<string> }, { readonly a: Cause.Cause<string> }>>()
-  })
-
-  it("Cause", () => {
-    expect(S.asSchema(S.Cause({ error: S.String, defect: S.Defect })))
-      .type.toBe<S.Schema<Cause.Cause<string>, S.CauseEncoded<string, unknown>>>()
-    expect(S.Cause({ error: S.String, defect: S.Defect })).type.toBe<S.Cause<typeof S.String, S.Defect>>()
-    expect(
-      S.asSchema(S.Cause({ error: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() }))
-    ).type.toBe<S.Schema<Cause.Cause<string>, S.CauseEncoded<string, unknown>, "a">>()
-    expect(S.Cause({ error: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })).type.toBe<
-      S.Cause<typeof S.String, S.Schema<unknown, unknown, "a">>
-    >()
-    expect(
-      S.asSchema(
-        S.Struct({ a: S.Cause({ error: S.String, defect: S.Defect }) })
-      )
-    ).type.toBe<
-      S.Schema<{ readonly a: Cause.Cause<string> }, { readonly a: S.CauseEncoded<string, unknown> }>
-    >()
-  })
-
   it("TypeLiteral", () => {
     expect(S.asSchema(hole<S.TypeLiteral<{ a: typeof S.String }, []>>()))
       .type.toBe<S.Schema<{ readonly a: string }, { readonly a: string }>>()
@@ -2432,85 +2124,6 @@ describe("Schema", () => {
     >()
   })
 
-  it("TupleType.Type", () => {
-    expect(hole<S.TupleType.Type<[], []>>()).type.toBe<readonly []>()
-    expect(hole<S.TupleType.Type<[typeof S.NumberFromString], []>>()).type.toBe<readonly [number]>()
-    expect(hole<S.TupleType.Type<[], [typeof S.NumberFromString]>>()).type.toBe<ReadonlyArray<number>>()
-    expect(hole<S.TupleType.Type<[typeof S.NumberFromString], [typeof S.NumberFromString]>>()).type.toBe<
-      readonly [number, ...Array<number>]
-    >()
-    expect(
-      hole<S.TupleType.Type<[typeof S.NumberFromString], [typeof S.NumberFromString, typeof S.NumberFromString]>>()
-    ).type.toBe<readonly [number, ...Array<number>, number]>()
-    expect(
-      hole<S.TupleType.Type<[typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">], []>>()
-    ).type.toBe<readonly [number, number?]>()
-    expect(
-      hole<
-        S.TupleType.Type<
-          [typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">],
-          [typeof S.NumberFromString]
-        >
-      >()
-    ).type.toBe<readonly [number, number?, ...Array<number>]>()
-  })
-
-  it("TupleType.Encoded", () => {
-    expect(hole<S.TupleType.Encoded<[], []>>()).type.toBe<readonly []>()
-    expect(hole<S.TupleType.Encoded<[typeof S.NumberFromString], []>>()).type.toBe<readonly [string]>()
-    expect(hole<S.TupleType.Encoded<[], [typeof S.NumberFromString]>>()).type.toBe<ReadonlyArray<string>>()
-    expect(hole<S.TupleType.Encoded<[typeof S.NumberFromString], [typeof S.NumberFromString]>>()).type.toBe<
-      readonly [string, ...Array<string>]
-    >()
-    expect(
-      hole<S.TupleType.Encoded<[typeof S.NumberFromString], [typeof S.NumberFromString, typeof S.NumberFromString]>>()
-    ).type.toBe<readonly [string, ...Array<string>, string]>()
-    expect(
-      hole<S.TupleType.Encoded<[typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">], []>>()
-    ).type.toBe<readonly [string, string?]>()
-    expect(
-      hole<
-        S.TupleType.Encoded<
-          [typeof S.NumberFromString, S.Element<typeof S.NumberFromString, "?">],
-          [typeof S.NumberFromString]
-        >
-      >()
-    ).type.toBe<readonly [string, string?, ...Array<string>]>()
-  })
-
-  it("TupleType.Context", () => {
-    expect(
-      hole<S.Schema.Context<S.TupleType<[typeof aContext], [typeof bContext, typeof cContext]>>>()
-    ).type.toBe<"a" | "b" | "c">()
-  })
-
-  it("SortedSetFromSelf", () => {
-    expect(
-      S.asSchema(S.SortedSetFromSelf(S.NumberFromString, N.Order, Str.Order))
-    ).type.toBe<S.Schema<SortedSet.SortedSet<number>, SortedSet.SortedSet<string>>>()
-    expect(S.SortedSetFromSelf(S.NumberFromString, N.Order, Str.Order))
-      .type.toBe<S.SortedSetFromSelf<typeof S.NumberFromString>>()
-  })
-
-  it("SortedSet", () => {
-    expect(S.asSchema(S.SortedSet(S.NumberFromString, N.Order)))
-      .type.toBe<S.Schema<SortedSet.SortedSet<number>, ReadonlyArray<string>>>()
-    expect(S.SortedSet(S.NumberFromString, N.Order))
-      .type.toBe<S.SortedSet<typeof S.NumberFromString>>()
-  })
-
-  it("Struct.Constructor", () => {
-    expect(
-      hole<
-        S.Struct.Constructor<{
-          a: S.PropertySignature<":", string, never, ":", string, true>
-          b: typeof S.Number
-          c: S.PropertySignature<":", boolean, never, ":", boolean, true>
-        }>
-      >()
-    ).type.toBe<{ readonly a?: string } & { readonly b: number } & { readonly c?: boolean }>()
-  })
-
   it("withConstructorDefault", () => {
     // @ts-expect-error
     S.propertySignature(S.String).pipe(S.withConstructorDefault(() => 1))
@@ -2518,37 +2131,6 @@ describe("Schema", () => {
       .type.toBe<S.PropertySignature<":", string, never, ":", string, true>>()
     expect(S.withConstructorDefault(S.propertySignature(S.String), () => "a"))
       .type.toBe<S.PropertySignature<":", string, never, ":", string, true>>()
-  })
-
-  it("Struct.make", () => {
-    const make1 = S.Struct({
-      a: S.propertySignature(S.String).pipe(S.withConstructorDefault(() => "")),
-      b: S.Number,
-      c: S.propertySignature(S.Boolean).pipe(S.withConstructorDefault(() => true))
-    }).make
-    expect(hole<Parameters<typeof make1>[0]>()).type.toBe<
-      { readonly a?: string; readonly b: number; readonly c?: boolean }
-    >()
-    const make2 = S.Struct({
-      a: S.withConstructorDefault(S.propertySignature(S.String), () => ""),
-      b: S.Number,
-      c: S.withConstructorDefault(S.propertySignature(S.Boolean), () => true)
-    }).make
-    expect(hole<Parameters<typeof make2>[0]>()).type.toBe<
-      { readonly a?: string; readonly b: number; readonly c?: boolean }
-    >()
-    const make3 = S.Struct({
-      a: S.withConstructorDefault(S.propertySignature(S.String), () => "")
-    }).make
-    expect(hole<Parameters<typeof make3>[0]>()).type.toBe<void | { readonly a?: string } | undefined>()
-    class AA extends S.Class<AA>("AA")({
-      a: S.propertySignature(S.String).pipe(S.withConstructorDefault(() => "")),
-      b: S.Number,
-      c: S.propertySignature(S.Boolean).pipe(S.withConstructorDefault(() => true))
-    }) {}
-    expect(hole<ConstructorParameters<typeof AA>>()).type.toBe<
-      [props: { readonly a?: string; readonly b: number; readonly c?: boolean }, options?: S.MakeOptions | undefined]
-    >()
   })
 
   it("withDecodingDefault", () => {
@@ -2659,107 +2241,115 @@ describe("Schema", () => {
     >()
   })
 
-  it("optionalToOptional", () => {
-    expect(
-      S.asSchema(S.Struct({ a: S.optionalToOptional(aContext, S.String, { decode: (o) => o, encode: (o) => o }) }))
-    ).type.toBe<S.Schema<{ readonly a?: string }, { readonly a?: string }, "a">>()
-    expect(
-      S.Struct({ a: S.optionalToOptional(aContext, S.String, { decode: (o) => o, encode: (o) => o }) })
-    ).type.toBe<S.Struct<{ a: S.PropertySignature<"?:", string, never, "?:", string, false, "a"> }>>()
-  })
+  describe("Optional Primitives", () => {
+    it("optionalToOptional", () => {
+      expect(
+        S.asSchema(S.Struct({ a: S.optionalToOptional(aContext, S.String, { decode: (o) => o, encode: (o) => o }) }))
+      ).type.toBe<S.Schema<{ readonly a?: string }, { readonly a?: string }, "a">>()
+      expect(
+        S.Struct({ a: S.optionalToOptional(aContext, S.String, { decode: (o) => o, encode: (o) => o }) })
+      ).type.toBe<S.Struct<{ a: S.PropertySignature<"?:", string, never, "?:", string, false, "a"> }>>()
+    })
 
-  it("optionalToRequired", () => {
-    expect(
-      S.asSchema(
+    it("optionalToRequired", () => {
+      expect(
+        S.asSchema(
+          S.Struct({
+            a: S.optionalToRequired(aContext, S.String, { decode: Option.getOrElse(() => ""), encode: Option.some })
+          })
+        )
+      ).type.toBe<S.Schema<{ readonly a: string }, { readonly a?: string }, "a">>()
+      expect(
         S.Struct({
           a: S.optionalToRequired(aContext, S.String, { decode: Option.getOrElse(() => ""), encode: Option.some })
         })
-      )
-    ).type.toBe<S.Schema<{ readonly a: string }, { readonly a?: string }, "a">>()
-    expect(
-      S.Struct({
-        a: S.optionalToRequired(aContext, S.String, { decode: Option.getOrElse(() => ""), encode: Option.some })
-      })
-    ).type.toBe<S.Struct<{ a: S.PropertySignature<":", string, never, "?:", string, false, "a"> }>>()
-  })
+      ).type.toBe<S.Struct<{ a: S.PropertySignature<":", string, never, "?:", string, false, "a"> }>>()
+    })
 
-  it("requiredToOptional", () => {
-    expect(
-      S.asSchema(
+    it("requiredToOptional", () => {
+      expect(
+        S.asSchema(
+          S.Struct({
+            a: S.requiredToOptional(aContext, S.String, { decode: Option.some, encode: Option.getOrElse(() => "") })
+          })
+        )
+      ).type.toBe<S.Schema<{ readonly a?: string }, { readonly a: string }, "a">>()
+      expect(
         S.Struct({
           a: S.requiredToOptional(aContext, S.String, { decode: Option.some, encode: Option.getOrElse(() => "") })
         })
-      )
-    ).type.toBe<S.Schema<{ readonly a?: string }, { readonly a: string }, "a">>()
-    expect(
-      S.Struct({
-        a: S.requiredToOptional(aContext, S.String, { decode: Option.some, encode: Option.getOrElse(() => "") })
+      ).type.toBe<S.Struct<{ a: S.PropertySignature<"?:", string, never, ":", string, false, "a"> }>>()
+    })
+  })
+
+  describe("Array Filters", () => {
+    describe("Array", () => {
+      it("minItems", () => {
+        expect(S.asSchema(S.Array(S.String).pipe(S.minItems(2))))
+          .type.toBe<S.Schema<ReadonlyArray<string>, ReadonlyArray<string>>>()
+        expect(S.Array(S.String).pipe(S.minItems(2)))
+          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
+        expect(S.Array(S.String).pipe(S.minItems(2)).from)
+          .type.toBe<S.Schema<ReadonlyArray<string>>>()
+        expect(S.asSchema(S.Array(S.String).pipe(S.minItems(1), S.maxItems(2))))
+          .type.toBe<S.Schema<ReadonlyArray<string>, ReadonlyArray<string>>>()
+        expect(S.Array(S.String).pipe(S.minItems(1), S.maxItems(2)))
+          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
       })
-    ).type.toBe<S.Struct<{ a: S.PropertySignature<"?:", string, never, ":", string, false, "a"> }>>()
-  })
 
-  it("minItems", () => {
-    expect(S.asSchema(S.Array(S.String).pipe(S.minItems(2))))
-      .type.toBe<S.Schema<ReadonlyArray<string>, ReadonlyArray<string>>>()
-    expect(S.Array(S.String).pipe(S.minItems(2)))
-      .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-    expect(S.Array(S.String).pipe(S.minItems(2)).from)
-      .type.toBe<S.Schema<ReadonlyArray<string>>>()
-    expect(S.asSchema(S.Array(S.String).pipe(S.minItems(1), S.maxItems(2))))
-      .type.toBe<S.Schema<ReadonlyArray<string>, ReadonlyArray<string>>>()
-    expect(S.Array(S.String).pipe(S.minItems(1), S.maxItems(2)))
-      .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-  })
+      it("maxItems", () => {
+        expect(S.asSchema(S.Array(S.String).pipe(S.maxItems(2))))
+          .type.toBe<S.Schema<ReadonlyArray<string>>>()
+        expect(S.Array(S.String).pipe(S.maxItems(2)))
+          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
+        expect(S.Array(S.String).pipe(S.maxItems(2)).from)
+          .type.toBe<S.Schema<ReadonlyArray<string>>>()
+        expect(S.asSchema(S.Array(S.String).pipe(S.maxItems(2), S.minItems(1))))
+          .type.toBe<S.Schema<ReadonlyArray<string>>>()
+        expect(S.Array(S.String).pipe(S.maxItems(2), S.minItems(1)))
+          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
+      })
 
-  it("minItems NonEmptyArray", () => {
-    expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.minItems(2))))
-      .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-    expect(S.NonEmptyArray(S.String).pipe(S.minItems(2)))
-      .type.toBe<S.filter<S.Schema<readonly [string, ...Array<string>]>>>()
-    expect(S.NonEmptyArray(S.String).pipe(S.minItems(2)).from)
-      .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-  })
+      it("itemsCount", () => {
+        expect(S.asSchema(S.Array(S.String).pipe(S.itemsCount(2))))
+          .type.toBe<S.Schema<ReadonlyArray<string>>>()
+        expect(S.Array(S.String).pipe(S.itemsCount(2)))
+          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
+        expect(S.Array(S.String).pipe(S.itemsCount(2)).from).type.toBe<S.Schema<ReadonlyArray<string>>>()
+      })
+    })
 
-  it("maxItems Array", () => {
-    expect(S.asSchema(S.Array(S.String).pipe(S.maxItems(2))))
-      .type.toBe<S.Schema<ReadonlyArray<string>>>()
-    expect(S.Array(S.String).pipe(S.maxItems(2)))
-      .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-    expect(S.Array(S.String).pipe(S.maxItems(2)).from)
-      .type.toBe<S.Schema<ReadonlyArray<string>>>()
-    expect(S.asSchema(S.Array(S.String).pipe(S.maxItems(2), S.minItems(1))))
-      .type.toBe<S.Schema<ReadonlyArray<string>>>()
-    expect(S.Array(S.String).pipe(S.maxItems(2), S.minItems(1)))
-      .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-  })
+    describe("NonEmptyArray", () => {
+      it("minItems", () => {
+        expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.minItems(2))))
+          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+        expect(S.NonEmptyArray(S.String).pipe(S.minItems(2)))
+          .type.toBe<S.filter<S.Schema<readonly [string, ...Array<string>]>>>()
+        expect(S.NonEmptyArray(S.String).pipe(S.minItems(2)).from)
+          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+      })
 
-  it("maxItems NonEmptyArray", () => {
-    expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.maxItems(2))))
-      .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-    expect(S.NonEmptyArray(S.String).pipe(S.maxItems(2))).type.toBe<
-      S.filter<S.Schema<readonly [string, ...Array<string>]>>
-    >()
-    expect(S.NonEmptyArray(S.String).pipe(S.maxItems(2)).from).type.toBe<
-      S.Schema<readonly [string, ...Array<string>]>
-    >()
-  })
+      it("maxItems", () => {
+        expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.maxItems(2))))
+          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+        expect(S.NonEmptyArray(S.String).pipe(S.maxItems(2))).type.toBe<
+          S.filter<S.Schema<readonly [string, ...Array<string>]>>
+        >()
+        expect(S.NonEmptyArray(S.String).pipe(S.maxItems(2)).from).type.toBe<
+          S.Schema<readonly [string, ...Array<string>]>
+        >()
+      })
 
-  it("itemsCount Array", () => {
-    expect(S.asSchema(S.Array(S.String).pipe(S.itemsCount(2))))
-      .type.toBe<S.Schema<ReadonlyArray<string>>>()
-    expect(S.Array(S.String).pipe(S.itemsCount(2)))
-      .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-    expect(S.Array(S.String).pipe(S.itemsCount(2)).from).type.toBe<S.Schema<ReadonlyArray<string>>>()
-  })
-
-  it("itemsCount NonEmptyArray", () => {
-    expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.itemsCount(2))))
-      .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-    expect(S.NonEmptyArray(S.String).pipe(S.itemsCount(2)))
-      .type.toBe<S.filter<S.Schema<readonly [string, ...Array<string>]>>>()
-    expect(S.NonEmptyArray(S.String).pipe(S.itemsCount(2)).from).type.toBe<
-      S.Schema<readonly [string, ...Array<string>]>
-    >()
+      it("itemsCount", () => {
+        expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.itemsCount(2))))
+          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+        expect(S.NonEmptyArray(S.String).pipe(S.itemsCount(2)))
+          .type.toBe<S.filter<S.Schema<readonly [string, ...Array<string>]>>>()
+        expect(S.NonEmptyArray(S.String).pipe(S.itemsCount(2)).from).type.toBe<
+          S.Schema<readonly [string, ...Array<string>]>
+        >()
+      })
+    })
   })
 
   it("TemplateLiteralParser", () => {
@@ -2850,31 +2440,604 @@ describe("Schema", () => {
       .type.toBe<S.Schema<readonly ["a", string | number], `a${string}` | `a${number}`>>()
   })
 
-  it("UndefinedOr", () => {
-    expect(S.UndefinedOr(S.Never))
-      .type.toBe<S.UndefinedOr<typeof S.Never>>()
+  describe("Filters", () => {
+    it("filter", () => {
+      S.String.pipe(S.filter((s, options, ast) => {
+        expect(s).type.toBe<string>()
+        expect(options).type.toBe<SchemaAST.ParseOptions>()
+        expect(ast).type.toBe<SchemaAST.Refinement>()
+        return undefined
+      }))
+      const predicateFilter1 = (u: unknown): boolean => typeof u === "string"
+      const FromFilter = S.Union(S.String, S.Number)
+      expect(pipe(FromFilter, S.filter(predicateFilter1)))
+        .type.toBe<S.filter<S.Union<[typeof S.String, typeof S.Number]>>>()
+      const FromRefinement = S.Struct({
+        a: S.optionalWith(S.String, { exact: true }),
+        b: S.optionalWith(S.Number, { exact: true })
+      })
+      expect(pipe(FromRefinement, S.filter(S.is(S.Struct({ b: S.Number })))))
+        .type.toBe<
+        S.refine<
+          { readonly a?: string; readonly b?: number } & { readonly b: number },
+          S.Schema<unknown, { readonly a?: string; readonly b?: number }>
+        >
+      >()
+      const LiteralFilter = S.Literal("a", "b")
+      const predicateFilter2 = (u: unknown): u is "a" => typeof u === "string" && u === "a"
+      expect(pipe(LiteralFilter, S.filter(predicateFilter2)))
+        .type.toBe<S.refine<"a", S.Schema<unknown, "a" | "b">>>()
+      expect(pipe(LiteralFilter, S.filter(S.is(S.Literal("a")))))
+        .type.toBe<S.refine<"a", S.Schema<unknown, "a" | "b">>>()
+      expect(pipe(LiteralFilter, S.filter(S.is(S.Literal("c")))))
+        .type.toBe<S.refine<never, S.Schema<unknown, "a" | "b">>>()
+      const UnionFilter = hole<
+        S.Schema<
+          { readonly a: string } | { readonly b: string },
+          { readonly a: string } | { readonly b: string },
+          never
+        >
+      >()
+      expect(pipe(UnionFilter, S.filter(S.is(S.Struct({ b: S.String })))))
+        .type.toBe<
+        S.refine<
+          ({ readonly a: string } | { readonly b: string }) & { readonly b: string },
+          S.Schema<unknown, { readonly a: string } | { readonly b: string }>
+        >
+      >()
+      expect(pipe(S.Number, S.filter((n): n is number & Brand.Brand<"MyNumber"> => n > 0)))
+        .type.toBe<S.refine<number & Brand.Brand<"MyNumber">, S.Schema<number>>>()
+      // annotations
+      pipe(
+        S.String,
+        S.filter(
+          (s) => {
+            expect(s).type.toBe<string>()
+            return true
+          },
+          {
+            arbitrary: (from, ctx) => (fc) => {
+              expect(from).type.toBe<Arbitrary.LazyArbitrary<string>>()
+              expect(ctx).type.toBe<Arbitrary.ArbitraryGenerationContext>()
+              return fc.string()
+            },
+            pretty: (from) => (s) => {
+              expect(from).type.toBe<Pretty.Pretty<string>>()
+              expect(s).type.toBe<string>()
+              return s
+            },
+            equivalence: (from) => (a, b) => {
+              expect(from).type.toBe<Equivalence.Equivalence<string>>()
+              expect(a).type.toBe<string>()
+              expect(b).type.toBe<string>()
+              return true
+            }
+          }
+        )
+      )
+      pipe(
+        S.String,
+        S.filter((s) => {
+          expect(s).type.toBe<string>()
+          return true
+        })
+      ).annotations({
+        arbitrary: (...x) => (fc) => {
+          expect(x).type.toBe<Array<any>>()
+          return fc.string()
+        },
+        pretty: (...x) => (s) => {
+          expect(x).type.toBe<Array<any>>()
+          return s
+        },
+        equivalence: (...x) => (a, b) => {
+          expect(x).type.toBe<Array<any>>()
+          expect(a).type.toBe<string>()
+          expect(b).type.toBe<string>()
+          return true
+        }
+      })
+    })
+
+    it("String Filters", () => {
+      expect(pipe(S.String, S.maxLength(5))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.maxLength(5))
+
+      expect(pipe(S.String, S.minLength(5))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.minLength(5))
+
+      expect(pipe(S.String, S.length(5))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.length(5))
+
+      expect(pipe(S.String, S.pattern(/a/))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.pattern(/a/))
+
+      expect(pipe(S.String, S.startsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.startsWith("a"))
+
+      expect(pipe(S.String, S.endsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.endsWith("a"))
+
+      expect(pipe(S.String, S.includes("a"))).type.toBe<S.filter<S.Schema<string>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      pipe(S.Null, S.includes("a"))
+    })
+
+    it("Number Filters", () => {
+      expect(pipe(S.Number, S.greaterThan(5))).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.greaterThan(5))
+
+      expect(pipe(S.Number, S.greaterThanOrEqualTo(5))).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.greaterThanOrEqualTo(5))
+
+      expect(pipe(S.Number, S.lessThan(5))).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.lessThan(5))
+
+      expect(pipe(S.Number, S.lessThanOrEqualTo(5))).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.lessThanOrEqualTo(5))
+
+      expect(pipe(S.Number, S.int())).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.int())
+
+      expect(pipe(S.Number, S.nonNaN())).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.nonNaN())
+
+      expect(pipe(S.Number, S.finite())).type.toBe<S.filter<S.Schema<number>>>()
+      // @ts-expect-error: Type 'null' is not assignable to type 'number'
+      pipe(S.Null, S.finite())
+    })
   })
 
-  it("NullOr", () => {
-    expect(S.NullOr(S.Never))
-      .type.toBe<S.NullOr<typeof S.Never>>()
-  })
+  describe("Data Types", () => {
+    it("Duration", () => {
+      expect(S.asSchema(S.Duration))
+        .type.toBe<S.Schema<Duration.Duration, S.DurationEncoded | readonly [seconds: number, nanos: number]>>()
+    })
 
-  it("NullishOr", () => {
-    expect(S.NullishOr(S.Never))
-      .type.toBe<S.NullishOr<typeof S.Never>>()
-  })
+    it("DurationFromSelf", () => {
+      expect(S.asSchema(S.DurationFromSelf)).type.toBe<S.Schema<Duration.Duration>>()
+    })
 
-  it("Config", () => {
-    expect(S.Config("A", S.String))
-      .type.toBe<Config.Config<string>>()
-    expect(S.Config("A", S.BooleanFromString))
-      .type.toBe<Config.Config<boolean>>()
-    expect(S.Config("A", S.TemplateLiteral(S.Literal("a"), S.String)))
-      .type.toBe<Config.Config<`a${string}`>>()
+    it("DurationFromMillis", () => {
+      expect(S.asSchema(S.DurationFromMillis)).type.toBe<S.Schema<Duration.Duration, number>>()
+    })
 
-    // passed schemas must be encodable to string
-    // @ts-expect-error
-    S.Config("A", S.Boolean)
+    it("DurationFromNanos", () => {
+      expect(S.asSchema(S.DurationFromNanos)).type.toBe<S.Schema<Duration.Duration, bigint>>()
+    })
+
+    it("BigDecimal", () => {
+      expect(S.asSchema(S.BigDecimal)).type.toBe<S.Schema<BigDecimal.BigDecimal, string>>()
+    })
+
+    it("BigDecimalFromSelf", () => {
+      expect(S.asSchema(S.BigDecimalFromSelf)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+    })
+
+    it("BigDecimalFromNumber", () => {
+      expect(S.asSchema(S.BigDecimalFromNumber)).type.toBe<S.Schema<BigDecimal.BigDecimal, number>>()
+    })
+
+    it("ChunkFromSelf", () => {
+      const schema = S.ChunkFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Chunk.Chunk<number>, Chunk.Chunk<string>>>()
+      expect(schema).type.toBe<S.ChunkFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.ChunkFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("Chunk", () => {
+      const schema = S.Chunk(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Chunk.Chunk<number>, ReadonlyArray<string>>>()
+      expect(schema).type.toBe<S.Chunk<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.Chunk<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.Array$<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.ChunkFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("NonEmptyChunkFromSelf", () => {
+      const schema = S.NonEmptyChunkFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Chunk.NonEmptyChunk<number>, Chunk.NonEmptyChunk<string>>>()
+      expect(schema).type.toBe<S.NonEmptyChunkFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.NonEmptyChunkFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("NonEmptyChunk", () => {
+      const schema = S.NonEmptyChunk(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Chunk.NonEmptyChunk<number>, readonly [string, ...Array<string>]>>()
+      expect(schema).type.toBe<S.NonEmptyChunk<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.NonEmptyChunk<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.NonEmptyArray<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.NonEmptyChunkFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("DataFromSelf", () => {
+      const schema = S.DataFromSelf(S.Struct({ a: S.NumberFromString }))
+      expect(schema)
+        .type.toBe<S.DataFromSelf<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+      expect(schema.annotations({}))
+        .type.toBe<S.DataFromSelf<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+    })
+
+    it("Data", () => {
+      const schema = S.Data(S.Struct({ a: S.NumberFromString }))
+      expect(schema)
+        .type.toBe<S.Data<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+      expect(schema.annotations({}))
+        .type.toBe<S.Data<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+      expect(schema.from).type.toBe<S.Schema<{ readonly a: number }, { readonly a: string }>>()
+      expect(schema.to).type.toBe<S.SchemaClass<{ readonly a: number }>>()
+    })
+
+    it("RedactedFromSelf", () => {
+      const schema = S.RedactedFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Redacted.Redacted<number>, Redacted.Redacted<string>>>()
+      expect(schema).type.toBe<S.RedactedFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.RedactedFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("Redacted", () => {
+      const schema = S.Redacted(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Redacted.Redacted<number>, string>>()
+      expect(schema).type.toBe<S.Redacted<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.Redacted<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<typeof S.NumberFromString>()
+      expect(schema.to).type.toBe<S.RedactedFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("OptionFromSelf", () => {
+      const schema = S.OptionFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Option.Option<number>, Option.Option<string>>>()
+      expect(schema).type.toBe<S.OptionFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.OptionFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("Option", () => {
+      const schema = S.Option(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Option.Option<number>, S.OptionEncoded<string>>>()
+      expect(schema).type.toBe<S.Option<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.Option<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<
+        S.Union<
+          [
+            S.Struct<{ _tag: S.Literal<["None"]> }>,
+            S.Struct<{ _tag: S.Literal<["Some"]>; value: typeof S.NumberFromString }>
+          ]
+        >
+      >()
+      expect(schema.to).type.toBe<S.OptionFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("OptionFromNullOr", () => {
+      const schema = S.OptionFromNullOr(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Option.Option<number>, string | null>>()
+      expect(schema).type.toBe<S.OptionFromNullOr<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.OptionFromNullOr<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.NullOr<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.OptionFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("OptionFromUndefinedOr", () => {
+      const schema = S.OptionFromUndefinedOr(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Option.Option<number>, string | undefined>>()
+      expect(schema).type.toBe<S.OptionFromUndefinedOr<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.OptionFromUndefinedOr<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.UndefinedOr<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.OptionFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("OptionFromNullishOr", () => {
+      const schema = S.OptionFromNullishOr(S.NumberFromString, null)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Option.Option<number>, string | null | undefined>>()
+      expect(schema).type.toBe<S.OptionFromNullishOr<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.OptionFromNullishOr<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.NullishOr<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.OptionFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("EitherFromSelf", () => {
+      const schema = S.EitherFromSelf({ right: S.NumberFromString, left: S.String })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Either.Either<number, string>, Either.Either<string, string>>>()
+      expect(schema).type.toBe<S.EitherFromSelf<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.EitherFromSelf<typeof S.NumberFromString, typeof S.String>>()
+
+      // should allow never as right
+      expect(S.EitherFromSelf({ right: S.Never, left: S.String }))
+        .type.toBe<S.EitherFromSelf<typeof S.Never, typeof S.String>>()
+      // should allow never as left
+      expect(S.EitherFromSelf({ right: S.String, left: S.Never }))
+        .type.toBe<S.EitherFromSelf<typeof S.String, typeof S.Never>>()
+    })
+
+    it("Either", () => {
+      const schema = S.Either({ right: S.NumberFromString, left: S.String })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Either.Either<number, string>, S.EitherEncoded<string, string>>>()
+      expect(schema).type.toBe<S.Either<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.Either<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.from).type.toBe<
+        S.Union<[
+          S.Struct<{
+            _tag: S.Literal<["Right"]>
+            right: typeof S.NumberFromString
+          }>,
+          S.Struct<{
+            _tag: S.Literal<["Left"]>
+            left: typeof S.String
+          }>
+        ]>
+      >()
+      expect(schema.to).type.toBe<S.EitherFromSelf<S.SchemaClass<number>, S.SchemaClass<string>>>()
+
+      // should allow never as right
+      expect(S.Either({ right: S.Never, left: S.String })).type.toBe<S.Either<typeof S.Never, typeof S.String>>()
+      // should allow never as left
+      expect(S.Either({ right: S.String, left: S.Never })).type.toBe<S.Either<typeof S.String, typeof S.Never>>()
+    })
+
+    it("EitherFromUnion", () => {
+      const schema = S.EitherFromUnion({ right: S.NumberFromString, left: S.Boolean })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Either.Either<number, boolean>, string | boolean>>()
+      expect(schema).type.toBe<S.EitherFromUnion<typeof S.NumberFromString, typeof S.Boolean>>()
+      expect(schema.annotations({})).type.toBe<S.EitherFromUnion<typeof S.NumberFromString, typeof S.Boolean>>()
+      expect(schema.from).type.toBe<
+        S.Union<[
+          S.transform<
+            typeof S.NumberFromString,
+            S.Struct<{
+              _tag: S.Literal<["Right"]>
+              right: typeof S.NumberFromString
+            }>
+          >,
+          S.transform<
+            typeof S.Boolean,
+            S.Struct<{
+              _tag: S.Literal<["Left"]>
+              right: typeof S.Boolean
+            }>
+          >
+        ]>
+      >()
+      expect(schema.to).type.toBe<S.EitherFromSelf<S.SchemaClass<number>, S.SchemaClass<boolean>>>()
+
+      // should allow never as right
+      expect(S.EitherFromUnion({ right: S.Never, left: S.String }))
+        .type.toBe<S.EitherFromUnion<typeof S.Never, typeof S.String>>()
+      // should allow never as left
+      expect(S.EitherFromUnion({ right: S.String, left: S.Never }))
+        .type.toBe<S.EitherFromUnion<typeof S.String, typeof S.Never>>()
+    })
+
+    it("ReadonlyMapFromSelf", () => {
+      const schema = S.ReadonlyMapFromSelf({ key: S.NumberFromString, value: S.String })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlyMap<number, string>, ReadonlyMap<string, string>>>()
+      expect(schema).type.toBe<S.ReadonlyMapFromSelf<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.ReadonlyMapFromSelf<typeof S.NumberFromString, typeof S.String>>()
+    })
+
+    it("ReadonlyMap", () => {
+      const schema = S.ReadonlyMap({ key: S.NumberFromString, value: S.String })
+      expect(S.asSchema(schema))
+        .type.toBe<S.Schema<ReadonlyMap<number, string>, ReadonlyArray<readonly [string, string]>>>()
+      expect(schema).type.toBe<S.ReadonlyMap$<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.ReadonlyMap$<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.from).type.toBe<S.Array$<S.Tuple<[typeof S.NumberFromString, typeof S.String]>>>()
+      expect(schema.to).type.toBe<S.ReadonlyMapFromSelf<S.SchemaClass<number>, S.SchemaClass<string>>>()
+    })
+
+    it("MapFromSelf", () => {
+      const schema = S.MapFromSelf({ key: S.NumberFromString, value: S.String })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Map<number, string>, ReadonlyMap<string, string>>>()
+      expect(schema).type.toBe<S.MapFromSelf<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.MapFromSelf<typeof S.NumberFromString, typeof S.String>>()
+    })
+
+    it("Map", () => {
+      const schema = S.Map({ key: S.NumberFromString, value: S.String })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Map<number, string>, ReadonlyArray<readonly [string, string]>>>()
+      expect(schema).type.toBe<S.Map$<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.Map$<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.from).type.toBe<S.Array$<S.Tuple<[typeof S.NumberFromString, typeof S.String]>>>()
+      expect(schema.to).type.toBe<S.MapFromSelf<S.SchemaClass<number>, S.SchemaClass<string>>>()
+    })
+
+    it("HashMapFromSelf", () => {
+      const schema = S.HashMapFromSelf({ key: S.NumberFromString, value: S.String })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<HashMap.HashMap<number, string>, HashMap.HashMap<string, string>>>()
+      expect(schema).type.toBe<S.HashMapFromSelf<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.HashMapFromSelf<typeof S.NumberFromString, typeof S.String>>()
+    })
+
+    it("HashMap", () => {
+      const schema = S.HashMap({ key: S.NumberFromString, value: S.String })
+      expect(S.asSchema(schema))
+        .type.toBe<S.Schema<HashMap.HashMap<number, string>, ReadonlyArray<readonly [string, string]>>>()
+      expect(schema).type.toBe<S.HashMap<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.annotations({})).type.toBe<S.HashMap<typeof S.NumberFromString, typeof S.String>>()
+      expect(schema.from).type.toBe<S.Array$<S.Tuple<[typeof S.NumberFromString, typeof S.String]>>>()
+      expect(schema.to).type.toBe<S.HashMapFromSelf<S.SchemaClass<number>, S.SchemaClass<string>>>()
+    })
+
+    it("ReadonlySetFromSelf", () => {
+      const schema = S.ReadonlySetFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlySet<number>, ReadonlySet<string>>>()
+      expect(schema).type.toBe<S.ReadonlySetFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.ReadonlySetFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("ReadonlySet", () => {
+      const schema = S.ReadonlySet(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlySet<number>, ReadonlyArray<string>>>()
+      expect(schema).type.toBe<S.ReadonlySet$<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.ReadonlySet$<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.Array$<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.ReadonlySetFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("SetFromSelf", () => {
+      const schema = S.SetFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Set<number>, ReadonlySet<string>>>()
+      expect(schema).type.toBe<S.SetFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.SetFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("Set", () => {
+      const schema = S.Set(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Set<number>, ReadonlyArray<string>>>()
+      expect(schema).type.toBe<S.Set$<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.Set$<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.Array$<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.SetFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("HashSetFromSelf", () => {
+      const schema = S.HashSetFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<HashSet.HashSet<number>, HashSet.HashSet<string>>>()
+      expect(schema).type.toBe<S.HashSetFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.HashSetFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("HashSet", () => {
+      const schema = S.HashSet(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<HashSet.HashSet<number>, ReadonlyArray<string>>>()
+      expect(schema).type.toBe<S.HashSet<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.HashSet<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.Array$<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.HashSetFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("ListFromSelf", () => {
+      const schema = S.ListFromSelf(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<List.List<number>, List.List<string>>>()
+      expect(schema).type.toBe<S.ListFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.ListFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("List", () => {
+      const schema = S.List(S.NumberFromString)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<List.List<number>, ReadonlyArray<string>>>()
+      expect(schema).type.toBe<S.List<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.List<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.Array$<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.ListFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("CauseFromSelf", () => {
+      const schema = S.CauseFromSelf({ error: S.String, defect: S.Unknown })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Cause.Cause<string>, Cause.Cause<string>>>()
+      expect(schema).type.toBe<S.CauseFromSelf<typeof S.String, typeof S.Unknown>>()
+      expect(schema.annotations({})).type.toBe<S.CauseFromSelf<typeof S.String, typeof S.Unknown>>()
+
+      const defectWithR = S.CauseFromSelf({ error: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })
+      expect(S.asSchema(defectWithR)).type.toBe<S.Schema<Cause.Cause<string>, Cause.Cause<string>, "a">>()
+      expect(defectWithR).type.toBe<S.CauseFromSelf<typeof S.String, S.Schema<unknown, unknown, "a">>>()
+    })
+
+    it("Cause", () => {
+      const schema = S.Cause({ error: S.String, defect: S.Defect })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Cause.Cause<string>, S.CauseEncoded<string, unknown>>>()
+      expect(schema).type.toBe<S.Cause<typeof S.String, typeof S.Defect>>()
+      expect(schema.annotations({})).type.toBe<S.Cause<typeof S.String, typeof S.Defect>>()
+      expect(schema.from).type.toBe<
+        S.SchemaClass<S.CauseEncoded<string, unknown>, S.CauseEncoded<string, unknown>, never>
+      >()
+      expect(schema.to).type.toBe<S.CauseFromSelf<S.SchemaClass<string>, S.SchemaClass<unknown>>>()
+
+      const defectWithR = S.Cause({ error: S.String, defect: hole<S.Schema<unknown, unknown, "a">>() })
+      expect(S.asSchema(defectWithR)).type.toBe<S.Schema<Cause.Cause<string>, S.CauseEncoded<string, unknown>, "a">>()
+      expect(defectWithR).type.toBe<S.Cause<typeof S.String, S.Schema<unknown, unknown, "a">>>()
+    })
+
+    it("ExitFromSelf", () => {
+      const schema = S.ExitFromSelf({ success: S.Number, failure: S.String, defect: S.Unknown })
+      expect(S.asSchema(schema)).type.toBe<S.Schema<Exit.Exit<number, string>, Exit.Exit<number, string>>>()
+      expect(schema).type.toBe<S.ExitFromSelf<typeof S.Number, typeof S.String, typeof S.Unknown>>()
+      expect(schema.annotations({})).type.toBe<S.ExitFromSelf<typeof S.Number, typeof S.String, typeof S.Unknown>>()
+
+      const defectWithR = S.ExitFromSelf({
+        success: S.Number,
+        failure: S.String,
+        defect: hole<S.Schema<unknown, unknown, "a">>()
+      })
+      expect(S.asSchema(defectWithR)).type.toBe<S.Schema<Exit.Exit<number, string>, Exit.Exit<number, string>, "a">>()
+      expect(defectWithR).type.toBe<S.ExitFromSelf<typeof S.Number, typeof S.String, S.Schema<unknown, unknown, "a">>>()
+    })
+
+    it("Exit", () => {
+      const schema = S.Exit({ success: S.NumberFromString, failure: S.String, defect: S.Defect })
+      expect(S.asSchema(schema))
+        .type.toBe<S.Schema<Exit.Exit<number, string>, S.ExitEncoded<string, string, unknown>>>()
+      expect(schema).type.toBe<S.Exit<typeof S.NumberFromString, typeof S.String, typeof S.Defect>>()
+      expect(schema.annotations({})).type.toBe<S.Exit<typeof S.NumberFromString, typeof S.String, typeof S.Defect>>()
+      expect(schema.from).type.toBe<
+        S.Union<[
+          S.Struct<{
+            _tag: S.Literal<["Failure"]>
+            cause: S.SchemaClass<S.CauseEncoded<string, unknown>, S.CauseEncoded<string, unknown>, never>
+          }>,
+          S.Struct<{
+            _tag: S.Literal<["Success"]>
+            value: typeof S.NumberFromString
+          }>
+        ]>
+      >()
+      expect(schema.to).type.toBe<
+        S.ExitFromSelf<S.SchemaClass<number>, S.SchemaClass<string>, S.SchemaClass<unknown>>
+      >()
+
+      const defectWithR = S.Exit({
+        success: S.Number,
+        failure: S.String,
+        defect: hole<S.Schema<unknown, unknown, "a">>()
+      })
+      expect(S.asSchema(defectWithR))
+        .type.toBe<S.Schema<Exit.Exit<number, string>, S.ExitEncoded<number, string, unknown>, "a">>()
+      expect(defectWithR).type.toBe<S.Exit<typeof S.Number, typeof S.String, S.Schema<unknown, unknown, "a">>>()
+    })
+
+    it("SortedSetFromSelf", () => {
+      const schema = S.SortedSetFromSelf(S.NumberFromString, N.Order, Str.Order)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<SortedSet.SortedSet<number>, SortedSet.SortedSet<string>>>()
+      expect(schema).type.toBe<S.SortedSetFromSelf<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.SortedSetFromSelf<typeof S.NumberFromString>>()
+    })
+
+    it("SortedSet", () => {
+      const schema = S.SortedSet(S.NumberFromString, N.Order)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<SortedSet.SortedSet<number>, ReadonlyArray<string>>>()
+      expect(schema).type.toBe<S.SortedSet<typeof S.NumberFromString>>()
+      expect(schema.annotations({})).type.toBe<S.SortedSet<typeof S.NumberFromString>>()
+      expect(schema.from).type.toBe<S.Array$<typeof S.NumberFromString>>()
+      expect(schema.to).type.toBe<S.SortedSetFromSelf<S.SchemaClass<number>>>()
+    })
+
+    it("Config", () => {
+      expect(S.Config("A", S.String))
+        .type.toBe<Config.Config<string>>()
+      expect(S.Config("A", S.BooleanFromString))
+        .type.toBe<Config.Config<boolean>>()
+      expect(S.Config("A", S.TemplateLiteral(S.Literal("a"), S.String)))
+        .type.toBe<Config.Config<`a${string}`>>()
+
+      // passed schemas must be encodable to string
+      // @ts-expect-error
+      S.Config("A", S.Boolean)
+    })
+
+    it("Defect", () => {
+      const schema = S.Defect
+      expect(S.asSchema(schema)).type.toBe<S.Schema<unknown>>()
+      expect(schema).type.toBe<typeof S.Defect>()
+    })
   })
 })

--- a/packages/effect/test/Schema/Schema/Cause/Cause.test.ts
+++ b/packages/effect/test/Schema/Schema/Cause/Cause.test.ts
@@ -113,13 +113,12 @@ describe("Cause", () => {
         schema,
         Cause.die(null),
         `(CauseEncoded<string> <-> Cause<string>)
-└─ Encoded side transformation failure
-   └─ CauseEncoded<string>
-      └─ { readonly _tag: "Die"; readonly defect: (string <-> object) }
-         └─ ["defect"]
-            └─ (string <-> object)
-               └─ Type side transformation failure
-                  └─ Expected object, actual null`
+└─ Type side transformation failure
+   └─ Cause<string>
+      └─ CauseEncoded<string>
+         └─ { readonly _tag: "Die"; readonly defect: object }
+            └─ ["defect"]
+               └─ Expected object, actual null`
       )
     })
 

--- a/packages/effect/test/Schema/Schema/Exit/Exit.test.ts
+++ b/packages/effect/test/Schema/Schema/Exit/Exit.test.ts
@@ -1,6 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { Exit } from "effect"
-import * as S from "effect/Schema"
+import { Cause, Exit, Schema as S } from "effect"
 import * as Util from "effect/test/Schema/TestUtils"
 
 describe("Exit", () => {
@@ -42,7 +41,25 @@ describe("Exit", () => {
     )
   })
 
-  it("encoding", async () => {
+  describe("encoding", async () => {
+    it("should raise an error when a non-encodable Cause is passed", async () => {
+      const schema = S.Exit({ failure: S.String, success: S.Number, defect: Util.Defect })
+      await Util.assertions.encoding.fail(
+        schema,
+        Exit.failCause(Cause.die(null)),
+        `(ExitEncoded<number, string, (string <-> object)> <-> Exit<number, string>)
+└─ Type side transformation failure
+   └─ Exit<number, string>
+      └─ Cause<string>
+         └─ CauseEncoded<string>
+            └─ { readonly _tag: "Die"; readonly defect: object }
+               └─ ["defect"]
+                  └─ Expected object, actual null`
+      )
+    })
+  })
+
+  it("using the built-in Defect schema as defect argument", async () => {
     const schema = S.Exit({ failure: S.String, success: S.Number, defect: S.Defect })
     await Util.assertions.encoding.succeed(schema, Exit.fail("error"), {
       _tag: "Failure",


### PR DESCRIPTION
- `Chunk`
- `NonEmptyChunk`
- `Redacted`
- `Option`
- `OptionFromNullOr`
- `OptionFromUndefinedOr`
- `OptionFromNullishOr`
- `Either`
- `EitherFromUnion`
- `ReadonlyMap`
- `Map`
- `HashMap`
- `ReadonlySet`
- `Set`
- `HashSet`
- `List`
- `Cause`
- `Exit`
- `SortedSet`
- `head`
- `headNonEmpty`
- `headOrElse`

**Example** (with `Schema.Chunk`)

Before

```ts
import { Schema } from "effect"

const schema = Schema.Chunk(Schema.Number)

// Property 'from' does not exist on type 'Chunk<typeof Number$>'
schema.from
```

After

```ts
import { Schema } from "effect"

const schema = Schema.Chunk(Schema.Number)

// Schema.Array$<typeof Schema.Number>
schema.from
```
