### PR TITLE
`Match.tagsTupleExhaustive` has been added

### DIFF
--- a/.changeset/tall-hotels-tap.md
+++ b/.changeset/tall-hotels-tap.md
@@ -1,0 +1,18 @@
+---
+"effect": minor
+---
+
+`Match.tagsTupleExhaustive` has been added
+
+```ts
+import { Either, Match, Option } from "effect"
+
+Match.value([Option.some(1), Either.left(33)]).pipe(
+  Match.tagsTupleExhaustive({
+    NoneLeft: (none, left) => {}, // (none: None<number>, left: Left<number, never>) => void
+    NoneRight: (none, right) => {}, // (none: None<number>, left: Right<number, never>) => void
+    SomeLeft: (some, left) => {}, // (none: Some<number>, left: Left<number, never>) => void
+    SomeRight: (some, right) => {} // (none: Some<number>, left: Right<number, never>) => void
+  })
+)
+```

--- a/packages/effect/dtslint/Match.tst.ts
+++ b/packages/effect/dtslint/Match.tst.ts
@@ -493,6 +493,49 @@ describe("Match", () => {
     )(value)
   })
 
+  it("tagsTupleExhaustive", () => {
+    pipe(
+      Match.type<[Value, Value]>(),
+      Match.tagsTupleExhaustive({
+        AA: (A1, A2) => {
+          expect(A1).type.toBe<{ _tag: "A"; a: number }>()
+          expect(A2).type.toBe<{ _tag: "A"; a: number }>()
+          return [A1.a, A2.a] as const
+        },
+        AB: (A, B) => {
+          expect(A).type.toBe<{ _tag: "A"; a: number }>()
+          expect(B).type.toBe<{ _tag: "B"; b: number }>()
+          return [A.a, "B"] as const
+        },
+        BA: (B, A) => {
+          expect(A).type.toBe<{ _tag: "A"; a: number }>()
+          expect(B).type.toBe<{ _tag: "B"; b: number }>()
+          return ["B", A.a] as const
+        },
+        BB: (B1, B2) => {
+          expect(B1).type.toBe<{ _tag: "B"; b: number }>()
+          expect(B2).type.toBe<{ _tag: "B"; b: number }>()
+          return ["B", "B"] as const
+        }
+      })
+    )([value, value])
+    expect().type.toBe<
+      readonly [number, number] | readonly [number, "B"] | readonly ["B", number] | readonly ["B", "B"]
+    >()
+
+    pipe(
+      Match.type<[Value, Value]>(),
+      Match.tagsTupleExhaustive({
+        AA: (_) => _.a,
+        BA: () => "B",
+        AB: () => "B",
+        BB: () => "B",
+        // @ts-expect-error: Type '() => boolean' is not assignable to type '"Excess property"'
+        C: () => false
+      })
+    )([value, value])
+  })
+
   it("tag", () => {
     expect(
       pipe(

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -873,6 +873,45 @@ export const tagsExhaustive: <
   internal.tagsExhaustive
 
 /**
+ * Matches values in tuple based on their `_tag` field and requires handling of all
+ * possible cases.
+ *
+ * **Details**
+ *
+ * This function is designed for tuple of **discriminated unions** where every possible
+ * `_tag` combinations must have a corresponding handler.
+ *
+ * @example
+ * ```ts
+ * import { Match, pipe } from "effect"
+ *
+ * const match = pipe(
+ *   Match.type<[{ _tag: "A"; a: string } | { _tag: "B"; b: number }, { _tag: "B"; b: number } | { _tag: "C"; c: boolean }]>(),
+ *   Match.tagsTupleExhaustive({
+ *     AB: (a, b) => [a.a, b.b],
+ *     AC: (a, c) => [a.a, c.c],
+ *     BB: (b, b) => [b.b, b.b],
+ *     BC: (b, c) => [b.b, c.c],
+ *   })
+ * )
+ * ```
+ *
+ * @category Defining patterns
+ * @since 1.0.0
+ */
+export const tagsTupleExhaustive: <
+  R extends ReadonlyArray<{ _tag: string }>,
+  Ret,
+  P extends internal.Combine<R>,
+  M extends P & Record<string, (...args: Array<any>) => any> & Record<Exclude<keyof M, keyof P>, "Excess property">
+>(
+  fields: M
+) => <I, F, A, Pr>(
+  self: Matcher<I, F, R, A, Pr, Ret>
+) => [Pr] extends [never] ? (u: I) => Unify<A | ReturnType<M[keyof M]>> : Unify<A | ReturnType<M[keyof M]>> = internal
+  .tagsTupleExhaustive
+
+/**
  * Excludes a specific value from matching while allowing all others.
  *
  * **Details**

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -7,6 +7,7 @@ import {
   assertRight,
   assertSome,
   assertTrue,
+  deepStrictEqual,
   doesNotThrow,
   strictEqual,
   throws
@@ -619,6 +620,32 @@ describe("Match", () => {
 
     strictEqual(match({ _tag: "A", a: 1 }), 1)
     strictEqual(match({ _tag: "B", b: 1 }), "B")
+  })
+
+  it("tagsExhaustive", () => {
+    type AB = { _tag: "A"; a: number } | { _tag: "B"; b: number }
+    const match = pipe(
+      M.type<[AB, AB]>(),
+      M.tagsTupleExhaustive({
+        AA: (a1, a2) => [a1.a, a2.a],
+        AB: (a, b) => [a.a, b.b],
+        BA: (b, a) => [b.b, a.a],
+        BB: (b1, b2) => [b1.b, b2.b]
+      })
+    )
+    M.value([Option.some(1), Either.left(33)]).pipe(
+      M.tagsTupleExhaustive({
+        NoneLeft: (none, left) => {}, // (none: Option.None<number>, left: Either.Left<number, never>) => void
+        NoneRight: (none, right) => {}, // (none: Option.None<number>, left: Either.Right<number, never>) => void
+        SomeLeft: (some, left) => {}, // (none: Option.Some<number>, left: Either.Left<number, never>) => void
+        SomeRight: (some, right) => {} // (none: Option.Some<number>, left: Either.Right<number, never>) => void
+      })
+    )
+
+    deepStrictEqual(match([{ _tag: "A", a: 1 }, { _tag: "A", a: 2 }]), [1, 2])
+    deepStrictEqual(match([{ _tag: "A", a: 3 }, { _tag: "B", b: 4 }]), [3, 4])
+    deepStrictEqual(match([{ _tag: "B", b: 5 }, { _tag: "A", a: 6 }]), [5, 6])
+    deepStrictEqual(match([{ _tag: "B", b: 7 }, { _tag: "B", b: 8 }]), [7, 8])
   })
 
   it("valueTags", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Match.tagsTupleExhaustive` has been added

```ts
import { Either, Match, Option } from "effect"

Match.value([Option.some(1), Either.left(33)]).pipe(
  Match.tagsTupleExhaustive({
    NoneLeft: (none, left) => {}, // (none: None<number>, left: Left<number, never>) => void
    NoneRight: (none, right) => {}, // (none: None<number>, left: Right<number, never>) => void
    SomeLeft: (some, left) => {}, // (none: Some<number>, left: Left<number, never>) => void
    SomeRight: (some, right) => {} // (none: Some<number>, left: Right<number, never>) => void
  })
)
```

It also preserves rendering of union member in type hints.
This is a special sugar for tagged sun-types designed to make it easier to work with a pattern in which the user wants to process all possible combinations of union members in a flat manner.

```ts
export const queenBeeState = (swarm: Swarm) => {
  const whiteSurroundedQueenBee = getSurroundedQueenBee(swarm, Side.White);
  const blackSurroundedQueenBee = getSurroundedQueenBee(swarm, Side.Black);

  return Match.value(
    distributive([whiteSurroundedQueenBee, blackSurroundedQueenBee])
  ).pipe(
    Match.when([{ _tag: "Some" }, { _tag: "Some" }], ([white, black]) =>
      QueenBeeState.BothSurrounded({ cells: [white.value, black.value] })
    ),
    Match.when([{ _tag: "None" }, { _tag: "Some" }], ([_white, black]) =>
      QueenBeeState.OneSurrounded({ cell: black.value })
    ),
    Match.when([{ _tag: "Some" }, { _tag: "None" }], ([white, _black]) =>
      QueenBeeState.OneSurrounded({ cell: white.value })
    ),
    Match.when([{ _tag: "None" }, { _tag: "None" }], ([_white, _black]) =>
      QueenBeeState.Free()
    ),
    Match.exhaustive
  );
};
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
