### PR TITLE
Fix JSONSchema generation for record values that include `undefined`, closes #4697

### DIFF
--- a/.changeset/slow-books-occur.md
+++ b/.changeset/slow-books-occur.md
@@ -1,0 +1,58 @@
+---
+"effect": patch
+---
+
+Fix JSONSchema generation for record values that include `undefined`, closes #4697.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.partial(
+  Schema.Struct(
+    { foo: Schema.Number },
+    {
+      key: Schema.String,
+      value: Schema.Number
+    }
+  )
+)
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+// throws
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.partial(
+  Schema.Struct(
+    { foo: Schema.Number },
+    {
+      key: Schema.String,
+      value: Schema.Number
+    }
+  )
+)
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+Output:
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "foo": {
+      "type": "number"
+    }
+  },
+  "additionalProperties": {
+    "type": "number"
+  }
+}
+*/
+```

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -684,14 +684,15 @@ const go = (
       let patternProperties: JsonSchema7 | undefined = undefined
       let propertyNames: JsonSchema7 | undefined = undefined
       for (const is of ast.indexSignatures) {
+        const pruned = pruneUndefined(is.type) ?? is.type
         const parameter = is.parameter
         switch (parameter._tag) {
           case "StringKeyword": {
-            output.additionalProperties = go(is.type, $defs, true, path, options)
+            output.additionalProperties = go(pruned, $defs, true, path, options)
             break
           }
           case "TemplateLiteral": {
-            patternProperties = go(is.type, $defs, true, path, options)
+            patternProperties = go(pruned, $defs, true, path, options)
             propertyNames = {
               type: "string",
               pattern: AST.getTemplateLiteralRegExp(parameter).source
@@ -699,13 +700,13 @@ const go = (
             break
           }
           case "Refinement": {
-            patternProperties = go(is.type, $defs, true, path, options)
+            patternProperties = go(pruned, $defs, true, path, options)
             propertyNames = go(parameter, $defs, true, path, options)
             break
           }
           case "SymbolKeyword": {
             const indexSignaturePath = path.concat("[symbol]")
-            output.additionalProperties = go(is.type, $defs, true, indexSignaturePath, options)
+            output.additionalProperties = go(pruned, $defs, true, indexSignaturePath, options)
             propertyNames = go(parameter, $defs, true, indexSignaturePath, options)
             break
           }

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -2199,6 +2199,15 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
         }
       )
     })
+
+    it("Record(string, number | undefined)", () => {
+      expectJSONSchemaAnnotations(Schema.Record({ key: Schema.String, value: Schema.UndefinedOr(JsonNumber) }), {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": { "type": "number" }
+      })
+    })
   })
 
   describe("Union", () => {

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -2200,12 +2200,38 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
       )
     })
 
-    it("Record(string, number | undefined)", () => {
+    it("Record(string, UndefinedOr(number))", () => {
       expectJSONSchemaAnnotations(Schema.Record({ key: Schema.String, value: Schema.UndefinedOr(JsonNumber) }), {
         "type": "object",
         "properties": {},
         "required": [],
         "additionalProperties": { "type": "number" }
+      })
+    })
+
+    it("partial(Struct + Record(string, number))", () => {
+      const schema = Schema.partial(
+        Schema.Struct(
+          { foo: Schema.Number },
+          {
+            key: Schema.String,
+            value: Schema.Number
+          }
+        )
+      )
+
+      expectJSONSchemaAnnotations(schema, {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [],
+        "properties": {
+          "foo": {
+            "type": "number"
+          }
+        },
+        "additionalProperties": {
+          "type": "number"
+        }
       })
     })
   })


### PR DESCRIPTION
Before

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.partial(
  Schema.Struct(
    { foo: Schema.Number },
    {
      key: Schema.String,
      value: Schema.Number
    }
  )
)

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
// throws
```

After

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.partial(
  Schema.Struct(
    { foo: Schema.Number },
    {
      key: Schema.String,
      value: Schema.Number
    }
  )
)

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
Output:
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [],
  "properties": {
    "foo": {
      "type": "number"
    }
  },
  "additionalProperties": {
    "type": "number"
  }
}
*/
```
