### PR TITLE
feat(Record): make fromIterableBy dual/pipeable

### DIFF
--- a/.changeset/feat-record-fromIterableBy-dual.md
+++ b/.changeset/feat-record-fromIterableBy-dual.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+feat(Record): make fromIterableBy dual/pipeable

--- a/packages/effect/src/Record.ts
+++ b/packages/effect/src/Record.ts
@@ -150,14 +150,25 @@ export const fromIterableWith: {
  * ```ts
  * import * as assert from "node:assert"
  * import { fromIterableBy } from "effect/Record"
+ * import { pipe } from "effect/Function"
  *
  * const users = [
  *   { id: "2", name: "name2" },
  *   { id: "1", name: "name1" }
  * ]
  *
+ * // data-first
  * assert.deepStrictEqual(
  *   fromIterableBy(users, user => user.id),
+ *   {
+ *     "2": { id: "2", name: "name2" },
+ *     "1": { id: "1", name: "name1" }
+ *   }
+ * )
+ *
+ * // data-last (pipeable)
+ * assert.deepStrictEqual(
+ *   pipe(users, fromIterableBy(user => user.id)),
  *   {
  *     "2": { id: "2", name: "name2" },
  *     "1": { id: "1", name: "name1" }
@@ -168,10 +179,21 @@ export const fromIterableWith: {
  * @category constructors
  * @since 2.0.0
  */
-export const fromIterableBy = <A, K extends string | symbol>(
-  items: Iterable<A>,
-  f: (a: A) => K
-): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(items, (a) => [f(a), a])
+export const fromIterableBy: {
+  <A, K extends string | symbol>(
+    f: (a: A) => K
+  ): (self: Iterable<A>) => Record<ReadonlyRecord.NonLiteralKey<K>, A>
+  <A, K extends string | symbol>(
+    self: Iterable<A>,
+    f: (a: A) => K
+  ): Record<ReadonlyRecord.NonLiteralKey<K>, A>
+} = dual(
+  2,
+  <A, K extends string | symbol>(
+    self: Iterable<A>,
+    f: (a: A) => K
+  ): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(self, (a) => [f(a), a])
+)
 
 /**
  * Builds a record from an iterable of key-value pairs.


### PR DESCRIPTION
## Summary

Make `Record.fromIterableBy` support both data-first and data-last (pipeable) calling conventions, consistent with `Record.fromIterableWith` and other dual APIs in the Record module.

### Before
```ts
// Only data-first works
pipe(rows, (rows) => Record.fromIterableBy(rows, Struct.get("authEmail")))
```

### After
```ts
// Both styles work
Record.fromIterableBy(rows, Struct.get("authEmail"))       // data-first
pipe(rows, Record.fromIterableBy(Struct.get("authEmail"))) // data-last
```

Closes #6092