### PR TITLE
fix(Cause): align toJSON key with actual property name

### DIFF
--- a/.changeset/fix-cause-tojson-key.md
+++ b/.changeset/fix-cause-tojson-key.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix(Cause): align toJSON key with actual property name

--- a/packages/effect/src/internal/cause.ts
+++ b/packages/effect/src/internal/cause.ts
@@ -60,7 +60,7 @@ const proto = {
       case "Interrupt":
         return { _id: "Cause", _tag: this._tag, fiberId: this.fiberId.toJSON() }
       case "Fail":
-        return { _id: "Cause", _tag: this._tag, failure: toJSON(this.error) }
+        return { _id: "Cause", _tag: this._tag, error: toJSON(this.error) }
       case "Sequential":
       case "Parallel":
         return { _id: "Cause", _tag: this._tag, left: toJSON(this.left), right: toJSON(this.right) }

--- a/packages/effect/test/Cause.test.ts
+++ b/packages/effect/test/Cause.test.ts
@@ -123,7 +123,7 @@ describe("Cause", () => {
         expectJSON(Cause.fail(Option.some(1)), {
           _id: "Cause",
           _tag: "Fail",
-          failure: {
+          error: {
             _id: "Option",
             _tag: "Some",
             value: 1
@@ -189,12 +189,12 @@ describe("Cause", () => {
           left: {
             _id: "Cause",
             _tag: "Fail",
-            failure: "failure 1"
+            error: "failure 1"
           },
           right: {
             _id: "Cause",
             _tag: "Fail",
-            failure: "failure 2"
+            error: "failure 2"
           }
         })
       })
@@ -206,12 +206,12 @@ describe("Cause", () => {
           left: {
             _id: "Cause",
             _tag: "Fail",
-            failure: "failure 1"
+            error: "failure 1"
           },
           right: {
             _id: "Cause",
             _tag: "Fail",
-            failure: "failure 2"
+            error: "failure 2"
           }
         })
       })


### PR DESCRIPTION
Closes #4683

## Summary

The Fail case in Cause.toJSON used the key "failure" but the actual property name is "error". All other variants (Die, Interrupt, Sequential, Parallel) already use keys matching their property names.

This inconsistency means:
- console.log(cause) shows { _tag: "Fail", failure: ... } 
- But accessing cause.failure is undefined — the actual property is cause.error

## Fix

Changed the toJSON key from "failure" to "error" in the Fail case to match the actual property name.

## Test Plan

- Updated existing toJSON test expectations in Cause.test.ts
- All 72 Cause tests pass