### PR TITLE
feat: expose raw sqlite client in `sql-sqlite-bun` and `sql-sqlite-node`

### DIFF
--- a/.changeset/crazy-icons-rush.md
+++ b/.changeset/crazy-icons-rush.md
@@ -1,0 +1,36 @@
+---
+"@effect/sql-sqlite-node": minor
+"@effect/sql-sqlite-bun": minor
+---
+
+## Raw Database Client Access
+
+Both `@effect/sql-sqlite-node` and `@effect/sql-sqlite-bun` now expose the underlying database client through a new `rawClient` property. This provides direct access to the native database APIs when needed for advanced operations.
+
+**Example**
+
+```ts
+import { SqliteClient } from "@effect/sql-sqlite-bun"
+import { Effect } from "effect"
+
+const program = Effect.gen(function* () {
+  const client = yield* SqliteClient.make({ filename: "test.db" })
+
+  // Access the raw Bun SQLite Database instance
+  const rawDb = yield* client.rawClient
+
+  // Use native database methods directly
+  const result = yield* Effect.try(() =>
+    rawClient.prepare("SELECT * FROM users").all()
+  )
+
+  return result
+})
+```
+
+The `rawClient` property returns:
+
+- `Effect<Database>` for `@effect/sql-sqlite-bun` (Bun's native SQLite Database)
+- `Effect<Database>` for `@effect/sql-sqlite-node` (better-sqlite3 Database)
+
+This enables users to access vendor-specific functionality while maintaining the Effect-based workflow.

--- a/packages/sql-sqlite-bun/examples/Client.test.ts
+++ b/packages/sql-sqlite-bun/examples/Client.test.ts
@@ -17,6 +17,7 @@ describe("Client", () => {
   test("works", () =>
     Effect.gen(function*() {
       const sql = yield* makeClient
+      const rawClient = yield* sql.rawClient
       yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
       yield* sql`INSERT INTO test (name) VALUES ('hello')`
       let rows = yield* sql`SELECT * FROM test`
@@ -24,6 +25,11 @@ describe("Client", () => {
       yield* pipe(sql`INSERT INTO test (name) VALUES ('world')`, sql.withTransaction)
       rows = yield* sql`SELECT * FROM test`
       expect(rows).toEqual([
+        { id: 1, name: "hello" },
+        { id: 2, name: "world" }
+      ])
+      const rawRows = yield* Effect.try(() => rawClient.query("SELECT * FROM test").all())
+      expect(rawRows).toEqual([
         { id: 1, name: "hello" },
         { id: 2, name: "world" }
       ])

--- a/packages/sql-sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql-sqlite-bun/src/SqliteClient.ts
@@ -15,6 +15,12 @@ import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 
+/**
+ * @category models
+ * @since 1.0.0
+ */
+export type { Database }
+
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
 /**
@@ -36,6 +42,7 @@ export type TypeId = typeof TypeId
 export interface SqliteClient extends Client.SqlClient {
   readonly [TypeId]: TypeId
   readonly config: SqliteClientConfig
+  readonly rawClient: Effect.Effect<Database>
   readonly export: Effect.Effect<Uint8Array, SqlError>
   readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 
@@ -67,6 +74,7 @@ export interface SqliteClientConfig {
 }
 
 interface SqliteConnection extends Connection {
+  readonly database: Database
   readonly export: Effect.Effect<Uint8Array, SqlError>
   readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 }
@@ -117,6 +125,7 @@ export const make = (
         })
 
       return identity<SqliteConnection>({
+        database: db,
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(run(sql, params), transformRows)
@@ -177,6 +186,7 @@ export const make = (
       {
         [TypeId]: TypeId as TypeId,
         config: options,
+        rawClient: Effect.flatMap(acquirer, (_) => Effect.succeed(_.database)),
         export: Effect.flatMap(acquirer, (_) => _.export),
         loadExtension: (path: string) => Effect.flatMap(acquirer, (_) => _.loadExtension(path))
       }

--- a/packages/sql-sqlite-node/test/Client.test.ts
+++ b/packages/sql-sqlite-node/test/Client.test.ts
@@ -52,6 +52,16 @@ describe("Client", () => {
       ])
     }))
 
+  it.scoped("should work with rawClient", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      const rawClient = yield* sql.rawClient
+      yield* Effect.sync(() => rawClient.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"))
+      yield* Effect.sync(() => rawClient.exec("INSERT INTO test (name) VALUES ('hello')"))
+      const rows = yield* Effect.try(() => rawClient.prepare("SELECT * FROM test").all())
+      assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+    }))
+
   it.scoped("withTransaction", () =>
     Effect.gen(function*() {
       const sql = yield* makeClient


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR is intended to expose the internal database client for `sql-sqlite-bun` and `sql-sqlite-node` packages. My primary reason for doing this was the need to feed the `better-auth` library with the raw database client, which currently is not available.

I think this can be afterwards added to the other sql packages.

Usage:
```ts
const sql = yield* SqliteClient.SqliteClient
const rawClient = yield* sql.rawClient
yield* Effect.sync(() => rawClient.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"))
yield* Effect.sync(() => rawClient.exec("INSERT INTO test (name) VALUES ('hello')"))
const rows = yield* Effect.try(() => rawClient.prepare("SELECT * FROM test").all())
assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
```
Or in my use-case:
```ts
const make = Effect.gen(function*() {
  const sql = yield* SqliteClient.SqliteClient;
  const rawClient = yield* sql.rawClient;

  const auth = yield* Effect.try(() =>
    betterAuth({
      database: rawClient,
      emailAndPassword: {
        enabled: true,
      },
    }),
  );

  return BetterAuthClient.of(auth);
});
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue N/A
- Closes N/A
