### PR TITLE
fix: incorrect prepareMessages for tool-call results in OpenAiLanguag…

### DIFF
--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -520,13 +520,10 @@ const prepareMessages: (
 
       case "tool": {
         for (const part of message.content) {
-          const result = part.result._tag === "Right"
-            ? part.result.right
-            : part.result.left
           messages.push({
             type: "function_call_output",
             call_id: part.id,
-            output: JSON.stringify(result)
+            output: JSON.stringify(part.result)
           })
         }
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

as per definition in Prompt.ts the result of a `ToolResultPart` is unknown (directly the result of the tool call and not an Effect value)

prepareMessgaes in the OpenAILanguageModel currently treats the result of a ToolResultPart as an effect value causing function calling to not work as expected
