### PR TITLE
Fix typos in effect/printer README.md for clarity

### DIFF
--- a/packages/printer/README.md
+++ b/packages/printer/README.md
@@ -38,7 +38,7 @@ bun add @effect/printer
 
 ## Overview
 
-This module defines a pretty printer to format text in a flexible and convenient way. The idea is to combine a `Doc`ument out of many small components, then using a layouter to convert it to an easily renderable `DocStream`, which can then be rendered to a variety of formats.
+This module defines a pretty printer to format text in a flexible and convenient way. The idea is to combine a `Document` out of many small components, then using a layout to convert it to an easily renderable `DocStream`, which can then be rendered to a variety of formats.
 
 The document consists of several parts:
  1. Just below is some general information about the library
@@ -170,7 +170,7 @@ There are two key concepts to laying a document out: the available width, and gr
 
 ### Available Width
 
-The layout algorithm will try to avoid exceeding the maximum width of the `Doc`ument by inserting line breaks where possible. The available layout combinators make it fairly straightforward to specify where, and under what circumstances, such a line break may be inserted by the layout algorithm (for example via the `seps` function).
+The layout algorithm will try to avoid exceeding the maximum width of the `Document` by inserting line breaks where possible. The available layout combinators make it fairly straightforward to specify where, and under what circumstances, such a line break may be inserted by the layout algorithm (for example via the `seps` function).
 
 There is also the concept of ribbon width. The ribbon is the part of a line that is printed (i.e. the line length without the leading indentation). The layout algorithms take a ribbon fraction argument, which specifies how much of a line should be filled before trying to break it up. A ribbon width of 0.5 in a document of width 80 will result in the layout algorithm trying to avoid exceeding `0.5 * 80 = 40` (ignoring current indentation depth).
 


### PR DESCRIPTION
Fixed typos in /packages/printer/README.md

I think `Document` was intended not `Doc`cument and so on across a few instances in the readme.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Fixed typos in 3 instances in /packages/printer/README.md for clarity, mostly changed from `Doc`ument to `Document`	 which seems to be the intended spelling.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
