### PR TITLE
fix(tests): add posibility to chain runif with only, closes #5199

### DIFF
--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -86,13 +86,10 @@ export namespace Vitest {
     | Array<Schema.Schema.Any | FC.Arbitrary<any>>
     | { [K in string]: Schema.Schema.Any | FC.Arbitrary<any> }
 
-  /**
-   * @since 1.0.0
-   */
   export interface Tester<R> extends Vitest.Test<R> {
     skip: Vitest.Test<R>
-    skipIf: (condition: unknown) => Vitest.Test<R>
-    runIf: (condition: unknown) => Vitest.Test<R>
+    skipIf: (condition: unknown) => Tester<R>
+    runIf: (condition: unknown) => Tester<R>
     only: Vitest.Test<R>
     each: <T>(
       cases: ReadonlyArray<T>

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -94,11 +94,9 @@ const makeTester = <R>(
   const skip: Vitest.Vitest.Tester<R>["only"] = (name, self, timeout) =>
     it.skip(name, testOptions(timeout), (ctx) => run(ctx, [ctx], self))
 
-  const skipIf: Vitest.Vitest.Tester<R>["skipIf"] = (condition) => (name, self, timeout) =>
-    it.skipIf(condition)(name, testOptions(timeout), (ctx) => run(ctx, [ctx], self))
+  const skipIf: Vitest.Vitest.Tester<R>["skipIf"] = (condition) => makeTester(mapEffect, it.skipIf(condition) as any)
 
-  const runIf: Vitest.Vitest.Tester<R>["runIf"] = (condition) => (name, self, timeout) =>
-    it.runIf(condition)(name, testOptions(timeout), (ctx) => run(ctx, [ctx], self))
+  const runIf: Vitest.Vitest.Tester<R>["runIf"] = (condition) => makeTester(mapEffect, it.runIf(condition) as any)
 
   const only: Vitest.Vitest.Tester<R>["only"] = (name, self, timeout) =>
     it.only(name, testOptions(timeout), (ctx) => run(ctx, [ctx], self))

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -38,7 +38,6 @@ it.scopedLive.each([1, 2, 3])(
 )
 
 // skip
-
 it.live.skip(
   "live skipped",
   () => Effect.die("skipped anyway")
@@ -65,6 +64,12 @@ it.effect.skipIf(false)("effect skipIf (false)", () => Effect.sync(() => expect(
 
 it.effect.runIf(true)("effect runIf (true)", () => Effect.sync(() => expect(1).toEqual(1)))
 it.effect.runIf(false)("effect runIf (false)", () => Effect.die("not run anyway"))
+
+describe("runIf.only", () => {
+  it.effect.runIf(true)("is not executed", () => Effect.sync(() => expect(true).toBe(false)))
+  it.effect.runIf(true).only("is executed", () => Effect.sync(() => expect(true).toBe(true)))
+  it.effect.runIf(true)("is not executed", () => Effect.sync(() => expect(true).toBe(false)))
+})
 
 // The following test is expected to fail because it simulates a test timeout.
 // Be aware that eventual "failure" of the test is only logged out.


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

- Add the possibility to chain .only after `runIf` as you could with vitest


## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #5199
- Closes #5199
