### PR TITLE
Parameterize HttpApi base errorSchema

### DIFF
--- a/packages/platform/src/HttpApi.ts
+++ b/packages/platform/src/HttpApi.ts
@@ -249,20 +249,30 @@ const makeProto = <Id extends string, Groups extends HttpApiGroup.HttpApiGroup.A
   return HttpApi as any
 }
 
+export interface HttpApiMakeOptions<E = never> {
+  errorSchema?: Schema.Schema<HttpApiDecodeError, E>
+}
+
 /**
  * An `HttpApi` is a collection of `HttpApiEndpoint`s. You can use an `HttpApi` to
  * represent a portion of your domain.
  *
  * The endpoints can be implemented later using the `HttpApiBuilder.make` api.
  *
+ * Allows a base error schema to be provided for transcoding HttpApiDecodeErrors.
+ * Defaults to `HttpApiDecodeError`.
+ *
  * @since 1.0.0
  * @category constructors
  */
-export const make = <const Id extends string>(identifier: Id): HttpApi<Id, never, HttpApiDecodeError> =>
+export const make = <const Id extends string>(
+  identifier: Id,
+  options?: HttpApiMakeOptions<any>
+): HttpApi<Id, never, HttpApiDecodeError> =>
   makeProto({
     identifier,
     groups: new Map() as any,
-    errorSchema: HttpApiDecodeError,
+    errorSchema: options?.errorSchema ?? HttpApiDecodeError,
     annotations: Context.empty(),
     middlewares: new Set()
   })

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -35,6 +35,7 @@ import * as HttpMethod from "./HttpMethod.js"
 import * as HttpMiddleware from "./HttpMiddleware.js"
 import * as HttpRouter from "./HttpRouter.js"
 import * as HttpServer from "./HttpServer.js"
+import type * as Error from "./HttpServerError.js"
 import * as HttpServerRequest from "./HttpServerRequest.js"
 import * as HttpServerResponse from "./HttpServerResponse.js"
 import * as Multipart from "./Multipart.js"
@@ -101,7 +102,7 @@ export const serve = <R = never>(
  * @category constructors
  */
 export const httpApp: Effect.Effect<
-  HttpApp.Default<never, HttpRouter.HttpRouter.DefaultServices>,
+  HttpApp.Default<Error.RouteNotFound, HttpRouter.HttpRouter.DefaultServices>,
   never,
   Router | HttpApi.Api | Middleware
 > = Effect.gen(function*() {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This allows users to customise how HttpApiDecodeErrors are represented on the wire, enabling the use of HttpApi for wire protocols that don't follow the Tagged Error approach to encoding errors.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #5465 
