### PR TITLE
add HttpApp.fromWebHandler for wrapping web handlers

### DIFF
--- a/.changeset/friendly-wasps-hunt.md
+++ b/.changeset/friendly-wasps-hunt.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+add HttpApp.fromWebHandler for wrapping web handlers


### PR DESCRIPTION
## Type

- [x] Feature

## Description

Adds `HttpApp.fromWebHandler` - the inverse of `toWebHandler`. This wraps a standard web handler `(Request) => Promise<Response>` so it can be used within an Effect HTTP application.

This completes the web interop API symmetry:

| Direction | Request | Response | HttpApp |
|-----------|---------|----------|---------|
| web → Effect | `fromWeb` ✅ | `fromWeb` ✅ | `fromWebHandler` ✅ |
| Effect → web | `toWeb` ✅ | `toWeb` ✅ | `toWebHandler` ✅ |

### Example Usage

```typescript
import { HttpApp } from "@effect/platform"

// Wrap any web handler (e.g., BetterAuth, Hono)
const WebApp = HttpApp.fromWebHandler(async (request) => {
  return new Response("Hello from web handler!")
})
```

### Tests

- Basic GET request
- POST with JSON body
- Request headers preservation
- Response status/headers preservation
- Round-trip with `toWebHandler`