### PR TITLE
Add `suffix` option to `FileSystem.makeTempFile`

### DIFF
--- a/.changeset/empty-cougars-count.md
+++ b/.changeset/empty-cougars-count.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform": minor
+"@effect/platform-node-shared": minor
+---
+
+Allow user to set extension of file created using `FileSystem.makeTempFile`

--- a/.changeset/empty-cougars-count.md
+++ b/.changeset/empty-cougars-count.md
@@ -1,6 +1,6 @@
 ---
-"@effect/platform": minor
-"@effect/platform-node-shared": minor
+"@effect/platform": patch
+"@effect/platform-node-shared": patch
 ---
 
 Allow user to set extension of file created using `FileSystem.makeTempFile`

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -382,7 +382,7 @@ const makeTempFileFactory = (method: string) => {
   return (options?: FileSystem.MakeTempFileOptions) =>
     pipe(
       Effect.zip(makeDirectory(options), randomHexString(6)),
-      Effect.map(([directory, random]) => Path.join(directory, random)),
+      Effect.map(([directory, random]) => Path.join(directory, random + (options?.suffix ?? ""))),
       Effect.tap((path) => Effect.scoped(open(path, { flag: "w+" })))
     )
 }

--- a/packages/platform-node-shared/test/FileSystem.test.ts
+++ b/packages/platform-node-shared/test/FileSystem.test.ts
@@ -53,6 +53,44 @@ describe("FileSystem", () => {
       assert(error._tag === "SystemError" && error.reason === "NotFound")
     })))
 
+  it("makeTempFile", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* (Fs.FileSystem)
+      let file = ""
+      yield* pipe(
+        Effect.gen(function*() {
+          file = yield* fs.makeTempFile({
+            "suffix": ".txt"
+          })
+          expect(file.endsWith(".txt")).toBe(true)
+          const stat = yield* fs.stat(file)
+          expect(stat.type).toEqual("File")
+        }),
+        Effect.scoped
+      )
+      const stat = yield* fs.stat(file)
+      expect(stat.type).toEqual("File")
+    })))
+
+  it("makeTempFileScoped", () =>
+    runPromise(Effect.gen(function*() {
+      const fs = yield* (Fs.FileSystem)
+      let file = ""
+      yield* pipe(
+        Effect.gen(function*() {
+          file = yield* fs.makeTempFileScoped({
+            "suffix": ".txt"
+          })
+          expect(file.endsWith(".txt")).toBe(true)
+          const stat = yield* fs.stat(file)
+          expect(stat.type).toEqual("File")
+        }),
+        Effect.scoped
+      )
+      const error = yield* Effect.flip(fs.stat(file))
+      assert(error._tag === "SystemError" && error.reason === "NotFound")
+    })))
+
   it("truncate", () =>
     runPromise(Effect.gen(function*() {
       const fs = yield* Fs.FileSystem

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -369,6 +369,7 @@ export interface MakeTempDirectoryOptions {
 export interface MakeTempFileOptions {
   readonly directory?: string
   readonly prefix?: string
+  readonly suffix?: string
 }
 
 /**


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This adds an additional option `suffix` to the `makeTempFile` options, so that a user can determine the extension of the generated file.

For example, if a user wants to write a JS file to disk and then dynamically import it.
