### PR TITLE
fix(@effect/ai-amazon-bedrock): emit finish part after metadata so streaming usage is populated

### DIFF
--- a/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
+++ b/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
@@ -638,6 +638,7 @@ const makeStreamResponse: (
 
     let trace: ConverseTrace | undefined = undefined
     let cacheWriteInputTokens: number | undefined = undefined
+    let pendingFinishReason: typeof Response.FinishReason.Encoded | undefined = undefined
     const usage: Mutable<typeof Response.Usage.Encoded> = {
       inputTokens: undefined,
       outputTokens: undefined,
@@ -659,16 +660,7 @@ const makeStreamResponse: (
           }
 
           case "messageStop": {
-            const reason = InternalUtilities.resolveFinishReason(event.messageStop.stopReason)
-            parts.push({
-              type: "finish",
-              reason,
-              usage,
-              metadata: {
-                bedrock: { trace, usage: { cacheWriteInputTokens } }
-              }
-            })
-
+            pendingFinishReason = InternalUtilities.resolveFinishReason(event.messageStop.stopReason)
             break
           }
 
@@ -889,6 +881,17 @@ const makeStreamResponse: (
             }
             if (Predicate.isNotUndefined(event.metadata.trace)) {
               trace = event.metadata.trace
+            }
+            if (Predicate.isNotUndefined(pendingFinishReason)) {
+              parts.push({
+                type: "finish",
+                reason: pendingFinishReason,
+                usage,
+                metadata: {
+                  bedrock: { trace, usage: { cacheWriteInputTokens } }
+                }
+              })
+              pendingFinishReason = undefined
             }
             break
           }


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

In `makeStreamResponse`, the `messageStop` event was emitting the `finish` part with a reference to a shared mutable `usage` object. The `metadata` event (which carries actual token counts) arrives *after* `messageStop` in the Bedrock Converse stream, but by that point `@effect/ai`'s `LanguageModel.streamText` has already run `Schema.decode` on the `finish` part, creating a new `Usage` class instance from the values at decode time (all `undefined`).

The fix defers emitting the `finish` part: `messageStop` now stores the finish reason in a closure variable, and the `metadata` handler emits the `finish` part after populating usage.

## Related

- Closes #6237