### PR TITLE
disable lsp diagnostics in dtslint

### DIFF
--- a/packages/effect/dtslint/tsconfig.json
+++ b/packages/effect/dtslint/tsconfig.json
@@ -7,6 +7,12 @@
   "compilerOptions": {
     "incremental": false,
     "composite": false,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "plugins": [
+      {
+        "name": "@effect/language-server",
+        "diagnostics": false
+      }
+    ]
   }
 }

--- a/packages/platform/dtslint/tsconfig.json
+++ b/packages/platform/dtslint/tsconfig.json
@@ -7,6 +7,12 @@
   "compilerOptions": {
     "incremental": false,
     "composite": false,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "plugins": [
+      {
+        "name": "@effect/language-server",
+        "diagnostics": false
+      }
+    ]
   }
 }

--- a/packages/typeclass/dtslint/tsconfig.json
+++ b/packages/typeclass/dtslint/tsconfig.json
@@ -7,6 +7,12 @@
   "compilerOptions": {
     "incremental": false,
     "composite": false,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "plugins": [
+      {
+        "name": "@effect/language-server",
+        "diagnostics": false
+      }
+    ]
   }
 }


### PR DESCRIPTION

## Type


- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Disable lsp diagnostics for dtslint packages