### PR TITLE
ParseResult.ArrayFormatter: correct `_tag` fields for `Refinement` an…

### DIFF
--- a/.changeset/sour-masks-laugh.md
+++ b/.changeset/sour-masks-laugh.md
@@ -1,0 +1,89 @@
+---
+"effect": patch
+---
+
+ParseResult.ArrayFormatter: correct `_tag` fields for `Refinement` and `Transformation` issues, closes #4564.
+
+This update fixes an issue where `ParseResult.ArrayFormatter` incorrectly labeled **Refinement** and **Transformation** errors as `Type` in the output.
+
+**Before**
+
+```ts
+import { Effect, ParseResult, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.NonEmptyString,
+  b: Schema.NumberFromString
+})
+
+const input = { a: "", b: "" }
+
+const program = Schema.decodeUnknown(schema, { errors: "all" })(input).pipe(
+  Effect.catchTag("ParseError", (err) =>
+    ParseResult.ArrayFormatter.formatError(err).pipe(
+      Effect.map((err) => JSON.stringify(err, null, 2))
+    )
+  )
+)
+
+program.pipe(Effect.runPromise).then(console.log)
+/*
+[
+  {
+    "_tag": "Type", ❌
+    "path": [
+      "a"
+    ],
+    "message": "Expected a non empty string, actual \"\""
+  },
+  {
+    "_tag": "Type", ❌
+    "path": [
+      "b"
+    ],
+    "message": "Unable to decode \"\" into a number"
+  }
+]
+*/
+```
+
+**After**
+
+```ts
+import { Effect, ParseResult, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.NonEmptyString,
+  b: Schema.NumberFromString
+})
+
+const input = { a: "", b: "" }
+
+const program = Schema.decodeUnknown(schema, { errors: "all" })(input).pipe(
+  Effect.catchTag("ParseError", (err) =>
+    ParseResult.ArrayFormatter.formatError(err).pipe(
+      Effect.map((err) => JSON.stringify(err, null, 2))
+    )
+  )
+)
+
+program.pipe(Effect.runPromise).then(console.log)
+/*
+[
+  {
+    "_tag": "Refinement", ✅
+    "path": [
+      "a"
+    ],
+    "message": "Expected a non empty string, actual \"\""
+  },
+  {
+    "_tag": "Transformation", ✅
+    "path": [
+      "b"
+    ],
+    "message": "Unable to decode \"\" into a number"
+  }
+]
+*/
+```

--- a/packages/effect/test/Schema/ParseResultFormatter.test.ts
+++ b/packages/effect/test/Schema/ParseResultFormatter.test.ts
@@ -579,7 +579,7 @@ describe("Formatters output", () => {
           S.String,
           {
             strict: true,
-            decode: (s, _, ast) => ParseResult.fail(new ParseResult.Type(ast, s, "message field")),
+            decode: (s, _, ast) => ParseResult.fail(new ParseResult.Type(ast, s, "transformation failure")),
             encode: ParseResult.succeed
           }
         )
@@ -589,12 +589,12 @@ describe("Formatters output", () => {
           input,
           `(string <-> string)
 └─ Transformation process failure
-   └─ message field`
+   └─ transformation failure`
         )
         expectSyncIssues(schema, input, [{
-          _tag: "Type",
+          _tag: "Transformation",
           path: [],
-          message: "message field"
+          message: "transformation failure"
         }])
       })
 
@@ -713,7 +713,7 @@ describe("Formatters output", () => {
          └─ Expected a non empty string, actual ""`
         )
         expectSyncIssues(schema, input, [{
-          _tag: "Type",
+          _tag: "Refinement",
           path: [],
           message: `Expected a non empty string, actual ""`
         }])
@@ -881,7 +881,7 @@ describe("Formatters output", () => {
    └─ Expected a string at least 1 character(s) long, actual ""`
         )
         expectSyncIssues(schema, input, [{
-          _tag: "Type",
+          _tag: "Refinement",
           path: [],
           message: `Expected a string at least 1 character(s) long, actual ""`
         }])
@@ -898,7 +898,7 @@ describe("Formatters output", () => {
    └─ Expected a string at least 1 character(s) long, actual ""`
         )
         expectSyncIssues(schema, input, [{
-          _tag: "Type",
+          _tag: "Refinement",
           path: [],
           message: `Expected a string at least 1 character(s) long, actual ""`
         }])


### PR DESCRIPTION
…d `Transformation` issues, closes #4564

This update fixes an issue where `ParseResult.ArrayFormatter` incorrectly labeled **Refinement** and **Transformation** errors as `Type` in the output.

**Before**

```ts
import { Effect, ParseResult, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.NonEmptyString,
  b: Schema.NumberFromString
})

const input = { a: "", b: "" }

const program = Schema.decodeUnknown(schema, { errors: "all" })(input).pipe(
  Effect.catchTag("ParseError", (err) =>
    ParseResult.ArrayFormatter.formatError(err).pipe(
      Effect.map((err) => JSON.stringify(err, null, 2))
    )
  )
)

program.pipe(Effect.runPromise).then(console.log)
/*
[
  {
    "_tag": "Type", ❌
    "path": [
      "a"
    ],
    "message": "Expected a non empty string, actual \"\""
  },
  {
    "_tag": "Type", ❌
    "path": [
      "b"
    ],
    "message": "Unable to decode \"\" into a number"
  }
]
*/
```

**After**

```ts
import { Effect, ParseResult, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.NonEmptyString,
  b: Schema.NumberFromString
})

const input = { a: "", b: "" }

const program = Schema.decodeUnknown(schema, { errors: "all" })(input).pipe(
  Effect.catchTag("ParseError", (err) =>
    ParseResult.ArrayFormatter.formatError(err).pipe(
      Effect.map((err) => JSON.stringify(err, null, 2))
    )
  )
)

program.pipe(Effect.runPromise).then(console.log)
/*
[
  {
    "_tag": "Refinement", ✅
    "path": [
      "a"
    ],
    "message": "Expected a non empty string, actual \"\""
  },
  {
    "_tag": "Transformation", ✅
    "path": [
      "b"
    ],
    "message": "Unable to decode \"\" into a number"
  }
]
*/
```
