### PR TITLE
Fix: disallow invalid _tag keys in TaggedEnum.$match handlers

### DIFF
--- a/.changeset/icy-books-eat.md
+++ b/.changeset/icy-books-eat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `$match` to disallow invalid `_tag` keys in `TaggedEnum` handler objects.

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -361,15 +361,20 @@ export declare namespace TaggedEnum {
       readonly $is: <Tag extends A["_tag"]>(tag: Tag) => (u: unknown) => u is Extract<A, { readonly _tag: Tag }>
       readonly $match: {
         <
-          Cases extends {
+          const Cases extends {
             readonly [Tag in A["_tag"]]: (args: Extract<A, { readonly _tag: Tag }>) => any
           }
-        >(cases: Cases): (value: A) => Unify<ReturnType<Cases[A["_tag"]]>>
+        >(
+          cases: Cases & { [K in Exclude<keyof Cases, A["_tag"]>]: never }
+        ): (value: A) => Unify<ReturnType<Cases[A["_tag"]]>>
         <
-          Cases extends {
+          const Cases extends {
             readonly [Tag in A["_tag"]]: (args: Extract<A, { readonly _tag: Tag }>) => any
           }
-        >(value: A, cases: Cases): Unify<ReturnType<Cases[A["_tag"]]>>
+        >(
+          value: A,
+          cases: Cases & { [K in Exclude<keyof Cases, A["_tag"]>]: never }
+        ): Unify<ReturnType<Cases[A["_tag"]]>>
       }
     }
   >
@@ -398,7 +403,7 @@ export declare namespace TaggedEnum {
           ) => any
         }
       >(
-        cases: Cases
+        cases: Cases & { [K in Exclude<keyof Cases, Z["taggedEnum"]["_tag"]>]: never }
       ): (self: TaggedEnum.Kind<Z, A, B, C, D>) => Unify<ReturnType<Cases[Z["taggedEnum"]["_tag"]]>>
       <
         A,
@@ -412,7 +417,7 @@ export declare namespace TaggedEnum {
         }
       >(
         self: TaggedEnum.Kind<Z, A, B, C, D>,
-        cases: Cases
+        cases: Cases & { [K in Exclude<keyof Cases, Z["taggedEnum"]["_tag"]>]: never }
       ): Unify<ReturnType<Cases[Z["taggedEnum"]["_tag"]]>>
     }
   }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes a type safety issue in `Data.TaggedEnum().$match` where handler objects could include keys that do not correspond to valid _tag variants of the enum.

Previously, TypeScript would allow extra keys such as "`RandomThing`" in the match object without error:

```ts
const result = $match({
  Foo: (foo) => foo.value,
  Bar: (bar) => bar.value,
  RandomThing: () => "should not compile" // ❌ no error
})(someTaggedEnum)
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #5148
