### PR TITLE
Escape JSON-pointers in JSONSchema.make

### DIFF
--- a/.changeset/nasty-ants-sip.md
+++ b/.changeset/nasty-ants-sip.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Escape JSON-pointers

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -555,7 +555,8 @@ const go = (
     const identifier = AST.getJSONIdentifier(ast)
     if (Option.isSome(identifier)) {
       const id = identifier.value
-      const out = { $ref: options.getRef(id) }
+      const escapedId = id.replace(/~/ig, "~0").replace(/\//ig, "~1")
+      const out = { $ref: options.getRef(escapedId) }
       if (!Record.has($defs, id)) {
         $defs[id] = out
         $defs[id] = go(ast, $defs, false, path, options)

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -3239,6 +3239,28 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
         "$ref": "#/$defs/7a8b06e3-ebc1-4bdd-ab0d-3ec493d96d95"
       })
     })
+
+    it("should escape special characters in the $ref", () => {
+      const input = Schema.Struct({ a: Schema.String })
+      class A extends Schema.Class<A>("~package/name")(input) {}
+      expectJSONSchemaProperty(A, {
+        "$defs": {
+          "~package/name": {
+            "type": "object",
+            "required": [
+              "a"
+            ],
+            "properties": {
+              "a": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "$ref": "#/$defs/~0package~1name"
+      })
+    })
   })
 
   it("compose", () => {


### PR DESCRIPTION

## Type


- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As of https://datatracker.ietf.org/doc/html/rfc6901#section-4, when referencing to a property name that contains tilde or slash, they should be replaced with escape sequences.

