### PR TITLE
fix(platform): preserve percent encoding in Url.setUrlParams and modifyUrlParams

### DIFF
--- a/packages/platform/src/Url.ts
+++ b/packages/platform/src/Url.ts
@@ -257,7 +257,7 @@ export const setUrlParams: {
   (url: URL, urlParams: UrlParams.UrlParams): URL
 } = dual(2, (url: URL, searchParams: UrlParams.UrlParams) =>
   mutate(url, (url) => {
-    url.search = UrlParams.toString(searchParams)
+    url.search = UrlParams.toPercentEncoded(searchParams)
   }))
 
 /**
@@ -320,5 +320,5 @@ export const modifyUrlParams: {
 } = dual(2, (url: URL, f: (urlParams: UrlParams.UrlParams) => UrlParams.UrlParams) =>
   mutate(url, (url) => {
     const params = f(UrlParams.fromInput(url.searchParams))
-    url.search = UrlParams.toString(params)
+    url.search = UrlParams.toPercentEncoded(params)
   }))

--- a/packages/platform/src/UrlParams.ts
+++ b/packages/platform/src/UrlParams.ts
@@ -229,6 +229,15 @@ export const makeUrl = (url: string, params: UrlParams, hash: Option.Option<stri
  */
 export const toString = (self: UrlParams): string => new URLSearchParams(self as any).toString()
 
+/**
+ * @since 1.0.0
+ * @category conversions
+ */
+export const toPercentEncoded = (self: UrlParams): string =>
+  self.map(([key, value]) =>
+    `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+  ).join("&")
+
 const baseUrl = (): string | undefined => {
   if (
     "location" in globalThis &&


### PR DESCRIPTION
## What
Fixes #6153 - `Url.modifyUrlParams` converts `%20` to `+` in query parameters, even when using an identity function.

## Root Cause
`Url.setUrlParams` and `Url.modifyUrlParams` both use `UrlParams.toString` to serialize params back to a search string. `UrlParams.toString` delegates to `new URLSearchParams(...).toString()` which encodes spaces as `+` per the `application/x-www-form-urlencoded` spec. This is correct for form request bodies but wrong for URL query strings where `%20` should be preserved.

## Reproduction
```ts
const url = new URL('https://example.com?foo=bar%20baz');
const url2 = Url.modifyUrlParams(url, identity);
url.href === url2.href; // false! %20 became +
```

## Fix
- Added `UrlParams.toPercentEncoded` which uses `encodeURIComponent` (producing `%20` for spaces)
- Updated `Url.setUrlParams` and `Url.modifyUrlParams` to use `toPercentEncoded` instead of `toString`
- Left `UrlParams.toString` unchanged for backward compatibility with `application/x-www-form-urlencoded` body encoding

## Files Changed
- `packages/platform/src/UrlParams.ts` - added `toPercentEncoded`  
- `packages/platform/src/Url.ts` - use `toPercentEncoded` in `setUrlParams` and `modifyUrlParams`