### PR TITLE
fix(platform): properly join URL paths in HttpClientRequest.appendUrl

### DIFF
--- a/.changeset/fix-append-url-path-joining.md
+++ b/.changeset/fix-append-url-path-joining.md
@@ -1,0 +1,19 @@
+---
+"@effect/platform": patch
+---
+
+Fix `HttpClientRequest.appendUrl` to properly join URL paths.
+
+Previously, `appendUrl` used simple string concatenation which could produce invalid URLs:
+```typescript
+// Before (broken):
+appendUrl("https://api.example.com/v1", "users")
+// Result: "https://api.example.com/v1users" (missing slash!)
+```
+
+Now it ensures proper path joining:
+```typescript
+// After (fixed):
+appendUrl("https://api.example.com/v1", "users")
+// Result: "https://api.example.com/v1/users"
+```

--- a/packages/platform/src/internal/httpClientRequest.ts
+++ b/packages/platform/src/internal/httpClientRequest.ts
@@ -250,17 +250,21 @@ export const setUrl = dual<
 export const appendUrl = dual<
   (path: string) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
   (self: ClientRequest.HttpClientRequest, path: string) => ClientRequest.HttpClientRequest
->(2, (self, url) =>
-  makeInternal(
+>(2, (self, path) => {
+  if (path === "") {
+    return self
+  }
+  const baseUrl = self.url.endsWith("/") ? self.url : self.url + "/"
+  const pathSegment = path.startsWith("/") ? path.slice(1) : path
+  return makeInternal(
     self.method,
-    self.url.endsWith("/") && url.startsWith("/") ?
-      self.url + url.slice(1) :
-      self.url + url,
+    baseUrl + pathSegment,
     self.urlParams,
     self.hash,
     self.headers,
     self.body
-  ))
+  )
+})
 
 /** @internal */
 export const prependUrl = dual<

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -202,6 +202,50 @@ describe("HttpClient", () => {
     )
   })
 
+  describe("appendUrl", () => {
+    it("joins path without trailing slash on base", () => {
+      const request = HttpClientRequest.get("https://api.example.com/v1").pipe(
+        HttpClientRequest.appendUrl("users")
+      )
+      strictEqual(request.url, "https://api.example.com/v1/users")
+    })
+
+    it("joins path with trailing slash on base", () => {
+      const request = HttpClientRequest.get("https://api.example.com/v1/").pipe(
+        HttpClientRequest.appendUrl("users")
+      )
+      strictEqual(request.url, "https://api.example.com/v1/users")
+    })
+
+    it("joins path with leading slash", () => {
+      const request = HttpClientRequest.get("https://api.example.com/v1").pipe(
+        HttpClientRequest.appendUrl("/users")
+      )
+      strictEqual(request.url, "https://api.example.com/v1/users")
+    })
+
+    it("joins path with both trailing and leading slashes", () => {
+      const request = HttpClientRequest.get("https://api.example.com/v1/").pipe(
+        HttpClientRequest.appendUrl("/users")
+      )
+      strictEqual(request.url, "https://api.example.com/v1/users")
+    })
+
+    it("joins nested paths", () => {
+      const request = HttpClientRequest.get("https://api.example.com/v1").pipe(
+        HttpClientRequest.appendUrl("users/123/posts")
+      )
+      strictEqual(request.url, "https://api.example.com/v1/users/123/posts")
+    })
+
+    it("handles empty path", () => {
+      const request = HttpClientRequest.get("https://api.example.com/v1").pipe(
+        HttpClientRequest.appendUrl("")
+      )
+      strictEqual(request.url, "https://api.example.com/v1")
+    })
+  })
+
   it.effect("matchStatus", () =>
     Effect.gen(function*() {
       const jp = yield* JsonPlaceholder


### PR DESCRIPTION
## Summary

Fixes `HttpClientRequest.appendUrl` to properly join URL paths instead of using simple string concatenation.

Closes #5971

## Problem

The current implementation could produce invalid URLs:
```typescript
// Before (broken):
HttpClientRequest.get("https://api.example.com/v1").pipe(
  HttpClientRequest.appendUrl("users")
)
// Result: "https://api.example.com/v1users" (missing slash!)
```

## Solution

Ensure proper path joining by:
1. Adding a trailing slash to base URL if missing
2. Removing leading slash from path if present

```typescript
// After (fixed):
HttpClientRequest.get("https://api.example.com/v1").pipe(
  HttpClientRequest.appendUrl("users")
)
// Result: "https://api.example.com/v1/users"
```

This matches the behavior of other HTTP client libraries like axios, got, and ky.

## Test Cases

| Base URL | Path | Result |
|----------|------|--------|
| `https://api.com/v1` | `users` | `https://api.com/v1/users` |
| `https://api.com/v1/` | `users` | `https://api.com/v1/users` |
| `https://api.com/v1` | `/users` | `https://api.com/v1/users` |
| `https://api.com/v1/` | `/users` | `https://api.com/v1/users` |

## Verification

- [x] Type check passes (`pnpm check`)
- [x] All tests pass (18/18 in HttpClient.test.ts)
- [x] Changeset added