### PR TITLE
use NoInfer on predicate parameter in recurWhile, recurUntil, collectWhile, collectUntil

### DIFF
--- a/.changeset/fix-recurwhile-recuruntil-type-inference.md
+++ b/.changeset/fix-recurwhile-recuruntil-type-inference.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Schedule.recurWhile` and `Schedule.recurUntil` not inferring the predicate argument type when used with `Effect.repeat`.

--- a/packages/effect/dtslint/Schedule.tst.ts
+++ b/packages/effect/dtslint/Schedule.tst.ts
@@ -1,4 +1,4 @@
-import { Console, Schedule } from "effect"
+import { Console, Effect, Schedule } from "effect"
 import { describe, expect, it, when } from "tstyche"
 
 describe("Schedule", () => {
@@ -30,5 +30,24 @@ describe("Schedule", () => {
         (s: string) => Console.log(s.trim())
       )
     )
+  })
+
+  it("recurWhile / recurUntil predicate argument inference", () => {
+    // predicate arg should infer from the In type of the surrounding Effect.repeat, not default to unknown
+    const stringEffect = Effect.sync(() => "foo")
+
+    expect(stringEffect.pipe(
+      Effect.repeat(Schedule.recurWhile((data) => {
+        expect(data).type.toBe<string>()
+        return data === "foo"
+      }))
+    )).type.toBe<Effect.Effect<string, never, never>>()
+
+    expect(stringEffect.pipe(
+      Effect.repeat(Schedule.recurUntil((data) => {
+        expect(data).type.toBe<string>()
+        return data === "foo"
+      }))
+    )).type.toBe<Effect.Effect<string, never, never>>()
   })
 })

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -456,7 +456,7 @@ export const collectAllOutputs: <Out, In, R>(self: Schedule<Out, In, R>) => Sche
  * @since 2.0.0
  * @category Collecting
  */
-export const collectUntil: <A>(f: Predicate<A>) => Schedule<Chunk.Chunk<A>, A> = internal.collectUntil
+export const collectUntil: <A>(f: Predicate<Types.NoInfer<A>>) => Schedule<Chunk.Chunk<A>, A> = internal.collectUntil
 
 /**
  * Collects all inputs into a `Chunk` until an effectful condition fails.
@@ -487,7 +487,7 @@ export const collectUntilEffect: <A, R>(
  * @since 2.0.0
  * @category Collecting
  */
-export const collectWhile: <A>(f: Predicate<A>) => Schedule<Chunk.Chunk<A>, A> = internal.collectWhile
+export const collectWhile: <A>(f: Predicate<Types.NoInfer<A>>) => Schedule<Chunk.Chunk<A>, A> = internal.collectWhile
 
 /**
  * Collects all inputs into a `Chunk` while an effectful condition holds.
@@ -1495,7 +1495,7 @@ export const provideService: {
  * @since 2.0.0
  * @category Recurrence Conditions
  */
-export const recurUntil: <A>(f: Predicate<A>) => Schedule<A, A> = internal.recurUntil
+export const recurUntil: <A>(f: Predicate<Types.NoInfer<A>>) => Schedule<A, A> = internal.recurUntil
 
 /**
  * A schedule that recurs until the given effectful predicate evaluates to true.
@@ -1568,7 +1568,7 @@ export const recurUpTo: (duration: Duration.DurationInput) => Schedule<Duration.
  * @since 2.0.0
  * @category Recurrence Conditions
  */
-export const recurWhile: <A>(f: Predicate<A>) => Schedule<A, A> = internal.recurWhile
+export const recurWhile: <A>(f: Predicate<Types.NoInfer<A>>) => Schedule<A, A> = internal.recurWhile
 
 /**
  * A schedule that recurs as long as the given effectful predicate evaluates to

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -106,7 +106,7 @@ describe("Schedule", () => {
     }))
   it.effect("union of two schedules should continue as long as either wants to continue", () =>
     Effect.gen(function*() {
-      const schedule = Schedule.recurWhile((b: boolean) => b).pipe(Schedule.union(Schedule.fixed("1 seconds")))
+      const schedule = Schedule.recurWhile<boolean>((b) => b).pipe(Schedule.union(Schedule.fixed("1 seconds")))
       const input = Chunk.make(true, false, false, false, false)
       const result = yield* runCollect(schedule.pipe(Schedule.compose(Schedule.elapsed)), input)
       const expected = [0, 0, 1, 2, 3].map(Duration.seconds)


### PR DESCRIPTION
fixes #6251.

**problem:** `Schedule.recurWhile((data) => data === "foo"`` infers `data` as `unknown` instead of the success type when used inside `Effect.repeat`. TypeScript eagerly resolves `A` from `f: Predicate<A>` at the call site where there's no contextual type for the predicate parameter.

**fix:** wrap the predicate with `NoInfer<A>` on the four public signatures with this shape. TypeScript stops inferring `A` from the predicate and picks it up from the `In` channel of the surrounding `repeat` instead.

type test added in `dtslint/Schedule.tst.ts`.