### PR TITLE
Schema: More Accurate Return Type for `parseJson(schema)`

### DIFF
--- a/.changeset/nine-toys-brush.md
+++ b/.changeset/nine-toys-brush.md
@@ -1,0 +1,40 @@
+---
+"effect": patch
+---
+
+Schema: More Accurate Return Type for `parseJson(schema)`.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+//      ┌─── Schema.SchemaClass<{ readonly a: number; }, string>
+//      ▼
+const schema = Schema.parseJson(
+  Schema.Struct({
+    a: Schema.NumberFromString
+  })
+)
+
+// @ts-expect-error: Property 'to' does not exist
+schema.to
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+//      ┌─── Schema.transform<Schema.SchemaClass<unknown, string, never>, Schema.Struct<{ a: typeof Schema.NumberFromString; }>>
+//      ▼
+const schema = Schema.parseJson(
+  Schema.Struct({
+    a: Schema.NumberFromString
+  })
+)
+
+//      ┌─── Schema.Struct<{ a: typeof Schema.NumberFromString; }>
+//      ▼
+schema.to
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -3808,4 +3808,24 @@ describe("Schema", () => {
       expect(schema).type.toBe<typeof S.Defect>()
     })
   })
+
+  describe("parseJson", () => {
+    it("no arguments", () => {
+      const schema = S.parseJson()
+      expect(S.asSchema(schema)).type.toBe<S.Schema<unknown, string>>()
+      expect(schema).type.toBe<S.SchemaClass<unknown, string>>()
+      expect(schema.annotations({})).type.toBe<S.SchemaClass<unknown, string>>()
+    })
+
+    it("single argument", () => {
+      const schema = S.parseJson(S.Struct({ a: S.Number }))
+      expect(S.asSchema(schema)).type.toBe<S.Schema<{ readonly a: number }, string>>()
+      expect(schema).type.toBe<S.transform<S.SchemaClass<unknown, string>, S.Struct<{ a: typeof S.Number }>>>()
+      expect(schema.annotations({})).type.toBe<
+        S.transform<S.SchemaClass<unknown, string>, S.Struct<{ a: typeof S.Number }>>
+      >()
+      expect(schema.from).type.toBe<S.SchemaClass<unknown, string>>()
+      expect(schema.to).type.toBe<S.Struct<{ a: typeof S.Number }>>()
+    })
+  })
 })

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3478,7 +3478,7 @@ export const compose: {
 } = dual(
   (args) => isSchema(args[1]),
   <B, A, R1, D, C, R2>(from: Schema<B, A, R1>, to: Schema<D, C, R2>): SchemaClass<D, A, R1 | R2> =>
-    make(AST.compose(from.ast, to.ast))
+    makeTransformationClass(from, to, AST.compose(from.ast, to.ast))
 )
 
 /**
@@ -4688,7 +4688,7 @@ export type ParseJsonOptions = {
 
 const getErrorMessage = (e: unknown): string => e instanceof Error ? e.message : String(e)
 
-const getParseJsonTransformation = (options?: ParseJsonOptions) =>
+const getParseJsonTransformation = (options?: ParseJsonOptions): SchemaClass<unknown, string> =>
   transformOrFail(
     String$.annotations({ description: "a string to be decoded into JSON" }),
     Unknown,
@@ -4730,7 +4730,7 @@ const getParseJsonTransformation = (options?: ParseJsonOptions) =>
  * @since 3.10.0
  */
 export const parseJson: {
-  <A, I, R>(schema: Schema<A, I, R>, options?: ParseJsonOptions): SchemaClass<A, string, R>
+  <S extends Schema.Any>(schema: S, options?: ParseJsonOptions): transform<SchemaClass<unknown, string>, S>
   (options?: ParseJsonOptions): SchemaClass<unknown, string>
 } = <A, I, R>(schemaOrOptions?: Schema<A, I, R> | ParseJsonOptions, o?: ParseJsonOptions) =>
   isSchema(schemaOrOptions)

--- a/packages/effect/test/Schema/Schema/parseJson.test.ts
+++ b/packages/effect/test/Schema/Schema/parseJson.test.ts
@@ -79,18 +79,18 @@ describe("parseJson", () => {
 
   describe("parseJson(schema)", () => {
     it("decoding", async () => {
-      const schema = S.parseJson(S.Struct({ a: S.Number }))
-      await Util.assertions.decoding.succeed(schema, `{"a":1}`, { a: 1 })
+      const schema = S.parseJson(S.Struct({ a: S.NumberFromString }))
+      await Util.assertions.decoding.succeed(schema, `{"a":"1"}`, { a: 1 })
       await Util.assertions.decoding.fail(
         schema,
         `{"a"}`,
         isBun
-          ? `(parseJson <-> { readonly a: number })
+          ? `(parseJson <-> { readonly a: NumberFromString })
 └─ Encoded side transformation failure
     └─ parseJson
       └─ Transformation process failure
           └─ JSON Parse error: Expected ':' before value in object property definition`
-          : `(parseJson <-> { readonly a: number })
+          : `(parseJson <-> { readonly a: NumberFromString })
 └─ Encoded side transformation failure
    └─ parseJson
       └─ Transformation process failure
@@ -99,17 +99,22 @@ describe("parseJson", () => {
       await Util.assertions.decoding.fail(
         schema,
         `{"a":"b"}`,
-        `(parseJson <-> { readonly a: number })
+        `(parseJson <-> { readonly a: NumberFromString })
 └─ Type side transformation failure
-   └─ { readonly a: number }
+   └─ { readonly a: NumberFromString }
       └─ ["a"]
-         └─ Expected number, actual "b"`
+         └─ NumberFromString
+            └─ Transformation process failure
+               └─ Unable to decode "b" into a number`
       )
+
+      await Util.assertions.decoding.succeed(schema.from, `{"a":"1"}`, { a: "1" })
+      await Util.assertions.decoding.succeed(schema.to, { a: "1" }, { a: 1 })
     })
 
     it("encoding", async () => {
-      const schema = S.parseJson(S.Struct({ a: S.Number }))
-      await Util.assertions.encoding.succeed(schema, { a: 1 }, `{"a":1}`)
+      const schema = S.parseJson(S.Struct({ a: S.NumberFromString }))
+      await Util.assertions.encoding.succeed(schema, { a: 1 }, `{"a":"1"}`)
     })
 
     describe("roundtrip", () => {


### PR DESCRIPTION
**Before**

```ts
import { Schema } from "effect"

//      ┌─── Schema.SchemaClass<{ readonly a: number; }, string>
//      ▼
const schema = Schema.parseJson(
  Schema.Struct({
    a: Schema.NumberFromString
  })
)

// @ts-expect-error: Property 'to' does not exist
schema.to
```

**After**

```ts
import { Schema } from "effect"

//      ┌─── Schema.transform<Schema.SchemaClass<unknown, string, never>, Schema.Struct<{ a: typeof Schema.NumberFromString; }>>
//      ▼
const schema = Schema.parseJson(
  Schema.Struct({
    a: Schema.NumberFromString
  })
)

//      ┌─── Schema.Struct<{ a: typeof Schema.NumberFromString; }>
//      ▼
schema.to
```
