### PR TITLE
fix: local cluster requires message store

### DIFF
--- a/packages/platform-node/src/NodeClusterSocket.ts
+++ b/packages/platform-node/src/NodeClusterSocket.ts
@@ -92,7 +92,7 @@ export const layer = <
     Layer.provide(runnerHealth),
     Layer.provideMerge(
       options?.storage === "local"
-        ? MessageStorage.layerNoop
+        ? MessageStorage.layerMemory
         : options?.storage === "byo"
         ? Layer.empty
         : Layer.orDie(SqlMessageStorage.layer)


### PR DESCRIPTION


## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Running the cluster socket in local mode currently causes a defect because persisted RPC messages require a message store. This fix uses the memory implementation over the noop.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
