### PR TITLE
Schema: More Accurate Return Type for `parseNumber`

### DIFF
--- a/.changeset/fresh-turtles-fix.md
+++ b/.changeset/fresh-turtles-fix.md
@@ -1,0 +1,29 @@
+---
+"effect": patch
+---
+
+Schema: More Accurate Return Type for `parseNumber`.
+
+**Before**
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.parseNumber(Schema.String)
+
+//      ┌─── Schema<string>
+//      ▼
+schema.from
+```
+
+**After**
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.parseNumber(Schema.String)
+
+//      ┌─── typeof Schema.String
+//      ▼
+schema.from
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -4062,5 +4062,17 @@ describe("Schema", () => {
       expect(pipe(S.Struct({ a: S.optionalWith(S.String, { exact: true }), b: S.Number }), S.pluck("a")))
         .type.toBe<S.SchemaClass<string | undefined, { readonly a?: string }>>()
     })
+
+    it("parseNumber", () => {
+      // @ts-expect-error: Type 'null' is not assignable to type 'string'
+      S.parseNumber(S.Null)
+
+      const schema = S.parseNumber(S.String)
+      expect(S.asSchema(schema)).type.toBe<S.Schema<number, string>>()
+      expect(schema).type.toBe<S.transformOrFail<typeof S.String, typeof S.Number>>()
+      expect(schema.annotations({})).type.toBe<S.transformOrFail<typeof S.String, typeof S.Number>>()
+      expect(schema.from).type.toBe<typeof S.String>()
+      expect(schema.to).type.toBe<typeof S.Number>()
+    })
   })
 })

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -5262,21 +5262,23 @@ export const clamp = (minimum: number, maximum: number) =>
  * @category number transformations
  * @since 3.10.0
  */
-export const parseNumber = <A extends string, I, R>(
-  self: Schema<A, I, R>
-): transformOrFail<Schema<A, I, R>, typeof Number$> =>
-  transformOrFail(
+export function parseNumber<S extends Schema.Any, A extends string>(
+  self: S & Schema<A, Schema.Encoded<S>, Schema.Context<S>>
+): transformOrFail<S, typeof Number$> {
+  return transformOrFail(
     self,
     Number$,
     {
       strict: false,
       decode: (i, _, ast) =>
-        ParseResult.fromOption(number_.parse(i), () =>
-          new ParseResult.Type(ast, i, `Unable to decode ${JSON.stringify(i)} into a number`)),
-      encode: (a) =>
-        ParseResult.succeed(String(a))
+        ParseResult.fromOption(
+          number_.parse(i),
+          () => new ParseResult.Type(ast, i, `Unable to decode ${JSON.stringify(i)} into a number`)
+        ),
+      encode: (a) => ParseResult.succeed(String(a))
     }
   )
+}
 
 /**
  * This schema transforms a `string` into a `number` by parsing the string using the `parse` function of the `effect/Number` module.


### PR DESCRIPTION
**Before**

```ts
import { Schema } from "effect"

const schema = Schema.parseNumber(Schema.String)

//      ┌─── Schema<string>
//      ▼
schema.from
```

**After**

```ts
import { Schema } from "effect"

const schema = Schema.parseNumber(Schema.String)

//      ┌─── typeof Schema.String
//      ▼
schema.from
```
