### PR TITLE
Updated deprecated OTel span attributes names and values

### DIFF
--- a/.changeset/quiet-cougars-wink.md
+++ b/.changeset/quiet-cougars-wink.md
@@ -1,0 +1,44 @@
+---
+"@effect/sql-sqlite-react-native": minor
+"@effect/sql-sqlite-node": minor
+"@effect/sql-sqlite-wasm": minor
+"@effect/sql-clickhouse": minor
+"@effect/sql-sqlite-bun": minor
+"@effect/sql-kysely": minor
+"@effect/sql-sqlite-do": minor
+"@effect/sql-libsql": minor
+"@effect/sql-mysql2": minor
+"@effect/sql-mssql": minor
+"@effect/sql-d1": minor
+"@effect/sql-pg": minor
+"@effect/sql": minor
+"@effect/opentelemetry": patch
+"@effect/platform": patch
+"effect": patch
+---
+
+Updated deprecated OTel Resource attributes names and values.
+
+Many of the attributes have undergone the process of deprecation not once, but twice. Most of the constants holding attribute names have been renamed. These are minor changes.
+
+Additionally, there were numerous changes to the attribute keys themselves. These changes can be considered major.
+
+In the `@opentelemetry/semantic-conventions` package, new attributes having ongoing discussion about them are going through a process called incubation, until a consensus about their necessity and form is reached. Otel team [recommends](https://github.com/open-telemetry/opentelemetry-js/blob/main/semantic-conventions/README.md#unstable-semconv) devs to copy them directly into their code. Luckily, it's not necessary because all of the new attribute names and values came out of this process (some of them were changed again) and are now considered stable.
+
+## Reasoning for minor version bump
+
+| Package                    | Major attribute changes                                                       | Major value changes               |
+| -------------------------- | ----------------------------------------------------------------------------- | --------------------------------- |
+| Clickhouse client          | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             |                                   |
+| MsSQL client               | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             | `mssql` -> `microsoft.sql_server` |
+| MySQL client               | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             |                                   |
+| Pg client                  | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             |                                   |
+| Bun SQLite client          | `db.system` -> `db.system.name`                                               |                                   |
+| Node SQLite client         | `db.system` -> `db.system.name`                                               |                                   |
+| React.Native SQLite client | `db.system` -> `db.system.name`                                               |                                   |
+| Wasm SQLite client         | `db.system` -> `db.system.name`                                               |                                   |
+| SQLite Do client           | `db.system` -> `db.system.name`                                               |                                   |
+| LibSQL client              | `db.system` -> `db.system.name`                                               |                                   |
+| D1 client                  | `db.system` -> `db.system.name`                                               |                                   |
+| Kysely client              | `db.statement` -> `db.query.text`                                             |                                   |
+| @effect/sql                | `db.statement` -> `db.query.text` <br/> `db.operation` -> `db.operation.name` |                                   |

--- a/packages/effect/src/internal/core-effect.ts
+++ b/packages/effect/src/internal/core-effect.ts
@@ -2168,6 +2168,7 @@ export const endSpan = <A, E>(span: Tracer.Span, exit: Exit<A, E>, clock: Clock.
       return
     }
     if (core.exitIsFailure(exit) && internalCause.spanToTrace.has(span)) {
+      // https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/#code-stacktrace
       span.attribute("code.stacktrace", internalCause.spanToTrace.get(span)!())
     }
     span.end(timingEnabled ? clock.unsafeCurrentTimeNanos() : bigint0, exit)

--- a/packages/opentelemetry/src/OtlpResource.ts
+++ b/packages/opentelemetry/src/OtlpResource.ts
@@ -1,6 +1,7 @@
 /**
  * @since 1.0.0
  */
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Arr from "effect/Array"
 import * as Config from "effect/Config"
 import * as Effect from "effect/Effect"
@@ -30,14 +31,14 @@ export const make = (options: {
     ? entriesToAttributes(Object.entries(options.attributes))
     : []
   resourceAttributes.push({
-    key: "service.name",
+    key: OtelSemConv.ATTR_SERVICE_NAME,
     value: {
       stringValue: options.serviceName
     }
   })
   if (options.serviceVersion) {
     resourceAttributes.push({
-      key: "service.version",
+      key: OtelSemConv.ATTR_SERVICE_VERSION,
       value: {
         stringValue: options.serviceVersion
       }
@@ -83,9 +84,9 @@ export const fromConfig: (
       ...options?.attributes
     }))
   )
-  const serviceName = options?.serviceName ?? attributes["service.name"] as string ??
+  const serviceName = options?.serviceName ?? attributes[OtelSemConv.ATTR_SERVICE_NAME] as string ??
     (yield* Config.string("OTEL_SERVICE_NAME"))
-  const serviceVersion = options?.serviceVersion ?? attributes["service.version"] as string ??
+  const serviceVersion = options?.serviceVersion ?? attributes[OtelSemConv.ATTR_SERVICE_VERSION] as string ??
     (yield* Config.string("OTEL_SERVICE_VERSION").pipe(Config.withDefault(undefined)))
   return make({
     serviceName,
@@ -100,7 +101,7 @@ export const fromConfig: (
  */
 export const unsafeServiceName = (resource: Resource): string => {
   const serviceNameAttribute = resource.attributes.find(
-    (attr) => attr.key === "service.name"
+    (attr) => attr.key === OtelSemConv.ATTR_SERVICE_NAME
   )
   if (!serviceNameAttribute || !serviceNameAttribute.value.stringValue) {
     throw new Error("Resource does not contain a service name")

--- a/packages/opentelemetry/src/OtlpTracer.ts
+++ b/packages/opentelemetry/src/OtlpTracer.ts
@@ -3,6 +3,7 @@
  */
 import type * as Headers from "@effect/platform/Headers"
 import type * as HttpClient from "@effect/platform/HttpClient"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Cause from "effect/Cause"
 import type * as Context from "effect/Context"
 import * as Duration from "effect/Duration"
@@ -224,19 +225,19 @@ const makeOtlpSpan = (self: SpanImpl): OtlpSpan => {
         droppedAttributesCount: 0,
         attributes: [
           {
-            "key": "exception.type",
+            "key": OtelSemConv.ATTR_EXCEPTION_TYPE,
             "value": {
               "stringValue": firstError.name
             }
           },
           {
-            "key": "exception.message",
+            "key": OtelSemConv.ATTR_EXCEPTION_MESSAGE,
             "value": {
               "stringValue": firstError.message
             }
           },
           {
-            "key": "exception.stacktrace",
+            "key": OtelSemConv.ATTR_EXCEPTION_STACKTRACE,
             "value": {
               "stringValue": Cause.pretty(status.exit.cause, { renderErrorCause: true })
             }

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -3,14 +3,7 @@
  */
 import type * as OtelApi from "@opentelemetry/api"
 import * as Resources from "@opentelemetry/resources"
-import {
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_SERVICE_VERSION,
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
-  SEMRESATTRS_TELEMETRY_SDK_NAME,
-  TELEMETRYSDKLANGUAGEVALUES_NODEJS,
-  TELEMETRYSDKLANGUAGEVALUES_WEBJS
-} from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Arr from "effect/Array"
 import * as Config from "effect/Config"
 import { GenericTag } from "effect/Context"
@@ -57,14 +50,14 @@ export const configToAttributes = (options: {
 }): Record<string, string> => {
   const attributes: Record<string, string> = {
     ...(options.attributes ?? undefined),
-    [SEMRESATTRS_SERVICE_NAME]: options.serviceName,
-    [SEMRESATTRS_TELEMETRY_SDK_NAME]: "@effect/opentelemetry",
-    [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]: typeof (globalThis as any).document === "undefined"
-      ? TELEMETRYSDKLANGUAGEVALUES_NODEJS
-      : TELEMETRYSDKLANGUAGEVALUES_WEBJS
+    [OtelSemConv.ATTR_SERVICE_NAME]: options.serviceName,
+    [OtelSemConv.ATTR_TELEMETRY_SDK_NAME]: "@effect/opentelemetry",
+    [OtelSemConv.ATTR_TELEMETRY_SDK_LANGUAGE]: typeof (globalThis as any).document === "undefined"
+      ? OtelSemConv.TELEMETRY_SDK_LANGUAGE_VALUE_NODEJS
+      : OtelSemConv.TELEMETRY_SDK_LANGUAGE_VALUE_WEBJS
   }
   if (options.serviceVersion) {
-    attributes[SEMRESATTRS_SERVICE_VERSION] = options.serviceVersion
+    attributes[OtelSemConv.ATTR_SERVICE_VERSION] = options.serviceVersion
   }
   return attributes
 }
@@ -99,7 +92,7 @@ export const layerFromEnv = (
         Effect.orDie
       )
       if (serviceName._tag === "Some") {
-        attributes[SEMRESATTRS_SERVICE_NAME] = serviceName.value
+        attributes[OtelSemConv.ATTR_SERVICE_NAME] = serviceName.value
       }
       if (additionalAttributes) {
         Object.assign(attributes, additionalAttributes)

--- a/packages/opentelemetry/src/internal/tracer.ts
+++ b/packages/opentelemetry/src/internal/tracer.ts
@@ -1,4 +1,5 @@
 import * as OtelApi from "@opentelemetry/api"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
@@ -236,8 +237,8 @@ export const layerTracer = Layer.effect(
     ([resource, provider]) =>
       Effect.sync(() =>
         provider.getTracer(
-          resource.attributes["service.name"] as string,
-          resource.attributes["service.version"] as string
+          resource.attributes[OtelSemConv.ATTR_SERVICE_NAME] as string,
+          resource.attributes[OtelSemConv.ATTR_SERVICE_VERSION] as string
         )
       )
   )

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -47,6 +47,7 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
+    "@opentelemetry/semantic-conventions": "^1.33.0",
     "find-my-way-ts": "^0.1.6",
     "msgpackr": "^1.11.4",
     "multipasta": "^0.2.5"

--- a/packages/platform/src/internal/httpClient.ts
+++ b/packages/platform/src/internal/httpClient.ts
@@ -1,3 +1,4 @@
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
@@ -226,22 +227,22 @@ export const make = (
           nameGenerator(request),
           { kind: "client", captureStackTrace: false },
           (span) => {
-            span.attribute("http.request.method", request.method)
-            span.attribute("server.address", url.origin)
+            span.attribute(OtelSemConv.ATTR_HTTP_REQUEST_METHOD, request.method)
+            span.attribute(OtelSemConv.ATTR_SERVER_ADDRESS, url.origin)
             if (url.port !== "") {
-              span.attribute("server.port", +url.port)
+              span.attribute(OtelSemConv.ATTR_SERVER_PORT, +url.port)
             }
-            span.attribute("url.full", url.toString())
-            span.attribute("url.path", url.pathname)
-            span.attribute("url.scheme", url.protocol.slice(0, -1))
+            span.attribute(OtelSemConv.ATTR_URL_FULL, url.toString())
+            span.attribute(OtelSemConv.ATTR_URL_PATH, url.pathname)
+            span.attribute(OtelSemConv.ATTR_URL_SCHEME, url.protocol.slice(0, -1))
             const query = url.search.slice(1)
             if (query !== "") {
-              span.attribute("url.query", query)
+              span.attribute(OtelSemConv.ATTR_URL_QUERY, query)
             }
             const redactedHeaderNames = fiber.getFiberRef(Headers.currentRedactedNames)
             const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames)
             for (const name in redactedHeaders) {
-              span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]))
+              span.attribute(OtelSemConv.ATTR_HTTP_REQUEST_HEADER(name), String(redactedHeaders[name]))
             }
             request = fiber.getFiberRef(currentTracerPropagation)
               ? internalRequest.setHeaders(request, TraceContext.toHeaders(span))
@@ -251,10 +252,10 @@ export const make = (
                 Effect.withParentSpan(span),
                 Effect.matchCauseEffect({
                   onSuccess: (response) => {
-                    span.attribute("http.response.status_code", response.status)
+                    span.attribute(OtelSemConv.ATTR_HTTP_RESPONSE_STATUS_CODE, response.status)
                     const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames)
                     for (const name in redactedHeaders) {
-                      span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]))
+                      span.attribute(OtelSemConv.ATTR_HTTP_RESPONSE_HEADER(name), String(redactedHeaders[name]))
                     }
                     if (scopedController) return Effect.succeed(response)
                     responseRegistry.register(response, controller)

--- a/packages/sql-clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql-clickhouse/src/ClickhouseClient.ts
@@ -9,7 +9,7 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import type { Primitive } from "@effect/sql/Statement"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -237,8 +237,8 @@ export const make = (
         compiler,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, "clickhouse"],
-          [Otel.SEMATTRS_DB_NAME, options.database ?? "default"]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_CLICKHOUSE],
+          [OtelSemConv.ATTR_DB_NAMESPACE, options.database ?? "default"]
         ],
         beginTransaction: "BEGIN TRANSACTION",
         transformRows

--- a/packages/sql-d1/src/D1Client.ts
+++ b/packages/sql-d1/src/D1Client.ts
@@ -7,7 +7,7 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Cache from "effect/Cache"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -171,7 +171,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as D1Client,

--- a/packages/sql-kysely/src/internal/patch.ts
+++ b/packages/sql-kysely/src/internal/patch.ts
@@ -1,6 +1,6 @@
 import type * as Client from "@effect/sql/SqlClient"
 import { SqlError } from "@effect/sql/SqlError"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Effect from "effect/Effect"
 import * as Effectable from "effect/Effectable"
 import type { Compilable } from "kysely"
@@ -72,7 +72,7 @@ function executeCommit(this: Executable) {
     kind: "client",
     captureStackTrace: false,
     attributes: {
-      [Otel.SEMATTRS_DB_STATEMENT]: this.compile().sql
+      [OtelSemConv.ATTR_DB_QUERY_TEXT]: this.compile().sql
     }
   }))
 }

--- a/packages/sql-libsql/src/LibsqlClient.ts
+++ b/packages/sql-libsql/src/LibsqlClient.ts
@@ -7,7 +7,7 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
 import * as Libsql from "@libsql/client"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -145,7 +145,7 @@ export const make = (
 
     const spanAttributes: Array<[string, unknown]> = [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+      [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
     ]
 
     class LibsqlConnectionImpl implements LibsqlConnection {

--- a/packages/sql-mssql/src/MssqlClient.ts
+++ b/packages/sql-mssql/src/MssqlClient.ts
@@ -6,7 +6,7 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -130,10 +130,10 @@ export const make = (
       undefined
     const spanAttributes: ReadonlyArray<[string, unknown]> = [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_MSSQL],
-      [Otel.SEMATTRS_DB_NAME, options.database ?? "master"],
-      ["server.address", options.server],
-      ["server.port", options.port ?? 1433]
+      [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER],
+      [OtelSemConv.ATTR_DB_NAMESPACE, options.database ?? "master"],
+      [OtelSemConv.ATTR_SERVER_ADDRESS, options.server],
+      [OtelSemConv.ATTR_SERVER_PORT, options.port ?? 1433]
     ]
 
     // eslint-disable-next-line prefer-const

--- a/packages/sql-mysql2/src/MysqlClient.ts
+++ b/packages/sql-mysql2/src/MysqlClient.ts
@@ -7,7 +7,7 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import { asyncPauseResume } from "@effect/sql/SqlStream"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -242,13 +242,13 @@ export const make = (
 
     const spanAttributes: Array<[string, unknown]> = [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_MYSQL],
-      ["server.address", options.host ?? "localhost"],
-      ["server.port", options.port ?? 3306]
+      [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_MYSQL],
+      [OtelSemConv.ATTR_SERVER_ADDRESS, options.host ?? "localhost"],
+      [OtelSemConv.ATTR_SERVER_PORT, options.port ?? 3306]
     ]
 
     if (options.database) {
-      spanAttributes.push([Otel.SEMATTRS_DB_NAME, options.database])
+      spanAttributes.push([OtelSemConv.ATTR_DB_NAMESPACE, options.database])
     }
 
     return Object.assign(

--- a/packages/sql-pg/src/PgClient.ts
+++ b/packages/sql-pg/src/PgClient.ts
@@ -7,7 +7,7 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import type { Custom, Fragment, Primitive } from "@effect/sql/Statement"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -281,10 +281,10 @@ export const make = (
         compiler,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_POSTGRESQL],
-          [Otel.SEMATTRS_DB_NAME, opts.database ?? options.username ?? "postgres"],
-          ["server.address", opts.host ?? "localhost"],
-          ["server.port", opts.port ?? 5432]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_POSTGRESQL],
+          [OtelSemConv.ATTR_DB_NAMESPACE, opts.database ?? options.username ?? "postgres"],
+          [OtelSemConv.ATTR_SERVER_ADDRESS, opts.host ?? "localhost"],
+          [OtelSemConv.ATTR_SERVER_PORT, opts.port ?? 5432]
         ],
         transformRows
       }),

--- a/packages/sql-sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql-sqlite-bun/src/SqliteClient.ts
@@ -6,7 +6,7 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import { Database } from "bun:sqlite"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -169,7 +169,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-do/src/SqliteClient.ts
+++ b/packages/sql-sqlite-do/src/SqliteClient.ts
@@ -7,6 +7,7 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -176,7 +177,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          ["db.system", "sqlite"]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-node/src/SqliteClient.ts
+++ b/packages/sql-sqlite-node/src/SqliteClient.ts
@@ -6,7 +6,7 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import Sqlite from "better-sqlite3"
 import * as Cache from "effect/Cache"
 import * as Config from "effect/Config"
@@ -233,7 +233,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql-sqlite-react-native/src/SqliteClient.ts
@@ -7,7 +7,7 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
 import * as Sqlite from "@op-engineering/op-sqlite"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -176,7 +176,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql-sqlite-wasm/src/SqliteClient.ts
@@ -9,7 +9,7 @@ import * as Statement from "@effect/sql/Statement"
 import * as WaSqlite from "@effect/wa-sqlite"
 import SQLiteESMFactory from "@effect/wa-sqlite/dist/wa-sqlite.mjs"
 import { MemoryVFS } from "@effect/wa-sqlite/src/examples/MemoryVFS.js"
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -243,7 +243,7 @@ export const makeMemory = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as SqliteClient,
@@ -402,7 +402,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [Otel.SEMATTRS_DB_SYSTEM, Otel.DBSYSTEMVALUES_SQLITE]
+          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_SQLITE]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -1,4 +1,4 @@
-import * as Otel from "@opentelemetry/semantic-conventions"
+import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Effect from "effect/Effect"
 import * as Effectable from "effect/Effectable"
 import * as FiberRef from "effect/FiberRef"
@@ -121,8 +121,8 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
           for (const [key, value] of this.spanAttributes) {
             span.attribute(key, value)
           }
-          span.attribute(Otel.SEMATTRS_DB_OPERATION, operation)
-          span.attribute(Otel.SEMATTRS_DB_STATEMENT, sql)
+          span.attribute(OtelSemConv.ATTR_DB_OPERATION_NAME, operation)
+          span.attribute(OtelSemConv.ATTR_DB_QUERY_TEXT, sql)
           return Effect.scoped(Effect.flatMap(this.acquirer, (_) => f(_, sql, params)))
         })
     )
@@ -153,8 +153,8 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
           for (const [key, value] of this.spanAttributes) {
             span.attribute(key, value)
           }
-          span.attribute(Otel.SEMATTRS_DB_OPERATION, "executeStream")
-          span.attribute(Otel.SEMATTRS_DB_STATEMENT, sql)
+          span.attribute(OtelSemConv.ATTR_DB_OPERATION_NAME, "executeStream")
+          span.attribute(OtelSemConv.ATTR_DB_QUERY_TEXT, sql)
           return Effect.map(this.acquirer, (_) => _.executeStream(sql, params, this.transformRows))
         })
     ))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
 
   packages/platform:
     dependencies:
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.33.0
+        version: 1.33.0
       find-my-way-ts:
         specifier: ^0.1.6
         version: 0.1.6
@@ -5812,6 +5815,7 @@ packages:
 
   libsql@0.4.5:
     resolution: {integrity: sha512-sorTJV6PNt94Wap27Sai5gtVLIea4Otb2LUiAUyr3p6BPOScGMKGt5F1b5X/XgkNtcsDKeX5qfeBDj+PdShclQ==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.7:


### PR DESCRIPTION
## Type

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Why?

1. Easier to identify attributes that do not conform to conventions
2. It's also easier to work with code of the same style everywhere
3. Lesser chance of typos, because attribute names' and values' correctness ensured by TS
4. Fewer magic strings/numbers. Even though, for example, "service.name" may be quite clear for some people, for others it may not be obvious why not for example, "spanSource.name", or "traceCreator.name". Plus, when it's imported, with those constants that have the same strings comes an inline JSDoc explanation of what this specific attribute means, where it comes from, and why it's called that way.
5. Brought stuff up to date

## PR Description

Many of the OpenTelemetry Span attributes have undergone the process of deprecation not once, but twice. Most of the constants holding attribute names have been renamed. These are minor changes.

Additionally, there were numerous changes to the attribute keys themselves. These changes can be considered major.

In the `@opentelemetry/semantic-conventions` package, new attributes having an ongoing discussion about them are going through a process called incubation, until a consensus about their necessity and form is reached. Otel team [recommends](https://github.com/open-telemetry/opentelemetry-js/blob/main/semantic-conventions/README.md#unstable-semconv) devs to copy them directly into their code. Luckily, it's not necessary because all the new attribute names and values emerged from this process (some of which were subsequently changed) and are now considered stable.

### Packages that need a major version bump

Or since all their versions are like `0._._`, I'm not sure if I'm using the correct term, but maybe it's a minor version bump?

| Package                    | Major attribute changes                                                       | Major value changes               |
| -------------------------- | ----------------------------------------------------------------------------- | --------------------------------- |
| Clickhouse client          | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             |                                   |
| MsSQL client               | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             | `mssql` -> `microsoft.sql_server` |
| MySQL client               | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             |                                   |
| Pg client                  | `db.system` -> `db.system.name` <br/> `db.name` -> `db.namespace`             |                                   |
| Bun SQLite client          | `db.system` -> `db.system.name`                                               |                                   |
| Node SQLite client         | `db.system` -> `db.system.name`                                               |                                   |
| React.Native SQLite client | `db.system` -> `db.system.name`                                               |                                   |
| Wasm SQLite client         | `db.system` -> `db.system.name`                                               |                                   |
| SQLite Do client           | `db.system` -> `db.system.name`                                               |                                   |
| LibSQL client              | `db.system` -> `db.system.name`                                               |                                   |
| D1 client                  | `db.system` -> `db.system.name`                                               |                                   |
| Kysely client              | `db.statement` -> `db.query.text`                                             |                                   |
| @effect/sql                | `db.statement` -> `db.query.text` <br/> `db.operation` -> `db.operation.name` |                                   |

<details>

<summary>

### (Expandable) Extended explanation of changes

</summary>

#### Clickhouse client

```plaintext
deprecated SEMATTRS_DB_SYSTEM ("db.system")
-> incubated(unstable/experimental)+deprecated ATTR_DB_SYSTEM ("db.system")
-> stable ATTR_DB_SYSTEM_NAME ("db.system.name")

deprecated SEMATTRS_DB_NAME ("db.name")
-> incubated(unstable/experimental)+deprecated ATTR_DB_NAME ("db.name")
-> stable ATTR_DB_NAMESPACE ("db.namespace")

plain string "clickhouse"
-> stable+uniform DB_SYSTEM_NAME_VALUE_CLICKHOUSE ("clickhouse")
```

#### MsSQL client

```plaintext
deprecated SEMATTRS_DB_SYSTEM ("db.system")
-> incubated(unstable/experimental)+deprecated ATTR_DB_SYSTEM ("db.system")
-> stable ATTR_DB_SYSTEM_NAME ("db.system.name")

deprecated DBSYSTEMVALUES_MSSQL ("mssql")
-> incubated(unstable/experimental) DB_SYSTEM_VALUE_MSSQL ("mssql").
   It's not formally deprecated, meaning it doesn't have `@deprecated` JSDoc
   comment in `@opentelemetry/semantic-conventions` package, but effectively
   those are enum values of deprecated attribute `ATTR_DB_SYSTEM`
-> stable DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER ("microsoft.sql_server")

deprecated SEMATTRS_DB_NAME ("db.name")
-> incubated(unstable/experimental)+deprecated ATTR_DB_NAME ("db.name")
-> stable ATTR_DB_NAMESPACE ("db.namespace")

plain string "server.address"
-> stable+uniform ATTR_SERVER_ADDRESS ("server.address")

plain string "server.port"
-> stable+uniform ATTR_SERVER_PORT ("server.port")
```

#### MySQL client

```plaintext
deprecated SEMATTRS_DB_SYSTEM ("db.system")
-> incubated(unstable/experimental)+deprecated ATTR_DB_SYSTEM ("db.system")
-> stable ATTR_DB_SYSTEM_NAME ("db.system.name")

deprecated DBSYSTEMVALUES_MYSQL ("mysql")
-> incubated(unstable/experimental) DB_SYSTEM_VALUE_MYSQL ("mysql").
   It's not formally deprecated, meaning it doesn't have `@deprecated` JSDoc
   comment in `@opentelemetry/semantic-conventions` package, but effectively
   those are enum values of deprecated attribute `ATTR_DB_SYSTEM`
-> stable DB_SYSTEM_NAME_VALUE_MYSQL ("mysql")

deprecated SEMATTRS_DB_NAME ("db.name")
-> incubated(unstable/experimental)+deprecated ATTR_DB_NAME ("db.name")
-> stable ATTR_DB_NAMESPACE ("db.namespace")

plain string "server.address"
-> stable+uniform ATTR_SERVER_ADDRESS ("server.address")

plain string "server.port"
-> stable+uniform ATTR_SERVER_PORT ("server.port")
```

#### Pg client

```plaintext
deprecated SEMATTRS_DB_SYSTEM ("db.system")
-> incubated(unstable/experimental)+deprecated ATTR_DB_SYSTEM ("db.system")
-> stable ATTR_DB_SYSTEM_NAME ("db.system.name")

deprecated DBSYSTEMVALUES_POSTGRESQL ("postgresql")
-> incubated(unstable/experimental) DB_SYSTEM_VALUE_POSTGRESQL ("postgresql").
   It's not formally deprecated, meaning it doesn't have `@deprecated` JSDoc
   comment in `@opentelemetry/semantic-conventions` package, but effectively
   those are enum values of deprecated attribute `ATTR_DB_SYSTEM`
-> stable DB_SYSTEM_NAME_VALUE_POSTGRESQL ("postgresql")

deprecated SEMATTRS_DB_NAME ("db.name")
-> incubated(unstable/experimental)+deprecated ATTR_DB_NAME ("db.name")
-> stable ATTR_DB_NAMESPACE ("db.namespace")

plain string "server.address"
-> stable+uniform ATTR_SERVER_ADDRESS ("server.address")

plain string "server.port"
-> stable+uniform ATTR_SERVER_PORT ("server.port")
```

#### Bun, Node, React.Native, Wasm, Do, LibSQL, and D1 SQLite clients

```plaintext
deprecated SEMATTRS_DB_SYSTEM ("db.system")
-> incubated(unstable/experimental)+deprecated ATTR_DB_SYSTEM ("db.system")
-> stable ATTR_DB_SYSTEM_NAME ("db.system.name")

deprecated DBSYSTEMVALUES_SQLITE ("sqlite")
-> incubated(unstable/experimental) DB_SYSTEM_VALUE_SQLITE ("sqlite").
   It's not formally deprecated, meaning it doesn't have `@deprecated` JSDoc
   comment in `@opentelemetry/semantic-conventions` package, but effectively
   those are enum values of deprecated attribute `ATTR_DB_SYSTEM`
-> stable DB_SYSTEM_NAME_VALUE_SQLITE ("sqlite")
```

#### Kysely client

```plaintext
deprecated SEMATTRS_DB_STATEMENT ("db.statement")
-> incubated(unstable/experimental)+deprecated ATTR_DB_STATEMENT ("db.statement")
-> stable ATTR_DB_QUERY_TEXT ("db.query.text")
```

#### @effect/opentelemetry/Resource.ts

```plaintext
deprecated SEMRESATTRS_SERVICE_NAME ("service.name")
-> stable ATTR_SERVICE_NAME ("service.name")

deprecated SEMRESATTRS_TELEMETRY_SDK_NAME ("telemetry.sdk.name")
-> stable ATTR_TELEMETRY_SDK_NAME ("telemetry.sdk.name")

deprecated SEMRESATTRS_TELEMETRY_SDK_LANGUAGE ("telemetry.sdk.language")
-> stable ATTR_TELEMETRY_SDK_LANGUAGE ("telemetry.sdk.language")

deprecated TELEMETRYSDKLANGUAGEVALUES_NODEJS ("nodejs")
-> stable TELEMETRY_SDK_LANGUAGE_VALUE_NODEJS ("nodejs")

deprecated TELEMETRYSDKLANGUAGEVALUES_WEBJS ("webjs")
-> stable TELEMETRY_SDK_LANGUAGE_VALUE_WEBJS ("webjs")

deprecated SEMRESATTRS_SERVICE_VERSION ("service.version")
-> stable ATTR_SERVICE_VERSION ("service.version")
```

#### @effect/sql/statement.ts

```plaintext
SEMATTRS_DB_OPERATION ("db.operation")
-> incubated(unstable/experimental)+deprecated ATTR_DB_OPERATION ("db.operation")
-> ATTR_DB_OPERATION_NAME ("db.operation.name")

deprecated SEMATTRS_DB_STATEMENT ("db.statement")
-> incubated(unstable/experimental)+deprecated ATTR_DB_STATEMENT ("db.statement")
-> stable ATTR_DB_QUERY_TEXT ("db.query.text")

```

... etc I've added a few more patch changes in the following commit, but I'm tired (I wrote the above description by hand) and don't care about writing such a detailed description anymore. Every other change that's left to mention here replaces strings with the same strings imported from the `@opentelemetry/semantic-conventions` package.

</details>