### PR TITLE
Add `Schema.requiredToOptionalOrFail` and refactor `VariantSchema.Overrideable`

### DIFF
--- a/.changeset/mighty-ads-heal.md
+++ b/.changeset/mighty-ads-heal.md
@@ -1,0 +1,8 @@
+---
+"@effect/experimental": minor
+"effect": minor
+---
+
+Add `Schema.requiredToOptionalOrFail`, an effectful version of `requiredToOptional` that allows decode/encode transformations to fail with `ParseIssue`.
+
+Refactor `VariantSchema.Overrideable` to use `requiredToOptionalOrFail`, making the property truly optional on the type side.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2290,6 +2290,41 @@ export const requiredToOptional = <FA, FI, FR, TA, TI, TR>(
   )
 
 /**
+ * Effectful version of `requiredToOptional`.
+ *
+ * Converts a required property to an optional property through effectful transformations.
+ *
+ * - `decode`: `none` as return value means the value will be missing in the output.
+ * - `encode`: `none` as argument means the value is missing in the input.
+ *
+ * @category PropertySignature
+ * @since 3.20.0
+ */
+export const requiredToOptionalOrFail = <FA, FI, FR, TA, TI, TR, RD, RE>(
+  from: Schema<FA, FI, FR>,
+  to: Schema<TA, TI, TR>,
+  options: {
+    readonly decode: (fa: FA) => Effect.Effect<option_.Option<TI>, ParseResult.ParseIssue, RD>
+    readonly encode: (o: option_.Option<TI>) => Effect.Effect<FA, ParseResult.ParseIssue, RE>
+  }
+): PropertySignature<"?:", TA, never, ":", FI, false, FR | TR | RD | RE> => {
+  const intermediate = transformOrFail(
+    from,
+    OptionFromSelf(encodedSchema(to)),
+    {
+      strict: true,
+      decode: (fa) => options.decode(fa),
+      encode: (o) => options.encode(o)
+    }
+  )
+  return requiredToOptional(
+    intermediate,
+    to,
+    { decode: identity, encode: identity }
+  )
+}
+
+/**
  * Converts an optional property to another optional property through a transformation `Option -> Option`.
  *
  * - `decode`:

--- a/packages/effect/test/Schema/Schema/requiredToOptionalOrFail.test.ts
+++ b/packages/effect/test/Schema/Schema/requiredToOptionalOrFail.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import * as ParseResult from "effect/ParseResult"
+import * as S from "effect/Schema"
+import * as Util from "../TestUtils.js"
+
+describe("requiredToOptionalOrFail", () => {
+  it("decode: returns Option.some for valid values", async () => {
+    const ps = S.requiredToOptionalOrFail(
+      S.NumberFromString,
+      S.Number,
+      {
+        decode: (n) => Effect.succeed(Option.some(n)),
+        encode: (o) => Effect.succeed(Option.getOrElse(o, () => 0))
+      }
+    )
+    const schema = S.Struct({ a: ps })
+    await Util.assertions.decoding.succeed(schema, { a: "1" }, { a: 1 })
+  })
+
+  it("decode: returns Option.none to omit the property", async () => {
+    const ps = S.requiredToOptionalOrFail(
+      S.NumberFromString,
+      S.Number,
+      {
+        decode: (n) => Effect.succeed(n === 0 ? Option.none() : Option.some(n)),
+        encode: (o) => Effect.succeed(Option.getOrElse(o, () => 0))
+      }
+    )
+    const schema = S.Struct({ a: ps })
+    await Util.assertions.decoding.succeed(schema, { a: "0" }, {})
+    await Util.assertions.decoding.succeed(schema, { a: "1" }, { a: 1 })
+  })
+
+  it("encode: receives Option.none when property is missing", async () => {
+    const ps = S.requiredToOptionalOrFail(
+      S.NumberFromString,
+      S.Number,
+      {
+        decode: (n) => Effect.succeed(Option.some(n)),
+        encode: (o) => Effect.succeed(Option.getOrElse(o, () => 0))
+      }
+    )
+    const schema = S.Struct({ a: ps })
+    await Util.assertions.encoding.succeed(schema, {}, { a: "0" })
+    await Util.assertions.encoding.succeed(schema, { a: 1 }, { a: "1" })
+  })
+
+  it("decode: can fail with ParseIssue", async () => {
+    const ps = S.requiredToOptionalOrFail(
+      S.Number,
+      S.Number,
+      {
+        decode: (n) =>
+          n < 0
+            ? ParseResult.fail(new ParseResult.Type(S.Number.ast, n, "must be non-negative"))
+            : Effect.succeed(Option.some(n)),
+        encode: (o) => Effect.succeed(Option.getOrElse(o, () => 0))
+      }
+    )
+    const schema = S.Struct({ a: ps })
+    await Util.assertions.decoding.succeed(schema, { a: 1 }, { a: 1 })
+    await Util.assertions.decoding.fail(
+      schema,
+      { a: -1 },
+      `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ (number <-> Option<number>)
+            └─ Transformation process failure
+               └─ must be non-negative`
+    )
+  })
+
+  it("encode: can fail with ParseIssue", async () => {
+    const ps = S.requiredToOptionalOrFail(
+      S.Number,
+      S.Number,
+      {
+        decode: (n) => Effect.succeed(Option.some(n)),
+        encode: (o) =>
+          Option.match(o, {
+            onNone: () => ParseResult.fail(new ParseResult.Type(S.Number.ast, o, "value is required")),
+            onSome: (n) => Effect.succeed(n)
+          })
+      }
+    )
+    const schema = S.Struct({ a: ps })
+    await Util.assertions.encoding.succeed(schema, { a: 1 }, { a: 1 })
+    await Util.assertions.encoding.fail(
+      schema,
+      {},
+      `(Struct (Encoded side) <-> Struct (Type side))
+└─ Encoded side transformation failure
+   └─ Struct (Encoded side)
+      └─ ["a"]
+         └─ (number <-> Option<number>)
+            └─ Transformation process failure
+               └─ value is required`
+    )
+  })
+})

--- a/packages/experimental/src/VariantSchema.ts
+++ b/packages/experimental/src/VariantSchema.ts
@@ -3,7 +3,7 @@
  */
 import type { Brand } from "effect/Brand"
 import type * as Effect from "effect/Effect"
-import { constUndefined, dual } from "effect/Function"
+import { dual } from "effect/Function"
 import * as Option from "effect/Option"
 import * as ParseResult from "effect/ParseResult"
 import { type Pipeable, pipeArguments } from "effect/Pipeable"
@@ -16,7 +16,9 @@ import * as Struct_ from "effect/Struct"
  * @since 1.0.0
  * @category type ids
  */
-export const TypeId: unique symbol = Symbol.for("@effect/experimental/VariantSchema")
+export const TypeId: unique symbol = Symbol.for(
+  "@effect/experimental/VariantSchema"
+)
 
 /**
  * @since 1.0.0
@@ -71,8 +73,9 @@ export declare namespace Struct {
    * @category models
    */
   export type Validate<A, Variant extends string> = {
-    readonly [K in keyof A]: A[K] extends { readonly [TypeId]: infer _ } ? Validate<A[K], Variant> :
-      A[K] extends Field<infer Config> ? [keyof Config] extends [Variant] ? {} : "field must have valid variants"
+    readonly [K in keyof A]: A[K] extends { readonly [TypeId]: infer _ } ? Validate<A[K], Variant>
+      : A[K] extends Field<infer Config> ? [keyof Config] extends [Variant] ? {}
+        : "field must have valid variants"
       : {}
   }
 }
@@ -128,7 +131,10 @@ export declare namespace Field {
    * @category models
    */
   export type Config = {
-    readonly [key: string]: Schema.Schema.All | Schema.PropertySignature.All | undefined
+    readonly [key: string]:
+      | Schema.Schema.All
+      | Schema.PropertySignature.All
+      | undefined
   }
 
   /**
@@ -157,7 +163,11 @@ export declare namespace Field {
  * @since 1.0.0
  * @category extractors
  */
-export type ExtractFields<V extends string, Fields extends Struct.Fields, IsDefault = false> = {
+export type ExtractFields<
+  V extends string,
+  Fields extends Struct.Fields,
+  IsDefault = false
+> = {
   readonly [
     K in keyof Fields as [Fields[K]] extends [Field<infer Config>] ? V extends keyof Config ? K
       : never
@@ -174,11 +184,12 @@ export type ExtractFields<V extends string, Fields extends Struct.Fields, IsDefa
  * @since 1.0.0
  * @category extractors
  */
-export type Extract<V extends string, A extends Struct<any>, IsDefault = false> = [A] extends [
-  Struct<infer Fields>
-] ?
-  IsDefault extends true
-    ? [A] extends [Schema.Schema.Any] ? A : Schema.Struct<Schema.Simplify<ExtractFields<V, Fields>>>
+export type Extract<
+  V extends string,
+  A extends Struct<any>,
+  IsDefault = false
+> = [A] extends [Struct<infer Fields>] ? IsDefault extends true ? [A] extends [Schema.Schema.Any] ? A
+    : Schema.Struct<Schema.Simplify<ExtractFields<V, Fields>>>
   : Schema.Struct<Schema.Simplify<ExtractFields<V, Fields>>>
   : never
 
@@ -189,9 +200,17 @@ const extract: {
       readonly isDefault?: IsDefault | undefined
     }
   ): <A extends Struct<any>>(self: A) => Extract<V, A, IsDefault>
-  <V extends string, A extends Struct<any>, const IsDefault extends boolean = false>(self: A, variant: V, options?: {
-    readonly isDefault?: IsDefault | undefined
-  }): Extract<V, A, IsDefault>
+  <
+    V extends string,
+    A extends Struct<any>,
+    const IsDefault extends boolean = false
+  >(
+    self: A,
+    variant: V,
+    options?: {
+      readonly isDefault?: IsDefault | undefined
+    }
+  ): Extract<V, A, IsDefault>
 } = dual(
   (args) => isStruct(args[0]),
   <V extends string, A extends Struct<any>>(
@@ -223,7 +242,7 @@ const extract: {
         fields[key] = value
       }
     }
-    return cache[cacheKey] = Schema.Struct(fields) as any
+    return (cache[cacheKey] = Schema.Struct(fields) as any)
   }
 )
 
@@ -297,7 +316,8 @@ type MissingSelfGeneric<Params extends string = ""> =
 export interface Union<Members extends ReadonlyArray<Struct<any>>> extends
   Schema.Union<
     {
-      readonly [K in keyof Members]: [Members[K]] extends [Schema.Schema.All] ? Members[K] : never
+      readonly [K in keyof Members]: [Members[K]] extends [Schema.Schema.All] ? Members[K]
+        : never
     }
   >
 {}
@@ -311,7 +331,10 @@ export declare namespace Union {
    * @since 1.0.0
    * @category models
    */
-  export type Variants<Members extends ReadonlyArray<Struct<any>>, Variants extends string> = {
+  export type Variants<
+    Members extends ReadonlyArray<Struct<any>>,
+    Variants extends string
+  > = {
     readonly [Variant in Variants]: Schema.Union<
       {
         [K in keyof Members]: Extract<Variant, Members[K]>
@@ -344,7 +367,10 @@ export declare namespace fromKey {
   /**
    * @since 1.0.0
    */
-  export type Rename<S, Key extends string> = S extends Schema.PropertySignature<
+  export type Rename<
+    S,
+    Key extends string
+  > = S extends Schema.PropertySignature<
     infer _TypeToken,
     infer _Type,
     infer _Key,
@@ -352,7 +378,15 @@ export declare namespace fromKey {
     infer _Encoded,
     infer _HasDefault,
     infer _R
-  > ? Schema.PropertySignature<_TypeToken, _Type, Key, _EncodedToken, _Encoded, _HasDefault, _R>
+  > ? Schema.PropertySignature<
+      _TypeToken,
+      _Type,
+      Key,
+      _EncodedToken,
+      _Encoded,
+      _HasDefault,
+      _R
+    >
     : S extends Schema.Schema.All ? fromKey<S, Key>
     : never
 }
@@ -387,36 +421,53 @@ export const make = <
   readonly fieldEvolve: {
     <
       Self extends Field<any> | Field.ValueAny,
-      const Mapping
-        extends (Self extends Field<infer S> ? { readonly [K in keyof S]?: (variant: S[K]) => Field.ValueAny }
-          : { readonly [K in Variants[number]]?: (variant: Self) => Field.ValueAny })
-    >(f: Mapping): (self: Self) => Field<
+      const Mapping extends Self extends Field<infer S>
+        ? { readonly [K in keyof S]?: (variant: S[K]) => Field.ValueAny }
+        : {
+          readonly [K in Variants[number]]?: (
+            variant: Self
+          ) => Field.ValueAny
+        }
+    >(
+      f: Mapping
+    ): (self: Self) => Field<
       Self extends Field<infer S> ? {
           readonly [K in keyof S]: K extends keyof Mapping
-            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]> : S[K]
+            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]>
             : S[K]
-        } :
-        {
+            : S[K]
+        }
+        : {
           readonly [K in Variants[number]]: K extends keyof Mapping
-            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]> : Self
+            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]>
+            : Self
             : Self
         }
     >
     <
       Self extends Field<any> | Field.ValueAny,
-      const Mapping extends (Self extends Field<infer S> ? {
+      const Mapping extends Self extends Field<infer S> ? {
           readonly [K in keyof S]?: (variant: S[K]) => Field.ValueAny
         }
-        : { readonly [K in Variants[number]]?: (variant: Self) => Field.ValueAny })
-    >(self: Self, f: Mapping): Field<
+        : {
+          readonly [K in Variants[number]]?: (
+            variant: Self
+          ) => Field.ValueAny
+        }
+    >(
+      self: Self,
+      f: Mapping
+    ): Field<
       Self extends Field<infer S> ? {
           readonly [K in keyof S]: K extends keyof Mapping
-            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]> : S[K]
+            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]>
             : S[K]
-        } :
-        {
+            : S[K]
+        }
+        : {
           readonly [K in Variants[number]]: K extends keyof Mapping
-            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]> : Self
+            ? Mapping[K] extends (arg: any) => any ? ReturnType<Mapping[K]>
+            : Self
             : Self
         }
     >
@@ -424,43 +475,43 @@ export const make = <
   readonly fieldFromKey: {
     <
       Self extends Field<any> | Field.ValueAny,
-      const Mapping extends (Self extends Field<infer S> ? { readonly [K in keyof S]?: string }
-        : { readonly [K in Variants[number]]?: string })
+      const Mapping extends Self extends Field<infer S> ? { readonly [K in keyof S]?: string }
+        : { readonly [K in Variants[number]]?: string }
     >(
       mapping: Mapping
     ): (self: Self) => Field<
       Self extends Field<infer S> ? {
-          readonly [K in keyof S]: K extends keyof Mapping ?
-            Mapping[K] extends string ? fromKey.Rename<S[K], Mapping[K]>
-            : S[K] :
-            S[K]
-        } :
-        {
-          readonly [K in Variants[number]]: K extends keyof Mapping ?
-            Mapping[K] extends string ? fromKey.Rename<Self, Mapping[K]>
-            : Self :
-            Self
+          readonly [K in keyof S]: K extends keyof Mapping
+            ? Mapping[K] extends string ? fromKey.Rename<S[K], Mapping[K]>
+            : S[K]
+            : S[K]
+        }
+        : {
+          readonly [K in Variants[number]]: K extends keyof Mapping
+            ? Mapping[K] extends string ? fromKey.Rename<Self, Mapping[K]>
+            : Self
+            : Self
         }
     >
     <
       Self extends Field<any> | Field.ValueAny,
-      const Mapping extends (Self extends Field<infer S> ? { readonly [K in keyof S]?: string }
-        : { readonly [K in Variants[number]]?: string })
+      const Mapping extends Self extends Field<infer S> ? { readonly [K in keyof S]?: string }
+        : { readonly [K in Variants[number]]?: string }
     >(
       self: Self,
       mapping: Mapping
     ): Field<
       Self extends Field<infer S> ? {
-          readonly [K in keyof S]: K extends keyof Mapping ?
-            Mapping[K] extends string ? fromKey.Rename<S[K], Mapping[K]>
-            : S[K] :
-            S[K]
-        } :
-        {
-          readonly [K in Variants[number]]: K extends keyof Mapping ?
-            Mapping[K] extends string ? fromKey.Rename<Self, Mapping[K]>
-            : Self :
-            Self
+          readonly [K in keyof S]: K extends keyof Mapping
+            ? Mapping[K] extends string ? fromKey.Rename<S[K], Mapping[K]>
+            : S[K]
+            : S[K]
+        }
+        : {
+          readonly [K in Variants[number]]: K extends keyof Mapping
+            ? Mapping[K] extends string ? fromKey.Rename<Self, Mapping[K]>
+            : Self
+            : Self
         }
     >
   }
@@ -471,11 +522,7 @@ export const make = <
     annotations?: Schema.Annotations.Schema<Self>
   ) => [Self] extends [never] ? MissingSelfGeneric
     :
-      & ClassFromFields<
-        Self,
-        Fields,
-        ExtractFields<Default, Fields, true>
-      >
+      & ClassFromFields<Self, Fields, ExtractFields<Default, Fields, true>>
       & {
         readonly [V in Variants[number]]: Extract<V, Struct<Fields>>
       }
@@ -485,7 +532,9 @@ export const make = <
   readonly extract: {
     <V extends Variants[number]>(
       variant: V
-    ): <A extends Struct<any>>(self: A) => Extract<V, A, V extends Default ? true : false>
+    ): <A extends Struct<any>>(
+      self: A
+    ) => Extract<V, A, V extends Default ? true : false>
     <V extends Variants[number], A extends Struct<any>>(
       self: A,
       variant: V
@@ -501,7 +550,10 @@ export const make = <
       const schema = extract(variantStruct, options.defaultVariant, {
         isDefault: true
       })
-      class Base extends Schema.Class<any>(identifier)(schema.fields, annotations) {
+      class Base extends Schema.Class<any>(identifier)(
+        schema.fields,
+        annotations
+      ) {
         static [TypeId] = fields
       }
       for (const variant of options.variants) {
@@ -516,7 +568,9 @@ export const make = <
     }
   }
   function FieldOnly<Keys extends Variants>(...keys: Keys) {
-    return function<S extends Schema.Schema.All | Schema.PropertySignature.All>(schema: S) {
+    return function<
+      S extends Schema.Schema.All | Schema.PropertySignature.All
+    >(schema: S) {
       const obj: Record<string, S> = {}
       for (const key of keys) {
         obj[key] = schema
@@ -525,7 +579,9 @@ export const make = <
     }
   }
   function FieldExcept<Keys extends Variants>(...keys: Keys) {
-    return function<S extends Schema.Schema.All | Schema.PropertySignature.All>(schema: S) {
+    return function<
+      S extends Schema.Schema.All | Schema.PropertySignature.All
+    >(schema: S) {
       const obj: Record<string, S> = {}
       for (const variant of options.variants) {
         if (!keys.includes(variant)) {
@@ -544,9 +600,13 @@ export const make = <
       self: Field<any> | Schema.Schema.All | Schema.PropertySignature.All,
       f: Record<string, (schema: Field.ValueAny) => Field.ValueAny>
     ): Field<any> => {
-      const field = isField(self) ? self : Field(Object.fromEntries(
-        options.variants.map((variant) => [variant, self])
-      ))
+      const field = isField(self)
+        ? self
+        : Field(
+          Object.fromEntries(
+            options.variants.map((variant) => [variant, self])
+          )
+        )
       return Field(Struct_.evolve(field.schemas, f))
     }
   )
@@ -555,7 +615,10 @@ export const make = <
     (
       self:
         | Field<{
-          readonly [key: string]: Schema.Schema.All | Schema.PropertySignature.Any | undefined
+          readonly [key: string]:
+            | Schema.Schema.All
+            | Schema.PropertySignature.Any
+            | undefined
         }>
         | Schema.Schema.All
         | Schema.PropertySignature.Any,
@@ -564,23 +627,24 @@ export const make = <
       const obj: Record<string, any> = {}
       if (isField(self)) {
         for (const [key, schema] of Object.entries(self.schemas)) {
-          obj[key] = mapping[key] !== undefined ? renameFieldValue(schema as any, mapping[key]) : schema
+          obj[key] = mapping[key] !== undefined
+            ? renameFieldValue(schema as any, mapping[key])
+            : schema
         }
       } else {
         for (const key of options.variants) {
-          obj[key] = mapping[key] !== undefined ? renameFieldValue(self as any, mapping[key]) : self
+          obj[key] = mapping[key] !== undefined
+            ? renameFieldValue(self as any, mapping[key])
+            : self
         }
       }
       return Field(obj)
     }
   )
-  const extractVariants = dual(
-    2,
-    (self: Struct<any>, variant: string): any =>
-      extract(self, variant, {
-        isDefault: variant === options.defaultVariant
-      })
-  )
+  const extractVariants = dual(2, (self: Struct<any>, variant: string): any =>
+    extract(self, variant, {
+      isDefault: variant === options.defaultVariant
+    }))
   return {
     Struct,
     Field,
@@ -604,31 +668,67 @@ export const Override = <A>(value: A): A & Brand<"Override"> => value as any
  * @since 1.0.0
  * @category overrideable
  */
-export interface Overrideable<To, From, R = never>
-  extends Schema.PropertySignature<":", (To & Brand<"Override">) | undefined, never, ":", From, true, R>
+export interface Overrideable<
+  To,
+  From,
+  R = never,
+  HasDefault extends boolean = false
+> extends
+  Schema.PropertySignature<
+    "?:",
+    To & Brand<"Override">,
+    never,
+    ":",
+    From,
+    HasDefault,
+    R
+  >
 {}
 
 /**
  * @since 1.0.0
  * @category overrideable
  */
-export const Overrideable = <From, IFrom, RFrom, To, ITo, R>(
+export const Overrideable = <
+  From,
+  IFrom,
+  RFrom,
+  To,
+  ITo,
+  R,
+  const HasDefault extends boolean = false
+>(
   from: Schema.Schema<From, IFrom, RFrom>,
   to: Schema.Schema<To, ITo>,
-  options: {
-    readonly generate: (_: Option.Option<ITo>) => Effect.Effect<From, ParseResult.ParseIssue, R>
-    readonly decode?: Schema.Schema<ITo, From>
-    readonly constructorDefault?: () => To
-  }
-): Overrideable<To, IFrom, RFrom | R> =>
-  Schema.transformOrFail(
-    from,
-    Schema.Union(Schema.Undefined, to as Schema.brand<Schema.Schema<To, ITo>, "Override">),
-    {
-      decode: (_) => options.decode ? ParseResult.decode(options.decode)(_) : ParseResult.succeed(undefined),
-      encode: (dt) => options.generate(dt === undefined ? Option.none() : Option.some(dt))
+  options: HasDefault extends true ? {
+      readonly generate: (_: Option.Option<ITo>) => Effect.Effect<From, ParseResult.ParseIssue, R>
+      readonly decode?: Schema.Schema<ITo, From>
+      readonly constructorDefault: () => To
     }
-  ).pipe(Schema.propertySignature, Schema.withConstructorDefault(options.constructorDefault ?? constUndefined as any))
+    : {
+      readonly generate: (_: Option.Option<ITo>) => Effect.Effect<From, ParseResult.ParseIssue, R>
+      readonly decode?: Schema.Schema<ITo, From>
+      readonly constructorDefault?: never
+    }
+): Overrideable<To, IFrom, RFrom | R, HasDefault> => {
+  const propertySignature = Schema.requiredToOptionalOrFail(
+    from,
+    to,
+    {
+      decode: (_) =>
+        options.decode
+          ? ParseResult.decode(options.decode)(_).pipe(ParseResult.map(Option.some))
+          : ParseResult.succeed(Option.none()),
+      encode: options.generate
+    }
+  )
+
+  if (options.constructorDefault) {
+    return Schema.withConstructorDefault(propertySignature, options.constructorDefault) as any
+  }
+
+  return propertySignature as any
+}
 
 const StructProto = {
   pipe() {
@@ -655,11 +755,16 @@ const Field = <const A extends Field.Config>(schemas: A): Field<A> => {
   return self
 }
 
-const Union = <Members extends ReadonlyArray<Struct<any>>, Variants extends ReadonlyArray<string>>(
+const Union = <
+  Members extends ReadonlyArray<Struct<any>>,
+  Variants extends ReadonlyArray<string>
+>(
   members: Members,
   variants: Variants
 ) => {
-  class VariantUnion extends (Schema.Union(...members.filter((member) => Schema.isSchema(member))) as any) {}
+  class VariantUnion extends (Schema.Union(
+    ...members.filter((member) => Schema.isSchema(member))
+  ) as any) {}
   for (const variant of variants) {
     Object.defineProperty(VariantUnion, variant, {
       value: Schema.Union(...members.map((member) => extract(member, variant)))
@@ -668,7 +773,9 @@ const Union = <Members extends ReadonlyArray<Struct<any>>, Variants extends Read
   return VariantUnion
 }
 
-const renameFieldValue = <F extends Schema.Schema.All | Schema.PropertySignature.Any>(
+const renameFieldValue = <
+  F extends Schema.Schema.All | Schema.PropertySignature.Any
+>(
   self: F,
   key: string
 ) =>

--- a/packages/experimental/test/VariantSchema.test.ts
+++ b/packages/experimental/test/VariantSchema.test.ts
@@ -1,0 +1,186 @@
+import * as VariantSchema from "@effect/experimental/VariantSchema"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option, ParseResult, Schema } from "effect"
+
+describe("VariantSchema", () => {
+  describe("Overrideable", () => {
+    it.effect("encoding without override uses generate function", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: () => Effect.succeed("generated-id")
+          })
+        })
+
+        const encoded = yield* Schema.encode(schema)({})
+        assert.deepStrictEqual(encoded, { id: "generated-id" })
+      }))
+
+    it.effect("encoding with Override uses provided value", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: (opt) => Option.isSome(opt) ? Effect.succeed(opt.value) : Effect.succeed("generated-id")
+          })
+        })
+
+        const encoded = yield* Schema.encode(schema)({
+          id: VariantSchema.Override("custom-id")
+        })
+        assert.deepStrictEqual(encoded, { id: "custom-id" })
+      }))
+
+    it.effect("decoding with no decode option returns object without the property", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: () => Effect.succeed("generated-id")
+          })
+        })
+
+        const decoded = yield* Schema.decode(schema)({ id: "some-id" })
+        assert.strictEqual("id" in decoded, false)
+      }))
+
+    it.effect("decoding uses decode option when provided", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: (opt) => Option.isSome(opt) ? Effect.succeed(opt.value) : Effect.succeed("generated-id"),
+            decode: Schema.String
+          })
+        })
+
+        const decoded = yield* Schema.decode(schema)({ id: "decoded-value" })
+        assert.strictEqual(decoded.id, "decoded-value")
+      }))
+
+    it.effect("constructor allows omitting the property", () =>
+      Effect.gen(function*() {
+        class Test extends Schema.Class<Test>("Test")({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: () => Effect.succeed("generated-id")
+          })
+        }) {}
+
+        const instance = new Test({})
+        assert.strictEqual("id" in instance, false)
+      }))
+
+    it.effect("constructor uses constructorDefault when provided", () =>
+      Effect.gen(function*() {
+        class Test extends Schema.Class<Test>("Test")({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: (opt) => Option.isSome(opt) ? Effect.succeed(opt.value) : Effect.succeed("generated-id"),
+            constructorDefault: () => VariantSchema.Override("default-id")
+          })
+        }) {}
+
+        const instance = new Test({})
+        assert.strictEqual(instance.id, "default-id")
+      }))
+
+    it.effect("generate receives Option.none when property is missing", () =>
+      Effect.gen(function*() {
+        let receivedOption: Option.Option<string> | undefined
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: (opt) => {
+              receivedOption = opt
+              return Effect.succeed("generated")
+            }
+          })
+        })
+
+        yield* Schema.encode(schema)({})
+        assert.deepStrictEqual(receivedOption, Option.none())
+      }))
+
+    it.effect("generate receives Option.some when value is provided with Override", () =>
+      Effect.gen(function*() {
+        let receivedOption: Option.Option<string> | undefined
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: (opt) => {
+              receivedOption = opt
+              return Option.isSome(opt) ? Effect.succeed(opt.value) : Effect.succeed("generated")
+            }
+          })
+        })
+
+        yield* Schema.encode(schema)({ id: VariantSchema.Override("my-value") })
+        assert.deepStrictEqual(receivedOption, Option.some("my-value"))
+      }))
+
+    it.effect("works with different From and To types", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          timestamp: VariantSchema.Overrideable(
+            Schema.String,
+            Schema.Date,
+            {
+              generate: (opt) =>
+                Option.isSome(opt) ? Effect.succeed(opt.value) : Effect.succeed(new Date().toISOString()),
+              decode: Schema.String
+            }
+          )
+        })
+
+        const now = new Date("2024-01-01T00:00:00.000Z")
+        const encoded = yield* Schema.encode(schema)({
+          timestamp: VariantSchema.Override(now)
+        })
+        assert.deepStrictEqual(encoded, { timestamp: now.toISOString() })
+
+        const decoded = yield* Schema.decode(schema)({ timestamp: "2024-01-01T00:00:00.000Z" })
+        assert.deepStrictEqual(
+          (decoded.timestamp as Date)?.getTime(),
+          new Date("2024-01-01T00:00:00.000Z").getTime()
+        )
+      }))
+
+    it.effect("generate can return Effect with error", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          id: VariantSchema.Overrideable(Schema.String, Schema.String, {
+            generate: () => ParseResult.fail(new ParseResult.Type(Schema.String.ast, "invalid", "Generation failed"))
+          })
+        })
+
+        const result = yield* Schema.encode(schema)({}).pipe(Effect.flip)
+        assert.include(String(result), "Generation failed")
+      }))
+
+    it.effect("works with Schema transformation on from type", () =>
+      Effect.gen(function*() {
+        const schema = Schema.Struct({
+          count: VariantSchema.Overrideable(Schema.NumberFromString, Schema.Number, {
+            generate: (opt) => Option.isSome(opt) ? Effect.succeed(opt.value) : Effect.succeed(0)
+          })
+        })
+
+        const encoded = yield* Schema.encode(schema)({ count: VariantSchema.Override(42) })
+        assert.deepStrictEqual(encoded, { count: "42" })
+
+        const encodedDefault = yield* Schema.encode(schema)({})
+        assert.deepStrictEqual(encodedDefault, { count: "0" })
+      }))
+  })
+
+  describe("Override", () => {
+    it("brands the value", () => {
+      const value = VariantSchema.Override("test")
+      assert.strictEqual(value, "test")
+    })
+
+    it("works with different types", () => {
+      const stringValue = VariantSchema.Override("hello")
+      const numberValue = VariantSchema.Override(123)
+      const objectValue = VariantSchema.Override({ foo: "bar" })
+
+      assert.strictEqual(stringValue, "hello")
+      assert.strictEqual(numberValue, 123)
+      assert.strictEqual((objectValue as { foo: string }).foo, "bar")
+    })
+  })
+})


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Add Schema.requiredToOptionalOrFail to effect, an effectful version of requiredToOptional where decode/encode transformations can fail with ParseIssue                                                                                                              
- Refactor VariantSchema.Overrideable to use requiredToOptionalOrFail, changing the property signature from required (":") with undefined union to truly optional ("?:"), simplifying the implementation and making the type-level representation more accurate
- Add tests for both requiredToOptionalOrFail and VariantSchema.Overrideable
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->
https://discord.com/channels/795981131316985866/1134177528098078861/1431621965784809522
