### PR TITLE
Default never type for `MutableHasMap.empty & MutableList.empty`

### DIFF
--- a/.changeset/friendly-geese-boil.md
+++ b/.changeset/friendly-geese-boil.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Default `never` type has been added to `MutableHasMap.empty` & `MutableList.empty` ctors

--- a/packages/effect/src/MutableHashMap.ts
+++ b/packages/effect/src/MutableHashMap.ts
@@ -102,7 +102,7 @@ class BucketIterator<K, V> implements Iterator<[K, V]> {
  * @since 2.0.0
  * @category constructors
  */
-export const empty = <K, V>(): MutableHashMap<K, V> => {
+export const empty = <K = never, V = never>(): MutableHashMap<K, V> => {
   const self = Object.create(MutableHashMapProto)
   self.referential = new Map()
   self.buckets = new Map()

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -97,7 +97,7 @@ const makeNode = <T>(value: T): LinkedListNode<T> => ({
  * @since 2.0.0
  * @category constructors
  */
-export const empty = <A>(): MutableList<A> => {
+export const empty = <A = never>(): MutableList<A> => {
   const list = Object.create(MutableListProto)
   list.head = undefined
   list.tail = undefined


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Default `never` type has been added to `MutableHasMap.empty` & `MutableList.empty` ctors
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
