### PR TITLE
[@effect/rpc] Pass through headers from rpc message -> client.post

### DIFF
--- a/.changeset/fancy-lands-march.md
+++ b/.changeset/fancy-lands-march.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Pass through `FromClientEncoded` request.headers to `client.post` in `makeProtocolHttp`'s `send` function.

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -705,13 +705,14 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
 
       const parser = serialization.unsafeMake()
 
+      const headers = request.headers;
       const encoded = parser.encode(request)
       const body = typeof encoded === "string" ?
         HttpBody.text(encoded, serialization.contentType) :
         HttpBody.uint8Array(encoded, serialization.contentType)
 
       if (isJson) {
-        return client.post("", { body }).pipe(
+        return client.post("", { headers, body }).pipe(
           Effect.flatMap((r) => r.json),
           Effect.scoped,
           Effect.flatMap((u) => {
@@ -729,7 +730,7 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
         )
       }
 
-      return client.post("", { body }).pipe(
+      return client.post("", { headers, body }).pipe(
         Effect.flatMap((r) =>
           Stream.runForEachChunk(r.stream, (chunk) => {
             const responses = Chunk.toReadonlyArray(chunk).flatMap(parser.decode) as Array<FromServerEncoded>


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Pass through `FromClientEncoded` `request.headers` to `client.post` in `makeProtocolHttp`'s `send` function.

