### PR TITLE
EFF-846 Backport content-length header removal

### DIFF
--- a/.changeset/quiet-crabs-deny.md
+++ b/.changeset/quiet-crabs-deny.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Remove the content-length header before sending FetchHttpClient requests.

--- a/packages/platform/src/internal/fetchHttpClient.ts
+++ b/packages/platform/src/internal/fetchHttpClient.ts
@@ -16,7 +16,10 @@ const fetch: Client.HttpClient = client.make((request, url, signal, fiber) => {
   const context = fiber.getFiberRef(FiberRef.currentContext)
   const fetch: typeof globalThis.fetch = context.unsafeMap.get(fetchTagKey) ?? globalThis.fetch
   const options: RequestInit = context.unsafeMap.get(requestInitTagKey) ?? {}
-  const headers = options.headers ? Headers.merge(Headers.fromInput(options.headers), request.headers) : request.headers
+  let headers = options.headers ? Headers.merge(Headers.fromInput(options.headers), request.headers) : request.headers
+  if (headers["content-length"]) {
+    headers = Headers.remove(headers, "content-length")
+  }
   const send = (body: BodyInit | undefined) =>
     Effect.map(
       Effect.tryPromise({

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -306,6 +306,35 @@ describe("HttpClient", () => {
       Effect.provideService(FetchHttpClient.RequestInit, { redirect: "manual" })
     ), 30000)
 
+  it.effect("fetch removes content-length header", () => {
+    let headers: globalThis.RequestInit["headers"] | undefined
+    const fetch: typeof globalThis.fetch = (_, init) => {
+      headers = init?.headers
+      return Promise.resolve(new Response("ok"))
+    }
+    return Effect.gen(function*() {
+      const client = yield* HttpClient.HttpClient
+
+      yield* HttpClientRequest.post("http://test/").pipe(
+        HttpClientRequest.bodyText("hello"),
+        client.execute
+      )
+
+      strictEqual((headers as Record<string, string> | undefined)?.["content-length"], undefined)
+      strictEqual((headers as Record<string, string> | undefined)?.["content-type"], "text/plain")
+      strictEqual((headers as Record<string, string> | undefined)?.["x-test"], "ok")
+    }).pipe(
+      Effect.provide(FetchHttpClient.layer),
+      Effect.provideService(FetchHttpClient.Fetch, fetch),
+      Effect.provideService(FetchHttpClient.RequestInit, {
+        headers: {
+          "content-length": "100",
+          "x-test": "ok"
+        }
+      })
+    )
+  })
+
   describe("retryTransient", () => {
     const makeTestClient = (status: number) => {
       const attemptsRef = Ref.unsafeMake(0)


### PR DESCRIPTION
## Summary
- Remove content-length from FetchHttpClient headers before invoking fetch
- Add regression coverage for request and RequestInit headers
- Add a changeset for @effect/platform

## Validation
- pnpm lint-fix
- pnpm test run packages/platform/test/HttpClient.test.ts
- pnpm check
- pnpm build
- pnpm docgen