### PR TITLE
fix(Data): preserve generic A in TaggedEnum $match arms

### DIFF
--- a/.changeset/cold-loops-arrive.md
+++ b/.changeset/cold-loops-arrive.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix $match generic type parameter inference inside arms (#6249)

--- a/packages/effect/dtslint/Data.tst.ts
+++ b/packages/effect/dtslint/Data.tst.ts
@@ -189,5 +189,30 @@ describe("Data", () => {
       expect<typeof A>().type.toBe<(<A>(args: { readonly a: A }) => { readonly _tag: "A"; readonly a: A })>()
       expect<typeof B>().type.toBe<(<B>(args: { readonly b?: B }) => { readonly _tag: "B"; readonly b?: B })>()
     })
+
+    it("should preserve the generic type parameter inside $match arms (#6249)", () => {
+      type TE<T> = Data.TaggedEnum<{
+        Leaf: { value: T }
+        Branch: { children: ReadonlyArray<TE<T>> }
+      }>
+
+      interface TEDefinition extends Data.TaggedEnum.WithGenerics<1> {
+        readonly taggedEnum: TE<this["A"]>
+      }
+
+      const TE = Data.taggedEnum<TEDefinition>()
+
+      function collectValues<A>(node: TE<A>): ReadonlyArray<A> {
+        return TE.$match(node, {
+          Leaf: (leaf) => {
+            expect(leaf.value).type.toBe<A>()
+            return [leaf.value]
+          },
+          Branch: (branch) => branch.children.flatMap(collectValues<A>)
+        })
+      }
+
+      expect(collectValues).type.toBe<<A>(node: TE<A>) => ReadonlyArray<A>>()
+    })
   })
 })

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -389,6 +389,17 @@ export declare namespace TaggedEnum {
     }
     readonly $match: {
       <
+        const Self extends TaggedEnum.Kind<Z, any, any, any, any>,
+        const Cases extends {
+          readonly [Tag in Self["_tag"]]: (
+            args: Extract<Self, { readonly _tag: Tag }>
+          ) => any
+        }
+      >(
+        self: Self,
+        cases: Cases & { [K in Exclude<keyof Cases, Self["_tag"]>]: never }
+      ): Unify<ReturnType<Cases[Self["_tag"]]>>
+      <
         A,
         B,
         C,
@@ -401,20 +412,6 @@ export declare namespace TaggedEnum {
       >(
         cases: Cases & { [K in Exclude<keyof Cases, Z["taggedEnum"]["_tag"]>]: never }
       ): (self: TaggedEnum.Kind<Z, A, B, C, D>) => Unify<ReturnType<Cases[Z["taggedEnum"]["_tag"]]>>
-      <
-        A,
-        B,
-        C,
-        D,
-        Cases extends {
-          readonly [Tag in Z["taggedEnum"]["_tag"]]: (
-            args: Extract<TaggedEnum.Kind<Z, A, B, C, D>, { readonly _tag: Tag }>
-          ) => any
-        }
-      >(
-        self: TaggedEnum.Kind<Z, A, B, C, D>,
-        cases: Cases & { [K in Exclude<keyof Cases, Z["taggedEnum"]["_tag"]>]: never }
-      ): Unify<ReturnType<Cases[Z["taggedEnum"]["_tag"]]>>
     }
   }
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The direct-form `$match(self, cases)` overload on `Data.TaggedEnum`'s `GenericMatchers` had `A, B, C, D` as explicit type parameters, with `cases` constrained against `TaggedEnum.Kind<Z, A, B, C, D>`. TypeScript infers `Cases` and the type params in a single pass; when the caller is itself a generic function (e.g. `function f<A>(node: Tree<A>)`), `A` is unbound at inference time and defaults to its constraint, so arms receive `unknown` instead of `A`:

```ts
function collectValues<A>(node: Tree<A>): ReadonlyArray<A> {
  return Tree.$match(node, {
    Leaf: ({ value }) => [value],
    //     ^^^^^ inferred as `unknown`, expected `A`
    Branch: ({ children }) => children.flatMap(collectValues),
  });
  // Type 'unknown[]' is not assignable to type 'readonly A[]'.
}
```

`Match.value(node).pipe(Match.tag(...))` works because `Match.value<const I>(i: I)` captures `I` as the concrete `Tree<A>` instance before any cases are typed.

### Fix

Reorder the two `$match` overloads so the direct form comes first, and rewrite the direct form to infer a single `const Self extends Kind<Z, any, any, any, any>` from `self`, then derive `Cases` from `Self`. The generic `A` flows in through `Self` via const inference, and arms get the expected concrete arg type.

The curried form (`$match(cases)(self)`) is unchanged — it still works for `pipe` + concrete types as before.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #6249
