### PR TITLE
Fix w3c traceparent header parsing

### DIFF
--- a/.changeset/mighty-boxes-greet.md
+++ b/.changeset/mighty-boxes-greet.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix w3c traceparent header parsing

--- a/packages/platform/src/HttpTraceContext.ts
+++ b/packages/platform/src/HttpTraceContext.ts
@@ -75,8 +75,8 @@ export const xb3: FromHeaders = (headers) => {
   }))
 }
 
-const w3cTraceId = /^[0-9a-f]{32}$/gi
-const w3cSpanId = /^[0-9a-f]{16}$/gi
+const w3cTraceId = /^[0-9a-f]{32}$/i
+const w3cSpanId = /^[0-9a-f]{16}$/i
 
 /**
  * @since 1.0.0

--- a/packages/platform/test/HttpTraceContext.test.ts
+++ b/packages/platform/test/HttpTraceContext.test.ts
@@ -1,7 +1,8 @@
 import { Headers } from "@effect/platform"
 import * as TraceContext from "@effect/platform/HttpTraceContext"
 import { Option } from "effect"
-import { describe, expect, it } from "vitest"
+import { assertNone, assertTrue } from "effect/test/util"
+import { describe, it } from "vitest"
 
 describe("HttpTraceContext", () => {
   describe("w3c", () => {
@@ -13,8 +14,8 @@ describe("HttpTraceContext", () => {
         traceparent: "00-d74bfb8ca565d03f77199ec3c0885d2f-694e4dd0b5ab44cd-01"
       }))
 
-      expect(Option.isSome(result1)).toBe(true)
-      expect(Option.isSome(result2)).toBe(true)
+      assertTrue(Option.isSome(result1))
+      assertTrue(Option.isSome(result2))
     })
 
     it("should return none when traceparent header is invalid", () => {
@@ -22,7 +23,7 @@ describe("HttpTraceContext", () => {
       const invalidFormat = TraceContext.w3c(Headers.fromInput({
         traceparent: "0099e04eb3282f5adee84c335ca51626da886b16145ac0f399-01"
       }))
-      expect(Option.isNone(invalidFormat)).toBe(true)
+      assertNone(invalidFormat)
 
       // Invalid version
       const non00Version = TraceContext.w3c(Headers.fromInput({

--- a/packages/platform/test/HttpTraceContext.test.ts
+++ b/packages/platform/test/HttpTraceContext.test.ts
@@ -1,0 +1,20 @@
+import { Headers } from "@effect/platform"
+import * as TraceContext from "@effect/platform/HttpTraceContext"
+import { Option } from "effect"
+import { describe, expect, it } from "vitest"
+
+describe("HttpTraceContext", () => {
+  describe("w3c", () => {
+    it("should parse traceIds and spanIds repeatedly", () => {
+      const result1 = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-99e04eb3282f5adee84c335ca51626da-886b16145ac0f399-01"
+      }))
+      const result2 = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-d74bfb8ca565d03f77199ec3c0885d2f-694e4dd0b5ab44cd-01"
+      }))
+
+      expect(Option.isSome(result1)).toBe(true)
+      expect(Option.isSome(result2)).toBe(true)
+    })
+  })
+})

--- a/packages/platform/test/HttpTraceContext.test.ts
+++ b/packages/platform/test/HttpTraceContext.test.ts
@@ -30,42 +30,42 @@ describe("HttpTraceContext", () => {
         traceparent: "01-99e04eb3282f5adee84c335ca51626da-886b16145ac0f399-01"
       }))
 
-      expect(Option.isNone(non00Version)).toBe(true)
+      assertNone(non00Version)
       // x included in trace
       const resultTraceNonHex = TraceContext.w3c(Headers.fromInput({
         traceparent: "00-x9e04eb3282f5adee84c335ca51626da-886b16145ac0f399-01"
       }))
-      expect(Option.isNone(resultTraceNonHex)).toBe(true)
+      assertNone(resultTraceNonHex)
 
       // 33 character trace
       const traceLarge = TraceContext.w3c(Headers.fromInput({
         traceparent: "00-99e04eb3282f5adee84c335ca51626daa-886b16145ac0f399-01"
       }))
-      expect(Option.isNone(traceLarge)).toBe(true)
+      assertNone(traceLarge)
 
       // 31 character trace
       const traceSmall = TraceContext.w3c(Headers.fromInput({
         traceparent: "00-99e04eb3282f5adee84c335ca51626d-886b16145ac0f399-01"
       }))
-      expect(Option.isNone(traceSmall)).toBe(true)
+      assertNone(traceSmall)
 
       // x included span
       const resultSpanNonHex = TraceContext.w3c(Headers.fromInput({
         traceparent: "00-a9e04eb3282f5adee84c335ca51626da-x86b16145ac0f399-01"
       }))
-      expect(Option.isNone(resultSpanNonHex)).toBe(true)
+      assertNone(resultSpanNonHex)
 
       // 15 characters span
       const spanSmall = TraceContext.w3c(Headers.fromInput({
         traceparent: "00-9e04eb3282f5adee84c335ca51626da-86b16145ac0f399-01"
       }))
-      expect(Option.isNone(spanSmall)).toBe(true)
+      assertNone(spanSmall)
 
       // 17 characters span
       const spanLarge = TraceContext.w3c(Headers.fromInput({
         traceparent: "00-9e04eb3282f5adee84c335ca51626daaa-86b16145ac0f399-01"
       }))
-      expect(Option.isNone(spanLarge)).toBe(true)
+      assertNone(spanLarge)
     })
   })
 })

--- a/packages/platform/test/HttpTraceContext.test.ts
+++ b/packages/platform/test/HttpTraceContext.test.ts
@@ -16,5 +16,55 @@ describe("HttpTraceContext", () => {
       expect(Option.isSome(result1)).toBe(true)
       expect(Option.isSome(result2)).toBe(true)
     })
+
+    it("should return none when traceparent header is invalid", () => {
+      // Invalid format
+      const invalidFormat = TraceContext.w3c(Headers.fromInput({
+        traceparent: "0099e04eb3282f5adee84c335ca51626da886b16145ac0f399-01"
+      }))
+      expect(Option.isNone(invalidFormat)).toBe(true)
+
+      // Invalid version
+      const non00Version = TraceContext.w3c(Headers.fromInput({
+        traceparent: "01-99e04eb3282f5adee84c335ca51626da-886b16145ac0f399-01"
+      }))
+
+      expect(Option.isNone(non00Version)).toBe(true)
+      // x included in trace
+      const resultTraceNonHex = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-x9e04eb3282f5adee84c335ca51626da-886b16145ac0f399-01"
+      }))
+      expect(Option.isNone(resultTraceNonHex)).toBe(true)
+
+      // 33 character trace
+      const traceLarge = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-99e04eb3282f5adee84c335ca51626daa-886b16145ac0f399-01"
+      }))
+      expect(Option.isNone(traceLarge)).toBe(true)
+
+      // 31 character trace
+      const traceSmall = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-99e04eb3282f5adee84c335ca51626d-886b16145ac0f399-01"
+      }))
+      expect(Option.isNone(traceSmall)).toBe(true)
+
+      // x included span
+      const resultSpanNonHex = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-a9e04eb3282f5adee84c335ca51626da-x86b16145ac0f399-01"
+      }))
+      expect(Option.isNone(resultSpanNonHex)).toBe(true)
+
+      // 15 characters span
+      const spanSmall = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-9e04eb3282f5adee84c335ca51626da-86b16145ac0f399-01"
+      }))
+      expect(Option.isNone(spanSmall)).toBe(true)
+
+      // 17 characters span
+      const spanLarge = TraceContext.w3c(Headers.fromInput({
+        traceparent: "00-9e04eb3282f5adee84c335ca51626daaa-86b16145ac0f399-01"
+      }))
+      expect(Option.isNone(spanLarge)).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Remove the /g flag of w3c traceparent header regexes to prevent the issue described here: 

https://medium.com/@nikjohn/regex-test-returns-alternating-results-bd9a1ae42cdd 

Also add minimal testing

Also add some test

## Related



- Related Issue #2445 
