### PR TITLE
cli: allow options after args

### DIFF
--- a/.changeset/soft-ears-judge.md
+++ b/.changeset/soft-ears-judge.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Allow options to appear after command arguments (relax POSIX utility syntax guideline 9) by continuing to scan for known options even when arguments are interspersed.

--- a/packages/cli/src/internal/cliApp.ts
+++ b/packages/cli/src/internal/cliApp.ts
@@ -110,7 +110,8 @@ export const run = dual<
                   )
                 ),
               onNonEmpty: (head) => {
-                const error = InternalHelpDoc.p(`Received unknown argument: '${head}'`)
+                const kind = head !== "-" && head.startsWith("-") ? "option" : "argument"
+                const error = InternalHelpDoc.p(`Received unknown ${kind}: '${head}'`)
                 return Effect.zipRight(printDocs(error), Effect.fail(InternalValidationError.invalidValue(error)))
               }
             })

--- a/packages/cli/src/internal/commandDescriptor.ts
+++ b/packages/cli/src/internal/commandDescriptor.ts
@@ -575,7 +575,7 @@ const parseInternal = (
       > =>
         parseCommandLine(self, args).pipe(Effect.flatMap((commandOptionsAndArgs) => {
           const [optionsAndArgs, forcedCommandArgs] = splitForcedArgs(commandOptionsAndArgs)
-          return InternalOptions.processCommandLine(self.options, optionsAndArgs, config).pipe(
+          return InternalOptions.processCommandLinePermissive(self.options, optionsAndArgs, config).pipe(
             Effect.flatMap(([error, commandArgs, optionsType]) =>
               InternalArgs.validate(
                 self.args,

--- a/packages/cli/test/CliApp.test.ts
+++ b/packages/cli/test/CliApp.test.ts
@@ -34,7 +34,7 @@ describe("CliApp", () => {
       const args = Array.make("node", "test.js", "--bar")
       const result = yield* Effect.flip(cli(args))
       expect(result).toEqual(ValidationError.invalidValue(HelpDoc.p(
-        "Received unknown argument: '--bar'"
+        "Received unknown option: '--bar'"
       )))
     }).pipe(runEffect))
 


### PR DESCRIPTION
Relaxes POSIX guideline 9 for commands: options can appear after args; continues scanning for known options past unknown tokens while keeping built-in parsing conservative. Adds tests + changeset.