### PR TITLE
fix(platform): remove eager cluster exports from main index

### DIFF
--- a/.changeset/lazy-cluster-exports.md
+++ b/.changeset/lazy-cluster-exports.md
@@ -1,0 +1,21 @@
+---
+"@effect/platform-bun": patch
+"@effect/platform-node": patch
+---
+
+Remove eager exports of cluster modules from main index
+
+These modules depend on @effect/rpc and @effect/cluster which are optional peer
+dependencies. Eagerly exporting them from the main index causes import failures
+when users have mismatched versions of these optional dependencies, or when
+package managers resolve them to incompatible versions.
+
+Users who need clustering can still import directly:
+- `import * as BunClusterHttp from "@effect/platform-bun/BunClusterHttp"`
+- `import * as BunClusterSocket from "@effect/platform-bun/BunClusterSocket"`
+- `import * as NodeClusterHttp from "@effect/platform-node/NodeClusterHttp"`
+- `import * as NodeClusterSocket from "@effect/platform-node/NodeClusterSocket"`
+
+This prevents the common error where importing `{ BunHttpServer }` or
+`{ NodeHttpServer }` fails due to transitive dependency resolution issues
+with @effect/rpc.

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -1,16 +1,6 @@
 /**
  * @since 1.0.0
  */
-export * as BunClusterHttp from "./BunClusterHttp.js"
-
-/**
- * @since 1.0.0
- */
-export * as BunClusterSocket from "./BunClusterSocket.js"
-
-/**
- * @since 1.0.0
- */
 export * as BunCommandExecutor from "./BunCommandExecutor.js"
 
 /**

--- a/packages/platform-node/examples/cluster.ts
+++ b/packages/platform-node/examples/cluster.ts
@@ -1,5 +1,6 @@
 import { Entity, RunnerAddress, Singleton } from "@effect/cluster"
-import { NodeClusterSocket, NodeRuntime } from "@effect/platform-node"
+import * as NodeClusterSocket from "@effect/platform-node/NodeClusterSocket"
+import { NodeRuntime } from "@effect/platform-node"
 import { Rpc } from "@effect/rpc"
 import { Effect, Layer, Logger, LogLevel, Option, Schema } from "effect"
 

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -1,16 +1,6 @@
 /**
  * @since 1.0.0
  */
-export * as NodeClusterHttp from "./NodeClusterHttp.js"
-
-/**
- * @since 1.0.0
- */
-export * as NodeClusterSocket from "./NodeClusterSocket.js"
-
-/**
- * @since 1.0.0
- */
 export * as NodeCommandExecutor from "./NodeCommandExecutor.js"
 
 /**


### PR DESCRIPTION
## Summary

Remove eager exports of `BunClusterHttp`, `BunClusterSocket`, `NodeClusterHttp`, and `NodeClusterSocket` from the main package index to prevent import failures when users have mismatched versions of optional peer dependencies.

## Problem

When importing anything from `@effect/platform-bun` (e.g., `{ BunHttpServer }`), the main index eagerly loads cluster modules which depend on `@effect/rpc`. If the user has mismatched versions, this causes runtime errors like:

```
SyntaxError: Export named 'Msgpackr' not found in module '@effect/platform/MsgPack.js'
```

This happens because:
1. **Bun resolves peer deps to minimum satisfying version**: `^0.69.3` → `0.69.5`
2. **pnpm resolves to latest satisfying version**: `^0.69.3` → `0.72.1`
3. Older `@effect/rpc` versions import `{ Msgpackr }` from `@effect/platform/MsgPack` which no longer exists

## Solution

Remove cluster modules from the main index. Users who need clustering can import directly:
- `@effect/platform-bun/BunClusterHttp`
- `@effect/platform-bun/BunClusterSocket`
- `@effect/platform-node/NodeClusterHttp`
- `@effect/platform-node/NodeClusterSocket`

## Test plan

- [x] `pnpm check` passes for platform-bun
- [x] `pnpm check` passes for platform-node
- [x] Updated example in platform-node to use direct import

🤖 Generated with [Claude Code](https://claude.com/claude-code)