### PR TITLE
chore: simplify `test-types` script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/setup
       - run: pnpm check
-      - run: pnpm dtslint
+      - run: pnpm test-types --target '>=5.4'
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Run the following commands to ensure your changes do not introduce any issues:
 - `pnpm circular`: Check for any circular dependencies in imports.
 - `pnpm lint`: Ensure the code adheres to our coding standards.
   - If you encounter style issues, use `pnpm lint-fix` to automatically correct some of these.
-- `pnpm dtslint`: Run type-level tests. Tests are written using [tstyche](https://tstyche.org/).
+- `pnpm test-types`: Run type-level tests. Tests are written using [tstyche](https://tstyche.org/).
 - `pnpm docgen`: Ensure the documentation generates correctly and reflects any changes made.
 
 ### Document Your Changes

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "lint": "eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
     "lint-fix": "pnpm lint --fix",
     "docgen": "pnpm --recursive --parallel exec docgen && node scripts/docs.mjs",
-    "dtslint": "pnpm --recursive --parallel run dtslint",
+    "test-types": "tstyche",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "pnpm codemod && pnpm build && TEST_DIST= pnpm vitest && changeset publish",
-    "tstyche": "tstyche --target '>=5.4'"
+    "changeset-publish": "pnpm codemod && pnpm build && TEST_DIST= pnpm vitest && changeset publish"
   },
   "resolutions": {
     "dependency-tree": "^10.0.9",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -36,7 +36,7 @@
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
-    "dtslint": "tstyche --target '>=5.4'",
+    "test-types": "tstyche",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -34,7 +34,7 @@
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
-    "dtslint": "tstyche --target '>=5.4'",
+    "test-types": "tstyche",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"

--- a/packages/typeclass/package.json
+++ b/packages/typeclass/package.json
@@ -36,7 +36,7 @@
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
-    "dtslint": "tstyche --target '>=5.4'",
+    "test-types": "tstyche",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

With this PR I would like to propose several simplifications of the `test-types` script.

#### `test-types`

First I would like to suggest rename the script from `dtslint` to `test-types`. This way it sounds similar to `test`, but for type-level tests.

#### `--target`

It also works similar. For instance, you can run `dtslint semigroup --watch`. But in current setup errors will be logged and the runner will not be very responsive. Try running `test-types semigroup --watch` from this branch and you will see the difference.

TSTyche is able to handle watch mode with several versions of TypeScript, but that is an expensive operation. All four `typescript` modules will be loaded into memory and four language services created.

This is the reason I suggest keeping the command simple and moving `--target` to CI. Currently one can opt-out by passing `--target currrent`, but isn’t it more optimal keeping `--target` as opt-in? For instance, `test-types semigroup --target 5.6 --watch`.

#### `--recursive`, `--parallel`

`--recursive` and `--parallel` look suboptimal for my eye. With `--recursive` (without `--target`) three instances of TSTyche are created, three `typescript` modules loaded and three language services created. Removing `--recursive` creates only a single language service and this allows a lot of caching as well (for instance, module resolutions).

With `--parallel` output becomes harder to ready. (Running JavaScript tests in parallel would give similar result.) Just try running `test-types` from this branch:

<img width="713" alt="Screenshot 2025-02-24 at 10 04 45" src="https://github.com/user-attachments/assets/3f9a66c9-9918-4695-a73a-784ae87ee211" />

Version of TypeScript and path to landed TSConfig are easy to find. But with `--recursive --parallel` the output gets noisy and paths of TSConfig and test file are hard to follow:

<img width="838" alt="Screenshot 2025-02-24 at 10 11 44" src="https://github.com/user-attachments/assets/424ea28f-6dd2-45d7-912c-5bec40e8f3d6" />

---

It can also be that I have missed something. Just wanted to draw your attention.