### PR TITLE
fix(effect): isolate scheduler runners per fiber

### DIFF
--- a/.changeset/giant-horses-clean.md
+++ b/.changeset/giant-horses-clean.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Runtime.runPromise` to isolate `AsyncLocalStorage` across concurrent calls.
+Fix scheduler task draining to isolate `AsyncLocalStorage` across fibers.

--- a/packages/cluster/test/Sharding.test.ts
+++ b/packages/cluster/test/Sharding.test.ts
@@ -96,10 +96,14 @@ describe.concurrent("Sharding", () => {
         yield* TestClock.adjust(1)
         const config = yield* ShardingConfig.ShardingConfig
         ;(config as any).runnerAddress = Option.some(RunnerAddress.make("localhost", 1234))
-        fiber.currentScheduler.scheduleTask(() => {
-          fiber.unsafeInterruptAsFork(FiberId.none)
-          Effect.runFork(testClock.adjust(30000))
-        }, 0)
+        fiber.currentScheduler.scheduleTask(
+          () => {
+            fiber.unsafeInterruptAsFork(FiberId.none)
+            Effect.runFork(testClock.adjust(30000))
+          },
+          0,
+          fiber
+        )
       }).pipe(
         Effect.provide(TestShardingWithoutRunners.pipe(
           Layer.provide(Layer.scoped(

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -21,7 +21,69 @@ export type Task = () => void
  */
 export interface Scheduler {
   shouldYield(fiber: RuntimeFiber<unknown, unknown>): number | false
-  scheduleTask(task: Task, priority: number): void
+  scheduleTask(task: Task, priority: number, fiber?: RuntimeFiber<unknown, unknown>): void
+}
+
+/**
+ * @since 3.20.0
+ * @category models
+ */
+export class SchedulerRunner {
+  running = false
+  tasks = new PriorityBuckets()
+
+  constructor(
+    readonly scheduleDrain: (depth: number, drain: (depth: number) => void) => void
+  ) {}
+
+  private starveInternal = (depth: number) => {
+    const tasks = this.tasks.buckets
+    this.tasks.buckets = []
+    for (const [_, toRun] of tasks) {
+      for (let i = 0; i < toRun.length; i++) {
+        toRun[i]()
+      }
+    }
+    if (this.tasks.buckets.length === 0) {
+      this.running = false
+    } else {
+      this.starve(depth)
+    }
+  }
+
+  private starve(depth = 0) {
+    this.scheduleDrain(depth, this.starveInternal)
+  }
+
+  scheduleTask(task: Task, priority: number) {
+    this.tasks.scheduleTask(task, priority)
+    if (!this.running) {
+      this.running = true
+      this.starve()
+    }
+  }
+  /**
+   * @since 3.20.0
+   * @category constructors
+   */
+  static cached(
+    scheduleDrain: (depth: number, drain: (depth: number) => void) => void
+  ) {
+    const fallback = new SchedulerRunner(scheduleDrain)
+    const runners = new WeakMap<RuntimeFiber<unknown, unknown>, SchedulerRunner>()
+
+    return (fiber?: RuntimeFiber<unknown, unknown>) => {
+      if (fiber === undefined) {
+        return fallback
+      }
+      let runner = runners.get(fiber)
+      if (runner === undefined) {
+        runner = new SchedulerRunner(scheduleDrain)
+        runners.set(fiber, runner)
+      }
+      return runner
+    }
+  }
 }
 
 /**
@@ -62,14 +124,13 @@ export class PriorityBuckets<in out T = Task> {
  * @category constructors
  */
 export class MixedScheduler implements Scheduler {
-  /**
-   * @since 2.0.0
-   */
-  running = false
-  /**
-   * @since 2.0.0
-   */
-  tasks = new PriorityBuckets()
+  private readonly getRunner = SchedulerRunner.cached((depth, drain) => {
+    if (depth >= this.maxNextTickBeforeTimer) {
+      setTimeout(() => drain(0), 0)
+    } else {
+      Promise.resolve(void 0).then(() => drain(depth + 1))
+    }
+  })
 
   constructor(
     /**
@@ -77,35 +138,6 @@ export class MixedScheduler implements Scheduler {
      */
     readonly maxNextTickBeforeTimer: number
   ) {}
-
-  /**
-   * @since 2.0.0
-   */
-  private starveInternal(depth: number) {
-    const tasks = this.tasks.buckets
-    this.tasks.buckets = []
-    for (const [_, toRun] of tasks) {
-      for (let i = 0; i < toRun.length; i++) {
-        toRun[i]()
-      }
-    }
-    if (this.tasks.buckets.length === 0) {
-      this.running = false
-    } else {
-      this.starve(depth)
-    }
-  }
-
-  /**
-   * @since 2.0.0
-   */
-  private starve(depth = 0) {
-    if (depth >= this.maxNextTickBeforeTimer) {
-      setTimeout(() => this.starveInternal(0), 0)
-    } else {
-      Promise.resolve(void 0).then(() => this.starveInternal(depth + 1))
-    }
-  }
 
   /**
    * @since 2.0.0
@@ -119,12 +151,8 @@ export class MixedScheduler implements Scheduler {
   /**
    * @since 2.0.0
    */
-  scheduleTask(task: Task, priority: number) {
-    this.tasks.scheduleTask(task, priority)
-    if (!this.running) {
-      this.running = true
-      this.starve()
-    }
+  scheduleTask(task: Task, priority: number, fiber?: RuntimeFiber<unknown, unknown>) {
+    this.getRunner(fiber).scheduleTask(task, priority)
   }
 }
 
@@ -155,9 +183,9 @@ export class SyncScheduler implements Scheduler {
   /**
    * @since 2.0.0
    */
-  scheduleTask(task: Task, priority: number) {
+  scheduleTask(task: Task, priority: number, fiber?: RuntimeFiber<unknown, unknown>) {
     if (this.deferred) {
-      defaultScheduler.scheduleTask(task, priority)
+      defaultScheduler.scheduleTask(task, priority, fiber)
     } else {
       this.tasks.scheduleTask(task, priority)
     }
@@ -207,9 +235,9 @@ export class ControlledScheduler implements Scheduler {
   /**
    * @since 2.0.0
    */
-  scheduleTask(task: Task, priority: number) {
+  scheduleTask(task: Task, priority: number, fiber?: RuntimeFiber<unknown, unknown>) {
     if (this.deferred) {
-      defaultScheduler.scheduleTask(task, priority)
+      defaultScheduler.scheduleTask(task, priority, fiber)
     } else {
       this.tasks.scheduleTask(task, priority)
     }
@@ -254,16 +282,16 @@ export const makeMatrix = (...record: Array<[number, Scheduler]>): Scheduler => 
       }
       return false
     },
-    scheduleTask(task, priority) {
+    scheduleTask(task, priority, fiber) {
       let scheduler: Scheduler | undefined = undefined
       for (const i of index) {
         if (priority >= i[0]) {
           scheduler = i[1]
         } else {
-          return (scheduler ?? defaultScheduler).scheduleTask(task, priority)
+          return (scheduler ?? defaultScheduler).scheduleTask(task, priority, fiber)
         }
       }
-      return (scheduler ?? defaultScheduler).scheduleTask(task, priority)
+      return (scheduler ?? defaultScheduler).scheduleTask(task, priority, fiber)
     }
   }
 }
@@ -298,31 +326,12 @@ export const makeBatched = (
   callback: (runBatch: () => void) => void,
   shouldYield: Scheduler["shouldYield"] = defaultShouldYield
 ) => {
-  let running = false
-  const tasks = new PriorityBuckets()
-  const starveInternal = () => {
-    const tasksToRun = tasks.buckets
-    tasks.buckets = []
-    for (const [_, toRun] of tasksToRun) {
-      for (let i = 0; i < toRun.length; i++) {
-        toRun[i]()
-      }
-    }
-    if (tasks.buckets.length === 0) {
-      running = false
-    } else {
-      starve()
-    }
-  }
+  const getRunner = SchedulerRunner.cached((_, drain) => {
+    callback(() => drain(0))
+  })
 
-  const starve = () => callback(starveInternal)
-
-  return make((task, priority) => {
-    tasks.scheduleTask(task, priority)
-    if (!running) {
-      running = true
-      starve()
-    }
+  return make((task, priority, fiber) => {
+    getRunner(fiber).scheduleTask(task, priority)
   }, shouldYield)
 }
 

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -70,14 +70,18 @@ class Semaphore {
   updateTakenUnsafe(fiber: Fiber.RuntimeFiber<any, any>, f: (n: number) => number): Effect.Effect<number> {
     this.taken = f(this.taken)
     if (this.waiters.size > 0) {
-      fiber.getFiberRef(currentScheduler).scheduleTask(() => {
-        const iter = this.waiters.values()
-        let item = iter.next()
-        while (item.done === false && this.free > 0) {
-          item.value()
-          item = iter.next()
-        }
-      }, fiber.getFiberRef(core.currentSchedulingPriority))
+      fiber.getFiberRef(currentScheduler).scheduleTask(
+        () => {
+          const iter = this.waiters.values()
+          let item = iter.next()
+          while (item.done === false && this.free > 0) {
+            item.value()
+            item = iter.next()
+          }
+        },
+        fiber.getFiberRef(core.currentSchedulingPriority),
+        fiber
+      )
     }
     return core.succeed(this.free)
   }
@@ -143,7 +147,7 @@ class Latch extends Effectable.Class<void> implements Effect.Latch {
       return core.void
     }
     this.scheduled = true
-    fiber.currentScheduler.scheduleTask(this.flushWaiters, fiber.getFiberRef(core.currentSchedulingPriority))
+    fiber.currentScheduler.scheduleTask(this.flushWaiters, fiber.getFiberRef(core.currentSchedulingPriority), fiber)
     return core.void
   }
   private flushWaiters = () => {

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -708,7 +708,8 @@ export class FiberRuntime<in out A, in out E = never> extends Effectable.Class<A
   drainQueueLaterOnExecutor() {
     this.currentScheduler.scheduleTask(
       this.run,
-      this.getFiberRef(core.currentSchedulingPriority)
+      this.getFiberRef(core.currentSchedulingPriority),
+      this
     )
   }
 
@@ -2209,9 +2210,13 @@ export const forEachConcurrentDiscard = <A, X, E, R>(
         const results = new Array()
         const interruptAll = () =>
           fibers.forEach((fiber) => {
-            fiber.currentScheduler.scheduleTask(() => {
-              fiber.unsafeInterruptAsFork(parent.id())
-            }, 0)
+            fiber.currentScheduler.scheduleTask(
+              () => {
+                fiber.unsafeInterruptAsFork(parent.id())
+              },
+              0,
+              fiber
+            )
           })
         const startOrder = new Array<FiberRuntime<Exit.Exit<X, E> | Effect.Blocked<X, E>>>()
         const joinOrder = new Array<FiberRuntime<Exit.Exit<X, E> | Effect.Blocked<X, E>>>()
@@ -2234,12 +2239,16 @@ export const forEachConcurrentDiscard = <A, X, E, R>(
             parent.currentRuntimeFlags,
             fiberScope.globalScope
           )
-          parent.currentScheduler.scheduleTask(() => {
-            if (interruptImmediately) {
-              fiber.unsafeInterruptAsFork(parent.id())
-            }
-            fiber.resume(runnable)
-          }, 0)
+          parent.currentScheduler.scheduleTask(
+            () => {
+              if (interruptImmediately) {
+                fiber.unsafeInterruptAsFork(parent.id())
+              }
+              fiber.resume(runnable)
+            },
+            0,
+            fiber
+          )
           return fiber
         }
         const onInterruptSignal = () => {
@@ -2295,9 +2304,13 @@ export const forEachConcurrentDiscard = <A, X, E, R>(
                 startOrder.push(fiber)
                 fibers.add(fiber)
                 if (interrupted) {
-                  fiber.currentScheduler.scheduleTask(() => {
-                    fiber.unsafeInterruptAsFork(parent.id())
-                  }, 0)
+                  fiber.currentScheduler.scheduleTask(
+                    () => {
+                      fiber.unsafeInterruptAsFork(parent.id())
+                    },
+                    0,
+                    fiber
+                  )
                 }
                 fiber.addObserver((wrapped) => {
                   let exit: Exit.Exit<any, any> | core.Blocked

--- a/packages/effect/src/internal/runtime.ts
+++ b/packages/effect/src/internal/runtime.ts
@@ -63,8 +63,6 @@ export const unsafeFork: {
 
   if (options?.scheduler) {
     fiberRefUpdates.push([scheduler_.currentScheduler, [[fiberId, options.scheduler]]])
-  } else if (!runtime.fiberRefs.locals.has(scheduler_.currentScheduler)) {
-    fiberRefUpdates.push([scheduler_.currentScheduler, [[fiberId, new scheduler_.MixedScheduler(2048)]]])
   }
 
   let fiberRefs = FiberRefs.updateManyAs(runtime.fiberRefs, {

--- a/packages/effect/test/Runtime.test.ts
+++ b/packages/effect/test/Runtime.test.ts
@@ -87,23 +87,29 @@ describe("Runtime", () => {
         Effect.sync(() => requestStore.getStore()?.userId ?? "NONE").pipe(
           Effect.flatMap((expected) =>
             Effect.async<Result>((resume) => {
-              fiber.currentScheduler.scheduleTask(() => {
-                resume(
-                  Effect.succeed({
-                    expected,
-                    observed: requestStore.getStore()?.userId ?? "NONE"
-                  })
-                )
-              }, 0)
+              fiber.currentScheduler.scheduleTask(
+                () => {
+                  resume(
+                    Effect.succeed({
+                      expected,
+                      observed: requestStore.getStore()?.userId ?? "NONE"
+                    })
+                  )
+                },
+                0,
+                fiber
+              )
             })
           )
         )
       )
 
+      const runtime = yield* Effect.runtime<never>()
+
       const runRequest = (userId: string): Promise<Result> =>
         requestStore.run(
           { userId },
-          () => Runtime.runPromise(Runtime.defaultRuntime)(readAlsOnScheduledContinuation)
+          () => Runtime.runPromise(runtime)(readAlsOnScheduledContinuation)
         )
 
       const results = yield* Effect.promise(() =>

--- a/packages/platform/src/internal/workerRunner.ts
+++ b/packages/platform/src/internal/workerRunner.ts
@@ -47,9 +47,13 @@ export const make = Effect.fnUntraced(function*<I, E, R, O>(
 
   yield* Deferred.await(closeLatch).pipe(
     Effect.onExit(() => {
-      fiber.currentScheduler.scheduleTask(() => {
-        fiber.unsafeInterruptAsFork(fiber.id())
-      }, 0)
+      fiber.currentScheduler.scheduleTask(
+        () => {
+          fiber.unsafeInterruptAsFork(fiber.id())
+        },
+        0,
+        fiber
+      )
       return Effect.void
     }),
     Effect.forkScoped

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -376,9 +376,13 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
               completed = true
               resume(exit)
               if (fiber && !fiber.unsafePoll()) {
-                parentFiber.currentScheduler.scheduleTask(() => {
-                  fiber.unsafeInterruptAsFork(parentFiber.id())
-                }, 0)
+                parentFiber.currentScheduler.scheduleTask(
+                  () => {
+                    fiber.unsafeInterruptAsFork(parentFiber.id())
+                  },
+                  0,
+                  fiber
+                )
               }
             }
           }

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -1142,7 +1142,7 @@ export const makeProtocolWorkerRunner: Effect.Effect<
 
   yield* Deferred.await(closeLatch).pipe(
     Effect.onExit(() => {
-      fiber.currentScheduler.scheduleTask(() => fiber.unsafeInterruptAsFork(fiber.id()), 0)
+      fiber.currentScheduler.scheduleTask(() => fiber.unsafeInterruptAsFork(fiber.id()), 0, fiber)
       return Effect.void
     }),
     Effect.forkScoped


### PR DESCRIPTION
## Summary
- isolate scheduler draining per fiber by adding `SchedulerRunner` and threading the target fiber through `scheduleTask`
- update runtime-facing regression coverage to extract a runtime with `Effect.runtime<never>()` and verify concurrent `Runtime.runPromise(runtime)` calls keep `AsyncLocalStorage` isolated
- expose `SchedulerRunner` and `SchedulerRunner.cached`, and update the changeset to describe the scheduler-level fix

## Validation
- `pnpm test run packages/effect/test/Runtime.test.ts`
- `pnpm lint-fix`
- `pnpm docgen` *(still fails in existing workspace state: `@effect/platform-node` example typechecking)*
- `pnpm check` *(still fails in existing workspace state: missing `pg` types in `packages/cluster/test/fixtures/utils-pg.ts` and `packages/sql-drizzle/test/utils-pg.ts`)*
- `pnpm clean && pnpm check` *(same existing failure)*
- `pnpm build` *(still fails in existing workspace state: missing TypeScript binaries while building some workspace packages)*