### PR TITLE
fix: unnecessary `as` in `all` function in the Effect `Either` module

### DIFF
--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -750,7 +750,7 @@ export const all: <const I extends Iterable<Either<any, any>> | Record<string, E
   ): Either<any, any> => {
     if (Symbol.iterator in input) {
       const out: Array<Either<any, any>> = []
-      for (const e of (input as Iterable<Either<any, any>>)) {
+      for (const e of input) {
         if (isLeft(e)) {
           return e
         }


### PR DESCRIPTION
## Type

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Removed unnecessary `as` in `all` function from the `Either` module. Currently the `input` is correctly inferred by the compiler as an `Iterable<Either<any, any>>`.  I believe the `as` in this case was a leftover of a previous implementation.

I also tried to remove the `@ts-expect-error` at the start of the function, but I did not manage to fix the type error.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
