### PR TITLE
Fix UrlParams.toRecord when there's a __proto__ key

### DIFF
--- a/.changeset/all-bikes-jump.md
+++ b/.changeset/all-bikes-jump.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix UrlParams.toRecord when there's a **proto** key

--- a/packages/platform/src/UrlParams.ts
+++ b/packages/platform/src/UrlParams.ts
@@ -261,7 +261,7 @@ const baseUrl = (): string | undefined => {
  * @category conversions
  */
 export const toRecord = (self: UrlParams): Record<string, string | Arr.NonEmptyArray<string>> => {
-  const out: Record<string, string | Arr.NonEmptyArray<string>> = {}
+  const out: Record<string, string | Arr.NonEmptyArray<string>> = Object.create(null)
   for (const [k, value] of self) {
     const curr = out[k]
     if (curr === undefined) {
@@ -272,7 +272,7 @@ export const toRecord = (self: UrlParams): Record<string, string | Arr.NonEmptyA
       curr.push(value)
     }
   }
-  return out
+  return { ...out }
 }
 
 /**

--- a/packages/platform/test/UrlParams.test.ts
+++ b/packages/platform/test/UrlParams.test.ts
@@ -109,6 +109,12 @@ describe("UrlParams", () => {
         { "a": "1", "b": "true", "c": "string", "e": ["1", "2", "3"] }
       )
     })
+
+    it("works with __proto__", () => {
+      const urlParams = UrlParams.fromInput({ ["__proto__"]: "foo" })
+      const result = UrlParams.toRecord(urlParams)
+      deepStrictEqual(result, { ["__proto__"]: "foo" })
+    })
   })
 
   describe("schemaStruct", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had a test run using fast-check that triggered an error in `UrlParams.toRecord` (`TypeError: curr.push is not a function`) as a key was called `__proto__`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
