### PR TITLE
fix(ai-openai): deduplicate response.output items to prevent invalid JSON concatenation

### DIFF
--- a/.changeset/fix-deduplicate-openai-output.md
+++ b/.changeset/fix-deduplicate-openai-output.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+fix(ai-openai): deduplicate response.output items to prevent invalid JSON concatenation

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -567,7 +567,16 @@ const makeResponse: (
       timestamp: DateTime.formatIso(DateTime.unsafeFromDate(createdAt))
     })
 
+    // Deduplicate output items by ID to handle OpenAI Responses API bug
+    // where duplicate OutputMessage items appear in response.output
+    const seenOutputIds = new Set<string>()
     for (const part of response.output) {
+      if (part.id && seenOutputIds.has(part.id)) {
+        continue
+      }
+      if (part.id) {
+        seenOutputIds.add(part.id)
+      }
       switch (part.type) {
         case "message": {
           for (const contentPart of part.content) {


### PR DESCRIPTION
## Summary

`generateObject` intermittently fails with a `parseJson` error when OpenAI's Responses API returns duplicate `OutputMessage` items in `response.output`.

## Root Cause

OpenAI's Responses API has a known bug where it intermittently returns duplicate `OutputMessage` items with identical IDs and content in `response.output`. The current code iterates over all output items and pushes every `output_text` as a text part. When these duplicate parts are later concatenated (via `text.join("")`), the result is invalid JSON:

```
{"name":"Acme Corp","amount":123.45}{"name":"Acme Corp","amount":123.45}
```

This causes schema parsing to fail with `Unexpected non-whitespace character after JSON`.

## Fix

Track seen output item IDs in a `Set` and skip duplicates before processing. This is a defensive measure against the documented OpenAI API behavior:

- [Structured Output via JSON schema sometimes outputs multiple responses](https://community.openai.com/t/1306731)
- [Responses API Bugs - duplicate output messages](https://community.openai.com/t/1251247)

## Changes

- `OpenAiLanguageModel.ts`: Add `seenOutputIds` Set to deduplicate `response.output` items by ID before processing

Fixes #6146


Made with [Cursor](https://cursor.com)