### PR TITLE
`HttpRouter.mountApp` prefix matching fixed

### DIFF
--- a/.changeset/clear-items-send.md
+++ b/.changeset/clear-items-send.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+`HttpRouter.mountApp` prefix matching fixed

--- a/packages/platform-node/test/HttpServer.test.ts
+++ b/packages/platform-node/test/HttpServer.test.ts
@@ -190,6 +190,14 @@ describe("HttpServer", () => {
       expect(todo).toEqual("/1")
       const root = yield* client.get("/child").pipe(Effect.flatMap((_) => _.text))
       expect(root).toEqual("/")
+      const rootSearch = yield* client.get("/child?foo=bar").pipe(Effect.flatMap((_) => _.text))
+      expect(rootSearch).toEqual("?foo=bar")
+      const rootSlash = yield* client.get("/child/").pipe(Effect.flatMap((_) => _.text))
+      expect(rootSlash).toEqual("/")
+      const invalid = yield* client.get("/child1/", {
+        urlParams: UrlParams.fromInput({ foo: 'bar' })
+      }).pipe(Effect.map((_) => _.status))
+      expect(invalid).toEqual(404)
     }).pipe(Effect.provide(NodeHttpServer.layerTest)))
 
   it.scoped("mountApp/includePrefix", () =>

--- a/packages/platform-node/test/HttpServer.test.ts
+++ b/packages/platform-node/test/HttpServer.test.ts
@@ -195,7 +195,7 @@ describe("HttpServer", () => {
       const rootSlash = yield* client.get("/child/").pipe(Effect.flatMap((_) => _.text))
       expect(rootSlash).toEqual("/")
       const invalid = yield* client.get("/child1/", {
-        urlParams: UrlParams.fromInput({ foo: 'bar' })
+        urlParams: { foo: "bar" }
       }).pipe(Effect.map((_) => _.status))
       expect(invalid).toEqual(404)
     }).pipe(Effect.provide(NodeHttpServer.layerTest)))


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Example router

```ts
HttpRouter.empty.pipe(
  HttpRouter.mountApp('/a', HttpServerResponse.text('OK')),
  HttpRouter.get('/ab', HttpServerResponse.text('Unreachable'))
)
```

the first mounted app matches everything that starts with `/a` which is unexpected as you would expect that it only matches on exactly `/a` or `/a/*`. It even get's more confusion if you explicitly add trailing slash to the mount.

My PR tries to fix that issue by doing the bare minimum. It might make sense to also add support for something like `/a*` if you want to match prefixes.
