### PR TITLE
fix: properly form otlp urls

### DIFF
--- a/.changeset/huge-olives-sink.md
+++ b/.changeset/huge-olives-sink.md
@@ -2,4 +2,4 @@
 "@effect/opentelemetry": patch
 ---
 
-properly form otlp urls
+use URL constructor for joining url's in Otlp.layer

--- a/.changeset/huge-olives-sink.md
+++ b/.changeset/huge-olives-sink.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+properly form otlp urls

--- a/packages/opentelemetry/src/Otlp.ts
+++ b/packages/opentelemetry/src/Otlp.ts
@@ -35,7 +35,7 @@ export const layer = (options: {
   Layer.mergeAll(
     OtlpLogger.layer({
       replaceLogger: options.replaceLogger,
-      url: `${options.baseUrl}/v1/logs`,
+      url: new URL("/v1/logs", options.baseUrl).toString(),
       resource: options.resource,
       headers: options.headers,
       exportInterval: options.loggerExportInterval,
@@ -44,14 +44,14 @@ export const layer = (options: {
       excludeLogSpans: options.loggerExcludeLogSpans
     }),
     OtlpMetrics.layer({
-      url: `${options.baseUrl}/v1/metrics`,
+      url: new URL("/v1/metrics", options.baseUrl).toString(),
       resource: options.resource,
       headers: options.headers,
       exportInterval: options.metricsExportInterval,
       shutdownTimeout: options.shutdownTimeout
     }),
     OtlpTracer.layer({
-      url: `${options.baseUrl}/v1/traces`,
+      url: new URL("/v1/traces", options.baseUrl).toString(),
       resource: options.resource,
       headers: options.headers,
       exportInterval: options.tracerExportInterval,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Using `baseUrl` with a trailing `/` leads to nothing being exported. When using a `URL` object + `toString()` method there is always a trailing slash..
```ts
Otlp.layer({ baseUrl: (yield* Config.url('ENDPOINT')).toString() }) // will end up exporting to `http://endpoint//v1/traces`
```

To fix this we should always use the `URL` module to construct urls..


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
