### PR TITLE
fixed typo in jsdocs

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6264,7 +6264,7 @@ export const fork: <A, E, R>(self: Effect<A, E, R>) => Effect<Fiber.RuntimeFiber
  * useful for tasks that need to run in the background independently, such as
  * periodic logging, monitoring, or background data processing.
  *
- * **Example** (Creating a Daemon Fibe)
+ * **Example** (Creating a Daemon Fiber)
  *
  * ```ts
  * import { Effect, Console, Schedule } from "effect"


### PR DESCRIPTION
Typo "fibe" in jsdocs