### PR TITLE
feat(http): add tracer header filter combinators to HttpClient

### DIFF
--- a/.changeset/httpclient-tracer-header-filter.md
+++ b/.changeset/httpclient-tracer-header-filter.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `withTracerRequestHeadersFilter`, `withTracerResponseHeadersFilter`, and `withTracerHeadersFilter` combinators to `HttpClient` for controlling which headers are captured as OTEL span attributes.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -687,8 +687,11 @@ export const make = (
             }
             const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames)
             const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames)
+            const requestHeaderFilter = fiber.getRef(TracerRequestHeadersFilter)
             for (const name in redactedHeaders) {
-              span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]))
+              if (requestHeaderFilter(name)) {
+                span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]))
+              }
             }
             request = fiber.getRef(TracerPropagationEnabled)
               ? HttpClientRequest.setHeaders(request, TraceContext.toHeaders(span))
@@ -700,8 +703,11 @@ export const make = (
                   onSuccess: (response) => {
                     span.attribute("http.response.status_code", response.status)
                     const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames)
+                    const responseHeaderFilter = fiber.getRef(TracerResponseHeadersFilter)
                     for (const name in redactedHeaders) {
-                      span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]))
+                      if (responseHeaderFilter(name)) {
+                        span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]))
+                      }
                     }
 
                     if (scopedController) return Effect.succeed(response)
@@ -1516,6 +1522,76 @@ export const SpanNameGenerator = Context.Reference<
 >("effect/http/HttpClient/SpanNameGenerator", {
   defaultValue: () => (request) => `http.client ${request.method}`
 })
+
+/**
+ * Context reference controlling which request headers are captured as OTEL span attributes.
+ * The predicate receives each header name (lower-cased) and should return `true` to include it.
+ *
+ * @category references
+ * @since 4.0.0
+ */
+export const TracerRequestHeadersFilter = Context.Reference<Predicate.Predicate<string>>(
+  "effect/http/HttpClient/TracerRequestHeadersFilter",
+  { defaultValue: () => constTrue }
+)
+
+/**
+ * Context reference controlling which response headers are captured as OTEL span attributes.
+ * The predicate receives each header name (lower-cased) and should return `true` to include it.
+ *
+ * @category references
+ * @since 4.0.0
+ */
+export const TracerResponseHeadersFilter = Context.Reference<Predicate.Predicate<string>>(
+  "effect/http/HttpClient/TracerResponseHeadersFilter",
+  { defaultValue: () => constTrue }
+)
+
+/**
+ * Restricts which request headers are recorded as OTEL span attributes.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const withTracerRequestHeadersFilter: {
+  (predicate: Predicate.Predicate<string>): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E, R>
+  <E, R>(self: HttpClient.With<E, R>, predicate: Predicate.Predicate<string>): HttpClient.With<E, R>
+} = dual(
+  2,
+  <E, R>(self: HttpClient.With<E, R>, predicate: Predicate.Predicate<string>): HttpClient.With<E, R> =>
+    transformResponse(self, Effect.provideService(TracerRequestHeadersFilter, predicate))
+)
+
+/**
+ * Restricts which response headers are recorded as OTEL span attributes.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const withTracerResponseHeadersFilter: {
+  (predicate: Predicate.Predicate<string>): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E, R>
+  <E, R>(self: HttpClient.With<E, R>, predicate: Predicate.Predicate<string>): HttpClient.With<E, R>
+} = dual(
+  2,
+  <E, R>(self: HttpClient.With<E, R>, predicate: Predicate.Predicate<string>): HttpClient.With<E, R> =>
+    transformResponse(self, Effect.provideService(TracerResponseHeadersFilter, predicate))
+)
+
+/**
+ * Restricts which headers are recorded as OTEL span attributes for both requests and responses.
+ * Equivalent to calling `withTracerRequestHeadersFilter` and `withTracerResponseHeadersFilter` with the same predicate.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const withTracerHeadersFilter: {
+  (predicate: Predicate.Predicate<string>): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E, R>
+  <E, R>(self: HttpClient.With<E, R>, predicate: Predicate.Predicate<string>): HttpClient.With<E, R>
+} = dual(
+  2,
+  <E, R>(self: HttpClient.With<E, R>, predicate: Predicate.Predicate<string>): HttpClient.With<E, R> =>
+    withTracerResponseHeadersFilter(withTracerRequestHeadersFilter(self, predicate), predicate)
+)
 
 /**
  * Creates an `HttpClient` layer and merges the layer construction context into client response effects.

--- a/packages/effect/test/HttpClient.test.ts
+++ b/packages/effect/test/HttpClient.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "@effect/vitest"
-import { Context, Effect, Layer, Schema, Stream, Struct } from "effect"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Context, Effect, Layer, Option, Ref, Schema, Stream, Struct, type Tracer } from "effect"
 import { TestClock } from "effect/testing"
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
@@ -121,6 +122,133 @@ const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
       })))
   })
 })
+
+it.effect("captures all request and response headers as span attributes by default", () =>
+  Effect.gen(function*() {
+    const spanRef = yield* Ref.make<Option.Option<Tracer.Span>>(Option.none())
+
+    const client = HttpClient.make((request) =>
+      Effect.gen(function*() {
+        const span = yield* Effect.orDie(Effect.currentSpan)
+        yield* Ref.set(spanRef, Option.some(span))
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(null, { status: 200, headers: { "X-Request-Id": "resp-abc" } })
+        )
+      })
+    )
+
+    yield* client.execute(
+      HttpClientRequest.get("http://test/").pipe(
+        HttpClientRequest.setHeaders({ "X-Request-Id": "req-abc" })
+      )
+    ).pipe(Effect.ignore)
+
+    const span = Option.getOrThrow(yield* Ref.get(spanRef))
+    deepStrictEqual(span.attributes.get("http.request.header.x-request-id"), "req-abc")
+    deepStrictEqual(span.attributes.get("http.response.header.x-request-id"), "resp-abc")
+  }))
+
+it.effect("withTracerRequestHeadersFilter only captures matching request headers as span attributes", () =>
+  Effect.gen(function*() {
+    const spanRef = yield* Ref.make<Option.Option<Tracer.Span>>(Option.none())
+
+    const client = HttpClient.make((request) =>
+      Effect.gen(function*() {
+        const span = yield* Effect.orDie(Effect.currentSpan)
+        yield* Ref.set(spanRef, Option.some(span))
+        return HttpClientResponse.fromWeb(request, new Response(null, { status: 200 }))
+      })
+    ).pipe(
+      HttpClient.withTracerRequestHeadersFilter((name) => name === "x-request-id")
+    )
+
+    yield* client.execute(
+      HttpClientRequest.get("http://test/").pipe(
+        HttpClientRequest.setHeaders({
+          "x-request-id": "abc",
+          "content-type": "application/json",
+          "accept": "application/json"
+        })
+      )
+    ).pipe(Effect.ignore)
+
+    const span = Option.getOrThrow(yield* Ref.get(spanRef))
+    deepStrictEqual(span.attributes.get("http.request.header.x-request-id"), "abc")
+    strictEqual(span.attributes.get("http.request.header.content-type"), undefined)
+    strictEqual(span.attributes.get("http.request.header.accept"), undefined)
+  }))
+
+it.effect("withTracerResponseHeadersFilter only captures matching response headers as span attributes", () =>
+  Effect.gen(function*() {
+    const spanRef = yield* Ref.make<Option.Option<Tracer.Span>>(Option.none())
+
+    const client = HttpClient.make((request) =>
+      Effect.gen(function*() {
+        const span = yield* Effect.orDie(Effect.currentSpan)
+        yield* Ref.set(spanRef, Option.some(span))
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(null, {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "x-request-id": "resp-123",
+              "cf-ray": "abc123"
+            }
+          })
+        )
+      })
+    ).pipe(
+      HttpClient.withTracerResponseHeadersFilter((name) => name === "x-request-id")
+    )
+
+    yield* client.get("http://test/").pipe(Effect.ignore)
+
+    const span = Option.getOrThrow(yield* Ref.get(spanRef))
+    deepStrictEqual(span.attributes.get("http.response.header.x-request-id"), "resp-123")
+    strictEqual(span.attributes.get("http.response.header.content-type"), undefined)
+    strictEqual(span.attributes.get("http.response.header.cf-ray"), undefined)
+  }))
+
+it.effect("withTracerHeadersFilter applies the same predicate to both request and response headers", () =>
+  Effect.gen(function*() {
+    const spanRef = yield* Ref.make<Option.Option<Tracer.Span>>(Option.none())
+
+    const client = HttpClient.make((request) =>
+      Effect.gen(function*() {
+        const span = yield* Effect.orDie(Effect.currentSpan)
+        yield* Ref.set(spanRef, Option.some(span))
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(null, {
+            status: 200,
+            headers: {
+              "x-request-id": "resp-abc",
+              "cf-ray": "ignored"
+            }
+          })
+        )
+      })
+    ).pipe(
+      HttpClient.withTracerHeadersFilter((name) => name === "x-request-id")
+    )
+
+    yield* client.execute(
+      HttpClientRequest.get("http://test/").pipe(
+        HttpClientRequest.setHeaders({
+          "x-request-id": "req-abc",
+          "content-type": "application/json"
+        })
+      )
+    ).pipe(Effect.ignore)
+
+    const span = Option.getOrThrow(yield* Ref.get(spanRef))
+    deepStrictEqual(span.attributes.get("http.request.header.x-request-id"), "req-abc")
+    strictEqual(span.attributes.get("http.request.header.content-type"), undefined)
+    deepStrictEqual(span.attributes.get("http.response.header.x-request-id"), "resp-abc")
+    strictEqual(span.attributes.get("http.response.header.cf-ray"), undefined)
+  }))
 
 const flakyTest = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(

--- a/packages/effect/typetest/unstable/http/HttpClient.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpClient.tst.ts
@@ -140,4 +140,28 @@ describe("HttpClient", () => {
       >()
     })
   })
+
+  describe("withTracerHeadersFilter", () => {
+    it("should support data-last and data-first usage on all three combinators", () => {
+      const predicate = (name: string) => name === "x-request-id"
+
+      const requestDataLast = client.pipe(HttpClient.withTracerRequestHeadersFilter(predicate))
+      expect(requestDataLast).type.toBe<HttpClient.HttpClient.With<HttpClientError.HttpClientError>>()
+
+      const requestDataFirst = HttpClient.withTracerRequestHeadersFilter(client, predicate)
+      expect(requestDataFirst).type.toBe<HttpClient.HttpClient.With<HttpClientError.HttpClientError>>()
+
+      const responseDataLast = client.pipe(HttpClient.withTracerResponseHeadersFilter(predicate))
+      expect(responseDataLast).type.toBe<HttpClient.HttpClient.With<HttpClientError.HttpClientError>>()
+
+      const responseDataFirst = HttpClient.withTracerResponseHeadersFilter(client, predicate)
+      expect(responseDataFirst).type.toBe<HttpClient.HttpClient.With<HttpClientError.HttpClientError>>()
+
+      const combinedDataLast = client.pipe(HttpClient.withTracerHeadersFilter(predicate))
+      expect(combinedDataLast).type.toBe<HttpClient.HttpClient.With<HttpClientError.HttpClientError>>()
+
+      const combinedDataFirst = HttpClient.withTracerHeadersFilter(client, predicate)
+      expect(combinedDataFirst).type.toBe<HttpClient.HttpClient.With<HttpClientError.HttpClientError>>()
+    })
+  })
 })


### PR DESCRIPTION
Opening this at @IMax153's request to replace Effect-TS/effect-smol#2132. Now that V4 development has merged back into this repo's `main` branch, the linked issue lives here as #6363, so I'm bringing the same change over.

## What this adds

Three new `HttpClient` combinators for controlling which headers get captured as OTEL span attributes:

- `withTracerRequestHeadersFilter`: filters which request headers are captured
- `withTracerResponseHeadersFilter`: filters which response headers are captured
- `withTracerHeadersFilter`: applies the same predicate to both

Each takes a `Predicate.Predicate<string>` that receives the header name (already lower-cased) and returns `true` to capture it. The default is `constTrue`, so every header is captured just like today. This is fully backward compatible.

## Why

`HttpClient` currently captures every header value as a span attribute unconditionally. For chatty APIs (Notion, Cloudflare-fronted services, CloudFront, etc.) that means 15-30+ low-signal attributes per span (`cf-ray`, `alt-svc`, `via`, and the like), which bloats trace storage and buries the few attributes that actually matter for debugging. `Headers.CurrentRedactedNames` only redacts values; the attributes are still emitted regardless. This gives callers a way to opt individual headers out entirely, matching the header-capture allowlist knobs already common in other OTEL client instrumentations (Java's `OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS`, for example).

## Testing

Adds four tests to `HttpClient.test.ts` (a default-capture-all baseline plus one per combinator) and a `tstyche` typetest block that verifies data-first/data-last usage across all three combinators.

## Credit

Thanks to @schickling for the well-researched issue #6363, the reproduction repo made this easy to verify, and to @IMax153 for the review on the original Effect-TS/effect-smol#2132.

Fixes #6363