### PR TITLE
Fix child process force-kill escalation

### DIFF
--- a/.changeset/fuzzy-cats-kill.md
+++ b/.changeset/fuzzy-cats-kill.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+Fix child process termination to escalate to `SIGKILL` when the initial signal does not stop the process within `forceKillAfter`.

--- a/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
@@ -498,9 +498,8 @@ const make = Effect.gen(function*() {
               Effect.catch(
                 killProcessGroup(command, childProcess, signal),
                 () => killProcess(command, childProcess, signal)
-              )
+              ).pipe(Effect.andThen(Deferred.await(exitSignal)))
             ).pipe(
-              Effect.andThen(Deferred.await(exitSignal)),
               Effect.ignore
             )
           })
@@ -545,9 +544,8 @@ const make = Effect.gen(function*() {
             Effect.catch(
               killProcessGroup(command, childProcess, signal),
               () => killProcess(command, childProcess, signal)
-            )
+            ).pipe(Effect.andThen(Deferred.await(exitSignal)))
           ).pipe(
-            Effect.andThen(Deferred.await(exitSignal)),
             Effect.asVoid
           )
         }

--- a/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
+++ b/packages/platform-node-shared/src/NodeChildProcessSpawner.ts
@@ -495,10 +495,10 @@ const make = Effect.gen(function*() {
             }
             // Process is still running, kill it
             return yield* killWithTimeout((command, childProcess, signal) =>
-              Effect.catch(
-                killProcessGroup(command, childProcess, signal),
-                () => killProcess(command, childProcess, signal)
-              ).pipe(Effect.andThen(Deferred.await(exitSignal)))
+              killProcessGroup(command, childProcess, signal).pipe(
+                Effect.catch(() => killProcess(command, childProcess, signal)),
+                Effect.andThen(Deferred.await(exitSignal))
+              )
             ).pipe(
               Effect.ignore
             )
@@ -541,10 +541,10 @@ const make = Effect.gen(function*() {
         const kill = (options?: ChildProcess.KillOptions | undefined) => {
           const killWithTimeout = withTimeout(childProcess, cmd, options)
           return killWithTimeout((command, childProcess, signal) =>
-            Effect.catch(
-              killProcessGroup(command, childProcess, signal),
-              () => killProcess(command, childProcess, signal)
-            ).pipe(Effect.andThen(Deferred.await(exitSignal)))
+            killProcessGroup(command, childProcess, signal).pipe(
+              Effect.catch(() => killProcess(command, childProcess, signal)),
+              Effect.andThen(Deferred.await(exitSignal))
+            )
           ).pipe(
             Effect.asVoid
           )

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -466,6 +466,7 @@ describe("NodeChildProcessSpawner", () => {
             const ready = path.join(directory, "ready")
             const handle = yield* ChildProcess.make("node", [
               "-e",
+              // Installing a listener suppresses Node's default SIGTERM exit so the test exercises force-kill escalation.
               "process.on('SIGTERM', () => {}); require('node:fs').writeFileSync(process.argv[1], ''); setInterval(() => {}, 1000)",
               ready
             ], {
@@ -507,6 +508,7 @@ describe("NodeChildProcessSpawner", () => {
             const completed = yield* Effect.scoped(Effect.gen(function*() {
               yield* ChildProcess.make("node", [
                 "-e",
+                // Installing a listener suppresses Node's default SIGTERM exit so the test exercises force-kill escalation.
                 "process.on('SIGTERM', () => {}); require('node:fs').writeFileSync(process.argv[1], ''); setTimeout(() => process.exit(0), 2000)",
                 ready
               ], {

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -8,6 +8,7 @@ import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import * as PlatformError from "effect/PlatformError"
+import * as Schedule from "effect/Schedule"
 import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import * as TestClock from "effect/testing/TestClock"
@@ -455,6 +456,83 @@ describe("NodeChildProcessSpawner", () => {
 
             const exit = yield* Effect.exit(handle.exitCode)
             assert.isTrue(exit._tag === "Failure")
+          }).pipe(Effect.scoped))
+
+        it.effect("should force kill a process after the initial signal times out", () =>
+          Effect.gen(function*() {
+            const fs = yield* FileSystem.FileSystem
+            const path = yield* Path.Path
+            const directory = yield* fs.makeTempDirectoryScoped()
+            const ready = path.join(directory, "ready")
+            const handle = yield* ChildProcess.make("node", [
+              "-e",
+              "process.on('SIGTERM', () => {}); require('node:fs').writeFileSync(process.argv[1], ''); setInterval(() => {}, 1000)",
+              ready
+            ], {
+              killSignal: "SIGKILL",
+              stdout: "ignore",
+              stderr: "ignore"
+            })
+
+            yield* fs.exists(ready).pipe(
+              Effect.repeat({
+                while: (exists) => !exists,
+                schedule: Schedule.spaced("10 millis")
+              }),
+              Effect.timeout("1 second"),
+              TestClock.withLive
+            )
+
+            const completed = yield* handle.kill({
+              killSignal: "SIGTERM",
+              forceKillAfter: "50 millis"
+            }).pipe(
+              Effect.as(true),
+              Effect.timeoutOrElse({
+                duration: "1 second",
+                orElse: () => Effect.succeed(false)
+              }),
+              TestClock.withLive
+            )
+
+            assert.isTrue(completed)
+          }).pipe(Effect.scoped))
+
+        it.effect("should force kill a process when its scope closes", () =>
+          Effect.gen(function*() {
+            const fs = yield* FileSystem.FileSystem
+            const path = yield* Path.Path
+            const directory = yield* fs.makeTempDirectoryScoped()
+            const ready = path.join(directory, "ready")
+            const completed = yield* Effect.scoped(Effect.gen(function*() {
+              yield* ChildProcess.make("node", [
+                "-e",
+                "process.on('SIGTERM', () => {}); require('node:fs').writeFileSync(process.argv[1], ''); setTimeout(() => process.exit(0), 2000)",
+                ready
+              ], {
+                killSignal: "SIGTERM",
+                forceKillAfter: "50 millis",
+                stdout: "ignore",
+                stderr: "ignore"
+              })
+
+              yield* fs.exists(ready).pipe(
+                Effect.repeat({
+                  while: (exists) => !exists,
+                  schedule: Schedule.spaced("10 millis")
+                }),
+                Effect.timeout("1 second")
+              )
+            })).pipe(
+              Effect.as(true),
+              Effect.timeoutOrElse({
+                duration: "1 second",
+                orElse: () => Effect.succeed(false)
+              }),
+              TestClock.withLive
+            )
+
+            assert.isTrue(completed)
           }).pipe(Effect.scoped))
       })
     })


### PR DESCRIPTION
## Summary

`forceKillAfter` currently times only delivery of the initial signal. Signal delivery completes immediately, so the `SIGKILL` fallback is never reached and termination can wait indefinitely when a child ignores the initial signal.

- include the child process exit wait in the `forceKillAfter` timeout
- escalate to `SIGKILL` when the initial signal does not stop the process
- cover both explicit `ChildProcessHandle.kill` calls and automatic scoped cleanup

## Testing

- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm test-types`
- `pnpm test packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts -t "should force kill a process"`
