### PR TITLE
Allow rpc middleware to wrap execution

### DIFF
--- a/.changeset/flat-queens-melt.md
+++ b/.changeset/flat-queens-melt.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+add wrap option to RpcMiddleware

--- a/packages/platform-node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-node/test/fixtures/rpc-schemas.ts
@@ -84,7 +84,7 @@ const TimingLive = Layer.succeed(
   TimingMiddleware,
   TimingMiddleware.of((options) =>
     options.next.pipe(
-      Metric.trackSuccess(rpcSuccesses),
+      Effect.tap(Metric.increment(rpcSuccesses)),
       Effect.tapDefect(() => Metric.increment(rpcDefects)),
       Effect.ensuring(Metric.increment(rpcCount))
     )

--- a/packages/platform-node/test/rpc-e2e.ts
+++ b/packages/platform-node/test/rpc-e2e.ts
@@ -100,5 +100,17 @@ export const e2eSuite = <E>(
         RpcClient.withHeaders({ userId: "123" }),
         Effect.provide(layer)
       ))
+
+    it.effect("server wrap middleware", () =>
+      Effect.gen(function*() {
+        const client = yield* UsersClient
+        const result = yield* client.TimedMethod({ shouldFail: false })
+        assert.equal(result, 1)
+        yield* client.TimedMethod({ shouldFail: true }).pipe(Effect.exit)
+        const { count, defect, success } = yield* client.GetTimingMiddlewareMetrics()
+        assert.notEqual(count, 0)
+        assert.notEqual(defect, 0)
+        assert.notEqual(success, 0)
+      }).pipe(Effect.provide(layer)))
   })
 }

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -417,7 +417,7 @@ const applyMiddleware = <A, E, R>(
   for (const tag of rpc.middlewares) {
     if (tag.wrap) {
       const middleware = Context.unsafeGet(context, tag)
-      handler = middleware({ ...options, next: handler })
+      handler = middleware({ ...options, next: handler as any })
     } else if (tag.optional) {
       const middleware = Context.unsafeGet(context, tag) as RpcMiddleware<any, any>
       const previous = handler


### PR DESCRIPTION
## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With this change, a new variant of an RpcMiddleware will be added that allows to wrap execution of requests.
This will allow things like providing scoped resources, accessing the exit result per-request alongside request type metadata, etc...

