### PR TITLE
fix: repair provider-defined tools (Tool cloning + Anthropic client tools)

### DIFF
--- a/.changeset/fix-anthropic-memory-tool.md
+++ b/.changeset/fix-anthropic-memory-tool.md
@@ -1,0 +1,11 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Fix client-executed provider tools (Memory, Text Editor, Computer Use, Bash) which were unusable on the wire.
+
+- `makeResponse` (and the streaming equivalents) now map a provider `tool_use` wire name (e.g. `"memory"`) back to the tool's custom name (e.g. `"AnthropicMemory"`) that the toolkit is keyed by, instead of raising `ToolNotFoundError`.
+- `AnthropicTool.MemoryCreateCommand` now includes the required `file_text` field, so a `create` command no longer drops the file body.
+- Optional parameters on client-executed provider tools now use `Schema.optionalKey` instead of `Schema.optional`, which the Anthropic codec rejected with "Unsupported AST Undefined": `Memory`/`TextEditor` `view_range`, `ComputerUse` `coordinate`, and `Bash` `restart`.
+
+Closes #2615.

--- a/.changeset/fix-tool-provider-defined-clone.md
+++ b/.changeset/fix-tool-provider-defined-clone.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Tool: preserve the tool kind when cloning provider-defined and dynamic tools.
+
+`Tool.addDependency`, `setParameters`, `setSuccess`, `setFailure`, `annotate`, and `annotateMerge` previously rebuilt the tool as a user-defined tool, which flipped `Tool.isProviderDefined` to `false`, corrupted the provider `id` (e.g. `anthropic.memory_20250818`), and crashed `Tool.getStrictMode`. These operations now clone the tool while preserving its prototype, `id`, and kind. Provider-defined tools also now carry an empty annotations context so `Tool.getStrictMode`/`annotate` work on them. Closes #2615.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -1618,12 +1618,15 @@ const makeResponse = Effect.fnUntraced(
               }
               : undefined
 
-            const params = yield* transformToolCallParams(options.tools, part.name, part.input)
+            // Map the provider wire name (e.g. "memory") back to the tool's
+            // custom name (e.g. "AnthropicMemory") that the toolkit is keyed by
+            const toolName = toolNameMapper.getCustomName(part.name)
+            const params = yield* transformToolCallParams(options.tools, toolName, part.input)
 
             parts.push({
               type: "tool-call",
               id: part.id,
-              name: part.name,
+              name: toolName,
               params,
               ...(Predicate.isNotUndefined(callerInfo)
                 ? { metadata: { anthropic: { caller: callerInfo } } }
@@ -2036,10 +2039,15 @@ const makeStreamResponse = Effect.fnUntraced(
                     }
                     : undefined
 
+                  // Map the provider wire name (e.g. "memory") back to the
+                  // tool's custom name (e.g. "AnthropicMemory") that the toolkit
+                  // is keyed by
+                  const toolName = toolNameMapper.getCustomName(part.name)
+
                   parts.push({
                     type: "tool-params-start",
                     id: part.id,
-                    name: part.name
+                    name: toolName
                   })
 
                   parts.push({
@@ -2053,12 +2061,12 @@ const makeStreamResponse = Effect.fnUntraced(
                     id: part.id
                   })
 
-                  const params = yield* transformToolCallParams(options.tools, part.name, part.input)
+                  const params = yield* transformToolCallParams(options.tools, toolName, part.input)
 
                   parts.push({
                     type: "tool-call",
                     id: part.id,
-                    name: part.name,
+                    name: toolName,
                     params,
                     ...(Predicate.isNotUndefined(callerInfo)
                       ? { metadata: { anthropic: { caller: callerInfo } } }
@@ -2206,10 +2214,15 @@ const makeStreamResponse = Effect.fnUntraced(
 
                 const hasParams = Object.keys(part.input).length > 0
                 const initialParams = hasParams ? JSON.stringify(part.input) : ""
+                // Map the provider wire name (e.g. "memory") back to the tool's
+                // custom name (e.g. "AnthropicMemory") that the toolkit is keyed
+                // by. The mapped name flows to the finalized tool-call via
+                // `contentBlock.name` on `content_block_stop`.
+                const toolName = toolNameMapper.getCustomName(part.name)
                 contentBlocks.set(event.index, {
                   type: "tool-call",
                   id: part.id,
-                  name: part.name,
+                  name: toolName,
                   params: initialParams,
                   firstDelta: initialParams.length > 0,
                   ...(Predicate.isNotUndefined(caller) ? { caller } : undefined)
@@ -2218,7 +2231,7 @@ const makeStreamResponse = Effect.fnUntraced(
                 parts.push({
                   type: "tool-params-start",
                   id: part.id,
-                  name: part.name
+                  name: toolName
                 })
 
                 break

--- a/packages/ai/anthropic/src/AnthropicTool.ts
+++ b/packages/ai/anthropic/src/AnthropicTool.ts
@@ -76,7 +76,7 @@ export const Bash_20241022 = Tool.providerDefined({
   success: Schema.String,
   parameters: Schema.Struct({
     command: Schema.String,
-    restart: Schema.optional(Schema.Boolean)
+    restart: Schema.optionalKey(Schema.Boolean)
   })
 })
 
@@ -106,7 +106,7 @@ export const Bash_20250124 = Tool.providerDefined({
   success: Schema.String,
   parameters: Schema.Struct({
     command: Schema.String,
-    restart: Schema.optional(Schema.Boolean)
+    restart: Schema.optionalKey(Schema.Boolean)
   })
 })
 
@@ -671,7 +671,7 @@ export const ComputerUseLeftClickAction = Schema.Struct({
    * The `[x, y]` coordinate on the screen to left click (defaults to the current
    * mouse position if omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for performing a left click, optionally at a specific coordinate.
@@ -829,7 +829,7 @@ export const ComputerUseDoubleClickAction = Schema.Struct({
    * The coordinate to double click (defaults to the current mouse position if
    * omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for performing a double click, optionally at a specific coordinate.
@@ -955,7 +955,7 @@ export const ComputerUseLeftMouseDownAction = Schema.Struct({
    * The coordinate at which the left mouse button should be held down (defaults
    * to the current mouse position if omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for pressing and holding the left mouse button, optionally at a specific coordinate.
@@ -982,7 +982,7 @@ export const ComputerUseLeftMouseUpAction = Schema.Struct({
    * The coordinate at which the left mouse button should be released (defaults
    * to the current mouse position if omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for releasing the left mouse button, optionally at a specific coordinate.
@@ -1023,7 +1023,7 @@ export const ComputerUseMiddleClickAction = Schema.Struct({
    * The coordinate to middle click (defaults to the current mouse position if
    * omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for performing a middle click, optionally at a specific coordinate.
@@ -1060,7 +1060,7 @@ export const ComputerUseRightClickAction = Schema.Struct({
    * The coordinate to right click (defaults to the current mouse position if
    * omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for performing a right click, optionally at a specific coordinate.
@@ -1099,7 +1099,7 @@ export const ComputerUseScrollAction = Schema.Struct({
    * The coordinate to start scrolling from (defaults to the current mouse
    * position if omitted).
    */
-  coordinate: Schema.optional(Coordinate),
+  coordinate: Schema.optionalKey(Coordinate),
   /**
    * The direction to scroll.
    */
@@ -1148,7 +1148,7 @@ export const ComputerUseTripleClickAction = Schema.Struct({
    * The coordinate to triple click (defaults to the current mouse position if
    * omitted).
    */
-  coordinate: Schema.optional(Coordinate)
+  coordinate: Schema.optionalKey(Coordinate)
 })
 /**
  * Computer-use action payload for performing a triple click, optionally at a specific coordinate.
@@ -1405,7 +1405,8 @@ export type ViewRange = typeof ViewRange.Type
  *
  * **Details**
  *
- * The payload contains `command: "create"` and a `path` string.
+ * The payload contains `command: "create"`, a `path` string, and the
+ * `file_text` content to write to the file.
  *
  * @category memory
  * @since 4.0.0
@@ -1415,7 +1416,11 @@ export const MemoryCreateCommand = Schema.Struct({
   /**
    * The path to the file that should be created.
    */
-  path: Schema.String
+  path: Schema.String,
+  /**
+   * The content to write to the file.
+   */
+  file_text: Schema.String
 })
 /**
  * Memory tool command payload for creating a new file at a path.
@@ -1578,7 +1583,7 @@ export const MemoryViewCommand = Schema.Struct({
   /**
    * The specific lines to view.
    */
-  view_range: Schema.optional(ViewRange)
+  view_range: Schema.optionalKey(ViewRange)
 })
 /**
  * Memory tool command payload for viewing a file or directory, optionally with a file line range.
@@ -1659,7 +1664,7 @@ export const TextEditorViewCommand = Schema.Struct({
    * Optional line range to view (only applies to files, not directories).
    * Lines are 1-indexed. Use -1 for end to read to end of file.
    */
-  view_range: Schema.optional(ViewRange)
+  view_range: Schema.optionalKey(ViewRange)
 })
 /**
  * Text editor command payload for viewing file contents or listing directory contents.

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -1,7 +1,7 @@
-import { AnthropicClient, AnthropicLanguageModel } from "@effect/ai-anthropic"
+import { AnthropicClient, AnthropicLanguageModel, AnthropicTool } from "@effect/ai-anthropic"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted, Schema, Stream } from "effect"
-import { LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
+import { AnthropicStructuredOutput, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("AnthropicLanguageModel", () => {
@@ -335,6 +335,140 @@ describe("AnthropicLanguageModel", () => {
 
     it.effect("uses native json_schema output for claude-sonnet-4-6", () =>
       assertNativeStructuredOutput("claude-sonnet-4-6"))
+  })
+
+  // The packaged `Memory_20250818` tool ships `customName: "AnthropicMemory"` /
+  // `providerName: "memory"`, and is a client-executed provider tool. These
+  // tests cover the round-trip that was broken on beta.98 (see #2615):
+  //  - the provider wire name ("memory") must resolve to the toolkit's custom
+  //    name ("AnthropicMemory"), otherwise `makeResponse` raises ToolNotFound
+  //  - `view_range` uses `Schema.optionalKey`, otherwise the Anthropic codec
+  //    rejects the tool schema with "Unsupported AST Undefined"
+  //  - `create` must carry `file_text`, otherwise the file body is dropped
+  describe("Memory tool", () => {
+    const memoryResponse = (request: HttpClientRequest.HttpClientRequest, input: unknown) =>
+      jsonResponse(request, {
+        id: "msg_test_1",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-20250514",
+        content: [{ type: "tool_use", id: "toolu_mem_1", name: "memory", input }],
+        stop_reason: "tool_use",
+        stop_sequence: null,
+        usage: {
+          cache_creation: null,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          inference_geo: null,
+          input_tokens: 10,
+          output_tokens: 5,
+          service_tier: null
+        }
+      })
+
+    it.effect("resolves the provider wire name to the tool's custom name (view)", () =>
+      Effect.gen(function*() {
+        let receivedParams: unknown = undefined
+        const toolkit = Toolkit.make(AnthropicTool.Memory_20250818({}))
+        const toolkitLayer = toolkit.toLayer({
+          AnthropicMemory: (params) => {
+            receivedParams = params
+            return Effect.succeed("memory listing")
+          }
+        })
+
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => Effect.succeed(memoryResponse(request, { command: "view", path: "/memories" })))
+          ))
+        )
+
+        const response = yield* LanguageModel.generateText({
+          prompt: "check memory",
+          toolkit
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(toolkitLayer),
+          Effect.provide(layer)
+        )
+
+        // Handler was resolved under the custom name and received the decoded command
+        assert.deepStrictEqual(receivedParams, { command: "view", path: "/memories" })
+
+        const toolResult = response.toolResults[0]
+        assert.isDefined(toolResult)
+        assert.strictEqual(toolResult.name, "AnthropicMemory")
+        assert.strictEqual(toolResult.result, "memory listing")
+      }))
+
+    it.effect("decodes the create command including file_text", () =>
+      Effect.gen(function*() {
+        let receivedParams: unknown = undefined
+        const toolkit = Toolkit.make(AnthropicTool.Memory_20250818({}))
+        const toolkitLayer = toolkit.toLayer({
+          AnthropicMemory: (params) => {
+            receivedParams = params
+            return Effect.succeed("File created successfully at: /memories/notes.txt")
+          }
+        })
+
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(memoryResponse(request, {
+                command: "create",
+                path: "/memories/notes.txt",
+                file_text: "hello world"
+              }))
+            )
+          ))
+        )
+
+        const response = yield* LanguageModel.generateText({
+          prompt: "save a note",
+          toolkit
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(toolkitLayer),
+          Effect.provide(layer)
+        )
+
+        assert.deepStrictEqual(receivedParams, {
+          command: "create",
+          path: "/memories/notes.txt",
+          file_text: "hello world"
+        })
+        assert.strictEqual(response.toolResults[0]?.name, "AnthropicMemory")
+      }))
+  })
+
+  // Client-executed (`requiresHandler`) provider tools have their `parameters`
+  // decoded via `toCodecAnthropic` when the model calls them. Optional
+  // parameters must use `Schema.optionalKey` (not `Schema.optional`), otherwise
+  // the codec rejects the schema with "Unsupported AST Undefined" (see #2615).
+  describe("client provider tool parameters compile with the Anthropic codec", () => {
+    const displayArgs = { displayWidthPx: 800, displayHeightPx: 600 }
+    const clientTools: ReadonlyArray<readonly [string, Tool.AnyProviderDefined]> = [
+      ["Bash_20241022", AnthropicTool.Bash_20241022({})],
+      ["Bash_20250124", AnthropicTool.Bash_20250124({})],
+      ["ComputerUse_20241022", AnthropicTool.ComputerUse_20241022(displayArgs)],
+      ["ComputerUse_20250124", AnthropicTool.ComputerUse_20250124(displayArgs)],
+      ["ComputerUse_20251124", AnthropicTool.ComputerUse_20251124(displayArgs)],
+      ["Memory_20250818", AnthropicTool.Memory_20250818({})],
+      ["TextEditor_20241022", AnthropicTool.TextEditor_20241022({})],
+      ["TextEditor_20250124", AnthropicTool.TextEditor_20250124({})],
+      ["TextEditor_20250429", AnthropicTool.TextEditor_20250429({})],
+      ["TextEditor_20250728", AnthropicTool.TextEditor_20250728({})]
+    ]
+
+    for (const [name, tool] of clientTools) {
+      it(name, () => {
+        const codec = AnthropicStructuredOutput.toCodecAnthropic(tool.parametersSchema)
+        assert.isDefined(codec)
+      })
+    }
   })
 })
 

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -1028,37 +1028,34 @@ export type RequiresHandler<Tool extends Any> = Tool extends ProviderDefined<
 // Constructors
 // =============================================================================
 
+// Clones a tool while preserving its prototype (and thus its kind, e.g.
+// user-defined vs. provider-defined vs. dynamic) and its own properties such
+// as `id`. Optional `overrides` replace individual fields on the clone.
+const clone = (self: Any, overrides?: Record<string, unknown>): any =>
+  Object.assign(Object.create(Object.getPrototypeOf(self)), self, overrides)
+
 const Proto = {
   [TypeId]: { _Requirements: identity },
   pipe() {
     return pipeArguments(this, arguments)
   },
   addDependency(this: Any) {
-    return userDefinedProto({ ...this })
+    return clone(this)
   },
   setParameters(this: Any, parametersSchema: Schema.Constraint) {
-    return userDefinedProto({
-      ...this,
-      parametersSchema
-    })
+    return clone(this, { parametersSchema })
   },
   setSuccess(this: Any, successSchema: Schema.Constraint) {
-    return userDefinedProto({ ...this, successSchema })
+    return clone(this, { successSchema })
   },
   setFailure(this: Any, failureSchema: Schema.Constraint) {
-    return userDefinedProto({ ...this, failureSchema })
+    return clone(this, { failureSchema })
   },
   annotate<I, S>(this: Any, tag: Context.Key<I, S>, value: S) {
-    return userDefinedProto({
-      ...this,
-      annotations: Context.add(this.annotations, tag, value)
-    })
+    return clone(this, { annotations: Context.add(this.annotations, tag, value) })
   },
   annotateMerge<I>(this: Any, context: Context.Context<I>) {
-    return userDefinedProto({
-      ...this,
-      annotations: Context.merge(this.annotations, context)
-    })
+    return clone(this, { annotations: Context.merge(this.annotations, context) })
   }
 }
 
@@ -1132,7 +1129,7 @@ const providerDefinedProto = <
     readonly failureMode: Mode
   },
   RequiresHandler
-> => Object.assign(Object.create(ProviderDefinedProto), { ...options })
+> => Object.assign(Object.create(ProviderDefinedProto), { annotations: Context.empty(), ...options })
 
 const dynamicProto = <
   const Name extends string,

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { DateTime, Effect, Fiber, identity, Latch, Schema, Stream } from "effect"
+import { Context, DateTime, Effect, Fiber, identity, Latch, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { AiError, LanguageModel, Response, Tool, Toolkit } from "effect/unstable/ai"
 import * as TestUtils from "./utils.ts"
@@ -919,8 +919,37 @@ describe("Tool", () => {
           })
         )
       }))
+
+    describe("addDependency", () => {
+      it("preserves the provider-defined tool identity", () => {
+        const tool = HandlerRequired({ testArg: "test-arg" })
+        const withDep = tool.addDependency(TestDependency)
+        assertTrue(Tool.isProviderDefined(withDep))
+        assertFalse(Tool.isUserDefined(withDep))
+        assertFalse(Tool.isDynamic(withDep))
+      })
+
+      it("preserves the provider-defined tool id", () => {
+        const tool = HandlerRequired({ testArg: "test-arg" })
+        const withDep = tool.addDependency(TestDependency)
+        strictEqual(withDep.id, "test.handler_required")
+      })
+    })
+
+    it("getStrictMode returns undefined without throwing", () => {
+      const tool = NoHandlerRequired({ testArg: "test-arg" })
+      strictEqual(Tool.getStrictMode(tool), undefined)
+    })
+
+    it("annotate preserves the provider-defined tool identity", () => {
+      const tool = NoHandlerRequired({ testArg: "test-arg" }).annotate(Tool.Strict, false)
+      assertTrue(Tool.isProviderDefined(tool))
+      strictEqual(Tool.getStrictMode(tool), false)
+    })
   })
 })
+
+class TestDependency extends Context.Service<TestDependency, { readonly value: number }>()("TestDependency") {}
 
 const FailureModeError = Tool.make("FailureModeError", {
   description: "A test tool",
@@ -1258,6 +1287,15 @@ describe("Dynamic", () => {
       const tool = Tool.dynamic("TestTool", {
         parameters: { type: "object", properties: {} }
       }).annotate(Tool.Strict, false)
+      strictEqual(Tool.getStrictMode(tool), false)
+    })
+
+    it("works with provider-defined tools", () => {
+      const tool = Tool.providerDefined({
+        id: "test.provider_tool",
+        customName: "ProviderTool",
+        providerName: "provider_tool"
+      })().annotate(Tool.Strict, false)
       strictEqual(Tool.getStrictMode(tool), false)
     })
   })


### PR DESCRIPTION
## Summary

Closes #6328. Re-opened from `effect-smol` [#2616](https://github.com/Effect-TS/effect-smol/pull/2616).

Two related sets of fixes.

### 1. Core `effect` — `Tool` cloning preserves the tool kind

`Tool.addDependency` (and `setParameters` / `setSuccess` / `setFailure` / `annotate` / `annotateMerge`) rebuilt the tool via `userDefinedProto`, which discarded the `ProviderDefined` / `Dynamic` prototype (so `Tool.isProviderDefined` flipped to `false`), regenerated `id` from the tool name (corrupting provider ids like `anthropic.memory_20250818`), and crashed `Tool.getStrictMode`. These operations now clone while preserving the receiver's prototype, `id`, and kind. Provider-defined tools also carry an empty annotations context.

### 2. `@effect/ai-anthropic` — client-executed provider tools are usable

The shipped Memory, Text Editor, Computer Use, and Bash tools (all `requiresHandler: true`, i.e. client-executed) were unusable on the wire:

- **Wire-name resolution.** `makeResponse` (and the streaming equivalents) handled a `tool_use` block by looking the tool up under the raw provider wire name (e.g. `"memory"`), while the toolkit is keyed by `customName` (e.g. `"AnthropicMemory"`) — raising `ToolNotFoundError`. The `tool_use` branches now map via `toolNameMapper.getCustomName(part.name)`, matching what the `server_tool_use` branches already did.
- **`MemoryCreateCommand` missing `file_text`.** A `create` dropped the file body. `file_text` is now a required field, matching the official Anthropic SDK types and the Vercel AI SDK.
- **`Schema.optional` → `Schema.optionalKey` on client-tool parameters.** `toCodecAnthropic` rejects `Schema.optional`'s explicit `undefined` with "Unsupported AST Undefined" (by design — it steers to `optionalKey`). This broke every client-executed provider tool with an optional parameter on response decode: Memory/Text Editor `view_range`, Computer Use `coordinate`, and Bash `restart`.

The `args` schemas (Computer Use `displayNumber`/`enableZoom`, Web Search/Fetch config) and the server-executed code-execution tools are unaffected and left as-is.

> Note on `str_replace.new_str`: the API docs prose calls it optional, but both the official Anthropic SDK types and the Vercel AI SDK model it as a required `string`, so it is left required.

## Tests

- `effect` — `Tool.test.ts`: `addDependency` keeps a provider-defined tool provider-defined and preserves its `id`; `getStrictMode`/`annotate` work on provider-defined tools.
- `@effect/ai-anthropic` — memory `tool_use` resolves to the custom name and the handler receives the decoded `view` / `create` (with `file_text`) command; a parametrized test asserts every client provider tool's `parameters` schema compiles through `toCodecAnthropic`.

Validation (against this repo's `main`): `pnpm check` (whole repo) and the `effect` + `ai/anthropic` test suites all pass.
