### PR TITLE
docs(ai): clarify reasoningTokens availability across providers

### DIFF
--- a/.changeset/clarify-reasoning-tokens-usage.md
+++ b/.changeset/clarify-reasoning-tokens-usage.md
@@ -1,0 +1,9 @@
+---
+"@effect/ai": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-amazon-bedrock": patch
+---
+
+Clarify that `Response.Usage.reasoningTokens` is only populated by providers whose API reports reasoning tokens as a discrete value (e.g. OpenAI via `output_tokens_details.reasoning_tokens`).
+
+The Anthropic Messages API and the Amazon Bedrock Converse API do **not** report reasoning tokens separately - when extended thinking is enabled, reasoning tokens are already included in `outputTokens`. The `@effect/ai-anthropic` and `@effect/ai-amazon-bedrock` providers therefore leave `reasoningTokens` unset. This documents the behavior so consumers do not rely on the field for cost calculations with these providers. No runtime behavior changes.

--- a/packages/ai/ai/src/Response.ts
+++ b/packages/ai/ai/src/Response.ts
@@ -2214,6 +2214,14 @@ export class Usage extends Schema.Class<Usage>("@effect/ai/AiResponse/Usage")({
   /**
    * The number of reasoning tokens that the model used to generate the output
    * for the request.
+   *
+   * **NOTE**: This value is only populated by providers whose API reports
+   * reasoning tokens as a discrete value (e.g. OpenAI via
+   * `output_tokens_details.reasoning_tokens`). Providers such as Anthropic and
+   * Amazon Bedrock do not report reasoning tokens separately - for those
+   * providers reasoning tokens are already included in `outputTokens`, and this
+   * field will be left unset. Do not rely on this field for cost calculations
+   * unless your provider is known to report it.
    */
   reasoningTokens: Schema.optional(Schema.Number),
   /**

--- a/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
+++ b/packages/ai/amazon-bedrock/src/AmazonBedrockLanguageModel.ts
@@ -609,6 +609,10 @@ const makeResponse: (
   parts.push({
     type: "finish",
     reason: finishReason,
+    // NOTE: `reasoningTokens` is intentionally left unset. The Bedrock Converse
+    // API does not report reasoning tokens as a discrete value - when extended
+    // thinking is enabled, reasoning tokens are already included in
+    // `outputTokens`. See the `TokenUsage` schema in `AmazonBedrockSchema.ts`.
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
@@ -657,6 +661,10 @@ const makeStreamResponse: (
     let trace: ConverseTrace | undefined = undefined
     let cacheWriteInputTokens: number | undefined = undefined
     let finishReason: Response.FinishReason | undefined = undefined
+    // NOTE: `reasoningTokens` is intentionally omitted. The Bedrock Converse API
+    // does not report reasoning tokens as a discrete value - when extended
+    // thinking is enabled, reasoning tokens are already included in
+    // `outputTokens`. See the `TokenUsage` schema in `AmazonBedrockSchema.ts`.
     const usage: Mutable<typeof Response.Usage.Encoded> = {
       inputTokens: undefined,
       outputTokens: undefined,

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -887,6 +887,10 @@ const makeResponse: (
     parts.push({
       type: "finish",
       reason: finishReason,
+      // NOTE: `reasoningTokens` is intentionally left unset. The Anthropic
+      // Messages API does not report reasoning tokens as a discrete value -
+      // when extended thinking is enabled, reasoning tokens are already
+      // included in `output_tokens`. See the `Usage` schema in `Generated.ts`.
       usage: {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,
@@ -951,6 +955,10 @@ const makeStreamResponse: (
       | "mcp_tool_result"
       | "container_upload"
       | undefined = undefined
+    // NOTE: `reasoningTokens` is intentionally omitted. The Anthropic Messages
+    // API does not report reasoning tokens as a discrete value - when extended
+    // thinking is enabled, reasoning tokens are already included in
+    // `output_tokens`. See the `Usage` schema in `Generated.ts`.
     const usage: Mutable<typeof Response.Usage.Encoded> = {
       inputTokens: undefined,
       outputTokens: undefined,


### PR DESCRIPTION
## Summary

Closes #6186 by documenting (rather than mis-populating) `Response.Usage.reasoningTokens`.

While investigating #6186 I confirmed that **neither** the Anthropic Messages API **nor** the Amazon Bedrock Converse API report reasoning/thinking tokens as a discrete value — in both cases reasoning tokens are already included in `outputTokens` (`output_tokens`). Only OpenAI exposes them separately (via `output_tokens_details.reasoning_tokens`), which is why `@effect/ai-openai` is the only provider that populates the field today.

This means the original issue's suggestion to use the Anthropic direct API "as a reference implementation" is not viable, and deriving the value via a tokenizer would be imprecise. The honest fix is to document the limitation so consumers don't rely on `reasoningTokens` for cost calculations with these providers.

### Evidence
- Amazon Bedrock `TokenUsage` schema has only `inputTokens` / `outputTokens` / `totalTokens` / `cacheReadInputTokens` / `cacheWriteInputTokens` — no reasoning field.
- Anthropic generated `Usage` / `BetaUsage` schemas (from Anthropic's OpenAPI spec) expose only `input_tokens` / `output_tokens` / cache fields / `server_tool_use` — no reasoning field. Anthropic's docs state `output_tokens` includes thinking + response text combined.

## Changes

- `@effect/ai`: document on `Response.Usage.reasoningTokens` that it is only populated by providers that report reasoning tokens discretely (e.g. OpenAI), and is left unset for Anthropic / Bedrock where those tokens are folded into `outputTokens`.
- `@effect/ai-anthropic`: add clarifying comments at the `generateText` and `streamText` usage-mapping sites explaining why `reasoningTokens` is intentionally unset.
- `@effect/ai-amazon-bedrock`: same clarifying comments at the `makeResponse` and stream-`metadata` usage-mapping sites.

**No runtime behavior changes** — comments and JSDoc only, plus a changeset.

## Test plan

- [x] `pnpm check` passes for `@effect/ai`, `@effect/ai-anthropic`, `@effect/ai-amazon-bedrock`
- [x] `eslint` passes for the three changed files
- [x] No runtime code paths modified (docs/comments only)

Made with [Cursor](https://cursor.com)