### PR TITLE
Schema: More Accurate Return Types

### DIFF
--- a/.changeset/flat-actors-battle.md
+++ b/.changeset/flat-actors-battle.md
@@ -1,0 +1,14 @@
+---
+"effect": patch
+---
+
+Schema: More Accurate Return Types for:
+
+- `transformLiteral`
+- `clamp`
+- `clampBigInt`
+- `clampDuration`
+- `clampBigDecimal`
+- `head`
+- `headNonEmpty`
+- `headOrElse`


### PR DESCRIPTION
- `transformLiteral`
- `clamp`
- `clampBigInt`
- `clampDuration`
- `clampBigDecimal`
- `head`
- `headNonEmpty`
- `headOrElse`
