### PR TITLE
feat(rpc): add supportsSpanPropagation option to RpcServer.toHttpApp

### DIFF
--- a/.changeset/rpc-toHttpApp-span-propagation.md
+++ b/.changeset/rpc-toHttpApp-span-propagation.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": minor
+---
+
+Add optional `supportsSpanPropagation` option to `RpcServer.toHttpApp` for enabling distributed tracing across HTTP RPC boundaries.

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -1231,6 +1231,7 @@ export const toHttpApp: <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly disableFatalDefects?: boolean | undefined
+    readonly supportsSpanPropagation?: boolean | undefined
   } | undefined
 ) => Effect.Effect<
   HttpApp.Default<never, Scope.Scope>,
@@ -1247,11 +1248,17 @@ export const toHttpApp: <Rpcs extends Rpc.Any>(
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
     readonly disableFatalDefects?: boolean | undefined
+    readonly supportsSpanPropagation?: boolean | undefined
   }
 ) {
   const { httpApp, protocol } = yield* makeProtocolWithHttpApp
+
+  const finalProtocol = options?.supportsSpanPropagation
+    ? { ...protocol, supportsSpanPropagation: true as const }
+    : protocol
+
   yield* make(group, options).pipe(
-    Effect.provideService(Protocol, protocol),
+    Effect.provideService(Protocol, finalProtocol),
     Effect.interruptible,
     Effect.forkScoped
   )


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add optional `supportsSpanPropagation` option to `RpcServer.toHttpApp`.

The HTTP protocol hardcodes `supportsSpanPropagation: false`, which makes sense as a default for typical HTTP RPC servers behind reverse proxies. But for same-origin setups like Cloudflare Durable Object RPC, the client and server share a trust boundary and propagating spans is expected.

This adds a single optional field to `toHttpApp`'s options. When set to `true`, it overrides the protocol's `supportsSpanPropagation` before providing it to `make()`. No changes to `makeProtocolWithHttpApp` — no breaking changes.

```ts
const httpApp = RpcServer.toHttpApp(myGroup, {
  supportsSpanPropagation: true
})
```

## Related

- Closes #6072
