### PR TITLE
fix(Metric): summary quantile values

### DIFF
--- a/.changeset/flat-keys-burn.md
+++ b/.changeset/flat-keys-burn.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix summary metric’s quantile values

--- a/packages/effect/src/internal/metric/hook.ts
+++ b/packages/effect/src/internal/metric/hook.ts
@@ -245,7 +245,7 @@ export const summary = (key: MetricKey.MetricKey.Summary): MetricHook.MetricHook
       if (item != null) {
         const [t, v] = item
         const age = Duration.millis(now - t)
-        if (Duration.greaterThanOrEqualTo(age, Duration.zero) && age <= maxAge) {
+        if (Duration.greaterThanOrEqualTo(age, Duration.zero) && Duration.lessThanOrEqualTo(age, maxAge)) {
           builder.push(v)
         }
       }

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -479,7 +479,7 @@ describe("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: [0, 1, 10]
+          quantiles: [0.25, 0.5, 0.75]
         }).pipe(
           Metric.taggedWithLabels(labels)
         )
@@ -493,6 +493,8 @@ describe("Metric", () => {
         strictEqual(result.sum, 4)
         strictEqual(result.min, 1)
         strictEqual(result.max, 3)
+        const medianQuantileValue = result.quantiles[1][1]
+        strictEqual(Option.getOrNull(medianQuantileValue), 1)
       }))
     it.effect("direct observe", () =>
       Effect.gen(function*() {
@@ -502,7 +504,7 @@ describe("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: [0, 1, 10]
+          quantiles: [0.25, 0.5, 0.75]
         }).pipe(
           Metric.taggedWithLabels(labels)
         )
@@ -516,6 +518,8 @@ describe("Metric", () => {
         strictEqual(result.sum, 4)
         strictEqual(result.min, 1)
         strictEqual(result.max, 3)
+        const medianQuantileValue = result.quantiles[1][1]
+        strictEqual(Option.getOrNull(medianQuantileValue), 1)
       }))
     it.effect("custom observe with mapInput", () =>
       Effect.gen(function*() {
@@ -525,7 +529,7 @@ describe("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: [0, 1, 10]
+          quantiles: [0.25, 0.5, 0.75]
         }).pipe(
           Metric.taggedWithLabels(labels),
           Metric.mapInput((s: string) => s.length)
@@ -540,6 +544,8 @@ describe("Metric", () => {
         strictEqual(result.sum, 4)
         strictEqual(result.min, 1)
         strictEqual(result.max, 3)
+        const medianQuantileValue = result.quantiles[1][1]
+        strictEqual(Option.getOrNull(medianQuantileValue), 1)
       }))
     it.effect("observeSummaryWith + taggedWith", () =>
       Effect.gen(function*() {
@@ -549,7 +555,7 @@ describe("Metric", () => {
           maxAge: Duration.minutes(1),
           maxSize: 10,
           error: 0,
-          quantiles: [0, 1, 10]
+          quantiles: [0.25, 0.5, 0.75]
         }).pipe(
           Metric.taggedWithLabels(labels),
           Metric.mapInput((s: string) => s.length)


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes an issue with the summary metric.

When accessing the value of a summary metric, each quantile of that value incorrectly shows a value of `0` if the time elapsed between when the value(s) was/were recorded and when the metric value is read is greater than zero.

I've reproduced this bug [here](https://effect.website/play/#eddfc884c24b). Remove the `Effect.sleep` to see how the behavior changes.