### PR TITLE
Add basic set operations to Graph

### DIFF
--- a/.changeset/hip-friends-kiss.md
+++ b/.changeset/hip-friends-kiss.md
@@ -1,0 +1,10 @@
+---
+"effect": minor
+---
+
+added graph set operations for combining and comparing graphs
+
+- `Graph.compose` - union of two graphs, merging nodes by identity
+- `Graph.intersection` - intersection of two graphs, keeping only common nodes and edges
+- `Graph.difference` - difference of two graphs, removing edges present in the second graph
+- `Graph.symmetricDifference` - symmetric difference of two graphs, keeping edges present in exactly one graph

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -579,6 +579,444 @@ export const mutate: {
 })
 
 // =============================================================================
+// Set Operations
+// =============================================================================
+
+/** @internal */
+type NodeMaps<N> = {
+  readonly byId: Map<string, { readonly index: NodeIndex; readonly data: N }>
+  readonly byIndex: Map<NodeIndex, string>
+}
+
+/** @internal */
+type EdgeIdentity<E> = { readonly sourceId: string; readonly targetId: string; readonly data: E }
+
+/** @internal */
+const buildNodeMaps = <N, E, T extends Kind>(graph: Graph<N, E, T>, nodeId: (node: N) => string): NodeMaps<N> => {
+  const byId = new Map<string, { readonly index: NodeIndex; readonly data: N }>()
+  const byIndex = new Map<NodeIndex, string>()
+
+  for (const [index, data] of graph.nodes) {
+    const id = nodeId(data)
+    byId.set(id, { index, data })
+    byIndex.set(index, id)
+  }
+
+  return { byId, byIndex }
+}
+
+/** @internal */
+const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
+  type === "undirected" && sourceId > targetId ? `${targetId}\0${sourceId}` : `${sourceId}\0${targetId}`
+
+/** @internal */
+const emptyLike = <N, E, T extends Kind>(
+  graph: Graph<N, E, T>,
+  mutate: (mutable: MutableGraph<N, E, T>) => void
+): Graph<N, E, T> => {
+  const mutable = beginMutation(graph)
+
+  mutable.nodes.clear()
+  mutable.edges.clear()
+  mutable.adjacency.clear()
+  mutable.reverseAdjacency.clear()
+  mutable.nextNodeIndex = 0
+  mutable.nextEdgeIndex = 0
+  mutable.acyclic = Option.some(true)
+
+  mutate(mutable)
+
+  return endMutation(mutable)
+}
+
+/**
+ * Returns the union of two graphs, merging nodes by identity.
+ *
+ * **Details**
+ *
+ * Nodes and edges present in both graphs use data from `that`. The result has
+ * the same graph kind as `self`.
+ *
+ * `G1 ∪ G2 = {V1 ∪ V2, E1 ∪ E2}`
+ *
+ * **Example** (Composing graphs)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<{ id: string }, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, { id: "A" })
+ *   const b = Graph.addNode(mutable, { id: "B" })
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ * })
+ *
+ * const right = Graph.directed<{ id: string }, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, { id: "B" })
+ *   const c = Graph.addNode(mutable, { id: "C" })
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const result = Graph.compose(left, right, (node) => node.id)
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.edgeCount(result)) // 2
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const compose: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(
+  3,
+  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>, nodeId: (node: N) => string): Graph<N, E, T> => {
+    const selfMaps = buildNodeMaps(self, nodeId)
+    const thatMaps = buildNodeMaps(that, nodeId)
+    const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
+    const edgeMap = new Map<string, EdgeIdentity<E>>()
+
+    for (const edge of self.edges.values()) {
+      const sourceId = selfMaps.byIndex.get(edge.source)
+      const targetId = selfMaps.byIndex.get(edge.target)
+      if (sourceId !== undefined && targetId !== undefined) {
+        edgeMap.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+      }
+    }
+
+    for (const edge of that.edges.values()) {
+      const sourceId = thatMaps.byIndex.get(edge.source)
+      const targetId = thatMaps.byIndex.get(edge.target)
+      if (sourceId !== undefined && targetId !== undefined) {
+        edgeMap.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+      }
+    }
+
+    return emptyLike(self, (mutable) => {
+      const newIndexMap = new Map<string, NodeIndex>()
+
+      for (const id of allNodeIds) {
+        const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
+        if (entry !== undefined) {
+          newIndexMap.set(id, addNode(mutable, entry.data))
+        }
+      }
+
+      for (const { sourceId, targetId, data } of edgeMap.values()) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    })
+  }
+)
+
+/**
+ * Returns the intersection of two graphs, matching nodes by identity.
+ *
+ * **Details**
+ *
+ * Node data comes from `self`, and edge data comes from `that`. The result has
+ * the same graph kind as `self`.
+ *
+ * `G1 ∩ G2 = {V1 ∩ V2, E1 ∩ E2}`
+ *
+ * **Example** (Finding shared structure)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "left")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "right")
+ * })
+ *
+ * const result = Graph.intersection(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 2
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const intersection: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const commonNodeIds = [...selfMaps.byId.keys()].filter((id) => thatMaps.byId.has(id))
+  const commonNodeIdSet = new Set(commonNodeIds)
+  const selfEdgeKeys = new Set<string>()
+
+  for (const edge of self.edges.values()) {
+    const sourceId = selfMaps.byIndex.get(edge.source)
+    const targetId = selfMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      selfEdgeKeys.add(edgeKey(self.type, sourceId, targetId))
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const id of commonNodeIds) {
+      const entry = selfMaps.byId.get(id)
+      if (entry !== undefined) {
+        newIndexMap.set(id, addNode(mutable, entry.data))
+      }
+    }
+
+    for (const edge of that.edges.values()) {
+      const sourceId = thatMaps.byIndex.get(edge.source)
+      const targetId = thatMaps.byIndex.get(edge.target)
+      if (
+        sourceId !== undefined &&
+        targetId !== undefined &&
+        commonNodeIdSet.has(sourceId) &&
+        commonNodeIdSet.has(targetId) &&
+        selfEdgeKeys.has(edgeKey(that.type, sourceId, targetId))
+      ) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns `self` without edges also present in `that`.
+ *
+ * **Details**
+ *
+ * All nodes from `self` are preserved. Edges are matched by endpoint identity,
+ * and edge data is ignored. The result has the same graph kind as `self`.
+ *
+ * `G1 \ G2 = {V1, E1 \ E2}`
+ *
+ * **Example** (Removing shared edges)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, b, c, "other")
+ * })
+ *
+ * const result = Graph.difference(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const difference: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const thatEdgeKeys = new Set<string>()
+
+  for (const edge of that.edges.values()) {
+    const sourceId = thatMaps.byIndex.get(edge.source)
+    const targetId = thatMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      thatEdgeKeys.add(edgeKey(that.type, sourceId, targetId))
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const [id, entry] of selfMaps.byId) {
+      newIndexMap.set(id, addNode(mutable, entry.data))
+    }
+
+    for (const edge of self.edges.values()) {
+      const sourceId = selfMaps.byIndex.get(edge.source)
+      const targetId = selfMaps.byIndex.get(edge.target)
+      if (
+        sourceId !== undefined && targetId !== undefined && !thatEdgeKeys.has(edgeKey(self.type, sourceId, targetId))
+      ) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns edges present in exactly one of two graphs.
+ *
+ * **Details**
+ *
+ * Keeps nodes from both graphs. Overlapping nodes use data from `that`. The
+ * result has the same graph kind as `self`.
+ *
+ * `G1 Δ G2 = {V1 ∪ V2, (E1 ∪ E2) \ (E1 ∩ E2)}`
+ *
+ * **Gotchas**
+ *
+ * Edges present in both graphs are removed even when their edge data differs.
+ *
+ * **Example** (Finding differing edges)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   const d = Graph.addNode(mutable, "D")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ *   Graph.addEdge(mutable, c, d, "C-D")
+ * })
+ *
+ * const result = Graph.symmetricDifference(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 4
+ * console.log(Graph.edgeCount(result)) // 2
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const symmetricDifference: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
+  const selfEdges = new Map<string, EdgeIdentity<E>>()
+  const thatEdges = new Map<string, EdgeIdentity<E>>()
+
+  for (const edge of self.edges.values()) {
+    const sourceId = selfMaps.byIndex.get(edge.source)
+    const targetId = selfMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      selfEdges.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+    }
+  }
+
+  for (const edge of that.edges.values()) {
+    const sourceId = thatMaps.byIndex.get(edge.source)
+    const targetId = thatMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      thatEdges.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const id of allNodeIds) {
+      const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
+      if (entry !== undefined) {
+        newIndexMap.set(id, addNode(mutable, entry.data))
+      }
+    }
+
+    for (const [key, { sourceId, targetId, data }] of selfEdges) {
+      if (!thatEdges.has(key)) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    }
+
+    for (const [key, { sourceId, targetId, data }] of thatEdges) {
+      if (!selfEdges.has(key)) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    }
+  })
+})
+
+// =============================================================================
 // Basic Node Operations
 // =============================================================================
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -18,6 +18,39 @@ const makeReversedUndirectedPath = () =>
     Graph.addEdge(mutable, c, b, 1)
   })
 
+type SetNode = { readonly id: string; readonly label: string }
+
+const graphNodeIds = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
+  new Set(Array.from(graph, ([, node]) => node.id))
+
+const graphNodeLabels = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
+  new Map(Array.from(graph, ([, node]) => [node.id, node.label]))
+
+const graphEdgeKeys = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
+  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
+  return new Set(
+    Array.from(Graph.edges(graph), ([, edge]) =>
+      graph.type === "directed"
+        ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
+        : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
+  )
+}
+
+const graphEdgeData = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
+  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
+  return new Map(
+    Array.from(
+      Graph.edges(graph),
+      ([, edge]) => [
+        graph.type === "directed"
+          ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
+          : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`,
+        edge.data
+      ]
+    )
+  )
+}
+
 describe("Graph", () => {
   describe("constructors", () => {
     it("should create empty directed graph", () => {
@@ -35,6 +68,115 @@ describe("Graph", () => {
       expect(Graph.nodeCount(graph)).toBe(0)
       expect(Graph.edgeCount(graph)).toBe(0)
     })
+  })
+
+  describe("set operations", () => {
+    const makeLeft = () =>
+      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "a", label: "A1" })
+        const b = Graph.addNode(mutable, { id: "b", label: "B1" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C1" })
+        Graph.addEdge(mutable, a, b, "left-ab")
+        Graph.addEdge(mutable, b, c, "left-bc")
+      })
+
+    const makeRight = () =>
+      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
+        const b = Graph.addNode(mutable, { id: "b", label: "B2" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C2" })
+        const d = Graph.addNode(mutable, { id: "d", label: "D2" })
+        Graph.addEdge(mutable, b, c, "right-bc")
+        Graph.addEdge(mutable, c, d, "right-cd")
+      })
+
+    it("compose merges nodes and edges by identity", () => {
+      const graph = Graph.compose(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B2"],
+          ["c", "C2"],
+          ["d", "D2"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "b->c", "c->d"]))
+      expect(graphEdgeData(graph)).toEqual(
+        new Map([
+          ["a->b", "left-ab"],
+          ["b->c", "right-bc"],
+          ["c->d", "right-cd"]
+        ])
+      )
+    })
+
+    it("intersection keeps shared nodes and shared edges", () => {
+      const graph = Graph.intersection(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["b", "c"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["b", "B1"],
+          ["c", "C1"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["b->c"]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["b->c", "right-bc"]]))
+    })
+
+    it("difference preserves self nodes and removes shared edges", () => {
+      const graph = Graph.difference(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B1"],
+          ["c", "C1"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b"]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["a->b", "left-ab"]]))
+    })
+
+    it("symmetricDifference keeps edges present in exactly one graph", () => {
+      const graph = Graph.symmetricDifference(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B2"],
+          ["c", "C2"],
+          ["d", "D2"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "c->d"]))
+      expect(graphEdgeData(graph)).toEqual(
+        new Map([
+          ["a->b", "left-ab"],
+          ["c->d", "right-cd"]
+        ])
+      )
+    })
+
+    it("matches undirected edges regardless of endpoint order", () => {
+      const left = Graph.undirected<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "left")
+      })
+      const right = Graph.undirected<string, string>((mutable) => {
+        const b = Graph.addNode(mutable, "B")
+        const a = Graph.addNode(mutable, "A")
+        Graph.addEdge(mutable, b, a, "right")
+      })
+
+      strictEqual(Graph.edgeCount(Graph.intersection(left, right, (n) => n)), 1)
+      strictEqual(Graph.edgeCount(Graph.difference(left, right, (n) => n)), 0)
+    })
+
   })
 
   it("toString", () => {

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -1,0 +1,72 @@
+import { Graph, pipe } from "effect"
+import { describe, expect, it } from "tstyche"
+
+interface Node {
+  readonly id: string
+}
+
+declare const directedNodes: Graph.DirectedGraph<Node, number>
+declare const undirectedNodes: Graph.UndirectedGraph<Node, number>
+
+describe("Graph", () => {
+  it("compose", () => {
+    expect(Graph.compose(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.compose(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("intersection", () => {
+    expect(Graph.intersection(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.intersection(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("difference", () => {
+    expect(Graph.difference(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.difference(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("symmetricDifference", () => {
+    expect(Graph.symmetricDifference(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.symmetricDifference(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+})


### PR DESCRIPTION
Split from #6394. Original implementation by @lloydrichards.

Adds the basic graph set operations:

- `Graph.compose`
- `Graph.intersection`
- `Graph.difference`
- `Graph.symmetricDifference`

Includes runtime tests, type tests, JSDoc examples, and the dedicated changeset.

This is PR 1 of 3 in the split stack.