### PR TITLE
fix(opentelemetry): honor MetricReader temporality in MetricProducer, closes #6253

### DIFF
--- a/.changeset/opentelemetry-metric-producer-temporality.md
+++ b/.changeset/opentelemetry-metric-producer-temporality.md
@@ -1,0 +1,5 @@
+---
+"@effect/opentelemetry": patch
+---
+
+Honor the registered `MetricReader`'s preferred `AggregationTemporality` in `MetricProducerImpl`. Previously, every Sum-typed data point (Counter, UpDownCounter, Frequency, Summary count/sum) and Gauge/Histogram data point was stamped with a hardcoded `CUMULATIVE`, causing `OTLPMetricExporter({ temporalityPreference: DELTA })` (and any other non-default temporality preference on the reader/exporter) to be silently ignored. The producer now queries `reader.selectAggregationTemporality(instrumentType)` per produced data point, matching the OpenTelemetry spec. When no reader is registered, behavior is unchanged. Fixes #6253.

--- a/packages/opentelemetry/src/internal/metrics.ts
+++ b/packages/opentelemetry/src/internal/metrics.ts
@@ -32,15 +32,23 @@ type MetricDataWithInstrumentDescriptor = MetricData & {
 
 /** @internal */
 export class MetricProducerImpl implements MetricProducer {
-  readonly resource: Resources.Resource
+  constructor(readonly resource: Resources.Resource) {}
+
+  startTimes = new Map<string, HrTime>()
+
   readonly readers: Array<MetricReader> = []
   private warnedConflictingTemporalities = false
 
-  constructor(resource: Resources.Resource) {
-    this.resource = resource
+  addReaders(readers: ReadonlyArray<MetricReader>) {
+    for (const reader of readers) this.readers.push(reader)
   }
 
-  startTimes = new Map<string, HrTime>()
+  removeReaders(readers: ReadonlyArray<MetricReader>) {
+    for (const reader of readers) {
+      const index = this.readers.indexOf(reader)
+      if (index !== -1) this.readers.splice(index, 1)
+    }
+  }
 
   startTimeFor(name: string, hrTime: HrTime) {
     if (this.startTimes.has(name)) {
@@ -50,14 +58,21 @@ export class MetricProducerImpl implements MetricProducer {
     return hrTime
   }
 
-  private temporalityFor(descriptorType: InstrumentType): AggregationTemporality {
+  /**
+   * Resolves the `AggregationTemporality` for an instrument type by asking the
+   * registered readers for their preference. Must be called with the type of the
+   * descriptor the data point is actually emitted under -- temporality selectors
+   * are per instrument type, so e.g. a summary's `_count`/`_sum` (emitted as
+   * `COUNTER`) can resolve differently to the summary itself (`UP_DOWN_COUNTER`).
+   */
+  private temporalityFor(instrumentType: InstrumentType): AggregationTemporality {
     if (this.readers.length === 0) {
       return AggregationTemporality.CUMULATIVE
     }
-    const selected = this.readers[0].selectAggregationTemporality(descriptorType)
+    const selected = this.readers[0].selectAggregationTemporality(instrumentType)
     if (
       this.readers.length > 1 &&
-      this.readers.some((r) => r.selectAggregationTemporality(descriptorType) !== selected)
+      this.readers.some((r) => r.selectAggregationTemporality(instrumentType) !== selected)
     ) {
       if (!this.warnedConflictingTemporalities) {
         this.warnedConflictingTemporalities = true
@@ -88,7 +103,6 @@ export class MetricProducerImpl implements MetricProducer {
       })
       const descriptor = descriptorFromKey(metricKey, attributes)
       const startTime = this.startTimeFor(descriptor.name, hrTimeNow)
-      const temporality = this.temporalityFor(descriptor.type)
 
       if (MetricState.isCounterState(metricState)) {
         const dataPoint: DataPoint<number> = {
@@ -104,7 +118,7 @@ export class MetricProducerImpl implements MetricProducer {
             dataPointType: DataPointType.SUM,
             descriptor,
             isMonotonic: descriptor.type === InstrumentType.COUNTER,
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(descriptor.type),
             dataPoints: [dataPoint]
           })
         }
@@ -121,7 +135,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.GAUGE,
             descriptor,
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(descriptor.type),
             dataPoints: [dataPoint]
           })
         }
@@ -160,7 +174,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.HISTOGRAM,
             descriptor,
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(descriptor.type),
             dataPoints: [dataPoint]
           })
         }
@@ -184,7 +198,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.SUM,
             descriptor: descriptorFromKey(metricKey, attributes),
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(descriptor.type),
             isMonotonic: true,
             dataPoints
           })
@@ -232,7 +246,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.SUM,
             descriptor: descriptorFromKey(metricKey, attributes, "quantiles"),
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(descriptor.type),
             isMonotonic: false,
             dataPoints
           })
@@ -244,7 +258,7 @@ export class MetricProducerImpl implements MetricProducer {
               type: InstrumentType.COUNTER,
               valueType: ValueType.INT
             },
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(InstrumentType.COUNTER),
             isMonotonic: true,
             dataPoints: [countDataPoint]
           })
@@ -256,7 +270,7 @@ export class MetricProducerImpl implements MetricProducer {
               type: InstrumentType.COUNTER,
               valueType: ValueType.DOUBLE
             },
-            aggregationTemporality: temporality,
+            aggregationTemporality: this.temporalityFor(InstrumentType.COUNTER),
             isMonotonic: true,
             dataPoints: [sumDataPoint]
           })
@@ -334,8 +348,11 @@ export const registerProducer = (
     Effect.sync(() => {
       const reader = metricReader()
       const readers: Array<MetricReader> = Array.isArray(reader) ? reader : [reader] as any
+      // `collect` needs the readers to resolve their preferred temporality, but the
+      // `MetricProducer` interface only hands the producer to the reader, not the
+      // reverse -- so record them here. `self` may be a user-supplied producer.
       if (self instanceof MetricProducerImpl) {
-        for (const r of readers) self.readers.push(r)
+        self.addReaders(readers)
       }
       readers.forEach((reader) => reader.setMetricProducer(self))
       return readers
@@ -348,7 +365,12 @@ export const registerProducer = (
       ).pipe(
         Effect.ignoreLogged,
         Effect.interruptible,
-        Effect.timeoutOption(options?.shutdownTimeout ?? 3000)
+        Effect.timeoutOption(options?.shutdownTimeout ?? 3000),
+        Effect.ensuring(Effect.sync(() => {
+          if (self instanceof MetricProducerImpl) {
+            self.removeReaders(readers)
+          }
+        }))
       )
   )
 

--- a/packages/opentelemetry/src/internal/metrics.ts
+++ b/packages/opentelemetry/src/internal/metrics.ts
@@ -1,5 +1,5 @@
 import type { HrTime } from "@opentelemetry/api"
-import { ValueType } from "@opentelemetry/api"
+import { diag, ValueType } from "@opentelemetry/api"
 import type * as Resources from "@opentelemetry/resources"
 import type {
   CollectionResult,
@@ -32,7 +32,13 @@ type MetricDataWithInstrumentDescriptor = MetricData & {
 
 /** @internal */
 export class MetricProducerImpl implements MetricProducer {
-  constructor(readonly resource: Resources.Resource) {}
+  readonly resource: Resources.Resource
+  readonly readers: Array<MetricReader> = []
+  private warnedConflictingTemporalities = false
+
+  constructor(resource: Resources.Resource) {
+    this.resource = resource
+  }
 
   startTimes = new Map<string, HrTime>()
 
@@ -42,6 +48,26 @@ export class MetricProducerImpl implements MetricProducer {
     }
     this.startTimes.set(name, hrTime)
     return hrTime
+  }
+
+  private temporalityFor(descriptorType: InstrumentType): AggregationTemporality {
+    if (this.readers.length === 0) {
+      return AggregationTemporality.CUMULATIVE
+    }
+    const selected = this.readers[0].selectAggregationTemporality(descriptorType)
+    if (
+      this.readers.length > 1 &&
+      this.readers.some((r) => r.selectAggregationTemporality(descriptorType) !== selected)
+    ) {
+      if (!this.warnedConflictingTemporalities) {
+        this.warnedConflictingTemporalities = true
+        diag.warn(
+          "@effect/opentelemetry: multiple MetricReaders registered with conflicting " +
+            "aggregationTemporality for the same instrument type; using the first reader's preference."
+        )
+      }
+    }
+    return selected
   }
 
   collect(_options?: MetricCollectOptions): Promise<CollectionResult> {
@@ -62,6 +88,7 @@ export class MetricProducerImpl implements MetricProducer {
       })
       const descriptor = descriptorFromKey(metricKey, attributes)
       const startTime = this.startTimeFor(descriptor.name, hrTimeNow)
+      const temporality = this.temporalityFor(descriptor.type)
 
       if (MetricState.isCounterState(metricState)) {
         const dataPoint: DataPoint<number> = {
@@ -77,7 +104,7 @@ export class MetricProducerImpl implements MetricProducer {
             dataPointType: DataPointType.SUM,
             descriptor,
             isMonotonic: descriptor.type === InstrumentType.COUNTER,
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             dataPoints: [dataPoint]
           })
         }
@@ -94,7 +121,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.GAUGE,
             descriptor,
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             dataPoints: [dataPoint]
           })
         }
@@ -133,7 +160,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.HISTOGRAM,
             descriptor,
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             dataPoints: [dataPoint]
           })
         }
@@ -157,7 +184,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.SUM,
             descriptor: descriptorFromKey(metricKey, attributes),
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             isMonotonic: true,
             dataPoints
           })
@@ -205,7 +232,7 @@ export class MetricProducerImpl implements MetricProducer {
           addMetricData({
             dataPointType: DataPointType.SUM,
             descriptor: descriptorFromKey(metricKey, attributes, "quantiles"),
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             isMonotonic: false,
             dataPoints
           })
@@ -217,7 +244,7 @@ export class MetricProducerImpl implements MetricProducer {
               type: InstrumentType.COUNTER,
               valueType: ValueType.INT
             },
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             isMonotonic: true,
             dataPoints: [countDataPoint]
           })
@@ -229,7 +256,7 @@ export class MetricProducerImpl implements MetricProducer {
               type: InstrumentType.COUNTER,
               valueType: ValueType.DOUBLE
             },
-            aggregationTemporality: AggregationTemporality.CUMULATIVE,
+            aggregationTemporality: temporality,
             isMonotonic: true,
             dataPoints: [sumDataPoint]
           })
@@ -307,6 +334,9 @@ export const registerProducer = (
     Effect.sync(() => {
       const reader = metricReader()
       const readers: Array<MetricReader> = Array.isArray(reader) ? reader : [reader] as any
+      if (self instanceof MetricProducerImpl) {
+        for (const r of readers) self.readers.push(r)
+      }
       readers.forEach((reader) => reader.setMetricProducer(self))
       return readers
     }),

--- a/packages/opentelemetry/test/Metrics.test.ts
+++ b/packages/opentelemetry/test/Metrics.test.ts
@@ -4,6 +4,7 @@ import { resourceFromAttributes } from "@opentelemetry/resources"
 import {
   AggregationTemporality,
   InMemoryMetricExporter,
+  InstrumentType,
   PeriodicExportingMetricReader
 } from "@opentelemetry/sdk-metrics"
 import * as Effect from "effect/Effect"
@@ -12,6 +13,42 @@ import * as internal from "../src/internal/metrics.js"
 
 const findMetric = (metrics: any, name: string) =>
   metrics.resourceMetrics.scopeMetrics[0].metrics.find((_: any) => _.descriptor.name === name)
+
+const makeProducer = () => new internal.MetricProducerImpl(resourceFromAttributes({ name: "test", version: "1.0.0" }))
+
+/** A reader whose exporter reports a single temporality for every instrument type. */
+const uniformReader = (temporality: AggregationTemporality) =>
+  new PeriodicExportingMetricReader({
+    exporter: new InMemoryMetricExporter(temporality),
+    exportIntervalMillis: 60_000_000
+  })
+
+/**
+ * Mirrors the real `DeltaTemporalitySelector` used by `OTLPMetricExporter`: the
+ * preference varies *per instrument type* rather than being a single constant.
+ */
+class DeltaSelectorExporter extends InMemoryMetricExporter {
+  constructor() {
+    super(AggregationTemporality.DELTA)
+  }
+  override selectAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality {
+    switch (instrumentType) {
+      case InstrumentType.COUNTER:
+      case InstrumentType.OBSERVABLE_COUNTER:
+      case InstrumentType.OBSERVABLE_GAUGE:
+      case InstrumentType.HISTOGRAM:
+        return AggregationTemporality.DELTA
+      default:
+        return AggregationTemporality.CUMULATIVE
+    }
+  }
+}
+
+const deltaSelectorReader = () =>
+  new PeriodicExportingMetricReader({
+    exporter: new DeltaSelectorExporter(),
+    exportIntervalMillis: 60_000_000
+  })
 
 describe("Metrics", () => {
   it.effect("gauge", () =>
@@ -300,14 +337,8 @@ describe("Metrics", () => {
 
   it.effect("counter honors reader's preferred temporality (DELTA)", () =>
     Effect.gen(function*() {
-      const producer = new internal.MetricProducerImpl(
-        resourceFromAttributes({ name: "test", version: "1.0.0" })
-      )
-      const reader = new PeriodicExportingMetricReader({
-        exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
-        exportIntervalMillis: 60_000_000
-      })
-      yield* Effect.scoped(internal.registerProducer(producer, () => reader))
+      const producer = makeProducer()
+      yield* internal.registerProducer(producer, () => uniformReader(AggregationTemporality.DELTA))
 
       const counter = Metric.counter("counter-temp", { incremental: true })
       yield* Metric.increment(counter)
@@ -317,18 +348,12 @@ describe("Metrics", () => {
       const metric = findMetric(JSON.parse(JSON.stringify(results)), "counter-temp")
       assert.equal(metric.aggregationTemporality, AggregationTemporality.DELTA)
       assert.equal(metric.isMonotonic, true)
-    }))
+    }).pipe(Effect.scoped))
 
   it.effect("gauge honors reader's preferred temporality (DELTA)", () =>
     Effect.gen(function*() {
-      const producer = new internal.MetricProducerImpl(
-        resourceFromAttributes({ name: "test", version: "1.0.0" })
-      )
-      const reader = new PeriodicExportingMetricReader({
-        exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
-        exportIntervalMillis: 60_000_000
-      })
-      yield* Effect.scoped(internal.registerProducer(producer, () => reader))
+      const producer = makeProducer()
+      yield* internal.registerProducer(producer, () => uniformReader(AggregationTemporality.DELTA))
 
       const gauge = Metric.gauge("gauge-temp")
       yield* Metric.set(gauge, 42)
@@ -336,18 +361,86 @@ describe("Metrics", () => {
       const results = yield* Effect.promise(() => producer.collect())
       const metric = findMetric(JSON.parse(JSON.stringify(results)), "gauge-temp")
       assert.equal(metric.aggregationTemporality, AggregationTemporality.DELTA)
-    }))
+    }).pipe(Effect.scoped))
 
   it.effect("falls back to CUMULATIVE when no reader is registered", () =>
     Effect.gen(function*() {
-      const producer = new internal.MetricProducerImpl(
-        resourceFromAttributes({ name: "test", version: "1.0.0" })
-      )
+      const producer = makeProducer()
       const counter = Metric.counter("counter-no-reader", { incremental: true })
       yield* Metric.increment(counter)
 
       const results = yield* Effect.promise(() => producer.collect())
       const metric = findMetric(JSON.parse(JSON.stringify(results)), "counter-no-reader")
+      assert.equal(metric.aggregationTemporality, AggregationTemporality.CUMULATIVE)
+    }))
+
+  it.effect("temporality is resolved per instrument type, not per metric key", () =>
+    Effect.gen(function*() {
+      const producer = makeProducer()
+      yield* internal.registerProducer(producer, deltaSelectorReader)
+
+      // An `UP_DOWN_COUNTER` -- the delta selector prefers CUMULATIVE for these.
+      const upDown = Metric.counter("per-type-updown")
+      yield* Metric.incrementBy(upDown, 3)
+      // A monotonic `COUNTER` -- the delta selector prefers DELTA.
+      const monotonic = Metric.counter("per-type-counter", { incremental: true })
+      yield* Metric.increment(monotonic)
+
+      const results = JSON.parse(JSON.stringify(yield* Effect.promise(() => producer.collect())))
+      assert.equal(
+        findMetric(results, "per-type-updown").aggregationTemporality,
+        AggregationTemporality.CUMULATIVE
+      )
+      assert.equal(
+        findMetric(results, "per-type-counter").aggregationTemporality,
+        AggregationTemporality.DELTA
+      )
+    }).pipe(Effect.scoped))
+
+  it.effect("summary _count/_sum use their own COUNTER temporality", () =>
+    Effect.gen(function*() {
+      const producer = makeProducer()
+      yield* internal.registerProducer(producer, deltaSelectorReader)
+
+      const summary = Metric.summary({
+        name: "per-type-summary",
+        maxAge: "60 seconds",
+        maxSize: 10,
+        error: 0.01,
+        quantiles: [0.5]
+      })
+      yield* Metric.update(summary, 5)
+
+      const results = JSON.parse(JSON.stringify(yield* Effect.promise(() => producer.collect())))
+      // `_count`/`_sum` are emitted as COUNTER descriptors, so they must follow the
+      // COUNTER preference (DELTA) rather than the summary's own UP_DOWN_COUNTER.
+      assert.equal(
+        findMetric(results, "per-type-summary_count").aggregationTemporality,
+        AggregationTemporality.DELTA
+      )
+      assert.equal(
+        findMetric(results, "per-type-summary_sum").aggregationTemporality,
+        AggregationTemporality.DELTA
+      )
+      assert.equal(
+        findMetric(results, "per-type-summary_quantiles").aggregationTemporality,
+        AggregationTemporality.CUMULATIVE
+      )
+    }).pipe(Effect.scoped))
+
+  it.effect("readers are unregistered when the scope closes", () =>
+    Effect.gen(function*() {
+      const producer = makeProducer()
+      yield* Effect.scoped(
+        internal.registerProducer(producer, () => uniformReader(AggregationTemporality.DELTA))
+      )
+      assert.equal(producer.readers.length, 0)
+
+      const counter = Metric.counter("counter-after-scope", { incremental: true })
+      yield* Metric.increment(counter)
+
+      const results = yield* Effect.promise(() => producer.collect())
+      const metric = findMetric(JSON.parse(JSON.stringify(results)), "counter-after-scope")
       assert.equal(metric.aggregationTemporality, AggregationTemporality.CUMULATIVE)
     }))
 })

--- a/packages/opentelemetry/test/Metrics.test.ts
+++ b/packages/opentelemetry/test/Metrics.test.ts
@@ -1,6 +1,11 @@
 import { assert, describe, it } from "@effect/vitest"
 import { ValueType } from "@opentelemetry/api"
 import { resourceFromAttributes } from "@opentelemetry/resources"
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  PeriodicExportingMetricReader
+} from "@opentelemetry/sdk-metrics"
 import * as Effect from "effect/Effect"
 import * as Metric from "effect/Metric"
 import * as internal from "../src/internal/metrics.js"
@@ -291,5 +296,58 @@ describe("Metrics", () => {
           }
         ]
       })
+    }))
+
+  it.effect("counter honors reader's preferred temporality (DELTA)", () =>
+    Effect.gen(function*() {
+      const producer = new internal.MetricProducerImpl(
+        resourceFromAttributes({ name: "test", version: "1.0.0" })
+      )
+      const reader = new PeriodicExportingMetricReader({
+        exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
+        exportIntervalMillis: 60_000_000
+      })
+      yield* Effect.scoped(internal.registerProducer(producer, () => reader))
+
+      const counter = Metric.counter("counter-temp", { incremental: true })
+      yield* Metric.increment(counter)
+      yield* Metric.increment(counter)
+
+      const results = yield* Effect.promise(() => producer.collect())
+      const metric = findMetric(JSON.parse(JSON.stringify(results)), "counter-temp")
+      assert.equal(metric.aggregationTemporality, AggregationTemporality.DELTA)
+      assert.equal(metric.isMonotonic, true)
+    }))
+
+  it.effect("gauge honors reader's preferred temporality (DELTA)", () =>
+    Effect.gen(function*() {
+      const producer = new internal.MetricProducerImpl(
+        resourceFromAttributes({ name: "test", version: "1.0.0" })
+      )
+      const reader = new PeriodicExportingMetricReader({
+        exporter: new InMemoryMetricExporter(AggregationTemporality.DELTA),
+        exportIntervalMillis: 60_000_000
+      })
+      yield* Effect.scoped(internal.registerProducer(producer, () => reader))
+
+      const gauge = Metric.gauge("gauge-temp")
+      yield* Metric.set(gauge, 42)
+
+      const results = yield* Effect.promise(() => producer.collect())
+      const metric = findMetric(JSON.parse(JSON.stringify(results)), "gauge-temp")
+      assert.equal(metric.aggregationTemporality, AggregationTemporality.DELTA)
+    }))
+
+  it.effect("falls back to CUMULATIVE when no reader is registered", () =>
+    Effect.gen(function*() {
+      const producer = new internal.MetricProducerImpl(
+        resourceFromAttributes({ name: "test", version: "1.0.0" })
+      )
+      const counter = Metric.counter("counter-no-reader", { incremental: true })
+      yield* Metric.increment(counter)
+
+      const results = yield* Effect.promise(() => producer.collect())
+      const metric = findMetric(JSON.parse(JSON.stringify(results)), "counter-no-reader")
+      assert.equal(metric.aggregationTemporality, AggregationTemporality.CUMULATIVE)
     }))
 })


### PR DESCRIPTION
Fixes #6253.

`@effect/opentelemetry`'s `MetricProducerImpl` was hardcoding `AggregationTemporality.CUMULATIVE` on every produced data point (Counter, UpDownCounter, Frequency, Summary count/sum, Gauge, Histogram). It never consulted the registered `MetricReader`, so any `temporalityPreference` (e.g. `DELTA`) configured on `OTLPMetricExporter` (or any custom `aggregationTemporalitySelector`) was silently overridden.

### Why this needs a small adaptation of the issue's suggested fix #1

The OTel `MetricProducer.collect()` interface only receives `{ timeoutMillis }` — not a reader reference. The reader is given to the producer one-way via `reader.setMetricProducer(producer)`. So the producer cannot query `selectAggregationTemporality` directly during `collect()` without first remembering the reader at registration time.

### What the fix does

- `MetricProducerImpl` now holds a list of registered `MetricReader`s, populated in `registerProducer`.
- `collect()` calls `reader.selectAggregationTemporality(descriptor.type)` per produced data point and stamps that on the result. The 5 hardcoded sites (Counter, Gauge, Histogram, Frequency, Summary count/sum) all go through one helper.
- No reader registered → unchanged (`CUMULATIVE`, matching the OTel default).
- Multiple readers, all agree → use that preference.
- Multiple readers, disagree → use the first reader's preference and emit a single `diag.warn(...)` (non-fatal, non-breaking).

### Why option (1) over option (2)

Option (1) is spec-compliant and requires zero user-side configuration; option (2) would have made users re-state the reader's preference on the producer side.

### Tests added (`packages/opentelemetry/test/Metrics.test.ts`)

- counter honors reader's preferred temporality (DELTA) — the exact issue repro
- gauge honors reader's preferred temporality (DELTA)
- falls back to CUMULATIVE when no reader is registered

All 60 tests in `@effect/opentelemetry` pass. `pnpm check`, `pnpm build`, `pnpm docgen` all green.

### Out of scope (noted as a follow-up)

`packages/opentelemetry/src/OtlpMetrics.ts` (the non-SDK direct-OTLP snapshot path) has the same hardcoded `CUMULATIVE`, but it does not use a `MetricReader`. A follow-up could add a `temporality` option to `OtlpMetrics.make` since there is no reader to query there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metric exports now honor each reader’s preferred aggregation temporality, including DELTA settings.
  * Temporality is selected appropriately by metric instrument type, including counters, gauges, histograms, and summaries.
  * Metrics revert to cumulative temporality when no reader is registered or after reader shutdown.
  * Added safeguards and validation for differing temporality preferences across readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->