### PR TITLE
Update addError to give precedence to newly added schemas

### DIFF
--- a/packages/platform/src/HttpApi.ts
+++ b/packages/platform/src/HttpApi.ts
@@ -184,10 +184,10 @@ const Proto = {
       identifier: this.identifier,
       groups: this.groups,
       errorSchema: HttpApiSchema.UnionUnify(
-        this.errorSchema,
         annotations?.status
           ? schema.annotations(HttpApiSchema.annotations({ status: annotations.status }))
-          : schema
+          : schema,
+        this.errorSchema
       ),
       annotations: this.annotations,
       middlewares: this.middlewares

--- a/packages/platform/src/HttpApiEndpoint.ts
+++ b/packages/platform/src/HttpApiEndpoint.ts
@@ -771,8 +771,8 @@ const Proto = {
     return makeProto({
       ...this,
       errorSchema: HttpApiSchema.UnionUnify(
+        annotations?.status ? schema.annotations(HttpApiSchema.annotations({ status: annotations.status })) : schema,
         this.errorSchema,
-        annotations?.status ? schema.annotations(HttpApiSchema.annotations({ status: annotations.status })) : schema
       )
     })
   },

--- a/packages/platform/src/HttpApiGroup.ts
+++ b/packages/platform/src/HttpApiGroup.ts
@@ -307,8 +307,8 @@ const Proto = {
       topLevel: this.topLevel,
       endpoints: this.endpoints,
       errorSchema: HttpApiSchema.UnionUnify(
+        annotations?.status ? schema.annotations(HttpApiSchema.annotations({ status: annotations.status })) : schema,
         this.errorSchema,
-        annotations?.status ? schema.annotations(HttpApiSchema.annotations({ status: annotations.status })) : schema
       ),
       annotations: this.annotations,
       middlewares: this.middlewares


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`HttpApiSchema.UnionUnify` creates a union whose members are listed in the order of `[...firstArgUnionMembers, ...secondArgUnionMembers]`. When encoding a union, Schema will try each member in the order that they appear.

So the `addError` method on each of the HttpApi* classes, by passing the user-provided schema as a second argument, causes older schemas that encompass newer schemas to take precedence over the newer ones.

By flipping the argument order, users are now able to use `addError` with a schema that (partly) encompasses an older one, to override the encoding behaviour for values conforming to those schemas.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related to https://github.com/Effect-TS/effect/issues/4751 (but doesn't fully fix it, as the default HttpApiDecodeError schema is still part of every HttpApi)
- Closes https://github.com/Effect-TS/effect/issues/5465
