### PR TITLE
Schema: respect custom constructors in `make` for `Schema.Class`, closes #4797

### DIFF
--- a/.changeset/clever-forks-move.md
+++ b/.changeset/clever-forks-move.md
@@ -1,0 +1,43 @@
+---
+"effect": patch
+---
+
+Schema: respect custom constructors in `make` for `Schema.Class`, closes #4797
+
+Previously, the `make` method did not support custom constructors defined using `Schema.Class` or `Schema.TaggedError`, resulting in type errors when passing custom constructor arguments.
+
+This update ensures that `make` now correctly uses the class constructor, allowing custom parameters and initialization logic.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+class MyError extends Schema.TaggedError<MyError>()("MyError", {
+  message: Schema.String
+}) {
+  constructor({ a, b }: { a: string; b: string }) {
+    super({ message: `${a}:${b}` })
+  }
+}
+
+// @ts-expect-error: Object literal may only specify known properties, and 'a' does not exist in type '{ readonly message: string; }'.ts(2353)
+MyError.make({ a: "1", b: "2" })
+```
+
+After
+
+```ts
+import { Schema } from "effect"
+
+class MyError extends Schema.TaggedError<MyError>()("MyError", {
+  message: Schema.String
+}) {
+  constructor({ a, b }: { a: string; b: string }) {
+    super({ message: `${a}:${b}` })
+  }
+}
+
+console.log(MyError.make({ a: "1", b: "2" }).message)
+// Output: "1:2"
+```

--- a/packages/effect/dtslint/Schema/TaggedError.tst.ts
+++ b/packages/effect/dtslint/Schema/TaggedError.tst.ts
@@ -6,13 +6,25 @@ describe("Schema.TaggedError", () => {
   it("should be yieldable", () => {
     class Err extends Schema.TaggedError<Err>()("Err", {}) {}
 
-    expect<Unify.Unify<Err>>()
-      .type.toBe<Err>()
+    expect<Unify.Unify<Err>>().type.toBe<Err>()
 
     expect(Effect.gen(function*($) {
       return yield* $(new Err())
-    }))
-      .type.toBe<Effect.Effect<never, Err>>()
+    })).type.toBe<Effect.Effect<never, Err>>()
+  })
+
+  it("make should respect custom constructors", () => {
+    class MyError extends Schema.TaggedError<MyError>()(
+      "MyError",
+      { message: Schema.String }
+    ) {
+      constructor({ a, b }: { a: string; b: string }) {
+        super({ message: `${a}:${b}` })
+      }
+    }
+
+    expect(MyError.make({ a: "a", b: "b" }).message).type.toBe<string>()
+    expect(new MyError({ a: "a", b: "b" }).message).type.toBe<string>()
   })
 
   it("Annotations as tuple", () => {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8484,10 +8484,7 @@ export interface Class<Self, Fields extends Struct.Fields, I, R, C, Inherited, P
   /** @since 3.10.0 */
   readonly ast: AST.Transformation
 
-  make(
-    props: RequiredKeys<C> extends never ? void | Simplify<C> : Simplify<C>,
-    options?: MakeOptions
-  ): Self
+  make<C extends new(...args: Array<any>) => any>(this: C, ...args: ConstructorParameters<C>): InstanceType<C>
 
   annotations(annotations: Annotations.Schema<Self>): SchemaClass<Self, Simplify<I>, R>
 

--- a/packages/effect/test/Schema/Schema/Class/TaggedError.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/TaggedError.test.ts
@@ -12,6 +12,20 @@ describe("TaggedError", () => {
     strictEqual(TE._tag, "TE")
   })
 
+  it("make should respect custom constructors", () => {
+    class MyError extends Schema.TaggedError<MyError>()(
+      "MyError",
+      { message: Schema.String }
+    ) {
+      constructor({ a, b }: { a: string; b: string }) {
+        super({ message: `${a}:${b}` })
+      }
+    }
+
+    strictEqual(MyError.make({ a: "a", b: "b" }).message, "a:b")
+    strictEqual(new MyError({ a: "a", b: "b" }).message, "a:b")
+  })
+
   it("should accept a Struct as argument", () => {
     const fields = { a: S.String, b: S.Number }
     class A extends S.TaggedError<A>()("A", S.Struct(fields)) {}


### PR DESCRIPTION
Previously, the `make` method did not support custom constructors defined using `Schema.Class` or `Schema.TaggedError`, resulting in type errors when passing custom constructor arguments.

This update ensures that `make` now correctly uses the class constructor, allowing custom parameters and initialization logic.

Before

```ts
import { Schema } from "effect"

class MyError extends Schema.TaggedError<MyError>()("MyError", {
  message: Schema.String
}) {
  constructor({ a, b }: { a: string; b: string }) {
    super({ message: `${a}:${b}` })
  }
}

// @ts-expect-error: Object literal may only specify known properties, and 'a' does not exist in type '{ readonly message: string; }'.ts(2353)
MyError.make({ a: "1", b: "2" })
```

After

```ts
import { Schema } from "effect"

class MyError extends Schema.TaggedError<MyError>()("MyError", {
  message: Schema.String
}) {
  constructor({ a, b }: { a: string; b: string }) {
    super({ message: `${a}:${b}` })
  }
}

console.log(MyError.make({ a: "1", b: "2" }).message)
// Output: "1:2"
```
