### PR TITLE
implement stack cleaning for bun

### DIFF
--- a/.changeset/tame-buckets-tickle.md
+++ b/.changeset/tame-buckets-tickle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Implement stack cleaning for Bun

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -555,18 +555,21 @@ export const Error: new<A extends Record<string, any> = {}>(
     : { readonly [P in keyof A]: A[P] }
 ) => Cause.YieldableError & Readonly<A> = (function() {
   const plainArgsSymbol = Symbol.for("effect/Data/Error/plainArgs")
-  return class Base extends core.YieldableError {
-    constructor(args: any) {
-      super(args?.message, args?.cause ? { cause: args.cause } : undefined)
-      if (args) {
-        Object.assign(this, args)
-        Object.defineProperty(this, plainArgsSymbol, { value: args, enumerable: false })
+  const O = {
+    BaseEffectError: class extends core.YieldableError {
+      constructor(args: any) {
+        super(args?.message, args?.cause ? { cause: args.cause } : undefined)
+        if (args) {
+          Object.assign(this, args)
+          Object.defineProperty(this, plainArgsSymbol, { value: args, enumerable: false })
+        }
       }
-    }
-    toJSON() {
-      return { ...(this as any)[plainArgsSymbol], ...this }
-    }
-  } as any
+      toJSON() {
+        return { ...(this as any)[plainArgsSymbol], ...this }
+      }
+    } as any
+  }
+  return O.BaseEffectError
 })()
 
 /**
@@ -577,9 +580,11 @@ export const TaggedError = <Tag extends string>(tag: Tag): new<A extends Record<
   args: Types.Equals<A, {}> extends true ? void
     : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P] }
 ) => Cause.YieldableError & { readonly _tag: Tag } & Readonly<A> => {
-  class Base extends Error<{}> {
-    readonly _tag = tag
+  const O = {
+    BaseEffectError: class extends Error<{}> {
+      readonly _tag = tag
+    }
   }
-  ;(Base.prototype as any).name = tag
-  return Base as any
+  ;(O.BaseEffectError.prototype as any).name = tag
+  return O.BaseEffectError as any
 }

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -14573,7 +14573,11 @@ function fnApply(options: {
     if (options.errorCall.stack) {
       const stackDef = options.errorDef.stack!.trim().split("\n")
       const stackCall = options.errorCall.stack.trim().split("\n")
-      cache = `${stackDef.slice(2).join("\n").trim()}\n${stackCall.slice(2).join("\n").trim()}`
+      let endStack = stackDef.slice(2).join("\n").trim()
+      if (!endStack.includes(`(`)) {
+        endStack = endStack.replace(/at (.*)/, "at ($1)")
+      }
+      cache = `${endStack}\n${stackCall.slice(2).join("\n").trim()}`
       return cache
     }
   }

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -774,23 +774,31 @@ export const structuralRegion = <A>(body: () => A, tester?: (a: unknown, b: unkn
   }
 }
 
-const tracingFunction = (name: string) => {
-  const wrap = {
-    [name]<A>(body: () => A) {
-      return body()
-    }
-  }
-  return function<A>(fn: () => A): A {
-    return wrap[name](fn)
+const standard = {
+  effect_internal_function: <A>(body: () => A) => {
+    return body()
   }
 }
+
+const forced = {
+  effect_internal_function: <A>(body: () => A) => {
+    try {
+      return body()
+    } finally {
+      //
+    }
+  }
+}
+
+const isNotOptimizedAway =
+  standard.effect_internal_function(() => new Error().stack)?.includes("effect_internal_function") === true
 
 /**
  * @since 3.2.2
  * @status experimental
  * @category tracing
  */
-export const internalCall = tracingFunction("effect_internal_function")
+export const internalCall = isNotOptimizedAway ? standard.effect_internal_function : forced.effect_internal_function
 
 const genConstructor = (function*() {}).constructor
 

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -984,6 +984,7 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
 
   for (let i = 1; i < lines.length; i++) {
     if (lines[i].includes(" at new BaseEffectError") || lines[i].includes(" at new YieldableError")) {
+      i++
       continue
     }
     if (lines[i].includes("Generator.next")) {

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -983,7 +983,7 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
   const lines = stack.startsWith(message) ? stack.slice(message.length).split("\n") : stack.split("\n")
 
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i].includes(" at new ")) {
+    if (lines[i].includes(" at new BaseEffectError") || lines[i].includes(" at new YieldableError")) {
       continue
     }
     if (lines[i].includes("Generator.next")) {

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -983,11 +983,13 @@ const prettyErrorStack = (message: string, stack: string, span?: Span | undefine
   const lines = stack.startsWith(message) ? stack.slice(message.length).split("\n") : stack.split("\n")
 
   for (let i = 1; i < lines.length; i++) {
+    if (lines[i].includes(" at new ")) {
+      continue
+    }
     if (lines[i].includes("Generator.next")) {
       break
     }
     if (lines[i].includes("effect_internal_function")) {
-      out.pop()
       break
     }
     out.push(


### PR DESCRIPTION
This program:
```ts
import { BunRuntime } from "@effect/platform-bun"
import { Data, Effect } from "effect"

class MyError extends Data.TaggedError("MyError") {
  message: string = "hey"
}

const bar = Effect.fn("bar")(function*() {
  throw new MyError()
})

const foo = Effect.fn("foo")(function*() {
  yield* bar()
})

const program = Effect.gen(function*() {
  yield* foo()
})

BunRuntime.runMain(program)
```
now prints:
```ts
michaelarnaldi@MacBook-Pro-3 effect % bun run ./scratchpad/traces/fn.ts
[10:58:38.220] ERROR (#1):
MyError: hey
    at <anonymous> (/Users/michaelarnaldi/repositories/effect/scratchpad/traces/fn.ts:9:9)
    at bar (/Users/michaelarnaldi/repositories/effect/scratchpad/traces/fn.ts:8:20)
    at bar (/Users/michaelarnaldi/repositories/effect/scratchpad/traces/fn.ts:13:10)
    at foo (/Users/michaelarnaldi/repositories/effect/scratchpad/traces/fn.ts:12:20)
    at foo (/Users/michaelarnaldi/repositories/effect/scratchpad/traces/fn.ts:17:10)
```