### PR TITLE
fix(Metric): summary min max values when no samples

### DIFF
--- a/.changeset/happy-ties-hide.md
+++ b/.changeset/happy-ties-hide.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix summary metric’s min/max values when no samples

--- a/packages/effect/src/internal/metric/hook.ts
+++ b/packages/effect/src/internal/metric/hook.ts
@@ -221,8 +221,8 @@ export const summary = (key: MetricKey.MetricKey.Summary): MetricHook.MetricHook
   let head = 0
   let count = 0
   let sum = 0
-  let min = Number.MAX_VALUE
-  let max = Number.MIN_VALUE
+  let min = 0
+  let max = 0
 
   // Just before the snapshot we filter out all values older than maxAge
   const snapshot = (now: number): ReadonlyArray<readonly [number, Option.Option<number>]> => {
@@ -264,14 +264,12 @@ export const summary = (key: MetricKey.MetricKey.Summary): MetricHook.MetricHook
       const target = head % maxSize
       values[target] = [timestamp, value] as const
     }
+
+    min = count === 0 ? value : Math.min(min, value)
+    max = count === 0 ? value : Math.max(max, value)
+
     count = count + 1
     sum = sum + value
-    if (value < min) {
-      min = value
-    }
-    if (value > max) {
-      max = value
-    }
   }
 
   return make({

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -617,10 +617,14 @@ describe("Metric", () => {
         const medianQuantileValue = result.quantiles[0][1]
         const minValue = result.min
         const maxValue = result.max
+        const countValue = result.count
+        const sumValue = result.sum
 
         strictEqual(Option.isNone(medianQuantileValue), true)
         strictEqual(minValue, 0)
         strictEqual(maxValue, 0)
+        strictEqual(countValue, 0)
+        strictEqual(sumValue, 0)
       }))
   })
   describe("Polling", () => {

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -601,6 +601,27 @@ describe("Metric", () => {
 
         strictEqual(Option.getOrNull(medianQuantileValue), 10)
       }))
+    it.effect("should return no values when no samples are present", () =>
+      Effect.gen(function*() {
+        const name = nextName()
+        const summary = Metric.summary({
+          name,
+          maxAge: Duration.minutes(1),
+          maxSize: 15,
+          error: 0.01,
+          quantiles: [0.5]
+        })
+
+        const result = yield* Metric.value(summary)
+
+        const medianQuantileValue = result.quantiles[0][1]
+        const minValue = result.min
+        const maxValue = result.max
+
+        strictEqual(Option.isNone(medianQuantileValue), true)
+        strictEqual(minValue, 0)
+        strictEqual(maxValue, 0)
+      }))
   })
   describe("Polling", () => {
     it.scopedLive("launch should be interruptible", () =>


### PR DESCRIPTION

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes an issue with the summary metric.

When no samples are collected (when `count` equals `0`), the summary would return `Number.MIN_VALUE` and `Number.MAX_VALUE` for `min` and `max`, respectively. I have added a test and updated the logic to return `0` instead.

However, I wonder if it should return `Option.Option<never>` instead, as it does for the quantile values. @IMax153 any thoughts?