### PR TITLE
fix(@effect/cli): use Ansi.blackBright for Weak spans so --help is readable on dark terminals

### DIFF
--- a/.changeset/fix-cli-weak-span-dark-terminal.md
+++ b/.changeset/fix-cli-weak-span-dark-terminal.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Fix `@effect/cli` help output to use `Ansi.blackBright` instead of `Ansi.black` for `Weak` spans. The previous black foreground was invisible on dark terminal backgrounds.

--- a/packages/cli/src/internal/helpDoc/span.ts
+++ b/packages/cli/src/internal/helpDoc/span.ts
@@ -139,7 +139,7 @@ export const toAnsiDoc = (self: Span.Span): Doc.AnsiDoc => {
       return Doc.annotate(Doc.text(self.value), Ansi.underlined)
     }
     case "Weak": {
-      return Doc.annotate(toAnsiDoc(self.value), Ansi.black)
+      return Doc.annotate(toAnsiDoc(self.value), Ansi.blackBright)
     }
   }
 }

--- a/packages/cli/test/HelpDoc.test.ts
+++ b/packages/cli/test/HelpDoc.test.ts
@@ -1,0 +1,17 @@
+import * as HelpDoc from "@effect/cli/HelpDoc"
+import * as Span from "@effect/cli/HelpDoc/Span"
+import * as AnsiDoc from "@effect/printer-ansi/AnsiDoc"
+import { describe, expect, it } from "@effect/vitest"
+
+describe("HelpDoc", () => {
+  describe("toAnsiDoc", () => {
+    it("Weak spans use bright black (dark gray), not black, so they are readable on dark terminals", () => {
+      const span = Span.weak("name")
+      const ansiDoc = HelpDoc.toAnsiDoc(HelpDoc.p(span))
+      const rendered = AnsiDoc.render(ansiDoc, { style: "pretty" })
+      // ANSI foreground code 30 = black — invisible on dark/black terminal backgrounds.
+      // Weak spans must not produce this code.
+      expect(rendered).not.toMatch(/\x1b\[[0-9;]*30[;m]/)
+    })
+  })
+})

--- a/packages/cli/test/HelpDoc.test.ts
+++ b/packages/cli/test/HelpDoc.test.ts
@@ -11,7 +11,9 @@ describe("HelpDoc", () => {
       const rendered = AnsiDoc.render(ansiDoc, { style: "pretty" })
       // ANSI foreground code 30 = black — invisible on dark/black terminal backgrounds.
       // Weak spans must not produce this code.
-      expect(rendered).not.toMatch(/\x1b\[[0-9;]*30[;m]/)
+      // String.fromCharCode(27) = ESC; avoids no-control-regex on both regex literals and new RegExp().
+      const ESC = String.fromCharCode(27)
+      expect(rendered).not.toMatch(new RegExp(ESC + "\\[[0-9;]*30[;m]"))
     })
   })
 })


### PR DESCRIPTION
Fixes #6200

`@effect/cli` marks "Weak" spans in `--help` output with `Ansi.black`, which produces ANSI code `30` (black foreground). On dark terminal backgrounds (the default in most modern terminals), the text becomes black-on-black and disappears. `NO_COLOR=1` does not help; the styling is applied in the annotation layer before the renderer sees it.

The fix is in `toAnsiDoc` in `packages/cli/src/internal/helpDoc/span.ts`:

```ts
// before
case "Weak": {
  return Doc.annotate(toAnsiDoc(self.value), Ansi.black)
}

// after
case "Weak": {
  return Doc.annotate(toAnsiDoc(self.value), Ansi.blackBright)
}
```

`Ansi.blackBright` is ANSI code `90` (dark gray), readable on dark and light backgrounds. `Ansi.dim` would be cleaner semantically for de-emphasized text, but it is not exported by `@effect/printer-ansi`, so `blackBright` is the right call within the current API.

I added a regression test that renders a `Weak` span through `HelpDoc.toAnsiDoc` and asserts ANSI code `30` is absent. All 162 existing CLI tests pass.

Love the library. Glad to contribute!
