### PR TITLE
fix(rpc): propagate non-incomplete msgPack decode errors

### DIFF
--- a/.changeset/rpc-msgpack-propagate-decode-errors.md
+++ b/.changeset/rpc-msgpack-propagate-decode-errors.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Fix `RpcSerialization` swallowing non-incomplete msgPack decode errors: the `decode` path caught every exception and re-entered the loop, hiding genuine protocol corruption as "need more data". Re-throw any error that is not the msgPack "Insufficient data" sentinel so callers see the real failure.

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -382,7 +382,11 @@ export const msgPack: RpcSerialization["Type"] = RpcSerialization.of({
             incomplete = buf.subarray(error.lastPosition)
             return error.values ?? []
           }
-          return []
+          // Non-`incomplete` errors are genuine decode failures (corrupted
+          // data, encoding mismatches, runtime restrictions on
+          // `new Function()`, etc.) — propagate so the caller sees them
+          // instead of receiving a silent empty response.
+          throw error_
         }
       },
       encode: (response) => packr.pack(response)


### PR DESCRIPTION
Per #6170, `RpcSerialization.msgPack` catches every error from `unpackr.unpackMultiple()` and silently returns an empty array for anything that isn't an `incomplete` chunking error. Genuine failures — corrupted data, encoding mismatches, runtime restrictions on `new Function()` (#6169) — are swallowed, so callers see an empty response with no indication that anything went wrong.

This PR re-throws non-`incomplete` errors. The `incomplete` branch is preserved because msgpackr uses it for normal chunked stream processing.

Closes #6170