### PR TITLE
fix(cli): replace all hyphens in shell completion command names

### DIFF
--- a/.changeset/fix-cli-completions-hyphen.md
+++ b/.changeset/fix-cli-completions-hyphen.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+fix(cli): replace all hyphens in shell completion command names

--- a/packages/cli/src/internal/commandDescriptor.ts
+++ b/packages/cli/src/internal/commandDescriptor.ts
@@ -1081,7 +1081,7 @@ const getBashCompletionsInternal = (
         : pipe(
           info.parentCommands,
           Arr.append(info.command.name),
-          Arr.map((command) => command.replace("-", "__"))
+          Arr.map((command) => command.replaceAll("-", "__"))
         )
       const caseName = Arr.join(preformatted, ",")
       const funcName = Arr.join(preformatted, "__")
@@ -1238,7 +1238,7 @@ const getZshCompletionsInternal = (
       : pipe(
         info.parentCommands,
         Arr.append(info.command.name),
-        Arr.map((command) => command.replace("-", "__"))
+        Arr.map((command) => command.replaceAll("-", "__"))
       )
     const underscoreName = Arr.join(preformatted, "__")
     const spaceName = Arr.join(preformatted, " ")


### PR DESCRIPTION
## Summary

- Fix `command.replace("-", "__")` to use `command.replaceAll("-", "__")` in both bash and zsh completion generators
- The previous code only replaced the **first** hyphen in command names, causing multi-hyphenated commands (e.g., `type-check-v2`) to produce incorrect sanitized names like `type__check-v2` instead of `type__check__v2`

## Background

The shell completion generators sanitize command names by replacing hyphens with double underscores (since hyphens are not allowed in bash/zsh function identifiers). However, `String.prototype.replace()` with a string argument only replaces the first occurrence, so commands with more than one hyphen were only partially sanitized.

Partially addresses #6114

## Test plan

- [x] Verified that both bash and zsh completion generators use the same fix
- [ ] Existing completion snapshot tests should be updated to reflect the fix