### PR TITLE
fix(ai): support empty tool parameters

### DIFF
--- a/.changeset/ai-tool-empty-params.md
+++ b/.changeset/ai-tool-empty-params.md
@@ -1,5 +1,5 @@
 ---
-"@effect/ai": patch
+"@effect/ai": minor
 ---
 
 Support `Tool.EmptyParams` as an explicit tool parameters schema.

--- a/.changeset/ai-tool-empty-params.md
+++ b/.changeset/ai-tool-empty-params.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai": patch
+---
+
+Support `Tool.EmptyParams` as an explicit tool parameters schema.

--- a/packages/ai/ai/dtslint/Tool.tst.ts
+++ b/packages/ai/ai/dtslint/Tool.tst.ts
@@ -1,0 +1,47 @@
+import type * as Response from "@effect/ai/Response"
+import * as Tool from "@effect/ai/Tool"
+import { Schema } from "effect"
+import { describe, expect, it } from "tstyche"
+
+describe("Tool", () => {
+  it("infers struct parameters", () => {
+    const _Read = Tool.make("Read", {
+      parameters: {
+        filePath: Schema.String
+      }
+    })
+
+    expect<Tool.Parameters<typeof _Read>>().type.toBe<{
+      readonly filePath: string
+    }>()
+    expect<Tool.ParametersEncoded<typeof _Read>>().type.toBe<{
+      readonly filePath: string
+    }>()
+    expect<Response.ToolCallParts<{ readonly Read: typeof _Read }>>().type.toBe<
+      Response.ToolCallPart<"Read", { readonly filePath: string }>
+    >()
+  })
+
+  it("infers empty parameters", () => {
+    const _Empty = Tool.make("Empty")
+
+    expect<Tool.ParametersSchema<typeof _Empty>>().type.toBe<typeof Tool.EmptyParams>()
+    expect<Tool.Parameters<typeof _Empty>>().type.toBe<{
+      readonly [x: string]: never
+    }>()
+    expect<Tool.ParametersEncoded<typeof _Empty>>().type.toBe<{
+      readonly [x: string]: never
+    }>()
+  })
+
+  it("accepts explicit empty parameters", () => {
+    const _Empty = Tool.make("Empty", {
+      parameters: Tool.EmptyParams
+    })
+
+    expect<Tool.ParametersSchema<typeof _Empty>>().type.toBe<typeof Tool.EmptyParams>()
+    expect<Tool.Parameters<typeof _Empty>>().type.toBe<{
+      readonly [x: string]: never
+    }>()
+  })
+})

--- a/packages/ai/ai/dtslint/Tool.tst.ts
+++ b/packages/ai/ai/dtslint/Tool.tst.ts
@@ -44,4 +44,51 @@ describe("Tool", () => {
       readonly [x: string]: never
     }>()
   })
+
+  it("infers setParameters with struct fields", () => {
+    const _Read = Tool.make("Read").setParameters({
+      filePath: Schema.String
+    })
+
+    expect<Tool.Parameters<typeof _Read>>().type.toBe<{
+      readonly filePath: string
+    }>()
+    expect<Tool.ParametersEncoded<typeof _Read>>().type.toBe<{
+      readonly filePath: string
+    }>()
+    expect<Response.ToolCallParts<{ readonly Read: typeof _Read }>>().type.toBe<
+      Response.ToolCallPart<"Read", { readonly filePath: string }>
+    >()
+  })
+
+  it("infers setParameters with a struct schema", () => {
+    const Parameters = Schema.Struct({
+      filePath: Schema.String
+    })
+    const _Read = Tool.make("Read").setParameters(Parameters)
+
+    expect<Tool.ParametersSchema<typeof _Read>>().type.toBe<typeof Parameters>()
+    expect<Tool.Parameters<typeof _Read>>().type.toBe<{
+      readonly filePath: string
+    }>()
+    expect<Tool.ParametersEncoded<typeof _Read>>().type.toBe<{
+      readonly filePath: string
+    }>()
+  })
+
+  it("infers setParameters with empty parameters", () => {
+    const _Empty = Tool.make("Empty", {
+      parameters: {
+        filePath: Schema.String
+      }
+    }).setParameters(Tool.EmptyParams)
+
+    expect<Tool.ParametersSchema<typeof _Empty>>().type.toBe<typeof Tool.EmptyParams>()
+    expect<Tool.Parameters<typeof _Empty>>().type.toBe<{
+      readonly [x: string]: never
+    }>()
+    expect<Tool.ParametersEncoded<typeof _Empty>>().type.toBe<{
+      readonly [x: string]: never
+    }>()
+  })
 })

--- a/packages/ai/ai/src/Response.ts
+++ b/packages/ai/ai/src/Response.ts
@@ -411,8 +411,7 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
  * @category Utility Types
  */
 export type ToolCallParts<Tools extends Record<string, Tool.Any>> = {
-  [Name in keyof Tools]: Name extends string ?
-    ToolCallPart<Name, Schema.Struct.Type<Tool.ParametersSchema<Tools[Name]>["fields"]>>
+  [Name in keyof Tools]: Name extends string ? ToolCallPart<Name, Tool.Parameters<Tools[Name]>>
     : never
 }[keyof Tools]
 
@@ -1473,7 +1472,7 @@ export interface ToolCallPartMetadata extends ProviderMetadata {}
  * @since 1.0.0
  * @category Schemas
  */
-export const ToolCallPart = <const Name extends string, Params extends Schema.Struct.Fields>(
+export const ToolCallPart = <const Name extends string, Params extends Tool.AnyParametersSchema>(
   /**
    * Name of the tool.
    */
@@ -1481,8 +1480,8 @@ export const ToolCallPart = <const Name extends string, Params extends Schema.St
   /**
    * Schema for the tool parameters.
    */
-  params: Schema.Struct<Params>
-): Schema.Schema<ToolCallPart<Name, Params>, ToolCallPartEncoded> =>
+  params: Params
+): Schema.Schema<ToolCallPart<Name, Schema.Schema.Type<Params>>, ToolCallPartEncoded> =>
   Schema.Struct({
     type: Schema.Literal("tool-call"),
     id: Schema.String,

--- a/packages/ai/ai/src/Tool.ts
+++ b/packages/ai/ai/src/Tool.ts
@@ -112,7 +112,7 @@ export type ProviderDefinedTypeId = typeof ProviderDefinedTypeId
 export interface Tool<
   Name extends string,
   Config extends {
-    readonly parameters: AnyStructSchema
+    readonly parameters: AnyParametersSchema
     readonly success: Schema.Schema.Any
     readonly failure: Schema.Schema.All
     readonly failureMode: FailureMode
@@ -186,7 +186,7 @@ export interface Tool<
    * Set the schema to use to validate the result of a tool call when successful.
    */
   setParameters<
-    ParametersSchema extends Schema.Struct<any> | Schema.Struct.Fields
+    ParametersSchema extends Schema.Struct<any> | Schema.Struct.Fields | EmptyParams
   >(
     schema: ParametersSchema
   ): Tool<
@@ -194,6 +194,7 @@ export interface Tool<
     {
       readonly parameters: ParametersSchema extends Schema.Struct<infer _> ? ParametersSchema
         : ParametersSchema extends Schema.Struct.Fields ? Schema.Struct<ParametersSchema>
+        : ParametersSchema extends EmptyParams ? EmptyParams
         : never
       readonly success: Config["success"]
       readonly failure: Config["failure"]
@@ -288,13 +289,13 @@ export interface ProviderDefined<
   Name extends string,
   Config extends {
     readonly args: AnyStructSchema
-    readonly parameters: AnyStructSchema
+    readonly parameters: AnyParametersSchema
     readonly success: Schema.Schema.Any
     readonly failure: Schema.Schema.All
     readonly failureMode: FailureMode
   } = {
     readonly args: Schema.Struct<{}>
-    readonly parameters: Schema.Struct<{}>
+    readonly parameters: EmptyParams
     readonly success: typeof Schema.Void
     readonly failure: typeof Schema.Never
     readonly failureMode: "error"
@@ -481,6 +482,14 @@ export const isProviderDefined = (
 // =============================================================================
 
 /**
+ * A type which represents any valid parameters schema.
+ *
+ * @since 1.0.0
+ * @category Utility Types
+ */
+export type AnyParametersSchema = Schema.Struct<any> | AnyTaggedRequestSchema | EmptyParams
+
+/**
  * A type which represents any `Tool`.
  *
  * @since 1.0.0
@@ -493,7 +502,7 @@ export interface Any extends Pipeable {
   readonly id: string
   readonly name: string
   readonly description?: string | undefined
-  readonly parametersSchema: AnyStructSchema
+  readonly parametersSchema: AnyParametersSchema
   readonly successSchema: Schema.Schema.Any
   readonly failureSchema: Schema.Schema.All
   readonly failureMode: FailureMode
@@ -582,7 +591,7 @@ export type Parameters<T> = T extends Tool<
   infer _Name,
   infer _Config,
   infer _Requirements
-> ? Schema.Struct.Type<_Config["parameters"]["fields"]>
+> ? Schema.Schema.Type<_Config["parameters"]>
   : never
 
 /**
@@ -816,7 +825,7 @@ const Proto = {
   },
   setParameters(
     this: Any,
-    parametersSchema: Schema.Struct<any> | Schema.Struct.Fields
+    parametersSchema: Schema.Struct<any> | Schema.Struct.Fields | EmptyParams
   ) {
     return userDefinedProto({
       ...this,
@@ -858,7 +867,7 @@ const ProviderDefinedProto = {
 
 const userDefinedProto = <
   const Name extends string,
-  Parameters extends AnyStructSchema,
+  Parameters extends AnyParametersSchema,
   Success extends Schema.Schema.Any,
   Failure extends Schema.Schema.All,
   Mode extends FailureMode
@@ -887,7 +896,7 @@ const userDefinedProto = <
 const providerDefinedProto = <
   const Name extends string,
   Args extends AnyStructSchema,
-  Parameters extends AnyStructSchema,
+  Parameters extends AnyParametersSchema,
   Success extends Schema.Schema.Any,
   Failure extends Schema.Schema.All,
   RequiresHandler extends boolean,
@@ -915,14 +924,15 @@ const providerDefinedProto = <
   RequiresHandler
 > => Object.assign(Object.create(ProviderDefinedProto), options)
 
-const constEmptyStruct = Schema.Struct({})
-
 /**
  * Creates a user-defined tool with the specified name and configuration.
  *
  * This is the primary constructor for creating custom tools that AI models
  * can call. The tool definition includes parameter validation, success/failure
  * schemas, and optional service dependencies.
+ *
+ * If a tool accepts no parameters but still needs an explicit empty object
+ * schema, use {@link EmptyParams}.
  *
  * @example
  * ```ts
@@ -941,7 +951,7 @@ const constEmptyStruct = Schema.Struct({})
  */
 export const make = <
   const Name extends string,
-  Parameters extends Schema.Struct.Fields = {},
+  Parameters extends Schema.Struct.Fields | EmptyParams = typeof EmptyParams,
   Success extends Schema.Schema.Any = typeof Schema.Void,
   Failure extends Schema.Schema.All = typeof Schema.Never,
   Mode extends FailureMode | undefined = undefined,
@@ -987,7 +997,9 @@ export const make = <
 ): Tool<
   Name,
   {
-    readonly parameters: Schema.Struct<Parameters>
+    readonly parameters: Parameters extends EmptyParams ? EmptyParams
+      : Parameters extends Schema.Struct.Fields ? Schema.Struct<Parameters>
+      : never
     readonly success: Success
     readonly failure: Failure
     readonly failureMode: Mode extends undefined ? "error" : Mode
@@ -999,9 +1011,11 @@ export const make = <
   return userDefinedProto({
     name,
     description: options?.description,
-    parametersSchema: options?.parameters
-      ? Schema.Struct(options?.parameters as any)
-      : constEmptyStruct,
+    parametersSchema: options?.parameters !== undefined
+      ? options.parameters === EmptyParams
+        ? EmptyParams
+        : Schema.Struct(options.parameters as any)
+      : EmptyParams,
     successSchema,
     failureSchema,
     failureMode: options?.failureMode ?? "error",
@@ -1046,7 +1060,7 @@ export const make = <
 export const providerDefined = <
   const Name extends string,
   Args extends Schema.Struct.Fields = {},
-  Parameters extends Schema.Struct.Fields = {},
+  Parameters extends Schema.Struct.Fields | EmptyParams = EmptyParams,
   Success extends Schema.Schema.Any = typeof Schema.Void,
   Failure extends Schema.Schema.All = typeof Schema.Never,
   RequiresHandler extends boolean = false
@@ -1105,7 +1119,9 @@ export const providerDefined = <
   Name,
   {
     readonly args: Schema.Struct<Args>
-    readonly parameters: Schema.Struct<Parameters>
+    readonly parameters: Parameters extends EmptyParams ? EmptyParams
+      : Parameters extends Schema.Struct.Fields ? Schema.Struct<Parameters>
+      : never
     readonly success: Success
     readonly failure: Failure
     readonly failureMode: Mode extends undefined ? "error" : Mode
@@ -1122,9 +1138,11 @@ export const providerDefined = <
     args,
     argsSchema: Schema.Struct(options.args as any),
     requiresHandler: options.requiresHandler ?? false,
-    parametersSchema: options?.parameters
-      ? Schema.Struct(options?.parameters as any)
-      : constEmptyStruct,
+    parametersSchema: options?.parameters !== undefined
+      ? options.parameters === EmptyParams
+        ? EmptyParams
+        : Schema.Struct(options.parameters as any)
+      : EmptyParams,
     successSchema,
     failureSchema,
     failureMode: failureMode ?? "error"
@@ -1209,7 +1227,7 @@ export const fromTaggedRequest = <S extends AnyTaggedRequestSchema>(
 export const getDescription = <
   Name extends string,
   Config extends {
-    readonly parameters: AnyStructSchema
+    readonly parameters: AnyParametersSchema
     readonly success: Schema.Schema.Any
     readonly failure: Schema.Schema.All
     readonly failureMode: FailureMode
@@ -1281,7 +1299,7 @@ export const getDescriptionFromSchemaAst = (
 export const getJsonSchema = <
   Name extends string,
   Config extends {
-    readonly parameters: AnyStructSchema
+    readonly parameters: AnyParametersSchema
     readonly success: Schema.Schema.Any
     readonly failure: Schema.Schema.All
     readonly failureMode: FailureMode
@@ -1506,4 +1524,41 @@ export const unsafeSecureJsonParse = (text: string): unknown => {
   } finally {
     Error.stackTraceLimit = stackTraceLimit
   }
+}
+
+/**
+ * Type of the `EmptyParams` schema used for tools with no parameters.
+ *
+ * **Details**
+ *
+ * It is a record schema with string keys and `never` values, so the generated
+ * parameter schema accepts an empty object shape with no properties.
+ *
+ * @category Schemas
+ * @since 1.0.0
+ */
+export interface EmptyParams extends Schema.Record$<typeof Schema.String, typeof Schema.Never> {}
+
+/**
+ * Schema for tools that accept no parameters.
+ *
+ * **When to use**
+ *
+ * Use when you need an explicit no-parameter `parameters` schema for a tool.
+ *
+ * **Details**
+ *
+ * This is `Schema.Record({ key: Schema.String, value: Schema.Never })`,
+ * representing an empty object parameter shape with no additional properties.
+ *
+ * @see {@link make} for the tool constructor that defaults omitted parameters to this schema
+ *
+ * @category Schemas
+ * @since 1.0.0
+ */
+export const EmptyParams: EmptyParams = Schema.Record({ key: Schema.String, value: Schema.Never })
+
+/** @internal */
+export function isEmptyParamsRecord(indexSignature: AST.IndexSignature): boolean {
+  return AST.isStringKeyword(indexSignature.parameter) && AST.isNeverKeyword(indexSignature.type)
 }

--- a/packages/ai/ai/src/Tool.ts
+++ b/packages/ai/ai/src/Tool.ts
@@ -487,7 +487,7 @@ export const isProviderDefined = (
  * @since 1.0.0
  * @category Utility Types
  */
-export type AnyParametersSchema = Schema.Struct<any> | AnyTaggedRequestSchema | EmptyParams
+export type AnyParametersSchema = AnyStructSchema | EmptyParams
 
 /**
  * A type which represents any `Tool`.

--- a/packages/ai/ai/src/Tool.ts
+++ b/packages/ai/ai/src/Tool.ts
@@ -186,16 +186,14 @@ export interface Tool<
    * Set the schema to use to validate the result of a tool call when successful.
    */
   setParameters<
-    ParametersSchema extends Schema.Struct<any> | Schema.Struct.Fields | EmptyParams
+    ParametersSchema extends AnyParametersSchema | Schema.Struct.Fields
   >(
     schema: ParametersSchema
   ): Tool<
     Name,
     {
-      readonly parameters: ParametersSchema extends Schema.Struct<infer _> ? ParametersSchema
-        : ParametersSchema extends Schema.Struct.Fields ? Schema.Struct<ParametersSchema>
-        : ParametersSchema extends EmptyParams ? EmptyParams
-        : never
+      readonly parameters: ParametersSchema extends Schema.Struct.Fields ? Schema.Struct<ParametersSchema>
+        : ParametersSchema
       readonly success: Config["success"]
       readonly failure: Config["failure"]
       readonly failureMode: Config["failureMode"]
@@ -825,7 +823,7 @@ const Proto = {
   },
   setParameters(
     this: Any,
-    parametersSchema: Schema.Struct<any> | Schema.Struct.Fields | EmptyParams
+    parametersSchema: AnyParametersSchema | Schema.Struct.Fields
   ) {
     return userDefinedProto({
       ...this,

--- a/packages/ai/ai/src/Toolkit.ts
+++ b/packages/ai/ai/src/Toolkit.ts
@@ -282,7 +282,7 @@ const Proto = {
         let schemas = schemasCache.get(tool)
         if (Predicate.isUndefined(schemas)) {
           const handler = context.unsafeMap.get(tool.id)! as Tool.Handler<any>
-          const decodeParameters = Schema.decodeUnknown(tool.parametersSchema) as any
+          const decodeParameters = Schema.decodeUnknown(tool.parametersSchema as Schema.Schema.Any) as any
           const resultSchema = Schema.Union(tool.successSchema, tool.failureSchema)
           const validateResult = Schema.validate(resultSchema) as any
           const encodeResult = Schema.encodeUnknown(resultSchema) as any

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "testFileMatch": [
-    "packages/*/dtslint/**/*.tst.*"
+    "packages/*/dtslint/**/*.tst.*",
+    "packages/ai/*/dtslint/**/*.tst.*"
   ]
 }


### PR DESCRIPTION
## Summary
- support Tool.EmptyParams as a tool parameters schema
- update tool call response typing to derive params from Tool.Parameters
- add tstyche coverage for AI tool parameter inference

## Testing
- pnpm test-types
- pnpm lint-fix
- pnpm test run packages/ai/ai/test/Tool.test.ts
- pnpm check