### PR TITLE
Add `HttpServerResponse.expireCookie`

### DIFF
--- a/.changeset/yummy-clouds-beam.md
+++ b/.changeset/yummy-clouds-beam.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Add `HttpServerResponse.expireCookie`

--- a/.changeset/yummy-clouds-beam.md
+++ b/.changeset/yummy-clouds-beam.md
@@ -1,5 +1,5 @@
 ---
-"@effect/platform": minor
+"@effect/platform": patch
 ---
 
 Add `HttpServerResponse.expireCookie`

--- a/packages/platform/src/HttpServerResponse.ts
+++ b/packages/platform/src/HttpServerResponse.ts
@@ -229,6 +229,22 @@ export const removeCookie: {
  * @since 1.0.0
  * @category combinators
  */
+export const expireCookie: {
+  (
+    name: string,
+    options?: Omit<Cookie["options"], "expires" | "maxAge">
+  ) => (self: HttpServerResponse) => HttpServerResponse,
+  (
+    self: HttpServerResponse,
+    name: string,
+    options?: Omit<Cookie["options"], "expires" | "maxAge">
+  ) => HttpServerResponse
+} = internal.expireCookie
+
+/**
+ * @since 1.0.0
+ * @category combinators
+ */
 export const replaceCookies: {
   (cookies: Cookies): (self: HttpServerResponse) => HttpServerResponse
   (self: HttpServerResponse, cookies: Cookies): HttpServerResponse

--- a/packages/platform/src/HttpServerResponse.ts
+++ b/packages/platform/src/HttpServerResponse.ts
@@ -233,12 +233,12 @@ export const expireCookie: {
   (
     name: string,
     options?: Omit<Cookie["options"], "expires" | "maxAge">
-  ) => (self: HttpServerResponse) => HttpServerResponse,
+  ): (self: HttpServerResponse) => HttpServerResponse
   (
     self: HttpServerResponse,
     name: string,
     options?: Omit<Cookie["options"], "expires" | "maxAge">
-  ) => HttpServerResponse
+  ): HttpServerResponse
 } = internal.expireCookie
 
 /**

--- a/packages/platform/src/internal/httpServerResponse.ts
+++ b/packages/platform/src/internal/httpServerResponse.ts
@@ -513,6 +513,32 @@ export const removeCookie = dual<
 )
 
 /** @internal */
+export const expireCookie = dual<
+  (
+    name: string,
+    options?: Omit<Cookies.Cookie["options"], "expires" | "maxAge">
+  ) => (self: ServerResponse.HttpServerResponse) => ServerResponse.HttpServerResponse,
+  (
+    self: ServerResponse.HttpServerResponse,
+    name: string,
+    options?: Omit<Cookies.Cookie["options"], "expires" | "maxAge">
+  ) => ServerResponse.HttpServerResponse
+>(
+  2,
+  (self, name, options) =>
+    new ServerResponseImpl(
+      self.status,
+      self.statusText,
+      self.headers,
+      Cookies.unsafeSet(self.cookies, name, "", {
+        ...(options ?? {}),
+        maxAge: 0,
+      }),
+      self.body
+    )
+)
+
+/** @internal */
 export const setHeaders = dual<
   (input: Headers.Input) => (self: ServerResponse.HttpServerResponse) => ServerResponse.HttpServerResponse,
   (self: ServerResponse.HttpServerResponse, input: Headers.Input) => ServerResponse.HttpServerResponse

--- a/packages/platform/src/internal/httpServerResponse.ts
+++ b/packages/platform/src/internal/httpServerResponse.ts
@@ -524,7 +524,7 @@ export const expireCookie = dual<
     options?: Omit<Cookies.Cookie["options"], "expires" | "maxAge">
   ) => ServerResponse.HttpServerResponse
 >(
-  2,
+  3,
   (self, name, options) =>
     new ServerResponseImpl(
       self.status,

--- a/packages/platform/src/internal/httpServerResponse.ts
+++ b/packages/platform/src/internal/httpServerResponse.ts
@@ -532,7 +532,7 @@ export const expireCookie = dual<
       self.headers,
       Cookies.unsafeSet(self.cookies, name, "", {
         ...(options ?? {}),
-        maxAge: 0,
+        maxAge: 0
       }),
       self.body
     )


### PR DESCRIPTION
Adds a function to instruct user agent (ie. the browser) to clear or expire the cookie.

`expireCookie` accepts options to target scoped cookies per RFC 6265.

Please see #5356 for context.