### PR TITLE
Arbitrary: `make` called on `Schema.Class` now respects property anno…

### DIFF
--- a/.changeset/lemon-peas-try.md
+++ b/.changeset/lemon-peas-try.md
@@ -1,0 +1,58 @@
+---
+"effect": patch
+---
+
+Arbitrary: `make` called on `Schema.Class` now respects property annotations, closes #4550.
+
+Previously, when calling `Arbitrary.make` on a `Schema.Class`, property-specific annotations (such as `arbitrary`) were ignored, leading to unexpected values in generated instances.
+
+Before
+
+Even though `a` had an `arbitrary` annotation, the generated values were random:
+
+```ts
+import { Arbitrary, FastCheck, Schema } from "effect"
+
+class Class extends Schema.Class<Class>("Class")({
+  a: Schema.NumberFromString.annotations({
+    arbitrary: () => (fc) => fc.constant(1)
+  })
+}) {}
+
+console.log(FastCheck.sample(Arbitrary.make(Class), 5))
+/*
+Example Output:
+[
+  Class { a: 2.6624670822171524e-44 },
+  Class { a: 3.4028177873105996e+38 },
+  Class { a: 3.402820626847944e+38 },
+  Class { a: 3.783505853677006e-44 },
+  Class { a: 3243685 }
+]
+*/
+```
+
+After
+
+Now, the values respect the `arbitrary` annotation and return the expected constant:
+
+```ts
+import { Arbitrary, FastCheck, Schema } from "effect"
+
+class Class extends Schema.Class<Class>("Class")({
+  a: Schema.NumberFromString.annotations({
+    arbitrary: () => (fc) => fc.constant(1)
+  })
+}) {}
+
+console.log(FastCheck.sample(Arbitrary.make(Class), 5))
+/*
+[
+  Class { a: 1 },
+  Class { a: 1 },
+  Class { a: 1 },
+  Class { a: 1 },
+  Class { a: 1 }
+]
+*/
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8907,7 +8907,7 @@ const makeClass = <Fields extends Struct.Fields>(
       }
 
       const declaration: Schema.Any = declare(
-        [typeSide],
+        [schema],
         {
           decode: () => (input, _, ast) =>
             input instanceof this || fallbackInstanceOf(input)

--- a/packages/effect/test/Schema/Arbitrary/Class.test.ts
+++ b/packages/effect/test/Schema/Arbitrary/Class.test.ts
@@ -1,8 +1,16 @@
 import { describe, it } from "@effect/vitest"
-import * as S from "effect/Schema"
+import { Arbitrary, FastCheck, Schema as S } from "effect"
 import * as Util from "effect/test/Schema/TestUtils"
 
 describe("Class", () => {
+  it("baseline", () => {
+    class Class extends S.Class<Class>("Class")({
+      a: S.String,
+      b: S.NumberFromString
+    }) {}
+    Util.assertions.arbitrary.validateGeneratedValues(Class)
+  })
+
   it("required property signature", () => {
     class Class extends S.Class<Class>("Class")({
       a: S.Number
@@ -31,11 +39,13 @@ describe("Class", () => {
     Util.assertions.arbitrary.validateGeneratedValues(Class)
   })
 
-  it("baseline", () => {
+  it("transformation property signature with annotation (#4550)", () => {
     class Class extends S.Class<Class>("Class")({
-      a: S.String,
-      b: S.NumberFromString
+      a: S.NumberFromString.annotations({
+        arbitrary: () => (fc) => fc.constant(1)
+      })
     }) {}
-    Util.assertions.arbitrary.validateGeneratedValues(Class)
+    const arb = Arbitrary.make(Class)
+    FastCheck.assert(FastCheck.property(arb, (a) => a.a === 1))
   })
 })


### PR DESCRIPTION
…tations, closes #4550

Previously, when calling `Arbitrary.make` on a `Schema.Class`, property-specific annotations (such as `arbitrary`) were ignored, leading to unexpected values in generated instances.

Before

Even though `a` had an `arbitrary` annotation, the generated values were random:

```ts
import { Arbitrary, FastCheck, Schema } from "effect"

class Class extends Schema.Class<Class>("Class")({
  a: Schema.NumberFromString.annotations({
    arbitrary: () => (fc) => fc.constant(1)
  })
}) {}

console.log(FastCheck.sample(Arbitrary.make(Class), 5))
/*
Example Output:
[
  Class { a: 2.6624670822171524e-44 },
  Class { a: 3.4028177873105996e+38 },
  Class { a: 3.402820626847944e+38 },
  Class { a: 3.783505853677006e-44 },
  Class { a: 3243685 }
]
*/
```

After

Now, the values respect the `arbitrary` annotation and return the expected constant:

```ts
import { Arbitrary, FastCheck, Schema } from "effect"

class Class extends Schema.Class<Class>("Class")({
  a: Schema.NumberFromString.annotations({
    arbitrary: () => (fc) => fc.constant(1)
  })
}) {}

console.log(FastCheck.sample(Arbitrary.make(Class), 5))
/*
[
  Class { a: 1 },
  Class { a: 1 },
  Class { a: 1 },
  Class { a: 1 },
  Class { a: 1 }
]
*/
```
