### PR TITLE
fix(Cron): do not skip earlier days when the upcoming day is missing from the month

### DIFF
--- a/.changeset/fix-cron-next-missing-day-overflow.md
+++ b/.changeset/fix-cron-next-missing-day-overflow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cron.next` skipping earlier matching days when the upcoming day-of-month does not exist in the current month. For an expression like `0 0 1,16,31 * *`, advancing from a date past the 16th selected day 31; in a month without 31 days this overflowed into the following month and landed on a later matching day (e.g. the 16th), silently skipping the 1st. `Cron.next` now wraps to the first matching day of the next month in that case, matching the behaviour of `Cron.prev` and other cron implementations.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -584,6 +584,12 @@ const stepCron = (cron: Cron, startFrom: DateTime.DateTime.Input | undefined, di
             } else {
               b = daysInMonth(current) - currentDay + boundary.day
             }
+          } else if (!prev && nextDay > daysInMonth(current)) {
+            // The next matching day does not exist in the current month (e.g. day 31
+            // in a 30-day month). Setting it directly would overflow into the following
+            // month and skip its earlier matching days, so wrap to the first matching
+            // day of the next month instead.
+            b = daysInMonth(current) - currentDay + boundary.day
           } else {
             b = nextDay - currentDay
           }

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -245,6 +245,21 @@ describe("Cron", () => {
     deepStrictEqual(prev(cron, from), new Date("2024-01-31T00:00:00.000Z"))
   })
 
+  it("next does not skip earlier days when the upcoming day is missing from the month", () => {
+    const tz = DateTime.zoneUnsafeMakeNamed("UTC")
+    const cron = Cron.unsafeParse("0 0 1,16,31 * *", tz)
+    // From Feb 18 the next matching day in February would be the 31st, which does
+    // not exist. Rolling onto it must not overshoot past March 1 (also a match).
+    deepStrictEqual(next(cron, new Date("2020-02-18T00:00:00.000Z")), new Date("2020-03-01T00:00:00.000Z"))
+    // `*/15` expands to days [1, 16, 31] and exhibits the same wrap.
+    deepStrictEqual(
+      next(Cron.unsafeParse("0 0 */15 * *", tz), new Date("2020-02-18T00:00:00.000Z")),
+      new Date("2020-03-01T00:00:00.000Z")
+    )
+    // 30-day month: from the 20th the next day is the 31st (missing) → July 1.
+    deepStrictEqual(next(cron, new Date("2024-06-20T00:00:00.000Z")), new Date("2024-07-01T00:00:00.000Z"))
+  })
+
   it("prev clamps to the last valid day when rolling back a month with only month constraints", () => {
     const tz = DateTime.zoneUnsafeMakeNamed("UTC")
     const cron = Cron.unsafeParse("0 0 0 * FEB *", tz)


### PR DESCRIPTION
## What

`Cron.next` could **skip a scheduled run** when the next matching day-of-month does not exist in the current month.

### Reproduction

```ts
import { Cron, Either } from "effect"

const cron = Either.getOrThrow(Cron.parse("0 0 1,16,31 * *")) // runs on the 1st, 16th, 31st

// From Feb 18 2020, the next run should be March 1 (the 31st doesn't exist in Feb):
Cron.next(cron, new Date("2020-02-18T00:00:00Z"))
// → 2020-03-16T00:00:00Z   ❌  (March 1 was silently skipped)
// expected: 2020-03-01T00:00:00Z
```

The same happens for any expression whose day set contains a day (e.g. `31`) that is absent from the current month, including `*/15` (which expands to days `[1, 16, 31]`).

### Root cause

In the day-of-month branch of `stepCron` (`packages/effect/src/Cron.ts`), when there is still a matching day `>= currentDay` in the table, the step is computed as `b = nextDay - currentDay` and applied with `setUTCDate(currentDay + b)`. If `nextDay` is larger than the number of days in the current month (e.g. `31` in February), `setUTCDate` overflows into the **next** month and lands on the wrong day. The subsequent loop iteration then finds the next matching day *within that overshot month* (e.g. the 16th), skipping the earlier matching days (e.g. the 1st).

### Fix

When the selected `nextDay` does not exist in the current month, wrap to the **first** matching day of the next month instead — reusing the exact formula already used for the "no matching day left this month" case. This mirrors the behaviour of `Cron.prev` (which already has an analogous `day 31` test) and matches other cron implementations (verified against `cron-parser`).

The change is scoped to the forward direction (`!prev`); for `prev`, `nextDay <= currentDay <= daysInMonth`, so the new condition is always false and that path is untouched.

## Tests

- Added `Cron > next does not skip earlier days when the upcoming day is missing from the month`, covering `1,16,31`, `*/15`, and a 30-day-month case. The test **fails without the fix** (returns `2020-03-16`) and **passes with it**.
- Full `Cron` suite: **25/25 pass**. Typecheck (`tsc -b`) and ESLint clean.
- Cross-checked `Cron.next` against `cron-parser` over 8000 randomly generated expressions/start times: **0 mismatches** with the fix (the failures above were present before).

A changeset is included (`effect`, patch).
