### PR TITLE
fix(@effect/platform): flatten anyOf when accumulating same-content-type union payloads

### DIFF
--- a/.changeset/fix-platform-flat-anyof-union-payload.md
+++ b/.changeset/fix-platform-flat-anyof-union-payload.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+`OpenApi.fromApi` now emits a flat `anyOf` array when multiple union members in `setPayload` share the same content type. Previously, each additional member was wrapped in a new `Union` node, producing deeply nested `anyOf: [ anyOf: [A, B], C ]` structures. The fix uses `HttpApiSchema.UnionUnifyAST` — already used by the response-map accumulator — to flatten unions as they are collected.

--- a/packages/platform/src/HttpApi.ts
+++ b/packages/platform/src/HttpApi.ts
@@ -419,7 +419,7 @@ const extractPayloads = (topAst: AST.AST): ReadonlyMap<string, {
         ast
       })
     } else {
-      current.ast = AST.Union.make([current.ast, ast])
+      current.ast = HttpApiSchema.UnionUnifyAST(current.ast, ast)
     }
   }
   if (topAst._tag === "Union") {

--- a/packages/platform/test/OpenApi.test.ts
+++ b/packages/platform/test/OpenApi.test.ts
@@ -1951,6 +1951,78 @@ describe("OpenApi", () => {
           expectSpecPaths(api, expected)
         })
       })
+
+      it("setPayload with a flat JSON union produces flat anyOf (not nested)", () => {
+        const A = Schema.Struct({ _tag: Schema.Literal("A"), a: Schema.String })
+        const B = Schema.Struct({ _tag: Schema.Literal("B"), b: Schema.Number })
+        const C = Schema.Struct({ _tag: Schema.Literal("C"), c: Schema.Boolean })
+        const api = HttpApi.make("api").add(
+          HttpApiGroup.make("group").add(
+            HttpApiEndpoint.post("post", "/")
+              .addSuccess(Schema.String)
+              .setPayload(Schema.Union(A, B, C))
+          )
+        )
+        expectSpecPaths(api, {
+          "/": {
+            "post": {
+              "tags": ["group"],
+              "operationId": "group.post",
+              "parameters": [],
+              "security": [],
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": ["_tag", "a"],
+                          "properties": {
+                            "_tag": { "enum": ["A"], "type": "string" },
+                            "a": { "type": "string" }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": ["_tag", "b"],
+                          "properties": {
+                            "_tag": { "enum": ["B"], "type": "string" },
+                            "b": { "type": "number" }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": ["_tag", "c"],
+                          "properties": {
+                            "_tag": { "enum": ["C"], "type": "string" },
+                            "c": { "type": "boolean" }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  }
+                },
+                "required": true
+              },
+              "responses": {
+                "200": {
+                  "description": "a string",
+                  "content": {
+                    "application/json": {
+                      "schema": { "type": "string" }
+                    }
+                  }
+                },
+                "400": HttpApiDecodeError
+              }
+            }
+          }
+        })
+      })
     })
 
     describe("HttpApiEndpoint.del", () => {


### PR DESCRIPTION
## Type
- [x] Bug Fix

## Description
`OpenApi.fromApi` emits nested `anyOf` when `setPayload` receives a union where all members share the same content type. For example, `Schema.Union(A, B, C)` where all three are JSON structs produces `anyOf: [ anyOf: [A, B], C ]` instead of the expected flat `anyOf: [A, B, C]`.

### Root cause
`extractPayloads` accumulates same-content-type members with `AST.Union.make([current.ast, ast])` on each pass. That builds a left-nested union tree — `Union([Union([A, B]), C])` — which the JSON Schema encoder faithfully reflects as nested `anyOf`.

### Fix
One line: replace `AST.Union.make([current.ast, ast])` with `HttpApiSchema.UnionUnifyAST(current.ast, ast)`.

`UnionUnifyAST` is already in the package and is already used for the same reason by the response-map accumulator (`extractResponseMap`, line 382). It flattens both sides through `extractUnionTypes` before creating the Union node, so the result stays flat no matter how many members land on the same content type. The asymmetry between the two accumulators is what introduced the bug.

## Tests
Adds one test to `packages/platform/test/OpenApi.test.ts`: `Schema.Union(A, B, C)` (three JSON structs) on a POST endpoint produces a flat `anyOf: [A, B, C]` in the generated spec, not nested.

## Related
- Closes #6052
