### PR TITLE
refactor: remove gen adapter `function* (_)` from sql-* tests

### DIFF
--- a/packages/sql-d1/test/Resolver.test.ts
+++ b/packages/sql-d1/test/Resolver.test.ts
@@ -5,7 +5,7 @@ import { Array, Effect, Option } from "effect"
 import * as Schema from "effect/Schema"
 import { D1Miniflare } from "./utils.js"
 
-const seededClient = Effect.gen(function*(_) {
+const seededClient = Effect.gen(function*() {
   const sql = yield* D1Client.D1Client
   yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
   yield* Effect.forEach(Array.range(1, 100), (id) => sql`INSERT INTO test ${sql.insert({ id, name: `name${id}` })}`)
@@ -15,22 +15,22 @@ const seededClient = Effect.gen(function*(_) {
 describe("Resolver", () => {
   describe("ordered", () => {
     it.scoped("insert", () =>
-      Effect.gen(function*(_) {
+      Effect.gen(function*() {
         const batches: Array<Array<string>> = []
-        const sql = yield* _(seededClient)
-        const Insert = yield* _(SqlResolver.ordered("Insert", {
+        const sql = yield* seededClient
+        const Insert = yield* SqlResolver.ordered("Insert", {
           Request: Schema.String,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           execute: (names) => {
             batches.push(names)
             return sql`INSERT INTO test ${sql.insert(names.map((name) => ({ name })))} RETURNING *`
           }
-        }))
+        })
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: Insert.execute("one"),
             two: Insert.execute("two")
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: { id: 101, name: "one" },
             two: { id: 102, name: "two" }
@@ -40,24 +40,23 @@ describe("Resolver", () => {
       }).pipe(Effect.provide(D1Miniflare.ClientLive)))
 
     it.scoped("result length mismatch", () =>
-      Effect.gen(function*(_) {
+      Effect.gen(function*() {
         const batches: Array<Array<number>> = []
-        const sql = yield* _(seededClient)
-        const Select = yield* _(SqlResolver.ordered("Select", {
+        const sql = yield* seededClient
+        const Select = yield* SqlResolver.ordered("Select", {
           Request: Schema.Number,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           execute: (ids) => {
             batches.push(ids)
             return sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
           }
-        }))
-        const error = yield* _(
-          Effect.all([
-            Select.execute(1),
-            Select.execute(2),
-            Select.execute(3),
-            Select.execute(101)
-          ], { batching: true }),
+        })
+        const error = yield* Effect.all([
+          Select.execute(1),
+          Select.execute(2),
+          Select.execute(3),
+          Select.execute(101)
+        ], { batching: true }).pipe(
           Effect.flip
         )
         assert(error instanceof SqlError.ResultLengthMismatch)
@@ -69,22 +68,22 @@ describe("Resolver", () => {
 
   describe("grouped", () => {
     it.scoped("find by name", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindByName = yield* _(SqlResolver.grouped("FindByName", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindByName = yield* SqlResolver.grouped("FindByName", {
           Request: Schema.String,
           RequestGroupKey: (name) => name,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultGroupKey: (result) => result.name,
           execute: (names) => sql`SELECT * FROM test WHERE name IN ${sql.in(names)}`
-        }))
-        yield* _(sql`INSERT INTO test ${sql.insert({ name: "name1" })}`)
+        })
+        yield* sql`INSERT INTO test ${sql.insert({ name: "name1" })}`
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindByName.execute("name1"),
             two: FindByName.execute("name2"),
             three: FindByName.execute("name0")
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: [{ id: 1, name: "name1" }, { id: 101, name: "name1" }],
             two: [{ id: 2, name: "name2" }],
@@ -94,22 +93,22 @@ describe("Resolver", () => {
       }).pipe(Effect.provide(D1Miniflare.ClientLive)))
 
     it.scoped("using raw rows", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindByName = yield* _(SqlResolver.grouped("FindByName", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindByName = yield* SqlResolver.grouped("FindByName", {
           Request: Schema.String,
           RequestGroupKey: (name) => name,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultGroupKey: (_, result: any) => result.name,
           execute: (names) => sql`SELECT * FROM test WHERE name IN ${sql.in(names)}`
-        }))
-        yield* _(sql`INSERT INTO test ${sql.insert({ name: "name1" })}`)
+        })
+        yield* sql`INSERT INTO test ${sql.insert({ name: "name1" })}`
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindByName.execute("name1"),
             two: FindByName.execute("name2"),
             three: FindByName.execute("name0")
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: [{ id: 1, name: "name1" }, { id: 101, name: "name1" }],
             two: [{ id: 2, name: "name2" }],
@@ -121,20 +120,20 @@ describe("Resolver", () => {
 
   describe("findById", () => {
     it.scoped("find by id", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindById = yield* _(SqlResolver.findById("FindById", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindById = yield* SqlResolver.findById("FindById", {
           Id: Schema.Number,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultId: (result) => result.id,
           execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
-        }))
+        })
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindById.execute(1),
             two: FindById.execute(2),
             three: FindById.execute(101)
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: Option.some({ id: 1, name: "name1" }),
             two: Option.some({ id: 2, name: "name2" }),
@@ -144,20 +143,20 @@ describe("Resolver", () => {
       }).pipe(Effect.provide(D1Miniflare.ClientLive)))
 
     it.scoped("using raw rows", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindById = yield* _(SqlResolver.findById("FindById", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindById = yield* SqlResolver.findById("FindById", {
           Id: Schema.Number,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultId: (_, result: any) => result.id,
           execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
-        }))
+        })
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindById.execute(1),
             two: FindById.execute(2),
             three: FindById.execute(101)
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: Option.some({ id: 1, name: "name1" }),
             two: Option.some({ id: 2, name: "name2" }),

--- a/packages/sql-drizzle/test/Pg.test.ts
+++ b/packages/sql-drizzle/test/Pg.test.ts
@@ -50,7 +50,7 @@ describe.sequential("Pg", () => {
   })
 
   it.effect("remote callback", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient
       const db = yield* Pg.PgDrizzle
       yield* sql`CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, snake_case TEXT NOT NULL)`

--- a/packages/sql-kysely/examples/sqlite.ts
+++ b/packages/sql-kysely/examples/sqlite.ts
@@ -20,7 +20,7 @@ const SqliteLive = Sqlite.SqliteClient.layer({
 
 const KyselyLive = Layer.effect(SqliteDB, SqliteKysely.make<Database>()).pipe(Layer.provide(SqliteLive))
 
-Effect.gen(function*(_) {
+Effect.gen(function*() {
   const db = yield* SqliteDB
 
   yield* db.schema

--- a/packages/sql-kysely/test/Kysely.test.ts
+++ b/packages/sql-kysely/test/Kysely.test.ts
@@ -28,7 +28,7 @@ const KyselyDBLive = Layer.sync(KyselyDB, () =>
 
 describe("Kysely", () => {
   it.effect("queries", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const db = yield* KyselyDB
 
       const createTableQuery = db.schema

--- a/packages/sql-kysely/test/Mssql.test.ts
+++ b/packages/sql-kysely/test/Mssql.test.ts
@@ -20,7 +20,7 @@ const MssqlLive = Layer.effect(MssqlDB, MssqlKysely.make<Database>()).pipe(Layer
 
 describe("MssqlKysely", () => {
   it.effect("queries", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const db = yield* MssqlDB
       yield* db.schema
         .createTable("users")

--- a/packages/sql-kysely/test/Mysql.test.ts
+++ b/packages/sql-kysely/test/Mysql.test.ts
@@ -20,7 +20,7 @@ const MysqlLive = Layer.effect(MysqlDB, MysqlKysely.make<Database>()).pipe(Layer
 
 describe("MysqlKysely", () => {
   it.effect("queries", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const db = yield* MysqlDB
 
       yield* db.schema

--- a/packages/sql-kysely/test/Pg.test.ts
+++ b/packages/sql-kysely/test/Pg.test.ts
@@ -20,7 +20,7 @@ const PgLive = Layer.effect(PgDB, PgKysely.make<Database>()).pipe(Layer.provide(
 
 describe("PgKysely", () => {
   it.effect("queries", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const db = yield* PgDB
       yield* db.schema
         .createTable("users")

--- a/packages/sql-kysely/test/Sqlite.test.ts
+++ b/packages/sql-kysely/test/Sqlite.test.ts
@@ -25,7 +25,7 @@ const KyselyLive = Layer.effect(SqliteDB, SqliteKysely.make<Database>()).pipe(La
 
 describe("SqliteKysely", () => {
   it.effect("queries", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const db = yield* SqliteDB
 
       yield* db.schema
@@ -53,7 +53,7 @@ describe("SqliteKysely", () => {
     }).pipe(Effect.provide(KyselyLive)))
 
   it.effect("select with resolver", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const db = yield* SqliteDB
 
       yield* db.schema

--- a/packages/sql-kysely/test/utils.ts
+++ b/packages/sql-kysely/test/utils.ts
@@ -22,8 +22,8 @@ export class PgContainer extends Context.Tag("test/PgContainer")<
   )
 
   static ClientLive = Layer.unwrapEffect(
-    Effect.gen(function*(_) {
-      const container = yield* _(PgContainer)
+    Effect.gen(function*() {
+      const container = yield* PgContainer
       return Pg.PgClient.layer({
         url: Redacted.make(container.getConnectionUri())
       })
@@ -44,8 +44,8 @@ export class MssqlContainer extends Context.Tag("test/MssqlContainer")<
   )
 
   static ClientLive = Layer.unwrapEffect(
-    Effect.gen(function*(_) {
-      const container = yield* _(MssqlContainer)
+    Effect.gen(function*() {
+      const container = yield* MssqlContainer
       return Mssql.MssqlClient.layer({
         server: container.getHost(),
         port: container.getPort(),
@@ -70,8 +70,8 @@ export class MysqlContainer extends Context.Tag("test/MysqlContainer")<
   )
 
   static ClientLive = Layer.unwrapEffect(
-    Effect.gen(function*(_) {
-      const container = yield* _(MysqlContainer)
+    Effect.gen(function*() {
+      const container = yield* MysqlContainer
       return Mysql.MysqlClient.layer({
         url: Redacted.make(container.getConnectionUri())
       })

--- a/packages/sql-libsql/test/Resolver.test.ts
+++ b/packages/sql-libsql/test/Resolver.test.ts
@@ -5,12 +5,10 @@ import { Array, Effect, Layer, Option } from "effect"
 import * as Schema from "effect/Schema"
 import { LibsqlContainer } from "./util.js"
 
-const seededClient = Effect.gen(function*(_) {
+const seededClient = Effect.gen(function*() {
   const sql = yield* LibsqlClient.LibsqlClient
-  yield* _(sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`)
-  yield* _(
-    Effect.forEach(Array.range(1, 100), (id) => sql`INSERT INTO test ${sql.insert({ id, name: `name${id}` })}`)
-  )
+  yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+  yield* Effect.forEach(Array.range(1, 100), (id) => sql`INSERT INTO test ${sql.insert({ id, name: `name${id}` })}`)
   yield* Effect.addFinalizer(() => sql`DROP TABLE test;`.pipe(Effect.orDie))
   return sql
 })
@@ -18,22 +16,22 @@ const seededClient = Effect.gen(function*(_) {
 layer(LibsqlContainer.ClientLive, { timeout: "30 seconds" })("Resolver", (it) => {
   it.layer(Layer.empty)("ordered", (it) => {
     it.scoped("insert", () =>
-      Effect.gen(function*(_) {
+      Effect.gen(function*() {
         const batches: Array<Array<string>> = []
-        const sql = yield* _(seededClient)
-        const Insert = yield* _(SqlResolver.ordered("Insert", {
+        const sql = yield* seededClient
+        const Insert = yield* SqlResolver.ordered("Insert", {
           Request: Schema.String,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           execute: (names) => {
             batches.push(names)
             return sql`INSERT INTO test ${sql.insert(names.map((name) => ({ name })))} RETURNING *`
           }
-        }))
+        })
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: Insert.execute("one"),
             two: Insert.execute("two")
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: { id: 101, name: "one" },
             two: { id: 102, name: "two" }
@@ -43,24 +41,23 @@ layer(LibsqlContainer.ClientLive, { timeout: "30 seconds" })("Resolver", (it) =>
       }))
 
     it.scoped("result length mismatch", () =>
-      Effect.gen(function*(_) {
+      Effect.gen(function*() {
         const batches: Array<Array<number>> = []
-        const sql = yield* _(seededClient)
-        const Select = yield* _(SqlResolver.ordered("Select", {
+        const sql = yield* seededClient
+        const Select = yield* SqlResolver.ordered("Select", {
           Request: Schema.Number,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           execute: (ids) => {
             batches.push(ids)
             return sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
           }
-        }))
-        const error = yield* _(
-          Effect.all([
-            Select.execute(1),
-            Select.execute(2),
-            Select.execute(3),
-            Select.execute(101)
-          ], { batching: true }),
+        })
+        const error = yield* Effect.all([
+          Select.execute(1),
+          Select.execute(2),
+          Select.execute(3),
+          Select.execute(101)
+        ], { batching: true }).pipe(
           Effect.flip
         )
         assert(error instanceof SqlError.ResultLengthMismatch)
@@ -72,22 +69,22 @@ layer(LibsqlContainer.ClientLive, { timeout: "30 seconds" })("Resolver", (it) =>
 
   it.layer(Layer.empty)("grouped", (it) => {
     it.scoped("find by name", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindByName = yield* _(SqlResolver.grouped("FindByName", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindByName = yield* SqlResolver.grouped("FindByName", {
           Request: Schema.String,
           RequestGroupKey: (name) => name,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultGroupKey: (result) => result.name,
           execute: (names) => sql`SELECT * FROM test WHERE name IN ${sql.in(names)}`
-        }))
-        yield* _(sql`INSERT INTO test ${sql.insert({ name: "name1" })}`)
+        })
+        yield* sql`INSERT INTO test ${sql.insert({ name: "name1" })}`
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindByName.execute("name1"),
             two: FindByName.execute("name2"),
             three: FindByName.execute("name0")
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: [{ id: 1, name: "name1" }, { id: 101, name: "name1" }],
             two: [{ id: 2, name: "name2" }],
@@ -97,22 +94,22 @@ layer(LibsqlContainer.ClientLive, { timeout: "30 seconds" })("Resolver", (it) =>
       }))
 
     it.scoped("using raw rows", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindByName = yield* _(SqlResolver.grouped("FindByName", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindByName = yield* SqlResolver.grouped("FindByName", {
           Request: Schema.String,
           RequestGroupKey: (name) => name,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultGroupKey: (_, result: any) => result.name,
           execute: (names) => sql`SELECT * FROM test WHERE name IN ${sql.in(names)}`
-        }))
-        yield* _(sql`INSERT INTO test ${sql.insert({ name: "name1" })}`)
+        })
+        yield* sql`INSERT INTO test ${sql.insert({ name: "name1" })}`
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindByName.execute("name1"),
             two: FindByName.execute("name2"),
             three: FindByName.execute("name0")
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: [{ id: 1, name: "name1" }, { id: 101, name: "name1" }],
             two: [{ id: 2, name: "name2" }],
@@ -124,20 +121,20 @@ layer(LibsqlContainer.ClientLive, { timeout: "30 seconds" })("Resolver", (it) =>
 
   it.layer(Layer.empty)("findById", (it) => {
     it.scoped("find by id", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindById = yield* _(SqlResolver.findById("FindById", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindById = yield* SqlResolver.findById("FindById", {
           Id: Schema.Number,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultId: (result) => result.id,
           execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
-        }))
+        })
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindById.execute(1),
             two: FindById.execute(2),
             three: FindById.execute(101)
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: Option.some({ id: 1, name: "name1" }),
             two: Option.some({ id: 2, name: "name2" }),
@@ -147,20 +144,20 @@ layer(LibsqlContainer.ClientLive, { timeout: "30 seconds" })("Resolver", (it) =>
       }))
 
     it.scoped("using raw rows", () =>
-      Effect.gen(function*(_) {
-        const sql = yield* _(seededClient)
-        const FindById = yield* _(SqlResolver.findById("FindById", {
+      Effect.gen(function*() {
+        const sql = yield* seededClient
+        const FindById = yield* SqlResolver.findById("FindById", {
           Id: Schema.Number,
           Result: Schema.Struct({ id: Schema.Number, name: Schema.String }),
           ResultId: (_, result: any) => result.id,
           execute: (ids) => sql`SELECT * FROM test WHERE id IN ${sql.in(ids)}`
-        }))
+        })
         assert.deepStrictEqual(
-          yield* _(Effect.all({
+          yield* Effect.all({
             one: FindById.execute(1),
             two: FindById.execute(2),
             three: FindById.execute(101)
-          }, { batching: true })),
+          }, { batching: true }),
           {
             one: Option.some({ id: 1, name: "name1" }),
             two: Option.some({ id: 2, name: "name2" }),


### PR DESCRIPTION
## Type

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the usage of gen adapters (function* (_)) in the `sdk-*` tests.


I decided to do these sql related tests in a single PR as the total change set was quite small. Happy to split into multiple PR's or commits if that's preferred.  

## Related

- Related Issue 
  - #5406
  - #5405
- Closes #
