### PR TITLE
rpc slash

### DIFF
--- a/.changeset/funny-islands-relate.md
+++ b/.changeset/funny-islands-relate.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add Stream.toAsyncIterableRuntime api

--- a/.changeset/tough-candles-deliver.md
+++ b/.changeset/tough-candles-deliver.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+remove trailing slash from rpc http requests

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -5333,6 +5333,17 @@ export const toReadableStreamRuntime: {
 } = internal.toReadableStreamRuntime
 
 /**
+ * Converts the stream to a `AsyncIterable` using the provided runtime.
+ *
+ * @since 3.15.0
+ * @category destructors
+ */
+export const toAsyncIterableRuntime: {
+  <A, XR>(runtime: Runtime<XR>): <E, R extends XR>(self: Stream<A, E, R>) => AsyncIterable<A>
+  <A, E, XR, R extends XR>(self: Stream<A, E, R>, runtime: Runtime<XR>): AsyncIterable<A>
+} = internal.toAsyncIterableRuntime
+
+/**
  * Applies the transducer to the stream and emits its outputs.
  *
  * @since 2.0.0

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -7201,6 +7201,66 @@ export const transduce = dual<
 )
 
 /** @internal */
+export const toAsyncIterableRuntime = dual<
+  <A, XR>(
+    runtime: Runtime.Runtime<XR>
+  ) => <E, R extends XR>(self: Stream.Stream<A, E, R>) => AsyncIterable<A>,
+  <A, E, XR, R extends XR>(
+    self: Stream.Stream<A, E, R>,
+    runtime: Runtime.Runtime<XR>
+  ) => AsyncIterable<A>
+>(
+  (args) => isStream(args[0]),
+  <A, E, XR, R extends XR>(
+    self: Stream.Stream<A, E, R>,
+    runtime: Runtime.Runtime<XR>
+  ): AsyncIterable<A> => {
+    const runFork = Runtime.runFork(runtime)
+    return {
+      [Symbol.asyncIterator]() {
+        let currentResolve: ((value: IteratorResult<A>) => void) | undefined = undefined
+        let currentReject: ((reason: any) => void) | undefined = undefined
+        let fiber: Fiber.RuntimeFiber<void, E> | undefined = undefined
+        const latch = Effect.unsafeMakeLatch(false)
+        return {
+          next() {
+            if (!fiber) {
+              fiber = runFork(runForEach(self, (value) =>
+                latch.whenOpen(Effect.sync(() => {
+                  latch.unsafeClose()
+                  currentResolve!({ done: false, value })
+                  currentResolve = undefined
+                  currentReject = undefined
+                }))))
+              fiber.addObserver((exit) => {
+                fiber = Effect.runFork(latch.whenOpen(Effect.sync(() => {
+                  if (exit._tag === "Failure") {
+                    currentReject!(exit.cause)
+                  } else {
+                    currentResolve!({ done: true, value: void 0 })
+                  }
+                  currentResolve = undefined
+                  currentReject = undefined
+                })))
+              })
+            }
+            return new Promise<IteratorResult<A>>((resolve, reject) => {
+              currentResolve = resolve
+              currentReject = reject
+              latch.unsafeOpen()
+            })
+          },
+          return() {
+            if (!fiber) return Promise.resolve({ done: true, value: void 0 })
+            return Effect.runPromise(Effect.as(Fiber.interrupt(fiber), { done: true, value: void 0 }))
+          }
+        }
+      }
+    }
+  }
+)
+
+/** @internal */
 export const unfold = <S, A>(s: S, f: (s: S) => Option.Option<readonly [A, S]>): Stream.Stream<A> =>
   unfoldChunk(s, (s) => pipe(f(s), Option.map(([a, s]) => [Chunk.of(a), s])))
 

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -710,7 +710,7 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
         HttpBody.uint8Array(encoded, serialization.contentType)
 
       if (isJson) {
-        return client.post("/", { body }).pipe(
+        return client.post("", { body }).pipe(
           Effect.flatMap((r) => r.json),
           Effect.scoped,
           Effect.flatMap((u) => {
@@ -728,7 +728,7 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
         )
       }
 
-      return client.post("/", { body }).pipe(
+      return client.post("", { body }).pipe(
         Effect.flatMap((r) =>
           Stream.runForEachChunk(r.stream, (chunk) => {
             const responses = Chunk.toReadonlyArray(chunk).flatMap(parser.decode) as Array<FromServerEncoded>


### PR DESCRIPTION
- **remove trailing slash from rpc http requests**
- **add Stream.toAsyncIterableRuntime api**
