### PR TITLE
fix(ConfigProvider.fromEnv): use import.meta.env instead of process.env

### DIFF
--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -108,8 +108,7 @@ export const fromEnv = (
   const makePathString = (path: ReadonlyArray<string>): string => pipe(path, Arr.join(pathDelim))
   const unmakePathString = (pathString: string): ReadonlyArray<string> => pathString.split(pathDelim)
 
-  const getEnv = () =>
-    typeof process !== "undefined" && "env" in process && typeof process.env === "object" ? process.env : {}
+  const getEnv = () => import.meta.env;
 
   const load = <A>(
     path: ReadonlyArray<string>,


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The reason for this is that this allows using environment variables in the browser with vite. Vite has a feature where all environment variables that have a `VITE_` prefix are exposed in `import.meta.env`. And even in node.js, `import.meta.env` is a alias to `process.env` so i don't see any reason why `ConfigProvider.fromEnv` only supported `process.env`

