### PR TITLE
Fix sql transforms when executing multiple statements

### DIFF
--- a/.changeset/slow-owls-mix.md
+++ b/.changeset/slow-owls-mix.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql": patch
+---
+
+Fix failing transform tests

--- a/.changeset/slow-owls-mix.md
+++ b/.changeset/slow-owls-mix.md
@@ -2,4 +2,4 @@
 "@effect/sql": patch
 ---
 
-Fix failing transform tests
+Fix sql transforms when executing multiple statements

--- a/.changeset/true-pears-open.md
+++ b/.changeset/true-pears-open.md
@@ -1,5 +1,0 @@
----
-"@effect/sql-mysql2": patch
----
-
-Add transform tests

--- a/.changeset/true-pears-open.md
+++ b/.changeset/true-pears-open.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-mysql2": patch
+---
+
+Add transform tests

--- a/packages/sql-mysql2/test/Model.test.ts
+++ b/packages/sql-mysql2/test/Model.test.ts
@@ -9,7 +9,7 @@ class User extends Model.Class<User>("User")({
   age: Schema.Int
 }) {}
 
-describe("Model", () => {
+describe.concurrent("Model", () => {
   it.effect("insert returns result", () =>
     Effect.gen(function*() {
       const repo = yield* Model.makeRepository(User, {

--- a/packages/sql-mysql2/test/Model.test.ts
+++ b/packages/sql-mysql2/test/Model.test.ts
@@ -9,7 +9,7 @@ class User extends Model.Class<User>("User")({
   age: Schema.Int
 }) {}
 
-describe.concurrent("Model", () => {
+describe("Model", () => {
   it.effect("insert returns result", () =>
     Effect.gen(function*() {
       const repo = yield* Model.makeRepository(User, {

--- a/packages/sql-mysql2/test/utils.ts
+++ b/packages/sql-mysql2/test/utils.ts
@@ -1,7 +1,7 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import type { StartedMySqlContainer } from "@testcontainers/mysql"
 import { MySqlContainer } from "@testcontainers/mysql"
-import { Context, Data, Effect, Layer, Redacted } from "effect"
+import { Context, Data, Effect, Layer, Redacted, String } from "effect"
 
 export class ContainerError extends Data.TaggedError("ContainerError")<{
   cause: unknown
@@ -27,6 +27,17 @@ export class MysqlContainer extends Context.Tag("test/MysqlContainer")<
       const container = yield* MysqlContainer
       return MysqlClient.layer({
         url: Redacted.make(container.getConnectionUri())
+      })
+    })
+  ).pipe(Layer.provide(this.Live))
+
+  static ClientWithTransformsLive = Layer.unwrapEffect(
+    Effect.gen(function*() {
+      const container = yield* MysqlContainer
+      return MysqlClient.layer({
+        url: Redacted.make(container.getConnectionUri()),
+        transformQueryNames: String.camelToSnake,
+        transformResultNames: String.snakeToCamel
       })
     })
   ).pipe(Layer.provide(this.Live))

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -951,14 +951,12 @@ export const defaultTransforms = (
       const row = rows[i]
       if (Array.isArray(row)) {
         newRows[i] = transformArrayNested(row) as any
-      } else if (typeof row === "object" && row !== null) {
+      } else {
         const obj: any = {}
         for (const key in row) {
           obj[transformer(key)] = transformValue(row[key])
         }
         newRows[i] = obj
-      } else {
-        newRows[i] = transformValue(row)
       }
     }
     return newRows
@@ -970,11 +968,15 @@ export const defaultTransforms = (
     const newRows: Array<A> = new Array(rows.length)
     for (let i = 0, len = rows.length; i < len; i++) {
       const row = rows[i]
-      const obj: any = {}
-      for (const key in row) {
-        obj[transformer(key)] = row[key]
+      if (Array.isArray(row)) {
+        newRows[i] = transformArray(row) as any
+      } else {
+        const obj: any = {}
+        for (const key in row) {
+          obj[transformer(key)] = row[key]
+        }
+        newRows[i] = obj
       }
-      newRows[i] = obj
     }
     return newRows
   }

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -949,11 +949,17 @@ export const defaultTransforms = (
     const newRows: Array<A> = new Array(rows.length)
     for (let i = 0, len = rows.length; i < len; i++) {
       const row = rows[i]
-      const obj: any = {}
-      for (const key in row) {
-        obj[transformer(key)] = transformValue(row[key])
+      if (Array.isArray(row)) {
+        newRows[i] = transformArrayNested(row) as any
+      } else if (typeof row === "object" && row !== null) {
+        const obj: any = {}
+        for (const key in row) {
+          obj[transformer(key)] = transformValue(row[key])
+        }
+        newRows[i] = obj
+      } else {
+        newRows[i] = transformValue(row)
       }
-      newRows[i] = obj
     }
     return newRows
   }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Before this change providing a transform function to `transformResultNames` resulted in a `NoSuchElementException` when using the `@effect/sql-mysql2` client. You can see this behavior in the regression tests that I have included.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
