### PR TITLE
fix(sql-drizzle): allow $count to be yielded as an Effect

### DIFF
--- a/.changeset/eighty-memes-accept.md
+++ b/.changeset/eighty-memes-accept.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-drizzle": patch
+---
+
+Allow `$count` to be yielded as an Effect.

--- a/packages/sql-drizzle/src/Mysql.ts
+++ b/packages/sql-drizzle/src/Mysql.ts
@@ -5,13 +5,14 @@ import type * as Client from "@effect/sql/SqlClient"
 import type { SqlError } from "@effect/sql/SqlError"
 import type { DrizzleConfig } from "drizzle-orm"
 import { MySqlSelectBase } from "drizzle-orm/mysql-core"
+import { MySqlCountBuilder } from "drizzle-orm/mysql-core/query-builders/count"
 import type { MySqlRemoteDatabase } from "drizzle-orm/mysql-proxy"
 import { drizzle } from "drizzle-orm/mysql-proxy"
 import { QueryPromise } from "drizzle-orm/query-promise"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
-import { makeRemoteCallback, patch } from "./internal/patch.js"
+import { makeRemoteCallback, patch, patchCount } from "./internal/patch.js"
 
 /**
  * @since 1.0.0
@@ -65,5 +66,12 @@ export const layerWithConfig: (config: DrizzleConfig) => Layer.Layer<MysqlDrizzl
 declare module "drizzle-orm" {
   export interface QueryPromise<T> extends Effect.Effect<T, SqlError> {}
 }
+
+declare module "drizzle-orm/mysql-core/query-builders/count" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  export interface MySqlCountBuilder<TSession = any> extends Effect.Effect<number, SqlError> {}
+}
+
 patch(QueryPromise.prototype)
 patch(MySqlSelectBase.prototype)
+patchCount(MySqlCountBuilder.prototype)

--- a/packages/sql-drizzle/src/Pg.ts
+++ b/packages/sql-drizzle/src/Pg.ts
@@ -5,13 +5,14 @@ import type * as Client from "@effect/sql/SqlClient"
 import type { SqlError } from "@effect/sql/SqlError"
 import type { DrizzleConfig } from "drizzle-orm"
 import { PgSelectBase } from "drizzle-orm/pg-core"
+import { PgCountBuilder } from "drizzle-orm/pg-core/query-builders/count"
 import type { PgRemoteDatabase } from "drizzle-orm/pg-proxy"
 import { drizzle } from "drizzle-orm/pg-proxy"
 import { QueryPromise } from "drizzle-orm/query-promise"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
-import { makeRemoteCallback, patch } from "./internal/patch.js"
+import { makeRemoteCallback, patch, patchCount } from "./internal/patch.js"
 
 /**
  * @since 1.0.0
@@ -64,5 +65,12 @@ export const layerWithConfig: (config: DrizzleConfig) => Layer.Layer<PgDrizzle, 
 declare module "drizzle-orm" {
   export interface QueryPromise<T> extends Effect.Effect<T, SqlError> {}
 }
+
+declare module "drizzle-orm/pg-core/query-builders/count" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  export interface PgCountBuilder<TSession = any> extends Effect.Effect<number, SqlError> {}
+}
+
 patch(QueryPromise.prototype)
 patch(PgSelectBase.prototype)
+patchCount(PgCountBuilder.prototype)

--- a/packages/sql-drizzle/src/Sqlite.ts
+++ b/packages/sql-drizzle/src/Sqlite.ts
@@ -6,12 +6,13 @@ import type { SqlError } from "@effect/sql/SqlError"
 import type { DrizzleConfig } from "drizzle-orm"
 import { QueryPromise } from "drizzle-orm/query-promise"
 import { SQLiteSelectBase } from "drizzle-orm/sqlite-core"
+import { SQLiteCountBuilder } from "drizzle-orm/sqlite-core/query-builders/count"
 import type { SqliteRemoteDatabase } from "drizzle-orm/sqlite-proxy"
 import { drizzle } from "drizzle-orm/sqlite-proxy"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
-import { makeRemoteCallback, patch } from "./internal/patch.js"
+import { makeRemoteCallback, patch, patchCount } from "./internal/patch.js"
 
 /**
  * @since 1.0.0
@@ -65,5 +66,12 @@ export const layerWithConfig: (config: DrizzleConfig) => Layer.Layer<SqliteDrizz
 declare module "drizzle-orm" {
   export interface QueryPromise<T> extends Effect.Effect<T, SqlError> {}
 }
+
+declare module "drizzle-orm/sqlite-core/query-builders/count" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  export interface SQLiteCountBuilder<TSession = any> extends Effect.Effect<number, SqlError> {}
+}
+
 patch(QueryPromise.prototype)
 patch(SQLiteSelectBase.prototype)
+patchCount(SQLiteCountBuilder.prototype)

--- a/packages/sql-drizzle/src/internal/patch.ts
+++ b/packages/sql-drizzle/src/internal/patch.ts
@@ -57,11 +57,7 @@ export const patchCount = (prototype: any) => {
             try: () => {
               const pre = currentRuntime
               currentRuntime = context
-              const promise = new Promise((resolve, reject) => originalThen.call(this, resolve, reject)).then(
-                (result) => {
-                  return result
-                }
-              )
+              const promise = new Promise((resolve, reject) => originalThen.call(this, resolve, reject))
               currentRuntime = pre
               return promise
             },

--- a/packages/sql-drizzle/src/internal/patch.ts
+++ b/packages/sql-drizzle/src/internal/patch.ts
@@ -86,7 +86,7 @@ export const makeRemoteCallback = Effect.gen(function*() {
         if (header && typeof header === "object" && "rows" in header) {
           return { rows: header.rows }
         }
-        return { rows: Array.isArray(header) ? header : [header] }
+        return { rows: [header] }
       }))).then((res) => {
         if (res._tag === "Left") {
           throw res.left.cause

--- a/packages/sql-drizzle/src/internal/patch.ts
+++ b/packages/sql-drizzle/src/internal/patch.ts
@@ -42,6 +42,39 @@ export const patch = (prototype: any) => {
 }
 
 /** @internal */
+export const patchCount = (prototype: any) => {
+  if (Effect.EffectTypeId in prototype) {
+    return
+  }
+
+  const originalThen = prototype.then
+  const PatchCountProto = {
+    ...Effectable.CommitPrototype,
+    commit(this: any) {
+      return Effect.runtime().pipe(
+        Effect.flatMap((context) =>
+          Effect.tryPromise({
+            try: () => {
+              const pre = currentRuntime
+              currentRuntime = context
+              const promise = new Promise((resolve, reject) => originalThen.call(this, resolve, reject)).then(
+                (result) => {
+                  return result
+                }
+              )
+              currentRuntime = pre
+              return promise
+            },
+            catch: (cause) => new SqlError({ cause, message: "Failed to execute CountBuilder" })
+          })
+        )
+      )
+    }
+  }
+  Object.assign(prototype, PatchCountProto)
+}
+
+/** @internal */
 export const makeRemoteCallback = Effect.gen(function*() {
   const client = yield* Client.SqlClient
   const constructionRuntime = yield* Effect.runtime<never>()
@@ -49,7 +82,12 @@ export const makeRemoteCallback = Effect.gen(function*() {
     const runPromise = Runtime.runPromise(currentRuntime ? currentRuntime : constructionRuntime)
     const statement = client.unsafe(sql, params)
     if (method === "execute") {
-      return runPromise(Effect.either(Effect.map(statement.raw, (header) => ({ rows: [header] })))).then((res) => {
+      return runPromise(Effect.either(Effect.map(statement.raw, (header) => {
+        if (header && typeof header === "object" && "rows" in header) {
+          return { rows: header.rows }
+        }
+        return { rows: Array.isArray(header) ? header : [header] }
+      }))).then((res) => {
         if (res._tag === "Left") {
           throw res.left.cause
         }

--- a/packages/sql-drizzle/test/Mysql.test.ts
+++ b/packages/sql-drizzle/test/Mysql.test.ts
@@ -68,6 +68,20 @@ describe.sequential("Mysql", () => {
       Effect.catchTag("ContainerError", () => Effect.void)
     ), { timeout: 60000 })
 
+  it.effect("$count", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      const db = yield* ORM
+
+      yield* sql`CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, snake_case TEXT NOT NULL)`
+      yield* db.insert(users).values({ name: "Alice", snakeCase: "alice" })
+      const result = yield* db.$count(users)
+      assert.strictEqual(result, 1)
+    }).pipe(
+      Effect.provide(ORM.Client),
+      Effect.catchTag("ContainerError", () => Effect.void)
+    ), { timeout: 60000 })
+
   it.effect("remote callback", () =>
     Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient

--- a/packages/sql-drizzle/test/Pg.test.ts
+++ b/packages/sql-drizzle/test/Pg.test.ts
@@ -51,6 +51,22 @@ describe.sequential("Pg", () => {
     timeout: 60000
   })
 
+  it.effect("$count", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      const db = yield* ORM
+
+      yield* sql`CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, snake_case TEXT NOT NULL)`
+      yield* db.insert(users).values({ name: "Alice", snakeCase: "alice" })
+      const result = yield* db.$count(users)
+      assert.strictEqual(result, 1)
+    }).pipe(
+      Effect.provide(ORM.Client),
+      Effect.catchTag("ContainerError", () => Effect.void)
+    ), {
+    timeout: 60000
+  })
+
   it.effect("remote callback", () =>
     Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient

--- a/packages/sql-drizzle/test/Sqlite.test.ts
+++ b/packages/sql-drizzle/test/Sqlite.test.ts
@@ -55,6 +55,16 @@ describe("SqliteDrizzle", () => {
       assert.deepStrictEqual(results, [{ id: 1, name: "Alice", snakeCase: "snake" }])
     }).pipe(Effect.provide(ORM.Client)))
 
+  it.effect("$count", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      const db = yield* ORM
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, snake_case TEXT)`
+      yield* db.insert(users).values({ name: "Alice", snakeCase: "snake" })
+      const result = yield* db.$count(users)
+      assert.strictEqual(result, 1)
+    }).pipe(Effect.provide(ORM.Client)))
+
   it.effect("remote callback", () =>
     Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Patches drizzle's `*CountBuilder` so `$count` can be yielded as an `Effect`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #6067 
