### PR TITLE
fix(Record): make fromIterableBy dual for pipe-friendly usage

### DIFF
--- a/.changeset/fix-record-fromiterableby.md
+++ b/.changeset/fix-record-fromiterableby.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix(Record): make fromIterableBy dual for pipe-friendly usage

--- a/packages/effect/src/Record.ts
+++ b/packages/effect/src/Record.ts
@@ -168,10 +168,21 @@ export const fromIterableWith: {
  * @category constructors
  * @since 2.0.0
  */
-export const fromIterableBy = <A, K extends string | symbol>(
-  items: Iterable<A>,
-  f: (a: A) => K
-): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(items, (a) => [f(a), a])
+export const fromIterableBy: {
+  <A, K extends string | symbol>(
+    f: (a: A) => K
+  ): (self: Iterable<A>) => Record<ReadonlyRecord.NonLiteralKey<K>, A>
+  <A, K extends string | symbol>(
+    self: Iterable<A>,
+    f: (a: A) => K
+  ): Record<ReadonlyRecord.NonLiteralKey<K>, A>
+} = dual(
+  2,
+  <A, K extends string | symbol>(
+    self: Iterable<A>,
+    f: (a: A) => K
+  ): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(self, (a) => [f(a), a])
+)
 
 /**
  * Builds a record from an iterable of key-value pairs.


### PR DESCRIPTION
## Summary

Wraps `Record.fromIterableBy` with `dual(2, ...)` so it supports both data-first and data-last (curried) calling conventions, consistent with `fromIterableWith` and other dual APIs in the codebase.

This enables the following pipe-friendly usage:

```ts
pipe(rows, Record.fromIterableBy(Struct.get("authEmail")))
```

Closes #6092

## Test plan

- [ ] Verify data-first usage still works: `Record.fromIterableBy(items, fn)`
- [ ] Verify data-last/curried usage works: `pipe(items, Record.fromIterableBy(fn))`
- [ ] Verify type inference is correct in both modes