### PR TITLE
refactor: allow to call Options.withDefault multiple times on the same Option

### DIFF
--- a/.changeset/light-files-kick.md
+++ b/.changeset/light-files-kick.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": minor
+---
+
+Allow to call Options.withDefault multiple times

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -1056,6 +1056,13 @@ const makeWithDefault = <A, const B>(
   options: Options.Options<A>,
   fallback: B
 ): Options.Options<A | B> => {
+  if (isInstruction(options) && options._tag === "WithDefault") {
+    const op = Object.create(proto)
+    op._tag = "WithDefault"
+    op.options = options.options
+    op.fallback = fallback
+    return op
+  }
   const op = Object.create(proto)
   op._tag = "WithDefault"
   op.options = options

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -245,6 +245,20 @@ describe("Options", () => {
       expect(result).toEqual(ValidationError.invalidValue(HelpDoc.p("'abc' is not a integer")))
     }).pipe(runEffect))
 
+  it("should take the value of the last withDefault if option is not passed", () =>
+    Effect.gen(function*() {
+      const option = pipe(Options.integer("t"), Options.withDefault(0), Options.withDefault(1))
+      const result = yield* process(option, [], CliConfig.defaultConfig)
+      expect(result).toEqual([[], 1])
+    }).pipe(runEffect))
+
+  it("should allow to overwrite the default of a boolean option", () =>
+    Effect.gen(function*() {
+      const option = pipe(Options.boolean("b"), Options.withDefault(true))
+      const result = yield* process(option, [], CliConfig.defaultConfig)
+      expect(result).toEqual([[], true])
+    }).pipe(runEffect))
+
   it("validates with case-sensitive configuration", () =>
     Effect.gen(function*() {
       const config = CliConfig.make({ isCaseSensitive: true, autoCorrectLimit: 2 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature (might be a bug fix)
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
This makes an Option use as default the value of the last `Options.withDefault` called.
```ts
pipe(Options.integer('i'), Options.withDefault(0), Options.withDefault(1))
```
1 will be the default value for `i` instead of currently 0

## Related

See this [discord message](https://discord.com/channels/795981131316985866/887401371089911868/1412519338849730680) for more details

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
