### PR TITLE
fix(ai-openrouter): handle usage-only terminal stream chunks

### DIFF
--- a/.changeset/quick-lamps-peel.md
+++ b/.changeset/quick-lamps-peel.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Fix OpenRouter streaming finalization for usage-only terminal chunks.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -753,7 +753,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
 
         const choice = event.choices[0]
 
-        if (Predicate.isUndefined(choice)) {
+        if (Predicate.isUndefined(choice) && Predicate.isUndefined(event.usage)) {
           return yield* new AiError.MalformedOutput({
             module: "OpenRouterLanguageModel",
             method: "makeResponse",
@@ -761,11 +761,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
           })
         }
 
-        const delta = choice.delta
-
-        if (Predicate.isUndefined(delta)) {
-          return parts
-        }
+        const delta = choice?.delta
 
         // Reasoning Parts
 
@@ -796,7 +792,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
           })
         }
 
-        if (Predicate.isNotNullable(delta.reasoning_details) && delta.reasoning_details.length > 0) {
+        if (Predicate.isNotNullable(delta?.reasoning_details) && delta.reasoning_details.length > 0) {
           for (const detail of delta.reasoning_details) {
             switch (detail.type) {
               case "reasoning.summary": {
@@ -826,13 +822,13 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
               }
             }
           }
-        } else if (Predicate.isNotNullable(delta.reasoning) && delta.reasoning.length > 0) {
+        } else if (Predicate.isNotNullable(delta?.reasoning) && delta.reasoning.length > 0) {
           emitReasoningPart(delta.reasoning)
         }
 
         // Text Parts
 
-        if (Predicate.isNotNullable(delta.content) && delta.content.length > 0) {
+        if (Predicate.isNotNullable(delta?.content) && delta.content.length > 0) {
           // End in-progress reasoning part if present before starting text
           if (Predicate.isNotUndefined(activeReasoningId)) {
             parts.push({
@@ -859,7 +855,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
 
         // Source Parts
 
-        if (Predicate.isNotNullable(delta.annotations)) {
+        if (Predicate.isNotNullable(delta?.annotations)) {
           for (const annotation of delta.annotations) {
             if (annotation.type === "url_citation") {
               parts.push({
@@ -880,7 +876,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
 
         // Tool Call Parts
 
-        if (Predicate.isNotNullable(delta.tool_calls) && delta.tool_calls.length > 0) {
+        if (Predicate.isNotNullable(delta?.tool_calls) && delta.tool_calls.length > 0) {
           for (const toolCall of delta.tool_calls) {
             // Get the active tool call, if present
             let activeToolCall = activeToolCalls[toolCall.index]
@@ -946,7 +942,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
 
         // File Parts
 
-        if (Predicate.isNotNullable(delta.images)) {
+        if (Predicate.isNotNullable(delta?.images)) {
           for (const image of delta.images) {
             parts.push({
               type: "file",
@@ -958,7 +954,7 @@ const makeStreamResponse: (stream: Stream.Stream<ChatStreamingResponseChunk, AiE
 
         // Finish Parts
 
-        if (Predicate.isNotNullable(choice.finish_reason)) {
+        if (Predicate.isNotNullable(choice?.finish_reason)) {
           finishReason = InternalUtilities.resolveFinishReason(choice.finish_reason)
         }
 


### PR DESCRIPTION
## Summary

Closes #6116.

It appears OpenRouter recently made a change where it can end a streamed response with a final chunk that contains usage data but no choices:

```js
data: { "choices": [], "usage": {"prompt_tokens": 13, "completion_tokens": 16, "total_tokens": 29, "cost": 0.000093, "is_byok": false, "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0, "audio_tokens": 0, "video_tokens": 0}, "cost_details": {"upstream_inference_cost": 0.000093, "upstream_inference_prompt_cost": 0.000013, "upstream_inference_completions_cost": 0.00008}, "completion_tokens_details": {"reasoning_tokens": 0, "image_tokens": 0, "audio_tokens": 0}} }
```

Right now `makeStreamResponse` assumes every streamed chunk has at least one choice. That means this terminal chunk gets treated as malformed, and the stream fails at the very end even though the model output was already streamed successfully.

This PR makes the streaming adapter a little more permissive in that one case. Chunks with neither a choice nor usage are still treated as malformed, but a terminal usage-only chunk is now allowed through so the existing finish and usage finalization logic can run normally.

OpenRouter documents that the final chunk includes usage stats, but they do not clearly say whether an empty `choices` array is valid (evidently it now is):
https://openrouter.ai/docs/api/reference/streaming

This appears to be the same OpenRouter streaming issue that was recently reported and fixed in Zed's agent:
- zed-industries/zed#50569
- zed-industries/zed#50603

## Tests?

I've validated the fix within my project impacted by the issue and it appears to work.

I did not see any unit tests within the repo that I could add to. Please let me know if I've missed that, or if adding some baseline tests for the package would be desired. 