### PR TITLE
Made Schema.brand not any-fy piped schemas

### DIFF
--- a/.changeset/flat-buttons-design.md
+++ b/.changeset/flat-buttons-design.md
@@ -1,0 +1,21 @@
+---
+"effect": patch
+---
+
+Made Schema.brand keep type of schema being piped into it even if brand schema was extracted into a variable. Type was previously Schema.any
+
+Before:
+
+```ts
+const UserIdBrandSchema = Schema.brand("UserId")
+const UserIdSchema = pipe(Schema.Number, UserIdBrandSchema)
+//    ^? Schema.brand<Schema.Schema.Any, "UserId">
+```
+
+After:
+
+```ts
+const UserIdBrandSchema = Schema.brand("UserId")
+const UserIdSchema = pipe(Schema.Number, UserIdBrandSchema)
+//    ^? Schema.brand<typeof Schema.Number, "UserId">
+```

--- a/packages/effect/dtslint/Schema/Brand.tst.ts
+++ b/packages/effect/dtslint/Schema/Brand.tst.ts
@@ -25,4 +25,17 @@ describe("SchemaBrand", () => {
       })
     )
   })
+
+  it("should not override types with any when extracted into a constant", () => {
+    const UserIdBrandSchema = Schema.brand("UserId")
+
+    const UserIdSchema = pipe(Schema.Number, UserIdBrandSchema)
+
+    type IUserId = Schema.Schema.Type<typeof UserIdSchema>
+
+    type IsAny<T> = 0 extends 1 & T ? true : false
+
+    expect<IsAny<IUserId>>().type.toBe<false>()
+    expect<IUserId>().type.toBeAssignableTo<number>()
+  })
 })

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3196,7 +3196,7 @@ export const brand = <S extends Schema.Any, B extends string | symbol>(
   brand: B,
   annotations?: Annotations.Schema<Schema.Type<S> & Brand<B>>
 ) =>
-(self: S): brand<S, B> => {
+<SubS extends S>(self: SubS): brand<SubS, B> => {
   const annotation: AST.BrandAnnotation = option_.match(AST.getBrandAnnotation(self.ast), {
     onNone: () => [brand],
     onSome: (brands) => [...brands, brand]


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When `Schema.brand` was extracted into a variable, other schemas, piped through that variable, resulted in `Schema.Any` type.

### Before

```ts
const UserIdBrandSchema = Schema.brand("UserId")
const UserIdSchema = pipe(Schema.Number, UserIdBrandSchema)
//    ^? Schema.brand<Schema.Schema.Any, "UserId">
```

### After

```ts
const UserIdBrandSchema = Schema.brand("UserId")
const UserIdSchema = pipe(Schema.Number, UserIdBrandSchema)
//    ^? Schema.brand<typeof Schema.Number, "UserId">
```

<!-- counter: 3 -->