### PR TITLE
Add `$matchStrict` to enforce valid `_tag` keys in `TaggedEnum` match handlers

### DIFF
--- a/.changeset/rare-llamas-watch.md
+++ b/.changeset/rare-llamas-watch.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add `$matchStrict` to `Data.TaggedEnum` to disallow unexpected `_tag` keys in match handlers

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -371,6 +371,30 @@ export declare namespace TaggedEnum {
           }
         >(value: A, cases: Cases): Unify<ReturnType<Cases[A["_tag"]]>>
       }
+      readonly $matchStrict: {
+        <
+          const Cases extends
+            & { readonly [Tag in A["_tag"]]: (args: Extract<A, { readonly _tag: Tag }>) => any }
+            & { readonly [Tag in Exclude<keyof Cases, A["_tag"]>]: never }
+        >(cases: Cases): (value: A) => Unify<ReturnType<Cases[A["_tag"]]>>
+        <
+          const Cases extends
+            & { readonly [Tag in A["_tag"]]: (args: Extract<A, { readonly _tag: Tag }>) => any }
+            & { readonly [Tag in Exclude<keyof Cases, A["_tag"]>]: never }
+        >(value: A, cases: Cases): Unify<ReturnType<Cases[A["_tag"]]>>
+        <
+          Ret,
+          const Cases extends
+            & { readonly [Tag in A["_tag"]]: (args: Extract<A, { readonly _tag: Tag }>) => Ret }
+            & { readonly [Tag in Exclude<keyof Cases, A["_tag"]>]: never }
+        >(cases: Cases): (value: A) => Ret
+        <
+          Ret,
+          const Cases extends
+            & { readonly [Tag in A["_tag"]]: (args: Extract<A, { readonly _tag: Tag }>) => Ret }
+            & { readonly [Tag in Exclude<keyof Cases, A["_tag"]>]: never }
+        >(value: A, cases: Cases): Ret
+      }
     }
   >
 
@@ -508,7 +532,7 @@ export const taggedEnum: {
     get(_target, tag, _receiver) {
       if (tag === "$is") {
         return Predicate.isTagged
-      } else if (tag === "$match") {
+      } else if (tag === "$match" || tag === "$matchStrict") {
         return taggedMatch
       }
       return tagged(tag as string)

--- a/packages/effect/test/Data.test.ts
+++ b/packages/effect/test/Data.test.ts
@@ -197,6 +197,7 @@ describe("Data", () => {
     const {
       $is,
       $match,
+      $matchStrict,
       InternalServerError,
       NotFound
     } = Data.taggedEnum<HttpError>()
@@ -222,6 +223,13 @@ describe("Data", () => {
     })
     strictEqual(matcher(a), 0)
     strictEqual(matcher(b), 1)
+
+    const matcherStrict = $matchStrict({
+      NotFound: () => 0,
+      InternalServerError: () => 1
+    })
+    strictEqual(matcherStrict(a), 0)
+    strictEqual(matcherStrict(b), 1)
   })
 
   it("taggedEnum - generics", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This PR introduces a new helper function, `$matchStrict`, for use with `Data.TaggedEnum`.

Unlike the existing `$match`, which allows arbitrary keys in the match handler object, `$matchStrict` enforces that all keys correspond exactly to the declared `_tag` values of the union. If an unexpected key is provided (e.g. due to a typo or incorrect assumption), TypeScript will produce a compile-time error.

Check the related issue for a code sample.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #5146 
- Closes #5146 
