### PR TITLE
Adjust `xForwardedHeaders` middleware to always use `x-forwarded-for`

### DIFF
--- a/.changeset/ten-singers-rest.md
+++ b/.changeset/ten-singers-rest.md
@@ -1,5 +1,5 @@
 ---
-"@effect/platform": minor
+"@effect/platform": patch
 ---
 
 Adjust `xForwardedHeaders` middleware to always use `x-forwarded-for`

--- a/.changeset/ten-singers-rest.md
+++ b/.changeset/ten-singers-rest.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Adjust `xForwardedHeaders` middleware to always use `x-forwarded-for`

--- a/packages/platform/src/internal/httpMiddleware.ts
+++ b/packages/platform/src/internal/httpMiddleware.ts
@@ -190,16 +190,10 @@ export const xForwardedHeaders = make((httpApp) =>
   Effect.updateService(httpApp, ServerRequest.HttpServerRequest, (request) => {
     const host = request.headers["x-forwarded-host"]
     const remoteAddress = request.headers["x-forwarded-for"]?.split(",")[0].trim()
-    return host
-      ? request.modify({
-        headers: Headers.set(
-          request.headers,
-          "host",
-          host
-        ),
-        remoteAddress
-      })
-      : request
+    return request.modify({
+      headers: host !== undefined ? Headers.set(request.headers, "host", host) : undefined,
+      remoteAddress
+    })
   })
 )
 

--- a/packages/platform/src/internal/httpMiddleware.ts
+++ b/packages/platform/src/internal/httpMiddleware.ts
@@ -187,17 +187,20 @@ export const tracer = make((httpApp) =>
 
 /** @internal */
 export const xForwardedHeaders = make((httpApp) =>
-  Effect.updateService(httpApp, ServerRequest.HttpServerRequest, (request) =>
-    request.headers["x-forwarded-host"]
+  Effect.updateService(httpApp, ServerRequest.HttpServerRequest, (request) => {
+    const host = request.headers["x-forwarded-host"]
+    const remoteAddress = request.headers["x-forwarded-for"]?.split(",")[0].trim()
+    return host
       ? request.modify({
         headers: Headers.set(
           request.headers,
           "host",
-          request.headers["x-forwarded-host"]
+          host
         ),
-        remoteAddress: request.headers["x-forwarded-for"]?.split(",")[0].trim()
+        remoteAddress
       })
-      : request)
+      : request
+  })
 )
 
 /** @internal */


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->



## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes https://github.com/Effect-TS/effect/issues/5292
- Related MDN docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#security_and_privacy_concerns