### PR TITLE
Fix `HttpLayerRouter` with `RpcServer` example

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -5088,7 +5088,8 @@ const UserHandlers = UserRpcs.toLayer({
 // Use `HttpLayerRouter` to register the rpc server
 const RpcRoute = RpcServer.layerHttpRouter({
   group: UserRpcs,
-  path: "/rpc"
+  path: "/rpc",
+  protocol: "http"
 }).pipe(
   Layer.provide(UserHandlers),
   Layer.provide(RpcSerialization.layerJson),


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

By the definition of `RpcServer.layerHttpRouter` we need to explicitly provide `protocol` parameters or the code will treat route as Websocket and will register it with `GET` method:

https://github.com/Effect-TS/effect/blob/main/packages/rpc/src/RpcServer.ts#L758-L760

https://github.com/Effect-TS/effect/blob/main/packages/rpc/src/RpcServer.ts#L881

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
