### PR TITLE
Allow client middleware failure

### DIFF
--- a/.changeset/funny-turkeys-sit.md
+++ b/.changeset/funny-turkeys-sit.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": minor
+---
+
+Allow RPC Client Middleware to shortcircuit with a failure

--- a/packages/platform-node/test/rpc-e2e.ts
+++ b/packages/platform-node/test/rpc-e2e.ts
@@ -2,7 +2,7 @@ import { RpcClient, RpcServer } from "@effect/rpc"
 import { assert, describe, it } from "@effect/vitest"
 import type { Layer } from "effect"
 import { Cause, Effect, Fiber, Option, Stream } from "effect"
-import { User, UsersClient } from "./fixtures/rpc-schemas.js"
+import { Unauthorized, User, UsersClient } from "./fixtures/rpc-schemas.js"
 
 export const e2eSuite = <E>(
   name: string,
@@ -16,6 +16,22 @@ export const e2eSuite = <E>(
         const user = yield* client.GetUser({ id: "1" })
         assert.instanceOf(user, User)
         assert.deepStrictEqual(user, new User({ id: "1", name: "Logged in user" }))
+      }).pipe(Effect.provide(layer)))
+
+    it.effect("should short circuit on client middleware failure", () =>
+      Effect.gen(function*() {
+        const client = yield* UsersClient
+        const failure = yield* client.GetUser({ id: "1" }, { headers: { userid: "-1" } }).pipe(Effect.flip)
+        assert.instanceOf(failure, Unauthorized)
+        assert.deepStrictEqual(failure.failedOn, "Client")
+      }).pipe(Effect.provide(layer)))
+
+    it.effect("should fail on server middleware failure", () =>
+      Effect.gen(function*() {
+        const client = yield* UsersClient
+        const failure = yield* client.GetUser({ id: "1" }, { headers: { userid: "-2" } }).pipe(Effect.flip)
+        assert.instanceOf(failure, Unauthorized)
+        assert.deepStrictEqual(failure.failedOn, "Server")
       }).pipe(Effect.provide(layer)))
 
     it.effect("nested method", () =>

--- a/packages/platform-node/test/rpc-e2e.ts
+++ b/packages/platform-node/test/rpc-e2e.ts
@@ -2,7 +2,7 @@ import { RpcClient, RpcServer } from "@effect/rpc"
 import { assert, describe, it } from "@effect/vitest"
 import type { Layer } from "effect"
 import { Cause, Effect, Fiber, Option, Stream } from "effect"
-import { Unauthorized, User, UsersClient } from "./fixtures/rpc-schemas.js"
+import { InvalidClientCredentials, Unauthorized, User, UsersClient } from "./fixtures/rpc-schemas.js"
 
 export const e2eSuite = <E>(
   name: string,
@@ -22,8 +22,7 @@ export const e2eSuite = <E>(
       Effect.gen(function*() {
         const client = yield* UsersClient
         const failure = yield* client.GetUser({ id: "1" }, { headers: { userid: "-1" } }).pipe(Effect.flip)
-        assert.instanceOf(failure, Unauthorized)
-        assert.deepStrictEqual(failure.failedOn, "Client")
+        assert.instanceOf(failure, InvalidClientCredentials)
       }).pipe(Effect.provide(layer)))
 
     it.effect("should fail on server middleware failure", () =>
@@ -31,7 +30,6 @@ export const e2eSuite = <E>(
         const client = yield* UsersClient
         const failure = yield* client.GetUser({ id: "1" }, { headers: { userid: "-2" } }).pipe(Effect.flip)
         assert.instanceOf(failure, Unauthorized)
-        assert.deepStrictEqual(failure.failedOn, "Server")
       }).pipe(Effect.provide(layer)))
 
     it.effect("nested method", () =>

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -118,7 +118,10 @@ export declare namespace RpcClient {
       infer _Error,
       infer _Middleware
     > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? AsMailbox extends true ? Effect.Effect<
-            Mailbox.ReadonlyMailbox<_A["Type"], _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"]>,
+            Mailbox.ReadonlyMailbox<
+              _A["Type"],
+              _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"] | _Middleware["~ClientError"]
+            >,
             never,
             | Scope.Scope
             | _Payload["Context"]
@@ -128,12 +131,13 @@ export declare namespace RpcClient {
           >
         : Stream.Stream<
           _A["Type"],
-          _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"],
+          _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"] | _Middleware["~ClientError"],
           _Payload["Context"] | _Success["Context"] | _Error["Context"] | _Middleware["failure"]["Context"]
         >
       : Effect.Effect<
         Discard extends true ? void : _Success["Type"],
-        Discard extends true ? E : _Error["Type"] | E | _Middleware["failure"]["Type"],
+        Discard extends true ? E | _Middleware["~ClientError"]
+          : _Error["Type"] | E | _Middleware["failure"]["Type"] | _Middleware["~ClientError"],
         _Payload["Context"] | _Success["Context"] | _Error["Context"] | _Middleware["failure"]["Context"]
       > :
       never
@@ -168,7 +172,10 @@ export declare namespace RpcClient {
     infer _Error,
     infer _Middleware
   > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? AsMailbox extends true ? Effect.Effect<
-          Mailbox.ReadonlyMailbox<_A["Type"], _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"]>,
+          Mailbox.ReadonlyMailbox<
+            _A["Type"],
+            _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"] | _Middleware["~ClientError"]
+          >,
           never,
           | Scope.Scope
           | _Payload["Context"]
@@ -178,12 +185,13 @@ export declare namespace RpcClient {
         >
       : Stream.Stream<
         _A["Type"],
-        _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"],
+        _E["Type"] | _Error["Type"] | E | _Middleware["failure"]["Type"] | _Middleware["~ClientError"],
         _Payload["Context"] | _Success["Context"] | _Error["Context"] | _Middleware["failure"]["Context"]
       >
     : Effect.Effect<
       Discard extends true ? void : _Success["Type"],
-      Discard extends true ? E : _Error["Type"] | E | _Middleware["failure"]["Type"],
+      Discard extends true ? E | _Middleware["~ClientError"]
+        : _Error["Type"] | E | _Middleware["failure"]["Type"] | _Middleware["~ClientError"],
       _Payload["Context"] | _Success["Context"] | _Error["Context"] | _Middleware["failure"]["Context"]
     > :
     never

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -387,15 +387,13 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
           }
           entries.set(id, entry)
           fiber = send.pipe(
-            Effect.matchCauseEffect({
-              onFailure: (cause) => Effect.sync(() => entry.resume(Exit.failCause(cause))),
-              onSuccess: (request) =>
-                options.onFromClient({
-                  message: request,
-                  context,
-                  discard
-                })
-            }),
+            Effect.flatMap((request) =>
+              options.onFromClient({
+                message: request,
+                context,
+                discard
+              })
+            ),
             span ? Effect.withParentSpan(span) : identity,
             Runtime.runFork(runtime)
           )

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -329,7 +329,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
 
   const onEffectRequest = (
     rpc: Rpc.AnyWithProps,
-    middleware: (request: Request<Rpcs>) => Effect.Effect<Request<Rpcs>>,
+    middleware: (request: Request<Rpcs>) => Effect.Effect<Request<Rpcs>, any>,
     span: Span | undefined,
     payload: any,
     headers: Headers.Headers,
@@ -414,7 +414,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
 
   const onStreamRequest = Effect.fnUntraced(function*(
     rpc: Rpc.AnyWithProps,
-    middleware: (request: Request<Rpcs>) => Effect.Effect<Request<Rpcs>>,
+    middleware: (request: Request<Rpcs>) => Effect.Effect<Request<Rpcs>, any>,
     payload: any,
     headers: Headers.Headers,
     streamBufferSize: number,
@@ -483,8 +483,10 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     return mailbox
   })
 
-  const getRpcClientMiddleware = (rpc: Rpc.AnyWithProps): (request: Request<Rpcs>) => Effect.Effect<Request<Rpcs>> => {
-    const middlewares: Array<RpcMiddleware.RpcMiddlewareClient> = []
+  const getRpcClientMiddleware = (
+    rpc: Rpc.AnyWithProps
+  ): (request: Request<Rpcs>) => Effect.Effect<Request<Rpcs>, any> => {
+    const middlewares: Array<RpcMiddleware.RpcMiddlewareClient<never, any>> = []
     for (const tag of rpc.middlewares.values()) {
       const middleware = context.unsafeMap.get(`${tag.key}/Client`)
       if (!middleware) continue
@@ -501,7 +503,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
               middlewares[i]({
                 rpc,
                 request
-              }) as Effect.Effect<Request<Rpcs>>,
+              }) as Effect.Effect<Request<Rpcs>, any>,
             step(nextRequest) {
               request = nextRequest
               i++

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -62,11 +62,11 @@ export interface SuccessValue {
  * @since 1.0.0
  * @category models
  */
-export interface RpcMiddlewareClient<R = never> {
+export interface RpcMiddlewareClient<R = never, EX = never> {
   (options: {
     readonly rpc: Rpc.AnyWithProps
     readonly request: Request<Rpc.Any>
-  }): Effect.Effect<Request<Rpc.Any>, never, R>
+  }): Effect.Effect<Request<Rpc.Any>, EX, R>
 }
 
 /**
@@ -283,10 +283,12 @@ export const Tag = <Self>(): <
  * @since 1.0.0
  * @category client
  */
-export const layerClient = <Id, S, R, EX = never, RX = never>(
-  tag: Context.Tag<Id, S>,
-  service: RpcMiddlewareClient<R> | Effect.Effect<RpcMiddlewareClient<R>, EX, RX>
-): Layer.Layer<ForClient<Id>, EX, R | Exclude<RX, Scope>> =>
+export const layerClient = <T extends Context.Tag<any, any>, R, EX = never, RX = never>(
+  tag: T,
+  service:
+    | RpcMiddlewareClient<R, TagClass.Failure<T>>
+    | Effect.Effect<RpcMiddlewareClient<R, TagClass.Failure<T>>, EX, RX>
+): Layer.Layer<ForClient<Context.Tag.Identifier<T>>, EX, R | Exclude<RX, Scope>> =>
   Layer.scopedContext(Effect.gen(function*() {
     const context = (yield* Effect.context<R | Scope>()).pipe(
       Context.omit(Scope)

--- a/packages/rpc/src/RpcMiddleware.ts
+++ b/packages/rpc/src/RpcMiddleware.ts
@@ -62,11 +62,11 @@ export interface SuccessValue {
  * @since 1.0.0
  * @category models
  */
-export interface RpcMiddlewareClient<R = never, EX = never> {
+export interface RpcMiddlewareClient<R = never, CE = never> {
   (options: {
     readonly rpc: Rpc.AnyWithProps
     readonly request: Request<Rpc.Any>
-  }): Effect.Effect<Request<Rpc.Any>, EX, R>
+  }): Effect.Effect<Request<Rpc.Any>, CE, R>
 }
 
 /**
@@ -98,12 +98,14 @@ export interface Any {
 export interface TagClass<
   Self,
   Name extends string,
-  Options
+  Options,
+  ClientError
 > extends
   TagClass.Base<
     Self,
     Name,
     Options,
+    ClientError,
     TagClass.Wrap<Options> extends true ? RpcMiddlewareWrap<
         TagClass.Provides<Options>,
         TagClass.Failure<Options>
@@ -188,8 +190,14 @@ export declare namespace TagClass {
    * @since 1.0.0
    * @category models
    */
-  export interface Base<Self, Name extends string, Options, Service> extends Context.Tag<Self, Service> {
-    new(_: never): Context.TagClassShape<Name, Service>
+  export type ClientError<Options> = Options extends { readonly "~ClientError": any } ? Options["~ClientError"] : never
+
+  /**
+   * @since 1.0.0
+   * @category models
+   */
+  export interface Base<Self, Name extends string, Options, ClientError, Service> extends Context.Tag<Self, Service> {
+    new(_: never): Context.TagClassShape<Name, Service> & { readonly "~ClientError": ClientError }
     readonly [TypeId]: TypeId
     readonly optional: Optional<Options>
     readonly failure: FailureSchema<Options>
@@ -197,6 +205,7 @@ export declare namespace TagClass {
       : undefined
     readonly requiredForClient: RequiredForClient<Options>
     readonly wrap: Wrap<Options>
+    readonly "~ClientError": ClientError
   }
 }
 
@@ -211,6 +220,7 @@ export interface TagClassAny extends Context.Tag<any, any> {
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
   readonly wrap: boolean
+  readonly "~ClientError": any
 }
 
 /**
@@ -224,13 +234,28 @@ export interface TagClassAnyWithProps extends Context.Tag<any, RpcMiddleware<any
   readonly failure: Schema.Schema.All
   readonly requiredForClient: boolean
   readonly wrap: boolean
+  readonly "~ClientError": any
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface AnyId {
+  readonly [TypeId]: TypeId
+  readonly "~ClientError"?: any
 }
 
 /**
  * @since 1.0.0
  * @category tags
  */
-export const Tag = <Self>(): <
+export const Tag = <
+  Self,
+  const Config extends {
+    clientError?: any
+  } = { clientError: never }
+>(): <
   const Name extends string,
   const Options extends {
     readonly wrap?: boolean
@@ -242,7 +267,7 @@ export const Tag = <Self>(): <
 >(
   id: Name,
   options?: Options | undefined
-) => TagClass<Self, Name, Options> =>
+) => TagClass<Self, Name, Options, "clientError" extends keyof Config ? Config["clientError"] : never> =>
 (
   id: string,
   options?: {
@@ -283,12 +308,12 @@ export const Tag = <Self>(): <
  * @since 1.0.0
  * @category client
  */
-export const layerClient = <T extends Context.Tag<any, any>, R, EX = never, RX = never>(
-  tag: T,
+export const layerClient = <Id, S, R, EX = never, RX = never>(
+  tag: Context.Tag<Id, S>,
   service:
-    | RpcMiddlewareClient<R, TagClass.Failure<T>>
-    | Effect.Effect<RpcMiddlewareClient<R, TagClass.Failure<T>>, EX, RX>
-): Layer.Layer<ForClient<Context.Tag.Identifier<T>>, EX, R | Exclude<RX, Scope>> =>
+    | RpcMiddlewareClient<R, TagClass.ClientError<Id>>
+    | Effect.Effect<RpcMiddlewareClient<R, TagClass.ClientError<Id>>, EX, RX>
+): Layer.Layer<ForClient<Id>, EX, R | Exclude<RX, Scope>> =>
   Layer.scopedContext(Effect.gen(function*() {
     const context = (yield* Effect.context<R | Scope>()).pipe(
       Context.omit(Scope)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Relax the RpcClientMiddleware allowing them to fail on client side raising the same error allowed in the server. This allows short circuit for errors such as "Unauthorized" when the client does not have credentials at all.