### PR TITLE
test: add coverage for Tuple.mapFirst, mapSecond, getEquivalence, getOrder

### DIFF
--- a/packages/effect/test/Tuple.test.ts
+++ b/packages/effect/test/Tuple.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { pipe, Tuple } from "effect"
+import { Equivalence, Order, pipe, Tuple } from "effect"
 
 describe("Tuple", () => {
   it("make", () => {
@@ -39,5 +39,29 @@ describe("Tuple", () => {
 
   it("at", () => {
     deepStrictEqual(Tuple.at([1, "hello", true], 1), "hello")
+  })
+
+  it("mapFirst", () => {
+    deepStrictEqual(Tuple.mapFirst(Tuple.make("a", 1), (s) => s + "!"), ["a!", 1])
+    deepStrictEqual(pipe(Tuple.make("a", 1), Tuple.mapFirst((s) => s + "!")), ["a!", 1])
+  })
+
+  it("mapSecond", () => {
+    deepStrictEqual(Tuple.mapSecond(Tuple.make("a", 1), (n) => n * 2), ["a", 2])
+    deepStrictEqual(pipe(Tuple.make("a", 1), Tuple.mapSecond((n) => n * 2)), ["a", 2])
+  })
+
+  it("getEquivalence", () => {
+    const equivalence = Tuple.getEquivalence(Equivalence.string, Equivalence.number)
+    strictEqual(equivalence(Tuple.make("a", 1), Tuple.make("a", 1)), true)
+    strictEqual(equivalence(Tuple.make("a", 1), Tuple.make("a", 2)), false)
+    strictEqual(equivalence(Tuple.make("a", 1), Tuple.make("b", 1)), false)
+  })
+
+  it("getOrder", () => {
+    const order = Tuple.getOrder(Order.string, Order.number)
+    strictEqual(order(Tuple.make("a", 1), Tuple.make("a", 2)), -1)
+    strictEqual(order(Tuple.make("a", 1), Tuple.make("a", 1)), 0)
+    strictEqual(order(Tuple.make("b", 1), Tuple.make("a", 1)), 1)
   })
 })


### PR DESCRIPTION
## What

Adds unit tests for four previously-untested `Tuple` exports:

- `Tuple.mapFirst`
- `Tuple.mapSecond`
- `Tuple.getEquivalence`
- `Tuple.getOrder`

## Why

These functions are part of the public `Tuple` API but had no test coverage. The
new tests exercise both the data-first and the pipeable (data-last) call forms
for `mapFirst`/`mapSecond`, and the equality / ordering semantics of
`getEquivalence` and `getOrder` (equal, less-than, greater-than cases).

## Scope

Test-only — no source or behavior changes, so no changeset is included (this PR
does not cause a version bump).

## Validation

- `vitest` for the `Tuple` suite passes locally.
- The asserted outputs were independently re-verified against the published
  `effect` runtime before submission.

## Disclosure

This contribution was prepared with AI assistance (Claude) and reviewed and
verified by the author before submission.
