### PR TITLE
Escape JSON Schema $id for empty struct

### DIFF
--- a/.changeset/bright-dolls-raise.md
+++ b/.changeset/bright-dolls-raise.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform": patch
+"effect": patch
+---
+
+Escape JSON Schema $id for empty struct

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -72,7 +72,7 @@ export interface JsonSchema7object extends JsonSchemaAnnotations {
  * @since 3.10.0
  */
 export interface JsonSchema7empty extends JsonSchemaAnnotations {
-  $id: "/schemas/{}"
+  $id: "/schemas/%7B%7D"
   anyOf: [
     { type: "object" },
     { type: "array" }
@@ -348,7 +348,7 @@ const constAnyObject: JsonSchema7 = {
 }
 
 const constEmpty: JsonSchema7 = {
-  "$id": "/schemas/{}",
+  "$id": "/schemas/%7B%7D",
   "anyOf": [
     { "type": "object" },
     { "type": "array" }

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -406,7 +406,7 @@ describe("fromAST", () => {
         it("NullOr(Struct({}))", () => {
           const schema = Schema.NullOr(Schema.Struct({}))
           expectJSONSchemaOpenApi31(schema, {
-            "$id": "/schemas/{}",
+            "$id": "/schemas/%7B%7D",
             "anyOf": [
               { "type": "object" },
               { "type": "array" }
@@ -834,7 +834,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
   it("empty struct: Schema.Struct({})", () => {
     const schema = Schema.Struct({})
     const jsonSchema: Root = {
-      "$id": "/schemas/{}",
+      "$id": "/schemas/%7B%7D",
       "anyOf": [{
         "type": "object"
       }, {

--- a/packages/platform/src/OpenApiJsonSchema.ts
+++ b/packages/platform/src/OpenApiJsonSchema.ts
@@ -69,7 +69,7 @@ export interface AnyObject extends Annotations {
  * @since 0.71.0
  */
 export interface Empty extends Annotations {
-  $id: "/schemas/{}"
+  $id: "/schemas/%7B%7D"
   anyOf: [
     { type: "object" },
     { type: "array" }


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previous `$id` of `/schemas/{}` seems was'nt a valid URI, as it should be escaped as of https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.1-6
Beware type literals have been changes as well so need to consider if may impact in some way pre-existing code.

