### PR TITLE
Fix HttpServerResponse.fromWeb losing Content-Type header

### DIFF
--- a/.changeset/fix-from-web-content-type.md
+++ b/.changeset/fix-from-web-content-type.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform": patch
+---
+
+HttpServerResponse: fix `fromWeb` to preserve Content-Type header when response has a body
+
+Previously, when converting a web `Response` to an `HttpServerResponse` via `fromWeb`, the `Content-Type` header was not passed to `Body.stream()`, causing it to default to `application/octet-stream`. This affected any code using `HttpApp.fromWebHandler` to wrap web handlers, as JSON responses would incorrectly have their Content-Type set to `application/octet-stream` instead of `application/json`.

--- a/packages/platform/src/HttpServerResponse.ts
+++ b/packages/platform/src/HttpServerResponse.ts
@@ -410,12 +410,16 @@ export const fromWeb = (response: Response): HttpServerResponse => {
     cookies: Cookies.fromSetCookie(setCookieHeaders)
   })
   if (response.body) {
+    const contentType = headers.get("content-type")
     self = setBody(
       self,
-      Body.stream(Stream.fromReadableStream({
-        evaluate: () => response.body!,
-        onError: (e) => e
-      }))
+      Body.stream(
+        Stream.fromReadableStream({
+          evaluate: () => response.body!,
+          onError: (e) => e
+        }),
+        contentType ?? undefined
+      )
     )
   }
   return self


### PR DESCRIPTION
## Summary

- Fix `HttpServerResponse.fromWeb` to preserve the `Content-Type` header when converting a web `Response` to `HttpServerResponse`
- Previously, when the response had a body, the Content-Type was not passed to `Body.stream()`, causing it to default to `application/octet-stream`
- This affected any code using `HttpApp.fromWebHandler` to wrap web handlers (e.g., integrating third-party auth libraries like Better Auth)

## Test Plan

- Added test `preserves response content-type header` - verifies JSON responses have correct content-type
- Added test `preserves custom content-type header` - verifies custom content-types like `text/html` are preserved
- Added test `json preserves content-type` - verifies `toWebHandler` correctly outputs content-type

All 175 tests pass.

## Example

Before this fix, wrapping a web handler would lose the Content-Type:

```ts
const webHandler = async () => Response.json({ message: "hello" })
const app = HttpApp.fromWebHandler(webHandler)
const handler = HttpApp.toWebHandler(app)
const response = await handler(new Request("http://localhost/"))

// Before: response.headers.get("Content-Type") === "application/octet-stream" ❌
// After:  response.headers.get("Content-Type") === "application/json" ✅
```