### PR TITLE
Preserve specific annotations when using `Schema.typeSchema`, closes #4609

### DIFF
--- a/.changeset/clean-lamps-tease.md
+++ b/.changeset/clean-lamps-tease.md
@@ -1,0 +1,58 @@
+---
+"effect": patch
+---
+
+Preserve specific annotations (e.g., `arbitrary`) when using `Schema.typeSchema`, closes #4609.
+
+Previously, annotations such as `arbitrary` were lost when calling `Schema.typeSchema` on a transformation. This update ensures that certain annotations, which depend only on the "to" side of the transformation, are preserved.
+
+Annotations that are now retained:
+
+- `examples`
+- `default`
+- `jsonSchema`
+- `arbitrary`
+- `pretty`
+- `equivalence`
+
+**Example**
+
+Before
+
+```ts
+import { Arbitrary, FastCheck, Schema } from "effect"
+
+const schema = Schema.NumberFromString.annotations({
+  arbitrary: () => (fc) => fc.constant(1)
+})
+
+const to = Schema.typeSchema(schema) // ❌ Annotation is lost
+
+console.log(FastCheck.sample(Arbitrary.make(to), 5))
+/*
+[
+  2.5223372357846707e-44,
+  -2.145443957806771e+25,
+  -3.4028179901346956e+38,
+  5.278086259208735e+29,
+  1.8216880036222622e-44
+]
+*/
+```
+
+After
+
+```ts
+import { Arbitrary, FastCheck, Schema } from "effect"
+
+const schema = Schema.NumberFromString.annotations({
+  arbitrary: () => (fc) => fc.constant(1)
+})
+
+const to = Schema.typeSchema(schema) // ✅ Annotation is now preserved
+
+console.log(FastCheck.sample(Arbitrary.make(to), 5))
+/*
+[ 1, 1, 1, 1, 1 ]
+*/
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2767,7 +2767,7 @@ export interface TypeLiteral<
   ): Simplify<TypeLiteral.Type<Fields, Records>>
 }
 
-const preserveMissingMessageAnnotation = AST.whiteListAnnotations([AST.MissingMessageAnnotationId])
+const preserveMissingMessageAnnotation = AST.pickAnnotations([AST.MissingMessageAnnotationId])
 
 const getDefaultTypeLiteralAST = <
   Fields extends Struct.Fields,
@@ -3299,7 +3299,7 @@ const intersectTypeLiterals = (
   throw new Error(errors_.getSchemaExtendErrorMessage(x, y, path))
 }
 
-const preserveRefinementAnnotations = AST.blackListAnnotations([AST.IdentifierAnnotationId])
+const preserveRefinementAnnotations = AST.omitAnnotations([AST.IdentifierAnnotationId])
 
 const addRefinementToMembers = (refinement: AST.Refinement, asts: ReadonlyArray<AST.AST>): Array<AST.Refinement> =>
   asts.map((ast) => new AST.Refinement(ast, refinement.filter, preserveRefinementAnnotations(refinement)))


### PR DESCRIPTION
Previously, annotations such as `arbitrary` were lost when calling `Schema.typeSchema` on a transformation. This update ensures that certain annotations, which depend only on the "to" side of the transformation, are preserved.

Annotations that are now retained:

- `examples`
- `default`
- `jsonSchema`
- `arbitrary`
- `pretty`
- `equivalence`

**Example**

Before

```ts
import { Arbitrary, FastCheck, Schema } from "effect"

const schema = Schema.NumberFromString.annotations({
  arbitrary: () => (fc) => fc.constant(1)
})

const to = Schema.typeSchema(schema) // ❌ Annotation is lost

console.log(FastCheck.sample(Arbitrary.make(to), 5))
/*
[
  2.5223372357846707e-44,
  -2.145443957806771e+25,
  -3.4028179901346956e+38,
  5.278086259208735e+29,
  1.8216880036222622e-44
]
*/
```

After

```ts
import { Arbitrary, FastCheck, Schema } from "effect"

const schema = Schema.NumberFromString.annotations({
  arbitrary: () => (fc) => fc.constant(1)
})

const to = Schema.typeSchema(schema) // ✅ Annotation is now preserved

console.log(FastCheck.sample(Arbitrary.make(to), 5))
/*
[ 1, 1, 1, 1, 1 ]
*/
```
