### PR TITLE
forbid __proto__ as name in do notation functions

### DIFF
--- a/.changeset/poor-dolls-melt.md
+++ b/.changeset/poor-dolls-melt.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Prevent binding **proto** to lexical scope in do notation

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7884,12 +7884,12 @@ export const Do: Effect<{}> = effect.Do
  */
 export const bind: {
   <N extends string, A extends object, B, E2, R2>(
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, effect.ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => Effect<B, E2, R2>
   ): <E1, R1>(self: Effect<A, E1, R1>) => Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E2 | E1, R2 | R1>
   <A extends object, N extends string, E1, R1, B, E2, R2>(
     self: Effect<A, E1, R1>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, effect.ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => Effect<B, E2, R2>
   ): Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E1 | E2, R1 | R2>
 } = effect.bind
@@ -8003,18 +8003,18 @@ export const bindAll: {
  * @since 2.0.0
  */
 export const bindTo: {
-  <N extends string>(name: N): <A, E, R>(self: Effect<A, E, R>) => Effect<{ [K in N]: A }, E, R>
-  <A, E, R, N extends string>(self: Effect<A, E, R>, name: N): Effect<{ [K in N]: A }, E, R>
+  <N extends string>(name: Exclude<N, effect.ForbiddenKeys<{}>>): <A, E, R>(self: Effect<A, E, R>) => Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect<A, E, R>, name: Exclude<N, effect.ForbiddenKeys<{}>>): Effect<{ [K in N]: A }, E, R>
 } = effect.bindTo
 
 const let_: {
   <N extends string, A extends object, B>(
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, effect.ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => B
   ): <E, R>(self: Effect<A, E, R>) => Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
   <A extends object, N extends string, E, R, B>(
     self: Effect<A, E, R>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, effect.ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => B
   ): Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
 } = effect.let_

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -398,37 +398,40 @@ export const diffFiberRefsAndRuntimeFlags = <A, E, R>(
 export const Do: Effect.Effect<{}> = core.succeed({})
 
 /* @internal */
+export type ForbiddenKeys<A> = doNotation.ForbiddenKeys<A>
+
+/* @internal */
 export const bind: {
   <N extends string, A extends object, B, E2, R2>(
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, doNotation.ForbiddenKeys<A>>,
     f: (a: Types.NoInfer<A>) => Effect.Effect<B, E2, R2>
   ): <E1, R1>(
     self: Effect.Effect<A, E1, R1>
   ) => Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E2 | E1, R2 | R1>
   <A extends object, N extends string, E1, R1, B, E2, R2>(
     self: Effect.Effect<A, E1, R1>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, doNotation.ForbiddenKeys<A>>,
     f: (a: Types.NoInfer<A>) => Effect.Effect<B, E2, R2>
   ): Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E1 | E2, R1 | R2>
 } = doNotation.bind<Effect.EffectTypeLambda>(core.map, core.flatMap)
 
 /* @internal */
 export const bindTo: {
-  <N extends string>(name: N): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<{ [K in N]: A }, E, R>
-  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, name: N): Effect.Effect<{ [K in N]: A }, E, R>
+  <N extends string>(name: Exclude<N, ForbiddenKeys<{}>>): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect.Effect<A, E, R>, name: Exclude<N, ForbiddenKeys<{}>>): Effect.Effect<{ [K in N]: A }, E, R>
 } = doNotation.bindTo<Effect.EffectTypeLambda>(core.map)
 
 /* @internal */
 export const let_: {
   <N extends string, A extends object, B>(
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, doNotation.ForbiddenKeys<A>>,
     f: (a: Types.NoInfer<A>) => B
   ): <E, R>(
     self: Effect.Effect<A, E, R>
   ) => Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
   <A extends object, N extends string, E, R, B>(
     self: Effect.Effect<A, E, R>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, doNotation.ForbiddenKeys<A>>,
     f: (a: Types.NoInfer<A>) => B
   ): Effect.Effect<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }, E, R>
 } = doNotation.let_<Effect.EffectTypeLambda>(core.map)

--- a/packages/effect/src/internal/doNotation.ts
+++ b/packages/effect/src/internal/doNotation.ts
@@ -2,6 +2,8 @@ import { dual } from "../Function.js"
 import type { Kind, TypeLambda } from "../HKT.js"
 import type { NoInfer } from "../Types.js"
 
+export type ForbiddenKeys<A> = keyof A | "__proto__"
+
 type Map<F extends TypeLambda> = {
   <A, B>(f: (a: A) => B): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
   <R, O, E, A, B>(self: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
@@ -22,20 +24,20 @@ export const let_ = <F extends TypeLambda>(
   map: Map<F>
 ): {
   <N extends string, A extends object, B>(
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => B
   ): <R, O, E>(
     self: Kind<F, R, O, E, A>
   ) => Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
   <R, O, E, A extends object, N extends string, B>(
     self: Kind<F, R, O, E, A>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => B
   ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 } =>
   dual(3, <R, O, E, A extends object, N extends string, B>(
     self: Kind<F, R, O, E, A>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => B
   ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
     map(self, (a) => Object.assign({}, a, { [name]: f(a) }) as any))
@@ -43,35 +45,35 @@ export const let_ = <F extends TypeLambda>(
 /** @internal */
 export const bindTo = <F extends TypeLambda>(map: Map<F>): {
   <N extends string>(
-    name: N
+    name: Exclude<N, ForbiddenKeys<{}>>
   ): <R, O, E, A>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, { [K in N]: A }>
   <R, O, E, A, N extends string>(
     self: Kind<F, R, O, E, A>,
-    name: N
+    name: Exclude<N, ForbiddenKeys<{}>>
   ): Kind<F, R, O, E, { [K in N]: A }>
 } =>
   dual(2, <R, O, E, A, N extends string>(
     self: Kind<F, R, O, E, A>,
-    name: N
+    name: Exclude<N, ForbiddenKeys<{}>>
   ): Kind<F, R, O, E, { [K in N]: A }> => map(self, (a) => ({ [name]: a } as { [K in N]: A })))
 
 /** @internal */
 export const bind = <F extends TypeLambda>(map: Map<F>, flatMap: FlatMap<F>): {
   <N extends string, A extends object, R2, O2, E2, B>(
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => Kind<F, R2, O2, E2, B>
   ): <R1, O1, E1>(
     self: Kind<F, R1, O1, E1, A>
   ) => Kind<F, R1 & R2, O1 | O2, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
   <R1, O1, E1, A extends object, N extends string, R2, O2, E2, B>(
     self: Kind<F, R1, O1, E1, A>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => Kind<F, R2, O2, E2, B>
   ): Kind<F, R1 & R2, O1 | O2, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
 } =>
   dual(3, <R1, O1, E1, A, N extends string, R2, O2, E2, B>(
     self: Kind<F, R1, O1, E1, A>,
-    name: Exclude<N, keyof A>,
+    name: Exclude<N, ForbiddenKeys<A>>,
     f: (a: NoInfer<A>) => Kind<F, R2, O2, E2, B>
   ): Kind<F, R1 & R2, O1 | O2, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
     flatMap(self, (a) =>

--- a/packages/effect/src/internal/doNotation.ts
+++ b/packages/effect/src/internal/doNotation.ts
@@ -2,8 +2,6 @@ import { dual } from "../Function.js"
 import type { Kind, TypeLambda } from "../HKT.js"
 import type { NoInfer } from "../Types.js"
 
-export type ForbiddenKeys<A> = keyof A | "__proto__"
-
 type Map<F extends TypeLambda> = {
   <A, B>(f: (a: A) => B): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
   <R, O, E, A, B>(self: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
@@ -18,6 +16,9 @@ type FlatMap<F extends TypeLambda> = {
     f: (a: A) => Kind<F, R2, O2, E2, B>
   ): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
 }
+
+/** @internal */
+export type ForbiddenKeys<A> = keyof A | "__proto__"
 
 /** @internal */
 export const let_ = <F extends TypeLambda>(

--- a/packages/effect/test/Effect/do-notation.test.ts
+++ b/packages/effect/test/Effect/do-notation.test.ts
@@ -22,6 +22,8 @@ describe("do notation", () => {
   it("bindTo", () => {
     expectRight(pipe(Effect.succeed(1), Effect.bindTo("a")), { a: 1 })
     expectLeft(pipe(Effect.fail("left"), Effect.bindTo("a")), "left")
+    // @ts-expect-error
+    expectRight(pipe(Effect.succeed(1), Effect.bindTo("__proto__")), { __proto__: 1 })
   })
 
   it("bind", () => {
@@ -37,6 +39,11 @@ describe("do notation", () => {
       pipe(Effect.fail("left"), Effect.bindTo("a"), Effect.bind("b", () => Effect.succeed(2))),
       "left"
     )
+    // @ts-expect-error
+    expectRight(pipe(Effect.succeed(1), Effect.bind("__proto__"), Effect.bind("b", ({ a }) => Effect.succeed(a + 1))), {
+      a: 1,
+      b: 2
+    })
   })
 
   it("let", () => {
@@ -45,6 +52,8 @@ describe("do notation", () => {
       pipe(Effect.fail("left"), Effect.bindTo("a"), Effect.let("b", () => 2)),
       "left"
     )
+    // @ts-expect-error
+    expectRight(pipe(Effect.succeed(1), Effect.bindTo("a"), Effect.let("__proto__", ({ a }) => a + 1)), { a: 1, __proto__: 2 })
   })
 
   describe("bindAll", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

If you use do notation to assign a value to the name 'proto' - it is silently dropped from the accumulated object at runtime. This PR excludes 'proto' from the usable names that can be assigned with do notation.

You can find a minimal reproduction of the issue here: https://effect.website/play/#ec84afe37206
