### PR TITLE
Allow Match.typeTags to specify a return type

### DIFF
--- a/.changeset/weak-pillows-cry.md
+++ b/.changeset/weak-pillows-cry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow Match.typeTags to specify a return type

--- a/packages/effect/dtslint/Match.tst.ts
+++ b/packages/effect/dtslint/Match.tst.ts
@@ -389,7 +389,28 @@ describe("Match", () => {
       })(value)
     ).type.toBe<string | number>()
 
+    expect(
+      Match.typeTags<Value, string | number>()({
+        A: (A) => {
+          expect(A).type.toBe<{ _tag: "A"; a: number }>()
+          return A.a
+        },
+        B: (B) => {
+          expect(B).type.toBe<{ _tag: "B"; b: number }>()
+          return "B"
+        }
+      })(value)
+    ).type.toBe<string | number>()
+
     Match.typeTags<Value>()({
+      A: (_) => _.a,
+      B: () => "B",
+      // @ts-expect-error: Type '() => boolean' is not assignable to type 'never'
+      C: () => false
+    })(value)
+
+    Match.typeTags<Value, string>()({
+      // @ts-expect-error: Type 'number' is not assignable to type 'string'
       A: (_) => _.a,
       B: () => "B",
       // @ts-expect-error: Type '() => boolean' is not assignable to type 'never'

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -259,15 +259,26 @@ export const valueTags: {
  * @category Creating a matcher
  * @since 1.0.0
  */
-export const typeTags: <I>() => <
-  P extends
-    & {
-      readonly [Tag in Types.Tags<"_tag", I> & string]: (
-        _: Extract<I, { readonly _tag: Tag }>
-      ) => any
-    }
-    & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
->(fields: P) => (input: I) => Unify<ReturnType<P[keyof P]>> = internal.typeTags
+export const typeTags: {
+  <I, Ret>(): <
+    P extends
+      & {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (
+          _: Extract<I, { readonly _tag: Tag }>
+        ) => Ret
+      }
+      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
+  >(fields: P) => (input: I) => Ret
+  <I>(): <
+    P extends
+      & {
+        readonly [Tag in Types.Tags<"_tag", I> & string]: (
+          _: Extract<I, { readonly _tag: Tag }>
+        ) => any
+      }
+      & { readonly [Tag in Exclude<keyof P, Types.Tags<"_tag", I>>]: never }
+  >(fields: P) => (input: I) => Unify<ReturnType<P[keyof P]>>
+} = internal.typeTags
 
 /**
  * Ensures that all branches of a matcher return a specific type.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As `Match.typeTags` can be assigned to a typed variable, this change adds an optional second generic for the return type.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
