### PR TITLE
fix(ai-openrouter): optional name in streaming tool calls

### DIFF
--- a/.changeset/fix-streaming-tool-call-schema.md
+++ b/.changeset/fix-streaming-tool-call-schema.md
@@ -1,0 +1,9 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Fix `ChatStreamingMessageToolCall` schema rejecting valid streaming tool call chunks.
+
+The OpenAI streaming spec splits tool calls across multiple SSE chunks — `function.name` is only present on the first chunk, but the schema required it on every chunk, causing a `MalformedOutput` error whenever the model returned a tool call.
+
+Made `function.name` optional to match `id` which was already optional.

--- a/packages/ai/openrouter/src/OpenRouterClient.ts
+++ b/packages/ai/openrouter/src/OpenRouterClient.ts
@@ -315,7 +315,7 @@ export class ChatStreamingMessageToolCall extends Schema.Class<ChatStreamingMess
   id: Schema.optionalWith(Schema.String, { nullable: true }),
   type: Schema.Literal("function"),
   function: Schema.Struct({
-    name: Schema.String,
+    name: Schema.optionalWith(Schema.String, { nullable: true }),
     arguments: Schema.String
   })
 }) {}


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix `ChatStreamingMessageToolCall` schema rejecting valid streaming tool call chunks.

The OpenAI streaming spec splits tool calls across multiple SSE chunks — `function.name` is only present on the first chunk, but the schema required it on every chunk, causing a `MalformedOutput` error whenever the model returned a tool call.

Made `function.name` optional to match `id` which was already optional.

## Related

- Closes #6070
