### PR TITLE
fix(effect): stop Schedule.cron crashing on a non-finite clock

### DIFF
--- a/.changeset/schedule-cron-non-finite-now.md
+++ b/.changeset/schedule-cron-non-finite-now.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Schedule.cron` crashing with `IllegalArgumentException: Invalid date` when the clock is advanced past the end of time (for example `TestClock.adjust(Infinity)`). A non-finite `now` produced an invalid `Date`, which made the internal `Cron.match`/`Cron.next` calls throw and crash the fiber. The cron schedule now finishes cleanly in that case, matching how other time-based schedules such as `Schedule.fixed` and `Schedule.spaced` already behave.

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -482,6 +482,15 @@ export const cron: {
   return makeWithState<[boolean, [number, number, number]], unknown, [number, number]>(
     [true, [Number.MIN_SAFE_INTEGER, 0, 0]],
     (now, _, [initial, previous]) => {
+      // past the end of time (e.g. `TestClock.adjust(Infinity)`) `now` is non-finite: no date to match, so stop
+      if (!Number.isFinite(now)) {
+        return core.succeed([
+          [false, previous],
+          [previous[1], previous[2]],
+          ScheduleDecision.done
+        ])
+      }
+
       if (now < previous[0]) {
         return core.succeed([
           [false, previous],

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -828,6 +828,17 @@ describe("Schedule", () => {
         yield* Effect.void.pipe(Effect.schedule(schedule))
         deepStrictEqual(log, [1, 1])
       }))
+    it.effect("finishes instead of crashing when the clock is past the end of time", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(new Date(2024, 0, 1, 0, 0, 0).getTime())
+        // advancing past the end of time makes `now` non-finite for the schedule
+        yield* TestClock.adjust(Infinity)
+        const exit = yield* Effect.void.pipe(
+          Effect.repeat(Schedule.cron("0 4 8-14 * *")),
+          Effect.exit
+        )
+        assertTrue(Exit.isSuccess(exit))
+      }))
   })
 })
 


### PR DESCRIPTION
Resolves #6292.

### Problem

Advancing the clock past the end of time, e.g. `TestClock.adjust(Infinity)`, crashes a running `Schedule.cron` with an uncaught `IllegalArgumentException: Invalid date` that kills the fiber:

```
IllegalArgumentException: Invalid date
  at unsafeFromDate (internal/dateTime.ts)
  at unsafeMakeZoned (internal/dateTime.ts)
  at match (Cron.ts)
  at ScheduleImpl.step (internal/schedule.ts)
```

### Cause

The cron schedule step turns the current time into a `Date` and runs calendar math on it:

```ts
const date = new Date(now)
if (initial && Cron.match(cron, date)) { ... }
next = Cron.next(cron, date).getTime()
```

When `now` is non-finite, `new Date(now)` is an Invalid Date. `Cron.match` / `Cron.next` then call `dateTime.unsafeMakeZoned`, whose `date.getTime()` is `NaN`, and `unsafeFromDate` throws by design. So the real bug is that `Schedule.cron` hands an invalid instant to the cron helpers.

Time-based neighbours like `Schedule.fixed` and `Schedule.spaced` do not crash here: they work with plain `now + delay` arithmetic and never build a `Date`, so a non-finite `now` just flows through.

### Fix

Guard the cron step: when `now` is non-finite there is no instant to match, so finish the schedule (`ScheduleDecision.done`) instead of throwing. This brings cron in line with how the other time-based schedules behave when the clock runs past the end of time, and leaves all finite behaviour untouched.

### Verification

Reproduced the crash deterministically (cron fails while `fixed` / `spaced` succeed under the same `now = Infinity`), confirmed the fix turns the failure into a clean `Success`, and added a regression test in the cron suite. `pnpm check` (tsc), `eslint`, and the full `Schedule` test suite (83 tests) all pass. Changeset included (`effect`: patch).
