### PR TITLE
fix(cli): make `Command.withSubcommands` not lose context type inference

### DIFF
--- a/.changeset/fix-cli-subcommands-requirements.md
+++ b/.changeset/fix-cli-subcommands-requirements.md
@@ -4,4 +4,3 @@
 
 - Fix `Command.withSubcommands` collapsing the inferred requirements type to `never` when given more than one subcommand
 - Export a `Command.Services` utility type to extract the required services from a `Command`
-

--- a/.changeset/fix-cli-subcommands-requirements.md
+++ b/.changeset/fix-cli-subcommands-requirements.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+- Fix `Command.withSubcommands` collapsing the inferred requirements type to `never` when given more than one subcommand
+- Export a `Command.Services` utility type to extract the required services from a `Command`
+

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -375,7 +375,7 @@ export type Error<C> = C extends Command<
  * @category utility types
  * @since 4.0.0
  */
-export type Error<C> = C extends Command<
+export type Services<C> = C extends Command<
   infer _Name,
   infer _Input,
   infer _ContextInput,

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -370,6 +370,21 @@ export type Error<C> = C extends Command<
   never
 
 /**
+ * A utility type to extract the required services type from a `Command`.
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export type Error<C> = C extends Command<
+  infer _Name,
+  infer _Input,
+  infer _ContextInput,
+  infer _Error,
+  infer _Requirements
+> ? _Requirements :
+  never
+
+/**
  * Service context for a specific command, enabling subcommands to access their parent's parsed configuration.
  *
  * **Details**
@@ -930,8 +945,7 @@ type ExtractSubcommand<T> = T extends Command<infer _Name, infer _Input, infer _
   : T extends Command.SubcommandGroup<infer Commands> ? Commands[number]
   : never
 type ExtractSubcommandErrors<T extends ReadonlyArray<Command.SubcommandEntry>> = Error<ExtractSubcommand<T[number]>>
-type ExtractSubcommandContext<T extends ReadonlyArray<Command.SubcommandEntry>> = ExtractSubcommand<T[number]> extends
-  Command<infer _Name, infer _Input, infer _CI, infer _E, infer _R> ? _R : never
+type ExtractSubcommandContext<T extends ReadonlyArray<Command.SubcommandEntry>> = Services<ExtractSubcommand<T[number]>>
 
 /**
  * Sets the description for a command.

--- a/packages/effect/typetest/unstable/cli/Command.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Command.tst.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Context, Effect } from "effect"
 import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli"
 import { describe, expect, it } from "tstyche"
 

--- a/packages/effect/typetest/unstable/cli/Command.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Command.tst.ts
@@ -3,6 +3,26 @@ import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli"
 import { describe, expect, it } from "tstyche"
 
 describe("Command", () => {
+  describe("withSubcommands", () => {
+    it("unions errors and requirements across multiple subcommands", () => {
+      class _ServiceA extends Context.Service<_ServiceA, string>()("ServiceA") {}
+      class _ServiceB extends Context.Service<_ServiceB, string>()("ServiceB") {}
+      class _ServiceC extends Context.Service<_ServiceC, string>()("ServiceC") {}
+
+      const childA = Command.make("child-a", {}, () => Effect.void as Effect.Effect<void, "err-a", _ServiceA>)
+      const childB = Command.make("child-b", {}, () => Effect.void as Effect.Effect<void, "err-b", _ServiceB>)
+      const childC = Command.make("child-c", {}, () => Effect.void as Effect.Effect<void, "err-c", _ServiceC>)
+
+      const root = Command.make("root").pipe(
+        Command.withSubcommands([childA, childB, childC])
+      )
+
+      expect(root).type.toBe<
+        Command.Command<"root", {}, {}, "err-a" | "err-b" | "err-c", _ServiceA | _ServiceB | _ServiceC>
+      >()
+    })
+  })
+
   describe("withSharedFlags", () => {
     it("adds shared flags to command input and parent context", () => {
       const root = Command.make("root", {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Added `Services<C>` utility type export to `unstable/cli/Command.ts` module (similar to `Error<C>`)
- Refactored `ExtractSubcommandContext` type to fix commands context type inference

## Related

- Closes Effect-TS/effect#6327
