### PR TITLE
Handle `Respondable` defects in `toResponseOrElseDefect`

### DIFF
--- a/.changeset/silent-yaks-behave.md
+++ b/.changeset/silent-yaks-behave.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Handle `Respondable` defects in `toResponseOrElseDefect`

--- a/packages/platform/src/HttpServerRespondable.ts
+++ b/packages/platform/src/HttpServerRespondable.ts
@@ -67,6 +67,8 @@ export const toResponseOrElse = (u: unknown, orElse: HttpServerResponse): Effect
 export const toResponseOrElseDefect = (u: unknown, orElse: HttpServerResponse): Effect.Effect<HttpServerResponse> => {
   if (ServerResponse.isServerResponse(u)) {
     return Effect.succeed(u)
+  } else if (isRespondable(u)) {
+    return Effect.catchAllCause(u[symbol](), () => Effect.succeed(orElse))
   }
   return Effect.succeed(orElse)
 }


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I copied the error handling behavior from the `toResponseOrElse` method for cases where the error matches the `isRespondable` type.

It turns out that the internal implementation of the HTTP server relies on defects tagged with this type. The issue I encountered: when a client sends an invalid JSON payload, the server currently responds with a 5xx status code, whereas it should be returning a 4xx.
