### PR TITLE
Fix Layer.updateService type signature

### DIFF
--- a/.changeset/fix-layer-updateservice-types.md
+++ b/.changeset/fix-layer-updateservice-types.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Layer.updateService type signature to correctly include service I in both input and output types

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -1215,12 +1215,12 @@ export const updateService = dual<
   <I, A>(
     tag: Context.Tag<I, A>,
     f: (a: A) => A
-  ) => <A1, E1, R1>(layer: Layer<A1, E1, R1>) => Layer<A1, E1, I | R1>,
+  ) => <A1, E1, R1>(layer: Layer<A1, E1, R1>) => Layer<I | A1, E1, I | R1>,
   <A1, E1, R1, I, A>(
     layer: Layer<A1, E1, R1>,
     tag: Context.Tag<I, A>,
     f: (a: A) => A
-  ) => Layer<A1, E1, I | R1>
+  ) => Layer<I | A1, E1, I | R1>
 >(3, (layer, tag, f) =>
   provide(
     layer,


### PR DESCRIPTION
## Summary

Fixes the type signature of `Layer.updateService` to correctly include the service `I` in both the input requirements (RIn) and output types (ROut).

## Problem

The `updateService` function:
- Reads an existing service `I` from the context to update it
- Outputs the updated service `I` along with the layer's outputs

The previous type signature was missing `I` in the output type (ROut position), which was incorrect.

## Solution

Updated the type signature:
- **ROut**: `I | A1` (outputs the updated service I plus the layer's original outputs)
- **E**: `E1` (same errors as input layer)
- **RIn**: `I | R1` (requires service I as input, plus the layer's original requirements)

## Changes

- Updated `Layer.updateService` type signature in both curried forms
- Added changeset documenting the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)