### PR TITLE
Fix: JSONB handling in @effect/sql-drizzle with PostgreSQL 

### DIFF
--- a/.changeset/busy-beans-change.md
+++ b/.changeset/busy-beans-change.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-drizzle": minor
+---
+
+Fix JSONB deserialization for db.insert in Effect + Drizzle integration

--- a/packages/sql-drizzle/src/internal/patch.ts
+++ b/packages/sql-drizzle/src/internal/patch.ts
@@ -49,11 +49,13 @@ export const makeRemoteCallback = Effect.gen(function*() {
     const runPromise = Runtime.runPromise(currentRuntime ? currentRuntime : constructionRuntime)
 
     const finalParams = params.map((e) => {
+      if (e === null || e === undefined) return e
+      if (typeof e !== "string") return e
+      const s = e.trim()
+      if (!(s.startsWith("{") || s.startsWith("["))) return e
       try {
-        if (e) {
-          return JSON.parse(e)
-        }
-      } catch (err) {
+        return JSON.parse(s)
+      } catch {
         return e
       }
     })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Closes: #5539

This PR includes Automatic JSON handling for SQL parameters: object/array values are now auto-serialized to JSON for execution, enabling seamless insertion and querying of JSON/JSONB columns without manual conversion or API changes.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
