### PR TITLE
add AiModels service to AnthropicClient.layerConfig

### DIFF
--- a/.changeset/strange-hairs-remain.md
+++ b/.changeset/strange-hairs-remain.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": minor
+---
+
+AnthropicClient.layerConfig has the same ROut as AnthropicClient.layer - specifically, AiModels.AiModels was missing

--- a/.changeset/strange-hairs-remain.md
+++ b/.changeset/strange-hairs-remain.md
@@ -1,5 +1,5 @@
 ---
-"@effect/ai-anthropic": minor
+"@effect/ai-anthropic": patch
 ---
 
 AnthropicClient.layerConfig has the same ROut as AnthropicClient.layer - specifically, AiModels.AiModels was missing

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -228,7 +228,7 @@ export const layerConfig = (
       client: HttpClient.HttpClient
     ) => HttpClient.HttpClient
   }>
-): Layer.Layer<AnthropicClient, ConfigError, HttpClient.HttpClient> =>
+): Layer.Layer<AiModels.AiModels | AnthropicClient, ConfigError, HttpClient.HttpClient> =>
   Config.unwrap(options).pipe(
     Effect.flatMap(make),
     Layer.effect(AnthropicClient),


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The problem, more specifically, is that the guide https://effect.website/docs/ai/introduction/ won't work if I simply substitute OpenAI with Anthropic. The change should be backward-compatible (only adds a ROut)

Meanwhile I expect ROut of Anthropic and OpenAI be the same, more so ROut of .layer and .layerConfig


