### PR TITLE
Add NonEmpty overloads to Iterable

### DIFF
--- a/.changeset/lazy-pens-cover.md
+++ b/.changeset/lazy-pens-cover.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add NonEmpty overloads to Iterable

--- a/packages/effect/dtslint/Iterable.tst.ts
+++ b/packages/effect/dtslint/Iterable.tst.ts
@@ -1,0 +1,482 @@
+import { Iterable, Effect, Option, Predicate } from "effect"
+import { NonEmptyArray } from "effect/Array"
+import { hole, pipe } from "effect/Function"
+import { describe, expect, it, when } from "tstyche"
+import { NonEmptyIterable } from "effect/NonEmptyIterable"
+
+declare const nonEmptyStrings: NonEmptyIterable<string>
+declare const nonEmptyNumbers: NonEmptyIterable<number>
+declare const numbers: Iterable<number>
+declare const strings: Iterable<string>
+declare const numbersOrStrings: Iterable<number | string>
+
+declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
+
+const symA = Symbol.for("a")
+const symB = Symbol.for("b")
+const symC = Symbol.for("c")
+
+interface Eff<R> {
+  readonly _R: (_: R) => void
+}
+interface R1 {
+  readonly _r1: unique symbol
+}
+interface R2 {
+  readonly _r2: unique symbol
+}
+interface R3 {
+  readonly _r3: unique symbol
+}
+declare const arg1: Eff<R1 | R2>
+declare const arg2: Eff<R1 | R2 | R3>
+
+describe("Iterable", () => {
+
+  it("isEmptyIterable", () => {
+    if (Iterable.isEmpty(numbers)) {
+      expect(numbers).type.toBe<Iterable<never>>()
+    }
+    // should play well with `Option.liftPredicate`
+    expect(Option.liftPredicate(Iterable.isEmpty)).type.toBe<
+      <A>(a: Iterable<A>) => Option.Option<Iterable<never>>
+    >()
+  })
+
+  it("map", () => {
+    expect(Iterable.map(strings, (s, i) => {
+      expect(s).type.toBe<string>()
+      expect(i).type.toBe<number>()
+      return s + "a"
+    })).type.toBe<Iterable<string>>()
+    expect(pipe(
+      strings,
+      Iterable.map((s, i) => {
+        expect(s).type.toBe<string>()
+        expect(i).type.toBe<number>()
+        return s + "a"
+      })
+    )).type.toBe<Iterable<string>>()
+
+    expect(Iterable.map(nonEmptyStrings, (s, i) => {
+      expect(s).type.toBe<string>()
+      expect(i).type.toBe<number>()
+      return s + "a"
+    })).type.toBe<NonEmptyIterable<string>>()
+    expect(pipe(
+      nonEmptyStrings,
+      Iterable.map((s, i) => {
+        expect(s).type.toBe<string>()
+        expect(i).type.toBe<number>()
+        return s + "a"
+      })
+    )).type.toBe<NonEmptyIterable<string>>()
+  })
+
+  it("groupBy", () => {
+    expect(Iterable.groupBy([1, 2, 3], (n) => {
+      expect(n).type.toBe<number>()
+      return String(n)
+    })).type.toBe<Record<string, NonEmptyArray<number>>>()
+    expect(pipe(
+      [1, 2, 3],
+      Iterable.groupBy((n) => {
+        expect(n).type.toBe<number>()
+        return String(n)
+      })
+    )).type.toBe<Record<string, NonEmptyArray<number>>>()
+    expect(
+      Iterable.groupBy([1, 2, 3], (n) => n > 0 ? "positive" as const : "negative" as const)
+    ).type.toBe<Record<string, NonEmptyArray<number>>>()
+    expect(Iterable.groupBy(["a", "b"], Symbol.for)).type.toBe<Record<symbol, NonEmptyArray<string>>>()
+    expect(Iterable.groupBy(["a", "b"], (s) => s === "a" ? symA : s === "b" ? symB : symC)).type.toBe<
+      Record<symbol, NonEmptyArray<string>>
+    >()
+  })
+
+  it("some", () => {
+    expect(Iterable.some(numbersOrStrings, (item, i) => {
+      expect(item).type.toBe<string | number>()
+      expect(i).type.toBe<number>()
+      return true
+    })).type.toBe<boolean>()
+    expect(pipe(
+      numbersOrStrings,
+      Iterable.some((item, i) => {
+        expect(item).type.toBe<string | number>()
+        expect(i).type.toBe<number>()
+        return true
+      })
+    )).type.toBe<boolean>()
+    if (Iterable.some(numbersOrStrings, Predicate.isString)) {
+      expect(numbersOrStrings).type.toBe<
+        Iterable<string | number>
+      >()
+    }
+  })
+
+  it("append", () => {
+    expect(Iterable.append(numbersOrStrings, true))
+      .type.toBe<NonEmptyIterable<string | number | boolean>>()
+    expect(pipe(numbersOrStrings, Iterable.append(true)))
+      .type.toBe<NonEmptyIterable<string | number | boolean>>()
+    expect(Iterable.append(true)(numbersOrStrings))
+      .type.toBe<NonEmptyIterable<string | number | boolean>>()
+  })
+
+  it("prepend", () => {
+    expect(Iterable.prepend(numbersOrStrings, true))
+      .type.toBe<NonEmptyIterable<string | number | boolean>>()
+    expect(pipe(numbersOrStrings, Iterable.prepend(true)))
+      .type.toBe<NonEmptyIterable<string | number | boolean>>()
+    expect(Iterable.prepend(true)(numbersOrStrings))
+      .type.toBe<NonEmptyIterable<string | number | boolean>>()
+  })
+
+  it("filter", () => {
+    expect(Iterable.filter(numbersOrStrings, (item, i) => {
+      expect(item).type.toBe<string | number>()
+      expect(i).type.toBe<number>()
+      return true
+    })).type.toBe<Iterable<string | number>>()
+    expect(pipe(
+      numbersOrStrings,
+      Iterable.filter((item, i) => {
+        expect(item).type.toBe<string | number>()
+        expect(i).type.toBe<number>()
+        return true
+      })
+    )).type.toBe<Iterable<string | number>>()
+
+    expect(Iterable.filter).type.not.toBeCallableWith(numbersOrStrings, (_item: string) => true)
+    when(pipe).isCalledWith(
+      numbersOrStrings,
+      expect(Iterable.filter).type.not.toBeCallableWith((_item: string) => true)
+    )
+
+    expect(Iterable.filter(numbers, predicateNumbersOrStrings)).type.toBe<Iterable<number>>()
+    expect(pipe(numbers, Iterable.filter(predicateNumbersOrStrings))).type.toBe<Iterable<number>>()
+
+    expect(Iterable.filter(numbersOrStrings, predicateNumbersOrStrings)).type.toBe<Iterable<string | number>>()
+    expect(pipe(numbersOrStrings, Iterable.filter(predicateNumbersOrStrings))).type.toBe<Iterable<string | number>>()
+
+    expect(Iterable.filter(numbersOrStrings, Predicate.isNumber)).type.toBe<Iterable<number>>()
+    expect(pipe(numbersOrStrings, Iterable.filter(Predicate.isNumber))).type.toBe<Iterable<number>>()
+  })
+
+  it("takeWhile", () => {
+    expect(Iterable.takeWhile(numbersOrStrings, (item, i) => {
+      expect(item).type.toBe<string | number>()
+      expect(i).type.toBe<number>()
+      return true
+    })).type.toBe<Iterable<string | number>>()
+    expect(pipe(
+      numbersOrStrings,
+      Iterable.takeWhile((item, i) => {
+        expect(item).type.toBe<string | number>()
+        expect(i).type.toBe<number>()
+        return true
+      })
+    )).type.toBe<Iterable<string | number>>()
+
+    expect(Iterable.takeWhile(numbers, predicateNumbersOrStrings)).type.toBe<Iterable<number>>()
+    expect(pipe(numbers, Iterable.takeWhile(predicateNumbersOrStrings))).type.toBe<Iterable<number>>()
+
+    expect(Iterable.takeWhile(numbersOrStrings, predicateNumbersOrStrings)).type.toBe<Iterable<string | number>>()
+    expect(pipe(numbersOrStrings, Iterable.takeWhile(predicateNumbersOrStrings))).type.toBe<Iterable<string | number>>()
+
+    expect(Iterable.takeWhile(numbersOrStrings, Predicate.isNumber)).type.toBe<Iterable<number>>()
+    expect(pipe(numbersOrStrings, Iterable.takeWhile(Predicate.isNumber))).type.toBe<Iterable<number>>()
+  })
+
+  it("findFirst", () => {
+    expect(Iterable.findFirst(numbersOrStrings, (item, i) => {
+      expect(item).type.toBe<string | number>()
+      expect(i).type.toBe<number>()
+      return true
+    })).type.toBe<Option.Option<string | number>>()
+    expect(pipe(
+      numbersOrStrings,
+      Iterable.findFirst((item, i) => {
+        expect(item).type.toBe<string | number>()
+        expect(i).type.toBe<number>()
+        return true
+      })
+    )).type.toBe<Option.Option<string | number>>()
+
+    expect(Iterable.findFirst(numbersOrStrings, Predicate.isNumber)).type.toBe<Option.Option<number>>()
+    expect(pipe(numbersOrStrings, Iterable.findFirst(Predicate.isNumber))).type.toBe<Option.Option<number>>()
+  })
+
+  it("findLast", () => {
+    expect(Iterable.findLast(numbersOrStrings, (item, i) => {
+      expect(item).type.toBe<string | number>()
+      expect(i).type.toBe<number>()
+      return true
+    })).type.toBe<Option.Option<string | number>>()
+    expect(pipe(
+      numbersOrStrings,
+      Iterable.findLast((item, i) => {
+        expect(item).type.toBe<string | number>()
+        expect(i).type.toBe<number>()
+        return true
+      })
+    )).type.toBe<Option.Option<string | number>>()
+
+    expect(Iterable.findLast(numbersOrStrings, Predicate.isNumber)).type.toBe<Option.Option<number>>()
+    expect(pipe(numbersOrStrings, Iterable.findLast(Predicate.isNumber))).type.toBe<Option.Option<number>>()
+
+  })
+
+  it("flatMap", () => {
+    expect(
+      Iterable.flatMap(strings, (item, i) => {
+        expect(item).type.toBe<string>()
+        expect(i).type.toBe<number>()
+        return Iterable.empty<number>()
+      })
+    ).type.toBe<Iterable<number>>()
+    expect(
+      pipe(
+        strings,
+        Iterable.flatMap((item, i) => {
+          expect(item).type.toBe<string>()
+          expect(i).type.toBe<number>()
+          return Iterable.empty<number>()
+        })
+      )
+    ).type.toBe<Iterable<number>>()
+
+    expect(
+      Iterable.flatMap(nonEmptyStrings, (item, i) => {
+        expect(item).type.toBe<string>()
+        expect(i).type.toBe<number>()
+        return Iterable.empty<number>()
+      })
+    ).type.toBe<Iterable<number>>()
+    expect(
+      pipe(
+        nonEmptyStrings,
+        Iterable.flatMap((item, i) => {
+          expect(item).type.toBe<string>()
+          expect(i).type.toBe<number>()
+          return Iterable.empty<number>()
+        })
+      )
+    ).type.toBe<Iterable<number>>()
+
+    expect(
+      Iterable.flatMap(nonEmptyStrings, (item, i) => {
+        expect(item).type.toBe<string>()
+        expect(i).type.toBe<number>()
+        return Iterable.of(item.length)
+      })
+    ).type.toBe<NonEmptyIterable<number>>()
+    expect(
+      pipe(
+        nonEmptyStrings,
+        Iterable.flatMap((item, i) => {
+          expect(item).type.toBe<string>()
+          expect(i).type.toBe<number>()
+          return Iterable.of(item.length)
+        })
+      )
+    ).type.toBe<NonEmptyIterable<number>>()
+  })
+
+  it("flatten", () => {
+    expect(Iterable.flatten(hole<Iterable<Iterable<number>>>())).type.toBe<Iterable<number>>()
+    expect(Iterable.flatten(hole<Iterable<NonEmptyIterable<number>>>())).type.toBe<Iterable<number>>()
+    expect(Iterable.flatten(hole<NonEmptyIterable<Iterable<number>>>())).type.toBe<Iterable<number>>()
+    expect(Iterable.flatten(hole<NonEmptyIterable<NonEmptyIterable<number>>>()))
+      .type.toBe<NonEmptyIterable<number>>()
+
+    expect(
+      hole<Effect.Effect<Iterable<Iterable<number>>>>().pipe(Effect.map((x) => {
+        expect(x).type.toBe<Iterable<Iterable<number>>>()
+        return Iterable.flatten(x)
+      }))
+    ).type.toBe<Effect.Effect<Iterable<number>, never, never>>()
+    expect(
+      hole<Effect.Effect<NonEmptyIterable<NonEmptyIterable<number>>>>().pipe(Effect.map((x) => {
+        expect(x).type.toBe<NonEmptyIterable<NonEmptyIterable<number>>>()
+        return Iterable.flatten(x)
+      }))
+    ).type.toBe<Effect.Effect<NonEmptyIterable<number>, never, never>>()
+
+    expect(Iterable.flatten([[arg1], [arg2]])).type.toBe<Iterable<Eff<R1 | R2> | Eff<R1 | R2 | R3>>>()
+    expect(Iterable.flatten([[arg2], [arg1]])).type.toBe<Iterable<Eff<R1 | R2> | Eff<R1 | R2 | R3>>>()
+  })
+
+  it("prependAll", () => {
+    // Iterable + Iterable
+    expect(Iterable.prependAll(strings, numbers)).type.toBe<Iterable<string | number>>()
+    expect(pipe(strings, Iterable.prependAll(numbers))).type.toBe<Iterable<string | number>>()
+
+    // NonEmptyIterable + Iterable
+    expect(Iterable.prependAll(nonEmptyStrings, numbers)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(nonEmptyStrings, Iterable.prependAll(numbers))).type.toBe<NonEmptyIterable<string | number>>()
+
+    // Iterable + NonEmptyIterable
+    expect(Iterable.prependAll(strings, nonEmptyNumbers)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(strings, Iterable.prependAll(nonEmptyNumbers))).type.toBe<NonEmptyIterable<string | number>>()
+
+    // NonEmptyIterable + NonEmptyIterable
+    expect(Iterable.prependAll(nonEmptyStrings, nonEmptyNumbers)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(nonEmptyStrings, Iterable.prependAll(nonEmptyNumbers))).type.toBe<
+      NonEmptyIterable<string | number>
+    >()
+  })
+
+  it("appendAll", () => {
+    // Iterable + Iterable
+    expect(Iterable.appendAll(strings, numbers)).type.toBe<Iterable<string | number>>()
+    expect(pipe(strings, Iterable.appendAll(numbers))).type.toBe<Iterable<string | number>>()
+
+    // NonEmptyIterable + Iterable
+    expect(Iterable.appendAll(nonEmptyStrings, numbers)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(nonEmptyStrings, Iterable.appendAll(numbers))).type.toBe<NonEmptyIterable<string | number>>()
+
+    // Iterable + NonEmptyIterable
+    expect(Iterable.appendAll(strings, nonEmptyNumbers)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(strings, Iterable.appendAll(nonEmptyNumbers))).type.toBe<NonEmptyIterable<string | number>>()
+
+    // NonEmptyIterable + NonEmptyIterable
+    expect(Iterable.appendAll(nonEmptyStrings, nonEmptyNumbers)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(nonEmptyStrings, Iterable.appendAll(nonEmptyNumbers)))
+      .type.toBe<NonEmptyIterable<string | number>>()
+  })
+
+  it("zip", () => {
+    expect(Iterable.zip(strings, numbers)).type.toBe<Iterable<[string, number]>>()
+    expect(pipe(strings, Iterable.zip(numbers))).type.toBe<Iterable<[string, number]>>()
+    expect(Iterable.zip(numbers)(strings)).type.toBe<Iterable<[string, number]>>()
+
+    expect(Iterable.zip(nonEmptyStrings, nonEmptyNumbers)).type.toBe<NonEmptyIterable<[string, number]>>()
+    expect(pipe(nonEmptyStrings, Iterable.zip(nonEmptyNumbers)))
+      .type.toBe<NonEmptyIterable<[string, number]>>()
+    expect(Iterable.zip(nonEmptyNumbers)(nonEmptyStrings)).type.toBe<NonEmptyIterable<[string, number]>>()
+  })
+
+  it("intersperse", () => {
+    expect(Iterable.intersperse(strings, "a")).type.toBe<Iterable<string>>()
+    expect(pipe(strings, Iterable.intersperse("a"))).type.toBe<Iterable<string>>()
+    expect(Iterable.intersperse("a")(strings)).type.toBe<Iterable<string>>()
+
+    expect(Iterable.intersperse(strings, 1)).type.toBe<Iterable<string | number>>()
+    expect(pipe(strings, Iterable.intersperse(1))).type.toBe<Iterable<string | number>>()
+    expect(Iterable.intersperse(1)(strings)).type.toBe<Iterable<string | number>>()
+
+    expect(Iterable.intersperse(nonEmptyStrings, "a")).type.toBe<NonEmptyIterable<string>>()
+    expect(pipe(nonEmptyStrings, Iterable.intersperse("a"))).type.toBe<NonEmptyIterable<string>>()
+    expect(Iterable.intersperse("a")(nonEmptyStrings)).type.toBe<NonEmptyIterable<string>>()
+
+    expect(Iterable.intersperse(nonEmptyStrings, 1)).type.toBe<NonEmptyIterable<string | number>>()
+    expect(pipe(nonEmptyStrings, Iterable.intersperse(1))).type.toBe<NonEmptyIterable<string | number>>()
+    expect(Iterable.intersperse(1)(nonEmptyStrings)).type.toBe<NonEmptyIterable<string | number>>()
+  })
+
+  it("dedupeAdjacent", () => {
+    // Iterable
+    expect(Iterable.dedupeAdjacent(strings)).type.toBe<Iterable<string>>()
+    expect(pipe(strings, Iterable.dedupeAdjacent)).type.toBe<Iterable<string>>()
+
+    // NonEmptyIterable
+    expect(Iterable.dedupeAdjacent(nonEmptyStrings)).type.toBe<NonEmptyIterable<string>>()
+    expect(pipe(nonEmptyStrings, Iterable.dedupeAdjacent)).type.toBe<NonEmptyIterable<string>>()
+  })
+
+  it("dedupeAdjacentWith", () => {
+    // Iterable
+    expect(
+      Iterable.dedupeAdjacentWith(strings, (a, b) => {
+        expect(a).type.toBe<string>()
+        expect(b).type.toBe<string>()
+        return true
+      })
+    ).type.toBe<Iterable<string>>()
+    expect(pipe(
+      strings,
+      Iterable.dedupeAdjacentWith((a, b) => {
+        expect(a).type.toBe<string>()
+        expect(b).type.toBe<string>()
+        return true
+      })
+    )).type.toBe<Iterable<string>>()
+
+    // NonEmptyIterable
+    expect(
+      Iterable.dedupeAdjacentWith(nonEmptyStrings, (a, b) => {
+        expect(a).type.toBe<string>()
+        expect(b).type.toBe<string>()
+        return true
+      })
+    ).type.toBe<NonEmptyIterable<string>>()
+    expect(
+      pipe(
+        nonEmptyStrings,
+        Iterable.dedupeAdjacentWith((a, b) => {
+          expect(a).type.toBe<string>()
+          expect(b).type.toBe<string>()
+          return true
+        })
+      )
+    ).type.toBe<NonEmptyIterable<string>>()
+  })
+
+  it("chunksOf", () => {
+    // Iterable
+    expect(Iterable.chunksOf(strings, 10)).type.toBe<Iterable<NonEmptyArray<string>>>()
+    expect(pipe(strings, Iterable.chunksOf(10))).type.toBe<Iterable<NonEmptyArray<string>>>()
+    expect(Iterable.chunksOf(10)(strings)).type.toBe<Iterable<NonEmptyArray<string>>>()
+
+    // NonEmptyIterable
+    expect(Iterable.chunksOf(nonEmptyStrings, 10))
+      .type.toBe<NonEmptyIterable<NonEmptyArray<string>>>()
+    expect(pipe(nonEmptyStrings, Iterable.chunksOf(10)))
+      .type.toBe<NonEmptyIterable<NonEmptyArray<string>>>()
+    expect(Iterable.chunksOf(10)(nonEmptyStrings))
+      .type.toBe<NonEmptyIterable<NonEmptyArray<string>>>()
+  })
+
+  it("zipWith", () => {
+    // Iterable + Iterable
+    expect(
+      Iterable.zipWith(strings, numbers, (a, b) => {
+        expect(a).type.toBe<string>()
+        expect(b).type.toBe<number>()
+        return [a, b] as [string, number]
+      })
+    ).type.toBe<Iterable<[string, number]>>()
+    expect(
+      pipe(
+        strings,
+        Iterable.zipWith(numbers, (a, b) => {
+          expect(a).type.toBe<string>()
+          expect(b).type.toBe<number>()
+          return [a, b] as [string, number]
+        })
+      )
+    ).type.toBe<Iterable<[string, number]>>()
+
+    // NonEmptyIterable + NonEmptyIterable
+    expect(
+      Iterable.zipWith(nonEmptyStrings, nonEmptyNumbers, (a, b) => {
+        expect(a).type.toBe<string>()
+        expect(b).type.toBe<number>()
+        return [a, b] as [string, number]
+      })
+    ).type.toBe<NonEmptyIterable<[string, number]>>()
+    expect(
+      pipe(
+        nonEmptyStrings,
+        Iterable.zipWith(nonEmptyNumbers, (a, b) => {
+          expect(a).type.toBe<string>()
+          expect(b).type.toBe<number>()
+          return [a, b] as [string, number]
+        })
+      )
+    ).type.toBe<NonEmptyIterable<[string, number]>>()
+  })
+
+})

--- a/packages/effect/src/Iterable.ts
+++ b/packages/effect/src/Iterable.ts
@@ -9,12 +9,43 @@ import type { Either } from "./Either.js"
 import * as E from "./Either.js"
 import * as Equal from "./Equal.js"
 import { dual, identity } from "./Function.js"
+import type { NonEmptyIterable } from "./NonEmptyIterable.js"
 import type { Option } from "./Option.js"
 import * as O from "./Option.js"
 import { isBoolean } from "./Predicate.js"
 import type * as Record from "./Record.js"
 import * as Tuple from "./Tuple.js"
 import type { NoInfer } from "./Types.js"
+
+
+declare namespace Iterable {
+
+  type Infer<S extends Iterable<any>> = S extends Iterable<infer A> ? A
+      : never
+
+  type With<S extends Iterable<any>, A> = S extends NonEmptyIterable<any> ? NonEmptyIterable<A>
+      : Iterable<A>
+
+  type OrNonEmpty<
+    S extends Iterable<any>,
+    T extends Iterable<any>,
+    A
+  > = S extends NonEmptyIterable<any> ? NonEmptyIterable<A>
+    : T extends NonEmptyIterable<any> ? NonEmptyIterable<A>
+    : Iterable<A>
+
+  type AndNonEmpty<
+    S extends Iterable<any>,
+    T extends Iterable<any>,
+    A
+  > = S extends NonEmptyIterable<any> ? T extends NonEmptyIterable<any> ? NonEmptyIterable<A>
+    : Iterable<A>
+    : Iterable<A>
+
+  type Flatten<T extends Iterable<Iterable<any>>> = T extends
+    NonEmptyIterable<NonEmptyIterable<any>> ? NonEmptyIterable<Infer<Infer<T>>>
+    : Iterable<Infer<Infer<T>>>
+}
 
 /**
  * Return a `Iterable` with element `i` initialized with `f(i)`.
@@ -36,7 +67,7 @@ import type { NoInfer } from "./Types.js"
  */
 export const makeBy = <A>(f: (i: number) => A, options?: {
   readonly length?: number
-}): Iterable<A> => {
+}): NonEmptyIterable<A> => {
   const max = options?.length !== undefined ? Math.max(1, Math.floor(options.length)) : Infinity
   return {
     [Symbol.iterator]() {
@@ -50,7 +81,7 @@ export const makeBy = <A>(f: (i: number) => A, options?: {
         }
       }
     }
-  }
+  } as NonEmptyIterable<A>
 }
 
 /**
@@ -69,7 +100,7 @@ export const makeBy = <A>(f: (i: number) => A, options?: {
  * @category constructors
  * @since 2.0.0
  */
-export const range = (start: number, end?: number): Iterable<number> => {
+export const range = (start: number, end?: number): NonEmptyIterable<number> => {
   if (end === undefined) {
     return makeBy((i) => start + i)
   }
@@ -95,8 +126,8 @@ export const range = (start: number, end?: number): Iterable<number> => {
  * @since 2.0.0
  */
 export const replicate: {
-  (n: number): <A>(a: A) => Iterable<A>
-  <A>(a: A, n: number): Iterable<A>
+  (n: number): <A>(a: A) => NonEmptyIterable<A>
+  <A>(a: A, n: number): NonEmptyIterable<A>
 } = dual(2, <A>(a: A, n: number): Iterable<A> => makeBy(() => a, { length: n }))
 
 /**
@@ -131,8 +162,8 @@ export const fromRecord = <K extends string, A>(self: Readonly<Record<K, A>>): I
  * @since 2.0.0
  */
 export const prepend: {
-  <B>(head: B): <A>(self: Iterable<A>) => Iterable<A | B>
-  <A, B>(self: Iterable<A>, head: B): Iterable<A | B>
+  <B>(head: B): <A>(self: Iterable<A>) => NonEmptyIterable<A | B>
+  <A, B>(self: Iterable<A>, head: B): NonEmptyIterable<A | B>
 } = dual(2, <A, B>(self: Iterable<A>, head: B): Iterable<A | B> => prependAll(self, [head]))
 
 /**
@@ -153,7 +184,11 @@ export const prepend: {
  * @since 2.0.0
  */
 export const prependAll: {
-  <B>(that: Iterable<B>): <A>(self: Iterable<A>) => Iterable<A | B>
+  <S extends Iterable<any>, T extends Iterable<any>>(
+    that: T
+  ): (self: S) => Iterable.OrNonEmpty<S, T, Iterable.Infer<S> | Iterable.Infer<T>>
+  <A, B>(self: NonEmptyIterable<A>, that: Iterable<B>): NonEmptyIterable<A | B>
+  <A, B>(self: Iterable<A>, that: NonEmptyIterable<B>): NonEmptyIterable<A | B>
   <A, B>(self: Iterable<A>, that: Iterable<B>): Iterable<A | B>
 } = dual(
   2,
@@ -167,8 +202,8 @@ export const prependAll: {
  * @since 2.0.0
  */
 export const append: {
-  <B>(last: B): <A>(self: Iterable<A>) => Iterable<A | B>
-  <A, B>(self: Iterable<A>, last: B): Iterable<A | B>
+  <B>(last: B): <A>(self: Iterable<A>) => NonEmptyIterable<A | B>
+  <A, B>(self: Iterable<A>, last: B): NonEmptyIterable<A | B>
 } = dual(2, <A, B>(self: Iterable<A>, last: B): Iterable<A | B> => appendAll(self, [last]))
 
 /**
@@ -178,7 +213,11 @@ export const append: {
  * @since 2.0.0
  */
 export const appendAll: {
-  <B>(that: Iterable<B>): <A>(self: Iterable<A>) => Iterable<A | B>
+  <S extends Iterable<any>, T extends Iterable<any>>(
+    that: T
+  ): (self: S) => Iterable.OrNonEmpty<S, T, Iterable.Infer<S> | Iterable.Infer<T>>
+  <A, B>(self: NonEmptyIterable<A>, that: Iterable<B>): NonEmptyIterable<A | B>
+  <A, B>(self: Iterable<A>, that: NonEmptyIterable<B>): NonEmptyIterable<A | B>
   <A, B>(self: Iterable<A>, that: Iterable<B>): Iterable<A | B>
 } = dual(
   2,
@@ -212,9 +251,9 @@ export const appendAll: {
  * @since 2.0.0
  */
 export const scan: {
-  <B, A>(b: B, f: (b: B, a: A) => B): (self: Iterable<A>) => Iterable<B>
-  <A, B>(self: Iterable<A>, b: B, f: (b: B, a: A) => B): Iterable<B>
-} = dual(3, <A, B>(self: Iterable<A>, b: B, f: (b: B, a: A) => B): Iterable<B> => ({
+  <B, A>(b: B, f: (b: B, a: A) => B): (self: Iterable<A>) => NonEmptyIterable<B>
+  <A, B>(self: Iterable<A>, b: B, f: (b: B, a: A) => B): NonEmptyIterable<B>
+} = dual(3, <A, B>(self: Iterable<A>, b: B, f: (b: B, a: A) => B): NonEmptyIterable<B> => ({
   [Symbol.iterator]() {
     let acc = b
     let iterator: Iterator<A> | undefined
@@ -232,7 +271,7 @@ export const scan: {
     }
     return { next }
   }
-}))
+}) as NonEmptyIterable<B>)
 
 /**
  * Determine if an `Iterable` is empty
@@ -455,7 +494,9 @@ export const findLast: {
  * @since 2.0.0
  */
 export const zip: {
+  <B>(that: NonEmptyIterable<B>): <A>(self: NonEmptyIterable<A>) => NonEmptyIterable<[A, B]>
   <B>(that: Iterable<B>): <A>(self: Iterable<A>) => Iterable<[A, B]>
+  <A, B>(self: NonEmptyIterable<A>, that: NonEmptyIterable<B>): NonEmptyIterable<[A, B]>
   <A, B>(self: Iterable<A>, that: Iterable<B>): Iterable<[A, B]>
 } = dual(
   2,
@@ -470,7 +511,9 @@ export const zip: {
  * @since 2.0.0
  */
 export const zipWith: {
+  <B, A, C>(that: NonEmptyIterable<B>, f: (a: A, b: B) => C): (self: NonEmptyIterable<A>) => NonEmptyIterable<C>
   <B, A, C>(that: Iterable<B>, f: (a: A, b: B) => C): (self: Iterable<A>) => Iterable<C>
+  <A, B, C>(self: NonEmptyIterable<A>, that: NonEmptyIterable<B>, f: (a: A, b: B) => C): NonEmptyIterable<C>
   <A, B, C>(self: Iterable<A>, that: Iterable<B>, f: (a: A, b: B) => C): Iterable<C>
 } = dual(3, <B, A, C>(self: Iterable<A>, that: Iterable<B>, f: (a: A, b: B) => C): Iterable<C> => ({
   [Symbol.iterator]() {
@@ -496,7 +539,10 @@ export const zipWith: {
  * @since 2.0.0
  */
 export const intersperse: {
-  <B>(middle: B): <A>(self: Iterable<A>) => Iterable<A | B>
+  <B>(
+    middle: B
+  ): <S extends Iterable<any>>(self: S) => Iterable.With<S, Iterable.Infer<S> | B>
+  <A, B>(self: NonEmptyIterable<A>, middle: B): NonEmptyIterable<A | B>
   <A, B>(self: Iterable<A>, middle: B): Iterable<A | B>
 } = dual(2, <A, B>(self: Iterable<A>, middle: B): Iterable<A | B> => ({
   [Symbol.iterator]() {
@@ -560,9 +606,10 @@ export const contains: {
  * @since 2.0.0
  */
 export const chunksOf: {
-  (n: number): <A>(self: Iterable<A>) => Iterable<Array<A>>
-  <A>(self: Iterable<A>, n: number): Iterable<Array<A>>
-} = dual(2, <A>(self: Iterable<A>, n: number): Iterable<Array<A>> => {
+  (n: number): <S extends Iterable<any>>(self: S) => Iterable.With<S, NonEmptyArray<Iterable.Infer<S>>>
+  <A>(self: NonEmptyIterable<A>, n: number): NonEmptyIterable<NonEmptyArray<A>>
+  <A>(self: Iterable<A>, n: number): Iterable<NonEmptyArray<A>>
+} = dual(2, <A>(self: Iterable<A>, n: number): Iterable<NonEmptyArray<A>> => {
   const safeN = Math.max(1, Math.floor(n))
   return ({
     [Symbol.iterator]() {
@@ -578,12 +625,12 @@ export const chunksOf: {
             const result = iterator.next()
             if (result.done) {
               iterator = undefined
-              return chunk.length === 0 ? { done: true, value: undefined } : { done: false, value: chunk }
+              return chunk.length === 0 ? { done: true, value: undefined } : { done: false, value: chunk as NonEmptyArray<A> }
             }
             chunk.push(result.value)
           }
 
-          return { done: false, value: chunk }
+          return { done: false, value: chunk as NonEmptyArray<A> }
         }
       }
     }
@@ -597,7 +644,10 @@ export const chunksOf: {
  * @since 2.0.0
  */
 export const groupWith: {
-  <A>(isEquivalent: (self: A, that: A) => boolean): (self: Iterable<A>) => Iterable<NonEmptyArray<A>>
+  <S extends Iterable<any>>(
+    isEquivalent: (self: Iterable.Infer<S>, that: Iterable.Infer<S>) => boolean
+  ): (self: S) => Iterable.With<S, NonEmptyArray<Iterable.Infer<S>>>
+  <A>(self: NonEmptyIterable<A>, isEquivalent: (self: A, that: A) => boolean): NonEmptyIterable<NonEmptyArray<A>>
   <A>(self: Iterable<A>, isEquivalent: (self: A, that: A) => boolean): Iterable<NonEmptyArray<A>>
 } = dual(
   2,
@@ -642,9 +692,12 @@ export const groupWith: {
  * @category grouping
  * @since 2.0.0
  */
-export const group: <A>(self: Iterable<A>) => Iterable<NonEmptyArray<A>> = groupWith(
+export const group: {
+  <A>(self: NonEmptyIterable<A>): NonEmptyIterable<NonEmptyArray<A>>
+  <A>(self: Iterable<A>): Iterable<NonEmptyArray<A>>
+} = groupWith(
   Equal.equivalence()
-)
+) as any
 
 /**
  * Splits an `Iterable` into sub-non-empty-arrays stored in an object, based on the result of calling a `string`-returning
@@ -700,16 +753,17 @@ export const empty = <A = never>(): Iterable<A> => constEmpty
  * @category constructors
  * @since 2.0.0
  */
-export const of = <A>(a: A): Iterable<A> => [a]
+export const of = <A>(a: A): NonEmptyIterable<A> => [a] as any
 
 /**
  * @category mapping
  * @since 2.0.0
  */
 export const map: {
-  <A, B>(
-    f: (a: NoInfer<A>, i: number) => B
-  ): (self: Iterable<A>) => Iterable<B>
+  <S extends Iterable<any>, B>(
+    f: (a: Iterable.Infer<S>, i: number) => B
+  ): (self: S) => Iterable.With<S, B>
+  <A, B>(self: NonEmptyIterable<A>, f: (a: NoInfer<A>, i: number) => B): NonEmptyIterable<B>
   <A, B>(self: Iterable<A>, f: (a: NoInfer<A>, i: number) => B): Iterable<B>
 } = dual(2, <A, B>(self: Iterable<A>, f: (a: A, i: number) => B): Iterable<B> => ({
   [Symbol.iterator]() {
@@ -734,9 +788,10 @@ export const map: {
  * @since 2.0.0
  */
 export const flatMap: {
-  <A, B>(
-    f: (a: NoInfer<A>, i: number) => Iterable<B>
-  ): (self: Iterable<A>) => Iterable<B>
+  <S extends Iterable<any>, T extends Iterable<any>>(
+    f: (a: Iterable.Infer<S>, i: number) => T
+  ): (self: S) => Iterable.AndNonEmpty<S, T, Iterable.Infer<T>>
+  <A, B>(self: NonEmptyIterable<A>, f: (a: NoInfer<A>, i: number) => NonEmptyIterable<B>): NonEmptyIterable<B>
   <A, B>(self: Iterable<A>, f: (a: NoInfer<A>, i: number) => Iterable<B>): Iterable<B>
 } = dual(
   2,
@@ -749,10 +804,10 @@ export const flatMap: {
  * @category sequencing
  * @since 2.0.0
  */
-export const flatten = <A>(self: Iterable<Iterable<A>>): Iterable<A> => ({
+export const flatten = <const S extends Iterable<Iterable<any>>>(self: S): Iterable.Flatten<S> => ({
   [Symbol.iterator]() {
     const outerIterator = self[Symbol.iterator]()
-    let innerIterator: Iterator<A> | undefined
+    let innerIterator: Iterator<Iterable.Infer<Iterable.Infer<S>>> | undefined
     function next() {
       if (innerIterator === undefined) {
         const next = outerIterator.next()
@@ -770,7 +825,7 @@ export const flatten = <A>(self: Iterable<Iterable<A>>): Iterable<A> => ({
     }
     return { next }
   }
-})
+}) as any
 
 /**
  * @category filtering
@@ -1018,7 +1073,10 @@ export const reduce: {
  * @since 2.0.0
  */
 export const dedupeAdjacentWith: {
-  <A>(isEquivalent: (self: A, that: A) => boolean): (self: Iterable<A>) => Iterable<A>
+  <S extends Iterable<any>>(
+    isEquivalent: (self: Iterable.Infer<S>, that: Iterable.Infer<S>) => boolean
+  ): (self: S) => Iterable.With<S, Iterable.Infer<S>>
+  <A>(self: NonEmptyIterable<A>, isEquivalent: (self: A, that: A) => boolean): NonEmptyIterable<A>
   <A>(self: Iterable<A>, isEquivalent: (self: A, that: A) => boolean): Iterable<A>
 } = dual(2, <A>(self: Iterable<A>, isEquivalent: (self: A, that: A) => boolean): Iterable<A> => ({
   [Symbol.iterator]() {
@@ -1051,7 +1109,10 @@ export const dedupeAdjacentWith: {
  *
  * @since 2.0.0
  */
-export const dedupeAdjacent: <A>(self: Iterable<A>) => Iterable<A> = dedupeAdjacentWith(Equal.equivalence())
+export const dedupeAdjacent = <S extends Iterable<any>>(
+  self: S
+): S extends NonEmptyIterable<infer A> ? NonEmptyIterable<A> : S extends Iterable<infer A> ? Iterable<A> : never =>
+  dedupeAdjacentWith(self, Equal.equivalence()) as any
 
 /**
  * Zips this Iterable crosswise with the specified Iterable using the specified combiner.
@@ -1060,7 +1121,10 @@ export const dedupeAdjacent: <A>(self: Iterable<A>) => Iterable<A> = dedupeAdjac
  * @category elements
  */
 export const cartesianWith: {
-  <A, B, C>(that: Iterable<B>, f: (a: A, b: B) => C): (self: Iterable<A>) => Iterable<C>
+  <S extends Iterable<any>, T extends Iterable<any>, C>(
+    that: T, f: (a: Iterable.Infer<S>, b: Iterable.Infer<T>) => C
+  ): (self: S) => Iterable.AndNonEmpty<S, T, C>
+  <A, B, C>(self: NonEmptyIterable<A>, that: NonEmptyIterable<B>, f: (a: A, b: B) => C): NonEmptyIterable<C>
   <A, B, C>(self: Iterable<A>, that: Iterable<B>, f: (a: A, b: B) => C): Iterable<C>
 } = dual(
   3,
@@ -1075,7 +1139,10 @@ export const cartesianWith: {
  * @category elements
  */
 export const cartesian: {
-  <B>(that: Iterable<B>): <A>(self: Iterable<A>) => Iterable<[A, B]>
+  <S extends Iterable<any>, T extends Iterable<any>, C>(
+    that: T
+  ): (self: S) => Iterable.AndNonEmpty<S, T, [Iterable.Infer<S>, Iterable.Infer<T>]>
+  <A, B>(self: NonEmptyIterable<A>, that: NonEmptyIterable<B>): NonEmptyIterable<[A, B]>
   <A, B>(self: Iterable<A>, that: Iterable<B>): Iterable<[A, B]>
 } = dual(
   2,


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This pull request add `NonEmptyIterable` overloads to `Iterable`. The code is based on corresponding type signatures and type level tests of `Array` module. Let me know what you think.