### PR TITLE
Allow Terminal.readLine to emulate native behavior

### DIFF
--- a/.changeset/puny-rats-post.md
+++ b/.changeset/puny-rats-post.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Allow `Terminal.readLine` to more closely emulate native behavior by echoing user input as well as responding to signals entered by the user


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previously, `Terminal.readLine` would not echo user input to the configured `stdout`, nor would it respond to signals entered by the user.

This PR allows the end user to see their input echoed back to the terminal when using `Terminal.readLine`, and allows responding to signals (i.e. `SIGINT`). 

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
