### PR TITLE
test: add coverage for String case-conversion functions

### DIFF
--- a/packages/effect/test/String.test.ts
+++ b/packages/effect/test/String.test.ts
@@ -277,4 +277,30 @@ describe("String", () => {
       deepStrictEqual(Array.from(result), ["", "$", "    $Hello,", "    $World!", " $"])
     })
   })
+
+  describe("case conversion", () => {
+    it("snakeToCamel", () => {
+      strictEqual(Str.snakeToCamel("foo_bar_baz"), "fooBarBaz")
+    })
+
+    it("snakeToPascal", () => {
+      strictEqual(Str.snakeToPascal("foo_bar_baz"), "FooBarBaz")
+    })
+
+    it("snakeToKebab", () => {
+      strictEqual(Str.snakeToKebab("foo_bar_baz"), "foo-bar-baz")
+    })
+
+    it("camelToSnake", () => {
+      strictEqual(Str.camelToSnake("fooBarBaz"), "foo_bar_baz")
+    })
+
+    it("pascalToSnake", () => {
+      strictEqual(Str.pascalToSnake("FooBarBaz"), "foo_bar_baz")
+    })
+
+    it("kebabToSnake", () => {
+      strictEqual(Str.kebabToSnake("foo-bar-baz"), "foo_bar_baz")
+    })
+  })
 })


### PR DESCRIPTION
## What

Adds unit tests for six previously-untested `String` case-conversion exports:

- `String.snakeToCamel`
- `String.snakeToPascal`
- `String.snakeToKebab`
- `String.camelToSnake`
- `String.pascalToSnake`
- `String.kebabToSnake`

## Why

These case-conversion helpers are part of the public `String` API but had no
test coverage. The new tests document and lock in the expected conversions with
a shared `foo_bar_baz` / `fooBarBaz` / `FooBarBaz` / `foo-bar-baz` example
across all six directions.

## Scope

Test-only — no source or behavior changes, so no changeset is included (this PR
does not cause a version bump).

## Validation

- `vitest` for the `String` suite passes locally.
- The asserted outputs were independently re-verified against the published
  `effect` runtime before submission.

## Disclosure

This contribution was prepared with AI assistance (Claude) and reviewed and
verified by the author before submission.
