### PR TITLE
refactor: remove gen adapter `function* (_)` from cli tests

### DIFF
--- a/packages/cli/test/Args.test.ts
+++ b/packages/cli/test/Args.test.ts
@@ -5,6 +5,7 @@ import * as ValidationError from "@effect/cli/ValidationError"
 import { FileSystem, Path } from "@effect/platform"
 import { NodeContext } from "@effect/platform-node"
 import { describe, expect, it } from "@effect/vitest"
+import { pipe } from "effect"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
@@ -16,98 +17,82 @@ const runEffect = <E, A>(
 
 describe("Args", () => {
   it("validates an valid argument with a default", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const args = Args.integer().pipe(Args.withDefault(0))
-      const result = yield* _(
-        Args.validate(args, Array.empty(), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.empty(), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), 0])
     }).pipe(runEffect))
 
   it("validates an valid optional argument", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const args = Args.integer().pipe(Args.optional)
-      let result = yield* _(
-        Args.validate(args, Array.empty(), CliConfig.defaultConfig)
-      )
+      let result = yield* Args.validate(args, Array.empty(), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Option.none()])
 
-      result = yield* _(
-        Args.validate(args, ["123"], CliConfig.defaultConfig)
-      )
+      result = yield* Args.validate(args, ["123"], CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Option.some(123)])
     }).pipe(runEffect))
 
   it("does not validate an invalid argument even when there is a default", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const args = Args.integer().pipe(Args.withDefault(0))
-      const result = yield* _(Effect.flip(
+      const result = yield* Effect.flip(
         Args.validate(args, Array.of("abc"), CliConfig.defaultConfig)
-      ))
+      )
       expect(result).toEqual(ValidationError.invalidArgument(HelpDoc.p("'abc' is not a integer")))
     }).pipe(runEffect))
 
   it("should validate an existing file that is expected to exist", () =>
-    Effect.gen(function*(_) {
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "Args.test.ts")
       const args = Args.file({ name: "files", exists: "yes" }).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.of(filePath)])
     }).pipe(runEffect))
 
   it("should return an error when a file that is expected to exist is not found", () =>
-    Effect.gen(function*(_) {
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "NotExist.test.ts")
       const args = Args.file({ name: "files", exists: "yes" }).pipe(Args.repeated)
-      const result = yield* _(
-        Effect.flip(Args.validate(args, Array.of(filePath), CliConfig.defaultConfig))
-      )
+      const result = yield* Effect.flip(Args.validate(args, Array.of(filePath), CliConfig.defaultConfig))
       expect(result).toEqual(ValidationError.invalidArgument(HelpDoc.p(
         `Path '${filePath}' must exist`
       )))
     }).pipe(runEffect))
 
   it("should validate a non-existent file that is expected not to exist", () =>
-    Effect.gen(function*(_) {
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "NotExist.test.ts")
       const args = Args.file({ name: "files", exists: "no" }).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.of(filePath)])
     }).pipe(runEffect))
 
   it("should validate a series of files", () =>
-    Effect.gen(function*(_) {
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "NotExist.test.ts")
       const args = Args.file({ name: "files", exists: "no" }).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.make(filePath, filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.make(filePath, filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.make(filePath, filePath)])
     }).pipe(runEffect))
 
   it("validates an valid argument with a Schema", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const args = Args.integer().pipe(Args.withSchema(Schema.Positive))
-      const result = yield* _(
-        Args.validate(args, ["123"], CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, ["123"], CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), 123])
     }).pipe(runEffect))
 
   it("does not validate an invalid argument with a Schema", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const args = Args.integer().pipe(Args.withSchema(Schema.Positive))
-      const result = yield* _(Effect.flip(
+      const result = yield* Effect.flip(
         Args.validate(args, Array.of("-123"), CliConfig.defaultConfig)
-      ))
+      )
       expect(result).toEqual(ValidationError.invalidArgument(HelpDoc.p(
         "Positive\n" +
           "└─ Predicate refinement failure\n" +
@@ -116,50 +101,44 @@ describe("Args", () => {
     }).pipe(runEffect))
 
   it("fileContent", () =>
-    Effect.gen(function*(_) {
-      const fs = yield* _(FileSystem.FileSystem)
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "fixtures/config.json")
-      const content = yield* _(fs.readFile(filePath))
+      const content = yield* fs.readFile(filePath)
       const args = Args.fileContent({ name: "files" }).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.of([filePath, content])])
     }).pipe(runEffect))
 
   it("fileText", () =>
-    Effect.gen(function*(_) {
-      const fs = yield* _(FileSystem.FileSystem)
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "fixtures/config.json")
-      const content = yield* _(fs.readFileString(filePath))
+      const content = yield* fs.readFileString(filePath)
       const args = Args.fileText({ name: "files" }).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.of([filePath, content])])
     }).pipe(runEffect))
 
   it("fileParse", () =>
-    Effect.gen(function*(_) {
-      const fs = yield* _(FileSystem.FileSystem)
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "fixtures/config.json")
-      const content = yield* _(fs.readFileString(filePath), Effect.map(JSON.parse))
+      const content = yield* pipe(fs.readFileString(filePath), Effect.map(JSON.parse))
       const args = Args.fileParse({ name: "files" }).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.of(content)])
     }).pipe(runEffect))
 
   it("fileSchema", () =>
-    Effect.gen(function*(_) {
-      const fs = yield* _(FileSystem.FileSystem)
-      const path = yield* _(Path.Path)
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
       const filePath = path.join(__dirname, "fixtures/config.json")
-      const content = yield* _(fs.readFileString(filePath), Effect.map(JSON.parse))
+      const content = yield* pipe(fs.readFileString(filePath), Effect.map(JSON.parse))
       const args = Args.fileSchema(
         Schema.Struct({
           foo: Schema.Boolean,
@@ -167,37 +146,29 @@ describe("Args", () => {
         }),
         { name: "files" }
       ).pipe(Args.repeated)
-      const result = yield* _(
-        Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
-      )
+      const result = yield* Args.validate(args, Array.of(filePath), CliConfig.defaultConfig)
       expect(result).toEqual([Array.empty(), Array.of(content)])
     }).pipe(runEffect))
 
   it("displays default value in help when default wrapped in Option.Some (primitive)", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const option = Args.withDefault(Args.integer({ name: "value" }), Option.some(123))
       const helpDoc = Args.getHelp(option)
-      yield* _(
-        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-primitive"))
-      )
+      yield* Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-primitive"))
     }).pipe(runEffect))
 
   it("displays default value in help when default wrapped in Option.Some (object)", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const defaultObject = { key: "value", number: 456 }
       const option = Args.withDefault(Args.text({ name: "config" }), Option.some(defaultObject))
       const helpDoc = Args.getHelp(option)
-      yield* _(
-        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-object"))
-      )
+      yield* Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-object"))
     }).pipe(runEffect))
 
   it("displays no default value in help when default is not Option.Some", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const option = Args.withDefault(Args.text({ name: "name" }), Option.none())
       const helpDoc = Args.getHelp(option)
-      yield* _(
-        Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-no-default"))
-      )
+      yield* Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-no-default"))
     }).pipe(runEffect))
 })

--- a/packages/cli/test/CliApp.test.ts
+++ b/packages/cli/test/CliApp.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, it } from "@effect/vitest"
 import { Array, Console, Effect, FiberRef, Layer, LogLevel } from "effect"
 import * as MockConsole from "./services/MockConsole.js"
 
-const MainLive = Effect.gen(function*(_) {
-  const console = yield* _(MockConsole.make)
+const MainLive = Effect.gen(function*() {
+  const console = yield* MockConsole.make
   return Layer.mergeAll(
     Console.setConsole(console),
     NodeContext.layer

--- a/packages/cli/test/Command.test.ts
+++ b/packages/cli/test/Command.test.ts
@@ -23,13 +23,13 @@ const clone = Command.make("clone", {
     Args.withFallbackConfig(Config.string("REPOSITORY"))
   )
 }, ({ repository }) =>
-  Effect.gen(function*(_) {
-    const { log } = yield* _(Messages)
-    const { verbose } = yield* _(git)
+  Effect.gen(function*() {
+    const { log } = yield* Messages
+    const { verbose } = yield* git
     if (verbose) {
-      yield* _(log(`Cloning ${repository}`))
+      yield* log(`Cloning ${repository}`)
     } else {
-      yield* _(log("Cloning"))
+      yield* log("Cloning")
     }
   })).pipe(Command.withDescription("Clone a repository into a new directory"))
 
@@ -39,14 +39,14 @@ const add = Command.make("add", {
   pathspec: Args.text({ name: "pathspec" })
 }).pipe(
   Command.withHandler(({ pathspec }) =>
-    Effect.gen(function*(_) {
-      yield* _(AddService)
-      const { log } = yield* _(Messages)
-      const { verbose } = yield* _(git)
+    Effect.gen(function*() {
+      yield* AddService
+      const { log } = yield* Messages
+      const { verbose } = yield* git
       if (verbose) {
-        yield* _(log(`Adding ${pathspec}`))
+        yield* log(`Adding ${pathspec}`)
       } else {
-        yield* _(log(`Adding`))
+        yield* log(`Adding`)
       }
     })
   ),
@@ -65,19 +65,19 @@ const run = git.pipe(
 describe("Command", () => {
   describe("git", () => {
     it("no sub-command", () =>
-      Effect.gen(function*(_) {
-        const messages = yield* _(Messages)
-        yield* _(run(["--verbose"]))
-        yield* _(run([]))
-        assert.deepStrictEqual(yield* _(messages.messages), ["shared", "shared"])
+      Effect.gen(function*() {
+        const messages = yield* Messages
+        yield* run(["--verbose"])
+        yield* run([])
+        assert.deepStrictEqual(yield* messages.messages, ["shared", "shared"])
       }).pipe(Effect.provide(EnvLive), Effect.runPromise))
 
     it("add", () =>
-      Effect.gen(function*(_) {
-        const messages = yield* _(Messages)
-        yield* _(run(["node", "git.js", "add", "file"]))
-        yield* _(run(["node", "git.js", "--verbose", "add", "file"]))
-        assert.deepStrictEqual(yield* _(messages.messages), [
+      Effect.gen(function*() {
+        const messages = yield* Messages
+        yield* run(["node", "git.js", "add", "file"])
+        yield* run(["node", "git.js", "--verbose", "add", "file"])
+        assert.deepStrictEqual(yield* messages.messages, [
           "shared",
           "Adding",
           "shared",
@@ -86,11 +86,11 @@ describe("Command", () => {
       }).pipe(Effect.provide(EnvLive), Effect.runPromise))
 
     it("clone", () =>
-      Effect.gen(function*(_) {
-        const messages = yield* _(Messages)
-        yield* _(run(["node", "git.js", "clone", "repo"]))
-        yield* _(run(["node", "git.js", "--verbose", "clone", "repo"]))
-        assert.deepStrictEqual(yield* _(messages.messages), [
+      Effect.gen(function*() {
+        const messages = yield* Messages
+        yield* run(["node", "git.js", "clone", "repo"])
+        yield* run(["node", "git.js", "--verbose", "clone", "repo"])
+        assert.deepStrictEqual(yield* messages.messages, [
           "shared",
           "Cloning",
           "shared",
@@ -99,10 +99,10 @@ describe("Command", () => {
       }).pipe(Effect.provide(EnvLive), Effect.runPromise))
 
     it("withFallbackConfig Options boolean", () =>
-      Effect.gen(function*(_) {
-        const messages = yield* _(Messages)
-        yield* _(run(["node", "git.js", "clone", "repo"]))
-        assert.deepStrictEqual(yield* _(messages.messages), [
+      Effect.gen(function*() {
+        const messages = yield* Messages
+        yield* run(["node", "git.js", "clone", "repo"])
+        assert.deepStrictEqual(yield* messages.messages, [
           "shared",
           "Cloning repo"
         ])
@@ -115,10 +115,10 @@ describe("Command", () => {
       ))
 
     it("withFallbackConfig Args", () =>
-      Effect.gen(function*(_) {
-        const messages = yield* _(Messages)
-        yield* _(run(["node", "git.js", "clone"]))
-        assert.deepStrictEqual(yield* _(messages.messages), [
+      Effect.gen(function*() {
+        const messages = yield* Messages
+        yield* run(["node", "git.js", "clone"])
+        assert.deepStrictEqual(yield* messages.messages, [
           "shared",
           "Cloning repo"
         ])

--- a/packages/cli/test/ConfigFile.test.ts
+++ b/packages/cli/test/ConfigFile.test.ts
@@ -12,13 +12,12 @@ const runEffect = <E, A>(
 
 describe("ConfigFile", () => {
   it("loads json files", () =>
-    Effect.gen(function*(_) {
-      const path = yield* _(Path.Path)
-      const result = yield* _(
-        Config.all([
-          Config.boolean("foo"),
-          Config.string("bar")
-        ]),
+    Effect.gen(function*() {
+      const path = yield* Path.Path
+      const result = yield* Config.all([
+        Config.boolean("foo"),
+        Config.string("bar")
+      ]).pipe(
         Effect.provide(ConfigFile.layer("config", {
           searchPaths: [path.join(__dirname, "fixtures")],
           formats: ["json"]
@@ -28,10 +27,9 @@ describe("ConfigFile", () => {
     }).pipe(runEffect))
 
   it("loads yaml", () =>
-    Effect.gen(function*(_) {
-      const path = yield* _(Path.Path)
-      const result = yield* _(
-        Config.integer("foo"),
+    Effect.gen(function*() {
+      const path = yield* Path.Path
+      const result = yield* Config.integer("foo").pipe(
         Effect.provide(ConfigFile.layer("config-file", {
           searchPaths: [path.join(__dirname, "fixtures")]
         }))

--- a/packages/cli/test/Primitive.test.ts
+++ b/packages/cli/test/Primitive.test.ts
@@ -13,42 +13,40 @@ describe("Primitive", () => {
   describe("Bool", () => {
     it("validates that truthy text representations of a boolean return true", () =>
       fc.assert(fc.asyncProperty(trueValuesArb, (str) =>
-        Effect.gen(function*(_) {
+        Effect.gen(function*() {
           const bool = Primitive.boolean(Option.none())
-          const result = yield* _(Primitive.validate(
+          const result = yield* Primitive.validate(
             bool,
             Option.some(str),
             CliConfig.defaultConfig
-          ))
+          )
           expect(result).toBe(true)
         }).pipe(runEffect))))
 
     it("validates that falsy text representations of a boolean return false", () =>
       fc.assert(fc.asyncProperty(falseValuesArb, (str) =>
-        Effect.gen(function*(_) {
+        Effect.gen(function*() {
           const bool = Primitive.boolean(Option.none())
-          const result = yield* _(Primitive.validate(
+          const result = yield* Primitive.validate(
             bool,
             Option.some(str),
             CliConfig.defaultConfig
-          ))
+          )
           expect(result).toBe(false)
         }).pipe(runEffect))))
 
     it("validates that invalid boolean representations are rejected", () =>
-      Effect.gen(function*(_) {
+      Effect.gen(function*() {
         const bool = Primitive.boolean(Option.none())
-        const result = yield* _(
-          Effect.flip(Primitive.validate(bool, Option.some("bad"), CliConfig.defaultConfig))
-        )
+        const result = yield* Effect.flip(Primitive.validate(bool, Option.some("bad"), CliConfig.defaultConfig))
         expect(result).toBe("Unable to recognize 'bad' as a valid boolean")
       }).pipe(runEffect))
 
     it("validates that the default value will be used if a value is not provided", () =>
       fc.assert(fc.asyncProperty(fc.boolean(), (value) =>
-        Effect.gen(function*(_) {
+        Effect.gen(function*() {
           const bool = Primitive.boolean(Option.some(value))
-          const result = yield* _(Primitive.validate(bool, Option.none(), CliConfig.defaultConfig))
+          const result = yield* Primitive.validate(bool, Option.none(), CliConfig.defaultConfig)
           expect(result).toBe(value)
         }).pipe(runEffect))))
   })
@@ -57,35 +55,35 @@ describe("Primitive", () => {
     it("validates a choice that is one of the alternatives", () =>
       fc.assert(
         fc.asyncProperty(pairsArb, ([[selectedName, selectedValue], pairs]) =>
-          Effect.gen(function*(_) {
+          Effect.gen(function*() {
             const alternatives = Function.unsafeCoerce<
               ReadonlyArray<[string, number]>,
               Array.NonEmptyReadonlyArray<[string, number]>
             >(pairs)
             const choice = Primitive.choice(alternatives)
-            const result = yield* _(Primitive.validate(
+            const result = yield* Primitive.validate(
               choice,
               Option.some(selectedName),
               CliConfig.defaultConfig
-            ))
+            )
             expect(result).toEqual(selectedValue)
           }).pipe(runEffect))
       ))
 
     it("does not validate a choice that is not one of the alternatives", () =>
       fc.assert(fc.asyncProperty(pairsArb, ([tuple, pairs]) =>
-        Effect.gen(function*(_) {
+        Effect.gen(function*() {
           const selectedName = tuple[0]
           const alternatives = Function.unsafeCoerce<
             ReadonlyArray<[string, number]>,
             Array.NonEmptyReadonlyArray<[string, number]>
           >(Array.filter(pairs, (pair) => !Equal.equals(tuple, pair)))
           const choice = Primitive.choice(alternatives)
-          const result = yield* _(Effect.flip(Primitive.validate(
+          const result = yield* Effect.flip(Primitive.validate(
             choice,
             Option.some(selectedName),
             CliConfig.defaultConfig
-          )))
+          ))
           expect(result).toMatch(/^Expected one of the following cases:\s.*/)
         }).pipe(runEffect))))
   })
@@ -103,12 +101,12 @@ describe("Primitive", () => {
   describe("Text", () => {
     it("validates all user-defined text", () =>
       fc.assert(fc.asyncProperty(fc.string(), (str) =>
-        Effect.gen(function*(_) {
-          const result = yield* _(Primitive.validate(
+        Effect.gen(function*() {
+          const result = yield* Primitive.validate(
             Primitive.text,
             Option.some(str),
             CliConfig.defaultConfig
-          ))
+          )
           expect(result).toEqual(str)
         }).pipe(runEffect))))
   })
@@ -122,19 +120,15 @@ const simplePrimitiveTestSuite = <A>(
   describe(`${primitiveTypeName}`, () => {
     it(`validates that valid values are accepted`, () =>
       fc.assert(fc.asyncProperty(arb, (value) =>
-        Effect.gen(function*(_) {
+        Effect.gen(function*() {
           const str = value instanceof Date ? value.toISOString() : `${value}`
-          const result = yield* _(
-            Primitive.validate(primitive, Option.some(str), CliConfig.defaultConfig)
-          )
+          const result = yield* Primitive.validate(primitive, Option.some(str), CliConfig.defaultConfig)
           expect(result).toEqual(value)
         }).pipe(runEffect))))
 
     it(`validates that invalid values are rejected`, () =>
-      Effect.gen(function*(_) {
-        const result = yield* _(
-          Effect.flip(Primitive.validate(primitive, Option.some("bad"), CliConfig.defaultConfig))
-        )
+      Effect.gen(function*() {
+        const result = yield* Effect.flip(Primitive.validate(primitive, Option.some("bad"), CliConfig.defaultConfig))
         expect(result).toBe(`'bad' is not a ${Primitive.getTypeName(primitive)}`)
       }).pipe(runEffect))
   })

--- a/packages/cli/test/Wizard.test.ts
+++ b/packages/cli/test/Wizard.test.ts
@@ -10,8 +10,8 @@ import * as Layer from "effect/Layer"
 import * as MockConsole from "./services/MockConsole.js"
 import * as MockTerminal from "./services/MockTerminal.js"
 
-const MainLive = Effect.gen(function*(_) {
-  const console = yield* _(MockConsole.make)
+const MainLive = Effect.gen(function*() {
+  const console = yield* MockConsole.make
   return Layer.mergeAll(
     Console.setConsole(console),
     NodeFileSystem.layer,
@@ -26,7 +26,7 @@ const runEffect = <E, A>(
 
 describe("Wizard", () => {
   it("should quit the wizard when CTRL+C is entered", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const cli = Command.make("foo", { message: Options.text("message") }).pipe(
         Command.run({
           name: "Test",
@@ -34,10 +34,10 @@ describe("Wizard", () => {
         })
       )
       const args = Array.make("node", "test", "--wizard")
-      const fiber = yield* _(Effect.fork(cli(args)))
-      yield* _(MockTerminal.inputKey("c", { ctrl: true }))
-      yield* _(Fiber.join(fiber))
-      const lines = yield* _(MockConsole.getLines({ stripAnsi: true }))
+      const fiber = yield* Effect.fork(cli(args))
+      yield* MockTerminal.inputKey("c", { ctrl: true })
+      yield* Fiber.join(fiber)
+      const lines = yield* MockConsole.getLines({ stripAnsi: true })
       const result = Array.some(lines, (line) => line.includes("Quitting wizard mode..."))
       expect(result).toBe(true)
     }).pipe(runEffect))

--- a/packages/cli/test/services/MockConsole.ts
+++ b/packages/cli/test/services/MockConsole.ts
@@ -25,8 +25,8 @@ const pattern = new RegExp(
 
 const stripAnsi = (str: string) => str.replace(pattern, "")
 
-export const make = Effect.gen(function*(_) {
-  const lines = yield* _(Ref.make(Array.empty<string>()))
+export const make = Effect.gen(function*() {
+  const lines = yield* Ref.make(Array.empty<string>())
 
   const getLines: MockConsole["getLines"] = (params = {}) =>
     Ref.get(lines).pipe(Effect.map((lines) =>

--- a/packages/cli/test/services/MockTerminal.ts
+++ b/packages/cli/test/services/MockTerminal.ts
@@ -39,11 +39,11 @@ export const MockTerminal = Context.GenericTag<Terminal.Terminal, MockTerminal>(
 // Constructors
 // =============================================================================
 
-export const make = Effect.gen(function*(_) {
-  const queue = yield* _(Effect.acquireRelease(
+export const make = Effect.gen(function*() {
+  const queue = yield* Effect.acquireRelease(
     Mailbox.make<Terminal.UserInput>(),
     (_) => _.shutdown
-  ))
+  )
 
   const inputText: MockTerminal["inputText"] = (text: string) => {
     const inputs = Array.map(text.split(""), (key) => toUserInput(key))


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the usage of gen adapters (function* (_)) in the cli tests.



## Related


- Related Issue #5405 
- Closes #
