### PR TITLE
fix(effect): respect times: 0 in Effect.retry options

### DIFF
--- a/.changeset/fix-schedule-retry-times-zero.md
+++ b/.changeset/fix-schedule-retry-times-zero.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.retry` to respect `times: 0` option by using explicit undefined check instead of truthy check.

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -2034,7 +2034,7 @@ export const fromRetryOptions = (options: Effect.Retry.Options<any>): Schedule.S
       return scheduleDefectWrap(applied)
     }) :
     withWhile
-  return options.times ?
+  return options.times !== undefined ?
     intersect(withUntil, recurs(options.times)) :
     withUntil
 }


### PR DESCRIPTION
## Summary
- Fix `Effect.retry` to properly handle `times: 0` option by using an explicit undefined check instead of a truthy check, which was incorrectly ignoring the value `0`.