### PR TITLE
Schema: `standardSchemaV1` now includes the schema, closes #4494

### DIFF
--- a/.changeset/shy-pots-dream.md
+++ b/.changeset/shy-pots-dream.md
@@ -1,0 +1,40 @@
+---
+"effect": patch
+---
+
+Schema: `standardSchemaV1` now includes the schema, closes #4494.
+
+This update fixes an issue where passing `Schema.standardSchemaV1(...)` directly to `JSONSchema.make` would throw a `TypeError`. The schema was missing from the returned object, causing the JSON schema generation to fail.
+
+Now `standardSchemaV1` includes the schema itself, so it can be used with `JSONSchema.make` without issues.
+
+**Example**
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const Person = Schema.Struct({
+  name: Schema.optionalWith(Schema.NonEmptyString, { exact: true })
+})
+
+const standardSchema = Schema.standardSchemaV1(Person)
+
+console.log(JSONSchema.make(standardSchema))
+/*
+{
+  '$schema': 'http://json-schema.org/draft-07/schema#',
+  '$defs': {
+    NonEmptyString: {
+      type: 'string',
+      description: 'a non empty string',
+      title: 'nonEmptyString',
+      minLength: 1
+    }
+  },
+  type: 'object',
+  required: [],
+  properties: { name: { '$ref': '#/$defs/NonEmptyString' } },
+  additionalProperties: false
+}
+*/
+```

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec"
 import type {
   Arbitrary,
   BigDecimal,
@@ -4246,5 +4247,11 @@ describe("Schema", () => {
       expect(schema.from).type.toBe<typeof S.String>()
       expect(schema.to).type.toBe<typeof S.Number>()
     })
+  })
+
+  it("standardSchemaV1", () => {
+    const standardSchema = S.standardSchemaV1(S.NumberFromString)
+    expect(S.asSchema(standardSchema)).type.toBe<S.Schema<number, string>>()
+    expect(standardSchema).type.toBe<StandardSchemaV1<string, number> & S.SchemaClass<number, string, never>>()
   })
 })

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -195,10 +195,10 @@ const makeStandardFailureFromParseIssue = (
 export const standardSchemaV1 = <A, I>(
   schema: Schema<A, I, never>,
   overrideOptions?: AST.ParseOptions
-): StandardSchemaV1<I, A> => {
+): StandardSchemaV1<I, A> & SchemaClass<A, I, never> => {
   const decodeUnknown = ParseResult.decodeUnknown(schema, { errors: "all" })
-  return {
-    "~standard": {
+  return class StandardSchemaV1Class extends make<A, I, never>(schema.ast) {
+    static "~standard" = {
       version: 1,
       vendor: "effect",
       validate(value) {

--- a/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
@@ -90,6 +90,12 @@ const expectAsyncFailure = async <I, A>(
 const AsyncNonEmptyString = AsyncString.pipe(Schema.minLength(1))
 
 describe("standardSchemaV1", () => {
+  it("should return a schema", () => {
+    const schema = Schema.NumberFromString
+    const standardSchema = Schema.standardSchemaV1(schema)
+    assertTrue(Schema.isSchema(standardSchema))
+  })
+
   it("sync decoding + sync issue formatting", () => {
     const schema = Schema.NonEmptyString
     const standardSchema = Schema.standardSchemaV1(schema)


### PR DESCRIPTION
This update fixes an issue where passing `Schema.standardSchemaV1(...)` directly to `JSONSchema.make` would throw a `TypeError`. The schema was missing from the returned object, causing the JSON schema generation to fail.

Now `standardSchemaV1` includes the schema itself, so it can be used with `JSONSchema.make` without issues.

**Example**

```ts
import { JSONSchema, Schema } from "effect"

const Person = Schema.Struct({
  name: Schema.optionalWith(Schema.NonEmptyString, { exact: true })
})

const standardSchema = Schema.standardSchemaV1(Person)

console.log(JSONSchema.make(standardSchema))
/*
{
  '$schema': 'http://json-schema.org/draft-07/schema#',
  '$defs': {
    NonEmptyString: {
      type: 'string',
      description: 'a non empty string',
      title: 'nonEmptyString',
      minLength: 1
    }
  },
  type: 'object',
  required: [],
  properties: { name: { '$ref': '#/$defs/NonEmptyString' } },
  additionalProperties: false
}
*/
```
