### PR TITLE
JsonLogger serializes errors

### DIFF
--- a/.changeset/mighty-mice-shake.md
+++ b/.changeset/mighty-mice-shake.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Logger Improvements: Error Serialization in JSON Logger

--- a/packages/effect/test/Logger.test.ts
+++ b/packages/effect/test/Logger.test.ts
@@ -477,6 +477,35 @@ describe("jsonLogger", () => {
     )
   })
 
+  it("errors", () => {
+    const date = new Date()
+    vi.setSystemTime(date)
+
+    const error = new Error("something went wrong")
+    const result = Logger.jsonLogger.log({
+      fiberId: FiberId.none,
+      logLevel: logLevelInfo,
+      message: error,
+      cause: Cause.empty,
+      context: FiberRefs.unsafeMake(new Map()),
+      spans: List.empty(),
+      annotations: HashMap.empty(),
+      date
+    })
+
+    strictEqual(
+      result,
+      JSON.stringify({
+        message: { name: "Error", message: "something went wrong" },
+        logLevel: "INFO",
+        timestamp: date.toJSON(),
+        annotations: {},
+        spans: {},
+        fiberId: ""
+      })
+    )
+  })
+
   it("circular objects", () => {
     const date = new Date()
     vi.setSystemTime(date)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
Added and updated tests in Logger.test.ts to verify that logging an Error object with Logger.jsonLogger produces the expected output, including the error's name and message.
This fixes

## Related
- Related Issue #4685 (the changes in this PR could be the first iteration to address this issue)
<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
