### PR TITLE
feat: add resume endpoint to WorkflowProxy

### DIFF
--- a/.changeset/good-hornets-sin.md
+++ b/.changeset/good-hornets-sin.md
@@ -1,0 +1,5 @@
+---
+"@effect/workflow": patch
+---
+
+Add a new endpoint to the Workflow Proxy to resume a workflow that has been suspended

--- a/packages/workflow/src/WorkflowProxyServer.ts
+++ b/packages/workflow/src/WorkflowProxyServer.ts
@@ -48,6 +48,10 @@ export const layerHttpApi = <
             workflow.name + "Discard" as any,
             ({ payload }: { payload: any }) => workflow.execute(payload, { discard: true } as any)
           )
+          .handle(
+            workflow.name + "Resume" as any,
+            ({ payload }: { payload: any }) => workflow.resume(payload.executionId)
+          )
       }
       return handlers as HttpApiBuilder.Handlers<never, never, never>
     })
@@ -75,8 +79,10 @@ export const layerRpcHandlers = <
       const workflow = workflow_ as Workflow.Workflow<string, any, any, any>
       const tag = `${prefix}${workflow.name}`
       const tagDiscard = `${tag}Discard`
+      const tagResume = `${tag}Resume`
       const key = `@effect/rpc/Rpc/${tag}`
       const keyDiscard = `${key}Discard`
+      const keyResume = `${key}Resume`
       handlers.set(key, {
         context,
         tag,
@@ -86,6 +92,11 @@ export const layerRpcHandlers = <
         context,
         tag: tagDiscard,
         handler: (payload: any) => workflow.execute(payload, { discard: true } as any) as any
+      } as any)
+      handlers.set(keyResume, {
+        context,
+        tag: tagResume,
+        handler: (payload: any) => workflow.resume(payload.executionId) as any
       } as any)
     }
     return Context.unsafeMake(handlers)
@@ -99,5 +110,5 @@ export type RpcHandlers<Workflows extends Workflow.Any, Prefix extends string> =
   infer _Payload,
   infer _Success,
   infer _Error
-> ? Rpc.Handler<`${Prefix}${_Name}`> | Rpc.Handler<`${Prefix}${_Name}Discard`>
+> ? Rpc.Handler<`${Prefix}${_Name}`> | Rpc.Handler<`${Prefix}${_Name}Discard`> | Rpc.Handler<`${Prefix}${_Name}Resume`>
   : never


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->


Expose a new endpoint to the Workflow Proxy to resume a workflow using its `executionId`. For example, using the `WorkflowProxyServer.layerHttpApi`:
```ts
yield* client.workflows.MyWorkflowResume({ executionId: '...' })
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
