### PR TITLE
Bug fix: change interruptible order in platform shutdown flow

### DIFF
--- a/packages/platform-bun/src/internal/worker.ts
+++ b/packages/platform-bun/src/internal/worker.ts
@@ -19,8 +19,8 @@ const platformWorkerImpl = Worker.makePlatform<globalThis.Worker>()({
             worker.postMessage([1])
             return Deferred.await(closeDeferred)
           }).pipe(
-            Effect.interruptible,
             Effect.timeout(5000),
+            Effect.interruptible,
             Effect.catchAllCause(() => Effect.sync(() => worker.terminate()))
           )
         ),

--- a/packages/platform-node/src/internal/worker.ts
+++ b/packages/platform-node/src/internal/worker.ts
@@ -20,8 +20,8 @@ const platformWorkerImpl = Worker.makePlatform<WorkerThreads.Worker>()({
             worker.postMessage([1])
             return Deferred.await(exitDeferred)
           }).pipe(
-            Effect.interruptible,
             Effect.timeout(5000),
+            Effect.interruptible,
             Effect.catchAllCause(() => Effect.sync(() => worker.terminate()))
           )
         ),


### PR DESCRIPTION
I was facing some process shutdown issues where the timeout seems to have blocked the shutdown of the process. After some investigation (thanks @fubhy) we realized that changing the order of the `Effect.interruptible` like the following fixed the issue:

```ts
      return Effect.as(
        Scope.addFinalizer(
          scope,
          Effect.suspend(() => {
            worker.postMessage([1])
            return Deferred.await(exitDeferred)
          }).pipe(
            Effect.timeout(5000),
            Effect.interruptible,
            Effect.catchAllCause(() => Effect.sync(() => worker.terminate()))
          )
        ),
        worker
      )
```