### PR TITLE
Schema: Improve `Literal` return type — now returns `SchemaClass` ins…

### DIFF
--- a/.changeset/twenty-wasps-worry.md
+++ b/.changeset/twenty-wasps-worry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Schema: Improve `Literal` return type — now returns `SchemaClass` instead of `Schema`

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -294,6 +294,11 @@ describe("Schema", () => {
     expect(S.Number.pipe(S.int(), S.brand("Int")).make(1)).type.toBe<number & Brand.Brand<"Int">>()
   })
 
+  it("Never", () => {
+    expect(S.Never).type.toBeAssignableTo<S.Schema<never>>()
+    expect(S.Never).type.toBeAssignableTo<S.SchemaClass<never>>()
+  })
+
   it("Primitives", () => {
     expect(S.asSchema(S.Void)).type.toBe<S.Schema<void, void>>()
     expect(S.Void).type.toBe<typeof S.Void>()
@@ -337,14 +342,14 @@ describe("Schema", () => {
     expect(S.Null).type.toBe<typeof S.Null>()
 
     expect(S.Literal()).type.toBe<S.Never>()
-    expect(S.asSchema(S.Literal("a"))).type.toBe<S.Schema<"a", "a">>()
+    expect(S.Literal(...[])).type.toBe<S.Never>()
+    expect(S.Literal(...([] as Array<"a" | "b">))).type.toBe<S.SchemaClass<"a" | "b">>()
+    expect(S.Literal(...([] as Array<never>))).type.toBe<S.SchemaClass<never>>()
+    expect(S.asSchema(S.Literal("a"))).type.toBe<S.Schema<"a">>()
     expect(S.Literal("a")).type.toBe<S.Literal<["a"]>>()
 
-    expect(S.asSchema(S.Literal("a", "b", "c"))).type.toBe<S.Schema<"a" | "b" | "c", "a" | "b" | "c">>()
+    expect(S.asSchema(S.Literal("a", "b", "c"))).type.toBe<S.Schema<"a" | "b" | "c">>()
     expect(S.Literal("a", "b", "c")).type.toBe<S.Literal<["a", "b", "c"]>>()
-
-    const literals = hole<Array<"a" | "b" | "c">>()
-    expect(S.Literal(...literals)).type.toBe<S.Schema<"a" | "b" | "c", "a" | "b" | "c">>()
 
     expect(S.Literal(1)).type.toBe<S.Literal<[1]>>()
     expect(S.Literal(2n)).type.toBe<S.Literal<[2n]>>()

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -670,22 +670,25 @@ export interface Literal<Literals extends array_.NonEmptyReadonlyArray<AST.Liter
   readonly literals: Readonly<Literals>
 }
 
-const getDefaultLiteralAST = <Literals extends array_.NonEmptyReadonlyArray<AST.LiteralValue>>(
+function getDefaultLiteralAST<Literals extends array_.NonEmptyReadonlyArray<AST.LiteralValue>>(
   literals: Literals
-) =>
-  AST.isMembers(literals)
+): AST.AST {
+  return AST.isMembers(literals)
     ? AST.Union.make(AST.mapMembers(literals, (literal) => new AST.Literal(literal)))
     : new AST.Literal(literals[0])
+}
 
-const makeLiteralClass = <Literals extends array_.NonEmptyReadonlyArray<AST.LiteralValue>>(
+function makeLiteralClass<Literals extends array_.NonEmptyReadonlyArray<AST.LiteralValue>>(
   literals: Literals,
   ast: AST.AST = getDefaultLiteralAST(literals)
-): Literal<Literals> => (class LiteralClass extends make<Literals[number]>(ast) {
-  static override annotations(annotations: Annotations.Schema<Literals[number]>): Literal<Literals> {
-    return makeLiteralClass(this.literals, mergeSchemaAnnotations(this.ast, annotations))
+): Literal<Literals> {
+  return class LiteralClass extends make<Literals[number]>(ast) {
+    static override annotations(annotations: Annotations.Schema<Literals[number]>): Literal<Literals> {
+      return makeLiteralClass(this.literals, mergeSchemaAnnotations(this.ast, annotations))
+    }
+    static literals = [...literals] as Literals
   }
-  static literals = [...literals] as Literals
-})
+}
 
 /**
  * @category constructors
@@ -697,10 +700,10 @@ export function Literal<Literals extends array_.NonEmptyReadonlyArray<AST.Litera
 export function Literal(): Never
 export function Literal<Literals extends ReadonlyArray<AST.LiteralValue>>(
   ...literals: Literals
-): Schema<Literals[number]>
+): SchemaClass<Literals[number]>
 export function Literal<Literals extends ReadonlyArray<AST.LiteralValue>>(
   ...literals: Literals
-): Schema<Literals[number]> | Never {
+): SchemaClass<Literals[number]> | Never {
   return array_.isNonEmptyReadonlyArray(literals) ? makeLiteralClass(literals) : Never
 }
 

--- a/packages/effect/test/Schema/Schema/Literal/Literal.test.ts
+++ b/packages/effect/test/Schema/Schema/Literal/Literal.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@effect/vitest"
 import * as S from "effect/Schema"
 import * as AST from "effect/SchemaAST"
 import * as Util from "effect/test/Schema/TestUtils"
-import { deepStrictEqual } from "effect/test/util"
+import { deepStrictEqual, strictEqual } from "effect/test/util"
 
 describe("Literal", () => {
   it("annotations()", () => {
@@ -19,8 +19,8 @@ describe("Literal", () => {
   })
 
   it("should return Never when no literals are provided", () => {
-    deepStrictEqual(S.Literal(), S.Never)
-    deepStrictEqual(S.Literal(...[]), S.Never)
+    strictEqual(S.Literal(), S.Never)
+    strictEqual(S.Literal(...[]), S.Never)
   })
 
   it("should return an unwrapped AST with exactly one literal", () => {

--- a/packages/effect/test/Schema/Schema/Literal/Literal.test.ts
+++ b/packages/effect/test/Schema/Schema/Literal/Literal.test.ts
@@ -18,6 +18,11 @@ describe("Literal", () => {
     deepStrictEqual(schema.literals, ["a", "b"])
   })
 
+  it("should return Never when no literals are provided", () => {
+    deepStrictEqual(S.Literal(), S.Never)
+    deepStrictEqual(S.Literal(...[]), S.Never)
+  })
+
   it("should return an unwrapped AST with exactly one literal", () => {
     deepStrictEqual(S.Literal(1).ast, new AST.Literal(1))
   })


### PR DESCRIPTION
…tead of `Schema`
