### PR TITLE
feat: Add Struct.entries

### DIFF
--- a/.changeset/curvy-sloths-tickle.md
+++ b/.changeset/curvy-sloths-tickle.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Add `Struct.entries` function

--- a/.changeset/curvy-sloths-tickle.md
+++ b/.changeset/curvy-sloths-tickle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Struct.entries` function

--- a/packages/effect/dtslint/Struct.tst.ts
+++ b/packages/effect/dtslint/Struct.tst.ts
@@ -328,4 +328,15 @@ describe("Struct", () => {
         .type.toBe<{ [x: `a${string}`]: number }>()
     })
   })
+
+  describe("entries", () => {
+    it("excludes symbol keys", () => {
+      const c = Symbol("c")
+      const value = { a: "a", b: 1, [c]: 2 }
+      // should not include symbol keys
+      expect(Struct.entries(value)).type.toBe<Array<["a" | "b", string | number]>>()
+      // when the object is passed as a parameter, the values should be narrowed
+      expect(Struct.entries({ a: "a", b: 1, [c]: 2 })).type.toBe<Array<["a" | "b", "a" | 1]>>()
+    })
+  })
 })

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -221,23 +221,24 @@ export const get =
 export const keys = <T extends {}>(o: T): Array<(keyof T) & string> => Object.keys(o) as Array<(keyof T) & string>
 
 /**
- * Retrieves the object entries in a typed manner
+ * Retrieves the entries (key-value pairs) of an object, where keys are strings,
+ * in a type-safe manner. Symbol keys are excluded from the result.
  *
  * @example
  * ```ts
  * import * as assert from "node:assert"
  * import { Struct } from "effect"
  *
- * const value = {
- *   a: 1,
- *   b: 2
- * }
+ * const c = Symbol("c")
+ * const value = { a: "foo", b: 1, [c]: true }
  *
  * const entries: Array<["a" | "b", number]> = Struct.entries(value)
  *
- * assert.deepStrictEqual(entries, [["a", 1], ["b", 2]])
+ * assert.deepStrictEqual(entries, [["a", "foo"], ["b", 1]])
  * ```
  *
- * @since 3.16.17
+ * @since 3.17.0
  */
-export const entries = <R>(obj: R): [keyof R, R[keyof R]][] => Object.entries(obj as any) as [keyof R, any][]
+export const entries = <const R>(obj: R): Array<[keyof R & string, R[keyof R & string]]> =>
+  Object.entries(obj as any) as any
+

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -241,4 +241,3 @@ export const keys = <T extends {}>(o: T): Array<(keyof T) & string> => Object.ke
  */
 export const entries = <const R>(obj: R): Array<[keyof R & string, R[keyof R & string]]> =>
   Object.entries(obj as any) as any
-

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -219,3 +219,25 @@ export const get =
  * @since 3.6.0
  */
 export const keys = <T extends {}>(o: T): Array<(keyof T) & string> => Object.keys(o) as Array<(keyof T) & string>
+
+/**
+ * Retrieves the object entries in a typed manner
+ *
+ * @example
+ * ```ts
+ * import * as assert from "node:assert"
+ * import { Struct } from "effect"
+ *
+ * const value = {
+ *   a: 1,
+ *   b: 2
+ * }
+ *
+ * const entries: Array<["a" | "b", number]> = Struct.entries(value)
+ *
+ * assert.deepStrictEqual(entries, [["a", 1], ["b", 2]])
+ * ```
+ *
+ * @since 3.16.17
+ */
+export const entries = <R>(obj: R): [keyof R, R[keyof R]][] => Object.entries(obj as any) as [keyof R, any][]

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -232,7 +232,7 @@ export const keys = <T extends {}>(o: T): Array<(keyof T) & string> => Object.ke
  * const c = Symbol("c")
  * const value = { a: "foo", b: 1, [c]: true }
  *
- * const entries: Array<["a" | "b", number]> = Struct.entries(value)
+ * const entries: Array<["a" | "b", string | number]> = Struct.entries(value)
  *
  * assert.deepStrictEqual(entries, [["a", "foo"], ["b", 1]])
  * ```

--- a/packages/effect/test/Struct.test.ts
+++ b/packages/effect/test/Struct.test.ts
@@ -120,4 +120,8 @@ describe("Struct", () => {
     strictEqual(pipe({ a: 1 }, Struct.get("a")), 1)
     strictEqual(pipe({}, Struct.get("a")), undefined)
   })
+
+  it("entries", () => {
+    deepStrictEqual(Struct.entries({ a: 1, b: 2 }), [["a", 1], ["b", 2]])
+  })
 })

--- a/packages/effect/test/Struct.test.ts
+++ b/packages/effect/test/Struct.test.ts
@@ -122,6 +122,8 @@ describe("Struct", () => {
   })
 
   it("entries", () => {
-    deepStrictEqual(Struct.entries({ a: 1, b: 2 }), [["a", 1], ["b", 2]])
+    const c = Symbol("c")
+    // should not include symbol keys
+    deepStrictEqual(Struct.entries({ a: "a", b: 1, [c]: 2 }), [["a", "a"], ["b", 1]])
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `Struct.entries` as a better-typed alternative to `Object.entries`.
The new function preserves the key type.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
