### PR TITLE
fix(Inspectable): handle BigInt in stringifyCircular

### DIFF
--- a/.changeset/fix-inspectable-bigint.md
+++ b/.changeset/fix-inspectable-bigint.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix(Inspectable): handle BigInt in stringifyCircular

--- a/packages/effect/src/Inspectable.ts
+++ b/packages/effect/src/Inspectable.ts
@@ -229,7 +229,7 @@ export const stringifyCircular = (obj: unknown, whitespace?: number | string | u
           : cache.push(value) && (redactableState.fiberRefs !== undefined && isRedactable(value)
             ? value[symbolRedactable](redactableState.fiberRefs)
             : value)
-        : value,
+        : typeof value === "bigint" ? String(value) + "n" : value,
     whitespace
   )
   ;(cache as any) = undefined


### PR DESCRIPTION
Closes #4662

## Summary

stringifyCircular crashes with "TypeError: Do not know how to serialize a BigInt" when the input object contains BigInt values. The format() method in the same file already handles BigInt by converting to string, but stringifyCircular uses JSON.stringify without BigInt handling in its replacer.

## Fix

Added BigInt type check in the stringifyCircular replacer function, converting BigInt values to their string representation (matching the existing pattern in format()).

## Test Plan

- All 29 Inspectable tests pass
- BigInt values are now serialized as "1n" instead of crashing