### PR TITLE
chore: tweak `HttpApiEndpoint` type test

### DIFF
--- a/packages/platform/dtslint/HttpApiEndpoint.tst.ts
+++ b/packages/platform/dtslint/HttpApiEndpoint.tst.ts
@@ -6,7 +6,10 @@ describe("HttpApiEndpoint", () => {
   it("should prevent duplicated params", () => {
     expect(
       HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
-        HttpApiSchema.param("id", Schema.NumberFromString)}`
-    ).type.toRaiseError(`Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'.`)
+        HttpApiSchema.param("id", Schema.NumberFromString)
+      }`
+    ).type.toRaiseError(
+      `Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'.`
+    )
   })
 })

--- a/packages/platform/dtslint/HttpApiEndpoint.tst.ts
+++ b/packages/platform/dtslint/HttpApiEndpoint.tst.ts
@@ -1,11 +1,12 @@
 import { HttpApiEndpoint, HttpApiSchema } from "@effect/platform"
 import { Schema } from "effect"
-import { describe, it } from "tstyche"
+import { describe, expect, it } from "tstyche"
 
 describe("HttpApiEndpoint", () => {
   it("should prevent duplicated params", () => {
-    HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
-      // @ts-expect-error: Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'
-      HttpApiSchema.param("id", Schema.NumberFromString)}`
+    expect(
+      HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
+        HttpApiSchema.param("id", Schema.NumberFromString)}`
+    ).type.toRaiseError(`Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param :id"'.`)
   })
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

To draw your attention, TSTyche 4 is coming with big news: the ability matchers. The idea is to replace each and every `// @ts-expect-error` with something like `.toBeApplicable`, `.toBeCallableWith()`, `.toBeConstructableWith()` and similar matchers.

The initial implementation of `.toBeCallableWith()` is already [public](https://tstyche.org/releases/tstyche-4#to-be-callable-with). I was trying it out with `effect` repo (a demo PR will follow soon) and bumped into the `HttpApiEndpoint` type test.

Hm.. I wonder what sounds better:

- to use `.toRaiseError()` here, because a custom error message is created? (this PR)
- or, to put together something like `.toBeTaggableWith()`, a new matcher for tagged templates?

The `.toBeCallableWith()` matcher does not cover tagged templates. It calls given expression with `()` straight forward. The usage of `.toBeTaggableWith()` could look this:

```ts
expect(HttpApiEndpoint.get("test")).type.not.toBeTaggableWith(
  `/${HttpApiSchema.param("id", Schema.NumberFromString)}/${HttpApiSchema.param("id", Schema.NumberFromString)}`,
);
```

Or even better (similar how [`.toBeApplicable` works](https://tstyche.org/releases/tstyche-4#to-be-applicable), perhaps?):

```ts
expect(HttpApiEndpoint.get("test")).type.not.toBeTaggableWith
  `/${HttpApiSchema.param("id", Schema.NumberFromString)}/${HttpApiSchema.param("id", Schema.NumberFromString)}`;
```

Differently from `.toRaiseError()`, it would test the behaviour. And in a way reflect a user story.

This is still a raw idea. Might be `.toBeTaggableWith()` could have better name as well. I was wondering, if it sounds useful to have a matcher like this or not?

Related: https://github.com/tstyche/tstyche/pull/450

---

On second thought, in this case two matcher can be used: one could test the behaviour and second one capture the custom message.