### PR TITLE
feat: support `URL` in `HttpClientRequest.prependUrl`

### DIFF
--- a/.changeset/light-comics-rest.md
+++ b/.changeset/light-comics-rest.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": minor
+---
+
+Support `URL` in `HttpClientRequest.prependUrl` parameter

--- a/packages/platform/src/HttpClientRequest.ts
+++ b/packages/platform/src/HttpClientRequest.ts
@@ -211,8 +211,8 @@ export const setUrl: {
  * @category combinators
  */
 export const prependUrl: {
-  (path: string): (self: HttpClientRequest) => HttpClientRequest
-  (self: HttpClientRequest, path: string): HttpClientRequest
+  (path: string | URL): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, path: string | URL): HttpClientRequest
 } = internal.prependUrl
 
 /**

--- a/packages/platform/src/internal/httpClientRequest.ts
+++ b/packages/platform/src/internal/httpClientRequest.ts
@@ -264,19 +264,22 @@ export const appendUrl = dual<
 
 /** @internal */
 export const prependUrl = dual<
-  (path: string) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
-  (self: ClientRequest.HttpClientRequest, path: string) => ClientRequest.HttpClientRequest
->(2, (self, url) =>
-  makeInternal(
+  (path: string | URL) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
+  (self: ClientRequest.HttpClientRequest, path: string | URL) => ClientRequest.HttpClientRequest
+>(2, (self, url) => {
+  const clone = typeof url === "string" ? url : url.toString()
+
+  return makeInternal(
     self.method,
-    url.endsWith("/") && self.url.startsWith("/") ?
+    clone.endsWith("/") && self.url.startsWith("/") ?
       url + self.url.slice(1) :
       url + self.url,
     self.urlParams,
     self.hash,
     self.headers,
     self.body
-  ))
+  )
+})
 
 /** @internal */
 export const updateUrl = dual<

--- a/packages/platform/test/HttpClientRequest.test.ts
+++ b/packages/platform/test/HttpClientRequest.test.ts
@@ -1,0 +1,19 @@
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest"
+import { describe, it } from "@effect/vitest"
+import { deepStrictEqual } from "@effect/vitest/utils"
+
+describe("HttpClientRequest", () => {
+  const intialRequest = HttpClientRequest.make("GET")("/test")
+
+  it("prependUrl with a string", () => {
+    const result = intialRequest.pipe(HttpClientRequest.prependUrl("https://example.com"))
+
+    deepStrictEqual(result.url, "https://example.com/test")
+  })
+
+  it("prependUrl with an URL instance", () => {
+    const result = intialRequest.pipe(HttpClientRequest.prependUrl(new URL("https://example.com")))
+
+    deepStrictEqual(result.url, "https://example.com/test")
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add support `URL` in `HttpClientRequest.prependUrl`.

This is be useful working with full URLs, especially when added as base URLs to custom `HttpClient`s and/or working with `Schema` `Config`s using `Schema.URL` when the URL is get from env.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
