### PR TITLE
fix(BigDecimal.normalize): return self if already normalized

### DIFF
--- a/.changeset/upset-clubs-kick.md
+++ b/.changeset/upset-clubs-kick.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Return `self` from `BigDecimal.normalize` for already-normalized values

--- a/packages/effect/src/BigDecimal.ts
+++ b/packages/effect/src/BigDecimal.ts
@@ -161,11 +161,11 @@ export const normalize = (self: BigDecimal): BigDecimal => {
 
       if (trail === 0) {
         self.normalized = self
+      } else {
+        const value = BigInt(digits.substring(0, digits.length - trail))
+        const scale = self.scale - trail
+        self.normalized = unsafeMakeNormalized(value, scale)
       }
-
-      const value = BigInt(digits.substring(0, digits.length - trail))
-      const scale = self.scale - trail
-      self.normalized = unsafeMakeNormalized(value, scale)
     }
   }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently normalize always normalize the digits whether it's already normalized or not. It fails with stricter assertions in Node 24.

## Related

- Related PR: https://github.com/Effect-TS/effect/pull/5791