### PR TITLE
Schema: enhance the internal `formatUnknown` function to handle vario…

### DIFF
--- a/.changeset/dry-vans-carry.md
+++ b/.changeset/dry-vans-carry.md
@@ -1,0 +1,41 @@
+---
+"effect": patch
+---
+
+Schema: enhance the internal `formatUnknown` function to handle various types including iterables, classes, and additional edge cases.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Array(Schema.Number)
+
+Schema.decodeUnknownSync(schema)(new Set([1, 2]))
+// throws Expected ReadonlyArray<number>, actual {}
+
+class A {
+  constructor(readonly a: number) {}
+}
+
+Schema.decodeUnknownSync(schema)(new A(1))
+// throws Expected ReadonlyArray<number>, actual {"a":1}
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+const schema = Schema.Array(Schema.Number)
+
+Schema.decodeUnknownSync(schema)(new Set([1, 2]))
+// throws Expected ReadonlyArray<number>, actual Set([1,2])
+
+class A {
+  constructor(readonly a: number) {}
+}
+
+Schema.decodeUnknownSync(schema)(new A(1))
+// throws Expected ReadonlyArray<number>, actual A({"a":1})
+```

--- a/packages/effect/src/internal/schema/util.ts
+++ b/packages/effect/src/internal/schema/util.ts
@@ -97,7 +97,7 @@ export const formatUnknown = (u: unknown, checkCircular: boolean = true): string
     const name = u.constructor.name
     return u.constructor !== Object.prototype.constructor ? `${name}(${pojo})` : pojo
   } catch (e) {
-    return String(u)
+    return "<circular structure>"
   }
 }
 

--- a/packages/effect/src/internal/schema/util.ts
+++ b/packages/effect/src/internal/schema/util.ts
@@ -53,9 +53,9 @@ export const formatDate = (date: Date): string => {
 }
 
 /** @internal */
-export const formatUnknown = (u: unknown): string => {
+export const formatUnknown = (u: unknown, checkCircular: boolean = true): string => {
   if (Array.isArray(u)) {
-    return `[${u.map(formatUnknown).join(",")}]`
+    return `[${u.map((i) => formatUnknown(i, checkCircular)).join(",")}]`
   }
   if (Predicate.isDate(u)) {
     return formatDate(u)
@@ -82,12 +82,16 @@ export const formatUnknown = (u: unknown): string => {
     return String(u) + "n"
   }
   if (Predicate.isIterable(u)) {
-    return `${u.constructor.name}(${formatUnknown(Array.from(u))})`
+    return `${u.constructor.name}(${formatUnknown(Array.from(u), checkCircular)})`
   }
   try {
-    JSON.stringify(u) // check for circular references
+    if (checkCircular) {
+      JSON.stringify(u) // check for circular references
+    }
     const pojo = `{${
-      ownKeys(u).map((k) => `${Predicate.isString(k) ? JSON.stringify(k) : String(k)}:${formatUnknown((u as any)[k])}`)
+      ownKeys(u).map((k) =>
+        `${Predicate.isString(k) ? JSON.stringify(k) : String(k)}:${formatUnknown((u as any)[k], false)}`
+      )
         .join(",")
     }}`
     const name = u.constructor.name

--- a/packages/effect/test/Schema/SchemaInternal.test.ts
+++ b/packages/effect/test/Schema/SchemaInternal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@effect/vitest"
+import { Chunk } from "effect"
 import * as util from "effect/internal/schema/util"
 import { deepStrictEqual, strictEqual } from "effect/test/util"
 
@@ -14,11 +15,70 @@ describe("effect/internal/schema/util", () => {
   })
 
   describe("formatUnknown", () => {
+    it("null", () => {
+      strictEqual(util.formatUnknown(null), "null")
+    })
+
+    it("undefined", () => {
+      strictEqual(util.formatUnknown(undefined), "undefined")
+    })
+
+    it("boolean", () => {
+      strictEqual(util.formatUnknown(true), "true")
+      strictEqual(util.formatUnknown(false), "false")
+    })
+
+    it("number", () => {
+      strictEqual(util.formatUnknown(1), "1")
+      strictEqual(util.formatUnknown(1.1), "1.1")
+      strictEqual(util.formatUnknown(-1), "-1")
+      strictEqual(util.formatUnknown(-1.1), "-1.1")
+      strictEqual(util.formatUnknown(0), "0")
+      strictEqual(util.formatUnknown(-0), "0")
+      strictEqual(util.formatUnknown(NaN), "NaN")
+      strictEqual(util.formatUnknown(Infinity), "Infinity")
+      strictEqual(util.formatUnknown(-Infinity), "-Infinity")
+    })
+
+    it("bigint", () => {
+      strictEqual(util.formatUnknown(1n), "1n")
+      strictEqual(util.formatUnknown(-1n), "-1n")
+      strictEqual(util.formatUnknown(0n), "0n")
+      strictEqual(util.formatUnknown(-0n), "0n")
+    })
+
+    it("symbol", () => {
+      const a = Symbol.for("effect/Schema/test/a")
+      strictEqual(util.formatUnknown(a), "Symbol(effect/Schema/test/a)")
+    })
+
+    it("string", () => {
+      strictEqual(util.formatUnknown(""), `""`)
+      strictEqual(util.formatUnknown("a"), `"a"`)
+      strictEqual(util.formatUnknown("ab"), `"ab"`)
+      strictEqual(util.formatUnknown("abc"), `"abc"`)
+    })
+
+    it("array", () => {
+      strictEqual(util.formatUnknown([]), "[]")
+      strictEqual(util.formatUnknown([1]), "[1]")
+      strictEqual(util.formatUnknown([1, 2]), "[1,2]")
+      strictEqual(util.formatUnknown([1, 2, 3]), "[1,2,3]")
+    })
+
+    it("object", () => {
+      strictEqual(util.formatUnknown({}), "{}")
+      strictEqual(util.formatUnknown({ a: 1 }), `{"a":1}`)
+      strictEqual(util.formatUnknown({ a: 1, b: 2 }), `{"a":1,"b":2}`)
+      const a = Symbol.for("effect/Schema/test/a")
+      strictEqual(util.formatUnknown({ [a]: 3 }), `{${String(a)}:3}`)
+    })
+
     it("should format symbol property signatures", () => {
       strictEqual(util.formatUnknown({ [Symbol.for("a")]: 1 }), "{Symbol(a):1}")
     })
 
-    it("should handle unexpected errors", () => {
+    it("should handle circular references", () => {
       const circular: any = { a: null }
       circular.a = circular
       strictEqual(util.formatUnknown(circular), "[object Object]")
@@ -35,6 +95,38 @@ describe("effect/internal/schema/util", () => {
       strictEqual(util.formatUnknown(ToString), "toString custom implementation")
       // should not detect arrays
       strictEqual(util.formatUnknown([1, 2, 3]), "[1,2,3]")
+    })
+
+    it("Date", () => {
+      strictEqual(util.formatUnknown(new Date("2024-01-01T00:00:00.000Z")), "2024-01-01T00:00:00.000Z")
+    })
+
+    it("iterables", () => {
+      strictEqual(util.formatUnknown(new Set([])), "Set([])")
+      strictEqual(util.formatUnknown(new Set([1, 2, 3])), "Set([1,2,3])")
+      strictEqual(util.formatUnknown(new Map([])), "Map([])")
+      strictEqual(util.formatUnknown(new Map([[1, "a"], [2, "b"], [3, "c"]])), `Map([[1,"a"],[2,"b"],[3,"c"]])`)
+    })
+
+    it("classes", () => {
+      class A {
+        constructor(readonly a: number) {}
+      }
+      strictEqual(util.formatUnknown(new A(1)), `A({"a":1})`)
+    })
+
+    it("Chunks", () => {
+      strictEqual(
+        util.formatUnknown(Chunk.make(1, 2, 3)),
+        `{
+  "_id": "Chunk",
+  "values": [
+    1,
+    2,
+    3
+  ]
+}`
+      )
     })
   })
 })

--- a/packages/effect/test/Schema/SchemaInternal.test.ts
+++ b/packages/effect/test/Schema/SchemaInternal.test.ts
@@ -81,7 +81,7 @@ describe("effect/internal/schema/util", () => {
     it("should handle circular references", () => {
       const circular: any = { a: null }
       circular.a = circular
-      strictEqual(util.formatUnknown(circular), "[object Object]")
+      strictEqual(util.formatUnknown(circular), "<circular structure>")
     })
 
     it("should detect data types with a custom `toString` implementation", () => {


### PR DESCRIPTION
…us types including iterables, classes, and additional edge cases.

Before

```ts
import { Schema } from "effect"

const schema = Schema.Array(Schema.Number)

Schema.decodeUnknownSync(schema)(new Set([1, 2]))
// throws Expected ReadonlyArray<number>, actual {}

class A {
  constructor(readonly a: number) {}
}

Schema.decodeUnknownSync(schema)(new A(1))
// throws Expected ReadonlyArray<number>, actual {"a":1}
```

After

```ts
import { Schema } from "effect"

const schema = Schema.Array(Schema.Number)

Schema.decodeUnknownSync(schema)(new Set([1, 2]))
// throws Expected ReadonlyArray<number>, actual Set([1,2])

class A {
  constructor(readonly a: number) {}
}

Schema.decodeUnknownSync(schema)(new A(1))
// throws Expected ReadonlyArray<number>, actual A({"a":1})
```
