### PR TITLE
refactor: remove gen adapter `function* (_)` from remaining tests

### DIFF
--- a/packages/cluster/test/ClusterWorkflowEngine.test.ts
+++ b/packages/cluster/test/ClusterWorkflowEngine.test.ts
@@ -288,7 +288,7 @@ const EmailWorkflowLayer = EmailWorkflow.toLayer(Effect.fn(function*(payload) {
       }
     })
   }).pipe(
-    EmailWorkflow.withCompensation(Effect.fnUntraced(function*(_) {
+    EmailWorkflow.withCompensation(Effect.fnUntraced(function*() {
       flags.set("compensation", true)
     })),
     Activity.retry({ times: 5 })

--- a/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/Schema/Schema/standardSchemaV1.test.ts
@@ -215,7 +215,7 @@ describe("standardSchemaV1", () => {
       const DepString = Schema.transformOrFail(Schema.Number, Schema.Number, {
         strict: true,
         decode: (n) =>
-          Effect.gen(function*(_) {
+          Effect.gen(function*() {
             const magicNumber = yield* MagicNumber
             return n * magicNumber
           }),
@@ -235,7 +235,7 @@ describe("standardSchemaV1", () => {
       const DepString = Schema.transformOrFail(Schema.Number, Schema.Number, {
         strict: true,
         decode: (n) =>
-          Effect.gen(function*(_) {
+          Effect.gen(function*() {
             const magicNumber = yield* MagicNumber
             yield* Effect.sleep("10 millis")
             return n * magicNumber

--- a/packages/opentelemetry/test/Metrics.test.ts
+++ b/packages/opentelemetry/test/Metrics.test.ts
@@ -10,7 +10,7 @@ const findMetric = (metrics: any, name: string) =>
 
 describe("Metrics", () => {
   it.effect("gauge", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const resource = resourceFromAttributes({
         name: "test",
         version: "1.0.0"
@@ -18,11 +18,11 @@ describe("Metrics", () => {
       const producer = new internal.MetricProducerImpl(resource)
       const gauge = Metric.gauge("rps")
 
-      yield* _(Metric.set(gauge, 10), Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
-      yield* _(Metric.set(gauge, 10), Effect.tagMetrics("key", "value"))
-      yield* _(Metric.set(gauge, 20), Effect.tagMetrics("key", "value"))
+      yield* Metric.set(gauge, 10).pipe(Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
+      yield* Metric.set(gauge, 10).pipe(Effect.tagMetrics("key", "value"))
+      yield* Metric.set(gauge, 20).pipe(Effect.tagMetrics("key", "value"))
 
-      const results = yield* _(Effect.promise(() => producer.collect()))
+      const results = yield* Effect.promise(() => producer.collect())
       const object = JSON.parse(JSON.stringify(results))
       assert.deepEqual(object.resourceMetrics.resource._rawAttributes, [
         ["name", "test"],
@@ -64,7 +64,7 @@ describe("Metrics", () => {
     }))
 
   it.effect("gauge bigint", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const producer = new internal.MetricProducerImpl(
         resourceFromAttributes({
           name: "test",
@@ -73,11 +73,11 @@ describe("Metrics", () => {
       )
       const gauge = Metric.gauge("rps-bigint", { bigint: true })
 
-      yield* _(Metric.set(gauge, 10n), Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
-      yield* _(Metric.set(gauge, 10n), Effect.tagMetrics("key", "value"))
-      yield* _(Metric.set(gauge, 20n), Effect.tagMetrics("key", "value"))
+      yield* Metric.set(gauge, 10n).pipe(Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
+      yield* Metric.set(gauge, 10n).pipe(Effect.tagMetrics("key", "value"))
+      yield* Metric.set(gauge, 20n).pipe(Effect.tagMetrics("key", "value"))
 
-      const results = yield* _(Effect.promise(() => producer.collect()))
+      const results = yield* Effect.promise(() => producer.collect())
       const object = JSON.parse(JSON.stringify(results))
       assert.deepEqual(object.resourceMetrics.resource._rawAttributes, [
         ["name", "test"],
@@ -119,7 +119,7 @@ describe("Metrics", () => {
     }))
 
   it.effect("counter", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const producer = new internal.MetricProducerImpl(
         resourceFromAttributes({
           name: "test",
@@ -128,11 +128,11 @@ describe("Metrics", () => {
       )
       const counter = Metric.counter("counter", { description: "Example" })
 
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"))
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"))
 
-      const results = yield* _(Effect.promise(() => producer.collect()))
+      const results = yield* Effect.promise(() => producer.collect())
       const object = JSON.parse(JSON.stringify(results))
       assert.deepEqual(object.resourceMetrics.resource._rawAttributes, [
         ["name", "test"],
@@ -175,7 +175,7 @@ describe("Metrics", () => {
     }))
 
   it.effect("counter-inc", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const producer = new internal.MetricProducerImpl(
         resourceFromAttributes({
           name: "test",
@@ -187,11 +187,11 @@ describe("Metrics", () => {
         incremental: true
       })
 
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"))
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"))
 
-      const results = yield* _(Effect.promise(() => producer.collect()))
+      const results = yield* Effect.promise(() => producer.collect())
       const object = JSON.parse(JSON.stringify(results))
       assert.deepEqual(object.resourceMetrics.resource._rawAttributes, [
         ["name", "test"],
@@ -234,7 +234,7 @@ describe("Metrics", () => {
     }))
 
   it.effect("counter-bigint", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const producer = new internal.MetricProducerImpl(
         resourceFromAttributes({
           name: "test",
@@ -247,11 +247,11 @@ describe("Metrics", () => {
         bigint: true
       })
 
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"))
-      yield* _(Metric.increment(counter), Effect.tagMetrics("key", "value"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"), Effect.tagMetrics("unit", "requests"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"))
+      yield* Metric.increment(counter).pipe(Effect.tagMetrics("key", "value"))
 
-      const results = yield* _(Effect.promise(() => producer.collect()))
+      const results = yield* Effect.promise(() => producer.collect())
       const object = JSON.parse(JSON.stringify(results))
       assert.deepEqual(object.resourceMetrics.resource._rawAttributes, [
         ["name", "test"],

--- a/packages/platform-browser/test/Worker.test.ts
+++ b/packages/platform-browser/test/Worker.test.ts
@@ -16,13 +16,11 @@ import {
 
 describe.sequential("Worker", () => {
   it("executes streams", () =>
-    Effect.gen(function*(_) {
-      const pool = yield* _(
-        EffectWorker.makePool<number, never, number>({
-          size: 1
-        })
-      )
-      const items = yield* _(pool.execute(99), Stream.runCollect)
+    Effect.gen(function*() {
+      const pool = yield* EffectWorker.makePool<number, never, number>({
+        size: 1
+      })
+      const items = yield* pool.execute(99).pipe(Stream.runCollect)
       assert.strictEqual(items.length, 100)
     }).pipe(
       Effect.scoped,
@@ -33,9 +31,9 @@ describe.sequential("Worker", () => {
     ))
 
   it("Serialized", () =>
-    Effect.gen(function*(_) {
-      const pool = yield* _(EffectWorker.makePoolSerialized({ size: 1 }))
-      const people = yield* _(pool.execute(new GetPersonById({ id: 123 })), Stream.runCollect)
+    Effect.gen(function*() {
+      const pool = yield* EffectWorker.makePoolSerialized({ size: 1 })
+      const people = yield* pool.execute(new GetPersonById({ id: 123 })).pipe(Stream.runCollect)
       assert.deepStrictEqual(Chunk.toReadonlyArray(people), [
         new Person({ id: 123, name: "test", data: new Uint8Array([1, 2, 3]) }),
         new Person({ id: 123, name: "ing", data: new Uint8Array([4, 5, 6]) })
@@ -49,15 +47,14 @@ describe.sequential("Worker", () => {
     ))
 
   it("Serialized with initialMessage", () =>
-    Effect.gen(function*(_) {
-      const pool = yield* _(EffectWorker.makePoolSerialized<WorkerMessage>({
+    Effect.gen(function*() {
+      const pool = yield* EffectWorker.makePoolSerialized<WorkerMessage>({
         size: 1,
         initialMessage: () => new InitialMessage({ name: "custom", data: new Uint8Array([1, 2, 3]) })
-      }))
-      let user = yield* _(pool.executeEffect(new GetUserById({ id: 123 })))
-      user = yield* _(pool.executeEffect(new GetUserById({ id: 123 })))
+      })
+      const user = yield* pool.executeEffect(new GetUserById({ id: 123 }))
       assert.deepStrictEqual(user, new User({ id: 123, name: "custom" }))
-      const people = yield* _(pool.execute(new GetPersonById({ id: 123 })), Stream.runCollect)
+      const people = yield* pool.execute(new GetPersonById({ id: 123 })).pipe(Stream.runCollect)
       assert.deepStrictEqual(Chunk.toReadonlyArray(people), [
         new Person({ id: 123, name: "test", data: new Uint8Array([1, 2, 3]) }),
         new Person({ id: 123, name: "ing", data: new Uint8Array([4, 5, 6]) })
@@ -71,12 +68,12 @@ describe.sequential("Worker", () => {
     ))
 
   it("tracing", () =>
-    Effect.gen(function*(_) {
-      const parentSpan = yield* _(Effect.currentSpan)
-      const pool = yield* _(EffectWorker.makePoolSerialized({
+    Effect.gen(function*() {
+      const parentSpan = yield* Effect.currentSpan
+      const pool = yield* EffectWorker.makePoolSerialized({
         size: 1
-      }))
-      const span = yield* _(pool.executeEffect(new GetSpan()), Effect.tapErrorCause(Effect.log))
+      })
+      const span = yield* pool.executeEffect(new GetSpan()).pipe(Effect.tapErrorCause(Effect.log))
       assert.deepStrictEqual(
         span.parent,
         Option.some({
@@ -94,11 +91,11 @@ describe.sequential("Worker", () => {
     ))
 
   it("SharedWorker", () =>
-    Effect.gen(function*(_) {
-      const pool = yield* _(EffectWorker.makePool<number, never, number>({
+    Effect.gen(function*() {
+      const pool = yield* EffectWorker.makePool<number, never, number>({
         size: 1
-      }))
-      const items = yield* _(pool.execute(99), Stream.runCollect)
+      })
+      const items = yield* pool.execute(99).pipe(Stream.runCollect)
       assert.strictEqual(items.length, 100)
     }).pipe(
       Effect.scoped,

--- a/packages/platform-browser/test/fixtures/serializedWorker.ts
+++ b/packages/platform-browser/test/fixtures/serializedWorker.ts
@@ -17,8 +17,8 @@ const WorkerLive = Runner.layerSerialized(WorkerMessage, {
   GetUserById: (req) => Effect.map(Name, (name) => new User({ id: req.id, name })),
   InitialMessage: (req) => Layer.succeed(Name, req.name),
   GetSpan: (_) =>
-    Effect.gen(function*(_) {
-      const span = yield* _(Effect.currentSpan, Effect.orDie)
+    Effect.gen(function*() {
+      const span = yield* Effect.currentSpan.pipe(Effect.orDie)
       return {
         traceId: span.traceId,
         spanId: span.spanId,

--- a/packages/platform-node/test/HttpClient.test.ts
+++ b/packages/platform-node/test/HttpClient.test.ts
@@ -18,8 +18,8 @@ const TodoWithoutId = Schema.Struct({
   ...Struct.omit(Todo.fields, "id")
 })
 
-const makeJsonPlaceholder = Effect.gen(function*(_) {
-  const defaultClient = yield* _(HttpClient.HttpClient)
+const makeJsonPlaceholder = Effect.gen(function*() {
+  const defaultClient = yield* HttpClient.HttpClient
   const client = defaultClient.pipe(
     HttpClient.mapRequest(HttpClientRequest.prependUrl("https://jsonplaceholder.typicode.com"))
   )
@@ -49,9 +49,8 @@ const JsonPlaceholderLive = Layer.effect(JsonPlaceholder, makeJsonPlaceholder)
 ].forEach(({ layer, name }) => {
   describe(`NodeHttpClient - ${name}`, () => {
     it.effect("google", () =>
-      Effect.gen(function*(_) {
-        const response = yield* _(
-          HttpClient.get("https://www.google.com/"),
+      Effect.gen(function*() {
+        const response = yield* HttpClient.get("https://www.google.com/").pipe(
           Effect.flatMap((_) => _.text)
         )
         expect(response).toContain("Google")

--- a/packages/platform-node/test/MsgPack.test.ts
+++ b/packages/platform-node/test/MsgPack.test.ts
@@ -21,7 +21,7 @@ server.listen({
 
 describe("MsgPack", () => {
   test("socket", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const socket = NodeSocket.makeNetChannel<MsgPack.MsgPackError>({ port, host: "localhost" }).pipe(
         MsgPack.duplex
       )
@@ -30,13 +30,13 @@ describe("MsgPack", () => {
         Stream.pipeThroughChannel(socket),
         Stream.runCollect
       )
-      const output = yield* _(outputEffect)
+      const output = yield* outputEffect
 
       assert.deepStrictEqual(Chunk.toArray(output), [{ hello: "world" }, { test: 123 }])
     }).pipe(Effect.runPromise))
 
   test("socket x10000", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const socket = NodeSocket.makeNetChannel<MsgPack.MsgPackError>({ port }).pipe(
         MsgPack.duplex
       )
@@ -46,7 +46,7 @@ describe("MsgPack", () => {
         Stream.pipeThroughChannel(socket),
         Stream.runCollect
       )
-      const output = yield* _(outputEffect)
+      const output = yield* outputEffect
 
       assert.deepStrictEqual(Chunk.toArray(output), msgs)
     }).pipe(Effect.runPromise))

--- a/packages/platform-node/test/Ndjson.test.ts
+++ b/packages/platform-node/test/Ndjson.test.ts
@@ -21,7 +21,7 @@ server.listen({
 
 describe("Ndjson", () => {
   test("socket", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const socket = NodeSocket.makeNetChannel<Ndjson.NdjsonError>({ port, host: "localhost" }).pipe(
         Ndjson.duplex()
       )
@@ -30,13 +30,13 @@ describe("Ndjson", () => {
         Stream.pipeThroughChannel(socket),
         Stream.runCollect
       )
-      const output = yield* _(outputEffect)
+      const output = yield* outputEffect
 
       assert.deepStrictEqual(Chunk.toArray(output), [{ hello: "world" }, { test: 123 }])
     }).pipe(Effect.runPromise))
 
   test("socket x10000", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const socket = NodeSocket.makeNetChannel<Ndjson.NdjsonError>({ port }).pipe(
         Ndjson.duplex()
       )
@@ -46,7 +46,7 @@ describe("Ndjson", () => {
         Stream.pipeThroughChannel(socket),
         Stream.runCollect
       )
-      const output = yield* _(outputEffect)
+      const output = yield* outputEffect
 
       assert.deepStrictEqual(Chunk.toArray(output), msgs)
     }).pipe(Effect.runPromise))

--- a/packages/sql-drizzle/test/Mysql.test.ts
+++ b/packages/sql-drizzle/test/Mysql.test.ts
@@ -69,7 +69,7 @@ describe.sequential("Mysql", () => {
     ), { timeout: 60000 })
 
   it.effect("remote callback", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient
       const db = yield* Mysql.MysqlDrizzle
       yield* sql`CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, snake_case TEXT NOT NULL)`
@@ -85,7 +85,7 @@ describe.sequential("Mysql", () => {
     ), { timeout: 60000 })
 
   it.effect("remote callback multiple values", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient
       const db = yield* Mysql.MysqlDrizzle
       yield* sql`CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, snake_case TEXT NOT NULL)`

--- a/packages/sql-drizzle/test/Sqlite.test.ts
+++ b/packages/sql-drizzle/test/Sqlite.test.ts
@@ -10,12 +10,12 @@ import { Effect, Layer } from "effect"
 
 const SqlClientLive = Layer.scoped(
   SqlClient.SqlClient,
-  Effect.gen(function*(_) {
-    const fs = yield* _(FileSystem.FileSystem)
-    const dir = yield* _(fs.makeTempDirectoryScoped())
-    return yield* _(SqliteClient.make({
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const dir = yield* fs.makeTempDirectoryScoped()
+    return yield* SqliteClient.make({
       filename: dir + "/test.db"
-    }))
+    })
   })
 ).pipe(
   Layer.provide(NodeFileSystem.layer),
@@ -36,7 +36,7 @@ class ORM extends Effect.Service<ORM>()("ORM", { effect: SqliteDrizzle.make({ sc
 
 describe("SqliteDrizzle", () => {
   it.effect("select", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient
       const db = yield* SqliteDrizzle.SqliteDrizzle
       yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, snake_case TEXT)`
@@ -46,7 +46,7 @@ describe("SqliteDrizzle", () => {
     }).pipe(Effect.provide(SqliteDrizzleLive)))
 
   it.effect("orm", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient
       const db = yield* ORM
       yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, snake_case TEXT)`
@@ -56,7 +56,7 @@ describe("SqliteDrizzle", () => {
     }).pipe(Effect.provide(ORM.Client)))
 
   it.effect("remote callback", () =>
-    Effect.gen(function*(_) {
+    Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient
       const db = yield* SqliteDrizzle.SqliteDrizzle
       yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, snake_case TEXT)`


### PR DESCRIPTION
## Type


- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the usage of gen adapters (`function* (_)`) in the tests of the remaining packages not address in the other PRs.

## Related


- Related Issue
  - #5405
  - #5406
  - #5409
