### PR TITLE
add `Schema.TaggedUnion`

### DIFF
--- a/.changeset/clean-bobcats-matter.md
+++ b/.changeset/clean-bobcats-matter.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Schema: add `taggedUnion` to create discriminiated unions

--- a/.changeset/clean-bobcats-matter.md
+++ b/.changeset/clean-bobcats-matter.md
@@ -4,7 +4,7 @@
 
 add `Schema.TaggedUnion` to create discriminiated unions
 
-This allows you to quickly create a serialiable discriminated union with
+This allows you to quickly create a serializable discriminated union with
 `_tag`'s for each case.
 
 ```ts

--- a/.changeset/clean-bobcats-matter.md
+++ b/.changeset/clean-bobcats-matter.md
@@ -2,4 +2,36 @@
 "effect": minor
 ---
 
-Schema: add `taggedUnion` to create discriminiated unions
+add `Schema.TaggedUnion` to create discriminiated unions
+
+This allows you to quickly create a serialiable discriminated union with
+`_tag`'s for each case.
+
+```ts
+import { Schema } from "effect"
+import { strictEqual } from "node:assert"
+
+export const HttpError = Schema.TaggedUnion({
+  BadRequest: {
+    status: Schema.tag(400),
+    message: Schema.String
+  },
+  NotFound: {
+    status: Schema.tag(404),
+    message: Schema.String
+  }
+})
+
+// access the member schemas
+HttpError.members.BadRequest
+
+// create an instance of a member
+const error = HttpError.members.NotFound.make({ message: "Not Found" })
+
+// use the provided $match helper to perform pattern matching
+const statusCode = HttpError.$match(error, {
+  BadRequest: (e) => e.status,
+  NotFound: (e) => e.status
+})
+strictEqual(statusCode, 404)
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -46,7 +46,7 @@ import * as record from "./Record.js"
 import * as redacted_ from "./Redacted.js"
 import * as Request from "./Request.js"
 import * as scheduler_ from "./Scheduler.js"
-import type { ParseOptions, LiteralValue } from "./SchemaAST.js"
+import type { LiteralValue, ParseOptions } from "./SchemaAST.js"
 import * as AST from "./SchemaAST.js"
 import * as sortedSet_ from "./SortedSet.js"
 import * as string_ from "./String.js"
@@ -8912,7 +8912,6 @@ const makeClass = <Fields extends Struct.Fields>(
 
   const [typeAnnotations, transformationAnnotations, encodedAnnotations] = getClassAnnotations(annotations)
 
-
   const declarationSurrogate = typeSchema_.annotations({
     identifier,
     ...typeAnnotations
@@ -10890,7 +10889,7 @@ export class ArrayFormatterIssue extends Struct({
  * @example
  * ```ts
  * import { Schema } from "effect"
- * 
+ *
  * const schema = Schema.taggedUnion({
  *   Circle: { radius: Schema.Number },
  *   Square: { sideLength: Schema.Number },
@@ -10904,21 +10903,12 @@ export class ArrayFormatterIssue extends Struct({
  */
 export function taggedUnion<
   Cases extends Record<string, Fields>,
-  Fields extends Struct.Fields,
->(
-  definitions: Cases,
-): Union<
-  {
-    [K in keyof Cases]: K extends LiteralValue
-      ? TaggedStruct<K, Cases[K]>
-      : never
-  }[keyof Cases][]
-> & {
-  [K in keyof Cases]: K extends LiteralValue
-    ? TaggedStruct<K, Cases[K]>
-    : never
-} {
-  const members = record.map(definitions, (fields, key) => TaggedStruct(key, fields))
+  Fields extends Struct.Fields
+>(cases: Cases):
+  & Union<Array<{ [K in keyof Cases]: K extends LiteralValue ? TaggedStruct<K, Cases[K]> : never }[keyof Cases]>>
+  & { [K in keyof Cases]: K extends LiteralValue ? TaggedStruct<K, Cases[K]> : never }
+{
+  const members = record.map(cases, (fields, key) => TaggedStruct(key, fields))
   const schema = Union(...record.values(members))
 
   return new Proxy(schema, {
@@ -10928,6 +10918,6 @@ export function taggedUnion<
       } else {
         return Reflect.get(target, key)
       }
-    },
+    }
   }) as any
 }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -10886,46 +10886,46 @@ export class ArrayFormatterIssue extends Struct({
 }) {}
 
 /**
- * @category taggedUnion
+ * @category TaggedUnion
  * @since 3.15.0
  */
-export interface taggedUnion<Cases extends Record<string, Struct.Fields>> extends
+export interface TaggedUnion<Cases extends Record<string, Struct.Fields>> extends
   AnnotableClass<
-    taggedUnion<Cases>,
-    taggedUnion.Members<Cases>["Type"],
-    taggedUnion.Members<Cases>["Encoded"],
-    taggedUnion.Members<Cases>["Context"]
+    TaggedUnion<Cases>,
+    TaggedUnion.Members<Cases>["Type"],
+    TaggedUnion.Members<Cases>["Encoded"],
+    TaggedUnion.Members<Cases>["Context"]
   >
 {
   readonly members: {
-    readonly [K in keyof Cases]: K extends string ? taggedUnion.Member<K, Cases[K]> : never
+    readonly [K in keyof Cases]: K extends string ? TaggedUnion.Member<K, Cases[K]> : never
   }
 
   readonly $match: {
     <
       C extends {
         readonly [Tag in keyof Cases]: (
-          args: Extract<taggedUnion.Members<Cases>["Type"], { readonly _tag: Tag }>
+          args: Extract<TaggedUnion.Members<Cases>["Type"], { readonly _tag: Tag }>
         ) => any
       }
-    >(cases: C): (value: taggedUnion.Members<Cases>["Type"]) => Unify<ReturnType<C[keyof C]>>
+    >(cases: C): (value: TaggedUnion.Members<Cases>["Type"]) => Unify<ReturnType<C[keyof C]>>
     <
       C extends {
         readonly [Tag in keyof Cases]: (
-          args: Extract<taggedUnion.Members<Cases>["Type"], { readonly _tag: Tag }>
+          args: Extract<TaggedUnion.Members<Cases>["Type"], { readonly _tag: Tag }>
         ) => any
       }
-    >(value: taggedUnion.Members<Cases>["Type"], cases: C): Unify<ReturnType<C[keyof C]>>
+    >(value: TaggedUnion.Members<Cases>["Type"], cases: C): Unify<ReturnType<C[keyof C]>>
   }
 }
 
 /**
- * @category taggedUnion
+ * @category TaggedUnion
  * @since 3.15.0
  */
-export declare namespace taggedUnion {
+export declare namespace TaggedUnion {
   /**
-   * @category taggedUnion
+   * @category TaggedUnion
    * @since 3.15.0
    */
   export interface Member<Tag extends string, Fields extends Struct.Fields> extends Data<TaggedStruct<Tag, Fields>> {
@@ -10933,7 +10933,7 @@ export declare namespace taggedUnion {
   }
 
   /**
-   * @category taggedUnion
+   * @category TaggedUnion
    * @since 3.15.0
    */
   export type Members<Cases extends Record<string, Struct.Fields>> = keyof Cases extends infer K
@@ -10950,7 +10950,7 @@ const constDataEnum$Match = data_.taggedEnum().$match
  * ```ts
  * import { Schema } from "effect"
  *
- * const schema = Schema.taggedUnion({
+ * const schema = Schema.TaggedUnion({
  *   Circle: { radius: Schema.Number },
  *   Square: { sideLength: Schema.Number },
  * })
@@ -10958,24 +10958,24 @@ const constDataEnum$Match = data_.taggedEnum().$match
  * Schema.decodeUnknownSync(schema)({ _tag: "Circle", radius: 10 })
  * ```
  *
- * @category taggedUnion
+ * @category TaggedUnion
  * @since 3.15.0
  */
-export function taggedUnion<
+export function TaggedUnion<
   Cases extends Record<string, Struct.Fields>
->(cases: Cases): taggedUnion<Cases> {
-  const members: Record<string, taggedUnion.Member<any, any>> = {}
+>(cases: Cases): TaggedUnion<Cases> {
+  const members: Record<string, TaggedUnion.Member<any, any>> = {}
   const unionArr = []
   for (const [key, fields] of Object.entries(cases)) {
     const taggedStruct = TaggedStruct(key, fields)
-    const dataTaggedStruct = Data(taggedStruct) as unknown as taggedUnion.Member<any, any>
+    const dataTaggedStruct = Data(taggedStruct) as unknown as TaggedUnion.Member<any, any>
     ;(dataTaggedStruct as any).make = (props: any, options?: {}) =>
       data_.unsafeStruct(taggedStruct.make(props, options))
     members[key] = dataTaggedStruct
     unionArr.push(dataTaggedStruct)
   }
 
-  const schema = Union(...unionArr) as Types.Mutable<taggedUnion<any>>
+  const schema = Union(...unionArr) as Types.Mutable<TaggedUnion<any>>
   schema.members = members
   schema.$match = constDataEnum$Match as any
 

--- a/packages/effect/test/Schema/Schema/TaggedUnion.test.ts
+++ b/packages/effect/test/Schema/Schema/TaggedUnion.test.ts
@@ -4,8 +4,8 @@ import * as S from "effect/Schema"
 import { strictEqual } from "node:assert"
 import * as Util from "../TestUtils.js"
 
-describe("taggedUnion", () => {
-  const schema = S.taggedUnion({
+describe("TaggedUnion", () => {
+  const schema = S.TaggedUnion({
     A: {},
     B: { value: S.String },
     C: { otherValue: S.Number }

--- a/packages/effect/test/Schema/Schema/taggedUnion.test.ts
+++ b/packages/effect/test/Schema/Schema/taggedUnion.test.ts
@@ -1,21 +1,40 @@
 import { describe, it } from "@effect/vitest"
+import * as Equal from "effect/Equal"
 import * as S from "effect/Schema"
 import * as Util from "effect/test/Schema/TestUtils"
+import { strictEqual } from "node:assert"
 
 describe("taggedUnion", () => {
-  it("should create a union of tagged structs", () => {
-    const schema = S.taggedUnion({
-      A: {},
-      B: { value: S.String },
-      C: { otherValue: S.Number }
+  const schema = S.taggedUnion({
+    A: {},
+    B: { value: S.String },
+    C: { otherValue: S.Number }
+  })
+
+  it("test roundtrip consistency", () => {
+    Util.assertions.testRoundtripConsistency(schema)
+  })
+
+  it("implements Equal", () => {
+    const value1 = S.decodeSync(schema)({ _tag: "A" })
+    const value2 = S.decodeSync(schema)({ _tag: "A" })
+    strictEqual(Equal.equals(value1, value2), true)
+  })
+
+  it("$match", () => {
+    const valueA = schema.members.A.make()
+    const valueB = schema.members.B.make({ value: "ok" })
+    let result = schema.$match(valueA, {
+      A: () => "A",
+      B: () => "B",
+      C: () => "C"
     })
-
-    const expected = S.Union(
-      S.TaggedStruct("A", {}),
-      S.TaggedStruct("B", { value: S.String }),
-      S.TaggedStruct("C", { otherValue: S.Number })
-    )
-
-    Util.assertions.ast.equals(schema, expected)
+    strictEqual(result, "A")
+    result = schema.$match(valueB, {
+      A: () => "A",
+      B: () => "B",
+      C: () => "C"
+    })
+    strictEqual(result, "B")
   })
 })

--- a/packages/effect/test/Schema/Schema/taggedUnion.test.ts
+++ b/packages/effect/test/Schema/Schema/taggedUnion.test.ts
@@ -7,13 +7,13 @@ describe("taggedUnion", () => {
     const schema = S.taggedUnion({
       A: {},
       B: { value: S.String },
-      C: { otherValue: S.Number },
+      C: { otherValue: S.Number }
     })
 
     const expected = S.Union(
       S.TaggedStruct("A", {}),
       S.TaggedStruct("B", { value: S.String }),
-      S.TaggedStruct("C", { otherValue: S.Number }),
+      S.TaggedStruct("C", { otherValue: S.Number })
     )
 
     Util.assertions.ast.equals(schema, expected)

--- a/packages/effect/test/Schema/Schema/taggedUnion.test.ts
+++ b/packages/effect/test/Schema/Schema/taggedUnion.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "@effect/vitest"
 import * as Equal from "effect/Equal"
 import * as S from "effect/Schema"
-import * as Util from "effect/test/Schema/TestUtils"
 import { strictEqual } from "node:assert"
+import * as Util from "../TestUtils.js"
 
 describe("taggedUnion", () => {
   const schema = S.taggedUnion({

--- a/packages/effect/test/Schema/Schema/taggedUnion.test.ts
+++ b/packages/effect/test/Schema/Schema/taggedUnion.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from "@effect/vitest"
+import * as S from "effect/Schema"
+import * as Util from "effect/test/Schema/TestUtils"
+
+describe("taggedUnion", () => {
+  it("should create a union of tagged structs", () => {
+    const schema = S.taggedUnion({
+      A: {},
+      B: { value: S.String },
+      C: { otherValue: S.Number },
+    })
+
+    const expected = S.Union(
+      S.TaggedStruct("A", {}),
+      S.TaggedStruct("B", { value: S.String }),
+      S.TaggedStruct("C", { otherValue: S.Number }),
+    )
+
+    Util.assertions.ast.equals(schema, expected)
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a `taggedEnum` function to `Schema`, for easily creating discriminated unions using TaggedStruct (similar to the `taggedEnum` function in `Data`).

## Related

- Closes #1834
