### PR TITLE
Resolve $refs in JSON schemas before sending them to Google

### DIFF
--- a/.changeset/witty-donkeys-melt.md
+++ b/.changeset/witty-donkeys-melt.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-google": minor
+---
+
+Resolve JSON schema $refs before sending them to Google

--- a/packages/ai/google/src/GoogleLanguageModel.ts
+++ b/packages/ai/google/src/GoogleLanguageModel.ts
@@ -191,7 +191,9 @@ export const make = Effect.fnUntraced(function*(options: {
       const responseFormat = providerOptions.responseFormat
       const responseMimeType = responseFormat.type === "json" ? "application/json" : undefined
       const responseSchema = responseFormat.type === "json"
-        ? InternalUtilities.jsonSchemaToOpenApiSchema(Tool.getJsonSchemaFromSchemaAst(responseFormat.schema.ast))
+        ? InternalUtilities.jsonSchemaToOpenApiSchema(
+          InternalUtilities.resolveRefs(Tool.getJsonSchemaFromSchemaAst(responseFormat.schema.ast))
+        )
         : undefined
       const request: typeof Generated.GenerateContentRequest.Encoded = {
         ...config,


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After wanting to try out Gemini with Effect I quickly ran into issues that stemmed from Google not supporting `$refs in JSON schemas. This means a lot of schemas just don't work.

This PR resolves $refs in JSON schemas before passing the schema to google. This lets us send the vast majority of useful schemas to Google. 

I tested on a whole bunch of schemas. Notably, `Class` schemas are now no problem.  

```ts
const SimpleStructSchema = Schema.Struct({
  foo: Schema.String,
});

const LessSimpleStructSchema = Schema.Struct({
  date: Schema.Date,
});

const NestedStructSchema = Schema.Struct({
  foo: Schema.String,
  nested: LessSimpleStructSchema,
  array: Schema.Array(LessSimpleStructSchema),
});

export class SimpleClassSchema extends Schema.Class<SimpleClassSchema>(
  "SimpleClassSchema",
)({
  foo: Schema.String,
}) {}

export class LessSimpleClassSchema extends Schema.Class<LessSimpleClassSchema>(
  "LessSimpleClassSchema",
)({
  int: Schema.Int,
  date: Schema.Date,
}) {}

export class NestedClassSchema extends Schema.Class<NestedClassSchema>(
  "NestedClassSchema",
)({
  nested: LessSimpleClassSchema,
}) {}

export class EvenMoreNestedSchema extends Schema.Class<EvenMoreNestedSchema>(
  "EvenMoreNestedSchema",
)({
  nested: NestedClassSchema,
}) {}

export class SchemaWithUnion extends Schema.Class<SchemaWithUnion>(
  "SchemaWithUnion",
)({
  union: Schema.Union(Schema.String, EvenMoreNestedSchema),
}) {}

export class TreeNode extends Schema.Class<TreeNode>("TreeNode")({
  value: Schema.String,
  children: Schema.Array(
    Schema.suspend((): Schema.Schema<TreeNode> => TreeNode),
  ),
}) {}

export class NodeA extends Schema.Class<NodeA>("NodeA")({
  value: Schema.String,
  b: Schema.optional(Schema.suspend((): Schema.Schema<NodeB> => NodeB)),
}) {}

export class NodeB extends Schema.Class<NodeB>("NodeB")({
  value: Schema.Number,
  a: Schema.optional(Schema.suspend(() => NodeA)),
}) {}

export class VariantA extends Schema.Class<VariantA>("VariantA")({
  type: Schema.Literal("A"),
  data: SimpleClassSchema,
}) {}

export class VariantB extends Schema.Class<VariantB>("VariantB")({
  type: Schema.Literal("B"),
  data: LessSimpleClassSchema,
}) {}

const DiscriminatedUnion = Schema.Union(VariantA, VariantB);

const TupleSchema = Schema.Struct({
  mixedTuple: Schema.Tuple(
    Schema.String,
    SimpleClassSchema,
    Schema.Array(LessSimpleClassSchema),
  ),
});

const OptionalComplexSchema = Schema.Struct({
  optionalNested: Schema.optional(NestedClassSchema),
  nullableNested: Schema.NullOr(EvenMoreNestedSchema),
  optionalArray: Schema.optional(Schema.Array(LessSimpleClassSchema)),
});

export class SharedSchema extends Schema.Class<SharedSchema>("SharedSchema")({
  id: Schema.String,
}) {}

export class MultiRefSchema extends Schema.Class<MultiRefSchema>(
  "MultiRefSchema",
)({
  first: SharedSchema,
  second: SharedSchema,
  third: SharedSchema,
  arrayOfShared: Schema.Array(SharedSchema),
}) {}

const NestedArraySchema = Schema.Struct({
  level1: Schema.Array(Schema.Array(Schema.Array(LessSimpleClassSchema))),
  level2: Schema.Array(Schema.Array(SimpleStructSchema)),
});

const RecordSchema = Schema.Struct({
  simpleRecord: Schema.Record({ key: Schema.String, value: Schema.Number }),
  complexRecord: Schema.Record({
    key: Schema.String,
    value: NestedClassSchema,
  }),
  nestedRecord: Schema.Record({
    key: Schema.String,
    value: Schema.Record({ key: Schema.String, value: LessSimpleClassSchema }),
  }),
});

const UnionA = Schema.Union(Schema.String, Schema.Number);
const UnionB = Schema.Union(Schema.Boolean, SimpleClassSchema);

const NestedUnionSchema = Schema.Struct({
  unionOfUnions: Schema.Union(UnionA, UnionB),
  arrayOfUnions: Schema.Array(
    Schema.Union(SimpleClassSchema, LessSimpleClassSchema, Schema.String),
  ),
});

const schemas = [
  // NodeA, // not supported - recursive
  // NodeB, // not supported - recursive
  // TreeNode, // not supported - recursive
  // TupleSchema, // gemini produces malformed output
  // RecordSchema, // not supported - gemini expects non-empty `properties`
  SimpleStructSchema,
  LessSimpleStructSchema,
  NestedStructSchema,
  SimpleClassSchema,
  LessSimpleClassSchema,
  NestedClassSchema,
  EvenMoreNestedSchema,
  SchemaWithUnion,
  DiscriminatedUnion,
  OptionalComplexSchema,
  MultiRefSchema,
  NestedArraySchema,
  NestedUnionSchema,
];

const main = Effect.gen(function* () {
  const model = yield* LanguageModel.LanguageModel;
  for (const schema of schemas) {
    const res = yield* model.generateObject({
      prompt: "Fill this json schema however",
      schema: schema as never,
    });
    yield* Effect.logInfo(res.value);
  }
}).pipe(Effect.provide(Layer.provideMerge(Gemini, GoogleAI)));

NodeRuntime.runMain(main);
```

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

https://discord.com/channels/795981131316985866/1424315524145483817

