### PR TITLE
align AiPlan constructor to fallback

### DIFF
--- a/packages/ai/ai/src/AiPlan.ts
+++ b/packages/ai/ai/src/AiPlan.ts
@@ -86,14 +86,14 @@ export declare namespace AiPlan {
  * @since 1.0.0
  * @category constructors
  */
-export const fromModel: <Provides, Requires, EW, Out, ES, RW = never, RS = never>(
-  model: AiModel.AiModel<Provides, Requires>,
-  options?: {
+export const make: <Provides, Requires, EW, Out, ES, RW = never, RS = never>(
+  options: {
+    readonly model: AiModel.AiModel<Provides, Requires>
     readonly attempts?: number | undefined
     readonly while?: ((error: EW) => boolean | Effect.Effect<boolean, never, RW>) | undefined
     readonly schedule?: Schedule.Schedule<Out, ES, RS> | undefined
   }
-) => AiPlan<EW & ES, Provides, RW | RS | Requires> = Internal.fromModel
+) => AiPlan<EW & ES, Provides, RW | RS | Requires> = Internal.make
 
 /**
  * @since 1.0.0

--- a/packages/ai/ai/src/internal/aiPlan.ts
+++ b/packages/ai/ai/src/internal/aiPlan.ts
@@ -88,16 +88,16 @@ const getRetryOptions = <Error, Provides, Requires>(
 }
 
 /** @internal */
-export const fromModel = <Provides, Requires, EW, Out, ES, RW = never, RS = never>(
-  model: AiModel.AiModel<Provides, Requires>,
-  options?: {
+export const make = <Provides, Requires, EW, Out, ES, RW = never, RS = never>(
+  options: {
+    readonly model: AiModel.AiModel<Provides, Requires>
     readonly attempts?: number | undefined
     readonly while?: ((error: EW) => boolean | Effect.Effect<boolean, never, RW>) | undefined
     readonly schedule?: Schedule.Schedule<Out, ES, RS> | undefined
   }
 ): AiPlan.AiPlan<EW & ES, Provides, RW | RS | Requires> =>
   makePlan([{
-    model,
+    model: options.model,
     check: Option.fromNullable(options?.while) as any,
     schedule: resolveSchedule(options ?? {})
   }])


### PR DESCRIPTION
```ts
import { AiLanguageModel, AiModels, AiPlan } from "@effect/ai"
import { AnthropicClient, AnthropicLanguageModel } from "@effect/ai-anthropic"
import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai"
import { FetchHttpClient, PlatformConfigProvider } from "@effect/platform"
import { BunContext, BunRuntime } from "@effect/platform-bun"
import { Config, Effect, Layer } from "effect"

const program = Effect.gen(function*() {
  const model = yield* AiLanguageModel.AiLanguageModel

  const response = yield* model.generateText({ prompt: "Tell me something nice about CityJS London!" })

  yield* Effect.log(response.text)
})

const main = Effect.gen(function*() {
  const plan = yield* AiPlan.make({
    model: OpenAiLanguageModel.model("gpt-4"),
    attempts: 1
  }, {
    model: AnthropicLanguageModel.model("claude-3-7-sonnet-latest"),
    attempts: 1
  }, {
    model: AnthropicLanguageModel.model("claude-3-5-sonnet-latest"),
    attempts: 1
  })

  yield* plan.use(program)
})

const layer = Layer.mergeAll(
  AiModels.layer,
  OpenAiClient.layerConfig({ apiKey: Config.redacted("OPENAI_API_KEY") }),
  AnthropicClient.layerConfig({ apiKey: Config.redacted("ANTHROPIC_API_KEY") })
)
  .pipe(Layer.provide(FetchHttpClient.layer))
  .pipe(Layer.provide(PlatformConfigProvider.layerDotEnv("scratchpad/cityjs-london/.env")))
  .pipe(Layer.provide(BunContext.layer))

BunRuntime.runMain(main.pipe(Effect.provide(layer)))
```