### PR TITLE
Make `Effect.liftPredicate` and `Either.liftPredicate` reusable

### DIFF
--- a/.changeset/happy-steaks-work.md
+++ b/.changeset/happy-steaks-work.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Modify the signatures of `Either.liftPredicate` and `Effect.predicate` to make them reusable.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1265,12 +1265,12 @@ describe("Effect", () => {
       return "b" as const
     })).type.toBe<Effect.Effect<string, "b">>()
 
-    expect(Effect.liftPredicate(hole<Predicate.Refinement<string | number, number>>(), (sn: string) => {
+    expect(Effect.liftPredicate(hole<Predicate.Refinement<string | number, number>>(), (sn) => {
       expect(sn).type.toBe<string | number>()
       return "b" as const
     })).type.toBe<(a: string | number) => Effect.Effect<number, "b">>()
     expect(Effect.liftPredicate(Predicate.isString, (sn) => {
-      expect(sn).type.toBe<string | number>()
+      expect(sn).type.toBe<unknown>()
       return "b" as const
     })).type.toBe<(a: unknown) => Effect.Effect<string, "b">>()
 

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1256,7 +1256,7 @@ describe("Effect", () => {
     expect(pipe(
       primitiveNumberOrString,
       Effect.liftPredicate(Predicate.isString, (sn) => {
-        expect(sn).type.toBe<string | number>()
+        expect(sn).type.toBe<unknown>()
         return "b" as const
       })
     )).type.toBe<Effect.Effect<string, "b">>()
@@ -1264,6 +1264,15 @@ describe("Effect", () => {
       expect(sn).type.toBe<string | number>()
       return "b" as const
     })).type.toBe<Effect.Effect<string, "b">>()
+
+    expect(Effect.liftPredicate(hole<Predicate.Refinement<string | number, number>>(), (sn: string) => {
+      expect(sn).type.toBe<string | number>()
+      return "b" as const
+    })).type.toBe<(a: string | number) => Effect.Effect<number, "b">>()
+    expect(Effect.liftPredicate(Predicate.isString, (sn) => {
+      expect(sn).type.toBe<string | number>()
+      return "b" as const
+    })).type.toBe<(a: unknown) => Effect.Effect<string, "b">>()
 
     expect(pipe(
       primitiveNumberOrString,
@@ -1301,12 +1310,12 @@ describe("Effect", () => {
     expect(pipe(
       primitiveNumber,
       Effect.liftPredicate(predicateNumbersOrStrings, (n) => {
-        expect(n).type.toBe<number>()
+        expect(n).type.toBe<string | number>()
         return "b" as const
       })
     )).type.toBe<Effect.Effect<number, "b">>()
     expect(Effect.liftPredicate(primitiveNumber, predicateNumbersOrStrings, (n) => {
-      expect(n).type.toBe<number>()
+      expect(n).type.toBe<string | number>()
       return "b" as const
     })).type.toBe<Effect.Effect<number, "b">>()
 

--- a/packages/effect/dtslint/Either.tst.ts
+++ b/packages/effect/dtslint/Either.tst.ts
@@ -74,6 +74,20 @@ describe("Either", () => {
     const primitiveNumber = hole<number>()
     const stringOrNumber = hole<string | number>()
     const predicateNumberOrString = hole<Predicate.Predicate<number | string>>()
+    const refinementNumberOrStringToNumber = hole<Predicate.Refinement<number | string, number>>()
+
+    expect(
+      Either.liftPredicate(predicateNumberOrString, (sn) => {
+        expect(sn).type.toBe<string | number>()
+        return "b" as const
+      })
+    ).type.toBe<(a: string | number) => Either.Either<string | number, "b">>()
+    expect(
+      Either.liftPredicate(refinementNumberOrStringToNumber, (sn) => {
+        expect(sn).type.toBe<string | number>()
+        return "b" as const
+      })
+    ).type.toBe<(a: string | number) => Either.Either<number, "b">>()
 
     expect(
       Either.liftPredicate(

--- a/packages/effect/dtslint/Either.tst.ts
+++ b/packages/effect/dtslint/Either.tst.ts
@@ -121,16 +121,16 @@ describe("Either", () => {
     ).type.toBe<Either.Either<string | number, "b">>()
 
     expect(
-      Either.liftPredicate(primitiveNumber, predicateNumberOrString, (n) => {
-        expect(n).type.toBe<number>()
+      Either.liftPredicate(primitiveNumber, predicateNumberOrString, (sn) => {
+        expect(sn).type.toBe<string | number>()
         return "b" as const
       })
     ).type.toBe<Either.Either<number, "b">>()
     expect(
       pipe(
         primitiveNumber,
-        Either.liftPredicate(predicateNumberOrString, (n) => {
-          expect(n).type.toBe<number>()
+        Either.liftPredicate(predicateNumberOrString, (sn) => {
+          expect(sn).type.toBe<string | number>()
           return "b" as const
         })
       )

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4969,14 +4969,14 @@ export const uninterruptibleMask: <A, E, R>(
  * @category Condition Checking
  * @since 3.4.0
  */
-export const liftPredicate: {
+export const liftPredicate: { // Note: I intentionally avoid using the NoInfer pattern here.
   <A, B extends A, E>(
-    refinement: Refinement<NoInfer<A>, B>,
-    orFailWith: (a: NoInfer<A>) => E
+    refinement: Refinement<A, B>,
+    orFailWith: (a: A) => E
   ): (a: A) => Effect<B, E>
-  <A, E>(predicate: Predicate<NoInfer<A>>, orFailWith: (a: NoInfer<A>) => E): (a: A) => Effect<A, E>
+  <B extends A, E, A = B>(predicate: Predicate<A>, orFailWith: (a: A) => E): (a: B) => Effect<B, E>
   <A, E, B extends A>(self: A, refinement: Refinement<A, B>, orFailWith: (a: A) => E): Effect<B, E>
-  <A, E>(self: A, predicate: Predicate<NoInfer<A>>, orFailWith: (a: NoInfer<A>) => E): Effect<A, E>
+  <B extends A, E, A = B>(self: B, predicate: Predicate<A>, orFailWith: (a: A) => E): Effect<B, E>
 } = effect.liftPredicate
 
 /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4969,7 +4969,7 @@ export const uninterruptibleMask: <A, E, R>(
  * @category Condition Checking
  * @since 3.4.0
  */
-export const liftPredicate: { // Note: I intentionally avoid using the NoInfer pattern here.
+export const liftPredicate: {
   <A, B extends A, E>(
     refinement: Refinement<A, B>,
     orFailWith: (a: A) => E

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -421,19 +421,14 @@ export const match: {
  * import { pipe, Either } from "effect"
  *
  * const isPositive = (n: number): boolean => n > 0
+ * const isPositiveEither = Either.liftPredicate(isPositive, n => `${n} is not positive`)
  *
  * assert.deepStrictEqual(
- *   pipe(
- *     1,
- *     Either.liftPredicate(isPositive, n => `${n} is not positive`)
- *   ),
+ *   isPositiveEither(1),
  *   Either.right(1)
  * )
  * assert.deepStrictEqual(
- *   pipe(
- *     0,
- *     Either.liftPredicate(isPositive, n => `${n} is not positive`)
- *   ),
+ *   isPositiveEither(0),
  *   Either.left("0 is not positive")
  * )
  * ```
@@ -441,22 +436,22 @@ export const match: {
  * @category lifting
  * @since 3.4.0
  */
-export const liftPredicate: {
-  <A, B extends A, E>(refinement: Refinement<NoInfer<A>, B>, orLeftWith: (a: NoInfer<A>) => E): (a: A) => Either<B, E>
-  <A, E>(
-    predicate: Predicate<NoInfer<A>>,
-    orLeftWith: (a: NoInfer<A>) => E
-  ): (a: A) => Either<A, E>
+export const liftPredicate: { // Note: I intentionally avoid using the NoInfer pattern here.
+  <A, B extends A, E>(refinement: Refinement<A, B>, orLeftWith: (a: A) => E): (a: A) => Either<B, E>
+  <B extends A, E, A = B>(
+    predicate: Predicate<A>,
+    orLeftWith: (a: A) => E
+  ): (a: B) => Either<B, E>
   <A, E, B extends A>(
     self: A,
     refinement: Refinement<A, B>,
     orLeftWith: (a: A) => E
   ): Either<B, E>
-  <A, E>(
-    self: A,
-    predicate: Predicate<NoInfer<A>>,
-    orLeftWith: (a: NoInfer<A>) => E
-  ): Either<A, E>
+  <B extends A, E, A = B>(
+    self: B,
+    predicate: Predicate<A>,
+    orLeftWith: (a: A) => E
+  ): Either<B, E>
 } = dual(
   3,
   <A, E>(a: A, predicate: Predicate<A>, orLeftWith: (a: A) => E): Either<A, E> =>

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -436,7 +436,7 @@ export const match: {
  * @category lifting
  * @since 3.4.0
  */
-export const liftPredicate: { // Note: I intentionally avoid using the NoInfer pattern here.
+export const liftPredicate: {
   <A, B extends A, E>(refinement: Refinement<A, B>, orLeftWith: (a: A) => E): (a: A) => Either<B, E>
   <B extends A, E, A = B>(
     predicate: Predicate<A>,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes # https://github.com/Effect-TS/effect/issues/4686
