### PR TITLE
Schema: TaggedError no longer crashes when the `message` field is explicitly defined

### DIFF
--- a/.changeset/tall-bobcats-rest.md
+++ b/.changeset/tall-bobcats-rest.md
@@ -1,0 +1,27 @@
+---
+"effect": patch
+---
+
+Schema: TaggedError no longer crashes when the `message` field is explicitly defined.
+
+If you define a `message` field in your schema, `TaggedError` will no longer add its own `message` getter. This avoids a stack overflow caused by infinite recursion.
+
+Before
+
+```ts
+import { Schema } from "effect"
+
+class Todo extends Schema.TaggedError<Todo>()("Todo", {
+  message: Schema.optional(Schema.String)
+}) {}
+
+// ❌ Throws "Maximum call stack size exceeded"
+console.log(Todo.make({}))
+```
+
+After
+
+```ts
+// ✅ Works correctly
+console.log(Todo.make({}))
+```

--- a/packages/effect/test/Schema/Schema/Class/TaggedError.test.ts
+++ b/packages/effect/test/Schema/Schema/Class/TaggedError.test.ts
@@ -261,4 +261,13 @@ describe("TaggedError", () => {
       })
     })
   })
+
+  it("should allow an optional `message` field", () => {
+    class MyError extends S.TaggedError<MyError>()("MyError", {
+      message: S.optional(S.String)
+    }) {}
+
+    const err = new MyError({})
+    strictEqual(err.message, "")
+  })
 })


### PR DESCRIPTION
If you define a `message` field in your schema, `TaggedError` will no longer add its own `message` getter. This avoids a stack overflow caused by infinite recursion.

Before

```ts
import { Schema } from "effect"

class Todo extends Schema.TaggedError<Todo>()("Todo", {
  message: Schema.optional(Schema.String)
}) {}

// ❌ Throws "Maximum call stack size exceeded"
console.log(Todo.make({}))
```

After

```ts
// ✅ Works correctly
console.log(Todo.make({}))
```
