### PR TITLE
fix(ai-anthropic): populate cachedInputTokens in streaming responses

### DIFF
--- a/.changeset/anthropic-streaming-cached-input-tokens.md
+++ b/.changeset/anthropic-streaming-cached-input-tokens.md
@@ -2,6 +2,4 @@
 "@effect/ai-anthropic": patch
 ---
 
-fix(ai-anthropic): populate `cachedInputTokens` in streaming responses from `cache_read_input_tokens`
-
-The streaming response builder never copied `cache_read_input_tokens` into the normalized `usage`, so `cachedInputTokens` was always `undefined`/`0` for `streamText`/`streamObject` even when prompt caching was active. The non-streaming path already maps it; this mirrors that mapping at `message_start`, where the Anthropic API reports the cache-read count.
+populate `cachedInputTokens` in streaming responses from `cache_read_input_tokens`

--- a/.changeset/anthropic-streaming-cached-input-tokens.md
+++ b/.changeset/anthropic-streaming-cached-input-tokens.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+fix(ai-anthropic): populate `cachedInputTokens` in streaming responses from `cache_read_input_tokens`
+
+The streaming response builder never copied `cache_read_input_tokens` into the normalized `usage`, so `cachedInputTokens` was always `undefined`/`0` for `streamText`/`streamObject` even when prompt caching was active. The non-streaming path already maps it; this mirrors that mapping at `message_start`, where the Anthropic API reports the cache-read count.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -971,6 +971,7 @@ const makeStreamResponse: (
           case "message_start": {
             // Track usage metadata
             usage.inputTokens = event.message.usage.input_tokens
+            usage.cachedInputTokens = event.message.usage.cache_read_input_tokens ?? undefined
             metaUsage = event.message.usage
 
             // Track response metadata


### PR DESCRIPTION
## Summary

The Anthropic streaming response builder (`makeStreamResponse`) populates `inputTokens`, `outputTokens`, and `totalTokens`, but never copies `cache_read_input_tokens` into the normalized `usage`. As a result `usage.cachedInputTokens` is always `undefined` for `streamText` / `streamObject`, even when prompt caching is active and the API reports a non-zero cache read at `message_start`. The non-streaming path already maps this field, so streaming and non-streaming disagree.

## Fix

Set `cachedInputTokens` from `cache_read_input_tokens` at `message_start` — where `input_tokens` is already read — mirroring the non-streaming mapping. The output payload shape is unchanged; only the previously-missing field is now populated.

```ts
case "message_start": {
  usage.inputTokens = event.message.usage.input_tokens
  usage.cachedInputTokens = event.message.usage.cache_read_input_tokens ?? undefined
  metaUsage = event.message.usage
  // ...
}
```

`event.message.usage` is `Generated.BetaUsage`, which already declares `cache_read_input_tokens`, so this matches the existing non-streaming mapping (`?? undefined`).

## Notes

I didn't add a streaming test — `packages/ai/anthropic` has no test harness for the language model adapter (no `test/` dir, and the sibling `ai-openai` package has none either), so there's no pattern yet for mocking the Anthropic SSE stream. Happy to follow up with a focused stream test once the maintainers point at the preferred mocking shape.

Cache *writes* (`cache_creation_input_tokens`) are out of scope — `@effect/ai`'s core `Usage` type has no corresponding field.

A changeset is included (`@effect/ai-anthropic`, patch).
