### PR TITLE
fix(platform): stop emitting content-length in HttpClientRequest.setBody

### DIFF
--- a/.changeset/fix-content-length-request.md
+++ b/.changeset/fix-content-length-request.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+fix: stop emitting content-length header in HttpClientRequest.setBody

--- a/packages/platform/src/internal/httpClientRequest.ts
+++ b/packages/platform/src/internal/httpClientRequest.ts
@@ -394,11 +394,9 @@ export const setBody = dual<
     if (contentType) {
       headers = Headers.set(headers, "content-type", contentType)
     }
-
-    const contentLength = body.contentLength
-    if (contentLength) {
-      headers = Headers.set(headers, "content-length", contentLength.toString())
-    }
+    // Do not set content-length here — the transport layer (fetch/undici)
+    // computes the correct value from what it actually sends on the wire.
+    // See https://github.com/Effect-TS/effect/issues/6240
   }
   return makeInternal(
     self.method,


### PR DESCRIPTION
## Type

* [x] Bug Fix

## Description

`HttpClientRequest.setBody` currently emits a `content-length` header from `body.contentLength` when building a request.

This can conflict with the behavior of the underlying transport layer (`fetch` / `undici`), which is responsible for determining the actual bytes sent on the wire and setting the corresponding `Content-Length` header when appropriate.

This change removes the automatic `content-length` header emission from `setBody` and leaves content length calculation to the transport implementation.

Users who need to explicitly control the header can still set it manually through request headers.

## Related

* Closes #6240
