### PR TITLE
Expose `isTimeoutException`

### DIFF
--- a/.changeset/wicked-suits-refuse.md
+++ b/.changeset/wicked-suits-refuse.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Expose `Cause.isTimeoutException`

--- a/.changeset/wicked-suits-refuse.md
+++ b/.changeset/wicked-suits-refuse.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Expose `Cause.isTimeoutException`

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -1420,6 +1420,7 @@ export const TimeoutException: new(message?: string | undefined) => TimeoutExcep
 /**
  * Checks if a given unknown value is a `TimeoutException`.
  *
+ * @since 3.15.0
  * @category Guards
  */
 export const isTimeoutException: (u: unknown) => u is TimeoutException = core.isTimeoutException

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -1418,6 +1418,13 @@ export const isRuntimeException: (u: unknown) => u is RuntimeException = core.is
 export const TimeoutException: new(message?: string | undefined) => TimeoutException = core.TimeoutException
 
 /**
+ * Checks if a given unknown value is a `TimeoutException`.
+ *
+ * @category Guards
+ */
+export const isTimeoutException: (u: unknown) => u is TimeoutException = core.isTimeoutException
+
+/**
  * Creates an instance of `UnknownException`, an error object used to handle
  * unknown errors such as those from rejected promises.
  *


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR exposes the `isTimeoutException` guard. It is defined in core but not exposed in `Cause`.

## Related

- Related Issue #4815 
