### PR TITLE
fix(effect): correct scheduler changeset level

### DIFF
--- a/.changeset/giant-horses-clean.md
+++ b/.changeset/giant-horses-clean.md
@@ -1,5 +1,5 @@
 ---
-"effect": patch
+"effect": minor
 ---
 
 Fix scheduler task draining to isolate `AsyncLocalStorage` across fibers.


### PR DESCRIPTION
## Summary
- correct the scheduler isolation changeset from a patch release to a minor release
- keep the existing changeset text and only update the release level

## Validation
- no code changes