### PR TITLE
Add ParseOptions argument to standardSchemaV1

### DIFF
--- a/.changeset/five-melons-leave.md
+++ b/.changeset/five-melons-leave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add ParseOptions argument to standardSchemaV1

--- a/.changeset/five-melons-leave.md
+++ b/.changeset/five-melons-leave.md
@@ -2,4 +2,6 @@
 "effect": patch
 ---
 
-Add ParseOptions argument to standardSchemaV1
+Schema: `standardSchemaV1` now returns all errors by default and supports custom options.
+
+The `standardSchemaV1` now returns **all validation errors** by default (`ParseOptions = { errors: "all" }`). Additionally, it now accepts an optional `overrideOptions` parameter, allowing you to customize the default parsing behavior as needed.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -194,9 +194,9 @@ const makeStandardFailureFromParseIssue = (
  */
 export const standardSchemaV1 = <A, I>(
   schema: Schema<A, I, never>,
-  options?: AST.ParseOptions
+  overrideOptions?: AST.ParseOptions
 ): StandardSchemaV1<I, A> => {
-  const decodeUnknown = ParseResult.decodeUnknown(schema, options)
+  const decodeUnknown = ParseResult.decodeUnknown(schema, { errors: "all" })
   return {
     "~standard": {
       version: 1,
@@ -204,7 +204,7 @@ export const standardSchemaV1 = <A, I>(
       validate(value) {
         const scheduler = new scheduler_.SyncScheduler()
         const fiber = Effect.runFork(
-          Effect.matchEffect(decodeUnknown(value), {
+          Effect.matchEffect(decodeUnknown(value, overrideOptions), {
             onFailure: makeStandardFailureFromParseIssue,
             onSuccess: (value) => Effect.succeed({ value })
           }),

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -192,8 +192,11 @@ const makeStandardFailureFromParseIssue = (
  * @category Standard Schema
  * @since 3.13.0
  */
-export const standardSchemaV1 = <A, I>(schema: Schema<A, I, never>): StandardSchemaV1<I, A> => {
-  const decodeUnknown = ParseResult.decodeUnknown(schema)
+export const standardSchemaV1 = <A, I>(
+  schema: Schema<A, I, never>,
+  options?: AST.ParseOptions
+): StandardSchemaV1<I, A> => {
+  const decodeUnknown = ParseResult.decodeUnknown(schema, options)
   return {
     "~standard": {
       version: 1,

--- a/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
@@ -252,7 +252,7 @@ describe("standardSchemaV1", () => {
       a: Schema.NonEmptyString,
       b: Schema.NonEmptyString
     })
-    const standardSchema = Schema.standardSchemaV1(schema, { errors: "all" })
+    const standardSchema = Schema.standardSchemaV1(schema)
     expectSyncSuccess(standardSchema, {
       a: "a",
       b: "b"
@@ -283,6 +283,59 @@ describe("standardSchemaV1", () => {
       {
         message: `Expected a non empty string, actual ""`,
         path: ["b"]
+      }
+    ])
+    expectSyncFailure(standardSchema, {
+      a: "a",
+      b: ""
+    }, [
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["b"]
+      }
+    ])
+    expectSyncFailure(standardSchema, {
+      a: "",
+      b: "b"
+    }, [
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["a"]
+      }
+    ])
+  })
+  it("sync decoding + sync first issue formatting", () => {
+    const schema = Schema.Struct({
+      a: Schema.NonEmptyString,
+      b: Schema.NonEmptyString
+    })
+    const standardSchema = Schema.standardSchemaV1(schema, { errors: "first" })
+    expectSyncSuccess(standardSchema, {
+      a: "a",
+      b: "b"
+    }, {
+      a: "a",
+      b: "b"
+    })
+    expectSyncFailure(standardSchema, null, [
+      {
+        message: "Expected { readonly a: NonEmptyString; readonly b: NonEmptyString }, actual null",
+        path: []
+      }
+    ])
+    expectSyncFailure(standardSchema, "", [
+      {
+        message: `Expected { readonly a: NonEmptyString; readonly b: NonEmptyString }, actual ""`,
+        path: []
+      }
+    ])
+    expectSyncFailure(standardSchema, {
+      a: "",
+      b: ""
+    }, [
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["a"]
       }
     ])
     expectSyncFailure(standardSchema, {

--- a/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
@@ -2,6 +2,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec"
 import { Context, Effect, ParseResult, Predicate, Schema } from "effect"
 import { assertTrue, deepStrictEqual, strictEqual } from "effect/test/util"
 import { describe, it } from "vitest"
+import { b } from "vitest/dist/chunks/suite.BJU7kdY9.js"
 import { AsyncString } from "../TestUtils.js"
 
 function validate<I, A>(
@@ -245,5 +246,63 @@ describe("standardSchemaV1", () => {
         assertTrue(issues[0].message.includes("Service not found: Min"))
       })
     })
+  })
+
+  it("sync decoding + sync all issues formatting", () => {
+    const schema = Schema.Struct({
+      a: Schema.NonEmptyString,
+      b: Schema.NonEmptyString
+    })
+    const standardSchema = Schema.standardSchemaV1(schema, { errors: "all" })
+    expectSyncSuccess(standardSchema, {
+      a: "a",
+      b: "b"
+    }, {
+      a: "a",
+      b: "b"
+    })
+    expectSyncFailure(standardSchema, null, [
+      {
+        message: "Expected { readonly a: NonEmptyString; readonly b: NonEmptyString }, actual null",
+        path: []
+      }
+    ])
+    expectSyncFailure(standardSchema, "", [
+      {
+        message: `Expected { readonly a: NonEmptyString; readonly b: NonEmptyString }, actual ""`,
+        path: []
+      }
+    ])
+    expectSyncFailure(standardSchema, {
+      a: "",
+      b: ""
+    }, [
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["a"]
+      },
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["b"]
+      }
+    ])
+    expectSyncFailure(standardSchema, {
+      a: "a",
+      b: ""
+    }, [
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["b"]
+      }
+    ])
+    expectSyncFailure(standardSchema, {
+      a: "",
+      b: "b"
+    }, [
+      {
+        message: `Expected a non empty string, actual ""`,
+        path: ["a"]
+      }
+    ])
   })
 })

--- a/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
@@ -2,7 +2,6 @@ import type { StandardSchemaV1 } from "@standard-schema/spec"
 import { Context, Effect, ParseResult, Predicate, Schema } from "effect"
 import { assertTrue, deepStrictEqual, strictEqual } from "effect/test/util"
 import { describe, it } from "vitest"
-import { b } from "vitest/dist/chunks/suite.BJU7kdY9.js"
 import { AsyncString } from "../TestUtils.js"
 
 function validate<I, A>(


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Add optional ParseOptions argument to standardSchemaV1. This will make form validation in form libraries like [@tanstack/form](https://tanstack.com/form/latest) more usable (i.e. display all errors to the user instead of just the first)

