### PR TITLE
feat: added Number.parseInteger

### DIFF
--- a/.changeset/nine-buses-brake.md
+++ b/.changeset/nine-buses-brake.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+added Number.parseInteger

--- a/.changeset/quiet-tables-listen.md
+++ b/.changeset/quiet-tables-listen.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Either.transposeOption

--- a/.changeset/tender-kangaroos-kiss.md
+++ b/.changeset/tender-kangaroos-kiss.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add `Array.window` function

--- a/.changeset/yellow-lemons-worry.md
+++ b/.changeset/yellow-lemons-worry.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Make Runtime.run* apis dual

--- a/packages/effect/dtslint/Array.tst.ts
+++ b/packages/effect/dtslint/Array.tst.ts
@@ -942,6 +942,18 @@ describe("Array", () => {
       .type.toBe<[[string, ...Array<string>], ...Array<[string, ...Array<string>]>]>()
   })
 
+  it("window", () => {
+    // Array
+    expect(Array.window(strings, 2)).type.toBe<Array<Array<string>>>()
+    expect(pipe(strings, Array.window(2))).type.toBe<Array<Array<string>>>()
+    expect(Array.window(2)(strings)).type.toBe<Array<Array<string>>>()
+
+    // NonEmptyArray
+    expect(Array.window(nonEmptyStrings, 2)).type.toBe<Array<Array<string>>>()
+    expect(pipe(nonEmptyStrings, Array.window(2))).type.toBe<Array<Array<string>>>()
+    expect(Array.window(2)(nonEmptyStrings)).type.toBe<Array<Array<string>>>()
+  })
+
   it("reverse", () => {
     // Array
     expect(Array.reverse(strings)).type.toBe<Array<string>>()

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1970,6 +1970,37 @@ export const chunksOf: {
 })
 
 /**
+ * Creates sliding windows of size `n` from an `Iterable`.
+ * If the number of elements is less than `n` or if `n` is not greater than zero,
+ * an empty array is returned.
+ *
+ * @example
+ * ```ts
+ * import { Array } from "effect"
+ *
+ * const numbers = [1, 2, 3, 4, 5]
+ * assert.deepStrictEqual(Array.window(numbers, 3), [[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+ * assert.deepStrictEqual(Array.window(numbers, 6), [])
+ * ```
+ *
+ * @category splitting
+ * @since 3.13.2
+ */
+export const window: {
+  (n: number): <A>(self: Iterable<A>) => Array<Array<A>>
+  <A>(self: Iterable<A>, n: number): Array<Array<A>>
+} = dual(2, <A>(self: Iterable<A>, n: number): Array<Array<A>> => {
+  const input = fromIterable(self)
+  if (n > 0 && isNonEmptyReadonlyArray(input)) {
+    return Array.from(
+      { length: input.length - (n - 1) },
+      (_, index) => input.slice(index, index + n)
+    )
+  }
+  return []
+})
+
+/**
  * Group equal, consecutive elements of a `NonEmptyReadonlyArray` into `NonEmptyArray`s using the provided `isEquivalent` function.
  *
  * @example

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -9,6 +9,7 @@ import type { TypeLambda } from "./HKT.js"
 import type { Inspectable } from "./Inspectable.js"
 import * as doNotation from "./internal/doNotation.js"
 import * as either from "./internal/either.js"
+import * as option_ from "./internal/option.js"
 import type { Option } from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { Predicate, Refinement } from "./Predicate.js"
@@ -965,4 +966,39 @@ export {
    * @since 2.0.0
    */
   let_ as let
+}
+
+/**
+ * Converts an `Option` of an `Either` into an `Either` of an `Option`.
+ *
+ * **Details**
+ *
+ * This function transforms an `Option<Either<A, E>>` into an
+ * `Either<Option<A>, E>`. If the `Option` is `None`, the resulting `Either`
+ * will be a `Right` with a `None` value. If the `Option` is `Some`, the
+ * inner `Either` will be executed, and its result wrapped in a `Some`.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Either, Option } from "effect"
+ *
+ * //      ┌─── Option<Either<number, never>>
+ * //      ▼
+ * const maybe = Option.some(Either.right(42))
+ *
+ * //      ┌─── Either<Option<number>, never, never>
+ * //      ▼
+ * const result = Either.transposeOption(maybe)
+ *
+ * console.log(Effect.runSync(result))
+ * // Output: { _id: 'Option', _tag: 'Some', value: 42 }
+ * ```
+ *
+ * @since 3.14.0
+ * @category Optional Wrapping & Unwrapping
+ */
+export const transposeOption = <A = never, E = never>(
+  self: Option<Either<A, E>>
+): Either<Option<A>, E> => {
+  return option_.isNone(self) ? right(option_.none) : map(self.value, option_.some)
 }

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -551,6 +551,7 @@ export const parse = (s: string): Option<number> => {
  * import { parseInteger } from "effect/Number"
  * 
  * assert.deepStrictEqual(parseInteger("42"), option.some(42))
+ * assert.deepStrictEqual(parseInteger("4.2"), option.some(4))
  * assert.deepStrictEqual(parseInteger("abc"), option.none)
  * assert.deepStrictEqual(parseInteger("101", 2), option.some(5))
  *

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -537,6 +537,7 @@ export const parse = (s: string): Option<number> => {
 
 /**
  * Tries to parse a string into a integer using Number.parseInt.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
  * 
  * @param string - A string to convert into a number.
  * 

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -548,12 +548,13 @@ export const parse = (s: string): Option<number> => {
  * @returns An `Option<number>` containing the parsed integer if successful.
  *
  * @example
+ * import { Option } from "effect"
  * import { parseInteger } from "effect/Number"
  *
- * assert.deepStrictEqual(parseInteger("42"), option.some(42))
- * assert.deepStrictEqual(parseInteger("4.2"), option.some(4))
- * assert.deepStrictEqual(parseInteger("abc"), option.none)
- * assert.deepStrictEqual(parseInteger("101", 2), option.some(5))
+ * assert.deepStrictEqual(parseInteger("42"), Option.some(42))
+ * assert.deepStrictEqual(parseInteger("4.2"), Option.some(4))
+ * assert.deepStrictEqual(parseInteger("abc"), Option.none)
+ * assert.deepStrictEqual(parseInteger("101", 2), Option.some(5))
  *
  * @category constructors
  * @since 3.14.0

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -538,31 +538,30 @@ export const parse = (s: string): Option<number> => {
 /**
  * Tries to parse a string into a integer using Number.parseInt.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
- * 
+ *
  * @param string - A string to convert into a number.
- * 
- * @param radix - A value between 2 and 36 that specifies the base of the number in string. 
- * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal. 
- * All other strings are considered decimal. 
- * 
+ *
+ * @param radix - A value between 2 and 36 that specifies the base of the number in string.
+ * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
+ * All other strings are considered decimal.
+ *
  * @returns An `Option<number>` containing the parsed integer if successful.
- * 
+ *
  * @example
  * import { parseInteger } from "effect/Number"
- * 
+ *
  * assert.deepStrictEqual(parseInteger("42"), option.some(42))
  * assert.deepStrictEqual(parseInteger("4.2"), option.some(4))
  * assert.deepStrictEqual(parseInteger("abc"), option.none)
  * assert.deepStrictEqual(parseInteger("101", 2), option.some(5))
  *
- *
  * @category constructors
  * @since 3.14.0
  */
 export const parseInteger = (string: string, radix?: number): Option<number> => {
-  const num = Number.parseInt(string, radix);
-  return Number.isNaN(num) ? option.none : option.some(num);
-};
+  const num = Number.parseInt(string, radix)
+  return Number.isNaN(num) ? option.none : option.some(num)
+}
 
 /**
  * Returns the number rounded with the given precision.

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -536,6 +536,33 @@ export const parse = (s: string): Option<number> => {
 }
 
 /**
+ * Tries to parse a string into a integer using Number.parseInt.
+ * 
+ * @param string - A string to convert into a number.
+ * 
+ * @param radix - A value between 2 and 36 that specifies the base of the number in string. 
+ * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal. 
+ * All other strings are considered decimal. 
+ * 
+ * @returns An `Option<number>` containing the parsed integer if successful.
+ * 
+ * @example
+ * import { parseInteger } from "effect/Number"
+ * 
+ * assert.deepStrictEqual(parseInteger("42"), option.some(42))
+ * assert.deepStrictEqual(parseInteger("abc"), option.none)
+ * assert.deepStrictEqual(parseInteger("101", 2), option.some(5))
+ *
+ *
+ * @category constructors
+ * @since 3.14.0
+ */
+export const parseInteger = (string: string, radix?: number): Option<number> => {
+  const num = Number.parseInt(string, radix);
+  return Number.isNaN(num) ? option.none : option.some(num);
+};
+
+/**
  * Returns the number rounded with the given precision.
  *
  * @param self - The number to round

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -553,7 +553,7 @@ export const parse = (s: string): Option<number> => {
  *
  * assert.deepStrictEqual(parseInteger("42"), Option.some(42))
  * assert.deepStrictEqual(parseInteger("4.2"), Option.some(4))
- * assert.deepStrictEqual(parseInteger("abc"), Option.none)
+ * assert.deepStrictEqual(parseInteger("abc"), Option.none())
  * assert.deepStrictEqual(parseInteger("101", 2), Option.some(5))
  *
  * @category constructors

--- a/packages/effect/src/Runtime.ts
+++ b/packages/effect/src/Runtime.ts
@@ -81,9 +81,16 @@ export interface RunForkOptions {
  * @since 2.0.0
  * @category execution
  */
-export const runFork: <R>(
-  runtime: Runtime<R>
-) => <A, E>(self: Effect.Effect<A, E, R>, options?: RunForkOptions) => Fiber.RuntimeFiber<A, E> = internal.unsafeFork
+export const runFork: {
+  <R>(
+    runtime: Runtime<R>
+  ): <A, E>(effect: Effect.Effect<A, E, R>, options?: RunForkOptions | undefined) => Fiber.RuntimeFiber<A, E>
+  <R, A, E>(
+    runtime: Runtime<R>,
+    effect: Effect.Effect<A, E, R>,
+    options?: RunForkOptions | undefined
+  ): Fiber.RuntimeFiber<A, E>
+} = internal.unsafeFork
 
 /**
  * Executes the effect synchronously returning the exit.
@@ -94,8 +101,10 @@ export const runFork: <R>(
  * @since 2.0.0
  * @category execution
  */
-export const runSyncExit: <R>(runtime: Runtime<R>) => <A, E>(effect: Effect.Effect<A, E, R>) => Exit.Exit<A, E> =
-  internal.unsafeRunSyncExit
+export const runSyncExit: {
+  <A, E, R>(runtime: Runtime<R>, effect: Effect.Effect<A, E, R>): Exit.Exit<A, E>
+  <R>(runtime: Runtime<R>): <A, E>(effect: Effect.Effect<A, E, R>) => Exit.Exit<A, E>
+} = internal.unsafeRunSyncExit
 
 /**
  * Executes the effect synchronously throwing in case of errors or async boundaries.
@@ -106,7 +115,10 @@ export const runSyncExit: <R>(runtime: Runtime<R>) => <A, E>(effect: Effect.Effe
  * @since 2.0.0
  * @category execution
  */
-export const runSync: <R>(runtime: Runtime<R>) => <A, E>(effect: Effect.Effect<A, E, R>) => A = internal.unsafeRunSync
+export const runSync: {
+  <A, E, R>(runtime: Runtime<R>, effect: Effect.Effect<A, E, R>): A
+  <R>(runtime: Runtime<R>): <A, E>(effect: Effect.Effect<A, E, R>) => A
+} = internal.unsafeRunSync
 
 /**
  * @since 2.0.0
@@ -126,10 +138,19 @@ export interface RunCallbackOptions<in A, in E = never> extends RunForkOptions {
  * @since 2.0.0
  * @category execution
  */
-export const runCallback: <R>(
-  runtime: Runtime<R>
-) => <A, E>(effect: Effect.Effect<A, E, R>, options?: RunCallbackOptions<A, E> | undefined) => Cancel<A, E> =
-  internal.unsafeRunCallback
+export const runCallback: {
+  <R>(
+    runtime: Runtime<R>
+  ): <A, E>(
+    effect: Effect.Effect<A, E, R>,
+    options?: RunCallbackOptions<A, E> | undefined
+  ) => (fiberId?: FiberId.FiberId, options?: RunCallbackOptions<A, E> | undefined) => void
+  <R, A, E>(
+    runtime: Runtime<R>,
+    effect: Effect.Effect<A, E, R>,
+    options?: RunCallbackOptions<A, E> | undefined
+  ): (fiberId?: FiberId.FiberId, options?: RunCallbackOptions<A, E> | undefined) => void
+} = internal.unsafeRunCallback
 
 /**
  * Runs the `Effect`, returning a JavaScript `Promise` that will be resolved
@@ -142,10 +163,16 @@ export const runCallback: <R>(
  * @since 2.0.0
  * @category execution
  */
-export const runPromise: <R>(
-  runtime: Runtime<R>
-) => <A, E>(effect: Effect.Effect<A, E, R>, options?: { readonly signal?: AbortSignal } | undefined) => Promise<A> =
-  internal.unsafeRunPromise
+export const runPromise: {
+  <R>(
+    runtime: Runtime<R>
+  ): <A, E>(effect: Effect.Effect<A, E, R>, options?: { readonly signal?: AbortSignal } | undefined) => Promise<A>
+  <R, A, E>(
+    runtime: Runtime<R>,
+    effect: Effect.Effect<A, E, R>,
+    options?: { readonly signal?: AbortSignal } | undefined
+  ): Promise<A>
+} = internal.unsafeRunPromise
 
 /**
  * Runs the `Effect`, returning a JavaScript `Promise` that will be resolved
@@ -157,12 +184,19 @@ export const runPromise: <R>(
  * @since 2.0.0
  * @category execution
  */
-export const runPromiseExit: <R>(
-  runtime: Runtime<R>
-) => <A, E>(
-  effect: Effect.Effect<A, E, R>,
-  options?: { readonly signal?: AbortSignal } | undefined
-) => Promise<Exit.Exit<A, E>> = internal.unsafeRunPromiseExit
+export const runPromiseExit: {
+  <R>(
+    runtime: Runtime<R>
+  ): <A, E>(
+    effect: Effect.Effect<A, E, R>,
+    options?: { readonly signal?: AbortSignal } | undefined
+  ) => Promise<Exit.Exit<A, E>>
+  <R, A, E>(
+    runtime: Runtime<R>,
+    effect: Effect.Effect<A, E, R>,
+    options?: { readonly signal?: AbortSignal } | undefined
+  ): Promise<Exit.Exit<A, E>>
+} = internal.unsafeRunPromiseExit
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -647,7 +647,7 @@ const parseQuotedIndex = (str: string): Option.Option<number> => {
       matchedIndex !== undefined && matchedIndex.length > 0 ?
         Option.some(matchedIndex) :
         Option.none(),
-      Option.flatMap(parseInteger)
+      Option.flatMap(number.parseInteger)
     )
   }
   return Option.none()
@@ -686,18 +686,11 @@ const splitIndexFrom = (key: string): Option.Option<[string, number]> => {
       matchedIndex !== undefined && matchedIndex.length > 0 ?
         Option.some(matchedIndex) :
         Option.none(),
-      Option.flatMap(parseInteger)
+      Option.flatMap(number.parseInteger)
     )
     return Option.all([optionalString, optionalIndex])
   }
   return Option.none()
-}
-
-const parseInteger = (str: string): Option.Option<number> => {
-  const parsedIndex = Number.parseInt(str)
-  return Number.isNaN(parsedIndex) ?
-    Option.none() :
-    Option.some(parsedIndex)
 }
 
 const keyName = (name: string): KeyComponent => ({

--- a/packages/effect/test/Array.test.ts
+++ b/packages/effect/test/Array.test.ts
@@ -956,6 +956,18 @@ describe("Array", () => {
     assertSingleChunk(Arr.make(1, 2), 3)
   })
 
+  it("window", () => {
+    deepStrictEqual(Arr.window(2)([]), [])
+
+    deepStrictEqual(Arr.window(2)([1, 2, 3, 4, 5]), [[1, 2], [2, 3], [3, 4], [4, 5]])
+    deepStrictEqual(Arr.window(3)([1, 2, 3, 4, 5]), [[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+
+    // n out of bounds
+    deepStrictEqual(Arr.window([1, 2, 3, 4, 5], 6), [])
+    deepStrictEqual(Arr.window([1, 2, 3, 4, 5], 0), [])
+    deepStrictEqual(Arr.window([1, 2, 3, 4, 5], -1), [])
+  })
+
   it("min", () => {
     deepStrictEqual(Arr.min(Num.Order)([2, 1, 3]), 1)
     deepStrictEqual(Arr.min(Num.Order)([3]), 3)

--- a/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
+++ b/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
 import * as Option from "effect/Option"
 
 describe("Effect", () => {
@@ -13,6 +14,22 @@ describe("Effect", () => {
     it.effect("Some", () =>
       Effect.gen(function*() {
         const result = yield* Effect.transposeOption(Option.some(Effect.succeed(42)))
+        assert.deepStrictEqual(result, Option.some(42))
+      }))
+  })
+})
+
+describe("Either", () => {
+  describe("transposeOption", () => {
+    it.effect("None", () =>
+      Effect.gen(function*() {
+        const result = yield* Either.transposeOption(Option.none())
+        assert.ok(Option.isNone(result))
+      }))
+
+    it.effect("Some", () =>
+      Effect.gen(function*() {
+        const result = yield* Either.transposeOption(Option.some(Either.right(42)))
         assert.deepStrictEqual(result, Option.some(42))
       }))
   })

--- a/packages/effect/test/Number.test.ts
+++ b/packages/effect/test/Number.test.ts
@@ -136,6 +136,7 @@ describe("Number", () => {
 
   it("parseInteger", () => {
     assertSome(Number.parseInteger("42"), 42)
+    assertSome(Number.parseInteger("4.2"), 4)
     assertSome(Number.parseInteger("ff", 16), 255)
     assertSome(Number.parseInteger(" 123 "), 123)
     assertNone(Number.parseInteger("abc"))

--- a/packages/effect/test/Number.test.ts
+++ b/packages/effect/test/Number.test.ts
@@ -134,6 +134,14 @@ describe("Number", () => {
     assertNone(Number.parse("a"))
   })
 
+  it("parseInteger", () => {
+    assertSome(Number.parseInteger("42"), 42)
+    assertSome(Number.parseInteger("ff", 16), 255)
+    assertSome(Number.parseInteger(" 123 "), 123)
+    assertNone(Number.parseInteger("abc"))
+    assertNone(Number.parseInteger(""))
+  })
+
   it("round", () => {
     strictEqual(Number.round(1.1234, 2), 1.12)
     strictEqual(Number.round(2)(1.1234), 1.12)

--- a/packages/effect/test/Runtime.test.ts
+++ b/packages/effect/test/Runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { Effect, Exit, FiberRef, Layer, pipe, Runtime } from "effect"
-import { assertTrue, deepStrictEqual, strictEqual } from "effect/test/util"
+import { assertTrue, deepStrictEqual, strictEqual, throwsAsync } from "effect/test/util"
 
 describe("Runtime", () => {
   it.effect("setFiberRef", () =>
@@ -28,10 +28,78 @@ describe("Runtime", () => {
       deepStrictEqual(result, { value: 0 })
     }))
 
+  it("runSync", () => {
+    deepStrictEqual(Runtime.runSync(Runtime.defaultRuntime)(Effect.succeed(1)), 1)
+    deepStrictEqual(Runtime.runSync(Runtime.defaultRuntime, Effect.succeed(1)), 1)
+  })
+
+  it("runSyncExit", () => {
+    deepStrictEqual(Runtime.runSyncExit(Runtime.defaultRuntime)(Effect.succeed(1)), Exit.succeed(1))
+    deepStrictEqual(Runtime.runSyncExit(Runtime.defaultRuntime, Effect.succeed(1)), Exit.succeed(1))
+
+    deepStrictEqual(Runtime.runSyncExit(Runtime.defaultRuntime)(Effect.fail(1)), Exit.fail(1))
+    deepStrictEqual(Runtime.runSyncExit(Runtime.defaultRuntime, Effect.fail(1)), Exit.fail(1))
+  })
+
+  it("runPromise", async () => {
+    deepStrictEqual(
+      await Runtime.runPromise(Runtime.defaultRuntime)(Effect.promise(async () => 1)),
+      1
+    )
+    throwsAsync(
+      async () => {
+        await Runtime.runPromise(Runtime.defaultRuntime)(
+          Effect.tryPromise({ try: () => new Promise((_, reject) => reject(1)), catch: () => "error" })
+        )
+      }
+    )
+
+    deepStrictEqual(
+      await Runtime.runPromise(Runtime.defaultRuntime, Effect.promise(async () => 1)),
+      1
+    )
+    throwsAsync(
+      async () => {
+        await Runtime.runPromise(
+          Runtime.defaultRuntime,
+          Effect.tryPromise({ try: () => new Promise((_, reject) => reject(1)), catch: () => "error" })
+        )
+      }
+    )
+  })
+
+  it("runPromiseExit", async () => {
+    deepStrictEqual(
+      await Runtime.runPromiseExit(Runtime.defaultRuntime)(Effect.promise(async () => 1)),
+      Exit.succeed(1)
+    )
+    deepStrictEqual(
+      await Runtime.runPromiseExit(Runtime.defaultRuntime)(
+        Effect.tryPromise({ try: () => new Promise((_, reject) => reject(1)), catch: () => "error" })
+      ),
+      Exit.fail("error")
+    )
+
+    deepStrictEqual(
+      await Runtime.runPromiseExit(Runtime.defaultRuntime, Effect.promise(async () => 1)),
+      Exit.succeed(1)
+    )
+    deepStrictEqual(
+      await Runtime.runPromiseExit(
+        Runtime.defaultRuntime,
+        Effect.tryPromise({ try: () => new Promise((_, reject) => reject(1)), catch: () => "error" })
+      ),
+      Exit.fail("error")
+    )
+  })
+
   it("runPromiseExit/signal", async () => {
     const aborted = AbortSignal.abort()
     assertTrue(
       Exit.isInterrupted(await Runtime.runPromiseExit(Runtime.defaultRuntime)(Effect.never, { signal: aborted }))
+    )
+    assertTrue(
+      Exit.isInterrupted(await Runtime.runPromiseExit(Runtime.defaultRuntime, Effect.never, { signal: aborted }))
     )
 
     const controller = new AbortController()
@@ -39,6 +107,11 @@ describe("Runtime", () => {
     assertTrue(
       Exit.isInterrupted(
         await Runtime.runPromiseExit(Runtime.defaultRuntime)(Effect.never, { signal: controller.signal })
+      )
+    )
+    assertTrue(
+      Exit.isInterrupted(
+        await Runtime.runPromiseExit(Runtime.defaultRuntime, Effect.never, { signal: controller.signal })
       )
     )
   })

--- a/packages/effect/test/util.ts
+++ b/packages/effect/test/util.ts
@@ -93,6 +93,25 @@ export function throws(thunk: () => void, error?: Error | ((u: unknown) => undef
   }
 }
 
+export async function throwsAsync(
+  thunk: () => Promise<void>,
+  error?: Error | ((u: unknown) => undefined),
+  ..._: Array<never>
+) {
+  try {
+    await thunk()
+    fail("Expected to throw an error")
+  } catch (e) {
+    if (error !== undefined) {
+      if (Predicate.isFunction(error)) {
+        error(e)
+      } else {
+        deepStrictEqual(e, error)
+      }
+    }
+  }
+}
+
 // ----------------------------
 // Option
 // ----------------------------

--- a/packages/opentelemetry/test/Tracer.test.ts
+++ b/packages/opentelemetry/test/Tracer.test.ts
@@ -94,10 +94,13 @@ describe("Tracer", () => {
             attributes: { "root": "yes" }
           }, async (span) => {
             try {
-              const parent = await Runtime.runPromise(runtime)(Tracer.withSpanContext(
-                effect,
-                span.spanContext()
-              ))
+              const parent = await Runtime.runPromise(
+                runtime,
+                Tracer.withSpanContext(
+                  effect,
+                  span.spanContext()
+                )
+              )
               const { spanId, traceId } = span.spanContext()
               expect(parent).toMatchObject({
                 spanId,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a Number.parseInteger constructor wrapping the js builtin `parseInt` and replaces an internal helper w/ it. 

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #4453
