### PR TITLE
Fix missing encoding of path parameters in HttpApiClient

### DIFF
--- a/.changeset/violet-things-feel.md
+++ b/.changeset/violet-things-feel.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix missing encoding of path parameters in HttpApiClient

--- a/packages/platform/src/HttpApiClient.ts
+++ b/packages/platform/src/HttpApiClient.ts
@@ -189,52 +189,49 @@ const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Any, ApiEr
         const encodeUrlParams = endpoint.urlParamsSchema.pipe(
           Option.map(Schema.encodeUnknown)
         )
-        const endpointFn = (request: {
+        const endpointFn = Effect.fnUntraced(function*(request: {
           readonly path: any
           readonly urlParams: any
           readonly payload: any
           readonly headers: any
           readonly withResponse?: boolean
-        }) =>
-          Effect.gen(function*() {
-            let httpRequest = HttpClientRequest.make(endpoint.method)(endpoint.path)
-            if (request && request.path) {
-              const encodedPathParams = encodePath._tag === "Some"
-                ? yield* encodePath.value(request.path)
-                : request.path
-              httpRequest = HttpClientRequest.setUrl(httpRequest, makeUrl(encodedPathParams))
+        }) {
+          let httpRequest = HttpClientRequest.make(endpoint.method)(endpoint.path)
+          if (request && request.path) {
+            const encodedPathParams = encodePath._tag === "Some"
+              ? yield* encodePath.value(request.path)
+              : request.path
+            httpRequest = HttpClientRequest.setUrl(httpRequest, makeUrl(encodedPathParams))
+          }
+          if (request && request.payload instanceof FormData) {
+            httpRequest = HttpClientRequest.bodyFormData(httpRequest, request.payload)
+          } else if (encodePayloadBody._tag === "Some") {
+            if (HttpMethod.hasBody(endpoint.method)) {
+              const body = (yield* encodePayloadBody.value(request.payload)) as HttpBody.HttpBody
+              httpRequest = HttpClientRequest.setBody(httpRequest, body)
+            } else {
+              const urlParams = (yield* encodePayloadBody.value(request.payload)) as Record<string, string>
+              httpRequest = HttpClientRequest.setUrlParams(httpRequest, urlParams)
             }
-            if (request && request.payload instanceof FormData) {
-              httpRequest = HttpClientRequest.bodyFormData(httpRequest, request.payload)
-            } else if (encodePayloadBody._tag === "Some") {
-              if (HttpMethod.hasBody(endpoint.method)) {
-                const body = (yield* encodePayloadBody.value(request.payload)) as HttpBody.HttpBody
-                httpRequest = HttpClientRequest.setBody(httpRequest, body)
-              } else {
-                const urlParams = (yield* encodePayloadBody.value(request.payload)) as Record<string, string>
-                httpRequest = HttpClientRequest.setUrlParams(httpRequest, urlParams)
-              }
-            }
-            if (encodeHeaders._tag === "Some") {
-              httpRequest = HttpClientRequest.setHeaders(
-                httpRequest,
-                (yield* encodeHeaders.value(request.headers)) as any
-              )
-            }
-            if (encodeUrlParams._tag === "Some") {
-              httpRequest = HttpClientRequest.appendUrlParams(
-                httpRequest,
-                (yield* encodeUrlParams.value(request.urlParams)) as any
-              )
-            }
-            const response = yield* httpClient.execute(httpRequest)
-            const value = yield* (options.transformResponse === undefined
-              ? decodeResponse(response)
-              : options.transformResponse(decodeResponse(response)))
-            return request?.withResponse === true ? [value, response] : value
-          }).pipe(
-            Effect.mapInputContext((input) => Context.merge(context, input))
-          )
+          }
+          if (encodeHeaders._tag === "Some") {
+            httpRequest = HttpClientRequest.setHeaders(
+              httpRequest,
+              (yield* encodeHeaders.value(request.headers)) as any
+            )
+          }
+          if (encodeUrlParams._tag === "Some") {
+            httpRequest = HttpClientRequest.appendUrlParams(
+              httpRequest,
+              (yield* encodeUrlParams.value(request.urlParams)) as any
+            )
+          }
+          const response = yield* httpClient.execute(httpRequest)
+          const value = yield* (options.transformResponse === undefined
+            ? decodeResponse(response)
+            : options.transformResponse(decodeResponse(response)))
+          return request?.withResponse === true ? [value, response] : value
+        }, Effect.mapInputContext((input) => Context.merge(context, input)))
 
         options.onEndpoint({
           ...onEndpointOptions,


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previously, handling of schema of path parameters was handled only on server, seems like was missing in client url generation.
The following project was outputting 1,2,3,4 (.toString of an array) instead of expected (1---2---3---4).

```ts
import {Schema} from "effect"
import {HttpApiEndpoint, HttpApi, HttpApiGroup, HttpApiSchema, HttpApiSwagger, HttpApiBuilder, HttpMiddleware} from "@effect/platform"

export const ColonSeparatedParam = Schema.split(":")

export class MyApiGroup extends HttpApiGroup.make("api").add(
    HttpApiEndpoint.get("getThings")`/categories/${HttpApiSchema.param("categories", ColonSeparatedParam)}`.addSuccess(Schema.String)
){}

export class MyApi extends HttpApi.make("api").add(MyApiGroup) {}
```

```ts
import { Effect, Layer} from "effect"
import { HttpApiSwagger, HttpApiBuilder, HttpMiddleware} from "@effect/platform"
import {NodeHttpServer, NodeRuntime} from "@effect/platform-node"
import { createServer } from "node:http"
import {MyApi} from "./shared"

const MyApiLayer = HttpApiBuilder.group(MyApi, "api", handlers => handlers.handle("getThings", r => Effect.succeed(r.path.categories.join("---"))))

const ApiLive = HttpApiBuilder.api(MyApi).pipe(
  Layer.provide(MyApiLayer)
)

HttpApiBuilder.serve(HttpMiddleware.logger).pipe(
  Layer.provide(HttpApiSwagger.layer()),
  Layer.provide(HttpApiBuilder.middlewareCors()),
  Layer.provide(ApiLive),
  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 })),
  Layer.launch,
  NodeRuntime.runMain
)
```

```ts
import {Effect} from "effect"
import {HttpApiClient, FetchHttpClient} from "@effect/platform"
import {NodeRuntime} from "@effect/platform-node"
import {MyApi} from "./shared"

const program = Effect.gen(function*(){
    const client = yield* HttpApiClient.make(MyApi, { baseUrl: "http://localhost:3000/"})

    const result = yield* client.api.getThings({
        path: {
            categories: ["1", "2", "3", "4"]
        }
    })
    yield* Effect.log(result)
}).pipe(
    Effect.provide(FetchHttpClient.layer)
)

NodeRuntime.runMain(program)
```