### PR TITLE
Fix missing CLI flag value handling

### DIFF
--- a/.changeset/fix-cli-missing-flag-values.md
+++ b/.changeset/fix-cli-missing-flag-values.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Report an error when a CLI flag, including `--completions`, is provided without its required value.

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -365,6 +365,9 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
     if (this.kind === "argument") {
       return `Invalid value for argument <${this.option}>: "${this.value}". Expected: ${this.expected}`
     }
+    if (this.value.length === 0) {
+      return `Missing value for flag --${this.option}. Expected: ${this.expected}`
+    }
     return `Invalid value for flag --${this.option}: "${this.value}". Expected: ${this.expected}`
   }
 }

--- a/packages/effect/src/unstable/cli/internal/parser.ts
+++ b/packages/effect/src/unstable/cli/internal/parser.ts
@@ -391,6 +391,18 @@ const invalidNegatedFlagValue = (
     kind: "flag"
   })
 
+const missingFlagValue = (spec: FlagParam): CliError.InvalidValue => {
+  const choices = Primitive.getChoiceKeys(spec.primitiveType)
+  return new CliError.InvalidValue({
+    option: spec.name,
+    value: "",
+    expected: choices === undefined
+      ? spec.typeName ?? Primitive.getTypeName(spec.primitiveType)
+      : choices.join(" | "),
+    kind: "flag"
+  })
+}
+
 /**
  * Checks whether a token is a boolean literal value.
  * Recognizes: true/false, yes/no, on/off, 1/0
@@ -497,8 +509,8 @@ const consumeFlagValueWithTokens = (
   }
 
   return {
-    _tag: "Value",
-    value: undefined,
+    _tag: "Error",
+    error: missingFlagValue(spec),
     tokens: []
   }
 }

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -116,6 +116,25 @@ describe("Command", () => {
   })
 
   describe("run", () => {
+    it.effect("should reject --completions without a shell", () =>
+      Effect.gen(function*() {
+        let invoked = false
+        const command = Command.make("demo", {}, () =>
+          Effect.sync(() => {
+            invoked = true
+          }))
+
+        yield* Command.runWith(command, { version: "1.0.0" })(["--completions"]).pipe(Effect.ignore)
+
+        const stderr = yield* TestConsole.errorLines
+        assert.isFalse(invoked)
+        assert.isTrue(
+          stderr.some((line) =>
+            String(line).includes("Missing value for flag --completions. Expected: bash | zsh | fish | sh")
+          )
+        )
+      }).pipe(Effect.provide(TestLayer)))
+
     it.effect("should execute handler with parsed config", () =>
       Effect.gen(function*() {
         const path = yield* Path.Path

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -135,6 +135,36 @@ describe("Command", () => {
         )
       }).pipe(Effect.provide(TestLayer)))
 
+    const missingValueCases: ReadonlyArray<{
+      readonly flag: Flag.Flag<unknown>
+      readonly name: string
+      readonly expected: string
+    }> = [
+      { flag: Flag.string("name").pipe(Flag.optional), name: "name", expected: "string" },
+      { flag: Flag.integer("count").pipe(Flag.optional), name: "count", expected: "integer" },
+      { flag: Flag.path("config").pipe(Flag.optional), name: "config", expected: "path" },
+      { flag: Flag.keyValuePair("env").pipe(Flag.optional), name: "env", expected: "key=value" }
+    ]
+
+    for (const { expected, flag, name } of missingValueCases) {
+      it.effect(`should reject --${name} without a ${expected} value`, () =>
+        Effect.gen(function*() {
+          let invoked = false
+          const command = Command.make("demo", { value: flag }, () =>
+            Effect.sync(() => {
+              invoked = true
+            }))
+
+          yield* Command.runWith(command, { version: "1.0.0" })([`--${name}`]).pipe(Effect.ignore)
+
+          const stderr = yield* TestConsole.errorLines
+          assert.isFalse(invoked)
+          assert.isTrue(
+            stderr.some((line) => String(line).includes(`Missing value for flag --${name}. Expected: ${expected}`))
+          )
+        }).pipe(Effect.provide(TestLayer)))
+    }
+
     it.effect("should execute handler with parsed config", () =>
       Effect.gen(function*() {
         const path = yield* Path.Path


### PR DESCRIPTION
Fixes #6329.

## Summary
- report missing values for non-boolean CLI flags during token consumption
- include expected choices in the diagnostic
- prevent bare `--completions` from invoking the application handler

## Validation
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test packages/effect/test/unstable/cli/Command.test.ts packages/effect/test/unstable/cli/Errors.test.ts`