### PR TITLE
Fixes to support building under TypeScript 5.9

### DIFF
--- a/.changeset/silly-keys-cheer.md
+++ b/.changeset/silly-keys-cheer.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-browser": patch
+"@effect/platform-node": patch
+"@effect/experimental": patch
+"effect": patch
+---
+
+Support building under TypeScript 5.9

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -578,11 +578,11 @@ describe("Match", () => {
     const match = pipe(
       M.type<Uint8Array | Uint16Array>(),
       M.when(M.instanceOf(Uint8Array), (_) => {
-        assertType<Uint8Array>()(_) satisfies true
+        assertType<Uint8Array<ArrayBuffer>>()(_) satisfies true
         return "uint8"
       }),
       M.when(M.instanceOf(Uint16Array), (_) => {
-        assertType<Uint16Array>()(_) satisfies true
+        assertType<Uint16Array<ArrayBuffer>>()(_) satisfies true
         return "uint16"
       }),
       M.orElse((_) => {

--- a/packages/experimental/src/EventJournal.ts
+++ b/packages/experimental/src/EventJournal.ts
@@ -431,7 +431,7 @@ export const makeIndexedDb = (options?: {
               if (state.done) return
               const remoteEntry = state.value
               const entry = remoteEntry.entry
-              entries.get(entry.id).onsuccess = (event) => {
+              entries.get(entry.id as Uint8Array<ArrayBuffer>).onsuccess = (event) => {
                 if ((event.target as any).result) {
                   remotes.put({
                     remoteId: options.remoteId,
@@ -516,7 +516,7 @@ export const makeIndexedDb = (options?: {
           const remotesStore = tx.objectStore("remotes")
           const remoteEntryIdStore = tx.objectStore("remoteEntryId")
 
-          remoteEntryIdStore.get(remoteId).onsuccess = (event) => {
+          remoteEntryIdStore.get(remoteId as Uint8Array<ArrayBuffer>).onsuccess = (event) => {
             const startEntryId = (event.target as any).result?.entryId
             const entryCursor = entriesStore.index("id").openCursor(
               startEntryId ? IDBKeyRange.lowerBound(startEntryId, true) : null,
@@ -526,7 +526,7 @@ export const makeIndexedDb = (options?: {
               const cursor = entryCursor.result
               if (!cursor) return
               const entry = decodeEntryIdb(cursor.value)
-              remotesStore.get([remoteId, entry.id]).onsuccess = (event) => {
+              remotesStore.get([remoteId as Uint8Array<ArrayBuffer>, entry.id as Uint8Array<ArrayBuffer>]).onsuccess = (event) => {
                 if (!(event.target as any).result) entries.push(entry)
                 cursor.continue()
               }

--- a/packages/experimental/src/EventJournal.ts
+++ b/packages/experimental/src/EventJournal.ts
@@ -526,7 +526,9 @@ export const makeIndexedDb = (options?: {
               const cursor = entryCursor.result
               if (!cursor) return
               const entry = decodeEntryIdb(cursor.value)
-              remotesStore.get([remoteId as Uint8Array<ArrayBuffer>, entry.id as Uint8Array<ArrayBuffer>]).onsuccess = (event) => {
+              remotesStore.get([remoteId as Uint8Array<ArrayBuffer>, entry.id as Uint8Array<ArrayBuffer>]).onsuccess = (
+                event
+              ) => {
                 if (!(event.target as any).result) entries.push(entry)
                 cursor.continue()
               }

--- a/packages/experimental/src/EventLogEncryption.ts
+++ b/packages/experimental/src/EventLogEncryption.ts
@@ -93,7 +93,9 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<typeof Event
           const iv = crypto.getRandomValues(new Uint8Array(12))
           const encryptedEntries = yield* Effect.promise(() =>
             Promise.all(
-              data.map((entry) => crypto.subtle.encrypt({ name: "AES-GCM", iv, tagLength: 128 }, key, entry as Uint8Array<ArrayBuffer>))
+              data.map((entry) =>
+                crypto.subtle.encrypt({ name: "AES-GCM", iv, tagLength: 128 }, key, entry as Uint8Array<ArrayBuffer>)
+              )
             )
           )
           return {

--- a/packages/experimental/src/EventLogEncryption.ts
+++ b/packages/experimental/src/EventLogEncryption.ts
@@ -73,7 +73,7 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<typeof Event
         return Effect.promise(() =>
           crypto.subtle.importKey(
             "raw",
-            Redacted.value(identity.privateKey),
+            Redacted.value(identity.privateKey) as Uint8Array<ArrayBuffer>,
             "AES-GCM",
             true,
             ["encrypt", "decrypt"]
@@ -93,7 +93,7 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<typeof Event
           const iv = crypto.getRandomValues(new Uint8Array(12))
           const encryptedEntries = yield* Effect.promise(() =>
             Promise.all(
-              data.map((entry) => crypto.subtle.encrypt({ name: "AES-GCM", iv, tagLength: 128 }, key, entry))
+              data.map((entry) => crypto.subtle.encrypt({ name: "AES-GCM", iv, tagLength: 128 }, key, entry as Uint8Array<ArrayBuffer>))
             )
           )
           return {
@@ -107,9 +107,9 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<typeof Event
           const decryptedData = (yield* Effect.promise(() =>
             Promise.all(entries.map((data) =>
               crypto.subtle.decrypt(
-                { name: "AES-GCM", iv: data.iv, tagLength: 128 },
+                { name: "AES-GCM", iv: data.iv as Uint8Array<ArrayBuffer>, tagLength: 128 },
                 key,
-                data.encryptedEntry
+                data.encryptedEntry as Uint8Array<ArrayBuffer>
               )
             ))
           )).map((buffer) => new Uint8Array(buffer))
@@ -117,12 +117,12 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<typeof Event
           return decoded.map((entry, i) => new RemoteEntry({ remoteSequence: entries[i].sequence, entry }))
         }),
       sha256: (data) =>
-        Effect.promise(() => crypto.subtle.digest("SHA-256", data)).pipe(
+        Effect.promise(() => crypto.subtle.digest("SHA-256", data as Uint8Array<ArrayBuffer>)).pipe(
           Effect.map((hash) => new Uint8Array(hash))
         ),
       sha256String: (data) =>
         Effect.map(
-          Effect.promise(() => crypto.subtle.digest("SHA-256", data)),
+          Effect.promise(() => crypto.subtle.digest("SHA-256", data as Uint8Array<ArrayBuffer>)),
           (hash) => {
             const hashArray = Array.from(new Uint8Array(hash))
             const hashHex = hashArray

--- a/packages/platform-browser/src/internal/httpClient.ts
+++ b/packages/platform-browser/src/internal/httpClient.ts
@@ -91,7 +91,7 @@ const sendBody = (
     case "Raw":
       return Effect.sync(() => xhr.send(body.body as any))
     case "Uint8Array":
-      return Effect.sync(() => xhr.send(body.body))
+      return Effect.sync(() => xhr.send(body.body as Uint8Array<ArrayBuffer>))
     case "FormData":
       return Effect.sync(() => xhr.send(body.formData))
     case "Stream":
@@ -274,7 +274,7 @@ export abstract class IncomingMessageImpl<E> extends Inspectable.Class
     }).pipe(
       Effect.map((response) => {
         if (typeof response === "string") {
-          return encoder.encode(response).buffer
+          return encoder.encode(response).buffer as ArrayBuffer
         }
         return response
       }),

--- a/packages/platform-node/src/internal/httpIncomingMessage.ts
+++ b/packages/platform-node/src/internal/httpIncomingMessage.ts
@@ -87,7 +87,7 @@ export abstract class HttpIncomingMessageImpl<E> extends Inspectable.Class
         NodeStream.toUint8Array(() => this.source, {
           onFailure: this.onError,
           maxBytes: Option.getOrUndefined(maxBodySize)
-        })
+        }).pipe(Effect.map((_) => _.buffer as ArrayBuffer))
     )
   }
 }


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes compile-time errors discovered when running tests for updated DOM types in TypeScript 5.9. This also addresses compile-time errors resulting from a change in TypeScript 5.8 where the global `ArrayBuffer` type is now distinct from `SharedArrayBuffer` and various typed arrays.

The changes herein are primarily internal casts to a more concrete type. Avoiding the casts would require more extensive changes to effect that I would rather leave up to the maintainers. The only non-cast change is to address a bug in `HttpIncomingMessage` which declares an `arrayBuffer` property that returns an effect for `ArrayBuffer`, but was actually returning an effect for a `Uint8Array`.

Some of the underlying errors can be seen by upgrading the version of `typescript` in the repository's `package.json`. Errors related to invalid casts to an `IDBValidKey` require the updated DOM types from https://github.com/microsoft/TypeScript/pull/61647.

## Related

https://github.com/microsoft/TypeScript/pull/61647#issuecomment-2852617744

