### PR TITLE
Add Array.removeOption and Chunk.removeOption

### DIFF
--- a/.changeset/six-pumpkins-yell.md
+++ b/.changeset/six-pumpkins-yell.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Array.removeOption and Chunk.removeOption

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1297,6 +1297,36 @@ export const remove: {
 })
 
 /**
+ * Delete the element at the specified index, creating a new `Array`,
+ * or return `None` if the index is out of bounds.
+ *
+ * @example
+ * ```ts
+ * import { Array, Option } from "effect"
+ *
+ * const numbers = [1, 2, 3, 4]
+ * const result = Array.removeOption(numbers, 2)
+ * assert.deepStrictEqual(result, Option.some([1, 2, 4]))
+ *
+ * const outOfBoundsResult = Array.removeOption(numbers, 5)
+ * assert.deepStrictEqual(outOfBoundsResult, Option.none())
+ * ```
+ *
+ * @since 3.16.0
+ */
+export const removeOption: {
+  (i: number): <A>(self: Iterable<A>) => Option.Option<Array<A>>
+  <A>(self: Iterable<A>, i: number): Option.Option<Array<A>>
+} = dual(2, <A>(self: Iterable<A>, i: number): Option.Option<Array<A>> => {
+  const out = Array.from(self)
+  if (isOutOfBounds(i, out)) {
+    return Option.none()
+  }
+  out.splice(i, 1)
+  return Option.some(out)
+})
+
+/**
  * Reverse an `Iterable`, creating a new `Array`.
  *
  * **Example**

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1309,6 +1309,7 @@ export const remove: {
  *
  * @example
  * ```ts
+ * import * as assert from "node:assert"
  * import { Array, Option } from "effect"
  *
  * const numbers = [1, 2, 3, 4]

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -1238,7 +1238,10 @@ export const remove: {
   <A>(self: Chunk<A>, i: number): Chunk<A>
 } = dual(
   2,
-  <A>(self: Chunk<A>, i: number): Chunk<A> => unsafeFromArray(RA.remove(toReadonlyArray(self), i))
+  <A>(self: Chunk<A>, i: number): Chunk<A> => {
+    if (i < 0 || i >= self.length) return self
+    return unsafeFromArray(RA.remove(toReadonlyArray(self), i))
+  }
 )
 
 /**
@@ -1249,7 +1252,10 @@ export const removeOption: {
   <A>(self: Chunk<A>, i: number): Option<Chunk<A>>
 } = dual(
   2,
-  <A>(self: Chunk<A>, i: number): Option<Chunk<A>> => O.map(RA.removeOption(toReadonlyArray(self), i), unsafeFromArray)
+  <A>(self: Chunk<A>, i: number): Option<Chunk<A>> => {
+    if (i < 0 || i >= self.length) return O.none()
+    return O.some(unsafeFromArray(RA.remove(toReadonlyArray(self), i)))
+  }
 )
 
 /**
@@ -1260,8 +1266,10 @@ export const modifyOption: {
   <A, B>(self: Chunk<A>, i: number, f: (a: A) => B): Option<Chunk<A | B>>
 } = dual(
   3,
-  <A, B>(self: Chunk<A>, i: number, f: (a: A) => B): Option<Chunk<A | B>> =>
-    O.map(RA.modifyOption(toReadonlyArray(self), i, f), unsafeFromArray)
+  <A, B>(self: Chunk<A>, i: number, f: (a: A) => B): Option<Chunk<A | B>> => {
+    if (i < 0 || i >= self.length) return O.none()
+    return O.some(unsafeFromArray(RA.modify(toReadonlyArray(self), i, f)))
+  }
 )
 
 /**

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -1242,6 +1242,17 @@ export const remove: {
 )
 
 /**
+ * @since 3.16.0
+ */
+export const removeOption: {
+  (i: number): <A>(self: Chunk<A>) => Option<Chunk<A>>
+  <A>(self: Chunk<A>, i: number): Option<Chunk<A>>
+} = dual(
+  2,
+  <A>(self: Chunk<A>, i: number): Option<Chunk<A>> => O.map(RA.removeOption(toReadonlyArray(self), i), unsafeFromArray)
+)
+
+/**
  * @since 2.0.0
  */
 export const modifyOption: {

--- a/packages/effect/test/Array.test.ts
+++ b/packages/effect/test/Array.test.ts
@@ -452,6 +452,20 @@ describe("Array", () => {
       deepStrictEqual(pipe(new Set([1, 2, 3]), Arr.remove(10)), [1, 2, 3])
     })
 
+    it("removeOption", () => {
+      assertSome(pipe([1, 2, 3], Arr.removeOption(0)), [2, 3])
+      // out of bound
+      assertNone(pipe([], Arr.removeOption(0)))
+      assertNone(pipe([1, 2, 3], Arr.removeOption(-1)))
+      assertNone(pipe([1, 2, 3], Arr.removeOption(10)))
+
+      assertSome(pipe(new Set([1, 2, 3]), Arr.removeOption(0)), [2, 3])
+      // out of bound
+      assertNone(pipe(new Set([]), Arr.removeOption(0)))
+      assertNone(pipe(new Set([1, 2, 3]), Arr.removeOption(-1)))
+      assertNone(pipe(new Set([1, 2, 3]), Arr.removeOption(10)))
+    })
+
     it("reverse", () => {
       deepStrictEqual(Arr.reverse([]), [])
       deepStrictEqual(Arr.reverse([1]), [1])

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -116,6 +116,11 @@ describe("Chunk", () => {
     assertEquals(pipe(Chunk.make(1, 2, 3), Chunk.remove(0)), Chunk.make(2, 3))
   })
 
+  it("removeOption", () => {
+    assertNone(pipe(Chunk.empty(), Chunk.removeOption(0)))
+    assertSome(pipe(Chunk.make(1, 2, 3), Chunk.removeOption(0)), Chunk.make(2, 3))
+  })
+
   it("chunksOf", () => {
     assertEquals(pipe(Chunk.empty(), Chunk.chunksOf(2)), Chunk.empty())
     assertEquals(


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `Array.removeOption` and `Chunk.removeOption` to match the other modifiers. This will help with migration from fp-ts's `RA.deleteAt`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #4436 (reopened to make it easier to keep the branch up to date)
- Closes #
