### PR TITLE
fix(platform): encode spaces as %20 in UrlParams.toString

### DIFF
--- a/.changeset/urlparams-percent-encoding-spaces.md
+++ b/.changeset/urlparams-percent-encoding-spaces.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix `UrlParams.toString` to encode spaces as `%20` instead of `+`, preserving percent-encoded spaces in `modifyUrlParams` and other URL utilities.

--- a/packages/platform/src/UrlParams.ts
+++ b/packages/platform/src/UrlParams.ts
@@ -227,7 +227,7 @@ export const makeUrl = (url: string, params: UrlParams, hash: Option.Option<stri
  * @since 1.0.0
  * @category conversions
  */
-export const toString = (self: UrlParams): string => new URLSearchParams(self as any).toString()
+export const toString = (self: UrlParams): string => new URLSearchParams(self as any).toString().replace(/\+/g, "%20")
 
 const baseUrl = (): string | undefined => {
   if (

--- a/packages/platform/test/Url.test.ts
+++ b/packages/platform/test/Url.test.ts
@@ -84,6 +84,17 @@ describe("Url", () => {
     expectUrl(Url.modifyUrlParams(testURL, UrlParams.append("key", "value")), "https://example.com/test?key=value")
   })
 
+  it("modifyUrlParams preserves percent-encoded spaces in unmodified params", () => {
+    const url = new URL("https://example.com?foo=bar%20baz")
+    const result = Url.modifyUrlParams(url, (params) => params)
+    deepStrictEqual(result.search, "?foo=bar%20baz")
+  })
+
+  it("modifyUrlParams encodes spaces as %20 in new params", () => {
+    const result = Url.modifyUrlParams(testURL, UrlParams.append("key", "hello world"))
+    deepStrictEqual(result.search, "?key=hello%20world")
+  })
+
   it("urlParams", () => {
     const params = Url.urlParams(new URL("https://example.com?foo=bar&baz=qux"))
     deepStrictEqual(params, UrlParams.fromInput([["foo", "bar"], ["baz", "qux"]]))


### PR DESCRIPTION
## Summary

`UrlParams.toString` used `new URLSearchParams(...).toString()`, which encodes spaces as `+` (application/x-www-form-urlencoded) instead of `%20` (RFC 3986). This caused `modifyUrlParams` to silently change any existing `%20`-encoded spaces to `+`, even when the caller made no modification to those params.

Closes #6153

## Problem

`URLSearchParams.toString()` follows the HTML form-encoding spec, where space is `+`. Percent-encoded spaces in the original URL got decoded during `fromInput(url.searchParams)`, then re-encoded as `+` by `toString`, changing the URL even with an identity function.

```js
const url = new URL("https://example.com?foo=bar%20baz")
Url.modifyUrlParams(url, (params) => params).href
// before: "https://example.com/?foo=bar+baz"  ← changed
// after:  "https://example.com/?foo=bar%20baz" ← preserved
```

## Fix

Replace `+` with `%20` in the `URLSearchParams.toString()` output. This is safe because `URLSearchParams` always encodes literal `+` characters as `%2B`, so any `+` in the output represents a space.

## Tests

- `modifyUrlParams` with an identity function preserves `%20`-encoded spaces.
- `modifyUrlParams` encodes newly added spaces as `%20`.
