### PR TITLE
@effect/ai-openai: Gpt5.1 fixed schema for effort

### DIFF
--- a/.changeset/cyan-garlics-beam.md
+++ b/.changeset/cyan-garlics-beam.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": minor
+---
+
+Added "none" effort as it being introduced for gpt-5.1 as a default value for effort

--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -382,7 +382,7 @@ export class AssistantSupportedModels extends S.Literal(
  * reasoning effort can result in faster responses and fewer tokens used
  * on reasoning in a response.
  */
-export class ReasoningEffort extends S.Literal("minimal", "low", "medium", "high") {}
+export class ReasoningEffort extends S.Literal("minimal", "low", "medium", "high", "none") {}
 
 export class CreateAssistantRequest extends S.Class<CreateAssistantRequest>("CreateAssistantRequest")({
   /**


### PR DESCRIPTION


- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


Added "none" effort as it being introduced for gpt-5.1 as a default value for effort


