### PR TITLE
fix(ai-openrouter): deduplicate reasoning parts when streaming

### DIFF
--- a/.changeset/whole-jokes-join.md
+++ b/.changeset/whole-jokes-join.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+fix(ai-openrouter): deduplicate reasoning parts when both `reasoning` and `reasoning_details` are present in a stream delta

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -796,10 +796,6 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
           })
         }
 
-        if (Predicate.isNotNullable(delta.reasoning) && delta.reasoning.length > 0) {
-          emitReasoningPart(delta.reasoning)
-        }
-
         if (Predicate.isNotNullable(delta.reasoning_details) && delta.reasoning_details.length > 0) {
           for (const detail of delta.reasoning_details) {
             switch (detail.type) {
@@ -830,6 +826,8 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
               }
             }
           }
+        } else if (Predicate.isNotNullable(delta.reasoning) && delta.reasoning.length > 0) {
+          emitReasoningPart(delta.reasoning)
         }
 
         // Text Parts


### PR DESCRIPTION


When a delta contains both `reasoning` and `reasoning_details`, the old code emitted a reasoning part for each, causing every token to appear twice in the stream and exported chat history. Use `else if` so `reasoning` is only a fallback when `reasoning_details` is absent.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a reasoning delta event contains both `reasoning` and `reasoning_details`, the old code emitted a reasoning part for each field, causing every token to appear twice. With this fix, `reasoning` is now only used as a fallback when `reasoning_details` is absent.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #6059
