### PR TITLE
Add Either.transposeMapOption

### DIFF
--- a/.changeset/dirty-lemons-lie.md
+++ b/.changeset/dirty-lemons-lie.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Either.transposeMapOption

--- a/packages/effect/dtslint/Either.tst.ts
+++ b/packages/effect/dtslint/Either.tst.ts
@@ -1,4 +1,4 @@
-import { Array, Either, hole, pipe, Predicate } from "effect"
+import { Array, Either, hole, Option, pipe, Predicate } from "effect"
 import { describe, expect, it } from "tstyche"
 
 declare const string$string: Either.Either<string, string>
@@ -316,4 +316,37 @@ describe("Either", () => {
       )
     ).type.toBe<Either.Either<{ a: number; b: string; c: boolean }, never>>()
   })
+})
+
+it("transposeMapOption", () => {
+  expect(Either.transposeMapOption(Option.none(), (value) => {
+    expect(value).type.toBe<never>()
+    return string$string
+  })).type.toBe<
+    Either.Either<Option.Option<string>, string>
+  >()
+  expect(pipe(
+    Option.none(),
+    Either.transposeMapOption((value) => {
+      expect(value).type.toBe<never>()
+      return string$string
+    })
+  )).type.toBe<
+    Either.Either<Option.Option<string>, string>
+  >()
+  expect(Either.transposeMapOption(Option.some(42), (value) => {
+    expect(value).type.toBe<number>()
+    return string$string
+  })).type.toBe<
+    Either.Either<Option.Option<string>, string>
+  >()
+  expect(pipe(
+    Option.some(42),
+    Either.transposeMapOption((value) => {
+      expect(value).type.toBe<number>()
+      return string$string
+    })
+  )).type.toBe<
+    Either.Either<Option.Option<string>, string>
+  >()
 })

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -1026,7 +1026,7 @@ export const transposeOption = <A = never, E = never>(
  * // Output: { _id: 'Either', _tag: 'Right', right: { _id: 'Option', _tag: 'Some', value: 84 } }
  * ```
  *
- * @since 3.14.0
+ * @since 3.15.0
  * @category Optional Wrapping & Unwrapping
  */
 export const transposeMapOption = dual<

--- a/packages/effect/src/Either.ts
+++ b/packages/effect/src/Either.ts
@@ -994,3 +994,47 @@ export const transposeOption = <A = never, E = never>(
 ): Either<Option<A>, E> => {
   return option_.isNone(self) ? right(option_.none) : map(self.value, option_.some)
 }
+
+/**
+ * Applies an `Either` on an `Option` and transposes the result.
+ *
+ * **Details**
+ *
+ * If the `Option` is `None`, the resulting `Either` will immediately succeed with a `Right` value of `None`.
+ * If the `Option` is `Some`, the transformation function will be applied to the inner value, and its result wrapped in a `Some`.
+ *
+ * @example
+ * ```ts
+ * import { Either, Option, pipe } from "effect"
+ *
+ * //          ┌─── Either<Option<number>, never>>
+ * //          ▼
+ * const noneResult = pipe(
+ *   Option.none(),
+ *   Either.transposeMapOption(() => Either.right(42)) // will not be executed
+ * )
+ * console.log(noneResult)
+ * // Output: { _id: 'Either', _tag: 'Right', right: { _id: 'Option', _tag: 'None' } }
+ *
+ * //          ┌─── Either<Option<number>, never>>
+ * //          ▼
+ * const someRightResult = pipe(
+ *   Option.some(42),
+ *   Either.transposeMapOption((value) => Either.right(value * 2))
+ * )
+ * console.log(someRightResult)
+ * // Output: { _id: 'Either', _tag: 'Right', right: { _id: 'Option', _tag: 'Some', value: 84 } }
+ * ```
+ *
+ * @since 3.14.0
+ * @category Optional Wrapping & Unwrapping
+ */
+export const transposeMapOption = dual<
+  <A, B, E = never>(
+    f: (self: A) => Either<B, E>
+  ) => (self: Option<A>) => Either<Option<B>, E>,
+  <A, B, E = never>(
+    self: Option<A>,
+    f: (self: A) => Either<B, E>
+  ) => Either<Option<B>, E>
+>(2, (self, f) => option_.isNone(self) ? right(option_.none) : map(f(self.value), option_.some))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add Either.transposeMapOption to Either.

Effect.transposeOption and Effect.transposeOption has been added to Effect, but only Either.transposeOption has to Either.
This PR adds Either.transposeMapOption.


<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
