### PR TITLE
JSONSchema: apply `encodeOption` to each example and retain successful results

### DIFF
--- a/.changeset/curly-poets-flash.md
+++ b/.changeset/curly-poets-flash.md
@@ -1,0 +1,42 @@
+---
+"effect": patch
+---
+
+JSONSchema: apply `encodeOption` to each example and retain successful results.
+
+**Example**
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.propertySignature(Schema.BigInt).annotations({ examples: [1n, 2n] })
+})
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "BigInt": {
+      "type": "string",
+      "description": "a string to be decoded into a bigint"
+    }
+  },
+  "type": "object",
+  "required": [
+    "a"
+  ],
+  "properties": {
+    "a": {
+      "$ref": "#/$defs/BigInt",
+      "examples": [
+        "1",
+        "2"
+      ]
+    }
+  },
+  "additionalProperties": false
+}
+*/
+```

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -2,8 +2,10 @@
  * @since 3.10.0
  */
 
+import * as Arr from "./Array.js"
 import * as errors_ from "./internal/schema/errors.js"
 import * as Option from "./Option.js"
+import * as ParseResult from "./ParseResult.js"
 import * as Predicate from "./Predicate.js"
 import * as Record from "./Record.js"
 import type * as Schema from "./Schema.js"
@@ -355,13 +357,23 @@ const constEmpty: JsonSchema7 = {
 
 const $schema = "http://json-schema.org/draft-07/schema#"
 
-const getJsonSchemaAnnotations = (annotated: AST.Annotated): JsonSchemaAnnotations =>
-  Record.getSomes({
+const getJsonSchemaAnnotations = (ast: AST.AST, annotated?: AST.Annotated): JsonSchemaAnnotations => {
+  annotated ??= ast
+  const out: JsonSchemaAnnotations = Record.getSomes({
     description: AST.getDescriptionAnnotation(annotated),
     title: AST.getTitleAnnotation(annotated),
-    examples: AST.getExamplesAnnotation(annotated),
     default: AST.getDefaultAnnotation(annotated)
   })
+  const oexamples = AST.getExamplesAnnotation(annotated)
+  if (Option.isSome(oexamples) && oexamples.value.length > 0) {
+    const getOption = ParseResult.getOption(ast, false)
+    const examples = Arr.filterMap(oexamples.value, (e) => getOption(e))
+    if (examples.length > 0) {
+      out.examples = examples
+    }
+  }
+  return out
+}
 
 const removeDefaultJsonSchemaAnnotations = (
   jsonSchemaAnnotations: JsonSchemaAnnotations,
@@ -627,11 +639,11 @@ const go = (
     case "TupleType": {
       const elements = ast.elements.map((e, i) => ({
         ...go(e.type, $defs, true, path.concat(i), options),
-        ...getJsonSchemaAnnotations(e)
+        ...getJsonSchemaAnnotations(e.type, e)
       }))
       const rest = ast.rest.map((annotatedAST) => ({
         ...go(annotatedAST.type, $defs, true, path, options),
-        ...getJsonSchemaAnnotations(annotatedAST)
+        ...getJsonSchemaAnnotations(annotatedAST.type, annotatedAST)
       }))
       const output: JsonSchema7Array = { type: "array" }
       // ---------------------------------------------
@@ -720,9 +732,10 @@ const go = (
         const name = ps.name
         if (Predicate.isString(name)) {
           const pruned = pruneUndefined(ps.type)
+          const type = pruned ?? ps.type
           output.properties[name] = {
-            ...go(pruned ?? ps.type, $defs, true, path.concat(ps.name), options),
-            ...getJsonSchemaAnnotations(ps)
+            ...go(type, $defs, true, path.concat(ps.name), options),
+            ...getJsonSchemaAnnotations(type, ps)
           }
           // ---------------------------------------------
           // handle optional property signatures

--- a/packages/effect/src/ParseResult.ts
+++ b/packages/effect/src/ParseResult.ts
@@ -443,7 +443,8 @@ const getSync = (ast: AST.AST, isDecoding: boolean, options?: AST.ParseOptions) 
     Either.getOrThrowWith(parser(input, overrideOptions), parseError)
 }
 
-const getOption = (ast: AST.AST, isDecoding: boolean, options?: AST.ParseOptions) => {
+/** @internal */
+export const getOption = (ast: AST.AST, isDecoding: boolean, options?: AST.ParseOptions) => {
   const parser = getEither(ast, isDecoding, options)
   return (input: unknown, overrideOptions?: AST.ParseOptions): Option.Option<any> =>
     Option.getRight(parser(input, overrideOptions))

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -3175,6 +3175,39 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
       "type": "string",
       "examples": ["a", "b"]
     })
+    expectJSONSchemaProperty(Schema.BigInt.annotations({ examples: [1n, 2n] }), {
+      "$defs": {
+        "BigInt": {
+          "type": "string",
+          "description": "a string to be decoded into a bigint"
+        }
+      },
+      "$ref": "#/$defs/BigInt"
+    })
+    expectJSONSchemaProperty(
+      Schema.Struct({
+        a: Schema.propertySignature(Schema.BigInt).annotations({ examples: [1n, 2n] })
+      }),
+      {
+        "$defs": {
+          "BigInt": {
+            "type": "string",
+            "description": "a string to be decoded into a bigint"
+          }
+        },
+        "type": "object",
+        "required": [
+          "a"
+        ],
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/BigInt",
+            "examples": ["1", "2"]
+          }
+        },
+        "additionalProperties": false
+      }
+    )
   })
 
   it("default JSON Schema annotation support", () => {


### PR DESCRIPTION
**Example**

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.Struct({
  a: Schema.propertySignature(Schema.BigInt).annotations({ examples: [1n, 2n] })
})

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$defs": {
    "BigInt": {
      "type": "string",
      "description": "a string to be decoded into a bigint"
    }
  },
  "type": "object",
  "required": [
    "a"
  ],
  "properties": {
    "a": {
      "$ref": "#/$defs/BigInt",
      "examples": [
        "1",
        "2"
      ]
    }
  },
  "additionalProperties": false
}
*/
```
