### PR TITLE
Improve inference of Metric.mapInput for use in Effect.pipe(...)

### DIFF
--- a/.changeset/grumpy-webs-kiss.md
+++ b/.changeset/grumpy-webs-kiss.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve inference on Metric.mapInput for use in Effect.pipe(...)

--- a/.changeset/grumpy-webs-kiss.md
+++ b/.changeset/grumpy-webs-kiss.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Improve inference on Metric.mapInput for use in Effect.pipe(...)
+Improve inference on Metric.trackSuccessWith for use in Effect.pipe(...)

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -152,6 +152,10 @@ export const make: MetricApply = internal.make
  * @category mapping
  */
 export const mapInput: {
+  <Type, In, Out, In2>(
+    self: Metric<Type, In, Out>,
+    f: (input: In2) => In
+  ): <E, R>(x: Effect.Effect<In2, E, R>) => Effect.Effect<In2, E, R>
   <In, In2>(f: (input: In2) => In): <Type, Out>(self: Metric<Type, In, Out>) => Metric<Type, In2, Out>
   <Type, In, Out, In2>(self: Metric<Type, In, Out>, f: (input: In2) => In): Metric<Type, In2, Out>
 } = internal.mapInput

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -152,10 +152,6 @@ export const make: MetricApply = internal.make
  * @category mapping
  */
 export const mapInput: {
-  <Type, In, Out, In2>(
-    self: Metric<Type, In, Out>,
-    f: (input: In2) => In
-  ): <E, R>(x: Effect.Effect<In2, E, R>) => Effect.Effect<In2, E, R>
   <In, In2>(f: (input: In2) => In): <Type, Out>(self: Metric<Type, In, Out>) => Metric<Type, In2, Out>
   <Type, In, Out, In2>(self: Metric<Type, In, Out>, f: (input: In2) => In): Metric<Type, In2, Out>
 } = internal.mapInput
@@ -681,14 +677,14 @@ export const trackSuccess: {
  * @category aspects
  */
 export const trackSuccessWith: {
-  <Type, In, Out, In2>(
+  <Type, In, Out, A>(
     metric: Metric<Type, In, Out>,
-    f: (value: In2) => In
-  ): <A extends In2, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <A extends In2, E, R, Type, In, Out, In2>(
+    f: (value: Types.NoInfer<A>) => In
+  ): <E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R, Type, In, Out>(
     self: Effect.Effect<A, E, R>,
     metric: Metric<Type, In, Out>,
-    f: (value: In2) => In
+    f: (value: A) => In
   ): Effect.Effect<A, E, R>
 } = internal.trackSuccessWith
 

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -684,7 +684,7 @@ export const trackSuccessWith: {
   <A, E, R, Type, In, Out>(
     self: Effect.Effect<A, E, R>,
     metric: Metric<Type, In, Out>,
-    f: (value: A) => In
+    f: (value: Types.NoInfer<A>) => In
   ): Effect.Effect<A, E, R>
 } = internal.trackSuccessWith
 

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -737,4 +737,72 @@ describe("Metric", () => {
       )
       strictEqual(value._tag, "Some")
     }))
+  describe("mapInput", () => {
+    it.effect("infers types in Effectful pipes", () => {
+      const counter = Metric.counter("counter")
+      const frequency = Metric.frequency("frequency")
+      const gauge = Metric.gauge("gauge")
+      const histogram = Metric.histogram(
+        "histogram",
+        MetricBoundaries.linear({ start: 0, width: 10, count: 11 })
+      )
+      const summary = Metric.summary({
+        name: "summary",
+        maxAge: Duration.minutes(1),
+        maxSize: 10,
+        error: 0,
+        quantiles: [0.25, 0.5, 1]
+      })
+      return Effect.Do.pipe(
+        Effect.let("step1", () => 1),
+        Metric.mapInput(counter, ({ step1 }) => step1),
+        Effect.let("someThingElse", () => ({ a: 3 })),
+        Metric.mapInput(gauge, ({ step1 }) => step1),
+        Metric.mapInput(histogram, ({ step1 }) => step1),
+        Effect.let("anotherPartOfTheState", () => ({ b: "seven" })),
+        Metric.mapInput(summary, ({ step1 }) => step1),
+        Effect.let("step2", () => 4),
+        Effect.let("step3", () => "foo"),
+        Metric.mapInput(counter, ({ step2 }) => step2),
+        Effect.let("irrelevant", () => "irrelevant"),
+        Metric.mapInput(gauge, ({ step2 }) => step2),
+        Metric.mapInput(histogram, ({ step2 }) => step2),
+        Effect.let("moreIrrelevant", () => "moreIrrelevant"),
+        Metric.mapInput(summary, ({ step2 }) => step2),
+        Effect.let("otherStuff", () => ({ x: "otherStuff" })),
+        Metric.mapInput(frequency, ({ step3 }) => step3),
+        Effect.let("step4", () => "bar"),
+        Metric.mapInput(frequency, ({ step4 }) => step4),
+        Effect.bind("results", () =>
+          Effect.all({
+            counter: Metric.value(counter),
+            gauge: Metric.value(gauge),
+            histogram: Metric.value(histogram),
+            summary: Metric.value(summary),
+            frequency: Metric.value(frequency)
+          }))
+      ).pipe(
+        Effect.map(({ results }) => {
+          deepStrictEqual(results.counter, MetricState.counter(5))
+          deepStrictEqual(results.gauge, MetricState.gauge(4))
+          strictEqual(results.histogram.count, 2)
+          strictEqual(results.histogram.sum, 5)
+          strictEqual(results.histogram.min, 1)
+          strictEqual(results.histogram.max, 4)
+          strictEqual(results.summary.count, 2)
+          strictEqual(results.summary.sum, 5)
+          strictEqual(results.summary.min, 1)
+          strictEqual(results.summary.max, 4)
+          deepStrictEqual(results.summary.quantiles.map((x) => x[1]).map(Option.getOrNull), [1, 1, 4])
+          deepStrictEqual(
+            results.frequency.occurrences,
+            new Map([
+              ["bar", 1],
+              ["foo", 1]
+            ])
+          )
+        })
+      )
+    })
+  })
 })

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -737,7 +737,7 @@ describe("Metric", () => {
       )
       strictEqual(value._tag, "Some")
     }))
-  describe("mapInput", () => {
+  describe("trackSuccessWith", () => {
     it.effect("infers types in Effectful pipes", () => {
       const counter = Metric.counter("counter")
       const frequency = Metric.frequency("frequency")
@@ -755,24 +755,24 @@ describe("Metric", () => {
       })
       return Effect.Do.pipe(
         Effect.let("step1", () => 1),
-        Metric.mapInput(counter, ({ step1 }) => step1),
+        Metric.trackSuccessWith(counter, ({ step1 }) => step1),
         Effect.let("someThingElse", () => ({ a: 3 })),
-        Metric.mapInput(gauge, ({ step1 }) => step1),
-        Metric.mapInput(histogram, ({ step1 }) => step1),
+        Metric.trackSuccessWith(gauge, ({ step1 }) => step1),
+        Metric.trackSuccessWith(histogram, ({ step1 }) => step1),
         Effect.let("anotherPartOfTheState", () => ({ b: "seven" })),
-        Metric.mapInput(summary, ({ step1 }) => step1),
+        Metric.trackSuccessWith(summary, ({ step1 }) => step1),
         Effect.let("step2", () => 4),
         Effect.let("step3", () => "foo"),
-        Metric.mapInput(counter, ({ step2 }) => step2),
+        Metric.trackSuccessWith(counter, ({ step2 }) => step2),
         Effect.let("irrelevant", () => "irrelevant"),
-        Metric.mapInput(gauge, ({ step2 }) => step2),
-        Metric.mapInput(histogram, ({ step2 }) => step2),
+        Metric.trackSuccessWith(gauge, ({ step2 }) => step2),
+        Metric.trackSuccessWith(histogram, ({ step2 }) => step2),
         Effect.let("moreIrrelevant", () => "moreIrrelevant"),
-        Metric.mapInput(summary, ({ step2 }) => step2),
+        Metric.trackSuccessWith(summary, ({ step2 }) => step2),
         Effect.let("otherStuff", () => ({ x: "otherStuff" })),
-        Metric.mapInput(frequency, ({ step3 }) => step3),
+        Metric.trackSuccessWith(frequency, ({ step3 }) => step3),
         Effect.let("step4", () => "bar"),
-        Metric.mapInput(frequency, ({ step4 }) => step4),
+        Metric.trackSuccessWith(frequency, ({ step4 }) => step4),
         Effect.bind("results", () =>
           Effect.all({
             counter: Metric.value(counter),


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

`Metric.mapInput` is extremely useful for plucking values or running pure computation from lexical scope built in an `Effect.bind` pipe to send into a Metric, but the current typings prevent inference of the contramapping function. This means that with a large lexical scope object which changes from one `bind` to the next, you have to manually define potentially large and always ephemeral types as part of the `mapInput` `f` argument signature.

I've illustrated the before and after in this playground: https://effect.website/play/#a9714d08c979

If it's preferable to define an alias with the inferable type, I'm happy to make the change. If this is undesirable altogether, I can always use my own implementation as in the playground example.

Figured this is a strong enough use case for `mapInput` that it might make sense to support in the library.
