### PR TITLE
Add support for Drizzle relational queries

### DIFF
--- a/.changeset/sixty-wasps-fold.md
+++ b/.changeset/sixty-wasps-fold.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-drizzle": minor
+---
+
+Adds a parallel API that preserves/propagates DrizzleConfig's generic through tag and service creation. This is necessary to be able to use Drizzle's relational queries.

--- a/packages/sql-drizzle/src/Pg.ts
+++ b/packages/sql-drizzle/src/Pg.ts
@@ -47,6 +47,72 @@ export class PgDrizzle extends Context.Tag("@effect/sql-drizzle/Pg")<
 >() {}
 
 /**
+ *
+ * @example
+ * ```ts
+ * const schema = {
+ *     account: pgTable("account", {
+ *         id: integer()
+ *     })
+ * }
+ * 
+ * export const PgLive = PgClient.layerConfig({
+ * 	url: Config.redacted(""),
+ * })
+ * 
+ * export const DrizzeLive = layerWithConfigGeneric({
+ * 	casing: "snake_case",
+ * 	schema,
+ * }).pipe(Layer.provide(PgLive))
+ * 
+ * export const DBLive = Layer.mergeAll(
+ * 	PgLive,
+ * 	DrizzeLive,
+ * )
+ * 
+ * export const DrizzleInstance = PgDrizzleFactory<typeof schema>()
+ * 
+ * const eff = Effect.gen(function* () {
+ * 		const drizle = yield* DrizzleInstance
+ *         // before account wouldn't be inferred.
+ * 		const result = yield* drizle.query.account.findFirst()
+ * }).pipe(Effect.provide(DBLive))
+ * ```
+ *
+ */
+
+/**
+ * @since 1.0.0
+ * @category tags
+ */
+export const PgDrizzleFactory = <TSchema extends Record<string, unknown> = Record<string, never>>() =>
+  Context.GenericTag<
+  "@effect/sql-drizzle/Pg",
+  PgRemoteDatabase<TSchema>
+>("@effect/sql-drizzle/Pg")
+
+/**
+ * @since 1.0.0
+ * @category constructors
+ */
+export const makeWithConfigGeneric = <TSchema extends Record<string, unknown> = Record<string, never>>(config: DrizzleConfig<TSchema>) =>
+  Effect.gen(function*() {
+    const db = drizzle(yield* makeRemoteCallback, config)
+    return db
+  })
+
+/**
+ * @since 1.0.0
+ * @category layers
+ */
+export const layerWithConfigGeneric = <
+  TSchema extends Record<string, unknown> = Record<string, never>
+>(
+  config: DrizzleConfig<TSchema>
+): Layer.Layer<"@effect/sql-drizzle/Pg", never, Client.SqlClient> =>
+  Layer.effect(PgDrizzleFactory<TSchema>(), makeWithConfigGeneric(config))
+
+/**
  * @since 1.0.0
  * @category layers
  */


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds support for Drizzle relational queries by propagating the DrizzleConfig generic.

Before:
```ts
const schema = {
    account: pgTable("account", {
        id: integer()
    })
}

export const PgLive = PgClient.layerConfig({
	url: Config.redacted(""),
})

export const DrizzeLive = layerWithConfig({
	casing: "snake_case",
	schema,
}).pipe(Layer.provide(PgLive))
```

type error: 
```ts
The expected type comes from property 'schema' which is declared here on type 'DrizzleConfig<Record<string, never>>'
```

After:
```ts
const schema = {
    account: pgTable("account", {
        id: integer()
    })
}

export const PgLive = PgClient.layerConfig({
	url: Config.redacted(""),
})

export const DrizzeLive = layerWithConfigGeneric({
	casing: "snake_case",
	schema,
}).pipe(Layer.provide(PgLive))

export const DBLive = Layer.mergeAll(
	PgLive,
	DrizzeLive,
)

export const DrizzleInstance = PgDrizzleFactory<typeof schema>()

const eff = Effect.gen(function* () {
		const drizle = yield* DrizzleInstance
        // before account wouldn't be inferred.
		const result = yield* drizle.query.account.findFirst()
}).pipe(Effect.provide(DBLive))
```