### PR TITLE
non-greedy matching for Schema.String in Schema.TemplateLiteralParser

### DIFF
--- a/.changeset/wide-candles-wait.md
+++ b/.changeset/wide-candles-wait.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use non-greedy matching for Schema.String in Schema.TemplateLiteralParser

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2098,7 +2098,7 @@ export const annotations = (ast: AST, overrides: Annotations): AST => {
  */
 export const keyof = (ast: AST): AST => Union.unify(_keyof(ast))
 
-const STRING_KEYWORD_PATTERN = "[\\s\\S]*" // any string, including newlines
+const STRING_KEYWORD_PATTERN = "[\\s\\S]*?" // any string, including newlines
 const NUMBER_KEYWORD_PATTERN = "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
 
 const getTemplateLiteralSpanTypePattern = (type: TemplateLiteralSpanType, capture: boolean): string => {

--- a/packages/effect/test/Schema/JSONSchema.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.test.ts
@@ -2134,7 +2134,7 @@ details: Cannot encode Symbol(effect/Schema/test/a) key to JSON Schema`
           "": { "type": "number" }
         },
         "propertyNames": {
-          "pattern": "^[\\s\\S]*-[\\s\\S]*$",
+          "pattern": "^[\\s\\S]*?-[\\s\\S]*?$",
           "type": "string"
         }
       }

--- a/packages/effect/test/Schema/Schema/TemplateLiteral/TemplateLiteral.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteral/TemplateLiteral.test.ts
@@ -58,22 +58,22 @@ schema (Union): boolean | symbol`)
     expectPattern(["a", "b"], "^ab$")
     expectPattern([S.Literal("a", "b"), "c"], "^(a|b)c$")
     expectPattern([S.Literal("a", "b"), "c", S.Literal("d", "e")], "^(a|b)c(d|e)$")
-    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)[\\s\\S]*(d|e)$")
-    expectPattern(["a", S.String], "^a[\\s\\S]*$")
-    expectPattern(["a", S.String, "b"], "^a[\\s\\S]*b$")
+    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)[\\s\\S]*?(d|e)$")
+    expectPattern(["a", S.String], "^a[\\s\\S]*?$")
+    expectPattern(["a", S.String, "b"], "^a[\\s\\S]*?b$")
     expectPattern(
       ["a", S.String, "b", S.Number],
-      "^a[\\s\\S]*b[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
+      "^a[\\s\\S]*?b[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
     )
     expectPattern(["a", S.Number], "^a[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$")
-    expectPattern([S.String, "a"], "^[\\s\\S]*a$")
+    expectPattern([S.String, "a"], "^[\\s\\S]*?a$")
     expectPattern([S.Number, "a"], "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?a$")
     expectPattern(
       [S.Union(S.String, S.Literal(1)), S.Union(S.Number, S.Literal(true))],
-      "^([\\s\\S]*|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$"
+      "^([\\s\\S]*?|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$"
     )
     expectPattern([S.Union(S.Literal("a", "b"), S.Literal(1, 2))], "^(a|b|1|2)$")
-    expectPattern(["c", S.Union(S.TemplateLiteral("a", S.String, "b"), S.Literal("e")), "d"], "^c(a[\\s\\S]*b|e)d$")
+    expectPattern(["c", S.Union(S.TemplateLiteral("a", S.String, "b"), S.Literal("e")), "d"], "^c(a[\\s\\S]*?b|e)d$")
     expectPattern(["<", S.TemplateLiteral("h", S.Literal(1, 2)), ">"], "^<h(1|2)>$")
     expectPattern(
       ["-", S.Union(S.TemplateLiteral("a", S.Literal("b", "c")), S.TemplateLiteral("d", S.Literal("e", "f")))],

--- a/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteralParser.test.ts
@@ -35,26 +35,26 @@ schema (Union): boolean | symbol`)
     expectPattern(["a", "b"], "^(a)(b)$")
     expectPattern([S.Literal("a", "b"), "c"], "^(a|b)(c)$")
     expectPattern([S.Literal("a", "b"), "c", S.Literal("d", "e")], "^(a|b)(c)(d|e)$")
-    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)([\\s\\S]*)(d|e)$")
-    expectPattern(["a", S.String], "^(a)([\\s\\S]*)$")
-    expectPattern(["a", S.String, "b"], "^(a)([\\s\\S]*)(b)$")
+    expectPattern([S.Literal("a", "b"), S.String, S.Literal("d", "e")], "^(a|b)([\\s\\S]*?)(d|e)$")
+    expectPattern(["a", S.String], "^(a)([\\s\\S]*?)$")
+    expectPattern(["a", S.String, "b"], "^(a)([\\s\\S]*?)(b)$")
     expectPattern(
       ["a", S.String, "b", S.Number],
-      "^(a)([\\s\\S]*)(b)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$"
+      "^(a)([\\s\\S]*?)(b)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$"
     )
     expectPattern(["a", S.Number], "^(a)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)$")
-    expectPattern([S.String, "a"], "^([\\s\\S]*)(a)$")
+    expectPattern([S.String, "a"], "^([\\s\\S]*?)(a)$")
     expectPattern([S.Number, "a"], "^([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?)(a)$")
     expectPattern([
       S.Union(S.String, S.Literal(1)),
       S.Union(S.Number, S.Literal(true))
-    ], "^([\\s\\S]*|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$")
+    ], "^([\\s\\S]*?|1)([+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?|true)$")
     expectPattern([S.Union(S.Literal("a", "b"), S.Literal(1, 2))], "^(a|b|1|2)$")
     expectPattern([
       "c",
       S.Union(S.TemplateLiteral("a", S.String, "b"), S.Literal("e")),
       "d"
-    ], "^(c)(a[\\s\\S]*b|e)(d)$")
+    ], "^(c)(a[\\s\\S]*?b|e)(d)$")
     expectPattern(["<", S.TemplateLiteral("h", S.Literal(1, 2)), ">"], "^(<)(h(?:1|2))(>)$")
     expectPattern(
       ["-", S.Union(S.TemplateLiteral("a", S.Literal("b", "c")), S.TemplateLiteral("d", S.Literal("e", "f")))],
@@ -137,6 +137,7 @@ schema (Union): boolean | symbol`)
       const schema = S.TemplateLiteralParser(S.NumberFromString, "a", S.NonEmptyString)
 
       await Util.assertions.decoding.succeed(schema, "100ab", [100, "a", "b"])
+      await Util.assertions.decoding.succeed(schema, "100ab23a", [100, "a", "b23a"])
       await Util.assertions.decoding.fail(
         schema,
         "-ab",


### PR DESCRIPTION

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR changes the regex used for Schema.String in TemplateLiteralParser from greedy to non-greedy (`[\\s\\S]*` -> `[\\s\\S]*?`). Greedy matching can consume too much input and prevent following spans from matching. The non-greedy version allows downstream segments to parse correctly. 

Minimal repro is shown in this playground: https://effect.website/play#a54077a17e06

Note the minimal repro avoids NumberFromString (case exercised in the added test) to avoid unsupported span error when extracting the regex via TemplateLiteral.

## Related

This was discussed briefly here: https://discord.com/channels/795981131316985866/1344319931625246770

