### PR TITLE
Improve child process cleanup with platform-specific termination

### DIFF
--- a/.changeset/fuzzy-dragons-decide.md
+++ b/.changeset/fuzzy-dragons-decide.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Improved child process cleanup

--- a/packages/platform-node-shared/test/CommandExecutor.test.ts
+++ b/packages/platform-node-shared/test/CommandExecutor.test.ts
@@ -413,6 +413,44 @@ describe("Command", () => {
       }).pipe(Effect.scoped)
     ))
 
+  it("should cleanup child processes when parent exits with non-zero code", () =>
+    runPromise(
+      Effect.gen(function*() {
+        const path = yield* Path.Path
+        const command = pipe(
+          Command.make("./parent-exits-early.sh"),
+          Command.workingDirectory(path.join(...TEST_BASH_SCRIPTS_PATH))
+        )
+
+        // Count processes before running the command
+        const beforeRun = yield* pipe(
+          Command.string(Command.make("bash", "-c", "ps aux | grep parent-exits-early.sh | grep -v grep | wc -l")),
+          Effect.map((s) => parseInt(s.trim())),
+          Effect.orElse(() => Effect.succeed(0))
+        )
+        expect(beforeRun).toBe(0)
+
+        // Run the command that will spawn children and then exit with error
+        const exitCode = yield* Command.exitCode(command)
+
+        // Verify it exited with code 1
+        expect(exitCode).toBe(1)
+
+        // Give a moment for cleanup to complete
+        yield* Effect.sleep(500)
+
+        // Check that no child processes are still running
+        const afterExit = yield* pipe(
+          Command.string(Command.make("bash", "-c", "ps aux | grep 'sleep 30' | grep -v grep | wc -l")),
+          Effect.map((s) => parseInt(s.trim())),
+          Effect.orElse(() => Effect.succeed(0))
+        )
+
+        // Child processes should be cleaned up after non-zero exit
+        expect(afterExit).toBe(0)
+      }).pipe(Effect.scoped)
+    ))
+
   it("should allow running commands in a shell", () =>
     runPromise(
       Effect.gen(function*(_) {

--- a/packages/platform-node-shared/test/CommandExecutor.test.ts
+++ b/packages/platform-node-shared/test/CommandExecutor.test.ts
@@ -366,6 +366,53 @@ describe("Command", () => {
       }).pipe(Effect.scoped)
     ))
 
+  it("should kill all child processes in process group", () =>
+    runPromise(
+      Effect.gen(function*() {
+        const path = yield* Path.Path
+        const command = pipe(
+          Command.make("./spawn-children.sh"),
+          Command.workingDirectory(path.join(...TEST_BASH_SCRIPTS_PATH))
+        )
+
+        // Start the process that spawns children and grandchildren
+        const proc = yield* Command.start(command)
+
+        // Give it time to spawn all processes
+        yield* Effect.sleep(500)
+
+        // Verify the main process is running
+        const isRunningBeforeKill = yield* proc.isRunning
+        expect(isRunningBeforeKill).toBe(true)
+
+        // Count processes before killing - should be at least 7 (1 parent + 3 children + 3 grandchildren)
+        const beforeKill = yield* pipe(
+          Command.string(Command.make("bash", "-c", "ps aux | grep spawn-children.sh | grep -v grep | wc -l")),
+          Effect.map((s) => parseInt(s.trim())),
+          Effect.orElse(() => Effect.succeed(0))
+        )
+        expect(beforeKill).toBeGreaterThanOrEqual(7)
+
+        // Kill the main process
+        yield* proc.kill()
+
+        // Verify the main process is no longer running
+        const isRunningAfterKill = yield* proc.isRunning
+        expect(isRunningAfterKill).toBe(false)
+
+        // Give a moment for cleanup to complete
+        yield* Effect.sleep(500)
+
+        // Check that no processes from the script are still running
+        const afterKill = yield* pipe(
+          Command.string(Command.make("bash", "-c", "ps aux | grep spawn-children.sh | grep -v grep | wc -l")),
+          Effect.map((s) => parseInt(s.trim())),
+          Effect.orElse(() => Effect.succeed(0))
+        )
+        expect(afterKill).toBe(0)
+      }).pipe(Effect.scoped)
+    ))
+
   it("should allow running commands in a shell", () =>
     runPromise(
       Effect.gen(function*(_) {

--- a/packages/platform-node-shared/test/fixtures/bash/parent-exits-early.sh
+++ b/packages/platform-node-shared/test/fixtures/bash/parent-exits-early.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# This script spawns child processes to test process group cleanup
+# This script spawns child processes and then exits early
 echo "Parent process started with PID $$"
 
-# Spawn multiple child processes
+# Spawn multiple child processes that will outlive the parent
 for i in {1..3}; do
   (
     # Child process
@@ -14,19 +14,18 @@ for i in {1..3}; do
     (
       grandchild_pid=$BASHPID
       echo "Grandchild of child $i started with PID $grandchild_pid"
-      # Keep running for 60 seconds
-      for j in {1..60}; do
-        sleep 1
-      done
+      # Keep running for 30 seconds
+      sleep 30
     ) &
 
     # Keep the child running
-    for j in {1..60}; do
-      sleep 1
-    done
+    sleep 30
   ) &
 done
 
-# Keep the parent running
-echo "Parent process waiting..."
-wait
+# Give children time to start
+sleep 0.5
+
+# Exit early (simulating a crash or early termination)
+echo "Parent exiting early with status 1..."
+exit 1

--- a/packages/platform-node-shared/test/fixtures/bash/spawn-children.sh
+++ b/packages/platform-node-shared/test/fixtures/bash/spawn-children.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# This script spawns child processes to test process group cleanup
+echo "Parent process started with PID $$"
+
+# Spawn multiple child processes
+for i in {1..3}; do
+  (
+    # Child process
+    child_pid=$BASHPID
+    echo "Child $i started with PID $child_pid"
+    
+    # Spawn a grandchild that runs for a long time
+    (
+      grandchild_pid=$BASHPID
+      echo "Grandchild of child $i started with PID $grandchild_pid"
+      # Keep running for 60 seconds
+      for j in {1..60}; do
+        sleep 1
+      done
+    ) &
+    
+    # Keep the child running
+    for j in {1..60}; do
+      sleep 1
+    done
+  ) &
+done
+
+# Keep the parent running
+echo "Parent process waiting..."
+wait


### PR DESCRIPTION
## Summary

Improves child process cleanup in `@effect/platform` Command execution by implementing platform-specific process tree termination:

- **Unix systems**: Uses `detached: true` to create process groups and `process.kill(-pid)` to terminate entire process groups
- **Windows systems**: Uses `taskkill /pid ${pid} /T /F` to terminate process trees
- **Fallback mechanism**: If the new cleanup approach fails, falls back to the original `handle.kill()` behavior

## Changes

- Added `detached: process.platform \!== "win32"` to spawn options for Unix process group creation
- Implemented platform-specific kill logic in both `acquireRelease` cleanup and the `kill()` method
- Used Effect's async patterns (`Effect.async`, `Effect.try`) with proper error handling via `toPlatformError`
- Added comprehensive test case with bash script that creates child and grandchild processes
- Test verifies that all processes in the tree are properly cleaned up

## Benefits

- **Better cleanup**: Ensures all spawned processes (including grandchildren) are terminated, not just the direct child
- **Platform-appropriate**: Uses the correct mechanism for each OS (process groups on Unix, process trees on Windows)
- **Backward compatible**: No breaking changes - behavior is functionally the same for users but with improved cleanup
- **Robust**: Falls back to original behavior if new approach fails

## Test plan

- [x] All existing CommandExecutor tests pass
- [x] New test case verifies process group cleanup works correctly
- [x] TypeScript compilation passes
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.ai/code)