### PR TITLE
Schema: More Accurate Return Type for `compose`

### DIFF
--- a/.changeset/dry-bulldogs-check.md
+++ b/.changeset/dry-bulldogs-check.md
@@ -1,0 +1,45 @@
+---
+"effect": patch
+---
+
+Schema: More Accurate Return Type for `compose`.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+//      ┌─── SchemaClass<number | null, string>
+//      ▼
+const schema = Schema.compose(
+  Schema.NumberFromString,
+  Schema.NullOr(Schema.Number)
+)
+
+// @ts-expect-error: Property 'from' does not exist
+schema.from
+
+// @ts-expect-error: Property 'to' does not exist
+schema.to
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+//      ┌─── transform<typeof Schema.NumberFromString, Schema.NullOr<typeof Schema.Number>>
+//      ▼
+const schema = Schema.compose(
+  Schema.NumberFromString,
+  Schema.NullOr(Schema.Number)
+)
+
+//      ┌─── typeof Schema.NumberFromString
+//      ▼
+schema.from
+
+//      ┌─── Schema.NullOr<typeof Schema.Number>
+//      ▼
+schema.to
+```

--- a/packages/effect/dtslint/Schema/Context.tst.ts
+++ b/packages/effect/dtslint/Schema/Context.tst.ts
@@ -255,8 +255,8 @@ describe("Schema Context", () => {
   })
 
   it("compose", () => {
-    expect(aContext.pipe(S.compose(bContext, { strict: false })))
-      .type.toBe<S.SchemaClass<number, string, "aContext" | "bContext">>()
+    expect(S.asSchema(aContext.pipe(S.compose(bContext, { strict: false }))))
+      .type.toBe<S.Schema<number, string, "aContext" | "bContext">>()
   })
 
   it("suspend", () => {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3433,39 +3433,43 @@ export const extend: {
  * @since 3.10.0
  */
 export const compose: {
-  <D, C extends B, R2, B>(
-    to: Schema<D, C, R2>
-  ): <A, R1>(from: Schema<B, A, R1>) => SchemaClass<D, A, R1 | R2>
-  <D, C, R2>(
-    to: Schema<D, C, R2>
-  ): <B extends C, A, R1>(from: Schema<B, A, R1>) => SchemaClass<D, A, R1 | R2>
-  <C, B, R2>(
-    to: Schema<C, B, R2>,
+  <To extends Schema.Any, From extends Schema.Any, C extends Schema.Type<From>>(
+    to: To & Schema<Schema.Type<To>, C, Schema.Context<To>>
+  ): (from: From) => transform<From, To>
+  <To extends Schema.Any>(
+    to: To
+  ): <From extends Schema.Any, B extends Schema.Encoded<To>>(
+    from: From & Schema<B, Schema.Encoded<From>, Schema.Context<From>>
+  ) => transform<From, To>
+  <To extends Schema.Any>(
+    to: To,
     options?: { readonly strict: true }
-  ): <A, R1>(from: Schema<B, A, R1>) => SchemaClass<C, A, R1 | R2>
-  <D, C, R2>(
-    to: Schema<D, C, R2>,
+  ): <From extends Schema.Any>(
+    from: From & Schema<Schema.Encoded<To>, Schema.Encoded<From>, Schema.Context<From>>
+  ) => transform<From, To>
+  <To extends Schema.Any>(
+    to: To,
     options: { readonly strict: false }
-  ): <B, A, R1>(from: Schema<B, A, R1>) => SchemaClass<D, A, R1 | R2>
+  ): <From extends Schema.Any>(from: From) => transform<From, To>
 
-  <B, A, R1, D, C extends B, R2>(
-    from: Schema<B, A, R1>,
-    to: Schema<D, C, R2>
-  ): SchemaClass<D, A, R1 | R2>
-  <B extends C, A, R1, D, C, R2>(
-    from: Schema<B, A, R1>,
-    to: Schema<D, C, R2>
-  ): SchemaClass<D, A, R1 | R2>
-  <B, A, R1, C, R2>(
-    from: Schema<B, A, R1>,
-    to: Schema<C, B, R2>,
+  <From extends Schema.Any, To extends Schema.Any, C extends Schema.Type<From>>(
+    from: From,
+    to: To & Schema<Schema.Type<To>, C, Schema.Context<To>>
+  ): transform<From, To>
+  <From extends Schema.Any, B extends Schema.Encoded<To>, To extends Schema.Any>(
+    from: From & Schema<B, Schema.Encoded<From>, Schema.Context<From>>,
+    to: To
+  ): transform<From, To>
+  <From extends Schema.Any, To extends Schema.Any>(
+    from: From & Schema<Schema.Encoded<To>, Schema.Encoded<From>, Schema.Context<From>>,
+    to: To,
     options?: { readonly strict: true }
-  ): SchemaClass<C, A, R1 | R2>
-  <B, A, R1, D, C, R2>(
-    from: Schema<B, A, R1>,
-    to: Schema<D, C, R2>,
+  ): transform<From, To>
+  <From extends Schema.Any, To extends Schema.Any>(
+    from: From,
+    to: To,
     options: { readonly strict: false }
-  ): SchemaClass<D, A, R1 | R2>
+  ): transform<From, To>
 } = dual(
   (args) => isSchema(args[1]),
   <B, A, R1, D, C, R2>(from: Schema<B, A, R1>, to: Schema<D, C, R2>): SchemaClass<D, A, R1 | R2> =>


### PR DESCRIPTION
**Before**

```ts
import { Schema } from "effect"

//      ┌─── SchemaClass<number | null, string>
//      ▼
const schema = Schema.compose(
  Schema.NumberFromString,
  Schema.NullOr(Schema.Number)
)

// @ts-expect-error: Property 'from' does not exist
schema.from

// @ts-expect-error: Property 'to' does not exist
schema.to
```

**After**

```ts
import { Schema } from "effect"

//      ┌─── transform<typeof Schema.NumberFromString, Schema.NullOr<typeof Schema.Number>>
//      ▼
const schema = Schema.compose(
  Schema.NumberFromString,
  Schema.NullOr(Schema.Number)
)

//      ┌─── typeof Schema.NumberFromString
//      ▼
schema.from

//      ┌─── Schema.NullOr<typeof Schema.Number>
//      ▼
schema.to
```
