### PR TITLE
Schema: add missing `from` property to `brand` interface

### DIFF
--- a/.changeset/gorgeous-terms-peel.md
+++ b/.changeset/gorgeous-terms-peel.md
@@ -1,0 +1,28 @@
+---
+"effect": patch
+---
+
+Schema: add missing `from` property to `brand` interface.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.String.pipe(Schema.brand("my-brand"))
+
+// @ts-expect-error: Property 'from' does not exist
+schema.from
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.String.pipe(Schema.brand("my-brand"))
+
+//      ┌─── typeof Schema.String
+//      ▼
+schema.from
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -1245,16 +1245,15 @@ describe("Schema", () => {
   })
 
   it("brand", () => {
-    expect(S.asSchema(pipe(S.Number, S.int(), S.brand("Int"))))
-      .type.toBe<S.Schema<number & Brand.Brand<"Int">, number>>()
-    expect(S.asSchema(pipe(S.Number, S.int(), S.brand("Int"))).annotations({}))
-      .type.toBe<S.Schema<number & Brand.Brand<"Int">, number>>()
-    expect(pipe(S.Number, S.int(), S.brand("Int")))
-      .type.toBe<S.brand<S.filter<typeof S.Number>, "Int">>()
-    expect(S.asSchema(pipe(S.NumberFromString, S.int(), S.brand("Int"))))
-      .type.toBe<S.Schema<number & Brand.Brand<"Int">, string>>()
-    expect(pipe(S.NumberFromString, S.int(), S.brand("Int")))
-      .type.toBe<S.brand<S.filter<typeof S.NumberFromString>, "Int">>()
+    const schema = pipe(S.Number, S.int(), S.brand("Int"))
+    expect(S.asSchema(schema)).type.toBe<S.Schema<number & Brand.Brand<"Int">, number>>()
+    expect(schema).type.toBe<S.brand<S.filter<typeof S.Number>, "Int">>()
+    expect(schema.annotations({})).type.toBe<S.brand<S.filter<typeof S.Number>, "Int">>()
+    expect(schema.from).type.toBe<S.filter<typeof S.Number>>()
+
+    const schema2 = pipe(S.NumberFromString, S.int(), S.brand("Int"))
+    expect(S.asSchema(schema2)).type.toBe<S.Schema<number & Brand.Brand<"Int">, string>>()
+    expect(schema2).type.toBe<S.brand<S.filter<typeof S.NumberFromString>, "Int">>()
   })
 
   it("partial", () => {

--- a/packages/effect/test/Schema/Schema/brand.test.ts
+++ b/packages/effect/test/Schema/Schema/brand.test.ts
@@ -9,6 +9,11 @@ describe("brand", () => {
     strictEqual(String(S.String.pipe(S.brand("my-brand"))), `string & Brand<"my-brand">`)
   })
 
+  it("should expose the original schema as `from`", () => {
+    const schema = S.String.pipe(S.brand("my-brand"))
+    strictEqual(schema.from, S.String)
+  })
+
   it("the constructor should validate the input by default", () => {
     const schema = S.NonEmptyString.pipe(S.brand("A"))
     Util.assertions.make.succeed(schema, "a")

--- a/packages/effect/test/Schema/Schema/filterEffect.test.ts
+++ b/packages/effect/test/Schema/Schema/filterEffect.test.ts
@@ -6,7 +6,7 @@ import * as Util from "effect/test/Schema/TestUtils"
 import { strictEqual } from "effect/test/util"
 
 describe("filterEffect", () => {
-  it("shoudl expose the original schema as `from`", async () => {
+  it("should expose the original schema as `from`", () => {
     const schema = S.filterEffect(S.String, () => Effect.succeed(true))
     strictEqual(schema.from, S.String)
     strictEqual(schema.to.ast, S.String.ast)

--- a/packages/effect/test/Schema/Schema/fromBrand.test.ts
+++ b/packages/effect/test/Schema/Schema/fromBrand.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@effect/vitest"
 import * as Brand from "effect/Brand"
 import * as S from "effect/Schema"
 import * as Util from "effect/test/Schema/TestUtils"
+import { strictEqual } from "effect/test/util"
 
 type Int = number & Brand.Brand<"Int">
 const Int = Brand.refined<Int>(
@@ -32,6 +33,12 @@ describe("fromBrand", () => {
 └─ Predicate refinement failure
    └─ Expected -1 to be positive`
     )
+  })
+
+  it("[internal] should expose the original schema as `from`", () => {
+    // the from property is not exposed in the public API
+    const schema: any = S.Number.pipe(S.fromBrand(PositiveInt))
+    strictEqual(schema.from, S.Number)
   })
 
   it("test roundtrip consistency", () => {


### PR DESCRIPTION
Before

```ts
import { Schema } from "effect"

const schema = Schema.String.pipe(Schema.brand("my-brand"))

// @ts-expect-error: Property 'from' does not exist
schema.from
```

After

```ts
import { Schema } from "effect"

const schema = Schema.String.pipe(Schema.brand("my-brand"))

//      ┌─── typeof Schema.String
//      ▼
schema.from
```
