### PR TITLE
remove error case from `Command.isRunning` type signature

### DIFF
--- a/.changeset/thirty-eagles-build.md
+++ b/.changeset/thirty-eagles-build.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Remove error case from `Command.isRunning` type signature

--- a/packages/platform/src/CommandExecutor.ts
+++ b/packages/platform/src/CommandExecutor.ts
@@ -99,7 +99,7 @@ export interface Process extends Inspectable {
   /**
    * Returns `true` if the process is still running, otherwise returns `false`.
    */
-  readonly isRunning: Effect<boolean, PlatformError>
+  readonly isRunning: Effect<boolean>
   /**
    * Kills the running process with the provided signal.
    *


### PR DESCRIPTION
@tim-smart any reason why this should be fallible?