### PR TITLE
add cache point support for user and tool messages in bedrock

### DIFF
--- a/.changeset/tender-walls-act.md
+++ b/.changeset/tender-walls-act.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-amazon-bedrock": patch
+---
+
+fix cache point support for user and tool messages

--- a/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
+++ b/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
@@ -406,6 +406,10 @@ const prepareMessages: (options: LanguageModel.ProviderOptions) => Effect.Effect
                 break
               }
             }
+
+            if (getCachePoint(message)) {
+              content.push(BEDROCK_CACHE_POINT)
+            }
           }
 
           messages.push({ role: "user", content })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `prepareMessages` function was adding cache points for system and assistant messages, but missing the same logic for user and tool messages. This meant that `cache_control` markers on user/tool messages were being silently ignored, preventing Bedrock from caching those message prefixes.

This fix adds the same `getCachePoint` check that exists for assistant messages to the user message group (which handles both user and tool role messages).

## Related

N/A