### PR TITLE
fix: correct typos in source code (receive, separate)

### DIFF
--- a/.changeset/fix-typos-receive-separate.md
+++ b/.changeset/fix-typos-receive-separate.md
@@ -1,0 +1,7 @@
+---
+"@effect/cluster": patch
+"@effect/rpc": patch
+"@effect/sql": patch
+---
+
+fix: correct typos in source code (receive, separate)

--- a/packages/cluster/src/RunnerServer.ts
+++ b/packages/cluster/src/RunnerServer.ts
@@ -139,7 +139,7 @@ export const layerHandlers = Runners.Rpcs.toLayer(Effect.gen(function*() {
 const constWaitUntilRead = { waitUntilRead: true } as const
 
 /**
- * The `RunnerServer` recieves messages from other Runners and forwards them to the
+ * The `RunnerServer` receives messages from other Runners and forwards them to the
  * `Sharding` layer.
  *
  * It also responds to `Ping` requests.
@@ -179,7 +179,7 @@ export const layerWithClients: Layer.Layer<
 /**
  * A `Runners` layer that is client only.
  *
- * It will not register with RunnerStorage and recieve shard assignments,
+ * It will not register with RunnerStorage and receive shard assignments,
  * so this layer can be used to embed a cluster client inside another effect
  * application.
  *

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -1045,18 +1045,18 @@ const defaultRetrySchedule = Schedule.exponential(500, 1.5).pipe(
 )
 
 const makePinger = Effect.fnUntraced(function*<A, E, R>(writePing: Effect.Effect<A, E, R>) {
-  let recievedPong = true
+  let receivedPong = true
   const latch = Effect.unsafeMakeLatch()
   const reset = () => {
-    recievedPong = true
+    receivedPong = true
     latch.unsafeClose()
   }
   const onPong = () => {
-    recievedPong = true
+    receivedPong = true
   }
   yield* Effect.suspend(() => {
-    if (!recievedPong) return latch.open
-    recievedPong = false
+    if (!receivedPong) return latch.open
+    receivedPong = false
     return writePing
   }).pipe(
     Effect.delay("10 seconds"),

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -423,7 +423,7 @@ export const layerJsonRpc = (options?: {
 }): Layer.Layer<RpcSerialization> => Layer.succeed(RpcSerialization, jsonRpc(options))
 
 /**
- * A rpc serialization layer that uses JSON-RPC for serialization seperated by
+ * A rpc serialization layer that uses JSON-RPC for serialization separated by
  * new lines.
  *
  * @since 1.0.0

--- a/packages/sql/src/Statement.ts
+++ b/packages/sql/src/Statement.ts
@@ -322,7 +322,7 @@ export interface Constructor {
   readonly or: (clauses: ReadonlyArray<string | Fragment>) => Fragment
 
   /**
-   * Create comma seperated values, with an optional prefix
+   * Create comma separated values, with an optional prefix
    *
    * Useful for `ORDER BY` and `GROUP BY` clauses
    */


### PR DESCRIPTION
## Summary

Fix spelling errors across multiple packages in source code:

- `packages/cluster/src/RunnerServer.ts`: `recieves` → `receives`, `recieve` → `receive`
- `packages/rpc/src/RpcClient.ts`: `recievedPong` → `receivedPong` (variable name)
- `packages/rpc/src/RpcSerialization.ts`: `seperated` → `separated`
- `packages/sql/src/Statement.ts`: `seperate` → `separate`

Only JSDoc comments and a local variable name are changed — no behavioral changes.