### PR TITLE
Schema: more precise return types when filters are involved

### DIFF
--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -98,3 +98,15 @@ Date filters:
 - `greaterThanDate`
 - `greaterThanOrEqualToDate`
 - `betweenDate`
+
+BigDecimal filters:
+
+- `greaterThanBigDecimal`
+- `greaterThanOrEqualToBigDecimal`
+- `lessThanBigDecimal`
+- `lessThanOrEqualToBigDecimal`
+- `positiveBigDecimal`
+- `nonNegativeBigDecimal`
+- `negativeBigDecimal`
+- `nonPositiveBigDecimal`
+- `betweenBigDecimal`

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -4,20 +4,6 @@
 
 Schema: more precise return types when filters are involved.
 
-- `maxLength`
-- `minLength`
-- `length`
-- `pattern`
-- `startsWith`
-- `endsWith`
-- `includes`
-- `lowercased`
-- `capitalized`
-- `uncapitalized`
-- `uppercased`
-- `nonEmptyString`
-- `trimmed`
-
 **Example** (with `Schema.maxLength`)
 
 Before
@@ -45,3 +31,35 @@ const schema = Schema.String.pipe(Schema.maxLength(10))
 // typeof Schema.String
 schema.from
 ```
+
+String filters:
+
+- `maxLength`
+- `minLength`
+- `length`
+- `pattern`
+- `startsWith`
+- `endsWith`
+- `includes`
+- `lowercased`
+- `capitalized`
+- `uncapitalized`
+- `uppercased`
+- `nonEmptyString`
+- `trimmed`
+
+Number filters:
+
+- `finite`
+- `greaterThan`
+- `greaterThanOrEqualTo`
+- `lessThan`
+- `lessThanOrEqualTo`
+- `int`
+- `multipleOf`
+- `between`
+- `nonNaN`
+- `positive`
+- `negative`
+- `nonPositive`
+- `nonNegative`

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -1,0 +1,35 @@
+---
+"effect": patch
+---
+
+Schema: more precise return types when filters are involved.
+
+- `maxLength`
+
+**Example** (with `Schema.maxLength`)
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+//      ┌─── Schema.filter<Schema.Schema<string, string, never>>
+//      ▼
+const schema = Schema.String.pipe(Schema.maxLength(10))
+
+// Schema<string, string, never>
+schema.from
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+//      ┌─── Schema.filter<typeof Schema.String>
+//      ▼
+const schema = Schema.String.pipe(Schema.maxLength(10))
+
+// typeof Schema.String
+schema.from
+```

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -5,6 +5,18 @@
 Schema: more precise return types when filters are involved.
 
 - `maxLength`
+- `minLength`
+- `length`
+- `pattern`
+- `startsWith`
+- `endsWith`
+- `includes`
+- `lowercased`
+- `capitalized`
+- `uncapitalized`
+- `uppercased`
+- `nonEmptyString`
+- `trimmed`
 
 **Example** (with `Schema.maxLength`)
 

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -83,3 +83,9 @@ Duration filters:
 - `greaterThanDuration`
 - `greaterThanOrEqualToDuration`
 - `betweenDuration`
+
+Array filters:
+
+- `minItems`
+- `maxItems`
+- `itemsCount`

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -63,3 +63,15 @@ Number filters:
 - `negative`
 - `nonPositive`
 - `nonNegative`
+
+BigInt filters:
+
+- `greaterThanBigInt`
+- `greaterThanOrEqualToBigInt`
+- `lessThanBigInt`
+- `lessThanOrEqualToBigInt`
+- `betweenBigInt`
+- `positiveBigInt`
+- `negativeBigInt`
+- `nonNegativeBigInt`
+- `nonPositiveBigInt`

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -89,3 +89,12 @@ Array filters:
 - `minItems`
 - `maxItems`
 - `itemsCount`
+
+Date filters:
+
+- `validDate`
+- `lessThanDate`
+- `lessThanOrEqualToDate`
+- `greaterThanDate`
+- `greaterThanOrEqualToDate`
+- `betweenDate`

--- a/.changeset/dull-needles-serve.md
+++ b/.changeset/dull-needles-serve.md
@@ -75,3 +75,11 @@ BigInt filters:
 - `negativeBigInt`
 - `nonNegativeBigInt`
 - `nonPositiveBigInt`
+
+Duration filters:
+
+- `lessThanDuration`
+- `lessThanOrEqualToDuration`
+- `greaterThanDuration`
+- `greaterThanOrEqualToDuration`
+- `betweenDuration`

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -2919,6 +2919,58 @@ describe("Schema", () => {
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
       })
     })
+
+    describe("Duration filters", () => {
+      it("lessThanDuration", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanDuration("10 millis"))
+
+        const schema = pipe(S.DurationFromSelf, S.lessThanDuration("10 millis"))
+        expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
+      })
+
+      it("lessThanOrEqualToDuration", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanOrEqualToDuration("10 millis"))
+
+        const schema = pipe(S.DurationFromSelf, S.lessThanOrEqualToDuration("10 millis"))
+        expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
+      })
+
+      it("greaterThanDuration", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanDuration("10 millis"))
+
+        const schema = pipe(S.DurationFromSelf, S.greaterThanDuration("10 millis"))
+        expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
+      })
+
+      it("greaterThanOrEqualToDuration", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanOrEqualToDuration("10 millis"))
+
+        const schema = pipe(S.DurationFromSelf, S.greaterThanOrEqualToDuration("10 millis"))
+        expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
+      })
+
+      it("betweenDuration", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.betweenDuration("10 millis", "50 millis"))
+
+        const schema = pipe(S.DurationFromSelf, S.betweenDuration("10 millis", "50 millis"))
+        expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
+      })
+    })
   })
 
   describe("Data Types", () => {

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -2827,6 +2827,98 @@ describe("Schema", () => {
         expect(schema.from).type.toBe<typeof S.Number>()
       })
     })
+
+    describe("BigInt Filters", () => {
+      it("greaterThanBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanBigInt(5n))
+
+        const schema = pipe(S.BigIntFromSelf, S.greaterThanBigInt(5n))
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("greaterThanOrEqualToBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanOrEqualToBigInt(5n))
+
+        const schema = pipe(S.BigIntFromSelf, S.greaterThanOrEqualToBigInt(5n))
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("lessThanBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanBigInt(5n))
+
+        const schema = pipe(S.BigIntFromSelf, S.lessThanBigInt(5n))
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("lessThanOrEqualToBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanOrEqualToBigInt(5n))
+
+        const schema = pipe(S.BigIntFromSelf, S.lessThanOrEqualToBigInt(5n))
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("betweenBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.betweenBigInt(1n, 5n))
+
+        const schema = pipe(S.BigIntFromSelf, S.betweenBigInt(1n, 5n))
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("positiveBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.positiveBigInt())
+
+        const schema = pipe(S.BigIntFromSelf, S.positiveBigInt())
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("negativeBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.negativeBigInt())
+
+        const schema = pipe(S.BigIntFromSelf, S.negativeBigInt())
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("nonNegativeBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonNegativeBigInt())
+
+        const schema = pipe(S.BigIntFromSelf, S.nonNegativeBigInt())
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+
+      it("nonPositiveBigInt", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.negativeBigInt())
+
+        const schema = pipe(S.BigIntFromSelf, S.nonPositiveBigInt())
+        expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
+      })
+    })
   })
 
   describe("Data Types", () => {

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -2282,76 +2282,6 @@ describe("Schema", () => {
     })
   })
 
-  describe("Array Filters", () => {
-    describe("Array", () => {
-      it("minItems", () => {
-        expect(S.asSchema(S.Array(S.String).pipe(S.minItems(2))))
-          .type.toBe<S.Schema<ReadonlyArray<string>, ReadonlyArray<string>>>()
-        expect(S.Array(S.String).pipe(S.minItems(2)))
-          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-        expect(S.Array(S.String).pipe(S.minItems(2)).from)
-          .type.toBe<S.Schema<ReadonlyArray<string>>>()
-        expect(S.asSchema(S.Array(S.String).pipe(S.minItems(1), S.maxItems(2))))
-          .type.toBe<S.Schema<ReadonlyArray<string>, ReadonlyArray<string>>>()
-        expect(S.Array(S.String).pipe(S.minItems(1), S.maxItems(2)))
-          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-      })
-
-      it("maxItems", () => {
-        expect(S.asSchema(S.Array(S.String).pipe(S.maxItems(2))))
-          .type.toBe<S.Schema<ReadonlyArray<string>>>()
-        expect(S.Array(S.String).pipe(S.maxItems(2)))
-          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-        expect(S.Array(S.String).pipe(S.maxItems(2)).from)
-          .type.toBe<S.Schema<ReadonlyArray<string>>>()
-        expect(S.asSchema(S.Array(S.String).pipe(S.maxItems(2), S.minItems(1))))
-          .type.toBe<S.Schema<ReadonlyArray<string>>>()
-        expect(S.Array(S.String).pipe(S.maxItems(2), S.minItems(1)))
-          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-      })
-
-      it("itemsCount", () => {
-        expect(S.asSchema(S.Array(S.String).pipe(S.itemsCount(2))))
-          .type.toBe<S.Schema<ReadonlyArray<string>>>()
-        expect(S.Array(S.String).pipe(S.itemsCount(2)))
-          .type.toBe<S.filter<S.Schema<ReadonlyArray<string>>>>()
-        expect(S.Array(S.String).pipe(S.itemsCount(2)).from).type.toBe<S.Schema<ReadonlyArray<string>>>()
-      })
-    })
-
-    describe("NonEmptyArray", () => {
-      it("minItems", () => {
-        expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.minItems(2))))
-          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-        expect(S.NonEmptyArray(S.String).pipe(S.minItems(2)))
-          .type.toBe<S.filter<S.Schema<readonly [string, ...Array<string>]>>>()
-        expect(S.NonEmptyArray(S.String).pipe(S.minItems(2)).from)
-          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-      })
-
-      it("maxItems", () => {
-        expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.maxItems(2))))
-          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-        expect(S.NonEmptyArray(S.String).pipe(S.maxItems(2))).type.toBe<
-          S.filter<S.Schema<readonly [string, ...Array<string>]>>
-        >()
-        expect(S.NonEmptyArray(S.String).pipe(S.maxItems(2)).from).type.toBe<
-          S.Schema<readonly [string, ...Array<string>]>
-        >()
-      })
-
-      it("itemsCount", () => {
-        expect(S.asSchema(S.NonEmptyArray(S.String).pipe(S.itemsCount(2))))
-          .type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
-        expect(S.NonEmptyArray(S.String).pipe(S.itemsCount(2)))
-          .type.toBe<S.filter<S.Schema<readonly [string, ...Array<string>]>>>()
-        expect(S.NonEmptyArray(S.String).pipe(S.itemsCount(2)).from).type.toBe<
-          S.Schema<readonly [string, ...Array<string>]>
-        >()
-      })
-    })
-  })
-
   it("TemplateLiteralParser", () => {
     expect(S.asSchema(S.TemplateLiteralParser("a")))
       .type.toBe<S.Schema<readonly ["a"], "a">>()
@@ -2969,6 +2899,69 @@ describe("Schema", () => {
         expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
+      })
+    })
+
+    describe("Array Filters", () => {
+      describe("Array", () => {
+        it("minItems", () => {
+          // @ts-expect-error
+          pipe(S.Null, S.minItems(2))
+
+          const schema = S.Array(S.String).pipe(S.minItems(2))
+          expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlyArray<string>>>()
+          expect(schema).type.toBe<S.filter<S.Array$<typeof S.String>>>()
+          expect(schema.annotations({})).type.toBe<S.filter<S.Array$<typeof S.String>>>()
+          expect(schema.from).type.toBe<S.Array$<typeof S.String>>()
+        })
+
+        it("maxItems", () => {
+          // @ts-expect-error
+          pipe(S.Null, S.maxItems(2))
+
+          const schema = S.Array(S.String).pipe(S.maxItems(2))
+          expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlyArray<string>>>()
+          expect(schema).type.toBe<S.filter<S.Array$<typeof S.String>>>()
+          expect(schema.annotations({})).type.toBe<S.filter<S.Array$<typeof S.String>>>()
+          expect(schema.from).type.toBe<S.Array$<typeof S.String>>()
+        })
+
+        it("itemsCount", () => {
+          // @ts-expect-error
+          pipe(S.Null, S.itemsCount(2))
+
+          const schema = S.Array(S.String).pipe(S.itemsCount(2))
+          expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlyArray<string>>>()
+          expect(schema).type.toBe<S.filter<S.Array$<typeof S.String>>>()
+          expect(schema.annotations({})).type.toBe<S.filter<S.Array$<typeof S.String>>>()
+          expect(schema.from).type.toBe<S.Array$<typeof S.String>>()
+        })
+      })
+
+      describe("NonEmptyArray", () => {
+        it("minItems", () => {
+          const schema = S.NonEmptyArray(S.String).pipe(S.minItems(2))
+          expect(S.asSchema(schema)).type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+          expect(schema).type.toBe<S.filter<S.NonEmptyArray<typeof S.String>>>()
+          expect(schema.annotations({})).type.toBe<S.filter<S.NonEmptyArray<typeof S.String>>>()
+          expect(schema.from).type.toBe<S.NonEmptyArray<typeof S.String>>()
+        })
+
+        it("maxItems", () => {
+          const schema = S.NonEmptyArray(S.String).pipe(S.maxItems(2))
+          expect(S.asSchema(schema)).type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+          expect(schema).type.toBe<S.filter<S.NonEmptyArray<typeof S.String>>>()
+          expect(schema.annotations({})).type.toBe<S.filter<S.NonEmptyArray<typeof S.String>>>()
+          expect(schema.from).type.toBe<S.NonEmptyArray<typeof S.String>>()
+        })
+
+        it("itemsCount", () => {
+          const schema = S.NonEmptyArray(S.String).pipe(S.itemsCount(2))
+          expect(S.asSchema(schema)).type.toBe<S.Schema<readonly [string, ...Array<string>]>>()
+          expect(schema).type.toBe<S.filter<S.NonEmptyArray<typeof S.String>>>()
+          expect(schema.annotations({})).type.toBe<S.filter<S.NonEmptyArray<typeof S.String>>>()
+          expect(schema.from).type.toBe<S.NonEmptyArray<typeof S.String>>()
+        })
       })
     })
   })

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -2539,34 +2539,62 @@ describe("Schema", () => {
       })
     })
 
-    it("String Filters", () => {
-      expect(pipe(S.String, S.maxLength(5))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.maxLength(5))
+    describe("String Filters", () => {
+      it("maxLength", () => {
+        // @ts-expect-error: Argument of type 'typeof Null' is not assignable to parameter of type 'never'
+        pipe(S.Null, S.maxLength(5))
+        // should allow generic context
+        const _f = <A extends string>(schema: S.Schema<A>) => schema.pipe(S.maxLength(5))
+        // should allow string subtypes
+        pipe(
+          S.TemplateLiteral("a", S.String),
+          S.maxLength(5, {
+            pretty: () => (s) => {
+              expect(s).type.toBe<`a${string}`>()
+              return "-"
+            }
+          })
+        )
 
-      expect(pipe(S.String, S.minLength(5))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.minLength(5))
+        const schema = pipe(
+          S.String,
+          S.maxLength(5, {
+            pretty: () => (s) => {
+              expect(s).type.toBe<string>()
+              return "-"
+            }
+          })
+        )
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
 
-      expect(pipe(S.String, S.length(5))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.length(5))
+      it("TODO", () => {
+        expect(pipe(S.String, S.minLength(5))).type.toBe<S.filter<S.Schema<string>>>()
+        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        pipe(S.Null, S.minLength(5))
 
-      expect(pipe(S.String, S.pattern(/a/))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.pattern(/a/))
+        expect(pipe(S.String, S.length(5))).type.toBe<S.filter<S.Schema<string>>>()
+        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        pipe(S.Null, S.length(5))
 
-      expect(pipe(S.String, S.startsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.startsWith("a"))
+        expect(pipe(S.String, S.pattern(/a/))).type.toBe<S.filter<S.Schema<string>>>()
+        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        pipe(S.Null, S.pattern(/a/))
 
-      expect(pipe(S.String, S.endsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.endsWith("a"))
+        expect(pipe(S.String, S.startsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
+        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        pipe(S.Null, S.startsWith("a"))
 
-      expect(pipe(S.String, S.includes("a"))).type.toBe<S.filter<S.Schema<string>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'
-      pipe(S.Null, S.includes("a"))
+        expect(pipe(S.String, S.endsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
+        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        pipe(S.Null, S.endsWith("a"))
+
+        expect(pipe(S.String, S.includes("a"))).type.toBe<S.filter<S.Schema<string>>>()
+        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        pipe(S.Null, S.includes("a"))
+      })
     })
 
     it("Number Filters", () => {

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -288,7 +288,7 @@ describe("Schema", () => {
     expect(AnnotatedString.pipe(S.annotations({}))).type.toBe<AnnotatedString>()
 
     expect(S.Number.pipe(S.int(), S.brand("Int"), S.annotations({})))
-      .type.toBe<S.brand<S.filter<S.Schema<number>>, "Int">>()
+      .type.toBe<S.brand<S.filter<typeof S.Number>, "Int">>()
     expect(S.Struct({ a: AnnotatedString }).pipe(S.annotations({}))).type.toBe<S.Struct<{ a: AnnotatedString }>>()
     expect(A.pipe(S.annotations({}))).type.toBe<S.SchemaClass<A, { readonly a: string }>>()
     expect(S.Number.pipe(S.int(), S.brand("Int")).make(1)).type.toBe<number & Brand.Brand<"Int">>()
@@ -1224,11 +1224,11 @@ describe("Schema", () => {
     expect(S.asSchema(pipe(S.Number, S.int(), S.brand("Int"))).annotations({}))
       .type.toBe<S.Schema<number & Brand.Brand<"Int">, number>>()
     expect(pipe(S.Number, S.int(), S.brand("Int")))
-      .type.toBe<S.brand<S.filter<S.Schema<number>>, "Int">>()
+      .type.toBe<S.brand<S.filter<typeof S.Number>, "Int">>()
     expect(S.asSchema(pipe(S.NumberFromString, S.int(), S.brand("Int"))))
       .type.toBe<S.Schema<number & Brand.Brand<"Int">, string>>()
     expect(pipe(S.NumberFromString, S.int(), S.brand("Int")))
-      .type.toBe<S.brand<S.filter<S.Schema<number, string>>, "Int">>()
+      .type.toBe<S.brand<S.filter<typeof S.NumberFromString>, "Int">>()
   })
 
   it("partial", () => {
@@ -2696,34 +2696,136 @@ describe("Schema", () => {
       })
     })
 
-    it("Number Filters", () => {
-      expect(pipe(S.Number, S.greaterThan(5))).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.greaterThan(5))
+    describe("Number Filters", () => {
+      it("finite", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.finite())
 
-      expect(pipe(S.Number, S.greaterThanOrEqualTo(5))).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.greaterThanOrEqualTo(5))
+        const schema = pipe(S.Number, S.finite())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
 
-      expect(pipe(S.Number, S.lessThan(5))).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.lessThan(5))
+      it("greaterThan", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThan(5))
 
-      expect(pipe(S.Number, S.lessThanOrEqualTo(5))).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.lessThanOrEqualTo(5))
+        const schema = pipe(S.Number, S.greaterThan(5))
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
 
-      expect(pipe(S.Number, S.int())).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.int())
+      it("greaterThanOrEqualTo", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanOrEqualTo(5))
 
-      expect(pipe(S.Number, S.nonNaN())).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.nonNaN())
+        const schema = pipe(S.Number, S.greaterThanOrEqualTo(5))
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
 
-      expect(pipe(S.Number, S.finite())).type.toBe<S.filter<S.Schema<number>>>()
-      // @ts-expect-error: Type 'null' is not assignable to type 'number'
-      pipe(S.Null, S.finite())
+      it("lessThan", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThan(5))
+
+        const schema = pipe(S.Number, S.lessThan(5))
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("lessThanOrEqualTo", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanOrEqualTo(5))
+
+        const schema = pipe(S.Number, S.lessThanOrEqualTo(5))
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("int", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.int())
+
+        const schema = pipe(S.Number, S.int())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("multipleOf", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.multipleOf(5))
+
+        const schema = pipe(S.Number, S.multipleOf(5))
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("between", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.between(1, 5))
+
+        const schema = pipe(S.Number, S.between(1, 5))
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("nonNaN", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonNaN())
+
+        const schema = pipe(S.Number, S.nonNaN())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("positive", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.positive())
+
+        const schema = pipe(S.Number, S.positive())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("negative", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.negative())
+
+        const schema = pipe(S.Number, S.negative())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("nonPositive", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonPositive())
+
+        const schema = pipe(S.Number, S.nonPositive())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
+
+      it("nonNegative", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonNegative())
+
+        const schema = pipe(S.Number, S.nonNegative())
+        expect(schema).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
+        expect(schema.from).type.toBe<typeof S.Number>()
+      })
     })
   })
 

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -2500,6 +2500,7 @@ describe("Schema", () => {
             }
           })
         )
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2510,6 +2511,7 @@ describe("Schema", () => {
         pipe(S.Null, S.minLength(5))
 
         const schema = pipe(S.String, S.minLength(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2520,6 +2522,7 @@ describe("Schema", () => {
         pipe(S.Null, S.length(5))
 
         const schema = pipe(S.String, S.length(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2530,6 +2533,7 @@ describe("Schema", () => {
         pipe(S.Null, S.pattern(/a/))
 
         const schema = pipe(S.String, S.pattern(/a/))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2540,6 +2544,7 @@ describe("Schema", () => {
         pipe(S.Null, S.startsWith("a"))
 
         const schema = pipe(S.String, S.startsWith("a"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2550,6 +2555,7 @@ describe("Schema", () => {
         pipe(S.Null, S.endsWith("a"))
 
         const schema = pipe(S.String, S.endsWith("a"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2560,6 +2566,7 @@ describe("Schema", () => {
         pipe(S.Null, S.includes("a"))
 
         const schema = pipe(S.String, S.includes("a"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2570,6 +2577,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lowercased())
 
         const schema = pipe(S.String, S.lowercased())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2580,6 +2588,7 @@ describe("Schema", () => {
         pipe(S.Null, S.uppercased())
 
         const schema = pipe(S.String, S.uppercased())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2590,6 +2599,7 @@ describe("Schema", () => {
         pipe(S.Null, S.capitalized())
 
         const schema = pipe(S.String, S.capitalized())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2600,6 +2610,7 @@ describe("Schema", () => {
         pipe(S.Null, S.uncapitalized())
 
         const schema = pipe(S.String, S.uncapitalized())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2610,6 +2621,7 @@ describe("Schema", () => {
         pipe(S.Null, S.nonEmptyString())
 
         const schema = pipe(S.String, S.nonEmptyString())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2620,6 +2632,7 @@ describe("Schema", () => {
         pipe(S.Null, S.trimmed())
 
         const schema = pipe(S.String, S.trimmed())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<string>>()
         expect(schema).type.toBe<S.filter<typeof S.String>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
         expect(schema.from).type.toBe<typeof S.String>()
@@ -2632,6 +2645,7 @@ describe("Schema", () => {
         pipe(S.Null, S.finite())
 
         const schema = pipe(S.Number, S.finite())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2642,6 +2656,7 @@ describe("Schema", () => {
         pipe(S.Null, S.greaterThan(5))
 
         const schema = pipe(S.Number, S.greaterThan(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2652,6 +2667,7 @@ describe("Schema", () => {
         pipe(S.Null, S.greaterThanOrEqualTo(5))
 
         const schema = pipe(S.Number, S.greaterThanOrEqualTo(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2662,6 +2678,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lessThan(5))
 
         const schema = pipe(S.Number, S.lessThan(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2672,6 +2689,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lessThanOrEqualTo(5))
 
         const schema = pipe(S.Number, S.lessThanOrEqualTo(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2682,6 +2700,7 @@ describe("Schema", () => {
         pipe(S.Null, S.int())
 
         const schema = pipe(S.Number, S.int())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2692,6 +2711,7 @@ describe("Schema", () => {
         pipe(S.Null, S.multipleOf(5))
 
         const schema = pipe(S.Number, S.multipleOf(5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2702,6 +2722,7 @@ describe("Schema", () => {
         pipe(S.Null, S.between(1, 5))
 
         const schema = pipe(S.Number, S.between(1, 5))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2712,6 +2733,7 @@ describe("Schema", () => {
         pipe(S.Null, S.nonNaN())
 
         const schema = pipe(S.Number, S.nonNaN())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2722,6 +2744,7 @@ describe("Schema", () => {
         pipe(S.Null, S.positive())
 
         const schema = pipe(S.Number, S.positive())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2732,6 +2755,7 @@ describe("Schema", () => {
         pipe(S.Null, S.negative())
 
         const schema = pipe(S.Number, S.negative())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2742,6 +2766,7 @@ describe("Schema", () => {
         pipe(S.Null, S.nonPositive())
 
         const schema = pipe(S.Number, S.nonPositive())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2752,6 +2777,7 @@ describe("Schema", () => {
         pipe(S.Null, S.nonNegative())
 
         const schema = pipe(S.Number, S.nonNegative())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<number>>()
         expect(schema).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.Number>>()
         expect(schema.from).type.toBe<typeof S.Number>()
@@ -2764,6 +2790,7 @@ describe("Schema", () => {
         pipe(S.Null, S.greaterThanBigInt(5n))
 
         const schema = pipe(S.BigIntFromSelf, S.greaterThanBigInt(5n))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2774,6 +2801,7 @@ describe("Schema", () => {
         pipe(S.Null, S.greaterThanOrEqualToBigInt(5n))
 
         const schema = pipe(S.BigIntFromSelf, S.greaterThanOrEqualToBigInt(5n))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2784,6 +2812,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lessThanBigInt(5n))
 
         const schema = pipe(S.BigIntFromSelf, S.lessThanBigInt(5n))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2794,6 +2823,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lessThanOrEqualToBigInt(5n))
 
         const schema = pipe(S.BigIntFromSelf, S.lessThanOrEqualToBigInt(5n))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2804,6 +2834,7 @@ describe("Schema", () => {
         pipe(S.Null, S.betweenBigInt(1n, 5n))
 
         const schema = pipe(S.BigIntFromSelf, S.betweenBigInt(1n, 5n))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2814,6 +2845,7 @@ describe("Schema", () => {
         pipe(S.Null, S.positiveBigInt())
 
         const schema = pipe(S.BigIntFromSelf, S.positiveBigInt())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2824,6 +2856,7 @@ describe("Schema", () => {
         pipe(S.Null, S.negativeBigInt())
 
         const schema = pipe(S.BigIntFromSelf, S.negativeBigInt())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2834,6 +2867,7 @@ describe("Schema", () => {
         pipe(S.Null, S.nonNegativeBigInt())
 
         const schema = pipe(S.BigIntFromSelf, S.nonNegativeBigInt())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2844,6 +2878,7 @@ describe("Schema", () => {
         pipe(S.Null, S.negativeBigInt())
 
         const schema = pipe(S.BigIntFromSelf, S.nonPositiveBigInt())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<bigint>>()
         expect(schema).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigIntFromSelf>>()
         expect(schema.from).type.toBe<typeof S.BigIntFromSelf>()
@@ -2856,6 +2891,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lessThanDuration("10 millis"))
 
         const schema = pipe(S.DurationFromSelf, S.lessThanDuration("10 millis"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Duration.Duration>>()
         expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
@@ -2866,6 +2902,7 @@ describe("Schema", () => {
         pipe(S.Null, S.lessThanOrEqualToDuration("10 millis"))
 
         const schema = pipe(S.DurationFromSelf, S.lessThanOrEqualToDuration("10 millis"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Duration.Duration>>()
         expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
@@ -2876,6 +2913,7 @@ describe("Schema", () => {
         pipe(S.Null, S.greaterThanDuration("10 millis"))
 
         const schema = pipe(S.DurationFromSelf, S.greaterThanDuration("10 millis"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Duration.Duration>>()
         expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
@@ -2886,6 +2924,7 @@ describe("Schema", () => {
         pipe(S.Null, S.greaterThanOrEqualToDuration("10 millis"))
 
         const schema = pipe(S.DurationFromSelf, S.greaterThanOrEqualToDuration("10 millis"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Duration.Duration>>()
         expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DurationFromSelf>()
@@ -2896,6 +2935,7 @@ describe("Schema", () => {
         pipe(S.Null, S.betweenDuration("10 millis", "50 millis"))
 
         const schema = pipe(S.DurationFromSelf, S.betweenDuration("10 millis", "50 millis"))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Duration.Duration>>()
         expect(schema).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DurationFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DurationFromSelf>()

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -3005,7 +3005,7 @@ describe("Schema", () => {
       })
     })
 
-    describe("Data Filters", () => {
+    describe("Date Filters", () => {
       it("validDate", () => {
         // @ts-expect-error
         pipe(S.Null, S.validDate())
@@ -3070,6 +3070,109 @@ describe("Schema", () => {
         expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
         expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
         expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+    })
+
+    describe("BigDecimal Filters", () => {
+      const bd = hole<BigDecimal.BigDecimal>()
+
+      it("greaterThanBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanBigDecimal(bd))
+
+        const schema = pipe(S.BigDecimalFromSelf, S.greaterThanBigDecimal(bd))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("greaterThanOrEqualToBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanOrEqualToBigDecimal(bd))
+
+        const schema = pipe(S.BigDecimalFromSelf, S.greaterThanOrEqualToBigDecimal(bd))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("lessThanBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanBigDecimal(bd))
+
+        const schema = pipe(S.BigDecimalFromSelf, S.lessThanBigDecimal(bd))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("lessThanOrEqualToBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanOrEqualToBigDecimal(bd))
+
+        const schema = pipe(S.BigDecimalFromSelf, S.lessThanOrEqualToBigDecimal(bd))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("positiveBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.positiveBigDecimal())
+
+        const schema = pipe(S.BigDecimalFromSelf, S.positiveBigDecimal())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("nonNegativeBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonNegativeBigDecimal())
+
+        const schema = pipe(S.BigDecimalFromSelf, S.nonNegativeBigDecimal())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("negativeBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.negativeBigDecimal())
+
+        const schema = pipe(S.BigDecimalFromSelf, S.negativeBigDecimal())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("nonPositiveBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonPositiveBigDecimal())
+
+        const schema = pipe(S.BigDecimalFromSelf, S.nonPositiveBigDecimal())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
+      })
+
+      it("betweenBigDecimal", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.betweenBigDecimal(bd, bd))
+
+        const schema = pipe(S.BigDecimalFromSelf, S.betweenBigDecimal(bd, bd))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<BigDecimal.BigDecimal>>()
+        expect(schema).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.BigDecimalFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.BigDecimalFromSelf>()
       })
     })
   })

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -3004,6 +3004,74 @@ describe("Schema", () => {
         })
       })
     })
+
+    describe("Data Filters", () => {
+      it("validDate", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.validDate())
+
+        const schema = pipe(S.DateFromSelf, S.validDate())
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Date>>()
+        expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+
+      it("lessThanDate", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanDate(new Date()))
+
+        const schema = pipe(S.DateFromSelf, S.lessThanDate(new Date()))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Date>>()
+        expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+
+      it("lessThanOrEqualToDate", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lessThanOrEqualToDate(new Date()))
+
+        const schema = pipe(S.DateFromSelf, S.lessThanOrEqualToDate(new Date()))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Date>>()
+        expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+
+      it("greaterThanDate", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanDate(new Date()))
+
+        const schema = pipe(S.DateFromSelf, S.greaterThanDate(new Date()))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Date>>()
+        expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+
+      it("greaterThanOrEqualToDate", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.greaterThanOrEqualToDate(new Date()))
+
+        const schema = pipe(S.DateFromSelf, S.greaterThanOrEqualToDate(new Date()))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Date>>()
+        expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+
+      it("betweenDate", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.betweenDate(new Date(0), new Date(100)))
+
+        const schema = pipe(S.DateFromSelf, S.betweenDate(new Date(0), new Date(100)))
+        expect(S.asSchema(schema)).type.toBe<S.Schema<Date>>()
+        expect(schema).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.DateFromSelf>>()
+        expect(schema.from).type.toBe<typeof S.DateFromSelf>()
+      })
+    })
   })
 
   describe("Data Types", () => {

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -2541,10 +2541,15 @@ describe("Schema", () => {
 
     describe("String Filters", () => {
       it("maxLength", () => {
-        // @ts-expect-error: Argument of type 'typeof Null' is not assignable to parameter of type 'never'
+        // @ts-expect-error: The intersection 'typeof Null & Schema<string, null, never>' was reduced to 'never' because property 'Type' has conflicting types in some constituents
         pipe(S.Null, S.maxLength(5))
         // should allow generic context
-        const _f = <A extends string>(schema: S.Schema<A>) => schema.pipe(S.maxLength(5))
+        const _f1 = <A extends string>(schema: S.Schema<A>) => schema.pipe(S.maxLength(5))
+        const _f2 = <A extends string>(schema: S.Schema<A>) =>
+          schema.pipe(
+            // @ts-expect-error: Type 'string' is not assignable to type 'number'
+            S.greaterThan(5)
+          )
         // should allow string subtypes
         pipe(
           S.TemplateLiteral("a", S.String),

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -1347,7 +1347,7 @@ describe("Schema", () => {
       >
     >()
     expect(S.Record({ key: pipe(S.String, S.minLength(2)), value: S.String }))
-      .type.toBe<S.Record$<S.filter<S.Schema<string>>, typeof S.String>>()
+      .type.toBe<S.Record$<S.filter<typeof S.String>, typeof S.String>>()
     expect(S.asSchema(S.Record({ key: S.Union(S.Literal("a"), S.Literal("b")), value: S.String })))
       .type.toBe<
       S.Schema<
@@ -2575,30 +2575,124 @@ describe("Schema", () => {
         expect(schema.from).type.toBe<typeof S.String>()
       })
 
-      it("TODO", () => {
-        expect(pipe(S.String, S.minLength(5))).type.toBe<S.filter<S.Schema<string>>>()
-        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      it("minLength", () => {
+        // @ts-expect-error
         pipe(S.Null, S.minLength(5))
 
-        expect(pipe(S.String, S.length(5))).type.toBe<S.filter<S.Schema<string>>>()
-        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        const schema = pipe(S.String, S.minLength(5))
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("length", () => {
+        // @ts-expect-error
         pipe(S.Null, S.length(5))
 
-        expect(pipe(S.String, S.pattern(/a/))).type.toBe<S.filter<S.Schema<string>>>()
-        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        const schema = pipe(S.String, S.length(5))
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("pattern", () => {
+        // @ts-expect-error
         pipe(S.Null, S.pattern(/a/))
 
-        expect(pipe(S.String, S.startsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
-        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        const schema = pipe(S.String, S.pattern(/a/))
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("startsWith", () => {
+        // @ts-expect-error
         pipe(S.Null, S.startsWith("a"))
 
-        expect(pipe(S.String, S.endsWith("a"))).type.toBe<S.filter<S.Schema<string>>>()
-        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        const schema = pipe(S.String, S.startsWith("a"))
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("endsWith", () => {
+        // @ts-expect-error
         pipe(S.Null, S.endsWith("a"))
 
-        expect(pipe(S.String, S.includes("a"))).type.toBe<S.filter<S.Schema<string>>>()
-        // @ts-expect-error: Type 'null' is not assignable to type 'string'
+        const schema = pipe(S.String, S.endsWith("a"))
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("includes", () => {
+        // @ts-expect-error
         pipe(S.Null, S.includes("a"))
+
+        const schema = pipe(S.String, S.includes("a"))
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("lowercased", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.lowercased())
+
+        const schema = pipe(S.String, S.lowercased())
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("uppercased", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.uppercased())
+
+        const schema = pipe(S.String, S.uppercased())
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("capitalized", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.capitalized())
+
+        const schema = pipe(S.String, S.capitalized())
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("uncapitalized", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.uncapitalized())
+
+        const schema = pipe(S.String, S.uncapitalized())
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("nonEmptyString", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.nonEmptyString())
+
+        const schema = pipe(S.String, S.nonEmptyString())
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
+      })
+
+      it("trimmed", () => {
+        // @ts-expect-error
+        pipe(S.Null, S.trimmed())
+
+        const schema = pipe(S.String, S.trimmed())
+        expect(schema).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.annotations({})).type.toBe<S.filter<typeof S.String>>()
+        expect(schema.from).type.toBe<typeof S.String>()
       })
     })
 

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -36,7 +36,7 @@
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
-    "dtslint": "pnpm -w tstyche",
+    "dtslint": "tstyche --target '>=5.4'",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5891,11 +5891,11 @@ export const LessThanDurationSchemaId: unique symbol = Symbol.for("effect/Schema
  * @category Duration filters
  * @since 3.10.0
  */
-export const lessThanDuration = <A extends duration_.Duration>(
+export const lessThanDuration = <S extends Schema.Any>(
   max: duration_.DurationInput,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends duration_.Duration>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => duration_.lessThan(a, max), {
       schemaId: LessThanDurationSchemaId,
@@ -5918,11 +5918,11 @@ export const LessThanOrEqualToDurationSchemaId: unique symbol = Symbol.for(
  * @category Duration filters
  * @since 3.10.0
  */
-export const lessThanOrEqualToDuration = <A extends duration_.Duration>(
+export const lessThanOrEqualToDuration = <S extends Schema.Any>(
   max: duration_.DurationInput,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends duration_.Duration>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => duration_.lessThanOrEqualTo(a, max), {
       schemaId: LessThanDurationSchemaId,
@@ -5943,11 +5943,11 @@ export const GreaterThanDurationSchemaId: unique symbol = Symbol.for("effect/Sch
  * @category Duration filters
  * @since 3.10.0
  */
-export const greaterThanDuration = <A extends duration_.Duration>(
+export const greaterThanDuration = <S extends Schema.Any>(
   min: duration_.DurationInput,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends duration_.Duration>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => duration_.greaterThan(a, min), {
       schemaId: GreaterThanDurationSchemaId,
@@ -5970,11 +5970,11 @@ export const GreaterThanOrEqualToDurationSchemaId: unique symbol = Symbol.for(
  * @category Duration filters
  * @since 3.10.0
  */
-export const greaterThanOrEqualToDuration = <A extends duration_.Duration>(
+export const greaterThanOrEqualToDuration = <S extends Schema.Any>(
   min: duration_.DurationInput,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends duration_.Duration>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => duration_.greaterThanOrEqualTo(a, min), {
       schemaId: GreaterThanOrEqualToDurationSchemaId,
@@ -5995,12 +5995,12 @@ export const BetweenDurationSchemaId: unique symbol = Symbol.for("effect/SchemaI
  * @category Duration filters
  * @since 3.10.0
  */
-export const betweenDuration = <A extends duration_.Duration>(
+export const betweenDuration = <S extends Schema.Any>(
   minimum: duration_.DurationInput,
   maximum: duration_.DurationInput,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends duration_.Duration>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => duration_.between(a, { minimum, maximum }), {
       schemaId: BetweenDurationSchemaId,

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4154,11 +4154,11 @@ export type MaxLengthSchemaId = typeof MaxLengthSchemaId
  * @category string filters
  * @since 3.10.0
  */
-export const maxLength = <A extends string, I, R, S extends Schema.Any = Schema<A, I, R>>(
+export const maxLength = <S extends Schema.Any>(
   maxLength: number,
   annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-(self: S & Schema<A, I, R>): filter<S> =>
+<A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter(
       (a) => a.length <= maxLength,

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6225,11 +6225,11 @@ export type MinItemsSchemaId = typeof MinItemsSchemaId
  * @category ReadonlyArray filters
  * @since 3.10.0
  */
-export const minItems = <A extends ReadonlyArray<any>>(
+export const minItems = <S extends Schema.Any>(
   n: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
+<A extends ReadonlyArray<any>>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
   const minItems = Math.floor(n)
   if (minItems < 1) {
     throw new Error(
@@ -6267,11 +6267,11 @@ export type MaxItemsSchemaId = typeof MaxItemsSchemaId
  * @category ReadonlyArray filters
  * @since 3.10.0
  */
-export const maxItems = <A extends ReadonlyArray<any>>(
+export const maxItems = <S extends Schema.Any>(
   n: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
+<A extends ReadonlyArray<any>>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
   const maxItems = Math.floor(n)
   if (maxItems < 1) {
     throw new Error(
@@ -6306,11 +6306,11 @@ export type ItemsCountSchemaId = typeof ItemsCountSchemaId
  * @category ReadonlyArray filters
  * @since 3.10.0
  */
-export const itemsCount = <A extends ReadonlyArray<any>>(
+export const itemsCount = <S extends Schema.Any>(
   n: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
+<A extends ReadonlyArray<any>>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
   const itemsCount = Math.floor(n)
   if (itemsCount < 0) {
     throw new Error(

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4156,23 +4156,21 @@ export type MaxLengthSchemaId = typeof MaxLengthSchemaId
  * @category string filters
  * @since 3.10.0
  */
-export const maxLength = <S extends Schema.Any>(
-  maxLength: number,
-  annotations?: Annotations.Filter<Schema.Type<S>>
-) =>
-<A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
-  self.pipe(
-    filter(
-      (a) => a.length <= maxLength,
-      {
-        schemaId: MaxLengthSchemaId,
-        title: `maxLength(${maxLength})`,
-        description: `a string at most ${maxLength} character(s) long`,
-        jsonSchema: { maxLength },
-        ...annotations
-      }
+export const maxLength =
+  <S extends Schema.Any>(maxLength: number, annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter(
+        (a) => a.length <= maxLength,
+        {
+          schemaId: MaxLengthSchemaId,
+          title: `maxLength(${maxLength})`,
+          description: `a string at most ${maxLength} character(s) long`,
+          jsonSchema: { maxLength },
+          ...annotations
+        }
+      )
     )
-  )
 
 /**
  * @category schema id
@@ -4393,19 +4391,18 @@ export const LowercasedSchemaId: unique symbol = Symbol.for("effect/SchemaId/Low
  * @category string filters
  * @since 3.10.0
  */
-export const lowercased = <S extends Schema.Any>(
-  annotations?: Annotations.Filter<Schema.Type<S>>
-) =>
-<A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
-  self.pipe(
-    filter((a) => a === a.toLowerCase(), {
-      schemaId: LowercasedSchemaId,
-      title: "lowercased",
-      description: "a lowercase string",
-      jsonSchema: { pattern: "^[^A-Z]*$" },
-      ...annotations
-    })
-  )
+export const lowercased =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => a === a.toLowerCase(), {
+        schemaId: LowercasedSchemaId,
+        title: "lowercased",
+        description: "a lowercase string",
+        jsonSchema: { pattern: "^[^A-Z]*$" },
+        ...annotations
+      })
+    )
 
 /**
  * @category string constructors
@@ -4427,19 +4424,18 @@ export const UppercasedSchemaId: unique symbol = Symbol.for("effect/SchemaId/Upp
  * @category string filters
  * @since 3.10.0
  */
-export const uppercased = <S extends Schema.Any>(
-  annotations?: Annotations.Filter<Schema.Type<S>>
-) =>
-<A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
-  self.pipe(
-    filter((a) => a === a.toUpperCase(), {
-      schemaId: UppercasedSchemaId,
-      title: "uppercased",
-      description: "an uppercase string",
-      jsonSchema: { pattern: "^[^a-z]*$" },
-      ...annotations
-    })
-  )
+export const uppercased =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => a === a.toUpperCase(), {
+        schemaId: UppercasedSchemaId,
+        title: "uppercased",
+        description: "an uppercase string",
+        jsonSchema: { pattern: "^[^a-z]*$" },
+        ...annotations
+      })
+    )
 
 /**
  * @category string constructors
@@ -4461,19 +4457,18 @@ export const CapitalizedSchemaId: unique symbol = Symbol.for("effect/SchemaId/Ca
  * @category string filters
  * @since 3.10.0
  */
-export const capitalized = <S extends Schema.Any>(
-  annotations?: Annotations.Filter<Schema.Type<S>>
-) =>
-<A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
-  self.pipe(
-    filter((a) => a[0]?.toUpperCase() === a[0], {
-      schemaId: CapitalizedSchemaId,
-      title: "capitalized",
-      description: "a capitalized string",
-      jsonSchema: { pattern: "^[^a-z]?.*$" },
-      ...annotations
-    })
-  )
+export const capitalized =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => a[0]?.toUpperCase() === a[0], {
+        schemaId: CapitalizedSchemaId,
+        title: "capitalized",
+        description: "a capitalized string",
+        jsonSchema: { pattern: "^[^a-z]?.*$" },
+        ...annotations
+      })
+    )
 
 /**
  * @category string constructors
@@ -4495,19 +4490,18 @@ export const UncapitalizedSchemaId: unique symbol = Symbol.for("effect/SchemaId/
  * @category string filters
  * @since 3.10.0
  */
-export const uncapitalized = <S extends Schema.Any>(
-  annotations?: Annotations.Filter<Schema.Type<S>>
-) =>
-<A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
-  self.pipe(
-    filter((a) => a[0]?.toLowerCase() === a[0], {
-      schemaId: UncapitalizedSchemaId,
-      title: "uncapitalized",
-      description: "a uncapitalized string",
-      jsonSchema: { pattern: "^[^A-Z]?.*$" },
-      ...annotations
-    })
-  )
+export const uncapitalized =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends string>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => a[0]?.toLowerCase() === a[0], {
+        schemaId: UncapitalizedSchemaId,
+        title: "uncapitalized",
+        description: "a uncapitalized string",
+        jsonSchema: { pattern: "^[^A-Z]?.*$" },
+        ...annotations
+      })
+    )
 
 /**
  * @category string constructors
@@ -4827,7 +4821,8 @@ export type FiniteSchemaId = typeof FiniteSchemaId
  * @since 3.10.0
  */
 export const finite =
-  <A extends number>(annotations?: Annotations.Filter<A>) => <I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
     self.pipe(
       filter(Number.isFinite, {
         schemaId: FiniteSchemaId,
@@ -4856,11 +4851,11 @@ export type GreaterThanSchemaId = typeof GreaterThanSchemaId
  * @category number filters
  * @since 3.10.0
  */
-export const greaterThan = <A extends number>(
+export const greaterThan = <S extends Schema.Any>(
   exclusiveMinimum: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a > exclusiveMinimum, {
       schemaId: GreaterThanSchemaId,
@@ -4889,11 +4884,11 @@ export type GreaterThanOrEqualToSchemaId = typeof GreaterThanOrEqualToSchemaId
  * @category number filters
  * @since 3.10.0
  */
-export const greaterThanOrEqualTo = <A extends number>(
+export const greaterThanOrEqualTo = <S extends Schema.Any>(
   minimum: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a >= minimum, {
       schemaId: GreaterThanOrEqualToSchemaId,
@@ -4914,11 +4909,11 @@ export const MultipleOfSchemaId: unique symbol = Symbol.for("effect/SchemaId/Mul
  * @category number filters
  * @since 3.10.0
  */
-export const multipleOf = <A extends number>(
+export const multipleOf = <S extends Schema.Any>(
   divisor: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
+<A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
   const positiveDivisor = Math.abs(divisor) // spec requires positive divisor
   return self.pipe(
     filter((a) => number_.remainder(a, divisor) === 0, {
@@ -4950,7 +4945,8 @@ export type IntSchemaId = typeof IntSchemaId
  * @since 3.10.0
  */
 export const int =
-  <A extends number>(annotations?: Annotations.Filter<A>) => <I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
     self.pipe(
       filter((a) => Number.isSafeInteger(a), {
         schemaId: IntSchemaId,
@@ -4980,8 +4976,8 @@ export type LessThanSchemaId = typeof LessThanSchemaId
  * @since 3.10.0
  */
 export const lessThan =
-  <A extends number>(exclusiveMaximum: number, annotations?: Annotations.Filter<A>) =>
-  <I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+  <S extends Schema.Any>(exclusiveMaximum: number, annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
     self.pipe(
       filter((a) => a < exclusiveMaximum, {
         schemaId: LessThanSchemaId,
@@ -5010,11 +5006,11 @@ export type LessThanOrEqualToSchemaId = typeof LessThanOrEqualToSchemaId
  * @category number filters
  * @since 3.10.0
  */
-export const lessThanOrEqualTo = <A extends number>(
+export const lessThanOrEqualTo = <S extends Schema.Any>(
   maximum: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a <= maximum, {
       schemaId: LessThanOrEqualToSchemaId,
@@ -5043,12 +5039,12 @@ export type BetweenSchemaId = typeof BetweenSchemaId
  * @category number filters
  * @since 3.10.0
  */
-export const between = <A extends number>(
+export const between = <S extends Schema.Any>(
   minimum: number,
   maximum: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a >= minimum && a <= maximum, {
       schemaId: BetweenSchemaId,
@@ -5076,7 +5072,8 @@ export type NonNaNSchemaId = typeof NonNaNSchemaId
  * @since 3.10.0
  */
 export const nonNaN =
-  <A extends number>(annotations?: Annotations.Filter<A>) => <I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
     self.pipe(
       filter((a) => !Number.isNaN(a), {
         schemaId: NonNaNSchemaId,
@@ -5090,34 +5087,36 @@ export const nonNaN =
  * @category number filters
  * @since 3.10.0
  */
-export const positive = <A extends number>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> => greaterThan(0, { title: "positive", ...annotations })
+export const positive = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
+  greaterThan(0, { title: "positive", ...annotations })
 
 /**
  * @category number filters
  * @since 3.10.0
  */
-export const negative = <A extends number>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> => lessThan(0, { title: "negative", ...annotations })
+export const negative = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
+  lessThan(0, { title: "negative", ...annotations })
 
 /**
  * @category number filters
  * @since 3.10.0
  */
-export const nonPositive = <A extends number>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> =>
+export const nonPositive = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
   lessThanOrEqualTo(0, { title: "nonPositive", ...annotations })
 
 /**
  * @category number filters
  * @since 3.10.0
  */
-export const nonNegative = <A extends number>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> =>
+export const nonNegative = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends number>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
   greaterThanOrEqualTo(0, { title: "nonNegative", ...annotations })
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6421,7 +6421,8 @@ export const ValidDateSchemaId: unique symbol = Symbol.for("effect/SchemaId/Vali
  * @since 3.10.0
  */
 export const validDate =
-  (annotations?: Annotations.Filter<Date>) => <I, R>(self: Schema<Date, I, R>): filter<Schema<Date, I, R>> =>
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends Date>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
     self.pipe(
       filter((a) => !Number.isNaN(a.getTime()), {
         schemaId: ValidDateSchemaId,
@@ -6442,13 +6443,13 @@ export const LessThanDateSchemaId: unique symbol = Symbol.for("effect/SchemaId/L
  * @category Date filters
  * @since 3.10.0
  */
-export const lessThanDate = <A extends Date>(
+export const lessThanDate = <S extends Schema.Any>(
   max: Date,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends Date>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
-    filter((a) => a < max, {
+    filter((a: Date) => a < max, {
       schemaId: LessThanDateSchemaId,
       [LessThanDateSchemaId]: { max },
       title: `lessThanDate(${util_.formatDate(max)})`,
@@ -6469,13 +6470,13 @@ export const LessThanOrEqualToDateSchemaId: unique symbol = Symbol.for(
  * @category Date filters
  * @since 3.10.0
  */
-export const lessThanOrEqualToDate = <A extends Date>(
+export const lessThanOrEqualToDate = <S extends Schema.Any>(
   max: Date,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends Date>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
-    filter((a) => a <= max, {
+    filter((a: Date) => a <= max, {
       schemaId: LessThanDateSchemaId,
       [LessThanDateSchemaId]: { max },
       title: `lessThanOrEqualToDate(${util_.formatDate(max)})`,
@@ -6494,13 +6495,13 @@ export const GreaterThanDateSchemaId: unique symbol = Symbol.for("effect/SchemaI
  * @category Date filters
  * @since 3.10.0
  */
-export const greaterThanDate = <A extends Date>(
+export const greaterThanDate = <S extends Schema.Any>(
   min: Date,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends Date>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
-    filter((a) => a > min, {
+    filter((a: Date) => a > min, {
       schemaId: GreaterThanDateSchemaId,
       [GreaterThanDateSchemaId]: { min },
       title: `greaterThanDate(${util_.formatDate(min)})`,
@@ -6521,13 +6522,13 @@ export const GreaterThanOrEqualToDateSchemaId: unique symbol = Symbol.for(
  * @category Date filters
  * @since 3.10.0
  */
-export const greaterThanOrEqualToDate = <A extends Date>(
+export const greaterThanOrEqualToDate = <S extends Schema.Any>(
   min: Date,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends Date>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
-    filter((a) => a >= min, {
+    filter((a: Date) => a >= min, {
       schemaId: GreaterThanOrEqualToDateSchemaId,
       [GreaterThanOrEqualToDateSchemaId]: { min },
       title: `greaterThanOrEqualToDate(${util_.formatDate(min)})`,
@@ -6546,14 +6547,14 @@ export const BetweenDateSchemaId: unique symbol = Symbol.for("effect/SchemaId/Be
  * @category Date filters
  * @since 3.10.0
  */
-export const betweenDate = <A extends Date>(
+export const betweenDate = <S extends Schema.Any>(
   min: Date,
   max: Date,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends Date>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
-    filter((a) => a <= max && a >= min, {
+    filter((a: Date) => a <= max && a >= min, {
       schemaId: BetweenDateSchemaId,
       [BetweenDateSchemaId]: { max, min },
       title: `betweenDate(${util_.formatDate(min)}, ${util_.formatDate(max)})`,

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7730,22 +7730,20 @@ export const GreaterThanBigDecimalSchemaId: unique symbol = Symbol.for("effect/S
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const greaterThanBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  min: bigDecimal_.BigDecimal,
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
-  const formatted = bigDecimal_.format(min)
-  return self.pipe(
-    filter((a) => bigDecimal_.greaterThan(a, min), {
-      schemaId: GreaterThanBigDecimalSchemaId,
-      [GreaterThanBigDecimalSchemaId]: { min },
-      title: `greaterThanBigDecimal(${formatted})`,
-      description: `a BigDecimal greater than ${formatted}`,
-      ...annotations
-    })
-  )
-}
+export const greaterThanBigDecimal =
+  <S extends Schema.Any>(min: bigDecimal_.BigDecimal, annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
+    const formatted = bigDecimal_.format(min)
+    return self.pipe(
+      filter((a) => bigDecimal_.greaterThan(a, min), {
+        schemaId: GreaterThanBigDecimalSchemaId,
+        [GreaterThanBigDecimalSchemaId]: { min },
+        title: `greaterThanBigDecimal(${formatted})`,
+        description: `a BigDecimal greater than ${formatted}`,
+        ...annotations
+      })
+    )
+  }
 
 /**
  * @category schema id
@@ -7759,22 +7757,20 @@ export const GreaterThanOrEqualToBigDecimalSchemaId: unique symbol = Symbol.for(
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const greaterThanOrEqualToBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  min: bigDecimal_.BigDecimal,
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
-  const formatted = bigDecimal_.format(min)
-  return self.pipe(
-    filter((a) => bigDecimal_.greaterThanOrEqualTo(a, min), {
-      schemaId: GreaterThanOrEqualToBigDecimalSchemaId,
-      [GreaterThanOrEqualToBigDecimalSchemaId]: { min },
-      title: `greaterThanOrEqualToBigDecimal(${formatted})`,
-      description: `a BigDecimal greater than or equal to ${formatted}`,
-      ...annotations
-    })
-  )
-}
+export const greaterThanOrEqualToBigDecimal =
+  <S extends Schema.Any>(min: bigDecimal_.BigDecimal, annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
+    const formatted = bigDecimal_.format(min)
+    return self.pipe(
+      filter((a) => bigDecimal_.greaterThanOrEqualTo(a, min), {
+        schemaId: GreaterThanOrEqualToBigDecimalSchemaId,
+        [GreaterThanOrEqualToBigDecimalSchemaId]: { min },
+        title: `greaterThanOrEqualToBigDecimal(${formatted})`,
+        description: `a BigDecimal greater than or equal to ${formatted}`,
+        ...annotations
+      })
+    )
+  }
 
 /**
  * @category schema id
@@ -7786,22 +7782,20 @@ export const LessThanBigDecimalSchemaId: unique symbol = Symbol.for("effect/Sche
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const lessThanBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  max: bigDecimal_.BigDecimal,
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
-  const formatted = bigDecimal_.format(max)
-  return self.pipe(
-    filter((a) => bigDecimal_.lessThan(a, max), {
-      schemaId: LessThanBigDecimalSchemaId,
-      [LessThanBigDecimalSchemaId]: { max },
-      title: `lessThanBigDecimal(${formatted})`,
-      description: `a BigDecimal less than ${formatted}`,
-      ...annotations
-    })
-  )
-}
+export const lessThanBigDecimal =
+  <S extends Schema.Any>(max: bigDecimal_.BigDecimal, annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
+    const formatted = bigDecimal_.format(max)
+    return self.pipe(
+      filter((a) => bigDecimal_.lessThan(a, max), {
+        schemaId: LessThanBigDecimalSchemaId,
+        [LessThanBigDecimalSchemaId]: { max },
+        title: `lessThanBigDecimal(${formatted})`,
+        description: `a BigDecimal less than ${formatted}`,
+        ...annotations
+      })
+    )
+  }
 
 /**
  * @category schema id
@@ -7815,22 +7809,20 @@ export const LessThanOrEqualToBigDecimalSchemaId: unique symbol = Symbol.for(
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const lessThanOrEqualToBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  max: bigDecimal_.BigDecimal,
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
-  const formatted = bigDecimal_.format(max)
-  return self.pipe(
-    filter((a) => bigDecimal_.lessThanOrEqualTo(a, max), {
-      schemaId: LessThanOrEqualToBigDecimalSchemaId,
-      [LessThanOrEqualToBigDecimalSchemaId]: { max },
-      title: `lessThanOrEqualToBigDecimal(${formatted})`,
-      description: `a BigDecimal less than or equal to ${formatted}`,
-      ...annotations
-    })
-  )
-}
+export const lessThanOrEqualToBigDecimal =
+  <S extends Schema.Any>(max: bigDecimal_.BigDecimal, annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
+    const formatted = bigDecimal_.format(max)
+    return self.pipe(
+      filter((a) => bigDecimal_.lessThanOrEqualTo(a, max), {
+        schemaId: LessThanOrEqualToBigDecimalSchemaId,
+        [LessThanOrEqualToBigDecimalSchemaId]: { max },
+        title: `lessThanOrEqualToBigDecimal(${formatted})`,
+        description: `a BigDecimal less than or equal to ${formatted}`,
+        ...annotations
+      })
+    )
+  }
 
 /**
  * @category schema id
@@ -7844,18 +7836,17 @@ export const PositiveBigDecimalSchemaId: unique symbol = Symbol.for(
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const positiveBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
-  self.pipe(
-    filter((a) => bigDecimal_.isPositive(a), {
-      schemaId: PositiveBigDecimalSchemaId,
-      title: "positiveBigDecimal",
-      description: `a positive BigDecimal`,
-      ...annotations
-    })
-  )
+export const positiveBigDecimal =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => bigDecimal_.isPositive(a), {
+        schemaId: PositiveBigDecimalSchemaId,
+        title: "positiveBigDecimal",
+        description: `a positive BigDecimal`,
+        ...annotations
+      })
+    )
 
 /**
  * @category BigDecimal constructors
@@ -7877,18 +7868,17 @@ export const NonNegativeBigDecimalSchemaId: unique symbol = Symbol.for(
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const nonNegativeBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
-  self.pipe(
-    filter((a) => a.value >= 0n, {
-      schemaId: NonNegativeBigDecimalSchemaId,
-      title: "nonNegativeBigDecimal",
-      description: `a non-negative BigDecimal`,
-      ...annotations
-    })
-  )
+export const nonNegativeBigDecimal =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => a.value >= 0n, {
+        schemaId: NonNegativeBigDecimalSchemaId,
+        title: "nonNegativeBigDecimal",
+        description: `a non-negative BigDecimal`,
+        ...annotations
+      })
+    )
 
 /**
  * @category BigDecimal constructors
@@ -7910,18 +7900,17 @@ export const NegativeBigDecimalSchemaId: unique symbol = Symbol.for(
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const negativeBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
-  self.pipe(
-    filter((a) => bigDecimal_.isNegative(a), {
-      schemaId: NegativeBigDecimalSchemaId,
-      title: "negativeBigDecimal",
-      description: `a negative BigDecimal`,
-      ...annotations
-    })
-  )
+export const negativeBigDecimal =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => bigDecimal_.isNegative(a), {
+        schemaId: NegativeBigDecimalSchemaId,
+        title: "negativeBigDecimal",
+        description: `a negative BigDecimal`,
+        ...annotations
+      })
+    )
 
 /**
  * @category BigDecimal constructors
@@ -7943,18 +7932,17 @@ export const NonPositiveBigDecimalSchemaId: unique symbol = Symbol.for(
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const nonPositiveBigDecimal = <A extends bigDecimal_.BigDecimal>(
-  annotations?: Annotations.Filter<A>
-) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
-  self.pipe(
-    filter((a) => a.value <= 0n, {
-      schemaId: NonPositiveBigDecimalSchemaId,
-      title: "nonPositiveBigDecimal",
-      description: `a non-positive BigDecimal`,
-      ...annotations
-    })
-  )
+export const nonPositiveBigDecimal =
+  <S extends Schema.Any>(annotations?: Annotations.Filter<Schema.Type<S>>) =>
+  <A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
+    self.pipe(
+      filter((a) => a.value <= 0n, {
+        schemaId: NonPositiveBigDecimalSchemaId,
+        title: "nonPositiveBigDecimal",
+        description: `a non-positive BigDecimal`,
+        ...annotations
+      })
+    )
 
 /**
  * @category BigDecimal constructors
@@ -7974,12 +7962,12 @@ export const BetweenBigDecimalSchemaId: unique symbol = Symbol.for("effect/Schem
  * @category BigDecimal filters
  * @since 3.10.0
  */
-export const betweenBigDecimal = <A extends bigDecimal_.BigDecimal>(
+export const betweenBigDecimal = <S extends Schema.Any>(
   minimum: bigDecimal_.BigDecimal,
   maximum: bigDecimal_.BigDecimal,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> => {
+<A extends bigDecimal_.BigDecimal>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> => {
   const formattedMinimum = bigDecimal_.format(minimum)
   const formattedMaximum = bigDecimal_.format(maximum)
   return self.pipe(

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4154,11 +4154,11 @@ export type MaxLengthSchemaId = typeof MaxLengthSchemaId
  * @category string filters
  * @since 3.10.0
  */
-export const maxLength = <A extends string>(
+export const maxLength = <A extends string, I, R, S extends Schema.Any = Schema<A, I, R>>(
   maxLength: number,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+(self: S & Schema<A, I, R>): filter<S> =>
   self.pipe(
     filter(
       (a) => a.length <= maxLength,

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5324,11 +5324,11 @@ export type GreaterThanBigIntSchemaId = typeof GreaterThanBigIntSchemaId
  * @category bigint filters
  * @since 3.10.0
  */
-export const greaterThanBigInt = <A extends bigint>(
+export const greaterThanBigInt = <S extends Schema.Any>(
   min: bigint,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a > min, {
       schemaId: GreaterThanBigIntSchemaId,
@@ -5355,11 +5355,11 @@ export type GreaterThanOrEqualToBigIntSchemaId = typeof GreaterThanOrEqualToBigI
  * @category bigint filters
  * @since 3.10.0
  */
-export const greaterThanOrEqualToBigInt = <A extends bigint>(
+export const greaterThanOrEqualToBigInt = <S extends Schema.Any>(
   min: bigint,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a >= min, {
       schemaId: GreaterThanOrEqualToBigIntSchemaId,
@@ -5388,11 +5388,11 @@ export type LessThanBigIntSchemaId = typeof LessThanBigIntSchemaId
  * @category bigint filters
  * @since 3.10.0
  */
-export const lessThanBigInt = <A extends bigint>(
+export const lessThanBigInt = <S extends Schema.Any>(
   max: bigint,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a < max, {
       schemaId: LessThanBigIntSchemaId,
@@ -5419,11 +5419,11 @@ export type LessThanOrEqualToBigIntSchemaId = typeof LessThanOrEqualToBigIntSche
  * @category bigint filters
  * @since 3.10.0
  */
-export const lessThanOrEqualToBigInt = <A extends bigint>(
+export const lessThanOrEqualToBigInt = <S extends Schema.Any>(
   max: bigint,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a <= max, {
       schemaId: LessThanOrEqualToBigIntSchemaId,
@@ -5450,12 +5450,12 @@ export type BetweenBigIntSchemaId = typeof BetweenBigIntSchemaId
  * @category bigint filters
  * @since 3.10.0
  */
-export const betweenBigInt = <A extends bigint>(
+export const betweenBigInt = <S extends Schema.Any>(
   min: bigint,
   max: bigint,
-  annotations?: Annotations.Filter<A>
+  annotations?: Annotations.Filter<Schema.Type<S>>
 ) =>
-<I, R>(self: Schema<A, I, R>): filter<Schema<A, I, R>> =>
+<A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>): filter<S> =>
   self.pipe(
     filter((a) => a >= min && a <= max, {
       schemaId: BetweenBigIntSchemaId,
@@ -5470,36 +5470,36 @@ export const betweenBigInt = <A extends bigint>(
  * @category bigint filters
  * @since 3.10.0
  */
-export const positiveBigInt = <A extends bigint>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> =>
+export const positiveBigInt = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
   greaterThanBigInt(0n, { title: "positiveBigInt", ...annotations })
 
 /**
  * @category bigint filters
  * @since 3.10.0
  */
-export const negativeBigInt = <A extends bigint>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> =>
+export const negativeBigInt = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
   lessThanBigInt(0n, { title: "negativeBigInt", ...annotations })
 
 /**
  * @category bigint filters
  * @since 3.10.0
  */
-export const nonNegativeBigInt = <A extends bigint>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> =>
+export const nonNegativeBigInt = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
   greaterThanOrEqualToBigInt(0n, { title: "nonNegativeBigInt", ...annotations })
 
 /**
  * @category bigint filters
  * @since 3.10.0
  */
-export const nonPositiveBigInt = <A extends bigint>(
-  annotations?: Annotations.Filter<A>
-): <I, R>(self: Schema<A, I, R>) => filter<Schema<A, I, R>> =>
+export const nonPositiveBigInt = <S extends Schema.Any>(
+  annotations?: Annotations.Filter<Schema.Type<S>>
+): <A extends bigint>(self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>) => filter<S> =>
   lessThanOrEqualToBigInt(0n, { title: "nonPositiveBigInt", ...annotations })
 
 /**

--- a/packages/effect/test/Schema/ParseResult.test.ts
+++ b/packages/effect/test/Schema/ParseResult.test.ts
@@ -233,14 +233,14 @@ describe("ParseIssue.actual", () => {
   })
 
   it("compose decode", () => {
-    const result = S.decodeEither(S.compose(S.NumberFromString, S.negative()(S.Number)))("1")
+    const result = S.decodeEither(S.compose(S.NumberFromString, S.Number.pipe(S.negative())))("1")
     if (Either.isRight(result)) throw new Error("Expected failure")
     strictEqual(result.left.issue.actual, "1")
     strictEqual((result.left.issue as ParseResult.Transformation).issue.actual, 1)
   })
 
   it("compose encode", () => {
-    const result = S.encodeEither(S.compose(S.length(5)(S.String), S.NumberFromString))(1)
+    const result = S.encodeEither(S.compose(S.String.pipe(S.length(5)), S.NumberFromString))(1)
     if (Either.isRight(result)) throw new Error("Expected failure")
     strictEqual(result.left.issue.actual, 1)
     strictEqual((result.left.issue as ParseResult.Transformation).issue.actual, "1")

--- a/packages/effect/test/Schema/Schema/Number/greaterThan.test.ts
+++ b/packages/effect/test/Schema/Schema/Number/greaterThan.test.ts
@@ -5,7 +5,7 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("greaterThan", () => {
-  const schema = S.greaterThan(0)(S.Number)
+  const schema = S.Number.pipe(S.greaterThan(0))
 
   it("test roundtrip consistency", () => {
     Util.assertions.testRoundtripConsistency(schema)

--- a/packages/effect/test/Schema/Schema/Number/greaterThanOrEqualTo.test.ts
+++ b/packages/effect/test/Schema/Schema/Number/greaterThanOrEqualTo.test.ts
@@ -5,7 +5,7 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("greaterThanOrEqualTo", () => {
-  const schema = S.greaterThanOrEqualTo(0)(S.Number)
+  const schema = S.Number.pipe(S.greaterThanOrEqualTo(0))
 
   it("test roundtrip consistency", () => {
     Util.assertions.testRoundtripConsistency(schema)

--- a/packages/effect/test/Schema/Schema/Number/lessThan.test.ts
+++ b/packages/effect/test/Schema/Schema/Number/lessThan.test.ts
@@ -6,18 +6,18 @@ import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("lessThan", () => {
   it("test roundtrip consistency", () => {
-    Util.assertions.testRoundtripConsistency(S.lessThan(0)(S.Number))
+    Util.assertions.testRoundtripConsistency(S.Number.pipe(S.lessThan(0)))
   })
 
   it("is", () => {
-    const is = P.is(S.lessThan(0)(S.Number))
+    const is = P.is(S.Number.pipe(S.lessThan(0)))
     assertFalse(is(0))
     assertFalse(is(1))
     assertTrue(is(-1))
   })
 
   it("decoding", async () => {
-    const schema = S.lessThan(0)(S.Number)
+    const schema = S.Number.pipe(S.lessThan(0))
     await Util.assertions.decoding.succeed(schema, -1)
     await Util.assertions.decoding.fail(
       schema,
@@ -36,7 +36,7 @@ describe("lessThan", () => {
   })
 
   it("pretty", () => {
-    const schema = S.lessThan(0)(S.Number)
+    const schema = S.Number.pipe(S.lessThan(0))
     Util.assertions.pretty(schema, 1, "1")
   })
 })

--- a/packages/effect/test/Schema/Schema/Number/lessThanOrEqualTo.test.ts
+++ b/packages/effect/test/Schema/Schema/Number/lessThanOrEqualTo.test.ts
@@ -6,18 +6,18 @@ import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("lessThanOrEqualTo", () => {
   it("test roundtrip consistency", () => {
-    Util.assertions.testRoundtripConsistency(S.lessThanOrEqualTo(0)(S.Number))
+    Util.assertions.testRoundtripConsistency(S.Number.pipe(S.lessThanOrEqualTo(0)))
   })
 
   it("is", () => {
-    const is = P.is(S.lessThanOrEqualTo(0)(S.Number))
+    const is = P.is(S.Number.pipe(S.lessThanOrEqualTo(0)))
     assertTrue(is(0))
     assertFalse(is(1))
     assertTrue(is(-1))
   })
 
   it("decoding", async () => {
-    const schema = S.lessThanOrEqualTo(0)(S.Number)
+    const schema = S.Number.pipe(S.lessThanOrEqualTo(0))
     await Util.assertions.decoding.succeed(schema, 0)
     await Util.assertions.decoding.succeed(schema, -1)
     await Util.assertions.decoding.fail(
@@ -30,7 +30,7 @@ describe("lessThanOrEqualTo", () => {
   })
 
   it("pretty", () => {
-    const schema = S.lessThanOrEqualTo(0)(S.Number)
+    const schema = S.Number.pipe(S.lessThanOrEqualTo(0))
     Util.assertions.pretty(schema, 1, "1")
   })
 })

--- a/packages/effect/test/Schema/Schema/Number/multipleOf.test.ts
+++ b/packages/effect/test/Schema/Schema/Number/multipleOf.test.ts
@@ -6,7 +6,7 @@ import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("multipleOf", () => {
   it("test roundtrip consistency", () => {
-    Util.assertions.testRoundtripConsistency(S.multipleOf(2)(S.Number))
+    Util.assertions.testRoundtripConsistency(S.Number.pipe(S.multipleOf(2)))
   })
 
   it("is", () => {

--- a/packages/effect/test/Schema/Schema/String/includes.test.ts
+++ b/packages/effect/test/Schema/Schema/String/includes.test.ts
@@ -5,7 +5,7 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("includes", () => {
-  const schema = S.includes("a")(S.String)
+  const schema = S.String.pipe(S.includes("a"))
 
   it("test roundtrip consistency", () => {
     Util.assertions.testRoundtripConsistency(schema)

--- a/packages/effect/test/Schema/Schema/String/maxLength.test.ts
+++ b/packages/effect/test/Schema/Schema/String/maxLength.test.ts
@@ -6,18 +6,18 @@ import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("maxLength", () => {
   it("test roundtrip consistency", () => {
-    Util.assertions.testRoundtripConsistency(S.maxLength(0)(S.String))
+    Util.assertions.testRoundtripConsistency(S.String.pipe(S.maxLength(1)))
   })
 
   it("is", () => {
-    const is = P.is(S.maxLength(1)(S.String))
+    const is = P.is(S.String.pipe(S.maxLength(1)))
     assertTrue(is(""))
     assertTrue(is("a"))
     assertFalse(is("aa"))
   })
 
   it("decoding", async () => {
-    const schema = S.maxLength(1)(S.String)
+    const schema = S.String.pipe(S.maxLength(1))
     await Util.assertions.decoding.succeed(schema, "")
     await Util.assertions.decoding.succeed(schema, "a")
     await Util.assertions.decoding.fail(
@@ -30,7 +30,7 @@ describe("maxLength", () => {
   })
 
   it("pretty", () => {
-    const schema = S.maxLength(0)(S.String)
+    const schema = S.String.pipe(S.maxLength(1))
     Util.assertions.pretty(schema, "a", `"a"`)
   })
 })

--- a/packages/effect/test/Schema/Schema/String/minLength.test.ts
+++ b/packages/effect/test/Schema/Schema/String/minLength.test.ts
@@ -6,18 +6,18 @@ import { assertFalse, assertTrue } from "effect/test/util"
 
 describe("minLength", () => {
   it("test roundtrip consistency", () => {
-    Util.assertions.testRoundtripConsistency(S.minLength(0)(S.String))
+    Util.assertions.testRoundtripConsistency(S.String.pipe(S.minLength(1)))
   })
 
   it("is", () => {
-    const is = P.is(S.minLength(1)(S.String))
+    const is = P.is(S.String.pipe(S.minLength(1)))
     assertFalse(is(""))
     assertTrue(is("a"))
     assertTrue(is("aa"))
   })
 
   it("decoding", async () => {
-    const schema = S.minLength(1)(S.String)
+    const schema = S.String.pipe(S.minLength(1))
     await Util.assertions.decoding.succeed(schema, "a")
     await Util.assertions.decoding.succeed(schema, "aa")
     await Util.assertions.decoding.fail(
@@ -30,7 +30,7 @@ describe("minLength", () => {
   })
 
   it("pretty", () => {
-    const schema = S.minLength(0)(S.String)
+    const schema = S.String.pipe(S.minLength(1))
     Util.assertions.pretty(schema, "a", `"a"`)
   })
 })

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -34,7 +34,7 @@
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
-    "dtslint": "pnpm -w tstyche",
+    "dtslint": "tstyche --target '>=5.4'",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"

--- a/packages/typeclass/package.json
+++ b/packages/typeclass/package.json
@@ -36,7 +36,7 @@
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
-    "dtslint": "pnpm -w tstyche",
+    "dtslint": "tstyche --target '>=5.4'",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"


### PR DESCRIPTION
**Example** (with `Schema.maxLength`)

Before

```ts
import { Schema } from "effect"

//      ┌─── Schema.filter<Schema.Schema<string, string, never>>
//      ▼
const schema = Schema.String.pipe(Schema.maxLength(10))

// Schema<string, string, never>
schema.from
```

After

```ts
import { Schema } from "effect"

//      ┌─── Schema.filter<typeof Schema.String>
//      ▼
const schema = Schema.String.pipe(Schema.maxLength(10))

// typeof Schema.String
schema.from
```
