### PR TITLE
Remove dependency on `@opentelemetry/semantic-conventions`

### DIFF
--- a/.changeset/polite-schools-cheat.md
+++ b/.changeset/polite-schools-cheat.md
@@ -1,0 +1,19 @@
+---
+"@effect/sql-sqlite-react-native": patch
+"@effect/sql-sqlite-node": patch
+"@effect/sql-sqlite-wasm": patch
+"@effect/sql-clickhouse": patch
+"@effect/sql-sqlite-bun": patch
+"@effect/opentelemetry": patch
+"@effect/sql-sqlite-do": patch
+"@effect/sql-kysely": patch
+"@effect/sql-libsql": patch
+"@effect/sql-mysql2": patch
+"@effect/sql-mssql": patch
+"@effect/platform": patch
+"@effect/sql-d1": patch
+"@effect/sql-pg": patch
+"@effect/sql": patch
+---
+
+Avoid issues with ESM builds by removing dependency on `@opentelemetry/semantic-conventions`

--- a/packages/opentelemetry/src/OtlpResource.ts
+++ b/packages/opentelemetry/src/OtlpResource.ts
@@ -1,11 +1,13 @@
 /**
  * @since 1.0.0
  */
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Arr from "effect/Array"
 import * as Config from "effect/Config"
 import * as Effect from "effect/Effect"
 import * as Inspectable from "effect/Inspectable"
+
+const ATTR_SERVICE_NAME = "service.name"
+const ATTR_SERVICE_VERSION = "service.version"
 
 /**
  * @since 1.0.0
@@ -31,14 +33,14 @@ export const make = (options: {
     ? entriesToAttributes(Object.entries(options.attributes))
     : []
   resourceAttributes.push({
-    key: OtelSemConv.ATTR_SERVICE_NAME,
+    key: ATTR_SERVICE_NAME,
     value: {
       stringValue: options.serviceName
     }
   })
   if (options.serviceVersion) {
     resourceAttributes.push({
-      key: OtelSemConv.ATTR_SERVICE_VERSION,
+      key: ATTR_SERVICE_VERSION,
       value: {
         stringValue: options.serviceVersion
       }
@@ -84,9 +86,9 @@ export const fromConfig: (
       ...options?.attributes
     }))
   )
-  const serviceName = options?.serviceName ?? attributes[OtelSemConv.ATTR_SERVICE_NAME] as string ??
+  const serviceName = options?.serviceName ?? attributes[ATTR_SERVICE_NAME] as string ??
     (yield* Config.string("OTEL_SERVICE_NAME"))
-  const serviceVersion = options?.serviceVersion ?? attributes[OtelSemConv.ATTR_SERVICE_VERSION] as string ??
+  const serviceVersion = options?.serviceVersion ?? attributes[ATTR_SERVICE_VERSION] as string ??
     (yield* Config.string("OTEL_SERVICE_VERSION").pipe(Config.withDefault(undefined)))
   return make({
     serviceName,
@@ -101,7 +103,7 @@ export const fromConfig: (
  */
 export const unsafeServiceName = (resource: Resource): string => {
   const serviceNameAttribute = resource.attributes.find(
-    (attr) => attr.key === OtelSemConv.ATTR_SERVICE_NAME
+    (attr) => attr.key === ATTR_SERVICE_NAME
   )
   if (!serviceNameAttribute || !serviceNameAttribute.value.stringValue) {
     throw new Error("Resource does not contain a service name")

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -47,7 +47,6 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0",
     "find-my-way-ts": "^0.1.6",
     "msgpackr": "^1.11.4",
     "multipasta": "^0.2.7"

--- a/packages/platform/src/internal/httpClient.ts
+++ b/packages/platform/src/internal/httpClient.ts
@@ -1,4 +1,3 @@
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
@@ -27,6 +26,17 @@ import * as TraceContext from "../HttpTraceContext.js"
 import * as UrlParams from "../UrlParams.js"
 import * as internalRequest from "./httpClientRequest.js"
 import * as internalResponse from "./httpClientResponse.js"
+
+const ATTR_HTTP_REQUEST_HEADER = (key: string): string => `http.request.header.${key}`
+const ATTR_HTTP_REQUEST_METHOD = "http.request.method"
+const ATTR_HTTP_RESPONSE_HEADER = (key: string): string => `http.response.header.${key}`
+const ATTR_HTTP_RESPONSE_STATUS_CODE = "http.response.status_code"
+const ATTR_SERVER_ADDRESS = "server.address"
+const ATTR_SERVER_PORT = "server.port"
+const ATTR_URL_FULL = "url.full"
+const ATTR_URL_PATH = "url.path"
+const ATTR_URL_SCHEME = "url.scheme"
+const ATTR_URL_QUERY = "url.query"
 
 /** @internal */
 export const TypeId: Client.TypeId = Symbol.for(
@@ -227,22 +237,22 @@ export const make = (
           nameGenerator(request),
           { kind: "client", captureStackTrace: false },
           (span) => {
-            span.attribute(OtelSemConv.ATTR_HTTP_REQUEST_METHOD, request.method)
-            span.attribute(OtelSemConv.ATTR_SERVER_ADDRESS, url.origin)
+            span.attribute(ATTR_HTTP_REQUEST_METHOD, request.method)
+            span.attribute(ATTR_SERVER_ADDRESS, url.origin)
             if (url.port !== "") {
-              span.attribute(OtelSemConv.ATTR_SERVER_PORT, +url.port)
+              span.attribute(ATTR_SERVER_PORT, +url.port)
             }
-            span.attribute(OtelSemConv.ATTR_URL_FULL, url.toString())
-            span.attribute(OtelSemConv.ATTR_URL_PATH, url.pathname)
-            span.attribute(OtelSemConv.ATTR_URL_SCHEME, url.protocol.slice(0, -1))
+            span.attribute(ATTR_URL_FULL, url.toString())
+            span.attribute(ATTR_URL_PATH, url.pathname)
+            span.attribute(ATTR_URL_SCHEME, url.protocol.slice(0, -1))
             const query = url.search.slice(1)
             if (query !== "") {
-              span.attribute(OtelSemConv.ATTR_URL_QUERY, query)
+              span.attribute(ATTR_URL_QUERY, query)
             }
             const redactedHeaderNames = fiber.getFiberRef(Headers.currentRedactedNames)
             const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames)
             for (const name in redactedHeaders) {
-              span.attribute(OtelSemConv.ATTR_HTTP_REQUEST_HEADER(name), String(redactedHeaders[name]))
+              span.attribute(ATTR_HTTP_REQUEST_HEADER(name), String(redactedHeaders[name]))
             }
             request = fiber.getFiberRef(currentTracerPropagation)
               ? internalRequest.setHeaders(request, TraceContext.toHeaders(span))
@@ -252,10 +262,10 @@ export const make = (
                 Effect.withParentSpan(span),
                 Effect.matchCauseEffect({
                   onSuccess: (response) => {
-                    span.attribute(OtelSemConv.ATTR_HTTP_RESPONSE_STATUS_CODE, response.status)
+                    span.attribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status)
                     const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames)
                     for (const name in redactedHeaders) {
-                      span.attribute(OtelSemConv.ATTR_HTTP_RESPONSE_HEADER(name), String(redactedHeaders[name]))
+                      span.attribute(ATTR_HTTP_RESPONSE_HEADER(name), String(redactedHeaders[name]))
                     }
                     if (scopedController) return Effect.succeed(response)
                     responseRegistry.register(response, controller)

--- a/packages/sql-clickhouse/package.json
+++ b/packages/sql-clickhouse/package.json
@@ -60,7 +60,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@clickhouse/client": "^1.6.0",
-    "@opentelemetry/semantic-conventions": "^1.33.0"
+    "@clickhouse/client": "^1.6.0"
   }
 }

--- a/packages/sql-clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql-clickhouse/src/ClickhouseClient.ts
@@ -9,7 +9,6 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import type { Primitive } from "@effect/sql/Statement"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -24,6 +23,9 @@ import type * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import * as Crypto from "node:crypto"
 import type { Readable } from "node:stream"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const ATTR_DB_NAMESPACE = "db.namespace"
 
 /**
  * @category type ids
@@ -237,8 +239,8 @@ export const make = (
         compiler,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "clickhouse"],
-          [OtelSemConv.ATTR_DB_NAMESPACE, options.database ?? "default"]
+          [ATTR_DB_SYSTEM_NAME, "clickhouse"],
+          [ATTR_DB_NAMESPACE, options.database ?? "default"]
         ],
         beginTransaction: "BEGIN TRANSACTION",
         transformRows

--- a/packages/sql-d1/package.json
+++ b/packages/sql-d1/package.json
@@ -63,7 +63,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@cloudflare/workers-types": "^4.20250515.0",
-    "@opentelemetry/semantic-conventions": "^1.33.0"
+    "@cloudflare/workers-types": "^4.20250515.0"
   }
 }

--- a/packages/sql-d1/src/D1Client.ts
+++ b/packages/sql-d1/src/D1Client.ts
@@ -7,7 +7,6 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Cache from "effect/Cache"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -17,6 +16,8 @@ import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import type * as Scope from "effect/Scope"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -171,7 +172,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as D1Client,

--- a/packages/sql-kysely/package.json
+++ b/packages/sql-kysely/package.json
@@ -50,9 +50,6 @@
     "test": "vitest",
     "coverage": "vitest --coverage"
   },
-  "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0"
-  },
   "devDependencies": {
     "@effect/sql": "workspace:^",
     "@effect/sql-mssql": "workspace:^",

--- a/packages/sql-kysely/src/internal/patch.ts
+++ b/packages/sql-kysely/src/internal/patch.ts
@@ -1,9 +1,10 @@
 import type * as Client from "@effect/sql/SqlClient"
 import { SqlError } from "@effect/sql/SqlError"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Effect from "effect/Effect"
 import * as Effectable from "effect/Effectable"
 import type { Compilable } from "kysely"
+
+const ATTR_DB_QUERY_TEXT = "db.query.text"
 
 interface Executable extends Compilable {
   execute: () => Promise<ReadonlyArray<unknown>>
@@ -72,7 +73,7 @@ function executeCommit(this: Executable) {
     kind: "client",
     captureStackTrace: false,
     attributes: {
-      [OtelSemConv.ATTR_DB_QUERY_TEXT]: this.compile().sql
+      [ATTR_DB_QUERY_TEXT]: this.compile().sql
     }
   }))
 }

--- a/packages/sql-libsql/package.json
+++ b/packages/sql-libsql/package.json
@@ -61,7 +61,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@libsql/client": "^0.12.0",
-    "@opentelemetry/semantic-conventions": "^1.33.0"
+    "@libsql/client": "^0.12.0"
   }
 }

--- a/packages/sql-libsql/src/LibsqlClient.ts
+++ b/packages/sql-libsql/src/LibsqlClient.ts
@@ -7,7 +7,6 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
 import * as Libsql from "@libsql/client"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -16,6 +15,8 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as Redacted from "effect/Redacted"
 import * as Scope from "effect/Scope"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -145,7 +146,7 @@ export const make = (
 
     const spanAttributes: Array<[string, unknown]> = [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+      [ATTR_DB_SYSTEM_NAME, "sqlite"]
     ]
 
     class LibsqlConnectionImpl implements LibsqlConnection {

--- a/packages/sql-mssql/package.json
+++ b/packages/sql-mssql/package.json
@@ -59,7 +59,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0",
     "tedious": "^18.3.0"
   }
 }

--- a/packages/sql-mssql/src/MssqlClient.ts
+++ b/packages/sql-mssql/src/MssqlClient.ts
@@ -6,7 +6,6 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -23,6 +22,11 @@ import type { DataType } from "tedious/lib/data-type.js"
 import type { ParameterOptions } from "tedious/lib/request.js"
 import type { Parameter } from "./Parameter.js"
 import type * as Procedure from "./Procedure.js"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const ATTR_DB_NAMESPACE = "db.namespace"
+const ATTR_SERVER_ADDRESS = "server.address"
+const ATTR_SERVER_PORT = "server.port"
 
 /**
  * @category type ids
@@ -130,10 +134,10 @@ export const make = (
       undefined
     const spanAttributes: ReadonlyArray<[string, unknown]> = [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER],
-      [OtelSemConv.ATTR_DB_NAMESPACE, options.database ?? "master"],
-      [OtelSemConv.ATTR_SERVER_ADDRESS, options.server],
-      [OtelSemConv.ATTR_SERVER_PORT, options.port ?? 1433]
+      [ATTR_DB_SYSTEM_NAME, "microsoft.sql_server"],
+      [ATTR_DB_NAMESPACE, options.database ?? "master"],
+      [ATTR_SERVER_ADDRESS, options.server],
+      [ATTR_SERVER_PORT, options.port ?? 1433]
     ]
 
     // eslint-disable-next-line prefer-const

--- a/packages/sql-mysql2/package.json
+++ b/packages/sql-mysql2/package.json
@@ -59,7 +59,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0",
     "mysql2": "^3.11.0"
   }
 }

--- a/packages/sql-mysql2/src/MysqlClient.ts
+++ b/packages/sql-mysql2/src/MysqlClient.ts
@@ -7,7 +7,6 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import { asyncPauseResume } from "@effect/sql/SqlStream"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -19,6 +18,11 @@ import * as Redacted from "effect/Redacted"
 import type { Scope } from "effect/Scope"
 import * as Stream from "effect/Stream"
 import * as Mysql from "mysql2"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const ATTR_DB_NAMESPACE = "db.namespace"
+const ATTR_SERVER_ADDRESS = "server.address"
+const ATTR_SERVER_PORT = "server.port"
 
 /**
  * @category type ids
@@ -242,13 +246,13 @@ export const make = (
 
     const spanAttributes: Array<[string, unknown]> = [
       ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-      [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_MYSQL],
-      [OtelSemConv.ATTR_SERVER_ADDRESS, options.host ?? "localhost"],
-      [OtelSemConv.ATTR_SERVER_PORT, options.port ?? 3306]
+      [ATTR_DB_SYSTEM_NAME, "mysql"],
+      [ATTR_SERVER_ADDRESS, options.host ?? "localhost"],
+      [ATTR_SERVER_PORT, options.port ?? 3306]
     ]
 
     if (options.database) {
-      spanAttributes.push([OtelSemConv.ATTR_DB_NAMESPACE, options.database])
+      spanAttributes.push([ATTR_DB_NAMESPACE, options.database])
     }
 
     return Object.assign(

--- a/packages/sql-pg/package.json
+++ b/packages/sql-pg/package.json
@@ -59,7 +59,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0",
     "postgres": "^3.4.4"
   }
 }

--- a/packages/sql-pg/src/PgClient.ts
+++ b/packages/sql-pg/src/PgClient.ts
@@ -7,7 +7,6 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import type { Custom, Fragment, Primitive } from "@effect/sql/Statement"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -21,6 +20,11 @@ import * as Stream from "effect/Stream"
 import type * as NodeStream from "node:stream"
 import type { ConnectionOptions } from "node:tls"
 import postgres from "postgres"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const ATTR_DB_NAMESPACE = "db.namespace"
+const ATTR_SERVER_ADDRESS = "server.address"
+const ATTR_SERVER_PORT = "server.port"
 
 /**
  * @category type ids
@@ -281,10 +285,10 @@ export const make = (
         compiler,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, OtelSemConv.DB_SYSTEM_NAME_VALUE_POSTGRESQL],
-          [OtelSemConv.ATTR_DB_NAMESPACE, opts.database ?? options.username ?? "postgres"],
-          [OtelSemConv.ATTR_SERVER_ADDRESS, opts.host ?? "localhost"],
-          [OtelSemConv.ATTR_SERVER_PORT, opts.port ?? 5432]
+          [ATTR_DB_SYSTEM_NAME, "postgresql"],
+          [ATTR_DB_NAMESPACE, opts.database ?? options.username ?? "postgres"],
+          [ATTR_SERVER_ADDRESS, opts.host ?? "localhost"],
+          [ATTR_SERVER_PORT, opts.port ?? 5432]
         ],
         transformRows
       }),

--- a/packages/sql-sqlite-bun/package.json
+++ b/packages/sql-sqlite-bun/package.json
@@ -45,9 +45,6 @@
     "test": "vitest",
     "coverage": "vitest --coverage"
   },
-  "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0"
-  },
   "devDependencies": {
     "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",

--- a/packages/sql-sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql-sqlite-bun/src/SqliteClient.ts
@@ -6,7 +6,6 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import { Database } from "bun:sqlite"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -15,6 +14,8 @@ import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -169,7 +170,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-do/package.json
+++ b/packages/sql-sqlite-do/package.json
@@ -45,9 +45,6 @@
     "test": "vitest",
     "coverage": "vitest --coverage"
   },
-  "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0"
-  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250515.0",
     "@effect/experimental": "workspace:^",

--- a/packages/sql-sqlite-do/src/SqliteClient.ts
+++ b/packages/sql-sqlite-do/src/SqliteClient.ts
@@ -7,7 +7,6 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -17,6 +16,8 @@ import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -177,7 +178,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-node/package.json
+++ b/packages/sql-sqlite-node/package.json
@@ -60,7 +60,6 @@
     "effect": "workspace:^"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0",
     "better-sqlite3": "^11.10.0"
   }
 }

--- a/packages/sql-sqlite-node/src/SqliteClient.ts
+++ b/packages/sql-sqlite-node/src/SqliteClient.ts
@@ -6,7 +6,6 @@ import * as Client from "@effect/sql/SqlClient"
 import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import Sqlite from "better-sqlite3"
 import * as Cache from "effect/Cache"
 import * as Config from "effect/Config"
@@ -17,6 +16,8 @@ import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -233,7 +234,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-react-native/package.json
+++ b/packages/sql-sqlite-react-native/package.json
@@ -56,8 +56,5 @@
     "@effect/sql": "workspace:^",
     "@op-engineering/op-sqlite": "7.1.0",
     "effect": "workspace:^"
-  },
-  "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0"
   }
 }

--- a/packages/sql-sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql-sqlite-react-native/src/SqliteClient.ts
@@ -7,7 +7,6 @@ import type { Connection } from "@effect/sql/SqlConnection"
 import { SqlError } from "@effect/sql/SqlError"
 import * as Statement from "@effect/sql/Statement"
 import * as Sqlite from "@op-engineering/op-sqlite"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
 import * as Context from "effect/Context"
@@ -17,6 +16,8 @@ import { identity } from "effect/Function"
 import { globalValue } from "effect/GlobalValue"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -176,7 +177,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql-sqlite-wasm/package.json
+++ b/packages/sql-sqlite-wasm/package.json
@@ -55,8 +55,5 @@
     "@effect/sql": "workspace:^",
     "@effect/wa-sqlite": "^0.1.2",
     "effect": "workspace:^"
-  },
-  "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0"
   }
 }

--- a/packages/sql-sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql-sqlite-wasm/src/SqliteClient.ts
@@ -9,7 +9,6 @@ import * as Statement from "@effect/sql/Statement"
 import * as WaSqlite from "@effect/wa-sqlite"
 import SQLiteESMFactory from "@effect/wa-sqlite/dist/wa-sqlite.mjs"
 import { MemoryVFS } from "@effect/wa-sqlite/src/examples/MemoryVFS.js"
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Chunk from "effect/Chunk"
 import * as Config from "effect/Config"
 import type { ConfigError } from "effect/ConfigError"
@@ -25,6 +24,8 @@ import * as Scope from "effect/Scope"
 import * as ScopedRef from "effect/ScopedRef"
 import * as Stream from "effect/Stream"
 import type { OpfsWorkerMessage } from "./internal/opfsWorker.js"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
  * @category type ids
@@ -243,7 +244,7 @@ export const makeMemory = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as SqliteClient,
@@ -402,7 +403,7 @@ export const make = (
         transactionAcquirer,
         spanAttributes: [
           ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [OtelSemConv.ATTR_DB_SYSTEM_NAME, "sqlite"]
+          [ATTR_DB_SYSTEM_NAME, "sqlite"]
         ],
         transformRows
       })) as SqliteClient,

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -48,7 +48,6 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "^1.33.0",
     "uuid": "^11.0.3"
   },
   "devDependencies": {

--- a/packages/sql/src/internal/statement.ts
+++ b/packages/sql/src/internal/statement.ts
@@ -1,4 +1,3 @@
-import * as OtelSemConv from "@opentelemetry/semantic-conventions"
 import * as Effect from "effect/Effect"
 import * as Effectable from "effect/Effectable"
 import * as FiberRef from "effect/FiberRef"
@@ -12,6 +11,9 @@ import type * as Tracer from "effect/Tracer"
 import type * as Connection from "../SqlConnection.js"
 import type * as Error from "../SqlError.js"
 import type * as Statement from "../Statement.js"
+
+const ATTR_DB_OPERATION_NAME = "db.operation.name"
+const ATTR_DB_QUERY_TEXT = "db.query.text"
 
 /** @internal */
 export const FragmentId: Statement.FragmentId = Symbol.for(
@@ -121,8 +123,8 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
           for (const [key, value] of this.spanAttributes) {
             span.attribute(key, value)
           }
-          span.attribute(OtelSemConv.ATTR_DB_OPERATION_NAME, operation)
-          span.attribute(OtelSemConv.ATTR_DB_QUERY_TEXT, sql)
+          span.attribute(ATTR_DB_OPERATION_NAME, operation)
+          span.attribute(ATTR_DB_QUERY_TEXT, sql)
           return Effect.scoped(Effect.flatMap(this.acquirer, (_) => f(_, sql, params)))
         })
     )
@@ -153,8 +155,8 @@ export class StatementPrimitive<A> extends Effectable.Class<ReadonlyArray<A>, Er
           for (const [key, value] of this.spanAttributes) {
             span.attribute(key, value)
           }
-          span.attribute(OtelSemConv.ATTR_DB_OPERATION_NAME, "executeStream")
-          span.attribute(OtelSemConv.ATTR_DB_QUERY_TEXT, sql)
+          span.attribute(ATTR_DB_OPERATION_NAME, "executeStream")
+          span.attribute(ATTR_DB_QUERY_TEXT, sql)
           return Effect.map(this.acquirer, (_) => _.executeStream(sql, params, this.transformRows))
         })
     ))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,9 +457,6 @@ importers:
 
   packages/platform:
     dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
       find-my-way-ts:
         specifier: ^0.1.6
         version: 0.1.6
@@ -645,9 +642,6 @@ importers:
 
   packages/sql:
     dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
       uuid:
         specifier: ^11.0.3
         version: 11.1.0
@@ -668,9 +662,6 @@ importers:
       '@clickhouse/client':
         specifier: ^1.6.0
         version: 1.11.2
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/experimental':
         specifier: workspace:^
@@ -694,9 +685,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250515.0
         version: 4.20250715.0
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/experimental':
         specifier: workspace:^
@@ -753,10 +741,6 @@ importers:
     publishDirectory: dist
 
   packages/sql-kysely:
-    dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/sql':
         specifier: workspace:^
@@ -801,9 +785,6 @@ importers:
       '@libsql/client':
         specifier: ^0.12.0
         version: 0.12.0
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/experimental':
         specifier: workspace:^
@@ -824,9 +805,6 @@ importers:
 
   packages/sql-mssql:
     dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
       tedious:
         specifier: ^18.3.0
         version: 18.6.1
@@ -850,9 +828,6 @@ importers:
 
   packages/sql-mysql2:
     dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
       mysql2:
         specifier: ^3.11.0
         version: 3.14.2
@@ -876,9 +851,6 @@ importers:
 
   packages/sql-pg:
     dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
       postgres:
         specifier: ^3.4.4
         version: 3.4.7
@@ -901,10 +873,6 @@ importers:
     publishDirectory: dist
 
   packages/sql-sqlite-bun:
-    dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/experimental':
         specifier: workspace:^
@@ -927,10 +895,6 @@ importers:
     publishDirectory: dist
 
   packages/sql-sqlite-do:
-    dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250515.0
@@ -948,9 +912,6 @@ importers:
 
   packages/sql-sqlite-node:
     dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -976,10 +937,6 @@ importers:
     publishDirectory: dist
 
   packages/sql-sqlite-react-native:
-    dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/experimental':
         specifier: workspace:^
@@ -996,10 +953,6 @@ importers:
     publishDirectory: dist
 
   packages/sql-sqlite-wasm:
-    dependencies:
-      '@opentelemetry/semantic-conventions':
-        specifier: ^1.33.0
-        version: 1.36.0
     devDependencies:
       '@effect/experimental':
         specifier: workspace:^
@@ -5070,6 +5023,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -7957,7 +7911,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -7968,7 +7922,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -8686,7 +8640,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
 
   '@types/ini@4.1.1': {}
 
@@ -8740,6 +8694,7 @@ snapshots:
   '@types/node@24.0.14':
     dependencies:
       undici-types: 7.8.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -9552,7 +9507,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -9561,7 +9516,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11040,7 +10995,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -11050,7 +11005,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11084,7 +11039,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -11109,7 +11064,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 22.16.4
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -13061,7 +13016,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.8.0: {}
+  undici-types@7.8.0:
+    optional: true
 
   undici@5.29.0:
     dependencies:


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The OpenTelemetry packages have issues with ESM builds. This PR removes the `@opentelemetry/semantic-conventions` dependency from all packages except the `@effect/opentelemetry` integration package in favor of statically declared attribute names / values.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
