### PR TITLE
Add Effect.transposeMapOption

### DIFF
--- a/.changeset/small-ties-love.md
+++ b/.changeset/small-ties-love.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Effect.traverseOption

--- a/.changeset/small-ties-love.md
+++ b/.changeset/small-ties-love.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-Add Effect.traverseOption
+Add Effect.transposeMapOption

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1392,4 +1392,37 @@ describe("Effect", () => {
       Effect.Effect<Option.Option<string>, "err-1", "dep-1">
     >()
   })
+
+  it("traverseOption", () => {
+    expect(Effect.traverseOption(Option.none(), (value) => {
+      expect(value).type.toBe<never>()
+      return string
+    })).type.toBe<
+      Effect.Effect<Option.Option<string>, "err-1", "dep-1">
+    >()
+    expect(pipe(
+      Option.none(),
+      Effect.traverseOption((value) => {
+        expect(value).type.toBe<never>()
+        return string
+      })
+    )).type.toBe<
+      Effect.Effect<Option.Option<string>, "err-1", "dep-1">
+    >()
+    expect(Effect.traverseOption(Option.some(42), (value) => {
+      expect(value).type.toBe<number>()
+      return string
+    })).type.toBe<
+      Effect.Effect<Option.Option<string>, "err-1", "dep-1">
+    >()
+    expect(pipe(
+      Option.some(42),
+      Effect.traverseOption((value) => {
+        expect(value).type.toBe<number>()
+        return string
+      })
+    )).type.toBe<
+      Effect.Effect<Option.Option<string>, "err-1", "dep-1">
+    >()
+  })
 })

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1393,8 +1393,8 @@ describe("Effect", () => {
     >()
   })
 
-  it("traverseOption", () => {
-    expect(Effect.traverseOption(Option.none(), (value) => {
+  it("transposeMapOption", () => {
+    expect(Effect.transposeMapOption(Option.none(), (value) => {
       expect(value).type.toBe<never>()
       return string
     })).type.toBe<
@@ -1402,14 +1402,14 @@ describe("Effect", () => {
     >()
     expect(pipe(
       Option.none(),
-      Effect.traverseOption((value) => {
+      Effect.transposeMapOption((value) => {
         expect(value).type.toBe<never>()
         return string
       })
     )).type.toBe<
       Effect.Effect<Option.Option<string>, "err-1", "dep-1">
     >()
-    expect(Effect.traverseOption(Option.some(42), (value) => {
+    expect(Effect.transposeMapOption(Option.some(42), (value) => {
       expect(value).type.toBe<number>()
       return string
     })).type.toBe<
@@ -1417,7 +1417,7 @@ describe("Effect", () => {
     >()
     expect(pipe(
       Option.some(42),
-      Effect.traverseOption((value) => {
+      Effect.transposeMapOption((value) => {
         expect(value).type.toBe<number>()
         return string
       })

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -13084,7 +13084,7 @@ export const transposeOption = <A = never, E = never, R = never>(
  * //          ▼
  * const noneResult = yield* pipe(
  *   Option.none(),
- *   Effect.traverseOption(() => Effect.succeed(42)) // will not be executed
+ *   Effect.transposeMapOption(() => Effect.succeed(42)) // will not be executed
  * )
  * console.log(Effect.runSync(noneResult))
  * // Output: { _id: 'Option', _tag: 'None' }
@@ -13093,7 +13093,7 @@ export const transposeOption = <A = never, E = never, R = never>(
  * //          ▼
  * const someSuccessResult = yield* pipe(
  *   Option.some(42),
- *   Effect.traverseOption((value) => Effect.succeed(value * 2))
+ *   Effect.transposeMapOption((value) => Effect.succeed(value * 2))
  * )
  * console.log(Effect.runSync(someSuccessResult))
  * // Output: { _id: 'Option', _tag: 'Some', value: 84 }
@@ -13101,7 +13101,7 @@ export const transposeOption = <A = never, E = never, R = never>(
  * @since 3.14.0
  * @category Optional Wrapping & Unwrapping
  */
-export const traverseOption = dual<
+export const transposeMapOption = dual<
   <A, B, E = never, R = never>(
     f: (self: A) => Effect<B, E, R>
   ) => (self: Option.Option<A>) => Effect<Option.Option<B>, E, R>,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -13078,11 +13078,11 @@ export const transposeOption = <A = never, E = never, R = never>(
  *
  * @example
  * ```ts
- * import { Effect, Option } from "effect"
+ * import { Effect, Option, pipe } from "effect"
  *
  * //          ┌─── Effect<Option<number>, never, never>>
  * //          ▼
- * const noneResult = yield* pipe(
+ * const noneResult = pipe(
  *   Option.none(),
  *   Effect.transposeMapOption(() => Effect.succeed(42)) // will not be executed
  * )
@@ -13091,12 +13091,13 @@ export const transposeOption = <A = never, E = never, R = never>(
  *
  * //          ┌─── Effect<Option<number>, never, never>>
  * //          ▼
- * const someSuccessResult = yield* pipe(
+ * const someSuccessResult = pipe(
  *   Option.some(42),
  *   Effect.transposeMapOption((value) => Effect.succeed(value * 2))
  * )
  * console.log(Effect.runSync(someSuccessResult))
  * // Output: { _id: 'Option', _tag: 'Some', value: 84 }
+ * ```
  *
  * @since 3.14.0
  * @category Optional Wrapping & Unwrapping

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -13068,6 +13068,16 @@ export const transposeOption = <A = never, E = never, R = never>(
   return option_.isNone(self) ? succeedNone : map(self.value, option_.some)
 }
 
+export const traverseOption = dual<
+  <A, B, E = never, R = never>(
+    f: (self: A) => Effect<B, E, R>
+  ) => (self: Option.Option<A>) => Effect<Option.Option<B>, E, R>,
+  <A, B, E = never, R = never>(
+    self: Option.Option<A>,
+    f: (self: A) => Effect<B, E, R>
+  ) => Effect<Option.Option<B>, E, R>
+>(2, (self, f) => option_.isNone(self) ? succeedNone : map(f(self.value), option_.some))
+
 /**
  * @since 2.0.0
  * @category Models

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -13068,6 +13068,39 @@ export const transposeOption = <A = never, E = never, R = never>(
   return option_.isNone(self) ? succeedNone : map(self.value, option_.some)
 }
 
+/**
+ * Applies an `Effect` on an `Option` and transposes the result.
+ *
+ * **Details**
+ *
+ * If the `Option` is `None`, the resulting `Effect` will immediately succeed with a `None` value.
+ * If the `Option` is `Some`, the effectful operation will be executed on the inner value, and its result wrapped in a `Some`.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Option } from "effect"
+ *
+ * //          ┌─── Effect<Option<number>, never, never>>
+ * //          ▼
+ * const noneResult = yield* pipe(
+ *   Option.none(),
+ *   Effect.traverseOption(() => Effect.succeed(42)) // will not be executed
+ * )
+ * console.log(Effect.runSync(noneResult))
+ * // Output: { _id: 'Option', _tag: 'None' }
+ *
+ * //          ┌─── Effect<Option<number>, never, never>>
+ * //          ▼
+ * const someSuccessResult = yield* pipe(
+ *   Option.some(42),
+ *   Effect.traverseOption((value) => Effect.succeed(value * 2))
+ * )
+ * console.log(Effect.runSync(someSuccessResult))
+ * // Output: { _id: 'Option', _tag: 'Some', value: 84 }
+ *
+ * @since 3.14.0
+ * @category Optional Wrapping & Unwrapping
+ */
 export const traverseOption = dual<
   <A, B, E = never, R = never>(
     f: (self: A) => Effect<B, E, R>

--- a/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
+++ b/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
@@ -18,27 +18,27 @@ describe("Effect", () => {
         assert.deepStrictEqual(result, Option.some(42))
       }))
   })
-  describe("traverseOption", () => {
+  describe("transposeMapOption", () => {
     describe("None", () => {
       it.effect("Success", () =>
         Effect.gen(function*() {
-          const resultDataFirst = yield* Effect.traverseOption(Option.none(), () => Effect.succeed(42))
+          const resultDataFirst = yield* Effect.transposeMapOption(Option.none(), () => Effect.succeed(42))
           assert.ok(Option.isNone(resultDataFirst))
 
           const resultDataLast = yield* pipe(
             Option.none(),
-            Effect.traverseOption(() => Effect.succeed(42))
+            Effect.transposeMapOption(() => Effect.succeed(42))
           )
           assert.ok(Option.isNone(resultDataLast))
         }))
       it.effect("Failure", () =>
         Effect.gen(function*() {
-          const resultDataFirst = yield* Effect.traverseOption(Option.none(), () => Effect.fail("Error"))
+          const resultDataFirst = yield* Effect.transposeMapOption(Option.none(), () => Effect.fail("Error"))
           assert.ok(Option.isNone(resultDataFirst))
 
           const resultDataLast = yield* pipe(
             Option.none(),
-            Effect.traverseOption(() => Effect.fail("Error"))
+            Effect.transposeMapOption(() => Effect.fail("Error"))
           )
           assert.ok(Option.isNone(resultDataLast))
         }))
@@ -48,26 +48,29 @@ describe("Effect", () => {
       describe("None", () => {
         it.effect("Success", () =>
           Effect.gen(function*() {
-            const resultDataFirst = yield* Effect.traverseOption(Option.some(42), (value) => Effect.succeed(value * 2))
+            const resultDataFirst = yield* Effect.transposeMapOption(Option.some(42), (value) =>
+              Effect.succeed(value * 2))
             assert.deepStrictEqual(resultDataFirst, Option.some(84))
 
             const resultDataLast = yield* pipe(
               Option.some(42),
-              Effect.traverseOption((value) => Effect.succeed(value * 2))
+              Effect.transposeMapOption((value) =>
+                Effect.succeed(value * 2)
+              )
             )
             assert.deepStrictEqual(resultDataLast, Option.some(84))
           }))
         it.effect("Failure", () =>
           Effect.gen(function*() {
             const resultDataFirst = yield* pipe(
-              Effect.traverseOption(Option.some(42), () => Effect.fail("error")),
+              Effect.transposeMapOption(Option.some(42), () => Effect.fail("error")),
               Effect.flip
             )
             assert.equal(resultDataFirst, "error")
 
             const resultDataLast = yield* pipe(
               Option.some(42),
-              Effect.traverseOption(() => Effect.fail("error")),
+              Effect.transposeMapOption(() => Effect.fail("error")),
               Effect.flip
             )
             assert.equal(resultDataLast, "error")

--- a/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
+++ b/packages/effect/test/Effect/optional-wrapping-unwrapping.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 
 describe("Effect", () => {
@@ -16,6 +17,63 @@ describe("Effect", () => {
         const result = yield* Effect.transposeOption(Option.some(Effect.succeed(42)))
         assert.deepStrictEqual(result, Option.some(42))
       }))
+  })
+  describe("traverseOption", () => {
+    describe("None", () => {
+      it.effect("Success", () =>
+        Effect.gen(function*() {
+          const resultDataFirst = yield* Effect.traverseOption(Option.none(), () => Effect.succeed(42))
+          assert.ok(Option.isNone(resultDataFirst))
+
+          const resultDataLast = yield* pipe(
+            Option.none(),
+            Effect.traverseOption(() => Effect.succeed(42))
+          )
+          assert.ok(Option.isNone(resultDataLast))
+        }))
+      it.effect("Failure", () =>
+        Effect.gen(function*() {
+          const resultDataFirst = yield* Effect.traverseOption(Option.none(), () => Effect.fail("Error"))
+          assert.ok(Option.isNone(resultDataFirst))
+
+          const resultDataLast = yield* pipe(
+            Option.none(),
+            Effect.traverseOption(() => Effect.fail("Error"))
+          )
+          assert.ok(Option.isNone(resultDataLast))
+        }))
+    })
+
+    describe("Some", () => {
+      describe("None", () => {
+        it.effect("Success", () =>
+          Effect.gen(function*() {
+            const resultDataFirst = yield* Effect.traverseOption(Option.some(42), (value) => Effect.succeed(value * 2))
+            assert.deepStrictEqual(resultDataFirst, Option.some(84))
+
+            const resultDataLast = yield* pipe(
+              Option.some(42),
+              Effect.traverseOption((value) => Effect.succeed(value * 2))
+            )
+            assert.deepStrictEqual(resultDataLast, Option.some(84))
+          }))
+        it.effect("Failure", () =>
+          Effect.gen(function*() {
+            const resultDataFirst = yield* pipe(
+              Effect.traverseOption(Option.some(42), () => Effect.fail("error")),
+              Effect.flip
+            )
+            assert.equal(resultDataFirst, "error")
+
+            const resultDataLast = yield* pipe(
+              Option.some(42),
+              Effect.traverseOption(() => Effect.fail("error")),
+              Effect.flip
+            )
+            assert.equal(resultDataLast, "error")
+          }))
+      })
+    })
   })
 })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Add `Effect.traverseOption`. Today in our codebase we're using a helper to do that, but I really think it would be a nice addition that would be useful to others. 

I'm aware that we could use the `Effect.transposeOption`:
```ts
pipe(
  Effect.succeed(Option.some('value')), 
  Effect.map(Option.map(someEffectfulOperation)), 
  Effect.flatMap(Effect.transposeOption)
)
```
But this is simpler and more relevant for all the use cases where I need it in my work:
```ts
pipe(
  Effect.succeed(Option.some('value')),
  Effect.flatMap(Effect.traverseOption(someEffectfulOperation))
)
```
So I'd still push for this addition, hence my move to try to open a PR for it! :)

For the naming of this method, in our codebase we used `optionTraverseEffect` but given the discussions in issue #3142, it seems that adding this method in the Effect module and using the term `traverse` would be the way to go.
Also, if you agree with this addition and have ideas on improving the documentation part of this feature I'm interested as I'm not fully happy with my final version.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #3142
- Closes #3142
