### PR TITLE
Add a timeout option to HttpClientRequest

### DIFF
--- a/.changeset/beige-birds-attack.md
+++ b/.changeset/beige-birds-attack.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Add a timeout option to HttpClientRequest

--- a/packages/platform/src/HttpClient.ts
+++ b/packages/platform/src/HttpClient.ts
@@ -358,7 +358,7 @@ export const makeWith: <E2, R2, E, R>(
  */
 export const make: (
   f: (
-    request: ClientRequest.HttpClientRequest,
+    request: Omit<ClientRequest.HttpClientRequest, "timeout">,
     url: URL,
     signal: AbortSignal,
     fiber: RuntimeFiber<ClientResponse.HttpClientResponse, Error.HttpClientError>

--- a/packages/platform/src/HttpClientRequest.ts
+++ b/packages/platform/src/HttpClientRequest.ts
@@ -1,6 +1,7 @@
 /**
  * @since 1.0.0
  */
+import type * as Duration from "effect/Duration"
 import type * as Effect from "effect/Effect"
 import type { Inspectable } from "effect/Inspectable"
 import type * as Option from "effect/Option"
@@ -41,6 +42,7 @@ export interface HttpClientRequest extends Inspectable, Pipeable {
   readonly hash: Option.Option<string>
   readonly headers: Headers.Headers
   readonly body: Body.HttpBody
+  readonly timeout?: Duration.DurationInput
 }
 
 /**
@@ -56,6 +58,7 @@ export interface Options {
   readonly body?: Body.HttpBody | undefined
   readonly accept?: string | undefined
   readonly acceptJson?: boolean | undefined
+  readonly timeout?: Duration.DurationInput
 }
 
 /**
@@ -399,3 +402,18 @@ export const bodyFileWeb: {
   (file: Body.HttpBody.FileLike): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, file: Body.HttpBody.FileLike): HttpClientRequest
 } = internal.bodyFileWeb
+
+/**
+ * @since 1.0.0
+ * @category combinators
+ */
+export const setTimeout: {
+  (timeout: Duration.DurationInput): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, timeout: Duration.DurationInput): HttpClientRequest
+} = internal.setTimeout
+
+/**
+ * @since 1.0.0
+ * @category combinators
+ */
+export const removeTimeout: (self: HttpClientRequest) => HttpClientRequest = internal.removeTimeout

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -23,7 +23,7 @@ import {
   Stream,
   Struct
 } from "effect"
-import { assertInclude, deepStrictEqual, strictEqual } from "effect/test/util"
+import { assertEquals, assertInclude, deepStrictEqual, strictEqual } from "effect/test/util"
 
 const Todo = Schema.Struct({
   userId: Schema.Number,
@@ -102,6 +102,14 @@ describe("HttpClient", () => {
         Stream.runFold("", (a, b) => a + new TextDecoder().decode(b))
       )
       assertInclude(response, "Google")
+    }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
+
+  it("google timeout", () =>
+    Effect.gen(function*() {
+      const error = yield* Effect.flip(HttpClient.get("https://www.google.com/", { timeout: "1 milli" }))
+      assertEquals(error._tag, "RequestError")
+      assertEquals(error.reason, "Transport")
+      assertEquals(error.cause!.toString(), "TimeoutException: Request timed out after '1ms'")
     }).pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise))
 
   it("jsonplaceholder", () =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a `timeout` option to `HttpClientRequest`, which results in a `Transport` `RequestError` if it's exceeded. I've erred on adding to the request rather than having it alongside to cater for cases where the client has been composed.

I'm sure that some of the implementation could be improved. 😄

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Thread https://discord.com/channels/795981131316985866/1359836164005302392
- Related Issue #
- Closes #
