### PR TITLE
EFF-784 Backport workflow suspension failure fixes

### DIFF
--- a/.changeset/short-cameras-watch.md
+++ b/.changeset/short-cameras-watch.md
@@ -1,0 +1,5 @@
+---
+"@effect/workflow": patch
+---
+
+Fix workflow suspension handling so mixed failures preserve non-interrupt causes and DurableDeferred.into isolates inner suspension state.

--- a/packages/workflow/src/DurableDeferred.ts
+++ b/packages/workflow/src/DurableDeferred.ts
@@ -3,7 +3,7 @@
  */
 import type { NonEmptyReadonlyArray } from "effect/Array"
 import type * as Brand from "effect/Brand"
-import type * as Cause from "effect/Cause"
+import * as Cause from "effect/Cause"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Encoding from "effect/Encoding"
@@ -99,6 +99,11 @@ const CurrentAttempt = Context.Reference<Activity.CurrentAttempt>()(
   }
 )
 
+const withoutInterrupts = <E>(cause: Cause.Cause<E>): Cause.Cause<E> =>
+  Cause.isInterrupted(cause) && !Cause.isInterruptedOnly(cause)
+    ? Cause.filter(cause, (cause) => !Cause.isInterruptType(cause))
+    : cause
+
 const await_: <Success extends Schema.Schema.Any, Error extends Schema.Schema.All>(
   self: DurableDeferred<Success, Error>
 ) => Effect.Effect<
@@ -159,12 +164,20 @@ export const into: {
 > =>
   Effect.contextWithEffect((context: Context.Context<WorkflowEngine | WorkflowInstance>) => {
     const engine = Context.get(context, EngineTag)
-    const instance = Context.get(context, InstanceTag)
-    return Effect.onExit(effect, (exit) => {
-      if (instance.suspended) return Effect.void
+    const parentInstance = Context.get(context, InstanceTag)
+    const instance = { ...parentInstance }
+    return Effect.onExit(Effect.provideService(effect, InstanceTag, instance), (exit) => {
+      if (Exit.isFailure(exit)) {
+        const isInterruptedOnly = Cause.isInterruptedOnly(exit.cause)
+        if (isInterruptedOnly && instance.suspended) {
+          parentInstance.suspended = true
+          return Effect.void
+        }
+        exit = Exit.failCause(withoutInterrupts(exit.cause))
+      }
       return engine.deferredDone(self, {
-        workflowName: instance.workflow.name,
-        executionId: instance.executionId,
+        workflowName: parentInstance.workflow.name,
+        executionId: parentInstance.executionId,
         deferredName: self.name,
         exit
       })

--- a/packages/workflow/src/DurableDeferred.ts
+++ b/packages/workflow/src/DurableDeferred.ts
@@ -99,11 +99,6 @@ const CurrentAttempt = Context.Reference<Activity.CurrentAttempt>()(
   }
 )
 
-const withoutInterrupts = <E>(cause: Cause.Cause<E>): Cause.Cause<E> =>
-  Cause.isInterrupted(cause) && !Cause.isInterruptedOnly(cause)
-    ? Cause.filter(cause, (cause) => !Cause.isInterruptType(cause))
-    : cause
-
 const await_: <Success extends Schema.Schema.Any, Error extends Schema.Schema.All>(
   self: DurableDeferred<Success, Error>
 ) => Effect.Effect<
@@ -167,13 +162,16 @@ export const into: {
     const parentInstance = Context.get(context, InstanceTag)
     const instance = { ...parentInstance }
     return Effect.onExit(Effect.provideService(effect, InstanceTag, instance), (exit) => {
-      if (Exit.isFailure(exit)) {
+      if (Exit.isFailure(exit) && Cause.isInterrupted(exit.cause)) {
         const isInterruptedOnly = Cause.isInterruptedOnly(exit.cause)
         if (isInterruptedOnly && instance.suspended) {
           parentInstance.suspended = true
           return Effect.void
+        } else if (!isInterruptedOnly) {
+          exit = Exit.failCause(
+            Cause.filter(exit.cause, (cause) => !Cause.isInterruptType(cause))
+          )
         }
-        exit = Exit.failCause(withoutInterrupts(exit.cause))
       }
       return engine.deferredDone(self, {
         workflowName: parentInstance.workflow.name,

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -256,6 +256,11 @@ const InstanceTag = Context.GenericTag<WorkflowInstance, WorkflowInstance["Type"
   "@effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )
 
+const withoutInterrupts = <E>(cause: Cause.Cause<E>): Cause.Cause<E> =>
+  Cause.isInterrupted(cause) && !Cause.isInterruptedOnly(cause)
+    ? Cause.filter(cause, (cause) => !Cause.isInterruptType(cause))
+    : cause
+
 /**
  * @since 1.0.0
  * @category Constructors
@@ -532,12 +537,15 @@ export const intoResult = <A, E, R>(
       Effect.scoped,
       Effect.matchCauseEffect({
         onSuccess: (value) => Effect.succeed(new Complete({ exit: Exit.succeed(value) })),
-        onFailure: (cause): Effect.Effect<Result<A, E>> =>
-          instance.suspended
+        onFailure: (cause): Effect.Effect<Result<A, E>> => {
+          const isInterruptedOnly = Cause.isInterruptedOnly(cause)
+          const filtered = withoutInterrupts(cause)
+          return instance.suspended && isInterruptedOnly
             ? Effect.succeed(new Suspended({ cause: instance.cause }))
-            : (!instance.interrupted && Cause.isInterruptedOnly(cause)) || (!captureDefects && Cause.isDie(cause))
-            ? Effect.failCause(cause as Cause.Cause<never>)
-            : Effect.succeed(new Complete({ exit: Exit.failCause(cause) }))
+            : (!instance.interrupted && isInterruptedOnly) || (!captureDefects && Cause.isDie(cause))
+            ? Effect.failCause(filtered as Cause.Cause<never>)
+            : Effect.succeed(new Complete({ exit: Exit.failCause(filtered) }))
+        }
       }),
       Effect.onExit((exit) => {
         if (Exit.isFailure(exit)) {
@@ -562,11 +570,6 @@ export const wrapActivityResult = <A, E, R>(
   Effect.contextWithEffect((context: Context.Context<WorkflowInstance>) => {
     const instance = Context.get(context, InstanceTag)
     const state = instance.activityState
-    if (instance.suspended) {
-      return waitForZero(instance).pipe(
-        Effect.andThen(suspend(instance))
-      )
-    }
     if (state.count === 0) state.latch.unsafeClose()
     state.count++
     return Effect.onExit(effect, (exit) => {

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -256,11 +256,6 @@ const InstanceTag = Context.GenericTag<WorkflowInstance, WorkflowInstance["Type"
   "@effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )
 
-const withoutInterrupts = <E>(cause: Cause.Cause<E>): Cause.Cause<E> =>
-  Cause.isInterrupted(cause) && !Cause.isInterruptedOnly(cause)
-    ? Cause.filter(cause, (cause) => !Cause.isInterruptType(cause))
-    : cause
-
 /**
  * @since 1.0.0
  * @category Constructors
@@ -537,9 +532,9 @@ export const intoResult = <A, E, R>(
       Effect.scoped,
       Effect.matchCauseEffect({
         onSuccess: (value) => Effect.succeed(new Complete({ exit: Exit.succeed(value) })),
-        onFailure: (cause): Effect.Effect<Result<A, E>> => {
+        onFailure(cause): Effect.Effect<Result<A, E>> {
           const isInterruptedOnly = Cause.isInterruptedOnly(cause)
-          const filtered = withoutInterrupts(cause)
+          const filtered = isInterruptedOnly ? cause : withoutInterrupts(cause)
           return instance.suspended && isInterruptedOnly
             ? Effect.succeed(new Suspended({ cause: instance.cause }))
             : (!instance.interrupted && isInterruptedOnly) || (!captureDefects && Cause.isDie(cause))
@@ -558,6 +553,11 @@ export const intoResult = <A, E, R>(
       Effect.uninterruptible
     )
   })
+
+const withoutInterrupts = <E>(cause: Cause.Cause<E>): Cause.Cause<E> =>
+  Cause.isInterrupted(cause)
+    ? Cause.filter(cause, (cause) => !Cause.isInterruptType(cause))
+    : cause
 
 /**
  * @since 1.0.0

--- a/packages/workflow/test/WorkflowEngine.test.ts
+++ b/packages/workflow/test/WorkflowEngine.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "@effect/vitest"
-import { DurableClock, Workflow, WorkflowEngine } from "@effect/workflow"
+import { assert, describe, expect, it } from "@effect/vitest"
+import { DurableClock, DurableDeferred, Workflow, WorkflowEngine } from "@effect/workflow"
+import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
+import * as FiberId from "effect/FiberId"
 import * as Layer from "effect/Layer"
 import * as Schema from "effect/Schema"
 import * as TestClock from "effect/TestClock"
@@ -36,7 +38,111 @@ describe("WorkflowEngine", () => {
         )
       )
     ))
+
+  it.effect("does not squash workflow failures after suspension", () =>
+    Effect.gen(function*() {
+      const instance = WorkflowEngine.WorkflowInstance.initial(TestWorkflow, "workflow-failure")
+      instance.suspended = true
+
+      const result = yield* Workflow.intoResult(Effect.fail("boom")).pipe(
+        Effect.provideService(WorkflowEngine.WorkflowInstance, instance)
+      )
+
+      assert.deepStrictEqual(result, new Workflow.Complete({ exit: Exit.fail("boom") }))
+    }))
+
+  it.effect("removes suspension interrupts from mixed workflow failures", () =>
+    Effect.gen(function*() {
+      const instance = WorkflowEngine.WorkflowInstance.initial(TestWorkflow, "mixed-workflow-failure")
+      const cause = Cause.parallel(Cause.fail("boom"), Cause.interrupt(FiberId.none))
+
+      const result = yield* Workflow.intoResult(Effect.failCause(cause)).pipe(
+        Effect.provideService(WorkflowEngine.WorkflowInstance, instance)
+      )
+
+      assert.deepStrictEqual(result, new Workflow.Complete({ exit: Exit.fail("boom") }))
+    }))
+
+  it.effect("DurableDeferred.into isolates inner suspension from failure recording", () =>
+    Effect.gen(function*() {
+      const exits: Array<Exit.Exit<number, string>> = []
+      const instance = WorkflowEngine.WorkflowInstance.initial(TestWorkflow, "deferred-failure")
+      const deferred = DurableDeferred.make("deferred-failure", {
+        success: Schema.Number,
+        error: Schema.String
+      })
+
+      yield* DurableDeferred.into(
+        Effect.flatMap(WorkflowEngine.WorkflowInstance, (instance) =>
+          Effect.zipRight(
+            Effect.sync(() => {
+              instance.suspended = true
+            }),
+            Effect.fail("boom")
+          )),
+        deferred
+      ).pipe(
+        Effect.exit,
+        Effect.provideService(WorkflowEngine.WorkflowInstance, instance),
+        Effect.provideService(WorkflowEngine.WorkflowEngine, makeDeferredEngine(exits))
+      )
+
+      assert.isFalse(instance.suspended)
+      assert.deepStrictEqual(exits, [Exit.fail("boom")])
+    }))
+
+  it.effect("DurableDeferred.into propagates interrupt-only suspension to the parent", () =>
+    Effect.gen(function*() {
+      const exits: Array<Exit.Exit<number, string>> = []
+      const instance = WorkflowEngine.WorkflowInstance.initial(TestWorkflow, "deferred-suspended")
+      const deferred = DurableDeferred.make("deferred-suspended", {
+        success: Schema.Number,
+        error: Schema.String
+      })
+
+      yield* DurableDeferred.into(
+        Effect.flatMap(WorkflowEngine.WorkflowInstance, (instance) =>
+          Effect.zipRight(
+            Effect.sync(() => {
+              instance.suspended = true
+            }),
+            Effect.interrupt
+          )),
+        deferred
+      ).pipe(
+        Effect.exit,
+        Effect.provideService(WorkflowEngine.WorkflowInstance, instance),
+        Effect.provideService(WorkflowEngine.WorkflowEngine, makeDeferredEngine(exits))
+      )
+
+      assert.isTrue(instance.suspended)
+      assert.deepStrictEqual(exits, [])
+    }))
 })
+
+const TestWorkflow = Workflow.make({
+  name: "TestWorkflow",
+  payload: {},
+  idempotencyKey: () => "test",
+  success: Schema.Number,
+  error: Schema.String
+})
+
+const makeDeferredEngine = (exits: Array<Exit.Exit<number, string>>): WorkflowEngine.WorkflowEngine["Type"] =>
+  WorkflowEngine.WorkflowEngine.of({
+    register: () => Effect.void,
+    execute: () => Effect.die("not implemented"),
+    poll: () => Effect.succeed(undefined),
+    interrupt: () => Effect.void,
+    resume: () => Effect.void,
+    activityExecute: () => Effect.die("not implemented"),
+    deferredResult: () => Effect.succeed(undefined),
+    deferredDone: (_deferred: DurableDeferred.Any, options: { readonly exit: Exit.Exit<unknown, unknown> }) =>
+      Effect.sync(() => {
+        exits.push(options.exit as Exit.Exit<number, string>)
+      }),
+    scheduleClock: () => Effect.void
+  } as any)
 
 const LongWorkflow = Workflow.make({
   name: "LongWorkflow",


### PR DESCRIPTION
## Summary

- Backport v4 workflow suspension failure handling to @effect/workflow.
- Strip suspension interrupts from mixed causes while preserving interrupt-only suspension behavior.
- Isolate DurableDeferred.into suspension state with a shallow-copied WorkflowInstance and add regression coverage.

## Validation

- pnpm lint-fix
- pnpm test run packages/workflow/test/WorkflowEngine.test.ts
- pnpm check
- pnpm build
- pnpm docgen
