### PR TITLE
fix (ai-openai): Ignore unrecognized events rather than cancelling the event stream. Closes #6277

### DIFF
--- a/.changeset/openai-skip-unrecognized-stream-events.md
+++ b/.changeset/openai-skip-unrecognized-stream-events.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-openai": patch
+---
+
+Skip unrecognized or malformed events in OpenAI streaming responses instead of aborting the whole stream.
+
+OpenAI emits events that are absent from the generated OpenAPI schema — most visibly `{"type":"keepalive"}` SSE heartbeats during long Responses turns (reasoning, tool calls, web search). These previously failed strict per-event decoding with `MalformedOutput` and tore down the entire in-progress stream. Such frames are now skipped (logged at debug level) and the stream continues; every recognized event is still decoded as before.

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -142,8 +142,7 @@ export const make = (options: {
             Effect.catchTag("ParseError", (error) =>
               Effect.logDebug("Skipping undecodable stream event", error).pipe(
                 Effect.as(Option.none())
-              )
-            )
+              ))
           )
         ),
         Stream.filterMap(identity),

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -14,6 +14,7 @@ import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
 import * as Redacted from "effect/Redacted"
 import * as Schema from "effect/Schema"
 import type * as Scope from "effect/Scope"
@@ -131,7 +132,21 @@ export const make = (options: {
         Stream.unwrapScoped,
         Stream.decodeText(),
         Stream.pipeThroughChannel(Sse.makeChannel()),
-        Stream.mapEffect((event) => decodeEvent(event.data)),
+        // Decode each SSE event, but don't let a single unrecognized or malformed
+        // frame abort the whole stream. OpenAI emits events absent from the generated
+        // schema (e.g. `keepalive` heartbeats during long Responses turns); skip what
+        // we can't decode and keep the stream alive.
+        Stream.mapEffect((event) =>
+          decodeEvent(event.data).pipe(
+            Effect.asSome,
+            Effect.catchTag("ParseError", (error) =>
+              Effect.logDebug("Skipping undecodable stream event", error).pipe(
+                Effect.as(Option.none())
+              )
+            )
+          )
+        ),
+        Stream.filterMap(identity),
         Stream.catchTags({
           RequestError: (error) =>
             AiError.HttpRequestError.fromRequestError({
@@ -141,12 +156,6 @@ export const make = (options: {
             }),
           ResponseError: (error) =>
             AiError.HttpResponseError.fromResponseError({
-              module: "OpenAiClient",
-              method: "streamRequest",
-              error
-            }),
-          ParseError: (error) =>
-            AiError.MalformedOutput.fromParseError({
               module: "OpenAiClient",
               method: "streamRequest",
               error


### PR DESCRIPTION
…e event stream. Closes #6277

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
