### PR TITLE
fix(platform): fix KeyValueStore.make type mismatch

### DIFF
--- a/.changeset/heavy-kangaroos-greet.md
+++ b/.changeset/heavy-kangaroos-greet.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix KeyValueStore.make type mismatch

--- a/packages/platform/src/KeyValueStore.ts
+++ b/packages/platform/src/KeyValueStore.ts
@@ -114,7 +114,9 @@ export const KeyValueStore: Context.Tag<KeyValueStore, KeyValueStore> = internal
  * @category constructors
  */
 export const make: (
-  impl: Omit<KeyValueStore, typeof TypeId | "has" | "modify" | "isEmpty" | "forSchema"> & Partial<KeyValueStore>
+  impl:
+    & Omit<KeyValueStore, typeof TypeId | "has" | "modify" | "modifyUint8Array" | "isEmpty" | "forSchema">
+    & Partial<KeyValueStore>
 ) => KeyValueStore = internal.make
 
 /**


### PR DESCRIPTION
The Omit was missing "modifyUint8Array"

https://discord.com/channels/795981131316985866/1098177242598756412/1391803548538376364

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add "modifyUint8Array" to `KeyValueStore.make`'s `Omit` to match the internal function
