### PR TITLE
Reintroduce CLI wizard mode

### DIFF
--- a/.changeset/cli-wizard-mode.md
+++ b/.changeset/cli-wizard-mode.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reintroduce interactive CLI wizard mode through the `--wizard` flag and `Command.wizard`.

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -35,7 +35,9 @@ import { mergeConfig, parseConfig } from "./internal/config.ts"
 import { getGlobalFlagsForCommandPath, getGlobalFlagsForCommandTree, getHelpForCommandPath } from "./internal/help.ts"
 import * as Lexer from "./internal/lexer.ts"
 import * as Parser from "./internal/parser.ts"
+import * as Wizard from "./internal/wizard.ts"
 import * as Param from "./Param.ts"
+import * as Prompt from "./Prompt.ts"
 
 /* ========================================================================== */
 /* Public Types                                                               */
@@ -1369,6 +1371,38 @@ export const provideEffectDiscard: {
 /* Execution                                                                  */
 /* ========================================================================== */
 
+/**
+ * Interactively constructs command-line arguments for a command.
+ *
+ * **Details**
+ *
+ * The returned arguments include the command name and can be inspected,
+ * modified, or passed to another command runner by the caller.
+ *
+ * **Example** (Constructing command arguments)
+ *
+ * ```ts
+ * import { Console, Effect } from "effect"
+ * import { Command } from "effect/unstable/cli"
+ *
+ * const command = Command.make("app")
+ *
+ * const program = Effect.gen(function*() {
+ *   const args = yield* Command.wizard(command)
+ *   yield* Console.log(args.join(" "))
+ * })
+ * ```
+ *
+ * @category command execution
+ * @since 4.0.0
+ */
+export const wizard = <Name extends string, Input, E, R, ContextInput>(
+  command: Command<Name, Input, ContextInput, E, R>,
+  options?: {
+    readonly prefix?: ReadonlyArray<string> | undefined
+  } | undefined
+): Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Environment> => Wizard.run(command, options)
+
 const getOutOfScopeGlobalFlagErrors = (
   allFlags: ReadonlyArray<GlobalFlag.GlobalFlag<any>>,
   activeFlags: ReadonlyArray<GlobalFlag.GlobalFlag<any>>,
@@ -1574,6 +1608,29 @@ export const runWith = <const Name extends string, Input, E, R, ContextInput>(
         })
         if (!hasEntry) continue
         const [, value] = yield* flag.flag.parse(emptyArgs)
+        if (flag === GlobalFlag.Wizard) {
+          return yield* Effect.gen(function*() {
+            yield* Console.log(Wizard.renderIntroduction(command.name, config.version, command.description))
+            const prefix = [
+              command.name,
+              ...args.filter((arg) => arg !== "--wizard" && !arg.startsWith("--wizard="))
+            ]
+            const wizardArgs = yield* Wizard.run(command, { commandPath, prefix })
+            yield* Console.log(Wizard.renderCompletion(wizardArgs))
+            const shouldRun = yield* Prompt.run(Prompt.toggle({
+              message: "Would you like to run the command?",
+              initial: true,
+              active: "yes",
+              inactive: "no"
+            }))
+            if (shouldRun) {
+              yield* Console.log()
+              yield* runWith(command, config)(wizardArgs.slice(1))
+            }
+          }).pipe(
+            Effect.catchTag("QuitError", () => Console.log(Wizard.renderQuit()))
+          )
+        }
         yield* flag.run(value, handlerCtx)
         return
       }

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -1618,7 +1618,7 @@ export const runWith = <const Name extends string, Input, E, R, ContextInput>(
             const wizardArgs = yield* Wizard.run(command, { commandPath, prefix })
             yield* Console.log(Wizard.renderCompletion(wizardArgs))
             const shouldRun = yield* Prompt.run(Prompt.toggle({
-              message: "Would you like to run the command?",
+              message: "Run this command?",
               initial: true,
               active: "yes",
               inactive: "no"

--- a/packages/effect/src/unstable/cli/GlobalFlag.ts
+++ b/packages/effect/src/unstable/cli/GlobalFlag.ts
@@ -5,7 +5,7 @@
  * This module defines two kinds of global flags: action flags, which run an
  * effect and stop normal command execution, and setting flags, which provide a
  * parsed value to the command handler through the Effect context. It also
- * defines the built-in help, version, shell-completion, and log-level flags
+ * defines the built-in help, version, wizard, shell-completion, and log-level flags
  * used by `Command.run` and `Command.runWith`.
  *
  * @since 4.0.0
@@ -186,6 +186,24 @@ export const Version: Action<boolean> = action({
 })
 
 /**
+ * Defines the global action flag for starting interactive wizard mode.
+ *
+ * **Details**
+ *
+ * `Command.run` and `Command.runWith` handle this action specially so the
+ * generated arguments can be passed back through the command parser.
+ *
+ * @category references
+ * @since 4.0.0
+ */
+export const Wizard: Action<boolean> = action({
+  flag: Flag.boolean("wizard").pipe(
+    Flag.withDescription("Start wizard mode for a command")
+  ),
+  run: () => Effect.void
+})
+
+/**
  * Defines the `--completions` global flag, which prints a shell completion script for
  * the given shell.
  *
@@ -260,7 +278,7 @@ export const LogLevel: Setting<"log-level", Option.Option<LogLevelType>> = setti
  *
  * **Details**
  *
- * The built-ins are `Help`, `Version`, `Completions`, and `LogLevel`.
+ * The built-ins are `Help`, `Version`, `Wizard`, `Completions`, and `LogLevel`.
  * `Command.runWith` prepends these built-ins when collecting and parsing global
  * flags.
  *
@@ -280,9 +298,10 @@ export const LogLevel: Setting<"log-level", Option.Option<LogLevelType>> = setti
 export const BuiltIns: readonly [
   Action<boolean>,
   Action<boolean>,
+  Action<boolean>,
   Action<Option.Option<"bash" | "zsh" | "fish">>,
   Setting<"log-level", Option.Option<LogLevelType>>
-] = [Help, Version, Completions, LogLevel]
+] = [Help, Version, Wizard, Completions, LogLevel]
 
 /**
  * Global flag included in the default command-runner configuration.

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -2101,9 +2101,19 @@ export const getUnderlyingSingleOrThrow = <Kind extends ParamKind, A>(
  */
 export const getParamMetadata = <Kind extends ParamKind, A>(
   param: Param<Kind, A>
-): { isOptional: boolean; isVariadic: boolean } => {
+): {
+  readonly isOptional: boolean
+  readonly isVariadic: boolean
+  readonly variadicMin: Option.Option<number>
+  readonly variadicMax: Option.Option<number>
+} => {
   return matchParam(param, {
-    Single: () => ({ isOptional: false, isVariadic: false }),
+    Single: () => ({
+      isOptional: false,
+      isVariadic: false,
+      variadicMin: Option.none(),
+      variadicMax: Option.none()
+    }),
     Map: (mapped) => getParamMetadata(mapped.param),
     Transform: (mapped) => getParamMetadata(mapped.param),
     Optional: (optional) => ({
@@ -2112,7 +2122,9 @@ export const getParamMetadata = <Kind extends ParamKind, A>(
     }),
     Variadic: (variadic) => ({
       ...getParamMetadata(variadic.param),
-      isVariadic: true
+      isVariadic: true,
+      variadicMin: variadic.min,
+      variadicMax: variadic.max
     })
   })
 }

--- a/packages/effect/src/unstable/cli/internal/ansi.ts
+++ b/packages/effect/src/unstable/cli/internal/ansi.ts
@@ -58,6 +58,9 @@ export const red = `${ESC}31m`
 export const green = `${ESC}32m`
 
 /** @internal */
+export const magenta = `${ESC}35m`
+
+/** @internal */
 export const white = `${ESC}37m`
 
 /** @internal */

--- a/packages/effect/src/unstable/cli/internal/wizard.ts
+++ b/packages/effect/src/unstable/cli/internal/wizard.ts
@@ -1,0 +1,246 @@
+import * as Console from "../../../Console.ts"
+import * as Effect from "../../../Effect.ts"
+import * as Option from "../../../Option.ts"
+import * as Redacted from "../../../Redacted.ts"
+import type * as Terminal from "../../../Terminal.ts"
+import type * as CliError from "../CliError.ts"
+import type * as Command from "../Command.ts"
+import * as Param from "../Param.ts"
+import * as Primitive from "../Primitive.ts"
+import * as Prompt from "../Prompt.ts"
+import * as Ansi from "./ansi.ts"
+import { toImpl } from "./command.ts"
+
+export interface Options {
+  readonly commandPath?: ReadonlyArray<string> | undefined
+  readonly prefix?: ReadonlyArray<string> | undefined
+}
+
+export const run: (
+  command: Command.Command.Any,
+  options?: Options
+) => Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
+  function*(command, options) {
+    const commandPath = options?.commandPath ?? [command.name]
+    const selected = getCommandAtPath(command, commandPath)
+    const commandLine = [...(options?.prefix ?? commandPath)]
+    yield* logCurrentCommand(commandLine)
+    yield* promptCommand(selected, commandLine)
+    return commandLine
+  }
+)
+
+const getCommandAtPath = (
+  command: Command.Command.Any,
+  commandPath: ReadonlyArray<string>
+): Command.Command.Any => {
+  let current = command
+  for (const name of commandPath.slice(1)) {
+    const child = current.subcommands
+      .flatMap((group) => group.commands)
+      .find((candidate) => candidate.name === name || candidate.alias === name)
+    if (child === undefined) {
+      break
+    }
+    current = child
+  }
+  return current
+}
+
+const promptCommand: (
+  command: Command.Command.Any,
+  commandLine: Array<string>
+) => Effect.Effect<void, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
+  function*(command, commandLine) {
+    const impl = toImpl(command)
+    const visibleSubcommands = command.subcommands.flatMap((group) => group.commands.filter((child) => !child.hidden))
+    const config = visibleSubcommands.length === 0 ? impl.config : impl.contextConfig
+
+    if (config.flags.length > 0) {
+      yield* Console.log(renderSection("Options Wizard", command.name))
+      for (const param of config.flags) {
+        commandLine.push(...yield* promptParam(param))
+      }
+      yield* logCurrentCommand(commandLine)
+    }
+
+    if (config.arguments.length > 0) {
+      yield* Console.log(renderSection("Args Wizard", command.name))
+      for (const param of config.arguments) {
+        commandLine.push(...yield* promptParam(param))
+      }
+      yield* logCurrentCommand(commandLine)
+    }
+
+    if (visibleSubcommands.length === 0) {
+      return
+    }
+
+    const child = yield* runPrompt(Prompt.select({
+      message: "Select which command you would like to execute",
+      choices: visibleSubcommands.map((command) => ({
+        title: command.name,
+        value: command,
+        ...(command.shortDescription !== undefined
+          ? { description: command.shortDescription }
+          : command.description !== undefined
+          ? { description: command.description }
+          : {})
+      }))
+    }))
+    commandLine.push(child.name)
+    yield* logCurrentCommand(commandLine)
+    yield* promptCommand(child, commandLine)
+  }
+)
+
+const promptParam: (
+  param: Param.Any
+) => Effect.Effect<Array<string>, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
+  function*(param) {
+    const single = Param.getUnderlyingSingleOrThrow(param)
+    const metadata = Param.getParamMetadata(param)
+
+    if (metadata.isOptional) {
+      const include = yield* runPrompt(Prompt.confirm({
+        message: `Provide ${formatName(single)}?`,
+        initial: false
+      }))
+      if (!include) {
+        return []
+      }
+    }
+
+    const count = !metadata.isVariadic
+      ? 1
+      : yield* runPrompt(Prompt.integer({
+        message: `How many values should be provided for ${formatName(single)}?`,
+        default: Option.getOrElse(metadata.variadicMin, () => 0),
+        min: Option.getOrElse(metadata.variadicMin, () => 0),
+        ...(Option.isSome(metadata.variadicMax) ? { max: metadata.variadicMax.value } : {})
+      }))
+    const values: Array<string> = []
+    for (let i = 0; i < count; i++) {
+      values.push(yield* promptSingle(single))
+    }
+
+    const parsed = single.kind === Param.flagKind
+      ? {
+        flags: { [single.name]: values },
+        arguments: []
+      }
+      : {
+        flags: {},
+        arguments: values
+      }
+    yield* param.parse(parsed)
+
+    if (single.kind === Param.argumentKind) {
+      return values
+    }
+    return values.flatMap((value) => [`--${single.name}`, value])
+  }
+)
+
+const promptSingle = (
+  single: Param.Single<Param.ParamKind, unknown>
+): Effect.Effect<string, Terminal.QuitError, Command.Environment> => {
+  const message = renderParamMessage(single)
+  switch (single.primitiveType._tag) {
+    case "Boolean":
+      return Effect.map(runPrompt(Prompt.toggle({ message })), String)
+    case "Choice": {
+      const choices = Primitive.getChoiceKeys(single.primitiveType) ?? []
+      return runPrompt(Prompt.select({
+        message,
+        choices: choices.map((choice) => ({ title: choice, value: choice }))
+      }))
+    }
+    case "Date":
+      return Effect.map(runPrompt(Prompt.date({ message })), (date) => date.toISOString())
+    case "Float":
+      return Effect.map(runPrompt(Prompt.float({ message })), String)
+    case "Integer":
+      return Effect.map(runPrompt(Prompt.integer({ message })), String)
+    case "Redacted":
+      return Effect.map(runPrompt(Prompt.password({ message })), Redacted.value)
+    default:
+      return runPrompt(Prompt.text({ message }))
+  }
+}
+
+const runPrompt = <A>(
+  prompt: Prompt.Prompt<A>
+): Effect.Effect<A, Terminal.QuitError, Command.Environment> => Prompt.run(prompt).pipe(Effect.tap(() => Console.log()))
+
+const formatName = (single: Param.Single<Param.ParamKind, unknown>): string =>
+  single.kind === Param.flagKind ? `--${single.name}` : single.name
+
+const renderParamMessage = (single: Param.Single<Param.ParamKind, unknown>): string => {
+  const name = Ansi.annotate(formatName(single), Ansi.bold, Ansi.white)
+  const type = Ansi.annotate(single.typeName ?? Primitive.getTypeName(single.primitiveType), Ansi.blackBright)
+  const description = Option.match(single.description, {
+    onNone: () => "",
+    onSome: (description) => `\n  ${description}`
+  })
+  return `${name} ${type}${description}\n${getPrimitiveInstruction(single.primitiveType)}`
+}
+
+const getPrimitiveInstruction = (primitive: Primitive.Primitive<unknown>): string => {
+  switch (primitive._tag) {
+    case "Boolean":
+      return "Select true or false"
+    case "Choice":
+      return "Select one of the following choices"
+    case "Date":
+      return "Enter a date"
+    case "Float":
+      return "Enter a floating point value"
+    case "Integer":
+      return "Enter an integer"
+    case "Path":
+    case "FileText":
+    case "FileParse":
+    case "FileSchema":
+      return "Select a file system path"
+    case "Redacted":
+      return "Enter some text (value will be redacted)"
+    case "KeyValuePair":
+      return "Enter a key=value pair"
+    default:
+      return "Enter some text"
+  }
+}
+
+const logCurrentCommand = (commandLine: ReadonlyArray<string>): Effect.Effect<void> =>
+  Console.log(
+    `${Ansi.annotate("COMMAND:", Ansi.bold, Ansi.cyanBright)} ${Ansi.annotate(commandLine.join(" "), Ansi.magenta)}`
+  )
+
+const renderSection = (section: string, commandName: string): string =>
+  `\n${Ansi.annotate(`${section} -`, Ansi.bold, Ansi.white)} ${Ansi.annotate(commandName, Ansi.magenta)}`
+
+export const renderIntroduction = (name: string, version: string, summary: string | undefined): string => {
+  const title = Ansi.annotate(`Wizard Mode for CLI Application: ${name} (${version})`, Ansi.bold, Ansi.white)
+  const suffix = summary === undefined || summary.length === 0 ? "" : ` -- ${summary}`
+  return [
+    `${title}${suffix}`,
+    "",
+    Ansi.annotate("Instructions", Ansi.bold),
+    `  The wizard mode will assist you with constructing commands for ${name} (${version}).`,
+    "  Please answer all prompts provided by the wizard.",
+    ""
+  ].join("\n")
+}
+
+export const renderCompletion = (commandLine: ReadonlyArray<string>): string =>
+  [
+    "",
+    Ansi.annotate("Wizard Mode Complete!", Ansi.bold, Ansi.white),
+    "",
+    "You may now execute your command directly with the following options and arguments:",
+    "",
+    `    ${Ansi.annotate(commandLine.join(" "), Ansi.cyanBright)}`
+  ].join("\n")
+
+export const renderQuit = (): string => `\n\n${Ansi.annotate("Quitting wizard mode...", Ansi.red)}`

--- a/packages/effect/src/unstable/cli/internal/wizard.ts
+++ b/packages/effect/src/unstable/cli/internal/wizard.ts
@@ -25,7 +25,7 @@ export const run: (
     const selected = getCommandAtPath(command, commandPath)
     const commandLine = [...(options?.prefix ?? commandPath)]
     yield* logCurrentCommand(commandLine)
-    yield* promptCommand(selected, commandLine)
+    yield* promptCommand(selected, commandLine, selected === command ? "ROOT" : selected.name)
     return commandLine
   }
 )
@@ -49,27 +49,32 @@ const getCommandAtPath = (
 
 const promptCommand: (
   command: Command.Command.Any,
-  commandLine: Array<string>
+  commandLine: Array<string>,
+  sectionName: string
 ) => Effect.Effect<void, CliError.CliError | Terminal.QuitError, Command.Environment> = Effect.fnUntraced(
-  function*(command, commandLine) {
+  function*(command, commandLine, sectionName) {
     const impl = toImpl(command)
     const visibleSubcommands = command.subcommands.flatMap((group) => group.commands.filter((child) => !child.hidden))
     const config = visibleSubcommands.length === 0 ? impl.config : impl.contextConfig
 
     if (config.flags.length > 0) {
-      yield* Console.log(renderSection("Options Wizard", command.name))
+      yield* Console.log(renderSection(sectionName, "FLAGS"))
       for (const param of config.flags) {
         commandLine.push(...yield* promptParam(param))
       }
-      yield* logCurrentCommand(commandLine)
+      if (config.arguments.length > 0 || visibleSubcommands.length > 0) {
+        yield* logCurrentCommand(commandLine)
+      }
     }
 
     if (config.arguments.length > 0) {
-      yield* Console.log(renderSection("Args Wizard", command.name))
+      yield* Console.log(renderSection(sectionName, "ARGUMENTS"))
       for (const param of config.arguments) {
         commandLine.push(...yield* promptParam(param))
       }
-      yield* logCurrentCommand(commandLine)
+      if (visibleSubcommands.length > 0) {
+        yield* logCurrentCommand(commandLine)
+      }
     }
 
     if (visibleSubcommands.length === 0) {
@@ -77,7 +82,7 @@ const promptCommand: (
     }
 
     const child = yield* runPrompt(Prompt.select({
-      message: "Select which command you would like to execute",
+      message: "Command",
       choices: visibleSubcommands.map((command) => ({
         title: command.name,
         value: command,
@@ -88,11 +93,19 @@ const promptCommand: (
           : {})
       }))
     }))
+    yield* Console.log()
     commandLine.push(child.name)
-    yield* logCurrentCommand(commandLine)
-    yield* promptCommand(child, commandLine)
+    if (hasWizardSteps(child)) {
+      yield* logCurrentCommand(commandLine)
+    }
+    yield* promptCommand(child, commandLine, child.name)
   }
 )
+
+const hasWizardSteps = (command: Command.Command.Any): boolean => {
+  const hasVisibleSubcommands = command.subcommands.some((group) => group.commands.some((child) => !child.hidden))
+  return hasVisibleSubcommands || toImpl(command).config.orderedParams.length > 0
+}
 
 const promptParam: (
   param: Param.Any
@@ -103,10 +116,11 @@ const promptParam: (
 
     if (metadata.isOptional) {
       const include = yield* runPrompt(Prompt.confirm({
-        message: `Provide ${formatName(single)}?`,
+        message: `Set ${renderParamLabel(single)}?`,
         initial: false
       }))
       if (!include) {
+        yield* Console.log()
         return []
       }
     }
@@ -114,7 +128,7 @@ const promptParam: (
     const count = !metadata.isVariadic
       ? 1
       : yield* runPrompt(Prompt.integer({
-        message: `How many values should be provided for ${formatName(single)}?`,
+        message: `${renderParamLabel(single)} count`,
         default: Option.getOrElse(metadata.variadicMin, () => 0),
         min: Option.getOrElse(metadata.variadicMin, () => 0),
         ...(Option.isSome(metadata.variadicMax) ? { max: metadata.variadicMax.value } : {})
@@ -134,6 +148,7 @@ const promptParam: (
         arguments: values
       }
     yield* param.parse(parsed)
+    yield* Console.log()
 
     if (single.kind === Param.argumentKind) {
       return values
@@ -148,7 +163,20 @@ const promptSingle = (
   const message = renderParamMessage(single)
   switch (single.primitiveType._tag) {
     case "Boolean":
-      return Effect.map(runPrompt(Prompt.toggle({ message })), String)
+      return Effect.map(
+        runPrompt(Prompt.confirm({
+          message,
+          label: {
+            confirm: "true",
+            deny: "false"
+          },
+          placeholder: {
+            defaultConfirm: "(T/f)",
+            defaultDeny: "(t/F)"
+          }
+        })),
+        String
+      )
     case "Choice": {
       const choices = Primitive.getChoiceKeys(single.primitiveType) ?? []
       return runPrompt(Prompt.select({
@@ -171,76 +199,89 @@ const promptSingle = (
 
 const runPrompt = <A>(
   prompt: Prompt.Prompt<A>
-): Effect.Effect<A, Terminal.QuitError, Command.Environment> => Prompt.run(prompt).pipe(Effect.tap(() => Console.log()))
+): Effect.Effect<A, Terminal.QuitError, Command.Environment> => Prompt.run(prompt)
 
 const formatName = (single: Param.Single<Param.ParamKind, unknown>): string =>
   single.kind === Param.flagKind ? `--${single.name}` : single.name
 
-const renderParamMessage = (single: Param.Single<Param.ParamKind, unknown>): string => {
-  const name = Ansi.annotate(formatName(single), Ansi.bold, Ansi.white)
-  const type = Ansi.annotate(single.typeName ?? Primitive.getTypeName(single.primitiveType), Ansi.blackBright)
-  const description = Option.match(single.description, {
-    onNone: () => "",
-    onSome: (description) => `\n  ${description}`
-  })
-  return `${name} ${type}${description}\n${getPrimitiveInstruction(single.primitiveType)}`
+const renderParamMessage = (single: Param.Single<Param.ParamKind, unknown>): string => renderParamLabel(single)
+
+const renderParamLabel = (single: Param.Single<Param.ParamKind, unknown>): string => {
+  const description = Option.getOrUndefined(single.description)?.trim()
+  const label = single.kind === Param.flagKind && description !== undefined && description.length <= 32
+    ? description
+    : humanize(single.name)
+  return single.kind === Param.flagKind ? `${label} (${formatName(single)})` : label
 }
 
-const getPrimitiveInstruction = (primitive: Primitive.Primitive<unknown>): string => {
-  switch (primitive._tag) {
-    case "Boolean":
-      return "Select true or false"
-    case "Choice":
-      return "Select one of the following choices"
-    case "Date":
-      return "Enter a date"
-    case "Float":
-      return "Enter a floating point value"
-    case "Integer":
-      return "Enter an integer"
-    case "Path":
-    case "FileText":
-    case "FileParse":
-    case "FileSchema":
-      return "Select a file system path"
-    case "Redacted":
-      return "Enter some text (value will be redacted)"
-    case "KeyValuePair":
-      return "Enter a key=value pair"
-    default:
-      return "Enter some text"
-  }
+const humanize = (name: string): string => {
+  const words = name.split(/[-_]+/).filter((word) => word.length > 0)
+  if (words.length === 0) return name
+  return [words[0][0].toUpperCase() + words[0].slice(1), ...words.slice(1)].join(" ")
 }
 
 const logCurrentCommand = (commandLine: ReadonlyArray<string>): Effect.Effect<void> =>
-  Console.log(
-    `${Ansi.annotate("COMMAND:", Ansi.bold, Ansi.cyanBright)} ${Ansi.annotate(commandLine.join(" "), Ansi.magenta)}`
-  )
+  Console.log(renderCommandBlock("Current command", commandLine, Ansi.magenta))
 
-const renderSection = (section: string, commandName: string): string =>
-  `\n${Ansi.annotate(`${section} -`, Ansi.bold, Ansi.white)} ${Ansi.annotate(commandName, Ansi.magenta)}`
+const renderSection = (commandName: string, section: string): string =>
+  `${Ansi.annotate(commandName.toUpperCase(), Ansi.bold, Ansi.cyanBright)} ${Ansi.annotate("·", Ansi.blackBright)} ${
+    Ansi.annotate(section, Ansi.bold, Ansi.white)
+  }`
 
 export const renderIntroduction = (name: string, version: string, summary: string | undefined): string => {
-  const title = Ansi.annotate(`Wizard Mode for CLI Application: ${name} (${version})`, Ansi.bold, Ansi.white)
-  const suffix = summary === undefined || summary.length === 0 ? "" : ` -- ${summary}`
+  const title = `${Ansi.annotate(name, Ansi.bold, Ansi.cyanBright)} ${Ansi.annotate(`v${version}`, Ansi.white)} ${
+    Ansi.annotate("· Command wizard", Ansi.bold, Ansi.white)
+  }`
   return [
-    `${title}${suffix}`,
-    "",
-    Ansi.annotate("Instructions", Ansi.bold),
-    `  The wizard mode will assist you with constructing commands for ${name} (${version}).`,
-    "  Please answer all prompts provided by the wizard.",
+    title,
+    ...(summary === undefined || summary.length === 0 ? [] : [summary]),
+    Ansi.annotate("Build a command interactively. Press Ctrl+C to cancel.", Ansi.blackBright),
     ""
   ].join("\n")
 }
 
 export const renderCompletion = (commandLine: ReadonlyArray<string>): string =>
-  [
-    "",
-    Ansi.annotate("Wizard Mode Complete!", Ansi.bold, Ansi.white),
-    "",
-    "You may now execute your command directly with the following options and arguments:",
-    "",
-    `    ${Ansi.annotate(commandLine.join(" "), Ansi.cyanBright)}`
-  ].join("\n")
+  renderCommandBlock("Command ready", commandLine, Ansi.cyanBright, Ansi.green)
 
-export const renderQuit = (): string => `\n\n${Ansi.annotate("Quitting wizard mode...", Ansi.red)}`
+export const renderQuit = (): string => `\n${Ansi.annotate("Wizard cancelled.", Ansi.red)}`
+
+const renderCommandBlock = (
+  label: string,
+  commandLine: ReadonlyArray<string>,
+  commandColor: string,
+  labelColor: string = Ansi.white
+): string => {
+  const lines = wrapCommand(commandLine)
+  return [
+    Ansi.annotate(label, Ansi.bold, labelColor),
+    ...lines.map((line) => Ansi.annotate(line, commandColor)),
+    ""
+  ].join("\n")
+}
+
+const wrapCommand = (commandLine: ReadonlyArray<string>): Array<string> => {
+  const width = 88
+  const firstIndent = "  $ "
+  const continuationIndent = "    "
+  const args = commandLine.map(formatShellArg)
+  const lines: Array<string> = []
+  let current = firstIndent
+
+  for (const arg of args) {
+    const separator = current === firstIndent || current === continuationIndent ? "" : " "
+    if (current.length + separator.length + arg.length > width && current !== firstIndent) {
+      lines.push(`${current} \\`)
+      current = `${continuationIndent}${arg}`
+    } else {
+      current += `${separator}${arg}`
+    }
+  }
+
+  if (current !== firstIndent) {
+    lines.push(current)
+  }
+  return lines
+}
+
+const formatShellArg = (arg: string): string =>
+  /^[A-Za-z0-9_./:@%+=,-]+$/.test(arg) ? arg : `'${arg.replaceAll("'", `'"'"'`)}'`

--- a/packages/effect/src/unstable/cli/internal/wizard.ts
+++ b/packages/effect/src/unstable/cli/internal/wizard.ts
@@ -81,7 +81,7 @@ const promptCommand: (
       return
     }
 
-    const child = yield* runPrompt(Prompt.select({
+    const child = yield* Prompt.run(Prompt.select({
       message: "Command",
       choices: visibleSubcommands.map((command) => ({
         title: command.name,
@@ -115,7 +115,7 @@ const promptParam: (
     const metadata = Param.getParamMetadata(param)
 
     if (metadata.isOptional) {
-      const include = yield* runPrompt(Prompt.confirm({
+      const include = yield* Prompt.run(Prompt.confirm({
         message: `Set ${renderParamLabel(single)}?`,
         initial: false
       }))
@@ -127,7 +127,7 @@ const promptParam: (
 
     const count = !metadata.isVariadic
       ? 1
-      : yield* runPrompt(Prompt.integer({
+      : yield* Prompt.run(Prompt.integer({
         message: `${renderParamLabel(single)} count`,
         default: Option.getOrElse(metadata.variadicMin, () => 0),
         min: Option.getOrElse(metadata.variadicMin, () => 0),
@@ -164,7 +164,7 @@ const promptSingle = (
   switch (single.primitiveType._tag) {
     case "Boolean":
       return Effect.map(
-        runPrompt(Prompt.confirm({
+        Prompt.run(Prompt.confirm({
           message,
           label: {
             confirm: "true",
@@ -179,27 +179,23 @@ const promptSingle = (
       )
     case "Choice": {
       const choices = Primitive.getChoiceKeys(single.primitiveType) ?? []
-      return runPrompt(Prompt.select({
+      return Prompt.run(Prompt.select({
         message,
         choices: choices.map((choice) => ({ title: choice, value: choice }))
       }))
     }
     case "Date":
-      return Effect.map(runPrompt(Prompt.date({ message })), (date) => date.toISOString())
+      return Effect.map(Prompt.run(Prompt.date({ message })), (date) => date.toISOString())
     case "Float":
-      return Effect.map(runPrompt(Prompt.float({ message })), String)
+      return Effect.map(Prompt.run(Prompt.float({ message })), String)
     case "Integer":
-      return Effect.map(runPrompt(Prompt.integer({ message })), String)
+      return Effect.map(Prompt.run(Prompt.integer({ message })), String)
     case "Redacted":
-      return Effect.map(runPrompt(Prompt.password({ message })), Redacted.value)
+      return Effect.map(Prompt.run(Prompt.password({ message })), Redacted.value)
     default:
-      return runPrompt(Prompt.text({ message }))
+      return Prompt.run(Prompt.text({ message }))
   }
 }
-
-const runPrompt = <A>(
-  prompt: Prompt.Prompt<A>
-): Effect.Effect<A, Terminal.QuitError, Command.Environment> => Prompt.run(prompt)
 
 const formatName = (single: Param.Single<Param.ParamKind, unknown>): string =>
   single.kind === Param.flagKind ? `--${single.name}` : single.name

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -153,7 +153,7 @@ describe("Command", () => {
         yield* Fiber.join(fiber)
 
         assert.deepStrictEqual(captured, ["Alice Smith"])
-        const output = (yield* TestConsole.logLines).join("\n")
+        const output = [...yield* TestConsole.logLines, ...yield* MockTerminal.displayLines].join("\n")
         assert.include(output, "Command wizard")
         assert.include(output, "Build a command interactively. Press Ctrl+C to cancel.")
         assert.include(output, "Current command")
@@ -179,7 +179,7 @@ describe("Command", () => {
         yield* MockTerminal.inputKey("c", { ctrl: true })
         yield* Fiber.join(fiber)
 
-        const output = (yield* TestConsole.logLines).join("\n")
+        const output = [...yield* TestConsole.logLines, ...yield* MockTerminal.displayLines].join("\n")
         assert.isFalse(invoked)
         assert.include(output, "Wizard cancelled.")
       }).pipe(Effect.provide(TestLayer)))
@@ -196,7 +196,7 @@ describe("Command", () => {
         yield* MockTerminal.inputKey("enter")
         yield* Fiber.join(fiber)
 
-        const output = (yield* TestConsole.logLines).join("\n")
+        const output = [...yield* TestConsole.logLines, ...yield* MockTerminal.displayLines].join("\n")
         assert.deepStrictEqual(captured, [true])
         assert.include(output, "Dry run (--dry-run)")
         assert.include(output, "deploy --dry-run true")

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -147,18 +147,22 @@ describe("Command", () => {
         }, ({ name }) => Effect.sync(() => captured.push(name)))
 
         const fiber = yield* Command.runWith(command, { version: "1.0.0" })(["--wizard"]).pipe(Effect.forkChild)
-        yield* MockTerminal.inputText("Alice")
+        yield* MockTerminal.inputText("Alice Smith")
         yield* MockTerminal.inputKey("enter")
         yield* MockTerminal.inputKey("enter")
         yield* Fiber.join(fiber)
 
-        assert.deepStrictEqual(captured, ["Alice"])
+        assert.deepStrictEqual(captured, ["Alice Smith"])
         const output = (yield* TestConsole.logLines).join("\n")
-        assert.include(output, "Wizard Mode for CLI Application: greet (1.0.0)")
-        assert.include(output, "COMMAND:")
-        assert.include(output, "Options Wizard -")
-        assert.include(output, "Wizard Mode Complete!")
-        assert.include(output, "greet --name Alice")
+        assert.include(output, "Command wizard")
+        assert.include(output, "Build a command interactively. Press Ctrl+C to cancel.")
+        assert.include(output, "Current command")
+        assert.include(output, "ROOT")
+        assert.include(output, "FLAGS")
+        assert.include(output, "Name (--name)")
+        assert.include(output, "Command ready")
+        assert.include(output, "$ greet --name 'Alice Smith'")
+        assert.include(output, "Run this command?")
       }).pipe(Effect.provide(TestLayer)))
 
     it.effect("should print a message when wizard mode is cancelled", () =>
@@ -177,7 +181,26 @@ describe("Command", () => {
 
         const output = (yield* TestConsole.logLines).join("\n")
         assert.isFalse(invoked)
-        assert.include(output, "Quitting wizard mode...")
+        assert.include(output, "Wizard cancelled.")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should render boolean wizard values consistently", () =>
+      Effect.gen(function*() {
+        const captured: Array<boolean> = []
+        const command = Command.make("deploy", {
+          dryRun: Flag.boolean("dry-run")
+        }, ({ dryRun }) => Effect.sync(() => captured.push(dryRun)))
+
+        const fiber = yield* Command.runWith(command, { version: "1.0.0" })(["--wizard"]).pipe(Effect.forkChild)
+        yield* MockTerminal.inputKey("y")
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+
+        const output = (yield* TestConsole.logLines).join("\n")
+        assert.deepStrictEqual(captured, [true])
+        assert.include(output, "Dry run (--dry-run)")
+        assert.include(output, "deploy --dry-run true")
+        assert.notInclude(output, "on / off")
       }).pipe(Effect.provide(TestLayer)))
 
     it.effect("should start wizard mode at a selected subcommand", () =>

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Context, Effect, FileSystem, Layer, Option, Path, Stdio } from "effect"
+import { Context, Effect, Fiber, FileSystem, Layer, Option, Path, Stdio } from "effect"
 import { TestConsole } from "effect/testing"
 import { Argument, CliConfig, CliOutput, Command, Flag, GlobalFlag } from "effect/unstable/cli"
 import { toImpl } from "effect/unstable/cli/internal/command"
@@ -116,6 +116,89 @@ describe("Command", () => {
   })
 
   describe("run", () => {
+    it.effect("should invoke the wizard programmatically from a command handler", () =>
+      Effect.gen(function*() {
+        const captured: Array<ReadonlyArray<string>> = []
+        const target = Command.make("greet", {
+          name: Flag.string("name"),
+          count: Argument.integer("count")
+        })
+        const command = Command.make("launcher", {}, () =>
+          Effect.flatMap(Command.wizard(target), (args) =>
+            Effect.sync(() => {
+              captured.push(args)
+            })))
+
+        const fiber = yield* Command.runWith(command, { version: "1.0.0" })([]).pipe(Effect.forkChild)
+        yield* MockTerminal.inputText("Alice")
+        yield* MockTerminal.inputKey("enter")
+        yield* MockTerminal.inputText("2")
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+
+        assert.deepStrictEqual(captured, [["greet", "--name", "Alice", "2"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should run wizard-generated arguments with --wizard", () =>
+      Effect.gen(function*() {
+        const captured: Array<string> = []
+        const command = Command.make("greet", {
+          name: Flag.string("name")
+        }, ({ name }) => Effect.sync(() => captured.push(name)))
+
+        const fiber = yield* Command.runWith(command, { version: "1.0.0" })(["--wizard"]).pipe(Effect.forkChild)
+        yield* MockTerminal.inputText("Alice")
+        yield* MockTerminal.inputKey("enter")
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+
+        assert.deepStrictEqual(captured, ["Alice"])
+        const output = (yield* TestConsole.logLines).join("\n")
+        assert.include(output, "Wizard Mode for CLI Application: greet (1.0.0)")
+        assert.include(output, "COMMAND:")
+        assert.include(output, "Options Wizard -")
+        assert.include(output, "Wizard Mode Complete!")
+        assert.include(output, "greet --name Alice")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should print a message when wizard mode is cancelled", () =>
+      Effect.gen(function*() {
+        let invoked = false
+        const command = Command.make("greet", {
+          name: Flag.string("name")
+        }, () =>
+          Effect.sync(() => {
+            invoked = true
+          }))
+
+        const fiber = yield* Command.runWith(command, { version: "1.0.0" })(["--wizard"]).pipe(Effect.forkChild)
+        yield* MockTerminal.inputKey("c", { ctrl: true })
+        yield* Fiber.join(fiber)
+
+        const output = (yield* TestConsole.logLines).join("\n")
+        assert.isFalse(invoked)
+        assert.include(output, "Quitting wizard mode...")
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should start wizard mode at a selected subcommand", () =>
+      Effect.gen(function*() {
+        const captured: Array<string> = []
+        const child = Command.make("child", {
+          value: Argument.string("value")
+        }, ({ value }) => Effect.sync(() => captured.push(value)))
+        const command = Command.make("root").pipe(Command.withSubcommands([child]))
+
+        const fiber = yield* Command.runWith(command, { version: "1.0.0" })(["child", "--wizard"]).pipe(
+          Effect.forkChild
+        )
+        yield* MockTerminal.inputText("selected")
+        yield* MockTerminal.inputKey("enter")
+        yield* MockTerminal.inputKey("enter")
+        yield* Fiber.join(fiber)
+
+        assert.deepStrictEqual(captured, ["selected"])
+      }).pipe(Effect.provide(TestLayer)))
+
     it.effect("should reject --completions without a shell", () =>
       Effect.gen(function*() {
         let invoked = false

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -57,6 +57,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
@@ -249,6 +250,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
@@ -293,6 +295,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
@@ -323,6 +326,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
@@ -351,6 +355,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
@@ -382,6 +387,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
@@ -408,6 +414,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
@@ -442,6 +449,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
@@ -520,6 +528,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
@@ -562,6 +571,7 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h                                                          Show help information
           --version, -v                                                       Show version information
+          --wizard                                                            Start wizard mode for a command
           --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
           --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1,16 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Data, Effect, Fiber, FileSystem, Layer, Match, Path, Queue, Redacted } from "effect"
-import { TestConsole } from "effect/testing"
 import { Prompt } from "effect/unstable/cli"
 import * as MockTerminal from "./services/MockTerminal.ts"
 
-const ConsoleLayer = TestConsole.layer
 const FileSystemLayer = FileSystem.layerNoop({})
 const PathLayer = Path.layer
 const TerminalLayer = MockTerminal.layer
 
 const TestLayer = Layer.mergeAll(
-  ConsoleLayer,
   FileSystemLayer,
   PathLayer,
   TerminalLayer
@@ -98,7 +95,7 @@ describe("Prompt.float", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, 12.5)
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const rendered = frames.join("\n")
 
@@ -212,7 +209,7 @@ describe("Prompt.text", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const lastFrame = frames.at(-1)
 
@@ -269,7 +266,7 @@ describe("Prompt.autoComplete", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "banana")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const filteredFrame = findFrame(frames, "[filter: ban]")
 
@@ -296,7 +293,7 @@ describe("Prompt.autoComplete", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "alpha")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const narrowedFrame = findFrame(frames, "[filter: al]")
       const expandedFrame = findFrame(frames, "[filter: a]")
@@ -325,7 +322,7 @@ describe("Prompt.autoComplete", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "alpha")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const narrowedFrame = findFrame(frames, "[filter: al]")
       const clearedFrame = findFrame(frames, "[filter: type to filter]")
@@ -356,7 +353,7 @@ describe("Prompt.autoComplete", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "cat")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
 
       assert.isTrue(output.some((line) => String(line).includes("\x07")))
@@ -380,7 +377,7 @@ describe("Prompt.autoComplete", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "fast")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       assert.isTrue(output.some((line) => String(line).includes("\x07")))
     }).pipe(Effect.provide(TestLayer)))
 
@@ -395,7 +392,7 @@ describe("Prompt.autoComplete", () => {
       const exit = yield* Prompt.run(prompt).pipe(Effect.exit)
       assert.isTrue(exit._tag === "Failure")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
 
       assert.isTrue(findFrame(frames, "No matches") !== undefined)
@@ -404,7 +401,6 @@ describe("Prompt.autoComplete", () => {
 
 describe("Prompt.file", () => {
   const FilePromptLayer = Layer.mergeAll(
-    ConsoleLayer,
     FileSystem.layerNoop({
       exists: () => Effect.succeed(true),
       readDirectory: (directory) =>
@@ -450,7 +446,7 @@ describe("Prompt.file", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "/workspace/banana.txt")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const filteredFrame = findFrame(frames, "[filter: ban]")
 
@@ -474,7 +470,7 @@ describe("Prompt.file", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "/workspace/banana.txt")
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toFrames(output)
       const narrowedFrame = findFrame(frames, "[filter: ban]")
       const expandedFrame = findFrame(frames, "[filter: ba]")
@@ -506,7 +502,7 @@ describe("Prompt.multiSelect", () => {
       yield* MockTerminal.inputKey("down")
       yield* Effect.yieldNow
 
-      const output = yield* TestConsole.logLines
+      const output = yield* MockTerminal.displayLines
       const frames = toRawFrames(output)
       const highlightedFrame = [...frames].reverse().find((frame) => frame.includes("Beta"))
 

--- a/packages/effect/test/unstable/cli/services/MockTerminal.ts
+++ b/packages/effect/test/unstable/cli/services/MockTerminal.ts
@@ -1,6 +1,5 @@
 import * as Array from "effect/Array"
 import type * as Cause from "effect/Cause"
-import * as Console from "effect/Console"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
@@ -14,6 +13,7 @@ import * as Terminal from "effect/Terminal"
 // =============================================================================
 
 export interface MockTerminal extends Terminal.Terminal {
+  readonly displayLines: Effect.Effect<ReadonlyArray<string>>
   readonly inputText: (text: string) => Effect.Effect<void>
   readonly inputKey: (key: string, modifiers?: Partial<MockTerminal.Modifiers>) => Effect.Effect<void>
 }
@@ -39,6 +39,7 @@ export const MockTerminal = Context.Service<Terminal.Terminal, MockTerminal>()(
 // =============================================================================
 
 export const make = Effect.gen(function*() {
+  const output: Array<string> = []
   const queue = yield* Effect.acquireRelease(
     Queue.make<Terminal.UserInput, Cause.Done>(),
     (queue) => Queue.shutdown(queue)
@@ -57,7 +58,10 @@ export const make = Effect.gen(function*() {
     return shouldQuit(input) ? Queue.end(queue) : Queue.offer(queue, input).pipe(Effect.asVoid)
   }
 
-  const display: MockTerminal["display"] = (input) => Console.log(input)
+  const display: MockTerminal["display"] = (input) =>
+    Effect.sync(() => {
+      output.push(input)
+    })
 
   const readInput: MockTerminal["readInput"] = Effect.succeed(Queue.asDequeue(queue))
 
@@ -70,6 +74,7 @@ export const make = Effect.gen(function*() {
   })
 
   return Object.assign(terminal, {
+    displayLines: Effect.sync(() => output.slice()),
     inputKey,
     inputText
   })
@@ -88,6 +93,11 @@ export const layer: Layer.Layer<Terminal.Terminal> = Layer.effect(MockTerminal, 
 export const columns: Effect.Effect<number, never, Terminal.Terminal> = Effect.flatMap(
   MockTerminal,
   (terminal) => terminal.columns
+)
+
+export const displayLines: Effect.Effect<ReadonlyArray<string>, never, Terminal.Terminal> = Effect.flatMap(
+  MockTerminal,
+  (terminal) => terminal.displayLines
 )
 
 export const readInput: Effect.Effect<


### PR DESCRIPTION
## Summary
- add the built-in `--wizard` flag and programmatic `Command.wizard` API
- generate validated flags, arguments, and subcommand paths through interactive prompts
- restore a structured, colored wizard flow with command previews, shell quoting, and cancellation handling

## Testing
- `pnpm test packages/effect/test/unstable/cli/Command.test.ts`
- `pnpm test-types Command.tst.ts`
- `pnpm check`
- `pnpm lint`

Closes #6331