### PR TITLE
fix(Match): handle null/undefined in Match.tag and Match.tagStartsWith

### DIFF
--- a/.changeset/fix-match-tag-nullable.md
+++ b/.changeset/fix-match-tag-nullable.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+fix(Match): handle null/undefined in `Match.tag` and `Match.tagStartsWith`
+
+Added null checks to `discriminator` and `discriminatorStartsWith` predicates to prevent crashes when matching nullable union types.
+
+Fixes #6017

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -351,8 +351,8 @@ export const discriminator = <D extends string>(field: D) =>
   const f = pattern[pattern.length - 1]
   const values: Array<P> = pattern.slice(0, -1) as any
   const pred = values.length === 1
-    ? (_: any) => _[field] === values[0]
-    : (_: any) => values.includes(_[field])
+    ? (_: any) => _ != null && _[field] === values[0]
+    : (_: any) => _ != null && values.includes(_[field])
 
   return <I, F, A, Pr>(
     self: Matcher<I, F, R, A, Pr, Ret>
@@ -377,7 +377,7 @@ export const discriminatorStartsWith = <D extends string>(field: D) =>
   pattern: P,
   f: Fn
 ) => {
-  const pred = (_: any) => typeof _[field] === "string" && _[field].startsWith(pattern)
+  const pred = (_: any) => _ != null && typeof _[field] === "string" && _[field].startsWith(pattern)
 
   return <I, F, A, Pr>(
     self: Matcher<I, F, R, A, Pr, Ret>

--- a/packages/effect/test/Match.test.ts
+++ b/packages/effect/test/Match.test.ts
@@ -207,6 +207,36 @@ describe("Match", () => {
     doesNotThrow(() => match(undefined))
   })
 
+  it("Match.tag with nullable union", () => {
+    const match = M.type<{ _tag: "A" } | undefined>().pipe(
+      M.tag("A", () => "matched A"),
+      M.when(undefined, () => "matched undefined"),
+      M.exhaustive
+    )
+    strictEqual(match({ _tag: "A" }), "matched A")
+    strictEqual(match(undefined), "matched undefined")
+  })
+
+  it("Match.tag with null union", () => {
+    const match = M.type<{ _tag: "A" } | null>().pipe(
+      M.tag("A", () => "matched A"),
+      M.when(null, () => "matched null"),
+      M.exhaustive
+    )
+    strictEqual(match({ _tag: "A" }), "matched A")
+    strictEqual(match(null), "matched null")
+  })
+
+  it("Match.tagStartsWith with nullable union", () => {
+    const match = M.type<{ _tag: "A.B" } | undefined>().pipe(
+      M.tagStartsWith("A", () => "matched A prefix"),
+      M.when(undefined, () => "matched undefined"),
+      M.exhaustive
+    )
+    strictEqual(match({ _tag: "A.B" }), "matched A prefix")
+    strictEqual(match(undefined), "matched undefined")
+  })
+
   it("discriminator multiple", () => {
     const result = pipe(
       M.value(Either.right(0)),


### PR DESCRIPTION
## Summary

Fixes #6017

`Match.tag` and `Match.tagStartsWith` now correctly handle nullable union types instead of crashing with "Cannot read properties of undefined (reading '_tag')".

## Problem

When using `Match.tag` on a union type that includes `null` or `undefined`, the predicate would crash because it accessed `_[field]` without first checking if `_` is nullish:

```typescript
const value = undefined as ({_tag: "A"} | undefined)
const res = Match.value(value).pipe(
  Match.tag('A', () => 'matched A'),  // crashes!
  Match.when(undefined, () => 'matched undefined'),
  Match.exhaustive
)
```

## Solution

Add `_ != null &&` guard to the predicates in `discriminator` and `discriminatorStartsWith`, following the same pattern already used in `discriminators` (which powers `Match.tags`).

## Changes

- `packages/effect/src/internal/matcher.ts`: Add null checks to predicates
- `packages/effect/test/Match.test.ts`: Add test cases for nullable unions

## Testing

Added 3 test cases:
- `Match.tag` with `undefined` union
- `Match.tag` with `null` union  
- `Match.tagStartsWith` with `undefined` union

All 62 Match tests pass.