### PR TITLE
fix: prevent cachedWithTTL from suppressing interruption of the cached effect

### DIFF
--- a/.changeset/cached-with-ttl-interrupt.md
+++ b/.changeset/cached-with-ttl-interrupt.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `Effect.cachedWithTTL` and `Effect.cachedInvalidateWithTTL` suppressing interruption (e.g. `Effect.timeout`) of the cached effect.
+
+The cached effect was executed under `uninterruptibleMask` while populating the cache, which prevented interruption-based combinators such as `Effect.timeout` from firing. The cached effect now runs with the caller's interruptibility restored, matching the behaviour of the non-cached effect.

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -263,12 +263,13 @@ export const cachedInvalidateWithTTL: {
 const computeCachedValue = <A, E, R>(
   self: Effect.Effect<A, E, R>,
   timeToLive: Duration.DurationInput,
-  start: number
+  start: number,
+  restore: <AX, EX, RX>(effect: Effect.Effect<AX, EX, RX>) => Effect.Effect<AX, EX, RX>
 ): Effect.Effect<Option.Option<[number, Deferred.Deferred<A, E>]>, never, R> => {
   const timeToLiveMillis = Duration.toMillis(Duration.decode(timeToLive))
   return pipe(
     core.deferredMake<A, E>(),
-    core.tap((deferred) => core.intoDeferred(self, deferred)),
+    core.tap((deferred) => core.intoDeferred(restore(self), deferred)),
     core.map((deferred) => Option.some([start + timeToLiveMillis, deferred]))
   )
 }
@@ -286,12 +287,12 @@ const getCachedValue = <A, E, R>(
         updateSomeAndGetEffectSynchronized(cache, (option) => {
           switch (option._tag) {
             case "None": {
-              return Option.some(computeCachedValue(self, timeToLive, time))
+              return Option.some(computeCachedValue(self, timeToLive, time, restore))
             }
             case "Some": {
               const [end] = option.value
               return end - time <= 0
-                ? Option.some(computeCachedValue(self, timeToLive, time))
+                ? Option.some(computeCachedValue(self, timeToLive, time, restore))
                 : Option.none()
             }
           }

--- a/packages/effect/test/Effect/caching.test.ts
+++ b/packages/effect/test/Effect/caching.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "@effect/vitest"
-import { assertTrue, strictEqual } from "@effect/vitest/utils"
+import { assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import { pipe } from "effect/Function"
 import * as Ref from "effect/Ref"
 import * as TestClock from "effect/TestClock"
@@ -61,5 +62,25 @@ describe("Effect", () => {
       assertTrue(b !== c)
       strictEqual(c, d)
       assertTrue(d !== e)
+    }))
+  it.live("cachedWithTTL - does not suppress interruption of the cached effect (timeout)", () =>
+    Effect.gen(function*() {
+      const cached = yield* pipe(
+        Effect.never,
+        Effect.timeoutFail({ duration: Duration.millis(10), onTimeout: () => "Timeout" as const }),
+        Effect.cachedWithTTL(Duration.minutes(1))
+      )
+      const exit = yield* Effect.exit(cached)
+      deepStrictEqual(exit, Exit.fail("Timeout"))
+    }))
+  it.live("cachedInvalidateWithTTL - does not suppress interruption of the cached effect (timeout)", () =>
+    Effect.gen(function*() {
+      const [cached] = yield* pipe(
+        Effect.never,
+        Effect.timeoutFail({ duration: Duration.millis(10), onTimeout: () => "Timeout" as const }),
+        Effect.cachedInvalidateWithTTL(Duration.minutes(1))
+      )
+      const exit = yield* Effect.exit(cached)
+      deepStrictEqual(exit, Exit.fail("Timeout"))
     }))
 })


### PR DESCRIPTION
Closes #6304

`Effect.cachedWithTTL` / `Effect.cachedInvalidateWithTTL` run the cached effect uninterruptibly: `getCachedValue` wraps populate-and-await in `core.uninterruptibleMask`, and `computeCachedValue` runs the user effect via `core.intoDeferred(self, deferred)` under that mask — so interruption-based combinators like `Effect.timeout` can never fire and the fiber hangs. (`Effect.cached` is unaffected because it maps to `effect.memoize`, a different path.)

The mask's `restore` was only applied to `deferredAwait`, not to running `self`. This threads `restore` into `computeCachedValue` and applies it to the cached effect:

```diff
-      core.intoDeferred(self, deferred)
+      core.intoDeferred(restore(self), deferred)
```

- Added `it.live` tests for both combinators asserting a timed-out cached effect yields `Exit.fail("Timeout")`; without the fix they hang ~15s and fail.
- `pnpm test run test/Effect/caching.test.ts` → 5 passed; `pnpm --filter=effect check` clean. Changeset included.


## Validation update (2026-09-22)
Merged the current v3 base, including its TSTyche 7.2.1 toolchain. The cached-effect regression remains unchanged. Validation passed: lint-fix; 5 caching tests; pnpm check; pnpm test-types --target '>=5.4' (7 compiler targets, 462 file runs, 5,600 tests); pnpm build; pnpm docgen. Head be17d310b.

AI assistance: OpenAI Codex.
