### PR TITLE
fix(cluster): guard unprocessedMessages against empty shardIds

### DIFF
--- a/packages/cluster/src/SqlMessageStorage.ts
+++ b/packages/cluster/src/SqlMessageStorage.ts
@@ -493,6 +493,7 @@ export const make = Effect.fnUntraced(function*(options?: {
 
     unprocessedMessages: Effect.fnUntraced(
       function*(shardIds, now) {
+        if (shardIds.length === 0) return []
         const rows = yield* getUnprocessedMessages(shardIds, now)
         if (rows.length === 0) {
           return []


### PR DESCRIPTION
## Summary

When no shards are assigned to a node, `unprocessedMessages` calls `getUnprocessedMessages` with an empty array. This produces `shard_id IN ()` — invalid SQL that errors on every poll cycle (~200ms):

```
ERROR: syntax error at or near ")" at character 122
STATEMENT: UPDATE "cluster_messages" SET last_read = NULL WHERE processed = FALSE AND shard_id IN ()
```

The PG dialect wraps this in a CTE with `FOR UPDATE`, so failed rollbacks also cascade into:

```
WARNING: you don't own a lock of type ExclusiveLock
```

**Fix:** Early return `[]` when `shardIds` is empty in `unprocessedMessages` (`packages/cluster/src/SqlMessageStorage.ts:496`).

## Test plan

- [ ] Verify `unprocessedMessages([])` returns `[]` without hitting the database
- [ ] Confirm no `syntax error at or near ")"` errors in logs when a node has no assigned shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)