### PR TITLE
datner/acquire disposable

### DIFF
--- a/.changeset/big-steaks-train.md
+++ b/.changeset/big-steaks-train.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add `Effect.acquireDisposable`

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -5461,6 +5461,29 @@ export const acquireRelease: {
 } = fiberRuntime.acquireRelease
 
 /**
+ * Constructs a scoped resource from an {@linkcode AsyncDisposable} or {@linkcode Disposable}
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using}
+ *
+ * @example
+ * import sqlite from "node:sqlite";
+ * import { Effect } from "effect";
+ *
+ * // Define how the resource is acquired
+ * const acquire = Effect.sync(() => new sqlite.DatabaseSync(":memory:"))
+ * const resource = Effect.acquireDisposable(acquire)
+ *
+ * @see {@link acquireRelease} for more information about scopes.
+ *
+ * @since 3.0.0
+ * @category Scoping, Resources & Finalization
+ */
+export const acquireDisposable: {
+  <A extends AsyncDisposable | Disposable, E, R>(
+    acquire: Effect<A, E, R>
+  ): Effect<A, E, R | Scope.Scope>
+} = fiberRuntime.acquireDisposable
+
+/**
  * Creates a scoped resource with an interruptible acquire action.
  *
  * **Details**

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -1692,6 +1692,17 @@ export const acquireRelease: {
   ))
 
 /* @internal */
+export const acquireDisposable: {
+  <A extends AsyncDisposable | Disposable, E, R>(
+    acquire: Effect.Effect<A, E, R>
+  ): Effect.Effect<A, E, R | Scope.Scope>
+} = (acquire) =>
+  acquireRelease(acquire, (resource) =>
+    Predicate.hasProperty(resource, Symbol.asyncDispose)
+      ? internalEffect.promise(() => resource[Symbol.asyncDispose]())
+      : core.sync(() => resource[Symbol.dispose]()))
+
+/* @internal */
 export const acquireReleaseInterruptible: {
   <X, R2>(
     release: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<X, never, R2>

--- a/packages/effect/test/Effect/acquire-release.test.ts
+++ b/packages/effect/test/Effect/acquire-release.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { assertTrue, strictEqual } from "@effect/vitest/utils"
+import { assertEquals, assertFalse, assertTrue, strictEqual } from "@effect/vitest/utils"
 import * as Cause from "effect/Cause"
 import * as Chunk from "effect/Chunk"
 import * as Effect from "effect/Effect"
@@ -7,6 +7,17 @@ import { equals } from "effect/Equal"
 import * as Exit from "effect/Exit"
 import { pipe } from "effect/Function"
 import * as Ref from "effect/Ref"
+
+const disposable = (hook: () => void) => ({
+  [Symbol.dispose]() {
+    hook()
+  }
+})
+const asyncDisposable = (hook: () => Promise<void>) => ({
+  async [Symbol.asyncDispose]() {
+    await hook()
+  }
+})
 
 describe("Effect", () => {
   it.effect("acquireUseRelease - happy path", () =>
@@ -107,5 +118,60 @@ describe("Effect", () => {
       const released = yield* (Ref.get(release))
       assertTrue(equals(Cause.defects(result), Chunk.of(useDied)))
       assertTrue(released)
+    }))
+  it.effect("acquireDisposable - happy path", () =>
+    Effect.gen(function*() {
+      let disposed = false
+      yield* Effect.succeed(
+        disposable(() => {
+          disposed = true
+        })
+      )
+        .pipe(
+          Effect.acquireDisposable,
+          Effect.tap(() => assertFalse(disposed)),
+          Effect.scoped
+        )
+      assertTrue(disposed)
+    }))
+  it.effect("acquireDisposable - happy path async", () =>
+    Effect.gen(function*() {
+      let disposed = false
+      yield* Effect.succeed(
+        asyncDisposable(() =>
+          new Promise((resolve) => {
+            disposed = true
+            resolve()
+          })
+        )
+      )
+        .pipe(
+          Effect.acquireDisposable,
+          Effect.tap(() => assertFalse(disposed)),
+          Effect.scoped
+        )
+      assertTrue(disposed)
+    }))
+  it.effect("acquireDisposable - error handling", () =>
+    Effect.gen(function*() {
+      const err = new Error("oh no!")
+      const exit = yield* Effect.succeed(
+        disposable(() => {
+          throw err
+        })
+      )
+        .pipe(
+          Effect.acquireDisposable,
+          Effect.scoped,
+          Effect.exit
+        )
+      const result = yield* Exit.matchEffect(
+        exit,
+        {
+          onFailure: Effect.succeed,
+          onSuccess: () => Effect.fail("effect should have failed")
+        }
+      )
+      assertEquals(Cause.defects(result), Chunk.of(err))
     }))
 })

--- a/packages/effect/test/Effect/acquire-release.test.ts
+++ b/packages/effect/test/Effect/acquire-release.test.ts
@@ -3,7 +3,6 @@ import { assertEquals, assertFalse, assertTrue, strictEqual } from "@effect/vite
 import * as Cause from "effect/Cause"
 import * as Chunk from "effect/Chunk"
 import * as Effect from "effect/Effect"
-import { equals } from "effect/Equal"
 import * as Exit from "effect/Exit"
 import { pipe } from "effect/Function"
 import * as Ref from "effect/Ref"
@@ -64,8 +63,8 @@ describe("Effect", () => {
         exit,
         Exit.matchEffect({ onFailure: Effect.succeed, onSuccess: () => Effect.fail("effect should have failed") })
       )
-      assertTrue(equals(Cause.failures(result), Chunk.of("use failed")))
-      assertTrue(equals(Cause.defects(result), Chunk.of(releaseDied)))
+      assertEquals(Cause.failures(result), Chunk.of("use failed"))
+      assertEquals(Cause.defects(result), Chunk.of(releaseDied))
     }))
   it.effect("acquireUseRelease - error handling + disconnect", () =>
     Effect.gen(function*() {
@@ -86,8 +85,8 @@ describe("Effect", () => {
           onSuccess: () => Effect.fail("effect should have failed")
         })
       )
-      assertTrue(equals(Cause.failures(result), Chunk.of("use failed")))
-      assertTrue(equals(Cause.defects(result), Chunk.of(releaseDied)))
+      assertEquals(Cause.failures(result), Chunk.of("use failed"))
+      assertEquals(Cause.defects(result), Chunk.of(releaseDied))
     }))
   it.effect("acquireUseRelease - beast mode error handling + disconnect", () =>
     Effect.gen(function*() {
@@ -116,7 +115,7 @@ describe("Effect", () => {
         )
       )
       const released = yield* (Ref.get(release))
-      assertTrue(equals(Cause.defects(result), Chunk.of(useDied)))
+      assertEquals(Cause.defects(result), Chunk.of(useDied))
       assertTrue(released)
     }))
   it.effect("acquireDisposable - happy path", () =>


### PR DESCRIPTION
- feat(effect): add `Effect.acquireDisposable`
- test(effect): happy path and failure for `Effect.acquireDisposable`
- test(effect): change `assertTrue(equals` to `assertEquals`
- chore: add changeset
