### PR TITLE
Fix PCGRandom.integer() bias: use Lemire rejection sampling

### DIFF
--- a/.changeset/pcg-random-integer-bias.md
+++ b/.changeset/pcg-random-integer-bias.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `PCGRandom.integer()` to use Lemire (2018) rejection sampling instead of `Math.round` + modulo, eliminating two sources of bias and halving state consumption per call.

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -614,7 +614,20 @@ export class PCGRandom {
    * @since 2.0.0
    */
   integer(max: number) {
-    return Math.round(this.number() * Number.MAX_SAFE_INTEGER) % max
+    if (max <= 0x100000000) {
+      // Lemire (2018) rejection sampling on raw 32-bit output eliminates
+      // modulo bias and Math.round boundary bias, using one _next() call
+      // instead of two. https://arxiv.org/abs/1805.10941
+      const threshold = ((-max >>> 0) % max) >>> 0
+      let result: number
+      do {
+        result = this._next() >>> 0
+      } while (result < threshold)
+      return result % max
+    }
+    // max exceeds 32-bit range — use float-based generation.
+    // Math.floor avoids the boundary bias of the previous Math.round approach.
+    return Math.floor(this.number() * max)
   }
 
   /**

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@effect/vitest"
 import { assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Array, Cause, Chunk, Data, Effect, Random } from "effect"
+import { PCGRandom } from "effect/Utils"
 
 describe("Random", () => {
   it.effect("integer is correctly distributed", () =>
@@ -12,6 +13,28 @@ describe("Random", () => {
       }
       assertTrue(lastRandom >= tenYearsMillis / 2)
     }))
+
+  it.effect("nextIntBetween produces values within bounds for small ranges", () =>
+    Effect.gen(function*() {
+      const ranges: ReadonlyArray<readonly [number, number]> = [[0, 2], [0, 3], [5, 8], [0, 100]]
+      for (const [min, max] of ranges) {
+        const values = yield* Effect.all(Array.replicate(Random.nextIntBetween(min, max), 500))
+        for (const v of values) {
+          assertTrue(v >= min && v < max)
+        }
+      }
+    }))
+
+  it("PCGRandom.integer produces values in [0, max) and is deterministic", () => {
+    const prng = new PCGRandom(42)
+    const results = globalThis.Array.from({ length: 20 }, () => prng.integer(10))
+    assertTrue(results.every((v) => v >= 0 && v < 10))
+    deepStrictEqual(results, [6, 9, 5, 5, 7, 6, 0, 1, 4, 3, 5, 5, 8, 4, 3, 5, 8, 4, 1, 8])
+
+    const prng2 = new PCGRandom(42)
+    const ones = globalThis.Array.from({ length: 10 }, () => prng2.integer(1))
+    assertTrue(ones.every((v) => v === 0))
+  })
   it.effect("shuffle", () =>
     Effect.gen(function*() {
       const start = Array.range(0, 100)


### PR DESCRIPTION
## Summary

`PCGRandom.integer()` used `Math.round(this.number() * Number.MAX_SAFE_INTEGER) % max`, which baked two sources of statistical bias into one expression and consumed twice the PRNG state per call.

Closes #6184

ryanleecode's comment in the thread spotted and quantified the bias clearly. I wanted to make sure a fix landed.

## Problem

**Math.round boundary bias:** `Math.round` maps `[0, 1)` to integers non-uniformly. Buckets at each end of the range receive half the probability mass of interior values.

**Modulo bias:** `Number.MAX_SAFE_INTEGER` is not evenly divisible by most values of `max`, so some output values have one extra preimage in the modulo cycle and are overrepresented.

**Double state consumption:** `number()` calls `_next()` twice to build a 53-bit float. Integer generation only needs one 32-bit draw.

The practical bias magnitude is tiny (ryanleecode's analysis put it at ~10^-16), but a PRNG that is correct-by-construction is worth having.

## Fix

For `max <= 2^32`: Lemire (2018) rejection sampling on raw 32-bit output ([arXiv:1805.10941](https://arxiv.org/abs/1805.10941)). Same approach as OpenBSD's `arc4random_uniform` and the PCG reference implementation. Every value in `[0, max)` gets exactly `floor((2^32 - threshold) / max)` accepting preimages, provably uniform.

For `max > 2^32` (e.g. `nextInt` passing `Number.MAX_SAFE_INTEGER`): falls back to `Math.floor(this.number() * max)`. `Math.floor` removes the `Math.round` boundary bias; residual floating-point discretization bias at that scale is negligible.

## Tests

- Bounds test: `nextIntBetween` stays in `[min, max)` across several small ranges, where rejection sampling is most aggressively exercised.
- Deterministic test against a known seed to catch regressions in output sequence.
