### PR TITLE
Fix openai streaming decoding error when using provider webSearch tool

### DIFF
--- a/.changeset/rude-bikes-tan.md
+++ b/.changeset/rude-bikes-tan.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Fix streaming decode: response.output_item.added may emit web_search_call without action (when status="in_progress").

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -393,6 +393,17 @@ export class ResponseFailedEvent extends Schema.Class<ResponseFailedEvent>(
   response: Generated.Response
 }) {}
 
+const WebSearchToolCallForAddEvent = Schema.asSchema(
+  Generated.WebSearchToolCall.pipe(
+    Schema.omit("action")
+  )
+)
+
+const AddEventOutputItem = Schema.Union(
+  Generated.OutputItem,
+  WebSearchToolCallForAddEvent
+)
+
 /**
  * Emitted when a new output item is added.
  *
@@ -417,7 +428,7 @@ export class ResponseOutputItemAddedEvent extends Schema.Class<ResponseOutputIte
   /**
    * The output item that was added.
    */
-  item: Generated.OutputItem
+  item: AddEventOutputItem
 }) {}
 
 /**


### PR DESCRIPTION

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When sending a stream request, `OpenAiClient.streamRequest` decodes each SSE `event.data` into `ResponseStreamEvent`(`OpenAiClient.ts:1803`). 

However, in real streams, `ResponseOutputItemAddedEvent` can emit a
  `web_search_call` item before it’s fully populated: the `action` field is not present yet (it only shows up later in `response.output_item.done`). This can cause an early decode failure while
  `OpenAiLanguageModel.makeStreamResponse` is processing the tool-call stream parts.

https://github.com/Effect-TS/effect/blob/65e9e35157cbdfb40826ddad34555c4ebcf7c0b0/packages/ai/openai/src/OpenAiClient.ts#L402-L421
<!--
Please add a brief summary/description of the pull request here.
-->

## Proposed Fix
I currently work around this by relaxing the schema to accept `web_search_call` without `action` in `ResponseOutputItemAddedEvent`, so it can accept an in-progress web_search_call item without action. (status="in_progress").

what do you think is the most appropriate way to model/handle this situations? @IMax153 

## Reproduce

You can reproduce this by enabling the `web_search` tool and asking the model to perform a search in streaming mode.

```ts
Toolkit.make(
  OpenAI.OpenAiTool.WebSearch({
    search_context_size: 'medium'
  })
)
```