### PR TITLE
feat: onFailure callback for SuspendOnFailure

### DIFF
--- a/.changeset/famous-masks-cover.md
+++ b/.changeset/famous-masks-cover.md
@@ -1,0 +1,5 @@
+---
+"@effect/workflow": patch
+---
+
+Provide an option to pass a callback when a failure occurs before suspending when using SuspendOnFailure


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

When using `SuspendOnFailure=true` annotation for a Workflow, it is difficult to know that the workflow is suspended because a failure happened. By providing an effectful callback in the annotation, we can for example log the `Cause` and `executionId` in a descriptive message explaining how to resume the workflow once the error has been fixed:

```ts
const MyWorkflow = Workflow.make({})
  .annotate(Workflow.SuspendOnFailure, {
    onFailure: ({ cause, instance }) =>
      Console.log(
        "Workflow is suspended because a failure occurred. Once it is fixed, you can resume the workflow using the executionId provided in this log.",
        { executionId: instance.executionId, workflow: instance.workflow.name, cause }
      )
  })
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
