### PR TITLE
fix: Duration.decode and Duration.times throwing on fractional values

### DIFF
--- a/.changeset/duration-fractional-nanos-micros.md
+++ b/.changeset/duration-fractional-nanos-micros.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Fix `Duration.decode` and `Duration.times` throwing on fractional values.
+
+`Duration.decode` accepts a decimal mantissa (e.g. `"1.5 micros"`), but the `nanos`/`micros` units passed the raw string to `BigInt`, which throws on non-integers. Fractional `nanos`/`micros` are now scaled to whole nanoseconds (rounded), e.g. `Duration.decode("1.5 micros")` is `1500` nanos and `Duration.decode("1.5 nanos")` is `2` nanos.
+
+`Duration.times` accepts any `number` multiplier, but multiplying a nanosecond-backed `Duration` by a non-integer threw because `BigInt` cannot convert a float. Non-integer multipliers are now supported, e.g. `Duration.times(Duration.nanos(2n), 2.5)` is `5` nanos.

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -113,13 +113,14 @@ export const decode = (input: DurationInput): Duration => {
     if (match) {
       const [_, valueStr, unit] = match
       const value = Number(valueStr)
+      const isFractional = valueStr.includes(".")
       switch (unit) {
         case "nano":
         case "nanos":
-          return nanos(BigInt(valueStr))
+          return isFractional ? make(BigInt(Math.round(value))) : nanos(BigInt(valueStr))
         case "micro":
         case "micros":
-          return micros(BigInt(valueStr))
+          return isFractional ? make(BigInt(Math.round(value * 1_000))) : micros(BigInt(valueStr))
         case "milli":
         case "millis":
           return millis(value)
@@ -651,7 +652,10 @@ export const times: {
   (self: DurationInput, times: number): Duration =>
     match(self, {
       onMillis: (millis) => make(millis * times),
-      onNanos: (nanos) => make(nanos * BigInt(times))
+      onNanos: (nanos) =>
+        Number.isInteger(times)
+          ? make(nanos * BigInt(times))
+          : make(BigInt(Math.round(Number(nanos) * times)))
     })
 )
 

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -39,6 +39,10 @@ describe("Duration", () => {
     deepStrictEqual(Duration.decode("1.5 seconds"), Duration.seconds(1.5))
     deepStrictEqual(Duration.decode("-1.5 seconds"), Duration.zero)
 
+    deepStrictEqual(Duration.decode("1.5 micros"), Duration.nanos(1500n))
+    deepStrictEqual(Duration.decode("1.5 nanos"), Duration.nanos(2n))
+    deepStrictEqual(Duration.decode("-1.5 nanos"), Duration.zero)
+
     deepStrictEqual(Duration.decode([500, 123456789]), Duration.nanos(500123456789n))
     deepStrictEqual(Duration.decode([-500, 123456789]), Duration.zero)
     deepStrictEqual(Duration.decode([Infinity, 0]), Duration.infinity)
@@ -224,6 +228,9 @@ describe("Duration", () => {
     deepStrictEqual(Duration.times(Duration.seconds(Infinity), 60), Duration.seconds(Infinity))
 
     deepStrictEqual(Duration.times("1 seconds", 60), Duration.minutes(1))
+
+    deepStrictEqual(Duration.times(Duration.nanos(2n), 2.5), Duration.nanos(5n))
+    deepStrictEqual(Duration.times(Duration.nanos(3n), 1.5), Duration.nanos(5n))
   })
 
   it("sum", () => {


### PR DESCRIPTION
## What

Two related crashes in `Duration` when given fractional values, both caused by passing a non-integer to `BigInt()`:

### 1. `Duration.decode("1.5 nanos" | "1.5 micros")` throws

`DURATION_REGEX` explicitly permits a decimal mantissa (`-?\d+(?:\.\d+)?`), so the input passes validation. But the `nanos`/`micros` branches pass the raw matched string straight to `BigInt`:

```ts
case "nanos":  return nanos(BigInt(valueStr))   // BigInt("1.5") -> SyntaxError
case "micros": return micros(BigInt(valueStr))  // BigInt("1.5") -> SyntaxError
```

Every other unit (`millis`, `seconds`, …) uses `Number(valueStr)` and works fine with decimals (there's already a passing test for `"1.5 seconds"`). Only `nanos`/`micros` crash.

### 2. `Duration.times(nanosDuration, 2.5)` throws

`times` is typed to accept any `number` multiplier, but the nanos branch does:

```ts
onNanos: (nanos) => make(nanos * BigInt(times))  // BigInt(2.5) -> RangeError
```

So multiplying a nanosecond-backed `Duration` by a non-integer throws, despite the type signature allowing it.

## Fix

- `decode`: for `nanos`/`micros`, when the value is fractional, scale to whole nanoseconds and round (nanos is the smallest representable unit). Integer inputs keep the existing `BigInt(valueStr)` path, preserving exact values for large integers (e.g. `"99999999999999999999 nanos"`).
  - `"1.5 micros"` -> `1500` nanos
  - `"1.5 nanos"` -> `2` nanos
  - `"-1.5 nanos"` -> `Duration.zero` (consistent with existing `"-1.5 seconds"` -> `zero`)
- `times`: keep exact bigint multiplication for integer multipliers (no precision loss for large durations); fall back to rounded `Number` math only for non-integer multipliers.
  - `Duration.times(Duration.nanos(2n), 2.5)` -> `5` nanos

## Tests

Added cases to the existing `decode` and `times` tests. Both fail on `main` (`SyntaxError: Cannot convert 1.5 to a BigInt` / `RangeError: ... not an integer`) and pass with the fix. Full `Duration` suite (48 tests), Schema `Duration` suite, and `Schedule` suite all pass; `tsc -b` and `eslint` are clean.

Part of #4349.