### PR TITLE
fix(platform): parse +json structured content types as JSON in HttpApiBuilder

### DIFF
--- a/.changeset/http-api-structured-json-content-type.md
+++ b/.changeset/http-api-structured-json-content-type.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix `HttpApiBuilder` to parse request bodies with structured JSON content types (RFC 6838 `+json` suffix) as JSON instead of `Uint8Array`. Custom JSON content types like `application/scim+json` and `application/vnd.api+json` now decode correctly on the server when used with `HttpApiSchema.withEncoding({ kind: "Json", contentType: "..." })`.

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -311,6 +311,122 @@ describe("HttpApi", () => {
     assert.deepStrictEqual(spec, OpenApiFixture as any)
   })
 
+  it.effect("withEncoding sets custom JSON content-type on success response", () => {
+    const Api = HttpApi.make("api").add(
+      HttpApiGroup.make("group").add(
+        HttpApiEndpoint.get("test")`/test`.addSuccess(
+          Schema.Struct({ value: Schema.String }).pipe(
+            HttpApiSchema.withEncoding({ kind: "Json", contentType: "application/scim+json" })
+          )
+        )
+      )
+    )
+    const ApiLive = HttpLayerRouter.addHttpApi(Api).pipe(
+      Layer.provide(
+        HttpApiBuilder.group(
+          Api,
+          "group",
+          (handlers) => handlers.handle("test", () => Effect.succeed({ value: "hello" }))
+        )
+      ),
+      HttpLayerRouter.serve,
+      Layer.provideMerge(NodeHttpServer.layerTest)
+    )
+    return Effect.gen(function*() {
+      const response = yield* HttpClient.get("/test")
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(response.headers["content-type"], "application/scim+json")
+    }).pipe(Effect.provide(ApiLive))
+  })
+
+  it.effect("withEncoding custom content-type on Class schema success response", () => {
+    class MyScimResult extends Schema.Class<MyScimResult>("MyScimResult")({ value: Schema.String }) {}
+    const Api = HttpApi.make("api").add(
+      HttpApiGroup.make("group").add(
+        HttpApiEndpoint.get("test")`/test`.addSuccess(
+          MyScimResult.pipe(
+            HttpApiSchema.withEncoding({ kind: "Json", contentType: "application/scim+json" })
+          )
+        )
+      )
+    )
+    const ApiLive = HttpLayerRouter.addHttpApi(Api).pipe(
+      Layer.provide(
+        HttpApiBuilder.group(
+          Api,
+          "group",
+          (handlers) => handlers.handle("test", () => Effect.succeed(new MyScimResult({ value: "hello" })))
+        )
+      ),
+      HttpLayerRouter.serve,
+      Layer.provideMerge(NodeHttpServer.layerTest)
+    )
+    return Effect.gen(function*() {
+      const response = yield* HttpClient.get("/test")
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(response.headers["content-type"], "application/scim+json")
+    }).pipe(Effect.provide(ApiLive))
+  })
+
+  it.effect("withEncoding client decodes custom JSON content-type response", () => {
+    const Api = HttpApi.make("api").add(
+      HttpApiGroup.make("group").add(
+        HttpApiEndpoint.get("test")`/test`.addSuccess(
+          Schema.Struct({ value: Schema.String }).pipe(
+            HttpApiSchema.withEncoding({ kind: "Json", contentType: "application/scim+json" })
+          )
+        )
+      )
+    )
+    const ApiLive = HttpLayerRouter.addHttpApi(Api).pipe(
+      Layer.provide(
+        HttpApiBuilder.group(
+          Api,
+          "group",
+          (handlers) => handlers.handle("test", () => Effect.succeed({ value: "hello" }))
+        )
+      ),
+      HttpLayerRouter.serve,
+      Layer.provideMerge(NodeHttpServer.layerTest)
+    )
+    return Effect.gen(function*() {
+      const client = yield* HttpApiClient.make(Api)
+      const result = yield* client.group.test({})
+      assert.deepStrictEqual(result, { value: "hello" })
+    }).pipe(Effect.provide(ApiLive))
+  })
+
+  it.effect("withEncoding payload with custom JSON content-type is parsed as JSON on server", () => {
+    const Api = HttpApi.make("api").add(
+      HttpApiGroup.make("group").add(
+        HttpApiEndpoint.post("test")`/test`
+          .setPayload(
+            Schema.Struct({ value: Schema.String }).pipe(
+              HttpApiSchema.withEncoding({ kind: "Json", contentType: "application/scim+json" })
+            )
+          )
+          .addSuccess(Schema.Struct({ received: Schema.String }))
+      )
+    )
+    const ApiLive = HttpLayerRouter.addHttpApi(Api).pipe(
+      Layer.provide(
+        HttpApiBuilder.group(
+          Api,
+          "group",
+          (handlers) =>
+            handlers.handle("test", ({ payload }) => Effect.succeed({ received: payload.value }))
+        )
+      ),
+      HttpLayerRouter.serve,
+      Layer.provideMerge(NodeHttpServer.layerTest)
+    )
+    return Effect.gen(function*() {
+      const client = yield* HttpApiClient.make(Api)
+      const result = yield* client.group.test({ payload: { value: "world" } })
+      assert.deepStrictEqual(result, { received: "world" })
+    }).pipe(Effect.provide(ApiLive))
+  })
+
   it.effect("error from plain text", () => {
     class RateLimitError extends Schema.TaggedError<RateLimitError>("RateLimitError")(
       "RateLimitError",

--- a/packages/platform/src/HttpApiBuilder.ts
+++ b/packages/platform/src/HttpApiBuilder.ts
@@ -558,7 +558,7 @@ const requestPayload = (
   const contentType = request.headers["content-type"]
     ? request.headers["content-type"].toLowerCase().trim()
     : "application/json"
-  if (contentType.includes("application/json")) {
+  if (contentType.includes("application/json") || contentType.includes("+json")) {
     return Effect.orDie(request.json)
   } else if (contentType.includes("multipart/form-data")) {
     return Effect.orDie(Option.match(multipartLimits, {


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description

#5908 has two complaints. The response `Content-Type` from `withEncoding` was already working correctly: `HttpServerResponse.json` already uses `encoding.contentType`. The request side is what's broken.

`requestPayload` in `HttpApiBuilder` only checked for `"application/json"`, so request bodies with `Content-Type: application/scim+json` (or any other RFC 6838 `+json` type like `application/vnd.api+json`) fell through to the `Uint8Array` branch instead of being decoded as JSON. The schema decode then fails because it receives raw bytes instead of a parsed object.

The fix is one line: `|| contentType.includes("+json")`. Consistent with how the other branches already use `includes`, and it handles content types with parameters like `application/scim+json; charset=utf-8`.

The regression was introduced in #4024 when explicit content-type dispatch replaced the catch-all JSON handling in `requestPayload`.

## Related

Closes #5908