### PR TITLE
chore: disable TypeScript's nightly workflow

### DIFF
--- a/.github/workflows/ts-nightly.yml
+++ b/.github/workflows/ts-nightly.yml
@@ -9,6 +9,8 @@ permissions: {}
 jobs:
   types:
     name: Types
+    # TODO enable after TSTyche adds TypeScript 7 support (see https://github.com/tstyche/tstyche/issues/443)
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR disables the TypeScript Nightly workflow.

In preparation for TypeScript 7, the nightly releases are currently [disabled](https://github.com/microsoft/TypeScript/actions/workflows/nightly.yaml) in TypeScript repo. I asked on Discord and it was confirmed that there will be no more nightly release of 6.x series.

Currently the daily workflow in this repo is testing against the same `typescript@6.0.0-dev.20260416` (see the logs). As soon as TypeScript will start publishing nightly releases of 7.x series the workflow will fail, because TSTyche does not support TypeScript 7 yet (this is because programatic API is not yet available).

There is no value of the workflow at the moment. (As an alternative: the workflow file could be removed altogether.)