### PR TITLE
Fix HttpApp stream flaky test

### DIFF
--- a/packages/platform/test/HttpApp.test.ts
+++ b/packages/platform/test/HttpApp.test.ts
@@ -38,20 +38,22 @@ describe("Http/App", () => {
     })
 
     test("stream scope", async () => {
+      let order = 0
       let streamFinalized = 0
       let handlerFinalized = 0
       const handler = HttpApp.toWebHandler(Effect.gen(function*() {
         yield* Effect.addFinalizer(() =>
           Effect.sync(() => {
-            handlerFinalized = Date.now()
+            handlerFinalized = order
+            order += 1
           })
         )
         const stream = Stream.make("foo", "bar").pipe(
           Stream.encodeText,
           Stream.ensuring(Effect.sync(() => {
-            streamFinalized = Date.now()
-          })),
-          Stream.tap(() => Effect.sleep(50))
+            streamFinalized = order
+            order += 1
+          }))
         )
         return HttpServerResponse.stream(stream)
       }))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Test Fix

## Description

Fix flaky test in HttpApp

Since it relied on Date.now(), it is possible to get same millisecond for both variables

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
