### PR TITLE
fix(rpc): encode defects with Schema.Defect in sendRequestDefect and sendDefect

### DIFF
--- a/.changeset/tall-suns-kneel.md
+++ b/.changeset/tall-suns-kneel.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Fix `sendRequestDefect` and `sendDefect` to encode defects with `Schema.Defect`, preventing `Error` objects from being serialized as `{}` due to non-enumerable properties.

--- a/packages/platform-node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-node/test/fixtures/rpc-schemas.ts
@@ -58,6 +58,7 @@ export const UserRpcs = RpcGroup.make(
     success: Schema.Number
   }),
   Rpc.make("ProduceDefect"),
+  Rpc.make("ProduceErrorDefect"),
   Rpc.make("Never"),
   Rpc.make("nested.test"),
   Rpc.make("TimedMethod", {
@@ -132,6 +133,7 @@ const UsersLive = UserRpcs.toLayer(Effect.gen(function*() {
     GetInterrupts: () => Effect.sync(() => interrupts),
     GetEmits: () => Effect.sync(() => emits),
     ProduceDefect: () => Effect.die("boom"),
+    ProduceErrorDefect: () => Effect.die(new Error("error defect message")),
     Never: () => Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => interrupts++))),
     "nested.test": () => Effect.void,
     TimedMethod: (_) => _.shouldFail ? Effect.die("boom") : Effect.succeed(1),

--- a/packages/platform-node/test/rpc-e2e.ts
+++ b/packages/platform-node/test/rpc-e2e.ts
@@ -85,6 +85,22 @@ export const e2eSuite = <E>(
         Effect.provide(layer)
       ))
 
+    it.effect("defect serializes Error objects", () =>
+      Effect.gen(function*() {
+        const client = yield* UsersClient
+        const cause = yield* client.ProduceErrorDefect().pipe(
+          Effect.sandbox,
+          Effect.flip
+        )
+        const defect = Cause.squash(cause)
+        // Error details should survive serialization, not be lost as {}
+        assert.instanceOf(defect, Error)
+        assert.include(defect.message, "error defect message")
+      }).pipe(
+        RpcClient.withHeaders({ userId: "123" }),
+        Effect.provide(layer)
+      ))
+
     it.live("never", () =>
       Effect.gen(function*() {
         const client = yield* UsersClient

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -600,6 +600,8 @@ export const make: <Rpcs extends Rpc.Any>(
       })
     )
 
+  const encodeDefect = Schema.encodeSync(Schema.Defect)
+
   const sendRequestDefect = (client: Client, requestId: RequestId, defect: unknown) =>
     Effect.catchAllCause(
       send(client.id, {
@@ -609,7 +611,7 @@ export const make: <Rpcs extends Rpc.Any>(
           _tag: "Failure",
           cause: {
             _tag: "Die",
-            defect
+            defect: encodeDefect(defect)
           }
         }
       }),
@@ -618,7 +620,7 @@ export const make: <Rpcs extends Rpc.Any>(
 
   const sendDefect = (client: Client, defect: unknown) =>
     Effect.catchAllCause(
-      send(client.id, { _tag: "Defect", defect }),
+      send(client.id, { _tag: "Defect", defect: encodeDefect(defect) }),
       (cause) =>
         Effect.annotateLogs(Effect.logDebug(cause), {
           module: "RpcServer",


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Error objects have non-enumerable properties (message, stack, name), so JSON.stringify produces {} and all error information is lost on the client. Use Schema.encodeSync(Schema.Defect) to properly serialize defects, matching the encoding already used in exitSchema and RpcMessage.ResponseDefectEncoded.

## Related

- Closes #6054
