### PR TITLE
Fix/catchtag errors #5075

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -14234,7 +14234,7 @@ export namespace fn {
    */
   export type Untraced = {
     <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>>(
-      body: (...args: NoInfer<Args>) => Generator<Eff, AEff, never>
+      body: (...args: Args) => Generator<Eff, AEff, never>
     ): (...args: Args) => Effect<
       AEff,
       [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect<infer _A, infer E, infer _R>>] ? E : never,

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3884,7 +3884,8 @@ export const catchTag: {
     ...tags: K
   ): <A, R>(self: Effect<A, E, R> & "missing error handler") => never
   <E, const K extends RA.NonEmptyReadonlyArray<E extends { _tag: string } ? E["_tag"] : never>, A1, E1, R1>(
-    ...args: [...tags: K, f: (e: Extract<NoInfer<E>, { _tag: K[number] }>) => Effect<A1, E1, R1>]
+    tags: K,
+    f: (e: Extract<NoInfer<E>, { _tag: K[number] }>) => Effect<A1, E1, R1>
   ): <A, R>(self: Effect<A, E, R>) => Effect<A | A1, Exclude<E, { _tag: K[number] }> | E1, R | R1>
   <A, E, R, const K extends RA.NonEmptyReadonlyArray<E extends { _tag: string } ? E["_tag"] : never>>(
     self: Effect<A, E, R> & "missing error handler",
@@ -3892,7 +3893,8 @@ export const catchTag: {
   ): never
   <A, E, R, const K extends RA.NonEmptyReadonlyArray<E extends { _tag: string } ? E["_tag"] : never>, R1, E1, A1>(
     self: Effect<A, E, R>,
-    ...args: [...tags: K, f: (e: Extract<NoInfer<E>, { _tag: K[number] }>) => Effect<A1, E1, R1>]
+    tags: K,
+    f: (e: Extract<NoInfer<E>, { _tag: K[number] }>) => Effect<A1, E1, R1>
   ): Effect<A | A1, Exclude<E, { _tag: K[number] }> | E1, R | R1>
 } = effect.catchTag
 
@@ -14232,7 +14234,7 @@ export namespace fn {
    */
   export type Untraced = {
     <Eff extends YieldWrap<Effect<any, any, any>>, AEff, Args extends Array<any>>(
-      body: (...args: Args) => Generator<Eff, AEff, never>
+      body: (...args: NoInfer<Args>) => Generator<Eff, AEff, never>
     ): (...args: Args) => Effect<
       AEff,
       [Eff] extends [never] ? never : [Eff] extends [YieldWrap<Effect<infer _A, infer E, infer _R>>] ? E : never,

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -241,7 +241,8 @@ export const catchTag: {
     ...tags: K
   ): <A, R>(self: Effect.Effect<A, E, R>) => never
   <E, const K extends Arr.NonEmptyReadonlyArray<E extends { _tag: string } ? E["_tag"] : never>, A1, E1, R1>(
-    ...args: [...tags: K, f: (e: Extract<Types.NoInfer<E>, { _tag: K[number] }>) => Effect.Effect<A1, E1, R1>]
+    tags: K,
+    f: (e: Extract<Types.NoInfer<E>, { _tag: K[number] }>) => Effect.Effect<A1, E1, R1>
   ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A | A1, Exclude<E, { _tag: K[number] }> | E1, R | R1>
   <A, E, R, const K extends Arr.NonEmptyReadonlyArray<E extends { _tag: string } ? E["_tag"] : never>>(
     self: Effect.Effect<A, E, R>,
@@ -249,7 +250,8 @@ export const catchTag: {
   ): never
   <A, E, R, const K extends Arr.NonEmptyReadonlyArray<E extends { _tag: string } ? E["_tag"] : never>, R1, E1, A1>(
     self: Effect.Effect<A, E, R>,
-    ...args: [...tags: K, f: (e: Extract<Types.NoInfer<E>, { _tag: K[number] }>) => Effect.Effect<A1, E1, R1>]
+    tags: K,
+    f: (e: Extract<Types.NoInfer<E>, { _tag: K[number] }>) => Effect.Effect<A1, E1, R1>
   ): Effect.Effect<A | A1, Exclude<E, { _tag: K[number] }> | E1, R | R1>
 } = dual(
   (args: any) => core.isEffect(args[0]),

--- a/packages/effect/test/Micro.test.ts
+++ b/packages/effect/test/Micro.test.ts
@@ -1097,6 +1097,39 @@ describe.concurrent("Micro", () => {
       }))
   })
 
+  describe("error handling 2", () => {
+    class ErrorA extends Micro.TaggedError("A") {}
+    class ErrorB extends Micro.TaggedError("B") {}
+
+    it.effect("catchTag", () =>
+      Micro.gen(function*() {
+        const error: ErrorA | ErrorB = new ErrorA()
+        const effect = Micro.failSync(() => error)
+
+        yield* pipe(
+          effect,
+          Effect.catchTag(
+            ["A"],
+            Effect.fnUntraced(function*(err) {
+              //                        ^?
+              return yield* Micro.succeed(err)
+            })
+          )
+        )
+
+        // const effect = Micro.failSync(() => error).pipe(
+        //   Micro.catchTag("A", (_) => Micro.succeed(1)),
+        //   Micro.catchTag("B", (_) => Micro.succeed(2)),
+        //   Micro.orElseSucceed(() => 3)
+        // )
+        // strictEqual(yield* effect, 1)
+        // error = new ErrorB()
+        // strictEqual(yield* effect, 2)
+        // error = new ErrorC()
+        // strictEqual(yield* effect, 3)
+      }))
+  })
+
   describe("zip", () => {
     it.effect("concurrent: false", () => {
       const executionOrder: Array<string> = []


### PR DESCRIPTION
## Description

This is just a draft, it helps me to highlight the problem I found. That `...args` trick is clever when it comes to step over the "_A rest parameter must be last in a parameter list._" error, but it seems to not play well with the kind of contextual parameters inference `Effect.fnUntraced` needs. OTOH the solution outlined in my commit requires manually passing an array of tags so the DX it's a little bit worse (and this should be ported to every overload of `catchTag`).

## Related

Related Issue #5075

