### PR TITLE
Add DateTime.nowAsDate

### DIFF
--- a/.changeset/big-suns-roll.md
+++ b/.changeset/big-suns-roll.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add DateTime.nowAsDate creator

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -439,7 +439,7 @@ export const now: Effect.Effect<Utc> = Internal.now
  * })
  * ```
  */
-export const nowAsDate: Effect.Effect<Date> = Effect.map(Internal.now, (dateTime) => toDate(dateTime))
+export const nowAsDate: Effect.Effect<Date> = Internal.nowAsDate
 
 /**
  * Get the current time using `Date.now`.

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -426,6 +426,22 @@ export const makeZonedFromString: (input: string) => Option.Option<Zoned> = Inte
 export const now: Effect.Effect<Utc> = Internal.now
 
 /**
+ * Get the current time using the `Clock` service.
+ *
+ * @since 3.14.0
+ * @category constructors
+ * @example
+ * ```ts
+ * import { DateTime, Effect } from "effect"
+ *
+ * Effect.gen(function* () {
+ *   const now = yield* DateTime.nowAsDate
+ * })
+ * ```
+ */
+export const nowAsDate: Effect.Effect<Date> = Effect.map(Internal.now, (dateTime) => toDate(dateTime))
+
+/**
  * Get the current time using `Date.now`.
  *
  * @since 3.6.0

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -300,6 +300,9 @@ export const makeZonedFromString = (input: string): Option.Option<DateTime.Zoned
 export const now: Effect.Effect<DateTime.Utc> = core.map(Clock.currentTimeMillis, makeUtc)
 
 /** @internal */
+export const nowAsDate: Effect.Effect<Date> = core.map(Clock.currentTimeMillis, (millis) => new Date(millis))
+
+/** @internal */
 export const unsafeNow: LazyArg<DateTime.Utc> = () => makeUtc(Date.now())
 
 // =============================================================================

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -438,4 +438,12 @@ describe("DateTime", () => {
         strictEqual(dt.toJSON(), "2023-12-31T12:00:00.000Z")
       }))
   })
+  describe("nowAsDate", () => {
+    it.effect("should mutate the date", () =>
+      Effect.gen(function*() {
+        yield* setTo2024NZ
+        const now = yield* DateTime.nowAsDate
+        deepStrictEqual(now, new Date("2023-12-31T11:00:00.000Z"))
+      }))
+  })
 })

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -439,7 +439,7 @@ describe("DateTime", () => {
       }))
   })
   describe("nowAsDate", () => {
-    it.effect("should mutate the date", () =>
+    it.effect("should return the current Date", () =>
       Effect.gen(function*() {
         yield* setTo2024NZ
         const now = yield* DateTime.nowAsDate


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
Add `DateTime.nowAsDate` creator

This is handy in codebases that use Date to model dates

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
