### PR TITLE
fix(FiberHandle): prevent clear() from wiping newer fiber during interrupt wait

### DIFF
--- a/.changeset/fix-fiberhandle-clear.md
+++ b/.changeset/fix-fiberhandle-clear.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix(FiberHandle): prevent clear() from wiping newer fiber during interrupt wait

--- a/packages/effect/src/FiberHandle.ts
+++ b/packages/effect/src/FiberHandle.ts
@@ -313,10 +313,12 @@ export const clear = <A, E>(self: FiberHandle<A, E>): Effect.Effect<void> =>
       if (self.state._tag === "Closed" || self.state.fiber === undefined) {
         return Effect.void
       }
+      const target = self.state.fiber
+
       return Effect.zipRight(
-        restore(Fiber.interruptAs(self.state.fiber, FiberId.combine(fiber.id(), internalFiberId))),
+        restore(Fiber.interruptAs(target, FiberId.combine(fiber.id(), internalFiberId))),
         Effect.sync(() => {
-          if (self.state._tag === "Open") {
+          if (self.state._tag === "Open" && self.state.fiber === target) {
             self.state.fiber = undefined
           }
         })


### PR DESCRIPTION
Fixes a race condition in FiberHandle.clear() where an unconditional state.fiber = undefined could wipe out a newer fiber reference stored by a concurrent run()/set() call during the interrupt wait window.

Save a reference to the target fiber before interrupting, then only clear if state.fiber === target.

Fixes #5906

## Test plan
- [x] Existing FiberHandle tests pass
- [ ] Issue author provided reproduction script that demonstrates the race