### PR TITLE
Schema: More Accurate Return Types for `DataFromSelf` and `Data`

### DIFF
--- a/.changeset/cyan-scissors-reflect.md
+++ b/.changeset/cyan-scissors-reflect.md
@@ -1,0 +1,43 @@
+---
+"effect": patch
+---
+
+Schema: More Accurate Return Types for `DataFromSelf` and `Data`.
+
+This update refines the return types of `DataFromSelf` and `Data`, making them clearer and more specific, especially when working with structured schemas.
+
+**Before**
+
+The return types were more generic, making it harder to see the underlying structure:
+
+```ts
+import { Schema } from "effect"
+
+const struct = Schema.Struct({ a: Schema.NumberFromString })
+
+//       ┌─── Schema.DataFromSelf<Schema<{ readonly a: number; }, { readonly a: string; }>>
+//       ▼
+const schema1 = Schema.DataFromSelf(struct)
+
+//       ┌─── Schema.Data<Schema<{ readonly a: number; }, { readonly a: string; }>>
+//       ▼
+const schema2 = Schema.Data(struct)
+```
+
+**After**
+
+Now, the return types clearly reflect the original schema structure:
+
+```ts
+import { Schema } from "effect"
+
+const struct = Schema.Struct({ a: Schema.NumberFromString })
+
+//       ┌─── Schema.DataFromSelf<Schema.Struct<{ a: typeof Schema.NumberFromString; }>>
+//       ▼
+const schema1 = Schema.DataFromSelf(struct)
+
+//       ┌─── Schema.Data<Schema.Struct<{ a: typeof Schema.NumberFromString; }>>
+//       ▼
+const schema2 = Schema.Data(struct)
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -3340,23 +3340,67 @@ describe("Schema", () => {
     })
 
     it("DataFromSelf", () => {
+      // @ts-expect-error
+      S.DataFromSelf(hole<S.Schema<string>>())
+      // @ts-expect-error
+      S.DataFromSelf(hole<S.Schema<{}, number>>())
+
       const schema = S.DataFromSelf(S.Struct({ a: S.NumberFromString }))
       expect(schema)
-        .type.toBe<S.DataFromSelf<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+        .type.toBe<
+        S.DataFromSelf<
+          S.Struct<{
+            a: typeof S.NumberFromString
+          }>
+        >
+      >()
       expect(schema.annotations({}))
-        .type.toBe<S.DataFromSelf<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+        .type.toBe<
+        S.DataFromSelf<
+          S.Struct<{
+            a: typeof S.NumberFromString
+          }>
+        >
+      >()
       // should expose the type parameters
-      expect(schema.typeParameters).type.toBe<readonly [S.Schema<{ readonly a: number }, { readonly a: string }>]>()
+      expect(schema.typeParameters).type.toBe<
+        readonly [
+          S.Struct<{
+            a: typeof S.NumberFromString
+          }>
+        ]
+      >()
     })
 
     it("Data", () => {
+      // @ts-expect-error
+      S.Data(hole<S.Schema<string>>())
+      // @ts-expect-error
+      S.Data(hole<S.Schema<{}, number>>())
+
       const schema = S.Data(S.Struct({ a: S.NumberFromString }))
       expect(schema)
-        .type.toBe<S.Data<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
+        .type.toBe<
+        S.Data<
+          S.Struct<{
+            a: typeof S.NumberFromString
+          }>
+        >
+      >()
       expect(schema.annotations({}))
-        .type.toBe<S.Data<S.Schema<{ readonly a: number }, { readonly a: string }>>>()
-      expect(schema.from).type.toBe<S.Schema<{ readonly a: number }, { readonly a: string }>>()
-      expect(schema.to).type.toBe<S.DataFromSelf<S.Schema<{ readonly a: number }>>>()
+        .type.toBe<
+        S.Data<
+          S.Struct<{
+            a: typeof S.NumberFromString
+          }>
+        >
+      >()
+      expect(schema.from).type.toBe<
+        S.Struct<{
+          a: typeof S.NumberFromString
+        }>
+      >()
+      expect(schema.to).type.toBe<S.DataFromSelf<S.SchemaClass<{ readonly a: number }>>>()
     })
 
     it("RedactedFromSelf", () => {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8227,12 +8227,10 @@ export interface DataFromSelf<Value extends Schema.Any> extends
  * @since 3.10.0
  */
 export const DataFromSelf = <
+  S extends Schema.Any,
   A extends Readonly<Record<string, any>> | ReadonlyArray<any>,
-  I extends Readonly<Record<string, any>> | ReadonlyArray<any>,
-  R
->(
-  value: Schema<A, I, R>
-): DataFromSelf<Schema<A, I, R>> => {
+  I extends Readonly<Record<string, any>> | ReadonlyArray<any>
+>(value: S & Schema<A & Schema.Type<S>, I & Schema.Encoded<S>, Schema.Context<S>>): DataFromSelf<S> => {
   return declare(
     [value],
     {
@@ -8251,7 +8249,9 @@ export const DataFromSelf = <
  * @category api interface
  * @since 3.13.3
  */
-export interface Data<Value extends Schema.Any> extends transform<Value, DataFromSelf<Schema<Schema.Type<Value>>>> {}
+export interface Data<Value extends Schema.Any>
+  extends transform<Value, DataFromSelf<SchemaClass<Schema.Type<Value>>>>
+{}
 
 /**
  * Type and Encoded must extend `Readonly<Record<string, any>> |
@@ -8261,12 +8261,10 @@ export interface Data<Value extends Schema.Any> extends transform<Value, DataFro
  * @since 3.10.0
  */
 export const Data = <
+  S extends Schema.Any,
   A extends Readonly<Record<string, any>> | ReadonlyArray<any>,
-  I extends Readonly<Record<string, any>> | ReadonlyArray<any>,
-  R
->(
-  value: Schema<A, I, R>
-): Data<Schema<A, I, R>> => {
+  I extends Readonly<Record<string, any>> | ReadonlyArray<any>
+>(value: S & Schema<A & Schema.Type<S>, I & Schema.Encoded<S>, Schema.Context<S>>): Data<S> => {
   return transform(
     value,
     DataFromSelf(typeSchema(value)),


### PR DESCRIPTION
This update refines the return types of `DataFromSelf` and `Data`, making them clearer and more specific, especially when working with structured schemas.

**Before**

The return types were more generic, making it harder to see the underlying structure:

```ts
import { Schema } from "effect"

const struct = Schema.Struct({ a: Schema.NumberFromString })

//       ┌─── Schema.DataFromSelf<Schema<{ readonly a: number; }, { readonly a: string; }>>
//       ▼
const schema1 = Schema.DataFromSelf(struct)

//       ┌─── Schema.Data<Schema<{ readonly a: number; }, { readonly a: string; }>>
//       ▼
const schema2 = Schema.Data(struct)
```

**After**

Now, the return types clearly reflect the original schema structure:

```ts
import { Schema } from "effect"

const struct = Schema.Struct({ a: Schema.NumberFromString })

//       ┌─── Schema.DataFromSelf<Schema.Struct<{ a: typeof Schema.NumberFromString; }>>
//       ▼
const schema1 = Schema.DataFromSelf(struct)

//       ┌─── Schema.Data<Schema.Struct<{ a: typeof Schema.NumberFromString; }>>
//       ▼
const schema2 = Schema.Data(struct)
```
