### PR TITLE
test: use Equal for succeed comparison

### DIFF
--- a/packages/effect/test/Schema/SchemaTest.ts
+++ b/packages/effect/test/Schema/SchemaTest.ts
@@ -5,6 +5,7 @@ import {
   Context,
   Effect,
   Either,
+  Equal,
   FastCheck,
   ParseResult,
   Predicate,
@@ -256,7 +257,12 @@ export const assertions = Effect.gen(function*() {
         effect: Effect.Effect<A, E>,
         a: A
       ) {
-        deepStrictEqual(await Effect.runPromise(Effect.either(effect)), Either.right(a))
+        const actual = await Effect.runPromise(Effect.either(effect))
+        const expected = Either.right(a)
+        if (Equal.equals(actual, expected)) {
+          return
+        }
+        deepStrictEqual(actual, expected)
       },
 
       /**


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Test fix

## Description

Node.js 24 has a change to deepStrictEqual for how it handles circular references in objects. Because of that, a test for `BigDecimal.normalized` is not passing. It seems to make sense to make use of Equal.equals when it is available, then fall back to deepStrictEqual.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
