### PR TITLE
Fix the content-type in HttpServerResponse.json

### DIFF
--- a/.changeset/clever-banks-admire.md
+++ b/.changeset/clever-banks-admire.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix the content-type in HttpServerResponse.json

--- a/packages/platform/src/internal/httpBody.ts
+++ b/packages/platform/src/internal/httpBody.ts
@@ -114,12 +114,13 @@ export const text = (body: string, contentType?: string): Body.Uint8Array =>
   uint8Array(encoder.encode(body), contentType ?? "text/plain")
 
 /** @internal */
-export const unsafeJson = (body: unknown): Body.Uint8Array => text(JSON.stringify(body), "application/json")
+export const unsafeJson = (body: unknown, contentType?: string): Body.Uint8Array =>
+  text(JSON.stringify(body), contentType ?? "application/json")
 
 /** @internal */
-export const json = (body: unknown): Effect.Effect<Body.Uint8Array, Body.HttpBodyError> =>
+export const json = (body: unknown, contentType?: string): Effect.Effect<Body.Uint8Array, Body.HttpBodyError> =>
   Effect.try({
-    try: () => unsafeJson(body),
+    try: () => unsafeJson(body, contentType),
     catch: (error) => HttpBodyError({ _tag: "JsonError", error })
   })
 

--- a/packages/platform/src/internal/httpServerResponse.ts
+++ b/packages/platform/src/internal/httpServerResponse.ts
@@ -197,14 +197,20 @@ export const json = (
   body: unknown,
   options?: ServerResponse.Options.WithContent | undefined
 ): Effect.Effect<ServerResponse.HttpServerResponse, Body.HttpBodyError> =>
-  Effect.map(internalBody.json(body), (body) =>
-    new ServerResponseImpl(
-      options?.status ?? 200,
-      options?.statusText,
-      options?.headers ? Headers.fromInput(options.headers) : Headers.empty,
-      options?.cookies ?? Cookies.empty,
-      body
-    ))
+  Effect.map(
+    internalBody.json(
+      body,
+      getContentType(options, options?.headers ? Headers.fromInput(options.headers) : Headers.empty)
+    ),
+    (body) =>
+      new ServerResponseImpl(
+        options?.status ?? 200,
+        options?.statusText,
+        options?.headers ? Headers.fromInput(options.headers) : Headers.empty,
+        options?.cookies ?? Cookies.empty,
+        body
+      )
+  )
 
 /** @internal */
 export const unsafeJson = (

--- a/packages/platform/test/HttpServerResponse.test.ts
+++ b/packages/platform/test/HttpServerResponse.test.ts
@@ -1,0 +1,30 @@
+import * as HttpServerResponse from "@effect/platform/HttpServerResponse"
+import { describe, it } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import * as Effect from "effect/Effect"
+
+describe("json", () => {
+  it.effect("with a content-type", () =>
+    Effect.gen(function*() {
+      const response = yield* HttpServerResponse.json({}, {
+        contentType: "application/custom+json",
+        headers: { "content-type": "application/other+json" }
+      })
+
+      strictEqual(response.headers["content-type"], "application/custom+json")
+    }))
+
+  it.effect("with a content-type header", () =>
+    Effect.gen(function*() {
+      const response = yield* HttpServerResponse.json({}, { headers: { "content-type": "application/custom+json" } })
+
+      strictEqual(response.headers["content-type"], "application/custom+json")
+    }))
+
+  it.effect("without a content-type", () =>
+    Effect.gen(function*() {
+      const response = yield* HttpServerResponse.json({})
+
+      strictEqual(response.headers["content-type"], "application/json")
+    }))
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Just been caught out in production as `HttpServerResponse.json` doesn't make use of the `contentType` option (or even a header). This change fixes that.

(I was quite surprised to find _no_ tests related to `HttpServerResponse`.)

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- https://github.com/PREreview/coar-notify/commit/70753797dba9067dce106ee4a8e6065145cb58f1
- https://github.com/PREreview/coar-notify/commit/2d4b28d46da59146c20b205b218ee467ad4af75b
- https://github.com/PREreview/coar-notify/commit/7f68087783874156e0535f99e3197a8cdd7a7220
