### PR TITLE
Ensure tool call parts are emitted immediately when streaming

### DIFF
--- a/.changeset/social-walls-share.md
+++ b/.changeset/social-walls-share.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai": patch
+---
+
+Ensure that tool calls are emitted as soon as possible when streaming

--- a/packages/ai/ai/test/LanguageModel.test.ts
+++ b/packages/ai/ai/test/LanguageModel.test.ts
@@ -1,0 +1,86 @@
+import * as LanguageModel from "@effect/ai/LanguageModel"
+import * as Response from "@effect/ai/Response"
+import * as Tool from "@effect/ai/Tool"
+import * as Toolkit from "@effect/ai/Toolkit"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Schema from "effect/Schema"
+import * as Stream from "effect/Stream"
+import * as TestClock from "effect/TestClock"
+import * as TestUtils from "./utilities.js"
+
+const MyTool = Tool.make("MyTool", {
+  parameters: { testParam: Schema.String },
+  success: Schema.Struct({ testSuccess: Schema.String })
+})
+
+const MyToolkit = Toolkit.make(MyTool)
+
+const MyToolkitLayer = MyToolkit.toLayer({
+  MyTool: () =>
+    Effect.succeed({ testSuccess: "test-success" }).pipe(
+      Effect.delay("10 seconds")
+    )
+})
+
+describe("LanguageModel", () => {
+  describe("streamText", () => {
+    it.effect("should emit tool calls before executing tool handlers", () =>
+      Effect.gen(function*() {
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const latch = yield* Effect.makeLatch()
+
+        const toolCallId = "tool-abc123"
+        const toolName = "MyTool"
+        const toolParams = { testParam: "test-param" }
+        const toolResult = { testSuccess: "test-success" }
+
+        yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          Stream.runForEach((part) =>
+            Effect.andThen(latch.open, () => {
+              parts.push(part)
+            })
+          ),
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: toolCallId,
+                name: toolName,
+                params: toolParams
+              }
+            ]
+          }),
+          Effect.provide(MyToolkitLayer),
+          Effect.fork
+        )
+
+        yield* latch.await
+
+        const toolCallPart = Response.makePart("tool-call", {
+          id: toolCallId,
+          name: toolName,
+          params: toolParams,
+          providerExecuted: false
+        })
+
+        const toolResultPart = Response.toolResultPart({
+          id: toolCallId,
+          name: toolName,
+          result: toolResult,
+          encodedResult: toolResult,
+          isFailure: false,
+          providerExecuted: false
+        })
+
+        assert.deepStrictEqual(parts, [toolCallPart])
+
+        yield* TestClock.adjust("10 seconds")
+
+        assert.deepStrictEqual(parts, [toolCallPart, toolResultPart])
+      }))
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There was a bug where tool call resolution would delay emission of the `"tool-call"` part when streaming text. This fixes that issue.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
