### PR TITLE
fix(rpc,ai): conform MCP Streamable HTTP transport to 2025-06-18

### DIFF
--- a/.changeset/jsonrpc-single-response-object.md
+++ b/.changeset/jsonrpc-single-response-object.md
@@ -1,0 +1,9 @@
+---
+"@effect/rpc": patch
+"@effect/ai": patch
+---
+
+Make the MCP Streamable HTTP transport conform to the 2025-06-18 specification so spec-conformant clients (Claude Desktop and Claude Code) can connect.
+
+- `@effect/rpc`: the JSON-RPC serialization now replies to a single request with a single response object instead of a one-element array. Batch requests still receive an array. MCP 2025-06-18 removed JSON-RPC batching, and clients built to that revision reject array-wrapped responses.
+- `@effect/ai`: `McpServer.layerHttp` and `McpServer.layerHttpRouter` now answer `GET` and `DELETE` on the MCP path with `405 Method Not Allowed` (advertising `Allow: POST`) instead of `404`, since the transport is stateless and serves MCP over `POST` only.

--- a/packages/ai/ai/src/McpServer.ts
+++ b/packages/ai/ai/src/McpServer.ts
@@ -2,8 +2,9 @@
  * @since 1.0.0
  */
 import * as Headers from "@effect/platform/Headers"
-import type * as HttpLayerRouter from "@effect/platform/HttpLayerRouter"
-import type * as HttpRouter from "@effect/platform/HttpRouter"
+import * as HttpLayerRouter from "@effect/platform/HttpLayerRouter"
+import * as HttpRouter from "@effect/platform/HttpRouter"
+import * as HttpServerResponse from "@effect/platform/HttpServerResponse"
 import type { RpcMessage } from "@effect/rpc"
 import type * as Rpc from "@effect/rpc/Rpc"
 import * as RpcClient from "@effect/rpc/RpcClient"
@@ -304,6 +305,11 @@ export class McpServer extends Context.Tag("@effect/ai/McpServer")<
    */
   static readonly layer: Layer.Layer<McpServer | McpServerClient> = Layer.scoped(McpServer, McpServer.make) as any
 }
+
+const McpMethodNotAllowed = HttpServerResponse.empty({
+  status: 405,
+  headers: Headers.fromInput({ allow: "POST" })
+})
 
 const LATEST_PROTOCOL_VERSION = "2025-06-18"
 const SUPPORTED_PROTOCOL_VERSIONS = [
@@ -612,11 +618,23 @@ export const layerHttp = <I = HttpRouter.Default>(options: {
   readonly version: string
   readonly path: HttpRouter.PathInput
   readonly routerTag?: HttpRouter.HttpRouter.TagClass<I, string, any, any>
-}): Layer.Layer<McpServer | McpServerClient> =>
-  layer(options).pipe(
+}): Layer.Layer<McpServer | McpServerClient> => {
+  const routerTag = options.routerTag ??
+    HttpRouter.Default as any as HttpRouter.HttpRouter.TagClass<I, string, any, any>
+
+  const methodNotAllowed = Layer.effectDiscard(Effect.gen(function*() {
+    const router = yield* routerTag
+
+    yield* router.get(options.path, Effect.succeed(McpMethodNotAllowed))
+    yield* router.del(options.path, Effect.succeed(McpMethodNotAllowed))
+  })).pipe(Layer.provide(routerTag.Live))
+
+  return layer(options).pipe(
     Layer.provide(RpcServer.layerProtocolHttp(options)),
-    Layer.provide(RpcSerialization.layerJsonRpc())
+    Layer.provide(RpcSerialization.layerJsonRpc()),
+    Layer.provideMerge(methodNotAllowed)
   )
+}
 
 /**
  * Run the McpServer, using HTTP for input and output.
@@ -634,11 +652,20 @@ export const layerHttpRouter = (options: {
   McpServer | McpServerClient,
   never,
   HttpLayerRouter.HttpRouter
-> =>
-  layer(options).pipe(
+> => {
+  const methodNotAllowed = Layer.effectDiscard(Effect.gen(function*() {
+    const router = yield* HttpLayerRouter.HttpRouter
+
+    yield* router.add("GET", options.path, Effect.succeed(McpMethodNotAllowed))
+    yield* router.add("DELETE", options.path, Effect.succeed(McpMethodNotAllowed))
+  }))
+
+  return layer(options).pipe(
     Layer.provide(RpcServer.layerProtocolHttpRouter(options)),
-    Layer.provide(RpcSerialization.layerJsonRpc())
+    Layer.provide(RpcSerialization.layerJsonRpc()),
+    Layer.provideMerge(methodNotAllowed)
   )
+}
 
 /**
  * Register an AiToolkit with the McpServer.

--- a/packages/ai/ai/test/McpServer.test.ts
+++ b/packages/ai/ai/test/McpServer.test.ts
@@ -1,0 +1,60 @@
+import * as McpServer from "@effect/ai/McpServer"
+import * as HttpLayerRouter from "@effect/platform/HttpLayerRouter"
+import { assert, describe, it } from "@effect/vitest"
+
+const ServerLayer = McpServer.layerHttpRouter({
+  name: "Test Server",
+  version: "1.0.0",
+  path: "/mcp"
+})
+
+const initialize = () =>
+  new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream"
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "probe", version: "0" }
+      }
+    })
+  })
+
+describe("McpServer", () => {
+  describe("Streamable HTTP transport", () => {
+    it("responds to a single request with a single JSON-RPC object, not a batch array", async () => {
+      const { dispose, handler } = HttpLayerRouter.toWebHandler(ServerLayer)
+
+      try {
+        const response = await handler(initialize())
+        const body = await response.json()
+
+        assert.isFalse(Array.isArray(body))
+        assert.strictEqual(body.id, 1)
+        assert.strictEqual(body.result.protocolVersion, "2025-06-18")
+      } finally {
+        await dispose()
+      }
+    })
+
+    it("answers GET with 405 instead of 404", async () => {
+      const { dispose, handler } = HttpLayerRouter.toWebHandler(ServerLayer)
+
+      try {
+        const response = await handler(new Request("http://localhost/mcp", { method: "GET" }))
+
+        assert.strictEqual(response.status, 405)
+        assert.strictEqual(response.headers.get("allow"), "POST")
+      } finally {
+        await dispose()
+      }
+    })
+  })
+})

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -98,19 +98,28 @@ export const jsonRpc = (options?: {
         readonly size: number
         readonly responses: Map<string, RpcMessage.FromServerEncoded>
       }>()
+      let decodedBatch = false
       return {
         decode: (bytes) => {
           const decoded: JsonRpcMessage | Array<JsonRpcMessage> = JSON.parse(
             typeof bytes === "string" ? bytes : decoder.decode(bytes)
           )
+          decodedBatch = Array.isArray(decoded)
           return decodeJsonRpcRaw(decoded, batches)
         },
         encode: (response) => {
           if (Array.isArray(response)) {
             if (response.length === 0) return undefined
+
+            if (!decodedBatch && response.length === 1) {
+              return JSON.stringify(encodeJsonRpcMessage(response[0]))
+            }
+
             return JSON.stringify(response.map(encodeJsonRpcMessage))
           }
+
           const encoded = encodeJsonRpcRaw(response as any, batches)
+
           return encoded && JSON.stringify(encoded)
         }
       }

--- a/packages/rpc/test/RpcSerialization.test.ts
+++ b/packages/rpc/test/RpcSerialization.test.ts
@@ -1,4 +1,5 @@
 import { RpcSerialization } from "@effect/rpc"
+import type { RpcMessage } from "@effect/rpc"
 import { assert, describe, it } from "@effect/vitest"
 
 describe("RpcSerialization", () => {
@@ -56,6 +57,37 @@ describe("RpcSerialization", () => {
       const decoded = parser.decode(encoded as Uint8Array)
       assert.strictEqual(decoded.length, 1)
       assert.deepStrictEqual(decoded[0], payload)
+    })
+  })
+
+  describe("jsonRpc", () => {
+    const exit = (id: string): RpcMessage.FromServerEncoded => ({
+      _tag: "Exit",
+      requestId: id,
+      exit: { _tag: "Success", value: { ok: true } }
+    })
+
+    it("encodes the response to a single request as an object, not a one-element array", () => {
+      const parser = RpcSerialization.jsonRpc().unsafeMake()
+
+      parser.decode(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }))
+      const encoded = JSON.parse(parser.encode([exit("1")]) as string)
+
+      assert.isFalse(Array.isArray(encoded))
+      assert.strictEqual(encoded.id, 1)
+    })
+
+    it("encodes the responses to a batch request as an array", () => {
+      const parser = RpcSerialization.jsonRpc().unsafeMake()
+
+      parser.decode(JSON.stringify([
+        { jsonrpc: "2.0", id: 1, method: "ping", params: {} },
+        { jsonrpc: "2.0", id: 2, method: "ping", params: {} }
+      ]))
+      const encoded = JSON.parse(parser.encode([exit("1"), exit("2")]) as string)
+
+      assert.isTrue(Array.isArray(encoded))
+      assert.strictEqual(encoded.length, 2)
     })
   })
 })


### PR DESCRIPTION
Closes #6274.

`McpServer.layerHttp` / `layerHttpRouter` serve MCP over the generic JSON-RPC RPC protocol. At the HTTP wire level this diverged from the MCP **Streamable HTTP** transport, so spec-conformant MCP clients reject the endpoint.

## Changes

### `@effect/rpc` — single request → single response object
The JSON-RPC serialization replied to a single request with a **one-element array** (`[{...}]`). MCP 2025-06-18 [removed JSON-RPC batching](https://modelcontextprotocol.io/specification/2025-06-18/changelog), and clients built to that revision expect a single response **object** and choke on the array.

The parser now tracks whether the decoded payload was a batch (top-level array) and frames the response to match: a single request gets a single object, a batch still gets an array. This is correct JSON-RPC 2.0 behavior generally, not MCP-specific — `RpcClient` already decodes both shapes, so existing RPC-over-HTTP consumers are unaffected.

### `@effect/ai` — `GET`/`DELETE` → `405` instead of `404`
The transport is stateless and serves MCP over `POST` only. `GET` (the optional server→client SSE stream) and `DELETE` (session teardown) now return `405 Method Not Allowed` with `Allow: POST`, so the path is distinguishable from "endpoint doesn't exist."

## Tests
Both fail on `main` and pass with this change:

- `packages/rpc/test/RpcSerialization.test.ts` — unit: single request → object, batch → array.
- `packages/ai/ai/test/McpServer.test.ts` — end-to-end via `HttpLayerRouter.toWebHandler`: `initialize` returns a single object; `GET` returns `405` with `Allow: POST`.

## Out of scope

- **`Mcp-Session-Id`**: deliberately not added. The transport is stateless, and omitting the header is precisely how the spec lets a server signal statelessness; returning an id that subsequent requests don't honor would be worse. Stateful session support is a separate feature.
- **OAuth / Dynamic Client Registration**: separate concern (see #6157). This matters for *how you verify* the fix: Claude Desktop's **native URL connector** additionally insists on OAuth DCR and will fail against a no-auth server regardless of this change. Verify the transport fix with **Claude Code**, the **`mcp-remote`** bridge, or a direct `initialize` request — not Desktop's native "add a URL" flow. (Confirmed against a live deployment with direct requests: `initialize` returns a single object, `tools/list` returns the full tool set, and `GET` → `405`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
