### PR TITLE
JSONSchema: preserve original key name when using `fromKey` followed by `annotations`, closes #4774

### DIFF
--- a/.changeset/thin-squids-cough.md
+++ b/.changeset/thin-squids-cough.md
@@ -1,0 +1,63 @@
+---
+"effect": patch
+---
+
+JSONSchema: preserve original key name when using `fromKey` followed by `annotations`, closes #4774.
+
+Before:
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.String)
+    .pipe(Schema.fromKey("b"))
+    .annotations({})
+})
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}
+*/
+```
+
+After:
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.String)
+    .pipe(Schema.fromKey("b"))
+    .annotations({})
+})
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "b"
+  ],
+  "properties": {
+    "b": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}
+*/
+```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1830,7 +1830,8 @@ const mergeSignatureAnnotations = (
           ast.from.type,
           ast.from.isOptional,
           ast.from.isReadonly,
-          ast.from.annotations
+          ast.from.annotations,
+          ast.from.fromKey
         ),
         new ToPropertySignature(ast.to.type, ast.to.isOptional, ast.to.isReadonly, {
           ...ast.to.annotations,

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1826,13 +1826,7 @@ const mergeSignatureAnnotations = (
     }
     case "PropertySignatureTransformation": {
       return new PropertySignatureTransformation(
-        new FromPropertySignature(
-          ast.from.type,
-          ast.from.isOptional,
-          ast.from.isReadonly,
-          ast.from.annotations,
-          ast.from.fromKey
-        ),
+        ast.from,
         new ToPropertySignature(ast.to.type, ast.to.isOptional, ast.to.isReadonly, {
           ...ast.to.annotations,
           ...annotations

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -2791,10 +2791,38 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
       })
 
       describe("fromKey", () => {
-        it("base", () => {
+        it("a <- b", () => {
           expectJSONSchemaProperty(
             Schema.Struct({
               a: Schema.NonEmptyString.pipe(Schema.propertySignature, Schema.fromKey("b"))
+            }),
+            {
+              "$defs": {
+                "NonEmptyString": {
+                  "type": "string",
+                  "title": "nonEmptyString",
+                  "description": "a non empty string",
+                  "minLength": 1
+                }
+              },
+              "type": "object",
+              "required": [
+                "b"
+              ],
+              "properties": {
+                "b": {
+                  "$ref": "#/$defs/NonEmptyString"
+                }
+              },
+              "additionalProperties": false
+            }
+          )
+        })
+
+        it("a <- b & annotations", () => {
+          expectJSONSchemaProperty(
+            Schema.Struct({
+              a: Schema.NonEmptyString.pipe(Schema.propertySignature, Schema.fromKey("b")).annotations({})
             }),
             {
               "$defs": {


### PR DESCRIPTION
Before:

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.String)
    .pipe(Schema.fromKey("b"))
    .annotations({})
})

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [
    "a"
  ],
  "properties": {
    "a": {
      "type": "string"
    }
  },
  "additionalProperties": false
}
*/
```

After:

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.String)
    .pipe(Schema.fromKey("b"))
    .annotations({})
})

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": [
    "b"
  ],
  "properties": {
    "b": {
      "type": "string"
    }
  },
  "additionalProperties": false
}
*/
```
