### PR TITLE
fix(Effect): add Refinement narrowing support for retry while option

### DIFF
--- a/.changeset/fix-retry-refinement.md
+++ b/.changeset/fix-retry-refinement.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix(Effect): add Refinement narrowing support for retry while option

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4257,6 +4257,7 @@ export declare namespace Retry {
   export type Return<R, E, A, O extends NoExcessProperties<Options<E>, O>> = Effect<
     A,
     | (O extends { schedule: Schedule.Schedule<infer _O, infer _I, infer _R> } ? E
+      : O extends { while: Refinement<E, infer E2> } ? Exclude<E, E2>
       : O extends { until: Refinement<E, infer E2> } ? E2
       : E)
     | (O extends { while: (...args: Array<any>) => Effect<infer _A, infer E, infer _R> } ? E : never)


### PR DESCRIPTION
## Summary

Adds `Refinement`-based type narrowing for the `while` option in `Effect.retry`, symmetric with the existing `until` narrowing.

When `while` receives a `Refinement<E, E2>`, the output error type is now narrowed to `Exclude<E, E2>` — the errors that cause `while` to return `false` and pass through.

Closes #6122

## Test plan

- [ ] Verify that type narrowing works correctly with `while` + Refinement
- [ ] Verify existing `until` narrowing is unchanged
- [ ] Verify behavior without Refinement is unchanged (still returns full `E`)