### PR TITLE
failing tests for extension-dependent prepared statements after loadExtension

### DIFF
--- a/packages/sql-sqlite-node/package.json
+++ b/packages/sql-sqlite-node/package.json
@@ -46,6 +46,7 @@
     "coverage": "vitest --coverage"
   },
   "devDependencies": {
+    "@effect-native/libcrsql": "^0.16.303",
     "@effect/experimental": "workspace:^",
     "@effect/platform": "workspace:^",
     "@effect/platform-node": "workspace:^",

--- a/packages/sql-sqlite-node/test/Client.test.ts
+++ b/packages/sql-sqlite-node/test/Client.test.ts
@@ -1,3 +1,4 @@
+import * as LibCrSql from "@effect-native/libcrsql"
 import { Reactivity } from "@effect/experimental"
 import { FileSystem } from "@effect/platform"
 import { NodeFileSystem } from "@effect/platform-node"
@@ -73,4 +74,60 @@ describe("Client", () => {
       const rows = yield* sql`SELECT * FROM test`
       assert.deepStrictEqual(rows, [])
     }))
+
+  describe("loading extensions", () => {
+    it.scoped("loads crsqlite extension", () =>
+      Effect.gen(function*() {
+        const sql = yield* makeClient
+        // Ensure a crsqlite function errors before extension is loaded
+        const beforeErr = yield* sql`SELECT crsql_sha()`.pipe(Effect.flip)
+        assert.equal(beforeErr._tag, "SqlError")
+
+        const extPath = yield* Effect.try(() => LibCrSql.getCrSqliteExtensionPathSync())
+        yield* sql.loadExtension(extPath)
+
+        // Use a different query after loading to avoid prepared statement cache issues
+        const rows = yield* sql<
+          { sha: string; site_id: string }
+        >`SELECT crsql_sha() as sha, hex(crsql_site_id()) AS site_id`
+        assert.strictEqual(rows.length, 1)
+        assert.strictEqual(typeof rows[0].site_id, "string")
+        assert(rows[0].site_id.length > 0)
+      }))
+
+    describe("prepared statements that depend on extension", () => {
+      it.scoped("fail before loading", () =>
+        Effect.gen(function*() {
+          const sql = yield* makeClient
+          const extInfoBeforeLoad = yield* sql<{ sha: string }>`SELECT crsql_sha() as sha`.pipe(Effect.flip)
+          assert.equal(extInfoBeforeLoad._tag, "SqlError")
+        }))
+      it.scoped("pass after loading", () =>
+        Effect.gen(function*() {
+          const sql = yield* makeClient
+
+          const extPath = yield* Effect.try(() => LibCrSql.getCrSqliteExtensionPathSync())
+          yield* sql.loadExtension(extPath)
+
+          const extInfoAfterLoad = yield* sql<{ sha: string }>`SELECT crsql_sha() as sha`
+          assert.strictEqual(extInfoAfterLoad.length, 1)
+          assert.deepStrictEqual(extInfoAfterLoad, [{ sha: "0d62b52b4662ee1a762c9fd9264d48a91ab8df83" }])
+        }))
+      it.scoped("fail before loading, then pass after", () =>
+        Effect.gen(function*() {
+          const sql = yield* makeClient
+
+          const extInfoBeforeLoad = yield* sql<{ sha: string }>`SELECT crsql_sha() as sha`.pipe(Effect.flip)
+          assert.equal(extInfoBeforeLoad._tag, "SqlError")
+
+          const extPath = yield* Effect.try(() => LibCrSql.getCrSqliteExtensionPathSync())
+          yield* sql.loadExtension(extPath)
+
+          // NOTE: This is the exact same query as before, but now it should succeed
+          const extInfoAfterLoad = yield* sql<{ sha: string }>`SELECT crsql_sha() as sha`
+          assert.strictEqual(extInfoAfterLoad.length, 1)
+          assert.deepStrictEqual(extInfoAfterLoad, [{ sha: "0d62b52b4662ee1a762c9fd9264d48a91ab8df83" }])
+        }))
+    })
+  })
 })


### PR DESCRIPTION
Type: Bug Fix (tests only)

Adds tests that reproduce the issue where statements prepared before calling loadExtension continue to fail when executed after the extension is loaded. This captures the behavior described in #5457 and provides a clear failing test for the subsequent fix.

Tests:

- Adds extension and prepared-statement tests:

Notes:

- This PR contains tests only and is expected to fail until the fix lands.

Proves Issue #5457

NEXT: Will create a separate PR with the actual fix