### PR TITLE
prepared‑statement cache to Bun sqlite client

### DIFF
--- a/.changeset/prepare-cache-bun.md
+++ b/.changeset/prepare-cache-bun.md
@@ -1,6 +1,5 @@
 ---
-"@effect/sql-sqlite-bun": patch
+"@effect/sql-sqlite-bun": minor
 ---
 
 Add prepared-statement cache and clear it after `loadExtension` to ensure extension-dependent queries are re-prepared with up-to-date functions and planning.
-

--- a/.changeset/prepare-cache-bun.md
+++ b/.changeset/prepare-cache-bun.md
@@ -1,0 +1,6 @@
+---
+"@effect/sql-sqlite-bun": patch
+---
+
+Add prepared-statement cache and clear it after `loadExtension` to ensure extension-dependent queries are re-prepared with up-to-date functions and planning.
+


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Introduces a prepared‑statement cache to @effect/sql-sqlite-bun and invalidates it after loadExtension. This aligns behavior with the Node client and ensures that extension‑dependent queries re‑prepare with the updated function set and query planning after an extension is loaded.
