### PR TITLE
Add Data.TaggedEnum example to taggedEnum JSDoc

### DIFF
--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -438,6 +438,20 @@ export declare namespace TaggedEnum {
  * ```
  *
  * @example
+ * ```ts
+ * import { Data } from "effect"
+ *
+ * type HttpError = Data.TaggedEnum<{
+ *   BadRequest: { readonly status: 400; readonly message: string }
+ *   NotFound: { readonly status: 404; readonly message: string }
+ * }>
+ *
+ * const { BadRequest, NotFound } = Data.taggedEnum<HttpError>()
+ *
+ * const notFound = NotFound({ status: 404, message: "Not Found" })
+ * ```
+ *
+ * @example
  * import { Data } from "effect"
  *
  * type MyResult<E, A> = Data.TaggedEnum<{

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -429,10 +429,12 @@ export declare namespace TaggedEnum {
  * ```ts
  * import { Data } from "effect"
  *
- * const { BadRequest, NotFound } = Data.taggedEnum<
- *   | { readonly _tag: "BadRequest"; readonly status: 400; readonly message: string }
- *   | { readonly _tag: "NotFound"; readonly status: 404; readonly message: string }
- * >()
+ * type HttpError = Data.TaggedEnum<{
+ *   BadRequest: { readonly status: 400; readonly message: string }
+ *   NotFound: { readonly status: 404; readonly message: string }
+ * }>
+ *
+ * const { BadRequest, NotFound } = Data.taggedEnum<HttpError>()
  *
  * const notFound = NotFound({ status: 404, message: "Not Found" })
  * ```


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The taggedEnum constructor was missing an example showing the common pattern of using Data.TaggedEnum<{...}> as the type parameter. The existing examples only showed the verbose union syntax and the generics case.

## Related

Conversation about it: https://discord.com/channels/795981131316985866/1486327719217201252

