### PR TITLE
fix(cluster): guard resetShards against empty shardIds

### DIFF
--- a/packages/cluster/src/SqlMessageStorage.ts
+++ b/packages/cluster/src/SqlMessageStorage.ts
@@ -572,8 +572,9 @@ export const make = Effect.fnUntraced(function*(options?: {
         withTracerDisabled
       ),
 
-    resetShards: (shardIds) =>
-      sql`
+    resetShards: (shardIds) => {
+      if (shardIds.length === 0) return Effect.void
+      return sql`
         UPDATE ${messagesTableSql}
         SET last_read = NULL
         WHERE processed = ${sqlFalse}
@@ -583,6 +584,7 @@ export const make = Effect.fnUntraced(function*(options?: {
         PersistenceError.refail,
         withTracerDisabled
       )
+    }
   })
 }, withTracerDisabled)
 


### PR DESCRIPTION
## Summary

When `resetShards` is called with an empty array, the query produces `shard_id IN ()` — invalid SQL:

```
ERROR: syntax error at or near ")" at character 122
STATEMENT: UPDATE "cluster_messages" SET last_read = NULL WHERE processed = FALSE AND shard_id IN ()
```

Same class of bug as `unprocessedMessages` — `shardIds.map(wrapString).join(",")` produces an empty string when the array is empty.

**Fix:** Early return `Effect.void` when `shardIds` is empty in `resetShards` (`packages/cluster/src/SqlMessageStorage.ts:576`).

## Test plan

- [ ] Verify `resetShards([])` returns without hitting the database
- [ ] Confirm no `syntax error` when resetting with no assigned shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)