### PR TITLE
fix(platform): return 499 instead of 503 when client disconnects during nested fiber execution

### DIFF
--- a/.changeset/fix-http-server-client-abort.md
+++ b/.changeset/fix-http-server-client-abort.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform": patch
+---
+
+Fix HTTP server returning 503 instead of 499 when client disconnects during nested fiber execution
+
+When a client disconnects and the request handler has child fibers (e.g., outbound HTTP calls), the server would incorrectly return 503 (Service Unavailable) instead of 499 (Client Closed Request). This happened because `causeResponse` only checked if the first interrupt in the cause tree was from `clientAbortFiberId`, but child fibers are interrupted by their parent's fiber ID. The fix now checks if `clientAbortFiberId` exists anywhere in the cause's interruptors.


### PR DESCRIPTION
## Summary

Fixes #5968

- Fix `causeResponse` to pre-compute whether `clientAbortFiberId` exists anywhere in the cause tree before traversing individual interrupt nodes
- When a client disconnects and the cause tree contains multiple interrupt entries, the server now correctly returns 499 instead of 503

## The Bug

In `causeResponse`, the original code checked `cause.fiberId === clientAbortFiberId` on each interrupt node during `Cause.reduce` traversal. This fails when the cause tree has a structure like:

```
Sequential(Interrupt(parentFiberId), Interrupt(clientAbortFiberId))
```

Because `Cause.reduce` visits the left branch first, it encounters `parentFiberId` before `clientAbortFiberId` and incorrectly returns 503.

## The Fix

Pre-compute whether `clientAbortFiberId` exists anywhere in the cause tree using `Cause.interruptors()` before entering the reduce loop:

```ts
const isClientAbort = HashSet.has(Cause.interruptors(cause), clientAbortFiberId)
```

Then use this flag when handling interrupt nodes instead of checking the individual node's fiber ID.

## Test

The test constructs a synthetic cause that mimics the problematic structure:

```ts
const parentFiberId = yield* Effect.fiberId
const childInterrupt = Cause.interrupt(parentFiberId)
const clientAbortInterrupt = Cause.interrupt(HttpServerError.clientAbortFiberId)
const cause = Cause.sequential(childInterrupt, clientAbortInterrupt)
const [response] = yield* HttpServerError.causeResponse(cause)
expect(response.status).toEqual(499)
```

Note: Effect's runtime properly propagates interrupt IDs to child fibers, so real HTTP tests with nested fibers don't reproduce this specific cause structure. The synthetic test directly exercises `causeResponse` with the problematic cause tree.