### PR TITLE
feat(cli): add Command.withConditionalBehavior for predicate based  wrapping of commands

### DIFF
--- a/.changeset/soft-oranges-arrive.md
+++ b/.changeset/soft-oranges-arrive.md
@@ -1,0 +1,9 @@
+---
+"@effect/cli": minor
+---
+
+Add withConditionalBehavior combinator for composable conditional command behaviors
+
+Introduces a new `withConditionalBehavior` combinator that allows wrapping commands with conditional behaviors based on CLI arguments. This composable approach replaces the need for separate `runWith*` methods and can be used for wizard mode, help display, or any custom behavior.
+
+The combinator accepts Effect's `Predicate` type, enabling the use of predicate combinators like `Predicate.and`, `Predicate.or`, and `Predicate.not` for complex conditional logic.


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
 This PR introduces a composable combinator approach for adding conditional behaviors to commands based on CLI arguments.

 Rather than adding separate runWith* methods for each conditional behavior (which would lead to API explosion with runWithWizard, runWithHelp, runWithValidation, etc.), this PR provides a single, extensible combinator pattern that follows functional composition principles.


```ts
 Command.withConditionalBehavior(predicate, behavior)
```

A combinator that wraps a command to conditionally trigger a behavior based on the provided predicate function:

```ts
  const command = Command.make("greet", {
    name: Options.text("name")
  }, ({ name }) => Effect.log(`Hello, ${name}!`))
    .pipe(
      Command.withConditionalBehavior(
        (args) => args.length <= 1,  // Trigger when no args provided
        "wizard"                      // Run wizard mode
      )
    )

  const cli = Command.run(command, {
    name: "MyApp",
    version: "1.0.0"
  })
```

Parameters:
  - predicate: (args: ReadonlyArray<string>) => boolean - Function that determines when to trigger the behavior
  - behavior: "wizard" | CustomBehaviorFunction - Either the built-in "wizard" mode or a custom function

 
  Wizard mode on bare command:
  ```ts
  Command.make("deploy", config).pipe(
    Command.withConditionalBehavior(
      (args) => args.length <= 1,
      "wizard"
    )
  )
  ```

```ts
  Command.make("migrate", config).pipe(
    Command.withConditionalBehavior(
      (args) => args.includes("--interactive"),
      (cmd, args) => Effect.gen(function* () {
        // Custom prompting logic
        const confirmed = yield* promptForConfirmation()
        return confirmed ? args : Effect.fail(new UserCancelled())
      })
    )
  )
```

## Related

- Related Issue #5699
- Closes #5699