### PR TITLE
fix: Tool calls with no argumets get ignored

### DIFF
--- a/.changeset/tiny-papers-rush.md
+++ b/.changeset/tiny-papers-rush.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Fix tools with no parameters not being called

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ docs/
 scratchpad/
 .direnv/
 .idea/
-.env
+.env*

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -247,7 +247,9 @@ export const make = (options: {
                 if (Predicate.isNotUndefined(toolCalls[chunk.index])) {
                   const tool = toolCalls[chunk.index]
                   try {
-                    const params = JSON.parse(tool.params)
+                    // If the tool call has no parameters, the model sends an empty string.
+                    const inputJson = tool.params === '' ? '{}' : tool.params;
+                    const params = JSON.parse(inputJson)
                     parts.push(
                       new AiResponse.ToolCallPart({
                         id: AiInput.ToolCallId.make(tool.id, constDisableValidation),

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -248,7 +248,7 @@ export const make = (options: {
                   const tool = toolCalls[chunk.index]
                   try {
                     // If the tool call has no parameters, the model sends an empty string.
-                    const inputJson = tool.params === '' ? '{}' : tool.params;
+                    const inputJson = tool.params === "" ? "{}" : tool.params
                     const params = JSON.parse(inputJson)
                     parts.push(
                       new AiResponse.ToolCallPart({


### PR DESCRIPTION
- **Provide empty object if the tool input has no parameters**
- **Gitignore**
- **Changeset**

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Repro

```ts
import { AiLanguageModel, AiTool, AiToolkit } from "@effect/ai"
import { Chunk, Config, Effect, Layer, Schema, Stream } from "effect"

import { AnthropicClient, AnthropicLanguageModel } from "@effect/ai-anthropic"
import { FetchHttpClient, HttpClient } from "@effect/platform"

const AnthropicClientLayer = AnthropicClient.layerConfig({
  apiKey: Config.redacted("ANTHROPIC_API_KEY"),
  transformClient: HttpClient.tap((response) => {
    console.log({
      request: response.request,
      status: response.status,
      headers: response.headers
    })
    return Effect.void;
  })
}).pipe(Layer.provide(FetchHttpClient.layer))

// Tool definitions.
class TestToolkit extends AiToolkit.make(
  AiTool.make("Test", {
    description: "Test tool",
    parameters: {
      // query: Schema.String.annotations({ description: 'what are you asking for?'})
    },
    success: Schema.Unknown,
    failure: Schema.Never
  })
) {
  static layer = TestToolkit.toLayer({
    Test: Effect.fn(function* () {
      return "Peach"
      // return Effect.fail(new Error('test'));
    })
  })
}

const main = Effect.fn(
  function* () {
    const response = yield* AiLanguageModel.streamText({
      prompt: "Call the test tool. and print me its result.",
      toolkit: yield* TestToolkit.pipe(Effect.provide(TestToolkit.layer)),
      disableToolCallResolution: true
    }).pipe(Stream.runCollect, Effect.map(Chunk.toArray))
    const parts = response.flatMap(r => r.parts);
    console.log(parts)
    if(!
      parts.some((p) => p._tag === "ToolCallPart")
    ){
      throw new Error("no tool calls")
    }
  },
  Effect.provide(
    AnthropicLanguageModel.model("claude-3-5-sonnet-20241022").pipe(
      Layer.provide(AnthropicClientLayer)
    )
  )
)

await Effect.runPromise(main())
```
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
