### PR TITLE
JSONSchema: respect annotations on declarations

### DIFF
--- a/.changeset/good-pillows-remember.md
+++ b/.changeset/good-pillows-remember.md
@@ -1,0 +1,59 @@
+---
+"effect": patch
+---
+
+JSONSchema: respect annotations on declarations.
+
+Previously, annotations added with `.annotations(...)` on `Schema.declare(...)` were not included in the generated JSON Schema output.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+class MyType {}
+
+const schema = Schema.declare<MyType>((x) => x instanceof MyType, {
+  jsonSchema: {
+    type: "my-type"
+  }
+}).annotations({
+  title: "My Title",
+  description: "My Description"
+})
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "my-type"
+}
+*/
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+class MyType {}
+
+const schema = Schema.declare<MyType>((x) => x instanceof MyType, {
+  jsonSchema: {
+    type: "my-type"
+  }
+}).annotations({
+  title: "My Title",
+  description: "My Description"
+})
+
+console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
+/*
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "My Description",
+  "title": "My Title",
+  "type": "my-type"
+}
+*/
+```

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -578,6 +578,9 @@ const go = (
         return go(t, $defs, handleIdentifier, path, options)
       }
     }
+    if (AST.isDeclaration(ast)) {
+      return { ...handler, ...getJsonSchemaAnnotations(ast) }
+    }
     return handler
   }
   const surrogate = AST.getSurrogateAnnotation(ast)

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -3682,6 +3682,25 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
       })
     })
 
+    it("Declaration", () => {
+      class MyType {}
+      const schema = Schema.declare<MyType>((x) => x instanceof MyType, {
+        jsonSchema: {
+          type: "my-type",
+          title: "default-title",
+          description: "default-description"
+        }
+      }).annotations({
+        title: "My Title",
+        description: "My Description"
+      })
+      expectJSONSchema(schema, {
+        "type": "my-type",
+        "title": "My Title",
+        "description": "My Description"
+      })
+    })
+
     it("Void", () => {
       expectJSONSchema(Schema.Void.annotations({ jsonSchema: { "type": "custom" } }), {
         "type": "custom"


### PR DESCRIPTION
Previously, annotations added with `.annotations(...)` on `Schema.declare(...)` were not included in the generated JSON Schema output.

Before

```ts
import { JSONSchema, Schema } from "effect"

class MyType {}

const schema = Schema.declare<MyType>((x) => x instanceof MyType, {
  jsonSchema: {
    type: "my-type"
  }
}).annotations({
  title: "My Title",
  description: "My Description"
})

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "my-type"
}
*/
```

After

```ts
import { JSONSchema, Schema } from "effect"

class MyType {}

const schema = Schema.declare<MyType>((x) => x instanceof MyType, {
  jsonSchema: {
    type: "my-type"
  }
}).annotations({
  title: "My Title",
  description: "My Description"
})

console.log(JSON.stringify(JSONSchema.make(schema), null, 2))
/*
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "description": "My Description",
  "title": "My Title",
  "type": "my-type"
}
*/
```
