### PR TITLE
Fix response schema when tool call resolution is disabled

### DIFF
--- a/.changeset/young-planets-burn.md
+++ b/.changeset/young-planets-burn.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai": patch
+---
+
+Ensure response schema includes toolkit tools even when tool call resolution is disabled

--- a/packages/ai/ai/src/LanguageModel.ts
+++ b/packages/ai/ai/src/LanguageModel.ts
@@ -767,10 +767,12 @@ export const make: (params: ConstructorParams) => Effect.Effect<Service> = Effec
         providerOptions.tools = tools
         providerOptions.toolChoice = toolChoice
 
+        // Construct the response schema with the tools from the toolkit
+        const ResponseSchema = Schema.mutable(Schema.Array(Response.Part(toolkit)))
+
         // If tool call resolution is disabled, return the response without
         // resolving the tool calls that were generated
         if (options.disableToolCallResolution === true) {
-          const ResponseSchema = Schema.mutable(Schema.Array(Response.Part(Toolkit.empty)))
           const rawContent = yield* params.generateText(providerOptions)
           const content = yield* Schema.decodeUnknown(ResponseSchema)(rawContent)
           return content as Array<Response.Part<Tools>>
@@ -780,7 +782,6 @@ export const make: (params: ConstructorParams) => Effect.Effect<Service> = Effec
 
         // Resolve the generated tool calls
         const toolResults = yield* resolveToolCalls(rawContent, toolkit, options.concurrency)
-        const ResponseSchema = Schema.mutable(Schema.Array(Response.Part(toolkit)))
         const content = yield* Schema.decodeUnknown(ResponseSchema)(rawContent)
 
         // Return the content merged with the tool call results


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR ensures that the response schema contains the tools from the toolkit even when tool call resolution is disabled.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
