### PR TITLE
Print primitive default values in cli --help output

### DIFF
--- a/.changeset/sad-areas-grin.md
+++ b/.changeset/sad-areas-grin.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+print primitive default values in cli help output

--- a/packages/cli/src/internal/args.ts
+++ b/packages/cli/src/internal/args.ts
@@ -535,16 +535,17 @@ const getHelpInternal = (self: Instruction): HelpDoc.HelpDoc => {
       return InternalHelpDoc.mapDescriptionList(
         getHelpInternal(self.args as Instruction),
         (span, block) => {
+          const defaultDescription = (value: unknown) => {
+            const inspectableValue = Predicate.isObject(value) ? value : String(value)
+            const displayValue = Inspectable.toStringUnknown(inspectableValue, 0)
+            return InternalHelpDoc.p(`This setting is optional. Defaults to: ${displayValue}`)
+          }
           const optionalDescription = Option.isOption(self.fallback)
             ? Option.match(self.fallback, {
               onNone: () => InternalHelpDoc.p("This setting is optional."),
-              onSome: (fallbackValue) => {
-                const inspectableValue = Predicate.isObject(fallbackValue) ? fallbackValue : String(fallbackValue)
-                const displayValue = Inspectable.toStringUnknown(inspectableValue, 0)
-                return InternalHelpDoc.p(`This setting is optional. Defaults to: ${displayValue}`)
-              }
+              onSome: defaultDescription
             })
-            : InternalHelpDoc.p("This setting is optional.")
+            : defaultDescription(self.fallback)
           return [span, InternalHelpDoc.sequence(block, optionalDescription)]
         }
       )

--- a/packages/cli/src/internal/options.ts
+++ b/packages/cli/src/internal/options.ts
@@ -789,16 +789,17 @@ const getHelpInternal = (self: Instruction): HelpDoc.HelpDoc => {
       return InternalHelpDoc.mapDescriptionList(
         getHelpInternal(self.options as Instruction),
         (span, block) => {
+          const defaultDescription = (value: unknown) => {
+            const inspectableValue = Predicate.isObject(value) ? value : String(value)
+            const displayValue = Inspectable.toStringUnknown(inspectableValue, 0)
+            return InternalHelpDoc.p(`This setting is optional. Defaults to: ${displayValue}`)
+          }
           const optionalDescription = Option.isOption(self.fallback)
             ? Option.match(self.fallback, {
               onNone: () => InternalHelpDoc.p("This setting is optional."),
-              onSome: (fallbackValue) => {
-                const inspectableValue = Predicate.isObject(fallbackValue) ? fallbackValue : String(fallbackValue)
-                const displayValue = Inspectable.toStringUnknown(inspectableValue, 0)
-                return InternalHelpDoc.p(`This setting is optional. Defaults to: ${displayValue}`)
-              }
+              onSome: defaultDescription
             })
-            : InternalHelpDoc.p("This setting is optional.")
+            : defaultDescription(self.fallback)
           return [span, InternalHelpDoc.sequence(block, optionalDescription)]
         }
       )

--- a/packages/cli/test/Args.test.ts
+++ b/packages/cli/test/Args.test.ts
@@ -171,4 +171,13 @@ describe("Args", () => {
       const helpDoc = Args.getHelp(option)
       yield* Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-no-default"))
     }).pipe(runEffect))
+
+  it("displays default value in help when default is a primitive value", () =>
+    Effect.gen(function*() {
+      const args = Args.withDefault(Args.integer({ name: "count" }), 42)
+      const helpDoc = Args.getHelp(args)
+      yield* Effect.promise(() =>
+        expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/args-default-primitive-value")
+      )
+    }).pipe(runEffect))
 })

--- a/packages/cli/test/Options.test.ts
+++ b/packages/cli/test/Options.test.ts
@@ -701,6 +701,27 @@ describe("Options", () => {
       yield* Effect.promise(() => expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/options-no-default"))
     }).pipe(runEffect))
 
+  it("displays default value in help when default is a primitive value", () =>
+    Effect.gen(function*() {
+      const option = Options.withDefault(Options.integer("count"), 42)
+      const helpDoc = Options.getHelp(option)
+      yield* Effect.promise(() =>
+        expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/options-default-primitive-value")
+      )
+    }).pipe(runEffect))
+
+  it("displays default value in help when default is a primitive boolean", () =>
+    Effect.gen(function*() {
+      const option = Options.withDefault(
+        Options.choiceWithValue("uppercase", [["true", true], ["false", false]]),
+        false
+      )
+      const helpDoc = Options.getHelp(option)
+      yield* Effect.promise(() =>
+        expect(helpDoc).toMatchFileSnapshot("./snapshots/help-output/options-default-primitive-boolean")
+      )
+    }).pipe(runEffect))
+
   describe("options after positional arguments", () => {
     it("parses a text option that appears after positional args", () =>
       Effect.gen(function*() {

--- a/packages/cli/test/snapshots/help-output/args-default-primitive-value
+++ b/packages/cli/test/snapshots/help-output/args-default-primitive-value
@@ -1,0 +1,31 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Weak",
+        "value": {
+          "_tag": "Text",
+          "value": "<count>",
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "An integer.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: 42",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/options-default-primitive-boolean
+++ b/packages/cli/test/snapshots/help-output/options-default-primitive-boolean
@@ -1,0 +1,42 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Text",
+          "value": "--uppercase",
+        },
+        "right": {
+          "_tag": "Sequence",
+          "left": {
+            "_tag": "Text",
+            "value": " ",
+          },
+          "right": {
+            "_tag": "Text",
+            "value": "true | false",
+          },
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "One of the following: true, false",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: false",
+          },
+        },
+      },
+    ],
+  ],
+}

--- a/packages/cli/test/snapshots/help-output/options-default-primitive-value
+++ b/packages/cli/test/snapshots/help-output/options-default-primitive-value
@@ -1,0 +1,42 @@
+{
+  "_tag": "DescriptionList",
+  "definitions": [
+    [
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Text",
+          "value": "--count",
+        },
+        "right": {
+          "_tag": "Sequence",
+          "left": {
+            "_tag": "Text",
+            "value": " ",
+          },
+          "right": {
+            "_tag": "Text",
+            "value": "integer",
+          },
+        },
+      },
+      {
+        "_tag": "Sequence",
+        "left": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "An integer.",
+          },
+        },
+        "right": {
+          "_tag": "Paragraph",
+          "value": {
+            "_tag": "Text",
+            "value": "This setting is optional. Defaults to: 42",
+          },
+        },
+      },
+    ],
+  ],
+}


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Amends the behavior of `--help` to print out the default value when it's a primitive value not wrapped in an `Option`. For example:

```
This setting is optional. Defaults to: 42
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #6098 
