### PR TITLE
fix: Fixed "oneOf" toolChoice for google language model

### DIFF
--- a/.changeset/eight-ears-sink.md
+++ b/.changeset/eight-ears-sink.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-google": patch
+---
+
+Fixed "oneOf" toolChoice for google language model

--- a/packages/ai/google/src/GoogleLanguageModel.ts
+++ b/packages/ai/google/src/GoogleLanguageModel.ts
@@ -945,7 +945,7 @@ const prepareTools: (options: LanguageModel.ProviderOptions, config: Config.Serv
     toolConfig = {
       functionCallingConfig: {
         mode: options.toolChoice.mode === "auto" ? "AUTO" : "ANY",
-        allowedFunctionNames: Array.from(allowedTools)
+        allowedFunctionNames: options.toolChoice.mode === "auto" ? undefined : Array.from(allowedTools)
       }
     }
   }


### PR DESCRIPTION


## Type


- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed the following error coming from `GoogleAiLanguageModel` when trying to pass `oneOf` along with `mode: 'auto'`:
```{"error":{"code":400,"message":"Please set allowed_function_names only when function calling mode is ANY.","status":"INVALID_ARGUMENT"}}```

