### PR TITLE
fix: `Match.tags` throwing on `undefined` input

### DIFF
--- a/.changeset/purple-months-begin.md
+++ b/.changeset/purple-months-begin.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Match.tags` throwing exception on `undefined` input value

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -396,7 +396,7 @@ export const discriminators = <D extends string>(field: D) =>
   fields: P
 ) => {
   const predicate = makeWhen(
-    (_: any) => _[field] in fields,
+    (arg: any) => arg != null && arg[field] in fields,
     (data: any) => (fields as any)[data[field]](data)
   )
 

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -7,6 +7,7 @@ import {
   assertRight,
   assertSome,
   assertTrue,
+  doesNotThrow,
   strictEqual,
   throws
 } from "effect/test/util"
@@ -197,6 +198,16 @@ describe("Match", () => {
       M.exhaustive
     )
     strictEqual(match({ type: "B" }), "B")
+  })
+
+  it("discriminator with nullables", () => {
+    const match = pipe(
+      M.type<{ _tag: "A" } | undefined>().pipe(
+        M.tags({ A: (x) => x._tag }),
+        M.orElse(() => null)
+      )
+    )
+    doesNotThrow(() => match(undefined))
   })
 
   it("discriminator multiple", () => {


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

By testing out [4303](https://github.com/Effect-TS/effect/issues/4303) I could successfully reproduce the issue.

I followed the stack trace and verified that there was no check for `null` or `undefined` before executing the `unsafe` type introspection with the `key in object` syntax. 

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #4303 
- Closes #4303 
