### PR TITLE
feat(DateTime): add toEpochSeconds method

### DIFF
--- a/.changeset/feat-datetime-epoch.md
+++ b/.changeset/feat-datetime-epoch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+feat(DateTime): add toEpochSeconds method

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -939,6 +939,14 @@ export const zonedOffsetIso: (self: Zoned) => string = Internal.zonedOffsetIso
 export const toEpochMillis: (self: DateTime) => number = Internal.toEpochMillis
 
 /**
+ * Get the seconds since the Unix epoch of a `DateTime`.
+ *
+ * @since 3.16.0
+ * @category conversions
+ */
+export const toEpochSeconds: (self: DateTime) => number = Internal.toEpochSeconds
+
+/**
  * Remove the time aspect of a `DateTime`, first adjusting for the time
  * zone. It will return a `DateTime.Utc` only containing the date.
  *

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -614,6 +614,9 @@ export const zonedOffsetIso = (self: DateTime.Zoned): string => offsetToString(z
 export const toEpochMillis = (self: DateTime.DateTime): number => self.epochMillis
 
 /** @internal */
+export const toEpochSeconds = (self: DateTime.DateTime): number => Math.floor(self.epochMillis / 1000)
+
+/** @internal */
 export const removeTime = (self: DateTime.DateTime): DateTime.Utc =>
   withDate(self, (date) => {
     date.setUTCHours(0, 0, 0, 0)


### PR DESCRIPTION
## Summary

Adds `DateTime.toEpochSeconds`, which returns the Unix timestamp in whole seconds, complementing the existing `toEpochMillis`.

This avoids the need for users to manually compute `Math.round(DateTime.toEpochMillis(dt) / 1000)` every time they need a Unix timestamp in seconds.

Closes #6148

## Test plan

- [ ] Verify `toEpochSeconds` returns correct integer seconds for known dates
- [ ] Verify it uses `Math.floor` for consistent truncation behavior