### PR TITLE
docs: fix foldWeightedDecompose example to type-check and terminate

### DIFF
--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -813,20 +813,23 @@ export const foldWeighted: <S, In>(
  * The `decompose` function will be used for decomposing elements that cause
  * an `S` aggregate to cross `max` into smaller elements. For example:
  *
- * ```ts skip-type-checking
- * pipe(
- *   Stream.make(1, 5, 1),
- *   Stream.transduce(
- *     Sink.foldWeightedDecompose(
- *       Chunk.empty<number>(),
- *       4,
- *       (n: number) => n,
- *       (n: number) => Chunk.make(n - 1, 1),
- *       (acc, el) => pipe(acc, Chunk.append(el))
- *     )
- *   ),
+ * ```ts
+ * import { Chunk, Effect, Sink, Stream } from "effect"
+ *
+ * const sink = Sink.foldWeightedDecompose({
+ *   initial: Chunk.empty<number>(),
+ *   maxCost: 4,
+ *   cost: (_acc, n: number) => n,
+ *   decompose: (n: number) => (n > 4 ? Chunk.make(4, n - 4) : Chunk.of(n)),
+ *   body: (acc, n) => Chunk.append(acc, n)
+ * })
+ *
+ * const program = Stream.make(1, 5, 1).pipe(
+ *   Stream.transduce(sink),
  *   Stream.runCollect
  * )
+ *
+ * Effect.runPromise(program).then(console.log)
  * ```
  *
  * The stream would emit the elements `Chunk(1), Chunk(4), Chunk(1, 1)`.


### PR DESCRIPTION
## Summary

The JSDoc example for `Sink.foldWeightedDecompose` used the old positional-argument
API (hidden behind ` ```ts skip-type-checking `) together with a `decompose` function
that never produced indivisible values. As a result the example failed to type-check
and hung at runtime — the behaviour reported in #5055.

This rewrites the example using the current object-style API and a terminating
`decompose`, and removes `skip-type-checking` so `@effect/docgen` validates the
example going forward. The documented output — `Chunk(1), Chunk(4), Chunk(1, 1)` —
is unchanged.

## Changes

- `packages/effect/src/Sink.ts` — replace the `foldWeightedDecompose` doc example
  (comment-only; no runtime/behaviour code touched).

## Tests

Verified the corrected example in isolation against the published `effect` package:

- `tsc --noEmit --strict` → passes (equivalent to docgen's example type-check)
- runtime via `tsx` → terminates and prints `[[1],[4],[1,1]]`, i.e.
  `Chunk(1), Chunk(4), Chunk(1, 1)` as documented

`@effect/docgen` could not be run locally in my environment; it will run in CI.
Happy to add a changeset if the project requires one for doc-only changes.

Resolves #5055

---

🤖 This PR was prepared with the assistance of AI tooling (Claude) and reviewed by a
human before submission.
