### PR TITLE
Add `Schedule.CurrentIterationMetadata` Reference 

### DIFF
--- a/.changeset/calm-geese-carry.md
+++ b/.changeset/calm-geese-carry.md
@@ -2,7 +2,7 @@
 "effect": minor
 ---
 
-`Schedule.LastIterationInfo` has been added
+`Schedule.CurrentIterationMetadata` has been added
 
 ```ts
 import { Effect, Schedule } from "effect"

--- a/.changeset/calm-geese-carry.md
+++ b/.changeset/calm-geese-carry.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Schedule.LastIterationInfo has been added

--- a/.changeset/calm-geese-carry.md
+++ b/.changeset/calm-geese-carry.md
@@ -8,30 +8,60 @@
 import { Effect, Schedule } from "effect"
 
 Effect.gen(function* () {
-  const iterationInfo = yield* Schedule.LastIterationInfo
-  //    ^? Option<Schedule.IterationInfo>
+  const [iterationMetadata] = yield* Schedule.CurrentIterationMetadata
+  //    ^? Chunk<Schedule.IterationInfo>
 
-  console.log(iterationInfo)
-}).pipe(
-  Effect.repeat(Schedule.recurs(2)) // <-- Effect.repeat
-)
-// Option.none()
-// Option.some({ duration: Duration.zero, iteration: 1 })
-// Option.some({ duration: Duration.zero, iteration: 2 })
+  console.log(iterationMetadata)
+}).pipe(Effect.repeat(Schedule.recurs(2)))
+// undefined
+// {
+//   elapsed: Duration.zero,
+//   elapsedSincePrevious: Duration.zero,
+//   input: undefined,
+//   now: 0,
+//   recurrence: 1,
+//   start: 0
+// }
+// {
+//   elapsed: Duration.zero,
+//   elapsedSincePrevious: Duration.zero,
+//   input: undefined,
+//   now: 0,
+//   recurrence: 2,
+//   start: 0
+// }
 
 Effect.gen(function* () {
   const iterationInfo = yield* Schedule.LastIterationInfo
 
   console.log(iterationInfo)
 }).pipe(
-  // Effect.schedule( // <-- Effect.schedule
-    Schedule.intersect(
-      Schedule.fibonacci("1 second"),
-      Schedule.recurs(3)
-    )
+  Effect.schedule(
+    Schedule.intersect(Schedule.fibonacci("1 second"), Schedule.recurs(3))
   )
 )
-// Option.some({ duration: Duration.seconds(1), iteration: 1 })
-// Option.some({ duration: Duration.seconds(1), iteration: 2 })
-// Option.some({ duration: Duration.seconds(2), iteration: 3 })
+// {
+//   elapsed: Duration.zero,
+//   elapsedSincePrevious: Duration.zero,
+//   recurrence: 1,
+//   input: undefined,
+//   now: 0,
+//   start: 0
+// },
+// {
+//   elapsed: Duration.seconds(1),
+//   elapsedSincePrevious: Duration.seconds(1),
+//   recurrence: 2,
+//   input: undefined,
+//   now: 1000,
+//   start: 0
+// },
+// {
+//   elapsed: Duration.seconds(2),
+//   elapsedSincePrevious: Duration.seconds(1),
+//   recurrence: 3,
+//   input: undefined,
+//   now: 2000,
+//   start: 0
+// }
 ```

--- a/.changeset/calm-geese-carry.md
+++ b/.changeset/calm-geese-carry.md
@@ -8,12 +8,19 @@
 import { Effect, Schedule } from "effect"
 
 Effect.gen(function* () {
-  const [iterationMetadata] = yield* Schedule.CurrentIterationMetadata
-  //    ^? Chunk<Schedule.IterationInfo>
+  const currentIterationMetadata = yield* Schedule.CurrentIterationMetadata
+  //     ^? Schedule.IterationMetadata
 
-  console.log(iterationMetadata)
+  console.log(currentIterationMetadata)
 }).pipe(Effect.repeat(Schedule.recurs(2)))
-// undefined
+// {
+//   elapsed: Duration.zero,
+//   elapsedSincePrevious: Duration.zero,
+//   input: undefined,
+//   now: 0,
+//   recurrence: 0,
+//   start: 0
+// }
 // {
 //   elapsed: Duration.zero,
 //   elapsedSincePrevious: Duration.zero,
@@ -32,9 +39,9 @@ Effect.gen(function* () {
 // }
 
 Effect.gen(function* () {
-  const iterationInfo = yield* Schedule.LastIterationInfo
+  const currentIterationMetadata = yield* Schedule.CurrentIterationMetadata
 
-  console.log(iterationInfo)
+  console.log(currentIterationMetadata)
 }).pipe(
   Effect.schedule(
     Schedule.intersect(Schedule.fibonacci("1 second"), Schedule.recurs(3))

--- a/.changeset/calm-geese-carry.md
+++ b/.changeset/calm-geese-carry.md
@@ -2,4 +2,36 @@
 "effect": minor
 ---
 
-Schedule.LastIterationInfo has been added
+`Schedule.LastIterationInfo` has been added
+
+```ts
+import { Effect, Schedule } from "effect"
+
+Effect.gen(function* () {
+  const iterationInfo = yield* Schedule.LastIterationInfo
+  //    ^? Option<Schedule.IterationInfo>
+
+  console.log(iterationInfo)
+}).pipe(
+  Effect.repeat(Schedule.recurs(2)) // <-- Effect.repeat
+)
+// Option.none()
+// Option.some({ duration: Duration.zero, iteration: 1 })
+// Option.some({ duration: Duration.zero, iteration: 2 })
+
+Effect.gen(function* () {
+  const iterationInfo = yield* Schedule.LastIterationInfo
+
+  console.log(iterationInfo)
+}).pipe(
+  // Effect.schedule( // <-- Effect.schedule
+    Schedule.intersect(
+      Schedule.fibonacci("1 second"),
+      Schedule.recurs(3)
+    )
+  )
+)
+// Option.some({ duration: Duration.seconds(1), iteration: 1 })
+// Option.some({ duration: Duration.seconds(1), iteration: 2 })
+// Option.some({ duration: Duration.seconds(2), iteration: 3 })
+```

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -141,7 +141,7 @@ export declare namespace Schedule {
  */
 export interface ScheduleDriver<out Out, in In = unknown, out R = never> extends Schedule.DriverVariance<Out, In, R> {
   readonly state: Effect.Effect<unknown>
-  readonly iterationMeta: Ref.Ref<Chunk.Chunk<IterationMetadata>>
+  readonly iterationMeta: Ref.Ref<IterationMetadata>
   readonly last: Effect.Effect<Out, Cause.NoSuchElementException>
   readonly reset: Effect.Effect<void>
   next(input: In): Effect.Effect<Out, Option.Option<never>, R>
@@ -2214,5 +2214,5 @@ export interface IterationMetadata {
  */
 export const CurrentIterationMetadata: Context.Reference<
   CurrentIterationMetadata,
-  Chunk.Chunk<IterationMetadata>
+  IterationMetadata
 > = internal.CurrentIterationMetadata

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -141,7 +141,7 @@ export declare namespace Schedule {
  */
 export interface ScheduleDriver<out Out, in In = unknown, out R = never> extends Schedule.DriverVariance<Out, In, R> {
   readonly state: Effect.Effect<unknown>
-  readonly lastIterationInfo: Ref.Ref<Option.Option<IterationInfo>>
+  readonly iterationMeta: Ref.Ref<Chunk.Chunk<IterationMetadata>>
   readonly last: Effect.Effect<Out, Cause.NoSuchElementException>
   readonly reset: Effect.Effect<void>
   next(input: In): Effect.Effect<Out, Option.Option<never>, R>
@@ -2191,7 +2191,7 @@ export const zipWith: {
  * @since 3.15.0
  * @category models
  */
-export interface LastIterationInfo {
+export interface CurrentIterationMetadata {
   readonly _: unique symbol
 }
 
@@ -2199,16 +2199,20 @@ export interface LastIterationInfo {
  * @since 3.15.0
  * @category models
  */
-export interface IterationInfo {
-  readonly duration: Duration.Duration
-  readonly iteration: number
+export interface IterationMetadata {
+  readonly input: unknown
+  readonly recurrence: number
+  readonly start: number
+  readonly now: number
+  readonly elapsed: Duration.Duration
+  readonly elapsedSincePrevious: Duration.Duration
 }
 
 /**
  * @since 3.15.0
  * @category models
  */
-export const LastIterationInfo: Context.Reference<
-  LastIterationInfo,
-  Option.Option<IterationInfo>
+export const CurrentIterationMetadata: Context.Reference<
+  CurrentIterationMetadata,
+  Array<IterationMetadata>
 > = internal.LastIterationInfo

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -2214,5 +2214,5 @@ export interface IterationMetadata {
  */
 export const CurrentIterationMetadata: Context.Reference<
   CurrentIterationMetadata,
-  Array<IterationMetadata>
+  Chunk.Chunk<IterationMetadata>
 > = internal.LastIterationInfo

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -14,6 +14,7 @@ import * as internal from "./internal/schedule.js"
 import type * as Option from "./Option.js"
 import type { Pipeable } from "./Pipeable.js"
 import type { Predicate } from "./Predicate.js"
+import type * as Ref from "./Ref.js"
 import type * as ScheduleDecision from "./ScheduleDecision.js"
 import type * as Intervals from "./ScheduleIntervals.js"
 import type * as Types from "./Types.js"
@@ -140,6 +141,7 @@ export declare namespace Schedule {
  */
 export interface ScheduleDriver<out Out, in In = unknown, out R = never> extends Schedule.DriverVariance<Out, In, R> {
   readonly state: Effect.Effect<unknown>
+  readonly lastIterationInfo: Ref.Ref<Option.Option<IterationInfo>>
   readonly last: Effect.Effect<Out, Cause.NoSuchElementException>
   readonly reset: Effect.Effect<void>
   next(input: In): Effect.Effect<Out, Option.Option<never>, R>
@@ -2184,3 +2186,29 @@ export const zipWith: {
     f: (out: Out, out2: Out2) => Out3
   ): Schedule<Out3, In & In2, R | R2>
 } = internal.zipWith
+
+/**
+ * @since 3.15.0
+ * @category models
+ */
+export interface LastIterationInfo {
+  readonly _: unique symbol
+}
+
+/**
+ * @since 3.15.0
+ * @category models
+ */
+export interface IterationInfo {
+  readonly duration: Duration.Duration
+  readonly iteration: number
+}
+
+/**
+ * @since 3.15.0
+ * @category models
+ */
+export const LastIterationInfo: Context.Reference<
+  LastIterationInfo,
+  Option.Option<IterationInfo>
+> = internal.LastIterationInfo

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -2215,4 +2215,4 @@ export interface IterationMetadata {
 export const CurrentIterationMetadata: Context.Reference<
   CurrentIterationMetadata,
   Chunk.Chunk<IterationMetadata>
-> = internal.LastIterationInfo
+> = internal.CurrentIterationMetadata

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -1946,7 +1946,7 @@ const repeatOrElseEffectLoop = <A, E, R, R1, B, C, E2, R2>(
       const selfWithLastIterationInfo = provideLastIterationInfo(self)
       return core.matchEffect(selfWithLastIterationInfo, {
         onFailure: (error) => provideLastIterationInfo(orElse(error, Option.some(b))),
-        onSuccess: (value) => repeatOrElseEffectLoop(selfWithLastIterationInfo, driver, orElse, value)
+        onSuccess: (value) => repeatOrElseEffectLoop(self, driver, orElse, value)
       })
     }
   })

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -1,4 +1,4 @@
-import * as Array from "../Array.js"
+import type * as Array from "../Array.js"
 import type * as Cause from "../Cause.js"
 import * as Chunk from "../Chunk.js"
 import * as Clock from "../Clock.js"
@@ -49,7 +49,7 @@ export const ScheduleDriverTypeId: Schedule.ScheduleDriverTypeId = Symbol.for(
 /** @internal */
 export const LastIterationInfo = Context.Reference<Schedule.CurrentIterationMetadata>()(
   "effect/Schedule/LastIterationInfo",
-  { defaultValue: () => Array.empty<Schedule.IterationMetadata>() }
+  { defaultValue: () => Chunk.empty<Schedule.IterationMetadata>() }
 )
 
 const scheduleVariance = {
@@ -1937,7 +1937,7 @@ const repeatOrElseEffectLoop = <A, E, R, R1, B, C, E2, R2>(
     onSuccess: (b) => {
       const provideLastIterationInfo = effect.provideServiceEffect(
         LastIterationInfo,
-        core.map(ref.get(driver.iterationMeta), Chunk.toArray)
+        ref.get(driver.iterationMeta)
       )
       const selfWithLastIterationInfo = provideLastIterationInfo(self)
       return core.matchEffect(selfWithLastIterationInfo, {
@@ -2038,7 +2038,7 @@ const retryOrElse_EffectLoop = <A, E, R, R1, A1, A2, E2, R2>(
     (e) => {
       const provideLastIterationInfo = effect.provideServiceEffect(
         LastIterationInfo,
-        core.map(ref.get(driver.iterationMeta), Chunk.toArray)
+        ref.get(driver.iterationMeta)
       )
 
       return core.matchEffect(driver.next(e), {
@@ -2093,7 +2093,7 @@ const scheduleFrom_EffectLoop = <In, E, R, R2, Out>(
 ): Effect.Effect<Out, E, R | R2> => {
   const provideLastIterationInfo = effect.provideServiceEffect(
     LastIterationInfo,
-    core.map(ref.get(driver.iterationMeta), Chunk.toArray)
+    ref.get(driver.iterationMeta)
   )
   return core.matchEffect(driver.next(initial), {
     onFailure: () => core.orDie(provideLastIterationInfo(driver.last)),

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -2103,7 +2103,7 @@ const scheduleFrom_EffectLoop = <In, E, R, R2, Out>(
     onFailure: () => core.orDie(provideLastIterationInfo(driver.last)),
     onSuccess: () => {
       const selfWithLastOptions = provideLastIterationInfo(self)
-      return core.flatMap(selfWithLastOptions, (a) => scheduleFrom_EffectLoop(selfWithLastOptions, a, driver))
+      return core.flatMap(selfWithLastOptions, (a) => scheduleFrom_EffectLoop(self, a, driver))
     }
   })
 }

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -2052,7 +2052,7 @@ const retryOrElse_EffectLoop = <A, E, R, R1, A1, A2, E2, R2>(
             core.orDie,
             core.flatMap((out) => provideLastIterationInfo(orElse(e, out)))
           ),
-        onSuccess: () => retryOrElse_EffectLoop(self, driver, orElse)
+        onSuccess: () => retryOrElse_EffectLoop(provideLastIterationInfo(self), driver, orElse)
       })
     }
   )

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -2052,7 +2052,7 @@ const retryOrElse_EffectLoop = <A, E, R, R1, A1, A2, E2, R2>(
             core.orDie,
             core.flatMap((out) => provideLastIterationInfo(orElse(e, out)))
           ),
-        onSuccess: () => retryOrElse_EffectLoop(provideLastIterationInfo(self), driver, orElse)
+        onSuccess: () => retryOrElse_EffectLoop(self, driver, orElse)
       })
     }
   )

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -2100,11 +2100,12 @@ const scheduleFrom_EffectLoop = <In, E, R, R2, Out>(
     ref.get(driver.iterationMeta)
   )
   return core.matchEffect(driver.next(initial), {
-    onFailure: () => core.orDie(provideLastIterationInfo(driver.last)),
-    onSuccess: () => {
-      const selfWithLastOptions = provideLastIterationInfo(self)
-      return core.flatMap(selfWithLastOptions, (a) => scheduleFrom_EffectLoop(self, a, driver))
-    }
+    onFailure: () => core.orDie(driver.last),
+    onSuccess: () =>
+      core.flatMap(
+        provideLastIterationInfo(self),
+        (a) => scheduleFrom_EffectLoop(self, a, driver)
+      )
   })
 }
 

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -47,8 +47,8 @@ export const ScheduleDriverTypeId: Schedule.ScheduleDriverTypeId = Symbol.for(
 ) as Schedule.ScheduleDriverTypeId
 
 /** @internal */
-export const LastIterationInfo = Context.Reference<Schedule.CurrentIterationMetadata>()(
-  "effect/Schedule/LastIterationInfo",
+export const CurrentIterationMetadata = Context.Reference<Schedule.CurrentIterationMetadata>()(
+  "effect/Schedule/CurrentIterationMetadata",
   { defaultValue: () => Chunk.empty<Schedule.IterationMetadata>() }
 )
 
@@ -1936,7 +1936,7 @@ const repeatOrElseEffectLoop = <A, E, R, R1, B, C, E2, R2>(
     onFailure: () => core.orDie(driver.last),
     onSuccess: (b) => {
       const provideLastIterationInfo = effect.provideServiceEffect(
-        LastIterationInfo,
+        CurrentIterationMetadata,
         ref.get(driver.iterationMeta)
       )
       const selfWithLastIterationInfo = provideLastIterationInfo(self)
@@ -2037,7 +2037,7 @@ const retryOrElse_EffectLoop = <A, E, R, R1, A1, A2, E2, R2>(
     self,
     (e) => {
       const provideLastIterationInfo = effect.provideServiceEffect(
-        LastIterationInfo,
+        CurrentIterationMetadata,
         ref.get(driver.iterationMeta)
       )
 
@@ -2092,7 +2092,7 @@ const scheduleFrom_EffectLoop = <In, E, R, R2, Out>(
   driver: Schedule.ScheduleDriver<Out, In, R2>
 ): Effect.Effect<Out, E, R | R2> => {
   const provideLastIterationInfo = effect.provideServiceEffect(
-    LastIterationInfo,
+    CurrentIterationMetadata,
     ref.get(driver.iterationMeta)
   )
   return core.matchEffect(driver.next(initial), {

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -1921,10 +1921,10 @@ const repeatOrElseEffectLoop = <A, E, R, R1, B, C, E2, R2>(
     onFailure: () => core.orDie(driver.last),
     onSuccess: (b) => {
       const provideLastIterationInfo = effect.provideServiceEffect(LastIterationInfo, ref.get(driver.lastIterationInfo))
-      const selfWithLastDuration = provideLastIterationInfo(self)
-      return core.matchEffect(selfWithLastDuration, {
+      const selfWithLastIterationInfo = provideLastIterationInfo(self)
+      return core.matchEffect(selfWithLastIterationInfo, {
         onFailure: (error) => provideLastIterationInfo(orElse(error, Option.some(b))),
-        onSuccess: (value) => repeatOrElseEffectLoop(selfWithLastDuration, driver, orElse, value)
+        onSuccess: (value) => repeatOrElseEffectLoop(selfWithLastIterationInfo, driver, orElse, value)
       })
     }
   })

--- a/packages/effect/test/Effect/repeating.test.ts
+++ b/packages/effect/test/Effect/repeating.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import { constFalse, constTrue, pipe } from "effect/Function"
+import * as Option from "effect/Option"
 import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
 
@@ -117,6 +119,27 @@ describe("Effect", () => {
       yield* pipe(Ref.update(ref, (n) => n + 1), Effect.repeat(Schedule.recurs(3)))
       const result = yield* (Ref.get(ref))
       strictEqual(result, 4)
+    }))
+
+  it.effect("repeat/schedule - ", () =>
+    Effect.gen(function*() {
+      const ref = yield* Ref.make<Array<Option.Option<Schedule.IterationInfo>>>([])
+      yield* Effect.gen(function*() {
+        const iterationInfo = yield* Schedule.LastIterationInfo
+        yield* Ref.update(ref, (infos) => [...infos, iterationInfo])
+      }).pipe(Effect.repeat(Schedule.recurs(2)))
+      const result = yield* (Ref.get(ref))
+      deepStrictEqual(result, [
+        Option.none(),
+        Option.some({
+          duration: Duration.zero,
+          iteration: 1
+        }),
+        Option.some({
+          duration: Duration.zero,
+          iteration: 2
+        })
+      ])
     }))
 
   it.effect("repeat/schedule + until", () =>

--- a/packages/effect/test/Effect/repeating.test.ts
+++ b/packages/effect/test/Effect/repeating.test.ts
@@ -125,8 +125,8 @@ describe("Effect", () => {
     Effect.gen(function*() {
       const ref = yield* Ref.make<Array<undefined | Schedule.IterationMetadata>>([])
       yield* Effect.gen(function*() {
-        const [lastIterationInfo] = yield* Schedule.CurrentIterationMetadata
-        yield* Ref.update(ref, (infos) => [...infos, lastIterationInfo])
+        const currentIterationMeta = yield* Schedule.CurrentIterationMetadata
+        yield* Ref.update(ref, (infos) => [...infos, currentIterationMeta])
       }).pipe(
         Effect.repeat(
           Schedule.intersect(Schedule.fixed("1 second"), Schedule.recurs(2))
@@ -136,7 +136,14 @@ describe("Effect", () => {
       yield* TestClock.adjust(Duration.seconds(50))
       const result = yield* (Ref.get(ref))
       deepStrictEqual(result, [
-        undefined,
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          recurrence: 0,
+          input: undefined,
+          now: 0,
+          start: 0
+        },
         {
           elapsed: Duration.zero,
           elapsedSincePrevious: Duration.zero,

--- a/packages/effect/test/Effect/retrying.test.ts
+++ b/packages/effect/test/Effect/retrying.test.ts
@@ -100,7 +100,7 @@ describe("Effect", () => {
       const result = yield* (Ref.get(ref))
       strictEqual(result, 4)
     }))
-  it.effect("retry/schedule - ", () =>
+  it.effect("retry/schedule - LastIterationInfo", () =>
     Effect.gen(function*() {
       const ref = yield* Ref.make<Array<Option.Option<Schedule.IterationInfo>>>([])
       yield* pipe(

--- a/packages/effect/test/Effect/retrying.test.ts
+++ b/packages/effect/test/Effect/retrying.test.ts
@@ -3,7 +3,6 @@ import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import { constFalse, constTrue, pipe } from "effect/Function"
-import * as Option from "effect/Option"
 import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
 
@@ -102,29 +101,41 @@ describe("Effect", () => {
     }))
   it.effect("retry/schedule - LastIterationInfo", () =>
     Effect.gen(function*() {
-      const ref = yield* Ref.make<Array<Option.Option<Schedule.IterationInfo>>>([])
+      const ref = yield* Ref.make<Array<undefined | Schedule.IterationMetadata>>([])
       yield* pipe(
         Effect.gen(function*() {
-          const iterationInfo = yield* Schedule.LastIterationInfo
-          yield* Ref.update(ref, (infos) => [...infos, iterationInfo])
+          const [lastIterationInfo] = yield* Schedule.CurrentIterationMetadata
+          yield* Ref.update(ref, (infos) => [...infos, lastIterationInfo])
         }),
         Effect.flipWith(Effect.retry(Schedule.recurs(3)))
       )
       const result = yield* (Ref.get(ref))
       deepStrictEqual(result, [
-        Option.none(),
-        Option.some({
-          duration: Duration.zero,
-          iteration: 1
-        }),
-        Option.some({
-          duration: Duration.zero,
-          iteration: 2
-        }),
-        Option.some({
-          duration: Duration.zero,
-          iteration: 3
-        })
+        undefined,
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          recurrence: 1,
+          input: undefined,
+          now: 0,
+          start: 0
+        },
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          recurrence: 2,
+          input: undefined,
+          now: 0,
+          start: 0
+        },
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          recurrence: 3,
+          input: undefined,
+          now: 0,
+          start: 0
+        }
       ])
     }))
 

--- a/packages/effect/test/Effect/retrying.test.ts
+++ b/packages/effect/test/Effect/retrying.test.ts
@@ -104,14 +104,21 @@ describe("Effect", () => {
       const ref = yield* Ref.make<Array<undefined | Schedule.IterationMetadata>>([])
       yield* pipe(
         Effect.gen(function*() {
-          const [lastIterationInfo] = yield* Schedule.CurrentIterationMetadata
-          yield* Ref.update(ref, (infos) => [...infos, lastIterationInfo])
+          const currentIterationMeta = yield* Schedule.CurrentIterationMetadata
+          yield* Ref.update(ref, (infos) => [...infos, currentIterationMeta])
         }),
         Effect.flipWith(Effect.retry(Schedule.recurs(3)))
       )
       const result = yield* (Ref.get(ref))
       deepStrictEqual(result, [
-        undefined,
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          recurrence: 0,
+          input: undefined,
+          now: 0,
+          start: 0
+        },
         {
           elapsed: Duration.zero,
           elapsedSincePrevious: Duration.zero,

--- a/packages/effect/test/Effect/scheduling.test.ts
+++ b/packages/effect/test/Effect/scheduling.test.ts
@@ -4,7 +4,6 @@ import * as Clock from "effect/Clock"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import { pipe } from "effect/Function"
-import * as Option from "effect/Option"
 import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
 import * as TestClock from "effect/TestClock"
@@ -27,9 +26,9 @@ describe("Effect", () => {
 
   it.effect("schedule - Schedule.LastIterationInfo", () =>
     Effect.gen(function*() {
-      const ref = yield* Ref.make<Array<Option.Option<Schedule.IterationInfo>>>([])
+      const ref = yield* Ref.make<Array<undefined | Schedule.IterationMetadata>>([])
       const effect = Effect.gen(function*() {
-        const lastIterationInfo = yield* Schedule.LastIterationInfo
+        const [lastIterationInfo] = yield* Schedule.CurrentIterationMetadata
 
         yield* Ref.update(ref, (array) => [...array, lastIterationInfo])
       })
@@ -39,22 +38,38 @@ describe("Effect", () => {
       const value = yield* Ref.get(ref)
 
       deepStrictEqual(value, [
-        Option.some({
-          duration: Duration.millis(1000),
-          iteration: 1
-        }),
-        Option.some({
-          duration: Duration.millis(1000),
-          iteration: 2
-        }),
-        Option.some({
-          duration: Duration.millis(2000),
-          iteration: 3
-        }),
-        Option.some({
-          duration: Duration.millis(3000),
-          iteration: 4
-        })
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          recurrence: 1,
+          input: undefined,
+          now: 0,
+          start: 0
+        },
+        {
+          elapsed: Duration.seconds(1),
+          elapsedSincePrevious: Duration.seconds(1),
+          recurrence: 2,
+          input: undefined,
+          now: 1000,
+          start: 0
+        },
+        {
+          elapsed: Duration.seconds(2),
+          elapsedSincePrevious: Duration.seconds(1),
+          recurrence: 3,
+          input: undefined,
+          now: 2000,
+          start: 0
+        },
+        {
+          elapsed: Duration.seconds(4),
+          elapsedSincePrevious: Duration.seconds(2),
+          recurrence: 4,
+          input: undefined,
+          now: 4000,
+          start: 0
+        }
       ])
     }))
 })

--- a/packages/effect/test/Effect/scheduling.test.ts
+++ b/packages/effect/test/Effect/scheduling.test.ts
@@ -28,7 +28,7 @@ describe("Effect", () => {
     Effect.gen(function*() {
       const ref = yield* Ref.make<Array<undefined | Schedule.IterationMetadata>>([])
       const effect = Effect.gen(function*() {
-        const [lastIterationInfo] = yield* Schedule.CurrentIterationMetadata
+        const lastIterationInfo = yield* Schedule.CurrentIterationMetadata
 
         yield* Ref.update(ref, (array) => [...array, lastIterationInfo])
       })

--- a/packages/effect/test/Stream/repeating.test.ts
+++ b/packages/effect/test/Stream/repeating.test.ts
@@ -73,7 +73,7 @@ describe("Stream", () => {
       const fiber = yield* pipe(
         Stream.fromEffect(
           Schedule.CurrentIterationMetadata.pipe(
-            Effect.flatMap(([lastIterationMetadata]) => Ref.update(ref, Chunk.append(lastIterationMetadata)))
+            Effect.flatMap((currentIterationMetadata) => Ref.update(ref, Chunk.append(currentIterationMetadata)))
           )
         ),
         Stream.repeat(Schedule.exponential(Duration.millis(10))),
@@ -85,7 +85,14 @@ describe("Stream", () => {
       yield* (Fiber.interrupt(fiber))
       const result = yield* (Ref.get(ref))
       deepStrictEqual(Array.from(result), [
-        undefined,
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          input: undefined,
+          now: 0,
+          recurrence: 0,
+          start: 0
+        },
         {
           elapsed: Duration.zero,
           elapsedSincePrevious: Duration.zero,

--- a/packages/effect/test/Stream/repeating.test.ts
+++ b/packages/effect/test/Stream/repeating.test.ts
@@ -67,6 +67,52 @@ describe("Stream", () => {
       deepStrictEqual(Array.from(result), [1, 1])
     }))
 
+  it.effect("repeat - Schedule.CurrentIterationMetadata", () =>
+    Effect.gen(function*() {
+      const ref = yield* (Ref.make(Chunk.empty<undefined | Schedule.IterationMetadata>()))
+      const fiber = yield* pipe(
+        Stream.fromEffect(
+          Schedule.CurrentIterationMetadata.pipe(
+            Effect.flatMap(([lastIterationMetadata]) => Ref.update(ref, Chunk.append(lastIterationMetadata)))
+          )
+        ),
+        Stream.repeat(Schedule.exponential(Duration.millis(10))),
+        Stream.runDrain,
+        Effect.fork
+      )
+
+      yield* (TestClock.adjust(Duration.millis(70)))
+      yield* (Fiber.interrupt(fiber))
+      const result = yield* (Ref.get(ref))
+      deepStrictEqual(Array.from(result), [
+        undefined,
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          input: undefined,
+          now: 0,
+          recurrence: 1,
+          start: 0
+        },
+        {
+          elapsed: Duration.millis(10),
+          elapsedSincePrevious: Duration.millis(10),
+          input: undefined,
+          now: 10,
+          recurrence: 2,
+          start: 0
+        },
+        {
+          elapsed: Duration.millis(30),
+          elapsedSincePrevious: Duration.millis(20),
+          input: undefined,
+          now: 30,
+          recurrence: 3,
+          start: 0
+        }
+      ])
+    }))
+
   it.effect("repeat - does not swallow errors on a repetition", () =>
     Effect.gen(function*() {
       const ref = yield* (Ref.make(0))

--- a/packages/effect/test/Stream/retrying.test.ts
+++ b/packages/effect/test/Stream/retrying.test.ts
@@ -122,8 +122,8 @@ describe("Stream", () => {
         Stream.fail(1),
         Stream.catchAll((x) =>
           Effect.gen(function*() {
-            const [lastIterationMetadata] = yield* Schedule.CurrentIterationMetadata
-            yield* Ref.update(iterationMetadata, Chunk.append(lastIterationMetadata))
+            const currentIterationMetadata = yield* Schedule.CurrentIterationMetadata
+            yield* Ref.update(iterationMetadata, Chunk.append(currentIterationMetadata))
             return yield* Effect.fail(x)
           })
         ),
@@ -135,7 +135,14 @@ describe("Stream", () => {
       yield* Fiber.interrupt(fiber)
       const result = yield* Ref.get(iterationMetadata)
       deepStrictEqual(Array.fromIterable(result), [
-        undefined,
+        {
+          elapsed: Duration.zero,
+          elapsedSincePrevious: Duration.zero,
+          input: undefined,
+          now: 0,
+          recurrence: 0,
+          start: 0
+        },
         {
           elapsed: Duration.zero,
           elapsedSincePrevious: Duration.zero,

--- a/packages/effect/test/Stream/scheduling.test.ts
+++ b/packages/effect/test/Stream/scheduling.test.ts
@@ -66,9 +66,9 @@ describe("Stream", () => {
       yield* Stream.make("A", "B", "C", "A", "B", "C").pipe(
         Stream.tap(() =>
           Effect.gen(function*() {
-            const [lastIterationMetadata] = yield* Schedule.CurrentIterationMetadata
+            const currentIterationMetadata = yield* Schedule.CurrentIterationMetadata
 
-            yield* Ref.update(result, Chunk.append(lastIterationMetadata))
+            yield* Ref.update(result, Chunk.append(currentIterationMetadata))
           })
         ),
         Stream.scheduleWith(schedule, {

--- a/packages/effect/test/Stream/scheduling.test.ts
+++ b/packages/effect/test/Stream/scheduling.test.ts
@@ -1,12 +1,10 @@
 import { describe, it } from "@effect/vitest"
 import { deepStrictEqual } from "@effect/vitest/utils"
-import * as Chunk from "effect/Chunk"
 import * as Clock from "effect/Clock"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
 import { identity, pipe } from "effect/Function"
-import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
 import * as Stream from "effect/Stream"
 import * as TestClock from "effect/TestClock"
@@ -53,30 +51,5 @@ describe("Stream", () => {
         Stream.runCollect
       )
       deepStrictEqual(Array.from(result), ["a", "b", "c", "Done", "a", "b", "c", "Done"])
-    }))
-
-  it.effect("scheduleWith - Schedule.CurrentIterationMetadata", () =>
-    Effect.gen(function*() {
-      const result = yield* Ref.make(Chunk.empty<undefined | Schedule.IterationMetadata>())
-      const schedule = pipe(
-        Schedule.recurs(2),
-        Schedule.zipRight(Schedule.fromFunction<string, string>(() => "Done"))
-      )
-
-      yield* Stream.make("A", "B", "C", "A", "B", "C").pipe(
-        Stream.tap(() =>
-          Effect.gen(function*() {
-            const currentIterationMetadata = yield* Schedule.CurrentIterationMetadata
-
-            yield* Ref.update(result, Chunk.append(currentIterationMetadata))
-          })
-        ),
-        Stream.scheduleWith(schedule, {
-          onElement: (s) => s.toLowerCase(),
-          onSchedule: identity
-        }),
-        Stream.runCollect
-      )
-      deepStrictEqual(Array.from(yield* Ref.get(result)), [])
     }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`Schedule.CurrentIterationMetadata` has been added


## Related
https://discord.com/channels/795981131316985866/795983589644304396/threads/1369205653343703070

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
