### PR TITLE
docs(Layer): clarify scopedDiscard JSDoc to match effectDiscard

### DIFF
--- a/.changeset/shiny-words-enjoy.md
+++ b/.changeset/shiny-words-enjoy.md
@@ -1,5 +1,0 @@
----
-"effect": minor
----
-
-fix(Layer): add "discarding its output" to scopedDiscard JSDoc comment for consistency with effectDiscard


### PR DESCRIPTION
## Type

- [x] Documentation Update

## Description

Updates the JSDoc comment for `scopedDiscard` to clarify that it discards the effect's output, making it consistent with `effectDiscard`.

**Before:**
```ts
/**
 * Constructs a layer from the specified scoped effect.
 */
```

**After:**
```ts
/**
 * Constructs a layer from the specified scoped effect, discarding its output.
 */
```


## Related

N/A