### PR TITLE
docs: fix JSDoc content for Predicate.isNumber to match the implementation

### DIFF
--- a/packages/effect/src/Predicate.ts
+++ b/packages/effect/src/Predicate.ts
@@ -334,8 +334,7 @@ export const isMap = (input: unknown): input is Map<unknown, unknown> => input i
 export const isString = (input: unknown): input is string => typeof input === "string"
 
 /**
- * A refinement that checks if a value is a `number`. Note that this
- * check returns `false` for `NaN`.
+ * A refinement that checks if a value is a `number`.
  *
  * @example
  * ```ts
@@ -345,9 +344,9 @@ export const isString = (input: unknown): input is string => typeof input === "s
  * assert.strictEqual(isNumber(123), true)
  * assert.strictEqual(isNumber(0), true)
  * assert.strictEqual(isNumber(-1.5), true)
+ * assert.strictEqual(isNumber(NaN), true)
  *
  * assert.strictEqual(isNumber("123"), false)
- * assert.strictEqual(isNumber(NaN), false) // Special case: NaN is a number type but returns false
  * ```
  *
  * @category guards


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

It seems like this was merged without this being resolved and someone in DC pointed this out, so fixing 😄 The implementation just does `typeof x === "number"` so `NaN` will pass it.

Do we need changeset for docs only update?

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
