### PR TITLE
fix(HttpClient): backport retryTransient fixes from v4

### DIFF
--- a/.changeset/fix-retry-transient-status-codes.md
+++ b/.changeset/fix-retry-transient-status-codes.md
@@ -1,0 +1,11 @@
+---
+"@effect/platform": patch
+---
+
+Fix `retryTransient` to use correct transient status codes
+
+Changed `isTransientResponse` from `status >= 429` to an explicit allowlist (408, 429, 500, 502, 503, 504). This correctly excludes 501 (Not Implemented) and 505+ permanent errors, while including 408 (Request Timeout) which was previously missed.
+
+Also aligned response retry behavior with v4: the `while` predicate now only applies to error retries, not response retries. Response retries are determined solely by `isTransientResponse`. This matches the semantic intent since `while` is typed for errors, not responses.
+
+Fixes #5995

--- a/packages/platform/src/HttpClient.ts
+++ b/packages/platform/src/HttpClient.ts
@@ -534,7 +534,7 @@ export const retryTransient: {
   >(
     options: {
       readonly mode?: Mode | undefined
-      readonly while?: Predicate.Predicate<NoInfer<Input>>
+      readonly while?: Predicate.Predicate<NoInfer<E>>
       readonly schedule?: Schedule.Schedule<B, NoInfer<Input>, R1>
       readonly times?: number
     } | Schedule.Schedule<B, NoInfer<Input>, R1>
@@ -552,7 +552,7 @@ export const retryTransient: {
     self: HttpClient.With<E, R>,
     options: {
       readonly mode?: Mode | undefined
-      readonly while?: Predicate.Predicate<NoInfer<Input>>
+      readonly while?: Predicate.Predicate<NoInfer<E>>
       readonly schedule?: Schedule.Schedule<B, NoInfer<Input>, R1>
       readonly times?: number
     } | Schedule.Schedule<B, NoInfer<Input>, R1>


### PR DESCRIPTION
## Summary

Fixes #5995

`HttpClient.retryTransient` now correctly identifies transient HTTP status codes.

## Problem

The previous logic `response.status >= 429` was incorrect:
- **408 (Request Timeout)** was NOT retried (408 < 429) — should be transient
- **501 (Not Implemented)** WAS retried (501 >= 429) — should NOT be transient (permanent)
- **505+ codes** were all retried — most are permanent errors

## Solution

Changed `isTransientResponse` from a simple comparison to an explicit allowlist matching industry standards (axios-retry, got, ky):

```typescript
// Before
const isTransientResponse = (response) => response.status >= 429

// After
const isTransientResponse = (response) => {
  const status = response.status
  return (
    status === 408 || // Request Timeout
    status === 429 || // Too Many Requests
    status === 500 || // Internal Server Error
    status === 502 || // Bad Gateway
    status === 503 || // Service Unavailable
    status === 504    // Gateway Timeout
  )
}
```

## Changes

- `packages/platform/src/internal/httpClient.ts`: Fix `isTransientResponse` logic
- `packages/platform/test/HttpClient.test.ts`: Add 9 tests for transient/non-transient status codes

## Testing

Added tests verifying:
- ✅ 408, 429, 500, 502, 503, 504 ARE retried (3 attempts with `times: 2`)
- ✅ 200, 501, 505 are NOT retried (1 attempt)

All 21 HttpClient tests pass.

## Note

I also noticed the `while` predicate uses `AND` for responses but `OR` for errors (see my comment on #5995). Happy to address that in a follow-up PR if desired.