### PR TITLE
Match the JS API for locale arguments

### DIFF
--- a/.changeset/proud-humans-wave.md
+++ b/.changeset/proud-humans-wave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Match the JS API for locale arguments

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -1445,7 +1445,7 @@ export const format: {
   (
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): (self: DateTime) => string
@@ -1453,7 +1453,7 @@ export const format: {
     self: DateTime,
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): string
@@ -1471,7 +1471,7 @@ export const formatLocal: {
   (
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): (self: DateTime) => string
@@ -1479,7 +1479,7 @@ export const formatLocal: {
     self: DateTime,
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): string
@@ -1497,7 +1497,7 @@ export const formatUtc: {
   (
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): (self: DateTime) => string
@@ -1505,7 +1505,7 @@ export const formatUtc: {
     self: DateTime,
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): string

--- a/packages/effect/src/String.ts
+++ b/packages/effect/src/String.ts
@@ -421,7 +421,7 @@ export const lastIndexOf = (searchString: string) => (self: string): Option.Opti
  * @since 2.0.0
  */
 export const localeCompare =
-  (that: string, locales?: Array<string>, options?: Intl.CollatorOptions) => (self: string): Ordering.Ordering =>
+  (that: string, locales?: Intl.LocalesArgument, options?: Intl.CollatorOptions) => (self: string): Ordering.Ordering =>
     number.sign(self.localeCompare(that, locales, options))
 
 /**
@@ -549,7 +549,7 @@ export const search: {
  *
  * @since 2.0.0
  */
-export const toLocaleLowerCase = (locale?: string | Array<string>) => (self: string): string =>
+export const toLocaleLowerCase = (locale?: Intl.LocalesArgument) => (self: string): string =>
   self.toLocaleLowerCase(locale)
 
 /**
@@ -564,7 +564,7 @@ export const toLocaleLowerCase = (locale?: string | Array<string>) => (self: str
  *
  * @since 2.0.0
  */
-export const toLocaleUpperCase = (locale?: string | Array<string>) => (self: string): string =>
+export const toLocaleUpperCase = (locale?: Intl.LocalesArgument) => (self: string): string =>
   self.toLocaleUpperCase(locale)
 
 /**

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -1051,7 +1051,7 @@ export const format: {
   (
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): (self: DateTime.DateTime) => string
@@ -1059,7 +1059,7 @@ export const format: {
     self: DateTime.DateTime,
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): string
@@ -1067,7 +1067,7 @@ export const format: {
   self: DateTime.DateTime,
   options?:
     | Intl.DateTimeFormatOptions & {
-      readonly locale?: string | undefined
+      readonly locale?: Intl.LocalesArgument
     }
     | undefined
 ): string => {
@@ -1089,7 +1089,7 @@ export const formatLocal: {
   (
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): (self: DateTime.DateTime) => string
@@ -1097,7 +1097,7 @@ export const formatLocal: {
     self: DateTime.DateTime,
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): string
@@ -1105,7 +1105,7 @@ export const formatLocal: {
   self: DateTime.DateTime,
   options?:
     | Intl.DateTimeFormatOptions & {
-      readonly locale?: string | undefined
+      readonly locale?: Intl.LocalesArgument
     }
     | undefined
 ): string => new Intl.DateTimeFormat(options?.locale, options).format(self.epochMillis))
@@ -1115,7 +1115,7 @@ export const formatUtc: {
   (
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): (self: DateTime.DateTime) => string
@@ -1123,7 +1123,7 @@ export const formatUtc: {
     self: DateTime.DateTime,
     options?:
       | Intl.DateTimeFormatOptions & {
-        readonly locale?: string | undefined
+        readonly locale?: Intl.LocalesArgument
       }
       | undefined
   ): string
@@ -1131,7 +1131,7 @@ export const formatUtc: {
   self: DateTime.DateTime,
   options?:
     | Intl.DateTimeFormatOptions & {
-      readonly locale?: string | undefined
+      readonly locale?: Intl.LocalesArgument
     }
     | undefined
 ): string =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This should catch all the cases where Effect uses the [Intl `locales` argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
