### PR TITLE
Fix Array Do documentation

### DIFF
--- a/.changeset/tender-papers-divide.md
+++ b/.changeset/tender-papers-divide.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Array Do documentation

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -3363,7 +3363,7 @@ export const cartesian: {
  * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Array` values
  * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
  * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
- * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+ * 5. Regular `Array` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
  *
  * **Example**
  *
@@ -3412,7 +3412,7 @@ export const Do: ReadonlyArray<{}> = of({})
  * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Array` values
  * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
  * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
- * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+ * 5. Regular `Array` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
  *
  * **Example**
  *
@@ -3473,7 +3473,7 @@ export const bind: {
  * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Array` values
  * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
  * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
- * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+ * 5. Regular `Array` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
  *
  * **Example**
  *
@@ -3538,7 +3538,7 @@ export {
    * 2. Within the do simulation scope, you can use the `bind` function to define variables and bind them to `Array` values
    * 3. You can accumulate multiple `bind` statements to define multiple variables within the scope
    * 4. Inside the do simulation scope, you can also use the `let` function to define variables and bind them to simple values
-   * 5. Regular `Option` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
+   * 5. Regular `Array` functions like `map` and `filter` can still be used within the do simulation. These functions will receive the accumulated variables as arguments within the scope
    *
    * **Example**
    *


### PR DESCRIPTION

## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The documentation currently says that regular `Option` functions can be used with `Array.Do`. Based on the context and the related code examples, I believe the documentation is supposed to state that regular `Array` functions can be used with `Array.Do`.
