### PR TITLE
chore(test): remove `assertType`

### DIFF
--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -2,6 +2,7 @@ import type { Either, Types } from "effect"
 import { Array as Arr, Context, Effect, hole, Option, pipe, Predicate, Schedule } from "effect"
 import type { NonEmptyArray, NonEmptyReadonlyArray } from "effect/Array"
 import type { Cause, NoSuchElementException, UnknownException } from "effect/Cause"
+import type { Exit } from "effect/Exit"
 import { describe, expect, it, when } from "tstyche"
 
 class TestError1 {
@@ -627,6 +628,20 @@ describe("Effect", () => {
         Effect.tapErrorTag("TestError1", Effect.log)
       )
     ).type.toBe<Effect.Effect<number, TestError1 | TestError2>>()
+  })
+
+  it("catchIf", () => {
+    expect(pipe(
+      Effect.fail<TestError1 | Error>(new TestError1()),
+      Effect.catchIf(
+        (error) => {
+          expect(error).type.toBe<TestError1 | Error>()
+          return true
+        },
+        Effect.succeed
+      ),
+      Effect.exit
+    )).type.toBe<Effect.Effect<Exit<Error | TestError1, Error | TestError1>, never, never>>()
   })
 
   it("catchTag", () => {

--- a/packages/effect/dtslint/Match.tst.ts
+++ b/packages/effect/dtslint/Match.tst.ts
@@ -233,6 +233,34 @@ describe("Match", () => {
           })
         )
       ).type.toBe<number>()
+
+      const match = pipe(
+        Match.type<Uint8Array | Uint16Array>(),
+        Match.when(Match.instanceOf(Uint8Array), (v) => {
+          // @tstyche if { target: [">=5.7"] } -- Before TypeScript 5.7, 'Uint8Array' was not generic
+          expect(v).type.toBe<Uint8Array<ArrayBuffer>>()
+          // @tstyche if { target: ["<5.7"] }
+          expect(v).type.toBe<Uint8Array>()
+          return "uint8"
+        }),
+        Match.when(Match.instanceOf(Uint16Array), (v) => {
+          // @tstyche if { target: [">=5.7"] } -- Before TypeScript 5.7, 'Uint16Array' was not generic
+          expect(v).type.toBe<Uint16Array<ArrayBuffer>>()
+          // @tstyche if { target: ["<5.7"] }
+          expect(v).type.toBe<Uint16Array>()
+          return "uint16"
+        }),
+        Match.orElse((v) => {
+          // @tstyche if { target: [">=5.7"] } -- Before TypeScript 5.7, 'Uint8Array' and 'Uint16Array' were not generic
+          expect(v).type.toBe<Uint8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike>>()
+          // @tstyche if { target: ["<5.7"] }
+          expect(v).type.toBe<Uint8Array | Uint16Array>()
+          return "a"
+        })
+      )
+
+      expect(match(new Uint8Array())).type.toBe<string>()
+      expect(match(new Uint16Array())).type.toBe<string>()
     })
 
     it("instanceOf prop", () => {

--- a/packages/effect/dtslint/Option.tst.ts
+++ b/packages/effect/dtslint/Option.tst.ts
@@ -6,21 +6,21 @@ declare const string: Option.Option<string>
 declare const numberOrString: Option.Option<string | number>
 
 declare const primitiveNumber: number
-declare const primitiveNumerOrString: string | number
+declare const primitiveNumberOrString: string | number
 declare const predicateNumbersOrStrings: Predicate.Predicate<number | string>
 
 describe("Option", () => {
   it("liftPredicate", () => {
     expect(
-      Option.liftPredicate(primitiveNumerOrString, Predicate.isString)
+      Option.liftPredicate(primitiveNumberOrString, Predicate.isString)
     ).type.toBe<Option.Option<string>>()
     expect(
-      pipe(primitiveNumerOrString, Option.liftPredicate(Predicate.isString))
+      pipe(primitiveNumberOrString, Option.liftPredicate(Predicate.isString))
     ).type.toBe<Option.Option<string>>()
 
     expect(
       Option.liftPredicate(
-        primitiveNumerOrString,
+        primitiveNumberOrString,
         (n): n is number => {
           expect(n).type.toBe<string | number>()
           return typeof n === "number"
@@ -29,7 +29,7 @@ describe("Option", () => {
     ).type.toBe<Option.Option<number>>()
     expect(
       pipe(
-        primitiveNumerOrString,
+        primitiveNumberOrString,
         Option.liftPredicate(
           (n): n is number => {
             expect(n).type.toBe<string | number>()

--- a/packages/effect/test/Effect/error-handling.test.ts
+++ b/packages/effect/test/Effect/error-handling.test.ts
@@ -11,7 +11,6 @@ import * as FiberId from "effect/FiberId"
 import { constFalse, constTrue, identity, pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import { causesArb } from "../utils/cause.js"
-import { assertType, satisfies } from "../utils/types.js"
 
 const ExampleError = new Error("Oh noes!")
 
@@ -269,7 +268,6 @@ describe("Effect", () => {
         Effect.exit
       )
       deepStrictEqual(result, Exit.fail({ _tag: "ErrorB" as const }))
-      satisfies<true>(assertType<Exit.Exit<ErrorA, ErrorB>>()(result))
     }))
   it.effect("catchTags - recovers from one of several tagged errors", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/Effect/structural.test.ts
+++ b/packages/effect/test/Effect/structural.test.ts
@@ -4,7 +4,6 @@ import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
-import { assertType, satisfies } from "../utils/types.js"
 
 describe("Effect", () => {
   describe("all", () => {
@@ -12,20 +11,17 @@ describe("Effect", () => {
       Effect.gen(function*() {
         const res = yield* (Effect.all([Effect.succeed(0), Effect.succeed(1)]))
         deepStrictEqual(res, [0, 1])
-        satisfies<true>(assertType<[number, number]>()(res))
       }))
     it.effect("should work with one empty array argument", () =>
       Effect.gen(function*() {
         const x = yield* (Effect.all([]))
         deepStrictEqual(x, [])
-        satisfies<true>(assertType<[]>()(x))
       }))
     it.effect("should work with an array argument", () =>
       Effect.gen(function*() {
         const y = Effect.all([0, 1, 2].map((n) => Effect.succeed(n + 1)))
         const x = yield* y
         deepStrictEqual(x, [1, 2, 3])
-        satisfies<true>(assertType<Array<number>>()(x))
       }))
     it.effect("should work with one record argument", () =>
       Effect.gen(function*() {
@@ -33,24 +29,16 @@ describe("Effect", () => {
         const { a, b } = result
         deepStrictEqual(a, 0)
         deepStrictEqual(b, 1)
-        satisfies<true>(
-          assertType<{
-            readonly a: number
-            readonly b: number
-          }>()(result)
-        )
       }))
     it.effect("should work with one iterable argument", () =>
       Effect.gen(function*() {
         const result = yield* (Effect.all(new Set([Effect.succeed(0), Effect.succeed(1)])))
         deepStrictEqual(result, [0, 1])
-        satisfies<true>(assertType<Array<number>>()(result))
       }))
     it.effect("should work with one empty record", () =>
       Effect.gen(function*() {
         const x = yield* (Effect.all({}))
         deepStrictEqual(x, {})
-        satisfies<true>(assertType<{}>()(x))
       }))
   })
   describe("all/ concurrency", () => {
@@ -60,7 +48,6 @@ describe("Effect", () => {
           concurrency: "unbounded"
         }))
         deepStrictEqual(res, [0, 1])
-        satisfies<true>(assertType<[number, number]>()(res))
       }))
     it.effect("should work with one empty array argument", () =>
       Effect.gen(function*() {
@@ -68,7 +55,6 @@ describe("Effect", () => {
           concurrency: "unbounded"
         }))
         deepStrictEqual(x, [])
-        satisfies<true>(assertType<[]>()(x))
       }))
     it.effect("should work with one record argument", () =>
       Effect.gen(function*() {
@@ -78,18 +64,11 @@ describe("Effect", () => {
         const { a, b } = result
         deepStrictEqual(a, 0)
         deepStrictEqual(b, 1)
-        satisfies<true>(
-          assertType<{
-            a: number
-            b: number
-          }>()(result)
-        )
       }))
     it.effect("should work with one empty record", () =>
       Effect.gen(function*() {
         const x = yield* (Effect.all({}, { concurrency: "unbounded" }))
         deepStrictEqual(x, {})
-        satisfies<true>(assertType<{}>()(x))
       }))
   })
   describe("all/ validate mode", () => {
@@ -97,13 +76,11 @@ describe("Effect", () => {
       Effect.gen(function*() {
         const res = yield* (Effect.all([Effect.succeed(0), Effect.succeed(1)], { mode: "validate" }))
         deepStrictEqual(res, [0, 1])
-        satisfies<true>(assertType<[number, number]>()(res))
       }))
     it.effect("failure should work with one array argument", () =>
       Effect.gen(function*() {
         const res = yield* (Effect.flip(Effect.all([Effect.fail(0), Effect.succeed(1)], { mode: "validate" })))
         deepStrictEqual(res, [Option.some(0), Option.none()])
-        satisfies<true>(assertType<[Option.Option<number>, Option.Option<never>]>()(res))
       }))
     it.effect("should work with one record argument", () =>
       Effect.gen(function*() {
@@ -111,12 +88,6 @@ describe("Effect", () => {
         const { a, b } = result
         deepStrictEqual(a, 0)
         deepStrictEqual(b, 1)
-        satisfies<true>(
-          assertType<{
-            readonly a: number
-            readonly b: number
-          }>()(result)
-        )
       }))
     it.effect("failure should work with one record argument", () =>
       Effect.gen(function*() {
@@ -126,18 +97,11 @@ describe("Effect", () => {
         const { a, b } = result
         assertSome(a, 0)
         assertNone(b)
-        satisfies<true>(
-          assertType<{
-            readonly a: Option.Option<number>
-            readonly b: Option.Option<never>
-          }>()(result)
-        )
       }))
     it.effect("should work with one iterable argument", () =>
       Effect.gen(function*() {
         const result = yield* (Effect.all(new Set([Effect.succeed(0), Effect.succeed(1)]), { mode: "validate" }))
         deepStrictEqual(result, [0, 1])
-        satisfies<true>(assertType<Array<number>>()(result))
       }))
   })
   describe("all/ either mode", () => {
@@ -145,13 +109,11 @@ describe("Effect", () => {
       Effect.gen(function*() {
         const res = yield* (Effect.all([Effect.succeed(0), Effect.succeed(1)], { mode: "either" }))
         deepStrictEqual(res, [Either.right(0), Either.right(1)])
-        satisfies<true>(assertType<[Either.Either<number>, Either.Either<number>]>()(res))
       }))
     it.effect("failure should work with one array argument", () =>
       Effect.gen(function*() {
         const res = yield* (Effect.all([Effect.fail(0), Effect.succeed(1)], { mode: "either" }))
         deepStrictEqual(res, [Either.left(0), Either.right(1)])
-        satisfies<true>(assertType<[Either.Either<never, number>, Either.Either<number>]>()(res))
       }))
     it.effect("should work with one record argument", () =>
       Effect.gen(function*() {
@@ -159,12 +121,6 @@ describe("Effect", () => {
         const { a, b } = result
         assertRight(a, 0)
         assertRight(b, 1)
-        satisfies<true>(
-          assertType<{
-            readonly a: Either.Either<number>
-            readonly b: Either.Either<number>
-          }>()(result)
-        )
       }))
     it.effect("failure should work with one record argument", () =>
       Effect.gen(function*() {
@@ -174,18 +130,11 @@ describe("Effect", () => {
         const { a, b } = result
         assertLeft(a, 0)
         assertRight(b, 1)
-        satisfies<true>(
-          assertType<{
-            readonly a: Either.Either<never, number>
-            readonly b: Either.Either<number>
-          }>()(result)
-        )
       }))
     it.effect("should work with one iterable argument", () =>
       Effect.gen(function*() {
         const result = yield* (Effect.all(new Set([Effect.succeed(0), Effect.succeed(1)]), { mode: "either" }))
         deepStrictEqual(result, [Either.right(0), Either.right(1)])
-        satisfies<true>(assertType<Array<Either.Either<number>>>()(result))
       }))
   })
   describe("allWith", () => {
@@ -196,7 +145,6 @@ describe("Effect", () => {
           Effect.allWith()
         )
         deepStrictEqual(res, [0, 1])
-        satisfies<true>(assertType<[number, number]>()(res))
       }))
   })
 })

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -11,7 +11,6 @@ import {
   throws
 } from "@effect/vitest/utils"
 import { Either, Match as M, Option, pipe, Predicate } from "effect"
-import { assertType } from "./utils/types.js"
 
 describe("Match", () => {
   it("TypeMatcher.pipe() method", () => {
@@ -571,16 +570,12 @@ describe("Match", () => {
   })
 
   it("instanceOf", () => {
-    // These type-level tests cannot be moved to a dtslint test because
-    // of the difference in the way the type is retrieved in ts 5.7
     const match = pipe(
       M.type<Uint8Array | Uint16Array>(),
       M.when(M.instanceOf(Uint8Array), (_) => {
-        assertType<Uint8Array>()(_) satisfies true
         return "uint8"
       }),
       M.when(M.instanceOf(Uint16Array), (_) => {
-        assertType<Uint16Array>()(_) satisfies true
         return "uint16"
       }),
       M.orElse((_) => {

--- a/packages/effect/test/Option.test.ts
+++ b/packages/effect/test/Option.test.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, it } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import {
   assertFalse,
   assertNone,
@@ -473,16 +473,12 @@ describe("Option", () => {
   })
 
   it("all/ tuple", () => {
-    assertType<Option.Option<[number, string]>>(Option.all([Option.some(1), Option.some("hello")]))
     assertSome(Option.all([]), [])
     assertSome(Option.all([Option.some(1), Option.some("hello")]), [1, "hello"])
     assertNone(Option.all([Option.some(1), Option.none()]))
   })
 
   it("all/ iterable", () => {
-    assertType<Option.Option<Array<number>>>(Option.all([Option.some(1), Option.some(2)]))
-    assertType<Option.Option<Array<number>>>(Option.all(new Set([Option.some(1), Option.some(2)])))
-
     assertSome(Option.all([]), [])
     assertNone(Option.all([Option.none()]))
     assertSome(Option.all([Option.some(1), Option.some(2)]), [1, 2])
@@ -491,7 +487,6 @@ describe("Option", () => {
   })
 
   it("all/ struct", () => {
-    assertType<Option.Option<{ a: number; b: string }>>(Option.all({ a: Option.some(1), b: Option.some("hello") }))
     assertSome(
       Option.all({ a: Option.some(1), b: Option.some("hello") }),
       { a: 1, b: "hello" }

--- a/packages/effect/test/utils/types.ts
+++ b/packages/effect/test/utils/types.ts
@@ -1,3 +1,0 @@
-export const assertType = <A>() => <B>(_: B): [A] extends [B] ? [B] extends [A] ? true : false : false => void 0 as any
-
-export const satisfies = <T>(type: T) => type


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR removes the `assertType()` utility which is used in few paces in run time tests. Seems like the utility is redundant, because type-level tests can cover all the cases and would be tested agains different TypeScript versions.

Before removing the assertions I was checked carefully if they exist in type tests already. Two cases were missing. So I tried to copy the code and adapt it for type testing. 