### PR TITLE
Re-export `default` from Undici

### DIFF
--- a/packages/platform-node/src/Undici.ts
+++ b/packages/platform-node/src/Undici.ts
@@ -6,4 +6,5 @@
  * @since 1.0.0
  * @category undici
  */
+export { default } from "undici"
 export * from "undici"

--- a/packages/platform-node/src/Undici.ts
+++ b/packages/platform-node/src/Undici.ts
@@ -2,9 +2,9 @@
  * @since 1.0.0
  */
 
+export { default } from "undici"
 /**
  * @since 1.0.0
  * @category undici
  */
-export { default } from "undici"
 export * from "undici"

--- a/packages/platform-node/src/Undici.ts
+++ b/packages/platform-node/src/Undici.ts
@@ -2,11 +2,13 @@
  * @since 1.0.0
  */
 
-/**
- * @since 1.0.0
- * @category undici
- */
-export { default } from "undici"
+export {
+  /**
+   * @since 1.0.0
+   * @category undici
+   */
+  default
+} from "undici"
 /**
  * @since 1.0.0
  * @category undici

--- a/packages/platform-node/src/Undici.ts
+++ b/packages/platform-node/src/Undici.ts
@@ -2,6 +2,10 @@
  * @since 1.0.0
  */
 
+/**
+ * @since 1.0.0
+ * @category undici
+ */
 export { default } from "undici"
 /**
  * @since 1.0.0


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This fixes a type error in the following code:

```ts
import Undici from '@effect/platform-node/Undici';
new Undici.cacheStores.MemoryCacheStore()
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

