### PR TITLE
feat: add Scope support as context for RPC Middleware

### DIFF
--- a/.changeset/gold-eggs-sin.md
+++ b/.changeset/gold-eggs-sin.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node": minor
+"@effect/rpc": minor
+---
+
+feat: add Scope support as context for RPC Middleware

--- a/packages/platform-node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-node/test/fixtures/rpc-schemas.ts
@@ -90,11 +90,11 @@ const rpcCount = Metric.counter("rpc_middleware_count")
 const TimingLive = Layer.succeed(
   TimingMiddleware,
   TimingMiddleware.of((options) =>
-    options.next.pipe(
+    Effect.addFinalizer((exit) => Effect.logInfo(exit)).pipe(Effect.zipRight(options.next.pipe(
       Effect.tap(Metric.increment(rpcSuccesses)),
       Effect.tapDefect(() => Metric.increment(rpcDefects)),
       Effect.ensuring(Metric.increment(rpcCount))
-    )
+    )))
   )
 )
 

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -33,7 +33,7 @@ export interface RpcMiddleware<Provides, E> {
     readonly rpc: Rpc.AnyWithProps
     readonly payload: unknown
     readonly headers: Headers
-  }): Effect.Effect<Provides, E>
+  }): Effect.Effect<Provides, E, Scope>
 }
 
 /**
@@ -46,8 +46,8 @@ export interface RpcMiddlewareWrap<Provides, E> {
     readonly rpc: Rpc.AnyWithProps
     readonly payload: unknown
     readonly headers: Headers
-    readonly next: Effect.Effect<SuccessValue, E, Provides>
-  }): Effect.Effect<SuccessValue, E>
+    readonly next: Effect.Effect<SuccessValue, E, Provides | Scope>
+  }): Effect.Effect<SuccessValue, E, Scope>
 }
 
 /**

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -414,7 +414,7 @@ const applyMiddleware = <A, E, R>(
   clientId: number,
   payload: A,
   headers: Headers.Headers,
-  handler: Effect.Effect<A, E, R>
+  handler: Effect.Effect<A, E, R | Scope.Scope>
 ) => {
   if (rpc.middlewares.size === 0) {
     return handler

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -246,7 +246,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
 
     let responded = false
     let effect = Effect.uninterruptible(Effect.matchCauseEffect(
-      Effect.interruptible(applyMiddleware(
+      Effect.interruptible(Effect.scoped(applyMiddleware(
         rpc,
         context,
         client.id,
@@ -255,7 +255,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
         isStream
           ? streamEffect(client, request, streamOrEffect)
           : streamOrEffect as Effect.Effect<any>
-      )),
+      ))),
       {
         onSuccess: (value) => {
           responded = true


### PR DESCRIPTION
exposes the ~~fact that rpc requests run in a Scope~~, and that middlware can subscribe to that.

apparently this is only the case on the http server protocol, so we need to update the other protocols to support something similar.