### PR TITLE
`Brand.unbranded` getter

### DIFF
--- a/.changeset/calm-zebras-relate.md
+++ b/.changeset/calm-zebras-relate.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+`Brand.unbranded` getter has been added

--- a/packages/effect/src/Brand.ts
+++ b/packages/effect/src/Brand.ts
@@ -18,7 +18,7 @@
  */
 import * as Arr from "./Array.js"
 import * as Either from "./Either.js"
-import { identity } from "./Function.js"
+import { identity, unsafeCoerce } from "./Function.js"
 import * as Option from "./Option.js"
 import type { Predicate } from "./Predicate.js"
 import type * as Types from "./Types.js"
@@ -350,3 +350,11 @@ export const all: <Brands extends readonly [Brand.Constructor<any>, ...Array<Bra
     is: (args: any): args is any => Either.isRight(either(args))
   })
 }
+
+/**
+ * Retrieves the unbranded value from a `Brand` instance.
+ *
+ * @since 3.15.0
+ * @category getters
+ */
+export const unbranded: <A extends Brand<any>>(branded: A) => Brand.Unbranded<A> = unsafeCoerce


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TS can't narrow the type of a tuple element when accessed via a branded index — which results in a wider result type.
It is possible to cast using `Brand.Brand.Unbranded`, but it's inconvenient — so I propose adding a corresponding utility function.
![image](https://github.com/user-attachments/assets/f214c11d-5bd3-45c8-83e6-325c71b384e4)



## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
