### PR TITLE
fix(@effect/ai-openai): map max_output_tokens finish reason to length

### DIFF
--- a/.changeset/openai-max-output-tokens-finish-reason.md
+++ b/.changeset/openai-max-output-tokens-finish-reason.md
@@ -2,15 +2,4 @@
 "@effect/ai-openai": patch
 ---
 
-Map the OpenAI Responses `max_output_tokens` finish reason to `"length"`.
-
-The OpenAI Responses API reports a budget/output-length truncation as
-`response.incomplete` with `incomplete_details.reason: "max_output_tokens"`
-(distinct from the Chat Completions `finish_reason: "length"`). That key was
-missing from the internal `finishReasonMap`, so `resolveFinishReason` fell
-through to `"unknown"` for a genuinely length-truncated response instead of the
-portable `"length"` finish reason. A truncated turn now surfaces with
-`finishReason: "length"`, so consumers can distinguish (and react to) a
-budget-truncated response rather than treating it as an unknown/transport-level
-failure. `content_filter` was already mapped; only `max_output_tokens` was
-missing.
+Map the OpenAI Responses `max_output_tokens` finish reason to `length` instead of falling through to `unknown`.

--- a/.changeset/openai-max-output-tokens-finish-reason.md
+++ b/.changeset/openai-max-output-tokens-finish-reason.md
@@ -1,0 +1,16 @@
+---
+"@effect/ai-openai": patch
+---
+
+Map the OpenAI Responses `max_output_tokens` finish reason to `"length"`.
+
+The OpenAI Responses API reports a budget/output-length truncation as
+`response.incomplete` with `incomplete_details.reason: "max_output_tokens"`
+(distinct from the Chat Completions `finish_reason: "length"`). That key was
+missing from the internal `finishReasonMap`, so `resolveFinishReason` fell
+through to `"unknown"` for a genuinely length-truncated response instead of the
+portable `"length"` finish reason. A truncated turn now surfaces with
+`finishReason: "length"`, so consumers can distinguish (and react to) a
+budget-truncated response rather than treating it as an unknown/transport-level
+failure. `content_filter` was already mapped; only `max_output_tokens` was
+missing.

--- a/packages/ai/openai/src/internal/utilities.ts
+++ b/packages/ai/openai/src/internal/utilities.ts
@@ -11,6 +11,7 @@ const finishReasonMap: Record<string, Response.FinishReason> = {
   content_filter: "content-filter",
   function_call: "tool-calls",
   length: "length",
+  max_output_tokens: "length",
   stop: "stop",
   tool_calls: "tool-calls"
 }


### PR DESCRIPTION
## What

`@effect/ai-openai`'s internal `finishReasonMap` (`packages/ai/openai/src/internal/utilities.ts`) was missing the OpenAI **Responses API** truncation reason `max_output_tokens`.

The Responses API reports a budget/output-length truncation as a `response.incomplete` lifecycle terminal with `incomplete_details.reason: "max_output_tokens"` — distinct from the Chat Completions `finish_reason: "length"`. `resolveFinishReason` reads `response.incomplete_details?.reason` and looks it up in `finishReasonMap`; with `max_output_tokens` absent, it fell through to:

```ts
return hasToolCalls ? "tool-calls" : "unknown"
```

So a genuinely length-truncated Responses turn surfaced `finishReason: "unknown"` instead of the portable `"length"`. Consumers that treat `"unknown"` as a transport-level / no-terminal-finish failure (rather than a real, recoverable budget truncation) then mis-handle a perfectly valid truncated response.

## Change

Add `max_output_tokens: "length"` to `finishReasonMap` (one line). `content_filter` was already mapped (`"content-filter"`); only `max_output_tokens` was missing. After this, both the streaming `response.incomplete` event handler and the non-streaming terminal resolve a budget truncation to `finishReason: "length"`.

A changeset is included (`@effect/ai-openai` patch).

## Notes

- `"max_output_tokens" → "length"` is the semantically correct mapping in the `@effect/ai` `FinishReason` contract (both denote "ran out of output budget"); no new finish-reason variant is needed.
- The `packages/ai/openai` package has no existing unit-test suite for these internal helpers, so this follows the same fix-plus-changeset shape as comparable small provider-adapter corrections.