### PR TITLE
Handle arbitrary length StreamChunkPart

### DIFF
--- a/.changeset/cold-carrots-visit.md
+++ b/.changeset/cold-carrots-visit.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Handle arbitrary length StreamChunkPart in OpenAiClient

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -291,13 +291,6 @@ export class StreamChunk extends Data.Class<{
    * @since 1.0.0
    */
   get asAiResponse(): AiResponse.AiResponse {
-    if (this.parts.length === 0) {
-      return AiResponse.AiResponse.fromText({
-        role: AiRole.model,
-        content: ""
-      })
-    }
-
     const aiResponseParts: Array<AiResponse.Part> = []
 
     for (let i = 0; i < this.parts.length; i++) {
@@ -314,6 +307,13 @@ export class StreamChunk extends Data.Class<{
           }))
           break
       }
+    }
+
+    if (aiResponseParts.length === 0) {
+      return AiResponse.AiResponse.fromText({
+        role: AiRole.model,
+        content: ""
+      })
     }
 
     return new AiResponse.AiResponse({

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -318,7 +318,7 @@ export class StreamChunk extends Data.Class<{
 
     return new AiResponse.AiResponse({
       role: AiRole.model,
-      parts: Chunk.fromIterable(aiResponseParts)
+      parts: Chunk.unsafeFromArray(aiResponseParts)
     })
   }
 }

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -284,8 +284,8 @@ export class StreamChunk extends Data.Class<{
    * @since 1.0.0
    */
   get text(): Option.Option<string> {
-    const contentParts = this.parts.filter((part) => part._tag === "Content").map((part) => part.content)
-    return contentParts.length > 0 ? Option.some(contentParts.join("")) : Option.none()
+    const firstContentPart = this.parts.find((part) => part._tag === "Content")
+    return firstContentPart ? Option.some(firstContentPart.content) : Option.none()
   }
   /**
    * @since 1.0.0


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This changes `OpenAiClient.StreamChunk.text` and `OpenAiClient.StreamChunk.asAiResponse` getters to respect arbitrary length `this.parts` instead of only considering the first part.

After patching this locally, I was able to use Google's Gemini models via [their OpenAI compatibility API.
](https://ai.google.dev/gemini-api/docs/openai)

### Areas to Review:
I'm not sure what is expected when there's multiple "Content" parts, all I know is that Gemini delivers one "Usage" and one "Content" part in the same chunk. For now I've `.join()`-ed all content parts into a single string.

I'm not certain why the `asAiReponse` implementation produces an empty string of content for the case when no parts are present (versus just providing an empty parts array).

https://github.com/Effect-TS/effect/blob/9a88bb9404ea6001b70d1aab62ce4630d5c56159/packages/ai/openai/src/OpenAiClient.ts#L293-L298

I've preserved this behavior in case, though I imagine it could be removed.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #4629
