### PR TITLE
fix `Graph.neighbors` for undirected graphs

### DIFF
--- a/.changeset/fix-graph-neighbors-undirected.md
+++ b/.changeset/fix-graph-neighbors-undirected.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix Graph.neighbors() returning self-loops in undirected graphs.
+
+Graph.neighbors() now correctly returns the other endpoint for undirected graphs instead of always returning edge.target, which caused nodes to appear as their own neighbors when queried from the target side of an edge.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1488,6 +1488,11 @@ export const neighbors = <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
   nodeIndex: NodeIndex
 ): Array<NodeIndex> => {
+  // For undirected graphs, use the specialized helper that returns the other endpoint
+  if (graph.type === "undirected") {
+    return getUndirectedNeighbors(graph as any, nodeIndex)
+  }
+
   const adjacencyList = getMapSafe(graph.adjacency, nodeIndex)
   if (Option.isNone(adjacencyList)) {
     return []

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1497,6 +1497,65 @@ describe("Graph", () => {
       })
     })
 
+    describe("neighbors with undirected graphs", () => {
+      it("should return correct neighbors for single edge", () => {
+        const graph = Graph.undirected<number, void>((mutable) => {
+          Graph.addNode(mutable, 0)
+          Graph.addNode(mutable, 1)
+          Graph.addEdge(mutable, 0, 1, undefined)
+        })
+
+        expect(Graph.neighbors(graph, 0)).toEqual([1])
+        expect(Graph.neighbors(graph, 1)).toEqual([0])
+      })
+
+      it("should return correct neighbors for linear graph", () => {
+        const graph = Graph.undirected<number, void>((mutable) => {
+          Graph.addNode(mutable, 0)
+          Graph.addNode(mutable, 1)
+          Graph.addNode(mutable, 2)
+          Graph.addEdge(mutable, 0, 1, undefined)
+          Graph.addEdge(mutable, 1, 2, undefined)
+        })
+
+        expect(Graph.neighbors(graph, 0)).toEqual([1])
+        expect(Graph.neighbors(graph, 1).sort()).toEqual([0, 2])
+        expect(Graph.neighbors(graph, 2)).toEqual([1])
+      })
+
+      it("should handle multiple edges between same nodes", () => {
+        const graph = Graph.undirected<number, void>((mutable) => {
+          Graph.addNode(mutable, 0)
+          Graph.addNode(mutable, 1)
+          Graph.addEdge(mutable, 0, 1, undefined)
+          Graph.addEdge(mutable, 0, 1, undefined)
+        })
+
+        // Should deduplicate neighbors
+        expect(Graph.neighbors(graph, 0)).toEqual([1])
+        expect(Graph.neighbors(graph, 1)).toEqual([0])
+      })
+
+      it("should handle self-loops", () => {
+        const graph = Graph.undirected<number, void>((mutable) => {
+          Graph.addNode(mutable, 0)
+          Graph.addEdge(mutable, 0, 0, undefined)
+        })
+
+        expect(Graph.neighbors(graph, 0)).toEqual([0])
+      })
+
+      it("should handle node with no neighbors", () => {
+        const graph = Graph.undirected<number, void>((mutable) => {
+          Graph.addNode(mutable, 0)
+          Graph.addNode(mutable, 1)
+        })
+
+        expect(Graph.neighbors(graph, 0)).toEqual([])
+        expect(Graph.neighbors(graph, 1)).toEqual([])
+      })
+    })
+
     describe("neighborsDirected", () => {
       it("should return incoming neighbors", () => {
         let nodeA: Graph.NodeIndex


### PR DESCRIPTION
Fixes #5667 