### PR TITLE
sqlite-bun query prep fail in Effect, not defect

### DIFF
--- a/.changeset/fix-sqlite-bun-query-prepare.md
+++ b/.changeset/fix-sqlite-bun-query-prepare.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-bun": patch
+---
+
+Wrap `db.query()` (prepare) errors in `SqlError` so they surface as catchable failures instead of defects.

--- a/packages/sql-sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql-sqlite-bun/src/SqliteClient.ts
@@ -104,10 +104,10 @@ export const make = (
       ) =>
         Effect.withFiberRuntime<Array<any>, SqlError>((fiber) => {
           const useSafeIntegers = Context.get(fiber.currentContext, Client.SafeIntegers)
-          const statement = db.query(sql)
-          // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
-          statement.safeIntegers(useSafeIntegers)
           try {
+            const statement = db.query(sql)
+            // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
+            statement.safeIntegers(useSafeIntegers)
             return Effect.succeed((statement.all(...(params as any)) ?? []) as Array<any>)
           } catch (cause) {
             return Effect.fail(new SqlError({ cause, message: "Failed to execute statement" }))
@@ -120,10 +120,10 @@ export const make = (
       ) =>
         Effect.withFiberRuntime<Array<any>, SqlError>((fiber) => {
           const useSafeIntegers = Context.get(fiber.currentContext, Client.SafeIntegers)
-          const statement = db.query(sql)
-          // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
-          statement.safeIntegers(useSafeIntegers)
           try {
+            const statement = db.query(sql)
+            // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
+            statement.safeIntegers(useSafeIntegers)
             return Effect.succeed((statement.values(...(params as any)) ?? []) as Array<any>)
           } catch (cause) {
             return Effect.fail(new SqlError({ cause, message: "Failed to execute statement" }))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Fix `@effect/sql-sqlite-bun` so prepare errors from `db.query` are returned as `SqlError` failures (catchable with `Effect.catchAll`) rather than fiber defects.

Repro snippet (before this change, the program dies instead of failing with `SqlError`):

```ts
import { Reactivity } from "@effect/experimental"
import { FileSystem } from "@effect/platform/FileSystem"
import { SqliteClient } from "@effect/sql-sqlite-bun"
import { Effect } from "effect"

const program = Effect.gen(function*() {
  const fs = yield* FileSystem
  const dir = yield* fs.makeTempDirectoryScoped()
  const sql = yield* SqliteClient.make({ filename: dir + "/test.db" })

  // Non-existent table triggers Bun's prepare error (db.query),
  // which *used to* surface as a defect (die), not a SqlError failure.
  yield* sql`SELECT * FROM non_existent_table`
}).pipe(
  Effect.scoped,
  Effect.provide([BunFileSystem.layer, Reactivity.layer]),
  // This should catch the SqlError after the fix.
  // Before the fix, this handler never ran because it died instead.
  Effect.catchAll((error) => Effect.succeed({ caught: true as const, error }))
)

Effect.runPromise(program).then(
  // After fix: { caught: true, error: SqlError }
  (result) => console.log(result),
  // Before fix: reject here (defect), not caught above.
  (err) => console.error("Died (not caught)", err)
)
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
