### PR TITLE
Backport HttpBody/HttpServerResponse contentType improvements

### DIFF
--- a/.changeset/few-phones-joke.md
+++ b/.changeset/few-phones-joke.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Backport Effect 4 `contentType` support for `HttpBody` JSON / URL-encoded constructors and `HttpServerResponse` JSON / URL-encoded helpers.

--- a/packages/platform/src/HttpBody.ts
+++ b/packages/platform/src/HttpBody.ts
@@ -165,13 +165,13 @@ export const text: (body: string, contentType?: string) => Uint8Array = internal
  * @since 1.0.0
  * @category constructors
  */
-export const unsafeJson: (body: unknown) => Uint8Array = internal.unsafeJson
+export const unsafeJson: (body: unknown, contentType?: string) => Uint8Array = internal.unsafeJson
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const json: (body: unknown) => Effect.Effect<Uint8Array, HttpBodyError> = internal.json
+export const json: (body: unknown, contentType?: string) => Effect.Effect<Uint8Array, HttpBodyError> = internal.json
 
 /**
  * @since 1.0.0
@@ -179,13 +179,13 @@ export const json: (body: unknown) => Effect.Effect<Uint8Array, HttpBodyError> =
  */
 export const jsonSchema: <A, I, R>(
   schema: Schema.Schema<A, I, R>
-) => (body: A) => Effect.Effect<Uint8Array, HttpBodyError, R> = internal.jsonSchema
+) => (body: A, contentType?: string) => Effect.Effect<Uint8Array, HttpBodyError, R> = internal.jsonSchema
 
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const urlParams: (urlParams: UrlParams.UrlParams) => Uint8Array = internal.urlParams
+export const urlParams: (urlParams: UrlParams.UrlParams, contentType?: string) => Uint8Array = internal.urlParams
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/HttpServerResponse.ts
+++ b/packages/platform/src/HttpServerResponse.ts
@@ -142,8 +142,10 @@ export const json: (
 export const schemaJson: <A, I, R>(
   schema: Schema.Schema<A, I, R>,
   options?: ParseOptions | undefined
-) => (body: A, options?: Options.WithContent | undefined) => Effect.Effect<HttpServerResponse, Body.HttpBodyError, R> =
-  internal.schemaJson
+) => (
+  body: A,
+  options?: Options.WithContentType | undefined
+) => Effect.Effect<HttpServerResponse, Body.HttpBodyError, R> = internal.schemaJson
 
 /**
  * @since 1.0.0

--- a/packages/platform/src/internal/httpBody.ts
+++ b/packages/platform/src/internal/httpBody.ts
@@ -114,26 +114,27 @@ export const text = (body: string, contentType?: string): Body.Uint8Array =>
   uint8Array(encoder.encode(body), contentType ?? "text/plain")
 
 /** @internal */
-export const unsafeJson = (body: unknown): Body.Uint8Array => text(JSON.stringify(body), "application/json")
+export const unsafeJson = (body: unknown, contentType?: string): Body.Uint8Array =>
+  text(JSON.stringify(body), contentType ?? "application/json")
 
 /** @internal */
-export const json = (body: unknown): Effect.Effect<Body.Uint8Array, Body.HttpBodyError> =>
+export const json = (body: unknown, contentType?: string): Effect.Effect<Body.Uint8Array, Body.HttpBodyError> =>
   Effect.try({
-    try: () => unsafeJson(body),
+    try: () => unsafeJson(body, contentType),
     catch: (error) => HttpBodyError({ _tag: "JsonError", error })
   })
 
 /** @internal */
-export const urlParams = (urlParams: UrlParams.UrlParams): Body.Uint8Array =>
-  text(UrlParams.toString(urlParams), "application/x-www-form-urlencoded")
+export const urlParams = (urlParams: UrlParams.UrlParams, contentType?: string): Body.Uint8Array =>
+  text(UrlParams.toString(urlParams), contentType ?? "application/x-www-form-urlencoded")
 
 /** @internal */
 export const jsonSchema = <A, I, R>(schema: Schema.Schema<A, I, R>, options?: ParseOptions) => {
   const encode = Schema.encode(schema, options)
-  return (body: A): Effect.Effect<Body.Uint8Array, Body.HttpBodyError, R> =>
+  return (body: A, contentType?: string): Effect.Effect<Body.Uint8Array, Body.HttpBodyError, R> =>
     Effect.flatMap(
       Effect.mapError(encode(body), (error) => HttpBodyError({ _tag: "SchemaError", error })),
-      json
+      (body) => json(body, contentType)
     )
 }
 

--- a/packages/platform/test/HttpApp.test.ts
+++ b/packages/platform/test/HttpApp.test.ts
@@ -1,7 +1,7 @@
 import { HttpApp, HttpServerResponse } from "@effect/platform"
 import { describe, test } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Context, Effect, FiberRef, Runtime, Stream } from "effect"
+import { Context, Effect, FiberRef, Runtime, Schema, Stream } from "effect"
 import * as Layer from "effect/Layer"
 
 describe("Http/App", () => {
@@ -18,6 +18,38 @@ describe("Http/App", () => {
       const handler = HttpApp.toWebHandler(HttpServerResponse.json({ foo: "bar" }))
       const response = await handler(new Request("http://localhost:3000/"))
       strictEqual(response.headers.get("Content-Type"), "application/json")
+    })
+
+    test("json supports contentType option", async () => {
+      const handler = HttpApp.toWebHandler(
+        HttpServerResponse.json({ foo: "bar" }, { contentType: "application/problem+json" })
+      )
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "application/problem+json")
+    })
+
+    test("json supports content-type header", async () => {
+      const handler = HttpApp.toWebHandler(
+        HttpServerResponse.json({ foo: "bar" }, { headers: { "content-type": "application/vnd.api+json" } })
+      )
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "application/vnd.api+json")
+    })
+
+    test("schemaJson supports contentType option", async () => {
+      const encode = HttpServerResponse.schemaJson(Schema.Struct({ foo: Schema.String }))
+      const handler = HttpApp.toWebHandler(encode({ foo: "bar" }, { contentType: "application/merge-patch+json" }))
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "application/merge-patch+json")
+    })
+
+    test("urlParams supports contentType option", async () => {
+      const handler = HttpApp.toWebHandler(
+        HttpServerResponse.urlParams({ foo: "bar" }, { contentType: "text/plain" })
+      )
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "text/plain")
+      strictEqual(await response.text(), "foo=bar")
     })
 
     test("cookies", async () => {

--- a/packages/platform/test/HttpBody.test.ts
+++ b/packages/platform/test/HttpBody.test.ts
@@ -1,0 +1,27 @@
+import { HttpBody, UrlParams } from "@effect/platform"
+import { describe, test } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import { Effect, Schema } from "effect"
+
+describe("HttpBody", () => {
+  test("json supports contentType", async () => {
+    const body = await Effect.runPromise(HttpBody.json({ foo: "bar" }, "application/problem+json"))
+    strictEqual(body.contentType, "application/problem+json")
+  })
+
+  test("unsafeJson supports contentType", () => {
+    const body = HttpBody.unsafeJson({ foo: "bar" }, "application/vnd.api+json")
+    strictEqual(body.contentType, "application/vnd.api+json")
+  })
+
+  test("jsonSchema supports contentType", async () => {
+    const encode = HttpBody.jsonSchema(Schema.Struct({ foo: Schema.String }))
+    const body = await Effect.runPromise(encode({ foo: "bar" }, "application/merge-patch+json"))
+    strictEqual(body.contentType, "application/merge-patch+json")
+  })
+
+  test("urlParams supports contentType", () => {
+    const body = HttpBody.urlParams(UrlParams.fromInput({ foo: "bar" }), "text/plain")
+    strictEqual(body.contentType, "text/plain")
+  })
+})


### PR DESCRIPTION
## Summary
- Backport Effect 4 content-type behavior for `HttpBody` by adding optional `contentType` support to `json`, `unsafeJson`, `jsonSchema`, and `urlParams`.
- Update `HttpServerResponse` JSON and URL-encoded constructors to consistently derive content type from `options.contentType`, then `options.headers[\"content-type\"]`, then defaults.
- Add regression tests for custom content-type handling and include a patch changeset for `@effect/platform`.

## Validation
- `pnpm lint-fix`
- `pnpm test run packages/platform/test/HttpBody.test.ts packages/platform/test/HttpApp.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes #6046 