### PR TITLE
Add support for ordering in Graph traversal

### DIFF
--- a/.changeset/quiet-moments-clean.md
+++ b/.changeset/quiet-moments-clean.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add support for ordering in Graph traversal


### PR DESCRIPTION


## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allows to provide an optional parameter to SearchConfig to apply an order for traversing nodes. Said order will be applied both for start root nodes, and direct neighbours encountered while traversing. But still, dfs/bfs order will be mantained. 