### PR TITLE
Fix infinite loop when ConfigProvider.fromJson is called with nested arrays

### DIFF
--- a/.changeset/silent-ducks-wear.md
+++ b/.changeset/silent-ducks-wear.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-fix ConfigProvider.fromJson being called with nested arrays, by handling consecutive KeyIndex components in configPathToString
+fix an infinite loop when calling ConfigProvider.fromJson with a nested array

--- a/.changeset/silent-ducks-wear.md
+++ b/.changeset/silent-ducks-wear.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix ConfigProvider.fromJson being called with nested arrays, by handling consecutive KeyIndex components in configPathToString

--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -747,6 +747,9 @@ const configPathToString = (path: ReadonlyArray<KeyComponent>): ReadonlyArray<st
         output.push(component.name)
         i += 1
       }
+    } else {
+      output.push(`[${component.index}]`)
+      i += 1
     }
   }
   return output

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -940,4 +940,12 @@ describe("ConfigProvider", () => {
         hostPorts: Array.from({ length: 3 }, () => ({ host: "localhost", port: 8080 }))
       })
     }))
+
+  it.effect("fromJson - should load configs from nested arrays", () =>
+    Effect.gen(function*() {
+      const configProvider = ConfigProvider.fromJson({ nestedArray: [["a", "b"]] })
+      const config = Config.array(Config.array(Config.string()), "nestedArray")
+      const result = yield* configProvider.load(config)
+      deepStrictEqual(result, [["a", "b"]])
+    }))
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a bug where the program would get stuck in a while loop when ConfigProvider.fromJson was called with a nested array, due to configPathToString expecting KeyIndex components to always follow KeyName components.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
