### PR TITLE
fix: do not use `performance.now` if it's not available

### DIFF
--- a/.changeset/fancy-vans-shave.md
+++ b/.changeset/fancy-vans-shave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure `performance.now` is only used if it's available

--- a/packages/effect/src/internal/clock.ts
+++ b/packages/effect/src/internal/clock.ts
@@ -40,7 +40,7 @@ export const globalClockScheduler: Clock.ClockScheduler = {
 
 const performanceNowNanos = (function() {
   const bigint1e6 = BigInt(1_000_000)
-  if (typeof performance === "undefined") {
+  if (typeof performance === "undefined" || typeof performance.now !== "function") {
     return () => BigInt(Date.now()) * bigint1e6
   }
   let origin: bigint


### PR DESCRIPTION
Ran into this in combination with partykit and cf workers