### PR TITLE
JSONSchema: Fix issue where invalid `default`s were included in the output

### DIFF
--- a/.changeset/fluffy-times-buy.md
+++ b/.changeset/fluffy-times-buy.md
@@ -1,0 +1,56 @@
+---
+"effect": patch
+---
+
+JSONSchema: Fix issue where invalid `default`s were included in the output.
+
+Now they are ignored, similar to invalid `examples`.
+
+Before
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.NonEmptyString.annotations({
+  default: ""
+})
+
+const jsonSchema = JSONSchema.make(schema)
+
+console.log(JSON.stringify(jsonSchema, null, 2))
+/*
+Output:
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "description": "a non empty string",
+  "title": "nonEmptyString",
+  "default": "",
+  "minLength": 1
+}
+*/
+```
+
+After
+
+```ts
+import { JSONSchema, Schema } from "effect"
+
+const schema = Schema.NonEmptyString.annotations({
+  default: ""
+})
+
+const jsonSchema = JSONSchema.make(schema)
+
+console.log(JSON.stringify(jsonSchema, null, 2))
+/*
+Output:
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "string",
+  "description": "a non empty string",
+  "title": "nonEmptyString",
+  "minLength": 1
+}
+*/
+```

--- a/packages/effect/src/JSONSchema.ts
+++ b/packages/effect/src/JSONSchema.ts
@@ -380,6 +380,11 @@ function getRawDefault(annotated: AST.Annotated | undefined): Option.Option<unkn
   return Option.none()
 }
 
+function encodeDefault(ast: AST.AST, def: unknown): Option.Option<unknown> {
+  const getOption = ParseResult.getOption(ast, false)
+  return getOption(def)
+}
+
 function getRawExamples(annotated: AST.Annotated | undefined): ReadonlyArray<unknown> | undefined {
   if (annotated !== undefined) return Option.getOrUndefined(AST.getExamplesAnnotation(annotated))
 }
@@ -414,7 +419,12 @@ function pruneJsonSchemaAnnotations(
   const out: JsonSchemaAnnotations = {}
   if (description !== undefined) out.description = description
   if (title !== undefined) out.title = title
-  if (Option.isSome(def)) out.default = def.value
+  if (Option.isSome(def)) {
+    const o = encodeDefault(ast, def.value)
+    if (Option.isSome(o)) {
+      out.default = o.value
+    }
+  }
   if (examples !== undefined) {
     const encodedExamples = encodeExamples(ast, examples)
     if (encodedExamples !== undefined) {

--- a/packages/effect/test/Schema/JSONSchema.new.test.ts
+++ b/packages/effect/test/Schema/JSONSchema.new.test.ts
@@ -2972,6 +2972,25 @@ schema (SymbolKeyword): symbol`
       })
     })
 
+    it("should filter out invalid examples", async () => {
+      await assertDraft7(Schema.NonEmptyString.annotations({ examples: ["", "a"] }), {
+        "type": "string",
+        "title": "nonEmptyString",
+        "description": "a non empty string",
+        "minLength": 1,
+        "examples": ["a"]
+      })
+    })
+
+    it("should filter out invalid defaults", async () => {
+      await assertDraft7(Schema.NonEmptyString.annotations({ default: "" }), {
+        "type": "string",
+        "title": "nonEmptyString",
+        "description": "a non empty string",
+        "minLength": 1
+      })
+    })
+
     describe("should encode the examples", () => {
       it("property signatures", async () => {
         const schema = Schema.Struct({


### PR DESCRIPTION
Now they are ignored, similar to invalid `examples`.

Before

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.NonEmptyString.annotations({
  default: ""
})

const jsonSchema = JSONSchema.make(schema)

console.log(JSON.stringify(jsonSchema, null, 2))
/*
Output:
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "string",
  "description": "a non empty string",
  "title": "nonEmptyString",
  "default": "",
  "minLength": 1
}
*/
```

After

```ts
import { JSONSchema, Schema } from "effect"

const schema = Schema.NonEmptyString.annotations({
  default: ""
})

const jsonSchema = JSONSchema.make(schema)

console.log(JSON.stringify(jsonSchema, null, 2))
/*
Output:
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "string",
  "description": "a non empty string",
  "title": "nonEmptyString",
  "minLength": 1
}
*/
```
