### PR TITLE
fix(Effect): handle transpiled generator bodies in Effect.fn

### DIFF
--- a/.changeset/fix-fn-iterator-result.md
+++ b/.changeset/fix-fn-iterator-result.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+fix(Effect): handle transpiled generator bodies in `Effect.fn`
+
+`Effect.fn(name)(body)` crashed at runtime with `RuntimeException: Not a valid effect: {}` when `body` was a generator function lowered by a compiler (e.g. `babel-preset-expo` on React Native / Hermes) into a plain function returning an iterator IIFE. Such a body fails the `isGeneratorFunction` check, so its return value was passed through as if it were an `Effect`. We now duck-type the result and re-wrap it with `fromIterator` when it is an iterator.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -14707,7 +14707,30 @@ function fnApply(options: {
     effect = core.fromIterator(() => options.body.apply(options.self, options.args))
   } else {
     try {
-      effect = options.body.apply(options.self, options.args)
+      const result = options.body.apply(options.self, options.args)
+      // Some compilers (e.g. `babel-preset-expo` on React Native / Hermes)
+      // lower destructured-param generators into a plain function that returns
+      // an iterator IIFE. Such a body fails `isGeneratorFunction` but its
+      // return value is an iterator, not an Effect. Detect and re-wrap.
+      if (
+        result !== null &&
+        typeof result === "object" &&
+        (result as any)[EffectTypeId] === undefined &&
+        typeof (result as any).next === "function" &&
+        typeof (result as any)[Symbol.iterator] === "function"
+      ) {
+        let firstIterator: any = result
+        effect = core.fromIterator(() => {
+          if (firstIterator !== null) {
+            const it = firstIterator
+            firstIterator = null
+            return it
+          }
+          return options.body.apply(options.self, options.args)
+        })
+      } else {
+        effect = result
+      }
     } catch (error) {
       fnError = error
       effect = die(error)

--- a/packages/effect/test/Effect/fn.test.ts
+++ b/packages/effect/test/Effect/fn.test.ts
@@ -76,6 +76,23 @@ describe("Effect.fn", () => {
     strictEqual(fn2.length, 1)
     strictEqual(Effect.runSync(fn2(2)), 2)
   })
+
+  it.effect("handles a non-generator body that returns an iterator (transpiled generator)", () =>
+    Effect.gen(function*() {
+      // Mimics `babel-preset-expo` lowering `function*({a}) { return a }` into
+      // a plain function that returns a generator IIFE iterator.
+      const body = function(arg: { a: number }) {
+        const a = arg.a
+        return (function*() {
+          return a
+        })()
+      }
+      const fn = Effect.fn("test")(body as any)
+      const v = yield* fn({ a: 42 }) as Effect.Effect<number>
+      strictEqual(v, 42)
+      const v2 = yield* fn({ a: 7 }) as Effect.Effect<number>
+      strictEqual(v2, 7)
+    }))
 })
 
 describe("Effect.fnUntraced", () => {


### PR DESCRIPTION
## Summary

`Effect.fn(name)(body)` crashes at runtime with `RuntimeException: Not a valid effect: {}` when `body` is a generator function that has been lowered by a bundler/transpiler into a non-generator function returning an iterator. For example, `babel-preset-expo` on React Native / Hermes rewrites destructured-param generators like this:

```js
// Source:
function*({ a }) { return a }

// babel-preset-expo output (approx):
function destr(_ref) {
  var a = _ref.a;
  return (function*() { return a })();
}
```

The lowered wrapper is no longer a `GeneratorFunction`, so `isGeneratorFunction(body)` in `fnApply` returns false. The else branch then takes `body.apply(...)`'s return value — an `Iterator`, not an `Effect` — and passes it to `withSpan`, which hands it to the fiber runLoop. The loop dies at the first instruction because the value has no `_op`.

### Repro

```ts
import { Effect } from "effect"

// Simulates a transpiler lowering `function*({a}) { return a }`
const body = function (arg: { a: number }) {
  const a = arg.a
  return (function* () { return a })()
}

const fn = Effect.fn("repro")(body as any)
await Effect.runPromise(fn({ a: 42 }))
// 💥 RuntimeException: Not a valid effect: {}
```

### Root cause

`isGeneratorFunction` in `Utils.ts` checks `u.constructor === function*(){}.constructor`. That works for native generators and for transpilers that preserve `function*` syntax in their output, but fails for any transformer that lowers `function*` into a plain function — including Babel's `@babel/plugin-transform-parameters`, which `babel-preset-expo` ships unconditionally on Hermes-native.

`Effect.fn` has had this hazard since it was introduced in 3.11.0. It is not a regression — it has always crashed under transformers that erase `function*` syntax.

### Fix

In `fnApply`'s else branch, after calling `body.apply(...)`, duck-type the result. If it looks like an iterator (has `.next` and `Symbol.iterator`) and isn't already an `Effect`, re-wrap it with `core.fromIterator`. The first iterator is consumed immediately; subsequent invocations re-apply `body` to produce fresh iterators (preserving `Effect.fn`'s reusable-wrapper contract).

`fnUntraced` does not need this change: it unconditionally wraps with `fromIterator`, so a transpiler-lowered body's returned iterator flows through correctly already.

### Test

Added a regression test in `packages/effect/test/Effect/fn.test.ts` constructing the exact shape the transpiler produces — a plain function returning a generator IIFE. Verified red → green against `main`.

### Related

- #6158 — missing absurd-guard hardening in `Effect.fn` (this PR resolves one observable manifestation; the broader hardening is still useful).
- #2708 — same family of "iterator vs Effect" runtime crash from a different source.
