### PR TITLE
Fix `Schedule.cron` when the test clock is adjusted to infinity

### DIFF
--- a/.changeset/cron-testclock-infinity.md
+++ b/.changeset/cron-testclock-infinity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Schedule.cron` when the test clock is adjusted to infinity.

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -482,7 +482,7 @@ export const cron: {
   return makeWithState<[boolean, [number, number, number]], unknown, [number, number]>(
     [true, [Number.MIN_SAFE_INTEGER, 0, 0]],
     (now, _, [initial, previous]) => {
-      if (!Number.isFinite(now)) {
+      if (now === Number.POSITIVE_INFINITY) {
         return core.succeed([
           [false, previous],
           [previous[1], previous[2]],

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -482,6 +482,14 @@ export const cron: {
   return makeWithState<[boolean, [number, number, number]], unknown, [number, number]>(
     [true, [Number.MIN_SAFE_INTEGER, 0, 0]],
     (now, _, [initial, previous]) => {
+      if (!Number.isFinite(now)) {
+        return core.succeed([
+          [false, previous],
+          [previous[1], previous[2]],
+          ScheduleDecision.done
+        ])
+      }
+
       if (now < previous[0]) {
         return core.succeed([
           [false, previous],

--- a/packages/effect/test/Effect/scheduling.test.ts
+++ b/packages/effect/test/Effect/scheduling.test.ts
@@ -1,8 +1,11 @@
 import { describe, it } from "@effect/vitest"
-import { deepStrictEqual } from "@effect/vitest/utils"
+import { assertTrue, deepStrictEqual } from "@effect/vitest/utils"
 import * as Clock from "effect/Clock"
+import * as Cron from "effect/Cron"
+import * as Deferred from "effect/Deferred"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
 import { pipe } from "effect/Function"
 import * as Ref from "effect/Ref"
 import * as Schedule from "effect/Schedule"
@@ -75,5 +78,26 @@ describe("Effect", () => {
           start: 0
         }
       ])
+    }))
+
+  it.effect("schedule - cron does not fail when the test clock is adjusted to infinity", () =>
+    Effect.gen(function*() {
+      const ref = yield* Ref.make(0)
+      const latch = yield* Deferred.make<void>()
+      const cron = Cron.unsafeParse("0 0 4 8-14 * *", "UTC")
+      const schedule = pipe(Schedule.cron(cron), Schedule.intersect(Schedule.recurs(10)))
+      const fiber = yield* pipe(
+        Ref.update(ref, (n) => n + 1),
+        Effect.zipLeft(Deferred.await(latch)),
+        Effect.repeat(schedule),
+        Effect.fork
+      )
+
+      yield* TestClock.adjust(Infinity)
+      yield* Deferred.succeed(latch, void 0)
+      yield* Fiber.join(fiber)
+
+      const value = yield* Ref.get(ref)
+      assertTrue(value > 0)
     }))
 })

--- a/packages/effect/test/Effect/scheduling.test.ts
+++ b/packages/effect/test/Effect/scheduling.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@effect/vitest"
-import { assertTrue, deepStrictEqual } from "@effect/vitest/utils"
+import { deepStrictEqual } from "@effect/vitest/utils"
 import * as Clock from "effect/Clock"
-import * as Cron from "effect/Cron"
 import * as Deferred from "effect/Deferred"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -82,22 +81,15 @@ describe("Effect", () => {
 
   it.effect("schedule - cron does not fail when the test clock is adjusted to infinity", () =>
     Effect.gen(function*() {
-      const ref = yield* Ref.make(0)
       const latch = yield* Deferred.make<void>()
-      const cron = Cron.unsafeParse("0 0 4 8-14 * *", "UTC")
-      const schedule = pipe(Schedule.cron(cron), Schedule.intersect(Schedule.recurs(10)))
       const fiber = yield* pipe(
-        Ref.update(ref, (n) => n + 1),
-        Effect.zipLeft(Deferred.await(latch)),
-        Effect.repeat(schedule),
+        Deferred.await(latch),
+        Effect.repeat(Schedule.cron("0 0 4 8-14 * *", "UTC")),
         Effect.fork
       )
 
       yield* TestClock.adjust(Infinity)
       yield* Deferred.succeed(latch, void 0)
       yield* Fiber.join(fiber)
-
-      const value = yield* Ref.get(ref)
-      assertTrue(value > 0)
     }))
 })


### PR DESCRIPTION
Fixes #6292 