### PR TITLE
Pass metadata into toolPart to allow multi step tool calls for @effect/ai-google

### DIFF
--- a/packages/ai/ai/src/Prompt.ts
+++ b/packages/ai/ai/src/Prompt.ts
@@ -1629,7 +1629,8 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           id: part.id,
           name: part.providerName ?? part.name,
           params: part.params,
-          providerExecuted: part.providerExecuted ?? false
+          providerExecuted: part.providerExecuted ?? false,
+          options: part.metadata
         }))
         break
       }
@@ -1641,7 +1642,8 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           name: part.providerName ?? part.name,
           isFailure: part.isFailure,
           result: part.encodedResult,
-          providerExecuted: part.providerExecuted ?? false
+          providerExecuted: part.providerExecuted ?? false,
+          options: part.metadata
         })
         if (part.providerExecuted) {
           assistantParts.push(toolPart)


### PR DESCRIPTION
…

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Prompt.fromResponseParts doesn't copy metadata to options when converting Response.ToolCallPart and Response.ToolResultPart to prompt parts.
This breaks multi-turn tool calls with Google's Gemini API, which requires thoughtSignature (stored in metadata.google.thoughtSignature) to be present in follow-up requests. Without this fix, Gemini returns a 400 error: "Function call is missing a thought_signature in functionCall parts."
The fix adds options: part.metadata when creating tool-call and tool-result parts in fromResponseParts.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #5954 
