### PR TITLE
EFF-933 Fix EntityManager defect replay

### DIFF
--- a/.changeset/fix-entity-manager-defect-replay.md
+++ b/.changeset/fix-entity-manager-defect-replay.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Fix EntityManager defect restarts so in-flight requests are replayed instead of being dropped when the old entity scope is interrupted.

--- a/packages/cluster/src/internal/entityManager.ts
+++ b/packages/cluster/src/internal/entityManager.ts
@@ -144,7 +144,8 @@ export const make = Effect.fnUntraced(function*<
     )
 
     const activeRequests: EntityState["activeRequests"] = new Map()
-    let defectRequestIds: Array<bigint> = []
+    let defectRequestIds = new Set<bigint>()
+    let isRestartingDueToDefect = false
 
     // the server is stored in a ref, so if there is a defect, we can
     // swap the server without losing the active requests
@@ -180,6 +181,14 @@ export const make = Effect.fnUntraced(function*<
                 if (!request) return Effect.void
 
                 request.sentReply = true
+
+                if (
+                  isShuttingDown &&
+                  Exit.isInterrupted(response.exit) &&
+                  defectRequestIds.has(response.requestId)
+                ) {
+                  return Effect.void
+                }
 
                 // For durable messages, ignore interrupts during shutdown.
                 // They will be retried when the entity is restarted.
@@ -277,9 +286,11 @@ export const make = Effect.fnUntraced(function*<
           })
         )
 
-        if (defectRequestIds.length > 0) {
+        if (defectRequestIds.size > 0) {
           for (const id of defectRequestIds) {
-            const { lastSentChunk, message } = activeRequests.get(id)!
+            const request = activeRequests.get(id)
+            if (!request) continue
+            const { lastSentChunk, message } = request
             yield* server.write(0, {
               ...message.envelope,
               id: RequestId(message.envelope.requestId),
@@ -290,7 +301,7 @@ export const make = Effect.fnUntraced(function*<
               } as any) as any
             })
           }
-          defectRequestIds = []
+          defectRequestIds.clear()
         }
 
         return server.write
@@ -301,11 +312,18 @@ export const make = Effect.fnUntraced(function*<
       if (!activeServers.has(address.entityId)) {
         return endLatch.open
       }
+      if (isRestartingDueToDefect) {
+        return Effect.void
+      }
+      defectRequestIds = new Set(activeRequests.keys())
+      isRestartingDueToDefect = true
       const effect = writeRef.unsafeRebuild()
-      defectRequestIds = Array.from(activeRequests.keys())
       return Effect.logError("Defect in entity, restarting", cause).pipe(
         Effect.andThen(Effect.ignore(retryDriver.next(void 0))),
         Effect.flatMap(() => activeServers.has(address.entityId) ? effect : endLatch.open),
+        Effect.ensuring(Effect.sync(() => {
+          isRestartingDueToDefect = false
+        })),
         Effect.annotateLogs({
           module: "EntityManager",
           address,

--- a/packages/cluster/test/Sharding.test.ts
+++ b/packages/cluster/test/Sharding.test.ts
@@ -511,6 +511,26 @@ describe.concurrent("Sharding", () => {
       expect(result).toEqual(new User({ id: 123, name: "User 123" }))
       expect(state.layerBuilds.current).toEqual(2)
     }).pipe(Effect.provide(TestSharding)))
+
+  it.effect("replays in-flight requests when restarting after a defect", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const state = yield* TestEntityState
+      const makeClient = yield* TestEntity.client
+      const client = makeClient("1")
+
+      yield* client.NeverFork().pipe(Effect.fork)
+      yield* TestClock.adjust(1)
+      assert.deepStrictEqual(state.envelopes.unsafeSize(), Option.some(1))
+
+      MutableRef.set(state.defectTrigger, true)
+      const result = yield* client.GetUser({ id: 123 })
+      assert.deepStrictEqual(result, new User({ id: 123, name: "User 123" }))
+      assert.strictEqual(state.layerBuilds.current, 2)
+
+      yield* TestClock.adjust(1)
+      assert.deepStrictEqual(state.envelopes.unsafeSize(), Option.some(4))
+    }).pipe(Effect.provide(TestSharding)))
 })
 
 const TestShardingConfig = ShardingConfig.layer({


### PR DESCRIPTION
## Summary
- Backport EntityManager defect restart replay handling from v4 PR #2339.
- Preserve in-flight request tracking during defect-triggered rebuilds and suppress shutdown interrupt replies for requests queued for replay.
- Add a Sharding regression test and changeset for @effect/cluster.

## Validation
- pnpm lint-fix
- pnpm test run packages/cluster/test/Sharding.test.ts
- pnpm check
- pnpm build
- pnpm docgen