### PR TITLE
Schema: More Accurate Return Types for `ArrayEnsure` and `NonEmptyArr…

### DIFF
--- a/.changeset/eight-windows-raise.md
+++ b/.changeset/eight-windows-raise.md
@@ -1,0 +1,39 @@
+---
+"effect": patch
+---
+
+Schema: More Accurate Return Types for `ArrayEnsure` and `NonEmptyArrayEnsure`.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+const schema1 = Schema.ArrayEnsure(Schema.String)
+
+// @ts-expect-error: Property 'from' does not exist
+schema1.from
+
+const schema2 = Schema.NonEmptyArrayEnsure(Schema.String)
+
+// @ts-expect-error: Property 'from' does not exist
+schema2.from
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+const schema1 = Schema.ArrayEnsure(Schema.String)
+
+//        ┌─── Schema.Union<[typeof Schema.String, Schema.Array$<typeof Schema.String>]>
+//        ▼
+schema1.from
+
+const schema2 = Schema.NonEmptyArrayEnsure(Schema.String)
+
+//        ┌─── Schema.Union<[typeof Schema.String, Schema.NonEmptyArray<typeof Schema.String>]>
+//        ▼
+schema2.from
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -3828,4 +3828,24 @@ describe("Schema", () => {
       expect(schema.to).type.toBe<S.Struct<{ a: typeof S.Number }>>()
     })
   })
+
+  it("ArrayEnsure", () => {
+    const schema = S.ArrayEnsure(S.NumberFromString)
+    expect(S.asSchema(schema)).type.toBe<S.Schema<ReadonlyArray<number>, string | ReadonlyArray<string>>>()
+    expect(schema).type.toBe<S.ArrayEnsure<typeof S.NumberFromString>>()
+    expect(schema.annotations({})).type.toBe<S.ArrayEnsure<typeof S.NumberFromString>>()
+    expect(schema.from).type.toBe<S.Union<[typeof S.NumberFromString, S.Array$<typeof S.NumberFromString>]>>()
+    expect(schema.to).type.toBe<S.SchemaClass<ReadonlyArray<number>>>()
+  })
+
+  it("NonEmptyArrayEnsure", () => {
+    const schema = S.NonEmptyArrayEnsure(S.NumberFromString)
+    expect(S.asSchema(schema)).type.toBe<
+      S.Schema<readonly [number, ...Array<number>], string | readonly [string, ...Array<string>]>
+    >()
+    expect(schema).type.toBe<S.NonEmptyArrayEnsure<typeof S.NumberFromString>>()
+    expect(schema.annotations({})).type.toBe<S.NonEmptyArrayEnsure<typeof S.NumberFromString>>()
+    expect(schema.from).type.toBe<S.Union<[typeof S.NumberFromString, S.NonEmptyArray<typeof S.NumberFromString>]>>()
+    expect(schema.to).type.toBe<S.SchemaClass<readonly [number, ...Array<number>]>>()
+  })
 })

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1595,13 +1595,8 @@ export const NonEmptyArray = <Value extends Schema.Any>(value: Value): NonEmptyA
  * @category api interface
  * @since 3.10.0
  */
-export interface ArrayEnsure<Value extends Schema.Any> extends
-  AnnotableClass<
-    ArrayEnsure<Value>,
-    ReadonlyArray<Schema.Type<Value>>,
-    Schema.Encoded<Value> | ReadonlyArray<Schema.Encoded<Value>>,
-    Schema.Context<Value>
-  >
+export interface ArrayEnsure<Value extends Schema.Any>
+  extends transform<Union<[Value, Array$<Value>]>, SchemaClass<ReadonlyArray<Schema.Type<Value>>>>
 {}
 
 /**
@@ -1610,24 +1605,20 @@ export interface ArrayEnsure<Value extends Schema.Any> extends
  */
 export const ArrayEnsure = <Value extends Schema.Any>(value: Value): ArrayEnsure<Value> => {
   const value_ = asSchema(value)
-  return class ArrayEnsureClass extends transform(Union(value_, Array$(value_)), Array$(typeSchema(value_)), {
+  const out = transform(Union(value_, Array$(value_)), Array$(typeSchema(value_)), {
     strict: true,
     decode: array_.ensure,
     encode: (arr) => arr.length === 1 ? arr[0] : arr
-  }) {}
+  })
+  return out as any
 }
 
 /**
  * @category api interface
  * @since 3.10.0
  */
-export interface NonEmptyArrayEnsure<Value extends Schema.Any> extends
-  AnnotableClass<
-    NonEmptyArrayEnsure<Value>,
-    array_.NonEmptyReadonlyArray<Schema.Type<Value>>,
-    Schema.Encoded<Value> | array_.NonEmptyReadonlyArray<Schema.Encoded<Value>>,
-    Schema.Context<Value>
-  >
+export interface NonEmptyArrayEnsure<Value extends Schema.Any>
+  extends transform<Union<[Value, NonEmptyArray<Value>]>, SchemaClass<array_.NonEmptyReadonlyArray<Schema.Type<Value>>>>
 {}
 
 /**
@@ -1636,13 +1627,12 @@ export interface NonEmptyArrayEnsure<Value extends Schema.Any> extends
  */
 export const NonEmptyArrayEnsure = <Value extends Schema.Any>(value: Value): NonEmptyArrayEnsure<Value> => {
   const value_ = asSchema(value)
-  return class NonEmptyArrayEnsureClass
-    extends transform(Union(value_, NonEmptyArray(value_)), NonEmptyArray(typeSchema(value_)), {
-      strict: true,
-      decode: array_.ensure as any,
-      encode: (arr) => arr.length === 1 ? arr[0] : arr
-    })
-  {}
+  const out = transform(Union(value_, NonEmptyArray(value_)), NonEmptyArray(typeSchema(value_)), {
+    strict: true,
+    decode: array_.ensure as any,
+    encode: (arr) => arr.length === 1 ? arr[0] : arr
+  })
+  return out as any
 }
 
 /**


### PR DESCRIPTION
…ayEnsure`

**Before**

```ts
import { Schema } from "effect"

const schema1 = Schema.ArrayEnsure(Schema.String)

// @ts-expect-error: Property 'from' does not exist
schema1.from

const schema2 = Schema.NonEmptyArrayEnsure(Schema.String)

// @ts-expect-error: Property 'from' does not exist
schema2.from
```

**After**

```ts
import { Schema } from "effect"

const schema1 = Schema.ArrayEnsure(Schema.String)

//        ┌─── Schema.Union<[typeof Schema.String, Schema.Array$<typeof Schema.String>]>
//        ▼
schema1.from

const schema2 = Schema.NonEmptyArrayEnsure(Schema.String)

//        ┌─── Schema.Union<[typeof Schema.String, Schema.NonEmptyArray<typeof Schema.String>]>
//        ▼
schema2.from
```
