### PR TITLE
remove test cases covered by test matrix

### DIFF
--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -922,6 +922,13 @@ describe("DateTime", () => {
           assertSomeIso(result, expectedResults[strategy])
         }
 
+        // Test default behavior ("compatible")
+        const defaultResult = DateTime.makeZoned(time, {
+          timeZone: zone,
+          adjustForTimeZone: true
+        })
+        assertSomeIso(defaultResult, expectedResults.compatible)
+
         // Test reject strategy
         const rejectResult = DateTime.makeZoned(time, {
           timeZone: zone,

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -936,33 +936,5 @@ describe("DateTime", () => {
         }
       }
     )
-
-    it("should use 'earlier' as default disambiguation for backward compatibility", () => {
-      const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3 }
-
-      // Test default behavior (no disambiguation specified)
-      const defaultResult = DateTime.makeZoned(ambiguousTime, {
-        timeZone: "Europe/Athens",
-        adjustForTimeZone: true
-      })
-
-      // Should produce the 'earlier' result
-      assertSomeIso(defaultResult, "2025-10-26T00:00:00.000Z")
-    })
-
-    it("should throw RangeError with 'reject' disambiguation for ambiguous times", () => {
-      const ambiguousTime = { year: 2025, month: 10, day: 26, hours: 3 }
-
-      throws(() => {
-        DateTime.unsafeMakeZoned(ambiguousTime, {
-          timeZone: "Europe/Athens",
-          adjustForTimeZone: true,
-          disambiguation: "reject"
-        })
-      }, (error) => {
-        assertInstanceOf(error, RangeError)
-        assertInclude(error.message, "Ambiguous time")
-      })
-    })
   })
 })

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -1,14 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import {
-  assertInclude,
-  assertInstanceOf,
-  assertNone,
-  assertRight,
-  assertSome,
-  deepStrictEqual,
-  strictEqual,
-  throws
-} from "@effect/vitest/utils"
+import { assertNone, assertRight, assertSome, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { DateTime, Duration, Effect, Option, TestClock } from "effect"
 
 const setTo2024NZ = TestClock.setTime(new Date("2023-12-31T11:00:00.000Z").getTime())


### PR DESCRIPTION
The test checking for "earlier" being used as a default is wrong ("compatible" is the default) and it is also not necessary.

The one that checks for `throw` on "reject" is also not necessary because we test "reject" already with the safe variant (`makeZoned` vs. `unsafeMakeZoned`) in the test matrix.