### PR TITLE
fixed parenthesis in `scripts/clean.mjs`

### DIFF
--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,7 +1,7 @@
 import * as Glob from "glob"
 import * as Fs from "node:fs"
 
-const dirs = [".", ...Glob.sync("packages/*/", ...Glob.sync("packages/ai/*/"))]
+const dirs = [".", ...Glob.sync("packages/*/"), ...Glob.sync("packages/ai/*/")]
 dirs.forEach((pkg) => {
   const files = [".tsbuildinfo", "docs", "build", "dist", "coverage"]
 


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previously, all packages under `packages/ai/` were ignored, because arguments of `Glob.sync` other than the first were ignored. Now the `dirs` array contains correct paths, such as `packages/ai/ai` or `packages/ai/google`.
