### PR TITLE
fix(effect): add missing absurd guards in Layer.buildWithScope and FiberRuntime.evaluateEffect

### DIFF
--- a/.changeset/soft-rocks-protect.md
+++ b/.changeset/soft-rocks-protect.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add missing `absurd` exhaustiveness guards in `Layer.buildWithScope` and `FiberRuntime.evaluateEffect`.

--- a/packages/effect/src/internal/fiberRuntime.ts
+++ b/packages/effect/src/internal/fiberRuntime.ts
@@ -962,6 +962,8 @@ export class FiberRuntime<in out A, in out E = never> extends Effectable.Class<A
           } else if (op._op === OpCodes.OP_ASYNC) {
             // Terminate this evaluation, async resumption will continue evaluation:
             effect = null
+          } else {
+            absurd(op as never)
           }
         } else {
           this.currentRuntimeFlags = pipe(this.currentRuntimeFlags, runtimeFlags_.enable(runtimeFlags_.WindDown))

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -8,7 +8,7 @@ import type * as Exit from "../Exit.js"
 import type { FiberRef } from "../FiberRef.js"
 import * as FiberRefsPatch from "../FiberRefsPatch.js"
 import type { LazyArg } from "../Function.js"
-import { constTrue, dual, pipe } from "../Function.js"
+import { absurd, constTrue, dual, pipe } from "../Function.js"
 import * as HashMap from "../HashMap.js"
 import type * as Layer from "../Layer.js"
 import type * as ManagedRuntime from "../ManagedRuntime.js"
@@ -490,6 +490,9 @@ const makeBuilder = <RIn, E, ROut>(
           )
         }
       )
+    }
+    default: {
+      return absurd(op)
     }
   }
 }


### PR DESCRIPTION
## Summary

`Layer.buildWithScope` and `FiberRuntime.evaluateEffect` were missing `absurd(...)` guards on their primitive-tag switches. When the discriminant is one of the runtime primitive op codes, the compiler can't prove exhaustiveness at the type level, so silent fall-through can mask a real bug.

## Why this matters

Effect's primitive op codes are tagged unions. Other internal switches use `absurd` as the default to make exhaustiveness explicit and crash loud if a new op code is added without updating every handler. These two paths missed the guard. Adding it does not change runtime behavior on any reachable input; it converts "silent fall through" into "loud failure" if a future op code is added.

## Changes

- `packages/effect/src/internal/layer.ts` - add `default: absurd(self)` on the buildWithScope switch.
- `packages/effect/src/internal/fiberRuntime.ts` - add the equivalent on evaluateEffect.

## Testing

`pnpm test --filter=effect`. No new tests; the guard is structural.

Fixes #6158
