### PR TITLE
Clarify Array rotate example

### DIFF
--- a/.changeset/upset-icons-spend.md
+++ b/.changeset/upset-icons-spend.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Clarify Array rotate example

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -1731,8 +1731,8 @@ export const setNonEmptyLast: {
  * ```ts
  * import { Array } from "effect"
  *
- * const result = Array.rotate(['a', 'b', 'c', 'd'], 2)
- * console.log(result) // ['c', 'd', 'a', 'b']
+ * const result = Array.rotate(['a', 'b', 'c', 'd', 'e'], 2)
+ * console.log(result) // [ 'd', 'e', 'a', 'b', 'c' ]
  * ```
  *
  * @since 2.0.0


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The current example of Array rotate is symmetric, making it difficult to see which direction the rotation will happen
