### PR TITLE
feat(ai-perplexity): add Perplexity Search integration

### DIFF
--- a/.changeset/perplexity-search.md
+++ b/.changeset/perplexity-search.md
@@ -1,0 +1,12 @@
+---
+"@effect/ai-perplexity": minor
+---
+
+Add `@effect/ai-perplexity` package providing Effect bindings for the
+[Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).
+
+The package exposes a `PerplexitySearch` service with a `search` method that
+returns typed `{ title, url, snippet, date? }` results. It supports the
+`max_results`, `search_domain_filter`, `search_recency_filter`, and date-range
+filters from the Search API. Authentication is read from the
+`PERPLEXITY_API_KEY` environment variable (with `PPLX_API_KEY` as a fallback).

--- a/packages/ai/perplexity/LICENSE
+++ b/packages/ai/perplexity/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Effectful Technologies Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ai/perplexity/README.md
+++ b/packages/ai/perplexity/README.md
@@ -1,0 +1,94 @@
+# `@effect/ai-perplexity`
+
+Effect bindings for the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).
+
+## Installation
+
+```sh
+pnpm add @effect/ai-perplexity @effect/ai @effect/platform effect
+```
+
+You will also need a platform-specific HTTP client implementation, e.g.
+`@effect/platform-node` or `@effect/platform-bun`.
+
+## Authentication
+
+The client reads its API key from the `PERPLEXITY_API_KEY` environment
+variable, falling back to `PPLX_API_KEY` if the former is not set. You can
+obtain a key from the
+[Perplexity API key console](https://www.perplexity.ai/account/api/keys).
+
+## Usage
+
+```ts
+import { NodeHttpClient } from "@effect/platform-node"
+import { PerplexitySearch } from "@effect/ai-perplexity"
+import { Effect, Layer } from "effect"
+
+const program = Effect.gen(function*() {
+  const search = yield* PerplexitySearch.PerplexitySearch
+  const response = yield* search.search({
+    query: "latest research on attention mechanisms",
+    maxResults: 5,
+    recencyFilter: "month"
+  })
+  for (const result of response.results) {
+    console.log(result.title, result.url)
+  }
+})
+
+const SearchLayer = PerplexitySearch.layerConfig().pipe(
+  Layer.provide(NodeHttpClient.layerUndici)
+)
+
+Effect.runPromise(program.pipe(Effect.provide(SearchLayer)))
+```
+
+### Search options
+
+`PerplexitySearch.search` accepts the following options (all but `query` are
+optional):
+
+| Option              | Type                                                 | Description                                                                                                       |
+| ------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `query`             | `string`                                             | The search query.                                                                                                 |
+| `maxResults`        | `number`                                             | Maximum results to return. Server default is 10.                                                                  |
+| `maxTokensPerPage`  | `number`                                             | Maximum tokens per result snippet.                                                                                |
+| `domainFilter`      | `ReadonlyArray<string>`                              | Allowlist (`"nytimes.com"`) **or** denylist (`"-pinterest.com"`). Cannot be mixed.                                |
+| `recencyFilter`     | `"hour" \| "day" \| "week" \| "month" \| "year"`     | Restrict results to a recency window.                                                                             |
+| `afterDateFilter`   | `string`                                             | Only return results published on or after this date (`m/d/yyyy`).                                                 |
+| `beforeDateFilter`  | `string`                                             | Only return results published on or before this date (`m/d/yyyy`).                                                |
+
+The response is decoded into `SearchResponse`, which exposes a `results`
+array of `{ title, url, snippet, date? }` items.
+
+### Domain filter caveat
+
+The Perplexity API does not accept a `search_domain_filter` array that mixes
+allowed and excluded domains. `PerplexitySearch.search` enforces this by
+failing fast with an `AiError.MalformedInput` if you pass an array containing
+both positive (`"nytimes.com"`) and negative (`"-pinterest.com"`) entries.
+
+### Manual layer composition
+
+If you want to provide the API key explicitly:
+
+```ts
+import { PerplexityClient, PerplexitySearch } from "@effect/ai-perplexity"
+import { NodeHttpClient } from "@effect/platform-node"
+import { Layer, Redacted } from "effect"
+
+const SearchLayer = PerplexitySearch.layer.pipe(
+  Layer.provide(PerplexityClient.layer({
+    apiKey: Redacted.make(process.env.PERPLEXITY_API_KEY!)
+  })),
+  Layer.provide(NodeHttpClient.layerUndici)
+)
+```
+
+## Documentation
+
+- [Search API quickstart](https://docs.perplexity.ai/docs/search/quickstart)
+- [Search API reference](https://docs.perplexity.ai/api-reference/search-post)
+- [Domain filters](https://docs.perplexity.ai/docs/search/filters/domain-filter)
+- [Date / recency filters](https://docs.perplexity.ai/docs/search/filters/date-time-filters)

--- a/packages/ai/perplexity/docgen.json
+++ b/packages/ai/perplexity/docgen.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../node_modules/@effect/docgen/schema.json",
+  "exclude": ["src/internal/**/*.ts"],
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/ai/perplexity/src/",
+  "examplesCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ES2022",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "paths": {
+      "effect": ["../../../../effect/src/index.js"],
+      "effect/*": ["../../../../effect/src/*.js"],
+      "@effect/platform": ["../../../../platform/src/index.js"],
+      "@effect/platform/*": ["../../../../platform/src/*.js"],
+      "@effect/ai": ["../../../ai/src/index.js"],
+      "@effect/ai/*": ["../../../ai/src/*.js"],
+      "@effect/ai-perplexity": ["../../../ai-perplexity/src/index.js"],
+      "@effect/ai-perplexity/*": ["../../../ai-perplexity/src/*.js"]
+    }
+  }
+}

--- a/packages/ai/perplexity/package.json
+++ b/packages/ai/perplexity/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@effect/ai-perplexity",
+  "type": "module",
+  "version": "0.1.0",
+  "license": "MIT",
+  "description": "Effect modules for working with the Perplexity Search API",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect.git",
+    "directory": "packages/ai/perplexity"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect/issues"
+  },
+  "tags": [
+    "typescript",
+    "algebraic-data-types",
+    "functional-programming"
+  ],
+  "keywords": [
+    "typescript",
+    "algebraic-data-types",
+    "functional-programming"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "build-utils prepare-v3",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "peerDependencies": {
+    "@effect/ai": "workspace:^",
+    "@effect/platform": "workspace:^",
+    "effect": "workspace:^"
+  },
+  "devDependencies": {
+    "@effect/ai": "workspace:^",
+    "@effect/platform": "workspace:^",
+    "@effect/platform-node": "workspace:^",
+    "effect": "workspace:^"
+  }
+}

--- a/packages/ai/perplexity/src/PerplexityClient.ts
+++ b/packages/ai/perplexity/src/PerplexityClient.ts
@@ -1,0 +1,176 @@
+/**
+ * @since 1.0.0
+ */
+import * as AiError from "@effect/ai/AiError"
+import * as Headers from "@effect/platform/Headers"
+import * as HttpClient from "@effect/platform/HttpClient"
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest"
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse"
+import * as Arr from "effect/Array"
+import * as Config from "effect/Config"
+import type { ConfigError } from "effect/ConfigError"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import { identity } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Redacted from "effect/Redacted"
+import type * as Schema from "effect/Schema"
+import type * as Scope from "effect/Scope"
+
+/**
+ * @since 1.0.0
+ * @category Context
+ */
+export class PerplexityClient extends Context.Tag(
+  "@effect/ai-perplexity/PerplexityClient"
+)<PerplexityClient, Service>() {}
+
+/**
+ * Represents the interface that the `PerplexityClient` service provides.
+ *
+ * This service abstracts the complexity of communicating with the Perplexity
+ * Search API. It exposes the underlying HTTP client (already configured with
+ * authentication and the Perplexity base URL) plus a high-level helper for
+ * decoding JSON responses into a schema.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export interface Service {
+  /**
+   * The underlying HTTP client capable of communicating with the Perplexity
+   * API. Pre-configured with authentication (`Authorization: Bearer ...`) and
+   * the API base URL.
+   */
+  readonly httpClient: HttpClient.HttpClient
+
+  /**
+   * Execute a request and decode the JSON response body using the supplied
+   * schema. Maps platform `HttpClient` errors to `@effect/ai` `AiError`s.
+   */
+  readonly executeRequest: <A, I, R>(
+    request: HttpClientRequest.HttpClientRequest,
+    schema: Schema.Schema<A, I, R>,
+    method: string
+  ) => Effect.Effect<A, AiError.AiError, R>
+}
+
+/**
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const make = (options: {
+  /**
+   * The API key used to authenticate with the Perplexity API.
+   *
+   * Wrapped in `Redacted` to avoid accidental logging. Sent as a Bearer token
+   * in the `Authorization` header on every request.
+   */
+  readonly apiKey?: Redacted.Redacted | undefined
+  /**
+   * The base URL of the Perplexity API. Defaults to `https://api.perplexity.ai`.
+   */
+  readonly apiUrl?: string | undefined
+  /**
+   * Optional transform applied to the underlying HTTP client (e.g. to add
+   * middleware, logging, retries).
+   */
+  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+}): Effect.Effect<Service, never, HttpClient.HttpClient | Scope.Scope> =>
+  Effect.gen(function*() {
+    const authHeader = "authorization"
+
+    yield* Effect.locallyScopedWith(Headers.currentRedactedNames, Arr.append(authHeader))
+
+    const httpClient = (yield* HttpClient.HttpClient).pipe(
+      HttpClient.mapRequest((request) =>
+        request.pipe(
+          HttpClientRequest.prependUrl(options.apiUrl ?? "https://api.perplexity.ai"),
+          options.apiKey
+            ? HttpClientRequest.setHeader(authHeader, `Bearer ${Redacted.value(options.apiKey)}`)
+            : identity,
+          HttpClientRequest.acceptJson
+        )
+      ),
+      options.transformClient ? options.transformClient : identity
+    )
+
+    const httpClientOk = HttpClient.filterStatusOk(httpClient)
+
+    const executeRequest = <A, I, R>(
+      request: HttpClientRequest.HttpClientRequest,
+      schema: Schema.Schema<A, I, R>,
+      method: string
+    ): Effect.Effect<A, AiError.AiError, R> =>
+      httpClientOk.execute(request).pipe(
+        Effect.flatMap(HttpClientResponse.schemaBodyJson(schema)),
+        Effect.catchTags({
+          RequestError: (error) =>
+            AiError.HttpRequestError.fromRequestError({
+              module: "PerplexityClient",
+              method,
+              error
+            }),
+          ResponseError: (error) =>
+            AiError.HttpResponseError.fromResponseError({
+              module: "PerplexityClient",
+              method,
+              error
+            }),
+          ParseError: (error) =>
+            Effect.fail(
+              new AiError.MalformedOutput({
+                module: "PerplexityClient",
+                method,
+                description: `Failed to decode response body: ${error.message}`,
+                cause: error
+              })
+            )
+        })
+      )
+
+    return PerplexityClient.of({
+      httpClient,
+      executeRequest
+    })
+  })
+
+/**
+ * @since 1.0.0
+ * @category Layers
+ */
+export const layer = (options: {
+  readonly apiKey?: Redacted.Redacted | undefined
+  readonly apiUrl?: string | undefined
+  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+}): Layer.Layer<PerplexityClient, never, HttpClient.HttpClient> => Layer.scoped(PerplexityClient, make(options))
+
+/**
+ * Build a `PerplexityClient` layer that reads its API key from environment
+ * configuration. Looks for `PERPLEXITY_API_KEY` first and falls back to
+ * `PPLX_API_KEY`. Either may be supplied; if neither is set the layer fails
+ * with a `ConfigError`.
+ *
+ * @since 1.0.0
+ * @category Layers
+ */
+export const layerConfig = (
+  options?: {
+    readonly apiKey?: Config.Config<Redacted.Redacted> | undefined
+    readonly apiUrl?: Config.Config<string> | undefined
+  }
+): Layer.Layer<PerplexityClient, ConfigError, HttpClient.HttpClient> =>
+  Layer.scoped(
+    PerplexityClient,
+    Effect.flatMap(
+      Config.all({
+        apiKey: options?.apiKey ?? Config.redacted("PERPLEXITY_API_KEY").pipe(
+          Config.orElse(() => Config.redacted("PPLX_API_KEY"))
+        ),
+        apiUrl: options?.apiUrl ?? Config.string("PERPLEXITY_API_URL").pipe(
+          Config.withDefault("https://api.perplexity.ai")
+        )
+      }),
+      make
+    )
+  )

--- a/packages/ai/perplexity/src/PerplexityClient.ts
+++ b/packages/ai/perplexity/src/PerplexityClient.ts
@@ -16,6 +16,10 @@ import * as Layer from "effect/Layer"
 import * as Redacted from "effect/Redacted"
 import type * as Schema from "effect/Schema"
 import type * as Scope from "effect/Scope"
+import Package from "../package.json" with { type: "json" }
+
+const integrationHeader = "X-Pplx-Integration"
+const integrationVersion = `effect/${Package.version}`
 
 /**
  * @since 1.0.0
@@ -89,6 +93,7 @@ export const make = (options: {
           options.apiKey
             ? HttpClientRequest.setHeader(authHeader, `Bearer ${Redacted.value(options.apiKey)}`)
             : identity,
+          HttpClientRequest.setHeader(integrationHeader, integrationVersion),
           HttpClientRequest.acceptJson
         )
       ),

--- a/packages/ai/perplexity/src/PerplexityConfig.ts
+++ b/packages/ai/perplexity/src/PerplexityConfig.ts
@@ -1,0 +1,56 @@
+/**
+ * @since 1.0.0
+ */
+import type { HttpClient } from "@effect/platform/HttpClient"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import { dual } from "effect/Function"
+
+/**
+ * @since 1.0.0
+ * @category Context
+ */
+export class PerplexityConfig extends Context.Tag("@effect/ai-perplexity/PerplexityConfig")<
+  PerplexityConfig,
+  PerplexityConfig.Service
+>() {
+  /**
+   * @since 1.0.0
+   */
+  static readonly getOrUndefined: Effect.Effect<typeof PerplexityConfig.Service | undefined> = Effect.map(
+    Effect.context<never>(),
+    (context) => context.unsafeMap.get(PerplexityConfig.key)
+  )
+}
+
+/**
+ * @since 1.0.0
+ */
+export declare namespace PerplexityConfig {
+  /**
+   * @since 1.0.0
+   * @category Models
+   */
+  export interface Service {
+    readonly transformClient?: (client: HttpClient) => HttpClient
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category Configuration
+ */
+export const withClientTransform: {
+  (transform: (client: HttpClient) => HttpClient): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient): Effect.Effect<A, E, R>
+} = dual<
+  (transform: (client: HttpClient) => HttpClient) => <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
+  <A, E, R>(self: Effect.Effect<A, E, R>, transform: (client: HttpClient) => HttpClient) => Effect.Effect<A, E, R>
+>(
+  2,
+  (self, transformClient) =>
+    Effect.flatMap(
+      PerplexityConfig.getOrUndefined,
+      (config) => Effect.provideService(self, PerplexityConfig, { ...config, transformClient })
+    )
+)

--- a/packages/ai/perplexity/src/PerplexitySearch.ts
+++ b/packages/ai/perplexity/src/PerplexitySearch.ts
@@ -1,0 +1,201 @@
+/**
+ * @since 1.0.0
+ */
+import * as AiError from "@effect/ai/AiError"
+import type * as HttpClient from "@effect/platform/HttpClient"
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest"
+import type * as Config from "effect/Config"
+import type { ConfigError } from "effect/ConfigError"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import type * as Redacted from "effect/Redacted"
+import * as Schema from "effect/Schema"
+import * as PerplexityClient from "./PerplexityClient.js"
+
+/**
+ * @since 1.0.0
+ * @category Schemas
+ */
+export class SearchResult extends Schema.Class<SearchResult>(
+  "@effect/ai-perplexity/SearchResult"
+)({
+  title: Schema.String,
+  url: Schema.String,
+  snippet: Schema.String,
+  date: Schema.optional(Schema.NullOr(Schema.String))
+}) {}
+
+/**
+ * @since 1.0.0
+ * @category Schemas
+ */
+export class SearchResponse extends Schema.Class<SearchResponse>(
+  "@effect/ai-perplexity/SearchResponse"
+)({
+  id: Schema.optional(Schema.String),
+  results: Schema.Array(SearchResult)
+}) {}
+
+/**
+ * Recency window for search results. Maps to the `search_recency_filter`
+ * request parameter.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export type RecencyFilter = "hour" | "day" | "week" | "month" | "year"
+
+/**
+ * Options accepted by `PerplexitySearch.search`.
+ *
+ * Matches the Perplexity Search API request body
+ * (https://docs.perplexity.ai/api-reference/search-post).
+ *
+ * @since 1.0.0
+ * @category Models
+ */
+export interface SearchOptions {
+  readonly query: string
+  /**
+   * Maximum number of results to return. The Perplexity default is 10.
+   */
+  readonly maxResults?: number | undefined
+  /**
+   * Maximum tokens returned per page snippet.
+   */
+  readonly maxTokensPerPage?: number | undefined
+  /**
+   * Domain allowlist or denylist. Prefix a domain with `-` to exclude it.
+   * Do **not** mix allowed and excluded domains in the same array — the API
+   * expects one mode at a time.
+   */
+  readonly domainFilter?: ReadonlyArray<string> | undefined
+  /**
+   * Restrict results to a recency window.
+   */
+  readonly recencyFilter?: RecencyFilter | undefined
+  /**
+   * Only return results published on or after this date. Format: `m/d/yyyy`.
+   */
+  readonly afterDateFilter?: string | undefined
+  /**
+   * Only return results published on or before this date. Format: `m/d/yyyy`.
+   */
+  readonly beforeDateFilter?: string | undefined
+}
+
+/**
+ * @since 1.0.0
+ * @category Context
+ */
+export class PerplexitySearch extends Context.Tag(
+  "@effect/ai-perplexity/PerplexitySearch"
+)<PerplexitySearch, Service>() {}
+
+/**
+ * @since 1.0.0
+ * @category Models
+ */
+export interface Service {
+  /**
+   * Run a Perplexity Search API query and return the decoded results.
+   */
+  readonly search: (
+    options: SearchOptions
+  ) => Effect.Effect<SearchResponse, AiError.AiError>
+}
+
+const validateDomainFilter = (filter: ReadonlyArray<string>): void => {
+  const hasAllow = filter.some((d) => !d.startsWith("-"))
+  const hasDeny = filter.some((d) => d.startsWith("-"))
+  if (hasAllow && hasDeny) {
+    throw new Error(
+      "PerplexitySearch: domainFilter cannot mix allowlist and denylist entries. " +
+        "Use either positive entries (e.g. 'nytimes.com') or negative entries (e.g. '-pinterest.com'), not both."
+    )
+  }
+}
+
+const buildBody = (options: SearchOptions): Record<string, unknown> => {
+  if (options.domainFilter && options.domainFilter.length > 0) {
+    validateDomainFilter(options.domainFilter)
+  }
+  const body: Record<string, unknown> = { query: options.query }
+  if (options.maxResults !== undefined) body.max_results = options.maxResults
+  if (options.maxTokensPerPage !== undefined) body.max_tokens_per_page = options.maxTokensPerPage
+  if (options.domainFilter !== undefined) body.search_domain_filter = options.domainFilter
+  if (options.recencyFilter !== undefined) body.search_recency_filter = options.recencyFilter
+  if (options.afterDateFilter !== undefined) body.search_after_date_filter = options.afterDateFilter
+  if (options.beforeDateFilter !== undefined) body.search_before_date_filter = options.beforeDateFilter
+  return body
+}
+
+/**
+ * Build the request body sent to the Perplexity Search API.
+ *
+ * Exposed mainly for testing — most callers should use
+ * `PerplexitySearch.search` instead.
+ *
+ * @since 1.0.0
+ * @category Utilities
+ */
+export const buildRequestBody = (options: SearchOptions): Record<string, unknown> => buildBody(options)
+
+/**
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const make: Effect.Effect<Service, never, PerplexityClient.PerplexityClient> = Effect.gen(function*() {
+  const client = yield* PerplexityClient.PerplexityClient
+
+  const search = (options: SearchOptions): Effect.Effect<SearchResponse, AiError.AiError> =>
+    Effect.suspend(() => {
+      let body: Record<string, unknown>
+      try {
+        body = buildBody(options)
+      } catch (error) {
+        return Effect.fail(
+          new AiError.MalformedInput({
+            module: "PerplexitySearch",
+            method: "search",
+            description: error instanceof Error ? error.message : String(error),
+            cause: error
+          })
+        )
+      }
+      const request = HttpClientRequest.post("/search").pipe(
+        HttpClientRequest.bodyUnsafeJson(body)
+      )
+      return client.executeRequest(request, SearchResponse, "search")
+    })
+
+  return { search }
+})
+
+/**
+ * Layer that builds the `PerplexitySearch` service from a `PerplexityClient`.
+ *
+ * @since 1.0.0
+ * @category Layers
+ */
+export const layer: Layer.Layer<PerplexitySearch, never, PerplexityClient.PerplexityClient> = Layer.effect(
+  PerplexitySearch,
+  make
+)
+
+/**
+ * Convenience layer that wires the `PerplexitySearch` service together with
+ * a `PerplexityClient` configured from environment variables. Reads the API
+ * key from `PERPLEXITY_API_KEY` (falling back to `PPLX_API_KEY`).
+ *
+ * @since 1.0.0
+ * @category Layers
+ */
+export const layerConfig = (
+  options?: {
+    readonly apiKey?: Config.Config<Redacted.Redacted> | undefined
+    readonly apiUrl?: Config.Config<string> | undefined
+  }
+): Layer.Layer<PerplexitySearch, ConfigError, HttpClient.HttpClient> =>
+  layer.pipe(Layer.provide(PerplexityClient.layerConfig(options)))

--- a/packages/ai/perplexity/src/index.ts
+++ b/packages/ai/perplexity/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @since 1.0.0
+ */
+export * as PerplexityClient from "./PerplexityClient.js"
+
+/**
+ * @since 1.0.0
+ */
+export * as PerplexityConfig from "./PerplexityConfig.js"
+
+/**
+ * @since 1.0.0
+ */
+export * as PerplexitySearch from "./PerplexitySearch.js"

--- a/packages/ai/perplexity/test/PerplexitySearch.test.ts
+++ b/packages/ai/perplexity/test/PerplexitySearch.test.ts
@@ -166,6 +166,7 @@ describe("PerplexitySearch", () => {
         assert.match(captured!.url, /\/search$/)
         assert.deepStrictEqual(captured!.body, { query: "effect typescript", max_results: 2 })
         assert.strictEqual(captured!.headers["authorization"], "Bearer test-api-key")
+        assert.match(captured!.headers["x-pplx-integration"], /^effect\//)
       }))
 
     it.effect("forwards filter options to the request body", () =>

--- a/packages/ai/perplexity/test/PerplexitySearch.test.ts
+++ b/packages/ai/perplexity/test/PerplexitySearch.test.ts
@@ -1,0 +1,247 @@
+import * as AiError from "@effect/ai/AiError"
+import * as HttpClient from "@effect/platform/HttpClient"
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
+import * as Layer from "effect/Layer"
+import * as Redacted from "effect/Redacted"
+import * as Ref from "effect/Ref"
+import * as PerplexityClient from "../src/PerplexityClient.js"
+import * as PerplexitySearch from "../src/PerplexitySearch.js"
+
+interface CapturedRequest {
+  readonly method: string
+  readonly url: string
+  readonly body: unknown
+  readonly headers: Record<string, string>
+}
+
+const makeMockHttpClient = (responseBody: unknown, status = 200) =>
+  Effect.gen(function*() {
+    const captured = yield* Ref.make<CapturedRequest | undefined>(undefined)
+    const client = HttpClient.make((request) =>
+      Effect.gen(function*() {
+        const text = request.body._tag === "Uint8Array"
+          ? new TextDecoder().decode(request.body.body)
+          : request.body._tag === "Raw"
+          ? String(request.body.body)
+          : ""
+        let parsed: unknown = text
+        try {
+          parsed = text.length > 0 ? JSON.parse(text) : undefined
+        } catch {
+          // leave as raw
+        }
+        yield* Ref.set(captured, {
+          method: request.method,
+          url: request.url,
+          body: parsed,
+          headers: request.headers as unknown as Record<string, string>
+        })
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(JSON.stringify(responseBody), {
+            status,
+            headers: { "content-type": "application/json" }
+          })
+        )
+      })
+    )
+    return { client, captured }
+  })
+
+const provideSearch = <A, E>(
+  effect: Effect.Effect<A, E, PerplexitySearch.PerplexitySearch>,
+  responseBody: unknown,
+  status = 200
+) =>
+  Effect.gen(function*() {
+    const { captured, client } = yield* makeMockHttpClient(responseBody, status)
+    const result = yield* effect.pipe(
+      Effect.provide(
+        PerplexitySearch.layer.pipe(
+          Layer.provide(
+            PerplexityClient.layer({
+              apiKey: Redacted.make("test-api-key")
+            })
+          ),
+          Layer.provide(Layer.succeed(HttpClient.HttpClient, client))
+        )
+      )
+    )
+    const captureValue = yield* Ref.get(captured)
+    return { result, captured: captureValue }
+  })
+
+describe("PerplexitySearch", () => {
+  describe("buildRequestBody", () => {
+    it("includes only the query when no options are set", () => {
+      const body = PerplexitySearch.buildRequestBody({ query: "hello" })
+      assert.deepStrictEqual(body, { query: "hello" })
+    })
+
+    it("maps camelCase options to the API's snake_case fields", () => {
+      const body = PerplexitySearch.buildRequestBody({
+        query: "hello",
+        maxResults: 5,
+        maxTokensPerPage: 256,
+        recencyFilter: "week",
+        afterDateFilter: "1/1/2025",
+        beforeDateFilter: "12/31/2025",
+        domainFilter: ["nytimes.com"]
+      })
+      assert.deepStrictEqual(body, {
+        query: "hello",
+        max_results: 5,
+        max_tokens_per_page: 256,
+        search_domain_filter: ["nytimes.com"],
+        search_recency_filter: "week",
+        search_after_date_filter: "1/1/2025",
+        search_before_date_filter: "12/31/2025"
+      })
+    })
+
+    it("accepts an allowlist", () => {
+      const body = PerplexitySearch.buildRequestBody({
+        query: "x",
+        domainFilter: ["nytimes.com", "wsj.com"]
+      })
+      assert.deepStrictEqual(body.search_domain_filter, ["nytimes.com", "wsj.com"])
+    })
+
+    it("accepts a denylist", () => {
+      const body = PerplexitySearch.buildRequestBody({
+        query: "x",
+        domainFilter: ["-pinterest.com", "-quora.com"]
+      })
+      assert.deepStrictEqual(body.search_domain_filter, ["-pinterest.com", "-quora.com"])
+    })
+
+    it("rejects mixed allow/deny domain filter entries", () => {
+      assert.throws(() =>
+        PerplexitySearch.buildRequestBody({
+          query: "x",
+          domainFilter: ["nytimes.com", "-pinterest.com"]
+        }), /cannot mix allowlist and denylist/)
+    })
+  })
+
+  describe("search", () => {
+    it.effect("decodes a successful response", () =>
+      Effect.gen(function*() {
+        const { captured, result } = yield* provideSearch(
+          Effect.gen(function*() {
+            const search = yield* PerplexitySearch.PerplexitySearch
+            return yield* search.search({ query: "effect typescript", maxResults: 2 })
+          }),
+          {
+            id: "abc",
+            results: [
+              {
+                title: "Effect TS",
+                url: "https://effect.website",
+                snippet: "Functional effects",
+                date: "2026-04-01"
+              },
+              {
+                title: "Effect GitHub",
+                url: "https://github.com/Effect-TS/effect",
+                snippet: "Source"
+              }
+            ]
+          }
+        )
+        assert.strictEqual(result.id, "abc")
+        assert.strictEqual(result.results.length, 2)
+        assert.strictEqual(result.results[0].title, "Effect TS")
+        assert.strictEqual(result.results[0].url, "https://effect.website")
+        assert.strictEqual(result.results[0].snippet, "Functional effects")
+        assert.strictEqual(result.results[0].date, "2026-04-01")
+        assert.strictEqual(result.results[1].title, "Effect GitHub")
+
+        // Verify request shape
+        assert.ok(captured)
+        assert.strictEqual(captured!.method, "POST")
+        assert.match(captured!.url, /\/search$/)
+        assert.deepStrictEqual(captured!.body, { query: "effect typescript", max_results: 2 })
+        assert.strictEqual(captured!.headers["authorization"], "Bearer test-api-key")
+      }))
+
+    it.effect("forwards filter options to the request body", () =>
+      Effect.gen(function*() {
+        const { captured } = yield* provideSearch(
+          Effect.gen(function*() {
+            const search = yield* PerplexitySearch.PerplexitySearch
+            yield* search.search({
+              query: "climate news",
+              maxResults: 3,
+              recencyFilter: "day",
+              domainFilter: ["-pinterest.com"],
+              afterDateFilter: "1/1/2025",
+              beforeDateFilter: "12/31/2025"
+            })
+          }),
+          { results: [] }
+        )
+        assert.deepStrictEqual(captured!.body, {
+          query: "climate news",
+          max_results: 3,
+          search_recency_filter: "day",
+          search_domain_filter: ["-pinterest.com"],
+          search_after_date_filter: "1/1/2025",
+          search_before_date_filter: "12/31/2025"
+        })
+      }))
+
+    it.effect("fails with MalformedInput when domainFilter mixes allow and deny", () =>
+      Effect.gen(function*() {
+        const { result } = yield* provideSearch(
+          Effect.gen(function*() {
+            const search = yield* PerplexitySearch.PerplexitySearch
+            return yield* search.search({
+              query: "x",
+              domainFilter: ["nytimes.com", "-pinterest.com"]
+            }).pipe(Effect.either)
+          }),
+          { results: [] }
+        )
+        assert.isTrue(Either.isLeft(result))
+        if (Either.isLeft(result)) {
+          assert.instanceOf(result.left, AiError.MalformedInput)
+          assert.match(result.left.description!, /cannot mix allowlist and denylist/)
+        }
+      }))
+
+    it.effect("fails with HttpResponseError on non-2xx status", () =>
+      Effect.gen(function*() {
+        const { result } = yield* provideSearch(
+          Effect.gen(function*() {
+            const search = yield* PerplexitySearch.PerplexitySearch
+            return yield* search.search({ query: "boom" }).pipe(Effect.either)
+          }),
+          { error: "unauthorized" },
+          401
+        )
+        assert.isTrue(Either.isLeft(result))
+        if (Either.isLeft(result)) {
+          assert.instanceOf(result.left, AiError.HttpResponseError)
+        }
+      }))
+
+    it.effect("fails with MalformedOutput when the response body cannot be decoded", () =>
+      Effect.gen(function*() {
+        const { result } = yield* provideSearch(
+          Effect.gen(function*() {
+            const search = yield* PerplexitySearch.PerplexitySearch
+            return yield* search.search({ query: "x" }).pipe(Effect.either)
+          }),
+          { results: "not-an-array" }
+        )
+        assert.isTrue(Either.isLeft(result))
+        if (Either.isLeft(result)) {
+          assert.instanceOf(result.left, AiError.MalformedOutput)
+        }
+      }))
+  })
+})

--- a/packages/ai/perplexity/tsconfig.build.json
+++ b/packages/ai/perplexity/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.src.json",
+  "references": [
+    { "path": "../ai/tsconfig.build.json" },
+    { "path": "../../effect/tsconfig.build.json" },
+    { "path": "../../platform/tsconfig.build.json" }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true,
+    "exactOptionalPropertyTypes": false
+  }
+}

--- a/packages/ai/perplexity/tsconfig.json
+++ b/packages/ai/perplexity/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages/ai/perplexity/tsconfig.src.json
+++ b/packages/ai/perplexity/tsconfig.src.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../ai/tsconfig.src.json" },
+    { "path": "../../effect/tsconfig.src.json" },
+    { "path": "../../platform/tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "build/src",
+    "exactOptionalPropertyTypes": false
+  }
+}

--- a/packages/ai/perplexity/tsconfig.test.json
+++ b/packages/ai/perplexity/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["test"],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "../../vitest/tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "noEmit": true,
+    "exactOptionalPropertyTypes": false
+  }
+}

--- a/packages/ai/perplexity/vitest.config.ts
+++ b/packages/ai/perplexity/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../../vitest.shared.js"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,22 @@ importers:
         version: link:../../effect
     publishDirectory: dist
 
+  packages/ai/perplexity:
+    devDependencies:
+      '@effect/ai':
+        specifier: workspace:^
+        version: link:../ai
+      '@effect/platform':
+        specifier: workspace:^
+        version: link:../../platform
+      '@effect/platform-node':
+        specifier: workspace:^
+        version: link:../../platform-node
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+    publishDirectory: dist
+
   packages/cli:
     dependencies:
       ini:
@@ -8370,7 +8386,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -8381,7 +8397,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -9129,7 +9145,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
 
   '@types/ini@4.1.1': {}
 
@@ -9187,6 +9203,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -10029,7 +10046,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -10038,7 +10055,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11545,7 +11562,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -11555,7 +11572,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11589,7 +11606,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -11614,7 +11631,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.16.4
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -13718,7 +13735,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@5.29.0:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,6 +42,7 @@
           "@effect/ai",
           "@effect/ai-anthropic",
           "@effect/ai-openai",
+          "@effect/ai-perplexity",
           "@effect/cli",
           "@effect/cluster",
           "@effect/experimental",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,6 +8,7 @@
     { "path": "packages/ai/anthropic/tsconfig.build.json" },
     { "path": "packages/ai/google/tsconfig.build.json" },
     { "path": "packages/ai/openai/tsconfig.build.json" },
+    { "path": "packages/ai/perplexity/tsconfig.build.json" },
     { "path": "packages/cli/tsconfig.build.json" },
     { "path": "packages/cluster/tsconfig.build.json" },
     { "path": "packages/experimental/tsconfig.build.json" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "packages/ai/anthropic" },
     { "path": "packages/ai/google" },
     { "path": "packages/ai/openai" },
+    { "path": "packages/ai/perplexity" },
     { "path": "packages/cli" },
     { "path": "packages/cluster" },
     { "path": "packages/experimental" },


### PR DESCRIPTION
## Summary

Adds a new `@effect/ai-perplexity` package providing Effect bindings for the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post).

### What's added

- `PerplexityClient` — HTTP client wrapper that handles authentication and error mapping (platform `HttpClient` errors → `@effect/ai` `AiError`).
- `PerplexitySearch` — service with a `search(options)` method that returns a typed `SearchResponse` (`results: { title, url, snippet, date? }[]`).
- Supports the documented Search API request fields: `max_results`, `max_tokens_per_page`, `search_domain_filter`, `search_recency_filter`, `search_after_date_filter`, `search_before_date_filter`.
- Validates that `search_domain_filter` does not mix allow- and deny-list entries (the API does not accept that), failing fast with `AiError.MalformedInput` if it does.
- API key is read from `PERPLEXITY_API_KEY`, falling back to `PPLX_API_KEY`, via `Config.redacted`. A custom URL can be supplied via `PERPLEXITY_API_URL` or programmatically.
- Includes a `PerplexityConfig` tag and `withClientTransform` helper, mirroring the pattern used by `@effect/ai-anthropic`.

### Tests

10 unit tests in `packages/ai/perplexity/test/PerplexitySearch.test.ts`, all using a mocked `HttpClient` (`HttpClient.make`) so no network calls are made:

- request body construction (camelCase → snake_case mapping, optional fields)
- allowlist / denylist domain filter handling, including the mixed-mode rejection
- success decoding into `SearchResponse`
- non-2xx → `AiError.HttpResponseError`
- malformed JSON body → `AiError.MalformedOutput`
- header / URL / method assertions on the captured request

Run with:

```
pnpm --filter @effect/ai-perplexity test
pnpm --filter @effect/ai-perplexity check
pnpm --filter @effect/ai-perplexity build
```

All three pass locally.

### Docs

- `packages/ai/perplexity/README.md` documents installation, authentication, basic usage, available options, and the domain-filter caveat.
- Includes a changeset (`@effect/ai-perplexity` minor) describing the addition.

### References

- Search API reference: https://docs.perplexity.ai/api-reference/search-post
- Search quickstart: https://docs.perplexity.ai/docs/search/quickstart
- Domain filters: https://docs.perplexity.ai/docs/search/filters/domain-filter
- Date / recency filters: https://docs.perplexity.ai/docs/search/filters/date-time-filters