### PR TITLE
otel issues

### DIFF
--- a/packages/opentelemetry/src/internal/tracer.ts
+++ b/packages/opentelemetry/src/internal/tracer.ts
@@ -63,6 +63,7 @@ export class OtelSpan implements EffectTracer.Span {
     options?: EffectTracer.SpanOptions
   ) {
     this[OtelSpanTypeId] = OtelSpanTypeId
+    console.log({ options })
     const active = contextApi.active()
     this.parent = effectParent._tag === "Some"
       ? effectParent

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1149,6 +1149,9 @@ importers:
       '@effect/workflow':
         specifier: workspace:*
         version: link:../packages/workflow
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.0.1
+        version: 2.0.1(@opentelemetry/api@1.9.0)
       effect:
         specifier: workspace:*
         version: link:../packages/effect

--- a/scratchpad/bs.ts
+++ b/scratchpad/bs.ts
@@ -1,0 +1,49 @@
+import { DevTools } from "@effect/experimental"
+import { NodeSdk } from "@effect/opentelemetry"
+import { NodeRuntime } from "@effect/platform-node"
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
+import { Console, Effect, FiberSet, Layer, Option, pipe, Schedule } from "effect"
+
+export const TracingLive = NodeSdk.layer(Effect.sync(() => ({
+  resource: {
+    serviceName: "test"
+  },
+  spanProcessor: new SimpleSpanProcessor(new InMemorySpanExporter())
+})))
+
+const program = Effect.gen(function*() {
+  const fs = yield* FiberSet.make()
+
+  yield* FiberSet.run(fs)(
+    Effect.gen(function*() {
+      // const currentSpan = yield* Effect.currentSpan.pipe(Effect.option)
+      // console.dir({ _tag: "start", currentSpan }, { depth: 20 })
+
+      yield* Effect.gen(function*() {
+        // const currentSpan = yield* Effect.currentSpan.pipe(Effect.option)
+
+        // // we actually have a parent span because of auto inherit via OTel Context
+        // if (Option.isSome(currentSpan) && Option.isSome(currentSpan.value.parent)) {
+        //   return yield* Effect.die("ya fucked up!")
+        // }
+      }).pipe(
+        Effect.withSpan("Iter", { root: true }),
+        Effect.repeat(Schedule.spaced("1 seconds")),
+        Effect.onExit(Console.dir)
+      )
+    })
+  )
+}).pipe(Effect.withSpan("main"))
+
+const DevToolsLive = DevTools.layer()
+
+Layer.mergeAll(program.pipe(Layer.scopedDiscard)).pipe(
+  // doesn't reach Otel
+  // Layer.provide([DevToolsLive, TracingLive]),
+  // reaches Otel, but no options passed!
+  Layer.provide(pipe(DevToolsLive, Layer.provideMerge(TracingLive))),
+  // this works
+  // Layer.provide(TracingLive),
+  Layer.launch,
+  NodeRuntime.runMain
+)

--- a/scratchpad/package.json
+++ b/scratchpad/package.json
@@ -39,6 +39,7 @@
     "@effect/typeclass": "workspace:*",
     "@effect/vitest": "workspace:*",
     "@effect/workflow": "workspace:*",
+    "@opentelemetry/sdk-trace-node": "^2.0.1",
     "effect": "workspace:*"
   }
 }


### PR DESCRIPTION
Findings while investigating issues with spans having parents they shouldn't have, related to https://github.com/Effect-TS/effect/commit/70fe803469db3355ffbf8359b52c351f1c2dc137

# 1 

`options` don't reach Otel Span maker when DevTools are involved

- run `pnpx tsx ./bs.ts` from scratchpad

observe options undefined in console.
play by choosing one of the 3 layer options, to see different results;
```ts
  // doesn't reach Otel
  // Layer.provide([DevToolsLive, TracingLive]),
  // reaches Otel, but no options passed!
  Layer.provide(pipe(DevToolsLive, Layer.provideMerge(TracingLive))),
  // this works
  // Layer.provide(TracingLive),
```