### PR TITLE
fix(ai-amazon-bedrock): emit streaming "finish" after metadata arrives

### DIFF
--- a/.changeset/fix-bedrock-streaming-usage.md
+++ b/.changeset/fix-bedrock-streaming-usage.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-amazon-bedrock": patch
+---
+
+Fix `@effect/ai-amazon-bedrock` streaming so the terminal `"finish"` part carries real token counts. The Bedrock Converse stream sends `metadata` (with the populated `usage` block) **after** `messageStop`, but the SDK was emitting `"finish"` synchronously on `messageStop`, capturing the still-empty `usage` defaults. Buffer the finish reason on `messageStop` and emit `"finish"` from the `metadata` case once `inputTokens` / `outputTokens` / `totalTokens` are filled in.

--- a/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
+++ b/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
@@ -656,6 +656,7 @@ const makeStreamResponse: (
 
     let trace: ConverseTrace | undefined = undefined
     let cacheWriteInputTokens: number | undefined = undefined
+    let finishReason: Response.FinishReason | undefined = undefined
     const usage: Mutable<typeof Response.Usage.Encoded> = {
       inputTokens: undefined,
       outputTokens: undefined,
@@ -677,16 +678,12 @@ const makeStreamResponse: (
           }
 
           case "messageStop": {
-            const reason = InternalUtilities.resolveFinishReason(event.messageStop.stopReason)
-            parts.push({
-              type: "finish",
-              reason,
-              usage,
-              metadata: {
-                bedrock: { trace, usage: { cacheWriteInputTokens } }
-              }
-            })
-
+            // Buffer the finish reason — the Bedrock Converse stream sends
+            // `metadata` (with usage / cache / trace) AFTER `messageStop`,
+            // so emitting the `"finish"` part here would leak the empty
+            // `usage` defaults from the case below to the caller. Wait for
+            // `metadata` to land and emit `"finish"` there.
+            finishReason = InternalUtilities.resolveFinishReason(event.messageStop.stopReason)
             break
           }
 
@@ -907,6 +904,22 @@ const makeStreamResponse: (
             }
             if (Predicate.isNotUndefined(event.metadata.trace)) {
               trace = event.metadata.trace
+            }
+            // Bedrock sends `metadata` after `messageStop`, so by the time
+            // we land here we have both the finish reason (buffered above)
+            // and the populated usage / cache / trace. Emit the `"finish"`
+            // part now so the caller sees real token counts on the
+            // terminal stream event.
+            if (Predicate.isNotUndefined(finishReason)) {
+              parts.push({
+                type: "finish",
+                reason: finishReason,
+                usage,
+                metadata: {
+                  bedrock: { trace, usage: { cacheWriteInputTokens } }
+                }
+              })
+              finishReason = undefined
             }
             break
           }


### PR DESCRIPTION
Closes #6237.

## Summary

The Bedrock Converse stream sends `metadata` (with the populated `usage` block) **after** `messageStop`. The SDK was emitting the `"finish"` part synchronously on `messageStop`, capturing the still-empty `{ inputTokens: undefined, outputTokens: undefined, totalTokens: undefined }` defaults — so the caller's terminal stream event always saw `usage.inputTokens === undefined` and `usage.outputTokens === undefined`, matching the reporter's symptom exactly.

## Fix

Buffer the finish reason on `messageStop`, then emit `"finish"` from the `metadata` case once `usage`, `cacheWriteInputTokens`, and `trace` are populated. The output payload shape (`reason` / `usage` / `metadata.bedrock`) is unchanged — only the timing moves.

```ts
case "messageStop": {
  finishReason = InternalUtilities.resolveFinishReason(event.messageStop.stopReason)
  break
}

case "metadata": {
  usage.inputTokens = event.metadata.usage.inputTokens
  // ... existing usage / cacheWrite / trace population ...
  if (Predicate.isNotUndefined(finishReason)) {
    parts.push({ type: "finish", reason: finishReason, usage, metadata: { bedrock: { trace, usage: { cacheWriteInputTokens } } } })
    finishReason = undefined
  }
  break
}
```

## Notes

I didn't add a streaming test — `converseStream` is `null as any` in the existing test harness in `AmazonBedrockLanguageModel.test.ts`, so there's no pattern yet for mocking `ConverseResponseStreamEvent`. Happy to follow up with a focused stream test once the maintainers point at the preferred mocking shape.