### PR TITLE
Fix `StreamAdapter` error forwarding

### DIFF
--- a/.changeset/plenty-gorillas-nail.md
+++ b/.changeset/plenty-gorillas-nail.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix `StreamAdapter` error forwarding

--- a/packages/platform-node-shared/src/internal/stream.ts
+++ b/packages/platform-node-shared/src/internal/stream.ts
@@ -345,7 +345,7 @@ class StreamAdapter<E, R> extends Readable {
       if (Exit.isSuccess(exit)) {
         this.push(null)
       } else {
-        this._destroy(Cause.squash(exit.cause) as any, constVoid)
+        this.destroy(Cause.squash(exit.cause) as any)
       }
     })
   }
@@ -355,9 +355,9 @@ class StreamAdapter<E, R> extends Readable {
     Effect.runSync(this.readLatch.open)
   }
 
-  _destroy(_error: Error | null, callback: (error?: Error | null | undefined) => void): void {
+  _destroy(error: Error | null, callback: (error?: Error | null | undefined) => void): void {
     if (!this.fiber) {
-      return callback(null)
+      return callback(error)
     }
     Effect.runFork(Fiber.interrupt(this.fiber)).addObserver((exit) => {
       callback(exit._tag === "Failure" ? Cause.squash(exit.cause) as any : null)

--- a/packages/platform-node-shared/src/internal/stream.ts
+++ b/packages/platform-node-shared/src/internal/stream.ts
@@ -7,7 +7,7 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import type { LazyArg } from "effect/Function"
-import { constVoid, dual } from "effect/Function"
+import { dual } from "effect/Function"
 import * as Mailbox from "effect/Mailbox"
 import * as Runtime from "effect/Runtime"
 import type * as AsyncInput from "effect/SingleProducerAsyncInput"
@@ -317,8 +317,8 @@ const readChunkChannel = <A>(
   })
 
 class StreamAdapter<E, R> extends Readable {
-  private readonly readLatch: Effect.Latch
-  private fiber: Fiber.RuntimeFiber<void, E> | undefined = undefined
+  readonly readLatch: Effect.Latch
+  fiber: Fiber.RuntimeFiber<void, E> | undefined = undefined
 
   constructor(
     runtime: Runtime.Runtime<R>,
@@ -327,18 +327,20 @@ class StreamAdapter<E, R> extends Readable {
     super({})
     this.readLatch = Effect.unsafeMakeLatch(false)
     this.fiber = Runtime.runFork(runtime)(
-      Stream.runForEachChunk(stream, (chunk) =>
-        this.readLatch.whenOpen(Effect.sync(() => {
-          if (chunk.length === 0) return
-          this.readLatch.unsafeClose()
-          for (const item of chunk) {
-            if (typeof item === "string") {
-              this.push(item, "utf8")
-            } else {
-              this.push(item)
+      this.readLatch.whenOpen(
+        Stream.runForEachChunk(stream, (chunk) =>
+          this.readLatch.whenOpen(Effect.sync(() => {
+            if (chunk.length === 0) return
+            this.readLatch.unsafeClose()
+            for (const item of chunk) {
+              if (typeof item === "string") {
+                this.push(item, "utf8")
+              } else {
+                this.push(item)
+              }
             }
-          }
-        })))
+          })))
+      )
     )
     this.fiber.addObserver((exit) => {
       this.fiber = undefined
@@ -351,8 +353,7 @@ class StreamAdapter<E, R> extends Readable {
   }
 
   _read(_size: number): void {
-    // TODO: refactor to use unsafeOpen when added to Effect
-    Effect.runSync(this.readLatch.open)
+    this.readLatch.unsafeOpen()
   }
 
   _destroy(error: Error | null, callback: (error?: Error | null | undefined) => void): void {
@@ -360,7 +361,7 @@ class StreamAdapter<E, R> extends Readable {
       return callback(error)
     }
     Effect.runFork(Fiber.interrupt(this.fiber)).addObserver((exit) => {
-      callback(exit._tag === "Failure" ? Cause.squash(exit.cause) as any : null)
+      callback(exit._tag === "Failure" ? Cause.squash(exit.cause) as any : error)
     })
   }
 }

--- a/packages/platform-node-shared/test/Stream.test.ts
+++ b/packages/platform-node-shared/test/Stream.test.ts
@@ -1,6 +1,6 @@
 import * as NodeStream from "@effect/platform-node-shared/NodeStream"
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Channel, Chunk, Stream } from "effect"
+import { Array, identity, Channel, Chunk, Either, Stream } from "effect"
 import * as Effect from "effect/Effect"
 import { Duplex, Readable, Transform } from "stream"
 import { createGzip, createUnzip } from "zlib"
@@ -165,4 +165,18 @@ describe("Stream", () => {
       )
       assert.strictEqual(Chunk.join(items, ""), Array.range(0, 10000).join(""))
     }).pipe(Effect.runPromise))
+
+  it("toReadable with error", () =>
+    Effect.gen(function*(_) {
+      const stream = Stream.fail("error")
+      const readable = yield* _(NodeStream.toReadable(stream))
+      const outStream = NodeStream.fromReadable<unknown, Uint8Array>(() => readable, identity)
+      const items = yield* _(
+        outStream,
+        Stream.runCollect,
+        Effect.either,
+      )
+      assert.deepEqual(items, Either.left("error" as const))
+    }
+    ).pipe(Effect.runPromise))
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If a `Stream` fails the error is not correctly handled by `StreamAdapter` which results in a stream that never emits an error. See 9c15bad28766e77c7a2fd34fc2fab3ce3ba292c2.

This fix now correctly calls the `destroy` function on the `Readable` which initializes an appropriate `callback` which when called emits the `error` event on the `Readable`.