### PR TITLE
Fix node stat

### DIFF
--- a/.changeset/large-cobras-sniff.md
+++ b/.changeset/large-cobras-sniff.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fixing stat error when `blksize` is undefined.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,10 @@
       "workerd"
     ],
     "onlyBuiltDependencies": [
-      "better-sqlite3"
+      "@parcel/watcher",
+      "better-sqlite3",
+      "sharp",
+      "unrs-resolver"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,10 +91,7 @@
       "workerd"
     ],
     "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "better-sqlite3",
-      "sharp",
-      "unrs-resolver"
+      "better-sqlite3"
     ]
   }
 }

--- a/packages/platform-node-shared/src/internal/fileSystem.ts
+++ b/packages/platform-node-shared/src/internal/fileSystem.ts
@@ -487,7 +487,7 @@ const makeFileInfo = (stat: NFS.Stats): FileSystem.File.Info => ({
   uid: Option.fromNullable(stat.uid),
   gid: Option.fromNullable(stat.gid),
   size: FileSystem.Size(stat.size),
-  blksize: Option.fromNullable(FileSystem.Size(stat.blksize)),
+  blksize: Option.map(Option.fromNullable(stat.blksize), FileSystem.Size),
   blocks: Option.fromNullable(stat.blocks)
 })
 const stat = (() => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`blksize` has type `Option<Size>`, but the `Size` constructor fails if the argument is `undefined`.
I ran into this issue with [Electron ASAR archives](https://www.electronjs.org/docs/latest/tutorial/asar-archives#fake-stat-information-of-fsstat).

