### PR TITLE
fix(platform): do not consume body when inspecting HttpIncomingMessage

### DIFF
--- a/.changeset/http-incoming-message-inspect-no-consume-body.md
+++ b/.changeset/http-incoming-message-inspect-no-consume-body.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Stop `HttpIncomingMessage` inspection from consuming the body. Logging or `toJSON`-ing an `HttpClientResponse` (or server request) with a streamed body previously read the body eagerly, which locked the underlying one-shot `ReadableStream` and made subsequent `response.stream` reads fail with `ReadableStream is locked`.

--- a/packages/platform/src/HttpIncomingMessage.ts
+++ b/packages/platform/src/HttpIncomingMessage.ts
@@ -101,28 +101,12 @@ export const withMaxBodySize = dual<
  * @since 1.0.0
  */
 export const inspect = <E>(self: HttpIncomingMessage<E>, that: object): object => {
-  const contentType = self.headers["content-type"] ?? ""
-  let body: unknown
-  if (contentType.includes("application/json")) {
-    try {
-      body = Effect.runSync(self.json)
-    } catch {
-      //
-    }
-  } else if (contentType.includes("text/") || contentType.includes("urlencoded")) {
-    try {
-      body = Effect.runSync(self.text)
-    } catch {
-      //
-    }
-  }
-  const obj: any = {
+  // NOTE: intentionally does not read the body here. Reading `self.text` /
+  // `self.json` eagerly consumes (and locks) the underlying one-shot body
+  // stream, which corrupts the message just by logging/inspecting it.
+  return {
     ...that,
     headers: Inspectable.redact(self.headers),
     remoteAddress: self.remoteAddress.toJSON()
   }
-  if (body !== undefined) {
-    obj.body = body
-  }
-  return obj
 }

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -293,6 +293,28 @@ describe("HttpClient", () => {
     })
   })
 
+  it.effect("logging a streamed response does not lock its body", () =>
+    Effect.gen(function*() {
+      const request = HttpClientRequest.get("http://example.com")
+      const source = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("data: hello\n\n"))
+            controller.enqueue(new TextEncoder().encode("data: world\n\n"))
+            controller.close()
+          }
+        }),
+        { headers: { "content-type": "text/event-stream; charset=utf-8" } }
+      )
+      const response = HttpClientResponse.fromWeb(request, source)
+
+      // Inspecting/logging the response must not consume its one-shot body.
+      Inspectable.toStringUnknown(response)
+
+      const body = yield* response.stream.pipe(Stream.decodeText(), Stream.mkString)
+      strictEqual(body, "data: hello\n\ndata: world\n\n")
+    }))
+
   it.effect("followRedirects", () =>
     Effect.gen(function*() {
       const defaultClient = yield* HttpClient.HttpClient


### PR DESCRIPTION
## Problem
Logging or `toJSON`-ing an `HttpClientResponse` whose body is being streamed locks the underlying `ReadableStream`, so a later `response.stream` read fails with `TypeError: Invalid state: ReadableStream is locked` (#5341).

## Root cause
`HttpIncomingMessage.inspect()` eagerly read the body via `Effect.runSync(self.text/self.json)`. For a one-shot streamed body this consumes and locks the stream. Note that `self.text` is async, so the `runSync` call actually always threw and the "body" value was swallowed anyway — the read was a pure destructive side effect.

## Fix
Make `inspect()` side-effect free: it no longer reads the body. An `Inspectable.toJSON` must not consume a one-shot resource simply by being logged.

## Testing
Added a test in `packages/platform/test/HttpClient.test.ts` ("logging a streamed response does not lock its body") — red before, green after. Full `HttpClient.test.ts` and `tsc -b` pass. Changeset included.

Closes #5341
