### PR TITLE
`HttpServerResponse.redirect` defaults to 302 Found status

### DIFF
--- a/.changeset/some-bottles-own.md
+++ b/.changeset/some-bottles-own.md
@@ -1,5 +1,5 @@
 ---
-"@effect/platform": minor
+"@effect/platform": patch
 ---
 
 Use `302 Found` status in `HttpServerResponse.redirect` as default

--- a/.changeset/some-bottles-own.md
+++ b/.changeset/some-bottles-own.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Use `302 Found` status in `HttpServerResponse.redirect` as default

--- a/packages/platform/src/internal/httpServerResponse.ts
+++ b/packages/platform/src/internal/httpServerResponse.ts
@@ -103,7 +103,7 @@ export const redirect = (
 ): ServerResponse.HttpServerResponse => {
   const headers = Headers.unsafeFromRecord({ location: location.toString() })
   return new ServerResponseImpl(
-    options?.status ?? 301,
+    options?.status ?? 302,
     options?.statusText,
     options?.headers ?
       Headers.merge(


### PR DESCRIPTION
`HttpServerResponse.redirect` defaults to a 301 status, which is risky:
- Search engines treat 301 as a permanent move and may rerank pages.
- Browsers cache 301s and stop requesting those URLs.

This behavior is why frameworks like Rails, Laravel, Django, and Phoenix use 302 instead—it’s safer and avoids surprises.

Since the platform package is still pre-1.0, we should switch the default to 302 to align with common practices and avoid unexpected behavior.