### PR TITLE
fix(rpc): make RpcSerialization.msgPack options configurable

### DIFF
--- a/.changeset/long-buckets-love.md
+++ b/.changeset/long-buckets-love.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+add RpcSerialization.makeMsgPack

--- a/packages/platform-node/test/NodeClusterSocket.test.ts
+++ b/packages/platform-node/test/NodeClusterSocket.test.ts
@@ -1,0 +1,122 @@
+import {
+  ClusterSchema,
+  Entity,
+  MessageStorage,
+  RunnerAddress,
+  RunnerHealth,
+  RunnerStorage,
+  ShardingConfig,
+  SocketRunner
+} from "@effect/cluster"
+import { NodeClusterSocket } from "@effect/platform-node"
+import { Rpc, RpcSerialization } from "@effect/rpc"
+import { describe, it } from "@effect/vitest"
+import { BigDecimal, Effect, Layer, Logger, LogLevel, Option, PrimaryKey, Schema } from "effect"
+
+class TestPayload extends Schema.Class<TestPayload>("TestPayload")({
+  id: Schema.String,
+  amount: Schema.BigDecimal
+}) {
+  [PrimaryKey.symbol]() {
+    return this.id
+  }
+}
+
+const TestEntity = Entity
+  .make("TestEntity", [
+    Rpc.make("Process", {
+      payload: TestPayload,
+      success: Schema.Void
+    })
+  ])
+  .annotateRpcs(ClusterSchema.Persisted, true)
+  .annotateRpcs(ClusterSchema.Uninterruptible, true)
+
+const TestEntityLayer = TestEntity.toLayer(
+  Effect.succeed({
+    Process: () => Effect.void
+  })
+)
+
+const RUNNER_PORT = 50_123
+// Build shared storage instances once, so runner and client see the same state.
+// MessageStorage.layerMemory requires ShardingConfig, so we provide a minimal one.
+const SharedStorage = Layer.mergeAll(
+  RunnerStorage.layerMemory,
+  MessageStorage.layerMemory
+).pipe(
+  Layer.provide(ShardingConfig.layerDefaults)
+)
+
+const makeRunnerLayer = (port: number) =>
+  TestEntityLayer.pipe(
+    Layer.provideMerge(SocketRunner.layer),
+    Layer.provide(RunnerHealth.layerNoop),
+    Layer.provide(NodeClusterSocket.layerSocketServer),
+    Layer.provide(NodeClusterSocket.layerClientProtocol),
+    Layer.provide(ShardingConfig.layer({
+      runnerAddress: Option.some(RunnerAddress.make("localhost", port)),
+      entityTerminationTimeout: 0,
+      entityMessagePollInterval: 5000,
+      sendRetryInterval: 100
+    })),
+    Layer.provide(RpcSerialization.layerMsgPack)
+  )
+
+const makeClientLayer = (port: number) =>
+  SocketRunner.layerClientOnly.pipe(
+    Layer.provide(NodeClusterSocket.layerClientProtocol),
+    Layer.provide(ShardingConfig.layer({
+      runnerAddress: Option.some(RunnerAddress.make("localhost", port)),
+      runnerListenAddress: Option.some(RunnerAddress.make("localhost", port)),
+      entityTerminationTimeout: 0,
+      entityMessagePollInterval: 5000,
+      sendRetryInterval: 100
+    })),
+    Layer.provide(RpcSerialization.layerMsgPack)
+  )
+
+// BigDecimal.normalize creates a circular `normalized` self-reference.
+// When a persisted message is sent with discard: true, the notify path in Runners.makeRpc
+// passes the raw envelope (with circular BigDecimal payload) to the runner via msgpack,
+// causing RangeError: Maximum call stack size exceeded.
+describe("SocketRunner", () => {
+  it.scopedLive(
+    "entity call with BigDecimal and discard should not stack overflow",
+    () =>
+      Effect.gen(function*() {
+        // Start the runner (with socket server and entity handler)
+        yield* Layer.launch(makeRunnerLayer(RUNNER_PORT)).pipe(Effect.forkScoped)
+
+        // Give the runner time to start and acquire shards
+        yield* Effect.sleep("2 seconds")
+        yield* Effect.log("Before starting the client")
+
+        // Send a message from the client with discard: true.
+        // The BigDecimal is normalized to trigger the circular `normalized` self-reference.
+        yield* Effect.gen(function*() {
+          yield* Effect.log("Starting the client")
+          yield* Effect.sleep("2 seconds")
+          const makeClient = yield* TestEntity.client
+          // Give the client time to discover the runner
+          yield* Effect.sleep("3 seconds")
+          const client = makeClient("entity-1")
+
+          const amount = BigDecimal.unsafeFromString("123.45")
+
+          yield* client.Process(
+            TestPayload.make({ id: "req-1", amount }),
+            { discard: true }
+          )
+        }).pipe(
+          Effect.provide(makeClientLayer(RUNNER_PORT)),
+          Effect.scoped
+        )
+      }).pipe(Effect.provide(
+        SharedStorage.pipe(Layer.provideMerge(
+          Logger.minimumLogLevel(LogLevel.None)
+        ))
+      )),
+    30_000
+  )
+})

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -352,43 +352,52 @@ interface JsonRpcResponse {
 type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse
 
 /**
+ * Create a MessagePack serialization with custom msgpackr options.
+ *
  * @since 1.0.0
  * @category serialization
  */
-export const msgPack: RpcSerialization["Type"] = RpcSerialization.of({
-  contentType: "application/msgpack",
-  includesFraming: true,
-  unsafeMake: () => {
-    const unpackr = new Msgpackr.Unpackr()
-    const packr = new Msgpackr.Packr()
-    const encoder = new TextEncoder()
-    let incomplete: Uint8Array | undefined = undefined
-    return {
-      decode: (bytes) => {
-        let buf = typeof bytes === "string" ? encoder.encode(bytes) : bytes
-        if (incomplete !== undefined) {
-          const prev = buf
-          bytes = new Uint8Array(incomplete.length + buf.length)
-          bytes.set(incomplete)
-          bytes.set(prev, incomplete.length)
-          buf = bytes
-          incomplete = undefined
-        }
-        try {
-          return unpackr.unpackMultiple(buf)
-        } catch (error_) {
-          const error = error_ as any
-          if (error.incomplete) {
-            incomplete = buf.subarray(error.lastPosition)
-            return error.values ?? []
+export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerialization["Type"] =>
+  RpcSerialization.of({
+    contentType: "application/msgpack",
+    includesFraming: true,
+    unsafeMake: () => {
+      const unpackr = new Msgpackr.Unpackr(options)
+      const packr = new Msgpackr.Packr(options)
+      const encoder = new TextEncoder()
+      let incomplete: Uint8Array | undefined = undefined
+      return {
+        decode(bytes) {
+          let buf = typeof bytes === "string" ? encoder.encode(bytes) : bytes
+          if (incomplete !== undefined) {
+            const prev = buf
+            bytes = new Uint8Array(incomplete.length + buf.length)
+            bytes.set(incomplete)
+            bytes.set(prev, incomplete.length)
+            buf = bytes
+            incomplete = undefined
           }
-          return []
-        }
-      },
-      encode: (response) => packr.pack(response)
+          try {
+            return unpackr.unpackMultiple(buf)
+          } catch (error_) {
+            const error = error_ as any
+            if (error.incomplete) {
+              incomplete = buf.subarray(error.lastPosition)
+              return error.values ?? []
+            }
+            throw error_
+          }
+        },
+        encode: (response) => packr.pack(response)
+      }
     }
-  }
-})
+  })
+
+/**
+ * @since 1.0.0
+ * @category serialization
+ */
+export const msgPack: RpcSerialization["Type"] = makeMsgPack()
 
 /**
  * A rpc serialization layer that uses JSON for serialization.

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -361,7 +361,7 @@ export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerializ
   RpcSerialization.of({
     contentType: "application/msgpack",
     includesFraming: true,
-    unsafeMake: () => {
+    unsafeMake() {
       const unpackr = new Msgpackr.Unpackr(options)
       const packr = new Msgpackr.Packr(options)
       const encoder = new TextEncoder()
@@ -397,7 +397,7 @@ export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerializ
  * @since 1.0.0
  * @category serialization
  */
-export const msgPack: RpcSerialization["Type"] = makeMsgPack()
+export const msgPack: RpcSerialization["Type"] = makeMsgPack({ useRecords: true })
 
 /**
  * A rpc serialization layer that uses JSON for serialization.

--- a/packages/rpc/test/RpcSerialization.test.ts
+++ b/packages/rpc/test/RpcSerialization.test.ts
@@ -1,0 +1,61 @@
+import { RpcSerialization } from "@effect/rpc"
+import { assert, describe, it } from "@effect/vitest"
+
+describe("RpcSerialization", () => {
+  describe("msgPack", () => {
+    it("encode and decode correctly", () => {
+      const parser = RpcSerialization.msgPack.unsafeMake()
+      const payload = { _tag: "Request", id: 1, method: "echo" }
+      const encoded = parser.encode(payload)
+      const decoded = parser.decode(encoded as Uint8Array)
+      assert.strictEqual(decoded.length, 1)
+      assert.deepStrictEqual(decoded[0], payload)
+    })
+
+    it("handles incomplete frames gracefully", () => {
+      const parser = RpcSerialization.msgPack.unsafeMake()
+      const helper = RpcSerialization.msgPack.unsafeMake()
+
+      const msg1 = helper.encode({ a: 1 }) as Uint8Array
+      const msg2 = helper.encode({ b: 2 }) as Uint8Array
+      const combined = new Uint8Array(msg1.length + msg2.length)
+      combined.set(msg1)
+      combined.set(msg2, msg1.length)
+
+      const truncated = combined.subarray(0, msg1.length + 2)
+      const decoded = parser.decode(truncated)
+
+      assert.strictEqual(decoded.length, 1)
+      assert.deepStrictEqual(decoded[0], { a: 1 })
+    })
+  })
+
+  describe("makeMsgPack", () => {
+    it("useRecords false encode and decode correctly", () => {
+      const parser = RpcSerialization.makeMsgPack({ useRecords: false }).unsafeMake()
+      const payload = { _tag: "Request", id: 1, method: "echo" }
+      const encoded = parser.encode(payload)
+      const decoded = parser.decode(encoded as Uint8Array)
+      assert.strictEqual(decoded.length, 1)
+      assert.deepStrictEqual(decoded[0], payload)
+    })
+
+    it("useRecords false handles nested objects with repeated structures", () => {
+      const parser = RpcSerialization.makeMsgPack({ useRecords: false }).unsafeMake()
+      const payload = {
+        _tag: "Chunk",
+        requestId: "1",
+        values: [
+          { _tag: "Exit", requestId: "1", exit: { _tag: "Success", value: { _tag: "Ok", data: "a" } } },
+          { _tag: "Exit", requestId: "2", exit: { _tag: "Success", value: { _tag: "Ok", data: "b" } } },
+          { _tag: "Exit", requestId: "3", exit: { _tag: "Success", value: { _tag: "Ok", data: "c" } } },
+          { _tag: "Exit", requestId: "4", exit: { _tag: "Success", value: { _tag: "Ok", data: "d" } } }
+        ]
+      }
+      const encoded = parser.encode(payload)
+      const decoded = parser.decode(encoded as Uint8Array)
+      assert.strictEqual(decoded.length, 1)
+      assert.deepStrictEqual(decoded[0], payload)
+    })
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/Effect-TS/effect/issues/6170

## Summary

- Adds `makeMsgPack(options)` factory for creating MessagePack serialization with custom msgpackr options
- Existing `msgPack` and `layerMsgPack` exports are unchanged (no breaking change)
- Fixes silent error swallowing in msgPack decode — non-incomplete errors are now rethrown instead of returning `[]`

## Problem

On Cloudflare Workers with `allow_eval_during_startup` (default for `compatibility_date >= 2025-06-01`), `RpcSerialization.msgPack` silently fails when decoding messages containing 3+ objects with the same key structure.

**Root cause:** `new Packr()` with no options sets `this.structures = []` because `undefined != false` evaluates to `true`. This enables msgpackr's record/structure path. When the Unpackr's `readObject.count` exceeds the JIT threshold (2), msgpackr calls `new Function()` to compile a fast reader — which CF Workers blocks during request handling with `EvalError: Code generation from strings disallowed for this context`.

The existing `catch { return [] }` in `RpcSerialization.msgPack` silently swallows this error, returning an empty response. The caller never receives data.

## Reproduction

https://github.com/bohdanbirdie/repro-effect-rpc-msgpack-cf-workers

- **`main` branch** — "before" state: reproduces the bug using inline msgpackr code (same as `RpcSerialization.msgPack`)
- **`fixed` branch** — "after" state: uses `bun patch` on `@effect/rpc` to apply this PR's changes, worker uses `RpcSerialization.makeMsgPack({ useRecords: false })`

Deploy either branch to CF Workers with `npx wrangler deploy` and curl the endpoint.

## Fix

Use `makeMsgPack` to create a serialization with custom options:

```typescript
import { Layer } from "effect"
import { RpcSerialization } from "@effect/rpc"

Layer.succeed(
  RpcSerialization,
  RpcSerialization.makeMsgPack({ useRecords: false })
)
```

This skips `this.structures = []` in the Packr constructor, preventing the record/JIT path entirely.

## Test plan

- [x] New unit tests for `msgPack` and `makeMsgPack` with custom options
- [x] Existing 101 e2e RpcServer tests pass (http, ws, tcp, worker × ndjson, msgpack, jsonrpc)
- [x] CF Workers deployment verified with `{ useRecords: false }`

## References

- [livestore PR with full investigation](https://github.com/livestorejs/livestore/pull/1163)
- [CF Workers `new Function()` restriction docs](https://developers.cloudflare.com/workers/reference/security-model/)
- [msgpackr `useRecords` docs](https://github.com/kriszyp/msgpackr#records--structures)
- [CF `allow_eval_during_startup` compat flag](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#dynamic-code-evaluation)