### PR TITLE
Fix multipart limit violations being silently swallowed

### DIFF
--- a/.changeset/multipart-onDone-clobbers-error.md
+++ b/.changeset/multipart-onDone-clobbers-error.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix multipart parser limit violations being silently swallowed
+
+`Multipart.makeChannel` stored the parser's failure and its end-of-parse signal in the same slot, and the terminal `onDone` callback unconditionally overwrote a captured failure with the completion sentinel (`Cause.Done`). Because the parser keeps running after signalling a limit or parse error and always calls `onDone` at the end, any violation reached in the same pump as end-of-input was lost — which is always the case when the body arrives in a single chunk. As a result, `maxParts` / `maxFileSize` / `maxFieldSize` limits were not enforced and the stream completed normally instead of failing. `onDone` now only records completion when no failure was already captured.

--- a/.changeset/multipart-onDone-clobbers-error.md
+++ b/.changeset/multipart-onDone-clobbers-error.md
@@ -3,5 +3,3 @@
 ---
 
 Fix multipart parser limit violations being silently swallowed
-
-`Multipart.makeChannel` stored the parser's failure and its end-of-parse signal in the same slot, and the terminal `onDone` callback unconditionally overwrote a captured failure with the completion sentinel (`Cause.Done`). Because the parser keeps running after signalling a limit or parse error and always calls `onDone` at the end, any violation reached in the same pump as end-of-input was lost — which is always the case when the body arrives in a single chunk. As a result, `maxParts` / `maxFileSize` / `maxFieldSize` limits were not enforced and the stream completed normally instead of failing. `onDone` now only records completion when no failure was already captured.

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -452,11 +452,6 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           exit = Option.some(Exit.fail(convertError(error_)))
         },
         onDone() {
-          // The parser keeps running after signalling a limit/parse error and
-          // always calls `onDone` at the end. Only record normal completion if
-          // no failure was captured, otherwise `onDone` clobbers the error and
-          // the violation is silently swallowed (single-pump bodies always hit
-          // this). See https://github.com/Effect-TS/effect/issues/6392.
           if (Option.isNone(exit)) {
             exit = Option.some(Exit.fail(Cause.Done()))
           }

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -452,7 +452,14 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           exit = Option.some(Exit.fail(convertError(error_)))
         },
         onDone() {
-          exit = Option.some(Exit.fail(Cause.Done()))
+          // The parser keeps running after signalling a limit/parse error and
+          // always calls `onDone` at the end. Only record normal completion if
+          // no failure was captured, otherwise `onDone` clobbers the error and
+          // the violation is silently swallowed (single-pump bodies always hit
+          // this). See https://github.com/Effect-TS/effect/issues/6392.
+          if (Option.isNone(exit)) {
+            exit = Option.some(Exit.fail(Cause.Done()))
+          }
         }
       })
 

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@effect/vitest"
 import { Effect, identity, Schema, Stream, Unify } from "effect"
 import { Multipart } from "effect/unstable/http"
-import { deepStrictEqual } from "node:assert"
+import { deepStrictEqual, strictEqual } from "node:assert"
 
 describe("Multipart", () => {
   it.effect("parses fields and streams file content", () =>
@@ -35,6 +35,34 @@ describe("Multipart", () => {
         ["test", "ing"],
         ["foo.txt", "A".repeat(1024 * 1024)]
       ])
+    }))
+
+  it.effect("fails when a limit is exceeded even if the whole body arrives in one chunk", () =>
+    Effect.gen(function*() {
+      // A raw body delivered as a single chunk makes the parser reach the
+      // max-parts error and end-of-input within one pump, so `onDone` used to
+      // clobber the captured failure and the violation was swallowed.
+      // https://github.com/Effect-TS/effect/issues/6392
+      const boundary = "----testboundary"
+      const part = (name: string) =>
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="${name}"; filename="${name}.txt"\r\n` +
+        `Content-Type: text/plain\r\n\r\n${name}\r\n`
+      const body = part("a") + part("b") + part("c") + `--${boundary}--\r\n`
+
+      // `Effect.flip` surfaces the expected failure as the success channel; if
+      // the stream wrongly completes instead, `flip` fails and the test fails.
+      const error = yield* Stream.make(new TextEncoder().encode(body)).pipe(
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        ),
+        Stream.runCollect,
+        Effect.provideService(Multipart.MaxParts, 2),
+        Effect.flip
+      )
+
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "TooManyParts")
     }))
 
   describe("FileSchema", () => {

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -39,10 +39,6 @@ describe("Multipart", () => {
 
   it.effect("fails when a limit is exceeded even if the whole body arrives in one chunk", () =>
     Effect.gen(function*() {
-      // A raw body delivered as a single chunk makes the parser reach the
-      // max-parts error and end-of-input within one pump, so `onDone` used to
-      // clobber the captured failure and the violation was swallowed.
-      // https://github.com/Effect-TS/effect/issues/6392
       const boundary = "----testboundary"
       const part = (name: string) =>
         `--${boundary}\r\n` +
@@ -50,8 +46,6 @@ describe("Multipart", () => {
         `Content-Type: text/plain\r\n\r\n${name}\r\n`
       const body = part("a") + part("b") + part("c") + `--${boundary}--\r\n`
 
-      // `Effect.flip` surfaces the expected failure as the success channel; if
-      // the stream wrongly completes instead, `flip` fails and the test fails.
       const error = yield* Stream.make(new TextEncoder().encode(body)).pipe(
         Stream.pipeThroughChannel(
           Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Fixes #6392.

`Multipart.makeChannel` (`packages/effect/src/unstable/http/Multipart.ts`) stores the parser's failure and its end-of-parse signal in the same `exit` slot. multipasta keeps running after it signals a limit/parse error and always calls `onDone` at the end, and the terminal `onDone` handler unconditionally overwrote a previously captured failure with the completion sentinel:

```ts
onError(error_) {
  exit = Option.some(Exit.fail(convertError(error_)))
},
onDone() {
  exit = Option.some(Exit.fail(Cause.Done())) // clobbers a captured failure
}
```

The consuming `loop` only inspects `exit` once `partsBuffer` is drained — which happens after the pump pull that calls `parser.end()` (→ `onDone`). Whenever the violation and end-of-input are reached in the same delivery — **always the case when the body arrives in a single chunk**, i.e. essentially every small upload — the captured `MultipartError` is overwritten by `Cause.Done()` and the stream completes normally. In practice this means `maxParts`, `maxFileSize`, and `maxFieldSize` are silently not enforced (`maxTotalSize` still trips because the body stream's `MaxBodySize` aborts it independently, before `onDone`).

### Fix

`onDone` now records normal completion only when no failure was already captured:

```ts
onDone() {
  if (Option.isNone(exit)) {
    exit = Option.some(Exit.fail(Cause.Done()))
  }
}
```

`onDone` is multipasta's terminal callback (fires once, after any `onError`), so first-signal-wins is the correct precedence.

### Test

Adds a regression test that feeds a 3-part body as a single chunk under `maxParts: 2` and asserts the stream fails with `TooManyParts`. Verified it **fails before** the fix (the stream wrongly completes) and **passes after** — the two pre-existing Multipart tests remain green (`vitest run test/unstable/http/Multipart.test.ts`: 3 passed).

### Note on affected versions

Reported against the published `@effect/platform` (0.94.5 and 0.97.0), where the same clobber uses `Exit.void`; on `main` the module has moved to `effect/unstable/http` and the sentinel is `Cause.Done()`, but the bug and fix are identical. Maintainers may want to backport to the `@effect/platform` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)