### PR TITLE
More type-safe`HashMap.has/get`

### DIFF
--- a/.changeset/famous-rockets-flash.md
+++ b/.changeset/famous-rockets-flash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+The `HashMap.has/get` family has become more type-safe.

--- a/.changeset/famous-rockets-flash.md
+++ b/.changeset/famous-rockets-flash.md
@@ -2,4 +2,5 @@
 "effect": patch
 ---
 
-The `HashMap.has/get` family has become more type-safe.
+- The `HashMap.has/get` family has become more type-safe.
+- Fix the related type errors in TestAnnotationsMap.ts.

--- a/packages/effect/src/HashMap.ts
+++ b/packages/effect/src/HashMap.ts
@@ -144,8 +144,8 @@ export const isEmpty: <K, V>(self: HashMap<K, V>) => boolean = HM.isEmpty
  * @category elements
  */
 export const get: {
-  <K1>(key: K1): <K, V>(self: HashMap<K, V>) => Option<V>
-  <K, V, K1>(self: HashMap<K, V>, key: K1): Option<V>
+  <K1 extends K, K>(key: K1): <V>(self: HashMap<K, V>) => Option<V>
+  <K1 extends K, K, V>(self: HashMap<K, V>, key: K1): Option<V>
 } = HM.get
 
 /**
@@ -155,8 +155,8 @@ export const get: {
  * @category elements
  */
 export const getHash: {
-  <K1>(key: K1, hash: number): <K, V>(self: HashMap<K, V>) => Option<V>
-  <K, V, K1>(self: HashMap<K, V>, key: K1, hash: number): Option<V>
+  <K1 extends K, K>(key: K1, hash: number): <V>(self: HashMap<K, V>) => Option<V>
+  <K1 extends K, K, V>(self: HashMap<K, V>, key: K1, hash: number): Option<V>
 } = HM.getHash
 
 /**
@@ -167,8 +167,8 @@ export const getHash: {
  * @category unsafe
  */
 export const unsafeGet: {
-  <K1>(key: K1): <K, V>(self: HashMap<K, V>) => V
-  <K, V, K1>(self: HashMap<K, V>, key: K1): V
+  <K1 extends K, K>(key: K1): <V>(self: HashMap<K, V>) => V
+  <K1 extends K, K, V>(self: HashMap<K, V>, key: K1): V
 } = HM.unsafeGet
 
 /**
@@ -178,8 +178,8 @@ export const unsafeGet: {
  * @category elements
  */
 export const has: {
-  <K1>(key: K1): <K, V>(self: HashMap<K, V>) => boolean
-  <K, V, K1>(self: HashMap<K, V>, key: K1): boolean
+  <K1 extends K, K>(key: K1): <K, V>(self: HashMap<K, V>) => boolean
+  <K1 extends K, K, V>(self: HashMap<K, V>, key: K1): boolean
 } = HM.has
 
 /**
@@ -190,8 +190,8 @@ export const has: {
  * @category elements
  */
 export const hasHash: {
-  <K1>(key: K1, hash: number): <K, V>(self: HashMap<K, V>) => boolean
-  <K, V, K1>(self: HashMap<K, V>, key: K1, hash: number): boolean
+  <K1 extends K, K>(key: K1, hash: number): <V>(self: HashMap<K, V>) => boolean
+  <K1 extends K, K, V>(self: HashMap<K, V>, key: K1, hash: number): boolean
 } = HM.hasHash
 
 /**

--- a/packages/effect/src/TestAnnotationMap.ts
+++ b/packages/effect/src/TestAnnotationMap.ts
@@ -67,8 +67,8 @@ export const update = dual<
   <A>(self: TestAnnotationMap, key: TestAnnotation.TestAnnotation<A>, f: (value: A) => A) => TestAnnotationMap
 >(3, <A>(self: TestAnnotationMap, key: TestAnnotation.TestAnnotation<A>, f: (value: A) => A) => {
   let value = key.initial
-  if (HashMap.has(self.map, key.identifier)) {
-    value = HashMap.unsafeGet(self.map, key.identifier) as A
+  if (HashMap.has(self.map, key)) {
+    value = HashMap.unsafeGet(self.map, key) as A
   }
   return overwrite(self, key, f(value))
 })
@@ -83,8 +83,8 @@ export const get = dual<
   <A>(key: TestAnnotation.TestAnnotation<A>) => (self: TestAnnotationMap) => A,
   <A>(self: TestAnnotationMap, key: TestAnnotation.TestAnnotation<A>) => A
 >(2, <A>(self: TestAnnotationMap, key: TestAnnotation.TestAnnotation<A>) => {
-  if (HashMap.has(self.map, key.identifier)) {
-    return HashMap.unsafeGet(self.map, key.identifier) as A
+  if (HashMap.has(self.map, key)) {
+    return HashMap.unsafeGet(self.map, key) as A
   }
   return key.initial
 })

--- a/packages/effect/src/internal/hashMap.ts
+++ b/packages/effect/src/internal/hashMap.ts
@@ -210,15 +210,15 @@ export const isEmpty = <K, V>(self: HM.HashMap<K, V>): boolean =>
 
 /** @internal */
 export const get = Dual.dual<
-  <K1>(key: K1) => <K, V>(self: HM.HashMap<K, V>) => Option.Option<V>,
-  <K, V, K1>(self: HM.HashMap<K, V>, key: K1) => Option.Option<V>
+  <K1 extends K, K>(key: K1) => <V>(self: HM.HashMap<K, V>) => Option.Option<V>,
+  <K, V, K1 extends K>(self: HM.HashMap<K, V>, key: K1) => Option.Option<V>
 >(2, (self, key) => getHash(self, key, Hash.hash(key)))
 
 /** @internal */
 export const getHash = Dual.dual<
-  <K1>(key: K1, hash: number) => <K, V>(self: HM.HashMap<K, V>) => Option.Option<V>,
-  <K, V, K1>(self: HM.HashMap<K, V>, key: K1, hash: number) => Option.Option<V>
->(3, <K, V, K1>(self: HM.HashMap<K, V>, key: K1, hash: number) => {
+  <K1 extends K, K>(key: K1, hash: number) => <V>(self: HM.HashMap<K, V>) => Option.Option<V>,
+  <K, V, K1 extends K>(self: HM.HashMap<K, V>, key: K1, hash: number) => Option.Option<V>
+>(3, <K, V, K1 extends K>(self: HM.HashMap<K, V>, key: K1, hash: number) => {
   let node = (self as HashMapImpl<K, V>)._root
   let shift = 0
 
@@ -265,8 +265,8 @@ export const getHash = Dual.dual<
 
 /** @internal */
 export const unsafeGet = Dual.dual<
-  <K1>(key: K1) => <K, V>(self: HM.HashMap<K, V>) => V,
-  <K, V, K1>(self: HM.HashMap<K, V>, key: K1) => V
+  <K1 extends K, K>(key: K1) => <V>(self: HM.HashMap<K, V>) => V,
+  <K, V, K1 extends K>(self: HM.HashMap<K, V>, key: K1) => V
 >(2, (self, key) => {
   const element = getHash(self, key, Hash.hash(key))
   if (Option.isNone(element)) {
@@ -277,14 +277,14 @@ export const unsafeGet = Dual.dual<
 
 /** @internal */
 export const has = Dual.dual<
-  <K1>(key: K1) => <K, V>(self: HM.HashMap<K, V>) => boolean,
-  <K, V, K1>(self: HM.HashMap<K, V>, key: K1) => boolean
+  <K1 extends K, K>(key: K1) => <V>(self: HM.HashMap<K, V>) => boolean,
+  <K, V, K1 extends K>(self: HM.HashMap<K, V>, key: K1) => boolean
 >(2, (self, key) => Option.isSome(getHash(self, key, Hash.hash(key))))
 
 /** @internal */
 export const hasHash = Dual.dual<
-  <K1>(key: K1, hash: number) => <K, V>(self: HM.HashMap<K, V>) => boolean,
-  <K, V, K1>(self: HM.HashMap<K, V>, key: K1, hash: number) => boolean
+  <K1 extends K, K>(key: K1, hash: number) => <V>(self: HM.HashMap<K, V>) => boolean,
+  <K, V, K1 extends K>(self: HM.HashMap<K, V>, key: K1, hash: number) => boolean
 >(3, (self, key, hash) => Option.isSome(getHash(self, key, hash)))
 
 /** @internal */


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- The `HashMap.has/get` family has become more type-safe.
- Fix the related type errors in TestAnnotationsMap.ts.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue # https://github.com/Effect-TS/effect/issues/4868
- Closes #
