### PR TITLE
feat: add support for RPC middleware providing multiple services

### DIFF
--- a/.changeset/silly-nails-tickle.md
+++ b/.changeset/silly-nails-tickle.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-node": minor
+"@effect/rpc": minor
+---
+
+feat: add support for RPC middleware providing multiple services
+`provides: [X, Y]`
+return `Context.make(...)`

--- a/packages/platform-node/test/rpc-e2e.ts
+++ b/packages/platform-node/test/rpc-e2e.ts
@@ -118,5 +118,12 @@ export const e2eSuite = <E>(
         assert.notEqual(defect, 0)
         assert.notEqual(success, 0)
       }).pipe(Effect.provide(layer)))
+
+    it.effect("supports Context provide", () =>
+      Effect.gen(function*() {
+        const client = yield* UsersClient
+        const context = yield* client.GetContext()
+        assert.deepStrictEqual(context, { Something: "something", SomethingElse: "something-else" })
+      }).pipe(Effect.provide(layer)))
   })
 }

--- a/packages/rpc/src/Rpc.ts
+++ b/packages/rpc/src/Rpc.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 import type { Headers } from "@effect/platform/Headers"
+import type { NonEmptyReadonlyArray } from "effect/Array"
 import * as Context_ from "effect/Context"
 import type { Effect } from "effect/Effect"
 import type { Exit as Exit_ } from "effect/Exit"
@@ -441,6 +442,9 @@ export type ExtractProvides<R extends Any, Tag extends string> = R extends
   Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ? _Middleware extends {
     readonly provides: Context_.Tag<infer _I, infer _S>
   } ? _I :
+  _Middleware extends {
+    readonly provides: NonEmptyReadonlyArray<Context_.Tag<any, any>>
+  } ? Context_.Tag.Identifier<_Middleware["provides"][number]> :
   never :
   never
 

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 import type { Headers } from "@effect/platform/Headers"
+import type { NonEmptyReadonlyArray } from "effect/Array"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
@@ -128,6 +129,10 @@ export declare namespace TagClass {
     readonly provides: Context.Tag<any, any>
     readonly optional?: false
   } ? Context.Tag.Identifier<Options["provides"]>
+    : Options extends {
+      readonly provides: NonEmptyReadonlyArray<Context.Tag<any, any>>
+      readonly optional?: false
+    } ? Context.Tag.Identifier<Options["provides"][number]>
     : never
 
   /**
@@ -136,6 +141,8 @@ export declare namespace TagClass {
    */
   export type Service<Options> = Options extends { readonly provides: Context.Tag<any, any> }
     ? Context.Tag.Service<Options["provides"]>
+    : Options extends { readonly provides: NonEmptyReadonlyArray<Context.Tag<any, any>> } ?
+      Context.Context<Context.Tag.Identifier<Options["provides"][number]>>
     : void
 
   /**
@@ -193,7 +200,8 @@ export declare namespace TagClass {
     readonly [TypeId]: TypeId
     readonly optional: Optional<Options>
     readonly failure: FailureSchema<Options>
-    readonly provides: Options extends { readonly provides: Context.Tag<any, any> } ? Options["provides"]
+    readonly provides: Options extends
+      { readonly provides: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> } ? Options["provides"]
       : undefined
     readonly requiredForClient: RequiredForClient<Options>
     readonly wrap: Wrap<Options>
@@ -207,7 +215,7 @@ export declare namespace TagClass {
 export interface TagClassAny extends Context.Tag<any, any> {
   readonly [TypeId]: TypeId
   readonly optional: boolean
-  readonly provides?: Context.Tag<any, any> | undefined
+  readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
   readonly wrap: boolean
@@ -220,7 +228,7 @@ export interface TagClassAny extends Context.Tag<any, any> {
 export interface TagClassAnyWithProps extends Context.Tag<any, RpcMiddleware<any, any> | RpcMiddlewareWrap<any, any>> {
   readonly [TypeId]: TypeId
   readonly optional: boolean
-  readonly provides?: Context.Tag<any, any>
+  readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
   readonly wrap: boolean
@@ -236,7 +244,7 @@ export const Tag = <Self>(): <
     readonly wrap?: boolean
     readonly optional?: boolean
     readonly failure?: Schema.Schema.All
-    readonly provides?: Context.Tag<any, any>
+    readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
     readonly requiredForClient?: boolean
   }
 >(
@@ -248,7 +256,7 @@ export const Tag = <Self>(): <
   options?: {
     readonly optional?: boolean
     readonly failure?: Schema.Schema.All
-    readonly provides?: Context.Tag<any, any>
+    readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
     readonly requiredForClient?: boolean
     readonly wrap?: boolean
   }

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -437,14 +437,20 @@ const applyMiddleware = <A, E, R>(
       handler = Effect.matchEffect(middleware(options), {
         onFailure: () => previous,
         onSuccess: tag.provides !== undefined
-          ? (value) => Effect.provideService(previous, tag.provides as any, value)
+          ? (value) =>
+            Array.isArray(tag.provides)
+              ? Effect.provide(previous, value) as any
+              : Effect.provideService(previous, tag.provides as any, value)
           : (_) => previous
       })
     } else {
       const middleware = Context.unsafeGet(context, tag) as RpcMiddleware<any, any>
+      const previous = handler
       handler = tag.provides !== undefined
-        ? Effect.provideServiceEffect(handler, tag.provides as any, middleware(options))
-        : Effect.zipRight(middleware(options), handler)
+        ? Array.isArray(tag.provides)
+          ? middleware(options).pipe(Effect.flatMap((value) => Effect.provide(previous, value))) as any
+          : Effect.provideServiceEffect(previous, tag.provides as any, middleware(options))
+        : Effect.zipRight(middleware(options), previous)
     }
   }
 


### PR DESCRIPTION
`provides: [X, Y]`
return `Context.make(...)`