### PR TITLE
align RPC middleware api

### DIFF
--- a/.changeset/loose-coins-like.md
+++ b/.changeset/loose-coins-like.md
@@ -1,6 +1,0 @@
----
-"@effect/platform-node": minor
-"@effect/rpc": minor
----
-
-feat: add `requires: Tag | [Tag, Tag2]`support to Middleware

--- a/.changeset/loose-coins-like.md
+++ b/.changeset/loose-coins-like.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node": minor
+"@effect/rpc": minor
+---
+
+feat: add `requires: Tag | [Tag, Tag2]`support to Middleware

--- a/.changeset/silly-nails-tickle.md
+++ b/.changeset/silly-nails-tickle.md
@@ -3,6 +3,4 @@
 "@effect/rpc": minor
 ---
 
-feat: add support for RPC middleware providing multiple services
-`provides: [X, Y]`
-return `Context.make(...)`
+Align RPC middleware api; only the `wrap` variant remains, and `provides` and `requires` are supported as second generic argument <Self, Config>

--- a/.changeset/silly-nails-tickle.md
+++ b/.changeset/silly-nails-tickle.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-node": minor
+"@effect/rpc": minor
+---
+
+feat: add support for RPC middleware providing multiple services
+`provides: [X, Y]`
+return `Context.make(...)`

--- a/packages/ai/ai/src/McpSchema.ts
+++ b/packages/ai/ai/src/McpSchema.ts
@@ -1784,11 +1784,9 @@ export class McpServerClient extends Context.Tag("@effect/ai/McpSchema/McpServer
  * @since 1.0.0
  * @category McpServerClient
  */
-export class McpServerClientMiddleware
-  extends RpcMiddleware.Tag<McpServerClientMiddleware>()("@effect/ai/McpSchema/McpServerClientMiddleware", {
-    provides: McpServerClient
-  })
-{}
+export class McpServerClientMiddleware extends RpcMiddleware.Tag<McpServerClientMiddleware, {
+  provides: McpServerClient
+}>()("@effect/ai/McpSchema/McpServerClientMiddleware") {}
 
 // =============================================================================
 // Protocol

--- a/packages/ai/ai/src/McpServer.ts
+++ b/packages/ai/ai/src/McpServer.ts
@@ -338,15 +338,18 @@ export const run: (
     idleTimeToLive: 10000
   })
 
-  const clientMiddleware = McpServerClientMiddleware.of(({ clientId }) =>
-    Effect.sync(() =>
-      McpServerClient.of({
-        clientId,
-        getClient: RcMap.get(clients, clientId).pipe(
-          Effect.map(({ client }) => client)
-        )
-      })
-    )
+  const clientMiddleware = McpServerClientMiddleware.of(
+    (next, { clientId }) =>
+      Effect.provideService(
+        next,
+        McpServerClient,
+        McpServerClient.of({
+          clientId,
+          getClient: RcMap.get(clients, clientId).pipe(
+            Effect.map(({ client }) => client)
+          )
+        })
+      )
   )
 
   const patchedProtocol = RpcServer.Protocol.of({

--- a/packages/platform-node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-node/test/fixtures/rpc-schemas.ts
@@ -43,6 +43,7 @@ export class Something extends Context.Tag("Something")<Something, "something">(
 export class SomethingElse extends Context.Tag("SomethingElse")<SomethingElse, "something-else">() {}
 
 class SomethingMiddleware extends RpcMiddleware.Tag<SomethingMiddleware>()("SomethingMiddleware", {
+  requires: CurrentUser,
   provides: [Something, SomethingElse]
 }) {}
 
@@ -120,12 +121,12 @@ const TimingLive = Layer.succeed(
 const SomethingLive = Layer.succeed(
   SomethingMiddleware,
   SomethingMiddleware.of(() =>
-    Effect.succeed(
+    CurrentUser.pipe(Effect.map(() =>
       Context.empty().pipe(
         Context.add(Something, "something"),
         Context.add(SomethingElse, "something-else")
       )
-    )
+    ))
   )
 )
 

--- a/packages/platform-node/test/rpc-e2e.ts
+++ b/packages/platform-node/test/rpc-e2e.ts
@@ -118,5 +118,12 @@ export const e2eSuite = <E>(
         assert.notEqual(defect, 0)
         assert.notEqual(success, 0)
       }).pipe(Effect.provide(layer)))
+
+    it.effect("supports Context provide", () =>
+      Effect.gen(function*() {
+        const client = yield* UsersClient
+        const context = yield* client.GetContext()
+        assert.deepStrictEqual(context, { Something: "something", SomethingElse: "something-else" })
+      }).pipe(Effect.provide(layer)))
   })
 }

--- a/packages/rpc/src/Rpc.ts
+++ b/packages/rpc/src/Rpc.ts
@@ -2,7 +2,6 @@
  * @since 1.0.0
  */
 import type { Headers } from "@effect/platform/Headers"
-import type { NonEmptyReadonlyArray } from "effect/Array"
 import * as Context_ from "effect/Context"
 import type { Effect } from "effect/Effect"
 import type { Exit as Exit_ } from "effect/Exit"
@@ -445,13 +444,8 @@ export type ExtractTag<R extends Any, Tag extends string> = R extends
  * @category models
  */
 export type ExtractProvides<R extends Any, Tag extends string> = R extends
-  Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ? _Middleware extends {
-    readonly provides: Context_.Tag<infer _I, infer _S>
-  } ? _I :
-  _Middleware extends {
-    readonly provides: NonEmptyReadonlyArray<Context_.Tag<any, any>>
-  } ? Context_.Tag.Identifier<_Middleware["provides"][number]> :
-  never :
+  Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ?
+  RpcMiddleware.TagClass.ExtractProvides<_Middleware> :
   never
 
 /**
@@ -459,13 +453,8 @@ export type ExtractProvides<R extends Any, Tag extends string> = R extends
  * @category models
  */
 export type ExtractRequires<R extends Any, Tag extends string> = R extends
-  Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ? _Middleware extends {
-    readonly requires: Context_.Tag<infer _I, infer _S>
-  } ? _I :
-  _Middleware extends {
-    readonly requires: Context_.Context<infer _I>
-  } ? _I :
-  never :
+  Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ?
+  RpcMiddleware.TagClass.ExtractRequires<_Middleware> :
   never
 
 /**

--- a/packages/rpc/src/Rpc.ts
+++ b/packages/rpc/src/Rpc.ts
@@ -458,6 +458,20 @@ export type ExtractProvides<R extends Any, Tag extends string> = R extends
  * @since 1.0.0
  * @category models
  */
+export type ExtractRequires<R extends Any, Tag extends string> = R extends
+  Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ? _Middleware extends {
+    readonly requires: Context_.Tag<infer _I, infer _S>
+  } ? _I :
+  _Middleware extends {
+    readonly requires: Context_.Context<infer _I>
+  } ? _I :
+  never :
+  never
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
 export type ExcludeProvides<Env, R extends Any, Tag extends string> = Exclude<
   Env,
   ExtractProvides<R, Tag>

--- a/packages/rpc/src/Rpc.ts
+++ b/packages/rpc/src/Rpc.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 import type { Headers } from "@effect/platform/Headers"
+import type { NonEmptyReadonlyArray } from "effect/Array"
 import * as Context_ from "effect/Context"
 import type { Effect } from "effect/Effect"
 import type { Exit as Exit_ } from "effect/Exit"
@@ -447,6 +448,9 @@ export type ExtractProvides<R extends Any, Tag extends string> = R extends
   Rpc<Tag, infer _Payload, infer _Success, infer _Error, infer _Middleware> ? _Middleware extends {
     readonly provides: Context_.Tag<infer _I, infer _S>
   } ? _I :
+  _Middleware extends {
+    readonly provides: NonEmptyReadonlyArray<Context_.Tag<any, any>>
+  } ? Context_.Tag.Identifier<_Middleware["provides"][number]> :
   never :
   never
 

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -116,7 +116,8 @@ export declare namespace RpcClient {
       infer _Payload,
       infer _Success,
       infer _Error,
-      infer _Middleware
+      infer _Middleware,
+      infer _Requirements
     > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? AsMailbox extends true ? Effect.Effect<
             Mailbox.ReadonlyMailbox<_A["Type"], _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"]>,
             never,
@@ -166,7 +167,8 @@ export declare namespace RpcClient {
     infer _Payload,
     infer _Success,
     infer _Error,
-    infer _Middleware
+    infer _Middleware,
+    infer _Requirements
   > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? AsMailbox extends true ? Effect.Effect<
           Mailbox.ReadonlyMailbox<_A["Type"], _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"]>,
           never,

--- a/packages/rpc/src/RpcGroup.ts
+++ b/packages/rpc/src/RpcGroup.ts
@@ -95,6 +95,8 @@ export interface RpcGroup<in out R extends Rpc.Any> extends Pipeable {
   ): Layer.Layer<
     Rpc.ToHandler<R>,
     EX,
+    | (R extends Rpc.Rpc<infer _A, infer _B, infer _C, infer _D, infer _E, infer _F> ? _F :
+      never)
     | Exclude<RX, Scope>
     | HandlersContext<R, Handlers>
   >
@@ -117,6 +119,8 @@ export interface RpcGroup<in out R extends Rpc.Any> extends Pipeable {
   ): Layer.Layer<
     Rpc.Handler<Tag>,
     EX,
+    | (R extends Rpc.Rpc<infer _A, infer _B, infer _C, infer _D, infer _E, infer _F> ? _F :
+      never)
     | Exclude<RX, Scope>
     | HandlerContext<R, Tag, Handler>
   >

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 import type { Headers } from "@effect/platform/Headers"
+import type { NonEmptyReadonlyArray } from "effect/Array"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
@@ -128,6 +129,10 @@ export declare namespace TagClass {
     readonly provides: Context.Tag<any, any>
     readonly optional?: false
   } ? Context.Tag.Identifier<Options["provides"]>
+    : Options extends {
+      readonly provides: NonEmptyReadonlyArray<Context.Tag<any, any>>
+      readonly optional?: false
+    } ? Context.Tag.Identifier<Options["provides"][number]>
     : never
 
   /**
@@ -136,6 +141,8 @@ export declare namespace TagClass {
    */
   export type Service<Options> = Options extends { readonly provides: Context.Tag<any, any> }
     ? Context.Tag.Service<Options["provides"]>
+    : Options extends { readonly provides: NonEmptyReadonlyArray<Context.Tag<any, any>> } ?
+      Context.Context<Context.Tag.Identifier<Options["provides"][number]>>
     : void
 
   /**
@@ -193,7 +200,8 @@ export declare namespace TagClass {
     readonly [TypeId]: TypeId
     readonly optional: Optional<Options>
     readonly failure: FailureSchema<Options>
-    readonly provides: Options extends { readonly provides: Context.Tag<any, any> } ? Options["provides"]
+    readonly provides: Options extends
+      { readonly provides: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> } ? Options["provides"]
       : undefined
     readonly requiredForClient: RequiredForClient<Options>
     readonly wrap: Wrap<Options>
@@ -207,7 +215,7 @@ export declare namespace TagClass {
 export interface TagClassAny extends Context.Tag<any, any> {
   readonly [TypeId]: TypeId
   readonly optional: boolean
-  readonly provides?: Context.Tag<any, any> | undefined
+  readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
   readonly wrap: boolean
@@ -220,7 +228,7 @@ export interface TagClassAny extends Context.Tag<any, any> {
 export interface TagClassAnyWithProps extends Context.Tag<any, RpcMiddleware<any, any> | RpcMiddlewareWrap<any, any>> {
   readonly [TypeId]: TypeId
   readonly optional: boolean
-  readonly provides?: Context.Tag<any, any>
+  readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
   readonly wrap: boolean
@@ -236,7 +244,7 @@ export const Tag = <Self>(): <
     readonly wrap?: boolean
     readonly optional?: boolean
     readonly failure?: Schema.Schema.All
-    readonly provides?: Context.Tag<any, any>
+    readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
     readonly requiredForClient?: boolean
   }
 >(
@@ -248,7 +256,7 @@ export const Tag = <Self>(): <
   options?: {
     readonly optional?: boolean
     readonly failure?: Schema.Schema.All
-    readonly provides?: Context.Tag<any, any>
+    readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
     readonly requiredForClient?: boolean
     readonly wrap?: boolean
   }

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -29,26 +29,15 @@ export type TypeId = typeof TypeId
  * @category models
  */
 export interface RpcMiddleware<Provides, E, Requires> {
-  (options: {
-    readonly clientId: number
-    readonly rpc: Rpc.AnyWithProps
-    readonly payload: unknown
-    readonly headers: Headers
-  }): Effect.Effect<Provides, E, Requires>
-}
-
-/**
- * @since 1.0.0
- * @category models
- */
-export interface RpcMiddlewareWrap<Provides, E, Requires> {
-  (options: {
-    readonly clientId: number
-    readonly rpc: Rpc.AnyWithProps
-    readonly payload: unknown
-    readonly headers: Headers
-    readonly next: Effect.Effect<SuccessValue, E, Provides>
-  }): Effect.Effect<SuccessValue, E, Requires>
+  (
+    next: Effect.Effect<SuccessValue, E, Provides>,
+    options: {
+      readonly clientId: number
+      readonly rpc: Rpc.AnyWithProps
+      readonly payload: unknown
+      readonly headers: Headers
+    }
+  ): Effect.Effect<SuccessValue, E, Requires>
 }
 
 /**
@@ -99,22 +88,22 @@ export interface Any {
 export interface TagClass<
   Self,
   Name extends string,
-  Options
+  Options,
+  Config extends {
+    requires?: any
+    provides?: any
+  }
 > extends
   TagClass.Base<
     Self,
     Name,
     Options,
-    TagClass.Wrap<Options> extends true ? RpcMiddlewareWrap<
-        TagClass.Provides<Options>,
-        TagClass.Failure<Options>,
-        TagClass.Requires<Options>
-      > :
-      RpcMiddleware<
-        TagClass.Service<Options>,
-        TagClass.FailureService<Options>,
-        TagClass.Requires<Options>
-      >
+    RpcMiddleware<
+      "provides" extends keyof Config ? Config["provides"] : never,
+      TagClass.Failure<Options>,
+      "requires" extends keyof Config ? Config["requires"] : never
+    >,
+    Config
   >
 {}
 
@@ -204,18 +193,9 @@ export declare namespace TagClass {
    * @since 1.0.0
    * @category models
    */
-  export type Wrap<Options> = Options extends { readonly wrap: true } ? true : false
-
-  /**
-   * @since 1.0.0
-   * @category models
-   */
   export type ExtractProvides<M> = M extends {
-    readonly provides: Context.Tag<infer _I, infer _S>
+    readonly provides: infer _I
   } ? _I :
-    M extends {
-      readonly provides: NonEmptyReadonlyArray<Context.Tag<any, any>>
-    } ? Context.Tag.Identifier<M["provides"][number]> :
     never
 
   /**
@@ -223,30 +203,31 @@ export declare namespace TagClass {
    * @category models
    */
   export type ExtractRequires<M extends TagClassAny> = M extends {
-    readonly requires: Context.Tag<infer _I, infer _S>
+    readonly requires: infer _I
   } ? _I :
-    M extends {
-      readonly requires: NonEmptyReadonlyArray<Context.Tag<any, any>>
-    } ? Context.Tag.Identifier<M["requires"][number]> :
     never
 
   /**
    * @since 1.0.0
    * @category models
    */
-  export interface Base<Self, Name extends string, Options, Service> extends Context.Tag<Self, Service> {
+  export interface Base<
+    Self,
+    Name extends string,
+    Options,
+    Service,
+    Config extends {
+      requires?: any
+      provides?: any
+    }
+  > extends Context.Tag<Self, Service> {
     new(_: never): Context.TagClassShape<Name, Service>
     readonly [TypeId]: TypeId
     readonly optional: Optional<Options>
     readonly failure: FailureSchema<Options>
-    readonly provides: Options extends
-      { readonly provides: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> } ? Options["provides"]
-      : undefined
-    readonly requires: Options extends
-      { readonly requires: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> } ? Options["requires"]
-      : undefined
+    readonly provides: "provides" extends keyof Config ? Config["provides"] : never
+    readonly requires: "requires" extends keyof Config ? Config["requires"] : never
     readonly requiredForClient: RequiredForClient<Options>
-    readonly wrap: Wrap<Options>
   }
 }
 
@@ -257,56 +238,52 @@ export declare namespace TagClass {
 export interface TagClassAny extends Context.Tag<any, any> {
   readonly [TypeId]: TypeId
   readonly optional: boolean
-  readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
-  readonly requires?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
+  readonly provides?: any | undefined
+  readonly requires?: any | undefined
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
-  readonly wrap: boolean
 }
 
 /**
  * @since 1.0.0
  * @category models
  */
-export interface TagClassAnyWithProps
-  extends Context.Tag<any, RpcMiddleware<any, any, any> | RpcMiddlewareWrap<any, any, any>>
-{
+export interface TagClassAnyWithProps extends Context.Tag<any, RpcMiddleware<any, any, any>> {
   readonly [TypeId]: TypeId
   readonly optional: boolean
-  readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
-  readonly requires?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>> | undefined
+  readonly provides?: any | undefined
+  readonly requires?: any | undefined
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
-  readonly wrap: boolean
 }
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const Tag = <Self>(): <
+export const Tag = <
+  Self,
+  Config extends {
+    requires?: any
+    provides?: any
+  } = { requires: never; provides: never }
+>(): <
   const Name extends string,
   const Options extends {
-    readonly wrap?: boolean
     readonly optional?: boolean
     readonly failure?: Schema.Schema.All
-    readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
-    readonly requires?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
     readonly requiredForClient?: boolean
   }
 >(
   id: Name,
   options?: Options | undefined
-) => TagClass<Self, Name, Options> =>
+) => TagClass<Self, Name, Options, Config> =>
 (
   id: string,
   options?: {
     readonly optional?: boolean
     readonly failure?: Schema.Schema.All
-    readonly provides?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
-    readonly requires?: Context.Tag<any, any> | NonEmptyReadonlyArray<Context.Tag<any, any>>
     readonly requiredForClient?: boolean
-    readonly wrap?: boolean
   }
 ) => {
   const Err = globalThis.Error as any
@@ -326,15 +303,8 @@ export const Tag = <Self>(): <
   })
   TagClass_[TypeId] = TypeId
   TagClass_.failure = options?.optional === true || options?.failure === undefined ? Schema.Never : options.failure
-  if (options?.provides) {
-    TagClass_.provides = options.provides
-  }
-  if (options?.requires) {
-    TagClass_.requires = options.requires
-  }
   TagClass_.optional = options?.optional ?? false
   TagClass_.requiredForClient = options?.requiredForClient ?? false
-  TagClass_.wrap = options?.wrap ?? false
   return TagClass as any
 }
 

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -210,6 +210,30 @@ export declare namespace TagClass {
    * @since 1.0.0
    * @category models
    */
+  export type ExtractProvides<M> = M extends {
+    readonly provides: Context.Tag<infer _I, infer _S>
+  } ? _I :
+    M extends {
+      readonly provides: NonEmptyReadonlyArray<Context.Tag<any, any>>
+    } ? Context.Tag.Identifier<M["provides"][number]> :
+    never
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
+  export type ExtractRequires<M extends TagClassAny> = M extends {
+    readonly requires: Context.Tag<infer _I, infer _S>
+  } ? _I :
+    M extends {
+      readonly requires: NonEmptyReadonlyArray<Context.Tag<any, any>>
+    } ? Context.Tag.Identifier<M["requires"][number]> :
+    never
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
   export interface Base<Self, Name extends string, Options, Service> extends Context.Tag<Self, Service> {
     new(_: never): Context.TagClassShape<Name, Service>
     readonly [TypeId]: TypeId

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -435,7 +435,7 @@ const applyMiddleware = <A, E, R>(
       const middleware = Context.unsafeGet(context, tag)
       handler = middleware({ ...options, next: handler as any })
     } else if (tag.optional) {
-      const middleware = Context.unsafeGet(context, tag) as RpcMiddleware<any, any>
+      const middleware = Context.unsafeGet(context, tag) as RpcMiddleware<any, any, any>
       const previous = handler
       handler = Effect.matchEffect(middleware(options), {
         onFailure: () => previous,
@@ -447,7 +447,7 @@ const applyMiddleware = <A, E, R>(
           : (_) => previous
       })
     } else {
-      const middleware = Context.unsafeGet(context, tag) as RpcMiddleware<any, any>
+      const middleware = Context.unsafeGet(context, tag) as RpcMiddleware<any, any, any>
       const previous = handler
       handler = tag.provides !== undefined
         ? Array.isArray(tag.provides)


### PR DESCRIPTION
Align RPC middleware api; only the `wrap` variant remains, and `provides` and `requires` are supported as second generic argument `<Self, Config>`