### PR TITLE
fix(platform): preserve percent-encoding in modifyUrlParams and setUrlParams

### DIFF
--- a/.changeset/fix-url-params-percent-encoding.md
+++ b/.changeset/fix-url-params-percent-encoding.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Preserve percent-encoding (`%20`) in `Url.modifyUrlParams` and `Url.setUrlParams`. Previously these functions used `URLSearchParams.toString()` which converts spaces to `+` per the `application/x-www-form-urlencoded` spec, silently mutating URLs. Added `UrlParams.toStringPercent` using RFC 3986 percent-encoding for URL context, while keeping the existing `toString` for form body encoding.

--- a/packages/platform/src/Url.ts
+++ b/packages/platform/src/Url.ts
@@ -257,7 +257,7 @@ export const setUrlParams: {
   (url: URL, urlParams: UrlParams.UrlParams): URL
 } = dual(2, (url: URL, searchParams: UrlParams.UrlParams) =>
   mutate(url, (url) => {
-    url.search = UrlParams.toString(searchParams)
+    url.search = UrlParams.toStringPercent(searchParams)
   }))
 
 /**
@@ -320,5 +320,5 @@ export const modifyUrlParams: {
 } = dual(2, (url: URL, f: (urlParams: UrlParams.UrlParams) => UrlParams.UrlParams) =>
   mutate(url, (url) => {
     const params = f(UrlParams.fromInput(url.searchParams))
-    url.search = UrlParams.toString(params)
+    url.search = UrlParams.toStringPercent(params)
   }))

--- a/packages/platform/src/UrlParams.ts
+++ b/packages/platform/src/UrlParams.ts
@@ -229,6 +229,17 @@ export const makeUrl = (url: string, params: UrlParams, hash: Option.Option<stri
  */
 export const toString = (self: UrlParams): string => new URLSearchParams(self as any).toString()
 
+/**
+ * Encode url params using percent-encoding (RFC 3986) instead of the
+ * `application/x-www-form-urlencoded` format used by `URLSearchParams`.
+ * This preserves `%20` for spaces rather than converting them to `+`.
+ *
+ * @since 1.0.0
+ * @category conversions
+ */
+export const toStringPercent = (self: UrlParams): string =>
+  self.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join("&")
+
 const baseUrl = (): string | undefined => {
   if (
     "location" in globalThis &&


### PR DESCRIPTION
## Summary

Fixes #6153

`Url.modifyUrlParams` and `Url.setUrlParams` use `UrlParams.toString` which delegates to `URLSearchParams.toString()`. Per the WHATWG URL spec, `URLSearchParams` serializes spaces as `+` (`application/x-www-form-urlencoded`). This silently mutates URLs:

```typescript
const url = new URL('https://example.com?foo=bar%20baz')
const url2 = Url.modifyUrlParams(url, identity)
url.href === url2.href // false! %20 became +
```

## Approach

Add `UrlParams.toStringPercent` that uses `encodeURIComponent` (RFC 3986 percent-encoding, spaces → `%20`) and use it in the two URL-modifying functions.

The existing `UrlParams.toString` is **preserved unchanged** for HTTP form body encoding (`httpBody.ts`), where `application/x-www-form-urlencoded` format (`+` for spaces) is the correct standard.

| Function | Before | After |
|----------|--------|-------|
| `modifyUrlParams(identity)` | `foo=bar+baz` | `foo=bar%20baz` |
| `setUrlParams` | `foo=bar+baz` | `foo=bar%20baz` |
| `httpBody` form encoding | `foo=bar+baz` | `foo=bar+baz` (unchanged) |