### PR TITLE
Implement new 'Off' LogLevel

### DIFF
--- a/.changeset/three-zoos-enter.md
+++ b/.changeset/three-zoos-enter.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Added new 'Off' LogLevel that works the exact same way as LogLevel.None

--- a/packages/effect/src/LogLevel.ts
+++ b/packages/effect/src/LogLevel.ts
@@ -20,7 +20,7 @@ import type { Pipeable } from "./Pipeable.js"
  * @property label - A label associated with the log level.
  * @property syslog -The syslog severity level of the log level.
  */
-export type LogLevel = All | Fatal | Error | Warning | Info | Debug | Trace | None
+export type LogLevel = All | Fatal | Error | Warning | Info | Debug | Trace | None | Off
 
 /**
  * @since 2.0.0
@@ -111,6 +111,17 @@ export interface Trace extends Pipeable {
  */
 export interface None extends Pipeable {
   readonly _tag: "None"
+  readonly label: "NONE"
+  readonly syslog: 7
+  readonly ordinal: number
+}
+
+/**
+ * @since 2.0.0
+ * @category model
+ */
+export interface Off extends Pipeable {
+  readonly _tag: "Off"
   readonly label: "OFF"
   readonly syslog: 7
   readonly ordinal: number
@@ -163,6 +174,12 @@ export const Trace: LogLevel = core.logLevelTrace
  * @category constructors
  */
 export const None: LogLevel = core.logLevelNone
+
+/**
+ * @since 2.0.0
+ * @category constructors
+ */
+export const Off: LogLevel = core.logLevelOff
 
 /**
  * @since 2.0.0
@@ -277,6 +294,8 @@ export const fromLiteral = (literal: Literal): LogLevel => {
       return Info
     case "Trace":
       return Trace
+    case "Off":
+      return Off
     case "None":
       return None
     case "Warning":

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -1678,6 +1678,17 @@ export const logLevelTrace: LogLevel.LogLevel = {
 export const logLevelNone: LogLevel.LogLevel = {
   _tag: "None",
   syslog: 7,
+  label: "NONE",
+  ordinal: Number.MAX_SAFE_INTEGER,
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+/** @internal */
+export const logLevelOff: LogLevel.LogLevel = {
+  _tag: "Off",
+  syslog: 7,
   label: "OFF",
   ordinal: Number.MAX_SAFE_INTEGER,
   pipe() {
@@ -1694,7 +1705,8 @@ export const allLogLevels: ReadonlyArray<LogLevel.LogLevel> = [
   logLevelWarning,
   logLevelError,
   logLevelFatal,
-  logLevelNone
+  logLevelNone,
+  logLevelOff
 ]
 
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/internal/logger.ts
+++ b/packages/effect/src/internal/logger.ts
@@ -302,6 +302,7 @@ const colors = {
 
 const logLevelColors: Record<LogLevel.LogLevel["_tag"], ReadonlyArray<string>> = {
   None: [],
+  Off: [],
   All: [],
   Trace: [colors.gray],
   Debug: [colors.blue],
@@ -312,6 +313,7 @@ const logLevelColors: Record<LogLevel.LogLevel["_tag"], ReadonlyArray<string>> =
 }
 const logLevelStyle: Record<LogLevel.LogLevel["_tag"], string> = {
   None: "",
+  Off: "",
   All: "",
   Trace: "color:gray",
   Debug: "color:blue",

--- a/packages/effect/test/LogLevel.test.ts
+++ b/packages/effect/test/LogLevel.test.ts
@@ -10,6 +10,7 @@ describe("LogLevel", () => {
     strictEqual(LogLevel.fromLiteral("Fatal"), LogLevel.Fatal)
     strictEqual(LogLevel.fromLiteral("Info"), LogLevel.Info)
     strictEqual(LogLevel.fromLiteral("None"), LogLevel.None)
+    strictEqual(LogLevel.fromLiteral("Off"), LogLevel.Off)
     strictEqual(LogLevel.fromLiteral("Trace"), LogLevel.Trace)
     strictEqual(LogLevel.fromLiteral("Warning"), LogLevel.Warning)
   })


### PR DESCRIPTION
WIP I am still testing this

Basically the issue was in our `.env` we set 

```
LOG_LEVEL=None
```

However `Config.logLevel('LOG_LEVEL')` results in a type error since `None` is not a valid label. It's supposed to be `Off`. So I am making a change to support both in a non breaking fashion to make it more intuitive and improve QoL. 

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
