### PR TITLE
Add catchTagOrDie and catchTagsOrDie

### DIFF
--- a/.changeset/catch-tag-or-die.md
+++ b/.changeset/catch-tag-or-die.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add `catchTagOrDie` and `catchTagsOrDie` for handling specific tagged errors while converting unmatched errors into defects.


### PR DESCRIPTION
## Summary
- Add `catchTagOrDie` — catches specific tagged errors by `_tag`, converting unmatched errors into defects (die). Unlike `catchTag`, unhandled errors are removed from the error channel entirely.
- Add `catchTagsOrDie` — same semantics but accepts an object of handlers (like `catchTags`).
- Both support dual (data-first and data-last) calling conventions and variadic tag arguments (for `catchTagOrDie`).

## Motivation

A common pattern is catching one specific tagged error and re-mapping it, while treating all other errors as unexpected defects. The natural approach doesn't work:

```ts
declare const findUser: Effect<User, DbNotFound | DbUnknown>

findUser.pipe(
  Effect.catchTag("DbNotFound", () => new MyError({ message: "not found" })),
  Effect.orDie // also turns MyError into a defect!
)
```

`orDie` kills *all* errors — including the `MyError` that was just introduced by the handler. The only workaround today is a manual `catchAll` branch:

```ts
findUser.pipe(
  Effect.catchAll((e) =>
    e._tag === "DbNotFound"
      ? Effect.fail(new MyError({ message: "not found" }))
      : Effect.die(e)
  )
)
```

`catchTagOrDie` makes this a one-liner:

```ts
findUser.pipe(
  Effect.catchTagOrDie("DbNotFound", () =>
    Effect.fail(new MyError({ message: "not found" }))
  )
)
// Effect<User, MyError>
```