### PR TITLE
fix: unnecessary `as` type cohercion in `Either.fromNullable`

### DIFF
--- a/packages/effect/dtslint/Either.tst.ts
+++ b/packages/effect/dtslint/Either.tst.ts
@@ -137,6 +137,38 @@ describe("Either", () => {
     ).type.toBe<Either.Either<number, "b">>()
   })
 
+  it("fromNullable", () => {
+    const nullableString = hole<string | null>()
+    const nullableObject = hole<{ a: string } | undefined>()
+
+    expect(
+      Either.fromNullable(
+        nullableString,
+        () => new Error()
+      )
+    ).type.toBe<Either.Either<string, Error>>()
+
+    expect(
+      pipe(
+        nullableString,
+        Either.fromNullable(() => new Error())
+      )
+    ).type.toBe<Either.Either<string, Error>>()
+
+    expect(
+      Either.fromNullable(nullableObject, () => new Error())
+    ).type.toBe<Either.Either<{ a: string }, Error>>()
+
+    expect(
+      pipe(
+        nullableObject,
+        Either.fromNullable(() => new Error())
+      )
+    ).type.toBe<
+      Either.Either<{ a: string }, Error>
+    >()
+  })
+
   it("filterOrLeft", () => {
     const predicateUnknown = hole<Predicate.Predicate<unknown>>()
 

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -158,7 +158,7 @@ export const fromNullable: {
 } = dual(
   2,
   <R, L>(self: R, onNullable: (right: R) => L): Either<NonNullable<R>, L> =>
-    self == null ? left(onNullable(self)) : right(self as NonNullable<R>)
+    self == null ? left(onNullable(self)) : right(self)
 )
 
 /**


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

Fixes unnecessary `as` in `Either.fromNullable`. Covered the change with type tests.
