### PR TITLE
docs: add AGENTS.md files for AI code assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,159 @@
+# EFFECT MONOREPO
+
+**Generated:** 2026-01-05 | **Commit:** f28f353d5 | **Branch:** main
+
+## OVERVIEW
+
+TypeScript standard library for production-grade software. Core primitives: Effect (typed errors + DI), Stream (backpressure), Schema (bidirectional codecs), Layer (DI construction).
+
+## STRUCTURE
+
+```
+effect/
+├── packages/
+│   ├── effect/          # Core library (~500 files, 14k+ LOC Effect.ts)
+│   ├── platform*/       # Runtime abstractions (node/bun/browser)
+│   ├── sql*/            # 14 SQL packages (base + 13 drivers)
+│   ├── ai/              # Nested workspace: 6 AI providers
+│   ├── cli/             # CLI framework
+│   ├── cluster/         # Distributed primitives
+│   ├── rpc/             # RPC framework
+│   ├── experimental/    # Unstable features
+│   ├── typeclass/       # FP abstractions
+│   ├── vitest/          # Test integration
+│   └── ...
+├── scripts/             # Build tooling (circular, codemod, version)
+└── .github/workflows/   # CI: check, pages, release, snapshot
+```
+
+## WHERE TO LOOK
+
+| Task           | Location                        | Notes                              |
+| -------------- | ------------------------------- | ---------------------------------- |
+| Core types     | `packages/effect/src/*.ts`      | Effect, Stream, Schema, Layer      |
+| Implementation | `packages/effect/src/internal/` | Never import directly              |
+| Platform IO    | `packages/platform/src/`        | FileSystem, HttpClient, HttpServer |
+| SQL queries    | `packages/sql/src/`             | SqlClient, Statement, Migrator     |
+| AI providers   | `packages/ai/*/src/`            | OpenAI, Anthropic, Google, etc     |
+| Test utilities | `packages/vitest/src/`          | it.effect, it.live, it.scoped      |
+| CLI building   | `packages/cli/src/`             | Command, Options, Args             |
+
+## CONVENTIONS
+
+### Code Style
+
+- **No semicolons**, double quotes, no trailing commas
+- **2-space indent**, 120 char line width
+- **Array<T>** not T[] (generic syntax)
+- **`_` prefix** for unused vars/args
+- **No console** in src/test dirs
+- **No barrel imports** in src (import from subpaths)
+
+### Module Pattern
+
+- Public API: `src/*.ts` (re-exports from internal)
+- Implementation: `src/internal/*.ts` (blocked via package.json exports)
+- Entry: `src/index.ts` (every package)
+
+### Naming
+
+- **TypeId**: `Symbol.for("effect/Foo")` for nominal types
+- **OpCodes**: `OP_*` constants in `internal/opCodes/`
+- **STM types**: `t` prefix (tRef, tQueue, tMap)
+- **Patch types**: `*Patch.ts` suffix
+
+### API Design
+
+- **Pipeable**: All types implement `Pipeable` interface
+- **dual()**: Data-first AND data-last via `Function.dual()`
+- **Generator syntax**: `Effect.gen(function*() { ... })`
+
+### Effect Patterns
+
+```typescript
+// Service definition
+class MyService extends Context.Tag("MyService")<MyService, { ... }>() {
+  static Live = Layer.succeed(this, { ... })
+}
+
+// Typed error
+class MyError extends Schema.TaggedError<MyError>()("MyError", { ... }) {}
+
+// Resource
+Effect.acquireRelease(acquire, release)
+```
+
+## ANTI-PATTERNS
+
+- **NEVER import from `internal/`** - blocked at package level
+- **NEVER use `any`** - type safety enforced
+- **NEVER use non-null assertion (`!`)** - model optionality properly
+- **NEVER use `as Type`** - use Schema/refinements
+- **NEVER use `Array.push(...spread)`** - ESLint error
+- **NEVER mutate** - all data structures immutable by default
+- **NEVER throw** - use Effect error channel
+
+## DEPRECATED
+
+- `packages/effect/src/Secret.ts` - Multiple methods deprecated
+- Check `@deprecated` JSDoc before using any API
+
+## COMMANDS
+
+```bash
+# Development
+pnpm check              # Type check all packages
+pnpm test               # Run vitest
+pnpm lint               # ESLint
+pnpm lint-fix           # Auto-fix
+
+# Build
+pnpm build              # Full build (tsc + babel)
+pnpm codegen            # Generate code
+
+# Validation
+pnpm circular           # Check circular deps
+pnpm test-types         # tstyche type tests
+
+# Release
+pnpm changeset-version  # Bump versions
+pnpm changeset-publish  # Build + test + publish
+```
+
+## TESTING
+
+```typescript
+import { describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("MyFeature", () => {
+  it.effect("description", () =>
+    Effect.gen(function* () {
+      // TestClock, TestServices available
+    })
+  )
+
+  it.live("real IO", () =>
+    Effect.gen(function* () {
+      // No test services
+    })
+  )
+
+  it.scoped("with scope", () =>
+    Effect.gen(function* () {
+      // Automatic scope management
+    })
+  )
+})
+```
+
+**Assertions**: `deepStrictEqual`, `strictEqual` from `@effect/vitest/utils`
+
+## NOTES
+
+- **pnpm only** - strict package manager
+- **ESM-first** - `type: "module"` in all packages
+- **TS 5.4+** - Uses latest features
+- **Bun tests disabled** - See check.yml:49 comment
+- **Nested AI workspace** - `packages/ai/*` has 6 sub-packages
+- **`.index.ts` files** - Internal index re-exports (dot prefix)

--- a/packages/ai/AGENTS.md
+++ b/packages/ai/AGENTS.md
@@ -1,0 +1,76 @@
+# EFFECT AI
+
+## OVERVIEW
+
+Type-safe AI provider integrations. Nested workspace with 6 sub-packages.
+
+## STRUCTURE
+
+```
+ai/
+├── ai/              # Core abstractions (AiModel, AiToolkit)
+├── openai/          # OpenAI provider
+├── anthropic/       # Anthropic provider
+├── google/          # Google AI provider
+├── amazon-bedrock/  # AWS Bedrock provider
+└── openrouter/      # OpenRouter provider
+```
+
+## WHERE TO LOOK
+
+| Task              | Location                           | Notes                       |
+| ----------------- | ---------------------------------- | --------------------------- |
+| Model abstraction | `ai/src/AiModel.ts`                | Provider-agnostic interface |
+| Tool definitions  | `ai/src/AiToolkit.ts`              | Schema-based tools          |
+| Embeddings        | `ai/src/EmbeddingModel.ts`         | Vector embeddings           |
+| OpenAI impl       | `openai/src/OpenAiClient.ts`       | GPT models                  |
+| Anthropic impl    | `anthropic/src/AnthropicClient.ts` | Claude models               |
+
+## CONVENTIONS
+
+### Provider Pattern
+
+```typescript
+// Provider-specific client
+const client = yield * OpenAiClient.OpenAiClient
+
+// Use via abstract interface
+const response = yield * AiModel.generate(model, prompt)
+```
+
+### Tool Definition
+
+```typescript
+const myTool = AiToolkit.make({
+  name: "search",
+  description: "Search the web",
+  parameters: Schema.Struct({ query: Schema.String }),
+  execute: ({ query }) => Effect.succeed(results)
+})
+```
+
+### Streaming
+
+```typescript
+const stream = AiModel.stream(model, prompt)
+yield* Stream.runForEach(stream, (chunk) => ...)
+```
+
+## GENERATED FILES
+
+Large `Generated.ts` files in each provider (7k-22k LOC):
+
+- Auto-generated type-safe API clients
+- Do not edit manually
+
+## ANTI-PATTERNS
+
+- **Never hardcode provider** - Use AiModel abstraction
+- **Never edit Generated.ts** - Regenerate from spec
+
+## NOTES
+
+- Nested workspace: `packages/ai/*` has own pnpm-workspace.yaml
+- EmbeddingModel supports batched requests via RequestResolver
+- Streaming responses use Effect Stream
+- All providers return Effect types

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,0 +1,79 @@
+# EFFECT CLI
+
+## OVERVIEW
+
+Type-safe CLI framework with commands, options, args, and prompts.
+
+## STRUCTURE
+
+```
+cli/
+├── src/
+│   ├── Command.ts       # Command definitions
+│   ├── Options.ts       # Flag/option parsing
+│   ├── Args.ts          # Positional arguments
+│   ├── Prompt.ts        # Interactive prompts
+│   └── internal/
+│       └── prompt/      # Prompt implementations
+└── test/
+```
+
+## WHERE TO LOOK
+
+| Task            | Location     | Notes                              |
+| --------------- | ------------ | ---------------------------------- |
+| Define commands | `Command.ts` | Command.make, Command.run          |
+| Parse flags     | `Options.ts` | Options.text, Options.boolean, etc |
+| Positional args | `Args.ts`    | Args.text, Args.file, etc          |
+| User prompts    | `Prompt.ts`  | Prompt.text, Prompt.confirm        |
+| Help generation | `HelpDoc.ts` | Auto-generated help                |
+
+## CONVENTIONS
+
+### Command Definition
+
+```typescript
+const cli = Command.make("myapp", {
+  version: Options.boolean("version").pipe(Options.withAlias("v")),
+  config: Options.file("config").pipe(Options.optional)
+}).pipe(
+  Command.withHandler(({ version, config }) =>
+    Effect.gen(function* () {
+      if (version) return yield* Console.log("1.0.0")
+      // ...
+    })
+  )
+)
+```
+
+### Subcommands
+
+```typescript
+const main = Command.make("app").pipe(
+  Command.withSubcommands([
+    Command.make("init", { ... }),
+    Command.make("build", { ... })
+  ])
+)
+```
+
+### Running
+
+```typescript
+Command.run(cli, {
+  name: "myapp",
+  version: "1.0.0"
+})
+```
+
+## ANTI-PATTERNS
+
+- **Never use process.argv directly** - Use Args/Options
+- **Never console.log** - Use Console service
+
+## NOTES
+
+- Options/Args use Schema for validation
+- Help text auto-generated from definitions
+- Prompts work with Terminal service
+- Completions can be generated for bash/zsh/fish

--- a/packages/effect/AGENTS.md
+++ b/packages/effect/AGENTS.md
@@ -1,0 +1,107 @@
+# EFFECT CORE PACKAGE
+
+## OVERVIEW
+
+Core Effect library: typed computations, streams, schema validation, dependency injection.
+
+## STRUCTURE
+
+```
+effect/
+├── src/
+│   ├── *.ts             # Public API (~140 modules)
+│   ├── internal/        # Implementation (never import)
+│   │   ├── opCodes/     # Discriminated union tags
+│   │   ├── stm/         # STM implementation
+│   │   └── ...
+│   └── .index.ts        # Internal re-exports
+├── test/                # Vitest tests
+└── dtslint/             # Type-level tests (tstyche)
+```
+
+## WHERE TO LOOK
+
+| Task              | Location                               | Notes                          |
+| ----------------- | -------------------------------------- | ------------------------------ |
+| Main Effect type  | `src/Effect.ts`                        | 14k LOC, all Effect operations |
+| Stream operations | `src/Stream.ts` + `internal/stream.ts` | Pull-based streaming           |
+| Schema validation | `src/Schema.ts` + `src/SchemaAST.ts`   | Bidirectional codecs           |
+| Fiber runtime     | `internal/fiberRuntime.ts`             | Execution engine               |
+| STM primitives    | `internal/stm/*.ts`                    | TRef, TQueue, TMap, etc        |
+
+## CORE TYPES
+
+```typescript
+Effect<A, E, R> // Success A, Error E, Context R
+Stream<A, E, R> // Pull-based lazy stream
+Schema<A, I, R> // Type A, Encoded I, Context R
+Layer<ROut, E, RIn> // Dependency construction
+Context<R> // Type-safe service container
+```
+
+## CONVENTIONS
+
+### Variance Markers
+
+```typescript
+readonly _A: Types.Covariant<A>
+readonly _E: Types.Covariant<E>
+readonly _R: Types.Contravariant<R>
+```
+
+### TypeId Pattern
+
+```typescript
+export const TypeId: unique symbol = Symbol.for("effect/MyType")
+export type TypeId = typeof TypeId
+```
+
+### Generator Protocol
+
+All Effect types implement `[Symbol.iterator]` for `Effect.gen`:
+
+```typescript
+Effect.gen(function* () {
+  const a = yield* someEffect
+  const b = yield* anotherEffect
+  return a + b
+})
+```
+
+## ANTI-PATTERNS
+
+- **No direct internal imports** - Use public re-exports only
+- **No `any`/`as`/`!`** - Type safety is paramount
+- **No throwing** - Return errors in Effect channel
+- **No mutation** - All data structures immutable
+
+## LARGE FILES
+
+| File                       | LOC    | Purpose                   |
+| -------------------------- | ------ | ------------------------- |
+| `Effect.ts`                | 14,809 | Core computation type     |
+| `Schema.ts`                | 10,914 | Validation/codec system   |
+| `internal/stream.ts`       | 8,801  | Stream implementation     |
+| `Micro.ts`                 | 4,405  | Lightweight Effect subset |
+| `internal/fiberRuntime.ts` | 3,842  | Fiber execution engine    |
+
+## TESTING
+
+```typescript
+import { it, describe } from "@effect/vitest"
+import { Effect, TestClock } from "effect"
+
+it.effect("uses TestClock", () =>
+  Effect.gen(function* () {
+    yield* TestClock.adjust("1 second")
+    // assertions
+  })
+)
+```
+
+## NOTES
+
+- `Micro` is subset of Effect for smaller bundles
+- `Channel` is primitive underlying Stream/Sink
+- `Cause` preserves full error trace (never loses info)
+- `FiberRef` is fiber-local storage (like ThreadLocal)

--- a/packages/effect/src/internal/AGENTS.md
+++ b/packages/effect/src/internal/AGENTS.md
@@ -1,0 +1,87 @@
+# EFFECT INTERNAL
+
+## OVERVIEW
+
+Implementation details for Effect core. Never import directly - use public API.
+
+## STRUCTURE
+
+```
+internal/
+├── opCodes/         # OP_* discriminator constants
+│   ├── effect.ts    # Effect instruction opcodes
+│   ├── cause.ts     # Cause variants
+│   ├── channel.ts   # Channel primitives
+│   └── ...
+├── stm/             # Software Transactional Memory
+│   ├── tRef.ts      # Transactional refs
+│   ├── tQueue.ts    # Transactional queues
+│   ├── tMap.ts      # Transactional maps
+│   └── opCodes/     # STM opcodes
+├── stream/          # Stream implementation
+│   ├── handoff.ts   # Sync coordination
+│   ├── pull.ts      # Pull protocol
+│   └── emit.ts      # Emission facade
+├── differ/          # Patch types
+│   ├── *Patch.ts    # chunkPatch, contextPatch, etc
+└── schema/          # Schema internals
+```
+
+## CONVENTIONS
+
+### OpCode Pattern
+
+```typescript
+// Definition (opCodes/*.ts)
+export const OP_SUCCESS = "Success" as const
+export type OP_SUCCESS = typeof OP_SUCCESS
+
+// Usage (implementation files)
+interface Success<A> {
+  readonly _tag: OP_SUCCESS
+  readonly value: A
+}
+```
+
+### STM Naming
+
+- `t` prefix: `tRef`, `tQueue`, `tMap`, `tArray`, `tSet`
+- 13 transactional data structures
+
+### State Machine Files
+
+- `*State.ts` suffix: `channelState`, `stmState`, `debounceState`
+- `*Signal.ts` suffix: `handoffSignal`
+- `*Reason.ts` suffix: `sinkEndReason`
+
+### Patch Pattern (Differ)
+
+```typescript
+// All patches implement:
+empty: Patch<Value, Patch>
+combine: (self: Patch, that: Patch) => Patch
+diff: (oldValue: Value, newValue: Value) => Patch
+patch: (patch: Patch, oldValue: Value) => Value
+```
+
+## KEY FILES
+
+| File              | LOC   | Purpose                        |
+| ----------------- | ----- | ------------------------------ |
+| `fiberRuntime.ts` | 3,842 | Fiber execution + trampolining |
+| `core.ts`         | 3,166 | Core primitives                |
+| `stream.ts`       | 8,801 | Stream implementation          |
+| `circular.ts`     | 895   | Breaks import cycles           |
+
+## ANTI-PATTERNS
+
+- **Never export from internal** - Package.json blocks `./internal/*`
+- **All exports marked `@internal`** - JSDoc annotation required
+- **OpCodes in separate files** - Keep constants isolated
+
+## NOTES
+
+- `circular.ts` exists to break import cycles
+- Handoff is sync Queue-like coordination primitive
+- FiberRuntime uses trampolining for stack safety
+- All 185 files use `/** @internal */` JSDoc

--- a/packages/platform/AGENTS.md
+++ b/packages/platform/AGENTS.md
@@ -1,0 +1,83 @@
+# EFFECT PLATFORM
+
+## OVERVIEW
+
+Runtime-agnostic abstractions for IO: filesystem, HTTP, workers, processes.
+
+## STRUCTURE
+
+```
+platform/
+├── src/
+│   ├── *.ts           # Public interfaces (Context.Tags)
+│   └── internal/      # Default implementations
+├── platform-node/     # Node.js runtime
+├── platform-bun/      # Bun runtime
+├── platform-browser/  # Browser runtime
+└── platform-node-shared/ # Shared Node/Bun code
+```
+
+## WHERE TO LOOK
+
+| Task            | Location                         | Notes                      |
+| --------------- | -------------------------------- | -------------------------- |
+| File operations | `FileSystem.ts`                  | read, write, stream, watch |
+| HTTP client     | `HttpClient.ts`                  | fetch-like API             |
+| HTTP server     | `HttpServer.ts`, `HttpRouter.ts` | Server abstractions        |
+| Process spawn   | `CommandExecutor.ts`             | Run external commands      |
+| Workers         | `Worker.ts`, `WorkerRunner.ts`   | Thread abstraction         |
+| Sockets         | `Socket.ts`                      | TCP/WebSocket              |
+
+## RUNTIME IMPLEMENTATIONS
+
+| Abstraction   | Node.js                | Bun                      |
+| ------------- | ---------------------- | ------------------------ |
+| HTTP Server   | `node:http` + adapters | `Bun.serve()` native     |
+| HTTP Client   | `http.request`/undici  | fetch API                |
+| File Response | `fs.createReadStream`  | `Bun.file()` (zero-copy) |
+| Workers       | `worker_threads`       | Web Workers              |
+| WebSockets    | `ws` package           | Built-in                 |
+
+## CONVENTIONS
+
+### Service Pattern
+
+```typescript
+// Interface via Context.Tag
+class FileSystem extends Context.Tag("@effect/platform/FileSystem")<
+  FileSystem,
+  FileSystem.FileSystem
+>() {}
+
+// Runtime-specific Layer
+const NodeFileSystem = Layer.succeed(FileSystem, nodeImpl)
+```
+
+### Error Types
+
+```typescript
+class SystemError extends Schema.TaggedError<SystemError>()(
+  "SystemError",
+  { reason: Schema.String, ... }
+) {}
+```
+
+### FiberRef Config
+
+```typescript
+// Request-scoped configuration
+const currentTracerConfig = FiberRef.unsafeMake<TracerConfig>(default)
+```
+
+## ANTI-PATTERNS
+
+- **Never hardcode runtime** - Use platform abstractions
+- **Never import platform-node in shared code** - Check Context.Tag
+- **No raw fetch/fs** - Use HttpClient/FileSystem services
+
+## NOTES
+
+- `platform-node-shared` reused by both Node and Bun
+- Bun uses Node compat for FileSystem, native for HTTP
+- All platform types are Effect-native (return Effect)
+- Use `Layer.provide` to inject runtime at app boundary

--- a/packages/sql/AGENTS.md
+++ b/packages/sql/AGENTS.md
@@ -1,0 +1,96 @@
+# EFFECT SQL
+
+## OVERVIEW
+
+Type-safe SQL with dialect abstraction. Base package + 13 driver implementations.
+
+## STRUCTURE
+
+```
+sql/                  # Base abstractions
+sql-pg/               # PostgreSQL (pg)
+sql-mysql2/           # MySQL (mysql2)
+sql-mssql/            # SQL Server (tedious)
+sql-sqlite-node/      # SQLite (better-sqlite3)
+sql-sqlite-bun/       # SQLite (Bun native)
+sql-sqlite-wasm/      # SQLite (WASM)
+sql-libsql/           # LibSQL/Turso
+sql-clickhouse/       # ClickHouse
+sql-d1/               # Cloudflare D1
+sql-drizzle/          # Drizzle ORM adapter
+sql-kysely/           # Kysely adapter
+```
+
+## WHERE TO LOOK
+
+| Task               | Location                 | Notes                        |
+| ------------------ | ------------------------ | ---------------------------- |
+| Query building     | `sql/src/Statement.ts`   | Template literal API         |
+| Client interface   | `sql/src/SqlClient.ts`   | execute, stream, transaction |
+| Migrations         | `sql/src/Migrator.ts`    | Forward-only migrations      |
+| Batching           | `sql/src/SqlResolver.ts` | Request/resolver pattern     |
+| Schema integration | `sql/src/SqlSchema.ts`   | Type-safe queries            |
+
+## CONVENTIONS
+
+### Template Literal API
+
+```typescript
+import { sql } from "@effect/sql"
+
+// Safe interpolation (parameterized)
+const query = sql`SELECT * FROM users WHERE id = ${userId}`
+
+// Identifier (table/column names)
+const table = sql.identifier("users")
+
+// Unsafe (raw SQL - use sparingly)
+const raw = sql.unsafe("DROP TABLE users")
+```
+
+### Helpers
+
+```typescript
+sql.in([1, 2, 3]) // IN (?, ?, ?)
+sql.insert({ name, age }) // INSERT helper
+sql.update({ name }) // UPDATE helper
+sql.and([cond1, cond2]) // AND conditions
+sql.or([cond1, cond2]) // OR conditions
+```
+
+### Transaction Pattern
+
+```typescript
+yield *
+  SqlClient.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`INSERT INTO ...`
+      yield* sql`UPDATE ...`
+      // Auto-commit on success, rollback on error
+    })
+  )
+```
+
+### Dialect-Specific
+
+```typescript
+sql.onDialect({
+  pg: () => sql`... RETURNING *`,
+  mysql: () => sql`...`,
+  _: () => sql`...` // fallback
+})
+```
+
+## ANTI-PATTERNS
+
+- **Never string concat SQL** - Use template literals
+- **Never skip transactions** - Use `withTransaction`
+- **No raw driver access** - Use SqlClient abstraction
+
+## NOTES
+
+- Nested transactions use savepoints
+- `SqlResolver` solves N+1 queries via batching
+- Row transforms: camelCase ↔ snake_case at boundary
+- Streaming only on PG (cursor) and MySQL (stream)
+- SQLite uses semaphore for connection serialization


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` files throughout the monorepo to provide context for AI coding assistants (Cursor, Claude, Copilot, etc).

## Changes

- Root `AGENTS.md` - monorepo overview, structure, conventions, commands
- `packages/effect/AGENTS.md` - core package types and patterns
- `packages/effect/src/internal/AGENTS.md` - internal implementation guidance
- `packages/platform/AGENTS.md` - runtime abstraction patterns
- `packages/sql/AGENTS.md` - SQL package usage
- `packages/cli/AGENTS.md` - CLI framework patterns
- `packages/ai/AGENTS.md` - AI provider integrations

These files help AI assistants understand Effect conventions, anti-patterns, and where to look for specific functionality.