### PR TITLE
Allow `toString` Method to Be Overridden in Schema Classes, closes #4577

### DIFF
--- a/.changeset/breezy-ties-sparkle.md
+++ b/.changeset/breezy-ties-sparkle.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Allow `toString` Method to Be Overridden in Schema Classes, closes #4577.
+
+Previously, attempting to override the `toString` method in schema classes caused a `TypeError` in the browser because the property was set as **read-only** (`writable: false`). This fix makes `toString` **writable**, allowing developers to override it when needed.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -9058,7 +9058,8 @@ const makeClass = <Fields extends Struct.Fields>(
             .join(", ")
         } })`
       },
-      configurable: true
+      configurable: true,
+      writable: true
     })
   }
   return klass


### PR DESCRIPTION
Previously, attempting to override the `toString` method in schema classes caused a `TypeError` in the browser because the property was set as **read-only** (`writable: false`). This fix makes `toString` **writable**, allowing developers to override it when needed.
