### PR TITLE
EFF-788: Support null K8s lastTransitionTime values

### DIFF
--- a/.changeset/k8s-null-last-transition-time.md
+++ b/.changeset/k8s-null-last-transition-time.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Allow Kubernetes pod condition `lastTransitionTime` values to be null.

--- a/packages/cluster/src/K8sHttpClient.ts
+++ b/packages/cluster/src/K8sHttpClient.ts
@@ -184,7 +184,7 @@ export class PodStatus extends Schema.Class<PodStatus>("@effect/cluster/K8sHttpC
   conditions: Schema.Array(Schema.Struct({
     type: Schema.String,
     status: Schema.String,
-    lastTransitionTime: Schema.String
+    lastTransitionTime: Schema.NullOr(Schema.String)
   })),
   podIP: Schema.String,
   hostIP: Schema.String
@@ -208,8 +208,8 @@ export class Pod extends Schema.Class<Pod>("@effect/cluster/K8sHttpClient/Pod")(
   }
 
   get isReadyOrInitializing(): boolean {
-    let initializedAt: string | undefined
-    let readyAt: string | undefined
+    let initializedAt: string | null | undefined
+    let readyAt: string | null | undefined
     for (let i = 0; i < this.status.conditions.length; i++) {
       const condition = this.status.conditions[i]
       switch (condition.type) {

--- a/packages/cluster/test/K8sHttpClient.test.ts
+++ b/packages/cluster/test/K8sHttpClient.test.ts
@@ -1,0 +1,34 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import * as K8sHttpClient from "../src/K8sHttpClient.js"
+
+describe("K8sHttpClient", () => {
+  describe("Pod", () => {
+    it.effect("decodes null lastTransitionTime values", () =>
+      Effect.sync(() => {
+        const pod = Schema.decodeSync(K8sHttpClient.Pod)({
+          status: {
+            phase: "Running",
+            conditions: [
+              {
+                type: "Initialized",
+                status: "True",
+                lastTransitionTime: null
+              },
+              {
+                type: "Ready",
+                status: "False",
+                lastTransitionTime: null
+              }
+            ],
+            podIP: "10.0.0.1",
+            hostIP: "10.0.0.2"
+          }
+        })
+
+        assert.strictEqual(pod.status.conditions[0]?.lastTransitionTime, null)
+        assert.isFalse(pod.isReady)
+        assert.isTrue(pod.isReadyOrInitializing)
+      }))
+  })
+})


### PR DESCRIPTION
## Summary
- Allow Kubernetes pod condition `lastTransitionTime` to decode as `null` in K8sHttpClient schemas
- Keep readiness initialization comparison compatible with null transition times
- Add regression test and changeset for @effect/cluster

## Validation
- pnpm lint-fix
- pnpm test run packages/cluster/test/K8sHttpClient.test.ts
- pnpm check
- pnpm build
- pnpm docgen
