### PR TITLE
EFF-516 Add Effect.validate api

### DIFF
--- a/.changeset/sixty-ravens-raise.md
+++ b/.changeset/sixty-ravens-raise.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.validate` overloads for iterable validation with the same semantics as `Effect.validateAll`, while preserving existing pairwise effect validation behavior.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -578,6 +578,20 @@ describe("Effect", () => {
     expect(Effect.validate(Effect.succeed(1), Effect.succeed("a"))).type.toBe<
       Effect.Effect<[number, string]>
     >()
+
+    expect(Effect.validate([1, 2, 3], Effect.succeed)).type.toBe<
+      Effect.Effect<Array<number>, [never, ...Array<never>]>
+    >()
+
+    expect(pipe([1, 2, 3], Effect.validate(Effect.succeed))).type.toBe<
+      Effect.Effect<Array<number>, [never, ...Array<never>]>
+    >()
+
+    expect(
+      Effect.validate([1, 2, 3], Effect.succeed, { discard: true })
+    ).type.toBe<
+      Effect.Effect<void, [never, ...Array<never>]>
+    >()
   })
 
   it("promise", () => {

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -12409,6 +12409,44 @@ export const runSyncExit: <A, E>(effect: Effect<A, E>) => Exit.Exit<A, E> = runt
  * @category Error Accumulation
  */
 export const validate: {
+  <A, B, E, R>(
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options?: {
+      readonly concurrency?: Concurrency | undefined
+      readonly batching?: boolean | "inherit" | undefined
+      readonly discard?: false | undefined
+      readonly concurrentFinalizers?: boolean | undefined
+    } | undefined
+  ): (elements: Iterable<A>) => Effect<Array<B>, RA.NonEmptyArray<E>, R>
+  <A, B, E, R>(
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options: {
+      readonly concurrency?: Concurrency | undefined
+      readonly batching?: boolean | "inherit" | undefined
+      readonly discard: true
+      readonly concurrentFinalizers?: boolean | undefined
+    }
+  ): (elements: Iterable<A>) => Effect<void, RA.NonEmptyArray<E>, R>
+  <A, B, E, R>(
+    elements: Iterable<A>,
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options?: {
+      readonly concurrency?: Concurrency | undefined
+      readonly batching?: boolean | "inherit" | undefined
+      readonly discard?: false | undefined
+      readonly concurrentFinalizers?: boolean | undefined
+    } | undefined
+  ): Effect<Array<B>, RA.NonEmptyArray<E>, R>
+  <A, B, E, R>(
+    elements: Iterable<A>,
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options: {
+      readonly concurrency?: Concurrency | undefined
+      readonly batching?: boolean | "inherit" | undefined
+      readonly discard: true
+      readonly concurrentFinalizers?: boolean | undefined
+    }
+  ): Effect<void, RA.NonEmptyArray<E>, R>
   <B, E1, R1>(
     that: Effect<B, E1, R1>,
     options?: {

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -2896,26 +2896,71 @@ export const using = dual<
 
 /** @internal */
 export const validate = dual<
-  <B, E1, R1>(
-    that: Effect.Effect<B, E1, R1>,
-    options?: {
-      readonly concurrent?: boolean | undefined
-      readonly batching?: boolean | "inherit" | undefined
-      readonly concurrentFinalizers?: boolean | undefined
-    }
-  ) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<[A, B], E | E1, R | R1>,
-  <A, E, R, B, E1, R1>(
-    self: Effect.Effect<A, E, R>,
-    that: Effect.Effect<B, E1, R1>,
-    options?: {
-      readonly concurrent?: boolean | undefined
-      readonly batching?: boolean | "inherit" | undefined
-      readonly concurrentFinalizers?: boolean | undefined
-    }
-  ) => Effect.Effect<[A, B], E | E1, R | R1>
+  {
+    <A, B, E, R>(
+      f: (a: A, i: number) => Effect.Effect<B, E, R>,
+      options?: {
+        readonly concurrency?: Concurrency | undefined
+        readonly batching?: boolean | "inherit" | undefined
+        readonly discard?: false | undefined
+        readonly concurrentFinalizers?: boolean | undefined
+      }
+    ): (elements: Iterable<A>) => Effect.Effect<Array<B>, RA.NonEmptyArray<E>, R>
+    <A, B, E, R>(
+      f: (a: A, i: number) => Effect.Effect<B, E, R>,
+      options: {
+        readonly concurrency?: Concurrency | undefined
+        readonly batching?: boolean | "inherit" | undefined
+        readonly discard: true
+        readonly concurrentFinalizers?: boolean | undefined
+      }
+    ): (elements: Iterable<A>) => Effect.Effect<void, RA.NonEmptyArray<E>, R>
+    <B, E1, R1>(
+      that: Effect.Effect<B, E1, R1>,
+      options?: {
+        readonly concurrent?: boolean | undefined
+        readonly batching?: boolean | "inherit" | undefined
+        readonly concurrentFinalizers?: boolean | undefined
+      }
+    ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<[A, B], E | E1, R | R1>
+  },
+  {
+    <A, B, E, R>(
+      elements: Iterable<A>,
+      f: (a: A, i: number) => Effect.Effect<B, E, R>,
+      options?: {
+        readonly concurrency?: Concurrency | undefined
+        readonly batching?: boolean | "inherit" | undefined
+        readonly discard?: false | undefined
+        readonly concurrentFinalizers?: boolean | undefined
+      }
+    ): Effect.Effect<Array<B>, RA.NonEmptyArray<E>, R>
+    <A, B, E, R>(
+      elements: Iterable<A>,
+      f: (a: A, i: number) => Effect.Effect<B, E, R>,
+      options: {
+        readonly concurrency?: Concurrency | undefined
+        readonly batching?: boolean | "inherit" | undefined
+        readonly discard: true
+        readonly concurrentFinalizers?: boolean | undefined
+      }
+    ): Effect.Effect<void, RA.NonEmptyArray<E>, R>
+    <A, E, R, B, E1, R1>(
+      self: Effect.Effect<A, E, R>,
+      that: Effect.Effect<B, E1, R1>,
+      options?: {
+        readonly concurrent?: boolean | undefined
+        readonly batching?: boolean | "inherit" | undefined
+        readonly concurrentFinalizers?: boolean | undefined
+      }
+    ): Effect.Effect<[A, B], E | E1, R | R1>
+  }
 >(
-  (args) => core.isEffect(args[1]),
-  (self, that, options) => validateWith(self, that, (a, b) => [a, b], options)
+  (args) => Predicate.isIterable(args[0]) || core.isEffect(args[1]),
+  ((self: any, that: any, options: any) =>
+    Predicate.isIterable(self) && Predicate.isFunction(that)
+      ? validateAll(self, that, options)
+      : validateWith(self, that, (a: any, b: any) => [a, b], options)) as any
 )
 
 /** @internal */

--- a/packages/effect/test/Effect/validation.test.ts
+++ b/packages/effect/test/Effect/validation.test.ts
@@ -36,6 +36,31 @@ describe("Effect", () => {
       const result = yield* pipe(Effect.succeed(1), Effect.validateWith(Effect.succeed(2), (a, b) => a + b))
       strictEqual(result, 3)
     }))
+  it.effect("validate (collection) - accumulate successes", () =>
+    Effect.gen(function*() {
+      const array = Array.from({ length: 10 }, (_, i) => i)
+      const result = yield* pipe(array, Effect.validate(Effect.succeed))
+      deepStrictEqual(Array.from(result), array)
+    }))
+  it.effect("validate (collection) - returns all errors if never valid", () =>
+    Effect.gen(function*() {
+      const array = Array.from({ length: 10 }, () => 0)
+      const result = yield* pipe(array, Effect.validate(Effect.fail), Effect.flip)
+      deepStrictEqual(Array.from(result), array)
+    }))
+  it.effect("validate (collection) - supports concurrency + discard", () =>
+    Effect.gen(function*() {
+      const array = Array.from({ length: 10 }, () => 0)
+      const result = yield* pipe(
+        array,
+        Effect.validate(Effect.fail, {
+          concurrency: "unbounded",
+          discard: true
+        }),
+        Effect.flip
+      )
+      deepStrictEqual(Array.from(result), array)
+    }))
   it.effect("validateAll - accumulate successes", () =>
     Effect.gen(function*() {
       const array = Array.from({ length: 10 }, (_, i) => i)


### PR DESCRIPTION
## Summary
- add iterable `Effect.validate` overloads that mirror `Effect.validateAll` behavior (including `concurrency`, `discard`, and data-first/data-last usage)
- preserve existing pairwise `Effect.validate` semantics by dispatching to the prior `validateWith` implementation for effect-to-effect usage
- add runtime and dtslint coverage for the new iterable overloads and include a changeset for `effect`