### PR TITLE
Fix: decoding of JsonRpc messages

### DIFF
--- a/.changeset/violet-nails-jump.md
+++ b/.changeset/violet-nails-jump.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Fix decoding JsonRpc messages

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -171,6 +171,7 @@ function decodeJsonRpcRaw(
     const messages: Array<RpcMessage.FromClientEncoded | RpcMessage.FromServerEncoded> = []
     for (let i = 0; i < decoded.length; i++) {
       const message = decodeJsonRpcMessage(decoded[i])
+      messages.push(message)
       if (message._tag === "Request") {
         batch.size++
         batches.set(message.id, batch)
@@ -178,7 +179,7 @@ function decodeJsonRpcRaw(
     }
     return messages
   }
-  return Array.isArray(decoded) ? decoded.map(decodeJsonRpcMessage) : [decodeJsonRpcMessage(decoded)]
+  return [decodeJsonRpcMessage(decoded)]
 }
 
 function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEncoded | RpcMessage.FromServerEncoded {


### PR DESCRIPTION
Fixes returning decoded messages in `decodeJsonRpcRaw` when input is an Array.

Closes #5665 