### PR TITLE
Expose disableFatalDefects option in RPC server public API

### DIFF
--- a/.changeset/brave-tigers-unite.md
+++ b/.changeset/brave-tigers-unite.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Expose disableFatalDefects option in RPC server public API

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -719,6 +719,7 @@ export const layer = <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly concurrency?: number | "unbounded" | undefined
+    readonly disableFatalDefects?: boolean | undefined
   }
 ): Layer.Layer<
   never,
@@ -745,6 +746,7 @@ export const layerHttpRouter = <Rpcs extends Rpc.Any>(options: {
   readonly spanPrefix?: string | undefined
   readonly spanAttributes?: Record<string, unknown> | undefined
   readonly concurrency?: number | "unbounded" | undefined
+  readonly disableFatalDefects?: boolean | undefined
 }): Layer.Layer<
   never,
   never,
@@ -1199,6 +1201,7 @@ export const toHttpApp: <Rpcs extends Rpc.Any>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly disableFatalDefects?: boolean | undefined
   } | undefined
 ) => Effect.Effect<
   HttpApp.Default<never, Scope.Scope>,
@@ -1213,6 +1216,7 @@ export const toHttpApp: <Rpcs extends Rpc.Any>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly disableFatalDefects?: boolean | undefined
   }
 ) {
   const { httpApp, protocol } = yield* makeProtocolWithHttpApp
@@ -1234,6 +1238,7 @@ export const toHttpAppWebsocket: <Rpcs extends Rpc.Any>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly disableFatalDefects?: boolean | undefined
   } | undefined
 ) => Effect.Effect<
   HttpApp.Default<never, Scope.Scope>,
@@ -1248,6 +1253,7 @@ export const toHttpAppWebsocket: <Rpcs extends Rpc.Any>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly disableFatalDefects?: boolean | undefined
   }
 ) {
   const { httpApp, protocol } = yield* makeProtocolWithHttpAppWebsocket
@@ -1278,6 +1284,7 @@ export const toWebHandler = <Rpcs extends Rpc.Any, LE>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly disableFatalDefects?: boolean | undefined
     readonly middleware?: (
       httpApp: HttpApp.Default
     ) => HttpApp.Default<


### PR DESCRIPTION
Exposes the `disableFatalDefects` option in public RPC server functions (`layer`, `layerHttpRouter`, `toHttpApp`, `toHttpAppWebsocket`, `toWebHandler`).