### PR TITLE
docs: Fix example in the platform’s Accessing the HttpServerRequest section

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -1135,8 +1135,9 @@ const api = HttpApi.make("myApi").add(
 )
 
 const groupLive = HttpApiBuilder.group(api, "group", (handlers) =>
-  handlers.handle("get", ({ request }) =>
+  handlers.handle("get", () =>
     Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest
       // Log the HTTP method for demonstration purposes
       console.log(request.method)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
This PR fixes the code example in the "Accessing the HttpServerRequest" section of the platform README. The previous example contained an incorrect usage of the request object. This update aligns it with the correct API behavior.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
