### PR TITLE
Fix `Stream.decodeText` to correctly handle multi-byte UTF-8 characters split across chunk boundaries.

### DIFF
--- a/.changeset/kind-mangos-heal.md
+++ b/.changeset/kind-mangos-heal.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.decodeText` to correctly handle multi-byte UTF-8 characters split across chunk boundaries.

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -8773,7 +8773,7 @@ export const decodeText = dual<
 >((args) => isStream(args[0]), (self, encoding = "utf-8") =>
   suspend(() => {
     const decoder = new TextDecoder(encoding)
-    return map(self, (s) => decoder.decode(s))
+    return map(self, (s) => decoder.decode(s, { stream: true }))
   }))
 
 /** @internal */

--- a/packages/effect/test/Stream/encoding.test.ts
+++ b/packages/effect/test/Stream/encoding.test.ts
@@ -22,4 +22,45 @@ describe("Stream", () => {
       )
       deepStrictEqual(Chunk.toReadonlyArray(decoded), items)
     }))
+
+  it.effect("decodeText handles multi-byte characters split across chunks", () =>
+    Effect.gen(function*() {
+      // 🌍 is U+1F30D — four UTF-8 bytes: [0xF0, 0x9F, 0x8C, 0x8D]
+      const bytes = new TextEncoder().encode("🌍")
+
+      // Split the bytes mid-character across two chunks
+      const stream = Stream.fromChunks(
+        Chunk.of(bytes.slice(0, 2)), // [0xF0, 0x9F]
+        Chunk.of(bytes.slice(2, 4)) // [0x8C, 0x8D]
+      )
+
+      const result = yield* pipe(
+        stream,
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      strictEqual(result, "🌍")
+    }))
+
+  it.effect("decodeText handles mixed ASCII and multi-byte characters across chunks", () =>
+    Effect.gen(function*() {
+      // "Hello 🌍!" encoded as UTF-8
+      const bytes = new TextEncoder().encode("Hello 🌍!")
+
+      // Split in the middle of the emoji (after "Hello " + first 2 bytes of emoji)
+      const splitPoint = 6 + 2 // "Hello " is 6 bytes, then 2 of 4 emoji bytes
+      const stream = Stream.fromChunks(
+        Chunk.of(bytes.slice(0, splitPoint)),
+        Chunk.of(bytes.slice(splitPoint))
+      )
+
+      const result = yield* pipe(
+        stream,
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      strictEqual(result, "Hello 🌍!")
+    }))
 })


### PR DESCRIPTION
See #6039 for more details.


<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Use `{ stream: true }` in `Stream.decodeText`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #6039 
