### PR TITLE
Schema: fix getPropertySignatures crash on Struct with optionalWith({ default })

### DIFF
--- a/.changeset/fix-schema-ast-transformation.md
+++ b/.changeset/fix-schema-ast-transformation.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Schema: fix `getPropertySignatures` crash on Struct with `optionalWith({ default })` and other Transformation-producing variants
+
+`SchemaAST.getPropertyKeyIndexedAccess` now handles `Transformation` AST nodes by delegating to `ast.to`, matching the existing behavior of `getPropertyKeys`. Previously, calling `getPropertySignatures` on a `Schema.Struct` containing `Schema.optionalWith` with `{ default }`, `{ as: "Option" }`, `{ nullable: true }`, or similar options would throw `"Unsupported schema (Transformation)"`.

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2328,6 +2328,8 @@ export const getPropertyKeyIndexedAccess = (ast: AST, name: PropertyKey): Proper
       return getPropertyKeyIndexedAccess(ast.f(), name)
     case "Refinement":
       return getPropertyKeyIndexedAccess(ast.from, name)
+    case "Transformation":
+      return getPropertyKeyIndexedAccess(ast.to, name)
   }
   throw new Error(errors_.getASTUnsupportedSchemaErrorMessage(ast))
 }

--- a/packages/effect/test/Schema/SchemaAST/getPropertySignatures.test.ts
+++ b/packages/effect/test/Schema/SchemaAST/getPropertySignatures.test.ts
@@ -43,4 +43,30 @@ describe("getPropertySignatures", () => {
       new AST.PropertySignature("b", S.Number.ast, false, true)
     ])
   })
+
+  it("Transformation (Struct with optionalWith default)", () => {
+    const schema = S.Struct({
+      a: S.String,
+      b: S.optionalWith(S.Number, { default: () => 0 })
+    })
+    deepStrictEqual(AST.getPropertySignatures(schema.ast), [
+      new AST.PropertySignature("a", S.String.ast, false, true),
+      new AST.PropertySignature("b", S.Number.ast, false, true)
+    ])
+  })
+
+  it("Transformation (Struct with optionalWith as Option)", () => {
+    const schema = S.Struct({
+      a: S.String,
+      b: S.optionalWith(S.Number, { as: "Option" })
+    })
+    const signatures = AST.getPropertySignatures(schema.ast)
+    deepStrictEqual(signatures.length, 2)
+    deepStrictEqual(signatures[0], new AST.PropertySignature("a", S.String.ast, false, true))
+    deepStrictEqual(signatures[1].name, "b")
+    deepStrictEqual(signatures[1].isOptional, false)
+    deepStrictEqual(signatures[1].isReadonly, true)
+    // b's type on the decoded side is Option<number> (a Declaration AST)
+    deepStrictEqual(signatures[1].type._tag, "Declaration")
+  })
 })


### PR DESCRIPTION
## Summary

- `SchemaAST.getPropertyKeyIndexedAccess` now handles `Transformation` AST nodes by delegating to `ast.to`, matching the existing behavior of `getPropertyKeys`
- Fixes a crash where `getPropertySignatures` throws `"Unsupported schema (Transformation)"` on any `Schema.Struct` containing `Schema.optionalWith` with `{ default }`, `{ as: "Option" }`, `{ nullable: true }`, or similar options
- This also fixes `@effect/ai`'s `Tool.getJsonSchema()` and `LanguageModel.streamText`, which call `getPropertySignatures` when building tool definitions

Closes #6085

## Root cause

`getPropertySignatures` falls through its switch to a [fallback path](https://github.com/Effect-TS/effect/blob/effect%403.19.19/packages/effect/src/SchemaAST.ts#L2219) that calls `getPropertyKeys(ast)` then `getPropertyKeyIndexedAccess(ast, name)`. `getPropertyKeys` handles `Transformation` (delegates to `ast.to`, added in #2343), but `getPropertyKeyIndexedAccess` did not — so the first half succeeds and the second half crashes.

At the time of #2343, this asymmetry was safe: `getPropertyKeys` gained `Transformation` support for `pick`/`omit`, which handle Transformations directly and never reach the fallback. The gap became observable when `@effect/ai`'s `Tool.getJsonSchema` started calling `getPropertySignatures` on tool parameter schemas that use `optionalWith({ default })`.

## Fix

One line — add `case "Transformation": return getPropertyKeyIndexedAccess(ast.to, name)`, mirroring `getPropertyKeys`.

## Tests

Two new test cases in `getPropertySignatures.test.ts`:
- `Transformation (Struct with optionalWith default)` — the `{ default }` variant
- `Transformation (Struct with optionalWith as Option)` — the `{ as: "Option" }` variant

Full suite passes (6152 tests, 0 failures), `pnpm check` clean.

## Related

`getIndexSignatures` has the same missing `Transformation` case. It doesn't crash (returns `[]` silently), but it causes `Schema.omit` to silently drop index signatures on Transformation structs. That's a separate bug with a different surface area.

## Playground repro

https://effect.website/play/#edb480bc7434