### PR TITLE
fix(cluster): use layerProtocolHttpRouter in HttpRunner

### DIFF
--- a/.changeset/gentle-planets-yawn.md
+++ b/.changeset/gentle-planets-yawn.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Fix `layerHttpOptions` and `layerWebsocketOptions` to use `layerProtocolHttpRouter` and `layerProtocolWebsocketRouter` instead of `layerProtocolHttp` and `layerProtocolWebsocket`, which were creating their own internal routers instead of using the router from context. This caused 404 errors for RPC routes when using `HttpRunner.layerHttp`.

--- a/packages/cluster/src/HttpRunner.ts
+++ b/packages/cluster/src/HttpRunner.ts
@@ -172,7 +172,7 @@ export const layerHttpOptions = (options: {
   | HttpRouter.HttpRouter
 > =>
   RunnerServer.layerWithClients.pipe(
-    Layer.provide(RpcServer.layerProtocolHttp(options))
+    Layer.provide(RpcServer.layerProtocolHttpRouter(options))
   )
 
 /**
@@ -193,7 +193,7 @@ export const layerWebsocketOptions = (options: {
   | HttpRouter.HttpRouter
 > =>
   RunnerServer.layerWithClients.pipe(
-    Layer.provide(RpcServer.layerProtocolWebsocket(options))
+    Layer.provide(RpcServer.layerProtocolWebsocketRouter(options))
   )
 
 /**


### PR DESCRIPTION
layerHttpOptions and layerWebsocketOptions were using layerProtocolHttp and layerProtocolWebsocket which create their own internal routers via routerTag.Live, ignoring the router from HttpLayerRouter.serve. This caused RPC routes to not be registered on the served router, resulting in 404 errors for inter-runner communication.

The fix is to use layerProtocolHttpRouter and layerProtocolWebsocketRouter which properly use the router from context.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #5918
- Closes #5918
