### PR TITLE
Schema: Use `additionalProperties` instead of `patternProperties` for…

### DIFF
--- a/.changeset/orange-cups-drop.md
+++ b/.changeset/orange-cups-drop.md
@@ -1,0 +1,60 @@
+---
+"effect": patch
+---
+
+Refactor `JSONSchema` to use `additionalProperties` instead of `patternProperties` for simple records, closes #4518.
+
+This update improves how records are represented in JSON Schema by replacing `patternProperties` with `additionalProperties`, resolving issues in OpenAPI schema generation.
+
+**Why the change?**
+
+- **Fixes OpenAPI issues** – Previously, records were represented using `patternProperties`, which caused problems with OpenAPI tools.
+- **Better schema compatibility** – Some tools, like `openapi-ts`, struggled with `patternProperties`, generating `Record<string, never>` instead of the correct type.
+- **Fixes missing example values** – When using `patternProperties`, OpenAPI failed to generate proper response examples, displaying only `{}`.
+- **Simplifies schema modification** – Users previously had to manually fix schemas with `OpenApi.Transform`, which was messy and lacked type safety.
+
+**Before**
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Record({ key: Schema.String, value: Schema.Number })
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [],
+  "properties": {},
+  "patternProperties": {
+    "": { // ❌ Empty string pattern
+      "type": "number"
+    }
+  }
+}
+*/
+```
+
+**After**
+
+Now, `additionalProperties` is used instead, which properly represents an open-ended record:
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Record({ key: Schema.String, value: Schema.Number })
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [],
+  "properties": {},
+  "additionalProperties": { // ✅ Represents unrestricted record keys
+    "type": "number"
+  }
+}
+*/
+```

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -635,13 +635,19 @@ const go = (
       if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
         return { ...constEmpty, ...getJsonSchemaAnnotations(ast) }
       }
+      const output: JsonSchema7Object = {
+        type: "object",
+        required: [],
+        properties: {},
+        additionalProperties: false
+      }
       let patternProperties: JsonSchema7 | undefined = undefined
       let propertyNames: JsonSchema7 | undefined = undefined
       for (const is of ast.indexSignatures) {
         const parameter = is.parameter
         switch (parameter._tag) {
           case "StringKeyword": {
-            patternProperties = go(is.type, $defs, true, path, options)
+            output.additionalProperties = go(is.type, $defs, true, path, options)
             break
           }
           case "TemplateLiteral": {
@@ -660,12 +666,6 @@ const go = (
           case "SymbolKeyword":
             throw new Error(errors_.getJSONSchemaUnsupportedParameterErrorMessage(path, parameter))
         }
-      }
-      const output: JsonSchema7Object = {
-        type: "object",
-        required: [],
-        properties: {},
-        additionalProperties: false
       }
       // ---------------------------------------------
       // handle property signatures

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -1961,10 +1961,8 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
             "type": "string"
           }
         },
-        "patternProperties": {
-          "": {
-            "type": "string"
-          }
+        "additionalProperties": {
+          "type": "string"
         }
       }
       expectJSONSchemaAnnotations(schema, jsonSchema)
@@ -2073,10 +2071,8 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
         "type": "object",
         "properties": {},
         "required": [],
-        "patternProperties": {
-          "": {
-            "type": "number"
-          }
+        "additionalProperties": {
+          "type": "number"
         }
       })
     })


### PR DESCRIPTION
… simple records, closes #4518

This update improves how records are represented in JSON Schema by replacing `patternProperties` with `additionalProperties`, resolving issues in OpenAPI schema generation.

**Why the change?**

- **Fixes OpenAPI issues** – Previously, records were represented using `patternProperties`, which caused problems with OpenAPI tools.
- **Better schema compatibility** – Some tools, like `openapi-ts`, struggled with `patternProperties`, generating `Record<string, never>` instead of the correct type.
- **Fixes missing example values** – When using `patternProperties`, OpenAPI failed to generate proper response examples, displaying only `{}`.
- **Simplifies schema modification** – Users previously had to manually fix schemas with `OpenApi.Transform`, which was messy and lacked type safety.

**Before**

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Record({ key: Schema.String, value: Schema.Number })

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [],
  "properties": {},
  "patternProperties": {
    "": { // ❌ Empty string pattern
      "type": "number"
    }
  }
}
*/
```

**After**

Now, `additionalProperties` is used instead, which properly represents an open-ended record:

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Record({ key: Schema.String, value: Schema.Number })

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [],
  "properties": {},
  "additionalProperties": { // ✅ Represents unrestricted record keys
    "type": "number"
  }
}
*/
```
