### PR TITLE
Add Function.memo

### DIFF
--- a/.changeset/cute-chairs-kneel.md
+++ b/.changeset/cute-chairs-kneel.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Function.memo

--- a/packages/effect/src/Function.ts
+++ b/packages/effect/src/Function.ts
@@ -1301,13 +1301,13 @@ const fnRoots = new WeakMap<Function, ArgNode<unknown>>()
  *   return x + y;
  * });
  *
- * add(2, 3); // logs "running expensiveFunction", returns 5
+ * add(2, 3); // logs "running add", returns 5
  * add(2, 3); // no log, returns cached 5
- * add(2, 4); // logs "running expensiveFunction", returns 6
+ * add(2, 4); // logs "running add", returns 6
  *
  * // Expected console output:
- * // running expensiveFunction
- * // running expensiveFunction
+ * // running add
+ * // running add
  * ```
  *
  * @since 3.20.0

--- a/packages/effect/test/Function.test.ts
+++ b/packages/effect/test/Function.test.ts
@@ -230,6 +230,49 @@ describe("Function", () => {
       expect(fn).toHaveBeenCalledTimes(1)
     })
 
+    it("trims trailing undefined optional args by default", () => {
+      const fn = vi.fn(function(a?: number, b?: number) {
+        return { a, b, length: arguments.length }
+      })
+      const m = Function.memo(fn)
+
+      expect(m(1)).toEqual({ a: 1, b: undefined, length: 1 })
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      expect(m(1, undefined)).toEqual({ a: 1, b: undefined, length: 1 })
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      expect(m(1, 2)).toEqual({ a: 1, b: 2, length: 2 })
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it("preserves trailing undefined when trimUndefined is disabled", () => {
+      const fn = vi.fn(function(a?: number, b?: number) {
+        return { a, b, length: arguments.length }
+      })
+      const m = Function.memo(fn, { trimUndefined: false })
+
+      expect(m(1)).toEqual({ a: 1, b: undefined, length: 1 })
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      expect(m(1, undefined)).toEqual({ a: 1, b: undefined, length: 2 })
+      expect(fn).toHaveBeenCalledTimes(2)
+
+      expect(m(1)).toEqual({ a: 1, b: undefined, length: 1 })
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it("only trims trailing undefined values", () => {
+      const fn = vi.fn((a?: number, b?: number, c?: number) => [a, b, c])
+      const m = Function.memo(fn)
+
+      expect(m(1, undefined, 3)).toEqual([1, undefined, 3])
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      expect(m(1, 3)).toEqual([1, 3, undefined])
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
+
     it("memoizes undefined results distinctly", () => {
       const fn = vi.fn((_: number): void => undefined)
       const memoFn = Function.memo(fn)


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add pure memoization wrapper function to the Function module.

Questions:
- Do you think there is value in the memoThis alias? It's rare that `this` is used in type signatures, and the implementation uses it so it's valid, but it might just be unnecessary noise.
- Should the helpers be in some internal file or are they ok where they are with the `@internal` tag?
- Should this also be used internally, to replace `Hash.cached` for example? And if so, what are all the candidates for replacing manual caching? Would those changes belong in this PR or another?