### PR TITLE
improve baseUrl handling in Otlp constructor

### DIFF
--- a/.changeset/calm-games-listen.md
+++ b/.changeset/calm-games-listen.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+improve baseUrl handling in Otlp constructor

--- a/packages/opentelemetry/src/Otlp.ts
+++ b/packages/opentelemetry/src/Otlp.ts
@@ -31,11 +31,12 @@ export const layer = (options: {
   readonly metricsExportInterval?: Duration.DurationInput | undefined
   readonly tracerExportInterval?: Duration.DurationInput | undefined
   readonly shutdownTimeout?: Duration.DurationInput | undefined
-}): Layer.Layer<never, never, HttpClient.HttpClient> =>
-  Layer.mergeAll(
+}): Layer.Layer<never, never, HttpClient.HttpClient> => {
+  const baseUrl = options.baseUrl.endsWith('/') ? options.baseUrl : options.baseUrl + '/';
+  return Layer.mergeAll(
     OtlpLogger.layer({
       replaceLogger: options.replaceLogger,
-      url: new URL("/v1/logs", options.baseUrl).toString(),
+      url: new URL("v1/logs", options.baseUrl).toString(),
       resource: options.resource,
       headers: options.headers,
       exportInterval: options.loggerExportInterval,
@@ -44,14 +45,14 @@ export const layer = (options: {
       excludeLogSpans: options.loggerExcludeLogSpans
     }),
     OtlpMetrics.layer({
-      url: new URL("/v1/metrics", options.baseUrl).toString(),
+      url: new URL("v1/metrics", options.baseUrl).toString(),
       resource: options.resource,
       headers: options.headers,
       exportInterval: options.metricsExportInterval,
       shutdownTimeout: options.shutdownTimeout
     }),
     OtlpTracer.layer({
-      url: new URL("/v1/traces", options.baseUrl).toString(),
+      url: new URL("v1/traces", options.baseUrl).toString(),
       resource: options.resource,
       headers: options.headers,
       exportInterval: options.tracerExportInterval,
@@ -60,3 +61,4 @@ export const layer = (options: {
       shutdownTimeout: options.shutdownTimeout
     })
   )
+}

--- a/packages/opentelemetry/src/OtlpTracer.ts
+++ b/packages/opentelemetry/src/OtlpTracer.ts
@@ -68,6 +68,10 @@ export const make: (
     shutdownTimeout: options.shutdownTimeout ?? Duration.seconds(3)
   })
 
+  const exportFn = (span: SpanImpl) => {
+    exporter.push(makeOtlpSpan(span))
+  }
+
   return Tracer.make({
     span(name, parent, context, links, startTime, kind) {
       return makeSpan({
@@ -82,9 +86,7 @@ export const make: (
         links,
         sampled: true,
         kind,
-        export(span) {
-          exporter.push(makeOtlpSpan(span))
-        }
+        export: exportFn
       })
     },
     context: options.context ?


### PR DESCRIPTION
There's probably a less janky way to do this, but I think this is pretty much what we want to do right?

The base url must end in a slash (be a directory not a file)
The path we are appending must not begin with a slash, it's relative not absolute

Should we perhaps strip whitespace from baseurl first to make this more robust?
Maybe we should be parsing the baseUrl with a SlashTerminatedUrl Schema? 🤓 

#5333 