### PR TITLE
fix: floor TestClock nanoseconds before BigInt conversion

### DIFF
--- a/.changeset/eight-apples-own.md
+++ b/.changeset/eight-apples-own.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `TestClock.unsafeCurrentTimeNanos()` to floor fractional millisecond instants before converting them to `BigInt`.

--- a/packages/effect/src/TestClock.ts
+++ b/packages/effect/src/TestClock.ts
@@ -158,7 +158,7 @@ export class TestClockImpl implements TestClock {
    * Unsafely returns the current time in nanoseconds.
    */
   unsafeCurrentTimeNanos(): bigint {
-    return BigInt(ref.unsafeGet(this.clockState).instant * 1000000)
+    return BigInt(Math.floor(this.unsafeCurrentTimeMillis() * 1000000))
   }
 
   /**

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -26,9 +26,9 @@ describe("TestClock", () => {
 
     it.effect("should floor nanoseconds for fractional millisecond instants", () =>
       Effect.gen(function*() {
-        yield* TestClock.setTime(34199023438.000004)
+        yield* TestClock.setTime(199023438.0000004)
         const testClock = yield* TestClock.testClock()
-        strictEqual(testClock.unsafeCurrentTimeNanos(), 34199023438000004n)
+        strictEqual(testClock.unsafeCurrentTimeNanos(), 199023438000000n)
       }))
   })
 })

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { deepStrictEqual } from "@effect/vitest/utils"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { DateTime, Effect, TestClock } from "effect"
 
 describe("TestClock", () => {
@@ -22,6 +22,13 @@ describe("TestClock", () => {
         yield* TestClock.setTime(DateTime.toDate(arbitraryDateTime))
         const now = yield* DateTime.now
         deepStrictEqual(now, arbitraryDateTime)
+      }))
+
+    it.effect("should floor nanoseconds for fractional millisecond instants", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(34199023438.000004)
+        const testClock = yield* TestClock.testClock()
+        strictEqual(testClock.unsafeCurrentTimeNanos(), 34199023438000004n)
       }))
   })
 })


### PR DESCRIPTION
## Summary
- floor fractional millisecond instants before converting `TestClock` nanoseconds to `BigInt`
- add a regression test covering a fractional millisecond timestamp that previously threw `RangeError`
- add a patch changeset for the `effect` package