### PR TITLE
Make `Effect.runPromise` and `Effect.runSync` Transparently Re-throw Original Errors

### DIFF
--- a/packages/effect/src/Runtime.ts
+++ b/packages/effect/src/Runtime.ts
@@ -1,7 +1,6 @@
 /**
  * @since 2.0.0
  */
-import type { Cause } from "./Cause.js"
 import type * as Context from "./Context.js"
 import type * as Effect from "./Effect.js"
 import type * as Exit from "./Exit.js"
@@ -9,7 +8,6 @@ import type * as Fiber from "./Fiber.js"
 import type * as FiberId from "./FiberId.js"
 import type * as FiberRef from "./FiberRef.js"
 import type * as FiberRefs from "./FiberRefs.js"
-import type { Inspectable } from "./Inspectable.js"
 import * as internal from "./internal/runtime.js"
 import type { Pipeable } from "./Pipeable.js"
 import type * as RuntimeFlags from "./RuntimeFlags.js"
@@ -224,54 +222,10 @@ export const make: <R>(
 
 /**
  * @since 2.0.0
- * @category symbols
- */
-export const FiberFailureId = Symbol.for("effect/Runtime/FiberFailure")
-/**
- * @since 2.0.0
- * @category symbols
- */
-export type FiberFailureId = typeof FiberFailureId
-
-/**
- * @since 2.0.0
- * @category symbols
- */
-export const FiberFailureCauseId: unique symbol = internal.FiberFailureCauseId
-
-/**
- * @since 2.0.0
- * @category exports
- */
-export type FiberFailureCauseId = typeof FiberFailureCauseId
-
-/**
- * @since 2.0.0
- * @category models
- */
-export interface FiberFailure extends Error, Inspectable {
-  readonly [FiberFailureId]: FiberFailureId
-  readonly [FiberFailureCauseId]: Cause<unknown>
-}
-
-/**
- * @since 2.0.0
  * @category guards
  */
 export const isAsyncFiberException: (u: unknown) => u is AsyncFiberException<unknown, unknown> =
   internal.isAsyncFiberException
-
-/**
- * @since 2.0.0
- * @category guards
- */
-export const isFiberFailure: (u: unknown) => u is FiberFailure = internal.isFiberFailure
-
-/**
- * @since 2.0.0
- * @category constructors
- */
-export const makeFiberFailure: <E>(cause: Cause<E>) => FiberFailure = internal.fiberFailure
 
 /**
  * @since 2.0.0

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -311,8 +311,11 @@ const prettyErrorStack = (error: any, appendStacks: string[] = []): void => {
 
 const rethrowCauseErrors = (cause: Cause.Cause<unknown>, callerFunction: Function | undefined): never => {
   if (InternalCause.isEmpty(cause)) {
+    // Can this branch ever be reached?
+    // TODO(dmaretskyi): Define a new error type for this.
     throw new Error('Fiber failed without a cause');
   } else if (InternalCause.isInterrupted(cause)) {
+    // TODO(dmaretskyi): Define a new error type for this.
     throw new Error('Fiber was interrupted');
   } else {
     const o: { stack: string } = {} as any;

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -26,7 +26,6 @@ import * as OpCodes from "./opCodes/effect.js"
 import * as runtimeFlags from "./runtimeFlags.js"
 import * as supervisor_ from "./supervisor.js"
 import type * as Tracer from "../Tracer.js"
-import * as Chunk from "../Chunk.js"
 
 const makeDual = <Args extends Array<any>, Return>(
   f: (runtime: Runtime.Runtime<never>, effect: Effect.Effect<any, any>, ...args: Args) => Return

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -197,7 +197,7 @@ const locationRegex = /at (.*)\((.*)\)/
  * Adds effect spans.
  * Removes effect internal functions.
  */
-// TODO(dmaretskyi): Move to cause.ts
+// TODO(dmaretskyi): Move to cause.ts and unify with existing PrettyError code.
 const prettyErrorStack = (error: any, appendStacks: Array<string> = []): void => {
   const span = error[InternalCause.spanSymbol]
 

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -25,6 +25,8 @@ import * as fiberScope from "./fiberScope.js"
 import * as OpCodes from "./opCodes/effect.js"
 import * as runtimeFlags from "./runtimeFlags.js"
 import * as supervisor_ from "./supervisor.js"
+import type * as Tracer from "../Tracer.js"
+import * as Chunk from "../Chunk.js"
 
 const makeDual = <Args extends Array<any>, Return>(
   f: (runtime: Runtime.Runtime<never>, effect: Effect.Effect<any, any>, ...args: Args) => Return
@@ -162,7 +164,7 @@ export const unsafeRunSync: {
 } = makeDual((runtime, effect) => {
   const result = unsafeRunSyncExit(runtime)(effect)
   if (result._tag === "Failure") {
-    throw fiberFailure(result.effect_instruction_i0)
+    rethrowCauseErrors(result.effect_instruction_i0, unsafeRunSync)
   }
   return result.effect_instruction_i0
 })
@@ -228,6 +230,115 @@ class FiberFailureImpl extends Error implements Runtime.FiberFailure {
   }
 }
 
+// TODO(dmaretskyi): Move to cause.ts
+const locationRegex = /at (.*)\((.*)\)/;
+
+/**
+ * Adds effect spans.
+ * Removes effect internal functions.
+ */
+// TODO(dmaretskyi): Move to cause.ts
+const prettyErrorStack = (error: any, appendStacks: string[] = []): void => {
+  const span = error[InternalCause.spanSymbol];
+
+  const lines = error.stack.split('\n');
+  const out = [];
+
+  let atStack = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (!atStack && !lines[i].startsWith('    at ')) {
+      out.push(lines[i]);
+      continue;
+    }
+    atStack = true;
+
+    if (lines[i].includes(' at new BaseEffectError') || lines[i].includes(' at new YieldableError')) {
+      i++;
+      continue;
+    }
+    if (lines[i].includes('Generator.next')) {
+      break;
+    }
+    if (lines[i].includes('effect_internal_function')) {
+      break;
+    }
+    out.push(
+      lines[i]
+        .replace(/at .*effect_instruction_i.*\((.*)\)/, 'at $1')
+        .replace(/EffectPrimitive\.\w+/, '<anonymous>')
+        .replace(/at Arguments\./, 'at '),
+    );
+  }
+
+  if (span) {
+    let current: Tracer.Span | Tracer.AnySpan | undefined = span;
+    let i = 0;
+    while (current && current._tag === 'Span' && i < 10) {
+      const stackFn = InternalCause.spanToTrace.get(current);
+      if (typeof stackFn === 'function') {
+        const stack = stackFn();
+        if (typeof stack === 'string') {
+          const locationMatchAll = stack.matchAll(locationRegex);
+          let match = false;
+          for (const [, location] of locationMatchAll) {
+            match = true;
+            out.push(`    at ${current.name} (${location})`);
+          }
+          if (!match) {
+            out.push(`    at ${current.name} (${stack.replace(/^at /, '')})`);
+          }
+        } else {
+          out.push(`    at ${current.name}`);
+        }
+      } else {
+        out.push(`    at ${current.name}`);
+      }
+      current = Option.getOrUndefined(current.parent);
+      i++;
+    }
+  }
+
+  out.push(...appendStacks);
+
+  Object.defineProperty(error, 'stack', {
+    value: out.join('\n'),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+};
+
+
+const rethrowCauseErrors = (cause: Cause.Cause<unknown>, callerFunction: Function | undefined): never => {
+  if (InternalCause.isEmpty(cause)) {
+    throw new Error('Fiber failed without a cause');
+  } else if (InternalCause.isInterrupted(cause)) {
+    throw new Error('Fiber was interrupted');
+  } else {
+    const o: { stack: string } = {} as any;
+    Error.captureStackTrace(o, callerFunction);
+    const stackFrames =  o.stack.split('\n').slice(1);
+    const errors: Error[] = [];
+
+    for(const failure of InternalCause.failures(cause)) {
+      prettyErrorStack(failure, stackFrames);
+      errors.push(failure as Error);
+    }
+    
+    for(const defect of InternalCause.defects(cause)) {
+      prettyErrorStack(defect, stackFrames);
+      errors.push(defect as Error);
+    }
+
+    if (errors.length === 1) {
+      throw errors[0];
+    } else {
+      throw new AggregateError(errors);
+    }
+  }
+}
+
+// TODO(dmaretskyi): Not used anymore.
 /** @internal */
 export const fiberFailure = <E>(cause: Cause.Cause<E>): Runtime.FiberFailure => {
   const limit = Error.stackTraceLimit
@@ -311,7 +422,7 @@ export const unsafeRunPromise: {
         return result.effect_instruction_i0
       }
       case OpCodes.OP_FAILURE: {
-        throw fiberFailure(result.effect_instruction_i0)
+        rethrowCauseErrors(result.effect_instruction_i0, unsafeRunPromise)
       }
     }
   })

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -275,6 +275,8 @@ const prettyErrorStack = (error: any, appendStacks: Array<string> = []): void =>
  * Stack frames from the effect runtime internals are removed.
  * Stack frames from the caller function is appended to the stack trace.
  *
+ * If cause has multiple failures or defects, they are wrapped in an `AggregateError`.
+ *
  * @internal
  * @param callerFunction - Function that called `rethrowCauseErrors`. Used to trim the caller stack trace.
  */

--- a/packages/effect/test/Schema/SchemaTest.ts
+++ b/packages/effect/test/Schema/SchemaTest.ts
@@ -1,7 +1,6 @@
 import type { SchemaAST } from "effect"
 import {
   Arbitrary,
-  Cause,
   Context,
   Effect,
   Either,
@@ -9,7 +8,6 @@ import {
   ParseResult,
   Predicate,
   Pretty,
-  Runtime,
   Schema
 } from "effect"
 

--- a/packages/effect/test/Schema/SchemaTest.ts
+++ b/packages/effect/test/Schema/SchemaTest.ts
@@ -236,15 +236,11 @@ export const assertions = Effect.gen(function*() {
         try {
           const a = await promise
           throw new Error(`Promise didn't reject, got: ${a}`)
-        } catch (e: unknown) {
-          // TODO(dmaretskyi): Needs to be updated.
-          if (Runtime.isFiberFailure(e) && Cause.isCause(e[Runtime.FiberFailureCauseId])) {
-            const cause = e[Runtime.FiberFailureCauseId]
-            if (Cause.isFailType(cause) && Predicate.hasProperty(cause.error, "message")) {
-              return deepStrictEqual(cause.error.message, message)
-            }
+        } catch (error: unknown) {
+          if (Predicate.hasProperty(error, "message")) {
+            return deepStrictEqual(error.message, message)
           }
-          throw new Error(`Unknown promise rejection: ${e}`)
+          throw new Error(`Unknown promise rejection: ${error}`)
         }
       }
     },

--- a/packages/effect/test/Schema/SchemaTest.ts
+++ b/packages/effect/test/Schema/SchemaTest.ts
@@ -237,6 +237,7 @@ export const assertions = Effect.gen(function*() {
           const a = await promise
           throw new Error(`Promise didn't reject, got: ${a}`)
         } catch (e: unknown) {
+          // TODO(dmaretskyi): Needs to be updated.
           if (Runtime.isFiberFailure(e) && Cause.isCause(e[Runtime.FiberFailureCauseId])) {
             const cause = e[Runtime.FiberFailureCauseId]
             if (Cause.isFailType(cause) && Predicate.hasProperty(cause.error, "message")) {

--- a/packages/effect/test/Schema/SchemaTest.ts
+++ b/packages/effect/test/Schema/SchemaTest.ts
@@ -1,15 +1,5 @@
 import type { SchemaAST } from "effect"
-import {
-  Arbitrary,
-  Context,
-  Effect,
-  Either,
-  FastCheck,
-  ParseResult,
-  Predicate,
-  Pretty,
-  Schema
-} from "effect"
+import { Arbitrary, Context, Effect, Either, FastCheck, ParseResult, Predicate, Pretty, Schema } from "effect"
 
 // Defines parameters for FastCheck that exclude typed properties
 export type UntypedParameters = Omit<FastCheck.Parameters<any>, "examples" | "reporter" | "asyncReporter">


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Motivation

This PR updates `Effect.runPromise` and `Effect.runSync` to re-throw the original errors from failed effects without wrapping them in internal structures like `FiberFailure`. This aligns error handling more closely with standard JavaScript behavior and improves ergonomics when integrating Effect into existing codebases.

Why This Matters:

- **Better interop with existing tools and environments**:
  - In Node.js, unhandled rejections are shown using the original error.
  - In test runners like Vitest or Jest, test failures show up as the original error, making debugging easier.
  - In browser consoles, the original error stack and message are preserved, making the experience consistent with non-effect code.
- **Improved transparency in mixed codebases**:
In apps that are adopting effect gradually, it's common to mix effect and non-effect code. If the effect fails due to an error thrown in some non-effect code inside the effect block, that exact error should propagate outward — as if the effect layer wasn’t there at all. This makes the effect block transparent and helps avoid confusion, especially for newcomers.

## Description

- If the `Cause` contains a single failure or defect, we re-throw the original error directly.
- If the `Cause` contains multiple errors, we throw an AggregateError containing all the causes.
- For users who need to inspect the full `Cause` structure, `Effect.runPromiseExit` and `Effect.runSyncExit` continue to expose the full details.
- `FiberFailure` error class becomes redundant and is removed.
- Errors that are re-thrown have their stacks cleaned from the Effect-runtime internals and Effect spans inserted in the correct place. This is similar to what `PrettyError` already does.
- Errors will have the full stack-trace available: including the code calling `Effect.runSync`/`Effect.runPromise` the Effect function stack as well as any vanilla JS functions called from inside Effect.

## TODO

- [ ] Clean-up error stack processing code and unify with existing code in `cause.ts`.
- [ ] Update the docs.
- [ ] Update failing tests.