### PR TITLE
Fix `causeResponse` to always return `internalServerError` for defects

### DIFF
--- a/.changeset/loud-donkeys-work.md
+++ b/.changeset/loud-donkeys-work.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix `causeResponse` to always return `internalServerError` for defects

--- a/.changeset/loud-donkeys-work.md
+++ b/.changeset/loud-donkeys-work.md
@@ -2,4 +2,4 @@
 "@effect/platform": patch
 ---
 
-Fix `causeResponse` to always return `internalServerError` for defects
+Ensure HttpApp defects are always 500

--- a/packages/platform/src/HttpServerRespondable.ts
+++ b/packages/platform/src/HttpServerRespondable.ts
@@ -67,8 +67,6 @@ export const toResponseOrElse = (u: unknown, orElse: HttpServerResponse): Effect
 export const toResponseOrElseDefect = (u: unknown, orElse: HttpServerResponse): Effect.Effect<HttpServerResponse> => {
   if (ServerResponse.isServerResponse(u)) {
     return Effect.succeed(u)
-  } else if (isRespondable(u)) {
-    return Effect.catchAllCause(u[symbol](), () => Effect.succeed(orElse))
   }
   return Effect.succeed(orElse)
 }

--- a/packages/platform/src/HttpServerRespondable.ts
+++ b/packages/platform/src/HttpServerRespondable.ts
@@ -59,3 +59,16 @@ export const toResponseOrElse = (u: unknown, orElse: HttpServerResponse): Effect
   }
   return Effect.succeed(orElse)
 }
+
+/**
+ * @since 1.0.0
+ * @category accessors
+ */
+export const toResponseOrElseDefect = (u: unknown, orElse: HttpServerResponse): Effect.Effect<HttpServerResponse> => {
+  if (ServerResponse.isServerResponse(u)) {
+    return Effect.succeed(u)
+  } else if (isRespondable(u)) {
+    return Effect.catchAllCause(u[symbol](), () => Effect.succeed(orElse))
+  }
+  return Effect.succeed(orElse)
+}

--- a/packages/platform/src/internal/httpServerError.ts
+++ b/packages/platform/src/internal/httpServerError.ts
@@ -40,7 +40,7 @@ export const causeResponse = <E>(
           return Option.some([Respondable.toResponseOrElse(cause.error, internalServerError), cause] as const)
         }
         case "Die": {
-          return Option.some([Effect.succeed(internalServerError), cause] as const)
+          return Option.some([Respondable.toResponseOrElseDefect(cause.defect, internalServerError), cause] as const)
         }
         case "Interrupt": {
           if (acc[1]._tag !== "Empty") {

--- a/packages/platform/src/internal/httpServerError.ts
+++ b/packages/platform/src/internal/httpServerError.ts
@@ -40,7 +40,7 @@ export const causeResponse = <E>(
           return Option.some([Respondable.toResponseOrElse(cause.error, internalServerError), cause] as const)
         }
         case "Die": {
-          return Option.some([Respondable.toResponseOrElse(cause.defect, internalServerError), cause] as const)
+          return Option.some([Effect.succeed(internalServerError), cause] as const)
         }
         case "Interrupt": {
           if (acc[1]._tag !== "Empty") {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR addresses the issue discussed in this Discord [thread](https://discord.com/channels/795981131316985866/1368586955914350794). In short, the defect handler changes its behavior based on the type of error within the defect, which shouldn't be the case.
