### PR TITLE
chore: test types against TypeScript’s nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,17 @@
+name: TypeScript's Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *"
+
+jobs:
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - run: pnpm test-types --target next


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

To draw your attention, passing `--target '>=5.4'` to TSTyche means that newly released TypeScript versions will be picked as well. For instance, `5.8` will be used as soon as it will be available on `npm`. This means that an arbitrary PR might be failing, because of unrelated reasons.

I think it is worth to run type tests agains TypeScript’s `next` version which is released daily. This can serve as an early warning solution.

Feel free to adjust the details. A good question is: how to setup notifications? GitHub Actions [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule) states:

> Notifications for scheduled workflows are sent to the user who last modified the cron syntax in the workflow file.

Hm.. Not sure about that. Should be some smarter way to setup notifications.