### PR TITLE
Preserve branded primitive types in `DeepMutable` transformation, clo…

### DIFF
--- a/.changeset/soft-meals-notice.md
+++ b/.changeset/soft-meals-notice.md
@@ -1,0 +1,46 @@
+---
+"effect": patch
+---
+
+Preserve branded primitive types in `DeepMutable` transformation, closes #4542.
+
+Previously, applying `DeepMutable` to branded primitive types (e.g., `string & Brand.Brand<"mybrand">`) caused unexpected behavior, where `String` prototype methods were incorrectly inherited.
+
+This fix ensures that branded types remain unchanged during transformation, preventing type inconsistencies.
+
+**Example**
+
+Before
+
+```ts
+import type { Brand, Types } from "effect"
+
+type T = string & Brand.Brand<"mybrand">
+
+/*
+type Result = {
+    [x: number]: string;
+    toString: () => string;
+    charAt: (pos: number) => string;
+    charCodeAt: (index: number) => number;
+    concat: (...strings: string[]) => string;
+    indexOf: (searchString: string, position?: number) => number;
+    ... 47 more ...;
+    [BrandTypeId]: {
+        ...;
+    };
+}
+*/
+type Result = Types.DeepMutable<T>
+```
+
+After
+
+```ts
+import type { Brand, Types } from "effect"
+
+type T = string & Brand.Brand<"mybrand">
+
+// type Result = string & Brand.Brand<"mybrand">
+type Result = Types.DeepMutable<T>
+```

--- a/packages/effect/dtslint/Types.tst.ts
+++ b/packages/effect/dtslint/Types.tst.ts
@@ -1,4 +1,4 @@
-import type * as Types from "effect/Types"
+import type { Brand, Types } from "effect"
 import { describe, expect, it } from "tstyche"
 
 describe("Types", () => {
@@ -140,20 +140,47 @@ describe("Types", () => {
       >().type.toBe<[string, number, boolean, bigint, symbol, never, null, "a", 1, true]>()
     })
 
-    describe("record", () => {
-      it("should convert a readonly record to a mutable record", () => {
+    describe("Branded", () => {
+      it("should leave a string brand unchanged", () => {
+        type T = string & Brand.Brand<"mybrand">
+        expect<Types.DeepMutable<T>>().type.toBe<T>()
+      })
+
+      it("should leave a number brand unchanged", () => {
+        type T = number & Brand.Brand<"mybrand">
+        expect<Types.DeepMutable<T>>().type.toBe<T>()
+      })
+
+      it("should leave a boolean brand unchanged", () => {
+        type T = boolean & Brand.Brand<"mybrand">
+        expect<Types.DeepMutable<T>>().type.toBe<T>()
+      })
+
+      it("should leave a bigint brand unchanged", () => {
+        type T = bigint & Brand.Brand<"mybrand">
+        expect<Types.DeepMutable<T>>().type.toBe<T>()
+      })
+
+      it("should leave a symbol brand unchanged", () => {
+        type T = symbol & Brand.Brand<"mybrand">
+        expect<Types.DeepMutable<T>>().type.toBe<T>()
+      })
+    })
+
+    describe("Index Signature", () => {
+      it("should convert an readonly Index Signature to a mutable Index Signature", () => {
         expect<Types.DeepMutable<{ readonly [x: string]: number }>>()
           .type.toBe<{ [x: string]: number }>()
       })
 
-      it("should leave a mutable record unchanged", () => {
+      it("should leave an Index Signature unchanged", () => {
         expect<Types.DeepMutable<{ [_: string]: number }>>()
           .type.toBe<{ [x: string]: number }>()
       })
     })
 
-    describe("struct", () => {
-      it("should convert an empty object", () => {
+    describe("Struct", () => {
+      it("should support an empty object", () => {
         expect<Types.DeepMutable<{}>>()
           .type.toBe<{}>()
       })
@@ -175,7 +202,7 @@ describe("Types", () => {
       })
     })
 
-    describe("array", () => {
+    describe("Array", () => {
       it("should convert a readonly empty array to a mutable empty array", () => {
         expect<Types.DeepMutable<readonly []>>()
           .type.toBe<[]>()
@@ -197,7 +224,7 @@ describe("Types", () => {
       })
     })
 
-    describe("tuple", () => {
+    describe("Tuple", () => {
       it("should convert a readonly tuple", () => {
         expect<Types.DeepMutable<readonly [string, number, boolean]>>()
           .type.toBe<[string, number, boolean]>()
@@ -209,7 +236,7 @@ describe("Types", () => {
       })
     })
 
-    describe("Set", () => {
+    describe("ReadonlySet", () => {
       it("should convert a ReadonlySet to a mutable Set", () => {
         expect<Types.DeepMutable<ReadonlySet<{ readonly value: TaggedValues<number> }>>>()
           .type.toBe<Set<{ value: { _tag: string; value: Array<number> } }>>()
@@ -221,7 +248,7 @@ describe("Types", () => {
       })
     })
 
-    describe("Map", () => {
+    describe("ReadonlyMap", () => {
       it("should convert a ReadonlyMap to a mutable Map", () => {
         expect<Types.DeepMutable<ReadonlyMap<TaggedValues<string>, ReadonlySet<TaggedValues<number>>>>>()
           .type.toBe<Map<{ _tag: string; value: Array<string> }, Set<{ _tag: string; value: Array<number> }>>>()
@@ -230,6 +257,30 @@ describe("Types", () => {
       it("should leave a mutable Map unchanged", () => {
         expect<Types.DeepMutable<Map<TaggedValues<string>, ReadonlySet<TaggedValues<number>>>>>()
           .type.toBe<Map<{ _tag: string; value: Array<string> }, Set<{ _tag: string; value: Array<number> }>>>()
+      })
+    })
+
+    describe("Union", () => {
+      it("should convert a readonly union to a mutable union", () => {
+        type T =
+          | ReadonlySet<{ readonly value: TaggedValues<number> }>
+          | ReadonlyMap<TaggedValues<string>, ReadonlySet<TaggedValues<number>>>
+        expect<Types.DeepMutable<T>>()
+          .type.toBe<
+          | Set<{ value: { _tag: string; value: Array<number> } }>
+          | Map<{ _tag: string; value: Array<string> }, Set<{ _tag: string; value: Array<number> }>>
+        >()
+      })
+
+      it("should leave a mutable union unchanged", () => {
+        type T =
+          | ReadonlySet<{ readonly value: TaggedValues<number> }>
+          | ReadonlyMap<TaggedValues<string>, ReadonlySet<TaggedValues<number>>>
+        expect<Types.DeepMutable<T>>()
+          .type.toBe<
+          | Set<{ value: { _tag: string; value: Array<number> } }>
+          | Map<{ _tag: string; value: Array<string> }, Set<{ _tag: string; value: Array<number> }>>
+        >()
       })
     })
   })

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -251,7 +251,7 @@ export type Mutable<T> = {
  */
 export type DeepMutable<T> = T extends ReadonlyMap<infer K, infer V> ? Map<DeepMutable<K>, DeepMutable<V>>
   : T extends ReadonlySet<infer V> ? Set<DeepMutable<V>>
-  : [keyof T] extends [never] ? T
+  : T extends string | number | boolean | bigint | symbol ? T
   : { -readonly [K in keyof T]: DeepMutable<T[K]> }
 
 /**


### PR DESCRIPTION
…ses #4542

Previously, applying `DeepMutable` to branded primitive types (e.g., `string & Brand.Brand<"mybrand">`) caused unexpected behavior, where `String` prototype methods were incorrectly inherited.

This fix ensures that branded types remain unchanged during transformation, preventing type inconsistencies.

**Example**

Before

```ts
import type { Brand, Types } from "effect"

type T = string & Brand.Brand<"mybrand">

/*
type Result = {
    [x: number]: string;
    toString: () => string;
    charAt: (pos: number) => string;
    charCodeAt: (index: number) => number;
    concat: (...strings: string[]) => string;
    indexOf: (searchString: string, position?: number) => number;
    ... 47 more ...;
    [BrandTypeId]: {
        ...;
    };
}
*/
type Result = Types.DeepMutable<T>
```

After

```ts
import type { Brand, Types } from "effect"

type T = string & Brand.Brand<"mybrand">

// type Result = string & Brand.Brand<"mybrand">
type Result = Types.DeepMutable<T>
```
