### PR TITLE
Fix Schema.Defect when seeing a null-prototype object

### DIFF
--- a/.changeset/breezy-schools-run.md
+++ b/.changeset/breezy-schools-run.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Schema.Defect when seeing a null-prototype object

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -9511,7 +9511,7 @@ export class Defect extends transform(
         err.stack = "stack" in i && typeof i.stack === "string" ? i.stack : ""
         return err
       }
-      return String(i)
+      return internalCause_.prettyErrorMessage(i)
     },
     encode: (a) => {
       if (a instanceof Error) {

--- a/packages/effect/test/Schema/Schema/Defect/Defect.test.ts
+++ b/packages/effect/test/Schema/Schema/Defect/Defect.test.ts
@@ -18,6 +18,14 @@ describe("Defect", () => {
       deepStrictEqual(err, new Error("message", { cause: { message: "message" } }))
     })
 
+    it("a null object with a message", async () => {
+      const defect = Object.create(null)
+      defect.message = "message"
+
+      const err = S.decodeUnknownSync(S.Defect)(defect)
+      deepStrictEqual(err, new Error("message", { cause: defect }))
+    })
+
     it("an object with a message and a name", () => {
       const err = S.decodeUnknownSync(S.Defect)({ message: "message", name: "name" })
       assertInstanceOf(err, Error)
@@ -30,6 +38,17 @@ describe("Defect", () => {
       assertInstanceOf(err, Error)
       strictEqual(err.message, "message")
       strictEqual(err.stack, "stack")
+    })
+
+    it("a null object without a message", async () => {
+      const defect = Object.create(null)
+      defect.a = 1
+
+      await Util.assertions.decoding.succeed(
+        S.Defect,
+        defect,
+        "{\"a\":1}"
+      )
     })
   })
 
@@ -46,6 +65,17 @@ describe("Defect", () => {
       await Util.assertions.encoding.succeed(
         S.Defect,
         { a: 1 },
+        "{\"a\":1}"
+      )
+    })
+
+    it("a null object", async () => {
+      const defect = Object.create(null)
+      defect.a = 1
+
+      await Util.assertions.encoding.succeed(
+        S.Defect,
+        defect,
         "{\"a\":1}"
       )
     })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had a test run fail due to an error cause being generated by fast-check as a null object; it's not possible to call `String()` on a object without a `toString()` implementation.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
