### PR TITLE
Possibility to handle remaining errors in `catchTags`

### DIFF
--- a/.changeset/soft-bears-play.md
+++ b/.changeset/soft-bears-play.md
@@ -1,0 +1,31 @@
+---
+"effect": minor
+---
+
+Possibility to recover from unhandled errors in `catchTags`.
+
+This addition introduces the possibility to define a function as a second parameter that gets the error type which was unhandled in the map before.
+
+```ts
+import { Data, Effect } from "effect"
+
+class A extends Data.TaggedError("A") {}
+class B extends Data.TaggedError("B") {}
+class C extends Data.TaggedError("C") {}
+class D extends Data.TaggedError("D") {}
+
+const program = Effect.gen(function* () {
+  const types = [A, B, C, D]
+  const Exception = types[Math.floor(Math.random() * types.length)]
+
+  return yield* new Exception()
+}).pipe(
+  Effect.catchTags(
+    {
+      A: (a) => Effect.succeed(a._tag),
+      B: (b) => Effect.succeed(b._tag)
+    },
+    (remaining) => Effect.succeed(`remaining: ${remaining._tag}`) // C | D
+  )
+)
+```

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4000,23 +4000,25 @@ export const catchTags: {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]
   >
-  <
-    E,
-    Cases extends
-      { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
-      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never })
+  <E,
+   Cases extends
+     { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+     & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never }),
+   OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
   >(
     cases: Cases,
-    onOther: (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
+    onOther: OnOther
   ): <A, R>(
     self: Effect<A, E, R>
   ) => Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
-    | Exclude<E, { _tag: keyof Cases }>
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect<infer A2, any, any> ? A2 : never),
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect<any, infer E2, any> ? E2 : never),
     | R
     | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect<any, any, infer R2> ? R2 : never)
   >
   <
     R,
@@ -4042,13 +4044,13 @@ export const catchTags: {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]
   >
-  <
-    E,
-    A,
-    R,
-    Cases extends
-      { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
-      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never })
+  <E,
+   A,
+   R,
+   Cases extends
+     { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+     & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never }),
+   OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
   >(
     self: Effect<A, E, R>,
     cases: Cases,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3955,7 +3955,7 @@ export const catchTags: {
   <
     E,
     Cases extends
-      { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+      { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
       & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never })
   >(
     cases: Cases,
@@ -3964,18 +3964,18 @@ export const catchTags: {
     self: Effect<A, E, R>
   ) => Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
   >
   <
     R,
     E,
     A,
     Cases extends
-      & { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
+      { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
       & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never })
   >(
     self: Effect<A, E, R>,
@@ -4007,11 +4007,11 @@ export const catchTags: {
     onOther: (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
   ): Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
   >
 } = effect.catchTags
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4054,14 +4054,16 @@ export const catchTags: {
   >(
     self: Effect<A, E, R>,
     cases: Cases,
-    onOther: (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
+    onOther: OnOther
   ): Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
-    | Exclude<E, { _tag: keyof Cases }>
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect<infer A2, any, any> ? A2 : never),
+    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect<any, infer E2, any> ? E2 : never),
     | R
     | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect<any, any, infer R2> ? R2 : never)
   >
 } = effect.catchTags
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3953,6 +3953,24 @@ export const catchTags: {
     }[keyof Cases]
   >
   <
+    E,
+    Cases extends
+      { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never })
+  >(
+    cases: Cases,
+    onOther: (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
+  ): <A, R>(
+    self: Effect<A, E, R>
+  ) => Effect<
+    | A
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | Exclude<E, { _tag: keyof Cases }>
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | R
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+  >
+  <
     R,
     E,
     A,
@@ -3975,6 +3993,25 @@ export const catchTags: {
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]
+  >
+  <
+    E,
+    A,
+    R,
+    Cases extends
+      { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never })
+  >(
+    self: Effect<A, E, R>,
+    cases: Cases,
+    onOther: (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
+  ): Effect<
+    | A
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | Exclude<E, { _tag: keyof Cases }>
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | R
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
   >
 } = effect.catchTags
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4000,11 +4000,12 @@ export const catchTags: {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]
   >
-  <E,
-   Cases extends
-     { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
-     & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never }),
-   OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
+  <
+    E,
+    Cases extends
+      & { [K in Extract<E, { _tag: string }>["_tag"]]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never }),
+    OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
   >(
     cases: Cases,
     onOther: OnOther
@@ -4012,12 +4013,18 @@ export const catchTags: {
     self: Effect<A, E, R>
   ) => Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect<infer A2, any, any> ? A2 : never),
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect<any, infer E2, any> ? E2 : never),
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect<any, any, infer R2> ? R2 : never)
   >
   <
@@ -4025,7 +4032,7 @@ export const catchTags: {
     E,
     A,
     Cases extends
-      { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
+      & { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
       & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never })
   >(
     self: Effect<A, E, R>,
@@ -4044,25 +4051,32 @@ export const catchTags: {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]
   >
-  <E,
-   A,
-   R,
-   Cases extends
-     { [K in Extract<E, { _tag: string }>['_tag']]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
-     & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>['_tag']>]: never }),
-   OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
+  <
+    E,
+    A,
+    R,
+    Cases extends
+      & { [K in Extract<E, { _tag: string }>["_tag"]]?: (error: Extract<E, { _tag: K }>) => Effect<any, any, any> }
+      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never }),
+    OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect<any, any, any>
   >(
     self: Effect<A, E, R>,
     cases: Cases,
     onOther: OnOther
   ): Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A1, any, any> ? A1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect<infer A2, any, any> ? A2 : never),
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E1, any> ? E1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect<any, infer E2, any> ? E2 : never),
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R1> ? R1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect<any, any, infer R2> ? R2 : never)
   >
 } = effect.catchTags

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3904,9 +3904,11 @@ export const catchTag: {
  * const program = Effect.gen(function* () {
  *   const n1 = yield* Random.next
  *   const n2 = yield* Random.next
+ *
  *   if (n1 < 0.5) {
  *     yield* Effect.fail(new HttpError())
  *   }
+ *
  *   if (n2 < 0.5) {
  *     yield* Effect.fail(new ValidationError())
  *   }
@@ -3922,6 +3924,52 @@ export const catchTag: {
  *     ValidationError: (_ValidationError) =>
  *       Effect.succeed(`Recovering from ValidationError`)
  *   })
+ * )
+ * ```
+ *
+ * **Example** (Handling Tagged Error Types and Remaining Errors)
+ *
+ * ```ts
+ * import { Effect, Random } from "effect"
+ *
+ * class HttpError {
+ *   readonly _tag = "HttpError"
+ * }
+ *
+ * class ValidationError {
+ *   readonly _tag = "ValidationError"
+ * }
+ *
+ * class AnotherValidationError {
+ *   readonly _tag = "ValidationError"
+ * }
+ *
+ * //      ┌─── Effect<string, HttpError | ValidationError | AnotherValidationError, never>
+ * //      ▼
+ * const program = Effect.gen(function* () {
+ *   const n1 = yield* Random.next
+ *   const n2 = yield* Random.next
+ *   const n3 = yield* Random.next
+ *
+ *   if (n1 < 0.5) {
+ *     yield* Effect.fail(new HttpError())
+ *   }
+ *   if (n2 < 0.5) {
+ *     yield* Effect.fail(new ValidationError())
+ *   }
+ *
+ *   return "some result"
+ * })
+ *
+ * //      ┌─── Effect<string, never, never>
+ * //      ▼
+ * const recovered = program.pipe(
+ *   Effect.catchTags({
+ *     HttpError: (_HttpError) =>
+ *       Effect.succeed(`Recovering from HttpError`),
+ *     ValidationError: (_ValidationError) =>
+ *       Effect.succeed(`Recovering from ValidationError`)
+ *   }, remaining => Effect.succeed(remaining._tag)) // AnotherValidationError
  * )
  * ```
  *

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -255,66 +255,76 @@ export const catchTag = dual<
 
 /** @internal */
 export const catchTags: {
-  <
-    E,
-    Cases extends (E extends { _tag: string } ? {
-        [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any>
-      } :
-      {})
-  >(
-    cases: Cases,
-    onOther?: (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
+  <E, Cases extends (E extends { _tag: string }
+    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+    : {}
+  )>(
+    cases: Cases
   ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
     | A
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<infer A, any, any>) ? A : never
-    }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
-    }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
     | R
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, any, infer R>) ? R : never
-    }[keyof Cases]
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
   >
-  <
-    R,
-    E,
-    A,
-    Cases extends (E extends { _tag: string } ? {
-        [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any>
-      } :
-      {})
+  <E, Cases extends (E extends { _tag: string }
+    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+    : {}), OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
+  >(
+    cases: Cases,
+    onOther: OnOther
+  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
+    | A
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect.Effect<infer A2, any, any> ? A2 : never),
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect.Effect<any, infer E2, any> ? E2 : never),
+    | R
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect.Effect<any, any, infer R2> ? R2 : never)
+  >
+  <R, E, A, Cases extends (E extends { _tag: string }
+    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+    : {}
+  )>(
+    self: Effect.Effect<A, E, R>,
+    cases: Cases
+  ): Effect.Effect<
+    | A
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | Exclude<E, { _tag: keyof Cases }>
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | R
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+  >
+  <R, E, A, Cases extends (E extends { _tag: string }
+    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+    : {}), OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
   >(
     self: Effect.Effect<A, E, R>,
     cases: Cases,
-    onOther?: (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
+    onOther: OnOther
   ): Effect.Effect<
     | A
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<infer A, any, any>) ? A : never
-    }[keyof Cases],
-    | Exclude<E, { _tag: keyof Cases }>
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
-    }[keyof Cases],
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect.Effect<infer A2, any, any> ? A2 : never),
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect.Effect<any, infer E2, any> ? E2 : never),
     | R
-    | {
-      [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, any, infer R>) ? R : never
-    }[keyof Cases]
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | (ReturnType<OnOther> extends Effect.Effect<any, any, infer R2> ? R2 : never)
   >
 } = dual(3, (self, cases, onOther) => {
   let keys: Array<string>
 
-  // If onOther handler provided, catch all errors and dispatch
   if (onOther) {
     return core.catchAll(self, (e) => {
       keys ??= Object.keys(cases)
       if (Predicate.hasProperty(e, "_tag") && Predicate.isString(e["_tag"]) && keys.includes(e["_tag"])) {
         return cases[e["_tag"]](e)
       }
-      // Remaining error
+
       return onOther(e)
     })
   }

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -315,7 +315,9 @@ export const catchTags: {
     | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<any, any, infer R2> ? R2 : never)
   >
-} = dual(3, (self, cases, onOther) => {
+} = dual(
+  (args) => core.isEffect(args[0]),
+  (self, cases, onOther?) => {
   let keys: Array<string>
 
   if (onOther) {

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -255,91 +255,134 @@ export const catchTag = dual<
 
 /** @internal */
 export const catchTags: {
-  <E, Cases extends (E extends { _tag: string }
-    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
-    : {}
-  )>(
+  <
+    E,
+    Cases
+      extends (E extends { _tag: string }
+        ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+        : {})
+  >(
     cases: Cases
   ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A1, any, any> ? A1 : never
+    }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, infer E1, any> ? E1 : never
+    }[keyof Cases],
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R1> ? R1 : never
+    }[keyof Cases]
   >
-  <E, Cases extends (E extends { _tag: string }
-    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
-    : {}), OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
+  <
+    E,
+    Cases
+      extends (E extends { _tag: string }
+        ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+        : {}),
+    OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
   >(
     cases: Cases,
     onOther: OnOther
   ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A1, any, any> ? A1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<infer A2, any, any> ? A2 : never),
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, infer E1, any> ? E1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<any, infer E2, any> ? E2 : never),
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R1> ? R1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<any, any, infer R2> ? R2 : never)
   >
-  <R, E, A, Cases extends (E extends { _tag: string }
-    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
-    : {}
-  )>(
+  <
+    R,
+    E,
+    A,
+    Cases
+      extends (E extends { _tag: string }
+        ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+        : {})
+  >(
     self: Effect.Effect<A, E, R>,
     cases: Cases
   ): Effect.Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases],
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A1, any, any> ? A1 : never
+    }[keyof Cases],
     | Exclude<E, { _tag: keyof Cases }>
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases],
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, infer E1, any> ? E1 : never
+    }[keyof Cases],
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R1> ? R1 : never
+    }[keyof Cases]
   >
-  <R, E, A, Cases extends (E extends { _tag: string }
-    ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
-    : {}), OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
+  <
+    R,
+    E,
+    A,
+    Cases
+      extends (E extends { _tag: string }
+        ? { [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any> }
+        : {}),
+    OnOther extends (error: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<any, any, any>
   >(
     self: Effect.Effect<A, E, R>,
     cases: Cases,
     onOther: OnOther
   ): Effect.Effect<
     | A
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A1, any, any> ? A1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<infer A1, any, any> ? A1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<infer A2, any, any> ? A2 : never),
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E1, any> ? E1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, infer E1, any> ? E1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<any, infer E2, any> ? E2 : never),
     | R
-    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R1> ? R1 : never }[keyof Cases]
+    | {
+      [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect.Effect<any, any, infer R1> ? R1 : never
+    }[keyof Cases]
     | (ReturnType<OnOther> extends Effect.Effect<any, any, infer R2> ? R2 : never)
   >
 } = dual(
   (args) => core.isEffect(args[0]),
   (self, cases, onOther?) => {
-  let keys: Array<string>
+    let keys: Array<string>
 
-  if (onOther) {
-    return core.catchAll(self, (e) => {
-      keys ??= Object.keys(cases)
-      if (Predicate.hasProperty(e, "_tag") && Predicate.isString(e["_tag"]) && keys.includes(e["_tag"])) {
-        return cases[e["_tag"]](e)
-      }
+    if (onOther) {
+      return core.catchAll(self, (e) => {
+        keys ??= Object.keys(cases)
+        if (Predicate.hasProperty(e, "_tag") && Predicate.isString(e["_tag"]) && keys.includes(e["_tag"])) {
+          return cases[e["_tag"]](e)
+        }
 
-      return onOther(e)
-    })
+        return onOther(e)
+      })
+    }
+
+    return core.catchIf(
+      self,
+      (e): e is { readonly _tag: string } => {
+        keys ??= Object.keys(cases)
+        return Predicate.hasProperty(e, "_tag") && Predicate.isString(e["_tag"]) && keys.includes(e["_tag"])
+      },
+      (e) => cases[e["_tag"]](e)
+    )
   }
-
-  return core.catchIf(
-    self,
-    (e): e is { readonly _tag: string } => {
-      keys ??= Object.keys(cases)
-      return Predicate.hasProperty(e, "_tag") && Predicate.isString(e["_tag"]) && keys.includes(e["_tag"])
-    },
-    (e) => cases[e["_tag"]](e)
-  )
-})
+)
 
 /* @internal */
 export const cause = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Cause.Cause<E>, never, R> =>

--- a/packages/effect/test/Effect/error-handling.test.ts
+++ b/packages/effect/test/Effect/error-handling.test.ts
@@ -283,6 +283,7 @@ describe("Effect", () => {
       const result = yield* (Effect.catchTags(effect, {
         ErrorA: (e) => Effect.succeed(e)
       }))
+
       deepStrictEqual(result, { _tag: "ErrorA" })
     }))
   it.effect("catchTags - does not recover from one of several tagged errors", () =>

--- a/packages/effect/test/Effect/error-handling.test.ts
+++ b/packages/effect/test/Effect/error-handling.test.ts
@@ -316,6 +316,26 @@ describe("Effect", () => {
       }))
       deepStrictEqual(result, { _tag: "ErrorB" })
     }))
+  it.effect("catchTags - recovers from tagged errors and remaining errors", () =>
+    Effect.gen(function*() {
+      interface ErrorA {
+        readonly _tag: "ErrorA"
+      }
+      interface ErrorB {
+        readonly _tag: "ErrorB"
+      }
+      interface ErrorC {
+        readonly _tag: "ErrorC"
+      }
+
+      const effect: Effect.Effect<never, ErrorA | ErrorB | ErrorC, never> = Effect.fail({ _tag: "ErrorC" })
+
+      const result = yield* (Effect.catchTags(effect, {
+        ErrorA: (e) => Effect.succeed(e),
+        ErrorB: (e) => Effect.succeed(e)
+      }, remaining => Effect.succeed(remaining)))
+      deepStrictEqual(result, { _tag: "ErrorC" })
+    }))
   it.effect("fold - sandbox -> terminate", () =>
     Effect.gen(function*() {
       const result = yield* pipe(

--- a/packages/effect/test/Effect/error-handling.test.ts
+++ b/packages/effect/test/Effect/error-handling.test.ts
@@ -334,7 +334,7 @@ describe("Effect", () => {
       const result = yield* (Effect.catchTags(effect, {
         ErrorA: (e) => Effect.succeed(e),
         ErrorB: (e) => Effect.succeed(e)
-      }, remaining => Effect.succeed(remaining)))
+      }, (remaining) => Effect.succeed(remaining)))
       deepStrictEqual(result, { _tag: "ErrorC" })
     }))
   it.effect("fold - sandbox -> terminate", () =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Sometimes, it’s necessary to recover from specific errors in `catchTags`, while still handling all other possible errors in a general way.

This PR is based on [this Discord thread](https://discord.com/channels/795981131316985866/1364558789801672734) and introduces a possible function as a second parameter to `catchTags`, allowing you to handle all the other errors that are not explicitly specified.

An example:

```ts
import { Data, Effect } from "effect"

class A extends Data.TaggedError("A") {}
class B extends Data.TaggedError("B") {}
class C extends Data.TaggedError("C") {}
class D extends Data.TaggedError("D") {}

const program = Effect.gen(function* () {
  const types = [A, B, C, D];
  const Exception = types[Math.floor(Math.random() * types.length)];

  return yield* new Exception
}).pipe(
  Effect.catchTags(
    {
      A: (a) => Effect.succeed(a._tag),
      B: (b) => Effect.succeed(b._tag),
    },
    remaining => Effect.succeed(`remaining: ${remaining._tag}`) // C | D
  )
);
```