### PR TITLE
docs(@effect/vitest): fix return type in fails example

### DIFF
--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -220,7 +220,7 @@ When adding new failing tests, you might not be able to fix them right away. Ins
 import { it } from "@effect/vitest"
 import { Effect, Exit } from "effect"
 
-function divide(a: number, b: number): number {
+function divide(a: number, b: number): Effect.Effect<number, string> {
   if (b === 0) return Effect.fail("Cannot divide by zero")
   return Effect.succeed(a / b)
 }


### PR DESCRIPTION
## Summary

- Fix the `divide` function's return type annotation in the "Expecting Tests to Fail" section of the `@effect/vitest` README
- Was annotated as `number` but actually returns `Effect.Effect<number, string>`

The `it.effect.fails` method itself was already added in #3973, so this just fixes the remaining type error in the example code.

Ref #5934