### PR TITLE
Add McpClient: Effect-native MCP client

### DIFF
--- a/.changeset/add-mcp-client-module.md
+++ b/.changeset/add-mcp-client-module.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Adds `McpClient`, an Effect-native Model Context Protocol client with automatic initialize/handshake, stdio and Streamable HTTP transports, typed methods for tools/resources/prompts/completion, and support for registering host-side handlers for server-initiated sampling, roots, and elicitation requests.

--- a/.changeset/fix-mcp-prompt-invalid-params.md
+++ b/.changeset/fix-mcp-prompt-invalid-params.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve `InvalidParams` errors when MCP prompt arguments fail schema decoding.

--- a/.changeset/mcp-server-version-negotiation.md
+++ b/.changeset/mcp-server-version-negotiation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Support MCP protocol versions `2025-11-25` and `2025-06-18`, including configurable server version negotiation, initialization lifecycle enforcement, current protocol schemas, and Streamable HTTP session and protocol-version validation.

--- a/.changeset/tender-spiders-cancel.md
+++ b/.changeset/tender-spiders-cancel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve numeric MCP request IDs when cancelling in-flight server requests.

--- a/.specs/mcp-server-version-negotiation.md
+++ b/.specs/mcp-server-version-negotiation.md
@@ -119,7 +119,7 @@ The following differences affect types already accepted, emitted, or exposed by 
 - Make request `_meta` open to arbitrary JSON-compatible keys while retaining typed `progressToken`.
 - Add shared request metadata to completion, sampling, and elicitation requests.
 - Add result metadata to completion, sampling, and roots results.
-- Preserve arbitrary result extension keys where client results are decoded.
+- Accept arbitrary result extension keys where client results are decoded. Retaining them in typed values is deferred because adding rest fields would remove existing `Schema.Class` constructors from exported result models.
 - Require integer MCP error codes at the schema boundary.
 - Verify that JSON-RPC parse and invalid-request errors can omit `id`; address this in RPC serialization only if wire tests show the generic layer cannot emit the official envelope.
 

--- a/.specs/mcp-server-version-negotiation.md
+++ b/.specs/mcp-server-version-negotiation.md
@@ -448,7 +448,7 @@ The initial initialize POST negotiates through its JSON payload and does not req
 2. Add optional `supportedProtocolVersions` to `run`, `layer`, `layerStdio`, and `layerHttp`.
 3. Require a non-empty readonly tuple when supplied.
 4. Snapshot the supplied tuple at server construction so external mutation cannot change active behavior.
-5. Validate duplicate entries at construction if the type cannot prevent them; fail with a specific configuration error rather than silently normalizing.
+5. Deduplicate entries at construction with an insertion-ordered `Set`, preserving the first occurrence and configured preference order.
 6. Pass the effective tuple into `layerHandlers` and the pure negotiation function.
 7. Use the verified default tuple when the option is omitted.
 

--- a/.specs/mcp-server-version-negotiation.md
+++ b/.specs/mcp-server-version-negotiation.md
@@ -1,0 +1,856 @@
+# MCP Server Version Negotiation
+
+## Status
+
+Planned.
+
+## Summary
+
+Update `packages/effect/src/unstable/ai/McpServer.ts` and its supporting MCP schemas so an MCP server:
+
+1. Supports the latest stable MCP protocol revision, `2025-11-25`.
+2. Can declare an ordered, non-empty set of supported protocol versions.
+3. Negotiates one protocol version during initialization as required by MCP.
+4. Associates the negotiated version with the session and enforces it for subsequent Streamable HTTP requests.
+5. Observes the initialization lifecycle through `notifications/initialized` before treating a client as ready for normal server-initiated traffic.
+
+The work is intentionally divided into independently reviewable units. Every unit includes its own tests and can be completed before starting the next dependent unit.
+
+## Specification Sources
+
+This plan targets the latest stable specification available when it was written:
+
+- [MCP versioning](https://modelcontextprotocol.io/docs/learn/versioning)
+- [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)
+- [Lifecycle and version negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+- [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+- [2025-11-25 schema](https://modelcontextprotocol.io/specification/2025-11-25/schema)
+- [2025-11-25 changelog](https://modelcontextprotocol.io/specification/2025-11-25/changelog)
+- [Authoritative TypeScript schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/2025-11-25/schema.ts)
+
+If the latest stable MCP revision changes before implementation begins, first update this document's target revision and repeat the schema audit in Task 1. Do not target the MCP `draft` revision.
+
+## Normative Requirements
+
+The implementation must preserve these protocol rules:
+
+1. Initialization is the first client-server protocol interaction.
+2. The client sends one `protocolVersion` string, normally its latest supported version. It does not send a list of versions.
+3. If the server supports the requested version, it must return that exact version.
+4. Otherwise, the server must return another version it supports and should prefer its latest supported version.
+5. The client decides whether it supports the alternative. If it does not, it disconnects.
+6. One negotiated version applies to the session.
+7. After a successful initialize response, the client sends `notifications/initialized` before normal operation.
+8. Before receiving `notifications/initialized`, the server should not send requests other than ping or notifications other than logging.
+9. Streamable HTTP clients must include `MCP-Protocol-Version` on subsequent requests.
+10. An invalid or unsupported `MCP-Protocol-Version` must produce HTTP 400.
+11. If a session identifies the negotiated version, an absent protocol-version header can be resolved from that session. The `2025-03-26` compatibility assumption is only needed when the server has no other way to identify the version.
+12. If the server issued `MCP-Session-Id`, clients must send it on subsequent HTTP requests. A missing required ID should produce HTTP 400; an unknown or expired supplied ID should produce HTTP 404.
+
+## Current State
+
+The implementation currently:
+
+- Defines private global versions in `McpServer.ts`, with `2025-06-18` as latest.
+- Always supports the same hard-coded set: `2025-06-18`, `2025-03-26`, `2024-11-05`, and `2024-10-07`.
+- Correctly echoes a requested version in that set and otherwise proposes its hard-coded latest version.
+- Rewrites the client's initialize payload with the selected version before storing it.
+- Stores initialize payloads in `Map<string, InitializePayload>` rather than storing explicit session state.
+- Emits `MCP-Protocol-Version` response headers but does not validate request headers.
+- Treats the session as initialized immediately after handling `initialize`.
+- Ignores `notifications/initialized`.
+- Has an `initializedClients` set used for outgoing notifications, but never adds clients to it.
+- Uses transient RPC client IDs for outgoing notification readiness, which does not model stable HTTP sessions.
+- Supplies an invalid `McpServerClient` during the initial request by asserting that an absent initialize payload exists.
+- Returns HTTP 404 plus an Effect defect for both missing and unknown sessions.
+
+Existing tests cover only unsupported-version fallback through one response header and a non-initialize request without a session ID.
+
+## Task 1 Audit Results
+
+The audit compared the implemented server surface with the official schemas for `2025-11-25`, `2025-06-18`, `2025-03-26`, `2024-11-05`, and `2024-10-07`. The version list must represent protocols the complete server can actually serve, not merely dates it can return from `initialize`.
+
+### Supported Version Decision
+
+The planned supported-version union is:
+
+```ts
+export const supportedProtocolVersions = [
+  "2025-11-25",
+  "2025-06-18"
+] as const
+```
+
+Both entries are conditional on completing the schema, lifecycle, capability, and transport work in this plan. Until that work lands, the current implementation does not fully conform to either revision.
+
+`2025-11-25` and `2025-06-18` can share the implemented common subset after the corrections below because the relevant `2025-11-25` additions are optional and capability-gated. Version-aware encoding must prevent `2025-11-25`-only fields or methods from being emitted in a `2025-06-18` session.
+
+Remove these revisions from the supported set:
+
+| Revision | Decision | Reason |
+| --- | --- | --- |
+| `2025-03-26` | Remove | It permits JSON-RPC batching, predates elicitation, resource links, structured tool output, and completion context, and therefore requires a materially different accepted method/schema surface. |
+| `2024-11-05` | Remove | It requires the legacy HTTP+SSE transport and predates several content and tool fields emitted by the common implementation. |
+| `2024-10-07` | Remove | Its tool result is `{ toolResult: unknown }`, fundamentally different from the modern `content`/`isError` result, and its method set also differs. |
+
+The removal is deliberate scope control. Supporting these revisions later requires separate compatibility work with version-specific schemas, method groups, encoders, capability tables, and transports.
+
+### Cross-Cutting Compatibility Findings
+
+The current implementation selects a version string but does not select a version-specific protocol surface. All sessions use the same RPC groups, handlers, capability generation, and schemas. This is insufficient whenever revisions differ in method availability or wire representation.
+
+The current `layerHttp` delegates to a generic POST-only RPC route. It does not yet satisfy Streamable HTTP requirements shared by the two planned revisions:
+
+- No GET route returning SSE or HTTP 405.
+- No `Accept` validation for the required media types.
+- No explicit empty HTTP 202 response for accepted notifications and responses.
+- No SSE delivery path for server requests and notifications.
+- No `Origin` validation.
+- Request-scoped transport client IDs cannot identify stable MCP sessions.
+
+Tasks 8 through 10 must close these gaps, or `layerHttp` must explicitly remain outside the conformance claim. Stdio can use the same two protocol schemas once the schema and lifecycle corrections are complete.
+
+### Required `2025-11-25` Schema Corrections
+
+The following differences affect types already accepted, emitted, or exposed by `McpServer`. They are required before advertising `2025-11-25`.
+
+#### Shared Metadata and Errors
+
+- Make request `_meta` open to arbitrary JSON-compatible keys while retaining typed `progressToken`.
+- Add shared request metadata to completion, sampling, and elicitation requests.
+- Add result metadata to completion, sampling, and roots results.
+- Preserve arbitrary result extension keys where client results are decoded.
+- Require integer MCP error codes at the schema boundary.
+- Verify that JSON-RPC parse and invalid-request errors can omit `id`; address this in RPC serialization only if wire tests show the generic layer cannot emit the official envelope.
+
+#### Initialization and Capabilities
+
+- Add `Implementation.icons`, `description`, and `websiteUrl`.
+- Add the official `Icon` model.
+- Decode `ClientCapabilities.sampling.context` and `sampling.tools`.
+- Decode `ClientCapabilities.elicitation.form` and `elicitation.url`; preserve empty elicitation capability objects as legacy form support.
+- Keep task capabilities unimplemented and unadvertised.
+- Keep the existing `extensions` field documented as a non-standard open capability extension; official revisions use `experimental` for their standardized experimental capability container.
+- Decide whether logging is truly deliverable before advertising `logging: {}`. A registered `logging/setLevel` handler alone does not prove server-to-client logging support.
+
+#### Notifications
+
+- Make `notifications/progress.progress` required.
+- Keep task and URL-elicitation notifications absent while those capabilities are unimplemented.
+
+#### Tools
+
+- Make `tools/call.arguments` optional on the wire and normalize omission to `{}` before invoking existing handlers.
+- Restrict `CallToolResult.structuredContent` to a JSON object; arrays and `null` are invalid.
+- Ensure generated tool `inputSchema` has root `type: "object"`.
+- Add optional `Tool.icons`, `outputSchema`, and metadata fields used by the official surface.
+- Keep task execution metadata absent unless task support is implemented.
+- Verify that errors from a found tool's argument validation are returned as tool execution errors with `isError: true`, not protocol errors.
+
+#### Resources, Prompts, and Content
+
+- Add optional icons to resources, resource templates, prompts, and resource links.
+- Add prompt `_meta`.
+- Add content `_meta` to text, image, audio, and embedded-resource blocks.
+- Add resource-content `_meta` and annotation `lastModified`.
+- Verify that `Schema.Uint8Array` encodes resource blobs, images, and audio as base64 strings accepted by the official schema.
+
+#### Completion
+
+- Add request and result metadata.
+- Enforce a maximum of 100 completion values.
+- Require integer totals in emitted and decoded completion results.
+
+#### Sampling
+
+- Fix `CreateMessageResult` to include required `role`, `content`, and `model`.
+- Allow sampling content to be one block or an array.
+- Make request `metadata` optional and object-valued.
+- Add sampling message `_meta`.
+- Keep sampling tool-use blocks, request `tools`, and `toolChoice` unimplemented unless the implementation also checks `ClientCapabilities.sampling.tools`.
+- Do not use non-`none` `includeContext` unless the client advertises `ClientCapabilities.sampling.context`.
+
+#### Elicitation
+
+- Keep the public helper form-only for this work; omitted `mode` is compatible form mode.
+- Add request metadata.
+- Constrain `requestedSchema` to the official flat object of supported primitive schemas rather than arbitrary JSON Schema.
+- Restrict accepted form content to the official string, number, boolean, and string-array record.
+- Keep URL mode, URL completion notifications, and error `-32042` unimplemented and unadvertised.
+
+### Optional `2025-11-25` Features Deferred
+
+The following features are optional and do not block support when their capabilities are absent:
+
+- Tasks and task-augmented requests.
+- Sampling tool use.
+- URL-mode elicitation.
+- Resource subscriptions; continue advertising `subscribe: false`.
+- Tool task-execution metadata.
+- Stream resumability and redelivery.
+
+Optional metadata fields such as icons may be omitted from server-produced values, but schemas for already exposed client inputs and results should decode them so typed client state is not silently incomplete.
+
+### Version-Specific Behavior Required for `2025-06-18`
+
+The common implementation must not emit `2025-11-25`-only protocol features in a `2025-06-18` session. The initial version table needs to capture at least:
+
+- No tasks or task-augmented requests.
+- No sampling tool use or tool-use sampling blocks.
+- No URL-mode elicitation or completion notification.
+- No `2025-11-25`-only implementation and icon metadata unless confirmed as tolerated extension data and intentionally supported.
+
+The exact field-level table must be derived from the official tagged `2025-06-18` schema while implementing Task 5. The encoder should operate on the negotiated session version rather than relying on clients to ignore newer fields.
+
+### Conformance Fixtures Required by Task 5
+
+Add focused fixtures for:
+
+- Official `2025-11-25` initialize request metadata, client capability subfields, implementation description, website, and icons.
+- An argumentless `tools/call` request.
+- Structured tool results accepting objects and rejecting arrays and `null`.
+- Progress notifications rejecting a missing `progress` value.
+- Completion metadata and the 100-value boundary.
+- A minimal sampling request without `metadata`.
+- A sampling result containing `role`, `content`, `model`, and array content.
+- Form elicitation accepting the official primitive subset and rejecting nested object schemas.
+- Image, audio, and resource blob base64 round trips.
+- A compatibility fixture for each of `2025-11-25` and `2025-06-18` validating emitted values against the official tagged schema.
+
+### Audit Completion Decision
+
+Task 1 is complete when these findings are accepted. Task 2 should define only the two planned constants above. Task 5 owns the schema corrections and version-specific compatibility fixtures; Tasks 6 through 10 own lifecycle and transport conformance.
+
+## Goals
+
+- Make supported protocol versions explicit server configuration.
+- Default to a verified set headed by `2025-11-25`.
+- Keep the initialize wire field scalar and specification-compatible.
+- Make negotiation deterministic and independently testable.
+- Preserve both the client's requested version and the selected session version.
+- Represent lifecycle state explicitly.
+- Enforce the selected version at the Streamable HTTP boundary.
+- Use expected protocol/transport errors rather than defects for invalid client input.
+- Correct outgoing notification readiness after `notifications/initialized`.
+- Document and test public API behavior.
+
+## Non-Goals
+
+- Changing the initialize request to send or accept an array of protocol versions.
+- Implementing an iterative negotiation exchange. MCP defines one client offer and one server response.
+- Implementing every optional feature introduced in `2025-11-25`, such as tasks, solely to advertise the revision.
+- Adding HTTP+SSE backward compatibility for the deprecated `2024-11-05` transport unless the schema/transport audit proves it is already promised by the current API.
+- Adding Streamable HTTP resumability, redelivery, or DELETE session termination unless required to complete version negotiation safely.
+- Refactoring unrelated tool, prompt, resource, or RPC behavior.
+- Correcting unrelated public layer output types as part of this change.
+
+## Design Decisions
+
+### Supported Versions Are Server Configuration
+
+Add an optional ordered, non-empty `supportedProtocolVersions` property to all server constructors. The first element is the server's preferred fallback version. Configuration order is authoritative; versions are not sorted lexicographically at runtime.
+
+Conceptual API:
+
+```ts
+export const supportedProtocolVersions = [
+  "2025-11-25",
+  "2025-06-18"
+] as const
+
+export type ProtocolVersion = typeof supportedProtocolVersions[number]
+
+export const latestProtocolVersion = supportedProtocolVersions[0]
+
+export interface ServerOptions {
+  readonly name: string
+  readonly version: string
+  readonly supportedProtocolVersions?: readonly [
+    ProtocolVersion,
+    ...Array<ProtocolVersion>
+  ]
+  readonly extensions?: Record<`${string}/${string}`, unknown>
+}
+```
+
+The exact exported names should be checked against nearby Effect naming conventions during Task 2. `ProtocolVersion` is the closed union of revisions this implementation knows how to serve, so server configuration cannot claim an arbitrary revision. `Schema.String` remains the initialize wire schema because future protocol versions must still be decodable as client offers even when unknown to this implementation; negotiation can then propose a known `ProtocolVersion`.
+
+### Defaults Include Only Verified Revisions
+
+The default list may include only revisions for which the implemented MCP subset is wire-compatible. Task 1 decides whether each current legacy entry remains in the default list. A version must not remain merely because it was previously present.
+
+### Negotiation Is Pure Selection
+
+Given a `string` client `requested` value and ordered `ProtocolVersion` server `supported` versions:
+
+```text
+if requested is supported:
+  selected = requested
+else:
+  selected = supported[0]
+```
+
+No error is returned merely because the offered version is unsupported. The normative lifecycle rules require the server to propose another supported version. The example `InvalidParams` response in the lifecycle error-handling section is not used for ordinary fallback.
+
+### Session State Owns the Negotiated Version
+
+Do not mutate the initialize payload. Store the original payload and negotiated version separately. Session state distinguishes negotiation from readiness:
+
+```ts
+type Session =
+  | {
+      readonly _tag: "Negotiated"
+      readonly initializePayload: InitializePayload
+      readonly protocolVersion: string
+    }
+  | {
+      readonly _tag: "Operational"
+      readonly initializePayload: InitializePayload
+      readonly protocolVersion: string
+    }
+```
+
+If transport delivery requires additional state, add it beside these fields without weakening the lifecycle distinction.
+
+### HTTP Validation Uses Session State
+
+For requests after initialize:
+
+1. Resolve the stable MCP session.
+2. Reject a missing required session ID with HTTP 400.
+3. Reject an unknown supplied session ID with HTTP 404.
+4. If `MCP-Protocol-Version` is present, require it to be a configured supported version and equal the session's negotiated version.
+5. Return HTTP 400 for invalid, unsupported, or session-mismatched values.
+6. If the header is absent, use the session's negotiated version because the server has another way to identify it.
+
+The initial initialize POST negotiates through its JSON payload and does not require the header.
+
+### Initialization Context Is Separate
+
+`McpServerClient` represents an initialized session and must not be fabricated for an initial `initialize` call. Restructure RPC middleware or request grouping so initialize can execute without `initializePayload!`, while operational handlers continue receiving `McpServerClient`.
+
+### Notification Readiness Uses Stable Session Identity
+
+`notifications/initialized` transitions a session to `Operational`. Outgoing non-logging notifications are sent only to operational sessions. HTTP readiness must not be keyed solely by the transient numeric RPC client ID.
+
+## Work Plan
+
+### Task 1: Audit `2025-11-25` Schema Compatibility
+
+**Objective:** Determine the exact schema and capability changes required before the server can truthfully advertise `2025-11-25`.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpSchema.ts`
+- Official MCP `2025-11-25` TypeScript and JSON schemas
+
+**Work:**
+
+1. Compare every MCP schema currently used by `McpServer.ts` with the official `2025-11-25` schema.
+2. Prioritize initialize payload/result, implementation metadata, client/server capabilities, tools, resources, prompts, completion, logging, elicitation, sampling, notifications, and error envelopes.
+3. Record whether each difference is required for decoding, encoding, or only an unimplemented optional capability.
+4. Verify the compatibility of each legacy version currently listed by the server.
+5. Decide the exact default supported-version tuple. Remove any revision whose implemented transport or wire behavior is incompatible.
+6. Convert the audit results into a checklist in the implementing pull request or append them to this specification if they materially change scope.
+
+**Acceptance criteria:**
+
+- Every default version has an explicit compatibility justification.
+- All required `2025-11-25` schema changes are identified.
+- Optional features not implemented by this server are identified and excluded from advertised capabilities.
+- No source behavior changes are included in this task unless needed to add focused schema conformance tests.
+
+**Verification:**
+
+- Decode official initialize request and result examples with local schemas.
+- Run any added targeted schema tests.
+
+**Depends on:** Nothing.
+
+### Task 2: Add Protocol Version Domain API
+
+**Objective:** Establish one public source of truth for the latest and default supported revisions.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`, or `McpSchema.ts` if the audit shows the domain belongs there
+- `packages/effect/typetest/` if exported tuple inference needs coverage
+
+**Work:**
+
+1. Add `2025-11-25` as the latest stable protocol version.
+2. Export the latest-version constant and readonly default supported-version tuple using repository naming conventions.
+3. Derive `ProtocolVersion` from the readonly tuple so it is the union of revisions the library can serve.
+4. Keep incoming initialize payloads typed as `string`, preserving the boundary between an arbitrary client offer and a server-supported version.
+5. Add compliant public JSDoc for each export.
+6. Remove the private duplicated latest/supported constants once all internal references use the new definitions.
+
+**Acceptance criteria:**
+
+- Consumers can reference the latest and default supported versions.
+- The latest value is `2025-11-25`.
+- The default tuple is readonly and ordered by server preference.
+- `ProtocolVersion` is inferred as the union of tuple members rather than `string`.
+- Server configuration rejects arbitrary version strings at compile time.
+- Unknown future strings remain valid in decoded initialize requests.
+
+**Verification:**
+
+- Targeted pure/type tests for exported values and inference.
+- `pnpm lint` for JSDoc and formatting.
+
+**Depends on:** Task 1.
+
+### Task 3: Add Pure Version Negotiation
+
+**Objective:** Isolate and test the specification's selection rules before changing server configuration.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+
+**Work:**
+
+1. Extract a small pure internal negotiation function accepting a `string` request and returning `ProtocolVersion`.
+2. Return the requested version when it is present in the ordered supported set.
+3. Return the first supported version otherwise.
+4. Replace the current inline global-array negotiation with the helper.
+5. Stop mutating the initialize payload solely to record the selected version; temporarily preserve equivalent downstream behavior until typed session state lands in Task 6.
+
+**Acceptance criteria:**
+
+- A supported request is echoed exactly.
+- An unsupported request selects the first server-supported version.
+- Selection does not depend on date parsing or lexical sorting.
+- The existing fallback behavior remains functional with the new latest default.
+
+**Verification:**
+
+- Pure tests for latest, older supported, unknown future, malformed-looking, and custom-order values.
+- Targeted `McpServer.test.ts` run.
+
+**Depends on:** Task 2.
+
+### Task 4: Configure Multiple Versions Per Server
+
+**Objective:** Let each MCP server instance declare its supported revisions.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+- `packages/effect/typetest/` for public option typing
+
+**Work:**
+
+1. Introduce one shared internal/public server options type.
+2. Add optional `supportedProtocolVersions` to `run`, `layer`, `layerStdio`, and `layerHttp`.
+3. Require a non-empty readonly tuple when supplied.
+4. Snapshot the supplied tuple at server construction so external mutation cannot change active behavior.
+5. Validate duplicate entries at construction if the type cannot prevent them; fail with a specific configuration error rather than silently normalizing.
+6. Pass the effective tuple into `layerHandlers` and the pure negotiation function.
+7. Use the verified default tuple when the option is omitted.
+
+**Acceptance criteria:**
+
+- Different server instances can negotiate different version sets in one process.
+- The first configured entry is the fallback.
+- Empty arrays are rejected by types, and untyped boundary input cannot create a server with no versions.
+- Configuration entries are restricted to the library's `ProtocolVersion` union.
+- All server constructors expose identical negotiation semantics.
+- Existing callers that omit the option continue to work.
+
+**Verification:**
+
+- Type test for non-empty tuple acceptance and empty tuple rejection.
+- Integration tests for custom exact match, custom fallback order, and isolated server instances.
+- Targeted MCP server tests and type tests.
+
+**Depends on:** Task 3.
+
+### Task 5: Implement Required `2025-11-25` Schema Updates
+
+**Objective:** Make the implemented MCP surface wire-compatible with the revision the server now advertises.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpSchema.ts`
+- Relevant MCP schema tests or `McpServer.test.ts`
+
+**Work:**
+
+1. Implement only the required schema changes identified in Task 1.
+2. Preserve open capability objects and extension points required by MCP.
+3. Add new optional metadata fields where decoding or encoding requires them.
+4. Do not advertise optional `2025-11-25` capabilities without corresponding handlers.
+5. Keep revision-specific schemas or boundary transforms localized if representations differ across supported revisions.
+6. Add version-aware encoding/decoding only where the audit demonstrates a real incompatibility.
+
+**Acceptance criteria:**
+
+- Official `2025-11-25` examples for the implemented surface decode.
+- Values emitted by the server validate against the official schema for the negotiated revision.
+- Older retained revisions continue to pass their compatibility fixtures.
+- No unsupported optional capability is added to initialize results.
+
+**Verification:**
+
+- Targeted schema round-trip tests.
+- Targeted MCP server tests.
+- `pnpm check` because source schema types change.
+
+**Depends on:** Tasks 1 and 4.
+
+### Task 6: Introduce Typed Session Lifecycle State
+
+**Objective:** Separate the client offer, negotiated version, and operational readiness.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- `packages/effect/src/unstable/ai/McpSchema.ts` if `McpServerClient` needs a clarified contract
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+
+**Work:**
+
+1. Replace `Map<string, InitializePayload>` with a typed session record.
+2. Preserve the original initialize payload unchanged.
+3. Store the negotiated version as a separate required field.
+4. Represent at least `Negotiated` and `Operational` states as a discriminated union.
+5. Create the negotiated state only for a successfully handled initialize request.
+6. Make `notifications/initialized` transition the matching session to operational.
+7. Define duplicate initialize and duplicate initialized-notification behavior explicitly. Prefer rejecting reinitialize within an existing session and making a duplicate initialized notification idempotent.
+8. Update `clientCapabilities`, filtering, and `McpServerClient` provisioning to read from session state.
+9. Remove the `initializePayload!` non-null assertion.
+10. Ensure the initialize handler does not require an already initialized `McpServerClient` service.
+
+**Acceptance criteria:**
+
+- The requested and negotiated versions are both available and cannot be confused.
+- Initial initialize handling never constructs an invalid `McpServerClient`.
+- The initialized notification changes lifecycle state.
+- Operational handlers receive a valid initialize payload and negotiated version.
+- Illegal partial session states are not representable.
+
+**Verification:**
+
+- Tests for original-offer preservation, negotiated state, initialized transition, duplicate notification, and reinitialize policy.
+- Targeted MCP server tests and `pnpm check`.
+
+**Depends on:** Tasks 4 and 5.
+
+### Task 7: Enforce Pre-Operational Lifecycle Rules
+
+**Objective:** Prevent normal traffic from bypassing initialization while preserving MCP's allowed initialization-phase traffic.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+
+**Work:**
+
+1. Reject normal requests received before initialize.
+2. Permit ping where the lifecycle specification allows it.
+3. Decide and document whether client requests after the initialize response but before `notifications/initialized` are rejected or accepted with no server-initiated traffic. Prefer rejection for normal operations because it produces a deterministic state boundary, but confirm interoperability with official SDK behavior before finalizing.
+4. Prevent server-initiated requests and non-logging notifications before the session becomes operational.
+5. Return typed MCP errors or deliberate HTTP responses for expected invalid ordering; do not use defects.
+
+**Acceptance criteria:**
+
+- Initialize is the first state-creating request.
+- Ping behavior matches the specification.
+- Normal operations cannot occur without a negotiated session.
+- No list-change notification is sent to a merely negotiated session.
+- Invalid ordering does not produce a server defect.
+
+**Verification:**
+
+- Lifecycle matrix tests covering no session, negotiated session, and operational session.
+- Targeted MCP server tests.
+
+**Depends on:** Task 6.
+
+### Task 8: Validate Streamable HTTP Session Identity
+
+**Objective:** Distinguish missing, unknown, and valid HTTP sessions according to the transport specification.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+
+**Work:**
+
+1. Keep initialize exempt from session-ID requirements.
+2. Return HTTP 400 when a subsequent request omits a session ID that the server issued.
+3. Return HTTP 404 when a supplied session ID is unknown or expired.
+4. Replace `Effect.die` for these expected inputs with typed validation or direct HTTP rejection.
+5. Ensure a stable MCP session ID, not a request-scoped RPC client ID, selects HTTP session state.
+6. Fix the test client so it retains its session ID when ordinary responses omit that header.
+7. Verify multiple sequential requests continue using one session.
+
+**Acceptance criteria:**
+
+- Missing and unknown IDs produce different required status codes.
+- Invalid client input does not create defects or noisy internal failures.
+- Three or more sequential HTTP requests use the same session successfully.
+- Session data does not leak between clients.
+
+**Verification:**
+
+- Raw HTTP integration tests for initialize, missing ID, unknown ID, valid ID, and multiple sessions.
+- Targeted MCP server tests.
+
+**Depends on:** Task 6.
+
+### Task 9: Enforce `MCP-Protocol-Version` for HTTP
+
+**Objective:** Ensure every subsequent HTTP request is interpreted using the session's negotiated revision.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+
+**Work:**
+
+1. Read `MCP-Protocol-Version` at the HTTP boundary after resolving the session.
+2. Accept a present value only when it is configured as supported and equals the session's negotiated version.
+3. Return HTTP 400 for malformed, unsupported, or session-mismatched values.
+4. When the header is absent and a valid session exists, use the negotiated version stored in the session.
+5. Apply the `2025-03-26` compatibility assumption only where there is genuinely no other version signal and doing so is relevant to an accepted transport flow.
+6. Continue returning the selected version in the initialize result.
+7. Decide whether to retain response `MCP-Protocol-Version` headers. Keep them if harmless, but do not use them as a substitute for request validation.
+8. Centralize header names and validation to avoid different behavior between requests and notifications.
+
+**Acceptance criteria:**
+
+- The initialize POST succeeds without a protocol-version header.
+- A subsequent request with the negotiated value succeeds.
+- A subsequent request without the header succeeds when session state identifies the version.
+- Unsupported and malformed values return HTTP 400.
+- A globally supported value that differs from the session version returns HTTP 400.
+- Version validation occurs before invoking application handlers.
+
+**Verification:**
+
+- Raw HTTP tests asserting status, headers, and whether handlers ran.
+- Tests for exact, absent, unknown, and mismatched header values.
+- Targeted MCP server tests.
+
+**Depends on:** Tasks 8 and 6.
+
+### Task 10: Correct Initialized Notification Delivery
+
+**Objective:** Send server notifications only to clients that completed initialization, using stable session identity.
+
+**Files:**
+
+- `packages/effect/src/unstable/ai/McpServer.ts`
+- Potentially `packages/effect/src/unstable/rpc/RpcServer.ts` only if the transport lacks the minimum stable-session routing hook
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+
+**Work:**
+
+1. Replace or remove `initializedClients: Set<number>`.
+2. Derive notification eligibility from operational session state.
+3. Associate active transport delivery channels with stable MCP sessions.
+4. Ensure one server message is delivered on only one active HTTP stream for a session.
+5. Do not broadcast notifications to all transport client IDs.
+6. Remove stale delivery-channel associations without deleting valid session negotiation state accidentally.
+7. If the existing HTTP RPC layer cannot expose a compliant GET/SSE channel, isolate the missing transport feature and document it rather than pretending queued notifications were delivered.
+8. Keep generic RPC changes minimal and MCP-agnostic if a transport hook is required.
+
+**Acceptance criteria:**
+
+- A negotiated-only client receives no list-change notifications.
+- An operational stdio/custom-transport client receives eligible notifications.
+- HTTP notification behavior is either conforming through one session stream or explicitly unsupported without dead state that claims otherwise.
+- Disconnected delivery channels are cleaned up.
+- Notifications are not duplicated across simultaneous streams.
+
+**Verification:**
+
+- Integration tests around registration-triggered list-change notifications before and after initialized.
+- Multi-client isolation test.
+- HTTP stream test if HTTP server-initiated delivery is supported by the resulting design.
+- Targeted MCP and any affected RPC tests.
+
+**Depends on:** Tasks 7 and 9.
+
+### Task 11: Add Complete Negotiation Conformance Coverage
+
+**Objective:** Consolidate the behavior into a readable regression suite based on the protocol lifecycle.
+
+**Files:**
+
+- `packages/effect/test/unstable/ai/McpServer.test.ts`
+- `packages/effect/typetest/` as needed
+
+**Work:**
+
+1. Organize tests into negotiation, lifecycle, HTTP session, HTTP version header, and notifications groups.
+2. Add a table-driven negotiation matrix covering every default supported version.
+3. Add custom configuration cases.
+4. Assert the initialize JSON-RPC result body, not only response headers.
+5. Assert `MCP-Session-Id`, HTTP statuses, notification HTTP 202 responses, and error bodies where applicable.
+6. Exercise multiple requests and multiple sessions.
+7. Remove tests superseded by stronger assertions without weakening coverage.
+
+**Acceptance criteria:**
+
+- Every normative requirement listed in this document maps to at least one test or an explicit documented transport limitation.
+- Tests fail if latest-version fallback, exact echo, session binding, lifecycle transition, or HTTP header enforcement regresses.
+- Tests use `it.effect` and `assert` utilities according to repository conventions.
+
+**Verification:**
+
+```sh
+pnpm test packages/effect/test/unstable/ai/McpServer.test.ts
+pnpm test-types <mcp-type-test-file>
+```
+
+**Depends on:** Tasks 2 through 10.
+
+### Task 12: Document and Release the API Change
+
+**Objective:** Make the new behavior discoverable and prepare it for release.
+
+**Files:**
+
+- Public JSDoc in `packages/effect/src/unstable/ai/McpServer.ts`
+- Public JSDoc in `McpSchema.ts` if exports were added there
+- `.changeset/<generated-name>.md`
+
+**Work:**
+
+1. Document the default versions and `supportedProtocolVersions` ordering.
+2. Explain that clients still send one version string.
+3. Document exact-match and preferred-fallback behavior.
+4. Document HTTP header enforcement and lifecycle expectations.
+5. Add a changeset covering the exported API, latest stable support, and runtime HTTP behavior.
+6. Run code generation only if modules were added or removed. Do not hand-edit generated barrels.
+
+**Acceptance criteria:**
+
+- Public options have complete compliant JSDoc.
+- The changeset accurately describes user-visible behavior.
+- Examples use `2025-11-25` or exported constants rather than stale literals.
+- No generated file is manually edited.
+
+**Verification:**
+
+```sh
+pnpm lint
+```
+
+**Depends on:** Task 11.
+
+### Task 13: Final Validation
+
+**Objective:** Verify the complete change using repository-required checks.
+
+**Work:**
+
+1. Run formatting and lint fixes.
+2. Run the targeted MCP runtime tests.
+3. Run targeted MCP type tests.
+4. Run the repository type checker.
+5. Inspect the final diff for unrelated changes, unsafe assertions, generated-file edits, and stale protocol literals.
+6. Confirm every acceptance criterion in this document is complete or explicitly recorded as blocked.
+
+**Verification:**
+
+```sh
+pnpm lint-fix
+pnpm test packages/effect/test/unstable/ai/McpServer.test.ts
+pnpm test-types <mcp-type-test-file>
+pnpm check
+```
+
+**Acceptance criteria:**
+
+- All commands pass.
+- No new `any`, non-null assertion, or defect-based expected failure is introduced.
+- The implementation defaults to verified `2025-11-25` support.
+- Custom ordered version sets negotiate correctly.
+- HTTP sessions enforce one negotiated version.
+- Final changes remain limited to MCP negotiation, lifecycle, required schemas, tests, documentation, and any minimal transport support proven necessary by tests.
+
+**Depends on:** Task 12.
+
+## Test Matrix
+
+| Area | Scenario | Expected result |
+| --- | --- | --- |
+| Default negotiation | Client requests `2025-11-25` | Response echoes `2025-11-25` |
+| Default negotiation | Client requests retained older revision | Response echoes requested revision |
+| Default negotiation | Client requests unknown future revision | Response selects first default revision |
+| Custom negotiation | Client requests configured revision | Response echoes requested revision |
+| Custom negotiation | Client requests unconfigured revision | Response selects first configured revision |
+| Isolation | Two servers configure different sets | Each uses only its own configuration |
+| Initialization | First request is initialize | Session enters negotiated state |
+| Initialization | Original offer differs from fallback | Original offer and selected version are both retained |
+| Lifecycle | Client sends initialized notification | Session enters operational state |
+| Lifecycle | Normal request has no session | Rejected without a defect |
+| Lifecycle | Notification queued before operational | Not delivered |
+| Lifecycle | Notification queued after operational | Delivered when transport supports it |
+| HTTP session | Initialize has no session header | Accepted and server issues session ID |
+| HTTP session | Subsequent request omits required session ID | HTTP 400 |
+| HTTP session | Subsequent request supplies unknown ID | HTTP 404 |
+| HTTP session | Multiple requests use valid ID | All resolve the same session |
+| HTTP version | Initialize omits version header | Accepted; body performs negotiation |
+| HTTP version | Subsequent header equals negotiated value | Accepted |
+| HTTP version | Subsequent header is absent with valid session | Session version is used |
+| HTTP version | Header is unsupported or malformed | HTTP 400 |
+| HTTP version | Header is supported but differs from session | HTTP 400 |
+| Schema | Official `2025-11-25` implemented examples | Decode and encode successfully |
+| Compatibility | Fixture for every retained older revision | Remains compatible |
+
+## Risks and Mitigations
+
+### Advertising a Version Without Implementing Its Wire Schema
+
+Mitigation: Task 1 gates the default list, and Task 5 implements required schema differences before lifecycle work relies on the new default.
+
+### Treating a Version List as Client-Server Intersection Negotiation
+
+Mitigation: Keep the wire request scalar and isolate the exact-match-or-first-supported algorithm in a pure function.
+
+### Breaking Existing Servers by Requiring New Configuration
+
+Mitigation: Make `supportedProtocolVersions` optional and retain a verified default tuple.
+
+### HTTP Client Compatibility When Enforcing Headers
+
+Mitigation: Resolve an omitted header from valid session state, as allowed by the specification, while rejecting present invalid or mismatched values.
+
+### Conflating HTTP Requests With MCP Sessions
+
+Mitigation: Key lifecycle state by stable MCP session ID and treat numeric RPC client IDs only as transport delivery handles.
+
+### Expanding Into a Full Streamable HTTP Rewrite
+
+Mitigation: Restrict generic RPC changes to the smallest routing hook demonstrated necessary by Task 10 tests. Record unsupported SSE behavior separately rather than implementing resumability or redelivery opportunistically.
+
+### Legacy Revision Transport Differences
+
+Mitigation: Remove a legacy revision from the default advertised set if the current server transport cannot actually honor it. Keeping a string in the list is not compatibility.
+
+## Completion Definition
+
+This project is complete when:
+
+1. `2025-11-25` is the verified latest default version.
+2. Every server constructor accepts an ordered non-empty supported-version set.
+3. Exact supported offers are echoed and unsupported offers receive the configured preferred version.
+4. The selected version is stored separately from the original initialize payload.
+5. Session state transitions through negotiated and operational phases.
+6. Streamable HTTP resolves and validates the negotiated version on subsequent requests.
+7. Missing, unknown, unsupported, and mismatched HTTP state produce deliberate specification-aligned responses rather than defects.
+8. Outgoing notification readiness follows `notifications/initialized` and stable session identity.
+9. The implemented surface conforms to official `2025-11-25` schemas without advertising unimplemented optional capabilities.
+10. Runtime tests, type tests, lint, and type checking pass.
+11. Public JSDoc and a changeset describe the behavior.

--- a/.specs/mcp-server-version-negotiation.md
+++ b/.specs/mcp-server-version-negotiation.md
@@ -854,3 +854,71 @@ This project is complete when:
 9. The implemented surface conforms to official `2025-11-25` schemas without advertising unimplemented optional capabilities.
 10. Runtime tests, type tests, lint, and type checking pass.
 11. Public JSDoc and a changeset describe the behavior.
+
+## Atomic Test Expansion Plan
+
+The test expansion is split into the following dependency-ordered subtasks. Each subtask must preserve all coverage established by its dependencies and should be reviewed independently.
+
+### 1. Structure
+
+- Reorganize `McpSchema.test.ts` and `McpServer.test.ts` into `2025-06-18`, `2025-11-25`, shared, and configuration suites without changing behavioral assertions.
+- Split mixed-version tests only where needed to make the asserted protocol revision explicit; use shared suites only for behavior that is invariant across revisions.
+- Verify with `pnpm lint-fix` and targeted runs of both MCP test files.
+
+**Depends on:** Nothing.
+
+### 2. HTTP Helper/Parameterized Shared Suites
+
+- Extend `makeTestClient` with the minimum raw-request controls needed to set or omit session and protocol headers deliberately while retaining automatic session handling for RPC calls.
+- Parameterize exact negotiation, initialize headers, lifecycle, valid-session requests, and omitted protocol-header behavior across `2025-06-18` and `2025-11-25`.
+- Keep revision-specific expected payloads in their version suites rather than adding conditionals to shared assertions.
+
+**Depends on:** Subtask 1.
+
+### 3. Schema Expansion
+
+- Add the Task 5 conformance fixtures to `McpSchema.test.ts`: metadata and capabilities, argumentless tool calls, structured content boundaries, required progress, completion limits, sampling, form elicitation, and binary round trips.
+- Validate emitted compatibility fixtures against local schemas representing each official tagged revision, with separate expected fields for `2025-06-18` and `2025-11-25`.
+- Add one focused rejection assertion for every audited schema boundary, without combining unrelated failures in a single fixture.
+
+**Depends on:** Subtask 2.
+
+### 4. Registered Feature Integrations
+
+- Register representative tools, prompts, resources, completions, logging handlers, sampling, and elicitation through `McpServer` and exercise each through the client.
+- Assert capability advertisement and wire results in both version suites, including absence of `2025-11-25`-only fields for `2025-06-18` sessions.
+- Cover list-change notification eligibility before and after `notifications/initialized` only for transports that can deliver it.
+
+**Depends on:** Subtask 3.
+
+### 5. Multi-Session HTTP Edges
+
+- Add raw HTTP tests for missing, unknown, expired, and cross-session `MCP-Session-Id` values, plus exact, absent, unsupported, malformed, and session-mismatched `MCP-Protocol-Version` values.
+- Exercise at least three sequential requests in one session and two interleaved sessions negotiated to different revisions.
+- Assert status, response headers, JSON-RPC body, and handler invocation or non-invocation for every rejection path.
+
+**Depends on:** Subtask 4.
+
+### 6. Connection Protocol Harness
+
+- Add a transport-level harness that controls connection identity and captures server-initiated messages independently of request-scoped RPC client IDs.
+- Cover negotiated and operational lifecycle states, duplicate initialization events, disconnect cleanup, notification isolation, and single-delivery behavior across simultaneous connections.
+- Reuse the parameterized version suites where wire behavior is shared and retain explicit revision suites where encoding differs.
+
+**Depends on:** Subtask 5.
+
+### 7. Typetests
+
+- Add targeted typetests for the readonly supported-version tuple, the `ProtocolVersion` union, non-empty custom configuration, constructor option parity, and rejection of empty or unknown version arrays.
+- Assert that initialize requests continue accepting arbitrary strings while server configuration accepts only implemented revisions.
+- Run the targeted MCP typetest file after runtime suites pass.
+
+**Depends on:** Subtask 6.
+
+### 8. Final Validation
+
+- Run `pnpm lint-fix`, both targeted MCP runtime suites, the targeted MCP typetest, and `pnpm check`.
+- Inspect the final diff for lost assertions, stale protocol literals outside fixtures, unsafe assertions, generated-file edits, and unrelated changes.
+- Map every normative requirement and Test Matrix row to a passing assertion or an explicit documented transport limitation.
+
+**Depends on:** Subtask 7.

--- a/packages/effect/MCP.md
+++ b/packages/effect/MCP.md
@@ -231,6 +231,113 @@ against the defined schema, ensuring that only `"yes"` or `"no"` responses are a
 declines to answer or the elicitation fails, a fallback value is provided—here, the default answer
 is `"no"`.
 
+## Client
+
+The `McpClient.ts` module provides an Effect-native MCP client. It performs the `initialize`/
+`notifications/initialized` handshake automatically, exposes the negotiated server info,
+capabilities, and instructions, and provides typed methods for calling tools, reading resources,
+listing prompts, and requesting completions.
+
+```typescript
+import { Effect } from "effect"
+import { McpClient } from "effect/unstable/ai"
+
+const program = Effect.gen(function*() {
+  const client = yield* McpClient.McpClient
+  console.log(client.serverInfo)
+
+  const tools = yield* McpClient.listTools()
+  console.log(tools)
+
+  const result = yield* McpClient.callTool({ name: "GreetTool", arguments: { name: "Ada" } })
+  console.log(result)
+})
+```
+
+`McpClient.layerStdio` spawns a child process and speaks newline-delimited JSON-RPC over its
+stdio, using the platform-agnostic `ChildProcessSpawner` service (provided, for example, by
+`NodeServices.layer` from `@effect/platform-node`):
+
+```typescript
+import { NodeServices } from "@effect/platform-node"
+import { Effect } from "effect"
+import { McpClient } from "effect/unstable/ai"
+
+const program = Effect.gen(function*() {
+  const tools = yield* McpClient.listTools()
+  console.log(tools)
+}).pipe(
+  Effect.provide(McpClient.layerStdio({
+    name: "Demo Client",
+    version: "1.0.0",
+    command: "node",
+    args: ["./server.js"]
+  })),
+  Effect.provide(NodeServices.layer)
+)
+```
+
+`McpClient.layerHttp` connects to a Streamable HTTP MCP server instead, given an `HttpClient` and
+a URL:
+
+```typescript
+import { Effect } from "effect"
+import { McpClient } from "effect/unstable/ai"
+import { FetchHttpClient } from "effect/unstable/http"
+
+const program = Effect.gen(function*() {
+  const tools = yield* McpClient.listTools()
+  console.log(tools)
+}).pipe(
+  Effect.provide(McpClient.layerHttp({
+    name: "Demo Client",
+    version: "1.0.0",
+    url: "http://localhost:3000/mcp"
+  })),
+  Effect.provide(FetchHttpClient.layer)
+)
+```
+
+### Host-side handlers
+
+A server can call back into the client to sample an LLM, list workspace roots, or elicit
+structured input from the user. Register handlers for these capabilities through the `handlers`
+option on `layer`, `layerStdio`, or `layerHttp`. The presence of each handler key determines the
+`ClientCapabilities` advertised during `initialize`.
+
+```typescript
+import { Effect } from "effect"
+import { McpClient } from "effect/unstable/ai"
+
+const ClientLayer = McpClient.layerStdio({
+  name: "Demo Client",
+  version: "1.0.0",
+  command: "node",
+  args: ["./server.js"],
+  handlers: {
+    elicitation: (params) =>
+      Effect.succeed({
+        action: "accept",
+        content: { answer: "yes" }
+      })
+  }
+})
+```
+
+In this example, whenever the connected server elicits structured input, the client immediately
+accepts with `{ answer: "yes" }`. A handler can also return `{ action: "decline" }` or
+`{ action: "cancel" }`, and can fail with an `McpSchema.McpError` to signal an RPC-level error back
+to the server.
+
+### Limitations
+
+`McpClient` does not open a standalone GET/SSE listener for the Streamable HTTP transport, so
+server-initiated requests and notifications are only observed while one of the client's own
+requests has an open response stream. Unsolicited pushes sent outside of any call (for example, a
+`notifications/tools/list_changed` sent while the client is otherwise idle) will be missed against
+servers that rely on the GET channel exclusively. `Last-Event-ID` resumability and the legacy
+HTTP+SSE (2024-11-05) transport are likewise not supported.
+
 ## Complete Working Example
 
 Here's a complete, copy/pastable MCP server example that combines all the concepts:

--- a/packages/effect/src/unstable/ai/McpClient.ts
+++ b/packages/effect/src/unstable/ai/McpClient.ts
@@ -1,0 +1,951 @@
+/**
+ * Builds Model Context Protocol (MCP) clients with Effect.
+ *
+ * The `McpClient` service performs the MCP `initialize`/`initialized`
+ * handshake against a server, exposes the negotiated server info,
+ * capabilities, and instructions, and provides typed methods for calling
+ * tools, reading resources, listing prompts, and requesting completions. This
+ * module also includes stdio and Streamable HTTP transport layers, plus
+ * support for registering host-side handlers for server-initiated sampling,
+ * roots, and elicitation requests.
+ *
+ * @since 4.0.0
+ */
+import type * as Cause from "../../Cause.ts"
+import * as Context from "../../Context.ts"
+import * as Effect from "../../Effect.ts"
+import * as Fiber from "../../Fiber.ts"
+import { constVoid } from "../../Function.ts"
+import * as Layer from "../../Layer.ts"
+import * as Option from "../../Option.ts"
+import type * as PlatformError from "../../PlatformError.ts"
+import * as Queue from "../../Queue.ts"
+import * as Schedule from "../../Schedule.ts"
+import * as Schema from "../../Schema.ts"
+import type * as Scope from "../../Scope.ts"
+import * as Stream from "../../Stream.ts"
+import * as Headers from "../http/Headers.ts"
+import * as HttpBody from "../http/HttpBody.ts"
+import * as HttpClient from "../http/HttpClient.ts"
+import { HttpClientErrorSchema } from "../http/HttpClientError.ts"
+import type { HttpClientError } from "../http/HttpClientError.ts"
+import * as ChildProcess from "../process/ChildProcess.ts"
+import type { ChildProcessSpawner } from "../process/ChildProcessSpawner.ts"
+import * as RpcClient from "../rpc/RpcClient.ts"
+import { RpcClientDefect, RpcClientError } from "../rpc/RpcClientError.ts"
+import type * as RpcGroup from "../rpc/RpcGroup.ts"
+import type * as RpcMessage from "../rpc/RpcMessage.ts"
+import * as RpcSerialization from "../rpc/RpcSerialization.ts"
+import * as RpcServer from "../rpc/RpcServer.ts"
+import {
+  type CallToolResult,
+  type ClientCapabilities,
+  type ClientRequestRpcs,
+  ClientRpcs,
+  type Complete,
+  type CompleteResult,
+  type CreateMessage,
+  type CreateMessageResult,
+  type Elicit,
+  ElicitAcceptResult,
+  ElicitDeclineResult,
+  type ElicitResult,
+  type GetPromptResult,
+  type Implementation,
+  type ListPromptsResult,
+  type ListResourcesResult,
+  type ListResourceTemplatesResult,
+  type ListRoots,
+  type ListRootsResult,
+  type ListToolsResult,
+  type McpError as McpErrorSchema,
+  MethodNotFound,
+  type ReadResourceResult,
+  type ServerCapabilities,
+  ServerNotificationRpcs,
+  ServerRequestRpcs
+} from "./McpSchema.ts"
+
+/**
+ * Type represented by `McpSchema.McpError`, the RPC-level error schema
+ * carried by every MCP request's `error` channel.
+ */
+type McpError = typeof McpErrorSchema.Type
+
+const LATEST_PROTOCOL_VERSION = "2025-06-18"
+const SUPPORTED_PROTOCOL_VERSIONS = [
+  LATEST_PROTOCOL_VERSION,
+  "2025-03-26",
+  "2024-11-05",
+  "2024-10-07"
+]
+const mcpSessionIdHeader = "mcp-session-id"
+const mcpProtocolVersionHeader = "mcp-protocol-version"
+
+/**
+ * RPC group combining the requests and notifications an MCP server can send
+ * to a client.
+ *
+ * **Details**
+ *
+ * Built the same way `McpSchema.ClientRpcs` combines
+ * `ClientRequestRpcs`/`ClientNotificationRpcs` (`McpSchema.ts`), but for the
+ * opposite direction.
+ */
+class ServerRpcs extends ServerRequestRpcs.merge(ServerNotificationRpcs) {}
+
+/**
+ * Error raised by `McpClient` itself for handshake and protocol-version
+ * failures, distinct from `McpSchema.McpError`, which is carried by every
+ * RPC's `error` schema.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class McpClientError extends Schema.ErrorClass<McpClientError>("effect/ai/McpClient/McpClientError")({
+  _tag: Schema.tag("McpClientError"),
+  message: Schema.String,
+  cause: Schema.optionalKey(Schema.Defect())
+}) {}
+
+/**
+ * The result returned by a registered elicitation handler.
+ *
+ * @category capabilities
+ * @since 4.0.0
+ */
+export type ElicitationHandlerResult =
+  | {
+    readonly action: "accept"
+    readonly content: { readonly [key: string]: string | number | boolean | ReadonlyArray<string> }
+  }
+  | {
+    readonly action: "decline" | "cancel"
+  }
+
+/**
+ * Host-side handlers for server-initiated MCP capabilities.
+ *
+ * **When to use**
+ *
+ * Use when a server needs to sample an LLM, list workspace roots, or elicit
+ * structured input from the user, by passing this through the `handlers`
+ * option of `McpClient.layer`, `layerStdio`, or `layerHttp`.
+ *
+ * **Details**
+ *
+ * The presence of each handler key determines the `ClientCapabilities` sent
+ * during `initialize`: `sampling: {}` is advertised only when `sampling` is
+ * set, `roots: { listChanged }` only when `roots` is set, and
+ * `elicitation: {}` only when `elicitation` is set. A client has exactly one
+ * handler per capability, known up front, so there is no separate
+ * layer-based registration API like there is for server tools and resources.
+ *
+ * @category capabilities
+ * @since 4.0.0
+ */
+export interface ClientCapabilityHandlers {
+  /**
+   * Handles `sampling/createMessage` requests from the server.
+   */
+  readonly sampling?: (
+    params: typeof CreateMessage.payloadSchema.Type
+  ) => Effect.Effect<typeof CreateMessageResult.Type, McpError>
+  /**
+   * Handles `roots/list` requests from the server, and optionally emits
+   * `notifications/roots/list_changed` notifications.
+   */
+  readonly roots?: {
+    readonly list: (
+      params: typeof ListRoots.payloadSchema.Type
+    ) => Effect.Effect<typeof ListRootsResult.Type, McpError>
+    /**
+     * When provided, `McpClient` forks a fiber that sends
+     * `notifications/roots/list_changed` on every emission from this stream.
+     */
+    readonly changes?: Stream.Stream<void> | undefined
+  }
+  /**
+   * Handles `elicitation/create` requests from the server.
+   */
+  readonly elicitation?: (
+    params: typeof Elicit.payloadSchema.Type
+  ) => Effect.Effect<ElicitationHandlerResult, McpError>
+}
+
+/**
+ * Service that stores the negotiated MCP session state and exposes a typed
+ * RPC client for the connected server.
+ *
+ * **Details**
+ *
+ * `serverInfo`, `serverCapabilities`, `instructions`, and `protocolVersion`
+ * are populated from the `initialize` response captured automatically while
+ * the service is constructed; the `initialize` request and
+ * `notifications/initialized` notification are never exposed as public
+ * methods since the handshake always runs automatically inside `run`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export class McpClient extends Context.Service<McpClient, {
+  readonly serverInfo: Implementation
+  readonly serverCapabilities: ServerCapabilities
+  readonly instructions: Option.Option<string>
+  readonly protocolVersion: string
+  readonly rpc: RpcClient.RpcClient<RpcGroup.Rpcs<typeof ClientRequestRpcs>, RpcClientError>
+}>()("effect/ai/McpClient") {}
+
+/**
+ * Runs an MCP client handshake over the current `RpcClient.Protocol` and
+ * `RpcServer.Protocol`, returning the connected `McpClient` service.
+ *
+ * **Details**
+ *
+ * `RpcClient.Protocol` carries outbound `ClientRequestRpcs`/
+ * `ClientNotificationRpcs` messages to the server, and `RpcServer.Protocol`
+ * dispatches inbound server-initiated requests
+ * (`ServerRequestRpcs`/`ServerNotificationRpcs`). Both protocols are expected
+ * to be built from the same physical connection (see `layerStdio`/`layerHttp`,
+ * which demultiplex a single duplex into this pair at the transport level), so
+ * this function simply starts the outbound `RpcClient` and the inbound
+ * `RpcServer` side by side, backed by the handler layer built from
+ * `options.handlers`.
+ *
+ * Performs the `initialize` request and sends `notifications/initialized`
+ * before returning, failing with `McpClientError` if the server responds
+ * with an unsupported protocol version.
+ *
+ * **Gotchas**
+ *
+ * `options.capabilities` is merged on top of the capabilities derived from
+ * `options.handlers` (see `ClientCapabilityHandlers`), not validated against
+ * it. Passing e.g. `capabilities: { sampling: {} }` without also setting
+ * `handlers.sampling` advertises sampling support to the server, but every
+ * `sampling/createMessage` request it then sends is answered with a
+ * `MethodNotFound` error, since the runtime dispatcher only has a handler for
+ * capabilities present in `options.handlers`. Only use `capabilities` to opt
+ * into extension fields the corresponding `handlers` entry doesn't already
+ * cover.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const run: (options: {
+  readonly name: string
+  readonly version: string
+  readonly capabilities?: ClientCapabilities | undefined
+  readonly handlers?: ClientCapabilityHandlers | undefined
+}) => Effect.Effect<
+  McpClient["Service"],
+  McpClientError,
+  RpcClient.Protocol | RpcServer.Protocol | Scope.Scope
+> = Effect.fnUntraced(function*(options: {
+  readonly name: string
+  readonly version: string
+  readonly capabilities?: ClientCapabilities | undefined
+  readonly handlers?: ClientCapabilityHandlers | undefined
+}) {
+  const handlers = options.handlers ?? {}
+
+  const client = yield* RpcClient.make(ClientRpcs, {
+    spanPrefix: "McpClient"
+  })
+
+  const capabilities = computeClientCapabilities(handlers, options.capabilities)
+
+  const handlersLayer = ServerRpcs.toLayer(
+    Effect.sync(() =>
+      ServerRpcs.of({
+        ping: () => Effect.succeed({}),
+        "sampling/createMessage": (params) =>
+          handlers.sampling
+            ? handlers.sampling(params)
+            : Effect.fail(methodNotSupported("sampling/createMessage")),
+        "roots/list": (params) =>
+          handlers.roots
+            ? handlers.roots.list(params)
+            : Effect.fail(methodNotSupported("roots/list")),
+        "elicitation/create": (params) =>
+          handlers.elicitation
+            ? Effect.map(handlers.elicitation(params), encodeElicitResult)
+            : Effect.fail(methodNotSupported("elicitation/create")),
+
+        // Notifications
+        "notifications/cancelled": (_) => Effect.void,
+        "notifications/progress": (_) => Effect.void,
+        "notifications/message": (_) => Effect.void,
+        "notifications/resources/updated": (_) => Effect.void,
+        "notifications/resources/list_changed": (_) => Effect.void,
+        "notifications/tools/list_changed": (_) => Effect.void,
+        "notifications/prompts/list_changed": (_) => Effect.void
+      })
+    )
+  )
+
+  yield* RpcServer.make(ServerRpcs, {
+    spanPrefix: "McpClient/Server",
+    disableFatalDefects: true
+  }).pipe(
+    Effect.provide(handlersLayer),
+    Effect.forkScoped
+  )
+
+  if (handlers.roots?.changes) {
+    yield* handlers.roots.changes.pipe(
+      // `discard: true` since notifications never receive a response - the
+      // MCP server treats `notifications/*` methods as JSON-RPC
+      // notifications and never sends an `Exit` back for them.
+      Stream.runForEach(() => client["notifications/roots/list_changed"]({}, { discard: true })),
+      Effect.forkScoped
+    )
+  }
+
+  const initResult = yield* client.initialize({
+    protocolVersion: LATEST_PROTOCOL_VERSION,
+    capabilities,
+    clientInfo: {
+      name: options.name,
+      version: options.version
+    }
+  }).pipe(
+    Effect.mapError((error) => new McpClientError({ message: "MCP initialize request failed", cause: error }))
+  )
+
+  if (!SUPPORTED_PROTOCOL_VERSIONS.includes(initResult.protocolVersion)) {
+    return yield* new McpClientError({
+      message: `Unsupported MCP protocol version returned by server: ${initResult.protocolVersion}`
+    })
+  }
+
+  // `discard: true`: see the comment above `notifications/roots/list_changed`.
+  yield* client["notifications/initialized"]({}, { discard: true }).pipe(
+    Effect.mapError((error) => new McpClientError({ message: "MCP notifications/initialized failed", cause: error }))
+  )
+
+  return McpClient.of({
+    serverInfo: initResult.serverInfo,
+    serverCapabilities: initResult.capabilities,
+    instructions: Option.fromUndefinedOr(initResult.instructions),
+    protocolVersion: initResult.protocolVersion,
+    rpc: client
+  })
+})
+
+/**
+ * Creates a layer that runs an MCP client handshake over an existing pair of
+ * `RpcClient.Protocol` and `RpcServer.Protocol` services, and provides the
+ * `McpClient` service.
+ *
+ * **When to use**
+ *
+ * Use when you already have a custom or externally provided protocol pair
+ * and want to start an MCP client as part of a layer graph.
+ *
+ * **Gotchas**
+ *
+ * Unlike `layerStdio` and `layerHttp`, this layer does not install a concrete
+ * transport. The surrounding layer graph must provide both
+ * `RpcClient.Protocol` and `RpcServer.Protocol`, built from the same physical
+ * connection.
+ *
+ * @see {@link run} for the effect form used by this layer
+ * @see {@link layerStdio} for a stdio-backed layer that spawns a child process and installs NDJSON-RPC serialization
+ * @see {@link layerHttp} for a Streamable-HTTP-backed layer
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = (options: {
+  readonly name: string
+  readonly version: string
+  readonly capabilities?: ClientCapabilities | undefined
+  readonly handlers?: ClientCapabilityHandlers | undefined
+}): Layer.Layer<McpClient, McpClientError, RpcClient.Protocol | RpcServer.Protocol> =>
+  Layer.effect(McpClient)(run(options))
+
+/**
+ * Spawns a child process and runs the MCP client handshake over its stdio,
+ * using newline-delimited JSON-RPC framing.
+ *
+ * **Example** (Connecting to an MCP server over stdio)
+ *
+ * ```ts
+ * import { Effect } from "effect"
+ * import { NodeServices } from "@effect/platform-node"
+ * import { McpClient } from "effect/unstable/ai"
+ *
+ * const program = Effect.gen(function*() {
+ *   const tools = yield* McpClient.listTools()
+ *   console.log(tools)
+ * }).pipe(
+ *   Effect.provide(McpClient.layerStdio({
+ *     name: "Demo Client",
+ *     version: "1.0.0",
+ *     command: "node",
+ *     args: ["./server.js"]
+ *   })),
+ *   Effect.provide(NodeServices.layer)
+ * )
+ * ```
+ *
+ * @see {@link layer} for the transport-agnostic base layer
+ * @see {@link layerHttp} for a Streamable-HTTP-backed layer
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerStdio = (options: {
+  readonly name: string
+  readonly version: string
+  readonly command: string
+  readonly args?: ReadonlyArray<string> | undefined
+  readonly env?: Record<string, string> | undefined
+  readonly cwd?: string | undefined
+  readonly capabilities?: ClientCapabilities | undefined
+  readonly handlers?: ClientCapabilityHandlers | undefined
+}): Layer.Layer<McpClient, McpClientError | PlatformError.PlatformError, ChildProcessSpawner> =>
+  layer(options).pipe(
+    Layer.provide(layerProtocolPairStdio(options)),
+    Layer.provide(RpcSerialization.layerNdJsonRpc())
+  )
+
+/**
+ * Runs the MCP client handshake against a Streamable HTTP MCP server.
+ *
+ * **Details**
+ *
+ * Attaches the `Mcp-Session-Id` header captured from the `initialize`
+ * response, and the negotiated `MCP-Protocol-Version` header, to every
+ * subsequent request.
+ *
+ * **Gotchas**
+ *
+ * This client does not open a standalone GET/SSE listener, so server-initiated
+ * requests and notifications are only observed while one of our own requests
+ * has an open response stream. Unsolicited pushes (e.g.
+ * `notifications/tools/list_changed` sent outside of any call) will be missed
+ * against servers that rely on the GET channel exclusively. `Last-Event-ID`
+ * resumability and the legacy HTTP+SSE (2024-11-05) transport are likewise out
+ * of scope.
+ *
+ * @see {@link layer} for the transport-agnostic base layer
+ * @see {@link layerStdio} for a stdio-backed layer
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerHttp = (options: {
+  readonly name: string
+  readonly version: string
+  readonly url: string
+  readonly headers?: Headers.Input | undefined
+  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+  readonly capabilities?: ClientCapabilities | undefined
+  readonly handlers?: ClientCapabilityHandlers | undefined
+}): Layer.Layer<McpClient, McpClientError, HttpClient.HttpClient> =>
+  layer(options).pipe(
+    Layer.provide(layerProtocolPairHttp(options)),
+    Layer.provide(RpcSerialization.layerJsonRpc())
+  )
+
+/**
+ * Sends an MCP `ping` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const ping: Effect.Effect<{}, McpError | RpcClientError, McpClient> = Effect.flatMap(
+  McpClient,
+  (client) => client.rpc.ping(undefined)
+)
+
+/**
+ * Sends an MCP `tools/list` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const listTools = (
+  params?: { readonly cursor?: string | undefined }
+): Effect.Effect<ListToolsResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["tools/list"](params))
+
+/**
+ * Sends an MCP `tools/call` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const callTool = (
+  params: { readonly name: string; readonly arguments?: Record<string, unknown> | undefined }
+): Effect.Effect<CallToolResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(
+    McpClient,
+    (client) => client.rpc["tools/call"]({ name: params.name, arguments: params.arguments ?? {} })
+  )
+
+/**
+ * Sends an MCP `resources/list` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const listResources = (
+  params?: { readonly cursor?: string | undefined }
+): Effect.Effect<ListResourcesResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["resources/list"](params))
+
+/**
+ * Sends an MCP `resources/read` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const readResource = (
+  params: { readonly uri: string }
+): Effect.Effect<ReadResourceResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["resources/read"](params))
+
+/**
+ * Sends an MCP `resources/templates/list` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const listResourceTemplates = (
+  params?: { readonly cursor?: string | undefined }
+): Effect.Effect<ListResourceTemplatesResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["resources/templates/list"](params))
+
+/**
+ * Sends an MCP `prompts/list` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const listPrompts = (
+  params?: { readonly cursor?: string | undefined }
+): Effect.Effect<ListPromptsResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["prompts/list"](params))
+
+/**
+ * Sends an MCP `prompts/get` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const getPrompt = (
+  params: { readonly name: string; readonly arguments?: Record<string, string> | undefined }
+): Effect.Effect<GetPromptResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["prompts/get"](params))
+
+/**
+ * Sends an MCP `completion/complete` request.
+ *
+ * @category client
+ * @since 4.0.0
+ */
+export const complete = (
+  params: typeof Complete.payloadSchema.Type
+): Effect.Effect<CompleteResult, McpError | RpcClientError, McpClient> =>
+  Effect.flatMap(McpClient, (client) => client.rpc["completion/complete"](params))
+
+// -----------------------------------------------------------------------------
+// Internal
+// -----------------------------------------------------------------------------
+
+const methodNotSupported = (method: string): MethodNotFound =>
+  new MethodNotFound({ message: `Method '${method}' is not supported by this client` })
+
+// `ElicitResult` is a `Schema.Union` of `Schema.Class` members
+// (`ElicitAcceptResult`/`ElicitDeclineResult`), and `RpcServer.make` encodes
+// handler return values with `Schema.encodeUnknownEffect` (`RpcServer.ts`
+// `encodeExit`). For a union of classes, `encodeUnknown` requires the input to
+// already be an instance of one of the member classes - a plain object
+// literal matching a member's shape is rejected outright - so the result must
+// be constructed as a real class instance here rather than a plain object.
+const encodeElicitResult = (result: ElicitationHandlerResult): typeof ElicitResult.Type =>
+  result.action === "accept"
+    ? new ElicitAcceptResult({ action: "accept", content: result.content })
+    : new ElicitDeclineResult({ action: result.action })
+
+const computeClientCapabilities = (
+  handlers: ClientCapabilityHandlers,
+  extra: ClientCapabilities | undefined
+): ClientCapabilities => {
+  const capabilities: Record<string, unknown> = {}
+  if (handlers.sampling) {
+    capabilities.sampling = {}
+  }
+  if (handlers.roots) {
+    capabilities.roots = { listChanged: handlers.roots.changes !== undefined }
+  }
+  if (handlers.elicitation) {
+    capabilities.elicitation = {}
+  }
+  // `extra` is merged on top unconditionally, without checking it against
+  // `handlers` - see the "Gotchas" section on `run`'s doc comment: a caller
+  // that sets e.g. `extra.sampling` without `handlers.sampling` ends up
+  // advertising a capability the runtime dispatcher (`run`, `ServerRpcs.toLayer`
+  // above) will actually respond to with `MethodNotFound`.
+  if (extra) {
+    Object.assign(capabilities, extra)
+  }
+  return capabilities as ClientCapabilities
+}
+
+/**
+ * Builds a paired `RpcClient.Protocol` / `RpcServer.Protocol` layer over a
+ * spawned child process's stdio.
+ *
+ * **Details**
+ *
+ * Mirrors `RpcServer.makeProtocolStdio` (`RpcServer.ts:1247-1299`), but
+ * splits reading and writing across two protocol services instead of one,
+ * sourcing/sinking from a `ChildProcessHandle` instead of the `Stdio`
+ * service: the `RpcClient.Protocol` decodes `handle.stdout` into responses
+ * for the outbound client, and the `RpcServer.Protocol` encodes responses
+ * from the inbound handler loop onto `handle.stdin`. Both protocols share a
+ * single outbound write queue so writes are serialized onto the one stdin
+ * sink.
+ */
+const layerProtocolPairStdio = (options: {
+  readonly command: string
+  readonly args?: ReadonlyArray<string> | undefined
+  readonly env?: Record<string, string> | undefined
+  readonly cwd?: string | undefined
+}): Layer.Layer<
+  RpcClient.Protocol | RpcServer.Protocol,
+  PlatformError.PlatformError,
+  ChildProcessSpawner | RpcSerialization.RpcSerialization
+> =>
+  Layer.unwrap(Effect.gen(function*() {
+    const handle = yield* ChildProcess.make(options.command, options.args ?? [], {
+      env: options.env,
+      cwd: options.cwd
+    })
+    const serialization = yield* RpcSerialization.RpcSerialization
+    const parser = serialization.makeUnsafe()
+
+    // A single outbound write queue serializes both the client's requests
+    // and the server's responses onto the one stdin sink, mirroring
+    // `RpcServer.makeProtocolStdio`'s single forked
+    // `Stream.fromQueue(queue).pipe(Stream.run(stdio.stdout()), ...)`.
+    const textEncoder = new TextEncoder()
+    const outboundQueue = yield* Queue.make<Uint8Array, Cause.Done>()
+    const offerEncoded = (encoded: Uint8Array | string) =>
+      Queue.offer(outboundQueue, typeof encoded === "string" ? textEncoder.encode(encoded) : encoded)
+    yield* Stream.fromQueue(outboundQueue).pipe(
+      Stream.run(handle.stdin),
+      Effect.retry(Schedule.spaced(500)),
+      Effect.forkScoped
+    )
+
+    let writeResponse!: (clientId: number, response: RpcMessage.FromServerEncoded) => Effect.Effect<void>
+    let writeRequest!: (clientId: number, request: RpcMessage.FromClientEncoded) => Effect.Effect<void>
+    // `RpcClient.make` assigns its own client ID from a process-wide counter
+    // (`RpcClient.ts`'s `clientIdCounter`), which will not generally be `0`.
+    // Captured from `send`'s first argument the same way `McpServer.run`'s
+    // per-client `RpcClient.make(ServerRequestRpcs, ...)` block captures `cid`
+    // (`McpServer.ts:385-389`), so that decoded responses are routed back to
+    // the client ID `RpcClient.make` is actually using.
+    let outboundClientId = 0
+
+    // Captures this fiber (the top-level fiber the whole layer is being built
+    // on) so that the stdout-reading fiber below can self-interrupt it once
+    // its retries are exhausted, mirroring `RpcServer.makeProtocolStdio`
+    // (`RpcServer.ts:1247-1272`), which interrupts the same fiber it captured
+    // `Fiber.getCurrent()` from at the top of its `Effect.gen`. Without this,
+    // a persistent decode error (e.g. a malformed line from the child
+    // process) would retry forever while silently dropping all subsequent
+    // stdout bytes instead of failing the connection loudly.
+    const layerFiber = Fiber.getCurrent()!
+
+    const stdoutFiber = yield* handle.stdout.pipe(
+      Stream.runForEach((data) => {
+        const decoded = parser.decode(data) as ReadonlyArray<
+          RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded
+        >
+        if (decoded.length === 0) return Effect.void
+        let i = 0
+        return Effect.whileLoop({
+          while: () => i < decoded.length,
+          body: () => {
+            const message = decoded[i++]
+            // Request-shaped messages (server-initiated requests/notifications)
+            // are routed to the inbound server dispatcher; everything else is a
+            // response to one of our own outbound requests.
+            return message._tag === "Request" || message._tag === "Ping" ||
+                message._tag === "Ack" || message._tag === "Interrupt" || message._tag === "Eof"
+              ? writeRequest(0, message as RpcMessage.FromClientEncoded)
+              : writeResponse(outboundClientId, message as RpcMessage.FromServerEncoded)
+          },
+          step: constVoid
+        })
+      }),
+      Effect.sandbox,
+      Effect.tapError(Effect.logError),
+      Effect.retry(Schedule.spaced(500)),
+      Effect.ensuring(Effect.forkDetach(Fiber.interrupt(layerFiber), { startImmediately: true })),
+      Effect.forkScoped
+    )
+
+    const clientProtocol = yield* RpcClient.Protocol.make(Effect.fnUntraced(function*(writeResponse_) {
+      writeResponse = writeResponse_
+      return {
+        send(clientId, request) {
+          outboundClientId = clientId
+          const encoded = parser.encode(request)
+          if (encoded === undefined) return Effect.void
+          return Effect.orDie(offerEncoded(encoded))
+        },
+        supportsAck: true,
+        supportsTransferables: false
+      }
+    }))
+
+    const disconnects = yield* Queue.make<number>()
+    const serverProtocol = yield* RpcServer.Protocol.make(Effect.fnUntraced(function*(writeRequest_) {
+      writeRequest = writeRequest_
+      return {
+        disconnects,
+        send(_clientId, response) {
+          const encoded = parser.encode(response)
+          if (encoded === undefined) return Effect.void
+          return Effect.orDie(offerEncoded(encoded))
+        },
+        end(_clientId) {
+          return Effect.void
+        },
+        clientIds: Effect.succeed(new Set([0])),
+        initialMessage: Effect.succeedNone,
+        supportsAck: true,
+        supportsTransferables: false,
+        supportsSpanPropagation: true
+      }
+    }))
+
+    // If the child process exits, there is no further way to deliver
+    // responses to pending outbound requests, so end the queue to unblock any
+    // writer, and interrupt the stdout-reading fiber so a crashed/exited
+    // server produces a clear "connection closed" failure for any in-flight
+    // `RpcClient` request instead of leaving callers hanging forever waiting
+    // on a response that will never arrive.
+    yield* handle.exitCode.pipe(
+      Effect.ignore,
+      Effect.andThen(Effect.all([
+        Queue.end(outboundQueue),
+        Fiber.interrupt(stdoutFiber)
+      ], { concurrency: "unbounded", discard: true })),
+      Effect.forkScoped
+    )
+
+    return Layer.mergeAll(
+      Layer.succeed(RpcClient.Protocol)(clientProtocol),
+      Layer.succeed(RpcServer.Protocol)(serverProtocol)
+    )
+  }))
+
+/**
+ * Builds a paired `RpcClient.Protocol` / `RpcServer.Protocol` layer over a
+ * Streamable HTTP MCP server.
+ *
+ * **Details**
+ *
+ * Each outbound request is sent as its own POST, and each decoded response
+ * chunk is inspected before the usual terminal-response bookkeeping
+ * (`RpcClient.makeProtocolHttp`, `RpcClient.ts:893-969`): chunks whose `_tag`
+ * matches a `ServerRequestRpcs`/`ServerNotificationRpcs` method are routed to
+ * the inbound `RpcServer.Protocol` dispatcher instead of the outbound
+ * client's response handler, and any reply built by the inbound handler loop
+ * is sent as a separate POST to the same URL, per the Streamable HTTP
+ * requirement that client responses to server-initiated requests ride their
+ * own POST body.
+ */
+const layerProtocolPairHttp = (options: {
+  readonly url: string
+  readonly headers?: Headers.Input | undefined
+  readonly transformClient?: ((client: HttpClient.HttpClient) => HttpClient.HttpClient) | undefined
+}): Layer.Layer<
+  RpcClient.Protocol | RpcServer.Protocol,
+  never,
+  HttpClient.HttpClient | RpcSerialization.RpcSerialization
+> =>
+  Layer.unwrap(Effect.gen(function*() {
+    const httpClient = yield* HttpClient.HttpClient
+    const serialization = yield* RpcSerialization.RpcSerialization
+    const isFramed = serialization.includesFraming
+    const baseHeaders = Headers.fromInput(options.headers)
+
+    let sessionId: string | undefined
+    let negotiatedProtocolVersion: string | undefined
+
+    const client = options.transformClient
+      ? options.transformClient(httpClient)
+      : httpClient
+
+    const httpClientError = (cause: HttpClientError) =>
+      new RpcClientError({ reason: HttpClientErrorSchema.fromHttpClientError(cause) })
+    const protocolDefect = (message: string, cause: unknown) =>
+      new RpcClientError({ reason: new RpcClientDefect({ message, cause }) })
+
+    const requestHeaders = (): Headers.Input => {
+      let headers = baseHeaders
+      if (sessionId !== undefined) {
+        headers = Headers.set(headers, mcpSessionIdHeader, sessionId)
+      }
+      if (negotiatedProtocolVersion !== undefined) {
+        headers = Headers.set(headers, mcpProtocolVersionHeader, negotiatedProtocolVersion)
+      }
+      return headers
+    }
+
+    // Captures the writer installed by `RpcServer.Protocol.make` below, so
+    // that decoded chunks matching an inbound method can be dispatched there
+    // instead of to the outbound response handler.
+    let writeInboundRequest!: (clientId: number, message: RpcMessage.FromClientEncoded) => Effect.Effect<void>
+
+    const sendRaw = (body: Uint8Array | string) =>
+      client.post(options.url, {
+        headers: requestHeaders(),
+        body: typeof body === "string"
+          ? HttpBody.text(body, serialization.contentType)
+          : HttpBody.uint8Array(body, serialization.contentType)
+      }).pipe(Effect.mapError(httpClientError))
+
+    const dispatch = (
+      clientId: number,
+      message: RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded,
+      writeResponse: (clientId: number, response: RpcMessage.FromServerEncoded) => Effect.Effect<void>
+    ) => {
+      switch (message._tag) {
+        case "Request": {
+          const rpc = ServerRequestRpcs.requests.get(message.tag) ?? ServerNotificationRpcs.requests.get(message.tag)
+          if (rpc) {
+            return writeInboundRequest(0, message as RpcMessage.FromClientEncoded)
+          }
+          // A `Request`-shaped chunk whose method tag matches neither
+          // `ServerRequestRpcs` nor `ServerNotificationRpcs` is either
+          // malformed or an as-yet-unsupported inbound method: log it rather
+          // than silently dropping it, mirroring `McpServer`'s exhaustive
+          // dispatch switch (`RpcServer.ts:445-492`), which never falls
+          // through unrecognized messages without at least routing them
+          // somewhere meaningful.
+          Effect.runFork(Effect.logWarning("Received unrecognized MCP inbound method", { tag: message.tag }))
+          return Effect.void
+        }
+        case "Ack":
+        case "Interrupt":
+        case "Ping":
+        case "Eof":
+          return writeInboundRequest(0, message as RpcMessage.FromClientEncoded)
+        case "Chunk":
+        case "Exit":
+        case "ClientProtocolError":
+        case "Defect":
+        case "Pong":
+          return writeResponse(clientId, message as RpcMessage.FromServerEncoded)
+      }
+    }
+
+    const send = Effect.fnUntraced(function*(
+      clientId: number,
+      request: RpcMessage.FromClientEncoded,
+      writeResponse: (clientId: number, response: RpcMessage.FromServerEncoded) => Effect.Effect<void>
+    ) {
+      if (request._tag !== "Request") {
+        return
+      }
+
+      const parser = serialization.makeUnsafe()
+      const encoded = parser.encode(request)!
+      const response = yield* client.post(options.url, {
+        headers: requestHeaders(),
+        body: typeof encoded === "string"
+          ? HttpBody.text(encoded, serialization.contentType)
+          : HttpBody.uint8Array(encoded, serialization.contentType)
+      }).pipe(Effect.mapError(httpClientError))
+
+      if (response.headers[mcpSessionIdHeader]) {
+        sessionId = response.headers[mcpSessionIdHeader]
+      }
+      if (response.headers[mcpProtocolVersionHeader]) {
+        negotiatedProtocolVersion = response.headers[mcpProtocolVersionHeader]
+      }
+
+      if (!isFramed) {
+        const text = yield* response.text.pipe(Effect.mapError(httpClientError))
+        if (text.length === 0) return
+        const responses = yield* Effect.try({
+          try: () => parser.decode(text),
+          catch: (cause) => protocolDefect("Error decoding HTTP response", cause)
+        })
+        if (!Array.isArray(responses)) {
+          return yield* protocolDefect("Expected an array of responses", responses)
+        }
+        let i = 0
+        yield* Effect.whileLoop({
+          while: () => i < responses.length,
+          body: () => dispatch(clientId, responses[i++], writeResponse),
+          step: constVoid
+        })
+        return
+      }
+
+      yield* Stream.runForEachArray(response.stream, (chunk) =>
+        Effect.try({
+          try: () => chunk.flatMap(parser.decode) as Array<RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded>,
+          catch: (cause) => protocolDefect("Error decoding HTTP response", cause)
+        }).pipe(
+          Effect.flatMap((responses) => {
+            if (responses.length === 0) return Effect.void
+            let i = 0
+            return Effect.whileLoop({
+              while: () => i < responses.length,
+              body: () => dispatch(clientId, responses[i++], writeResponse),
+              step: constVoid
+            })
+          })
+        )).pipe(
+          Effect.mapError((cause) => cause instanceof RpcClientError ? cause : httpClientError(cause))
+        )
+    })
+
+    const clientProtocol = yield* RpcClient.Protocol.make(Effect.fnUntraced(function*(writeResponse) {
+      return {
+        send: (clientId, request) => send(clientId, request, writeResponse),
+        supportsAck: false,
+        supportsTransferables: false
+      }
+    }))
+
+    const disconnects = yield* Queue.make<number>()
+    const serverProtocol = yield* RpcServer.Protocol.make(Effect.fnUntraced(function*(writeRequest) {
+      writeInboundRequest = writeRequest
+      return {
+        disconnects,
+        send(_clientId, response) {
+          // Client responses to server-initiated requests ride their own
+          // POST body, per the Streamable HTTP transport requirement.
+          const parser = serialization.makeUnsafe()
+          const encoded = parser.encode(response)
+          if (encoded === undefined) return Effect.void
+          return Effect.ignore(sendRaw(encoded))
+        },
+        end(_clientId) {
+          return Effect.void
+        },
+        clientIds: Effect.succeed(new Set([0])),
+        initialMessage: Effect.succeedNone,
+        supportsAck: false,
+        supportsTransferables: false,
+        supportsSpanPropagation: false
+      }
+    }))
+
+    return Layer.mergeAll(
+      Layer.succeed(RpcClient.Protocol)(clientProtocol),
+      Layer.succeed(RpcServer.Protocol)(serverProtocol)
+    )
+  }))

--- a/packages/effect/src/unstable/ai/McpClient.ts
+++ b/packages/effect/src/unstable/ai/McpClient.ts
@@ -60,6 +60,7 @@ import {
   type ListToolsResult,
   type McpError as McpErrorSchema,
   MethodNotFound,
+  ProtocolVersion,
   type ReadResourceResult,
   type ServerCapabilities,
   ServerNotificationRpcs,
@@ -72,13 +73,11 @@ import {
  */
 type McpError = typeof McpErrorSchema.Type
 
-const LATEST_PROTOCOL_VERSION = "2025-06-18"
-const SUPPORTED_PROTOCOL_VERSIONS = [
-  LATEST_PROTOCOL_VERSION,
-  "2025-03-26",
-  "2024-11-05",
-  "2024-10-07"
-]
+// Protocol versions the client understands, sourced from the shared MCP schema
+// (ordered newest-first) so the client and server negotiate against the same
+// set instead of drifting copies.
+const SUPPORTED_PROTOCOL_VERSIONS: ReadonlyArray<string> = ProtocolVersion.literals
+const LATEST_PROTOCOL_VERSION = ProtocolVersion.literals[0]
 const mcpSessionIdHeader = "mcp-session-id"
 const mcpProtocolVersionHeader = "mcp-protocol-version"
 
@@ -291,16 +290,6 @@ export const run: (options: {
     Effect.forkScoped
   )
 
-  if (handlers.roots?.changes) {
-    yield* handlers.roots.changes.pipe(
-      // `discard: true` since notifications never receive a response - the
-      // MCP server treats `notifications/*` methods as JSON-RPC
-      // notifications and never sends an `Exit` back for them.
-      Stream.runForEach(() => client["notifications/roots/list_changed"]({}, { discard: true })),
-      Effect.forkScoped
-    )
-  }
-
   const initResult = yield* client.initialize({
     protocolVersion: LATEST_PROTOCOL_VERSION,
     capabilities,
@@ -322,6 +311,21 @@ export const run: (options: {
   yield* client["notifications/initialized"]({}, { discard: true }).pipe(
     Effect.mapError((error) => new McpClientError({ message: "MCP notifications/initialized failed", cause: error }))
   )
+
+  // Only start forwarding roots change notifications once the
+  // initialize/initialized handshake has completed: per the MCP lifecycle the
+  // client must not send notifications other than `notifications/initialized`
+  // before the handshake finishes, and a `changes` stream that emits on
+  // subscription would otherwise race (or precede) it.
+  if (handlers.roots?.changes) {
+    yield* handlers.roots.changes.pipe(
+      // `discard: true` since notifications never receive a response - the
+      // MCP server treats `notifications/*` methods as JSON-RPC
+      // notifications and never sends an `Exit` back for them.
+      Stream.runForEach(() => client["notifications/roots/list_changed"]({}, { discard: true })),
+      Effect.forkScoped
+    )
+  }
 
   return McpClient.of({
     serverInfo: initResult.serverInfo,
@@ -623,8 +627,23 @@ const layerProtocolPairStdio = (options: {
   Layer.unwrap(Effect.gen(function*() {
     const handle = yield* ChildProcess.make(options.command, options.args ?? [], {
       env: options.env,
-      cwd: options.cwd
+      cwd: options.cwd,
+      // Merge `env` onto the parent environment rather than replacing it, so a
+      // caller-supplied `env` does not strip `PATH`/`HOME` and leave the server
+      // unable to locate its own runtime.
+      extendEnv: true
     })
+
+    // Continuously drain the child's stderr so a server that logs verbosely to
+    // stderr cannot deadlock on a full pipe; forward output to the debug log
+    // rather than discarding it silently.
+    const stderrDecoder = new TextDecoder()
+    yield* handle.stderr.pipe(
+      Stream.runForEach((chunk) => Effect.logDebug("MCP server stderr", stderrDecoder.decode(chunk, { stream: true }))),
+      Effect.ignore,
+      Effect.forkScoped
+    )
+
     const serialization = yield* RpcSerialization.RpcSerialization
     const parser = serialization.makeUnsafe()
 
@@ -791,7 +810,10 @@ const layerProtocolPairHttp = (options: {
       new RpcClientError({ reason: new RpcClientDefect({ message, cause }) })
 
     const requestHeaders = (): Headers.Input => {
-      let headers = baseHeaders
+      // The Streamable HTTP transport requires every request to advertise both
+      // JSON and SSE response support; forced on top of caller headers so it
+      // cannot be accidentally dropped.
+      let headers = Headers.set(baseHeaders, "accept", "application/json, text/event-stream")
       if (sessionId !== undefined) {
         headers = Headers.set(headers, mcpSessionIdHeader, sessionId)
       }

--- a/packages/effect/src/unstable/ai/McpClient.ts
+++ b/packages/effect/src/unstable/ai/McpClient.ts
@@ -871,6 +871,28 @@ const layerProtocolPairHttp = (options: {
       }
     }
 
+    // The negotiated protocol version is authoritative in the `initialize`
+    // result body; a spec-compliant server is only required to advertise it
+    // there (plus an optional response header), so capture it from the body and
+    // echo it on every subsequent request per the Streamable HTTP spec, rather
+    // than relying on the server to also send it back as a response header.
+    const captureNegotiatedVersion = (
+      responses: ReadonlyArray<RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded>
+    ): void => {
+      for (const message of responses) {
+        if (
+          message._tag === "Exit" &&
+          message.exit._tag === "Success" &&
+          typeof message.exit.value === "object" &&
+          message.exit.value !== null &&
+          typeof (message.exit.value as { protocolVersion?: unknown }).protocolVersion === "string"
+        ) {
+          negotiatedProtocolVersion = (message.exit.value as { protocolVersion: string }).protocolVersion
+          return
+        }
+      }
+    }
+
     const send = Effect.fnUntraced(function*(
       clientId: number,
       request: RpcMessage.FromClientEncoded,
@@ -879,6 +901,7 @@ const layerProtocolPairHttp = (options: {
       if (request._tag !== "Request") {
         return
       }
+      const isInitialize = request.tag === "initialize"
 
       const parser = serialization.makeUnsafe()
       const encoded = parser.encode(request)!
@@ -906,6 +929,9 @@ const layerProtocolPairHttp = (options: {
         if (!Array.isArray(responses)) {
           return yield* protocolDefect("Expected an array of responses", responses)
         }
+        if (isInitialize) {
+          captureNegotiatedVersion(responses)
+        }
         let i = 0
         yield* Effect.whileLoop({
           while: () => i < responses.length,
@@ -922,6 +948,9 @@ const layerProtocolPairHttp = (options: {
         }).pipe(
           Effect.flatMap((responses) => {
             if (responses.length === 0) return Effect.void
+            if (isInitialize) {
+              captureNegotiatedVersion(responses)
+            }
             let i = 0
             return Effect.whileLoop({
               while: () => i < responses.length,

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -2362,7 +2362,7 @@ export class McpServerClient extends Context.Service<McpServerClient, {
  */
 export class McpServerClientMiddleware extends RpcMiddleware.Service<McpServerClientMiddleware, {
   provides: McpServerClient
-}>()("effect/ai/McpSchema/McpServerClientMiddleware") {}
+}>()("effect/ai/McpSchema/McpServerClientMiddleware", { error: InvalidRequest }) {}
 
 // =============================================================================
 // Protocol
@@ -2461,10 +2461,9 @@ export type FailureEncoded<Group extends RpcGroup.Any> = RpcGroup.Rpcs<
   : never
   : never
 
-class InitializeRequestRpcs extends RpcGroup.make(Initialize) {}
+class LifecycleRequestRpcs extends RpcGroup.make(Initialize, Ping) {}
 
 class OperationalClientRequestRpcs extends RpcGroup.make(
-  Ping,
   Complete,
   SetLevel,
   GetPrompt,
@@ -2490,7 +2489,7 @@ class OperationalClientRequestRpcs extends RpcGroup.make(
  * @category protocols
  * @since 4.0.0
  */
-export class ClientRequestRpcs extends InitializeRequestRpcs.merge(OperationalClientRequestRpcs) {}
+export class ClientRequestRpcs extends LifecycleRequestRpcs.merge(OperationalClientRequestRpcs) {}
 
 /**
  * Encoded union of all client-to-server MCP request messages.

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -143,16 +143,19 @@ export type ProgressToken = typeof ProgressToken.Type
  * @since 4.0.0
  */
 export class RequestMeta extends Schema.Opaque<RequestMeta>()(Schema.Struct({
-  _meta: optional(Schema.Struct({
-    /**
-     * If specified, the caller is requesting out-of-band progress notifications
-     * for this request (as represented by notifications/progress). The value of
-     * this parameter is an opaque token that will be attached to any subsequent
-     * notifications. The receiver is not obligated to provide these
-     * notifications.
-     */
-    progressToken: optional(ProgressToken)
-  }))
+  _meta: optional(Schema.StructWithRest(
+    Schema.Struct({
+      /**
+       * If specified, the caller is requesting out-of-band progress notifications
+       * for this request (as represented by notifications/progress). The value of
+       * this parameter is an opaque token that will be attached to any subsequent
+       * notifications. The receiver is not obligated to provide these
+       * notifications.
+       */
+      progressToken: optional(ProgressToken)
+    }),
+    [Schema.Record(Schema.String, Schema.Json)]
+  ))
 })) {}
 
 /**
@@ -299,7 +302,21 @@ export class Annotations extends Schema.Opaque<Annotations>()(Schema.Struct({
    * effectively required, while 0 means "least important," and indicates that
    * the data is entirely optional.
    */
-  priority: optional(Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 1 })))
+  priority: optional(Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 1 }))),
+  lastModified: optional(Schema.String)
+})) {}
+
+/**
+ * Describes an icon associated with an MCP implementation or protocol object.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export class Icon extends Schema.Opaque<Icon>()(Schema.Struct({
+  src: Schema.String,
+  mimeType: optional(Schema.String),
+  sizes: optional(Schema.Array(Schema.String)),
+  theme: optional(Schema.Literals(["light", "dark"]))
 })) {}
 
 /**
@@ -311,7 +328,10 @@ export class Annotations extends Schema.Opaque<Annotations>()(Schema.Struct({
 export class Implementation extends Schema.Opaque<Implementation>()(Schema.Struct({
   name: Schema.String,
   title: optional(Schema.String),
-  version: Schema.String
+  version: Schema.String,
+  description: optional(Schema.String),
+  icons: optional(Schema.Array(Icon)),
+  websiteUrl: optional(Schema.String)
 })) {}
 
 /**
@@ -354,11 +374,17 @@ export class ClientCapabilities extends Schema.Class<ClientCapabilities>(
   /**
    * Present if the client supports sampling from an LLM.
    */
-  sampling: optional(Schema.Struct({})),
+  sampling: optional(Schema.Struct({
+    context: optional(Schema.Struct({})),
+    tools: optional(Schema.Struct({}))
+  })),
   /**
    * Present if the client supports elicitation from the server.
    */
-  elicitation: optional(Schema.Struct({}))
+  elicitation: optional(Schema.Struct({
+    form: optional(Schema.Struct({})),
+    url: optional(Schema.Struct({}))
+  }))
 }) {}
 
 /**
@@ -449,7 +475,7 @@ export class McpErrorBase extends Schema.Class<McpErrorBase>(
   /**
    * The error type that occurred.
    */
-  code: Schema.Number,
+  code: Schema.Int,
   /**
    * A short description of the error. The message SHOULD be limited to a
    * concise single sentence.
@@ -797,7 +823,7 @@ export class ProgressNotification extends Rpc.make("notifications/progress", {
      * The progress thus far. This should increase every time progress is made,
      * even if the total is unknown.
      */
-    progress: optional(Schema.Number),
+    progress: Schema.Number,
     /**
      * Total number of items to process (or total progress required), if known.
      */
@@ -856,6 +882,7 @@ export class Resource extends Schema.Class<Resource>(
    * window usage.
    */
   size: optional(Schema.Number),
+  icons: optional(Schema.Array(Icon)),
   /**
    * Optional additional metadata for the client.
    *
@@ -904,6 +931,7 @@ export class ResourceTemplate extends Schema.Class<ResourceTemplate>(
    * Optional annotations for the client.
    */
   annotations: optional(Annotations),
+  icons: optional(Schema.Array(Icon)),
 
   /**
    * Optional additional metadata for the client.
@@ -958,7 +986,7 @@ export class BlobResourceContents extends Schema.Opaque<BlobResourceContents>()(
   /**
    * The binary data of the item decoded from a base64-encoded string.
    */
-  blob: Schema.Uint8Array
+  blob: Schema.Uint8ArrayFromBase64
 })) {}
 
 /**
@@ -1167,7 +1195,9 @@ export class Prompt extends Schema.Class<Prompt>(
   /**
    * A list of arguments to use for templating the prompt.
    */
-  arguments: optional(Schema.Array(PromptArgument))
+  arguments: optional(Schema.Array(PromptArgument)),
+  icons: optional(Schema.Array(Icon)),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 }) {}
 
 /**
@@ -1185,7 +1215,8 @@ export class TextContent extends Schema.Opaque<TextContent>()(Schema.Struct({
   /**
    * Optional annotations for the client.
    */
-  annotations: optional(Annotations)
+  annotations: optional(Annotations),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 })) {}
 
 /**
@@ -1199,7 +1230,7 @@ export class ImageContent extends Schema.Opaque<ImageContent>()(Schema.Struct({
   /**
    * The image data.
    */
-  data: Schema.Uint8Array,
+  data: Schema.Uint8ArrayFromBase64,
   /**
    * The MIME type of the image. Different providers may support different
    * image types.
@@ -1208,7 +1239,8 @@ export class ImageContent extends Schema.Opaque<ImageContent>()(Schema.Struct({
   /**
    * Optional annotations for the client.
    */
-  annotations: optional(Annotations)
+  annotations: optional(Annotations),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 })) {}
 
 /**
@@ -1222,7 +1254,7 @@ export class AudioContent extends Schema.Opaque<AudioContent>()(Schema.Struct({
   /**
    * The audio data.
    */
-  data: Schema.Uint8Array,
+  data: Schema.Uint8ArrayFromBase64,
   /**
    * The MIME type of the audio. Different providers may support different
    * audio types.
@@ -1231,7 +1263,8 @@ export class AudioContent extends Schema.Opaque<AudioContent>()(Schema.Struct({
   /**
    * Optional annotations for the client.
    */
-  annotations: optional(Annotations)
+  annotations: optional(Annotations),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 })) {}
 
 /**
@@ -1251,7 +1284,8 @@ export class EmbeddedResource extends Schema.Opaque<EmbeddedResource>()(Schema.S
   /**
    * Optional annotations for the client.
    */
-  annotations: optional(Annotations)
+  annotations: optional(Annotations),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 })) {}
 
 /**
@@ -1469,7 +1503,19 @@ export class Tool extends Schema.Class<Tool>(
   /**
    * A JSON Schema object defining the expected parameters for the tool.
    */
-  inputSchema: Schema.Any,
+  inputSchema: Schema.StructWithRest(
+    Schema.Struct({
+      type: Schema.Literal("object")
+    }),
+    [Schema.Record(Schema.String, Schema.Json)]
+  ),
+  outputSchema: optional(Schema.StructWithRest(
+    Schema.Struct({
+      type: Schema.Literal("object")
+    }),
+    [Schema.Record(Schema.String, Schema.Json)]
+  )),
+  icons: optional(Schema.Array(Icon)),
   /**
    * Optional additional tool information.
    */
@@ -1526,7 +1572,7 @@ export class ListTools extends Rpc.make("tools/list", {
 export class CallToolResult extends Schema.Class<CallToolResult>("@effect/ai/McpSchema/CallToolResult")({
   ...ResultMeta.fields,
   content: Schema.Array(ContentBlock),
-  structuredContent: optional(Schema.Any),
+  structuredContent: optional(Schema.Record(Schema.String, Schema.Json)),
   /**
    * Whether the tool call ended in an error.
    *
@@ -1555,10 +1601,7 @@ export class CallTool extends Rpc.make("tools/call", {
   payload: {
     ...RequestMeta.fields,
     name: Schema.String,
-    arguments: Schema.Record(
-      Schema.String,
-      Schema.Any
-    )
+    arguments: optionalWithDefault(Schema.Record(Schema.String, Schema.Any), () => ({}))
   }
 }) {}
 
@@ -1683,7 +1726,13 @@ export class LoggingMessageNotification extends Rpc.make("notifications/message"
  */
 export class SamplingMessage extends Schema.Opaque<SamplingMessage>()(Schema.Struct({
   role: Role,
-  content: Schema.Union([TextContent, ImageContent, AudioContent])
+  content: Schema.Union([
+    TextContent,
+    ImageContent,
+    AudioContent,
+    Schema.Array(Schema.Union([TextContent, ImageContent, AudioContent]))
+  ]),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 })) {}
 
 /**
@@ -1785,6 +1834,14 @@ export class ModelPreferences extends Schema.Class<ModelPreferences>(
 export class CreateMessageResult extends Schema.Class<CreateMessageResult>(
   "@effect/ai/McpSchema/CreateMessageResult"
 )({
+  ...ResultMeta.fields,
+  role: Role,
+  content: Schema.Union([
+    TextContent,
+    ImageContent,
+    AudioContent,
+    Schema.Array(Schema.Union([TextContent, ImageContent, AudioContent]))
+  ]),
   /**
    * The name of the model that generated the message.
    */
@@ -1815,6 +1872,7 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
   success: CreateMessageResult,
   error: McpError,
   payload: {
+    ...RequestMeta.fields,
     messages: Schema.Array(SamplingMessage),
     /**
      * The server's preferences for which model to select. The client MAY ignore
@@ -1842,7 +1900,7 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
      * Optional metadata to pass through to the LLM provider. The format of
      * this metadata is provider-specific.
      */
-    metadata: Schema.Any
+    metadata: optional(Schema.Record(Schema.String, Schema.Json))
   }
 }) {}
 
@@ -1886,16 +1944,17 @@ export class PromptReference extends Schema.Opaque<PromptReference>()(Schema.Str
  * @since 4.0.0
  */
 export class CompleteResult extends Schema.Opaque<CompleteResult>()(Schema.Struct({
+  ...ResultMeta.fields,
   completion: Schema.Struct({
     /**
      * An array of completion values. Must not exceed 100 items.
      */
-    values: Schema.Array(Schema.String),
+    values: Schema.Array(Schema.String).check(Schema.isMaxLength(100)),
     /**
      * The total number of completion options available. This can exceed the
      * number of values actually sent in the response.
      */
-    total: optional(Schema.Number),
+    total: optional(Schema.Int),
     /**
      * Indicates whether there are additional completion options beyond those
      * provided in the current response, even if the exact total is unknown.
@@ -1927,6 +1986,7 @@ export class Complete extends Rpc.make("completion/complete", {
   success: CompleteResult,
   error: McpError,
   payload: Schema.Struct({
+    ...RequestMeta.fields,
     ref: Schema.Union([PromptReference, ResourceReference]),
     /**
      * The argument's information
@@ -1983,7 +2043,8 @@ export class Root extends Schema.Class<Root>(
    * identifier for the root, which may be useful for display purposes or for
    * referencing the root in other parts of the application.
    */
-  name: optional(Schema.String)
+  name: optional(Schema.String),
+  _meta: optional(Schema.Record(Schema.String, Schema.Json))
 }) {}
 
 /**
@@ -1999,6 +2060,7 @@ export class Root extends Schema.Class<Root>(
 export class ListRootsResult extends Schema.Class<ListRootsResult>(
   "@effect/ai/McpSchema/ListRootsResult"
 )({
+  ...ResultMeta.fields,
   roots: Schema.Array(Root)
 }) {}
 
@@ -2045,6 +2107,100 @@ export class RootsListChangedNotification extends Rpc.make("notifications/roots/
 // Elicitation
 // =============================================================================
 
+const ElicitationSchemaMetadata = {
+  title: optional(Schema.String),
+  description: optional(Schema.String)
+}
+
+const ElicitationStringSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  ...ElicitationSchemaMetadata,
+  minLength: optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  maxLength: optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  format: optional(Schema.Literals(["email", "uri", "date", "date-time"])),
+  default: optional(Schema.String)
+})
+
+const ElicitationUntitledSingleSelectSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  ...ElicitationSchemaMetadata,
+  enum: Schema.Array(Schema.String),
+  default: optional(Schema.String)
+})
+
+const ElicitationLegacyTitledEnumSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  ...ElicitationSchemaMetadata,
+  enum: Schema.Array(Schema.String),
+  enumNames: Schema.Array(Schema.String),
+  default: optional(Schema.String)
+})
+
+const ElicitationTitledEnumOption = Schema.Struct({
+  const: Schema.String,
+  title: Schema.String
+})
+
+const ElicitationTitledSingleSelectSchema = Schema.Struct({
+  type: Schema.Literal("string"),
+  ...ElicitationSchemaMetadata,
+  oneOf: Schema.Array(ElicitationTitledEnumOption),
+  default: optional(Schema.String)
+})
+
+const ElicitationNumberSchema = Schema.Struct({
+  type: Schema.Literals(["number", "integer"]),
+  ...ElicitationSchemaMetadata,
+  minimum: optional(Schema.Number),
+  maximum: optional(Schema.Number),
+  default: optional(Schema.Number)
+})
+
+const ElicitationBooleanSchema = Schema.Struct({
+  type: Schema.Literal("boolean"),
+  ...ElicitationSchemaMetadata,
+  default: optional(Schema.Boolean)
+})
+
+const ElicitationUntitledMultiSelectSchema = Schema.Struct({
+  type: Schema.Literal("array"),
+  ...ElicitationSchemaMetadata,
+  items: Schema.Struct({
+    type: Schema.Literal("string"),
+    enum: Schema.Array(Schema.String)
+  }),
+  minItems: optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  maxItems: optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  default: optional(Schema.Array(Schema.String))
+})
+
+const ElicitationTitledMultiSelectSchema = Schema.Struct({
+  type: Schema.Literal("array"),
+  ...ElicitationSchemaMetadata,
+  items: Schema.Struct({
+    anyOf: Schema.Array(ElicitationTitledEnumOption)
+  }),
+  minItems: optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  maxItems: optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  default: optional(Schema.Array(Schema.String))
+})
+
+const ElicitationPrimitiveSchema = Schema.Union([
+  ElicitationUntitledSingleSelectSchema,
+  ElicitationTitledSingleSelectSchema,
+  ElicitationLegacyTitledEnumSchema,
+  ElicitationStringSchema,
+  ElicitationNumberSchema,
+  ElicitationBooleanSchema,
+  ElicitationUntitledMultiSelectSchema,
+  ElicitationTitledMultiSelectSchema
+])
+
+const ElicitationContent = Schema.Record(
+  Schema.String,
+  Schema.Union([Schema.String, Schema.Number, Schema.Boolean, Schema.Array(Schema.String)])
+)
+
 /**
  * Schema for an accepted client response to an elicitation request.
  *
@@ -2066,7 +2222,7 @@ export class ElicitAcceptResult extends Schema.Class<ElicitAcceptResult>(
    * The submitted form data, only present when action is "accept".
    * Contains values matching the requested schema.
    */
-  content: Schema.Any
+  content: optional(ElicitationContent)
 }) {}
 
 /**
@@ -2115,6 +2271,8 @@ export class Elicit extends Rpc.make("elicitation/create", {
   success: ElicitResult,
   error: McpError,
   payload: {
+    ...RequestMeta.fields,
+    mode: optional(Schema.Literal("form")),
     /**
      * A message to display to the user, explaining what they are being
      * elicited for.
@@ -2124,7 +2282,12 @@ export class Elicit extends Rpc.make("elicitation/create", {
      * A restricted subset of JSON Schema.
      * Only top-level properties are allowed, without nesting.
      */
-    requestedSchema: Schema.Any
+    requestedSchema: Schema.Struct({
+      $schema: optional(Schema.String),
+      type: Schema.Literal("object"),
+      properties: Schema.Record(Schema.String, ElicitationPrimitiveSchema),
+      required: optional(Schema.Array(Schema.String))
+    })
   }
 }) {}
 

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -702,6 +702,22 @@ export class Ping extends Rpc.make("ping", {
 // =============================================================================
 
 /**
+ * Schema for protocol versions supported by the MCP server implementation.
+ *
+ * @category initialization
+ * @since 4.0.0
+ */
+export const ProtocolVersion = Schema.Literals(["2025-11-25", "2025-06-18"])
+
+/**
+ * Protocol version supported by the MCP server implementation.
+ *
+ * @category initialization
+ * @since 4.0.0
+ */
+export type ProtocolVersion = typeof ProtocolVersion.Type
+
+/**
  * Schema for the server's response to an initialize request from the client.
  *
  * @category initialization
@@ -2329,6 +2345,7 @@ export class ElicitationDeclined
 export class McpServerClient extends Context.Service<McpServerClient, {
   readonly clientId: number
   readonly initializePayload: typeof Initialize.payloadSchema["Type"]
+  readonly protocolVersion: ProtocolVersion
   readonly getClient: Effect.Effect<
     RpcClient.RpcClient<RpcGroup.Rpcs<typeof ServerRequestRpcs>, RpcClientError>,
     never,
@@ -2444,21 +2461,10 @@ export type FailureEncoded<Group extends RpcGroup.Any> = RpcGroup.Rpcs<
   : never
   : never
 
-/**
- * RPC group for requests that MCP clients send to the server.
- *
- * **Details**
- *
- * The group includes initialization, resource, prompt, tool, logging,
- * completion, and ping requests, and installs `McpServerClientMiddleware` for
- * handlers.
- *
- * @category protocols
- * @since 4.0.0
- */
-export class ClientRequestRpcs extends RpcGroup.make(
+class InitializeRequestRpcs extends RpcGroup.make(Initialize) {}
+
+class OperationalClientRequestRpcs extends RpcGroup.make(
   Ping,
-  Initialize,
   Complete,
   SetLevel,
   GetPrompt,
@@ -2471,6 +2477,20 @@ export class ClientRequestRpcs extends RpcGroup.make(
   CallTool,
   ListTools
 ).middleware(McpServerClientMiddleware) {}
+
+/**
+ * RPC group for requests that MCP clients send to the server.
+ *
+ * **Details**
+ *
+ * The group includes initialization, resource, prompt, tool, logging,
+ * completion, and ping requests. Requests after initialization use
+ * `McpServerClientMiddleware` to access the current session.
+ *
+ * @category protocols
+ * @since 4.0.0
+ */
+export class ClientRequestRpcs extends InitializeRequestRpcs.merge(OperationalClientRequestRpcs) {}
 
 /**
  * Encoded union of all client-to-server MCP request messages.

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -2336,8 +2336,9 @@ export class ElicitationDeclined
  *
  * **Details**
  *
- * It exposes the current client id, the client's initialize payload, and a
- * scoped RPC client for server-initiated requests back to that client.
+ * It exposes the current client id, the original client initialize payload,
+ * the negotiated protocol version, and a scoped RPC client for
+ * server-initiated requests back to that client.
  *
  * @category client
  * @since 4.0.0

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -568,9 +568,18 @@ export const run: (options: ServerOptions) => Effect.Effect<
                 }
               }
               if (request.tag === "notifications/cancelled") {
+                const payload = request.payload
+                if (
+                  typeof payload !== "object" ||
+                  payload === null ||
+                  !("requestId" in payload) ||
+                  (typeof payload.requestId !== "string" && typeof payload.requestId !== "number")
+                ) {
+                  return Effect.void
+                }
                 return f(clientId, {
                   _tag: "Interrupt",
-                  requestId: String((request.payload as any).requestId)
+                  requestId: payload.requestId
                 })
               }
               const handler = handlers.mapUnsafe.get(request.tag) as Rpc.Handler<string>

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -333,13 +333,34 @@ export class McpServer extends Context.Service<McpServer, {
   static readonly layer: Layer.Layer<McpServer | McpServerClient> = Layer.effect(McpServer)(McpServer.make) as any
 }
 
-const LATEST_PROTOCOL_VERSION = "2025-06-18"
-const SUPPORTED_PROTOCOL_VERSIONS = [
-  LATEST_PROTOCOL_VERSION,
-  "2025-03-26",
-  "2024-11-05",
-  "2024-10-07"
-]
+/**
+ * Protocol versions supported by the MCP server implementation, ordered from
+ * newest to oldest.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const supportedProtocolVersions = [
+  "2025-11-25",
+  "2025-06-18"
+] as const
+
+/**
+ * Union of protocol versions supported by the MCP server implementation.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ProtocolVersion = typeof supportedProtocolVersions[number]
+
+/**
+ * Latest protocol version supported by the MCP server implementation.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const latestProtocolVersion = supportedProtocolVersions[0]
+
 const mcpSessionIdHeader = "mcp-session-id"
 const mcpProtocolVersionHeader = "mcp-protocol-version"
 
@@ -1285,15 +1306,10 @@ const layerHandlers = (serverInfo: {
         // Requests
         ping: () => Effect.succeed({}),
         initialize(params, { client }) {
-          const requestedVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(params.protocolVersion)
-            ? params.protocolVersion
-            : LATEST_PROTOCOL_VERSION
-          if (requestedVersion !== params.protocolVersion) {
-            params = {
-              ...params,
-              protocolVersion: requestedVersion
-            }
-          }
+          const protocolVersion = negotiateProtocolVersion(params.protocolVersion, supportedProtocolVersions)
+          const initializePayload = protocolVersion === params.protocolVersion
+            ? params
+            : { ...params, protocolVersion }
           const capabilities: Types.DeepMutable<typeof ServerCapabilities.Type> = {
             completions: {}
           }
@@ -1316,19 +1332,19 @@ const layerHandlers = (serverInfo: {
             const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
             if (httpRequest) {
               const sessionId = crypto.randomUUID()
-              options.clientSessions.set(sessionId, params)
+              options.clientSessions.set(sessionId, initializePayload)
               appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
                 Effect.succeed(HttpServerResponse.setHeaders(res, {
                   [mcpSessionIdHeader]: sessionId,
-                  [mcpProtocolVersionHeader]: requestedVersion
+                  [mcpProtocolVersionHeader]: protocolVersion
                 })))
             } else {
-              options.clientSessions.set(String(client.id), params)
+              options.clientSessions.set(String(client.id), initializePayload)
             }
             return Effect.succeed({
               capabilities,
               serverInfo,
-              protocolVersion: requestedVersion
+              protocolVersion
             })
           })
         },
@@ -1408,6 +1424,18 @@ const layerHandlers = (serverInfo: {
       })
     })
   )
+
+const negotiateProtocolVersion = (
+  requested: string,
+  supported: readonly [ProtocolVersion, ...Array<ProtocolVersion>]
+): ProtocolVersion => {
+  for (const version of supported) {
+    if (version === requested) {
+      return version
+    }
+  }
+  return supported[0]
+}
 
 const resolveResourceContent = (
   uri: string,

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -558,12 +558,14 @@ export const run: (options: ServerOptions) => Effect.Effect<
             const rpc = ClientNotificationRpcs.requests.get(request.tag)
             if (rpc) {
               if (isHttp) {
-                const fiber = Fiber.getCurrent()!
-                const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
-                appendPreResponseHandlerUnsafe(
-                  httpRequest,
-                  () => Effect.succeed(HttpServerResponse.empty({ status: 202 }))
-                )
+                const fiber = Fiber.getCurrent()
+                if (fiber) {
+                  const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
+                  appendPreResponseHandlerUnsafe(
+                    httpRequest,
+                    () => Effect.succeed(HttpServerResponse.empty({ status: 202 }))
+                  )
+                }
               }
               if (request.tag === "notifications/cancelled") {
                 return f(clientId, {

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -530,7 +530,19 @@ export const run: (options: ServerOptions) => Effect.Effect<
             if (isHttp) {
               const fiber = Fiber.getCurrent()!
               const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
+              const requestProtocolVersion = httpRequest.headers[mcpProtocolVersionHeader]
               const session = getSession(clientSessions, clientId, httpRequest.headers)
+              if (
+                request.tag !== "initialize" &&
+                requestProtocolVersion !== undefined &&
+                requestProtocolVersion !== session?.protocolVersion
+              ) {
+                appendPreResponseHandlerUnsafe(
+                  httpRequest,
+                  () => Effect.succeed(HttpServerResponse.empty({ status: 400 }))
+                )
+                return Effect.void
+              }
               if (session) {
                 appendPreResponseHandlerUnsafe(httpRequest, (_, res) =>
                   Effect.succeed(

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -423,6 +423,7 @@ export const run: (options: ServerOptions) => Effect.Effect<
   )
   const handlers = yield* Layer.build(layerHandlers(options, {
     clientSessions,
+    supportsServerNotifications: !isHttp,
     supportedProtocolVersions: configuredProtocolVersions
   }))
 
@@ -745,6 +746,12 @@ export const layerStdio = (options: ServerOptions): Layer.Layer<McpServer | McpS
  *
  * This layer composes `layer(options)`, `RpcServer.layerProtocolHttp(options)`,
  * and `RpcSerialization.layerJsonRpc()`.
+ *
+ * **Gotchas**
+ *
+ * This layer does not expose a standalone SSE stream, so it does not advertise
+ * list-change notifications. Use a connection-oriented protocol when the
+ * server must push requests or notifications outside a client POST.
  *
  * @see {@link layerStdio} for exposing the server over stdio
  * @see {@link layer} for the base MCP server layer without a transport protocol
@@ -1392,6 +1399,7 @@ const layerHandlers = (serverInfo: {
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }, options: {
   readonly clientSessions: Map<string, Session>
+  readonly supportsServerNotifications: boolean
   readonly supportedProtocolVersions: Arr.NonEmptyReadonlyArray<ProtocolVersion>
 }) =>
   ClientRpcs.toLayer(
@@ -1413,16 +1421,15 @@ const layerHandlers = (serverInfo: {
             completions: {}
           }
           if (server.tools.length > 0) {
-            capabilities.tools = { listChanged: true }
+            capabilities.tools = options.supportsServerNotifications ? { listChanged: true } : {}
           }
           if (server.resources.length > 0 || server.resourceTemplates.length > 0) {
-            capabilities.resources = {
-              listChanged: true,
-              subscribe: false
-            }
+            capabilities.resources = options.supportsServerNotifications
+              ? { listChanged: true, subscribe: false }
+              : { subscribe: false }
           }
           if (server.prompts.length > 0) {
-            capabilities.prompts = { listChanged: true }
+            capabilities.prompts = options.supportsServerNotifications ? { listChanged: true } : {}
           }
           if (serverInfo.extensions) {
             capabilities.extensions = serverInfo.extensions as any

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -730,7 +730,10 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
     const mcpTool = new McpTool({
       name: tool.name,
       description: Tool.getDescription(tool),
-      inputSchema: Tool.getJsonSchema(tool),
+      inputSchema: {
+        ...Tool.getJsonSchema(tool),
+        type: "object"
+      },
       annotations: {
         ...(Context.getOption(tool.annotations, Tool.Title).pipe(
           Option.map((title) => ({ title })),
@@ -764,7 +767,11 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
             onSuccess: (result: any) =>
               new CallToolResult({
                 isError: false,
-                structuredContent: typeof result.encodedResult === "object" ? result.encodedResult : undefined,
+                structuredContent: typeof result.encodedResult === "object" &&
+                    result.encodedResult !== null &&
+                    !Array.isArray(result.encodedResult)
+                  ? result.encodedResult
+                  : undefined,
                 content: [{
                   type: "text",
                   text: JSON.stringify(result.encodedResult)
@@ -953,13 +960,17 @@ export const registerResource: {
       const handler = (input: string) =>
         handle(input).pipe(
           Effect.flatMap(encodeArray),
-          Effect.map((values) => ({
-            completion: {
-              values: values as Array<string>,
-              total: values.length,
-              hasMore: false
+          Effect.map((values) => {
+            const total = values.length
+            const completionValues = values.slice(0, 100).filter((value): value is string => typeof value === "string")
+            return {
+              completion: {
+                values: completionValues,
+                total,
+                hasMore: total > 100
+              }
             }
-          })),
+          }),
           Effect.catchCause((cause) => {
             const prettyError = Cause.prettyErrors(cause)[0]
             return Effect.fail(new InternalError({ message: prettyError.message }))
@@ -1123,13 +1134,17 @@ export const registerPrompt = <
       const handler = (input: string) =>
         handle(input).pipe(
           Effect.flatMap(encodeArray),
-          Effect.map((values) => ({
-            completion: {
-              values: values as Array<string>,
-              total: values.length,
-              hasMore: false
+          Effect.map((values) => {
+            const total = values.length
+            const completionValues = values.slice(0, 100).filter((value): value is string => typeof value === "string")
+            return {
+              completion: {
+                values: completionValues,
+                total,
+                hasMore: total > 100
+              }
             }
-          })),
+          }),
           Effect.catchCause((cause) => {
             const prettyError = Cause.prettyErrors(cause)[0]
             return Effect.fail(new InternalError({ message: prettyError.message }))
@@ -1229,13 +1244,17 @@ export const elicit: <S extends Schema.ConstraintEncoder<Record<string, unknown>
   readonly message: string
   readonly schema: S
 }) {
-  const { getClient } = yield* McpServerClient
+  const { getClient, initializePayload } = yield* McpServerClient
   const client = yield* getClient
   const schema = options.schema
-  const request = Elicit.payloadSchema.make({
+  const request = yield* Schema.decodeUnknownEffect(Elicit.payloadSchema)({
     message: options.message,
     requestedSchema: Tool.getJsonSchemaFromSchema(schema)
-  })
+  }).pipe(Effect.orDie)
+  const elicitation = initializePayload.capabilities.elicitation
+  if (elicitation === undefined || (elicitation.form === undefined && elicitation.url !== undefined)) {
+    return yield* new ElicitationDeclined({ request })
+  }
   const res = yield* client["elicitation/create"](request).pipe(
     Effect.catchCause((cause) => Effect.fail(new ElicitationDeclined({ cause: Cause.squash(cause), request })))
   )

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -467,12 +467,19 @@ export const run: (options: ServerOptions) => Effect.Effect<
       const fiber = Fiber.getCurrent()!
       const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
       if (httpRequest) {
+        const hasSessionId = httpRequest.headers[mcpSessionIdHeader] !== undefined
         appendPreResponseHandlerUnsafe(
           httpRequest,
-          () => Effect.succeed(HttpServerResponse.empty({ status: 404 }))
+          () => Effect.succeed(HttpServerResponse.empty({ status: hasSessionId ? 404 : 400 }))
         )
       }
-      return Effect.fail(new InvalidRequest({ message: "MCP session does not exist; initialize the client first" }))
+      return Effect.fail(
+        new InvalidRequest({
+          message: httpRequest?.headers[mcpSessionIdHeader] === undefined
+            ? "MCP session ID is required; initialize the client first"
+            : "MCP session does not exist or has expired; initialize a new session"
+        })
+      )
     }
     if (session._tag !== "Operational") {
       return Effect.fail(

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -50,6 +50,7 @@ import {
   GetPromptResult,
   InternalError,
   InvalidParams,
+  InvalidRequest,
   isParam,
   ListPromptsResult,
   ListResourcesResult,
@@ -74,6 +75,7 @@ import type {
   Param,
   PromptArgument,
   PromptMessage,
+  ProtocolVersion as McpProtocolVersion,
   ReadResourceResult,
   ServerCapabilities
 } from "./McpSchema.ts"
@@ -351,7 +353,7 @@ export const supportedProtocolVersions = [
  * @category models
  * @since 4.0.0
  */
-export type ProtocolVersion = typeof supportedProtocolVersions[number]
+export type ProtocolVersion = McpProtocolVersion
 
 /**
  * Latest protocol version supported by the MCP server implementation.
@@ -379,6 +381,19 @@ export interface ServerOptions {
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }
 
+type InitializePayload = typeof Initialize.payloadSchema.Type
+
+type Session =
+  & {
+    readonly initializePayload: InitializePayload
+    readonly protocolVersion: ProtocolVersion
+  }
+  & ({
+    readonly _tag: "Negotiated"
+  } | {
+    readonly _tag: "Operational"
+  })
+
 const mcpSessionIdHeader = "mcp-session-id"
 const mcpProtocolVersionHeader = "mcp-protocol-version"
 
@@ -402,7 +417,7 @@ export const run: (options: ServerOptions) => Effect.Effect<
   const protocol = yield* RpcServer.Protocol
   const server = yield* McpServer
   const isHttp = Option.isSome(yield* Effect.serviceOption(HttpRouter.HttpRouter))
-  const clientSessions = new Map<string, typeof Initialize.payloadSchema.Type>()
+  const clientSessions = new Map<string, Session>()
   const configuredProtocolVersions = yield* resolveProtocolVersions(
     options.supportedProtocolVersions ?? supportedProtocolVersions
   )
@@ -446,10 +461,9 @@ export const run: (options: ServerOptions) => Effect.Effect<
     idleTimeToLive: 10000
   })
 
-  const clientMiddleware = McpServerClientMiddleware.of((effect, { client, headers, rpc }) => {
-    const initializePayload = getInitializedClient(clientSessions, client.id, headers)
-    const isInitialize = rpc._tag === "initialize"
-    if (!isInitialize && !initializePayload) {
+  const clientMiddleware = McpServerClientMiddleware.of((effect, { client, headers }) => {
+    const session = getSession(clientSessions, client.id, headers)
+    if (!session) {
       const fiber = Fiber.getCurrent()!
       const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
       if (httpRequest) {
@@ -465,7 +479,8 @@ export const run: (options: ServerOptions) => Effect.Effect<
       McpServerClient,
       McpServerClient.of({
         clientId: client.id,
-        initializePayload: initializePayload!,
+        initializePayload: session.initializePayload,
+        protocolVersion: session.protocolVersion,
         getClient: RcMap.get(clients, client.id).pipe(
           Effect.map(({ client }) => client)
         )
@@ -485,11 +500,11 @@ export const run: (options: ServerOptions) => Effect.Effect<
             if (isHttp) {
               const fiber = Fiber.getCurrent()!
               const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
-              const client = getInitializedClient(clientSessions, clientId, httpRequest.headers)
-              if (client) {
+              const session = getSession(clientSessions, clientId, httpRequest.headers)
+              if (session) {
                 appendPreResponseHandlerUnsafe(httpRequest, (_, res) =>
                   Effect.succeed(
-                    HttpServerResponse.setHeader(res, mcpProtocolVersionHeader, client.protocolVersion)
+                    HttpServerResponse.setHeader(res, mcpProtocolVersionHeader, session.protocolVersion)
                   ))
               }
             }
@@ -1331,7 +1346,7 @@ const layerHandlers = (serverInfo: {
   readonly version: string
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }, options: {
-  readonly clientSessions: Map<string, typeof Initialize.payloadSchema.Type>
+  readonly clientSessions: Map<string, Session>
   readonly supportedProtocolVersions: Arr.NonEmptyReadonlyArray<ProtocolVersion>
 }) =>
   ClientRpcs.toLayer(
@@ -1344,9 +1359,11 @@ const layerHandlers = (serverInfo: {
         ping: () => Effect.succeed({}),
         initialize(params, { client }) {
           const protocolVersion = negotiateProtocolVersion(params.protocolVersion, options.supportedProtocolVersions)
-          const initializePayload = protocolVersion === params.protocolVersion
-            ? params
-            : { ...params, protocolVersion }
+          const session: Session = {
+            _tag: "Negotiated",
+            initializePayload: params,
+            protocolVersion
+          }
           const capabilities: Types.DeepMutable<typeof ServerCapabilities.Type> = {
             completions: {}
           }
@@ -1368,15 +1385,22 @@ const layerHandlers = (serverInfo: {
           return Effect.withFiber((fiber) => {
             const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
             if (httpRequest) {
+              if (getSession(options.clientSessions, client.id, httpRequest.headers)) {
+                return Effect.fail(new InvalidRequest({ message: "This MCP session has already been initialized" }))
+              }
               const sessionId = crypto.randomUUID()
-              options.clientSessions.set(sessionId, initializePayload)
+              options.clientSessions.set(sessionId, session)
               appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
                 Effect.succeed(HttpServerResponse.setHeaders(res, {
                   [mcpSessionIdHeader]: sessionId,
                   [mcpProtocolVersionHeader]: protocolVersion
                 })))
             } else {
-              options.clientSessions.set(String(client.id), initializePayload)
+              const sessionId = String(client.id)
+              if (options.clientSessions.has(sessionId)) {
+                return Effect.fail(new InvalidRequest({ message: "This MCP connection has already been initialized" }))
+              }
+              options.clientSessions.set(sessionId, session)
             }
             return Effect.succeed({
               capabilities,
@@ -1418,13 +1442,13 @@ const layerHandlers = (serverInfo: {
           ),
         "prompts/list": (_, { client, headers }) =>
           Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
-            return new ListPromptsResult({ prompts: filterByClient(initialized, server.prompts, "prompt") })
+            const session = getSession(options.clientSessions, client.id, headers)
+            return new ListPromptsResult({ prompts: filterByClient(session, server.prompts, "prompt") })
           }),
         "resources/list": (_, { client, headers }) =>
           Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
-            return new ListResourcesResult({ resources: filterByClient(initialized, server.resources, "resource") })
+            const session = getSession(options.clientSessions, client.id, headers)
+            return new ListResourcesResult({ resources: filterByClient(session, server.resources, "resource") })
           }),
         "resources/read": ({ uri }) =>
           server.findResource(uri).pipe(
@@ -1436,9 +1460,9 @@ const layerHandlers = (serverInfo: {
           InternalError.notImplemented,
         "resources/templates/list": (_, { client, headers }) =>
           Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
+            const session = getSession(options.clientSessions, client.id, headers)
             return new ListResourceTemplatesResult({
-              resourceTemplates: filterByClient(initialized, server.resourceTemplates, "template")
+              resourceTemplates: filterByClient(session, server.resourceTemplates, "template")
             })
           }),
         "tools/call": (r) =>
@@ -1447,15 +1471,26 @@ const layerHandlers = (serverInfo: {
           ),
         "tools/list": (_, { client, headers }) =>
           Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
+            const session = getSession(options.clientSessions, client.id, headers)
             return new ListToolsResult({
-              tools: filterByClient(initialized, server.tools, "tool")
+              tools: filterByClient(session, server.tools, "tool")
             })
           }),
 
         // Notifications
         "notifications/cancelled": (_) => Effect.void,
-        "notifications/initialized": (_) => Effect.void,
+        "notifications/initialized": (_, { client, headers }) =>
+          Effect.sync(() => {
+            const sessionId = getSessionId(client.id, headers)
+            const session = options.clientSessions.get(sessionId)
+            if (session === undefined || session._tag === "Operational") {
+              return
+            }
+            options.clientSessions.set(sessionId, { ...session, _tag: "Operational" })
+            if (headers[mcpSessionIdHeader] === undefined) {
+              server.initializedClients.add(client.id)
+            }
+          }),
         "notifications/progress": (_) => Effect.void,
         "notifications/roots/list_changed": (_) => Effect.void
       })
@@ -1514,32 +1549,34 @@ const filterByClient = <
   },
   P extends keyof A
 >(
-  client: typeof Initialize.payloadSchema.Type | undefined,
+  session: Session | undefined,
   items: ReadonlyArray<A>,
   prop: P
 ): Array<A[P]> => {
-  if (!client) {
+  if (!session) {
     return items.map((item) => item[prop])
   }
   const out = Arr.empty<A[P]>()
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
     const enabledWhen = Context.getOrUndefined(item.annotations, EnabledWhen)
-    if (!enabledWhen || enabledWhen(client)) {
+    if (!enabledWhen || enabledWhen(session.initializePayload)) {
       out.push(item[prop])
     }
   }
   return out
 }
 
-const getInitializedClient = (
-  sessions: Map<string, typeof Initialize.payloadSchema.Type>,
+const getSessionId = (
   clientId: number,
   headers: Headers.Headers
-) => {
+): string => {
   const sessionId = headers[mcpSessionIdHeader]
-  if (sessionId === undefined) {
-    return sessions.get(String(clientId))
-  }
-  return sessions.get(sessionId)
+  return sessionId === undefined ? String(clientId) : sessionId
 }
+
+const getSession = (
+  sessions: Map<string, Session>,
+  clientId: number,
+  headers: Headers.Headers
+): Session | undefined => sessions.get(getSessionId(clientId, headers))

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -369,7 +369,10 @@ export const latestProtocolVersion = supportedProtocolVersions[0]
  * **Details**
  *
  * `supportedProtocolVersions` is ordered by preference. The server uses its
- * first entry when the client requests an unsupported version.
+ * first entry when the client requests an unsupported version, removes
+ * duplicate entries while preserving order, and defaults to
+ * `supportedProtocolVersions`. Clients still offer one version string during
+ * initialization rather than sending their complete supported-version set.
  *
  * @category models
  * @since 4.0.0
@@ -404,7 +407,8 @@ const mcpProtocolVersionHeader = "mcp-protocol-version"
  *
  * The server performs initialization and session handling, serves registered
  * tools, resources, and prompts, and forwards queued server notifications to
- * initialized clients.
+ * initialized connection-oriented clients. Normal requests are accepted only
+ * after the client sends `notifications/initialized`.
  *
  * @category constructors
  * @since 4.0.0

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -1173,7 +1173,7 @@ export const registerPrompt = <
   R,
   Params extends Schema.Struct.Fields = {},
   const Completions extends {
-    readonly [K in keyof Params]?: (input: string) => Effect.Effect<Array<Params[K]>, any, any>
+    readonly [K in keyof Params]?: (input: string) => Effect.Effect<Array<Params[K]["Type"]>, any, any>
   } = {}
 >(
   options: {
@@ -1241,20 +1241,23 @@ export const registerPrompt = <
       handle: (params) =>
         decode(params).pipe(
           Effect.mapError((error) => new InvalidParams({ message: error.message })),
-          Effect.flatMap((params) => options.content(params as any)),
-          Effect.map((messages) => {
-            messages = typeof messages === "string" ?
-              [{
-                role: "user",
-                content: TextContent.make({ text: messages })
-              }] :
-              messages
-            return new GetPromptResult({ messages, description: prompt.description })
-          }),
-          Effect.catchCause((cause) => {
-            const prettyError = Cause.prettyErrors(cause)[0]
-            return Effect.fail(new InternalError({ message: prettyError.message }))
-          }),
+          Effect.flatMap((params) =>
+            options.content(params as any).pipe(
+              Effect.map((messages) => {
+                messages = typeof messages === "string" ?
+                  [{
+                    role: "user",
+                    content: TextContent.make({ text: messages })
+                  }] :
+                  messages
+                return new GetPromptResult({ messages, description: prompt.description })
+              }),
+              Effect.catchCause((cause) => {
+                const prettyError = Cause.prettyErrors(cause)[0]
+                return Effect.fail(new InternalError({ message: prettyError.message }))
+              })
+            )
+          ),
           Effect.provideContext(services as Context.Context<unknown>)
         )
     })

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -361,6 +361,24 @@ export type ProtocolVersion = typeof supportedProtocolVersions[number]
  */
 export const latestProtocolVersion = supportedProtocolVersions[0]
 
+/**
+ * Configuration shared by MCP server runners and transport layers.
+ *
+ * **Details**
+ *
+ * `supportedProtocolVersions` is ordered by preference. The server uses its
+ * first entry when the client requests an unsupported version.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ServerOptions {
+  readonly name: string
+  readonly version: string
+  readonly supportedProtocolVersions?: Arr.NonEmptyReadonlyArray<ProtocolVersion> | undefined
+  readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
+}
+
 const mcpSessionIdHeader = "mcp-session-id"
 const mcpProtocolVersionHeader = "mcp-protocol-version"
 
@@ -376,23 +394,22 @@ const mcpProtocolVersionHeader = "mcp-protocol-version"
  * @category constructors
  * @since 4.0.0
  */
-export const run: (options: {
-  readonly name: string
-  readonly version: string
-  readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}) => Effect.Effect<
+export const run: (options: ServerOptions) => Effect.Effect<
   never,
   never,
   McpServer | RpcServer.Protocol
-> = Effect.fnUntraced(function*(options: {
-  readonly name: string
-  readonly version: string
-}) {
+> = Effect.fnUntraced(function*(options: ServerOptions) {
   const protocol = yield* RpcServer.Protocol
   const server = yield* McpServer
   const isHttp = Option.isSome(yield* Effect.serviceOption(HttpRouter.HttpRouter))
   const clientSessions = new Map<string, typeof Initialize.payloadSchema.Type>()
-  const handlers = yield* Layer.build(layerHandlers(options, { clientSessions }))
+  const configuredProtocolVersions = yield* resolveProtocolVersions(
+    options.supportedProtocolVersions ?? supportedProtocolVersions
+  )
+  const handlers = yield* Layer.build(layerHandlers(options, {
+    clientSessions,
+    supportedProtocolVersions: configuredProtocolVersions
+  }))
 
   const clients = yield* RcMap.make({
     lookup: Effect.fnUntraced(function*(clientId: number) {
@@ -578,12 +595,17 @@ export const run: (options: {
  * @category layers
  * @since 4.0.0
  */
-export const layer = (options: {
-  readonly name: string
-  readonly version: string
-  readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, RpcServer.Protocol> =>
-  Layer.effectDiscard(Effect.forkScoped(run(options))).pipe(
+export const layer = (options: ServerOptions): Layer.Layer<McpServer | McpServerClient, never, RpcServer.Protocol> =>
+  Layer.effectDiscard(
+    Effect.flatMap(
+      resolveProtocolVersions(options.supportedProtocolVersions ?? supportedProtocolVersions),
+      (configuredProtocolVersions) =>
+        Effect.forkScoped(run({
+          ...options,
+          supportedProtocolVersions: configuredProtocolVersions
+        }))
+    )
+  ).pipe(
     Layer.provideMerge(McpServer.layer)
   )
 
@@ -645,11 +667,7 @@ export const layer = (options: {
  * @category layers
  * @since 4.0.0
  */
-export const layerStdio = (options: {
-  readonly name: string
-  readonly version: string
-  readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, Stdio> =>
+export const layerStdio = (options: ServerOptions): Layer.Layer<McpServer | McpServerClient, never, Stdio> =>
   layer(options).pipe(
     Layer.provide(RpcServer.layerProtocolStdio),
     Layer.provide(RpcSerialization.layerNdJsonRpc())
@@ -674,12 +692,11 @@ export const layerStdio = (options: {
  * @category layers
  * @since 4.0.0
  */
-export const layerHttp = (options: {
-  readonly name: string
-  readonly version: string
-  readonly path: HttpRouter.PathInput
-  readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, HttpRouter.HttpRouter> =>
+export const layerHttp = (
+  options: ServerOptions & {
+    readonly path: HttpRouter.PathInput
+  }
+): Layer.Layer<McpServer | McpServerClient, never, HttpRouter.HttpRouter> =>
   layer(options).pipe(
     Layer.provide(RpcServer.layerProtocolHttp(options)),
     Layer.provide(RpcSerialization.layerJsonRpc())
@@ -1296,6 +1313,7 @@ const layerHandlers = (serverInfo: {
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }, options: {
   readonly clientSessions: Map<string, typeof Initialize.payloadSchema.Type>
+  readonly supportedProtocolVersions: Arr.NonEmptyReadonlyArray<ProtocolVersion>
 }) =>
   ClientRpcs.toLayer(
     Effect.gen(function*() {
@@ -1306,7 +1324,7 @@ const layerHandlers = (serverInfo: {
         // Requests
         ping: () => Effect.succeed({}),
         initialize(params, { client }) {
-          const protocolVersion = negotiateProtocolVersion(params.protocolVersion, supportedProtocolVersions)
+          const protocolVersion = negotiateProtocolVersion(params.protocolVersion, options.supportedProtocolVersions)
           const initializePayload = protocolVersion === params.protocolVersion
             ? params
             : { ...params, protocolVersion }
@@ -1427,7 +1445,7 @@ const layerHandlers = (serverInfo: {
 
 const negotiateProtocolVersion = (
   requested: string,
-  supported: readonly [ProtocolVersion, ...Array<ProtocolVersion>]
+  supported: Arr.NonEmptyReadonlyArray<ProtocolVersion>
 ): ProtocolVersion => {
   for (const version of supported) {
     if (version === requested) {
@@ -1435,6 +1453,18 @@ const negotiateProtocolVersion = (
     }
   }
   return supported[0]
+}
+
+const resolveProtocolVersions = (
+  versions: ReadonlyArray<ProtocolVersion>
+): Effect.Effect<Arr.NonEmptyReadonlyArray<ProtocolVersion>> => {
+  const first = versions[0]
+  if (first === undefined) {
+    return Effect.die(new Error("MCP server requires at least one supported protocol version"))
+  }
+  const unique = new Set(versions)
+  unique.delete(first)
+  return Effect.succeed([first, ...unique])
 }
 
 const resolveResourceContent = (

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -553,6 +553,14 @@ export const run: (options: ServerOptions) => Effect.Effect<
             }
             const rpc = ClientNotificationRpcs.requests.get(request.tag)
             if (rpc) {
+              if (isHttp) {
+                const fiber = Fiber.getCurrent()!
+                const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
+                appendPreResponseHandlerUnsafe(
+                  httpRequest,
+                  () => Effect.succeed(HttpServerResponse.empty({ status: 202 }))
+                )
+              }
               if (request.tag === "notifications/cancelled") {
                 return f(clientId, {
                   _tag: "Interrupt",

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -472,7 +472,14 @@ export const run: (options: ServerOptions) => Effect.Effect<
           () => Effect.succeed(HttpServerResponse.empty({ status: 404 }))
         )
       }
-      return Effect.die(new Error(`Mcp-Session-Id does not exist`))
+      return Effect.fail(new InvalidRequest({ message: "MCP session does not exist; initialize the client first" }))
+    }
+    if (session._tag !== "Operational") {
+      return Effect.fail(
+        new InvalidRequest({
+          message: "MCP session is not operational; send notifications/initialized first"
+        })
+      )
     }
     return Effect.provideService(
       effect,
@@ -487,6 +494,22 @@ export const run: (options: ServerOptions) => Effect.Effect<
       })
     )
   })
+
+  const markSessionOperational = (clientId: number, headers: Headers.Headers) =>
+    Effect.withFiber((fiber) => {
+      const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
+      const requestHeaders = httpRequest?.headers ?? headers
+      const sessionId = getSessionId(clientId, requestHeaders)
+      const session = clientSessions.get(sessionId)
+      if (session === undefined || session._tag === "Operational") {
+        return Effect.void
+      }
+      clientSessions.set(sessionId, { ...session, _tag: "Operational" })
+      if (requestHeaders[mcpSessionIdHeader] === undefined) {
+        server.initializedClients.add(clientId)
+      }
+      return Effect.void
+    })
 
   const patchedProtocol = RpcServer.Protocol.of({
     ...protocol,
@@ -517,7 +540,7 @@ export const run: (options: ServerOptions) => Effect.Effect<
                 })
               }
               const handler = handlers.mapUnsafe.get(request.tag) as Rpc.Handler<string>
-              return handler
+              const handled = handler
                 ? handler.handler(request.payload, {
                   rpc,
                   requestId: RpcMessage.RequestId(request.id),
@@ -525,6 +548,9 @@ export const run: (options: ServerOptions) => Effect.Effect<
                   headers: Headers.fromInput(request.headers)
                 }) as any as Effect.Effect<void>
                 : Effect.void
+              return request.tag === "notifications/initialized"
+                ? Effect.andThen(markSessionOperational(clientId, Headers.fromInput(request.headers)), handled)
+                : handled
             }
             return f(clientId, request)
           }
@@ -1479,18 +1505,7 @@ const layerHandlers = (serverInfo: {
 
         // Notifications
         "notifications/cancelled": (_) => Effect.void,
-        "notifications/initialized": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const sessionId = getSessionId(client.id, headers)
-            const session = options.clientSessions.get(sessionId)
-            if (session === undefined || session._tag === "Operational") {
-              return
-            }
-            options.clientSessions.set(sessionId, { ...session, _tag: "Operational" })
-            if (headers[mcpSessionIdHeader] === undefined) {
-              server.initializedClients.add(client.id)
-            }
-          }),
+        "notifications/initialized": (_) => Effect.void,
         "notifications/progress": (_) => Effect.void,
         "notifications/roots/list_changed": (_) => Effect.void
       })

--- a/packages/effect/src/unstable/ai/index.ts
+++ b/packages/effect/src/unstable/ai/index.ts
@@ -37,6 +37,11 @@ export * as LanguageModel from "./LanguageModel.ts"
 /**
  * @since 4.0.0
  */
+export * as McpClient from "./McpClient.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as McpSchema from "./McpSchema.ts"
 
 /**

--- a/packages/effect/test/unstable/ai/McpClient.test.ts
+++ b/packages/effect/test/unstable/ai/McpClient.test.ts
@@ -229,7 +229,7 @@ describe("McpClient", () => {
 
       assert.strictEqual(client.serverInfo.name, "TestServer")
       assert.strictEqual(client.serverInfo.version, "1.0.0")
-      assert.strictEqual(client.protocolVersion, "2025-06-18")
+      assert.strictEqual(client.protocolVersion, "2025-11-25")
       assert.isTrue(Option.isNone(client.instructions))
     }).pipe(Effect.scoped))
 
@@ -505,7 +505,7 @@ describe("McpClient (HTTP transport)", () => {
       const client = yield* makeHttpTestClient()
 
       assert.strictEqual(client.serverInfo.name, "TestServer")
-      assert.strictEqual(client.protocolVersion, "2025-06-18")
+      assert.strictEqual(client.protocolVersion, "2025-11-25")
 
       const read = yield* McpClient.readResource({ uri: "file:///echo.txt" }).pipe(
         Effect.provideService(McpClient.McpClient, client)

--- a/packages/effect/test/unstable/ai/McpClient.test.ts
+++ b/packages/effect/test/unstable/ai/McpClient.test.ts
@@ -1,0 +1,541 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Fiber, Layer, Option, Queue, Schema, Sink, Stdio, Stream } from "effect"
+import type * as Cause from "effect/Cause"
+import * as McpClient from "effect/unstable/ai/McpClient"
+import { CreateMessageResult, ListRootsResult, McpServerClient, Root } from "effect/unstable/ai/McpSchema"
+import * as McpServer from "effect/unstable/ai/McpServer"
+import * as Tool from "effect/unstable/ai/Tool"
+import * as Toolkit from "effect/unstable/ai/Toolkit"
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
+import * as HttpRouter from "effect/unstable/http/HttpRouter"
+import { ChildProcessSpawner } from "effect/unstable/process"
+
+const SampleTool = Tool.make("Sample", {
+  description: "Asks the connected client to sample an LLM message",
+  success: Schema.String,
+  dependencies: [McpServerClient]
+})
+
+const ListClientRootsTool = Tool.make("ListClientRoots", {
+  description: "Asks the connected client for its list of roots",
+  success: Schema.Array(Schema.String),
+  dependencies: [McpServerClient]
+})
+
+const SamplingAndRootsToolkit = Toolkit.make(SampleTool, ListClientRootsTool)
+
+const SamplingAndRootsToolkitLayer = McpServer.toolkit(SamplingAndRootsToolkit).pipe(
+  Layer.provideMerge(
+    SamplingAndRootsToolkit.toLayer({
+      Sample: () =>
+        Effect.gen(function*() {
+          const { getClient } = yield* McpServerClient
+          const client = yield* getClient
+          const result = yield* client["sampling/createMessage"]({
+            messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+            maxTokens: 100,
+            metadata: {}
+          })
+          return result.model
+        }).pipe(Effect.scoped, Effect.orDie),
+      ListClientRoots: () =>
+        Effect.gen(function*() {
+          const { getClient } = yield* McpServerClient
+          const client = yield* getClient
+          const result = yield* client["roots/list"](undefined)
+          return result.roots.map((root) => root.uri)
+        }).pipe(Effect.scoped, Effect.orDie)
+    })
+  )
+)
+
+const EchoResource = McpServer.resource({
+  uri: "file:///echo.txt",
+  name: "Echo Resource",
+  description: "A simple echo resource",
+  mimeType: "text/plain",
+  content: Effect.succeed("hello from resource")
+})
+
+const GreetPrompt = McpServer.prompt({
+  name: "Greet",
+  description: "Greets someone",
+  parameters: {
+    name: Schema.String
+  },
+  content: ({ name }) => Effect.succeed(`Hello, ${name}!`)
+})
+
+const AskNameTool = Tool.make("AskName", {
+  description: "Asks the connected client for their name via elicitation",
+  success: Schema.String,
+  dependencies: [McpServerClient]
+})
+
+const AskNameToolkit = Toolkit.make(AskNameTool)
+
+const AskNameToolkitLayer = McpServer.toolkit(AskNameToolkit).pipe(
+  Layer.provideMerge(
+    AskNameToolkit.toLayer({
+      AskName: () =>
+        McpServer.elicit({
+          message: "What is your name?",
+          schema: Schema.Struct({ name: Schema.String })
+        }).pipe(
+          Effect.map((result) => `Got name: ${result.name}`),
+          Effect.catchTag("ElicitationDeclined", () => Effect.succeed("declined"))
+        )
+    })
+  )
+)
+
+// A factory rather than a module-level constant: `Layer.build` memoizes layer
+// construction keyed by the `Layer` object's identity in the ambient
+// `Layer.CurrentMemoMap`, which persists across the several `it.live` bodies
+// in this file (each sharing the same top-level fiber/context). Reusing the
+// same `Layer` instance across tests would replay the *first* test's
+// already-torn-down server instead of building a fresh one.
+const makeServerLayer = () =>
+  McpServer.layerStdio({ name: "TestServer", version: "1.0.0" }).pipe(
+    Layer.provideMerge(Layer.mergeAll(
+      EchoResource,
+      GreetPrompt,
+      AskNameToolkitLayer,
+      SamplingAndRootsToolkitLayer
+    ))
+  )
+
+/**
+ * Fake `ChildProcessSpawner` that, instead of spawning a real OS process,
+ * connects its `ChildProcessHandle`'s stdin/stdout to two in-memory queues
+ * that are already wired to a running `McpServer.layerStdio` instance. This
+ * keeps the stdio transport test deterministic and CI-fast, matching the
+ * convention already established by
+ * `packages/effect/test/unstable/process/ChildProcess.test.ts`.
+ */
+const makeFakeChildProcessHandle = Effect.fnUntraced(function*(options?: {
+  /**
+   * Invoked with each raw chunk the (fake) client process writes to its
+   * stdout, i.e. what the server reads as its stdin - lets a test observe
+   * outbound client traffic (e.g. notifications) that the server itself
+   * discards without any observable side effect.
+   */
+  readonly onClientMessage?: (data: Uint8Array) => void
+  /**
+   * Rewrites each raw chunk the (fake) server process writes to its stdout,
+   * i.e. what the client reads. Lets a test simulate a server responding
+   * with e.g. an unsupported protocol version without reimplementing the
+   * RPC/transport layers by hand.
+   */
+  readonly rewriteServerMessage?: (data: Uint8Array) => Uint8Array
+}) {
+  // `Stdio.stdout()` accepts `string | Uint8Array` (`Stdio.ts`), and the
+  // `as any` casts below let the server/client's ndjson-serialized `string`
+  // writes flow directly into these `Uint8Array`-typed queues unconverted -
+  // so a raw item read back out may actually be a `string` at runtime.
+  const toBytes = (data: Uint8Array | string): Uint8Array => typeof data === "string" ? textEncoder.encode(data) : data
+  const textEncoder = new TextEncoder()
+
+  const toServer = yield* Queue.make<Uint8Array, Cause.Done>()
+  const toClient = yield* Queue.make<Uint8Array, Cause.Done>()
+
+  const fakeStdio = Stdio.make({
+    args: Effect.succeed([]),
+    stdin: options?.onClientMessage
+      ? Stream.tap(Stream.fromQueue(toServer), (data) => Effect.sync(() => options.onClientMessage!(toBytes(data))))
+      : Stream.fromQueue(toServer),
+    stdout: () => Sink.fromQueue(toClient) as any,
+    stderr: () => Sink.drain
+  })
+
+  const clientStdout = options?.rewriteServerMessage
+    ? Stream.map(Stream.fromQueue(toClient), (data) => options.rewriteServerMessage!(toBytes(data)))
+    : Stream.fromQueue(toClient)
+
+  const handle = ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.never,
+    isRunning: Effect.succeed(true),
+    kill: () => Effect.void,
+    stdin: Sink.fromQueue(toServer).pipe(Sink.mapError((e) => e as never)) as any,
+    stdout: clientStdout as any,
+    stderr: Stream.empty,
+    all: clientStdout as any,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    unref: Effect.sync(() => Effect.void)
+  })
+
+  return { handle, fakeStdio } as const
+})
+
+/**
+ * Forks the build of a `McpClient.layerStdio` layer wired to a fresh
+ * `makeServerLayer()` instance over fake in-memory stdio, and returns the
+ * build fiber without joining it - lets a test observe a failed build (e.g.
+ * an unsupported protocol version rejection) as well as a successful one.
+ */
+const forkTestClientBuild = (options?: {
+  readonly handlers?: McpClient.ClientCapabilityHandlers
+  readonly onClientMessage?: (data: Uint8Array) => void
+  readonly rewriteServerMessage?: (data: Uint8Array) => Uint8Array
+}) =>
+  Effect.gen(function*() {
+    const { fakeStdio, handle } = yield* makeFakeChildProcessHandle({
+      ...(options?.onClientMessage ? { onClientMessage: options.onClientMessage } : {}),
+      ...(options?.rewriteServerMessage ? { rewriteServerMessage: options.rewriteServerMessage } : {})
+    })
+
+    // `RpcServer.makeProtocolStdio` captures `Fiber.getCurrent()` at the point
+    // it is run, and interrupts that fiber once its stdin reader completes
+    // (including on ordinary scope-close). Building the server layer directly
+    // on this test's own fiber would let that self-interrupt tear down the
+    // rest of the test; forking the build onto its own fiber isolates it, the
+    // same way a real program builds this layer as (part of) its own
+    // top-level `Layer.launch` fiber rather than inline in caller code.
+    yield* Effect.forkChild(Layer.build(makeServerLayer().pipe(Layer.provide(Layer.succeed(Stdio.Stdio, fakeStdio)))))
+
+    const fakeSpawnerLayer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.succeed(handle))
+    )
+
+    return yield* Effect.forkChild(Layer.build(
+      McpClient.layerStdio({
+        name: "TestClient",
+        version: "1.0.0",
+        command: "fake",
+        handlers: options?.handlers
+      }).pipe(
+        Layer.provide(fakeSpawnerLayer)
+      )
+    ))
+  })
+
+const makeTestClient = (options?: {
+  readonly handlers?: McpClient.ClientCapabilityHandlers
+  readonly onClientMessage?: (data: Uint8Array) => void
+}) =>
+  Effect.gen(function*() {
+    const clientBuildFiber = yield* forkTestClientBuild(options)
+    const context = yield* Fiber.join(clientBuildFiber)
+    return Context.get(context, McpClient.McpClient)
+  })
+
+describe("McpClient", () => {
+  it.live("performs the initialize handshake automatically", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient()
+
+      assert.strictEqual(client.serverInfo.name, "TestServer")
+      assert.strictEqual(client.serverInfo.version, "1.0.0")
+      assert.strictEqual(client.protocolVersion, "2025-06-18")
+      assert.isTrue(Option.isNone(client.instructions))
+    }).pipe(Effect.scoped))
+
+  it.live("fails the handshake when the server responds with an unsupported protocol version", () =>
+    Effect.gen(function*() {
+      const textDecoder = new TextDecoder()
+      const textEncoder = new TextEncoder()
+
+      // Rewrites the real server's `initialize` response on the wire,
+      // swapping its negotiated `protocolVersion` for one outside
+      // `SUPPORTED_PROTOCOL_VERSIONS`, without needing to hand-roll a fake
+      // RPC server: this is otherwise unreachable because the real
+      // `McpServer` always normalizes to a supported version.
+      const rewriteServerMessage = (data: Uint8Array): Uint8Array => {
+        const text = textDecoder.decode(data)
+        if (!text.includes("\"protocolVersion\"")) return data
+        return textEncoder.encode(text.replace(/"protocolVersion":"[^"]*"/, "\"protocolVersion\":\"1999-01-01\""))
+      }
+
+      const clientBuildFiber = yield* forkTestClientBuild({ rewriteServerMessage })
+      const error = yield* Fiber.join(clientBuildFiber).pipe(Effect.flip)
+
+      assert.instanceOf(error, McpClient.McpClientError)
+      assert.include(error.message, "Unsupported MCP protocol version")
+    }).pipe(Effect.scoped))
+
+  it.live("lists and reads resources", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient()
+
+      const list = yield* McpClient.listResources().pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+      assert.strictEqual(list.resources.length, 1)
+      assert.strictEqual(list.resources[0].uri, "file:///echo.txt")
+
+      const read = yield* McpClient.readResource({ uri: "file:///echo.txt" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+      assert.strictEqual(read.contents.length, 1)
+      const content = read.contents[0] as { text?: string }
+      assert.strictEqual(content.text, "hello from resource")
+    }).pipe(Effect.scoped))
+
+  it.live("lists prompts and gets a prompt", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient()
+
+      const list = yield* McpClient.listPrompts().pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+      assert.strictEqual(list.prompts.length, 1)
+      assert.strictEqual(list.prompts[0].name, "Greet")
+
+      const result = yield* McpClient.getPrompt({ name: "Greet", arguments: { name: "Ada" } }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+      assert.strictEqual(result.messages.length, 1)
+      assert.strictEqual((result.messages[0].content as { text?: string }).text, "Hello, Ada!")
+    }).pipe(Effect.scoped))
+
+  it.live("calls a tool that elicits input, and the client's elicitation handler responds", () =>
+    Effect.gen(function*() {
+      let sawMessage: string | undefined
+      const client = yield* makeTestClient({
+        handlers: {
+          elicitation: (params) => {
+            sawMessage = params.message
+            return Effect.succeed({ action: "accept", content: { name: "Grace" } })
+          }
+        }
+      })
+
+      const result = yield* McpClient.callTool({ name: "AskName" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+
+      assert.strictEqual(sawMessage, "What is your name?")
+      assert.notStrictEqual(result.isError, true)
+      assert.strictEqual((result.content[0] as { text?: string }).text, JSON.stringify("Got name: Grace"))
+    }).pipe(Effect.scoped))
+
+  it.live("propagates a decline from the client's elicitation handler", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient({
+        handlers: { elicitation: () => Effect.succeed({ action: "decline" }) }
+      })
+
+      const result = yield* McpClient.callTool({ name: "AskName" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+
+      assert.strictEqual((result.content[0] as { text?: string }).text, JSON.stringify("declined"))
+    }).pipe(Effect.scoped))
+
+  it.live("fails the server's elicit call when no elicitation handler is registered", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient()
+
+      const result = yield* McpClient.callTool({ name: "AskName" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+
+      // With no `elicitation` handler registered, `McpClient` responds to the
+      // server's `elicitation/create` request with an RPC-level error
+      // (`MethodNotFound`) rather than hanging or crashing the connection.
+      // `McpServer.elicit` turns any such failure into `ElicitationDeclined`,
+      // which this fixture's tool handler catches the same way it does an
+      // explicit decline, so the tool call still succeeds with "declined".
+      assert.notStrictEqual(result.isError, true)
+      assert.strictEqual((result.content[0] as { text?: string }).text, JSON.stringify("declined"))
+    }).pipe(Effect.scoped))
+
+  it.live("calls a tool that samples an LLM, and the client's sampling handler responds", () =>
+    Effect.gen(function*() {
+      let sawMaxTokens: number | undefined
+      const client = yield* makeTestClient({
+        handlers: {
+          sampling: (params) => {
+            sawMaxTokens = params.maxTokens
+            return Effect.succeed(
+              new CreateMessageResult({
+                role: "assistant",
+                content: { type: "text", text: "sampled" },
+                model: "test-model"
+              })
+            )
+          }
+        }
+      })
+
+      const result = yield* McpClient.callTool({ name: "Sample" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+
+      assert.strictEqual(sawMaxTokens, 100)
+      assert.notStrictEqual(result.isError, true)
+      assert.strictEqual((result.content[0] as { text?: string }).text, JSON.stringify("test-model"))
+    }).pipe(Effect.scoped))
+
+  it.live("fails the server's sampling call when no sampling handler is registered", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient()
+
+      const result = yield* McpClient.callTool({ name: "Sample" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+
+      // With no `sampling` handler registered, `McpClient` responds to the
+      // server's `sampling/createMessage` request with an RPC-level error
+      // (`MethodNotFound`), which surfaces as a tool error rather than
+      // hanging or crashing the connection.
+      assert.strictEqual(result.isError, true)
+    }).pipe(Effect.scoped))
+
+  it.live("calls a tool that lists client roots, and the client's roots handler responds", () =>
+    Effect.gen(function*() {
+      const client = yield* makeTestClient({
+        handlers: {
+          roots: {
+            list: () => Effect.succeed(new ListRootsResult({ roots: [new Root({ uri: "file:///project" })] }))
+          }
+        }
+      })
+
+      const result = yield* McpClient.callTool({ name: "ListClientRoots" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+
+      assert.notStrictEqual(result.isError, true)
+      assert.strictEqual(
+        (result.content[0] as { text?: string }).text,
+        JSON.stringify(["file:///project"])
+      )
+    }).pipe(Effect.scoped))
+
+  it.live("forwards roots.changes stream emissions as notifications/roots/list_changed", () =>
+    Effect.gen(function*() {
+      const changes = yield* Queue.make<void>()
+      const textDecoder = new TextDecoder()
+      const seenMessages: Array<string> = []
+
+      const client = yield* makeTestClient({
+        handlers: {
+          roots: {
+            list: () => Effect.succeed(new ListRootsResult({ roots: [] })),
+            changes: Stream.fromQueue(changes)
+          }
+        },
+        // `McpServer` acknowledges `notifications/roots/list_changed` with
+        // `Effect.void` and exposes no observable side effect, so the raw
+        // bytes written to the fake child process's stdin (what the server
+        // reads) are inspected directly here to confirm the notification
+        // McpClient actually reaches the wire, rather than only asserting
+        // that the connection stays alive afterwards.
+        onClientMessage: (data) => seenMessages.push(textDecoder.decode(data))
+      })
+
+      yield* Queue.offer(changes, void 0)
+
+      // The notification write and this `ping` both go through the same
+      // serialized outbound queue (`layerProtocolPairStdio`), so waiting for
+      // the `ping` response guarantees the notification was already written
+      // and observed by `onClientMessage` beforehand.
+      const result = yield* McpClient.ping.pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+      assert.deepStrictEqual(result, {})
+
+      assert.isTrue(seenMessages.some((message) => message.includes("notifications/roots/list_changed")))
+    }).pipe(Effect.scoped))
+})
+
+describe("McpClient (HTTP transport)", () => {
+  const makeHttpTestClient = (options?: {
+    /**
+     * Rewrites the parsed JSON body of every HTTP response the fake server
+     * returns before it reaches the fetch caller - lets a test splice in an
+     * extra, unrecognized-method JSON-RPC message alongside a legitimate
+     * response.
+     */
+    readonly rewriteResponseBody?: (body: unknown) => unknown
+  }) =>
+    Effect.gen(function*() {
+      const httpServerLayer = McpServer.layerHttp({
+        name: "TestServer",
+        version: "1.0.0",
+        path: "/mcp"
+      }).pipe(
+        Layer.provideMerge(Layer.mergeAll(EchoResource, GreetPrompt))
+      )
+      const { dispose, handler } = HttpRouter.toWebHandler(httpServerLayer, { disableLogger: true })
+      yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
+
+      let sessionId: string | null = null
+      const customFetch: typeof fetch = async (input, init) => {
+        const request = input instanceof Request ? input : new Request(input, init)
+        if (sessionId) {
+          request.headers.set("Mcp-Session-Id", sessionId)
+        }
+        const response = await handler(request)
+        const newSessionId = response.headers.get("Mcp-Session-Id")
+        if (newSessionId) {
+          sessionId = newSessionId
+        }
+        if (!options?.rewriteResponseBody) {
+          return response
+        }
+        const contentType = response.headers.get("content-type")
+        const text = await response.text()
+        if (text.length === 0) return new Response(text, response)
+        const rewritten = options.rewriteResponseBody(JSON.parse(text))
+        const headers = new Headers(response.headers)
+        if (contentType) headers.set("content-type", contentType)
+        return new Response(JSON.stringify(rewritten), { status: response.status, headers })
+      }
+
+      const context = yield* Layer.build(
+        McpClient.layerHttp({
+          name: "TestClient",
+          version: "1.0.0",
+          url: "http://localhost/mcp"
+        }).pipe(
+          Layer.provide(FetchHttpClient.layer),
+          Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch))
+        )
+      )
+      return Context.get(context, McpClient.McpClient)
+    })
+
+  it.effect("performs the initialize handshake and round-trips a resource over Streamable HTTP", () =>
+    Effect.gen(function*() {
+      const client = yield* makeHttpTestClient()
+
+      assert.strictEqual(client.serverInfo.name, "TestServer")
+      assert.strictEqual(client.protocolVersion, "2025-06-18")
+
+      const read = yield* McpClient.readResource({ uri: "file:///echo.txt" }).pipe(
+        Effect.provideService(McpClient.McpClient, client)
+      )
+      const content = read.contents[0] as { text?: string }
+      assert.strictEqual(content.text, "hello from resource")
+    }).pipe(Effect.scoped))
+
+  it.effect(
+    "ignores an unrecognized inbound method spliced into a response batch, without dropping the sibling response",
+    () =>
+      Effect.gen(function*() {
+        // Splices an extra, unrecognized-method JSON-RPC message into every
+        // response body alongside whatever the real server actually
+        // returned, simulating a malformed/unsupported inbound push
+        // arriving in the same batch as a legitimate response.
+        const client = yield* makeHttpTestClient({
+          rewriteResponseBody: (body) => {
+            const rogueMessage = { jsonrpc: "2.0", method: "bogus/unrecognized", params: {} }
+            return Array.isArray(body) ? [...body, rogueMessage] : [body, rogueMessage]
+          }
+        })
+
+        assert.strictEqual(client.serverInfo.name, "TestServer")
+
+        const read = yield* McpClient.readResource({ uri: "file:///echo.txt" }).pipe(
+          Effect.provideService(McpClient.McpClient, client)
+        )
+        const content = read.contents[0] as { text?: string }
+        assert.strictEqual(content.text, "hello from resource")
+      }).pipe(Effect.scoped)
+  )
+})

--- a/packages/effect/test/unstable/ai/McpSchema.test.ts
+++ b/packages/effect/test/unstable/ai/McpSchema.test.ts
@@ -1,0 +1,191 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Exit, Schema } from "effect"
+import * as McpSchema from "effect/unstable/ai/McpSchema"
+
+const decode = <S extends Schema.Top>(schema: S, input: unknown) => Schema.decodeUnknownEffect(schema)(input)
+
+const assertRejected = <S extends Schema.Top>(schema: S, input: unknown) =>
+  Effect.gen(function*() {
+    assert.isTrue(Exit.isFailure(yield* Effect.exit(decode(schema, input))))
+  })
+
+const InitializeResult20250618 = Schema.Struct({
+  protocolVersion: Schema.Literal("2025-06-18"),
+  capabilities: Schema.Struct({
+    completions: Schema.optionalKey(Schema.Struct({}))
+  }),
+  serverInfo: Schema.Struct({
+    name: Schema.String,
+    title: Schema.optionalKey(Schema.String),
+    version: Schema.String
+  }),
+  instructions: Schema.optionalKey(Schema.String),
+  _meta: Schema.optionalKey(Schema.Record(Schema.String, Schema.Json))
+})
+
+describe("McpSchema", () => {
+  it.effect("decodes 2025-11-25 initialization metadata and capabilities", () =>
+    Effect.gen(function*() {
+      const value = yield* decode(McpSchema.Initialize.payloadSchema, {
+        protocolVersion: "2025-11-25",
+        _meta: { progressToken: "init", "io.example/trace": { id: 1 } },
+        capabilities: {
+          sampling: { context: {}, tools: {} },
+          elicitation: { form: {}, url: {} },
+          "io.example/capability": { enabled: true }
+        },
+        clientInfo: {
+          name: "client",
+          version: "1",
+          description: "Example client",
+          websiteUrl: "https://example.com",
+          icons: [{ src: "https://example.com/icon.svg", mimeType: "image/svg+xml", theme: "light" }]
+        }
+      })
+      assert.deepStrictEqual(value._meta?.["io.example/trace"], { id: 1 })
+      assert.deepStrictEqual(value.capabilities.sampling?.tools, {})
+    }))
+
+  it.effect("normalizes omitted tool arguments and constrains structured content", () =>
+    Effect.gen(function*() {
+      const call = yield* decode(McpSchema.CallTool.payloadSchema, { name: "status" })
+      assert.deepStrictEqual(call.arguments, {})
+      yield* decode(McpSchema.CallToolResult, { content: [], structuredContent: { status: "ok" } })
+      yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: [] })
+      yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: null })
+    }))
+
+  it.effect("requires progress and enforces completion limits", () =>
+    Effect.gen(function*() {
+      yield* assertRejected(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1 })
+      yield* decode(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1, progress: 0 })
+      yield* decode(McpSchema.CompleteResult, {
+        _meta: { trace: true },
+        completion: { values: Array.from({ length: 100 }, (_, index) => String(index)), total: 100 }
+      })
+      yield* assertRejected(McpSchema.CompleteResult, {
+        completion: { values: Array.from({ length: 101 }, (_, index) => String(index)) }
+      })
+      yield* assertRejected(McpSchema.CompleteResult, { completion: { values: [], total: 0.5 } })
+    }))
+
+  it.effect("accepts corrected sampling requests and results", () =>
+    Effect.gen(function*() {
+      yield* decode(McpSchema.CreateMessage.payloadSchema, {
+        messages: [{ role: "user", content: { type: "text", text: "Hello", _meta: { source: "test" } } }],
+        maxTokens: 32
+      })
+      yield* decode(McpSchema.CreateMessageResult, {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }, { type: "text", text: "there" }],
+        model: "example-model",
+        _meta: { trace: true },
+        "io.example/result": { retained: true }
+      })
+    }))
+
+  it.effect("constrains form elicitation schemas and accepted content", () =>
+    Effect.gen(function*() {
+      const value = yield* decode(McpSchema.Elicit.payloadSchema, {
+        message: "Profile",
+        requestedSchema: {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "object",
+          properties: {
+            name: { type: "string", minLength: 1 },
+            age: { type: "integer", minimum: 0 },
+            enabled: { type: "boolean" },
+            color: { type: "string", enum: ["red", "blue"] },
+            legacyColor: { type: "string", enum: ["red"], enumNames: ["Red"] },
+            titledColor: {
+              type: "string",
+              oneOf: [{ const: "red", title: "Red" }]
+            },
+            tags: { type: "array", items: { type: "string", enum: ["effect"] } },
+            titledTags: {
+              type: "array",
+              items: { anyOf: [{ const: "effect", title: "Effect" }] }
+            }
+          },
+          required: ["name"]
+        }
+      })
+      assert.deepStrictEqual(value.requestedSchema.properties.titledColor, {
+        type: "string",
+        oneOf: [{ const: "red", title: "Red" }]
+      })
+      assert.deepStrictEqual(value.requestedSchema.properties.titledTags, {
+        type: "array",
+        items: { anyOf: [{ const: "effect", title: "Effect" }] }
+      })
+      yield* assertRejected(McpSchema.Elicit.payloadSchema, {
+        message: "Nested",
+        requestedSchema: {
+          type: "object",
+          properties: { nested: { type: "object", properties: {} } }
+        }
+      })
+      yield* decode(McpSchema.ElicitResult, {
+        action: "accept",
+        content: { name: "Ada", age: 42, enabled: true, tags: ["effect"] }
+      })
+      yield* assertRejected(McpSchema.ElicitResult, { action: "accept", content: { nested: { value: true } } })
+    }))
+
+  it.effect("decodes root metadata and accepts result extensions", () =>
+    Effect.gen(function*() {
+      const result = yield* decode(McpSchema.ListRootsResult, {
+        roots: [{ uri: "file:///workspace", _meta: { source: "client" } }],
+        "io.example/result": true
+      })
+      assert.deepStrictEqual(result.roots[0]?._meta, { source: "client" })
+    }))
+
+  it.effect("decodes the 2025-06-18 common compatibility surface", () =>
+    Effect.gen(function*() {
+      const initialize = yield* decode(McpSchema.InitializeResult, {
+        protocolVersion: "2025-06-18",
+        capabilities: { completions: {} },
+        serverInfo: { name: "server", version: "1.0.0" }
+      })
+      assert.strictEqual(initialize.protocolVersion, "2025-06-18")
+      assert.deepStrictEqual(initialize.serverInfo, { name: "server", version: "1.0.0" })
+      const emitted = yield* Schema.encodeUnknownEffect(McpSchema.InitializeResult)(initialize)
+      yield* decode(InitializeResult20250618, emitted)
+
+      yield* decode(McpSchema.CreateMessageResult, {
+        role: "assistant",
+        content: { type: "text", text: "compatible" },
+        model: "model"
+      })
+      yield* decode(McpSchema.Elicit.payloadSchema, {
+        message: "Choose",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            choice: { type: "string", enum: ["a"], enumNames: ["Option A"] }
+          }
+        }
+      })
+    }))
+
+  it.effect("round trips binary content as base64", () =>
+    Effect.gen(function*() {
+      const bytes = new Uint8Array([0, 1, 2, 255])
+      for (const schema of [McpSchema.ImageContent, McpSchema.AudioContent] as const) {
+        const encoded = yield* Schema.encodeUnknownEffect(schema)({
+          type: schema === McpSchema.ImageContent ? "image" : "audio",
+          data: bytes,
+          mimeType: "application/octet-stream"
+        })
+        assert.strictEqual(encoded.data, "AAEC/w==")
+      }
+      const encoded = yield* Schema.encodeUnknownEffect(McpSchema.BlobResourceContents)({
+        uri: "file:///blob",
+        blob: bytes
+      })
+      assert.strictEqual(encoded.blob, "AAEC/w==")
+      const decoded = yield* decode(McpSchema.BlobResourceContents, encoded)
+      assert.deepStrictEqual(decoded.blob, bytes)
+    }))
+})

--- a/packages/effect/test/unstable/ai/McpSchema.test.ts
+++ b/packages/effect/test/unstable/ai/McpSchema.test.ts
@@ -24,168 +24,174 @@ const InitializeResult20250618 = Schema.Struct({
 })
 
 describe("McpSchema", () => {
-  it.effect("decodes 2025-11-25 initialization metadata and capabilities", () =>
-    Effect.gen(function*() {
-      const value = yield* decode(McpSchema.Initialize.payloadSchema, {
-        protocolVersion: "2025-11-25",
-        _meta: { progressToken: "init", "io.example/trace": { id: 1 } },
-        capabilities: {
-          sampling: { context: {}, tools: {} },
-          elicitation: { form: {}, url: {} },
-          "io.example/capability": { enabled: true }
-        },
-        clientInfo: {
-          name: "client",
-          version: "1",
-          description: "Example client",
-          websiteUrl: "https://example.com",
-          icons: [{ src: "https://example.com/icon.svg", mimeType: "image/svg+xml", theme: "light" }]
-        }
-      })
-      assert.deepStrictEqual(value._meta?.["io.example/trace"], { id: 1 })
-      assert.deepStrictEqual(value.capabilities.sampling?.tools, {})
-    }))
-
-  it.effect("normalizes omitted tool arguments and constrains structured content", () =>
-    Effect.gen(function*() {
-      const call = yield* decode(McpSchema.CallTool.payloadSchema, { name: "status" })
-      assert.deepStrictEqual(call.arguments, {})
-      yield* decode(McpSchema.CallToolResult, { content: [], structuredContent: { status: "ok" } })
-      yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: [] })
-      yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: null })
-    }))
-
-  it.effect("requires progress and enforces completion limits", () =>
-    Effect.gen(function*() {
-      yield* assertRejected(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1 })
-      yield* decode(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1, progress: 0 })
-      yield* decode(McpSchema.CompleteResult, {
-        _meta: { trace: true },
-        completion: { values: Array.from({ length: 100 }, (_, index) => String(index)), total: 100 }
-      })
-      yield* assertRejected(McpSchema.CompleteResult, {
-        completion: { values: Array.from({ length: 101 }, (_, index) => String(index)) }
-      })
-      yield* assertRejected(McpSchema.CompleteResult, { completion: { values: [], total: 0.5 } })
-    }))
-
-  it.effect("accepts corrected sampling requests and results", () =>
-    Effect.gen(function*() {
-      yield* decode(McpSchema.CreateMessage.payloadSchema, {
-        messages: [{ role: "user", content: { type: "text", text: "Hello", _meta: { source: "test" } } }],
-        maxTokens: 32
-      })
-      yield* decode(McpSchema.CreateMessageResult, {
-        role: "assistant",
-        content: [{ type: "text", text: "Hello" }, { type: "text", text: "there" }],
-        model: "example-model",
-        _meta: { trace: true },
-        "io.example/result": { retained: true }
-      })
-    }))
-
-  it.effect("constrains form elicitation schemas and accepted content", () =>
-    Effect.gen(function*() {
-      const value = yield* decode(McpSchema.Elicit.payloadSchema, {
-        message: "Profile",
-        requestedSchema: {
-          $schema: "https://json-schema.org/draft/2020-12/schema",
-          type: "object",
-          properties: {
-            name: { type: "string", minLength: 1 },
-            age: { type: "integer", minimum: 0 },
-            enabled: { type: "boolean" },
-            color: { type: "string", enum: ["red", "blue"] },
-            legacyColor: { type: "string", enum: ["red"], enumNames: ["Red"] },
-            titledColor: {
-              type: "string",
-              oneOf: [{ const: "red", title: "Red" }]
-            },
-            tags: { type: "array", items: { type: "string", enum: ["effect"] } },
-            titledTags: {
-              type: "array",
-              items: { anyOf: [{ const: "effect", title: "Effect" }] }
-            }
+  describe("2025-11-25", () => {
+    it.effect("decodes initialization metadata and capabilities", () =>
+      Effect.gen(function*() {
+        const value = yield* decode(McpSchema.Initialize.payloadSchema, {
+          protocolVersion: "2025-11-25",
+          _meta: { progressToken: "init", "io.example/trace": { id: 1 } },
+          capabilities: {
+            sampling: { context: {}, tools: {} },
+            elicitation: { form: {}, url: {} },
+            "io.example/capability": { enabled: true }
           },
-          required: ["name"]
-        }
-      })
-      assert.deepStrictEqual(value.requestedSchema.properties.titledColor, {
-        type: "string",
-        oneOf: [{ const: "red", title: "Red" }]
-      })
-      assert.deepStrictEqual(value.requestedSchema.properties.titledTags, {
-        type: "array",
-        items: { anyOf: [{ const: "effect", title: "Effect" }] }
-      })
-      yield* assertRejected(McpSchema.Elicit.payloadSchema, {
-        message: "Nested",
-        requestedSchema: {
-          type: "object",
-          properties: { nested: { type: "object", properties: {} } }
-        }
-      })
-      yield* decode(McpSchema.ElicitResult, {
-        action: "accept",
-        content: { name: "Ada", age: 42, enabled: true, tags: ["effect"] }
-      })
-      yield* assertRejected(McpSchema.ElicitResult, { action: "accept", content: { nested: { value: true } } })
-    }))
-
-  it.effect("decodes root metadata and accepts result extensions", () =>
-    Effect.gen(function*() {
-      const result = yield* decode(McpSchema.ListRootsResult, {
-        roots: [{ uri: "file:///workspace", _meta: { source: "client" } }],
-        "io.example/result": true
-      })
-      assert.deepStrictEqual(result.roots[0]?._meta, { source: "client" })
-    }))
-
-  it.effect("decodes the 2025-06-18 common compatibility surface", () =>
-    Effect.gen(function*() {
-      const initialize = yield* decode(McpSchema.InitializeResult, {
-        protocolVersion: "2025-06-18",
-        capabilities: { completions: {} },
-        serverInfo: { name: "server", version: "1.0.0" }
-      })
-      assert.strictEqual(initialize.protocolVersion, "2025-06-18")
-      assert.deepStrictEqual(initialize.serverInfo, { name: "server", version: "1.0.0" })
-      const emitted = yield* Schema.encodeUnknownEffect(McpSchema.InitializeResult)(initialize)
-      yield* decode(InitializeResult20250618, emitted)
-
-      yield* decode(McpSchema.CreateMessageResult, {
-        role: "assistant",
-        content: { type: "text", text: "compatible" },
-        model: "model"
-      })
-      yield* decode(McpSchema.Elicit.payloadSchema, {
-        message: "Choose",
-        requestedSchema: {
-          type: "object",
-          properties: {
-            choice: { type: "string", enum: ["a"], enumNames: ["Option A"] }
+          clientInfo: {
+            name: "client",
+            version: "1",
+            description: "Example client",
+            websiteUrl: "https://example.com",
+            icons: [{ src: "https://example.com/icon.svg", mimeType: "image/svg+xml", theme: "light" }]
           }
-        }
-      })
-    }))
-
-  it.effect("round trips binary content as base64", () =>
-    Effect.gen(function*() {
-      const bytes = new Uint8Array([0, 1, 2, 255])
-      for (const schema of [McpSchema.ImageContent, McpSchema.AudioContent] as const) {
-        const encoded = yield* Schema.encodeUnknownEffect(schema)({
-          type: schema === McpSchema.ImageContent ? "image" : "audio",
-          data: bytes,
-          mimeType: "application/octet-stream"
         })
-        assert.strictEqual(encoded.data, "AAEC/w==")
-      }
-      const encoded = yield* Schema.encodeUnknownEffect(McpSchema.BlobResourceContents)({
-        uri: "file:///blob",
-        blob: bytes
-      })
-      assert.strictEqual(encoded.blob, "AAEC/w==")
-      const decoded = yield* decode(McpSchema.BlobResourceContents, encoded)
-      assert.deepStrictEqual(decoded.blob, bytes)
-    }))
+        assert.deepStrictEqual(value._meta?.["io.example/trace"], { id: 1 })
+        assert.deepStrictEqual(value.capabilities.sampling?.tools, {})
+      }))
+
+    it.effect("normalizes omitted tool arguments and constrains structured content", () =>
+      Effect.gen(function*() {
+        const call = yield* decode(McpSchema.CallTool.payloadSchema, { name: "status" })
+        assert.deepStrictEqual(call.arguments, {})
+        yield* decode(McpSchema.CallToolResult, { content: [], structuredContent: { status: "ok" } })
+        yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: [] })
+        yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: null })
+      }))
+
+    it.effect("requires progress and enforces completion limits", () =>
+      Effect.gen(function*() {
+        yield* assertRejected(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1 })
+        yield* decode(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1, progress: 0 })
+        yield* decode(McpSchema.CompleteResult, {
+          _meta: { trace: true },
+          completion: { values: Array.from({ length: 100 }, (_, index) => String(index)), total: 100 }
+        })
+        yield* assertRejected(McpSchema.CompleteResult, {
+          completion: { values: Array.from({ length: 101 }, (_, index) => String(index)) }
+        })
+        yield* assertRejected(McpSchema.CompleteResult, { completion: { values: [], total: 0.5 } })
+      }))
+
+    it.effect("accepts corrected sampling requests and results", () =>
+      Effect.gen(function*() {
+        yield* decode(McpSchema.CreateMessage.payloadSchema, {
+          messages: [{ role: "user", content: { type: "text", text: "Hello", _meta: { source: "test" } } }],
+          maxTokens: 32
+        })
+        yield* decode(McpSchema.CreateMessageResult, {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }, { type: "text", text: "there" }],
+          model: "example-model",
+          _meta: { trace: true },
+          "io.example/result": { retained: true }
+        })
+      }))
+
+    it.effect("constrains form elicitation schemas and accepted content", () =>
+      Effect.gen(function*() {
+        const value = yield* decode(McpSchema.Elicit.payloadSchema, {
+          message: "Profile",
+          requestedSchema: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            type: "object",
+            properties: {
+              name: { type: "string", minLength: 1 },
+              age: { type: "integer", minimum: 0 },
+              enabled: { type: "boolean" },
+              color: { type: "string", enum: ["red", "blue"] },
+              legacyColor: { type: "string", enum: ["red"], enumNames: ["Red"] },
+              titledColor: {
+                type: "string",
+                oneOf: [{ const: "red", title: "Red" }]
+              },
+              tags: { type: "array", items: { type: "string", enum: ["effect"] } },
+              titledTags: {
+                type: "array",
+                items: { anyOf: [{ const: "effect", title: "Effect" }] }
+              }
+            },
+            required: ["name"]
+          }
+        })
+        assert.deepStrictEqual(value.requestedSchema.properties.titledColor, {
+          type: "string",
+          oneOf: [{ const: "red", title: "Red" }]
+        })
+        assert.deepStrictEqual(value.requestedSchema.properties.titledTags, {
+          type: "array",
+          items: { anyOf: [{ const: "effect", title: "Effect" }] }
+        })
+        yield* assertRejected(McpSchema.Elicit.payloadSchema, {
+          message: "Nested",
+          requestedSchema: {
+            type: "object",
+            properties: { nested: { type: "object", properties: {} } }
+          }
+        })
+        yield* decode(McpSchema.ElicitResult, {
+          action: "accept",
+          content: { name: "Ada", age: 42, enabled: true, tags: ["effect"] }
+        })
+        yield* assertRejected(McpSchema.ElicitResult, { action: "accept", content: { nested: { value: true } } })
+      }))
+
+    it.effect("decodes root metadata and accepts result extensions", () =>
+      Effect.gen(function*() {
+        const result = yield* decode(McpSchema.ListRootsResult, {
+          roots: [{ uri: "file:///workspace", _meta: { source: "client" } }],
+          "io.example/result": true
+        })
+        assert.deepStrictEqual(result.roots[0]?._meta, { source: "client" })
+      }))
+  })
+
+  describe("2025-06-18", () => {
+    it.effect("decodes the common compatibility surface", () =>
+      Effect.gen(function*() {
+        const initialize = yield* decode(McpSchema.InitializeResult, {
+          protocolVersion: "2025-06-18",
+          capabilities: { completions: {} },
+          serverInfo: { name: "server", version: "1.0.0" }
+        })
+        assert.strictEqual(initialize.protocolVersion, "2025-06-18")
+        assert.deepStrictEqual(initialize.serverInfo, { name: "server", version: "1.0.0" })
+        const emitted = yield* Schema.encodeUnknownEffect(McpSchema.InitializeResult)(initialize)
+        yield* decode(InitializeResult20250618, emitted)
+
+        yield* decode(McpSchema.CreateMessageResult, {
+          role: "assistant",
+          content: { type: "text", text: "compatible" },
+          model: "model"
+        })
+        yield* decode(McpSchema.Elicit.payloadSchema, {
+          message: "Choose",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              choice: { type: "string", enum: ["a"], enumNames: ["Option A"] }
+            }
+          }
+        })
+      }))
+  })
+
+  describe("shared", () => {
+    it.effect("round trips binary content as base64", () =>
+      Effect.gen(function*() {
+        const bytes = new Uint8Array([0, 1, 2, 255])
+        for (const schema of [McpSchema.ImageContent, McpSchema.AudioContent] as const) {
+          const encoded = yield* Schema.encodeUnknownEffect(schema)({
+            type: schema === McpSchema.ImageContent ? "image" : "audio",
+            data: bytes,
+            mimeType: "application/octet-stream"
+          })
+          assert.strictEqual(encoded.data, "AAEC/w==")
+        }
+        const encoded = yield* Schema.encodeUnknownEffect(McpSchema.BlobResourceContents)({
+          uri: "file:///blob",
+          blob: bytes
+        })
+        assert.strictEqual(encoded.blob, "AAEC/w==")
+        const decoded = yield* decode(McpSchema.BlobResourceContents, encoded)
+        assert.deepStrictEqual(decoded.blob, bytes)
+      }))
+  })
 })

--- a/packages/effect/test/unstable/ai/McpSchema.test.ts
+++ b/packages/effect/test/unstable/ai/McpSchema.test.ts
@@ -25,16 +25,11 @@ const InitializeResult20250618 = Schema.Struct({
 
 describe("McpSchema", () => {
   describe("2025-11-25", () => {
-    it.effect("decodes initialization metadata and capabilities", () =>
+    it.effect("decodes implementation descriptions, websites, and icons", () =>
       Effect.gen(function*() {
         const value = yield* decode(McpSchema.Initialize.payloadSchema, {
           protocolVersion: "2025-11-25",
-          _meta: { progressToken: "init", "io.example/trace": { id: 1 } },
-          capabilities: {
-            sampling: { context: {}, tools: {} },
-            elicitation: { form: {}, url: {} },
-            "io.example/capability": { enabled: true }
-          },
+          capabilities: {},
           clientInfo: {
             name: "client",
             version: "1",
@@ -43,61 +38,80 @@ describe("McpSchema", () => {
             icons: [{ src: "https://example.com/icon.svg", mimeType: "image/svg+xml", theme: "light" }]
           }
         })
-        assert.deepStrictEqual(value._meta?.["io.example/trace"], { id: 1 })
-        assert.deepStrictEqual(value.capabilities.sampling?.tools, {})
+        assert.deepStrictEqual(value.clientInfo, {
+          name: "client",
+          version: "1",
+          description: "Example client",
+          websiteUrl: "https://example.com",
+          icons: [{ src: "https://example.com/icon.svg", mimeType: "image/svg+xml", theme: "light" }]
+        })
       }))
 
-    it.effect("normalizes omitted tool arguments and constrains structured content", () =>
+    it.effect("decodes sampling and form elicitation capability subfields", () =>
       Effect.gen(function*() {
-        const call = yield* decode(McpSchema.CallTool.payloadSchema, { name: "status" })
-        assert.deepStrictEqual(call.arguments, {})
-        yield* decode(McpSchema.CallToolResult, { content: [], structuredContent: { status: "ok" } })
-        yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: [] })
-        yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: null })
+        const value = yield* decode(McpSchema.Initialize.payloadSchema, {
+          protocolVersion: "2025-11-25",
+          capabilities: {
+            sampling: { context: {} },
+            elicitation: { form: {} },
+            "io.example/capability": { enabled: true }
+          },
+          clientInfo: { name: "client", version: "1" }
+        })
+        assert.deepStrictEqual(value.capabilities.sampling?.context, {})
+        assert.deepStrictEqual(value.capabilities.elicitation?.form, {})
       }))
 
-    it.effect("requires progress and enforces completion limits", () =>
+    it.effect("decodes icons on protocol objects", () =>
       Effect.gen(function*() {
-        yield* assertRejected(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1 })
-        yield* decode(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1, progress: 0 })
-        yield* decode(McpSchema.CompleteResult, {
-          _meta: { trace: true },
-          completion: { values: Array.from({ length: 100 }, (_, index) => String(index)), total: 100 }
+        const icons = [{ src: "https://example.com/icon.svg", sizes: ["16x16"], theme: "dark" as const }]
+        const resource = yield* decode(McpSchema.Resource, {
+          uri: "file:///resource",
+          name: "resource",
+          icons
         })
-        yield* assertRejected(McpSchema.CompleteResult, {
-          completion: { values: Array.from({ length: 101 }, (_, index) => String(index)) }
+        const template = yield* decode(McpSchema.ResourceTemplate, {
+          uriTemplate: "file:///{name}",
+          name: "template",
+          icons
         })
-        yield* assertRejected(McpSchema.CompleteResult, { completion: { values: [], total: 0.5 } })
+        const prompt = yield* decode(McpSchema.Prompt, { name: "prompt", icons })
+        const tool = yield* decode(McpSchema.Tool, { name: "tool", inputSchema: { type: "object" }, icons })
+        assert.deepStrictEqual(resource.icons, icons)
+        assert.deepStrictEqual(template.icons, icons)
+        assert.deepStrictEqual(prompt.icons, icons)
+        assert.deepStrictEqual(tool.icons, icons)
       }))
 
-    it.effect("accepts corrected sampling requests and results", () =>
+    it.effect("accepts single sampling content", () =>
       Effect.gen(function*() {
-        yield* decode(McpSchema.CreateMessage.payloadSchema, {
-          messages: [{ role: "user", content: { type: "text", text: "Hello", _meta: { source: "test" } } }],
-          maxTokens: 32
+        const message = yield* decode(McpSchema.SamplingMessage, {
+          role: "user",
+          content: { type: "text", text: "Hello", _meta: { source: "test" } }
         })
-        yield* decode(McpSchema.CreateMessageResult, {
+        assert.strictEqual(Array.isArray(message.content), false)
+      }))
+
+    it.effect("accepts array sampling content", () =>
+      Effect.gen(function*() {
+        const result = yield* decode(McpSchema.CreateMessageResult, {
           role: "assistant",
           content: [{ type: "text", text: "Hello" }, { type: "text", text: "there" }],
           model: "example-model",
           _meta: { trace: true },
           "io.example/result": { retained: true }
         })
+        assert.strictEqual(Array.isArray(result.content), true)
       }))
 
-    it.effect("constrains form elicitation schemas and accepted content", () =>
+    it.effect("accepts titled and untitled single- and multi-select elicitation", () =>
       Effect.gen(function*() {
         const value = yield* decode(McpSchema.Elicit.payloadSchema, {
-          message: "Profile",
+          message: "Choose",
           requestedSchema: {
-            $schema: "https://json-schema.org/draft/2020-12/schema",
             type: "object",
             properties: {
-              name: { type: "string", minLength: 1 },
-              age: { type: "integer", minimum: 0 },
-              enabled: { type: "boolean" },
               color: { type: "string", enum: ["red", "blue"] },
-              legacyColor: { type: "string", enum: ["red"], enumNames: ["Red"] },
               titledColor: {
                 type: "string",
                 oneOf: [{ const: "red", title: "Red" }]
@@ -107,30 +121,77 @@ describe("McpSchema", () => {
                 type: "array",
                 items: { anyOf: [{ const: "effect", title: "Effect" }] }
               }
-            },
-            required: ["name"]
+            }
           }
+        })
+        assert.deepStrictEqual(value.requestedSchema.properties.color, {
+          type: "string",
+          enum: ["red", "blue"]
         })
         assert.deepStrictEqual(value.requestedSchema.properties.titledColor, {
           type: "string",
           oneOf: [{ const: "red", title: "Red" }]
         })
+        assert.deepStrictEqual(value.requestedSchema.properties.tags, {
+          type: "array",
+          items: { type: "string", enum: ["effect"] }
+        })
         assert.deepStrictEqual(value.requestedSchema.properties.titledTags, {
           type: "array",
           items: { anyOf: [{ const: "effect", title: "Effect" }] }
         })
-        yield* assertRejected(McpSchema.Elicit.payloadSchema, {
-          message: "Nested",
+      }))
+
+    it.effect("preserves elicitation defaults and explicit form mode", () =>
+      Effect.gen(function*() {
+        const value = yield* decode(McpSchema.Elicit.payloadSchema, {
+          mode: "form",
+          message: "Preferences",
           requestedSchema: {
             type: "object",
-            properties: { nested: { type: "object", properties: {} } }
+            properties: {
+              name: { type: "string", default: "Ada" },
+              count: { type: "integer", default: 1 },
+              enabled: { type: "boolean", default: true },
+              colors: {
+                type: "array",
+                items: { type: "string", enum: ["red", "blue"] },
+                default: ["red"]
+              }
+            }
           }
         })
+        assert.strictEqual(value.mode, "form")
+        assert.strictEqual(value.requestedSchema.properties.name?.default, "Ada")
+        assert.strictEqual(value.requestedSchema.properties.count?.default, 1)
+        assert.strictEqual(value.requestedSchema.properties.enabled?.default, true)
+        assert.deepStrictEqual(value.requestedSchema.properties.colors?.default, ["red"])
+      }))
+
+    it.effect("accepts primitive elicitation result content", () =>
+      Effect.gen(function*() {
         yield* decode(McpSchema.ElicitResult, {
           action: "accept",
           content: { name: "Ada", age: 42, enabled: true, tags: ["effect"] }
         })
         yield* assertRejected(McpSchema.ElicitResult, { action: "accept", content: { nested: { value: true } } })
+      }))
+
+    it.effect("decodes resource links and resource content metadata", () =>
+      Effect.gen(function*() {
+        const link = yield* decode(McpSchema.ResourceLink, {
+          type: "resource_link",
+          uri: "file:///guide",
+          name: "guide",
+          _meta: { source: "tool" }
+        })
+        const content = yield* decode(McpSchema.TextResourceContents, {
+          uri: "file:///guide",
+          text: "Guide",
+          _meta: { revision: 2 }
+        })
+        assert.deepStrictEqual(link._meta, { source: "tool" })
+        assert.deepStrictEqual(content._meta, { revision: 2 })
       }))
 
     it.effect("decodes root metadata and accepts result extensions", () =>
@@ -144,7 +205,7 @@ describe("McpSchema", () => {
   })
 
   describe("2025-06-18", () => {
-    it.effect("decodes the common compatibility surface", () =>
+    it.effect("round trips the initialization compatibility surface", () =>
       Effect.gen(function*() {
         const initialize = yield* decode(McpSchema.InitializeResult, {
           protocolVersion: "2025-06-18",
@@ -155,12 +216,89 @@ describe("McpSchema", () => {
         assert.deepStrictEqual(initialize.serverInfo, { name: "server", version: "1.0.0" })
         const emitted = yield* Schema.encodeUnknownEffect(McpSchema.InitializeResult)(initialize)
         yield* decode(InitializeResult20250618, emitted)
+      }))
 
-        yield* decode(McpSchema.CreateMessageResult, {
-          role: "assistant",
-          content: { type: "text", text: "compatible" },
-          model: "model"
+    it.effect("decodes implementation, resource, prompt, and tool titles", () =>
+      Effect.gen(function*() {
+        const implementation = yield* decode(McpSchema.Implementation, {
+          name: "server",
+          title: "Example Server",
+          version: "1"
         })
+        const resource = yield* decode(McpSchema.Resource, {
+          uri: "file:///guide",
+          name: "guide",
+          title: "Guide"
+        })
+        const prompt = yield* decode(McpSchema.Prompt, { name: "review", title: "Review" })
+        const tool = yield* decode(McpSchema.Tool, {
+          name: "search",
+          title: "Search",
+          inputSchema: { type: "object" }
+        })
+        assert.strictEqual(implementation.title, "Example Server")
+        assert.strictEqual(resource.title, "Guide")
+        assert.strictEqual(prompt.title, "Review")
+        assert.strictEqual(tool.title, "Search")
+      }))
+
+    it.effect("normalizes omitted tool arguments", () =>
+      Effect.gen(function*() {
+        const call = yield* decode(McpSchema.CallTool.payloadSchema, { name: "status" })
+        assert.deepStrictEqual(call.arguments, {})
+      }))
+
+    it.effect("requires object-root tool input and output schemas", () =>
+      Effect.gen(function*() {
+        yield* decode(McpSchema.Tool, {
+          name: "status",
+          inputSchema: { type: "object", properties: { verbose: { type: "boolean" } } },
+          outputSchema: { type: "object", properties: { status: { type: "string" } } }
+        })
+        yield* assertRejected(McpSchema.Tool, { name: "status", inputSchema: { type: "array" } })
+        yield* assertRejected(McpSchema.Tool, {
+          name: "status",
+          inputSchema: { type: "object" },
+          outputSchema: { type: "string" }
+        })
+      }))
+
+    it.effect("constrains structured tool output to an object", () =>
+      Effect.gen(function*() {
+        yield* decode(McpSchema.CallToolResult, { content: [], structuredContent: { status: "ok" } })
+        yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: [] })
+        yield* assertRejected(McpSchema.CallToolResult, { content: [], structuredContent: null })
+      }))
+
+    it.effect("defaults and preserves completion context", () =>
+      Effect.gen(function*() {
+        const omitted = yield* decode(McpSchema.Complete.payloadSchema, {
+          ref: { type: "ref/prompt", name: "review" },
+          argument: { name: "language", value: "t" }
+        })
+        const explicit = yield* decode(McpSchema.Complete.payloadSchema, {
+          ref: { type: "ref/resource", uri: "file:///{path}" },
+          argument: { name: "path", value: "src" },
+          context: { arguments: { project: "effect" } }
+        })
+        assert.deepStrictEqual(omitted.context, { arguments: {} })
+        assert.deepStrictEqual(explicit.context, { arguments: { project: "effect" } })
+      }))
+
+    it.effect("enforces completion result limits", () =>
+      Effect.gen(function*() {
+        yield* decode(McpSchema.CompleteResult, {
+          _meta: { trace: true },
+          completion: { values: Array.from({ length: 100 }, (_, index) => String(index)), total: 100 }
+        })
+        yield* assertRejected(McpSchema.CompleteResult, {
+          completion: { values: Array.from({ length: 101 }, (_, index) => String(index)) }
+        })
+        yield* assertRejected(McpSchema.CompleteResult, { completion: { values: [], total: 0.5 } })
+      }))
+
+    it.effect("accepts legacy enumNames form elicitation", () =>
+      Effect.gen(function*() {
         yield* decode(McpSchema.Elicit.payloadSchema, {
           message: "Choose",
           requestedSchema: {
@@ -171,9 +309,88 @@ describe("McpSchema", () => {
           }
         })
       }))
+
+    it.effect("rejects nested form elicitation schemas", () =>
+      assertRejected(McpSchema.Elicit.payloadSchema, {
+        message: "Nested",
+        requestedSchema: {
+          type: "object",
+          properties: { nested: { type: "object", properties: {} } }
+        }
+      }))
+
+    it.effect("requires progress values", () =>
+      Effect.gen(function*() {
+        yield* assertRejected(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1 })
+        yield* decode(McpSchema.ProgressNotification.payloadSchema, { progressToken: 1, progress: 0 })
+      }))
   })
 
   describe("shared", () => {
+    it.effect("preserves custom request metadata keys", () =>
+      Effect.gen(function*() {
+        const value = yield* decode(McpSchema.RequestMeta, {
+          _meta: { progressToken: "request", "io.example/trace": { id: 1 } }
+        })
+        assert.deepStrictEqual(value._meta?.["io.example/trace"], { id: 1 })
+      }))
+
+    it.effect("requires integer MCP error codes", () =>
+      Effect.gen(function*() {
+        const error = yield* decode(McpSchema.McpError, { code: -32001, message: "Custom error" })
+        assert.strictEqual(error.code, -32001)
+        yield* assertRejected(McpSchema.McpError, { code: -32001.5, message: "Invalid code" })
+      }))
+
+    it.effect("enforces annotation priority bounds", () =>
+      Effect.gen(function*() {
+        yield* decode(McpSchema.Annotations, { priority: 0 })
+        yield* decode(McpSchema.Annotations, { priority: 1 })
+        yield* assertRejected(McpSchema.Annotations, { priority: -0.01 })
+        yield* assertRejected(McpSchema.Annotations, { priority: 1.01 })
+      }))
+
+    it.effect("enforces model priority bounds", () =>
+      Effect.gen(function*() {
+        yield* decode(McpSchema.ModelPreferences, {
+          costPriority: 0,
+          speedPriority: 0.5,
+          intelligencePriority: 1
+        })
+        yield* assertRejected(McpSchema.ModelPreferences, { costPriority: -0.01 })
+        yield* assertRejected(McpSchema.ModelPreferences, { speedPriority: 1.01 })
+        yield* assertRejected(McpSchema.ModelPreferences, { intelligencePriority: 2 })
+      }))
+
+    it.effect("applies tool annotation defaults", () =>
+      Effect.gen(function*() {
+        const annotations = yield* decode(McpSchema.ToolAnnotations, {})
+        assert.deepStrictEqual(annotations, {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: true
+        })
+      }))
+
+    it.effect("rejects malformed base64 content", () =>
+      Effect.gen(function*() {
+        yield* assertRejected(McpSchema.ImageContent, {
+          type: "image",
+          data: "Zm9vY",
+          mimeType: "image/png"
+        })
+        yield* assertRejected(McpSchema.AudioContent, {
+          type: "audio",
+          data: "Zm9vYmF-",
+          mimeType: "audio/mpeg"
+        })
+        yield* assertRejected(McpSchema.BlobResourceContents, {
+          uri: "file:///blob",
+          blob: "=Zm9vYmF"
+        })
+      }))
+
     it.effect("round trips binary content as base64", () =>
       Effect.gen(function*() {
         const bytes = new Uint8Array([0, 1, 2, 255])
@@ -184,6 +401,8 @@ describe("McpSchema", () => {
             mimeType: "application/octet-stream"
           })
           assert.strictEqual(encoded.data, "AAEC/w==")
+          const decoded = yield* decode(schema, encoded)
+          assert.deepStrictEqual(decoded.data, bytes)
         }
         const encoded = yield* Schema.encodeUnknownEffect(McpSchema.BlobResourceContents)({
           uri: "file:///blob",

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -5,8 +5,6 @@ import type * as Arr from "effect/Array"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as McpServer from "effect/unstable/ai/McpServer"
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
-import * as HttpClient from "effect/unstable/http/HttpClient"
-import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
@@ -69,30 +67,7 @@ const makeTestClient = (
       Effect.provide(clientLayer)
     )
 
-    const httpClient = yield* HttpClient.HttpClient.pipe(
-      Effect.provide(clientLayer)
-    )
-
-    const sendInitialized = () =>
-      Effect.promise(() => {
-        const headers = new Headers({ "content-type": "application/json" })
-        if (sessionId) {
-          headers.set("Mcp-Session-Id", sessionId)
-        }
-        return handler(
-          new Request("http://localhost/mcp", {
-            method: "POST",
-            headers,
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              method: "notifications/initialized",
-              params: {}
-            })
-          })
-        )
-      })
-
-    return { client, responses, httpClient, sendInitialized }
+    return { client, responses }
   })
 
 describe("McpServer", () => {
@@ -223,6 +198,10 @@ describe("McpServer", () => {
           version: "1.0.0"
         }
       })
+      const beforeInitialized = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
+      strictEqual(beforeInitialized._tag, "Failure")
+
+      yield* Effect.ignore(client["notifications/initialized"]({}))
       const result = yield* client["tools/call"]({ name: "session", arguments: {} })
 
       strictEqual(result.content[0]?.type, "text")
@@ -236,7 +215,7 @@ describe("McpServer", () => {
 
   it.effect("accepts duplicate initialized notifications", () =>
     Effect.gen(function*() {
-      const { client, sendInitialized } = yield* makeTestClient()
+      const { client } = yield* makeTestClient()
 
       yield* client.initialize({
         protocolVersion: "2025-11-25",
@@ -246,22 +225,17 @@ describe("McpServer", () => {
           version: "1.0.0"
         }
       })
-      const first = yield* sendInitialized()
-      const second = yield* sendInitialized()
-
-      strictEqual(first.ok, true)
-      strictEqual(second.ok, true)
+      yield* Effect.ignore(client["notifications/initialized"]({}))
+      yield* Effect.ignore(client["notifications/initialized"]({}))
     }))
 
-  it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>
+  it.effect("allows ping but rejects normal requests before initialization", () =>
     Effect.gen(function*() {
-      const { httpClient } = yield* makeTestClient()
+      const { client } = yield* makeTestClient()
 
-      const response = yield* HttpClientRequest.post("http://locahost/mcp").pipe(
-        HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", method: "ping", params: {}, id: 0 }),
-        httpClient.execute
-      )
+      yield* client.ping({})
+      const exit = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
 
-      strictEqual(response.status, 404)
+      strictEqual(exit._tag, "Failure")
     }))
 })

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
 import { Effect, Layer } from "effect"
+import type * as Arr from "effect/Array"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as McpServer from "effect/unstable/ai/McpServer"
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
@@ -10,43 +11,47 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 
-const makeTestClient = Effect.gen(function*() {
-  const responses: Array<Response> = []
+const makeTestClient = (
+  supportedProtocolVersions: Arr.NonEmptyReadonlyArray<McpServer.ProtocolVersion> = McpServer.supportedProtocolVersions
+) =>
+  Effect.gen(function*() {
+    const responses: Array<Response> = []
 
-  const serverLayer = McpServer.layerHttp({
-    name: "TestServer",
-    version: "1.0.0",
-    path: "/mcp"
-  })
-  const { handler, dispose } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
-  yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
+    const serverLayer = McpServer.layerHttp({
+      name: "TestServer",
+      version: "1.0.0",
+      path: "/mcp",
+      supportedProtocolVersions
+    })
+    const { handler, dispose } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
+    yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
 
-  let sessionId: string | null = null
-  const customFetch: typeof fetch = async (input, init) => {
-    const request = input instanceof Request ? input : new Request(input, init)
-    if (sessionId) {
-      request.headers.set("Mcp-Session-Id", sessionId)
+    let sessionId: string | null = null
+    const customFetch: typeof fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (sessionId) {
+        request.headers.set("Mcp-Session-Id", sessionId)
+      }
+      const response = await handler(request)
+      sessionId = response.headers.get("Mcp-Session-Id")
+      responses.push(response.clone())
+      return response
     }
-    const response = await handler(request)
-    sessionId = response.headers.get("Mcp-Session-Id")
-    responses.push(response.clone())
-    return response
-  }
 
-  const clientLayer = RpcClient.layerProtocolHttp({ url: "http://localhost/mcp" }).pipe(
-    Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
-    Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch))
-  )
-  const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(
-    Effect.provide(clientLayer)
-  )
+    const clientLayer = RpcClient.layerProtocolHttp({ url: "http://localhost/mcp" }).pipe(
+      Layer.provideMerge([FetchHttpClient.layer, RpcSerialization.layerJsonRpc()]),
+      Layer.provide(Layer.succeed(FetchHttpClient.Fetch, customFetch))
+    )
+    const client = yield* RpcClient.make(McpSchema.ClientRpcs).pipe(
+      Effect.provide(clientLayer)
+    )
 
-  const httpClient = yield* HttpClient.HttpClient.pipe(
-    Effect.provide(clientLayer)
-  )
+    const httpClient = yield* HttpClient.HttpClient.pipe(
+      Effect.provide(clientLayer)
+    )
 
-  return { client, responses, httpClient }
-})
+    return { client, responses, httpClient }
+  })
 
 describe("McpServer", () => {
   it("exposes supported protocol versions from latest to oldest", () => {
@@ -59,7 +64,7 @@ describe("McpServer", () => {
   it.effect("echoes supported protocol versions during initialization", () =>
     Effect.gen(function*() {
       for (const protocolVersion of McpServer.supportedProtocolVersions) {
-        const { client } = yield* makeTestClient
+        const { client } = yield* makeTestClient()
 
         const result = yield* client.initialize({
           protocolVersion,
@@ -76,7 +81,7 @@ describe("McpServer", () => {
 
   it.effect("falls back to the latest protocol version for unsupported offers", () =>
     Effect.gen(function*() {
-      const { client, responses } = yield* makeTestClient
+      const { client, responses } = yield* makeTestClient()
 
       const result = yield* client.initialize({
         protocolVersion: "9999-01-01",
@@ -96,7 +101,7 @@ describe("McpServer", () => {
 
   it.effect("falls back to the latest protocol version for malformed offers", () =>
     Effect.gen(function*() {
-      const { client } = yield* makeTestClient
+      const { client } = yield* makeTestClient()
 
       const result = yield* client.initialize({
         protocolVersion: "not-a-version",
@@ -110,9 +115,66 @@ describe("McpServer", () => {
       strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
     }))
 
+  it.effect("uses each server's configured protocol version preference", () =>
+    Effect.gen(function*() {
+      const preferredLegacy = yield* makeTestClient(["2025-06-18", "2025-11-25"])
+      const latestOnly = yield* makeTestClient(["2025-11-25"])
+      const initialize = {
+        protocolVersion: "9999-01-01",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      }
+
+      const legacyResult = yield* preferredLegacy.client.initialize(initialize)
+      const latestResult = yield* latestOnly.client.initialize(initialize)
+
+      strictEqual(legacyResult.protocolVersion, "2025-06-18")
+      strictEqual(latestResult.protocolVersion, "2025-11-25")
+    }))
+
+  it.effect("deduplicates configured protocol versions", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient(["2025-11-25", "2025-11-25", "2025-06-18"])
+
+      const result = yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+
+      strictEqual(result.protocolVersion, "2025-06-18")
+    }))
+
+  it.effect("snapshots configured protocol versions at server startup", () =>
+    Effect.gen(function*() {
+      const versions: [McpServer.ProtocolVersion, ...Array<McpServer.ProtocolVersion>] = ["2025-11-25"]
+      const { client } = yield* makeTestClient(versions)
+      const initialize = {
+        protocolVersion: "9999-01-01",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      }
+
+      const first = yield* client.initialize(initialize)
+      versions[0] = "2025-06-18"
+      const second = yield* client.initialize(initialize)
+
+      strictEqual(first.protocolVersion, "2025-11-25")
+      strictEqual(second.protocolVersion, "2025-11-25")
+    }))
+
   it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>
     Effect.gen(function*() {
-      const { httpClient } = yield* makeTestClient
+      const { httpClient } = yield* makeTestClient()
 
       const response = yield* HttpClientRequest.post("http://locahost/mcp").pipe(
         HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", method: "ping", params: {}, id: 0 }),

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
-import { Effect, Layer } from "effect"
+import { Context, Effect, Layer } from "effect"
 import type * as Arr from "effect/Array"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as McpServer from "effect/unstable/ai/McpServer"
@@ -17,12 +17,35 @@ const makeTestClient = (
   Effect.gen(function*() {
     const responses: Array<Response> = []
 
-    const serverLayer = McpServer.layerHttp({
+    const protocolLayer = McpServer.layerHttp({
       name: "TestServer",
       version: "1.0.0",
       path: "/mcp",
       supportedProtocolVersions
     })
+    const serverLayer = Layer.effectDiscard(Effect.gen(function*() {
+      const server = yield* McpServer.McpServer
+      yield* server.addTool({
+        tool: new McpSchema.Tool({
+          name: "session",
+          inputSchema: { type: "object" }
+        }),
+        annotations: Context.empty(),
+        handle: () =>
+          Effect.gen(function*() {
+            const client = yield* McpSchema.McpServerClient
+            return new McpSchema.CallToolResult({
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  requested: client.initializePayload.protocolVersion,
+                  negotiated: client.protocolVersion
+                })
+              }]
+            })
+          })
+      })
+    })).pipe(Layer.provideMerge(protocolLayer))
     const { handler, dispose } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
     yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
 
@@ -33,7 +56,7 @@ const makeTestClient = (
         request.headers.set("Mcp-Session-Id", sessionId)
       }
       const response = await handler(request)
-      sessionId = response.headers.get("Mcp-Session-Id")
+      sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
       responses.push(response.clone())
       return response
     }
@@ -50,7 +73,26 @@ const makeTestClient = (
       Effect.provide(clientLayer)
     )
 
-    return { client, responses, httpClient }
+    const sendInitialized = () =>
+      Effect.promise(() => {
+        const headers = new Headers({ "content-type": "application/json" })
+        if (sessionId) {
+          headers.set("Mcp-Session-Id", sessionId)
+        }
+        return handler(
+          new Request("http://localhost/mcp", {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              method: "notifications/initialized",
+              params: {}
+            })
+          })
+        )
+      })
+
+    return { client, responses, httpClient, sendInitialized }
   })
 
 describe("McpServer", () => {
@@ -151,12 +193,11 @@ describe("McpServer", () => {
       strictEqual(result.protocolVersion, "2025-06-18")
     }))
 
-  it.effect("snapshots configured protocol versions at server startup", () =>
+  it.effect("rejects reinitializing an existing HTTP session", () =>
     Effect.gen(function*() {
-      const versions: [McpServer.ProtocolVersion, ...Array<McpServer.ProtocolVersion>] = ["2025-11-25"]
-      const { client } = yield* makeTestClient(versions)
+      const { client } = yield* makeTestClient()
       const initialize = {
-        protocolVersion: "9999-01-01",
+        protocolVersion: "2025-11-25",
         capabilities: {},
         clientInfo: {
           name: "TestClient",
@@ -164,12 +205,52 @@ describe("McpServer", () => {
         }
       }
 
-      const first = yield* client.initialize(initialize)
-      versions[0] = "2025-06-18"
-      const second = yield* client.initialize(initialize)
+      yield* client.initialize(initialize)
+      const exit = yield* Effect.exit(client.initialize(initialize))
 
-      strictEqual(first.protocolVersion, "2025-11-25")
-      strictEqual(second.protocolVersion, "2025-11-25")
+      strictEqual(exit._tag, "Failure")
+    }))
+
+  it.effect("preserves the requested version separately from the negotiated version", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient()
+
+      yield* client.initialize({
+        protocolVersion: "9999-01-01",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+      const result = yield* client["tools/call"]({ name: "session", arguments: {} })
+
+      strictEqual(result.content[0]?.type, "text")
+      if (result.content[0]?.type === "text") {
+        strictEqual(
+          result.content[0].text,
+          JSON.stringify({ requested: "9999-01-01", negotiated: McpServer.latestProtocolVersion })
+        )
+      }
+    }))
+
+  it.effect("accepts duplicate initialized notifications", () =>
+    Effect.gen(function*() {
+      const { client, sendInitialized } = yield* makeTestClient()
+
+      yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+      const first = yield* sendInitialized()
+      const second = yield* sendInitialized()
+
+      strictEqual(first.ok, true)
+      strictEqual(second.ok, true)
     }))
 
   it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -67,7 +67,21 @@ const makeTestClient = (
       Effect.provide(clientLayer)
     )
 
-    return { client, responses }
+    const request = (body: unknown, headers?: globalThis.HeadersInit) =>
+      Effect.promise(() =>
+        handler(
+          new Request("http://localhost/mcp", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...headers
+            },
+            body: JSON.stringify(body)
+          })
+        )
+      )
+
+    return { client, request, responses }
   })
 
 describe("McpServer", () => {
@@ -237,5 +251,33 @@ describe("McpServer", () => {
       const exit = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
 
       strictEqual(exit._tag, "Failure")
+    }))
+
+  it.effect("returns 400 when a normal HTTP request omits the session id", () =>
+    Effect.gen(function*() {
+      const { request } = yield* makeTestClient()
+
+      const response = yield* request({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "session", arguments: {} }
+      })
+
+      strictEqual(response.status, 400)
+    }))
+
+  it.effect("returns 404 when an HTTP request supplies an unknown session id", () =>
+    Effect.gen(function*() {
+      const { request } = yield* makeTestClient()
+
+      const response = yield* request({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "session", arguments: {} }
+      }, { "Mcp-Session-Id": "unknown" })
+
+      strictEqual(response.status, 404)
     }))
 })

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -85,21 +85,59 @@ const makeTestClient = (
     return { client, getSessionId: () => sessionId, request, responses }
   })
 
-describe("McpServer", () => {
-  it("exposes supported protocol versions from latest to oldest", () => {
-    strictEqual(McpServer.supportedProtocolVersions.length, 2)
-    strictEqual(McpServer.supportedProtocolVersions[0], "2025-11-25")
-    strictEqual(McpServer.supportedProtocolVersions[1], "2025-06-18")
-    strictEqual(McpServer.latestProtocolVersion, McpServer.supportedProtocolVersions[0])
-  })
-
-  it.effect("echoes supported protocol versions during initialization", () =>
+const exactVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
+  it.effect("echoes the supported protocol version during initialization", () =>
     Effect.gen(function*() {
-      for (const protocolVersion of McpServer.supportedProtocolVersions) {
-        const { client } = yield* makeTestClient()
+      const { client } = yield* makeTestClient()
+
+      const result = yield* client.initialize({
+        protocolVersion,
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+
+      strictEqual(result.protocolVersion, protocolVersion)
+    }))
+}
+
+describe("McpServer", () => {
+  describe("configuration", () => {
+    it("exposes supported protocol versions from latest to oldest", () => {
+      strictEqual(McpServer.supportedProtocolVersions.length, 2)
+      strictEqual(McpServer.supportedProtocolVersions[0], "2025-11-25")
+      strictEqual(McpServer.supportedProtocolVersions[1], "2025-06-18")
+      strictEqual(McpServer.latestProtocolVersion, McpServer.supportedProtocolVersions[0])
+    })
+
+    it.effect("uses each server's configured protocol version preference", () =>
+      Effect.gen(function*() {
+        const preferredLegacy = yield* makeTestClient(["2025-06-18", "2025-11-25"])
+        const latestOnly = yield* makeTestClient(["2025-11-25"])
+        const initialize = {
+          protocolVersion: "9999-01-01",
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        }
+
+        const legacyResult = yield* preferredLegacy.client.initialize(initialize)
+        const latestResult = yield* latestOnly.client.initialize(initialize)
+
+        strictEqual(legacyResult.protocolVersion, "2025-06-18")
+        strictEqual(latestResult.protocolVersion, "2025-11-25")
+      }))
+
+    it.effect("deduplicates configured protocol versions", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient(["2025-11-25", "2025-11-25", "2025-06-18"])
 
         const result = yield* client.initialize({
-          protocolVersion,
+          protocolVersion: "2025-06-18",
           capabilities: {},
           clientInfo: {
             name: "TestClient",
@@ -107,298 +145,272 @@ describe("McpServer", () => {
           }
         })
 
-        strictEqual(result.protocolVersion, protocolVersion)
-      }
-    }))
+        strictEqual(result.protocolVersion, "2025-06-18")
+      }))
+  })
 
-  it.effect("does not advertise HTTP list-change notifications without an SSE stream", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
+  describe("2025-06-18", () => {
+    exactVersionSuite("2025-06-18")
+  })
 
-      const result = yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
+  describe("2025-11-25", () => {
+    exactVersionSuite("2025-11-25")
 
-      strictEqual(result.capabilities.tools?.listChanged, undefined)
-    }))
+    it.effect("does not advertise HTTP list-change notifications without an SSE stream", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient()
 
-  it.effect("falls back to the latest protocol version for unsupported offers", () =>
-    Effect.gen(function*() {
-      const { client, responses } = yield* makeTestClient()
+        const result = yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
 
-      const result = yield* client.initialize({
-        protocolVersion: "9999-01-01",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
+        strictEqual(result.capabilities.tools?.listChanged, undefined)
+      }))
+
+    it.effect("falls back to the latest protocol version for unsupported offers", () =>
+      Effect.gen(function*() {
+        const { client, responses } = yield* makeTestClient()
+
+        const result = yield* client.initialize({
+          protocolVersion: "9999-01-01",
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        })
+
+        yield* client.ping({})
+
+        strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
+        strictEqual(responses.length, 2)
+        strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), McpServer.latestProtocolVersion)
+      }))
+
+    it.effect("returns initialization session and protocol headers", () =>
+      Effect.gen(function*() {
+        const { client, responses } = yield* makeTestClient()
+
+        const result = yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
+
+        strictEqual(result.protocolVersion, "2025-11-25")
+        strictEqual(responses.length, 1)
+        strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-11-25")
+        strictEqual(typeof responses[0].headers.get("Mcp-Session-Id"), "string")
+      }))
+
+    it.effect("falls back to the latest protocol version for malformed offers", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient()
+
+        const result = yield* client.initialize({
+          protocolVersion: "not-a-version",
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        })
+
+        strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
+      }))
+
+    it.effect("rejects reinitializing an existing HTTP session", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient()
+        const initialize = {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
         }
-      })
 
-      yield* client.ping({})
+        yield* client.initialize(initialize)
+        const exit = yield* Effect.exit(client.initialize(initialize))
 
-      strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
-      strictEqual(responses.length, 2)
-      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), McpServer.latestProtocolVersion)
-    }))
+        strictEqual(exit._tag, "Failure")
+      }))
 
-  it.effect("returns initialization session and protocol headers", () =>
-    Effect.gen(function*() {
-      const { client, responses } = yield* makeTestClient()
+    it.effect("preserves the requested version separately from the negotiated version", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient()
 
-      const result = yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
+        yield* client.initialize({
+          protocolVersion: "9999-01-01",
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        })
+        const beforeInitialized = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
+        strictEqual(beforeInitialized._tag, "Failure")
 
-      strictEqual(result.protocolVersion, "2025-11-25")
-      strictEqual(responses.length, 1)
-      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-11-25")
-      strictEqual(typeof responses[0].headers.get("Mcp-Session-Id"), "string")
-    }))
+        yield* Effect.ignore(client["notifications/initialized"]({}))
+        const result = yield* client["tools/call"]({ name: "session", arguments: {} })
 
-  it.effect("falls back to the latest protocol version for malformed offers", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
-
-      const result = yield* client.initialize({
-        protocolVersion: "not-a-version",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
+        strictEqual(result.content[0]?.type, "text")
+        if (result.content[0]?.type === "text") {
+          strictEqual(
+            result.content[0].text,
+            JSON.stringify({
+              notifications: false,
+              requested: "9999-01-01",
+              negotiated: McpServer.latestProtocolVersion
+            })
+          )
         }
-      })
+      }))
 
-      strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
-    }))
+    it.effect("accepts duplicate initialized notifications", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient()
 
-  it.effect("uses each server's configured protocol version preference", () =>
-    Effect.gen(function*() {
-      const preferredLegacy = yield* makeTestClient(["2025-06-18", "2025-11-25"])
-      const latestOnly = yield* makeTestClient(["2025-11-25"])
-      const initialize = {
-        protocolVersion: "9999-01-01",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
-        }
-      }
+        yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        })
+        yield* Effect.ignore(client["notifications/initialized"]({}))
+        yield* Effect.ignore(client["notifications/initialized"]({}))
+      }))
 
-      const legacyResult = yield* preferredLegacy.client.initialize(initialize)
-      const latestResult = yield* latestOnly.client.initialize(initialize)
+    it.effect("accepts the negotiated protocol version header", () =>
+      Effect.gen(function*() {
+        const { client, getSessionId, request } = yield* makeTestClient()
+        yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
 
-      strictEqual(legacyResult.protocolVersion, "2025-06-18")
-      strictEqual(latestResult.protocolVersion, "2025-11-25")
-    }))
+        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+          "Mcp-Session-Id": getSessionId() ?? "",
+          "Mcp-Protocol-Version": "2025-11-25"
+        })
 
-  it.effect("deduplicates configured protocol versions", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient(["2025-11-25", "2025-11-25", "2025-06-18"])
+        strictEqual(response.status, 200)
+        strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+      }))
 
-      const result = yield* client.initialize({
-        protocolVersion: "2025-06-18",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
-        }
-      })
+    it.effect("returns 400 for an unsupported protocol version header", () =>
+      Effect.gen(function*() {
+        const { client, getSessionId, request } = yield* makeTestClient()
+        yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
 
-      strictEqual(result.protocolVersion, "2025-06-18")
-    }))
+        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+          "Mcp-Session-Id": getSessionId() ?? "",
+          "Mcp-Protocol-Version": "not-a-version"
+        })
 
-  it.effect("rejects reinitializing an existing HTTP session", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
-      const initialize = {
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
-        }
-      }
+        strictEqual(response.status, 400)
+      }))
 
-      yield* client.initialize(initialize)
-      const exit = yield* Effect.exit(client.initialize(initialize))
+    it.effect("returns 400 when the protocol version differs from the session", () =>
+      Effect.gen(function*() {
+        const { client, getSessionId, request } = yield* makeTestClient()
+        yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
 
-      strictEqual(exit._tag, "Failure")
-    }))
+        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+          "Mcp-Session-Id": getSessionId() ?? "",
+          "Mcp-Protocol-Version": "2025-06-18"
+        })
 
-  it.effect("preserves the requested version separately from the negotiated version", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
+        strictEqual(response.status, 400)
+      }))
 
-      yield* client.initialize({
-        protocolVersion: "9999-01-01",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
-        }
-      })
-      const beforeInitialized = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
-      strictEqual(beforeInitialized._tag, "Failure")
+    it.effect("uses the session version when the protocol header is omitted", () =>
+      Effect.gen(function*() {
+        const { client, getSessionId, request } = yield* makeTestClient()
+        yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
 
-      yield* Effect.ignore(client["notifications/initialized"]({}))
-      const result = yield* client["tools/call"]({ name: "session", arguments: {} })
+        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+          "Mcp-Session-Id": getSessionId() ?? ""
+        })
 
-      strictEqual(result.content[0]?.type, "text")
-      if (result.content[0]?.type === "text") {
-        strictEqual(
-          result.content[0].text,
-          JSON.stringify({
-            notifications: false,
-            requested: "9999-01-01",
-            negotiated: McpServer.latestProtocolVersion
-          })
-        )
-      }
-    }))
+        strictEqual(response.status, 200)
+        strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+      }))
 
-  it.effect("accepts duplicate initialized notifications", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
+    it.effect("returns 202 for accepted initialized notifications", () =>
+      Effect.gen(function*() {
+        const { client, getSessionId, request } = yield* makeTestClient()
+        yield* client.initialize({
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "TestClient", version: "1.0.0" }
+        })
 
-      yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
-        }
-      })
-      yield* Effect.ignore(client["notifications/initialized"]({}))
-      yield* Effect.ignore(client["notifications/initialized"]({}))
-    }))
+        const response = yield* request({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {}
+        }, { "Mcp-Session-Id": getSessionId() ?? "" })
 
-  it.effect("allows ping but rejects normal requests before initialization", () =>
-    Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
+        strictEqual(response.status, 202)
+      }))
+  })
 
-      yield* client.ping({})
-      const exit = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
+  describe("shared", () => {
+    it.effect("allows ping but rejects normal requests before initialization", () =>
+      Effect.gen(function*() {
+        const { client } = yield* makeTestClient()
 
-      strictEqual(exit._tag, "Failure")
-    }))
+        yield* client.ping({})
+        const exit = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
 
-  it.effect("returns 400 when a normal HTTP request omits the session id", () =>
-    Effect.gen(function*() {
-      const { request } = yield* makeTestClient()
+        strictEqual(exit._tag, "Failure")
+      }))
 
-      const response = yield* request({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: { name: "session", arguments: {} }
-      })
+    it.effect("returns 400 when a normal HTTP request omits the session id", () =>
+      Effect.gen(function*() {
+        const { request } = yield* makeTestClient()
 
-      strictEqual(response.status, 400)
-    }))
+        const response = yield* request({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "session", arguments: {} }
+        })
 
-  it.effect("returns 404 when an HTTP request supplies an unknown session id", () =>
-    Effect.gen(function*() {
-      const { request } = yield* makeTestClient()
+        strictEqual(response.status, 400)
+      }))
 
-      const response = yield* request({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "tools/call",
-        params: { name: "session", arguments: {} }
-      }, { "Mcp-Session-Id": "unknown" })
+    it.effect("returns 404 when an HTTP request supplies an unknown session id", () =>
+      Effect.gen(function*() {
+        const { request } = yield* makeTestClient()
 
-      strictEqual(response.status, 404)
-    }))
+        const response = yield* request({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "session", arguments: {} }
+        }, { "Mcp-Session-Id": "unknown" })
 
-  it.effect("accepts the negotiated protocol version header", () =>
-    Effect.gen(function*() {
-      const { client, getSessionId, request } = yield* makeTestClient()
-      yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
-
-      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-        "Mcp-Session-Id": getSessionId() ?? "",
-        "Mcp-Protocol-Version": "2025-11-25"
-      })
-
-      strictEqual(response.status, 200)
-      strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
-    }))
-
-  it.effect("returns 400 for an unsupported protocol version header", () =>
-    Effect.gen(function*() {
-      const { client, getSessionId, request } = yield* makeTestClient()
-      yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
-
-      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-        "Mcp-Session-Id": getSessionId() ?? "",
-        "Mcp-Protocol-Version": "not-a-version"
-      })
-
-      strictEqual(response.status, 400)
-    }))
-
-  it.effect("returns 400 when the protocol version differs from the session", () =>
-    Effect.gen(function*() {
-      const { client, getSessionId, request } = yield* makeTestClient()
-      yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
-
-      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-        "Mcp-Session-Id": getSessionId() ?? "",
-        "Mcp-Protocol-Version": "2025-06-18"
-      })
-
-      strictEqual(response.status, 400)
-    }))
-
-  it.effect("uses the session version when the protocol header is omitted", () =>
-    Effect.gen(function*() {
-      const { client, getSessionId, request } = yield* makeTestClient()
-      yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
-
-      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-        "Mcp-Session-Id": getSessionId() ?? ""
-      })
-
-      strictEqual(response.status, 200)
-      strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
-    }))
-
-  it.effect("returns 202 for accepted initialized notifications", () =>
-    Effect.gen(function*() {
-      const { client, getSessionId, request } = yield* makeTestClient()
-      yield* client.initialize({
-        protocolVersion: "2025-11-25",
-        capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
-      })
-
-      const response = yield* request({
-        jsonrpc: "2.0",
-        method: "notifications/initialized",
-        params: {}
-      }, { "Mcp-Session-Id": getSessionId() ?? "" })
-
-      strictEqual(response.status, 202)
-    }))
+        strictEqual(response.status, 404)
+      }))
+  })
 })

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -36,6 +36,7 @@ const makeTestClient = (
               content: [{
                 type: "text",
                 text: JSON.stringify({
+                  notifications: server.initializedClients.has(client.clientId),
                   requested: client.initializePayload.protocolVersion,
                   negotiated: client.protocolVersion
                 })
@@ -108,6 +109,19 @@ describe("McpServer", () => {
 
         strictEqual(result.protocolVersion, protocolVersion)
       }
+    }))
+
+  it.effect("does not advertise HTTP list-change notifications without an SSE stream", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient()
+
+      const result = yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      strictEqual(result.capabilities.tools?.listChanged, undefined)
     }))
 
   it.effect("falls back to the latest protocol version for unsupported offers", () =>
@@ -222,7 +236,11 @@ describe("McpServer", () => {
       if (result.content[0]?.type === "text") {
         strictEqual(
           result.content[0].text,
-          JSON.stringify({ requested: "9999-01-01", negotiated: McpServer.latestProtocolVersion })
+          JSON.stringify({
+            notifications: false,
+            requested: "9999-01-01",
+            negotiated: McpServer.latestProtocolVersion
+          })
         )
       }
     }))

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -144,6 +144,22 @@ describe("McpServer", () => {
       strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), McpServer.latestProtocolVersion)
     }))
 
+  it.effect("returns initialization session and protocol headers", () =>
+    Effect.gen(function*() {
+      const { client, responses } = yield* makeTestClient()
+
+      const result = yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      strictEqual(result.protocolVersion, "2025-11-25")
+      strictEqual(responses.length, 1)
+      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-11-25")
+      strictEqual(typeof responses[0].headers.get("Mcp-Session-Id"), "string")
+    }))
+
   it.effect("falls back to the latest protocol version for malformed offers", () =>
     Effect.gen(function*() {
       const { client } = yield* makeTestClient()
@@ -349,5 +365,40 @@ describe("McpServer", () => {
       })
 
       strictEqual(response.status, 400)
+    }))
+
+  it.effect("uses the session version when the protocol header is omitted", () =>
+    Effect.gen(function*() {
+      const { client, getSessionId, request } = yield* makeTestClient()
+      yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+        "Mcp-Session-Id": getSessionId() ?? ""
+      })
+
+      strictEqual(response.status, 200)
+      strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+    }))
+
+  it.effect("returns 202 for accepted initialized notifications", () =>
+    Effect.gen(function*() {
+      const { client, getSessionId, request } = yield* makeTestClient()
+      yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const response = yield* request({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {}
+      }, { "Mcp-Session-Id": getSessionId() ?? "" })
+
+      strictEqual(response.status, 202)
     }))
 })

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -9,9 +9,22 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 
-const makeTestClient = (
-  supportedProtocolVersions: Arr.NonEmptyReadonlyArray<McpServer.ProtocolVersion> = McpServer.supportedProtocolVersions
-) =>
+interface MakeTestClientOptions {
+  readonly supportedProtocolVersions?: Arr.NonEmptyReadonlyArray<McpServer.ProtocolVersion>
+}
+
+interface RawRequestOptions {
+  readonly body: unknown
+  readonly sessionId?: string
+  readonly protocolVersion?: string
+}
+
+interface OperationalRequestOptions {
+  readonly body: unknown
+  readonly protocolVersion?: string
+}
+
+const makeTestClient = (options: MakeTestClientOptions = {}) =>
   Effect.gen(function*() {
     const responses: Array<Response> = []
 
@@ -19,7 +32,7 @@ const makeTestClient = (
       name: "TestServer",
       version: "1.0.0",
       path: "/mcp",
-      supportedProtocolVersions
+      supportedProtocolVersions: options.supportedProtocolVersions ?? McpServer.supportedProtocolVersions
     })
     const serverLayer = Layer.effectDiscard(Effect.gen(function*() {
       const server = yield* McpServer.McpServer
@@ -68,38 +81,148 @@ const makeTestClient = (
       Effect.provide(clientLayer)
     )
 
-    const request = (body: unknown, headers?: globalThis.HeadersInit) =>
-      Effect.promise(() =>
+    const initialize = (protocolVersion: string) =>
+      client.initialize({
+        protocolVersion,
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+    const rawRequest = ({ body, protocolVersion, sessionId }: RawRequestOptions) => {
+      const headers = new Headers({ "content-type": "application/json" })
+      if (sessionId !== undefined) {
+        headers.set("Mcp-Session-Id", sessionId)
+      }
+      if (protocolVersion !== undefined) {
+        headers.set("Mcp-Protocol-Version", protocolVersion)
+      }
+      return Effect.promise(() =>
         handler(
           new Request("http://localhost/mcp", {
             method: "POST",
-            headers: {
-              "content-type": "application/json",
-              ...headers
-            },
+            headers,
             body: JSON.stringify(body)
           })
         )
       )
+    }
 
-    return { client, getSessionId: () => sessionId, request, responses }
+    const operationalRequest = ({ body, protocolVersion }: OperationalRequestOptions) =>
+      rawRequest({
+        body,
+        sessionId: sessionId ?? undefined,
+        protocolVersion
+      })
+
+    return { client, initialize, operationalRequest, rawRequest, responses }
   })
 
-const exactVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
+const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
   it.effect("echoes the supported protocol version during initialization", () =>
     Effect.gen(function*() {
-      const { client } = yield* makeTestClient()
+      const { initialize } = yield* makeTestClient()
 
-      const result = yield* client.initialize({
-        protocolVersion,
-        capabilities: {},
-        clientInfo: {
-          name: "TestClient",
-          version: "1.0.0"
+      const result = yield* initialize(protocolVersion)
+
+      strictEqual(result.protocolVersion, protocolVersion)
+    }))
+
+  it.effect("returns initialization session and protocol headers", () =>
+    Effect.gen(function*() {
+      const { initialize, responses } = yield* makeTestClient()
+
+      const result = yield* initialize(protocolVersion)
+
+      strictEqual(result.protocolVersion, protocolVersion)
+      strictEqual(responses.length, 1)
+      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), protocolVersion)
+      strictEqual(typeof responses[0].headers.get("Mcp-Session-Id"), "string")
+    }))
+
+  it.effect("rejects reinitializing an existing HTTP session", () =>
+    Effect.gen(function*() {
+      const { initialize } = yield* makeTestClient()
+
+      yield* initialize(protocolVersion)
+      const exit = yield* Effect.exit(initialize(protocolVersion))
+
+      strictEqual(exit._tag, "Failure")
+    }))
+
+  it.effect("preserves the requested version separately from the negotiated version", () =>
+    Effect.gen(function*() {
+      const { client, initialize } = yield* makeTestClient({ supportedProtocolVersions: [protocolVersion] })
+
+      yield* initialize("9999-01-01")
+      const beforeInitialized = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
+      strictEqual(beforeInitialized._tag, "Failure")
+
+      yield* Effect.ignore(client["notifications/initialized"]({}))
+      const result = yield* client["tools/call"]({ name: "session", arguments: {} })
+
+      strictEqual(result.content[0]?.type, "text")
+      if (result.content[0]?.type === "text") {
+        strictEqual(
+          result.content[0].text,
+          JSON.stringify({
+            notifications: false,
+            requested: "9999-01-01",
+            negotiated: protocolVersion
+          })
+        )
+      }
+    }))
+
+  it.effect("accepts duplicate initialized notifications", () =>
+    Effect.gen(function*() {
+      const { client, initialize } = yield* makeTestClient()
+
+      yield* initialize(protocolVersion)
+      yield* Effect.ignore(client["notifications/initialized"]({}))
+      yield* Effect.ignore(client["notifications/initialized"]({}))
+    }))
+
+  it.effect("accepts the negotiated protocol version header", () =>
+    Effect.gen(function*() {
+      const { initialize, operationalRequest } = yield* makeTestClient()
+      yield* initialize(protocolVersion)
+
+      const response = yield* operationalRequest({
+        body: { jsonrpc: "2.0", id: 1, method: "ping", params: {} },
+        protocolVersion
+      })
+
+      strictEqual(response.status, 200)
+      strictEqual(response.headers.get("Mcp-Protocol-Version"), protocolVersion)
+    }))
+
+  it.effect("uses the session version when the protocol header is omitted", () =>
+    Effect.gen(function*() {
+      const { initialize, operationalRequest } = yield* makeTestClient()
+      yield* initialize(protocolVersion)
+
+      const response = yield* operationalRequest({
+        body: { jsonrpc: "2.0", id: 1, method: "ping", params: {} }
+      })
+
+      strictEqual(response.status, 200)
+      strictEqual(response.headers.get("Mcp-Protocol-Version"), protocolVersion)
+    }))
+
+  it.effect("returns 202 for accepted initialized notifications", () =>
+    Effect.gen(function*() {
+      const { initialize, operationalRequest } = yield* makeTestClient()
+      yield* initialize(protocolVersion)
+
+      const response = yield* operationalRequest({
+        body: {
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {}
         }
       })
 
-      strictEqual(result.protocolVersion, protocolVersion)
+      strictEqual(response.status, 202)
     }))
 }
 
@@ -114,8 +237,10 @@ describe("McpServer", () => {
 
     it.effect("uses each server's configured protocol version preference", () =>
       Effect.gen(function*() {
-        const preferredLegacy = yield* makeTestClient(["2025-06-18", "2025-11-25"])
-        const latestOnly = yield* makeTestClient(["2025-11-25"])
+        const preferredLegacy = yield* makeTestClient({
+          supportedProtocolVersions: ["2025-06-18", "2025-11-25"]
+        })
+        const latestOnly = yield* makeTestClient({ supportedProtocolVersions: ["2025-11-25"] })
         const initialize = {
           protocolVersion: "9999-01-01",
           capabilities: {},
@@ -134,7 +259,9 @@ describe("McpServer", () => {
 
     it.effect("deduplicates configured protocol versions", () =>
       Effect.gen(function*() {
-        const { client } = yield* makeTestClient(["2025-11-25", "2025-11-25", "2025-06-18"])
+        const { client } = yield* makeTestClient({
+          supportedProtocolVersions: ["2025-11-25", "2025-11-25", "2025-06-18"]
+        })
 
         const result = yield* client.initialize({
           protocolVersion: "2025-06-18",
@@ -150,11 +277,11 @@ describe("McpServer", () => {
   })
 
   describe("2025-06-18", () => {
-    exactVersionSuite("2025-06-18")
+    protocolVersionSuite("2025-06-18")
   })
 
   describe("2025-11-25", () => {
-    exactVersionSuite("2025-11-25")
+    protocolVersionSuite("2025-11-25")
 
     it.effect("does not advertise HTTP list-change notifications without an SSE stream", () =>
       Effect.gen(function*() {
@@ -189,22 +316,6 @@ describe("McpServer", () => {
         strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), McpServer.latestProtocolVersion)
       }))
 
-    it.effect("returns initialization session and protocol headers", () =>
-      Effect.gen(function*() {
-        const { client, responses } = yield* makeTestClient()
-
-        const result = yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "TestClient", version: "1.0.0" }
-        })
-
-        strictEqual(result.protocolVersion, "2025-11-25")
-        strictEqual(responses.length, 1)
-        strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-11-25")
-        strictEqual(typeof responses[0].headers.get("Mcp-Session-Id"), "string")
-      }))
-
     it.effect("falls back to the latest protocol version for malformed offers", () =>
       Effect.gen(function*() {
         const { client } = yield* makeTestClient()
@@ -221,101 +332,14 @@ describe("McpServer", () => {
         strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
       }))
 
-    it.effect("rejects reinitializing an existing HTTP session", () =>
-      Effect.gen(function*() {
-        const { client } = yield* makeTestClient()
-        const initialize = {
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: {
-            name: "TestClient",
-            version: "1.0.0"
-          }
-        }
-
-        yield* client.initialize(initialize)
-        const exit = yield* Effect.exit(client.initialize(initialize))
-
-        strictEqual(exit._tag, "Failure")
-      }))
-
-    it.effect("preserves the requested version separately from the negotiated version", () =>
-      Effect.gen(function*() {
-        const { client } = yield* makeTestClient()
-
-        yield* client.initialize({
-          protocolVersion: "9999-01-01",
-          capabilities: {},
-          clientInfo: {
-            name: "TestClient",
-            version: "1.0.0"
-          }
-        })
-        const beforeInitialized = yield* Effect.exit(client["tools/call"]({ name: "session", arguments: {} }))
-        strictEqual(beforeInitialized._tag, "Failure")
-
-        yield* Effect.ignore(client["notifications/initialized"]({}))
-        const result = yield* client["tools/call"]({ name: "session", arguments: {} })
-
-        strictEqual(result.content[0]?.type, "text")
-        if (result.content[0]?.type === "text") {
-          strictEqual(
-            result.content[0].text,
-            JSON.stringify({
-              notifications: false,
-              requested: "9999-01-01",
-              negotiated: McpServer.latestProtocolVersion
-            })
-          )
-        }
-      }))
-
-    it.effect("accepts duplicate initialized notifications", () =>
-      Effect.gen(function*() {
-        const { client } = yield* makeTestClient()
-
-        yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: {
-            name: "TestClient",
-            version: "1.0.0"
-          }
-        })
-        yield* Effect.ignore(client["notifications/initialized"]({}))
-        yield* Effect.ignore(client["notifications/initialized"]({}))
-      }))
-
-    it.effect("accepts the negotiated protocol version header", () =>
-      Effect.gen(function*() {
-        const { client, getSessionId, request } = yield* makeTestClient()
-        yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "TestClient", version: "1.0.0" }
-        })
-
-        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-          "Mcp-Session-Id": getSessionId() ?? "",
-          "Mcp-Protocol-Version": "2025-11-25"
-        })
-
-        strictEqual(response.status, 200)
-        strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
-      }))
-
     it.effect("returns 400 for an unsupported protocol version header", () =>
       Effect.gen(function*() {
-        const { client, getSessionId, request } = yield* makeTestClient()
-        yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "TestClient", version: "1.0.0" }
-        })
+        const { initialize, operationalRequest } = yield* makeTestClient()
+        yield* initialize("2025-11-25")
 
-        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-          "Mcp-Session-Id": getSessionId() ?? "",
-          "Mcp-Protocol-Version": "not-a-version"
+        const response = yield* operationalRequest({
+          body: { jsonrpc: "2.0", id: 1, method: "ping", params: {} },
+          protocolVersion: "not-a-version"
         })
 
         strictEqual(response.status, 400)
@@ -323,54 +347,15 @@ describe("McpServer", () => {
 
     it.effect("returns 400 when the protocol version differs from the session", () =>
       Effect.gen(function*() {
-        const { client, getSessionId, request } = yield* makeTestClient()
-        yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "TestClient", version: "1.0.0" }
-        })
+        const { initialize, operationalRequest } = yield* makeTestClient()
+        yield* initialize("2025-11-25")
 
-        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-          "Mcp-Session-Id": getSessionId() ?? "",
-          "Mcp-Protocol-Version": "2025-06-18"
+        const response = yield* operationalRequest({
+          body: { jsonrpc: "2.0", id: 1, method: "ping", params: {} },
+          protocolVersion: "2025-06-18"
         })
 
         strictEqual(response.status, 400)
-      }))
-
-    it.effect("uses the session version when the protocol header is omitted", () =>
-      Effect.gen(function*() {
-        const { client, getSessionId, request } = yield* makeTestClient()
-        yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "TestClient", version: "1.0.0" }
-        })
-
-        const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
-          "Mcp-Session-Id": getSessionId() ?? ""
-        })
-
-        strictEqual(response.status, 200)
-        strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
-      }))
-
-    it.effect("returns 202 for accepted initialized notifications", () =>
-      Effect.gen(function*() {
-        const { client, getSessionId, request } = yield* makeTestClient()
-        yield* client.initialize({
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "TestClient", version: "1.0.0" }
-        })
-
-        const response = yield* request({
-          jsonrpc: "2.0",
-          method: "notifications/initialized",
-          params: {}
-        }, { "Mcp-Session-Id": getSessionId() ?? "" })
-
-        strictEqual(response.status, 202)
       }))
   })
 
@@ -387,13 +372,15 @@ describe("McpServer", () => {
 
     it.effect("returns 400 when a normal HTTP request omits the session id", () =>
       Effect.gen(function*() {
-        const { request } = yield* makeTestClient()
+        const { rawRequest } = yield* makeTestClient()
 
-        const response = yield* request({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "tools/call",
-          params: { name: "session", arguments: {} }
+        const response = yield* rawRequest({
+          body: {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name: "session", arguments: {} }
+          }
         })
 
         strictEqual(response.status, 400)
@@ -401,14 +388,17 @@ describe("McpServer", () => {
 
     it.effect("returns 404 when an HTTP request supplies an unknown session id", () =>
       Effect.gen(function*() {
-        const { request } = yield* makeTestClient()
+        const { rawRequest } = yield* makeTestClient()
 
-        const response = yield* request({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "tools/call",
-          params: { name: "session", arguments: {} }
-        }, { "Mcp-Session-Id": "unknown" })
+        const response = yield* rawRequest({
+          body: {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name: "session", arguments: {} }
+          },
+          sessionId: "unknown"
+        })
 
         strictEqual(response.status, 404)
       }))

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -49,11 +49,36 @@ const makeTestClient = Effect.gen(function*() {
 })
 
 describe("McpServer", () => {
-  it.effect("replays MCP session and negotiated protocol headers after initialize", () =>
+  it("exposes supported protocol versions from latest to oldest", () => {
+    strictEqual(McpServer.supportedProtocolVersions.length, 2)
+    strictEqual(McpServer.supportedProtocolVersions[0], "2025-11-25")
+    strictEqual(McpServer.supportedProtocolVersions[1], "2025-06-18")
+    strictEqual(McpServer.latestProtocolVersion, McpServer.supportedProtocolVersions[0])
+  })
+
+  it.effect("echoes supported protocol versions during initialization", () =>
+    Effect.gen(function*() {
+      for (const protocolVersion of McpServer.supportedProtocolVersions) {
+        const { client } = yield* makeTestClient
+
+        const result = yield* client.initialize({
+          protocolVersion,
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        })
+
+        strictEqual(result.protocolVersion, protocolVersion)
+      }
+    }))
+
+  it.effect("falls back to the latest protocol version for unsupported offers", () =>
     Effect.gen(function*() {
       const { client, responses } = yield* makeTestClient
 
-      yield* client.initialize({
+      const result = yield* client.initialize({
         protocolVersion: "9999-01-01",
         capabilities: {},
         clientInfo: {
@@ -64,8 +89,25 @@ describe("McpServer", () => {
 
       yield* client.ping({})
 
+      strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
       strictEqual(responses.length, 2)
-      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-06-18")
+      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), McpServer.latestProtocolVersion)
+    }))
+
+  it.effect("falls back to the latest protocol version for malformed offers", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient
+
+      const result = yield* client.initialize({
+        protocolVersion: "not-a-version",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+
+      strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
     }))
 
   it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -14,6 +14,7 @@ import * as RpcClient from "effect/unstable/rpc/RpcClient"
 interface MakeTestClientOptions {
   readonly supportedProtocolVersions?: Arr.NonEmptyReadonlyArray<McpServer.ProtocolVersion>
   readonly register?: Effect.Effect<void, never, McpServer.McpServer>
+  readonly onSessionToolCall?: () => void
 }
 
 interface RawRequestOptions {
@@ -47,6 +48,7 @@ const makeTestClient = (options: MakeTestClientOptions = {}) =>
         annotations: Context.empty(),
         handle: () =>
           Effect.gen(function*() {
+            options.onSessionToolCall?.()
             const client = yield* McpSchema.McpServerClient
             return new McpSchema.CallToolResult({
               content: [{
@@ -120,7 +122,41 @@ const makeTestClient = (options: MakeTestClientOptions = {}) =>
         ...(protocolVersion === undefined ? {} : { protocolVersion })
       })
 
-    return { client, initialize, operationalRequest, rawRequest, responses }
+    const createRawSession = () => {
+      let rawSessionId: string | undefined
+      const initialize = (protocolVersion: string, clientName = "RawClient") =>
+        Effect.gen(function*() {
+          const response = yield* rawRequest({
+            body: {
+              jsonrpc: "2.0",
+              id: 0,
+              method: "initialize",
+              params: {
+                protocolVersion,
+                capabilities: {},
+                clientInfo: { name: clientName, version: "1.0.0" }
+              }
+            }
+          })
+          rawSessionId = response.headers.get("Mcp-Session-Id") ?? undefined
+          return response
+        })
+      const request = (body: unknown, protocolVersion?: string) =>
+        rawRequest({
+          body,
+          ...(rawSessionId === undefined ? {} : { sessionId: rawSessionId }),
+          ...(protocolVersion === undefined ? {} : { protocolVersion })
+        })
+      return {
+        initialize,
+        request,
+        get sessionId() {
+          return rawSessionId
+        }
+      }
+    }
+
+    return { client, createRawSession, initialize, operationalRequest, rawRequest, responses }
   })
 
 const ObjectTool = Tool.make("object-output", {
@@ -223,6 +259,19 @@ const makeRepresentativeClient = (protocolVersion: McpServer.ProtocolVersion, cl
     return fixture.client
   })
 
+const pingRequest = (id: number) => ({ jsonrpc: "2.0", id, method: "ping", params: {} })
+const initializedNotification = {
+  jsonrpc: "2.0",
+  method: "notifications/initialized",
+  params: {}
+}
+const sessionToolRequest = (id: number) => ({
+  jsonrpc: "2.0",
+  id,
+  method: "tools/call",
+  params: { name: "session", arguments: {} }
+})
+
 const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
   it.effect("echoes the supported protocol version during initialization", () =>
     Effect.gen(function*() {
@@ -243,6 +292,48 @@ const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
       strictEqual(responses.length, 1)
       strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), protocolVersion)
       strictEqual(typeof responses[0].headers.get("Mcp-Session-Id"), "string")
+    }))
+
+  it.effect("returns initialization headers and body over raw HTTP", () =>
+    Effect.gen(function*() {
+      const { createRawSession } = yield* makeTestClient()
+      const session = createRawSession()
+
+      const response = yield* session.initialize(protocolVersion)
+
+      strictEqual(response.status, 200)
+      strictEqual(response.headers.get("Mcp-Protocol-Version"), protocolVersion)
+      strictEqual(response.headers.get("Mcp-Session-Id"), session.sessionId)
+      strictEqual(response.headers.get("content-type"), "application/json")
+      deepStrictEqual(yield* Effect.promise(() => response.json()), {
+        jsonrpc: "2.0",
+        id: 0,
+        result: {
+          protocolVersion,
+          capabilities: { completions: {}, tools: {} },
+          serverInfo: { name: "TestServer", version: "1.0.0" }
+        }
+      }, "raw initialization response")
+    }))
+
+  it.effect("handles at least three sequential requests in one HTTP session", () =>
+    Effect.gen(function*() {
+      const { createRawSession } = yield* makeTestClient()
+      const session = createRawSession()
+      yield* session.initialize(protocolVersion)
+      const notification = yield* session.request(initializedNotification, protocolVersion)
+
+      const first = yield* session.request(pingRequest(1), protocolVersion)
+      const second = yield* session.request(pingRequest(2))
+      const third = yield* session.request(pingRequest(3), protocolVersion)
+
+      strictEqual(notification.status, 202)
+      strictEqual(first.status, 200)
+      strictEqual(second.status, 200)
+      strictEqual(third.status, 200)
+      deepStrictEqual(yield* Effect.promise(() => first.json()), { jsonrpc: "2.0", id: 1, result: {} })
+      deepStrictEqual(yield* Effect.promise(() => second.json()), { jsonrpc: "2.0", id: 2, result: {} })
+      deepStrictEqual(yield* Effect.promise(() => third.json()), { jsonrpc: "2.0", id: 3, result: {} })
     }))
 
   it.effect("rejects reinitializing an existing HTTP session", () =>
@@ -300,6 +391,7 @@ const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
 
       strictEqual(response.status, 200)
       strictEqual(response.headers.get("Mcp-Protocol-Version"), protocolVersion)
+      strictEqual(response.headers.get("content-type"), "application/json")
     }))
 
   it.effect("uses the session version when the protocol header is omitted", () =>
@@ -329,6 +421,60 @@ const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
       })
 
       strictEqual(response.status, 202)
+      strictEqual(yield* Effect.promise(() => response.text()), "")
+    }))
+
+  it.effect("rejects unsupported and malformed protocol headers", () =>
+    Effect.gen(function*() {
+      const { createRawSession } = yield* makeTestClient()
+      const session = createRawSession()
+      yield* session.initialize(protocolVersion)
+      yield* session.request(initializedNotification)
+
+      const unsupported = yield* session.request(pingRequest(1), "9999-01-01")
+      const malformed = yield* session.request(pingRequest(2), "not-a-version")
+
+      strictEqual(unsupported.status, 400)
+      strictEqual(malformed.status, 400)
+    }))
+
+  it.effect("rejects a protocol header that differs from the negotiated version", () =>
+    Effect.gen(function*() {
+      const { createRawSession } = yield* makeTestClient()
+      const session = createRawSession()
+      yield* session.initialize(protocolVersion)
+
+      const response = yield* session.request(
+        pingRequest(1),
+        protocolVersion === "2025-11-25" ? "2025-06-18" : "2025-11-25"
+      )
+
+      strictEqual(response.status, 400)
+    }))
+
+  it.effect("does not invoke handlers for rejected protocol headers", () =>
+    Effect.gen(function*() {
+      let invocations = 0
+      const { createRawSession } = yield* makeTestClient({
+        onSessionToolCall: () => {
+          invocations++
+        }
+      })
+      const session = createRawSession()
+      yield* session.initialize(protocolVersion)
+      yield* session.request(initializedNotification)
+
+      const unsupported = yield* session.request(sessionToolRequest(1), "9999-01-01")
+      const malformed = yield* session.request(sessionToolRequest(2), "not-a-version")
+      const mismatch = yield* session.request(
+        sessionToolRequest(3),
+        protocolVersion === "2025-11-25" ? "2025-06-18" : "2025-11-25"
+      )
+
+      strictEqual(unsupported.status, 400)
+      strictEqual(malformed.status, 400)
+      strictEqual(mismatch.status, 400)
+      strictEqual(invocations, 0)
     }))
 
   it.effect("advertises registered capabilities", () =>
@@ -627,35 +773,56 @@ describe("McpServer", () => {
 
         strictEqual(result.protocolVersion, McpServer.latestProtocolVersion)
       }))
-
-    it.effect("returns 400 for an unsupported protocol version header", () =>
-      Effect.gen(function*() {
-        const { initialize, operationalRequest } = yield* makeTestClient()
-        yield* initialize("2025-11-25")
-
-        const response = yield* operationalRequest({
-          body: { jsonrpc: "2.0", id: 1, method: "ping", params: {} },
-          protocolVersion: "not-a-version"
-        })
-
-        strictEqual(response.status, 400)
-      }))
-
-    it.effect("returns 400 when the protocol version differs from the session", () =>
-      Effect.gen(function*() {
-        const { initialize, operationalRequest } = yield* makeTestClient()
-        yield* initialize("2025-11-25")
-
-        const response = yield* operationalRequest({
-          body: { jsonrpc: "2.0", id: 1, method: "ping", params: {} },
-          protocolVersion: "2025-06-18"
-        })
-
-        strictEqual(response.status, 400)
-      }))
   })
 
   describe("shared", () => {
+    it.effect("supports interleaved sessions negotiated to different versions", () =>
+      Effect.gen(function*() {
+        const { createRawSession } = yield* makeTestClient()
+        const legacy = createRawSession()
+        const latest = createRawSession()
+
+        const legacyInitialize = yield* legacy.initialize("2025-06-18", "LegacyClient")
+        const latestInitialize = yield* latest.initialize("2025-11-25", "LatestClient")
+        const legacyNotification = yield* legacy.request(initializedNotification, "2025-06-18")
+        const latestNotification = yield* latest.request(initializedNotification, "2025-11-25")
+        const latestPing = yield* latest.request(pingRequest(1), "2025-11-25")
+        const legacyPing = yield* legacy.request(pingRequest(2), "2025-06-18")
+
+        strictEqual(typeof legacy.sessionId, "string")
+        strictEqual(typeof latest.sessionId, "string")
+        strictEqual(legacy.sessionId === latest.sessionId, false)
+        strictEqual(legacyInitialize.headers.get("Mcp-Protocol-Version"), "2025-06-18")
+        strictEqual(latestInitialize.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+        strictEqual(legacyNotification.status, 202)
+        strictEqual(latestNotification.status, 202)
+        strictEqual(latestPing.status, 200)
+        strictEqual(latestPing.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+        strictEqual(legacyPing.status, 200)
+        strictEqual(legacyPing.headers.get("Mcp-Protocol-Version"), "2025-06-18")
+      }))
+
+    it.effect("isolates session IDs and negotiated versions in both directions", () =>
+      Effect.gen(function*() {
+        const { createRawSession } = yield* makeTestClient()
+        const legacy = createRawSession()
+        const latest = createRawSession()
+        yield* legacy.initialize("2025-06-18")
+        yield* latest.initialize("2025-11-25")
+
+        const legacyAsLatest = yield* legacy.request(pingRequest(1), "2025-11-25")
+        const latestAsLegacy = yield* latest.request(pingRequest(2), "2025-06-18")
+        const legacyOwnVersion = yield* legacy.request(pingRequest(3), "2025-06-18")
+        const latestOwnVersion = yield* latest.request(pingRequest(4), "2025-11-25")
+
+        strictEqual(legacyAsLatest.status, 400)
+        strictEqual(latestAsLegacy.status, 400)
+        strictEqual(legacyOwnVersion.status, 200)
+        strictEqual(legacyOwnVersion.headers.get("Mcp-Protocol-Version"), "2025-06-18")
+        strictEqual(latestOwnVersion.status, 200)
+        strictEqual(latestOwnVersion.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+      }))
+
     it.effect("allows ping but rejects normal requests before initialization", () =>
       Effect.gen(function*() {
         const { client } = yield* makeTestClient()

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -81,7 +81,7 @@ const makeTestClient = (
         )
       )
 
-    return { client, request, responses }
+    return { client, getSessionId: () => sessionId, request, responses }
   })
 
 describe("McpServer", () => {
@@ -279,5 +279,57 @@ describe("McpServer", () => {
       }, { "Mcp-Session-Id": "unknown" })
 
       strictEqual(response.status, 404)
+    }))
+
+  it.effect("accepts the negotiated protocol version header", () =>
+    Effect.gen(function*() {
+      const { client, getSessionId, request } = yield* makeTestClient()
+      yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+        "Mcp-Session-Id": getSessionId() ?? "",
+        "Mcp-Protocol-Version": "2025-11-25"
+      })
+
+      strictEqual(response.status, 200)
+      strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-11-25")
+    }))
+
+  it.effect("returns 400 for an unsupported protocol version header", () =>
+    Effect.gen(function*() {
+      const { client, getSessionId, request } = yield* makeTestClient()
+      yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+        "Mcp-Session-Id": getSessionId() ?? "",
+        "Mcp-Protocol-Version": "not-a-version"
+      })
+
+      strictEqual(response.status, 400)
+    }))
+
+  it.effect("returns 400 when the protocol version differs from the session", () =>
+    Effect.gen(function*() {
+      const { client, getSessionId, request } = yield* makeTestClient()
+      yield* client.initialize({
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const response = yield* request({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }, {
+        "Mcp-Session-Id": getSessionId() ?? "",
+        "Mcp-Protocol-Version": "2025-06-18"
+      })
+
+      strictEqual(response.status, 400)
     }))
 })

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -1,9 +1,11 @@
 import { describe, it } from "@effect/vitest"
-import { strictEqual } from "@effect/vitest/utils"
-import { Context, Effect, Layer } from "effect"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Context, Effect, Layer, Schema } from "effect"
 import type * as Arr from "effect/Array"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as McpServer from "effect/unstable/ai/McpServer"
+import * as Tool from "effect/unstable/ai/Tool"
+import * as Toolkit from "effect/unstable/ai/Toolkit"
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
 import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
@@ -11,6 +13,7 @@ import * as RpcClient from "effect/unstable/rpc/RpcClient"
 
 interface MakeTestClientOptions {
   readonly supportedProtocolVersions?: Arr.NonEmptyReadonlyArray<McpServer.ProtocolVersion>
+  readonly register?: Effect.Effect<void, never, McpServer.McpServer>
 }
 
 interface RawRequestOptions {
@@ -57,6 +60,9 @@ const makeTestClient = (options: MakeTestClientOptions = {}) =>
             })
           })
       })
+      if (options.register) {
+        yield* options.register
+      }
     })).pipe(Layer.provideMerge(protocolLayer))
     const { handler, dispose } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
     yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
@@ -81,11 +87,11 @@ const makeTestClient = (options: MakeTestClientOptions = {}) =>
       Effect.provide(clientLayer)
     )
 
-    const initialize = (protocolVersion: string) =>
+    const initialize = (protocolVersion: string, clientName = "TestClient") =>
       client.initialize({
         protocolVersion,
         capabilities: {},
-        clientInfo: { name: "TestClient", version: "1.0.0" }
+        clientInfo: { name: clientName, version: "1.0.0" }
       })
 
     const rawRequest = ({ body, protocolVersion, sessionId }: RawRequestOptions) => {
@@ -110,11 +116,111 @@ const makeTestClient = (options: MakeTestClientOptions = {}) =>
     const operationalRequest = ({ body, protocolVersion }: OperationalRequestOptions) =>
       rawRequest({
         body,
-        sessionId: sessionId ?? undefined,
-        protocolVersion
+        ...(sessionId === null ? {} : { sessionId }),
+        ...(protocolVersion === undefined ? {} : { protocolVersion })
       })
 
     return { client, initialize, operationalRequest, rawRequest, responses }
+  })
+
+const ObjectTool = Tool.make("object-output", {
+  success: Schema.Struct({ status: Schema.String })
+})
+const PrimitiveTool = Tool.make("primitive-output", { success: Schema.String })
+const ArrayTool = Tool.make("array-output", { success: Schema.Array(Schema.String) })
+const FailingTool = Tool.make("failing", {
+  success: Schema.String,
+  failure: Schema.String
+})
+const RepresentativeToolkit = Toolkit.make(ObjectTool, PrimitiveTool, ArrayTool, FailingTool)
+
+const enabledAnnotations = Context.make(
+  McpSchema.EnabledWhen,
+  (payload) => payload.clientInfo.name === "EnabledClient"
+)
+const FiniteNumberFromString = Schema.NumberFromString.check(Schema.isFinite())
+const CountString = Schema.String.check(Schema.isPattern(/^\d+$/))
+
+const registerRepresentativeCapabilities = Effect.gen(function*() {
+  const server = yield* McpServer.McpServer
+
+  yield* server.addTool({
+    tool: new McpSchema.Tool({ name: "argumentless", inputSchema: { type: "object" } }),
+    annotations: Context.empty(),
+    handle: (arguments_) =>
+      Effect.succeed(
+        new McpSchema.CallToolResult({
+          content: [{ type: "text", text: JSON.stringify(arguments_) }]
+        })
+      )
+  })
+  yield* server.addTool({
+    tool: new McpSchema.Tool({ name: "enabled-tool", inputSchema: { type: "object" } }),
+    annotations: enabledAnnotations,
+    handle: () => Effect.succeed(new McpSchema.CallToolResult({ content: [] }))
+  })
+
+  yield* McpServer.registerToolkit(RepresentativeToolkit).pipe(
+    Effect.provide(RepresentativeToolkit.toLayer({
+      "object-output": () => Effect.succeed({ status: "ok" }),
+      "primitive-output": () => Effect.succeed("ok"),
+      "array-output": () => Effect.succeed(["ok"]),
+      failing: () => Effect.fail("handler failed")
+    }))
+  )
+
+  yield* McpServer.registerResource({
+    uri: "file:///text",
+    name: "text-resource",
+    content: Effect.succeed("text content")
+  })
+  yield* McpServer.registerResource({
+    uri: "file:///binary",
+    name: "binary-resource",
+    content: Effect.succeed(new Uint8Array([1, 2, 3]))
+  })
+  yield* McpServer.registerResource({
+    uri: "file:///enabled",
+    name: "enabled-resource",
+    content: Effect.succeed("enabled"),
+    annotations: enabledAnnotations
+  })
+
+  const id = McpSchema.param("id", FiniteNumberFromString)
+  yield* McpServer.registerResource`file:///items/${id}`({
+    name: "item-template",
+    completion: {
+      id: () => Effect.succeed(Array.from({ length: 105 }, (_, index) => index))
+    },
+    content: (uri, value) => Effect.succeed(`${uri}:${value}`)
+  })
+  yield* McpServer.registerResource`file:///enabled-items/${id}`({
+    name: "enabled-template",
+    content: (_uri, value) => Effect.succeed(String(value)),
+    annotations: enabledAnnotations
+  })
+
+  yield* McpServer.registerPrompt({
+    name: "count-prompt",
+    parameters: { count: CountString },
+    completion: {
+      count: () => Effect.succeed(Array.from({ length: 105 }, (_, index) => String(index)))
+    },
+    content: ({ count }) => Effect.succeed(`Count: ${count}`)
+  })
+  yield* McpServer.registerPrompt({
+    name: "enabled-prompt",
+    content: () => Effect.succeed("enabled"),
+    annotations: enabledAnnotations
+  })
+})
+
+const makeRepresentativeClient = (protocolVersion: McpServer.ProtocolVersion, clientName = "TestClient") =>
+  Effect.gen(function*() {
+    const fixture = yield* makeTestClient({ register: registerRepresentativeCapabilities })
+    yield* fixture.initialize(protocolVersion, clientName)
+    yield* Effect.ignore(fixture.client["notifications/initialized"]({}))
+    return fixture.client
   })
 
 const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
@@ -223,6 +329,196 @@ const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
       })
 
       strictEqual(response.status, 202)
+    }))
+
+  it.effect("advertises registered capabilities", () =>
+    Effect.gen(function*() {
+      const { initialize } = yield* makeTestClient({ register: registerRepresentativeCapabilities })
+
+      const result = yield* initialize(protocolVersion)
+
+      deepStrictEqual(result.capabilities, {
+        completions: {},
+        tools: {},
+        resources: { subscribe: false },
+        prompts: {}
+      })
+    }))
+
+  it.effect("returns InvalidParams for an unknown tool", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const error = yield* Effect.flip(client["tools/call"]({ name: "unknown" }))
+
+      strictEqual(error instanceof McpSchema.InvalidParams, true)
+    }))
+
+  it.effect("normalizes omitted tool arguments", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const result = yield* client["tools/call"]({ name: "argumentless" })
+
+      strictEqual(result.content[0]?.type, "text")
+      if (result.content[0]?.type === "text") {
+        strictEqual(result.content[0].text, "{}")
+      }
+    }))
+
+  it.effect("returns toolkit handler failures as tool errors", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const result = yield* client["tools/call"]({ name: "failing" })
+
+      strictEqual(result.isError, true)
+      strictEqual(result.content[0]?.type, "text")
+    }))
+
+  it.effect("includes structured content only for object tool output", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const object = yield* client["tools/call"]({ name: "object-output" })
+      const primitive = yield* client["tools/call"]({ name: "primitive-output" })
+      const array = yield* client["tools/call"]({ name: "array-output" })
+
+      deepStrictEqual(object.structuredContent, { status: "ok" })
+      strictEqual(primitive.structuredContent, undefined)
+      strictEqual(array.structuredContent, undefined)
+    }))
+
+  it.effect("returns InvalidParams for an unknown prompt", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const error = yield* Effect.flip(client["prompts/get"]({ name: "unknown" }))
+
+      strictEqual(error instanceof McpSchema.InvalidParams, true)
+    }))
+
+  it.effect("converts string prompts to user text messages", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const result = yield* client["prompts/get"]({
+        name: "count-prompt",
+        arguments: { count: "2" }
+      })
+
+      strictEqual(result.messages[0]?.role, "user")
+      strictEqual(result.messages[0]?.content.type, "text")
+      if (result.messages[0]?.content.type === "text") {
+        strictEqual(result.messages[0].content.text, "Count: 2")
+      }
+    }))
+
+  it.effect("returns InvalidParams for prompt argument decode errors", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const error = yield* Effect.flip(client["prompts/get"]({
+        name: "count-prompt",
+        arguments: { count: "not-a-number" }
+      }))
+
+      strictEqual(error instanceof McpSchema.InvalidParams, true)
+    }))
+
+  it.effect("returns empty contents for an unknown resource", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const result = yield* client["resources/read"]({ uri: "file:///unknown" })
+
+      deepStrictEqual(result.contents, [])
+    }))
+
+  it.effect("converts string and Uint8Array resource content", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const text = yield* client["resources/read"]({ uri: "file:///text" })
+      const binary = yield* client["resources/read"]({ uri: "file:///binary" })
+
+      deepStrictEqual(text.contents, [{ uri: "file:///text", text: "text content" }])
+      deepStrictEqual(binary.contents, [{ uri: "file:///binary", blob: new Uint8Array([1, 2, 3]) }])
+    }))
+
+  it.effect("decodes resource template parameters and rejects invalid values", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const result = yield* client["resources/read"]({ uri: "file:///items/2" })
+      const error = yield* Effect.flip(client["resources/read"]({ uri: "file:///items/not-a-number" }))
+
+      deepStrictEqual(result.contents, [{ uri: "file:///items/2", text: "file:///items/2:2" }])
+      strictEqual(error instanceof McpSchema.InvalidParams, true)
+    }))
+
+  it.effect("returns an empty result for an unknown completion", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const result = yield* client["completion/complete"]({
+        ref: { type: "ref/prompt", name: "unknown" },
+        argument: { name: "value", value: "" }
+      })
+
+      deepStrictEqual(result.completion, { values: [], total: 0, hasMore: false })
+    }))
+
+  it.effect("truncates resource and prompt completions to 100 values", () =>
+    Effect.gen(function*() {
+      const client = yield* makeRepresentativeClient(protocolVersion)
+
+      const resource = yield* client["completion/complete"]({
+        ref: { type: "ref/resource", uri: "file:///items/{id}" },
+        argument: { name: "id", value: "" }
+      })
+      const prompt = yield* client["completion/complete"]({
+        ref: { type: "ref/prompt", name: "count-prompt" },
+        argument: { name: "count", value: "" }
+      })
+
+      strictEqual(resource.completion.values.length, 100)
+      strictEqual(resource.completion.values[0], "0")
+      strictEqual(resource.completion.values[99], "99")
+      strictEqual(resource.completion.total, 105)
+      strictEqual(resource.completion.hasMore, true)
+      strictEqual(prompt.completion.values.length, 100)
+      strictEqual(prompt.completion.values[0], "0")
+      strictEqual(prompt.completion.values[99], "99")
+      strictEqual(prompt.completion.total, 105)
+      strictEqual(prompt.completion.hasMore, true)
+    }))
+
+  it.effect("filters registered entries using the initialize payload", () =>
+    Effect.gen(function*() {
+      const disabled = yield* makeRepresentativeClient(protocolVersion)
+      const enabled = yield* makeRepresentativeClient(protocolVersion, "EnabledClient")
+
+      const disabledTools = yield* disabled["tools/list"]({})
+      const enabledTools = yield* enabled["tools/list"]({})
+      const disabledResources = yield* disabled["resources/list"]({})
+      const enabledResources = yield* enabled["resources/list"]({})
+      const disabledTemplates = yield* disabled["resources/templates/list"]({})
+      const enabledTemplates = yield* enabled["resources/templates/list"]({})
+      const disabledPrompts = yield* disabled["prompts/list"]({})
+      const enabledPrompts = yield* enabled["prompts/list"]({})
+
+      strictEqual(disabledTools.tools.some((tool) => tool.name === "enabled-tool"), false)
+      strictEqual(enabledTools.tools.some((tool) => tool.name === "enabled-tool"), true)
+      strictEqual(disabledResources.resources.some((resource) => resource.name === "enabled-resource"), false)
+      strictEqual(enabledResources.resources.some((resource) => resource.name === "enabled-resource"), true)
+      strictEqual(
+        disabledTemplates.resourceTemplates.some((template) => template.name === "enabled-template"),
+        false
+      )
+      strictEqual(enabledTemplates.resourceTemplates.some((template) => template.name === "enabled-template"), true)
+      strictEqual(disabledPrompts.prompts.some((prompt) => prompt.name === "enabled-prompt"), false)
+      strictEqual(enabledPrompts.prompts.some((prompt) => prompt.name === "enabled-prompt"), true)
     }))
 }
 

--- a/packages/effect/test/unstable/ai/McpServerConnection.test.ts
+++ b/packages/effect/test/unstable/ai/McpServerConnection.test.ts
@@ -1,0 +1,337 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Deferred, Effect, Queue } from "effect"
+import * as McpSchema from "effect/unstable/ai/McpSchema"
+import * as McpServer from "effect/unstable/ai/McpServer"
+import type * as RpcMessage from "effect/unstable/rpc/RpcMessage"
+import * as RpcServer from "effect/unstable/rpc/RpcServer"
+
+interface TestClient {
+  readonly id: number
+  readonly messages: ReadonlyArray<unknown>
+  readonly send: (message: RpcMessage.FromClientEncoded) => Effect.Effect<void>
+  readonly take: Effect.Effect<unknown>
+  readonly disconnect: Effect.Effect<void>
+}
+
+const makeHarness = (options?: {
+  readonly register?: Effect.Effect<void, never, McpServer.McpServer>
+}) =>
+  Effect.gen(function*() {
+    const server = yield* McpServer.McpServer.make
+    if (options?.register) {
+      yield* options.register.pipe(Effect.provideService(McpServer.McpServer, server))
+    }
+
+    const disconnects = yield* Queue.make<number>()
+    const activeClientIds = new Set<number>()
+    const clients = new Map<number, {
+      readonly messages: Array<unknown>
+      readonly outgoing: Queue.Queue<unknown>
+    }>()
+    let receive = (_clientId: number, _message: RpcMessage.FromClientEncoded): Effect.Effect<void> =>
+      Effect.die("MCP test protocol has not started")
+
+    const protocol = yield* RpcServer.Protocol.make((write) =>
+      Effect.sync(() => {
+        receive = write
+        return {
+          disconnects,
+          send(clientId, message) {
+            const client = clients.get(clientId)
+            if (!client || !activeClientIds.has(clientId)) return Effect.void
+            client.messages.push(message)
+            return Queue.offer(client.outgoing, message)
+          },
+          end(clientId) {
+            return Effect.sync(() => {
+              activeClientIds.delete(clientId)
+            })
+          },
+          clientIds: Effect.sync(() => new Set(activeClientIds)),
+          initialMessage: Effect.succeedNone,
+          supportsAck: false,
+          supportsTransferables: false,
+          supportsSpanPropagation: false
+        }
+      })
+    )
+
+    yield* McpServer.run({
+      name: "TestServer",
+      version: "1.0.0"
+    }).pipe(
+      Effect.provideService(McpServer.McpServer, server),
+      Effect.provideService(RpcServer.Protocol, protocol),
+      Effect.forkScoped
+    )
+
+    const connect = (id: number) =>
+      Effect.gen(function*() {
+        const messages: Array<unknown> = []
+        const outgoing = yield* Queue.make<unknown>()
+        clients.set(id, { messages, outgoing })
+        activeClientIds.add(id)
+        return {
+          id,
+          messages,
+          send: (message) => receive(id, message),
+          take: Queue.take(outgoing),
+          disconnect: Effect.sync(() => {
+            activeClientIds.delete(id)
+            Queue.offerUnsafe(disconnects, id)
+          })
+        } satisfies TestClient
+      })
+
+    return {
+      clientIds: protocol.clientIds,
+      connect,
+      server
+    }
+  })
+
+const request = (
+  id: string | number,
+  tag: string,
+  payload: unknown
+): RpcMessage.RequestEncoded => ({
+  _tag: "Request",
+  id,
+  tag,
+  payload,
+  headers: []
+})
+
+const initialize = (client: TestClient, protocolVersion: McpServer.ProtocolVersion, id = 1) =>
+  Effect.gen(function*() {
+    yield* client.send(request(id, "initialize", {
+      protocolVersion,
+      capabilities: {},
+      clientInfo: { name: `Client-${client.id}`, version: "1.0.0" }
+    }))
+    return yield* client.take
+  })
+
+const initialized = (client: TestClient) => client.send(request(0, "notifications/initialized", {}))
+
+const isExit = (message: unknown): message is RpcMessage.ResponseExitEncoded =>
+  typeof message === "object" &&
+  message !== null &&
+  "_tag" in message &&
+  message._tag === "Exit" &&
+  "requestId" in message &&
+  (typeof message.requestId === "string" || typeof message.requestId === "number") &&
+  "exit" in message &&
+  typeof message.exit === "object" &&
+  message.exit !== null &&
+  "_tag" in message.exit &&
+  (message.exit._tag === "Success" || message.exit._tag === "Failure")
+
+const isNotification = (message: unknown, tag: string): boolean =>
+  typeof message === "object" &&
+  message !== null &&
+  "_tag" in message &&
+  message._tag === "Request" &&
+  "tag" in message &&
+  message.tag === tag
+
+const assertExit = (message: unknown, requestId: string | number): RpcMessage.ResponseExitEncoded => {
+  if (!isExit(message)) {
+    assert.fail(`Expected an Exit response for request ${requestId}`)
+  }
+  assert.strictEqual(message.requestId, requestId)
+  return message
+}
+
+const protocolVersionSuite = (protocolVersion: McpServer.ProtocolVersion) => {
+  it.effect("initialize creates negotiated state", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+
+      const response = assertExit(yield* initialize(client, protocolVersion), 1)
+
+      assert.strictEqual(response.exit._tag, "Success")
+      if (response.exit._tag === "Success") {
+        assert.deepStrictEqual(response.exit.value, {
+          capabilities: { completions: {} },
+          protocolVersion,
+          serverInfo: { name: "TestServer", version: "1.0.0" }
+        })
+      }
+      assert.strictEqual(harness.server.initializedClients.has(client.id), false)
+      assert.deepStrictEqual(yield* harness.clientIds, new Set([101]))
+    }))
+
+  it.effect("rejects normal requests before notifications/initialized", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+      yield* initialize(client, protocolVersion)
+
+      yield* client.send(request(2, "tools/list", {}))
+      const response = assertExit(yield* client.take, 2)
+
+      assert.strictEqual(response.exit._tag, "Failure")
+    }))
+
+  it.effect("initialized marks the stable client operational", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+      yield* initialize(client, protocolVersion)
+
+      yield* initialized(client)
+      yield* client.send(request(2, "tools/list", {}))
+      const response = assertExit(yield* client.take, 2)
+
+      assert.strictEqual(harness.server.initializedClients.has(101), true)
+      assert.strictEqual(response.exit._tag, "Success")
+    }))
+
+  it.effect("withholds a queued list-change notification until operational", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+
+      yield* harness.server.notifications["notifications/tools/list_changed"]({})
+      yield* Effect.yieldNow
+      assert.strictEqual(client.messages.length, 0)
+
+      yield* initialize(client, protocolVersion)
+      assert.strictEqual(
+        client.messages.some((message) => isNotification(message, "notifications/tools/list_changed")),
+        false
+      )
+
+      yield* initialized(client)
+      const notification = yield* client.take
+
+      assert.strictEqual(isNotification(notification, "notifications/tools/list_changed"), true)
+    }))
+
+  it.effect("delivers each server notification once", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+      yield* initialize(client, protocolVersion)
+      yield* initialized(client)
+
+      yield* harness.server.notifications["notifications/message"]({ level: "info", data: "once" })
+      const notification = yield* client.take
+
+      assert.strictEqual(isNotification(notification, "notifications/message"), true)
+      assert.strictEqual(
+        client.messages.filter((message) => isNotification(message, "notifications/message")).length,
+        1
+      )
+    }))
+
+  it.effect("isolates two clients", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const first = yield* harness.connect(101)
+      const second = yield* harness.connect(202)
+      yield* initialize(first, protocolVersion)
+      yield* initialize(second, protocolVersion)
+      yield* initialized(first)
+      yield* initialized(second)
+
+      yield* first.send(request(10, "tools/list", {}))
+      const response = assertExit(yield* first.take, 10)
+
+      assert.strictEqual(response.exit._tag, "Success")
+      assert.strictEqual(second.messages.length, 1)
+      assert.deepStrictEqual(yield* harness.clientIds, new Set([101, 202]))
+    }))
+
+  it.effect("removes a disconnected client from outgoing eligibility", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const disconnected = yield* harness.connect(101)
+      const active = yield* harness.connect(202)
+      yield* initialize(disconnected, protocolVersion)
+      yield* initialize(active, protocolVersion)
+      yield* initialized(disconnected)
+      yield* initialized(active)
+      yield* disconnected.disconnect
+
+      yield* harness.server.notifications["notifications/message"]({ level: "info", data: "active only" })
+      const notification = yield* active.take
+
+      assert.strictEqual(isNotification(notification, "notifications/message"), true)
+      assert.strictEqual(
+        disconnected.messages.some((message) => isNotification(message, "notifications/message")),
+        false
+      )
+      assert.deepStrictEqual(yield* harness.clientIds, new Set([202]))
+      assert.strictEqual(harness.server.initializedClients.has(101), false)
+    }))
+
+  it.effect("rejects duplicate initialize", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+      yield* initialize(client, protocolVersion)
+
+      const response = assertExit(yield* initialize(client, protocolVersion, 2), 2)
+
+      assert.strictEqual(response.exit._tag, "Failure")
+    }))
+
+  it.effect("accepts duplicate initialized notifications", () =>
+    Effect.gen(function*() {
+      const harness = yield* makeHarness()
+      const client = yield* harness.connect(101)
+      yield* initialize(client, protocolVersion)
+
+      yield* initialized(client)
+      yield* initialized(client)
+      yield* client.send(request(2, "tools/list", {}))
+      const response = assertExit(yield* client.take, 2)
+
+      assert.strictEqual(response.exit._tag, "Success")
+      assert.deepStrictEqual(Array.from(harness.server.initializedClients), [101])
+    }))
+
+  it.effect("notifications/cancelled interrupts a matching in-flight request", () =>
+    Effect.gen(function*() {
+      const started = yield* Deferred.make<void>()
+      const interrupted = yield* Deferred.make<void>()
+      const harness = yield* makeHarness({
+        register: Effect.gen(function*() {
+          const server = yield* McpServer.McpServer
+          yield* server.addTool({
+            tool: new McpSchema.Tool({ name: "blocking", inputSchema: { type: "object" } }),
+            annotations: Context.empty(),
+            handle: () =>
+              Deferred.succeed(started, undefined).pipe(
+                Effect.andThen(Effect.never),
+                Effect.onInterrupt(() => Deferred.succeed(interrupted, undefined))
+              )
+          })
+        })
+      })
+      const client = yield* harness.connect(101)
+      yield* initialize(client, protocolVersion)
+      yield* initialized(client)
+
+      yield* client.send(request(77, "tools/call", { name: "blocking", arguments: {} }))
+      yield* Deferred.await(started)
+      yield* client.send(request(78, "notifications/cancelled", { requestId: 77, reason: "test" }))
+
+      yield* Deferred.await(interrupted)
+      const response = assertExit(yield* client.take, 77)
+      assert.strictEqual(response.exit._tag, "Failure")
+    }))
+}
+
+describe("McpServer connection protocol", () => {
+  describe("2025-06-18", () => {
+    protocolVersionSuite("2025-06-18")
+  })
+
+  describe("2025-11-25", () => {
+    protocolVersionSuite("2025-11-25")
+  })
+})

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -1,0 +1,10 @@
+import { McpServer } from "effect/unstable/ai"
+import { describe, expect, it } from "tstyche"
+
+describe("McpServer", () => {
+  it("exposes supported protocol version literals", () => {
+    expect(McpServer.supportedProtocolVersions).type.toBe<readonly ["2025-11-25", "2025-06-18"]>()
+    expect<McpServer.ProtocolVersion>().type.toBe<"2025-11-25" | "2025-06-18">()
+    expect(McpServer.latestProtocolVersion).type.toBe<"2025-11-25">()
+  })
+})

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -7,4 +7,22 @@ describe("McpServer", () => {
     expect<McpServer.ProtocolVersion>().type.toBe<"2025-11-25" | "2025-06-18">()
     expect(McpServer.latestProtocolVersion).type.toBe<"2025-11-25">()
   })
+
+  it("requires a non-empty list of known protocol versions", () => {
+    expect(McpServer.layer).type.toBeCallableWith({
+      name: "TestServer",
+      version: "1.0.0",
+      supportedProtocolVersions: ["2025-06-18", "2025-11-25"] as const
+    })
+    expect(McpServer.layer).type.not.toBeCallableWith({
+      name: "TestServer",
+      version: "1.0.0",
+      supportedProtocolVersions: [] as const
+    })
+    expect(McpServer.layer).type.not.toBeCallableWith({
+      name: "TestServer",
+      version: "1.0.0",
+      supportedProtocolVersions: ["2025-03-26"] as const
+    })
+  })
 })

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -1,4 +1,5 @@
-import { McpServer } from "effect/unstable/ai"
+import type * as Effect from "effect/Effect"
+import { McpSchema, McpServer } from "effect/unstable/ai"
 import { describe, expect, it } from "tstyche"
 
 describe("McpServer", () => {
@@ -24,5 +25,11 @@ describe("McpServer", () => {
       version: "1.0.0",
       supportedProtocolVersions: ["2025-03-26"] as const
     })
+  })
+
+  it("exposes the negotiated protocol version to handlers", () => {
+    expect(McpSchema.McpServerClient.useSync((client) => client.protocolVersion)).type.toBe<
+      Effect.Effect<"2025-11-25" | "2025-06-18", never, McpSchema.McpServerClient>
+    >()
   })
 })

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -3,33 +3,75 @@ import { McpSchema, McpServer } from "effect/unstable/ai"
 import { describe, expect, it } from "tstyche"
 
 describe("McpServer", () => {
-  it("exposes supported protocol version literals", () => {
-    expect(McpServer.supportedProtocolVersions).type.toBe<readonly ["2025-11-25", "2025-06-18"]>()
-    expect<McpServer.ProtocolVersion>().type.toBe<"2025-11-25" | "2025-06-18">()
-    expect(McpServer.latestProtocolVersion).type.toBe<"2025-11-25">()
+  describe("configuration", () => {
+    it("exposes the exact supported protocol versions", () => {
+      expect(McpServer.supportedProtocolVersions).type.toBe<readonly ["2025-11-25", "2025-06-18"]>()
+      expect<McpServer.ProtocolVersion>().type.toBe<"2025-11-25" | "2025-06-18">()
+    })
+
+    it("accepts the same server options across constructors", () => {
+      const options = {
+        name: "TestServer",
+        version: "1.0.0",
+        supportedProtocolVersions: [
+          McpServer.supportedProtocolVersions[1],
+          McpServer.supportedProtocolVersions[0]
+        ] as const
+      }
+
+      expect(McpServer.run).type.toBeCallableWith(options)
+      expect(McpServer.layer).type.toBeCallableWith(options)
+      expect(McpServer.layerStdio).type.toBeCallableWith(options)
+      expect(McpServer.layerHttp).type.toBeCallableWith({ ...options, path: "/mcp" })
+    })
+
+    it("accepts singleton custom configurations", () => {
+      expect(McpServer.layer).type.toBeCallableWith({
+        name: "TestServer",
+        version: "1.0.0",
+        supportedProtocolVersions: [McpServer.supportedProtocolVersions[1]] as const
+      })
+    })
+
+    it("rejects empty and unknown protocol version arrays", () => {
+      expect(McpServer.layer).type.not.toBeCallableWith({
+        name: "TestServer",
+        version: "1.0.0",
+        supportedProtocolVersions: [] as const
+      })
+      expect(McpServer.layer).type.not.toBeCallableWith({
+        name: "TestServer",
+        version: "1.0.0",
+        supportedProtocolVersions: ["2025-03-26"] as const
+      })
+    })
   })
 
-  it("requires a non-empty list of known protocol versions", () => {
-    expect(McpServer.layer).type.toBeCallableWith({
-      name: "TestServer",
-      version: "1.0.0",
-      supportedProtocolVersions: ["2025-06-18", "2025-11-25"] as const
-    })
-    expect(McpServer.layer).type.not.toBeCallableWith({
-      name: "TestServer",
-      version: "1.0.0",
-      supportedProtocolVersions: [] as const
-    })
-    expect(McpServer.layer).type.not.toBeCallableWith({
-      name: "TestServer",
-      version: "1.0.0",
-      supportedProtocolVersions: ["2025-03-26"] as const
+  describe("2025-06-18", () => {
+    it("is a supported protocol version", () => {
+      expect<"2025-06-18">().type.toBeAssignableTo<McpServer.ProtocolVersion>()
     })
   })
 
-  it("exposes the negotiated protocol version to handlers", () => {
-    expect(McpSchema.McpServerClient.useSync((client) => client.protocolVersion)).type.toBe<
-      Effect.Effect<"2025-11-25" | "2025-06-18", never, McpSchema.McpServerClient>
-    >()
+  describe("2025-11-25", () => {
+    it("is the latest supported protocol version", () => {
+      expect<"2025-11-25">().type.toBeAssignableTo<McpServer.ProtocolVersion>()
+      expect(McpServer.latestProtocolVersion).type.toBe<"2025-11-25">()
+    })
+  })
+
+  describe("shared", () => {
+    it("keeps initialize request protocol versions open to future literals", () => {
+      type InitializeProtocolVersion = typeof McpSchema.Initialize.payloadSchema.Type["protocolVersion"]
+
+      expect<InitializeProtocolVersion>().type.toBe<string>()
+      expect<"2099-01-01">().type.toBeAssignableTo<InitializeProtocolVersion>()
+    })
+
+    it("exposes the negotiated protocol version to handlers", () => {
+      expect(McpSchema.McpServerClient.useSync((client) => client.protocolVersion)).type.toBe<
+        Effect.Effect<"2025-11-25" | "2025-06-18", never, McpSchema.McpServerClient>
+      >()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Ports the Effect-native **`McpClient`** (Model Context Protocol client) from
[effect-smol#2534] into `Effect-TS/effect`, and bases it on the MCP
protocol-version-negotiation / spec-compliance work from [effect-smol#2601] so
the client relies on current, compliant schemas and a compliant server
counterpart.

Because GitHub cannot transfer PRs between repositories, this is the replacement
PR for the effect-smol → effect migration:

- **Client** — replaces [effect-smol#2534] (@polRk)
- **Base** — incorporates [effect-smol#2601] (@IMax153)

## What was taken, how, and why

### Base — [effect-smol#2601] (@IMax153), 18 commits, brought in via `git cherry-pick`

The 18 commits of #2601 are included **verbatim with original authorship
preserved** because the client depends on the schema and negotiation work they
contain. The effect-smol base at #2601's branch point was byte-identical to
`effect/main` for these files, so the cherry-pick applied with **zero
conflicts**. #2601 provides:

- MCP protocol versions **`2025-11-25`** and `2025-06-18` with per-session
  negotiation and lifecycle enforcement.
- Fixes to the MCP schemas the client relies on — notably `CreateMessageResult`
  (adds required `role`/`content`), sampling `metadata` made optional,
  elicitation content constrained to primitives, base64 binary content, `_meta`.
- A Streamable-HTTP-compliant `McpServer.layerHttp` (session identity,
  `MCP-Protocol-Version` enforcement, 400/404/202, notification gating) — the
  compliant server this client is tested against.

### Client — [effect-smol#2534] (@polRk) + spec-compliance fixes on top

`McpClient`: automatic `initialize`/`initialized` handshake, stdio and Streamable
HTTP transports, typed methods for tools/resources/prompts/completion, and
host-side handlers for server-initiated sampling/roots/elicitation.

Adapted to #2601's stricter schemas, then fixed against the MCP `2025-06-18`
spec and the official `@modelcontextprotocol/sdk` (via a conformance audit):

- Send the required `Accept: application/json, text/event-stream` header on every
  Streamable HTTP request (compliant servers otherwise reply `406`).
- Derive supported/latest protocol versions from the shared
  `McpSchema.ProtocolVersion`; offer the latest and validate the negotiated one.
- Send `MCP-Protocol-Version` from the negotiated `initialize` **result body**
  (a compliant server is not required to echo it as a response header).
- Fork the `roots/list_changed` forwarder only after the handshake completes
  (MCP lifecycle ordering).
- Spawn the stdio server with `extendEnv: true` (a custom `env` no longer strips
  `PATH`/`HOME`) and drain the child's `stderr` (avoids deadlock on a full pipe).

## Known limitations / follow-ups (tracked separately)

Deferred to keep this PR reviewable; each needs its own tests:

- **SSE responses** — the HTTP transport decodes JSON responses only, not
  `text/event-stream`. Needed for servers (including the official SDK) that
  stream POST responses.
- **HTTP hang-safety** — in-flight requests aren't failed on child-process exit;
  `send()` lacks the terminal/empty-response guards from
  `RpcClient.makeProtocolHttp`.
- **Cancellation** — interrupting a request doesn't emit
  `notifications/cancelled`, and inbound `notifications/cancelled` is a no-op.
- **HTTP session lifecycle** — no `DELETE` termination, no 404 session-expiry
  handling.
- **Systemic (shared `effect-rpc` JSON-RPC serialization, affects `McpServer`
  too)** — JSON-RPC notifications are emitted carrying an `id`, which is not
  standard-JSON-RPC-compliant for third-party peers. Out of scope here.

## Test plan

- `pnpm check` — clean
- `pnpm test packages/effect/test/unstable/ai/` — **431 passed** (15 files),
  including #2601's schema/server/connection conformance suites and the
  McpClient stdio + Streamable HTTP suites
- `pnpm lint` and `pnpm docgen` — clean

[effect-smol#2534]: https://github.com/Effect-TS/effect-smol/pull/2534
[effect-smol#2601]: https://github.com/Effect-TS/effect-smol/pull/2601
