### PR TITLE
fix(Metric): summary quantile value when overshoots

### DIFF
--- a/.changeset/itchy-cows-march.md
+++ b/.changeset/itchy-cows-march.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix summary metric’s quantile value calculation

--- a/packages/effect/src/internal/metric/hook.ts
+++ b/packages/effect/src/internal/metric/hook.ts
@@ -391,7 +391,8 @@ const resolveQuantile = (
     }
     // Split into two chunks - the first chunk contains all elements of the same
     // value as the chunk head
-    const sameHead = Arr.span(rest_1, (n) => n <= rest_1[0])
+    const headValue = Arr.headNonEmpty(rest_1) // Get head value since rest_1 is non-empty
+    const sameHead = Arr.span(rest_1, (n) => n === headValue)
     // How many elements do we want to accept for this quantile
     const desired = quantile_1 * sampleCount_1
     // The error margin
@@ -417,12 +418,14 @@ const resolveQuantile = (
       rest_1 = rest_2
       continue
     }
-    // If we have too many elements, select the previous value and hand back the
-    // the rest as leftover
+    // If consuming this chunk leads to too many elements (rank is too high)
     if (candConsumed > desired + allowedError) {
+      const valueToReturn = Option.isNone(current_1)
+        ? Option.some(headValue)
+        : current_1
       return {
         quantile: quantile_1,
-        value: current_1,
+        value: valueToReturn,
         consumed: consumed_1,
         rest: rest_1
       }


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes an issue within summary metric.

When calculating the value for a quantile, if the first chunk of elements of the same value (`10` x 6) was great than the target rank, it would return `Option.none()` since `current_1 ` hasn't yet been set to some value.