### PR TITLE
`Url.setPassword` supports `Redacted<string>` values

### DIFF
--- a/.changeset/wet-walls-begin.md
+++ b/.changeset/wet-walls-begin.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+`Url.setPassword` supports `Redacted<string>` values

--- a/packages/platform/src/Url.ts
+++ b/packages/platform/src/Url.ts
@@ -4,6 +4,7 @@
 import * as Cause from "effect/Cause"
 import * as Either from "effect/Either"
 import { dual } from "effect/Function"
+import * as Redacted from "effect/Redacted"
 import * as UrlParams from "./UrlParams.js"
 
 /**
@@ -158,9 +159,14 @@ export const setHref: {
  * @category Setters
  */
 export const setPassword: {
-  (password: string): (url: URL) => URL
-  (url: URL, password: string): URL
-} = immutableURLSetter("password")
+  (password: string | Redacted.Redacted): (url: URL) => URL
+  (url: URL, password: string | Redacted.Redacted): URL
+} = dual(2, (url: URL, password: string | Redacted.Redacted) =>
+  mutate(url, (url) => {
+    url.password = typeof password === "string"
+      ? password :
+      Redacted.value(password)
+  }))
 
 /**
  * Updates the path of the URL.

--- a/packages/platform/test/Url.test.ts
+++ b/packages/platform/test/Url.test.ts
@@ -2,7 +2,7 @@ import * as Url from "@effect/platform/Url"
 import * as UrlParams from "@effect/platform/UrlParams"
 import { describe, it } from "@effect/vitest"
 import { assertTrue, deepStrictEqual } from "@effect/vitest/utils"
-import { Cause, Either } from "effect"
+import { Cause, Either, Redacted } from "effect"
 
 describe("Url", () => {
   const testURL = new URL("https://example.com/test")
@@ -53,6 +53,10 @@ describe("Url", () => {
 
   it("setPassword", () => {
     expectUrl(Url.setPassword(testURL, "newpassword"), "https://:newpassword@example.com/test")
+  })
+
+  it("setPassword - Redacted", () => {
+    expectUrl(Url.setPassword(testURL, Redacted.make("newpassword")), "https://:newpassword@example.com/test")
   })
 
   it("setPathname", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
