### PR TITLE
Add `Terminal` method for writing to stderr

### DIFF
--- a/.changeset/terminal-display-error.md
+++ b/.changeset/terminal-display-error.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform": patch
+"@effect/platform-node-shared": patch
+---
+
+Add `displayError` method to `Terminal` for writing to stderr.

--- a/packages/cli/test/services/MockTerminal.ts
+++ b/packages/cli/test/services/MockTerminal.ts
@@ -60,6 +60,8 @@ export const make = Effect.gen(function*() {
 
   const display: MockTerminal["display"] = (input) => Console.log(input)
 
+  const displayError: MockTerminal["displayError"] = (input) => Console.error(input)
+
   const readInput: MockTerminal["readInput"] = Effect.succeed(queue)
 
   return MockTerminal.of({
@@ -67,6 +69,7 @@ export const make = Effect.gen(function*() {
     rows: Effect.succeed(24),
     isTTY: Effect.succeed(true),
     display,
+    displayError,
     readInput,
     readLine: Effect.succeed(""),
     inputKey,

--- a/packages/platform-node-shared/test/Terminal.test.ts
+++ b/packages/platform-node-shared/test/Terminal.test.ts
@@ -1,12 +1,35 @@
 import * as NodeTerminal from "@effect/platform-node-shared/NodeTerminal"
 import * as Terminal from "@effect/platform/Terminal"
 import { describe, expect, it } from "@effect/vitest"
+import * as Chunk from "effect/Chunk"
 import * as Effect from "effect/Effect"
+import * as Ref from "effect/Ref"
 
 const runPromise = <E, A>(self: Effect.Effect<A, E, Terminal.Terminal>) =>
   Effect.runPromise(
     Effect.provide(self, NodeTerminal.layer)
   )
+
+const makeTestTerminal = Effect.gen(function*() {
+  const displayOutput = yield* Ref.make(Chunk.empty<string>())
+  const displayErrorOutput = yield* Ref.make(Chunk.empty<string>())
+
+  const terminal = Terminal.Terminal.of({
+    columns: Effect.succeed(80),
+    rows: Effect.succeed(24),
+    isTTY: Effect.succeed(true),
+    readInput: Effect.die("not implemented"),
+    readLine: Effect.die("not implemented"),
+    display: (text) => Ref.update(displayOutput, Chunk.append(text)),
+    displayError: (text) => Ref.update(displayErrorOutput, Chunk.append(text))
+  })
+
+  return {
+    terminal,
+    displayOutput,
+    displayErrorOutput
+  }
+})
 
 describe("Terminal", () => {
   it("columns", () =>
@@ -29,4 +52,26 @@ describe("Terminal", () => {
       const isTTY = yield* terminal.isTTY
       expect(typeof isTTY).toEqual("boolean")
     })))
+
+  it("display", () =>
+    Effect.gen(function*() {
+      const { displayOutput, terminal } = yield* makeTestTerminal
+
+      yield* terminal.display("hello")
+      yield* terminal.display("world")
+
+      const output = yield* Ref.get(displayOutput)
+      expect(Chunk.toArray(output)).toEqual(["hello", "world"])
+    }).pipe(Effect.runPromise))
+
+  it("displayError", () =>
+    Effect.gen(function*() {
+      const { displayErrorOutput, terminal } = yield* makeTestTerminal
+
+      yield* terminal.displayError("error1")
+      yield* terminal.displayError("error2")
+
+      const errors = yield* Ref.get(displayErrorOutput)
+      expect(Chunk.toArray(errors)).toEqual(["error1", "error2"])
+    }).pipe(Effect.runPromise))
 })

--- a/packages/platform/src/Terminal.ts
+++ b/packages/platform/src/Terminal.ts
@@ -42,6 +42,10 @@ export interface Terminal {
    * Displays text to the the default standard output.
    */
   readonly display: (text: string) => Effect<void, PlatformError>
+  /**
+   * Displays text to the the default standard error.
+   */
+  readonly displayError: (text: string) => Effect<void, PlatformError>
 }
 
 /**


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Sometimes you need to write to stderr for non-logging reasons. Gives us some symmetry with having Terminal methods for writing to stdout and stderr.
