### PR TITLE
Fix JsonRpc client side message handling

### DIFF
--- a/.changeset/beige-years-hug.md
+++ b/.changeset/beige-years-hug.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Fix JsonRpc client message handling

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -848,7 +848,8 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
 
       if (isJson) {
         return client.post("", { body }).pipe(
-          Effect.flatMap((r) => r.json),
+          Effect.flatMap((r) => r.text),
+          Effect.map((text) => parser.decode(text)),
           Effect.mapError((cause) =>
             new RpcClientError({
               reason: "Protocol",

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -36,7 +36,13 @@ export const json: RpcSerialization["Type"] = RpcSerialization.of({
   unsafeMake: () => {
     const decoder = new TextDecoder()
     return {
-      decode: (bytes) => [JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))],
+      decode: (bytes) => {
+        const decoded = JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))
+        if (Array.isArray(decoded)) {
+          return decoded
+        }
+        return [decoded]
+      },
       encode: (response) => JSON.stringify(response)
     }
   }


### PR DESCRIPTION
For non streamed responses the response is never decoded by the provided `RpcSerialization`. This is however required for JsonRpc to work. Once we are decoding however, json decoding no longer worked, which is why it needed to be adjusted.

Closes #5670 