### PR TITLE
Invalidate prepared-statement cache after loadExtension (Node)

### DIFF
--- a/.changeset/clear-prepare-cache-on-load-extension.md
+++ b/.changeset/clear-prepare-cache-on-load-extension.md
@@ -3,13 +3,3 @@
 ---
 
 Invalidate the prepared-statement cache after `loadExtension`.
-
-Prepared statements created before loading a SQLite extension could fail even
-after the extension was loaded (e.g. "no such function" for extension
-functions) because they were reused from the prepare cache. Clearing the cache
-after `db.loadExtension` ensures statements are re-prepared with the updated
-function set and query plan.
-
-Also adds tests that verify extension functions fail before load and succeed
-after, including the same SQL text succeeding post-load.
-

--- a/.changeset/clear-prepare-cache-on-load-extension.md
+++ b/.changeset/clear-prepare-cache-on-load-extension.md
@@ -1,0 +1,15 @@
+---
+"@effect/sql-sqlite-node": patch
+---
+
+Invalidate the prepared-statement cache after `loadExtension`.
+
+Prepared statements created before loading a SQLite extension could fail even
+after the extension was loaded (e.g. "no such function" for extension
+functions) because they were reused from the prepare cache. Clearing the cache
+after `db.loadExtension` ensures statements are re-prepared with the updated
+function set and query plan.
+
+Also adds tests that verify extension functions fail before load and succeed
+after, including the same SQL text succeeding post-load.
+

--- a/packages/sql-sqlite-node/src/SqliteClient.ts
+++ b/packages/sql-sqlite-node/src/SqliteClient.ts
@@ -202,10 +202,14 @@ export const make = (
           })
         },
         loadExtension(path) {
-          return Effect.try({
-            try: () => db.loadExtension(path),
-            catch: (cause) => new SqlError({ cause, message: "Failed to load extension" })
-          })
+          return Effect.tap(
+            Effect.try({
+              try: () => db.loadExtension(path),
+              catch: (cause) => new SqlError({ cause, message: "Failed to load extension" })
+            }),
+            // Newly loaded extension may affect query planning, so clear the cache to ensure all queries are re-planned
+            () => prepareCache.invalidateAll
+          )
         }
       })
     })

--- a/packages/sql-sqlite-node/src/SqliteClient.ts
+++ b/packages/sql-sqlite-node/src/SqliteClient.ts
@@ -207,7 +207,6 @@ export const make = (
               try: () => db.loadExtension(path),
               catch: (cause) => new SqlError({ cause, message: "Failed to load extension" })
             }),
-            // Newly loaded extension may affect query planning, so clear the cache to ensure all queries are re-planned
             () => prepareCache.invalidateAll
           )
         }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Invalidate the prepared-statement cache after `loadExtension`.

Prepared statements created before loading a SQLite extension could fail even
after the extension was loaded (e.g. "no such function" for extension
functions) because they were reused from the prepare cache. Clearing the cache
after `db.loadExtension` ensures statements are re-prepared with the updated
function set and query plan.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Tests in PR #5458
- Closes #5457
