### PR TITLE
Update eslint-plugin and enable no-import-from-barrel rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import * as effectEslint from "@effect/eslint-plugin"
 import { fixupPluginRules } from "@eslint/compat"
 import { FlatCompat } from "@eslint/eslintrc"
 import js from "@eslint/js"
@@ -24,9 +25,9 @@ export default [
   ...compat.extends(
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@effect/recommended"
+    "plugin:@typescript-eslint/recommended"
   ),
+  ...effectEslint.configs.dprint,
   {
     plugins: {
       import: fixupPluginRules(_import),
@@ -134,6 +135,21 @@ export default [
     files: ["packages/*/src/**/*", "packages/*/test/**/*"],
     rules: {
       "no-console": "error"
+    }
+  },
+  {
+    files: ["packages/*/src/**/*"],
+    rules: {
+      "@effect/no-import-from-barrel-package": [
+        "error",
+        {
+          packageNames: [
+            "effect",
+            "@effect/platform",
+            "@effect/sql"
+          ]
+        }
+      ]
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@edge-runtime/vm": "^4.0.0",
     "@effect/build-utils": "^0.7.7",
     "@effect/docgen": "https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@fd06738",
-    "@effect/eslint-plugin": "^0.2.0",
+    "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.1.0",
     "@effect/vitest": "workspace:^",
     "@eslint/compat": "^1.1.1",

--- a/packages/sql-sqlite-node/src/SqliteClient.ts
+++ b/packages/sql-sqlite-node/src/SqliteClient.ts
@@ -2,7 +2,6 @@
  * @since 1.0.0
  */
 import * as Reactivity from "@effect/experimental/Reactivity"
-import { SqlClient } from "@effect/sql"
 import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
@@ -125,7 +124,7 @@ export const make = (
         raw: boolean
       ) =>
         Effect.withFiberRuntime<ReadonlyArray<any>, SqlError>((fiber) => {
-          if (Context.get(fiber.currentContext, SqlClient.SafeIntegers)) {
+          if (Context.get(fiber.currentContext, Client.SafeIntegers)) {
             statement.safeIntegers(true)
           }
           try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         specifier: https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@fd06738
         version: https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@fd06738(tsx@4.17.0)(typescript@5.7.2)
       '@effect/eslint-plugin':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.3.2
+        version: 0.3.2
       '@effect/language-service':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1971,8 +1971,8 @@ packages:
       tsx: ^4.19.3
       typescript: ^5.8.2
 
-  '@effect/eslint-plugin@0.2.0':
-    resolution: {integrity: sha512-PC/hEDGctYGYIjZyhM6kbD4FyHxLgoYNoQNjGkCXcFEzi71vQc3PJKe2JnCgzcUDvr/Nc2qgTVU4ONYwjHzQGA==}
+  '@effect/eslint-plugin@0.3.2':
+    resolution: {integrity: sha512-c4Vs9t3r54A4Zpl+wo8+PGzZz3JWYsip41H+UrebRLjQ2Hk/ap63IeCgN/HWcYtxtyhRopjp7gW9nOQ2Snbl+g==}
 
   '@effect/language-service@0.1.0':
     resolution: {integrity: sha512-BnlM8LlaqCAYgdRfxlbR7gXGh/FD1scL1fPgNVJEPoOM08od1jtJz+iKhwfaud8TPnnhZR+TED2h5ynjanLeCQ==}
@@ -9591,7 +9591,7 @@ snapshots:
       tsx: 4.17.0
       typescript: 5.7.2
 
-  '@effect/eslint-plugin@0.2.0':
+  '@effect/eslint-plugin@0.3.2':
     dependencies:
       '@dprint/formatter': 0.4.1
       '@dprint/typescript': 0.91.4


### PR DESCRIPTION

## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR updates the eslint plugin (so that now also natively supports eslint9's style of config).
It also enables, only for sources folders, the rule that will prevent imports like #4779 
Enabling this rule revealed a similar issue inside the @effect/sql package.
To keep the rule fast, it just does static analysis (to avoid enable of type info).
So packageNames has to be manually provided in the rule config.
