### PR TITLE
improve: cause error output

### DIFF
--- a/.changeset/petite-doodles-help.md
+++ b/.changeset/petite-doodles-help.md
@@ -42,8 +42,7 @@ after:
     at runTest (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
     at processTicksAndRejections (node:internal/process/task_queues:105:5)
     at async Promise.all (index 0)
-    at runSuite (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1718:7)
-{    
+    at runSuite (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1718:7) {
       testValue: 1
-}
+    }
 ```

--- a/.changeset/petite-doodles-help.md
+++ b/.changeset/petite-doodles-help.md
@@ -1,0 +1,49 @@
+---
+"effect": patch
+---
+
+improve: Enhance Cause.pretty output with additional error fields, similar to classic throw of Error.
+
+code:
+
+```
+class MyError extends Error {
+  testValue = 1
+}
+console.log(Cause.pretty(Cause.die(new MyError("my message")), { renderErrorCause: true }))
+```
+
+before:
+
+```
+Error: my message
+    at /pj/effect/effect/packages/effect/test/Cause.test.ts:1081:51
+    at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+    at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+    at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+    at new Promise (<anonymous>)
+    at runWithTimeout (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+    at runTest (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async Promise.all (index 0)
+    at runSuite (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1718:7)
+```
+
+after:
+
+```
+"Error: my message
+    at /pj/effect/effect/packages/effect/test/Cause.test.ts:1081:51
+    at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+    at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+    at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+    at new Promise (<anonymous>)
+    at runWithTimeout (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+    at runTest (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+    at processTicksAndRejections (node:internal/process/task_queues:105:5)
+    at async Promise.all (index 0)
+    at runSuite (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1718:7)
+{    
+      testValue: 1
+}
+```

--- a/.changeset/petite-doodles-help.md
+++ b/.changeset/petite-doodles-help.md
@@ -17,7 +17,7 @@ before:
 
 ```
 Error: my message
-    at /pj/effect/effect/packages/effect/test/Cause.test.ts:1081:51
+    at /pj/effect/effect/packages/effect/test/Cause.test.ts:1079:51
     at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
     at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
     at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
@@ -32,8 +32,8 @@ Error: my message
 after:
 
 ```
-"Error: my message
-    at /pj/effect/effect/packages/effect/test/Cause.test.ts:1081:51
+Error: my message
+    at /pj/effect/effect/packages/effect/test/Cause.test.ts:1079:51
     at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
     at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
     at file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20

--- a/.changeset/petite-doodles-help.md
+++ b/.changeset/petite-doodles-help.md
@@ -3,12 +3,13 @@
 ---
 
 improve: Enhance Cause.pretty output with additional error fields, similar to classic throw of Error.
+also allows for printing `bigint` values as string.
 
 code:
 
 ```
 class MyError extends Error {
-  testValue = 1
+  testValue = BigInt(1)
 }
 console.log(Cause.pretty(Cause.die(new MyError("my message")), { renderErrorCause: true }))
 ```
@@ -43,6 +44,6 @@ Error: my message
     at processTicksAndRejections (node:internal/process/task_queues:105:5)
     at async Promise.all (index 0)
     at runSuite (file:///pj/effect/effect/node_modules/.pnpm/@vitest+runner@3.2.4/node_modules/@vitest/runner/dist/chunk-hooks.js:1718:7) {
-      testValue: 1
+      testValue: "1"
     }
 ```

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -879,7 +879,15 @@ export const pretty = <E>(cause: Cause.Cause<E>, options?: {
     if (options?.renderErrorCause !== true || e.cause === undefined) {
       return e.stack
     }
-    return `${e.stack} {\n${renderErrorCause(e.cause as PrettyError, "  ")}\n}`
+    const { cause, message: _, name: __, stack, ...rest } = e
+    const json = stringifyCircular(toJSON(rest), 2, 2)
+    return !cause && !!Object.keys(rest).length ?
+      stack :
+      `${stack} {${
+        json.replace(/^[\t ]*"[^:\n\r]+(?<!\\)":/gm, function(match) {
+          return match.replace(/"/g, "")
+        })
+      }${cause ? ",\n" + renderErrorCause(cause as PrettyError, "  ") : ""}\n}`
   }).join("\n")
 }
 

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -1080,7 +1080,7 @@ describe("Cause", () => {
               "name: \"[myspan]\",",
               "parent: {},",
               "context: {},",
-              `startTime: "${span.startTime}",`,
+              `startTime: "${(span as any).startTime}",`,
               "kind: \"internal\",",
               "_tag: \"Span\",",
               `spanId: "${span.spanId}",`,

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -1072,12 +1072,7 @@ describe("Cause", () => {
               Effect.runSync
             )
             const cause = exit.cause
-            class MyError extends Error {
-              testValue = 1
-            }
             const pretty = simplifyStackTrace(Cause.pretty(cause, { renderErrorCause: true }))
-            // const pretty = Cause.pretty(cause, { renderErrorCause: true })
-            // const pretty = Cause.pretty(Cause.die(new MyError("my message")), { renderErrorCause: true })
             deepStrictEqual(pretty, [
               `Error: my message`,
               "at [myspan]",

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -1072,8 +1072,13 @@ describe("Cause", () => {
               Effect.runSync
             )
             const cause = exit.cause
-            const pretty = Cause.pretty(cause, { renderErrorCause: true })
-            deepStrictEqual(simplifyStackTrace(pretty), [
+            class MyError extends Error {
+              testValue = 1
+            }
+            const pretty = simplifyStackTrace(Cause.pretty(cause, { renderErrorCause: true }))
+            // const pretty = Cause.pretty(cause, { renderErrorCause: true })
+            // const pretty = Cause.pretty(Cause.die(new MyError("my message")), { renderErrorCause: true })
+            deepStrictEqual(pretty, [
               `Error: my message`,
               "at [myspan]",
               "span: {",
@@ -1090,7 +1095,6 @@ describe("Cause", () => {
               "attributes: {},",
               "events: [],",
               "links: []",
-              "},",
               "[cause]: Error: my cause"
             ])
           })


### PR DESCRIPTION
When throwing an Error classically, extra fields of the error are printed, this is however not the case with effect pretty printing causes.

This PR tries to enhance the error info, when `renderErrorCause: true` is passed.