### PR TITLE
fix(cli): fix Prompt.text clear when input wraps terminal lines

### DIFF
--- a/.changeset/fix-prompt-text-wrap.md
+++ b/.changeset/fix-prompt-text-wrap.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Fixed `Prompt.text` rendering duplicate lines when input text wraps to a new terminal line.

--- a/packages/cli/src/internal/prompt/text.ts
+++ b/packages/cli/src/internal/prompt/text.ts
@@ -49,7 +49,10 @@ function renderClearScreen(state: State, options: Options) {
         )
     })
     // Ensure that the prior prompt output is cleaned up
-    const clearOutput = InternalAnsiUtils.eraseText(options.message, columns)
+    // Calculate full rendered line: "? " + message + " › " + input
+    const inputValue = state.value.length > 0 ? state.value : options.default
+    const fullLine = `? ${options.message} \u203a ${inputValue}`
+    const clearOutput = InternalAnsiUtils.eraseText(fullLine, columns)
     // Concatenate and render all documents
     return clearError.pipe(
       Doc.cat(clearOutput),


### PR DESCRIPTION
## Summary

When the user's input in `Prompt.text` exceeds the terminal width and wraps to a new line, `renderClearScreen` miscalculates lines to erase because it only considers `options.message`, not the full rendered line including the input value.

This causes duplicate prompt lines to be printed on each keystroke after the text wraps:

```
? What would you like to say? › what do you propose to add to play around with? it can be
? What would you like to say? › what do you propose to add to play around with? it can be
? What would you like to say? › what do you propose to add to play around with? it can be
...
```

## Root Cause

In `renderClearScreen`, line erasure is calculated based only on `options.message`:

```typescript
const clearOutput = InternalAnsiUtils.eraseText(options.message, columns)
```

But the actual rendered line includes: `"? " + message + " › " + inputValue`

## Fix

Calculate the full rendered line length:

```typescript
const inputValue = state.value.length > 0 ? state.value : options.default
const fullLine = `? ${options.message} › ${inputValue}`
const clearOutput = InternalAnsiUtils.eraseText(fullLine, columns)
```

## Related

This is the same root cause as #5978 (for `Prompt.select`), and applies the equivalent fix from #5979 to `Prompt.text`.

Closes #5978