### PR TITLE
Avoid invalid SQL queries when shardIds is empty

### DIFF
--- a/packages/cluster/src/SqlRunnerStorage.ts
+++ b/packages/cluster/src/SqlRunnerStorage.ts
@@ -440,14 +440,16 @@ export const make = Effect.fnUntraced(function*(options: {
   ).join(", ")
 
   const acquiredLocks = (address: string, shardIds: ReadonlyArray<string>) =>
-    sql<{ shard_id: string }>`
-      SELECT shard_id FROM ${sql(locksTable)}
-      WHERE address = ${address}
-      AND acquired_at >= ${lockExpiresAt}
-      AND shard_id IN ${stringLiteralArr(shardIds)}
-    `.values.pipe(
-      Effect.map((rows) => rows.map((row) => row[0] as string))
-    )
+    shardIds.length === 0
+      ? Effect.succeed([])
+      : sql<{ shard_id: string }>`
+        SELECT shard_id FROM ${sql(locksTable)}
+        WHERE address = ${address}
+        AND acquired_at >= ${lockExpiresAt}
+        AND shard_id IN ${stringLiteralArr(shardIds)}
+      `.values.pipe(
+        Effect.map((rows) => rows.map((row) => row[0] as string))
+      )
 
   const wrapString = sql.onDialectOrElse({
     mssql: () => (s: string) => `N'${s}'`,


### PR DESCRIPTION




<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I was seeing
```
"syntax error at or near \")\""
```

Due to a query like

```
UPDATE "effect_cluster_messages"
SET last_read = NULL
WHERE processed = FALSE
AND shard_id IN ()
```

The diff in this commit is smaller when viewed with the `-w` option.
