### PR TITLE
Add `failWith` and `failWithM`

### DIFF
--- a/.changeset/blue-ducks-lay.md
+++ b/.changeset/blue-ducks-lay.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `failWith` and `failWithM` to `Effect`

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -13359,6 +13359,62 @@ export const transposeMapOption = dual<
 >(2, (self, f) => option_.isNone(self) ? succeedNone : map(f(self.value), option_.some))
 
 /**
+ * Returns a function that turns an `Option` and a failure `E` into
+ * an `Effect<A>` that fails in `E`.
+ *
+ * **Details**
+ *
+ * This function allows you to "unwrap" an `Option` by turning the `None` case
+ * in a checked exception.
+ *
+ * @example
+ * ```ts
+ * import { Option } from "effect"
+ *
+ * //      ┌─── Effect<number, Error, never>
+ * //      ▼
+ * const program = Option.some(1).pipe(Option.failWith(() => new Error()))
+ * ```
+ */
+export const failWith: {
+  <E>(f: () => E): <A, E, R>(self: Option.Option<A>) => Effect<A, E, R>
+  <A, E, R>(self: Option.Option<A>, f: () => E): Effect<A, E, R>
+} = dual(
+  2,
+  <A, E>(self: Option.Option<A>, f: () => E) => option_.isNone(self) ? fail(f()) : succeed(self.value)
+)
+
+/**
+ * Returns a function that turns an `Effect<Option<A>>` into
+ * an `Effect<A>` that fails in `E`.
+ *
+ * **Details**
+ *
+ * This function allows you to "unwrap" an `Option` by turning the `None` case
+ * in a checked exception.
+ *
+ * @example
+ * ```ts
+ * import { Option } from "effect"
+ *
+ * //      ┌─── Effect<number, Error, never>
+ * //      ▼
+ * const program = Effect.succeed(Option.some(1))().pipe(Option.failWith(() => new Error()))
+ * ```
+ */
+export const failWithM: {
+  <E2>(f: () => E2): <A, E1, R>(self: Effect<Option.Option<A>>) => Effect<A, E1 | E2, R>
+  <E2, A, E1, R>(self: Effect<Option.Option<A>, E1>, f: () => E2): Effect<A, E1 | E2, R>
+} = dual(
+  2,
+  <A, E>(self: Effect<Option.Option<A>>, f: () => E) =>
+    flatMap(
+      self,
+      (o: Option.Option<A>) => option_.isNone(o) ? fail(f()) : succeed(o.value)
+    )
+)
+
+/**
  * @since 2.0.0
  * @category Models
  */

--- a/packages/effect/test/Effect/failWith.test.ts
+++ b/packages/effect/test/Effect/failWith.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "@effect/vitest"
+import { assertLeft, strictEqual } from "@effect/vitest/utils"
+import { Effect, Option, pipe } from "effect"
+
+describe("Effect", () => {
+  it.effect("failWith - unwraps the value", () =>
+    Effect.gen(function*() {
+      const result = yield* pipe(
+        Option.some(1).pipe(Effect.failWith(() => new Error()))
+      )
+      strictEqual(result, 1)
+    }))
+
+  it.effect("failWith - errors on empty", () =>
+    Effect.gen(function*() {
+      const error = new Error()
+      const result = yield* pipe(
+        Option.none().pipe(Effect.failWith(() => error)),
+        Effect.either
+      )
+      assertLeft(result, error)
+    }))
+
+  it.effect("failWithM - unwraps the value", () =>
+    Effect.gen(function*() {
+      const result = yield* pipe(
+        Effect.succeed(Option.some(1)).pipe(Effect.failWithM(() => new Error()))
+      )
+      strictEqual(result, 1)
+    }))
+
+  it.effect("failWithM - errors on empty", () =>
+    Effect.gen(function*() {
+      const error = new Error()
+      const result = yield* pipe(
+        Effect.succeed(Option.none()).pipe(Effect.failWithM(() => error)),
+        Effect.either
+      )
+      assertLeft(result, error)
+    }))
+})


### PR DESCRIPTION
These are inspired by the Haskell package `errors`'s module `Control.Error.Util`, which offers these two functions:

```haskell
failWith :: Applicative m => e -> Maybe a -> ExceptT e m a
failWithM :: Applicative m => e -> m (Maybe a) -> ExceptT e m a
```

Since our `m` is `Effect` in both cases, we end up with these signatures in Effect:

```typescript
failWith: <A, E, R>(self: Option.Option<A>, f: () => E): Effect<A, E, R>
failWithM: <E1, A, E2, R>(self: Effect<Option.Option<A>, E1>, f: () => E2): Effect<A, E1 | E2, R>
```

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Steal `failWith` and `failWithM` from the Haskell ecosystem

-----

### Notes
I don't think I understand the test failures. They do work if I run `pnpm test`, but `pnpm check` brings about type errors related to `TestServices`. I don't see in the tests exactly what's wrong, help would be appreciated :).

I wrote some basic documentation and tried to follow the style used in the rest of the doc comments I saw, but I'm (very) open to comments on how to improve that.

Thanks to @gcanti on Discord.

Thanks.
