### PR TITLE
fix(cli): fix Prompt.select clear when descriptions wrap

### DIFF
--- a/.changeset/fix-select-prompt-clear.md
+++ b/.changeset/fix-select-prompt-clear.md
@@ -1,0 +1,7 @@
+---
+"@effect/cli": patch
+---
+
+Fix `Prompt.select` rendering issue when choice descriptions cause terminal line wrapping.
+
+The `handleClear` function now correctly calculates the number of terminal rows to erase by accounting for the actual rendered content length of each choice, including descriptions that are only shown for the selected item.


### PR DESCRIPTION
## Summary

Fixes #5978

When using `Prompt.select` with choices that have long descriptions, navigating between options causes duplicate prompt lines to appear instead of updating in place. This happens because `handleClear` doesn't account for terminal line wrapping.

## Changes

- Modified `handleClear` in `select.ts` to calculate actual rendered line lengths
- Pass `state` to `handleClear` to determine which choice has its description displayed
- Calculate wrapped lines using actual content (`prefix + title + description`) instead of empty newlines

## Root Cause

The previous implementation used:
```ts
const text = "\n".repeat(Math.min(options.choices.length, options.maxPerPage)) + options.message
```

This assumes each choice takes exactly 1 terminal row. However:
1. Choices render as `prefix (2 chars) + title + description`
2. Descriptions are only shown for the **selected** item
3. When `content length > terminal width`, the line wraps to multiple rows

The fix calculates actual content length per choice to properly determine rows to erase.

## Testing

Tested locally with long descriptions in a narrow terminal - navigation now updates cleanly without leaving artifacts.