### PR TITLE
Fix HttpApi discarding annotations from Union and Literal schemas

### DIFF
--- a/.changeset/fluffy-jokes-repair.md
+++ b/.changeset/fluffy-jokes-repair.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix HttpApi discarding annotations from Union and Literal schemas

--- a/packages/platform/src/HttpApiSchema.ts
+++ b/packages/platform/src/HttpApiSchema.ts
@@ -566,7 +566,7 @@ export const Uint8Array = (options?: {
 
 const astCache = globalValue(
   "@effect/platform/HttpApiSchema/astCache",
-  () => new WeakMap<AST.AST, Schema.Schema.Any>()
+  () => new WeakMap<AST.AST, ReadonlyArray<Schema.Schema.Any>>()
 )
 
 /**
@@ -577,25 +577,23 @@ export const deunionize = (
   schema: Schema.Schema.Any
 ): void => {
   if (astCache.has(schema.ast)) {
-    schemas.add(astCache.get(schema.ast)!)
+    astCache.get(schema.ast)!.forEach((s) => schemas.add(s))
     return
   }
   const ast = schema.ast
   if (ast._tag === "Union") {
+    const memberSchemas: Array<Schema.Schema.Any> = []
     for (const astType of ast.types) {
-      if (astCache.has(astType)) {
-        schemas.add(astCache.get(astType)!)
-        continue
-      }
       const memberSchema = Schema.make(AST.annotations(astType, {
         ...ast.annotations,
         ...astType.annotations
       }))
-      astCache.set(astType, memberSchema)
+      memberSchemas.push(memberSchema)
       schemas.add(memberSchema)
     }
+    astCache.set(ast, memberSchemas)
   } else {
-    astCache.set(ast, schema)
+    astCache.set(ast, [schema])
     schemas.add(schema)
   }
 }

--- a/packages/platform/src/HttpApiSchema.ts
+++ b/packages/platform/src/HttpApiSchema.ts
@@ -221,18 +221,16 @@ export const getStatusError = <A extends Schema.Schema.All>(self: A): number => 
  * @internal
  */
 export const extractUnionTypes = (ast: AST.AST): ReadonlyArray<AST.AST> => {
-  function process(ast: AST.AST): void {
-    if (AST.isUnion(ast)) {
-      for (const type of ast.types) {
-        process(type)
-      }
+  if (AST.isUnion(ast)) {
+    const types = ast.types.flatMap((type) => extractUnionTypes(type))
+    if (Reflect.ownKeys(ast.annotations).length === 0) {
+      return types
     } else {
-      out.push(ast)
+      return [AST.Union.make(types, ast.annotations)]
     }
+  } else {
+    return [ast]
   }
-  const out: Array<AST.AST> = []
-  process(ast)
-  return out
 }
 
 /** @internal */

--- a/packages/platform/test/HttpApiBuilder.test.ts
+++ b/packages/platform/test/HttpApiBuilder.test.ts
@@ -1,8 +1,7 @@
-import type { HttpApiEndpoint } from "@effect/platform"
-import { HttpApiBuilder } from "@effect/platform"
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, HttpServer } from "@effect/platform"
 import { describe, it } from "@effect/vitest"
-import { deepStrictEqual } from "@effect/vitest/utils"
-import { identity, Schema } from "effect"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Effect, identity, Layer, Schema } from "effect"
 
 const assertNormalizedUrlParams = <UrlParams extends Schema.Schema.Any>(
   schema: UrlParams & HttpApiEndpoint.HttpApiEndpoint.ValidateUrlParams<UrlParams>,
@@ -280,5 +279,29 @@ describe("HttpApiBuilder", () => {
       assertNormalizedUrlParams(schema, { a: "a" }, { a: ["a"] })
       assertNormalizedUrlParams(schema, { a: ["a"] }, { a: ["a"] })
     })
+  })
+
+  it("Union response status", async () => {
+    const Union = Schema.Union(Schema.Literal("A"), Schema.Literal("B"))
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("group")
+        .add(HttpApiEndpoint.get("endpoint1", "/1").addSuccess(Union, { status: 201 }))
+        .add(HttpApiEndpoint.get("endpoint2", "/2").addSuccess(Union))
+    )
+    const ApiImplementation = HttpApiBuilder.api(Api).pipe(
+      Layer.provide(
+        HttpApiBuilder.group(Api, "group", (_) =>
+          _
+            .handle("endpoint1", () => Effect.succeed("A"))
+            .handle("endpoint2", () => Effect.succeed("A")))
+      ),
+      Layer.merge(HttpServer.layerContext)
+    )
+    const { handler } = HttpApiBuilder.toWebHandler(ApiImplementation)
+
+    const response1 = await handler(new Request("http://localhost:3000/1"))
+    strictEqual(response1.status, 201)
+    const response2 = await handler(new Request("http://localhost:3000/2"))
+    strictEqual(response2.status, 200)
   })
 })

--- a/packages/platform/test/OpenApi.test.ts
+++ b/packages/platform/test/OpenApi.test.ts
@@ -938,6 +938,40 @@ describe("OpenApi", () => {
             }
           })
         })
+
+        it("Schema.Literal annotations", () => {
+          const api = HttpApi.make("Api").add(
+            HttpApiGroup.make("group").add(
+              HttpApiEndpoint.get("endpoint")`/`
+                .addSuccess(Schema.Literal("a", "b").annotations({ title: "Letter" }))
+            )
+          )
+          expectSpecPaths(api, {
+            "/": {
+              "get": {
+                "tags": ["group"],
+                "operationId": "group.endpoint",
+                "parameters": [],
+                "security": [],
+                "responses": {
+                  "200": {
+                    "description": "Success",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "string",
+                          "enum": ["a", "b"],
+                          "title": "Letter"
+                        }
+                      }
+                    }
+                  },
+                  "400": HttpApiDecodeError
+                }
+              }
+            }
+          })
+        })
       })
 
       describe("addSuccess + withEncoding", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

- [x] Bug Fix

## Description

This change makes HttpApi preserve annotations from Union schemas.

Previously, the types from every Union would be extracted and unified in the same new Union.
Now it does not break Unions which have at least 1 annotation, but still merge Unions without any annotations.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #6245
