### PR TITLE
fix log level cli arg infinite loop

### DIFF
--- a/.changeset/ten-crabs-serve.md
+++ b/.changeset/ten-crabs-serve.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+fix log level cli arg infinite loop

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -162,7 +162,7 @@ const handleBuiltInOption = <R, E, A>(
       const nextArgs = executable.split(/\s+/)
       // Filter out the log level option before re-executing the command
       for (let i = 0; i < args.length; i++) {
-        if (args[i] === "--log-level" || args[i - 1] === "--log-level") {
+        if (isLogLevelArg(args[i]) || isLogLevelArg(args[i - 1])) {
           continue
         }
         nextArgs.push(args[i])
@@ -355,4 +355,8 @@ const renderWizardArgs = (args: ReadonlyArray<string>) => {
       InternalSpan.highlight(params, Color.cyan)
     ))
   ])
+}
+
+const isLogLevelArg = (arg?: string) => {
+  return arg && (arg === "--log-level" || arg.startsWith("--log-level="))
 }

--- a/packages/cli/test/CliApp.test.ts
+++ b/packages/cli/test/CliApp.test.ts
@@ -97,5 +97,21 @@ describe("CliApp", () => {
         yield* cli(["node", "logging.js", "--log-level", "debug"])
         expect(logLevel).toEqual(LogLevel.Debug)
       }).pipe(runEffect))
+
+    it("should set the minimum log level when using equals syntax (--log-level=...)", () =>
+      Effect.gen(function*() {
+        let logLevel: LogLevel.LogLevel | undefined = undefined
+        const logging = Command.make("logging").pipe(Command.withHandler(() =>
+          Effect.gen(function*() {
+            logLevel = yield* FiberRef.get(FiberRef.currentMinimumLogLevel)
+          })
+        ))
+        const cli = Command.run(logging, {
+          name: "Test",
+          version: "1.0.0"
+        })
+        yield* cli(["node", "logging.js", "--log-level=debug"])
+        expect(logLevel).toEqual(LogLevel.Debug)
+      }).pipe(runEffect))
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Bug Fix

## Description
When passing `--log-level` argument with equal symbol syntax, for example `--log-level=debug` cli program ends up in infinite loop.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes https://github.com/Effect-TS/effect/issues/5659
