### PR TITLE
Added accumulator response parts and utils to accumulate from stream and normal response parts

### DIFF
--- a/.changeset/full-toes-say.md
+++ b/.changeset/full-toes-say.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai": minor
+---
+
+Added ai response accumulator parts and useful utilities to accumulate from streaming parts and normal parts

--- a/packages/ai/ai/src/Prompt.ts
+++ b/packages/ai/ai/src/Prompt.ts
@@ -1664,7 +1664,7 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
         }
         case "tool": {
           flushDeltas()
-          if (part.value.state === "params-done") {
+          if (part.value.status === "params-done") {
             assistantParts.push(
               makePart("tool-call", {
                 id: part.id,
@@ -1673,7 +1673,7 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
                 providerExecuted: part.providerExecuted ?? false
               })
             )
-          } else if (part.value.state === "result-error") {
+          } else if (part.value.status === "result-error") {
             assistantParts.push(
               makePart("tool-call", {
                 id: part.id,
@@ -1691,7 +1691,7 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
                 isFailure: true
               })
             )
-          } else if (part.value.state === "result-done") {
+          } else if (part.value.status === "result-done") {
             assistantParts.push(
               makePart("tool-call", {
                 id: part.id,
@@ -1713,7 +1713,7 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           break
         }
         case "text-accumulated": {
-          if (part.state === "streaming") {
+          if (part.status === "streaming") {
             flushReasoningDeltas()
             textDeltas.push(part.text)
           } else {
@@ -1727,7 +1727,7 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           break
         }
         case "reasoning-accumulated": {
-          if (part.state === "streaming") {
+          if (part.status === "streaming") {
             flushTextDeltas()
             reasoningDeltas.push(part.text)
           } else {

--- a/packages/ai/ai/src/Response.ts
+++ b/packages/ai/ai/src/Response.ts
@@ -3087,7 +3087,10 @@ export const toolPart = <
       readonly params: infer Params
       readonly result: infer Success
     }
-  } ? ToolPart<Name, Params, Success, never> :
+  } ? ToolPart<Name, Params, Success, never>
+  : Params extends {
+    readonly name: infer Name extends string
+  } ? ToolPart<Name, never, never, never> :
   never => makePart("tool", params) as any
 
 // =============================================================================

--- a/packages/ai/ai/src/Response.ts
+++ b/packages/ai/ai/src/Response.ts
@@ -2809,7 +2809,6 @@ export const ToolPart = <
     type: Schema.Literal("tool"),
     providerName: Schema.optional(Schema.String)
   })
-  failure.ast._tag === "NeverKeyword"
   const Encoded = Schema.Struct({
     ...Base.fields,
     name: Schema.String,

--- a/packages/ai/ai/test/Response.test.ts
+++ b/packages/ai/ai/test/Response.test.ts
@@ -12,42 +12,42 @@ describe("Response", () => {
         const parts = [
           Response.textAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "Hello"
           }),
           Response.textAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: ", "
           }),
           Response.textAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "World!"
           }),
           Response.textAccumulatedPart({
             id: "1",
-            state: "done",
+            status: "done",
             text: ""
           }),
           Response.reasoningAccumulatedPart({
             id: "2",
-            state: "streaming",
+            status: "streaming",
             text: "I "
           }),
           Response.reasoningAccumulatedPart({
             id: "2",
-            state: "streaming",
+            status: "streaming",
             text: "am "
           }),
           Response.reasoningAccumulatedPart({
             id: "2",
-            state: "streaming",
+            status: "streaming",
             text: "thinking!"
           }),
           Response.reasoningAccumulatedPart({
             id: "2",
-            state: "done",
+            status: "done",
             text: ""
           })
         ]
@@ -56,12 +56,12 @@ describe("Response", () => {
           Response.textAccumulatedPart({
             id: "1",
             text: "Hello, World!",
-            state: "done"
+            status: "done"
           }),
           Response.reasoningAccumulatedPart({
             id: "2",
             text: "I am thinking!",
-            state: "done"
+            status: "done"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -74,17 +74,17 @@ describe("Response", () => {
         const parts = [
           Response.textAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "Hello"
           }),
           Response.textAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: ", "
           }),
           Response.textAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "World!"
           })
         ]
@@ -93,7 +93,7 @@ describe("Response", () => {
           Response.textAccumulatedPart({
             id: "1",
             text: "Hello, World!",
-            state: "streaming"
+            status: "streaming"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -106,17 +106,17 @@ describe("Response", () => {
         const parts = [
           Response.reasoningAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "I "
           }),
           Response.reasoningAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "am "
           }),
           Response.reasoningAccumulatedPart({
             id: "1",
-            state: "streaming",
+            status: "streaming",
             text: "thinking!"
           })
         ]
@@ -125,7 +125,7 @@ describe("Response", () => {
           Response.reasoningAccumulatedPart({
             id: "1",
             text: "I am thinking!",
-            state: "streaming"
+            status: "streaming"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -141,7 +141,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-start"
+              status: "params-start"
             }
           }),
           Response.toolPart({
@@ -149,7 +149,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "{location: '"
             }
           }),
@@ -158,7 +158,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "NYC"
             }
           }),
@@ -167,7 +167,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "'}"
             }
           }),
@@ -176,7 +176,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-done",
+              status: "params-done",
               params: {
                 location: "NYC"
               }
@@ -190,7 +190,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-done",
+              status: "params-done",
               params: {
                 location: "NYC"
               }
@@ -210,7 +210,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-start"
+              status: "params-start"
             }
           }),
           Response.toolPart({
@@ -218,7 +218,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "{location: '"
             }
           }),
@@ -227,7 +227,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "NYC"
             }
           })
@@ -239,7 +239,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "{location: 'NYC"
             }
           })
@@ -257,7 +257,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-start"
+              status: "params-start"
             }
           }),
           Response.toolPart({
@@ -265,7 +265,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "{location: '"
             }
           }),
@@ -274,7 +274,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "NYC"
             }
           }),
@@ -283,7 +283,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "'}"
             }
           }),
@@ -292,7 +292,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-done",
+              status: "params-done",
               params: {
                 location: "NYC"
               }
@@ -303,7 +303,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-done",
+              status: "result-done",
               params: {
                 location: "NYC"
               },
@@ -323,7 +323,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-done",
+              status: "result-done",
               params: {
                 location: "NYC"
               },
@@ -349,7 +349,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-start"
+              status: "params-start"
             }
           }),
           Response.toolPart({
@@ -357,7 +357,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "{location: '"
             }
           }),
@@ -366,7 +366,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "NYC"
             }
           }),
@@ -375,7 +375,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "'}"
             }
           }),
@@ -384,7 +384,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-done",
+              status: "params-done",
               params: {
                 location: "NYC"
               }
@@ -395,7 +395,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-error",
+              status: "result-error",
               params: {
                 location: "NYC"
               },
@@ -415,7 +415,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-error",
+              status: "result-error",
               params: {
                 location: "NYC"
               },
@@ -472,7 +472,7 @@ describe("Response", () => {
           Response.textAccumulatedPart({
             id: "1",
             text: "Hello, World!",
-            state: "done"
+            status: "done"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -507,7 +507,7 @@ describe("Response", () => {
           Response.reasoningAccumulatedPart({
             id: "2",
             text: "I am thinking!",
-            state: "done"
+            status: "done"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -539,7 +539,7 @@ describe("Response", () => {
           Response.textAccumulatedPart({
             id: "1",
             text: "Hello, World!",
-            state: "streaming"
+            status: "streaming"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -571,7 +571,7 @@ describe("Response", () => {
           Response.reasoningAccumulatedPart({
             id: "2",
             text: "I am thinking!",
-            state: "streaming"
+            status: "streaming"
           })
         ]
         assert.deepStrictEqual(accumulatedParts, expected)
@@ -618,7 +618,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-done",
+              status: "params-done",
               params: {
                 location: "NYC"
               }
@@ -654,7 +654,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "params-streaming",
+              status: "params-streaming",
               params: "{location: 'NYC"
             }
           })
@@ -715,7 +715,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-done",
+              status: "result-done",
               params: {
                 location: "NYC"
               },
@@ -784,7 +784,7 @@ describe("Response", () => {
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-error",
+              status: "result-error",
               params: {
                 location: "NYC"
               },
@@ -887,19 +887,19 @@ describe("Response", () => {
           Response.reasoningAccumulatedPart({
             id: "2",
             text: "I am thinking!",
-            state: "done"
+            status: "done"
           }),
           Response.textAccumulatedPart({
             id: "1",
             text: "Hello, World!",
-            state: "done"
+            status: "done"
           }),
           Response.toolPart({
             id: "1",
             name: "getWeather",
             providerExecuted: false,
             value: {
-              state: "result-error",
+              status: "result-error",
               params: {
                 location: "NYC"
               },
@@ -957,7 +957,7 @@ describe("Response", () => {
             Response.textAccumulatedPart({
               id: "1",
               text: "Hello, World!",
-              state: "done"
+              status: "done"
             })
           ]
           assert.deepStrictEqual(accumulatedParts, expected)
@@ -980,7 +980,7 @@ describe("Response", () => {
             Response.reasoningAccumulatedPart({
               id: "1",
               text: "I am thinking!",
-              state: "done"
+              status: "done"
             })
           ]
           assert.deepStrictEqual(accumulatedParts, expected)
@@ -1010,7 +1010,7 @@ describe("Response", () => {
               name: "getWeather",
               providerExecuted: false,
               value: {
-                state: "params-done",
+                status: "params-done",
                 params: {
                   location: "NYC"
                 }
@@ -1056,7 +1056,7 @@ describe("Response", () => {
               name: "getWeather",
               providerExecuted: false,
               value: {
-                state: "result-done",
+                status: "result-done",
                 params: {
                   location: "NYC"
                 },
@@ -1108,7 +1108,7 @@ describe("Response", () => {
               name: "getWeather",
               providerExecuted: false,
               value: {
-                state: "result-error",
+                status: "result-error",
                 params: {
                   location: "NYC"
                 },
@@ -1163,12 +1163,12 @@ describe("Response", () => {
           const expected: Array<Response.AccumulatedPart<any>> = [
             Response.reasoningAccumulatedPart({
               id: "1",
-              state: "done",
+              status: "done",
               text: "I am thinking!"
             }),
             Response.textAccumulatedPart({
               id: "2",
-              state: "done",
+              status: "done",
               text: "Hello, World!"
             }),
             Response.toolPart({
@@ -1176,7 +1176,7 @@ describe("Response", () => {
               name: "getWeather",
               providerExecuted: false,
               value: {
-                state: "result-error",
+                status: "result-error",
                 params: {
                   location: "NYC"
                 },

--- a/packages/ai/ai/test/Response.test.ts
+++ b/packages/ai/ai/test/Response.test.ts
@@ -1,0 +1,1198 @@
+import * as IdGenerator from "@effect/ai/IdGenerator"
+import * as Response from "@effect/ai/Response"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+describe("Response", () => {
+  describe("mergeAccumulatedParts", () => {
+    it.effect(
+      "should handle complete text and response deltas",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "Hello"
+          }),
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: ", "
+          }),
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "World!"
+          }),
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "done",
+            text: ""
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            state: "streaming",
+            text: "I "
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            state: "streaming",
+            text: "am "
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            state: "streaming",
+            text: "thinking!"
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            state: "done",
+            text: ""
+          })
+        ]
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.textAccumulatedPart({
+            id: "1",
+            text: "Hello, World!",
+            state: "done"
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            text: "I am thinking!",
+            state: "done"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should handle incomplete text delta with status 'streaming'",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "Hello"
+          }),
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: ", "
+          }),
+          Response.textAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "World!"
+          })
+        ]
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.textAccumulatedPart({
+            id: "1",
+            text: "Hello, World!",
+            state: "streaming"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should handle incomplete reasoning delta with status 'streaming'",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.reasoningAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "I "
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "am "
+          }),
+          Response.reasoningAccumulatedPart({
+            id: "1",
+            state: "streaming",
+            text: "thinking!"
+          })
+        ]
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.reasoningAccumulatedPart({
+            id: "1",
+            text: "I am thinking!",
+            state: "streaming"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should handle complete tool call params",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-start"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "{location: '"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "NYC"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "'}"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-done",
+              params: {
+                location: "NYC"
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-done",
+              params: {
+                location: "NYC"
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should handle incomplete tool call params",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-start"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "{location: '"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "NYC"
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "{location: 'NYC"
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should handle complete tool call params and tool result",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-start"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "{location: '"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "NYC"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "'}"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-done",
+              params: {
+                location: "NYC"
+              }
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-done",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                temperature: 12
+              },
+              encodedResult: {
+                temperature: 12
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-done",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                temperature: 12
+              },
+              encodedResult: {
+                temperature: 12
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should handle complete tool call and tool result error",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-start"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "{location: '"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "NYC"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "'}"
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-done",
+              params: {
+                location: "NYC"
+              }
+            }
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-error",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                message: "Unknown location"
+              },
+              encodedResult: {
+                message: "Unknown location"
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-error",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                message: "Unknown location"
+              },
+              encodedResult: {
+                message: "Unknown location"
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return an empty accumulated parts if no parts need to be merged",
+      Effect.fnUntraced(function*() {
+        const parts: Array<Response.AccumulatedPart<any>> = []
+        const accumulatedParts = yield* Response.mergeAccumulatedParts(parts)
+        const expected: Array<Response.AccumulatedPart<any>> = []
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+  })
+
+  describe("accumulateStreamParts", () => {
+    it.effect(
+      "should return a text part with status 'done' for complete text stream parts",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.textStartPart({
+            id: "1"
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: "Hello"
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: ", "
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: "World!"
+          }),
+          Response.textEndPart({
+            id: "1"
+          })
+        ]
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.textAccumulatedPart({
+            id: "1",
+            text: "Hello, World!",
+            state: "done"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return a reasoning part with status 'done' for complete reasoning stream parts",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.reasoningStartPart({
+            id: "2"
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "I "
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "am "
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "thinking!"
+          }),
+          Response.reasoningEndPart({
+            id: "2"
+          })
+        ]
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            text: "I am thinking!",
+            state: "done"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return a text part with status 'streaming' for streaming text",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.textStartPart({
+            id: "1"
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: "Hello"
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: ", "
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: "World!"
+          })
+        ]
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.textAccumulatedPart({
+            id: "1",
+            text: "Hello, World!",
+            state: "streaming"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return a reasoning part with status 'streaming' for streaming reasoning",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.reasoningStartPart({
+            id: "2"
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "I "
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "am "
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "thinking!"
+          })
+        ]
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            text: "I am thinking!",
+            state: "streaming"
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return a tool with status 'params-done' for complete tool call params",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolParamsStartPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "{location: '"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "NYC"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "'}"
+          }),
+          Response.toolParamsEndPart({
+            id: "1"
+          }),
+          Response.toolCallPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            params: {
+              location: "NYC"
+            }
+          })
+        ] as Array<Response.StreamPart<any>>
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-done",
+              params: {
+                location: "NYC"
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return a tool with status 'params-streaming' for tool call streaming params",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolParamsStartPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "{location: '"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "NYC"
+          })
+        ] as Array<Response.StreamPart<any>>
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "params-streaming",
+              params: "{location: 'NYC"
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should accumulate complete tool call params and tool result",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolParamsStartPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "{location: '"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "NYC"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "'}"
+          }),
+          Response.toolParamsEndPart({
+            id: "1"
+          }),
+          Response.toolCallPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            params: {
+              location: "NYC"
+            }
+          }),
+          Response.toolResultPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            isFailure: false,
+            result: {
+              temperature: 12
+            },
+            encodedResult: {
+              temperature: 12
+            }
+          })
+        ] as Array<Response.StreamPart<any>>
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-done",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                temperature: 12
+              },
+              encodedResult: {
+                temperature: 12
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should accumulate complete tool call and return tool result error as status 'result-error'",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.toolParamsStartPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "{location: '"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "NYC"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "'}"
+          }),
+          Response.toolParamsEndPart({
+            id: "1"
+          }),
+          Response.toolCallPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            params: {
+              location: "NYC"
+            }
+          }),
+          Response.toolResultPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            isFailure: true,
+            result: {
+              message: "Unknown location"
+            },
+            encodedResult: {
+              message: "Unknown location"
+            }
+          })
+        ] as Array<Response.StreamPart<any>>
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-error",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                message: "Unknown location"
+              },
+              encodedResult: {
+                message: "Unknown location"
+              }
+            }
+          })
+        ] as Array<Response.AccumulatedPart<any>>
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should preserve order for the streaming parts",
+      Effect.fnUntraced(function*() {
+        const parts = [
+          Response.reasoningStartPart({
+            id: "2"
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "I "
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "am "
+          }),
+          Response.reasoningDeltaPart({
+            id: "2",
+            delta: "thinking!"
+          }),
+          Response.reasoningEndPart({
+            id: "2"
+          }),
+          Response.textStartPart({
+            id: "1"
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: "Hello"
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: ", "
+          }),
+          Response.textDeltaPart({
+            id: "1",
+            delta: "World!"
+          }),
+          Response.textEndPart({
+            id: "1"
+          }),
+          Response.toolParamsStartPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "{location: '"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "NYC"
+          }),
+          Response.toolParamsDeltaPart({
+            id: "1",
+            delta: "'}"
+          }),
+          Response.toolParamsEndPart({
+            id: "1"
+          }),
+          Response.toolCallPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            params: {
+              location: "NYC"
+            }
+          }),
+          Response.toolResultPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            isFailure: true,
+            result: {
+              message: "Unknown location"
+            },
+            encodedResult: {
+              message: "Unknown location"
+            }
+          })
+        ] as Array<Response.StreamPart<any>>
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected = [
+          Response.reasoningAccumulatedPart({
+            id: "2",
+            text: "I am thinking!",
+            state: "done"
+          }),
+          Response.textAccumulatedPart({
+            id: "1",
+            text: "Hello, World!",
+            state: "done"
+          }),
+          Response.toolPart({
+            id: "1",
+            name: "getWeather",
+            providerExecuted: false,
+            value: {
+              state: "result-error",
+              params: {
+                location: "NYC"
+              },
+              result: {
+                message: "Unknown location"
+              },
+              encodedResult: {
+                message: "Unknown location"
+              }
+            }
+          })
+        ]
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+
+    it.effect(
+      "should return an empty accumulated parts if no stream parts provided",
+      Effect.fnUntraced(function*() {
+        const parts: Array<Response.StreamPart<any>> = []
+        const accumulatedParts = yield* Response.accumulateStreamParts([], parts)
+        const expected: Array<Response.AccumulatedPart<any>> = []
+        assert.deepStrictEqual(accumulatedParts, expected)
+      })
+    )
+  })
+
+  describe("accumulateParts", () => {
+    const IdGeneratorTest = Layer.effect(
+      IdGenerator.IdGenerator,
+      Effect.gen(function*() {
+        let counter = 1
+        return {
+          generateId: () =>
+            Effect.gen(function*() {
+              const id = counter.toString()
+              counter++
+              return id
+            })
+        }
+      })
+    )
+
+    it.effect(
+      "should return a text accumulated part for a text part",
+      () =>
+        Effect.gen(function*() {
+          const parts: Array<Response.Part<any>> = [
+            Response.textPart({
+              text: "Hello, World!"
+            })
+          ]
+          const accumulatedParts = yield* Response.accumulateParts([], parts)
+          const expected: Array<Response.AccumulatedPart<any>> = [
+            Response.textAccumulatedPart({
+              id: "1",
+              text: "Hello, World!",
+              state: "done"
+            })
+          ]
+          assert.deepStrictEqual(accumulatedParts, expected)
+        }).pipe(
+          Effect.provide(IdGeneratorTest)
+        )
+    )
+
+    it.effect(
+      "should return a reasoning accumulated part for a reasoning part",
+      () =>
+        Effect.gen(function*() {
+          const parts: Array<Response.Part<any>> = [
+            Response.reasoningPart({
+              text: "I am thinking!"
+            })
+          ]
+          const accumulatedParts = yield* Response.accumulateParts([], parts)
+          const expected: Array<Response.AccumulatedPart<any>> = [
+            Response.reasoningAccumulatedPart({
+              id: "1",
+              text: "I am thinking!",
+              state: "done"
+            })
+          ]
+          assert.deepStrictEqual(accumulatedParts, expected)
+        }).pipe(
+          Effect.provide(IdGeneratorTest)
+        )
+    )
+
+    it.effect(
+      "should return a tool accumulated part with status 'params-done' for a tool call part",
+      () =>
+        Effect.gen(function*() {
+          const parts: Array<Response.Part<any>> = [
+            Response.toolCallPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              params: {
+                location: "NYC"
+              }
+            })
+          ]
+          const accumulatedParts = yield* Response.accumulateParts([], parts)
+          const expected: Array<Response.AccumulatedPart<any>> = [
+            Response.toolPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              value: {
+                state: "params-done",
+                params: {
+                  location: "NYC"
+                }
+              }
+            })
+          ]
+          assert.deepStrictEqual(accumulatedParts, expected)
+        }).pipe(
+          Effect.provide(IdGeneratorTest)
+        )
+    )
+
+    it.effect(
+      "should return a tool accumulated part with status 'result-done' for a tool call part and a successful tool result part respectively",
+      () =>
+        Effect.gen(function*() {
+          const parts: Array<Response.Part<any>> = [
+            Response.toolCallPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              params: {
+                location: "NYC"
+              }
+            }),
+            Response.toolResultPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              isFailure: false,
+              result: {
+                teperature: 12
+              },
+              encodedResult: {
+                teperature: 12
+              }
+            })
+          ]
+          const accumulatedParts = yield* Response.accumulateParts([], parts)
+          const expected: Array<Response.AccumulatedPart<any>> = [
+            Response.toolPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              value: {
+                state: "result-done",
+                params: {
+                  location: "NYC"
+                },
+                result: {
+                  teperature: 12
+                },
+                encodedResult: {
+                  teperature: 12
+                }
+              }
+            })
+          ]
+          assert.deepStrictEqual(accumulatedParts, expected)
+        }).pipe(
+          Effect.provide(IdGeneratorTest)
+        )
+    )
+
+    it.effect(
+      "should return a tool accumulated part with status 'result-error' for a tool call part and a failure tool result part respectively",
+      () =>
+        Effect.gen(function*() {
+          const parts: Array<Response.Part<any>> = [
+            Response.toolCallPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              params: {
+                location: "NYC"
+              }
+            }),
+            Response.toolResultPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              isFailure: true,
+              result: {
+                message: "Uknown location"
+              },
+              encodedResult: {
+                message: "Uknown location"
+              }
+            })
+          ]
+          const accumulatedParts = yield* Response.accumulateParts([], parts)
+          const expected: Array<Response.AccumulatedPart<any>> = [
+            Response.toolPart({
+              id: "1",
+              name: "getWeather",
+              providerExecuted: false,
+              value: {
+                state: "result-error",
+                params: {
+                  location: "NYC"
+                },
+                result: {
+                  message: "Uknown location"
+                },
+                encodedResult: {
+                  message: "Uknown location"
+                }
+              }
+            })
+          ]
+          assert.deepStrictEqual(accumulatedParts, expected)
+        }).pipe(
+          Effect.provide(IdGeneratorTest)
+        )
+    )
+
+    it.effect(
+      "should presever the order of the parts",
+      () =>
+        Effect.gen(function*() {
+          const parts: Array<Response.Part<any>> = [
+            Response.reasoningPart({
+              text: "I am thinking!"
+            }),
+            Response.textPart({
+              text: "Hello, World!"
+            }),
+            Response.toolCallPart({
+              id: "3",
+              name: "getWeather",
+              providerExecuted: false,
+              params: {
+                location: "NYC"
+              }
+            }),
+            Response.toolResultPart({
+              id: "3",
+              name: "getWeather",
+              providerExecuted: false,
+              isFailure: true,
+              result: {
+                message: "Uknown location"
+              },
+              encodedResult: {
+                message: "Uknown location"
+              }
+            })
+          ]
+          const accumulatedParts = yield* Response.accumulateParts([], parts)
+          const expected: Array<Response.AccumulatedPart<any>> = [
+            Response.reasoningAccumulatedPart({
+              id: "1",
+              state: "done",
+              text: "I am thinking!"
+            }),
+            Response.textAccumulatedPart({
+              id: "2",
+              state: "done",
+              text: "Hello, World!"
+            }),
+            Response.toolPart({
+              id: "3",
+              name: "getWeather",
+              providerExecuted: false,
+              value: {
+                state: "result-error",
+                params: {
+                  location: "NYC"
+                },
+                result: {
+                  message: "Uknown location"
+                },
+                encodedResult: {
+                  message: "Uknown location"
+                }
+              }
+            })
+          ]
+          assert.deepStrictEqual(accumulatedParts, expected)
+        }).pipe(
+          Effect.provide(IdGeneratorTest)
+        )
+    )
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This pull request adds 3 new ai response parts--`TextAccumulatedPart`, `ReasoningAccumulatedPart`, and `ToolPart`--and utilities to convert from streaming and normal parts to accumulated parts.

- `TextAccumulatedPart`: same as `TextPart` but with `state` field representing either `"streaming"` or `"done"`
- `ReasoningAccumulatedPart`: same as `ReasoningPart` but with `state` field representing either `"streaming"` or `"done"`
- `ToolPart` combines all of the other tool parts into one part, keeping each previous context, and distinguish each state by their `value.state` field, where it holds values such as:
  - `"params-start"`: when params are started to streaming in
  - `"params-streaming"`: when params are streaming in
  - `"params-malformed"`: when params are malformed
  - ` "params-done"`: when params are done streaming
  -  `"result-error"`: when the tool returned an error result
  - `"result-done"`: when the tool call result is returned

These all accumulated parts and other necessary parts are represented by `AccumulatedPart`.

utilities:

- `mergeAccumulatedParts`: merges two accumulated parts into one accumulated parts
- `accumulateParts`: accumulate over normal parts given already existing accumulated parts
- `accumulateStreamParts`: accumulate over stream parts given already existing accumulated parts

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
