### PR TITLE
Fix HttpRunner double-slash routing

### DIFF
--- a/.changeset/deep-books-stand.md
+++ b/.changeset/deep-books-stand.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Fix HttpRunner double-slash routing

--- a/packages/cluster/src/HttpRunner.ts
+++ b/packages/cluster/src/HttpRunner.ts
@@ -23,6 +23,8 @@ import type { RunnerStorage } from "./RunnerStorage.js"
 import * as Sharding from "./Sharding.js"
 import type * as ShardingConfig from "./ShardingConfig.js"
 
+const normalizePath = (path: string): string => path.startsWith("/") ? path : `/${path}`
+
 /**
  * @since 1.0.0
  * @category Layers
@@ -43,7 +45,9 @@ export const layerClientProtocolHttp = (options: {
       return (address) => {
         const clientWithUrl = HttpClient.mapRequest(
           client,
-          HttpClientRequest.prependUrl(`http${https ? "s" : ""}://${address.host}:${address.port}/${options.path}`)
+          HttpClientRequest.prependUrl(
+            `http${https ? "s" : ""}://${address.host}:${address.port}${normalizePath(options.path)}`
+          )
         )
         return RpcClient.makeProtocolHttp(clientWithUrl).pipe(
           Effect.provideService(RpcSerialization.RpcSerialization, serialization)
@@ -81,7 +85,7 @@ export const layerClientProtocolWebsocket = (options: {
       const constructor = yield* Socket.WebSocketConstructor
       return Effect.fnUntraced(function*(address) {
         const socket = yield* Socket.makeWebSocket(
-          `ws${https ? "s" : ""}://${address.host}:${address.port}/${options.path}`
+          `ws${https ? "s" : ""}://${address.host}:${address.port}${normalizePath(options.path)}`
         ).pipe(
           Effect.provideService(Socket.WebSocketConstructor, constructor)
         )

--- a/packages/cluster/test/HttpRunner.test.ts
+++ b/packages/cluster/test/HttpRunner.test.ts
@@ -1,0 +1,106 @@
+import * as HttpClient from "@effect/platform/HttpClient"
+import * as HttpClientError from "@effect/platform/HttpClientError"
+import { RpcSerialization } from "@effect/rpc"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Layer, Ref } from "effect"
+import * as HttpRunner from "../src/HttpRunner.js"
+import { RunnerAddress, Runners } from "../src/index.js"
+
+describe("HttpRunner", () => {
+  describe("layerClientProtocolHttp", () => {
+    const makeUrlCapturingClient = (urlRef: Ref.Ref<Array<string>>) =>
+      HttpClient.make((request, url) =>
+        Ref.update(urlRef, (urls) => [...urls, url.toString()]).pipe(
+          Effect.flatMap(() =>
+            Effect.fail(
+              new HttpClientError.RequestError({
+                request,
+                reason: "Transport",
+                cause: new Error("Mock - URL captured")
+              })
+            )
+          )
+        )
+      )
+
+    const testRequest = {
+      _tag: "Request" as const,
+      id: "1",
+      tag: "test",
+      payload: {},
+      headers: [] as ReadonlyArray<[string, string]>
+    }
+
+    it.scoped("path '/' produces http://host:port/", () =>
+      Effect.gen(function*() {
+        const urlRef = yield* Ref.make<Array<string>>([])
+
+        const layer = HttpRunner.layerClientProtocolHttp({ path: "/" }).pipe(
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, makeUrlCapturingClient(urlRef))),
+          Layer.provide(RpcSerialization.layerNdjson)
+        )
+
+        const makeProtocol = yield* Effect.provide(Runners.RpcClientProtocol, layer)
+        const protocol = yield* makeProtocol(RunnerAddress.make("localhost", 3000))
+
+        yield* protocol.send(testRequest).pipe(Effect.ignore)
+
+        const urls = yield* Ref.get(urlRef)
+        expect(urls[0]).toBe("http://localhost:3000/")
+      }))
+
+    it.scoped("path '' produces http://host:port/", () =>
+      Effect.gen(function*() {
+        const urlRef = yield* Ref.make<Array<string>>([])
+
+        const layer = HttpRunner.layerClientProtocolHttp({ path: "" }).pipe(
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, makeUrlCapturingClient(urlRef))),
+          Layer.provide(RpcSerialization.layerNdjson)
+        )
+
+        const makeProtocol = yield* Effect.provide(Runners.RpcClientProtocol, layer)
+        const protocol = yield* makeProtocol(RunnerAddress.make("localhost", 3000))
+
+        yield* protocol.send(testRequest).pipe(Effect.ignore)
+
+        const urls = yield* Ref.get(urlRef)
+        expect(urls[0]).toBe("http://localhost:3000/")
+      }))
+
+    it.scoped("path '/rpc' produces http://host:port/rpc", () =>
+      Effect.gen(function*() {
+        const urlRef = yield* Ref.make<Array<string>>([])
+
+        const layer = HttpRunner.layerClientProtocolHttp({ path: "/rpc" }).pipe(
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, makeUrlCapturingClient(urlRef))),
+          Layer.provide(RpcSerialization.layerNdjson)
+        )
+
+        const makeProtocol = yield* Effect.provide(Runners.RpcClientProtocol, layer)
+        const protocol = yield* makeProtocol(RunnerAddress.make("localhost", 3000))
+
+        yield* protocol.send(testRequest).pipe(Effect.ignore)
+
+        const urls = yield* Ref.get(urlRef)
+        expect(urls[0]).toBe("http://localhost:3000/rpc")
+      }))
+
+    it.scoped("path 'rpc' produces http://host:port/rpc", () =>
+      Effect.gen(function*() {
+        const urlRef = yield* Ref.make<Array<string>>([])
+
+        const layer = HttpRunner.layerClientProtocolHttp({ path: "rpc" }).pipe(
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, makeUrlCapturingClient(urlRef))),
+          Layer.provide(RpcSerialization.layerNdjson)
+        )
+
+        const makeProtocol = yield* Effect.provide(Runners.RpcClientProtocol, layer)
+        const protocol = yield* makeProtocol(RunnerAddress.make("localhost", 3000))
+
+        yield* protocol.send(testRequest).pipe(Effect.ignore)
+
+        const urls = yield* Ref.get(urlRef)
+        expect(urls[0]).toBe("http://localhost:3000/rpc")
+      }))
+  })
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Summary

Fix `HttpRunner` double-slash routing

Fixed by normalizing `layerClientProtocolHttp` and `layerClientProtocolWebsocket` generated path(s).

### Other fix ideas

1. Enforce `layerClientProtocolHttp`/`layerClientProtocolWebsocket` input path prop is of type `/${string}`
2. Remove trailing `/` from `layerClientProtocolHttpDefault` and `layerClientProtocolWebsocketDefault` instantiations

### Decision

Went for the normalization fix because : 
- Fix idea 1. is not backwards compatible  -> breaking change ; normalizing felt less intrusive
- Fix idea 2. works specifically for instantiated defaults, but as methods are still exposed through `HttpClient`, underlying issue still remains

### To be noted

- Longer-term I think fix idea 1. is more relevant. I however wasn't sure if it was worth introducing a breaking change for this fix ; If you feel like it makes more sense, happy to change the proposed solution.

- I read the contributing guidelines but as I'm not familiar with this repository, please feel free to redirect me to correct documentation/best practices if I'm missing something here. 

## Changes 

- Add and reuse a local `normalizePath` fn in `HttpRunner.layerClientProtocolWebsocket` and `HttpRunner.layerClientProtocolHttp`
- Add 4 functional tests to confirm behaviour

## Related

- Related Issue #5919
- Closes #5919
