### PR TITLE
feat: add graph set operators

### DIFF
--- a/.changeset/fair-jobs-like.md
+++ b/.changeset/fair-jobs-like.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add a `maxDepth` option to `Graph` search configuration, allowing `dfs` and `bfs` traversals to limit returned nodes by depth from the configured start nodes.

--- a/.changeset/fair-jobs-like.md
+++ b/.changeset/fair-jobs-like.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-add a `radius` option to `Graph` search configuration, allowing `dfs` and `bfs` traversals to limit returned nodes by edge distance from the configured start nodes.
+add a `radius` option to `Graph` search configuration, allowing `dfs`, `bfs`, and `dfsPostOrder` traversals to limit returned nodes by edge distance from the configured start nodes. Traversals can also use `direction: "undirected"` to follow edges in either direction.

--- a/.changeset/fair-jobs-like.md
+++ b/.changeset/fair-jobs-like.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-add a `maxDepth` option to `Graph` search configuration, allowing `dfs` and `bfs` traversals to limit returned nodes by depth from the configured start nodes.
+add a `radius` option to `Graph` search configuration, allowing `dfs` and `bfs` traversals to limit returned nodes by edge distance from the configured start nodes.

--- a/.changeset/hip-friends-kiss.md
+++ b/.changeset/hip-friends-kiss.md
@@ -1,0 +1,10 @@
+---
+"effect": minor
+---
+
+added graph set operations for combining and comparing graphs
+
+- `Graph.compose` - union of two graphs, merging nodes by identity
+- `Graph.intersection` - intersection of two graphs, keeping only common nodes and edges
+- `Graph.difference` - difference of two graphs, removing edges present in the second graph
+- `Graph.symmetricDifference` - symmetric difference of two graphs, keeping edges present in exactly one graph

--- a/.changeset/hip-friends-kiss.md
+++ b/.changeset/hip-friends-kiss.md
@@ -4,7 +4,8 @@
 
 added graph set operations for combining and comparing graphs
 
-- `Graph.union` - union of two graphs, merging nodes by identity
+- `Graph.make` - creates a graph constructor for a dynamically selected graph kind
+- `Graph.compose` - composition of two graphs, merging nodes by identity
 - `Graph.intersection` - intersection of two graphs, keeping only common nodes and edges
 - `Graph.difference` - difference of two graphs, removing edges present in the second graph
 - `Graph.symmetricDifference` - symmetric difference of two graphs, keeping edges present in exactly one graph

--- a/.changeset/hip-friends-kiss.md
+++ b/.changeset/hip-friends-kiss.md
@@ -4,7 +4,7 @@
 
 added graph set operations for combining and comparing graphs
 
-- `Graph.compose` - union of two graphs, merging nodes by identity
+- `Graph.union` - union of two graphs, merging nodes by identity
 - `Graph.intersection` - intersection of two graphs, keeping only common nodes and edges
 - `Graph.difference` - difference of two graphs, removing edges present in the second graph
 - `Graph.symmetricDifference` - symmetric difference of two graphs, keeping edges present in exactly one graph

--- a/.changeset/six-pumas-take.md
+++ b/.changeset/six-pumas-take.md
@@ -1,0 +1,9 @@
+---
+"effect": minor
+---
+
+add advanced graph set operations for deriving related graph structures
+
+- `Graph.complement` - complement over the existing node set, adding missing edges between distinct nodes
+- `Graph.neighborhood` - induced subgraph containing nodes within a radius of a node
+- `Graph.sum` - disjoint union of two graphs without merging equal node data

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -579,6 +579,444 @@ export const mutate: {
 })
 
 // =============================================================================
+// Set Operations
+// =============================================================================
+
+/** @internal */
+type NodeMaps<N> = {
+  readonly byId: Map<string, { readonly index: NodeIndex; readonly data: N }>
+  readonly byIndex: Map<NodeIndex, string>
+}
+
+/** @internal */
+type EdgeIdentity<E> = { readonly sourceId: string; readonly targetId: string; readonly data: E }
+
+/** @internal */
+const buildNodeMaps = <N, E, T extends Kind>(graph: Graph<N, E, T>, nodeId: (node: N) => string): NodeMaps<N> => {
+  const byId = new Map<string, { readonly index: NodeIndex; readonly data: N }>()
+  const byIndex = new Map<NodeIndex, string>()
+
+  for (const [index, data] of graph.nodes) {
+    const id = nodeId(data)
+    byId.set(id, { index, data })
+    byIndex.set(index, id)
+  }
+
+  return { byId, byIndex }
+}
+
+/** @internal */
+const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
+  type === "undirected" && sourceId > targetId ? `${targetId}\0${sourceId}` : `${sourceId}\0${targetId}`
+
+/** @internal */
+const emptyLike = <N, E, T extends Kind>(
+  graph: Graph<N, E, T>,
+  mutate: (mutable: MutableGraph<N, E, T>) => void
+): Graph<N, E, T> => {
+  const mutable = beginMutation(graph)
+
+  mutable.nodes.clear()
+  mutable.edges.clear()
+  mutable.adjacency.clear()
+  mutable.reverseAdjacency.clear()
+  mutable.nextNodeIndex = 0
+  mutable.nextEdgeIndex = 0
+  mutable.acyclic = Option.some(true)
+
+  mutate(mutable)
+
+  return endMutation(mutable)
+}
+
+/**
+ * Returns the union of two graphs, merging nodes by identity.
+ *
+ * **Details**
+ *
+ * Nodes and edges present in both graphs use data from `that`. The result has
+ * the same graph kind as `self`.
+ *
+ * `G1 ∪ G2 = {V1 ∪ V2, E1 ∪ E2}`
+ *
+ * **Example** (Composing graphs)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<{ id: string }, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, { id: "A" })
+ *   const b = Graph.addNode(mutable, { id: "B" })
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ * })
+ *
+ * const right = Graph.directed<{ id: string }, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, { id: "B" })
+ *   const c = Graph.addNode(mutable, { id: "C" })
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const result = Graph.compose(left, right, (node) => node.id)
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.edgeCount(result)) // 2
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const compose: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(
+  3,
+  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>, nodeId: (node: N) => string): Graph<N, E, T> => {
+    const selfMaps = buildNodeMaps(self, nodeId)
+    const thatMaps = buildNodeMaps(that, nodeId)
+    const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
+    const edgeMap = new Map<string, EdgeIdentity<E>>()
+
+    for (const edge of self.edges.values()) {
+      const sourceId = selfMaps.byIndex.get(edge.source)
+      const targetId = selfMaps.byIndex.get(edge.target)
+      if (sourceId !== undefined && targetId !== undefined) {
+        edgeMap.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+      }
+    }
+
+    for (const edge of that.edges.values()) {
+      const sourceId = thatMaps.byIndex.get(edge.source)
+      const targetId = thatMaps.byIndex.get(edge.target)
+      if (sourceId !== undefined && targetId !== undefined) {
+        edgeMap.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+      }
+    }
+
+    return emptyLike(self, (mutable) => {
+      const newIndexMap = new Map<string, NodeIndex>()
+
+      for (const id of allNodeIds) {
+        const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
+        if (entry !== undefined) {
+          newIndexMap.set(id, addNode(mutable, entry.data))
+        }
+      }
+
+      for (const { sourceId, targetId, data } of edgeMap.values()) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    })
+  }
+)
+
+/**
+ * Returns the intersection of two graphs, matching nodes by identity.
+ *
+ * **Details**
+ *
+ * Node data comes from `self`, and edge data comes from `that`. The result has
+ * the same graph kind as `self`.
+ *
+ * `G1 ∩ G2 = {V1 ∩ V2, E1 ∩ E2}`
+ *
+ * **Example** (Finding shared structure)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "left")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "right")
+ * })
+ *
+ * const result = Graph.intersection(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 2
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const intersection: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const commonNodeIds = [...selfMaps.byId.keys()].filter((id) => thatMaps.byId.has(id))
+  const commonNodeIdSet = new Set(commonNodeIds)
+  const selfEdgeKeys = new Set<string>()
+
+  for (const edge of self.edges.values()) {
+    const sourceId = selfMaps.byIndex.get(edge.source)
+    const targetId = selfMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      selfEdgeKeys.add(edgeKey(self.type, sourceId, targetId))
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const id of commonNodeIds) {
+      const entry = selfMaps.byId.get(id)
+      if (entry !== undefined) {
+        newIndexMap.set(id, addNode(mutable, entry.data))
+      }
+    }
+
+    for (const edge of that.edges.values()) {
+      const sourceId = thatMaps.byIndex.get(edge.source)
+      const targetId = thatMaps.byIndex.get(edge.target)
+      if (
+        sourceId !== undefined &&
+        targetId !== undefined &&
+        commonNodeIdSet.has(sourceId) &&
+        commonNodeIdSet.has(targetId) &&
+        selfEdgeKeys.has(edgeKey(that.type, sourceId, targetId))
+      ) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns `self` without edges also present in `that`.
+ *
+ * **Details**
+ *
+ * All nodes from `self` are preserved. Edges are matched by endpoint identity,
+ * and edge data is ignored. The result has the same graph kind as `self`.
+ *
+ * `G1 \ G2 = {V1, E1 \ E2}`
+ *
+ * **Example** (Removing shared edges)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, b, c, "other")
+ * })
+ *
+ * const result = Graph.difference(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const difference: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const thatEdgeKeys = new Set<string>()
+
+  for (const edge of that.edges.values()) {
+    const sourceId = thatMaps.byIndex.get(edge.source)
+    const targetId = thatMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      thatEdgeKeys.add(edgeKey(that.type, sourceId, targetId))
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const [id, entry] of selfMaps.byId) {
+      newIndexMap.set(id, addNode(mutable, entry.data))
+    }
+
+    for (const edge of self.edges.values()) {
+      const sourceId = selfMaps.byIndex.get(edge.source)
+      const targetId = selfMaps.byIndex.get(edge.target)
+      if (
+        sourceId !== undefined && targetId !== undefined && !thatEdgeKeys.has(edgeKey(self.type, sourceId, targetId))
+      ) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns edges present in exactly one of two graphs.
+ *
+ * **Details**
+ *
+ * Keeps nodes from both graphs. Overlapping nodes use data from `that`. The
+ * result has the same graph kind as `self`.
+ *
+ * `G1 Δ G2 = {V1 ∪ V2, (E1 ∪ E2) \ (E1 ∩ E2)}`
+ *
+ * **Gotchas**
+ *
+ * Edges present in both graphs are removed even when their edge data differs.
+ *
+ * **Example** (Finding differing edges)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   const d = Graph.addNode(mutable, "D")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ *   Graph.addEdge(mutable, c, d, "C-D")
+ * })
+ *
+ * const result = Graph.symmetricDifference(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 4
+ * console.log(Graph.edgeCount(result)) // 2
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const symmetricDifference: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
+  const selfEdges = new Map<string, EdgeIdentity<E>>()
+  const thatEdges = new Map<string, EdgeIdentity<E>>()
+
+  for (const edge of self.edges.values()) {
+    const sourceId = selfMaps.byIndex.get(edge.source)
+    const targetId = selfMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      selfEdges.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+    }
+  }
+
+  for (const edge of that.edges.values()) {
+    const sourceId = thatMaps.byIndex.get(edge.source)
+    const targetId = thatMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      thatEdges.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const id of allNodeIds) {
+      const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
+      if (entry !== undefined) {
+        newIndexMap.set(id, addNode(mutable, entry.data))
+      }
+    }
+
+    for (const [key, { sourceId, targetId, data }] of selfEdges) {
+      if (!thatEdges.has(key)) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    }
+
+    for (const [key, { sourceId, targetId, data }] of thatEdges) {
+      if (!selfEdges.has(key)) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    }
+  })
+})
+
+// =============================================================================
 // Basic Node Operations
 // =============================================================================
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1016,6 +1016,212 @@ export const symmetricDifference: {
   })
 })
 
+/**
+ * Returns the complement over the existing node set.
+ *
+ * **Details**
+ *
+ * Adds every missing edge between distinct nodes. The `createEdge` function
+ * receives the source and target node data for each added edge. The result has
+ * the same graph kind as `self`.
+ *
+ * `G' = {V, (V x V) \ E}`
+ *
+ * **Example** (Finding missing relationships)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ * })
+ *
+ * const result = Graph.complement(graph, (source, target) => `${source}-${target}`)
+ *
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const complement: {
+  <N, E>(
+    createEdge: (source: N, target: N) => E
+  ): <T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    createEdge: (source: N, target: N) => E
+  ): Graph<N, E, T>
+} = dual(2, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  createEdge: (source: N, target: N) => E
+): Graph<N, E, T> => {
+  const nodeEntries = Array.from(self.nodes)
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<NodeIndex, NodeIndex>()
+
+    for (const [oldIndex, data] of nodeEntries) {
+      newIndexMap.set(oldIndex, addNode(mutable, data))
+    }
+
+    for (let i = 0; i < nodeEntries.length; i++) {
+      const [sourceOldIndex, sourceData] = nodeEntries[i]
+      const start = self.type === "undirected" ? i + 1 : 0
+
+      for (let j = start; j < nodeEntries.length; j++) {
+        const [targetOldIndex, targetData] = nodeEntries[j]
+        if (sourceOldIndex === targetOldIndex || hasEdge(self, sourceOldIndex, targetOldIndex)) {
+          continue
+        }
+
+        const sourceIndex = newIndexMap.get(sourceOldIndex)
+        const targetIndex = newIndexMap.get(targetOldIndex)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, createEdge(sourceData, targetData))
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Direction for neighborhood expansion in directed graphs.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type NeighborhoodDirection = "outgoing" | "incoming" | "both"
+
+/**
+ * Returns the induced subgraph containing nodes within a radius of a node.
+ *
+ * **Details**
+ *
+ * The `radius` option is the maximum edge distance from `nodeIndex` and
+ * defaults to `1`. The `direction` option controls directed graph traversal and
+ * defaults to `"both"`. The result has the same graph kind as `self` and keeps
+ * all original edges whose endpoints are both reached.
+ *
+ * **Example** (Getting a local neighborhood)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const result = Graph.neighborhood(graph, 1, { radius: 1 })
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const neighborhood: {
+  (
+    nodeIndex: NodeIndex,
+    options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+  ): <N, E, T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    nodeIndex: NodeIndex,
+    options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+  ): Graph<N, E, T>
+} = dual((args) => isGraph(args[0]), <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  nodeIndex: NodeIndex,
+  options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+): Graph<N, E, T> => {
+  const radius = options?.radius ?? 1
+  const direction = options?.direction ?? "both"
+  const reached = new Set<NodeIndex>()
+
+  if (direction === "outgoing" || direction === "both") {
+    for (const index of indices(bfs(self, { start: [nodeIndex], direction: "outgoing", maxDepth: radius }))) {
+      reached.add(index)
+    }
+  }
+
+  if (direction === "incoming" || direction === "both") {
+    for (const index of indices(bfs(self, { start: [nodeIndex], direction: "incoming", maxDepth: radius }))) {
+      reached.add(index)
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<NodeIndex, NodeIndex>()
+
+    for (const oldIndex of reached) {
+      newIndexMap.set(oldIndex, addNode(mutable, Option.getOrThrow(getNode(self, oldIndex))))
+    }
+
+    for (const edge of self.edges.values()) {
+      if (reached.has(edge.source) && reached.has(edge.target)) {
+        const sourceIndex = newIndexMap.get(edge.source)
+        const targetIndex = newIndexMap.get(edge.target)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns the disjoint union of two graphs.
+ *
+ * **Details**
+ *
+ * Copies all nodes and edges from both graphs without merging equal node data.
+ * The result has the same graph kind as `self`.
+ *
+ * `G1 + G2 = {disjoint V1 + V2, disjoint E1 + E2}`
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const sum: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>
+  ): Graph<N, E, T>
+} = dual(
+  2,
+  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>): Graph<N, E, T> =>
+    emptyLike(self, (mutable) => {
+      const copyInto = (graph: Graph<N, E, T>) => {
+        const indexMap = new Map<NodeIndex, NodeIndex>()
+
+        for (const [oldIndex, data] of graph.nodes) {
+          indexMap.set(oldIndex, addNode(mutable, data))
+        }
+
+        for (const edge of graph.edges.values()) {
+          const sourceIndex = indexMap.get(edge.source)
+          const targetIndex = indexMap.get(edge.target)
+          if (sourceIndex !== undefined && targetIndex !== undefined) {
+            addEdge(mutable, sourceIndex, targetIndex, edge.data)
+          }
+        }
+      }
+
+      copyInto(self)
+      copyInto(that)
+    })
+)
+
 // =============================================================================
 // Basic Node Operations
 // =============================================================================

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4649,6 +4649,7 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
 export interface SearchConfig {
   readonly start?: Array<NodeIndex>
   readonly direction?: Direction
+  readonly maxDepth?: number
 }
 
 /**
@@ -4658,7 +4659,8 @@ export interface SearchConfig {
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges. Throws a `GraphError`
+ * chooses whether to follow outgoing or incoming edges. The `maxDepth` option
+ * limits traversal by edge distance from the start nodes. Throws a `GraphError`
  * if any configured start node does not exist.
  *
  * **Example** (Traversing depth-first)
@@ -4702,6 +4704,7 @@ export const dfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
+  const maxDepth = config.maxDepth ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -4712,12 +4715,12 @@ export const dfs: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
-      const stack = [...start]
+      const stack: Array<readonly [NodeIndex, number]> = start.map((node) => [node, 0])
       const discovered = new Set<NodeIndex>()
 
       const nextMapped = () => {
         while (stack.length > 0) {
-          const current = stack.pop()!
+          const [current, depth] = stack.pop()!
 
           if (discovered.has(current)) {
             continue
@@ -4730,11 +4733,13 @@ export const dfs: {
             continue
           }
 
-          const neighbors = getTraversalNeighbors(graph, current, direction)
-          for (let i = neighbors.length - 1; i >= 0; i--) {
-            const neighbor = neighbors[i]
-            if (!discovered.has(neighbor)) {
-              stack.push(neighbor)
+          if (depth < maxDepth) {
+            const neighbors = getTraversalNeighbors(graph, current, direction)
+            for (let i = neighbors.length - 1; i >= 0; i--) {
+              const neighbor = neighbors[i]
+              if (!discovered.has(neighbor)) {
+                stack.push([neighbor, depth + 1])
+              }
             }
           }
 
@@ -4756,7 +4761,8 @@ export const dfs: {
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges. Throws a `GraphError`
+ * chooses whether to follow outgoing or incoming edges. The `maxDepth` option
+ * limits traversal by edge distance from the start nodes. Throws a `GraphError`
  * if any configured start node does not exist.
  *
  * **Example** (Traversing breadth-first)
@@ -4800,6 +4806,7 @@ export const bfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
+  const maxDepth = config.maxDepth ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -4810,20 +4817,22 @@ export const bfs: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
-      const queue = [...start]
+      const queue: Array<readonly [NodeIndex, number]> = start.map((node) => [node, 0])
       const discovered = new Set<NodeIndex>()
 
       const nextMapped = () => {
         while (queue.length > 0) {
-          const current = queue.shift()!
+          const [current, depth] = queue.shift()!
 
           if (!discovered.has(current)) {
             discovered.add(current)
 
-            const neighbors = getTraversalNeighbors(graph, current, direction)
-            for (const neighbor of neighbors) {
-              if (!discovered.has(neighbor)) {
-                queue.push(neighbor)
+            if (depth < maxDepth) {
+              const neighbors = getTraversalNeighbors(graph, current, direction)
+              for (const neighbor of neighbors) {
+                if (!discovered.has(neighbor)) {
+                  queue.push([neighbor, depth + 1])
+                }
               }
             }
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -3313,11 +3313,30 @@ export const toMermaid: {
 })
 
 // =============================================================================
-// Direction Types for Bidirectional Traversal
+// Edge Direction Types
 // =============================================================================
 
 /**
- * Direction for graph traversal, indicating which edges to follow.
+ * Direction of directed edges relative to a node.
+ *
+ * **Details**
+ *
+ * `"outgoing"` selects edges whose source is the node, while `"incoming"`
+ * selects edges whose target is the node.
+ *
+ * @category models
+ * @since 3.18.0
+ */
+export type Direction = "outgoing" | "incoming"
+
+/**
+ * Controls how traversal follows directed edges.
+ *
+ * **Details**
+ *
+ * `"outgoing"` follows edges from source to target, `"incoming"` follows them
+ * from target to source, and `"undirected"` allows traversal in either
+ * direction.
  *
  * **Example** (Traversing by direction)
  *
@@ -3327,28 +3346,23 @@ export const toMermaid: {
  * const graph = Graph.directed<string, string>((mutable) => {
  *   const a = Graph.addNode(mutable, "A")
  *   const b = Graph.addNode(mutable, "B")
- *   Graph.addEdge(mutable, a, b, "A->B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, a, c, "A-C")
  * })
  *
- * // Follow outgoing edges (normal direction)
- * const outgoingNodes = Array.from(
- *   Graph.indices(Graph.dfs(graph, { start: [0], direction: "outgoing" }))
- * )
+ * const outgoing = Array.from(
+ *   Graph.indices(Graph.bfs(graph, { start: [0], direction: "outgoing" }))
+ * ) // [0, 1, 2]
  *
- * // Follow incoming edges (reverse direction)
- * const incomingNodes = Array.from(
- *   Graph.indices(Graph.dfs(graph, { start: [1], direction: "incoming" }))
- * )
+ * const incoming = Array.from(
+ *   Graph.indices(Graph.bfs(graph, { start: [1], direction: "incoming" }))
+ * ) // [1, 0]
+ *
+ * const undirected = Array.from(
+ *   Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected" }))
+ * ) // [1, 0, 2]
  * ```
- *
- * @category models
- * @since 3.18.0
- */
-export type Direction = "outgoing" | "incoming"
-
-/**
- * Direction for graph traversal, including traversal that ignores edge
- * direction.
  *
  * @category models
  * @since 4.0.0

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -5013,7 +5013,7 @@ export const dfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
-  const maxDepth = config.maxDepth ?? Infinity
+  const max = config.maxDepth ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -5024,33 +5024,68 @@ export const dfs: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
-      const stack: Array<readonly [NodeIndex, number]> = start.map((node) => [node, 0])
-      const discovered = new Set<NodeIndex>()
+      const depths = max === Infinity ? undefined : new Map<NodeIndex, number>()
+      const stack: Array<readonly [NodeIndex, number]> = []
+      const yielded = new Set<NodeIndex>()
+
+      if (depths === undefined) {
+        for (const node of start) {
+          stack.push([node, 0])
+        }
+      } else {
+        const starts = new Set<NodeIndex>()
+        for (let i = start.length - 1; i >= 0; i--) {
+          const node = start[i]
+          if (!starts.has(node)) {
+            starts.add(node)
+            stack.push([node, 0])
+            depths.set(node, 0)
+          }
+        }
+        stack.reverse()
+      }
 
       const nextMapped = () => {
         while (stack.length > 0) {
           const [current, depth] = stack.pop()!
 
-          if (discovered.has(current)) {
+          if (depths === undefined) {
+            if (yielded.has(current)) {
+              continue
+            }
+          } else if (depths.get(current) !== depth) {
             continue
           }
-
-          discovered.add(current)
 
           const nodeDataOption = getNode(graph, current)
           if (Option.isNone(nodeDataOption)) {
             continue
           }
 
-          if (depth < maxDepth) {
+          if (depth < max) {
             const neighbors = getTraversalNeighbors(graph, current, direction)
             for (let i = neighbors.length - 1; i >= 0; i--) {
               const neighbor = neighbors[i]
-              if (!discovered.has(neighbor)) {
-                stack.push([neighbor, depth + 1])
+              const nextDepth = depth + 1
+              if (depths === undefined) {
+                if (!yielded.has(neighbor)) {
+                  stack.push([neighbor, nextDepth])
+                }
+                continue
+              }
+              const neighborDepth = depths.get(neighbor)
+              if (neighborDepth === undefined || nextDepth < neighborDepth) {
+                depths.set(neighbor, nextDepth)
+                stack.push([neighbor, nextDepth])
               }
             }
           }
+
+          if (yielded.has(current)) {
+            continue
+          }
+
+          yielded.add(current)
 
           return { done: false, value: f(current, nodeDataOption.value) }
         }
@@ -5115,7 +5150,7 @@ export const bfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
-  const maxDepth = config.maxDepth ?? Infinity
+  const max = config.maxDepth ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -5136,7 +5171,7 @@ export const bfs: {
           if (!discovered.has(current)) {
             discovered.add(current)
 
-            if (depth < maxDepth) {
+            if (depth < max) {
               const neighbors = getTraversalNeighbors(graph, current, direction)
               for (const neighbor of neighbors) {
                 if (!discovered.has(neighbor)) {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1201,7 +1201,7 @@ export const complement: {
  * @category models
  * @since 4.0.0
  */
-export type NeighborhoodDirection = "outgoing" | "incoming" | "both"
+export type NeighborhoodDirection = "outgoing" | "incoming" | "undirected"
 
 /**
  * Returns the induced subgraph containing nodes within a radius of a node.
@@ -1211,7 +1211,8 @@ export type NeighborhoodDirection = "outgoing" | "incoming" | "both"
  * The `radius` option is the maximum edge distance from `nodeIndex` and
  * defaults to `1`. The `direction` option controls directed graph traversal and
  * defaults to `"outgoing"`. The result has the same graph kind as `self` and
- * keeps all original edges whose endpoints are both reached.
+ * keeps all original edges whose endpoints are both reached. `"undirected"`
+ * ignores edge direction while finding reachable nodes.
  *
  * **Example** (Getting a local neighborhood)
  *
@@ -1253,14 +1254,28 @@ export const neighborhood: {
   const direction = options?.direction ?? "outgoing"
   const reached = new Set<NodeIndex>()
 
-  if (direction === "outgoing" || direction === "both") {
-    for (const index of indices(bfs(self, { start: [nodeIndex], direction: "outgoing", maxDepth: radius }))) {
-      reached.add(index)
+  if (direction === "undirected") {
+    if (!hasNode(self, nodeIndex)) {
+      throw missingNode(nodeIndex)
     }
-  }
-
-  if (direction === "incoming" || direction === "both") {
-    for (const index of indices(bfs(self, { start: [nodeIndex], direction: "incoming", maxDepth: radius }))) {
+    const queue: Array<readonly [NodeIndex, number]> = [[nodeIndex, 0]]
+    reached.add(nodeIndex)
+    for (let i = 0; i < queue.length; i++) {
+      const [current, depth] = queue[i]
+      if (depth >= radius) {
+        continue
+      }
+      for (const traversalDirection of ["outgoing", "incoming"] as const) {
+        for (const neighbor of getTraversalNeighbors(self, current, traversalDirection)) {
+          if (!reached.has(neighbor)) {
+            reached.add(neighbor)
+            queue.push([neighbor, depth + 1])
+          }
+        }
+      }
+    }
+  } else {
+    for (const index of indices(bfs(self, { start: [nodeIndex], direction, maxDepth: radius }))) {
       reached.add(index)
     }
   }

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1201,7 +1201,7 @@ export const complement: {
  * @category models
  * @since 4.0.0
  */
-export type NeighborhoodDirection = "outgoing" | "incoming" | "undirected"
+export type NeighborhoodDirection = TraversalDirection
 
 /**
  * Returns the induced subgraph containing nodes within a radius of a node.
@@ -1254,30 +1254,8 @@ export const neighborhood: {
   const direction = options?.direction ?? "outgoing"
   const reached = new Set<NodeIndex>()
 
-  if (direction === "undirected") {
-    if (!hasNode(self, nodeIndex)) {
-      throw missingNode(nodeIndex)
-    }
-    const queue: Array<readonly [NodeIndex, number]> = [[nodeIndex, 0]]
-    reached.add(nodeIndex)
-    for (let i = 0; i < queue.length; i++) {
-      const [current, depth] = queue[i]
-      if (depth >= radius) {
-        continue
-      }
-      for (const traversalDirection of ["outgoing", "incoming"] as const) {
-        for (const neighbor of getTraversalNeighbors(self, current, traversalDirection)) {
-          if (!reached.has(neighbor)) {
-            reached.add(neighbor)
-            queue.push([neighbor, depth + 1])
-          }
-        }
-      }
-    }
-  } else {
-    for (const index of indices(bfs(self, { start: [nodeIndex], direction, maxDepth: radius }))) {
-      reached.add(index)
-    }
+  for (const index of indices(bfs(self, { start: [nodeIndex], direction, maxDepth: radius }))) {
+    reached.add(index)
   }
 
   return make(self.type)<N, E>((mutable) => {
@@ -3376,6 +3354,15 @@ export const toMermaid: {
  */
 export type Direction = "outgoing" | "incoming"
 
+/**
+ * Direction for graph traversal, including traversal that ignores edge
+ * direction.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type TraversalDirection = Direction | "undirected"
+
 // =============================================================================
 // Graph Structure Analysis Algorithms
 // =============================================================================
@@ -3646,11 +3633,21 @@ const getUndirectedNeighbors = <N, E>(
 const getTraversalNeighbors = <N, E, T extends Kind>(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
   nodeIndex: NodeIndex,
-  direction: Direction
-): Array<NodeIndex> =>
-  graph.type === "undirected"
-    ? getUndirectedNeighbors(graph as any, nodeIndex)
-    : getDirectedNeighbors(graph as Graph<N, E, "directed"> | MutableGraph<N, E, "directed">, nodeIndex, direction)
+  direction: TraversalDirection
+): Array<NodeIndex> => {
+  if (graph.type === "undirected") {
+    return getUndirectedNeighbors(graph as any, nodeIndex)
+  }
+  const directed = graph as Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+  if (direction !== "undirected") {
+    return getDirectedNeighbors(directed, nodeIndex, direction)
+  }
+  const neighbors = new Set(getDirectedNeighbors(directed, nodeIndex, "outgoing"))
+  for (const neighbor of getDirectedNeighbors(directed, nodeIndex, "incoming")) {
+    neighbors.add(neighbor)
+  }
+  return Array.from(neighbors)
+}
 
 const getTraversableNeighbor = <E, T extends Kind>(
   graph: Graph<unknown, E, T> | MutableGraph<unknown, E, T>,
@@ -4956,7 +4953,7 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
  *
  * `start` supplies the node indices where traversal begins. If it is omitted,
  * the iterator is empty. `direction` chooses whether traversal follows
- * outgoing or incoming edges.
+ * outgoing edges, incoming edges, or ignores edge direction.
  *
  * **Gotchas**
  *
@@ -4972,7 +4969,7 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
  */
 export interface SearchConfig {
   readonly start?: Array<NodeIndex>
-  readonly direction?: Direction
+  readonly direction?: TraversalDirection
   readonly maxDepth?: number
 }
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -702,6 +702,32 @@ const buildEdgeMap = <N, E, T extends Kind, NI, EI>(
 }
 
 /** @internal */
+const addNodesByIdentity = <N, E, T extends Kind, NI>(
+  mutable: MutableGraph<N, E, T>,
+  nodes: Iterable<readonly [NI, N]>
+): MutableHashMap.MutableHashMap<NI, NodeIndex> => {
+  const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
+  for (const [identity, data] of nodes) {
+    MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
+  }
+  return indexByIdentity
+}
+
+/** @internal */
+const addEdgeByIdentity = <N, E, T extends Kind, NI, EI>(
+  mutable: MutableGraph<N, E, T>,
+  indexByIdentity: MutableHashMap.MutableHashMap<NI, NodeIndex>,
+  identity: EdgeIdentity<NI, EI>,
+  data: E
+): void => {
+  const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
+  const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
+  if (sourceIndex !== undefined && targetIndex !== undefined) {
+    addEdge(mutable, sourceIndex, targetIndex, data)
+  }
+}
+
+/** @internal */
 const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>): void => {
   if (self.type !== that.type) {
     throw new GraphError({ message: `Cannot combine ${self.type} and ${that.type} graphs` })
@@ -790,17 +816,10 @@ export const compose: {
     }
 
     return make(self.type)<N, E>((mutable) => {
-      const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
-      for (const [identity, data] of nodes) {
-        MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
-      }
+      const indexByIdentity = addNodesByIdentity(mutable, nodes)
 
       for (const [identity, data] of edges) {
-        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
-        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
-        if (sourceIndex !== undefined && targetIndex !== undefined) {
-          addEdge(mutable, sourceIndex, targetIndex, data)
-        }
+        addEdgeByIdentity(mutable, indexByIdentity, identity, data)
       }
     })
   }
@@ -889,18 +908,11 @@ export const intersection: {
   }
 
   return make(self.type)<N, E>((mutable) => {
-    const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
-    for (const [identity, data] of nodes) {
-      MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
-    }
+    const indexByIdentity = addNodesByIdentity(mutable, nodes)
 
     for (const [identity, data] of thatEdges) {
       if (MutableHashMap.has(selfEdges, identity)) {
-        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
-        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
-        if (sourceIndex !== undefined && targetIndex !== undefined) {
-          addEdge(mutable, sourceIndex, targetIndex, data)
-        }
+        addEdgeByIdentity(mutable, indexByIdentity, identity, data)
       }
     }
   })
@@ -974,22 +986,14 @@ export const difference: {
   const thatEdges = buildEdgeMap(that, thatMaps, getEdgeIdentity)
 
   return make(self.type)<N, E>((mutable) => {
-    const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
-
-    for (const [identity, data] of selfMaps.byIdentity) {
-      MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
-    }
+    const indexByIdentity = addNodesByIdentity(mutable, selfMaps.byIdentity)
 
     for (const edge of self.edges.values()) {
       const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
       const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
       const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
       if (!MutableHashMap.has(thatEdges, edgeIdentity)) {
-        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, sourceIdentity))
-        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, targetIdentity))
-        if (sourceIndex !== undefined && targetIndex !== undefined) {
-          addEdge(mutable, sourceIndex, targetIndex, edge.data)
-        }
+        addEdgeByIdentity(mutable, indexByIdentity, edgeIdentity, edge.data)
       }
     }
   })
@@ -1077,29 +1081,17 @@ export const symmetricDifference: {
   }
 
   return make(self.type)<N, E>((mutable) => {
-    const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
-
-    for (const [identity, data] of nodes) {
-      MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
-    }
+    const indexByIdentity = addNodesByIdentity(mutable, nodes)
 
     for (const [identity, data] of selfEdges) {
       if (!MutableHashMap.has(thatEdges, identity)) {
-        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
-        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
-        if (sourceIndex !== undefined && targetIndex !== undefined) {
-          addEdge(mutable, sourceIndex, targetIndex, data)
-        }
+        addEdgeByIdentity(mutable, indexByIdentity, identity, data)
       }
     }
 
     for (const [identity, data] of thatEdges) {
       if (!MutableHashMap.has(selfEdges, identity)) {
-        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
-        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
-        if (sourceIndex !== undefined && targetIndex !== undefined) {
-          addEdge(mutable, sourceIndex, targetIndex, data)
-        }
+        addEdgeByIdentity(mutable, indexByIdentity, identity, data)
       }
     }
   })

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1196,14 +1196,6 @@ export const complement: {
 })
 
 /**
- * Direction for neighborhood expansion in directed graphs.
- *
- * @category models
- * @since 4.0.0
- */
-export type NeighborhoodDirection = TraversalDirection
-
-/**
  * Returns the induced subgraph containing nodes within a radius of a node.
  *
  * **Details**
@@ -1238,17 +1230,17 @@ export type NeighborhoodDirection = TraversalDirection
 export const neighborhood: {
   (
     nodeIndex: NodeIndex,
-    options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+    options?: { readonly radius?: number; readonly direction?: TraversalDirection }
   ): <N, E, T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
   <N, E, T extends Kind = "directed">(
     self: Graph<N, E, T>,
     nodeIndex: NodeIndex,
-    options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+    options?: { readonly radius?: number; readonly direction?: TraversalDirection }
   ): Graph<N, E, T>
 } = dual((args) => isGraph(args[0]), <N, E, T extends Kind>(
   self: Graph<N, E, T>,
   nodeIndex: NodeIndex,
-  options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+  options?: { readonly radius?: number; readonly direction?: TraversalDirection }
 ): Graph<N, E, T> => {
   const radius = options?.radius ?? 1
   const direction = options?.direction ?? "outgoing"

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1246,7 +1246,7 @@ export const neighborhood: {
   const direction = options?.direction ?? "outgoing"
   const reached = new Set<NodeIndex>()
 
-  for (const index of indices(bfs(self, { start: [nodeIndex], direction, maxDepth: radius }))) {
+  for (const index of indices(bfs(self, { start: [nodeIndex], direction, radius }))) {
     reached.add(index)
   }
 
@@ -4959,7 +4959,8 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
  *
  * `start` supplies the node indices where traversal begins. If it is omitted,
  * the iterator is empty. `direction` chooses whether traversal follows
- * outgoing edges, incoming edges, or ignores edge direction.
+ * outgoing edges, incoming edges, or ignores edge direction. `radius` limits
+ * traversal by edge distance from the nearest start node.
  *
  * **Gotchas**
  *
@@ -4976,7 +4977,7 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
 export interface SearchConfig {
   readonly start?: Array<NodeIndex>
   readonly direction?: TraversalDirection
-  readonly maxDepth?: number
+  readonly radius?: number
 }
 
 /**
@@ -4986,7 +4987,7 @@ export interface SearchConfig {
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges. The `maxDepth` option
+ * chooses whether to follow outgoing or incoming edges. The `radius` option
  * limits traversal by edge distance from the start nodes. Throws a `GraphError`
  * if any configured start node does not exist.
  *
@@ -5031,7 +5032,7 @@ export const dfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
-  const max = config.maxDepth ?? Infinity
+  const radius = config.radius ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -5042,7 +5043,7 @@ export const dfs: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
-      const depths = max === Infinity ? undefined : new Map<NodeIndex, number>()
+      const depths = radius === Infinity ? undefined : new Map<NodeIndex, number>()
       const stack: Array<readonly [NodeIndex, number]> = []
       const yielded = new Set<NodeIndex>()
 
@@ -5080,7 +5081,7 @@ export const dfs: {
             continue
           }
 
-          if (depth < max) {
+          if (depth < radius) {
             const neighbors = getTraversalNeighbors(graph, current, direction)
             for (let i = neighbors.length - 1; i >= 0; i--) {
               const neighbor = neighbors[i]
@@ -5123,7 +5124,7 @@ export const dfs: {
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges. The `maxDepth` option
+ * chooses whether to follow outgoing or incoming edges. The `radius` option
  * limits traversal by edge distance from the start nodes. Throws a `GraphError`
  * if any configured start node does not exist.
  *
@@ -5168,7 +5169,7 @@ export const bfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
-  const max = config.maxDepth ?? Infinity
+  const radius = config.radius ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -5189,7 +5190,7 @@ export const bfs: {
           if (!discovered.has(current)) {
             discovered.add(current)
 
-            if (depth < max) {
+            if (depth < radius) {
               const neighbors = getTraversalNeighbors(graph, current, direction)
               for (const neighbor of neighbors) {
                 if (!discovered.has(neighbor)) {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1196,6 +1196,23 @@ export const complement: {
 })
 
 /**
+ * Configuration for selecting a graph neighborhood.
+ *
+ * **Details**
+ *
+ * `radius` limits the edge distance from the center node and defaults to `1`.
+ * `direction` controls how directed edges are traversed and defaults to
+ * `"outgoing"`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface NeighborhoodConfig {
+  readonly radius?: number
+  readonly direction?: TraversalDirection
+}
+
+/**
  * Returns the induced subgraph containing nodes within a radius of a node.
  *
  * **Details**
@@ -1230,17 +1247,17 @@ export const complement: {
 export const neighborhood: {
   (
     nodeIndex: NodeIndex,
-    options?: { readonly radius?: number; readonly direction?: TraversalDirection }
+    options?: NeighborhoodConfig
   ): <N, E, T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
   <N, E, T extends Kind = "directed">(
     self: Graph<N, E, T>,
     nodeIndex: NodeIndex,
-    options?: { readonly radius?: number; readonly direction?: TraversalDirection }
+    options?: NeighborhoodConfig
   ): Graph<N, E, T>
 } = dual((args) => isGraph(args[0]), <N, E, T extends Kind>(
   self: Graph<N, E, T>,
   nodeIndex: NodeIndex,
-  options?: { readonly radius?: number; readonly direction?: TraversalDirection }
+  options?: NeighborhoodConfig
 ): Graph<N, E, T> => {
   const radius = options?.radius ?? 1
   const direction = options?.direction ?? "outgoing"

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -372,6 +372,32 @@ const missingNode = (node: number) => new GraphError({ message: `Node ${node} do
  */
 export const isGraph = (u: unknown): u is Graph<unknown, unknown> => hasProperty(u, TypeId)
 
+/** @internal */
+const make = <T extends Kind>(type: T) =>
+<N, E>(
+  mutate?: (mutable: MutableGraph<N, E, T>) => void
+): Graph<N, E, T> => {
+  const graph: Mutable<Graph<N, E, T>> = Object.create(ProtoGraph)
+
+  graph.type = type
+  graph.nodes = new Map()
+  graph.edges = new Map()
+  graph.adjacency = new Map()
+  graph.reverseAdjacency = new Map()
+  graph.nextNodeIndex = 0
+  graph.nextEdgeIndex = 0
+  graph.acyclic = Option.some(true)
+  graph.mutable = false
+
+  if (mutate !== undefined) {
+    const mutable = beginMutation(graph)
+    mutate(mutable)
+    return endMutation(mutable)
+  }
+
+  return graph
+}
+
 /**
  * Creates a directed graph, optionally with initial mutations.
  *
@@ -393,26 +419,9 @@ export const isGraph = (u: unknown): u is Graph<unknown, unknown> => hasProperty
  * @category constructors
  * @since 3.18.0
  */
-export const directed = <N, E>(mutate?: (mutable: MutableDirectedGraph<N, E>) => void): DirectedGraph<N, E> => {
-  const graph: Mutable<DirectedGraph<N, E>> = Object.create(ProtoGraph)
-  graph.type = "directed"
-  graph.nodes = new Map()
-  graph.edges = new Map()
-  graph.adjacency = new Map()
-  graph.reverseAdjacency = new Map()
-  graph.nextNodeIndex = 0
-  graph.nextEdgeIndex = 0
-  graph.acyclic = Option.some(true)
-  graph.mutable = false
-
-  if (mutate) {
-    const mutable = beginMutation(graph as DirectedGraph<N, E>)
-    mutate(mutable as MutableDirectedGraph<N, E>)
-    return endMutation(mutable)
-  }
-
-  return graph
-}
+export const directed = <N, E>(
+  mutate?: (mutable: MutableDirectedGraph<N, E>) => void
+): DirectedGraph<N, E> => make("directed")(mutate)
 
 /**
  * Creates an undirected graph, optionally with initial mutations.
@@ -435,26 +444,9 @@ export const directed = <N, E>(mutate?: (mutable: MutableDirectedGraph<N, E>) =>
  * @category constructors
  * @since 3.18.0
  */
-export const undirected = <N, E>(mutate?: (mutable: MutableUndirectedGraph<N, E>) => void): UndirectedGraph<N, E> => {
-  const graph: Mutable<UndirectedGraph<N, E>> = Object.create(ProtoGraph)
-  graph.type = "undirected"
-  graph.nodes = new Map()
-  graph.edges = new Map()
-  graph.adjacency = new Map()
-  graph.reverseAdjacency = new Map()
-  graph.nextNodeIndex = 0
-  graph.nextEdgeIndex = 0
-  graph.acyclic = Option.some(true)
-  graph.mutable = false
-
-  if (mutate) {
-    const mutable = beginMutation(graph)
-    mutate(mutable as MutableUndirectedGraph<N, E>)
-    return endMutation(mutable)
-  }
-
-  return graph
-}
+export const undirected = <N, E>(
+  mutate?: (mutable: MutableUndirectedGraph<N, E>) => void
+): UndirectedGraph<N, E> => make("undirected")(mutate)
 
 // =============================================================================
 // Scoped Mutable API
@@ -609,26 +601,6 @@ const buildNodeMaps = <N, E, T extends Kind>(graph: Graph<N, E, T>, nodeId: (nod
 const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
   type === "undirected" && sourceId > targetId ? `${targetId}\0${sourceId}` : `${sourceId}\0${targetId}`
 
-/** @internal */
-const emptyLike = <N, E, T extends Kind>(
-  graph: Graph<N, E, T>,
-  mutate: (mutable: MutableGraph<N, E, T>) => void
-): Graph<N, E, T> => {
-  const mutable = beginMutation(graph)
-
-  mutable.nodes.clear()
-  mutable.edges.clear()
-  mutable.adjacency.clear()
-  mutable.reverseAdjacency.clear()
-  mutable.nextNodeIndex = 0
-  mutable.nextEdgeIndex = 0
-  mutable.acyclic = Option.some(true)
-
-  mutate(mutable)
-
-  return endMutation(mutable)
-}
-
 /**
  * Returns the union of two graphs, merging nodes by identity.
  *
@@ -699,7 +671,7 @@ export const compose: {
       }
     }
 
-    return emptyLike(self, (mutable) => {
+    return make(self.type)((mutable) => {
       const newIndexMap = new Map<string, NodeIndex>()
 
       for (const id of allNodeIds) {
@@ -785,7 +757,7 @@ export const intersection: {
     }
   }
 
-  return emptyLike(self, (mutable) => {
+  return make(self.type)((mutable) => {
     const newIndexMap = new Map<string, NodeIndex>()
 
     for (const id of commonNodeIds) {
@@ -880,7 +852,7 @@ export const difference: {
     }
   }
 
-  return emptyLike(self, (mutable) => {
+  return make(self.type)((mutable) => {
     const newIndexMap = new Map<string, NodeIndex>()
 
     for (const [id, entry] of selfMaps.byId) {
@@ -984,7 +956,7 @@ export const symmetricDifference: {
     }
   }
 
-  return emptyLike(self, (mutable) => {
+  return make(self.type)((mutable) => {
     const newIndexMap = new Map<string, NodeIndex>()
 
     for (const id of allNodeIds) {
@@ -1060,7 +1032,7 @@ export const complement: {
 ): Graph<N, E, T> => {
   const nodeEntries = Array.from(self.nodes)
 
-  return emptyLike(self, (mutable) => {
+  return make(self.type)((mutable) => {
     const newIndexMap = new Map<NodeIndex, NodeIndex>()
 
     for (const [oldIndex, data] of nodeEntries) {
@@ -1157,7 +1129,7 @@ export const neighborhood: {
     }
   }
 
-  return emptyLike(self, (mutable) => {
+  return make(self.type)((mutable) => {
     const newIndexMap = new Map<NodeIndex, NodeIndex>()
 
     for (const oldIndex of reached) {
@@ -1200,7 +1172,7 @@ export const sum: {
 } = dual(
   2,
   <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>): Graph<N, E, T> =>
-    emptyLike(self, (mutable) => {
+    make(self.type)((mutable) => {
       const copyInto = (graph: Graph<N, E, T>) => {
         const indexMap = new Map<NodeIndex, NodeIndex>()
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -706,7 +706,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  * Nodes with equal identities in one input graph are coalesced. The last node
  * supplies the data, and redirected edges can collapse or become self-loops.
  *
- * **Example** (Composing graphs)
+ * **Example** (Combining graphs)
  *
  * ```ts
  * import { Graph } from "effect"
@@ -723,7 +723,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  *   Graph.addEdge(mutable, b, c, "B-C")
  * })
  *
- * const result = Graph.compose(left, right, {
+ * const result = Graph.union(left, right, {
  *   nodeIdentity: (node) => node.id
  * })
  *
@@ -734,7 +734,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  * @category set operations
  * @since 4.0.0
  */
-export const compose: {
+export const union: {
   <N, E, T extends Kind = "directed", NI = N, EI = E>(
     that: Graph<N, E, T>,
     options?: IdentityOptions<N, E, NI, EI>

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -709,7 +709,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
 }
 
 /**
- * Returns the union of two graphs, merging nodes by identity.
+ * Composes two graphs, merging nodes by identity.
  *
  * **Details**
  *
@@ -742,7 +742,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  *   Graph.addEdge(mutable, b, c, "B-C")
  * })
  *
- * const result = Graph.union(left, right, {
+ * const result = Graph.compose(left, right, {
  *   nodeIdentity: (node) => node.id
  * })
  *
@@ -753,7 +753,7 @@ const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>):
  * @category set operations
  * @since 4.0.0
  */
-export const union: {
+export const compose: {
   <N, E, T extends Kind = "directed", NI = N, EI = E>(
     that: Graph<N, E, T>,
     options?: IdentityOptions<N, E, NI, EI>
@@ -1219,7 +1219,7 @@ export interface NeighborhoodConfig {
  *
  * const result = Graph.neighborhood(graph, 1, { radius: 1 })
  *
- * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.nodeCount(result)) // 2
  * ```
  *
  * @category set operations
@@ -5394,7 +5394,8 @@ export const topo: {
  *
  * Nodes are emitted after their reachable descendants have been processed. If
  * no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges.
+ * chooses whether to follow outgoing or incoming edges. The `radius` option
+ * limits traversal by edge distance from the start nodes.
  *
  * **Example** (Traversing in postorder)
  *
@@ -5433,6 +5434,7 @@ export const dfsPostOrder: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
+  const radius = config.radius ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -5443,6 +5445,9 @@ export const dfsPostOrder: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
+      const reached = radius === Infinity
+        ? undefined
+        : new Set(indices(bfs(graph, { start, direction, radius })))
       const stack: Array<{ node: NodeIndex; visitedChildren: boolean }> = []
       const discovered = new Set<NodeIndex>()
       const finished = new Set<NodeIndex>()
@@ -5467,7 +5472,11 @@ export const dfsPostOrder: {
 
             for (let i = neighbors.length - 1; i >= 0; i--) {
               const neighbor = neighbors[i]
-              if (!discovered.has(neighbor) && !finished.has(neighbor)) {
+              if (
+                (reached === undefined || reached.has(neighbor)) &&
+                !discovered.has(neighbor) &&
+                !finished.has(neighbor)
+              ) {
                 stack.push({ node: neighbor, visitedChildren: false })
               }
             }

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -15,6 +15,7 @@ import { dual } from "./Function.ts"
 import * as Hash from "./Hash.ts"
 import type { Inspectable } from "./Inspectable.ts"
 import { NodeInspectSymbol } from "./Inspectable.ts"
+import * as MutableHashMap from "./MutableHashMap.ts"
 import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { pipeArguments } from "./Pipeable.ts"
@@ -372,31 +373,54 @@ const missingNode = (node: number) => new GraphError({ message: `Node ${node} do
  */
 export const isGraph = (u: unknown): u is Graph<unknown, unknown> => hasProperty(u, TypeId)
 
-/** @internal */
-const make = <T extends Kind>(type: T) =>
-<N, E>(
-  mutate?: (mutable: MutableGraph<N, E, T>) => void
-): Graph<N, E, T> => {
-  const graph: Mutable<Graph<N, E, T>> = Object.create(ProtoGraph)
+/**
+ * Creates a graph constructor for the specified graph kind.
+ *
+ * **When to use**
+ *
+ * Use when the graph kind is selected dynamically. Prefer `directed` or
+ * `undirected` when the kind is known statically.
+ *
+ * **Example** (Constructing by kind)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const makeGraph = Graph.make("directed")
+ * const graph = makeGraph<string, number>((mutable) => {
+ *   Graph.addNode(mutable, "A")
+ * })
+ *
+ * console.log(graph.type) // "directed"
+ * ```
+ *
+ * @see {@link directed} for constructing a directed graph directly
+ * @see {@link undirected} for constructing an undirected graph directly
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make =
+  <T extends Kind>(type: T) => <N, E>(mutate?: (mutable: MutableGraph<N, E, T>) => void): Graph<N, E, T> => {
+    const graph: Mutable<Graph<N, E, T> | MutableGraph<N, E, T>> = Object.create(ProtoGraph)
+    graph.type = type
+    graph.nodes = new Map()
+    graph.edges = new Map()
+    graph.adjacency = new Map()
+    graph.reverseAdjacency = new Map()
+    graph.nextNodeIndex = 0
+    graph.nextEdgeIndex = 0
+    graph.acyclic = Option.some(true)
 
-  graph.type = type
-  graph.nodes = new Map()
-  graph.edges = new Map()
-  graph.adjacency = new Map()
-  graph.reverseAdjacency = new Map()
-  graph.nextNodeIndex = 0
-  graph.nextEdgeIndex = 0
-  graph.acyclic = Option.some(true)
-  graph.mutable = false
+    if (mutate === undefined) {
+      graph.mutable = false
+      return graph as Graph<N, E, T>
+    }
 
-  if (mutate !== undefined) {
-    const mutable = beginMutation(graph)
+    graph.mutable = true
+    const mutable = graph as MutableGraph<N, E, T>
     mutate(mutable)
     return endMutation(mutable)
   }
-
-  return graph
-}
 
 /**
  * Creates a directed graph, optionally with initial mutations.
@@ -419,9 +443,9 @@ const make = <T extends Kind>(type: T) =>
  * @category constructors
  * @since 3.18.0
  */
-export const directed = <N, E>(
+export const directed: <N, E>(
   mutate?: (mutable: MutableDirectedGraph<N, E>) => void
-): DirectedGraph<N, E> => make("directed")(mutate)
+) => DirectedGraph<N, E> = make("directed")
 
 /**
  * Creates an undirected graph, optionally with initial mutations.
@@ -444,9 +468,9 @@ export const directed = <N, E>(
  * @category constructors
  * @since 3.18.0
  */
-export const undirected = <N, E>(
+export const undirected: <N, E>(
   mutate?: (mutable: MutableUndirectedGraph<N, E>) => void
-): UndirectedGraph<N, E> => make("undirected")(mutate)
+) => UndirectedGraph<N, E> = make("undirected")
 
 // =============================================================================
 // Scoped Mutable API
@@ -575,31 +599,95 @@ export const mutate: {
 // =============================================================================
 
 /** @internal */
-type NodeMaps<N> = {
-  readonly byId: Map<string, { readonly index: NodeIndex; readonly data: N }>
-  readonly byIndex: Map<NodeIndex, string>
+type NodeMaps<N, I> = {
+  readonly byIdentity: MutableHashMap.MutableHashMap<I, N>
+  readonly byIndex: Map<NodeIndex, I>
 }
 
 /** @internal */
-type EdgeIdentity<E> = { readonly sourceId: string; readonly targetId: string; readonly data: E }
+class EdgeIdentity<NI, EI> implements Equal.Equal {
+  readonly type: Kind
+  readonly source: NI
+  readonly target: NI
+  readonly identity: EI
 
-/** @internal */
-const buildNodeMaps = <N, E, T extends Kind>(graph: Graph<N, E, T>, nodeId: (node: N) => string): NodeMaps<N> => {
-  const byId = new Map<string, { readonly index: NodeIndex; readonly data: N }>()
-  const byIndex = new Map<NodeIndex, string>()
-
-  for (const [index, data] of graph.nodes) {
-    const id = nodeId(data)
-    byId.set(id, { index, data })
-    byIndex.set(index, id)
+  constructor(
+    type: Kind,
+    source: NI,
+    target: NI,
+    identity: EI
+  ) {
+    this.type = type
+    this.source = source
+    this.target = target
+    this.identity = identity
   }
 
-  return { byId, byIndex }
+  [Equal.symbol](that: Equal.Equal): boolean {
+    if (!(that instanceof EdgeIdentity) || this.type !== that.type || !Equal.equals(this.identity, that.identity)) {
+      return false
+    }
+
+    if (this.type === "directed") {
+      return Equal.equals(this.source, that.source) && Equal.equals(this.target, that.target)
+    }
+
+    return (
+      (Equal.equals(this.source, that.source) && Equal.equals(this.target, that.target)) ||
+      (Equal.equals(this.source, that.target) && Equal.equals(this.target, that.source))
+    )
+  }
+
+  [Hash.symbol](): number {
+    const hash = Hash.hash(this.identity)
+    return this.type === "directed"
+      ? Hash.combine(Hash.hash(this.target))(Hash.combine(Hash.hash(this.source))(hash))
+      : Hash.optimize(hash ^ (Hash.hash(this.source) + Hash.hash(this.target)))
+  }
+}
+
+/**
+ * Configures node and edge identity for graph set operations.
+ *
+ * **Details**
+ *
+ * Both functions default to using the complete node or edge data. Edge identity
+ * also includes the identities of its endpoint nodes and the graph kind.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface IdentityOptions<N, E, NI = N, EI = E> {
+  readonly nodeIdentity?: (node: N) => NI
+  readonly edgeIdentity?: (edge: E) => EI
 }
 
 /** @internal */
-const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
-  type === "undirected" && sourceId > targetId ? `${targetId}\0${sourceId}` : `${sourceId}\0${targetId}`
+const buildNodeMaps = <N, E, T extends Kind, I>(
+  graph: Graph<N, E, T>,
+  identity: (node: N) => I
+): NodeMaps<N, I> => {
+  const byIdentity = MutableHashMap.empty<I, N>()
+  const byIndex = new Map<NodeIndex, I>()
+
+  for (const [index, data] of graph.nodes) {
+    const nodeIdentity = identity(data)
+    MutableHashMap.set(byIdentity, nodeIdentity, data)
+    byIndex.set(index, nodeIdentity)
+  }
+
+  return { byIdentity, byIndex }
+}
+
+/** @internal */
+const nodeIdentityAt = <N, I>(maps: NodeMaps<N, I>, index: NodeIndex): I => maps.byIndex.get(index) as I
+
+/** @internal */
+const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>): void => {
+  if (self.type !== that.type) {
+    throw new GraphError({ message: `Cannot combine ${self.type} and ${that.type} graphs` })
+  }
+}
 
 /**
  * Returns the union of two graphs, merging nodes by identity.
@@ -607,9 +695,16 @@ const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
  * **Details**
  *
  * Nodes and edges present in both graphs use data from `that`. The result has
- * the same graph kind as `self`.
+ * the same graph kind as `self`. Throws a `GraphError` when the graph kinds do
+ * not match. `nodeIdentity` and `edgeIdentity` default to the complete node and
+ * edge data. Edge identity also includes the endpoint identities.
  *
  * `G1 ∪ G2 = {V1 ∪ V2, E1 ∪ E2}`
+ *
+ * **Gotchas**
+ *
+ * Nodes with equal identities in one input graph are coalesced. The last node
+ * supplies the data, and redirected edges can collapse or become self-loops.
  *
  * **Example** (Composing graphs)
  *
@@ -628,7 +723,9 @@ const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
  *   Graph.addEdge(mutable, b, c, "B-C")
  * })
  *
- * const result = Graph.compose(left, right, (node) => node.id)
+ * const result = Graph.compose(left, right, {
+ *   nodeIdentity: (node) => node.id
+ * })
  *
  * console.log(Graph.nodeCount(result)) // 3
  * console.log(Graph.edgeCount(result)) // 2
@@ -638,52 +735,60 @@ const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
  * @since 4.0.0
  */
 export const compose: {
-  <N, E, T extends Kind = "directed">(
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     that: Graph<N, E, T>,
-    nodeId: (node: N) => string
-  ): (self: Graph<N, E, T>) => Graph<N, E, T>
-  <N, E, T extends Kind = "directed">(
+    options?: IdentityOptions<N, E, NI, EI>
+  ): (self: Graph<N, E, NoInfer<T>>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     self: Graph<N, E, T>,
-    that: Graph<N, E, T>,
-    nodeId: (node: N) => string
+    that: Graph<N, E, NoInfer<T>>,
+    options?: IdentityOptions<N, E, NI, EI>
   ): Graph<N, E, T>
 } = dual(
-  3,
-  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>, nodeId: (node: N) => string): Graph<N, E, T> => {
-    const selfMaps = buildNodeMaps(self, nodeId)
-    const thatMaps = buildNodeMaps(that, nodeId)
-    const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
-    const edgeMap = new Map<string, EdgeIdentity<E>>()
+  (args) => isGraph(args[0]) && isGraph(args[1]),
+  <N, E, T extends Kind, NI, EI>(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    options?: IdentityOptions<N, E, NI, EI>
+  ): Graph<N, E, T> => {
+    assertSameKind(self, that)
+    const getNodeIdentity = options?.nodeIdentity ?? ((node: N) => node as unknown as NI)
+    const getEdgeIdentity = options?.edgeIdentity ?? ((edge: E) => edge as unknown as EI)
+    const selfMaps = buildNodeMaps(self, getNodeIdentity)
+    const thatMaps = buildNodeMaps(that, getNodeIdentity)
+    const nodes = MutableHashMap.empty<NI, N>()
+    const edges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+
+    for (const [identity, data] of selfMaps.byIdentity) {
+      MutableHashMap.set(nodes, identity, data)
+    }
+    for (const [identity, data] of thatMaps.byIdentity) {
+      MutableHashMap.set(nodes, identity, data)
+    }
 
     for (const edge of self.edges.values()) {
-      const sourceId = selfMaps.byIndex.get(edge.source)
-      const targetId = selfMaps.byIndex.get(edge.target)
-      if (sourceId !== undefined && targetId !== undefined) {
-        edgeMap.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
-      }
+      const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
+      const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
+      const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+      MutableHashMap.set(edges, edgeIdentity, edge.data)
     }
 
     for (const edge of that.edges.values()) {
-      const sourceId = thatMaps.byIndex.get(edge.source)
-      const targetId = thatMaps.byIndex.get(edge.target)
-      if (sourceId !== undefined && targetId !== undefined) {
-        edgeMap.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
-      }
+      const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
+      const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
+      const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+      MutableHashMap.set(edges, edgeIdentity, edge.data)
     }
 
-    return make(self.type)((mutable) => {
-      const newIndexMap = new Map<string, NodeIndex>()
-
-      for (const id of allNodeIds) {
-        const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
-        if (entry !== undefined) {
-          newIndexMap.set(id, addNode(mutable, entry.data))
-        }
+    return make(self.type)<N, E>((mutable) => {
+      const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
+      for (const [identity, data] of nodes) {
+        MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
       }
 
-      for (const { sourceId, targetId, data } of edgeMap.values()) {
-        const sourceIndex = newIndexMap.get(sourceId)
-        const targetIndex = newIndexMap.get(targetId)
+      for (const [identity, data] of edges) {
+        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
+        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
         if (sourceIndex !== undefined && targetIndex !== undefined) {
           addEdge(mutable, sourceIndex, targetIndex, data)
         }
@@ -698,9 +803,16 @@ export const compose: {
  * **Details**
  *
  * Node data comes from `self`, and edge data comes from `that`. The result has
- * the same graph kind as `self`.
+ * the same graph kind as `self`. Throws a `GraphError` when the graph kinds do
+ * not match. `nodeIdentity` and `edgeIdentity` default to the complete node and
+ * edge data. Edge identity also includes the endpoint identities.
  *
  * `G1 ∩ G2 = {V1 ∩ V2, E1 ∩ E2}`
+ *
+ * **Gotchas**
+ *
+ * Nodes with equal identities in one input graph are coalesced. The last node
+ * supplies the data, and redirected edges can collapse or become self-loops.
  *
  * **Example** (Finding shared structure)
  *
@@ -710,16 +822,16 @@ export const compose: {
  * const left = Graph.directed<string, string>((mutable) => {
  *   const a = Graph.addNode(mutable, "A")
  *   const b = Graph.addNode(mutable, "B")
- *   Graph.addEdge(mutable, a, b, "left")
+ *   Graph.addEdge(mutable, a, b, "shared")
  * })
  *
  * const right = Graph.directed<string, string>((mutable) => {
  *   const a = Graph.addNode(mutable, "A")
  *   const b = Graph.addNode(mutable, "B")
- *   Graph.addEdge(mutable, a, b, "right")
+ *   Graph.addEdge(mutable, a, b, "shared")
  * })
  *
- * const result = Graph.intersection(left, right, (node) => node)
+ * const result = Graph.intersection(left, right)
  *
  * console.log(Graph.nodeCount(result)) // 2
  * console.log(Graph.edgeCount(result)) // 1
@@ -729,58 +841,63 @@ export const compose: {
  * @since 4.0.0
  */
 export const intersection: {
-  <N, E, T extends Kind = "directed">(
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     that: Graph<N, E, T>,
-    nodeId: (node: N) => string
-  ): (self: Graph<N, E, T>) => Graph<N, E, T>
-  <N, E, T extends Kind = "directed">(
+    options?: IdentityOptions<N, E, NI, EI>
+  ): (self: Graph<N, E, NoInfer<T>>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     self: Graph<N, E, T>,
-    that: Graph<N, E, T>,
-    nodeId: (node: N) => string
+    that: Graph<N, E, NoInfer<T>>,
+    options?: IdentityOptions<N, E, NI, EI>
   ): Graph<N, E, T>
-} = dual(3, <N, E, T extends Kind>(
+} = dual((args) => isGraph(args[0]) && isGraph(args[1]), <N, E, T extends Kind, NI, EI>(
   self: Graph<N, E, T>,
   that: Graph<N, E, T>,
-  nodeId: (node: N) => string
+  options?: IdentityOptions<N, E, NI, EI>
 ): Graph<N, E, T> => {
-  const selfMaps = buildNodeMaps(self, nodeId)
-  const thatMaps = buildNodeMaps(that, nodeId)
-  const commonNodeIds = [...selfMaps.byId.keys()].filter((id) => thatMaps.byId.has(id))
-  const commonNodeIdSet = new Set(commonNodeIds)
-  const selfEdgeKeys = new Set<string>()
+  assertSameKind(self, that)
+  const getNodeIdentity = options?.nodeIdentity ?? ((node: N) => node as unknown as NI)
+  const getEdgeIdentity = options?.edgeIdentity ?? ((edge: E) => edge as unknown as EI)
+  const selfMaps = buildNodeMaps(self, getNodeIdentity)
+  const thatMaps = buildNodeMaps(that, getNodeIdentity)
+  const nodes = MutableHashMap.empty<NI, N>()
+  const selfEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+  const thatEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
 
-  for (const edge of self.edges.values()) {
-    const sourceId = selfMaps.byIndex.get(edge.source)
-    const targetId = selfMaps.byIndex.get(edge.target)
-    if (sourceId !== undefined && targetId !== undefined) {
-      selfEdgeKeys.add(edgeKey(self.type, sourceId, targetId))
+  for (const [identity, data] of selfMaps.byIdentity) {
+    if (MutableHashMap.has(thatMaps.byIdentity, identity)) {
+      MutableHashMap.set(nodes, identity, data)
     }
   }
 
-  return make(self.type)((mutable) => {
-    const newIndexMap = new Map<string, NodeIndex>()
+  for (const edge of self.edges.values()) {
+    const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
+    const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
+    const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+    MutableHashMap.set(selfEdges, edgeIdentity, edge.data)
+  }
 
-    for (const id of commonNodeIds) {
-      const entry = selfMaps.byId.get(id)
-      if (entry !== undefined) {
-        newIndexMap.set(id, addNode(mutable, entry.data))
-      }
+  for (const edge of that.edges.values()) {
+    const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
+    const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
+    if (MutableHashMap.has(nodes, sourceIdentity) && MutableHashMap.has(nodes, targetIdentity)) {
+      const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+      MutableHashMap.set(thatEdges, edgeIdentity, edge.data)
+    }
+  }
+
+  return make(self.type)<N, E>((mutable) => {
+    const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
+    for (const [identity, data] of nodes) {
+      MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
     }
 
-    for (const edge of that.edges.values()) {
-      const sourceId = thatMaps.byIndex.get(edge.source)
-      const targetId = thatMaps.byIndex.get(edge.target)
-      if (
-        sourceId !== undefined &&
-        targetId !== undefined &&
-        commonNodeIdSet.has(sourceId) &&
-        commonNodeIdSet.has(targetId) &&
-        selfEdgeKeys.has(edgeKey(that.type, sourceId, targetId))
-      ) {
-        const sourceIndex = newIndexMap.get(sourceId)
-        const targetIndex = newIndexMap.get(targetId)
+    for (const [identity, data] of thatEdges) {
+      if (MutableHashMap.has(selfEdges, identity)) {
+        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
+        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
         if (sourceIndex !== undefined && targetIndex !== undefined) {
-          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+          addEdge(mutable, sourceIndex, targetIndex, data)
         }
       }
     }
@@ -792,10 +909,17 @@ export const intersection: {
  *
  * **Details**
  *
- * All nodes from `self` are preserved. Edges are matched by endpoint identity,
- * and edge data is ignored. The result has the same graph kind as `self`.
+ * All nodes from `self` are preserved. Edges are matched by endpoint and edge
+ * identities. The result has the same graph kind as `self`. Throws a
+ * `GraphError` when the graph kinds do not match. `nodeIdentity` and
+ * `edgeIdentity` default to the complete node and edge data.
  *
  * `G1 \ G2 = {V1, E1 \ E2}`
+ *
+ * **Gotchas**
+ *
+ * Nodes with equal identities in one input graph are coalesced. The last node
+ * supplies the data, and redirected edges can collapse or become self-loops.
  *
  * **Example** (Removing shared edges)
  *
@@ -813,10 +937,10 @@ export const intersection: {
  * const right = Graph.directed<string, string>((mutable) => {
  *   const b = Graph.addNode(mutable, "B")
  *   const c = Graph.addNode(mutable, "C")
- *   Graph.addEdge(mutable, b, c, "other")
+ *   Graph.addEdge(mutable, b, c, "B-C")
  * })
  *
- * const result = Graph.difference(left, right, (node) => node)
+ * const result = Graph.difference(left, right)
  *
  * console.log(Graph.nodeCount(result)) // 3
  * console.log(Graph.edgeCount(result)) // 1
@@ -826,47 +950,48 @@ export const intersection: {
  * @since 4.0.0
  */
 export const difference: {
-  <N, E, T extends Kind = "directed">(
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     that: Graph<N, E, T>,
-    nodeId: (node: N) => string
-  ): (self: Graph<N, E, T>) => Graph<N, E, T>
-  <N, E, T extends Kind = "directed">(
+    options?: IdentityOptions<N, E, NI, EI>
+  ): (self: Graph<N, E, NoInfer<T>>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     self: Graph<N, E, T>,
-    that: Graph<N, E, T>,
-    nodeId: (node: N) => string
+    that: Graph<N, E, NoInfer<T>>,
+    options?: IdentityOptions<N, E, NI, EI>
   ): Graph<N, E, T>
-} = dual(3, <N, E, T extends Kind>(
+} = dual((args) => isGraph(args[0]) && isGraph(args[1]), <N, E, T extends Kind, NI, EI>(
   self: Graph<N, E, T>,
   that: Graph<N, E, T>,
-  nodeId: (node: N) => string
+  options?: IdentityOptions<N, E, NI, EI>
 ): Graph<N, E, T> => {
-  const selfMaps = buildNodeMaps(self, nodeId)
-  const thatMaps = buildNodeMaps(that, nodeId)
-  const thatEdgeKeys = new Set<string>()
+  assertSameKind(self, that)
+  const getNodeIdentity = options?.nodeIdentity ?? ((node: N) => node as unknown as NI)
+  const getEdgeIdentity = options?.edgeIdentity ?? ((edge: E) => edge as unknown as EI)
+  const selfMaps = buildNodeMaps(self, getNodeIdentity)
+  const thatMaps = buildNodeMaps(that, getNodeIdentity)
+  const thatEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
 
   for (const edge of that.edges.values()) {
-    const sourceId = thatMaps.byIndex.get(edge.source)
-    const targetId = thatMaps.byIndex.get(edge.target)
-    if (sourceId !== undefined && targetId !== undefined) {
-      thatEdgeKeys.add(edgeKey(that.type, sourceId, targetId))
-    }
+    const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
+    const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
+    const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+    MutableHashMap.set(thatEdges, edgeIdentity, edge.data)
   }
 
-  return make(self.type)((mutable) => {
-    const newIndexMap = new Map<string, NodeIndex>()
+  return make(self.type)<N, E>((mutable) => {
+    const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
 
-    for (const [id, entry] of selfMaps.byId) {
-      newIndexMap.set(id, addNode(mutable, entry.data))
+    for (const [identity, data] of selfMaps.byIdentity) {
+      MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
     }
 
     for (const edge of self.edges.values()) {
-      const sourceId = selfMaps.byIndex.get(edge.source)
-      const targetId = selfMaps.byIndex.get(edge.target)
-      if (
-        sourceId !== undefined && targetId !== undefined && !thatEdgeKeys.has(edgeKey(self.type, sourceId, targetId))
-      ) {
-        const sourceIndex = newIndexMap.get(sourceId)
-        const targetIndex = newIndexMap.get(targetId)
+      const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
+      const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
+      const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+      if (!MutableHashMap.has(thatEdges, edgeIdentity)) {
+        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, sourceIdentity))
+        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, targetIdentity))
         if (sourceIndex !== undefined && targetIndex !== undefined) {
           addEdge(mutable, sourceIndex, targetIndex, edge.data)
         }
@@ -881,13 +1006,18 @@ export const difference: {
  * **Details**
  *
  * Keeps nodes from both graphs. Overlapping nodes use data from `that`. The
- * result has the same graph kind as `self`.
+ * result has the same graph kind as `self`. Throws a `GraphError` when the
+ * graph kinds do not match. `nodeIdentity` and `edgeIdentity` default to the
+ * complete node and edge data. Edge identity also includes the endpoint
+ * identities.
  *
  * `G1 Δ G2 = {V1 ∪ V2, (E1 ∪ E2) \ (E1 ∩ E2)}`
  *
  * **Gotchas**
  *
- * Edges present in both graphs are removed even when their edge data differs.
+ * Edges with different projected identities are distinct.
+ * Nodes with equal identities in one input graph are coalesced. The last node
+ * supplies the data, and redirected edges can collapse or become self-loops.
  *
  * **Example** (Finding differing edges)
  *
@@ -910,7 +1040,7 @@ export const difference: {
  *   Graph.addEdge(mutable, c, d, "C-D")
  * })
  *
- * const result = Graph.symmetricDifference(left, right, (node) => node)
+ * const result = Graph.symmetricDifference(left, right)
  *
  * console.log(Graph.nodeCount(result)) // 4
  * console.log(Graph.edgeCount(result)) // 2
@@ -920,66 +1050,72 @@ export const difference: {
  * @since 4.0.0
  */
 export const symmetricDifference: {
-  <N, E, T extends Kind = "directed">(
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     that: Graph<N, E, T>,
-    nodeId: (node: N) => string
-  ): (self: Graph<N, E, T>) => Graph<N, E, T>
-  <N, E, T extends Kind = "directed">(
+    options?: IdentityOptions<N, E, NI, EI>
+  ): (self: Graph<N, E, NoInfer<T>>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed", NI = N, EI = E>(
     self: Graph<N, E, T>,
-    that: Graph<N, E, T>,
-    nodeId: (node: N) => string
+    that: Graph<N, E, NoInfer<T>>,
+    options?: IdentityOptions<N, E, NI, EI>
   ): Graph<N, E, T>
-} = dual(3, <N, E, T extends Kind>(
+} = dual((args) => isGraph(args[0]) && isGraph(args[1]), <N, E, T extends Kind, NI, EI>(
   self: Graph<N, E, T>,
   that: Graph<N, E, T>,
-  nodeId: (node: N) => string
+  options?: IdentityOptions<N, E, NI, EI>
 ): Graph<N, E, T> => {
-  const selfMaps = buildNodeMaps(self, nodeId)
-  const thatMaps = buildNodeMaps(that, nodeId)
-  const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
-  const selfEdges = new Map<string, EdgeIdentity<E>>()
-  const thatEdges = new Map<string, EdgeIdentity<E>>()
+  assertSameKind(self, that)
+  const getNodeIdentity = options?.nodeIdentity ?? ((node: N) => node as unknown as NI)
+  const getEdgeIdentity = options?.edgeIdentity ?? ((edge: E) => edge as unknown as EI)
+  const selfMaps = buildNodeMaps(self, getNodeIdentity)
+  const thatMaps = buildNodeMaps(that, getNodeIdentity)
+  const nodes = MutableHashMap.empty<NI, N>()
+  const selfEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+  const thatEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+
+  for (const [identity, data] of selfMaps.byIdentity) {
+    MutableHashMap.set(nodes, identity, data)
+  }
+
+  for (const [identity, data] of thatMaps.byIdentity) {
+    MutableHashMap.set(nodes, identity, data)
+  }
 
   for (const edge of self.edges.values()) {
-    const sourceId = selfMaps.byIndex.get(edge.source)
-    const targetId = selfMaps.byIndex.get(edge.target)
-    if (sourceId !== undefined && targetId !== undefined) {
-      selfEdges.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
-    }
+    const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
+    const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
+    const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+    MutableHashMap.set(selfEdges, edgeIdentity, edge.data)
   }
 
   for (const edge of that.edges.values()) {
-    const sourceId = thatMaps.byIndex.get(edge.source)
-    const targetId = thatMaps.byIndex.get(edge.target)
-    if (sourceId !== undefined && targetId !== undefined) {
-      thatEdges.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
-    }
+    const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
+    const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
+    const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
+    MutableHashMap.set(thatEdges, edgeIdentity, edge.data)
   }
 
-  return make(self.type)((mutable) => {
-    const newIndexMap = new Map<string, NodeIndex>()
+  return make(self.type)<N, E>((mutable) => {
+    const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
 
-    for (const id of allNodeIds) {
-      const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
-      if (entry !== undefined) {
-        newIndexMap.set(id, addNode(mutable, entry.data))
-      }
+    for (const [identity, data] of nodes) {
+      MutableHashMap.set(indexByIdentity, identity, addNode(mutable, data))
     }
 
-    for (const [key, { sourceId, targetId, data }] of selfEdges) {
-      if (!thatEdges.has(key)) {
-        const sourceIndex = newIndexMap.get(sourceId)
-        const targetIndex = newIndexMap.get(targetId)
+    for (const [identity, data] of selfEdges) {
+      if (!MutableHashMap.has(thatEdges, identity)) {
+        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
+        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
         if (sourceIndex !== undefined && targetIndex !== undefined) {
           addEdge(mutable, sourceIndex, targetIndex, data)
         }
       }
     }
 
-    for (const [key, { sourceId, targetId, data }] of thatEdges) {
-      if (!selfEdges.has(key)) {
-        const sourceIndex = newIndexMap.get(sourceId)
-        const targetIndex = newIndexMap.get(targetId)
+    for (const [identity, data] of thatEdges) {
+      if (!MutableHashMap.has(selfEdges, identity)) {
+        const sourceIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.source))
+        const targetIndex = Option.getOrUndefined(MutableHashMap.get(indexByIdentity, identity.target))
         if (sourceIndex !== undefined && targetIndex !== undefined) {
           addEdge(mutable, sourceIndex, targetIndex, data)
         }
@@ -1032,7 +1168,7 @@ export const complement: {
 ): Graph<N, E, T> => {
   const nodeEntries = Array.from(self.nodes)
 
-  return make(self.type)((mutable) => {
+  return make(self.type)<N, E>((mutable) => {
     const newIndexMap = new Map<NodeIndex, NodeIndex>()
 
     for (const [oldIndex, data] of nodeEntries) {
@@ -1129,7 +1265,7 @@ export const neighborhood: {
     }
   }
 
-  return make(self.type)((mutable) => {
+  return make(self.type)<N, E>((mutable) => {
     const newIndexMap = new Map<NodeIndex, NodeIndex>()
 
     for (const oldIndex of reached) {
@@ -1154,7 +1290,8 @@ export const neighborhood: {
  * **Details**
  *
  * Copies all nodes and edges from both graphs without merging equal node data.
- * The result has the same graph kind as `self`.
+ * The result has the same graph kind as `self`. Throws a `GraphError` when the
+ * graph kinds do not match.
  *
  * `G1 + G2 = {disjoint V1 + V2, disjoint E1 + E2}`
  *
@@ -1162,37 +1299,31 @@ export const neighborhood: {
  * @since 4.0.0
  */
 export const sum: {
-  <N, E, T extends Kind = "directed">(
-    that: Graph<N, E, T>
-  ): (self: Graph<N, E, T>) => Graph<N, E, T>
-  <N, E, T extends Kind = "directed">(
-    self: Graph<N, E, T>,
-    that: Graph<N, E, T>
-  ): Graph<N, E, T>
-} = dual(
-  2,
-  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>): Graph<N, E, T> =>
-    make(self.type)((mutable) => {
-      const copyInto = (graph: Graph<N, E, T>) => {
-        const indexMap = new Map<NodeIndex, NodeIndex>()
+  <N, E, T extends Kind>(that: Graph<N, E, T>): (self: Graph<N, E, NoInfer<T>>) => Graph<N, E, T>
+  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, NoInfer<T>>): Graph<N, E, T>
+} = dual(2, <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>): Graph<N, E, T> => {
+  assertSameKind(self, that)
+  return make(self.type)<N, E>((mutable) => {
+    const copyInto = (graph: Graph<N, E, T>) => {
+      const indexMap = new Map<NodeIndex, NodeIndex>()
 
-        for (const [oldIndex, data] of graph.nodes) {
-          indexMap.set(oldIndex, addNode(mutable, data))
-        }
-
-        for (const edge of graph.edges.values()) {
-          const sourceIndex = indexMap.get(edge.source)
-          const targetIndex = indexMap.get(edge.target)
-          if (sourceIndex !== undefined && targetIndex !== undefined) {
-            addEdge(mutable, sourceIndex, targetIndex, edge.data)
-          }
-        }
+      for (const [oldIndex, data] of graph.nodes) {
+        indexMap.set(oldIndex, addNode(mutable, data))
       }
 
-      copyInto(self)
-      copyInto(that)
-    })
-)
+      for (const edge of graph.edges.values()) {
+        const sourceIndex = indexMap.get(edge.source)
+        const targetIndex = indexMap.get(edge.target)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+
+    copyInto(self)
+    copyInto(that)
+  })
+})
 
 // =============================================================================
 // Basic Node Operations

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1210,8 +1210,8 @@ export type NeighborhoodDirection = "outgoing" | "incoming" | "both"
  *
  * The `radius` option is the maximum edge distance from `nodeIndex` and
  * defaults to `1`. The `direction` option controls directed graph traversal and
- * defaults to `"both"`. The result has the same graph kind as `self` and keeps
- * all original edges whose endpoints are both reached.
+ * defaults to `"outgoing"`. The result has the same graph kind as `self` and
+ * keeps all original edges whose endpoints are both reached.
  *
  * **Example** (Getting a local neighborhood)
  *
@@ -1250,7 +1250,7 @@ export const neighborhood: {
   options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
 ): Graph<N, E, T> => {
   const radius = options?.radius ?? 1
-  const direction = options?.direction ?? "both"
+  const direction = options?.direction ?? "outgoing"
   const reached = new Set<NodeIndex>()
 
   if (direction === "outgoing" || direction === "both") {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -683,6 +683,25 @@ const buildNodeMaps = <N, E, T extends Kind, I>(
 const nodeIdentityAt = <N, I>(maps: NodeMaps<N, I>, index: NodeIndex): I => maps.byIndex.get(index) as I
 
 /** @internal */
+const buildEdgeMap = <N, E, T extends Kind, NI, EI>(
+  graph: Graph<N, E, T>,
+  nodeMaps: NodeMaps<N, NI>,
+  identity: (edge: E) => EI
+): MutableHashMap.MutableHashMap<EdgeIdentity<NI, EI>, E> => {
+  const edges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+  for (const edge of graph.edges.values()) {
+    const sourceIdentity = nodeIdentityAt(nodeMaps, edge.source)
+    const targetIdentity = nodeIdentityAt(nodeMaps, edge.target)
+    MutableHashMap.set(
+      edges,
+      new EdgeIdentity(graph.type, sourceIdentity, targetIdentity, identity(edge.data)),
+      edge.data
+    )
+  }
+  return edges
+}
+
+/** @internal */
 const assertSameKind = <N, E>(self: Graph<N, E, Kind>, that: Graph<N, E, Kind>): void => {
   if (self.type !== that.type) {
     throw new GraphError({ message: `Cannot combine ${self.type} and ${that.type} graphs` })
@@ -757,7 +776,7 @@ export const union: {
     const selfMaps = buildNodeMaps(self, getNodeIdentity)
     const thatMaps = buildNodeMaps(that, getNodeIdentity)
     const nodes = MutableHashMap.empty<NI, N>()
-    const edges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+    const edges = buildEdgeMap(self, selfMaps, getEdgeIdentity)
 
     for (const [identity, data] of selfMaps.byIdentity) {
       MutableHashMap.set(nodes, identity, data)
@@ -766,18 +785,8 @@ export const union: {
       MutableHashMap.set(nodes, identity, data)
     }
 
-    for (const edge of self.edges.values()) {
-      const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
-      const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
-      const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
-      MutableHashMap.set(edges, edgeIdentity, edge.data)
-    }
-
-    for (const edge of that.edges.values()) {
-      const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
-      const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
-      const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
-      MutableHashMap.set(edges, edgeIdentity, edge.data)
+    for (const [identity, data] of buildEdgeMap(that, thatMaps, getEdgeIdentity)) {
+      MutableHashMap.set(edges, identity, data)
     }
 
     return make(self.type)<N, E>((mutable) => {
@@ -861,20 +870,13 @@ export const intersection: {
   const selfMaps = buildNodeMaps(self, getNodeIdentity)
   const thatMaps = buildNodeMaps(that, getNodeIdentity)
   const nodes = MutableHashMap.empty<NI, N>()
-  const selfEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+  const selfEdges = buildEdgeMap(self, selfMaps, getEdgeIdentity)
   const thatEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
 
   for (const [identity, data] of selfMaps.byIdentity) {
     if (MutableHashMap.has(thatMaps.byIdentity, identity)) {
       MutableHashMap.set(nodes, identity, data)
     }
-  }
-
-  for (const edge of self.edges.values()) {
-    const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
-    const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
-    const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
-    MutableHashMap.set(selfEdges, edgeIdentity, edge.data)
   }
 
   for (const edge of that.edges.values()) {
@@ -969,14 +971,7 @@ export const difference: {
   const getEdgeIdentity = options?.edgeIdentity ?? ((edge: E) => edge as unknown as EI)
   const selfMaps = buildNodeMaps(self, getNodeIdentity)
   const thatMaps = buildNodeMaps(that, getNodeIdentity)
-  const thatEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
-
-  for (const edge of that.edges.values()) {
-    const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
-    const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
-    const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
-    MutableHashMap.set(thatEdges, edgeIdentity, edge.data)
-  }
+  const thatEdges = buildEdgeMap(that, thatMaps, getEdgeIdentity)
 
   return make(self.type)<N, E>((mutable) => {
     const indexByIdentity = MutableHashMap.empty<NI, NodeIndex>()
@@ -1070,8 +1065,8 @@ export const symmetricDifference: {
   const selfMaps = buildNodeMaps(self, getNodeIdentity)
   const thatMaps = buildNodeMaps(that, getNodeIdentity)
   const nodes = MutableHashMap.empty<NI, N>()
-  const selfEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
-  const thatEdges = MutableHashMap.empty<EdgeIdentity<NI, EI>, E>()
+  const selfEdges = buildEdgeMap(self, selfMaps, getEdgeIdentity)
+  const thatEdges = buildEdgeMap(that, thatMaps, getEdgeIdentity)
 
   for (const [identity, data] of selfMaps.byIdentity) {
     MutableHashMap.set(nodes, identity, data)
@@ -1079,20 +1074,6 @@ export const symmetricDifference: {
 
   for (const [identity, data] of thatMaps.byIdentity) {
     MutableHashMap.set(nodes, identity, data)
-  }
-
-  for (const edge of self.edges.values()) {
-    const sourceIdentity = nodeIdentityAt(selfMaps, edge.source)
-    const targetIdentity = nodeIdentityAt(selfMaps, edge.target)
-    const edgeIdentity = new EdgeIdentity(self.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
-    MutableHashMap.set(selfEdges, edgeIdentity, edge.data)
-  }
-
-  for (const edge of that.edges.values()) {
-    const sourceIdentity = nodeIdentityAt(thatMaps, edge.source)
-    const targetIdentity = nodeIdentityAt(thatMaps, edge.target)
-    const edgeIdentity = new EdgeIdentity(that.type, sourceIdentity, targetIdentity, getEdgeIdentity(edge.data))
-    MutableHashMap.set(thatEdges, edgeIdentity, edge.data)
   }
 
   return make(self.type)<N, E>((mutable) => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3009,6 +3009,49 @@ describe("Graph", () => {
       expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
     })
 
+    it("should limit DFS traversal by maxDepth", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        const d = Graph.addNode(mutable, "D")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, b, c, 2)
+        Graph.addEdge(mutable, c, d, 3)
+      })
+
+      const dfsIterator = Graph.dfs(graph, { start: [0], maxDepth: 1 })
+
+      expect(Array.from(Graph.indices(dfsIterator))).toEqual([0, 1])
+    })
+
+    it("should limit BFS traversal by maxDepth", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        const d = Graph.addNode(mutable, "D")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, a, c, 2)
+        Graph.addEdge(mutable, b, d, 3)
+      })
+
+      const bfsIterator = Graph.bfs(graph, { start: [0], maxDepth: 1 })
+
+      expect(Array.from(Graph.indices(bfsIterator))).toEqual([0, 1, 2])
+    })
+
+    it("should only include start nodes when maxDepth is zero", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, 1)
+      })
+
+      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], maxDepth: 0 })))).toEqual([0])
+      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], maxDepth: 0 })))).toEqual([0])
+    })
+
     it("should provide values() method for Topo iterator", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -177,6 +177,100 @@ describe("Graph", () => {
       strictEqual(Graph.edgeCount(Graph.difference(left, right, (n) => n)), 0)
     })
 
+    it("complement adds missing directed edges", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "a", label: "A" })
+        const b = Graph.addNode(mutable, { id: "b", label: "B" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, b, c, "B-C")
+      })
+
+      const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
+
+      expect(Graph.nodeCount(result)).toBe(3)
+      expect(Graph.edgeCount(result)).toBe(4)
+      expect(graphEdgeData(result)).toEqual(
+        new Map([
+          ["a->c", "A-C"],
+          ["b->a", "B-A"],
+          ["c->a", "C-A"],
+          ["c->b", "C-B"]
+        ])
+      )
+    })
+
+    it("complement adds missing undirected edges once", () => {
+      const graph = Graph.undirected<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        Graph.addNode(mutable, { id: "C", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+      })
+
+      const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
+
+      expect(result.type).toBe("undirected")
+      expect(Graph.edgeCount(result)).toBe(2)
+      expect(graphEdgeData(result)).toEqual(
+        new Map([
+          ["A--C", "A-C"],
+          ["B--C", "B-C"]
+        ])
+      )
+    })
+
+    it("neighborhood returns the induced subgraph within radius", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        const c = Graph.addNode(mutable, { id: "C", label: "C" })
+        const d = Graph.addNode(mutable, { id: "D", label: "D" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, b, c, "B-C")
+        Graph.addEdge(mutable, c, d, "C-D")
+        Graph.addEdge(mutable, c, b, "C-B")
+      })
+
+      const result = Graph.neighborhood(graph, 1, { radius: 1, direction: "outgoing" })
+
+      expect(graphNodeIds(result)).toEqual(new Set(["B", "C"]))
+      expect(graphEdgeKeys(result)).toEqual(new Set(["B->C", "C->B"]))
+    })
+
+    it("neighborhood can include incoming and outgoing nodes", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        const c = Graph.addNode(mutable, { id: "C", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, b, c, "B-C")
+      })
+
+      const result = Graph.neighborhood(graph, 1)
+
+      expect(graphNodeIds(result)).toEqual(new Set(["A", "B", "C"]))
+      expect(graphEdgeKeys(result)).toEqual(new Set(["A->B", "B->C"]))
+    })
+
+    it("sum keeps equal nodes disjoint", () => {
+      const left = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "left")
+      })
+      const right = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "right")
+      })
+
+      const result = Graph.sum(left, right)
+
+      expect(Graph.nodeCount(result)).toBe(4)
+      expect(Graph.edgeCount(result)).toBe(2)
+      expect(Array.from(Graph.values(Graph.nodes(result)))).toEqual(["A", "B", "A", "B"])
+    })
   })
 
   it("toString", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1,4 +1,4 @@
-import { assertNone, assertSome, strictEqual } from "@effect/vitest/utils"
+import { assertNone, assertSome, strictEqual, throws } from "@effect/vitest/utils"
 import { Equal, Graph, Hash, Option } from "effect"
 import { describe, expect, it } from "vitest"
 
@@ -19,6 +19,22 @@ const makeReversedUndirectedPath = () =>
   })
 
 type SetNode = { readonly id: string; readonly label: string }
+
+class SetNodeKey implements Equal.Equal {
+  readonly id: string
+
+  constructor(id: string) {
+    this.id = id
+  }
+
+  [Equal.symbol](that: Equal.Equal): boolean {
+    return that instanceof SetNodeKey && this.id === that.id
+  }
+
+  [Hash.symbol](): number {
+    return Hash.string(this.id)
+  }
+}
 
 const graphNodeIds = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
   new Set(Array.from(graph, ([, node]) => node.id))
@@ -77,7 +93,7 @@ describe("Graph", () => {
         const b = Graph.addNode(mutable, { id: "b", label: "B1" })
         const c = Graph.addNode(mutable, { id: "c", label: "C1" })
         Graph.addEdge(mutable, a, b, "left-ab")
-        Graph.addEdge(mutable, b, c, "left-bc")
+        Graph.addEdge(mutable, b, c, "shared-bc")
       })
 
     const makeRight = () =>
@@ -85,12 +101,12 @@ describe("Graph", () => {
         const b = Graph.addNode(mutable, { id: "b", label: "B2" })
         const c = Graph.addNode(mutable, { id: "c", label: "C2" })
         const d = Graph.addNode(mutable, { id: "d", label: "D2" })
-        Graph.addEdge(mutable, b, c, "right-bc")
+        Graph.addEdge(mutable, b, c, "shared-bc")
         Graph.addEdge(mutable, c, d, "right-cd")
       })
 
     it("compose merges nodes and edges by identity", () => {
-      const graph = Graph.compose(makeLeft(), makeRight(), (n) => n.id)
+      const graph = Graph.compose(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
       expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
       expect(graphNodeLabels(graph)).toEqual(
@@ -105,14 +121,14 @@ describe("Graph", () => {
       expect(graphEdgeData(graph)).toEqual(
         new Map([
           ["a->b", "left-ab"],
-          ["b->c", "right-bc"],
+          ["b->c", "shared-bc"],
           ["c->d", "right-cd"]
         ])
       )
     })
 
     it("intersection keeps shared nodes and shared edges", () => {
-      const graph = Graph.intersection(makeLeft(), makeRight(), (n) => n.id)
+      const graph = Graph.intersection(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
       expect(graphNodeIds(graph)).toEqual(new Set(["b", "c"]))
       expect(graphNodeLabels(graph)).toEqual(
@@ -122,11 +138,11 @@ describe("Graph", () => {
         ])
       )
       expect(graphEdgeKeys(graph)).toEqual(new Set(["b->c"]))
-      expect(graphEdgeData(graph)).toEqual(new Map([["b->c", "right-bc"]]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["b->c", "shared-bc"]]))
     })
 
     it("difference preserves self nodes and removes shared edges", () => {
-      const graph = Graph.difference(makeLeft(), makeRight(), (n) => n.id)
+      const graph = Graph.difference(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
       expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c"]))
       expect(graphNodeLabels(graph)).toEqual(
@@ -141,7 +157,7 @@ describe("Graph", () => {
     })
 
     it("symmetricDifference keeps edges present in exactly one graph", () => {
-      const graph = Graph.symmetricDifference(makeLeft(), makeRight(), (n) => n.id)
+      const graph = Graph.symmetricDifference(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
       expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
       expect(graphNodeLabels(graph)).toEqual(
@@ -161,20 +177,143 @@ describe("Graph", () => {
       )
     })
 
-    it("matches undirected edges regardless of endpoint order", () => {
-      const left = Graph.undirected<string, string>((mutable) => {
+    it("uses node data as identity by default", () => {
+      const left = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "shared")
+      })
+      const right = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "shared")
+      })
+
+      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 2)
+      strictEqual(Graph.edgeCount(left.pipe(Graph.intersection(right))), 1)
+      strictEqual(Graph.edgeCount(Graph.difference(left, right)), 0)
+      strictEqual(Graph.edgeCount(left.pipe(Graph.symmetricDifference(right))), 0)
+    })
+
+    it("supports hashable node identities", () => {
+      const graph = Graph.compose(makeLeft(), makeRight(), {
+        nodeIdentity: (node) => new SetNodeKey(node.id)
+      })
+
+      strictEqual(Graph.nodeCount(graph), 4)
+      strictEqual(Graph.edgeCount(graph), 3)
+    })
+
+    it("supports undefined node data and identities", () => {
+      const left = Graph.directed<undefined, never>((mutable) => {
+        Graph.addNode(mutable, undefined)
+      })
+      const right = Graph.directed<undefined, never>((mutable) => {
+        Graph.addNode(mutable, undefined)
+      })
+
+      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 1)
+    })
+
+    it("coalesces duplicate node identities", () => {
+      const left = Graph.directed<SetNode, string>((mutable) => {
+        const first = Graph.addNode(mutable, { id: "a", label: "first" })
+        const last = Graph.addNode(mutable, { id: "a", label: "last" })
+        Graph.addEdge(mutable, first, last, "same")
+      })
+      const right = Graph.directed<SetNode, string>()
+      const result = Graph.compose(left, right, { nodeIdentity: (node) => node.id })
+      const edge = Array.from(Graph.edges(result))[0][1]
+
+      strictEqual(Graph.nodeCount(result), 1)
+      strictEqual(Array.from(Graph.values(Graph.nodes(result)))[0].label, "last")
+      strictEqual(edge.source, edge.target)
+    })
+
+    it("includes edge data in edge identity", () => {
+      const left = Graph.directed<string, string>((mutable) => {
         const a = Graph.addNode(mutable, "A")
         const b = Graph.addNode(mutable, "B")
         Graph.addEdge(mutable, a, b, "left")
       })
+      const right = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "right")
+      })
+
+      strictEqual(Graph.edgeCount(Graph.compose(left, right)), 2)
+      strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 0)
+      strictEqual(Graph.edgeCount(Graph.difference(left, right)), 1)
+      strictEqual(Graph.edgeCount(Graph.symmetricDifference(left, right)), 2)
+    })
+
+    it("uses edge data from that for equivalent edges", () => {
+      const left = Graph.directed<string, { readonly id: string; readonly label: string }>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, { id: "shared", label: "left" })
+      })
+      const right = Graph.directed<string, { readonly id: string; readonly label: string }>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, { id: "shared", label: "right" })
+      })
+      const options = { edgeIdentity: (edge: { readonly id: string }) => edge.id }
+
+      strictEqual(Array.from(Graph.edges(Graph.compose(left, right, options)))[0][1].data.label, "right")
+      strictEqual(Array.from(Graph.edges(Graph.intersection(left, right, options)))[0][1].data.label, "right")
+    })
+
+    it("deduplicates equal edges in intersections", () => {
+      const left = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "shared")
+      })
+      const right = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "shared")
+        Graph.addEdge(mutable, a, b, "shared")
+      })
+
+      strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 1)
+    })
+
+    it("rejects graphs with different kinds", () => {
+      const directed: Graph.Graph<string, string, Graph.Kind> = Graph.directed()
+      const undirected: Graph.Graph<string, string, Graph.Kind> = Graph.undirected()
+
+      throws(
+        () => Graph.compose(directed, undirected),
+        (error) => {
+          strictEqual(error instanceof Graph.GraphError, true)
+          if (error instanceof Graph.GraphError) {
+            strictEqual(error.message, "Cannot combine directed and undirected graphs")
+          }
+        }
+      )
+      throws(() => Graph.sum(directed, undirected), (error) => {
+        strictEqual(error instanceof Graph.GraphError, true)
+      })
+    })
+
+    it("matches undirected edges regardless of endpoint order", () => {
+      const left = Graph.undirected<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "shared")
+      })
       const right = Graph.undirected<string, string>((mutable) => {
         const b = Graph.addNode(mutable, "B")
         const a = Graph.addNode(mutable, "A")
-        Graph.addEdge(mutable, b, a, "right")
+        Graph.addEdge(mutable, b, a, "shared")
       })
 
-      strictEqual(Graph.edgeCount(Graph.intersection(left, right, (n) => n)), 1)
-      strictEqual(Graph.edgeCount(Graph.difference(left, right, (n) => n)), 0)
+      const options = { nodeIdentity: (node: string) => new SetNodeKey(node) }
+      strictEqual(Graph.edgeCount(Graph.intersection(left, right, options)), 1)
+      strictEqual(Graph.edgeCount(Graph.difference(left, right, options)), 0)
     })
 
     it("complement adds missing directed edges", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3258,7 +3258,7 @@ describe("Graph", () => {
       expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
     })
 
-    it("should limit DFS traversal by maxDepth", () => {
+    it("should limit DFS traversal by radius", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")
         const b = Graph.addNode(mutable, "B")
@@ -3269,7 +3269,7 @@ describe("Graph", () => {
         Graph.addEdge(mutable, c, d, 3)
       })
 
-      const dfsIterator = Graph.dfs(graph, { start: [0], maxDepth: 1 })
+      const dfsIterator = Graph.dfs(graph, { start: [0], radius: 1 })
 
       expect(Array.from(Graph.indices(dfsIterator))).toEqual([0, 1])
     })
@@ -3286,12 +3286,12 @@ describe("Graph", () => {
         Graph.addEdge(mutable, c, d, 4)
       })
 
-      const dfsIterator = Graph.dfs(graph, { start: [0], maxDepth: 2 })
+      const dfsIterator = Graph.dfs(graph, { start: [0], radius: 2 })
 
       assert.deepStrictEqual(Array.from(Graph.indices(dfsIterator)), [0, 1, 2, 3])
     })
 
-    it("should limit BFS traversal by maxDepth", () => {
+    it("should limit BFS traversal by radius", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")
         const b = Graph.addNode(mutable, "B")
@@ -3302,20 +3302,20 @@ describe("Graph", () => {
         Graph.addEdge(mutable, b, d, 3)
       })
 
-      const bfsIterator = Graph.bfs(graph, { start: [0], maxDepth: 1 })
+      const bfsIterator = Graph.bfs(graph, { start: [0], radius: 1 })
 
       expect(Array.from(Graph.indices(bfsIterator))).toEqual([0, 1, 2])
     })
 
-    it("should only include start nodes when maxDepth is zero", () => {
+    it("should only include start nodes when radius is zero", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")
         const b = Graph.addNode(mutable, "B")
         Graph.addEdge(mutable, a, b, 1)
       })
 
-      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], maxDepth: 0 })))).toEqual([0])
-      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], maxDepth: 0 })))).toEqual([0])
+      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], radius: 0 })))).toEqual([0])
+      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], radius: 0 })))).toEqual([0])
     })
 
     it("should provide values() method for Topo iterator", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -378,7 +378,7 @@ describe("Graph", () => {
       expect(graphEdgeKeys(result)).toEqual(new Set(["B->C", "C->B"]))
     })
 
-    it("neighborhood can include incoming and outgoing nodes", () => {
+    it("neighborhood follows outgoing edges by default", () => {
       const graph = Graph.directed<SetNode, string>((mutable) => {
         const a = Graph.addNode(mutable, { id: "A", label: "A" })
         const b = Graph.addNode(mutable, { id: "B", label: "B" })
@@ -389,8 +389,8 @@ describe("Graph", () => {
 
       const result = Graph.neighborhood(graph, 1)
 
-      expect(graphNodeIds(result)).toEqual(new Set(["A", "B", "C"]))
-      expect(graphEdgeKeys(result)).toEqual(new Set(["A->B", "B->C"]))
+      expect(graphNodeIds(result)).toEqual(new Set(["B", "C"]))
+      expect(graphEdgeKeys(result)).toEqual(new Set(["B->C"]))
     })
 
     it("sum keeps equal nodes disjoint", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -18,6 +18,39 @@ const makeReversedUndirectedPath = () =>
     Graph.addEdge(mutable, c, b, 1)
   })
 
+type SetNode = { readonly id: string; readonly label: string }
+
+const graphNodeIds = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
+  new Set(Array.from(graph, ([, node]) => node.id))
+
+const graphNodeLabels = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
+  new Map(Array.from(graph, ([, node]) => [node.id, node.label]))
+
+const graphEdgeKeys = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
+  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
+  return new Set(
+    Array.from(Graph.edges(graph), ([, edge]) =>
+      graph.type === "directed"
+        ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
+        : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
+  )
+}
+
+const graphEdgeData = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
+  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
+  return new Map(
+    Array.from(
+      Graph.edges(graph),
+      ([, edge]) => [
+        graph.type === "directed"
+          ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
+          : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`,
+        edge.data
+      ]
+    )
+  )
+}
+
 describe("Graph", () => {
   describe("constructors", () => {
     it("should create empty directed graph", () => {
@@ -35,6 +68,115 @@ describe("Graph", () => {
       expect(Graph.nodeCount(graph)).toBe(0)
       expect(Graph.edgeCount(graph)).toBe(0)
     })
+  })
+
+  describe("set operations", () => {
+    const makeLeft = () =>
+      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "a", label: "A1" })
+        const b = Graph.addNode(mutable, { id: "b", label: "B1" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C1" })
+        Graph.addEdge(mutable, a, b, "left-ab")
+        Graph.addEdge(mutable, b, c, "left-bc")
+      })
+
+    const makeRight = () =>
+      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
+        const b = Graph.addNode(mutable, { id: "b", label: "B2" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C2" })
+        const d = Graph.addNode(mutable, { id: "d", label: "D2" })
+        Graph.addEdge(mutable, b, c, "right-bc")
+        Graph.addEdge(mutable, c, d, "right-cd")
+      })
+
+    it("compose merges nodes and edges by identity", () => {
+      const graph = Graph.compose(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B2"],
+          ["c", "C2"],
+          ["d", "D2"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "b->c", "c->d"]))
+      expect(graphEdgeData(graph)).toEqual(
+        new Map([
+          ["a->b", "left-ab"],
+          ["b->c", "right-bc"],
+          ["c->d", "right-cd"]
+        ])
+      )
+    })
+
+    it("intersection keeps shared nodes and shared edges", () => {
+      const graph = Graph.intersection(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["b", "c"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["b", "B1"],
+          ["c", "C1"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["b->c"]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["b->c", "right-bc"]]))
+    })
+
+    it("difference preserves self nodes and removes shared edges", () => {
+      const graph = Graph.difference(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B1"],
+          ["c", "C1"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b"]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["a->b", "left-ab"]]))
+    })
+
+    it("symmetricDifference keeps edges present in exactly one graph", () => {
+      const graph = Graph.symmetricDifference(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B2"],
+          ["c", "C2"],
+          ["d", "D2"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "c->d"]))
+      expect(graphEdgeData(graph)).toEqual(
+        new Map([
+          ["a->b", "left-ab"],
+          ["c->d", "right-cd"]
+        ])
+      )
+    })
+
+    it("matches undirected edges regardless of endpoint order", () => {
+      const left = Graph.undirected<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "left")
+      })
+      const right = Graph.undirected<string, string>((mutable) => {
+        const b = Graph.addNode(mutable, "B")
+        const a = Graph.addNode(mutable, "A")
+        Graph.addEdge(mutable, b, a, "right")
+      })
+
+      strictEqual(Graph.edgeCount(Graph.intersection(left, right, (n) => n)), 1)
+      strictEqual(Graph.edgeCount(Graph.difference(left, right, (n) => n)), 0)
+    })
+
   })
 
   it("toString", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -393,6 +393,21 @@ describe("Graph", () => {
       expect(graphEdgeKeys(result)).toEqual(new Set(["B->C"]))
     })
 
+    it("neighborhood can ignore edge direction", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        const c = Graph.addNode(mutable, { id: "C", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, a, c, "A-C")
+      })
+
+      const result = Graph.neighborhood(graph, 1, { radius: 2, direction: "undirected" })
+
+      expect(graphNodeIds(result)).toEqual(new Set(["A", "B", "C"]))
+      expect(graphEdgeKeys(result)).toEqual(new Set(["A->B", "A->C"]))
+    })
+
     it("sum keeps equal nodes disjoint", () => {
       const left = Graph.directed<string, string>((mutable) => {
         const a = Graph.addNode(mutable, "A")

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3460,6 +3460,19 @@ describe("Graph", () => {
       expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0] })))).toEqual([0, 1, 2])
       expect(Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0] })))).toEqual([2, 1, 0])
     })
+
+    it("should ignore edge direction during traversal", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, a, c, 2)
+      })
+
+      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [1], direction: "undirected" })))).toEqual([1, 0, 2])
+      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected" })))).toEqual([1, 0, 2])
+    })
   })
 
   describe("DfsPostOrder Iterator", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -106,8 +106,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, c, d, "right-cd")
       })
 
-    it("compose merges nodes and edges by identity", () => {
-      const graph = Graph.compose(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
+    it("union merges nodes and edges by identity", () => {
+      const graph = Graph.union(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
       expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
       expect(graphNodeLabels(graph)).toEqual(
@@ -190,14 +190,14 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, "shared")
       })
 
-      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 2)
+      strictEqual(Graph.nodeCount(Graph.union(left, right)), 2)
       strictEqual(Graph.edgeCount(left.pipe(Graph.intersection(right))), 1)
       strictEqual(Graph.edgeCount(Graph.difference(left, right)), 0)
       strictEqual(Graph.edgeCount(left.pipe(Graph.symmetricDifference(right))), 0)
     })
 
     it("supports hashable node identities", () => {
-      const graph = Graph.compose(makeLeft(), makeRight(), {
+      const graph = Graph.union(makeLeft(), makeRight(), {
         nodeIdentity: (node) => new SetNodeKey(node.id)
       })
 
@@ -213,7 +213,7 @@ describe("Graph", () => {
         Graph.addNode(mutable, undefined)
       })
 
-      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 1)
+      strictEqual(Graph.nodeCount(Graph.union(left, right)), 1)
     })
 
     it("coalesces duplicate node identities", () => {
@@ -223,7 +223,7 @@ describe("Graph", () => {
         Graph.addEdge(mutable, first, last, "same")
       })
       const right = Graph.directed<SetNode, string>()
-      const result = Graph.compose(left, right, { nodeIdentity: (node) => node.id })
+      const result = Graph.union(left, right, { nodeIdentity: (node) => node.id })
       const edge = Array.from(Graph.edges(result))[0][1]
 
       strictEqual(Graph.nodeCount(result), 1)
@@ -243,7 +243,7 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, "right")
       })
 
-      strictEqual(Graph.edgeCount(Graph.compose(left, right)), 2)
+      strictEqual(Graph.edgeCount(Graph.union(left, right)), 2)
       strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 0)
       strictEqual(Graph.edgeCount(Graph.difference(left, right)), 1)
       strictEqual(Graph.edgeCount(Graph.symmetricDifference(left, right)), 2)
@@ -262,7 +262,7 @@ describe("Graph", () => {
       })
       const options = { edgeIdentity: (edge: { readonly id: string }) => edge.id }
 
-      strictEqual(Array.from(Graph.edges(Graph.compose(left, right, options)))[0][1].data.label, "right")
+      strictEqual(Array.from(Graph.edges(Graph.union(left, right, options)))[0][1].data.label, "right")
       strictEqual(Array.from(Graph.edges(Graph.intersection(left, right, options)))[0][1].data.label, "right")
     })
 
@@ -287,7 +287,7 @@ describe("Graph", () => {
       const undirected: Graph.Graph<string, string, Graph.Kind> = Graph.undirected()
 
       throws(
-        () => Graph.compose(directed, undirected),
+        () => Graph.union(directed, undirected),
         (error) => {
           strictEqual(error instanceof Graph.GraphError, true)
           if (error instanceof Graph.GraphError) {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1,3 +1,4 @@
+import { assert } from "@effect/vitest"
 import { assertNone, assertSome, strictEqual, throws } from "@effect/vitest/utils"
 import { Equal, Graph, Hash, Option } from "effect"
 import { describe, expect, it } from "vitest"
@@ -3256,6 +3257,23 @@ describe("Graph", () => {
       const dfsIterator = Graph.dfs(graph, { start: [0], maxDepth: 1 })
 
       expect(Array.from(Graph.indices(dfsIterator))).toEqual([0, 1])
+    })
+
+    it("should use the shortest discovered depth when limiting DFS traversal", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        const d = Graph.addNode(mutable, "D")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, b, c, 2)
+        Graph.addEdge(mutable, a, c, 3)
+        Graph.addEdge(mutable, c, d, 4)
+      })
+
+      const dfsIterator = Graph.dfs(graph, { start: [0], maxDepth: 2 })
+
+      assert.deepStrictEqual(Array.from(Graph.indices(dfsIterator)), [0, 1, 2, 3])
     })
 
     it("should limit BFS traversal by maxDepth", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -106,11 +106,12 @@ describe("Graph", () => {
         Graph.addEdge(mutable, c, d, "right-cd")
       })
 
-    it("union merges nodes and edges by identity", () => {
-      const graph = Graph.union(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
+    it("compose merges nodes and edges by identity", () => {
+      const graph = Graph.compose(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
-      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
-      expect(graphNodeLabels(graph)).toEqual(
+      assert.deepStrictEqual(graphNodeIds(graph), new Set(["a", "b", "c", "d"]))
+      assert.deepStrictEqual(
+        graphNodeLabels(graph),
         new Map([
           ["a", "A1"],
           ["b", "B2"],
@@ -118,8 +119,9 @@ describe("Graph", () => {
           ["d", "D2"]
         ])
       )
-      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "b->c", "c->d"]))
-      expect(graphEdgeData(graph)).toEqual(
+      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["a->b", "b->c", "c->d"]))
+      assert.deepStrictEqual(
+        graphEdgeData(graph),
         new Map([
           ["a->b", "left-ab"],
           ["b->c", "shared-bc"],
@@ -131,37 +133,40 @@ describe("Graph", () => {
     it("intersection keeps shared nodes and shared edges", () => {
       const graph = Graph.intersection(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
-      expect(graphNodeIds(graph)).toEqual(new Set(["b", "c"]))
-      expect(graphNodeLabels(graph)).toEqual(
+      assert.deepStrictEqual(graphNodeIds(graph), new Set(["b", "c"]))
+      assert.deepStrictEqual(
+        graphNodeLabels(graph),
         new Map([
           ["b", "B1"],
           ["c", "C1"]
         ])
       )
-      expect(graphEdgeKeys(graph)).toEqual(new Set(["b->c"]))
-      expect(graphEdgeData(graph)).toEqual(new Map([["b->c", "shared-bc"]]))
+      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["b->c"]))
+      assert.deepStrictEqual(graphEdgeData(graph), new Map([["b->c", "shared-bc"]]))
     })
 
     it("difference preserves self nodes and removes shared edges", () => {
       const graph = Graph.difference(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
-      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c"]))
-      expect(graphNodeLabels(graph)).toEqual(
+      assert.deepStrictEqual(graphNodeIds(graph), new Set(["a", "b", "c"]))
+      assert.deepStrictEqual(
+        graphNodeLabels(graph),
         new Map([
           ["a", "A1"],
           ["b", "B1"],
           ["c", "C1"]
         ])
       )
-      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b"]))
-      expect(graphEdgeData(graph)).toEqual(new Map([["a->b", "left-ab"]]))
+      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["a->b"]))
+      assert.deepStrictEqual(graphEdgeData(graph), new Map([["a->b", "left-ab"]]))
     })
 
     it("symmetricDifference keeps edges present in exactly one graph", () => {
       const graph = Graph.symmetricDifference(makeLeft(), makeRight(), { nodeIdentity: (node) => node.id })
 
-      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
-      expect(graphNodeLabels(graph)).toEqual(
+      assert.deepStrictEqual(graphNodeIds(graph), new Set(["a", "b", "c", "d"]))
+      assert.deepStrictEqual(
+        graphNodeLabels(graph),
         new Map([
           ["a", "A1"],
           ["b", "B2"],
@@ -169,8 +174,9 @@ describe("Graph", () => {
           ["d", "D2"]
         ])
       )
-      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "c->d"]))
-      expect(graphEdgeData(graph)).toEqual(
+      assert.deepStrictEqual(graphEdgeKeys(graph), new Set(["a->b", "c->d"]))
+      assert.deepStrictEqual(
+        graphEdgeData(graph),
         new Map([
           ["a->b", "left-ab"],
           ["c->d", "right-cd"]
@@ -190,14 +196,14 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, "shared")
       })
 
-      strictEqual(Graph.nodeCount(Graph.union(left, right)), 2)
+      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 2)
       strictEqual(Graph.edgeCount(left.pipe(Graph.intersection(right))), 1)
       strictEqual(Graph.edgeCount(Graph.difference(left, right)), 0)
       strictEqual(Graph.edgeCount(left.pipe(Graph.symmetricDifference(right))), 0)
     })
 
     it("supports hashable node identities", () => {
-      const graph = Graph.union(makeLeft(), makeRight(), {
+      const graph = Graph.compose(makeLeft(), makeRight(), {
         nodeIdentity: (node) => new SetNodeKey(node.id)
       })
 
@@ -213,7 +219,7 @@ describe("Graph", () => {
         Graph.addNode(mutable, undefined)
       })
 
-      strictEqual(Graph.nodeCount(Graph.union(left, right)), 1)
+      strictEqual(Graph.nodeCount(Graph.compose(left, right)), 1)
     })
 
     it("coalesces duplicate node identities", () => {
@@ -223,7 +229,7 @@ describe("Graph", () => {
         Graph.addEdge(mutable, first, last, "same")
       })
       const right = Graph.directed<SetNode, string>()
-      const result = Graph.union(left, right, { nodeIdentity: (node) => node.id })
+      const result = Graph.compose(left, right, { nodeIdentity: (node) => node.id })
       const edge = Array.from(Graph.edges(result))[0][1]
 
       strictEqual(Graph.nodeCount(result), 1)
@@ -243,7 +249,7 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, "right")
       })
 
-      strictEqual(Graph.edgeCount(Graph.union(left, right)), 2)
+      strictEqual(Graph.edgeCount(Graph.compose(left, right)), 2)
       strictEqual(Graph.edgeCount(Graph.intersection(left, right)), 0)
       strictEqual(Graph.edgeCount(Graph.difference(left, right)), 1)
       strictEqual(Graph.edgeCount(Graph.symmetricDifference(left, right)), 2)
@@ -262,7 +268,7 @@ describe("Graph", () => {
       })
       const options = { edgeIdentity: (edge: { readonly id: string }) => edge.id }
 
-      strictEqual(Array.from(Graph.edges(Graph.union(left, right, options)))[0][1].data.label, "right")
+      strictEqual(Array.from(Graph.edges(Graph.compose(left, right, options)))[0][1].data.label, "right")
       strictEqual(Array.from(Graph.edges(Graph.intersection(left, right, options)))[0][1].data.label, "right")
     })
 
@@ -287,7 +293,7 @@ describe("Graph", () => {
       const undirected: Graph.Graph<string, string, Graph.Kind> = Graph.undirected()
 
       throws(
-        () => Graph.union(directed, undirected),
+        () => Graph.compose(directed, undirected),
         (error) => {
           strictEqual(error instanceof Graph.GraphError, true)
           if (error instanceof Graph.GraphError) {
@@ -328,9 +334,10 @@ describe("Graph", () => {
 
       const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
 
-      expect(Graph.nodeCount(result)).toBe(3)
-      expect(Graph.edgeCount(result)).toBe(4)
-      expect(graphEdgeData(result)).toEqual(
+      strictEqual(Graph.nodeCount(result), 3)
+      strictEqual(Graph.edgeCount(result), 4)
+      assert.deepStrictEqual(
+        graphEdgeData(result),
         new Map([
           ["a->c", "A-C"],
           ["b->a", "B-A"],
@@ -350,9 +357,10 @@ describe("Graph", () => {
 
       const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
 
-      expect(result.type).toBe("undirected")
-      expect(Graph.edgeCount(result)).toBe(2)
-      expect(graphEdgeData(result)).toEqual(
+      strictEqual(result.type, "undirected")
+      strictEqual(Graph.edgeCount(result), 2)
+      assert.deepStrictEqual(
+        graphEdgeData(result),
         new Map([
           ["A--C", "A-C"],
           ["B--C", "B-C"]
@@ -374,8 +382,8 @@ describe("Graph", () => {
 
       const result = Graph.neighborhood(graph, 1, { radius: 1, direction: "outgoing" })
 
-      expect(graphNodeIds(result)).toEqual(new Set(["B", "C"]))
-      expect(graphEdgeKeys(result)).toEqual(new Set(["B->C", "C->B"]))
+      assert.deepStrictEqual(graphNodeIds(result), new Set(["B", "C"]))
+      assert.deepStrictEqual(graphEdgeKeys(result), new Set(["B->C", "C->B"]))
     })
 
     it("neighborhood follows outgoing edges by default", () => {
@@ -389,8 +397,8 @@ describe("Graph", () => {
 
       const result = Graph.neighborhood(graph, 1)
 
-      expect(graphNodeIds(result)).toEqual(new Set(["B", "C"]))
-      expect(graphEdgeKeys(result)).toEqual(new Set(["B->C"]))
+      assert.deepStrictEqual(graphNodeIds(result), new Set(["B", "C"]))
+      assert.deepStrictEqual(graphEdgeKeys(result), new Set(["B->C"]))
     })
 
     it("neighborhood can ignore edge direction", () => {
@@ -404,8 +412,8 @@ describe("Graph", () => {
 
       const result = Graph.neighborhood(graph, 1, { radius: 2, direction: "undirected" })
 
-      expect(graphNodeIds(result)).toEqual(new Set(["A", "B", "C"]))
-      expect(graphEdgeKeys(result)).toEqual(new Set(["A->B", "A->C"]))
+      assert.deepStrictEqual(graphNodeIds(result), new Set(["A", "B", "C"]))
+      assert.deepStrictEqual(graphEdgeKeys(result), new Set(["A->B", "A->C"]))
     })
 
     it("sum keeps equal nodes disjoint", () => {
@@ -422,9 +430,9 @@ describe("Graph", () => {
 
       const result = Graph.sum(left, right)
 
-      expect(Graph.nodeCount(result)).toBe(4)
-      expect(Graph.edgeCount(result)).toBe(2)
-      expect(Array.from(Graph.values(Graph.nodes(result)))).toEqual(["A", "B", "A", "B"])
+      strictEqual(Graph.nodeCount(result), 4)
+      strictEqual(Graph.edgeCount(result), 2)
+      assert.deepStrictEqual(Array.from(Graph.values(Graph.nodes(result))), ["A", "B", "A", "B"])
     })
   })
 
@@ -3271,7 +3279,7 @@ describe("Graph", () => {
 
       const dfsIterator = Graph.dfs(graph, { start: [0], radius: 1 })
 
-      expect(Array.from(Graph.indices(dfsIterator))).toEqual([0, 1])
+      assert.deepStrictEqual(Array.from(Graph.indices(dfsIterator)), [0, 1])
     })
 
     it("should use the shortest discovered depth when limiting DFS traversal", () => {
@@ -3304,7 +3312,7 @@ describe("Graph", () => {
 
       const bfsIterator = Graph.bfs(graph, { start: [0], radius: 1 })
 
-      expect(Array.from(Graph.indices(bfsIterator))).toEqual([0, 1, 2])
+      assert.deepStrictEqual(Array.from(Graph.indices(bfsIterator)), [0, 1, 2])
     })
 
     it("should only include start nodes when radius is zero", () => {
@@ -3314,8 +3322,8 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, b, 1)
       })
 
-      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], radius: 0 })))).toEqual([0])
-      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], radius: 0 })))).toEqual([0])
+      assert.deepStrictEqual(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], radius: 0 }))), [0])
+      assert.deepStrictEqual(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], radius: 0 }))), [0])
     })
 
     it("should provide values() method for Topo iterator", () => {
@@ -3470,12 +3478,33 @@ describe("Graph", () => {
         Graph.addEdge(mutable, a, c, 2)
       })
 
-      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [1], direction: "undirected" })))).toEqual([1, 0, 2])
-      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected" })))).toEqual([1, 0, 2])
+      assert.deepStrictEqual(
+        Array.from(Graph.indices(Graph.dfs(graph, { start: [1], direction: "undirected" }))),
+        [1, 0, 2]
+      )
+      assert.deepStrictEqual(
+        Array.from(Graph.indices(Graph.bfs(graph, { start: [1], direction: "undirected" }))),
+        [1, 0, 2]
+      )
     })
   })
 
   describe("DfsPostOrder Iterator", () => {
+    it("should limit traversal by radius", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, b, c, 2)
+      })
+
+      assert.deepStrictEqual(
+        Array.from(Graph.indices(Graph.dfsPostOrder(graph, { start: [0], radius: 1 }))),
+        [1, 0]
+      )
+    })
+
     it("should traverse in postorder for simple chain", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -1,0 +1,106 @@
+import { Graph, pipe } from "effect"
+import { describe, expect, it } from "tstyche"
+
+declare const directed: Graph.DirectedGraph<string, number>
+declare const undirected: Graph.UndirectedGraph<string, number>
+
+interface Node {
+  readonly id: string
+}
+
+declare const directedNodes: Graph.DirectedGraph<Node, number>
+declare const undirectedNodes: Graph.UndirectedGraph<Node, number>
+
+describe("Graph", () => {
+  it("compose", () => {
+    expect(Graph.compose(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.compose(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("intersection", () => {
+    expect(Graph.intersection(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.intersection(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("difference", () => {
+    expect(Graph.difference(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.difference(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("symmetricDifference", () => {
+    expect(Graph.symmetricDifference(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.symmetricDifference(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("complement", () => {
+    expect(Graph.complement(directed, (source, target) => {
+      expect(source).type.toBe<string>()
+      expect(target).type.toBe<string>()
+      return source.length + target.length
+    })).type.toBe<Graph.DirectedGraph<string, number>>()
+
+    expect(pipe(
+      undirected,
+      Graph.complement((source, target) => {
+        expect(source).type.toBe<string>()
+        expect(target).type.toBe<string>()
+        return source.length + target.length
+      })
+    )).type.toBe<Graph.UndirectedGraph<string, number>>()
+  })
+
+  it("neighborhood", () => {
+    expect(Graph.neighborhood(directed, 0)).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(Graph.neighborhood(directed, 0, { radius: 2, direction: "both" })).type.toBe<
+      Graph.DirectedGraph<string, number>
+    >()
+    expect(pipe(undirected, Graph.neighborhood(0, { radius: 2, direction: "outgoing" }))).type.toBe<
+      Graph.UndirectedGraph<string, number>
+    >()
+  })
+
+  it("sum", () => {
+    expect(Graph.sum(directed, directed)).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(pipe(undirected, Graph.sum(undirected))).type.toBe<Graph.UndirectedGraph<string, number>>()
+  })
+})

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -12,62 +12,86 @@ declare const directedNodes: Graph.DirectedGraph<Node, number>
 declare const undirectedNodes: Graph.UndirectedGraph<Node, number>
 
 describe("Graph", () => {
+  it("make", () => {
+    expect(
+      Graph.make("directed")<string, number>((mutable) => {
+        expect(mutable).type.toBe<Graph.MutableDirectedGraph<string, number>>()
+      })
+    ).type.toBe<Graph.DirectedGraph<string, number>>()
+
+    expect(
+      Graph.make("undirected")<string, number>((mutable) => {
+        expect(mutable).type.toBe<Graph.MutableUndirectedGraph<string, number>>()
+      })
+    ).type.toBe<Graph.UndirectedGraph<string, number>>()
+  })
+
   it("compose", () => {
-    expect(Graph.compose(directedNodes, directedNodes, (node) => {
-      expect(node).type.toBe<Node>()
-      return node.id
+    expect(Graph.compose(directedNodes, directedNodes, {
+      nodeIdentity: (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      },
+      edgeIdentity: (edge) => {
+        expect(edge).type.toBe<number>()
+        return edge
+      }
     })).type.toBe<Graph.DirectedGraph<Node, number>>()
 
     expect(pipe(
       undirectedNodes,
-      Graph.compose(undirectedNodes, (node) => {
-        expect(node).type.toBe<Node>()
-        return node.id
+      Graph.compose(undirectedNodes, {
+        nodeIdentity: (node) => {
+          expect(node).type.toBe<Node>()
+          return node.id
+        }
       })
     )).type.toBe<Graph.UndirectedGraph<Node, number>>()
   })
 
   it("intersection", () => {
-    expect(Graph.intersection(directedNodes, directedNodes, (node) => {
-      expect(node).type.toBe<Node>()
-      return node.id
-    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+    expect(Graph.intersection(directedNodes, directedNodes)).type.toBe<Graph.DirectedGraph<Node, number>>()
 
     expect(pipe(
       undirectedNodes,
-      Graph.intersection(undirectedNodes, (node) => {
-        expect(node).type.toBe<Node>()
-        return node.id
-      })
+      Graph.intersection(undirectedNodes)
     )).type.toBe<Graph.UndirectedGraph<Node, number>>()
   })
 
   it("difference", () => {
-    expect(Graph.difference(directedNodes, directedNodes, (node) => {
-      expect(node).type.toBe<Node>()
-      return node.id
+    expect(Graph.difference(directedNodes, directedNodes, {
+      nodeIdentity: (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      }
     })).type.toBe<Graph.DirectedGraph<Node, number>>()
 
     expect(pipe(
       undirectedNodes,
-      Graph.difference(undirectedNodes, (node) => {
-        expect(node).type.toBe<Node>()
-        return node.id
+      Graph.difference(undirectedNodes, {
+        nodeIdentity: (node) => {
+          expect(node).type.toBe<Node>()
+          return node.id
+        }
       })
     )).type.toBe<Graph.UndirectedGraph<Node, number>>()
   })
 
   it("symmetricDifference", () => {
-    expect(Graph.symmetricDifference(directedNodes, directedNodes, (node) => {
-      expect(node).type.toBe<Node>()
-      return node.id
+    expect(Graph.symmetricDifference(directedNodes, directedNodes, {
+      nodeIdentity: (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      }
     })).type.toBe<Graph.DirectedGraph<Node, number>>()
 
     expect(pipe(
       undirectedNodes,
-      Graph.symmetricDifference(undirectedNodes, (node) => {
-        expect(node).type.toBe<Node>()
-        return node.id
+      Graph.symmetricDifference(undirectedNodes, {
+        nodeIdentity: (node) => {
+          expect(node).type.toBe<Node>()
+          return node.id
+        }
       })
     )).type.toBe<Graph.UndirectedGraph<Node, number>>()
   })

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -26,8 +26,8 @@ describe("Graph", () => {
     ).type.toBe<Graph.UndirectedGraph<string, number>>()
   })
 
-  it("compose", () => {
-    expect(Graph.compose(directedNodes, directedNodes, {
+  it("union", () => {
+    expect(Graph.union(directedNodes, directedNodes, {
       nodeIdentity: (node) => {
         expect(node).type.toBe<Node>()
         return node.id
@@ -40,7 +40,7 @@ describe("Graph", () => {
 
     expect(pipe(
       undirectedNodes,
-      Graph.compose(undirectedNodes, {
+      Graph.union(undirectedNodes, {
         nodeIdentity: (node) => {
           expect(node).type.toBe<Node>()
           return node.id

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -124,8 +124,8 @@ describe("Graph", () => {
   })
 
   it("undirected traversal", () => {
-    expect(Graph.dfs(directed, { direction: "undirected" })).type.toBe<Graph.NodeWalker<string>>()
-    expect(Graph.bfs(directed, { direction: "undirected" })).type.toBe<Graph.NodeWalker<string>>()
+    expect(Graph.dfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
+    expect(Graph.bfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
   })
 
   it("sum", () => {

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -115,7 +115,7 @@ describe("Graph", () => {
 
   it("neighborhood", () => {
     expect(Graph.neighborhood(directed, 0)).type.toBe<Graph.DirectedGraph<string, number>>()
-    expect(Graph.neighborhood(directed, 0, { radius: 2, direction: "both" })).type.toBe<
+    expect(Graph.neighborhood(directed, 0, { radius: 2, direction: "undirected" })).type.toBe<
       Graph.DirectedGraph<string, number>
     >()
     expect(pipe(undirected, Graph.neighborhood(0, { radius: 2, direction: "outgoing" }))).type.toBe<

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -26,8 +26,8 @@ describe("Graph", () => {
     ).type.toBe<Graph.UndirectedGraph<string, number>>()
   })
 
-  it("union", () => {
-    expect(Graph.union(directedNodes, directedNodes, {
+  it("compose", () => {
+    expect(Graph.compose(directedNodes, directedNodes, {
       nodeIdentity: (node) => {
         expect(node).type.toBe<Node>()
         return node.id
@@ -40,7 +40,7 @@ describe("Graph", () => {
 
     expect(pipe(
       undirectedNodes,
-      Graph.union(undirectedNodes, {
+      Graph.compose(undirectedNodes, {
         nodeIdentity: (node) => {
           expect(node).type.toBe<Node>()
           return node.id
@@ -126,6 +126,7 @@ describe("Graph", () => {
   it("undirected traversal", () => {
     expect(Graph.dfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
     expect(Graph.bfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
+    expect(Graph.dfsPostOrder(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
   })
 
   it("sum", () => {

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -123,6 +123,11 @@ describe("Graph", () => {
     >()
   })
 
+  it("undirected traversal", () => {
+    expect(Graph.dfs(directed, { direction: "undirected" })).type.toBe<Graph.NodeWalker<string>>()
+    expect(Graph.bfs(directed, { direction: "undirected" })).type.toBe<Graph.NodeWalker<string>>()
+  })
+
   it("sum", () => {
     expect(Graph.sum(directed, directed)).type.toBe<Graph.DirectedGraph<string, number>>()
     expect(pipe(undirected, Graph.sum(undirected))).type.toBe<Graph.UndirectedGraph<string, number>>()


### PR DESCRIPTION
## Type

- [x] Refactor
- [x] Feature

## Description

Have added 4 basic and 3 advanced set operators to the Graph module to be able to build and explore for interesting structures. These include:

- `Graph.compose` - $(G1 ∪ G2 = { V1 ∪ V2, E1 ∪ E2 })$
  merges two graphs by node identity, combining nodes and edges from both. Overlapping data from that wins.
- `Graph.intersection` - $(G1 ∩ G2 = { V1 ∩ V2, E1 ∩ E2 })$
  keeps only nodes and edges present in both graphs.
- `Graph.difference` - $(G1 \ G2 = { V1, E1 \ E2 })$
  keeps all nodes from self, but removes edges that also exist in that.
- `Graph.symmetricDifference` - $(G1 Δ G2 = { V1 ∪ V2, (E1 ∪ E2) \ (E1 ∩ E2) })$
  keeps edges that exist in exactly one graph, removing shared edges.
- `Graph.complement` - $(G' = { V, (V × V) \ E })$
  keeps the same nodes, but adds every missing non-self edge.
- `Graph.neighborhood` - $(Nᵣ(v) = G[{ u ∈ V | distance(v, u) ≤ r }])$
  builds an induced subgraph around a node within a radius.
- `Graph.sum` - $(G1 + G2 = { V1 ⊔ V2, E1 ⊔ E2 })$
  creates a disjoint union of two graphs without merging equal nodes.

Most of the implementation was done similar to `NetworkX` when it came to making decisions around when `self` or `that` would win on conflict and the main decision on node equality is left to the implementor where they need to pass a nodeId callback to be able to identify each node.

One additional refactor (separate commit) was the additional logic to `Graph.bfs` and `Graph.dfs` to allow for a `maxDepth`.  This was important to be able to reuse the BFS in the `neighbordhood` op and create a custom version like I did in my utils experiment.

Some fun and exciting things can be done with this functionality.

<img width="916" height="363" alt="Screenshot 2026-06-23 at 22 26 49" src="https://github.com/user-attachments/assets/a5a7b6f4-9112-45e5-891e-490e5e9862d8" />

## For Reviewing

To make things easier to review I've broken up the three main parts so they can be reviewed separately and left off the type tests till last. Any feedback or requests I will initial add as commits on top of the current tree and then rebase together to clean up once approved


## Related

Came up as a request in Slack with a bit of back and forth discussion with @fubhy.  I then spend a couple of days building [similar functions in my own repo](https://github.com/lloydrichards/edu_effect-okf/blob/main/apps/cli/src/lib/graph-utils.ts) to be sure of the api as well as test out their implementation with some real examples.

- Slack [thread](https://discord.com/channels/795981131316985866/1518570933864894485)
- effct-smol [PR #2482](https://github.com/Effect-TS/effect-smol/pull/2482)