### PR TITLE
v3 fix: Made field-less `Schema.Struct({})` respect `onExcessProperty: 'ignore' | 'preserve' | 'error'`

### DIFF
--- a/.changeset/lazy-toes-hug.md
+++ b/.changeset/lazy-toes-hug.md
@@ -1,0 +1,76 @@
+---
+"effect": patch
+---
+
+Made field-less `Schema.Struct({})` respect `onExcessProperty: 'ignore' | 'preserve' | 'error'`
+
+Motivation: you remove one field, the resulting object gets fewer fields. You
+remove another, fewer again. You remove the last; suddenly all the fields come
+back, without respect to the default `onExcessProperty: "ignore"`. If the user
+wanted to get all the fields, they have an option to set
+`onExcessProperty: "preserve"`.
+
+I tried attempting to defend old behavior with "`{}` means
+`typeof obj === 'object' && obj !== null` and effect's schema tries to be
+closer to typescript's behaviour, by treating `Schema.Struct({})` as something
+passing the condition". And this might hold in isolation. But considering the
+context, by this logic, any fields which are not explicitly mentioned in
+`Schema.Struct({ ... })` should be preserved in all decoded objects, not only
+the ones that have `{}` signature, to follow typescript's assignability rules.
+And this is not what happens. The behavior should be consistent between
+field-less structs and field-ful.
+
+```ts
+const arg = { hello: 'asd', redundant: 'asd' }
+function fn(param: { hello: string }) {}
+fn(arg)
+```
+
+
+New behavior
+
+```ts
+import * as Schema from 'effect/Schema'
+
+const Something = Schema.Struct({})
+const decodeSomething = Schema.decodeSync(Something);
+
+const obj = { hello: 'stripped by default, unless asked otherwise' }
+
+console.log(decodeSomething(obj))
+// {}
+
+console.log(decodeSomething(obj, { onExcessProperty: 'ignore' }))
+// {}
+
+console.log(decodeSomething(obj, { onExcessProperty: 'preserve' }))
+// { hello: "stripped by default, unless asked otherwise" }
+
+decodeSomething(obj, { onExcessProperty: 'error' })
+// error: {}
+// └─ ["hello"]
+//    └─ is unexpected, expected: never
+```
+
+Old behavior:
+
+```ts
+import * as Schema from 'effect/Schema'
+
+const Something = Schema.Struct({})
+const decodeSomething = Schema.decodeSync(Something);
+
+const obj = { hello: 'stripped by default, unless asked otherwise' }
+
+console.log(decodeSomething(obj))
+// { hello: 'stripped by default, unless asked otherwise' }
+
+console.log(decodeSomething(obj, { onExcessProperty: 'ignore' }))
+// { hello: 'stripped by default, unless asked otherwise' }
+
+console.log(decodeSomething(obj, { onExcessProperty: 'preserve' }))
+// { hello: "stripped by default, unless asked otherwise" }
+
+decodeSomething(obj, { onExcessProperty: 'error' })
+// doesn't throw
+```

--- a/packages/effect/src/ParseResult.ts
+++ b/packages/effect/src/ParseResult.ts
@@ -1120,7 +1120,36 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
     }
     case "TypeLiteral": {
       if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
-        return fromRefinement(ast, Predicate.isNotNullable)
+        const makeUnexpectedPropertyIssue = (input: { [x: PropertyKey]: unknown }, key: PropertyKey) =>
+          new Pointer(key, input, new Unexpected(input[key], `is unexpected, expected: never`))
+
+        return (input, options) => {
+          if (!Predicate.isNotNullable(input)) {
+            return Either.left(new Type(ast, input))
+          }
+          // Only plain objects have "excess properties"; other non-nullish
+          // values (strings, numbers, arrays) pass through unchanged since {}
+          // accepts them.
+          if (!Predicate.isRecord(input)) {
+            return Either.right(input)
+          }
+          // "preserve" keeps the input (and all its properties) as-is.
+          if (options?.onExcessProperty === "preserve") {
+            return Either.right(input)
+          }
+          // "error": every own key is unexpected for an empty struct.
+          if (options?.onExcessProperty === "error") {
+            const keys = Reflect.ownKeys(input)
+            if (Arr.isNonEmptyArray(keys)) {
+              const issues = options.errors === "all"
+                ? sortByIndex(Arr.map(keys, (key, i) => [i, makeUnexpectedPropertyIssue(input, key)]))
+                : makeUnexpectedPropertyIssue(input, keys[0])
+              return Either.left(new Composite(ast, input, issues, {}))
+            }
+          }
+          // "ignore" (or "error" with no excess keys): strip everything to an empty object.
+          return Either.right({})
+        }
       }
 
       const propertySignatures: Array<readonly [Parser, AST.PropertySignature]> = []

--- a/packages/effect/src/ParseResult.ts
+++ b/packages/effect/src/ParseResult.ts
@@ -1102,7 +1102,36 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
     }
     case "TypeLiteral": {
       if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
-        return fromRefinement(ast, Predicate.isNotNullable)
+        const makeUnexpectedPropertyIssue = (input: { [x: PropertyKey]: unknown }, key: PropertyKey) =>
+          new Pointer(key, input, new Unexpected(input[key], `is unexpected, expected: never`))
+
+        return (input, options) => {
+          if (!Predicate.isNotNullable(input)) {
+            return Either.left(new Type(ast, input))
+          }
+          // Only plain objects have "excess properties"; other non-nullish
+          // values (strings, numbers, arrays) pass through unchanged since {}
+          // accepts them.
+          if (!Predicate.isRecord(input)) {
+            return Either.right(input)
+          }
+          // "preserve" keeps the input (and all its properties) as-is.
+          if (options?.onExcessProperty === "preserve") {
+            return Either.right(input)
+          }
+          // "error": every own key is unexpected for an empty struct.
+          if (options?.onExcessProperty === "error") {
+            const keys = Reflect.ownKeys(input)
+            if (Arr.isNonEmptyArray(keys)) {
+              const issues  = options.errors === "all"
+                ? sortByIndex(Arr.map(keys, (key, i) => [i, makeUnexpectedPropertyIssue(input, key)]))
+                : makeUnexpectedPropertyIssue(input, keys[0])
+              return Either.left(new Composite(ast, input, issues, {}))
+            }
+          }
+          // "ignore" (or "error" with no excess keys): strip everything to an empty object.
+          return Either.right({})
+        }
       }
 
       const propertySignatures: Array<readonly [Parser, AST.PropertySignature]> = []

--- a/packages/effect/test/Schema/Schema/Record/Record.test.ts
+++ b/packages/effect/test/Schema/Schema/Record/Record.test.ts
@@ -77,7 +77,7 @@ describe("record", () => {
     it("Record(never, number)", async () => {
       const schema = S.Record({ key: S.Never, value: S.Number })
       await Util.assertions.decoding.succeed(schema, {})
-      await Util.assertions.decoding.succeed(schema, { a: 1 })
+      await Util.assertions.decoding.succeed(schema, { a: 1 }, {})
     })
 
     it("Record(string, number)", async () => {

--- a/packages/effect/test/Schema/Schema/Struct/Struct.test.ts
+++ b/packages/effect/test/Schema/Schema/Struct/Struct.test.ts
@@ -46,7 +46,7 @@ describe("Struct", () => {
     it("empty", async () => {
       const schema = S.Struct({})
       await Util.assertions.decoding.succeed(schema, {})
-      await Util.assertions.decoding.succeed(schema, { a: 1 })
+      await Util.assertions.decoding.succeed(schema, { a: 1 }, {})
       await Util.assertions.decoding.succeed(schema, [])
 
       await Util.assertions.decoding.fail(
@@ -54,6 +54,17 @@ describe("Struct", () => {
         null,
         `Expected {}, actual null`
       )
+
+      await Util.assertions.decoding.fail(
+        schema,
+        { a: 1 },
+        `{}
+└─ ["a"]
+   └─ is unexpected, expected: never`,
+        { parseOptions: Util.onExcessPropertyError }
+      )
+
+      await Util.assertions.decoding.succeed(schema, { a: 1 }, { a: 1 }, { parseOptions: Util.onExcessPropertyPreserve })
     })
 
     it("required property signature", async () => {
@@ -196,7 +207,7 @@ describe("Struct", () => {
     it("empty", async () => {
       const schema = S.Struct({})
       await Util.assertions.encoding.succeed(schema, {}, {})
-      await Util.assertions.encoding.succeed(schema, { a: 1 }, { a: 1 })
+      await Util.assertions.encoding.succeed(schema, { a: 1 }, {})
       await Util.assertions.encoding.succeed(schema, [], [])
 
       await Util.assertions.encoding.fail(
@@ -204,6 +215,17 @@ describe("Struct", () => {
         null as any,
         `Expected {}, actual null`
       )
+
+      await Util.assertions.encoding.fail(
+        schema,
+        { a: 1 },
+        `{}
+└─ ["a"]
+   └─ is unexpected, expected: never`,
+        { parseOptions: Util.onExcessPropertyError }
+      )
+
+      await Util.assertions.encoding.succeed(schema, { a: 1 }, { a: 1 }, { parseOptions: Util.onExcessPropertyPreserve })
     })
 
     it("required property signature", async () => {

--- a/packages/effect/test/Schema/Schema/Struct/Struct.test.ts
+++ b/packages/effect/test/Schema/Schema/Struct/Struct.test.ts
@@ -46,7 +46,7 @@ describe("Struct", () => {
     it("empty", async () => {
       const schema = S.Struct({})
       await Util.assertions.decoding.succeed(schema, {})
-      await Util.assertions.decoding.succeed(schema, { a: 1 })
+      await Util.assertions.decoding.succeed(schema, { a: 1 }, {})
       await Util.assertions.decoding.succeed(schema, [])
 
       await Util.assertions.decoding.fail(
@@ -54,6 +54,19 @@ describe("Struct", () => {
         null,
         `Expected {}, actual null`
       )
+
+      await Util.assertions.decoding.fail(
+        schema,
+        { a: 1 },
+        `{}
+└─ ["a"]
+   └─ is unexpected, expected: never`,
+        { parseOptions: Util.onExcessPropertyError }
+      )
+
+      await Util.assertions.decoding.succeed(schema, { a: 1 }, { a: 1 }, {
+        parseOptions: Util.onExcessPropertyPreserve
+      })
     })
 
     it("required property signature", async () => {
@@ -196,7 +209,7 @@ describe("Struct", () => {
     it("empty", async () => {
       const schema = S.Struct({})
       await Util.assertions.encoding.succeed(schema, {}, {})
-      await Util.assertions.encoding.succeed(schema, { a: 1 }, { a: 1 })
+      await Util.assertions.encoding.succeed(schema, { a: 1 }, {})
       await Util.assertions.encoding.succeed(schema, [], [])
 
       await Util.assertions.encoding.fail(
@@ -204,6 +217,19 @@ describe("Struct", () => {
         null as any,
         `Expected {}, actual null`
       )
+
+      await Util.assertions.encoding.fail(
+        schema,
+        { a: 1 },
+        `{}
+└─ ["a"]
+   └─ is unexpected, expected: never`,
+        { parseOptions: Util.onExcessPropertyError }
+      )
+
+      await Util.assertions.encoding.succeed(schema, { a: 1 }, { a: 1 }, {
+        parseOptions: Util.onExcessPropertyPreserve
+      })
     })
 
     it("required property signature", async () => {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Motivation: you remove one field in the schema; the decoded object gets fewer fields. You remove another; fewer again. You remove the last; suddenly, all the fields come back, regardless of the default `onExcessProperty: "ignore"`. If the user wants to retrieve all fields, they can set `onExcessProperty: "preserve"`.

I tried to defend old behavior with "`{}` means `typeof obj === 'object' && obj !== null` and effect's schema tries to be closer to TypeScript's behaviour, by treating `Schema.Struct({})` as something passing the condition". And this might hold in isolation. But considering the context, by this logic, any fields which are not explicitly mentioned in `Schema.Struct({ ... })` should be preserved in all decoded objects, not only the ones that have `{}` signature, to follow TypeScript's assignability rules. And this is not what happens. The behavior should be consistent between field-less and field-ful structs.

## Related

- https://github.com/Effect-TS/effect/pull/6434