### PR TITLE
chore: upgrade TSTyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "playwright": "^1.52.0",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
-    "tstyche": "^4.0.0",
+    "tstyche": "^4.1.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vite": "^6.1.1",

--- a/packages/effect/dtslint/Config.tst.ts
+++ b/packages/effect/dtslint/Config.tst.ts
@@ -1,5 +1,5 @@
 import { Brand, Config, hole, pipe } from "effect"
-import { describe, expect, it } from "tstyche"
+import { describe, expect, it, when } from "tstyche"
 
 declare const string: Config.Config<string>
 declare const number: Config.Config<number>
@@ -42,12 +42,9 @@ describe("Config", () => {
   })
 
   it("branded", () => {
-    // @ts-expect-error
-    Config.branded("NAME", Int)
-    // @ts-expect-error
-    Config.branded(number, Str)
-    // @ts-expect-error
-    number.pipe(Config.branded(Str))
+    expect(Config.branded).type.not.toBeCallableWith("NAME", Int)
+    expect(Config.branded).type.not.toBeCallableWith(number, Str)
+    when(number.pipe).isCalledWith(expect(Config.branded).type.not.toBeCallableWith(Str))
 
     expect(Config.branded(number, Int)).type.toBe<Config.Config<Int>>()
     expect(Config.branded("NAME", Str)).type.toBe<Config.Config<Str>>()

--- a/packages/effect/dtslint/Context.tst.ts
+++ b/packages/effect/dtslint/Context.tst.ts
@@ -1,5 +1,5 @@
 import { Context, Effect } from "effect"
-import { describe, expect, it } from "tstyche"
+import { describe, expect, it, when } from "tstyche"
 
 describe("Context", () => {
   it("`key` field", () => {
@@ -17,8 +17,7 @@ describe("Context", () => {
       static readonly StaticField = "StaticField"
     }
 
-    // @ts-expect-error
-    Context.empty().pipe(Context.add(Foo, 123))
+    when(Context.empty().pipe).isCalledWith(expect(Context.add).type.not.toBeCallableWith(Foo, 123))
 
     const ctx = Context.empty().pipe(Context.add(Foo, { bar: "2" }))
     expect(ctx).type.toBe<Context.Context<Foo>>()

--- a/packages/effect/dtslint/HKT.tst.ts
+++ b/packages/effect/dtslint/HKT.tst.ts
@@ -3,6 +3,6 @@ import type { HKT } from "effect"
 export function testIssue536<F extends HKT.TypeLambda, G extends HKT.TypeLambda, R, W, E, A>(
   x: HKT.Kind<F, R, W, E, A>
 ): HKT.Kind<G, R, W, E, A> {
-  // @ts-expect-error
+  // @ts-expect-error: Type 'Kind<F, R, W, E, A>' is not assignable to type 'Kind<G, R, W, E, A>'
   return x
 }

--- a/packages/effect/dtslint/Schema/Schema.tst.ts
+++ b/packages/effect/dtslint/Schema/Schema.tst.ts
@@ -49,7 +49,7 @@ declare const cContext: S.Schema<boolean, boolean, "c">
 describe("Schema", () => {
   describe("SchemaClass", () => {
     it("the constructor should not be callable", () => {
-      // @ts-expect-error
+      // @ts-expect-error! TODO use '.toHaveConstructSignatures()' when it will be implemented
       new S.String()
     })
   })

--- a/packages/effect/dtslint/Schema/TaggedClass.tst.ts
+++ b/packages/effect/dtslint/Schema/TaggedClass.tst.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "tstyche"
 
 describe("Schema.TaggedClass", () => {
   it("Annotations as tuple", () => {
-    // @ts-expect-error
+    // @ts-expect-error!
     class _A extends Schema.TaggedClass<_A>()("A", { id: Schema.Number }, [
       undefined,
       undefined,

--- a/packages/effect/dtslint/Schema/TaggedError.tst.ts
+++ b/packages/effect/dtslint/Schema/TaggedError.tst.ts
@@ -28,7 +28,7 @@ describe("Schema.TaggedError", () => {
   })
 
   it("Annotations as tuple", () => {
-    // @ts-expect-error
+    // @ts-expect-error!
     class _A extends Schema.TaggedError<_A>()("A", { id: Schema.Number }, [
       undefined,
       undefined,

--- a/packages/effect/dtslint/Schema/TaggedRequest.tst.ts
+++ b/packages/effect/dtslint/Schema/TaggedRequest.tst.ts
@@ -25,7 +25,7 @@ describe("Schema.TaggedRequest", () => {
   })
 
   it("Annotations as tuple", () => {
-    // @ts-expect-error
+    // @ts-expect-error!
     class _A extends Schema.TaggedRequest<_A>()("A", {
       failure: Schema.String,
       success: Schema.Number,

--- a/packages/platform/dtslint/HttpApiEndpoint.tst.ts
+++ b/packages/platform/dtslint/HttpApiEndpoint.tst.ts
@@ -1,15 +1,14 @@
+/* eslint @typescript-eslint/no-unused-expressions: "off" */
+
 import { HttpApiEndpoint, HttpApiSchema } from "@effect/platform"
 import { Schema } from "effect"
-import { describe, expect, it } from "tstyche"
+import { describe, it } from "tstyche"
 
 describe("HttpApiEndpoint", () => {
   it("should prevent duplicated params", () => {
-    expect(
-      HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
-        HttpApiSchema.param("id", Schema.NumberFromString)
-      }`
-    ).type.toRaiseError(
-      `Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param: id"'.`
-    )
+    HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
+      // @ts-expect-error: Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param: id"'
+      HttpApiSchema.param("id", Schema.NumberFromString)
+    }`
   })
 })

--- a/packages/platform/dtslint/HttpApiEndpoint.tst.ts
+++ b/packages/platform/dtslint/HttpApiEndpoint.tst.ts
@@ -8,7 +8,6 @@ describe("HttpApiEndpoint", () => {
   it("should prevent duplicated params", () => {
     HttpApiEndpoint.get("test")`/${HttpApiSchema.param("id", Schema.NumberFromString)}/${
       // @ts-expect-error: Argument of type 'Param<"id", typeof NumberFromString>' is not assignable to parameter of type '"Duplicate param: id"'
-      HttpApiSchema.param("id", Schema.NumberFromString)
-    }`
+      HttpApiSchema.param("id", Schema.NumberFromString)}`
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       tstyche:
-        specifier: ^4.0.0
-        version: 4.0.0(typescript@5.8.3)
+        specifier: ^4.1.0
+        version: 4.1.0(typescript@5.8.3)
       tsx:
         specifier: ^4.19.4
         version: 4.19.4
@@ -5614,7 +5614,6 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.7:
@@ -7254,8 +7253,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tstyche@4.0.0:
-    resolution: {integrity: sha512-ek8LfTl/raR7VB1bjmSxUjNByGHtJlaCNWeudTASRF4ykLQqTPKcK0HhsOv5LiM1+OEBJ7bmeD+DlrjQPTozVw==}
+  tstyche@4.1.0:
+    resolution: {integrity: sha512-1t/y779vIplrDmKdiGZE5XglVy9PEXrMLbn42mTDg/tG7b0MeW5HyGmzfQ6nctffHli7GlENQKwL/xUb3aYFSg==}
     engines: {node: '>=20.9'}
     hasBin: true
     peerDependencies:
@@ -14864,7 +14863,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tstyche@4.0.0(typescript@5.8.3):
+  tstyche@4.1.0(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
 

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
+  "checkSuppressedErrors": true,
   "testFileMatch": [
     "packages/*/dtslint/**/*.tst.*"
   ]


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

I have just shipped TSTyche 4.1. Now it collects `// @ts-expect-error` directives (in the type test files only), requires to provide a message after the directive and checks it as well. The following:

```ts
// @ts-expect-error: Argument of type 'boolean' is not assignable to parameter of type 'string'
doSomething(false);
```

fails with:

<img width="769" alt="Screenshot 2025-06-26 at 12 45 41" src="https://github.com/user-attachments/assets/333b3d79-3bb8-4df3-8dec-7810bdf49baf" />

---

As you know, the downside of `// @ts-expect-error` is that it hides *any* amount of *any* errors in the following line. That does not work with type tests.

I think, it is better to handle `// @ts-expect-error` instead of having `.toRaiseError()` matcher. There are no red squiggles when the directive is used. Therefore I plan to remove `.toRaiseError()` in the future.

---

To ignore a directive, append the `!` character after it: `// @ts-expect-error!`. For instance, this is useful in case if there is an upstream bug.

That is explained when the message fragment is not provided:

<img width="506" alt="Screenshot 2025-06-26 at 12 58 51" src="https://github.com/user-attachments/assets/cbafa7ab-14ff-4c81-b1a9-1176f285570c" />

