### PR TITLE
Adds DST disambiguation support to the DateTime library and fix a timezone offset calculation bug.

### DIFF
--- a/.changeset/warm-berries-bow.md
+++ b/.changeset/warm-berries-bow.md
@@ -1,0 +1,26 @@
+---
+"effect": minor
+---
+
+## DateTime Library: DST Disambiguation & Timezone Fix
+
+This release addresses timezone handling issues and adds comprehensive DST (Daylight Saving Time) disambiguation support to the DateTime library.
+
+### Bug Fix: Timezone Offset Calculation
+
+Fixed incorrect UTC conversions when using `DateTime.makeZoned` with `adjustForTimeZone: true`. The issue was caused by improper offset calculation in the `makeZonedFromAdjusted` function, where `calculateNamedOffset` was called with the wrong reference point. The fix implements a precise offset sampling algorithm that tests candidate UTC times and validates them against the target local time.
+
+**Example of the fix:**
+
+- Input: 01:00 Athens time on March 30, 2025
+- Before: 2025-03-29T22:00:00.000Z (incorrect)
+- After: 2025-03-29T23:00:00.000Z (correct UTC conversion)
+
+### New Feature: DST Disambiguation Support
+
+Added four disambiguation strategies for handling DST edge cases:
+
+- `'compatible'` - Maintains backward compatibility
+- `'earlier'` - Choose earlier time during ambiguous periods (default)
+- `'later'` - Choose later time during ambiguous periods
+- `'reject'` - Throw error for ambiguous times

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -161,6 +161,59 @@ export declare namespace DateTime {
   export interface Proto extends Pipeable, Inspectable {
     readonly [TypeId]: TypeId
   }
+
+  /**
+   * Strategies for resolving ambiguous local times during DST transitions.
+   *
+   * When converting local time to UTC, two scenarios can create ambiguity:
+   *
+   * 1. **Fall-back transitions**: When clocks move backward (e.g., 02:00 → 01:00),
+   *    the same local time occurs twice. Example: "01:30" happens twice.
+   *
+   * 2. **Spring-forward transitions**: When clocks move forward (e.g., 02:00 → 03:00),
+   *    some local times don't exist. Example: "02:30" never occurs.
+   *
+   * **Disambiguation strategies:**
+   *
+   * - `"compatible"`: Behavior matching Temporal API and legacy JavaScript Date and moment.js.
+   *   For repeated times, chooses the earlier occurrence. For gap times, chooses the later interpretation.
+   *
+   * - `"earlier"`: **Default behavior** for backward compatibility with previous Effect versions.
+   *   For repeated times, always choose the earlier occurrence. For gap times, choose the time before the gap.
+   *
+   * - `"later"`: For repeated times, always choose the later occurrence.
+   *   For gap times, choose the time after the gap.
+   *
+   * - `"reject"`: Throw an `IllegalArgumentException` when encountering ambiguous or non-existent times.
+   *
+   * @example
+   * ```ts
+   * import { DateTime } from "effect"
+   *
+   * // Fall-back example: 01:30 on Nov 2, 2025 in New York happens twice
+   * const ambiguousTime = { year: 2025, month: 11, day: 2, hours: 1, minutes: 30 }
+   * const timeZone = DateTime.zoneUnsafeMakeNamed("America/New_York")
+   *
+   * DateTime.makeZoned(ambiguousTime, { timeZone, adjustForTimeZone: true, disambiguation: "earlier" })
+   * // Earlier occurrence (DST time): 2025-11-02T05:30:00.000Z
+   *
+   * DateTime.makeZoned(ambiguousTime, { timeZone, adjustForTimeZone: true, disambiguation: "later" })
+   * // Later occurrence (standard time): 2025-11-02T06:30:00.000Z
+   *
+   * // Gap example: 02:30 on Mar 9, 2025 in New York doesn't exist
+   * const gapTime = { year: 2025, month: 3, day: 9, hours: 2, minutes: 30 }
+   *
+   * DateTime.makeZoned(gapTime, { timeZone, adjustForTimeZone: true, disambiguation: "earlier" })
+   * // Time before gap: 2025-03-09T06:30:00.000Z (01:30 EST)
+   *
+   * DateTime.makeZoned(gapTime, { timeZone, adjustForTimeZone: true, disambiguation: "later" })
+   * // Time after gap: 2025-03-09T07:30:00.000Z (03:30 EDT)
+   * ```
+   *
+   * @since 3.18.0
+   * @category models
+   */
+  export type Disambiguation = "compatible" | "earlier" | "later" | "reject"
 }
 
 /**
@@ -332,24 +385,52 @@ export const unsafeMake: <A extends DateTime.Input>(input: A) => DateTime.Preser
  * `adjustForTimeZone` is set to `true`. In that case, the input is treated as
  * already in the time zone.
  *
+ * When `adjustForTimeZone` is true and ambiguous times occur during DST transitions,
+ * the `disambiguation` option controls how to resolve the ambiguity:
+ * - `compatible` (default): Choose earlier time for repeated times, later for gaps
+ * - `earlier`: Always choose the earlier of two possible times
+ * - `later`: Always choose the later of two possible times
+ * - `reject`: Throw an error when ambiguous times are encountered
+ *
  * @since 3.6.0
  * @category constructors
  * @example
  * ```ts
  * import { DateTime } from "effect"
  *
+ * // Basic usage
  * DateTime.unsafeMakeZoned(new Date(), { timeZone: "Europe/London" })
+ *
+ * // With disambiguation for DST transitions
+ * DateTime.unsafeMakeZoned(
+ *   { year: 2025, month: 11, day: 2, hours: 1, minutes: 30 },
+ *   {
+ *     timeZone: "America/New_York",
+ *     adjustForTimeZone: true,
+ *     disambiguation: "later" // Choose second occurrence of 1:30 AM
+ *   }
+ * )
  * ```
  */
 export const unsafeMakeZoned: (input: DateTime.Input, options?: {
   readonly timeZone?: number | string | TimeZone | undefined
   readonly adjustForTimeZone?: boolean | undefined
+  readonly disambiguation?: DateTime.Disambiguation | undefined
 }) => Zoned = Internal.unsafeMakeZoned
 
 /**
  * Create a `DateTime.Zoned` using `DateTime.make` and a time zone.
  *
- * The input is treated as UTC and then the time zone is attached.
+ * The input is treated as UTC and then the time zone is attached, unless
+ * `adjustForTimeZone` is set to `true`. In that case, the input is treated as
+ * already in the time zone.
+ *
+ * When `adjustForTimeZone` is true and ambiguous times occur during DST transitions,
+ * the `disambiguation` option controls how to resolve the ambiguity:
+ * - `compatible` (default): Choose earlier time for repeated times, later for gaps
+ * - `earlier`: Always choose the earlier of two possible times
+ * - `later`: Always choose the later of two possible times
+ * - `reject`: Throw an error when ambiguous times are encountered
  *
  * If the date time input or time zone is invalid, `None` will be returned.
  *
@@ -359,7 +440,18 @@ export const unsafeMakeZoned: (input: DateTime.Input, options?: {
  * ```ts
  * import { DateTime } from "effect"
  *
+ * // Basic usage
  * DateTime.makeZoned(new Date(), { timeZone: "Europe/London" })
+ *
+ * // Handle DST ambiguity during fall-back
+ * DateTime.makeZoned(
+ *   { year: 2025, month: 11, day: 2, hours: 1, minutes: 30 },
+ *   {
+ *     timeZone: "America/New_York",
+ *     adjustForTimeZone: true,
+ *     disambiguation: "earlier" // Choose first occurrence of 1:30 AM
+ *   }
+ * )
  * ```
  */
 export const makeZoned: (
@@ -367,6 +459,7 @@ export const makeZoned: (
   options?: {
     readonly timeZone?: number | string | TimeZone | undefined
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }
 ) => Option.Option<Zoned> = Internal.makeZoned
 
@@ -491,9 +584,11 @@ export const toUtc: (self: DateTime) => Utc = Internal.toUtc
 export const setZone: {
   (zone: TimeZone, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): (self: DateTime) => Zoned
   (self: DateTime, zone: TimeZone, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): Zoned
 } = Internal.setZone
 
@@ -519,9 +614,11 @@ export const setZone: {
 export const setZoneOffset: {
   (offset: number, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): (self: DateTime) => Zoned
   (self: DateTime, offset: number, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): Zoned
 } = Internal.setZoneOffset
 
@@ -616,9 +713,11 @@ export const zoneToString: (self: TimeZone) => string = Internal.zoneToString
 export const setZoneNamed: {
   (zoneId: string, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): (self: DateTime) => Option.Option<Zoned>
   (self: DateTime, zoneId: string, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): Option.Option<Zoned>
 } = Internal.setZoneNamed
 
@@ -642,9 +741,11 @@ export const setZoneNamed: {
 export const unsafeSetZoneNamed: {
   (zoneId: string, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): (self: DateTime) => Zoned
   (self: DateTime, zoneId: string, options?: {
     readonly adjustForTimeZone?: boolean | undefined
+    readonly disambiguation?: DateTime.Disambiguation | undefined
   }): Zoned
 } = Internal.unsafeSetZoneNamed
 

--- a/packages/effect/test/DateTime.disambiguation.test.ts
+++ b/packages/effect/test/DateTime.disambiguation.test.ts
@@ -1,0 +1,551 @@
+import { describe, it } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import { DateTime, Option } from "effect"
+
+describe("DateTime DST Disambiguation", () => {
+  describe("Spring Forward Gap Times (non-existent times)", () => {
+    it("should handle Athens spring forward gap times", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+
+      // 02:30 on March 30, 2025 doesn't exist (clocks jump 02:00 → 03:00)
+      const gapTime = { year: 2025, month: 3, day: 30, hours: 2, minutes: 30, seconds: 0, millis: 0 }
+
+      // Compatible and later should choose time after gap
+      const compatibleResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "compatible"
+      })
+      const laterResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "later"
+      })
+
+      if (Option.isSome(compatibleResult) && Option.isSome(laterResult)) {
+        strictEqual(DateTime.formatIso(DateTime.toUtc(compatibleResult.value)), "2025-03-30T00:30:00.000Z")
+        strictEqual(DateTime.formatIso(DateTime.toUtc(laterResult.value)), "2025-03-30T00:30:00.000Z")
+      } else {
+        throw new Error("Gap time handling failed")
+      }
+
+      // Earlier should choose time before gap
+      const earlierResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "earlier"
+      })
+
+      if (Option.isSome(earlierResult)) {
+        strictEqual(DateTime.formatIso(DateTime.toUtc(earlierResult.value)), "2025-03-30T00:30:00.000Z")
+      }
+
+      // Reject should succeed for gap times
+      const rejectResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "reject"
+      })
+
+      if (Option.isSome(rejectResult)) {
+        strictEqual(DateTime.formatIso(DateTime.toUtc(rejectResult.value)), "2025-03-30T00:30:00.000Z")
+      } else {
+        throw new Error("Gap time with reject should succeed")
+      }
+    })
+
+    it("should handle New York spring forward gap times", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("America/New_York")
+
+      // 02:30 on March 9, 2025 doesn't exist (clocks jump 02:00 → 03:00)
+      const gapTime = { year: 2025, month: 3, day: 9, hours: 2, minutes: 30, seconds: 0, millis: 0 }
+
+      const compatibleResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "compatible"
+      })
+      const earlierResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "earlier"
+      })
+      const laterResult = DateTime.makeZoned(gapTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "later"
+      })
+
+      if (Option.isSome(compatibleResult) && Option.isSome(earlierResult) && Option.isSome(laterResult)) {
+        strictEqual(DateTime.formatIso(DateTime.toUtc(compatibleResult.value)), "2025-03-09T07:30:00.000Z")
+        strictEqual(DateTime.formatIso(DateTime.toUtc(earlierResult.value)), "2025-03-09T06:30:00.000Z")
+        strictEqual(DateTime.formatIso(DateTime.toUtc(laterResult.value)), "2025-03-09T07:30:00.000Z")
+      } else {
+        throw new Error("Gap time handling failed")
+      }
+    })
+
+    it("should handle different gap times consistently", () => {
+      const testCases = [
+        {
+          zone: "Europe/Athens",
+          time: { year: 2025, month: 3, day: 30, hours: 3, minutes: 0 },
+          expected: {
+            compatible: "2025-03-30T01:00:00.000Z",
+            earlier: "2025-03-30T00:00:00.000Z",
+            later: "2025-03-30T01:00:00.000Z"
+          }
+        },
+        {
+          zone: "America/New_York",
+          time: { year: 2025, month: 3, day: 9, hours: 2, minutes: 0 },
+          expected: {
+            compatible: "2025-03-09T07:00:00.000Z",
+            earlier: "2025-03-09T06:00:00.000Z",
+            later: "2025-03-09T07:00:00.000Z"
+          }
+        }
+      ]
+
+      testCases.forEach(({ expected, time, zone }) => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed(zone)
+        const parts = { ...time, seconds: 0, millis: 0 }
+
+        const strategies = ["compatible", "earlier", "later"] as const
+        strategies.forEach((strategy) => {
+          const result = DateTime.makeZoned(parts, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy
+          })
+
+          if (Option.isSome(result)) {
+            const utcString = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(utcString, expected[strategy], `Failed for ${zone} with ${strategy} strategy`)
+          } else {
+            throw new Error(`Expected success for ${zone} with ${strategy} strategy`)
+          }
+        })
+      })
+    })
+  })
+
+  describe("Fall Back Ambiguous Times (repeated times)", () => {
+    it("should handle Athens fall back ambiguous times", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+
+      // 03:00 on October 26, 2025 happens twice (clocks fall back 03:00 → 02:00)
+      const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3, minutes: 0, seconds: 0, millis: 0 }
+
+      const compatibleResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "compatible"
+      })
+      const earlierResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "earlier"
+      })
+      const laterResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "later"
+      })
+
+      if (Option.isSome(compatibleResult) && Option.isSome(earlierResult) && Option.isSome(laterResult)) {
+        // Compatible and earlier should choose the first occurrence
+        strictEqual(DateTime.formatIso(DateTime.toUtc(compatibleResult.value)), "2025-10-26T00:00:00.000Z")
+        strictEqual(DateTime.formatIso(DateTime.toUtc(earlierResult.value)), "2025-10-26T00:00:00.000Z")
+        // Later should choose the second occurrence
+        strictEqual(DateTime.formatIso(DateTime.toUtc(laterResult.value)), "2025-10-26T01:00:00.000Z")
+      } else {
+        throw new Error("Ambiguous time handling failed")
+      }
+
+      // Reject should fail
+      const rejectResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "reject"
+      })
+      strictEqual(Option.isNone(rejectResult), true)
+    })
+
+    it("should handle New York fall back ambiguous times", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("America/New_York")
+
+      // 01:30 on November 2, 2025 happens twice
+      const ambiguousTime = { year: 2025, month: 11, day: 2, hours: 1, minutes: 30, seconds: 0, millis: 0 }
+
+      const compatibleResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "compatible"
+      })
+      const earlierResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "earlier"
+      })
+      const laterResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "later"
+      })
+
+      if (Option.isSome(compatibleResult) && Option.isSome(earlierResult) && Option.isSome(laterResult)) {
+        strictEqual(DateTime.formatIso(DateTime.toUtc(compatibleResult.value)), "2025-11-02T05:30:00.000Z")
+        strictEqual(DateTime.formatIso(DateTime.toUtc(earlierResult.value)), "2025-11-02T05:30:00.000Z")
+        strictEqual(DateTime.formatIso(DateTime.toUtc(laterResult.value)), "2025-11-02T06:30:00.000Z")
+      } else {
+        throw new Error("Ambiguous time handling failed")
+      }
+    })
+
+    it("should handle multiple timezone ambiguous times", () => {
+      const testCases = [
+        {
+          zone: "Europe/London",
+          time: { year: 2025, month: 10, day: 26, hours: 1, minutes: 30 },
+          expected: {
+            compatible: "2025-10-26T00:30:00.000Z",
+            earlier: "2025-10-26T00:30:00.000Z",
+            later: "2025-10-26T01:30:00.000Z"
+          }
+        },
+        {
+          zone: "Europe/Berlin",
+          time: { year: 2025, month: 10, day: 26, hours: 2, minutes: 30 },
+          expected: {
+            compatible: "2025-10-26T00:30:00.000Z",
+            earlier: "2025-10-26T00:30:00.000Z",
+            later: "2025-10-26T01:30:00.000Z"
+          }
+        }
+      ]
+
+      testCases.forEach(({ expected, time, zone }) => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed(zone)
+        const parts = { ...time, seconds: 0, millis: 0 }
+
+        const strategies = ["compatible", "earlier", "later"] as const
+        strategies.forEach((strategy) => {
+          const result = DateTime.makeZoned(parts, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy
+          })
+
+          if (Option.isSome(result)) {
+            const utcString = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(utcString, expected[strategy], `Failed for ${zone} with ${strategy} strategy`)
+          } else {
+            throw new Error(`Expected success for ${zone} with ${strategy} strategy`)
+          }
+        })
+      })
+    })
+  })
+
+  describe("Normal Times (no DST transition)", () => {
+    it("should handle normal times correctly across timezones", () => {
+      const testCases = [
+        {
+          zone: "Europe/Athens",
+          time: { year: 2025, month: 3, day: 27, hours: 1, minutes: 0 }, // Before DST (safe date)
+          expected: "2025-03-26T23:00:00.000Z" // Temporal confirmed
+        },
+        {
+          zone: "Europe/Athens",
+          time: { year: 2025, month: 3, day: 30, hours: 4, minutes: 0 }, // After DST
+          expected: "2025-03-30T01:00:00.000Z"
+        },
+        {
+          zone: "America/New_York",
+          time: { year: 2025, month: 3, day: 9, hours: 1, minutes: 0 }, // Before DST
+          expected: "2025-03-09T06:00:00.000Z"
+        },
+        {
+          zone: "Australia/Sydney",
+          time: { year: 2025, month: 4, day: 6, hours: 1, minutes: 0 }, // Before DST ends
+          expected: "2025-04-05T14:00:00.000Z"
+        },
+        {
+          zone: "Europe/London",
+          time: { year: 2025, month: 3, day: 29, hours: 1, minutes: 0 }, // Day before DST transition
+          expected: "2025-03-29T01:00:00.000Z"
+        }
+      ]
+
+      testCases.forEach(({ expected, time, zone }) => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed(zone)
+        const parts = { ...time, seconds: 0, millis: 0 }
+
+        // All disambiguation strategies should return the same result for normal times
+        const strategies = ["compatible", "earlier", "later", "reject"] as const
+        strategies.forEach((strategy) => {
+          const result = DateTime.makeZoned(parts, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy
+          })
+
+          if (Option.isSome(result)) {
+            const utcString = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(
+              utcString,
+              expected,
+              `Failed for ${zone} at ${time.hours}:${time.minutes} with ${strategy} strategy`
+            )
+          } else {
+            throw new Error(`Expected success for normal time in ${zone} with ${strategy} strategy`)
+          }
+        })
+      })
+    })
+  })
+
+  describe("Edge Cases and Error Handling", () => {
+    it("should handle reject disambiguation for gap times correctly", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+      const gapTime = { year: 2025, month: 3, day: 30, hours: 2, minutes: 30, seconds: 0, millis: 0 }
+
+      // Reject is allowed for gap times, only throws for ambiguous times
+      const result = DateTime.makeZoned(gapTime, { timeZone, adjustForTimeZone: true, disambiguation: "reject" })
+      if (Option.isSome(result)) {
+        const utcString = DateTime.formatIso(DateTime.toUtc(result.value))
+        strictEqual(utcString, "2025-03-30T00:30:00.000Z") // Should work correctly
+      } else {
+        throw new Error("Gap time with reject should succeed")
+      }
+    })
+
+    it("should throw errors for reject disambiguation with ambiguous times", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+      const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3, minutes: 0, seconds: 0, millis: 0 }
+
+      try {
+        DateTime.unsafeMakeZoned(ambiguousTime, { timeZone, adjustForTimeZone: true, disambiguation: "reject" })
+        throw new Error("Expected exception for ambiguous time with reject disambiguation")
+      } catch (error) {
+        strictEqual(error instanceof Error, true)
+        if (error instanceof Error) {
+          strictEqual(error.message.includes("Ambiguous time"), true)
+        }
+      }
+    })
+
+    it("should work with different minute values", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("America/New_York")
+
+      // Test different minutes during gap time
+      const minutes = [0, 15, 30, 45]
+      minutes.forEach((minute) => {
+        const gapTime = { year: 2025, month: 3, day: 9, hours: 2, minutes: minute, seconds: 0, millis: 0 }
+
+        const result = DateTime.makeZoned(gapTime, {
+          timeZone,
+          adjustForTimeZone: true,
+          disambiguation: "compatible"
+        })
+
+        if (Option.isSome(result)) {
+          const utcString = DateTime.formatIso(DateTime.toUtc(result.value))
+          // Should consistently handle different minute values within gap
+          strictEqual(utcString.includes("2025-03-09T07:"), true, `Failed for minute ${minute}`)
+        } else {
+          throw new Error(`Expected success for gap time with minute ${minute}`)
+        }
+      })
+    })
+  })
+
+  describe("Disambiguation Strategy Defaults", () => {
+    it("should use earlier as default disambiguation for backward compatibility", () => {
+      const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+      const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3, minutes: 0, seconds: 0, millis: 0 }
+
+      // Without specifying disambiguation, should default to 'earlier' for backward compatibility
+      const defaultResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true
+      })
+      const explicitResult = DateTime.makeZoned(ambiguousTime, {
+        timeZone,
+        adjustForTimeZone: true,
+        disambiguation: "earlier"
+      })
+
+      if (Option.isSome(defaultResult) && Option.isSome(explicitResult)) {
+        const defaultUtc = DateTime.formatIso(DateTime.toUtc(defaultResult.value))
+        const explicitUtc = DateTime.formatIso(DateTime.toUtc(explicitResult.value))
+        strictEqual(
+          defaultUtc,
+          explicitUtc,
+          "Default disambiguation should match explicit 'earlier' for backward compatibility"
+        )
+      } else {
+        throw new Error("Default disambiguation failed")
+      }
+    })
+  })
+
+  describe("Standard DST Conformance", () => {
+    describe("Gap Time Validation", () => {
+      it("should handle Athens 02:30 gap time correctly", () => {
+        // This is the problematic case where Effect previously differed
+        const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+        const gapTime = { year: 2025, month: 3, day: 30, hours: 2, minutes: 30, seconds: 0, millis: 0 }
+
+        // Expected results (all strategies return the same result for this gap time)
+        const expectedResult = "2025-03-30T00:30:00.000Z"
+
+        const strategies = ["compatible", "earlier", "later"] as const
+
+        strategies.forEach((strategy) => {
+          const result = DateTime.makeZoned(gapTime, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy
+          })
+
+          if (Option.isSome(result)) {
+            const utcResult = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(
+              utcResult,
+              expectedResult,
+              `Athens 02:30 gap time with '${strategy}' strategy should work correctly`
+            )
+          } else {
+            throw new Error(`Gap time should not return None for '${strategy}' strategy`)
+          }
+        })
+      })
+
+      it("should handle Athens 03:00 gap time correctly", () => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+        const gapTime = { year: 2025, month: 3, day: 30, hours: 3, minutes: 0, seconds: 0, millis: 0 }
+
+        // Expected results for each strategy
+        const expectedResults = {
+          compatible: "2025-03-30T01:00:00.000Z",
+          earlier: "2025-03-30T00:00:00.000Z",
+          later: "2025-03-30T01:00:00.000Z"
+        }
+
+        Object.entries(expectedResults).forEach(([strategy, expected]) => {
+          const result = DateTime.makeZoned(gapTime, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy as any
+          })
+
+          if (Option.isSome(result)) {
+            const utcResult = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(
+              utcResult,
+              expected,
+              `Athens 03:00 gap time with '${strategy}' strategy should work correctly`
+            )
+          } else {
+            throw new Error(`Gap time should not return None for '${strategy}' strategy`)
+          }
+        })
+      })
+
+      it("should handle New York 02:30 gap time correctly", () => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed("America/New_York")
+        const gapTime = { year: 2025, month: 3, day: 9, hours: 2, minutes: 30, seconds: 0, millis: 0 }
+
+        // Expected results
+        const expectedResults = {
+          compatible: "2025-03-09T07:30:00.000Z",
+          earlier: "2025-03-09T06:30:00.000Z",
+          later: "2025-03-09T07:30:00.000Z"
+        }
+
+        Object.entries(expectedResults).forEach(([strategy, expected]) => {
+          const result = DateTime.makeZoned(gapTime, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy as any
+          })
+
+          if (Option.isSome(result)) {
+            const utcResult = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(
+              utcResult,
+              expected,
+              `New York 02:30 gap time with '${strategy}' strategy should work correctly`
+            )
+          } else {
+            throw new Error(`Gap time should not return None for '${strategy}' strategy`)
+          }
+        })
+      })
+    })
+
+    describe("Ambiguous Time Validation", () => {
+      it("should handle Athens fall-back transitions correctly", () => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+        const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3, minutes: 0, seconds: 0, millis: 0 }
+
+        // Expected results for each strategy
+        const expectedResults = {
+          compatible: "2025-10-26T00:00:00.000Z", // earlier
+          earlier: "2025-10-26T00:00:00.000Z",
+          later: "2025-10-26T01:00:00.000Z"
+        }
+
+        Object.entries(expectedResults).forEach(([strategy, expected]) => {
+          const result = DateTime.makeZoned(ambiguousTime, {
+            timeZone,
+            adjustForTimeZone: true,
+            disambiguation: strategy as any
+          })
+
+          if (Option.isSome(result)) {
+            const utcResult = DateTime.formatIso(DateTime.toUtc(result.value))
+            strictEqual(
+              utcResult,
+              expected,
+              `Athens ambiguous time with '${strategy}' strategy should work correctly`
+            )
+          } else {
+            throw new Error(`Ambiguous time should not return None for '${strategy}' strategy`)
+          }
+        })
+      })
+
+      it("should handle reject strategy properly", () => {
+        const timeZone = DateTime.zoneUnsafeMakeNamed("Europe/Athens")
+
+        // Test gap time with reject (should succeed)
+        const gapTime = { year: 2025, month: 3, day: 30, hours: 2, minutes: 30, seconds: 0, millis: 0 }
+        const gapResult = DateTime.makeZoned(gapTime, {
+          timeZone,
+          adjustForTimeZone: true,
+          disambiguation: "reject"
+        })
+
+        if (Option.isSome(gapResult)) {
+          const utcResult = DateTime.formatIso(DateTime.toUtc(gapResult.value))
+          strictEqual(utcResult, "2025-03-30T00:30:00.000Z", "Gap time with reject should succeed")
+        } else {
+          throw new Error("Gap time with reject should succeed")
+        }
+
+        // Test ambiguous time with reject (should throw)
+        const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3, minutes: 0, seconds: 0, millis: 0 }
+        const ambiguousResult = DateTime.makeZoned(ambiguousTime, {
+          timeZone,
+          adjustForTimeZone: true,
+          disambiguation: "reject"
+        })
+
+        strictEqual(Option.isNone(ambiguousResult), true, "Ambiguous time with reject should return None")
+      })
+    })
+  })
+})


### PR DESCRIPTION
  Type

  - Feature
  - Bug Fix

  Description

  This PR adds DST (Daylight Saving Time) disambiguation support to the DateTime library and fixes a timezone offset calculation bug.

  Key Features Added:

  - DST Disambiguation: New disambiguation parameter with 4 strategies: "compatible", "earlier", "later", and "reject"
  - Timezone Offset Fixes: Corrected UTC conversion when using makeZoned with adjustForTimeZone: true

  Problems Solved:

  1. DST Ambiguity: Previously, the library had no way to handle ambiguous times during DST transitions:
    - Fall-back transitions: When clocks move backward (e.g., 02:00 → 01:00), the same local time occurs twice
    - Spring-forward transitions: When clocks move forward (e.g., 02:00 → 03:00), some local times don't exist
  2. Timezone Offset Bug: Critical bug in makeZonedFromAdjusted where timezone offset calculation was incorrect, causing DateTime values to be off by the UTC
  offset difference.

**Example of the fix:**

- Input: 01:00 Athens time on March 30, 2025
- Before: 2025-03-29T22:00:00.000Z (incorrect)
- After: 2025-03-29T23:00:00.000Z (correct UTC conversion)

  API Changes:

  All functions that accept adjustForTimeZone now also accept optional disambiguation:
  - makeZoned / unsafeMakeZoned
  - setZone / setZoneOffset
  - setZoneNamed / unsafeSetZoneNamed

Defaults to existing Effect.ts DateTime behaviour which matches 'earlier'

  Example Usage:

  // Handle ambiguous time during fall-back transition
  DateTime.makeZoned(
    { year: 2025, month: 11, day: 2, hours: 1, minutes: 30 },
    {
      timeZone: "America/New_York",
      adjustForTimeZone: true,
      disambiguation: "later" // Choose second occurrence of 1:30 AM
    }
  )

  Breaking Changes: None - all changes are backward compatible with "earlier" as the default disambiguation strategy.

  Related

  - Closes #5273
  - Closes #5274 (cancelled previous PR for this feature)
