### PR TITLE
fix(@effect/vitest): fix compatibility with Vitest 4.0 (#5976)

### DIFF
--- a/.changeset/fix-vitest-4-compatibility.md
+++ b/.changeset/fix-vitest-4-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Fix compatibility with Vitest 4.0 by switching to the top-level onTestFinished export.

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "effect": "workspace:^",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.0 || ^4.0.0"
   },
   "devDependencies": {
     "effect": "workspace:^",

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -29,7 +29,7 @@ const runPromise = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A,
   Effect.gen(function*() {
     const exitFiber = yield* Effect.fork(Effect.exit(effect))
 
-    ctx?.onTestFinished(() =>
+    V.onTestFinished(() =>
       Fiber.interrupt(exitFiber).pipe(
         Effect.asVoid,
         Effect.runPromise


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes an incompatibility with Vitest 4.0 in `@effect/vitest`.

Vitest 4.0 has removed (or changed) the `onTestFinished` method on the test context object, causing a `TypeError: ctx?.onTestFinished is not a function`.

The fix switches to using the top-level `onTestFinished` hook imported directly from `vitest`. This is the recommended approach in modern Vitest versions and is fully backward compatible with the current peer dependency (`vitest: ^3.2.0`), as this export has been available since Vitest 0.34.0.

Additionally, `@effect/vitest`'s `peerDependencies` have been updated to explicitly support Vitest 4.x.

## Related

- Closes #5976
