### PR TITLE
fix consistent fallthrough to error case

### DIFF
--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -425,9 +425,7 @@ const prepareMessages: (
                   const imageUrl = `data:${mediaType};base64,${base64}`
                   content.push({ type: "input_image", image_url: imageUrl, detail })
                 }
-              }
-
-              if (part.mediaType === "application/pdf") {
+              } else if (part.mediaType === "application/pdf") {
                 if (typeof part.data === "string" && isFileId(part.data, config)) {
                   content.push({ type: "input_file", file_id: part.data })
                 }
@@ -442,13 +440,13 @@ const prepareMessages: (
                   const fileData = `data:application/pdf;base64,${base64}`
                   content.push({ type: "input_file", filename: fileName, file_data: fileData })
                 }
+              } else {
+                return yield* new AiError.MalformedInput({
+                  module: "OpenAiLanguageModel",
+                  method: "prepareMessages",
+                  description: `Detected unsupported media type for file: '${part.mediaType}'`
+                })
               }
-
-              return yield* new AiError.MalformedInput({
-                module: "OpenAiLanguageModel",
-                method: "prepareMessages",
-                description: `Detected unsupported media type for file: '${part.mediaType}'`
-              })
             }
           }
         }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

In `packages/ai/openai/src/OpenAiLanguageModel.ts` the logic around handling file parts currently always falls through to the error case for unsupported media type, this PR fixes that, bringing the logic in line with `packages/ai/anthropic/src/AnthropicLanguageModel.ts`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
