### PR TITLE
Retry failed Redis script loads

### DIFF
--- a/.changeset/retry-redis-script-load.md
+++ b/.changeset/retry-redis-script-load.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Redis script evaluation so transient `SCRIPT LOAD` failures are retried instead of being cached indefinitely.

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -11,8 +11,10 @@
  */
 import * as Cache from "../../Cache.ts"
 import * as Context from "../../Context.ts"
+import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
 import * as Equal from "../../Equal.ts"
+import * as Exit from "../../Exit.ts"
 import { constant, identity } from "../../Function.ts"
 import * as Hash from "../../Hash.ts"
 import * as Schema from "../../Schema.ts"
@@ -50,10 +52,13 @@ export const make = Effect.fnUntraced(function*(
     readonly send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) => Effect.Effect<A, RedisError>
   }
 ) {
-  const scriptCache = yield* Cache.make({
-    lookup: (script: Script<any>) => options.send<string>("SCRIPT", "LOAD", script.lua),
-    capacity: Number.POSITIVE_INFINITY
-  })
+  const scriptCache = yield* Cache.makeWith(
+    (script: Script<any>) => options.send<string>("SCRIPT", "LOAD", script.lua),
+    {
+      capacity: Number.POSITIVE_INFINITY,
+      timeToLive: (exit) => Exit.isSuccess(exit) ? Duration.infinity : Duration.zero
+    }
+  )
 
   const eval_ = <
     Config extends {

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -3,6 +3,43 @@ import { Effect } from "effect"
 import { Redis } from "effect/unstable/persistence"
 
 describe("Redis", () => {
+  it.effect("retries script loading when SCRIPT LOAD fails", () =>
+    Effect.gen(function*() {
+      const commands: Array<readonly [command: string, args: ReadonlyArray<string>]> = []
+      let scriptLoadAttempts = 0
+      const redis = yield* Redis.make({
+        send: (command, ...args) =>
+          Effect.suspend(() => {
+            commands.push([command, args])
+            if (command === "SCRIPT") {
+              scriptLoadAttempts += 1
+              if (scriptLoadAttempts === 1) {
+                return Effect.fail(new Redis.RedisError({ cause: new Error("ERR transient script load failure") }))
+              }
+              return Effect.succeed("sha" as any)
+            }
+            return Effect.succeed("ok")
+          })
+      })
+      const evalScript = redis.eval(
+        Redis.script((key: string) => [key], {
+          lua: "return KEYS[1]",
+          numberOfKeys: 1
+        }).withReturnType<string>()
+      )
+
+      const first = yield* Effect.result(evalScript("key"))
+      const second = yield* evalScript("key")
+
+      assert.strictEqual(first._tag, "Failure")
+      assert.strictEqual(second, "ok")
+      assert.deepStrictEqual(commands.map(([command]) => command), [
+        "SCRIPT",
+        "SCRIPT",
+        "EVALSHA"
+      ])
+    }))
+
   it.effect("reloads and retries scripts when EVALSHA returns NOSCRIPT", () =>
     Effect.gen(function*() {
       const commands: Array<readonly [command: string, args: ReadonlyArray<string>]> = []


### PR DESCRIPTION
## Summary

Redis Lua scripts are loaded through `SCRIPT LOAD` and cached before being invoked with `EVALSHA`. The script cache currently stores failed loads indefinitely, so a transient Redis failure during `SCRIPT LOAD` can poison a running process until the Redis service is recreated.

This changes the script cache TTL so successful script loads continue to be cached forever, while failed loads are immediately evicted and retried on the next evaluation.