### PR TITLE
Hotfix/OpenAI tool result

### DIFF
--- a/.changeset/tired-rockets-rush.md
+++ b/.changeset/tired-rockets-rush.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+fixed message shape of tool call result being sent to openai for tool call result

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -525,7 +525,7 @@ const prepareMessages: (
           messages.push({
             type: "function_call_output",
             call_id: part.id,
-            result: JSON.stringify(part.result)
+            output: JSON.stringify(part.result)
           })
         }
 


### PR DESCRIPTION


## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently tool call results are being passed to OpenAI in "result" field, however according to [OpenAI Documentation](https://platform.openai.com/docs/guides/function-calling) it have it be named "output"

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
