### PR TITLE
add additional predicate typings for HttpMiddleware.cors allowOrigins

### DIFF
--- a/.changeset/tidy-seals-grow.md
+++ b/.changeset/tidy-seals-grow.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+add additional predicate typings for HttpMiddleware.cors allowOrigins

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -13,6 +13,7 @@ import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as ParseResult from "effect/ParseResult"
 import { type Pipeable, pipeArguments } from "effect/Pipeable"
+import type * as Predicate from "effect/Predicate"
 import type { ReadonlyRecord } from "effect/Record"
 import * as Redacted from "effect/Redacted"
 import * as Schema from "effect/Schema"
@@ -964,7 +965,7 @@ export const middleware: {
  */
 export const middlewareCors = (
   options?: {
-    readonly allowedOrigins?: ReadonlyArray<string> | undefined
+    readonly allowedOrigins?: ReadonlyArray<string> | Predicate.Predicate<string> | undefined
     readonly allowedMethods?: ReadonlyArray<string> | undefined
     readonly allowedHeaders?: ReadonlyArray<string> | undefined
     readonly exposedHeaders?: ReadonlyArray<string> | undefined

--- a/packages/platform/src/HttpLayerRouter.ts
+++ b/packages/platform/src/HttpLayerRouter.ts
@@ -10,6 +10,7 @@ import * as FiberRef from "effect/FiberRef"
 import { compose, constant, dual, identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
+import type * as Predicate from "effect/Predicate"
 import * as Scope from "effect/Scope"
 import * as Tracer from "effect/Tracer"
 import type * as Types from "effect/Types"
@@ -903,7 +904,7 @@ export declare namespace middleware {
  */
 export const cors = (
   options?: {
-    readonly allowedOrigins?: ReadonlyArray<string> | undefined
+    readonly allowedOrigins?: ReadonlyArray<string> | Predicate.Predicate<string> | undefined
     readonly allowedMethods?: ReadonlyArray<string> | undefined
     readonly allowedHeaders?: ReadonlyArray<string> | undefined
     readonly exposedHeaders?: ReadonlyArray<string> | undefined

--- a/packages/platform/src/HttpMiddleware.ts
+++ b/packages/platform/src/HttpMiddleware.ts
@@ -122,7 +122,7 @@ export const searchParamsParser: <E, R>(
  */
 export const cors: (
   options?: {
-    readonly allowedOrigins?: ReadonlyArray<string> | undefined
+    readonly allowedOrigins?: ReadonlyArray<string> | Predicate.Predicate<string> | undefined
     readonly allowedMethods?: ReadonlyArray<string> | undefined
     readonly allowedHeaders?: ReadonlyArray<string> | undefined
     readonly exposedHeaders?: ReadonlyArray<string> | undefined


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

#5552 added a predicate for HttpMiddleware.cors allowOrigins.
This PR surfaces the predicate typing so that developers can use it via the public APIs: HttpApiBuilder, HttpLayerRouter, HttpMiddleware

