### PR TITLE
docs(platform): clarify FileSystem.watch recursive option behavior

### DIFF
--- a/packages/platform-node/CHANGELOG.md
+++ b/packages/platform-node/CHANGELOG.md
@@ -515,7 +515,7 @@
 
   Added a `recursive` option to `FileSystem.watch` that allows watching for changes in subdirectories. When set to `true`, the watcher will monitor changes in all nested directories.
 
-  Note: The `recursive` option behavior depends on the backend implementation. When using `@parcel/watcher` (default), watching is always recursive on all platforms and this option is ignored. When using the Node.js `fs.watch()` fallback, the `recursive` option is supported on all platforms (Node.js v20+).
+  Note: The `recursive` option behavior depends on the backend implementation. When using the default Node.js `fs.watch()` backend, the `recursive` option is supported on all platforms (Node.js v20+). When using `@parcel/watcher` (via `NodeFileSystem/ParcelWatcher` layer), watching is always recursive on all platforms and this option is ignored.
 
   Example:
 

--- a/packages/platform/src/FileSystem.ts
+++ b/packages/platform/src/FileSystem.ts
@@ -236,10 +236,10 @@ export interface FileSystem {
    * Set the `recursive` option to `true` to watch for changes in subdirectories as well.
    *
    * Note: The `recursive` option behavior depends on the backend implementation:
-   * - When using `@parcel/watcher` (default in `@effect/platform-node`):
+   * - When using the default Node.js `fs.watch()` backend: The `recursive`
+   *   option is supported on all platforms (Node.js v20+).
+   * - When using `@parcel/watcher` (via `NodeFileSystem/ParcelWatcher` layer):
    *   Watching is always recursive on all platforms. This option is ignored.
-   * - When using Node.js `fs.watch()` fallback: The `recursive` option is
-   *   supported on all platforms (Node.js v20+).
    */
   readonly watch: (path: string, options?: WatchOptions) => Stream<WatchEvent, PlatformError>
   /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Update API docs and previous change log for how `recursive` option for `FileSystem.watch` is supported, and how it's handled.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related PR #5174

It seems that it was AI slop that added "recursive option is only supported on macOS and Windows" to changelog and API docs. By the time recursive option was added, not only that Node.js v18 was already EOL, which meant all LTS at that time supported recursive watch for all OS, but also that `platform-node` was already using `@parcel/watch` by default which is always recursive.
