### PR TITLE
PgClient: add statementTimeout and queryTimeout options

### DIFF
--- a/.changeset/pg-statement-query-timeout.md
+++ b/.changeset/pg-statement-query-timeout.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+PgClient: add `statementTimeout` and `queryTimeout` options, passed through to `pg`'s `statement_timeout` / `query_timeout`.

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -114,6 +114,15 @@ export interface PgClientConfig {
   readonly password?: Redacted.Redacted | undefined
 
   readonly connectTimeout?: Duration.Input | undefined
+  /**
+   * Sets the server-side `statement_timeout` for every connection, cancelling
+   * any statement that runs longer than the given duration.
+   */
+  readonly statementTimeout?: Duration.Input | undefined
+  /**
+   * Client-side timeout for each query, enforced by `pg`.
+   */
+  readonly queryTimeout?: Duration.Input | undefined
 
   readonly stream?: (() => Duplex) | undefined
 
@@ -161,6 +170,12 @@ export const make = (options: PgPoolConfig): Effect.Effect<PgClient, SqlError, S
         ...(options.stream ? { stream: options.stream } : {}),
         connectionTimeoutMillis: options.connectTimeout
           ? Duration.toMillis(Duration.fromInputUnsafe(options.connectTimeout))
+          : undefined,
+        statement_timeout: options.statementTimeout
+          ? Duration.toMillis(Duration.fromInputUnsafe(options.statementTimeout))
+          : undefined,
+        query_timeout: options.queryTimeout
+          ? Duration.toMillis(Duration.fromInputUnsafe(options.queryTimeout))
           : undefined,
         idleTimeoutMillis: options.idleTimeout
           ? Duration.toMillis(Duration.fromInputUnsafe(options.idleTimeout))
@@ -232,6 +247,12 @@ export const makeClient = (
         ssl: options.ssl,
         port: options.port,
         ...(options.stream ? { stream: options.stream } : {}),
+        statement_timeout: options.statementTimeout
+          ? Duration.toMillis(Duration.fromInputUnsafe(options.statementTimeout))
+          : undefined,
+        query_timeout: options.queryTimeout
+          ? Duration.toMillis(Duration.fromInputUnsafe(options.queryTimeout))
+          : undefined,
         application_name: options.applicationName ?? "@effect/sql-pg",
         types: options.types
       })


### PR DESCRIPTION
## Migration

Replacement for [Effect-TS/effect-smol#2617](https://github.com/Effect-TS/effect-smol/pull/2617), opened after Effect V4 development moved back to this repository. Please refer to the original PR for its existing discussion and review history.

This is a direct migration of the original two-file change onto the current `Effect-TS/effect:main` branch.

## Motivation

`PgClientConfig` exposes `connectTimeout`, but there is no way to bound statement execution: the `pg` driver `statement_timeout` (server-side cancel) and `query_timeout` (client-side) options are not passed through, so a hung or runaway statement waits indefinitely unless the caller rebuilds pool acquisition via `fromPool`.

This hardening gap affects Cloudflare Workers Durable Objects, where a wedged socket may otherwise only be recovered by the platform resetting the object.

## Changes

- Add `statementTimeout` and `queryTimeout` (`Duration.Input`) to `PgClientConfig`.
- Wire them to `pg` as `statement_timeout` and `query_timeout` in both `make` (pool) and `makeClient` (single client).
- Add a patch changeset for `@effect/sql-pg`.

## Validation

- `pnpm lint-fix`
- `pnpm check`
- `pnpm test packages/sql/pg/test/Client.test.ts --run` (23 tests passed)