### PR TITLE
docs(platform): add protocol for rpc docs

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -5105,7 +5105,8 @@ const UserHandlers = UserRpcs.toLayer({
 // Use `HttpLayerRouter` to register the rpc server
 const RpcRoute = RpcServer.layerHttpRouter({
   group: UserRpcs,
-  path: "/rpc"
+  path: "/rpc",
+  protocol: "http"
 }).pipe(
   Layer.provide(UserHandlers),
   Layer.provide(RpcSerialization.layerJson),


### PR DESCRIPTION
This example does not work without "protocol"