### PR TITLE
Fix NoSuchElementException instantiation in fastPath in FiberRuntime

### DIFF
--- a/.changeset/nice-socks-lead.md
+++ b/.changeset/nice-socks-lead.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix NoSuchElementException instantiation in fastPath and add corresponding test case

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -259,7 +259,7 @@ const fastPath = <A, E, R>(effect: Effect.Effect<A, E, R>): Exit.Exit<A, E> | un
     }
     case "None": {
       // @ts-expect-error
-      return core.exitFail(core.NoSuchElementException())
+      return core.exitFail(new core.NoSuchElementException())
     }
   }
 }

--- a/packages/effect/test/Effect/sync.test.ts
+++ b/packages/effect/test/Effect/sync.test.ts
@@ -4,6 +4,7 @@ import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
 
 const sum = (n: number): number => {
   if (n < 0) {
@@ -22,6 +23,10 @@ describe("Effect", () => {
     } else {
       expect(exit._tag).toBe("Failure")
     }
+  })
+  it("sync - effect subtype fastPath with NoSuchElementException", () => {
+    const exit = Effect.runSyncExit(Option.none())
+    deepStrictEqual(exit, Exit.fail(new Cause.NoSuchElementException()))
   })
   it.effect("sync - effect", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
…nding test case

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previously errored with TypeError: Class constructor Base cannot be invoked without 'new'
