### PR TITLE
fix(platform-node): Handle empty chunks in streams

### DIFF
--- a/.changeset/gold-beds-rest.md
+++ b/.changeset/gold-beds-rest.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Fix: Handle empty chunks in http server stream bodies

--- a/packages/platform-node/src/internal/httpServer.ts
+++ b/packages/platform-node/src/internal/httpServer.ts
@@ -458,6 +458,10 @@ const handleResponse = (request: ServerRequest.HttpServerRequest, response: Serv
           Stream.runForEachChunk((chunk) =>
             Effect.async<void>((resume) => {
               const array = Chunk.toReadonlyArray(chunk)
+              if (array.length === 0) {
+                resume(Effect.void)
+                return
+              }
               for (let i = 0; i < array.length - 1; i++) {
                 nodeResponse.write(array[i])
               }


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Prior to this change, `HttpServerResponse.stream` mishandled empty chunks emitted by passed `Stream`s, causing hard-to-debug hangs and crashes. This change adds a dedicated branch for empty chunks to handle this case.

I've tested this fix for my broken application use case by monkeypatching the node_modules folder.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
N/A
