### PR TITLE
fix(effect): TMap.remove/removeAll clears entire bucket on hash collision

### DIFF
--- a/.changeset/fix-tmap-remove-colliding-keys.md
+++ b/.changeset/fix-tmap-remove-colliding-keys.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix TMap.remove and removeAll erroneously clearing entire bucket on hash collision.

--- a/packages/effect/src/internal/stm/tMap.ts
+++ b/packages/effect/src/internal/stm/tMap.ts
@@ -305,7 +305,7 @@ export const remove = dual<
     const buckets = tRef.unsafeGet(self.tBuckets, journal)
     const index = indexOf(key, buckets.chunk.length)
     const bucket = tRef.unsafeGet(buckets.chunk[index], journal)
-    const [toRemove, toRetain] = Chunk.partition(bucket, (entry) => Equal.equals(entry[1], key))
+    const [toRetain, toRemove] = Chunk.partition(bucket, (entry) => Equal.equals(entry[0], key))
     if (Chunk.isNonEmpty(toRemove)) {
       const currentSize = tRef.unsafeGet(self.tSize, journal)
       tRef.unsafeSet(buckets.chunk[index], toRetain, journal)
@@ -325,7 +325,7 @@ export const removeAll = dual<
       const buckets = tRef.unsafeGet(self.tBuckets, journal)
       const index = indexOf(next.value, buckets.chunk.length)
       const bucket = tRef.unsafeGet(buckets.chunk[index], journal)
-      const [toRemove, toRetain] = Chunk.partition(bucket, (entry) => Equal.equals(next.value)(entry[0]))
+      const [toRetain, toRemove] = Chunk.partition(bucket, (entry) => Equal.equals(next.value)(entry[0]))
       if (Chunk.isNonEmpty(toRemove)) {
         const currentSize = tRef.unsafeGet(self.tSize, journal)
         tRef.unsafeSet(buckets.chunk[index], toRetain, journal)

--- a/packages/effect/test/TMap.test.ts
+++ b/packages/effect/test/TMap.test.ts
@@ -13,6 +13,16 @@ class HashContainer implements Equal.Equal {
   }
 }
 
+class CollidingKey implements Equal.Equal {
+  constructor(readonly id: string) {}
+  [Hash.symbol](): number {
+    return 1
+  }
+  [Equal.symbol](that: unknown): boolean {
+    return that instanceof CollidingKey && this.id === that.id
+  }
+}
+
 const mapEntriesArb: fc.Arbitrary<Array<readonly [string, number]>> = fc.uniqueArray(fc.char())
   .chain((keys) =>
     fc.uniqueArray(fc.integer())
@@ -188,6 +198,50 @@ describe("TMap", () => {
       )
       const result = yield* (STM.commit(transaction))
       assertNone(result)
+    }))
+
+  it.effect("remove - preserves colliding keys", () =>
+    Effect.gen(function*() {
+      const a = new CollidingKey("a")
+      const b = new CollidingKey("b")
+      const c = new CollidingKey("c")
+      const transaction = STM.gen(function*() {
+        const map = yield* (TMap.make([a, 1], [b, 2], [c, 3]))
+        yield* (pipe(map, TMap.remove(b)))
+        return yield* (STM.all({
+          a: pipe(map, TMap.get(a)),
+          b: pipe(map, TMap.get(b)),
+          c: pipe(map, TMap.get(c)),
+          size: TMap.size(map)
+        }))
+      })
+      const result = yield* (STM.commit(transaction))
+      assertSome(result.a, 1)
+      assertNone(result.b)
+      assertSome(result.c, 3)
+      strictEqual(result.size, 2)
+    }))
+
+  it.effect("removeAll - preserves colliding keys", () =>
+    Effect.gen(function*() {
+      const a = new CollidingKey("a")
+      const b = new CollidingKey("b")
+      const c = new CollidingKey("c")
+      const transaction = STM.gen(function*() {
+        const map = yield* (TMap.make([a, 1], [b, 2], [c, 3]))
+        yield* (pipe(map, TMap.removeAll([b])))
+        return yield* (STM.all({
+          a: pipe(map, TMap.get(a)),
+          b: pipe(map, TMap.get(b)),
+          c: pipe(map, TMap.get(c)),
+          size: TMap.size(map)
+        }))
+      })
+      const result = yield* (STM.commit(transaction))
+      assertSome(result.a, 1)
+      assertNone(result.b)
+      assertSome(result.c, 3)
+      strictEqual(result.size, 2)
     }))
 
   it.effect("removeIf", () =>


### PR DESCRIPTION
## Summary

`TMap.remove` and `TMap.removeAll` were clearing every entry in a bucket whenever two keys hashed to the same slot. The fix is a 2-line change in `packages/effect/src/internal/stm/tMap.ts`.

## Why this matters

Bucket-level data loss on hash collision is a correctness bug for any user storing entries whose key types collide (custom `Hash` implementations, value types with low-entropy hashes). The bug was reported in #6225 with a minimal repro showing three entries in a single bucket where removing one drops the other two. The fixed code has two related issues:

1. `Chunk.partition` returns `[predicate-true, predicate-false]`. The destructuring `const [toRemove, toRetain] = ...` was backwards.
2. The predicate was `Equal.equals(entry[1], key)`, comparing the entry's *value* against the key instead of the entry's key (`entry[0]`).

Together these meant the code was retaining the matched key and removing every other key in the bucket.

## Changes

- `packages/effect/src/internal/stm/tMap.ts` - swap the destructuring to `[toRetain, toRemove]` and compare `entry[0]` (key) against the key in both `remove` and `removeAll`.
- `packages/effect/test/TMap.test.ts` - add two regression tests using a `CollidingKey` type whose `Hash` always returns 1, forcing every entry into one bucket.
- `.changeset/fix-tmap-remove-colliding-keys.md` - patch-level changeset.

## Testing

`pnpm test --filter=effect -- TMap.test` (Vitest). The new `remove - preserves colliding keys` and `removeAll - preserves colliding keys` tests fail on `main` and pass with the fix.

Fixes #6225