### PR TITLE
Fix Graph.toGraphViz DOT escaping

### DIFF
--- a/.changeset/fix-graphviz-dot-escaping.md
+++ b/.changeset/fix-graphviz-dot-escaping.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Graph.toGraphViz` to quote unsafe DOT graph names and escape labels as literal text.

--- a/.changeset/fix-graphviz-dot-escaping.md
+++ b/.changeset/fix-graphviz-dot-escaping.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `Graph.toGraphViz` to quote unsafe DOT graph names and escape labels as literal text.
+Fix `Graph.toGraphViz` to quote DOT graph names and escape labels as literal text.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2753,7 +2753,7 @@ export interface GraphVizOptions<N, E> {
   readonly graphName?: string
 }
 
-const escapeLabel = (value: string): string =>
+const escapeGraphVizString = (value: string): string =>
   value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\r\n|\r|\n/g, "\\n")
 
 /**
@@ -2775,7 +2775,7 @@ const escapeLabel = (value: string): string =>
  *
  * const dot = Graph.toGraphViz(graph)
  * console.log(dot)
- * // digraph G {
+ * // digraph "G" {
  * //   "0" [label="Node A"];
  * //   "1" [label="Node B"];
  * //   "2" [label="Node C"];
@@ -2809,22 +2809,20 @@ export const toGraphViz: {
   const isDirected = graph.type === "directed"
   const graphType = isDirected ? "digraph" : "graph"
   const edgeOperator = isDirected ? "->" : "--"
-  const canUseBareGraphName = /^[A-Za-z_][A-Za-z0-9_]*$/.test(graphName) &&
-    !/^(?:node|edge|graph|digraph|subgraph|strict)$/i.test(graphName)
-  const graphId = canUseBareGraphName ? graphName : `"${escapeLabel(graphName)}"`
+  const graphId = `"${escapeGraphVizString(graphName)}"`
 
   const lines: Array<string> = []
   lines.push(`${graphType} ${graphId} {`)
 
   // Add nodes
   for (const [nodeIndex, nodeData] of graph.nodes) {
-    const label = escapeLabel(nodeLabel(nodeData))
+    const label = escapeGraphVizString(nodeLabel(nodeData))
     lines.push(`  "${nodeIndex}" [label="${label}"];`)
   }
 
   // Add edges
   for (const [, edgeData] of graph.edges) {
-    const label = escapeLabel(edgeLabel(edgeData.data))
+    const label = escapeGraphVizString(edgeLabel(edgeData.data))
     lines.push(`  "${edgeData.source}" ${edgeOperator} "${edgeData.target}" [label="${label}"];`)
   }
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2753,18 +2753,6 @@ export interface GraphVizOptions<N, E> {
   readonly graphName?: string
 }
 
-const dotKeywords = new Set(["node", "edge", "graph", "digraph", "subgraph", "strict"])
-
-const dotBareIdRegex = /^(?:[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|-?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?))$/
-
-const escapeDotQuotedString = (value: string): string =>
-  value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\r\n|\r|\n/g, "\\n")
-
-const toDotId = (value: string): string =>
-  dotBareIdRegex.test(value) && !dotKeywords.has(value.toLowerCase()) ? value : `"${escapeDotQuotedString(value)}"`
-
-const toGraphVizLabel = (value: string): string => escapeDotQuotedString(value)
-
 /**
  * Exports a graph to GraphViz DOT format for visualization.
  *
@@ -2818,19 +2806,25 @@ export const toGraphViz: {
   const isDirected = graph.type === "directed"
   const graphType = isDirected ? "digraph" : "graph"
   const edgeOperator = isDirected ? "->" : "--"
+  const escape = (value: string): string =>
+    value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\r\n|\r|\n/g, "\\n")
+  const graphId = /^(?:[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|-?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?))$/.test(graphName) &&
+      !/^(?:node|edge|graph|digraph|subgraph|strict)$/i.test(graphName)
+    ? graphName
+    : `"${escape(graphName)}"`
 
   const lines: Array<string> = []
-  lines.push(`${graphType} ${toDotId(graphName)} {`)
+  lines.push(`${graphType} ${graphId} {`)
 
   // Add nodes
   for (const [nodeIndex, nodeData] of graph.nodes) {
-    const label = toGraphVizLabel(nodeLabel(nodeData))
+    const label = escape(nodeLabel(nodeData))
     lines.push(`  "${nodeIndex}" [label="${label}"];`)
   }
 
   // Add edges
   for (const [, edgeData] of graph.edges) {
-    const label = toGraphVizLabel(edgeLabel(edgeData.data))
+    const label = escape(edgeLabel(edgeData.data))
     lines.push(`  "${edgeData.source}" ${edgeOperator} "${edgeData.target}" [label="${label}"];`)
   }
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2753,6 +2753,9 @@ export interface GraphVizOptions<N, E> {
   readonly graphName?: string
 }
 
+const escapeLabel = (value: string): string =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\r\n|\r|\n/g, "\\n")
+
 /**
  * Exports a graph to GraphViz DOT format for visualization.
  *
@@ -2806,25 +2809,22 @@ export const toGraphViz: {
   const isDirected = graph.type === "directed"
   const graphType = isDirected ? "digraph" : "graph"
   const edgeOperator = isDirected ? "->" : "--"
-  const escape = (value: string): string =>
-    value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\r\n|\r|\n/g, "\\n")
-  const graphId = /^(?:[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|-?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?))$/.test(graphName) &&
-      !/^(?:node|edge|graph|digraph|subgraph|strict)$/i.test(graphName)
-    ? graphName
-    : `"${escape(graphName)}"`
+  const canUseBareGraphName = /^[A-Za-z_][A-Za-z0-9_]*$/.test(graphName) &&
+    !/^(?:node|edge|graph|digraph|subgraph|strict)$/i.test(graphName)
+  const graphId = canUseBareGraphName ? graphName : `"${escapeLabel(graphName)}"`
 
   const lines: Array<string> = []
   lines.push(`${graphType} ${graphId} {`)
 
   // Add nodes
   for (const [nodeIndex, nodeData] of graph.nodes) {
-    const label = escape(nodeLabel(nodeData))
+    const label = escapeLabel(nodeLabel(nodeData))
     lines.push(`  "${nodeIndex}" [label="${label}"];`)
   }
 
   // Add edges
   for (const [, edgeData] of graph.edges) {
-    const label = escape(edgeLabel(edgeData.data))
+    const label = escapeLabel(edgeLabel(edgeData.data))
     lines.push(`  "${edgeData.source}" ${edgeOperator} "${edgeData.target}" [label="${label}"];`)
   }
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2753,6 +2753,18 @@ export interface GraphVizOptions<N, E> {
   readonly graphName?: string
 }
 
+const dotKeywords = new Set(["node", "edge", "graph", "digraph", "subgraph", "strict"])
+
+const dotBareIdRegex = /^(?:[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*|-?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?))$/
+
+const escapeDotQuotedString = (value: string): string =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\r\n|\r|\n/g, "\\n")
+
+const toDotId = (value: string): string =>
+  dotBareIdRegex.test(value) && !dotKeywords.has(value.toLowerCase()) ? value : `"${escapeDotQuotedString(value)}"`
+
+const toGraphVizLabel = (value: string): string => escapeDotQuotedString(value)
+
 /**
  * Exports a graph to GraphViz DOT format for visualization.
  *
@@ -2808,17 +2820,17 @@ export const toGraphViz: {
   const edgeOperator = isDirected ? "->" : "--"
 
   const lines: Array<string> = []
-  lines.push(`${graphType} ${graphName} {`)
+  lines.push(`${graphType} ${toDotId(graphName)} {`)
 
   // Add nodes
   for (const [nodeIndex, nodeData] of graph.nodes) {
-    const label = nodeLabel(nodeData).replace(/"/g, "\\\"")
+    const label = toGraphVizLabel(nodeLabel(nodeData))
     lines.push(`  "${nodeIndex}" [label="${label}"];`)
   }
 
   // Add edges
   for (const [, edgeData] of graph.edges) {
-    const label = edgeLabel(edgeData.data).replace(/"/g, "\\\"")
+    const label = toGraphVizLabel(edgeLabel(edgeData.data))
     lines.push(`  "${edgeData.source}" ${edgeOperator} "${edgeData.target}" [label="${label}"];`)
   }
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -2021,14 +2021,14 @@ describe("Graph", () => {
       const graph = Graph.directed<string, number>()
       const dot = Graph.toGraphViz(graph)
 
-      expect(dot).toBe("digraph G {\n}")
+      expect(dot).toBe("digraph \"G\" {\n}")
     })
 
     it("should export empty undirected graph", () => {
       const graph = Graph.undirected<string, number>()
       const dot = Graph.toGraphViz(graph)
 
-      expect(dot).toBe("graph G {\n}")
+      expect(dot).toBe("graph \"G\" {\n}")
     })
 
     it("should export directed graph with nodes and edges", () => {
@@ -2043,7 +2043,7 @@ describe("Graph", () => {
 
       const dot = Graph.toGraphViz(graph)
 
-      expect(dot).toContain("digraph G {")
+      expect(dot).toContain("digraph \"G\" {")
       expect(dot).toContain("\"0\" [label=\"Node A\"];")
       expect(dot).toContain("\"1\" [label=\"Node B\"];")
       expect(dot).toContain("\"2\" [label=\"Node C\"];")
@@ -2062,7 +2062,7 @@ describe("Graph", () => {
 
       const dot = Graph.toGraphViz(graph)
 
-      expect(dot).toContain("graph G {")
+      expect(dot).toContain("graph \"G\" {")
       expect(dot).toContain("\"0\" -- \"1\" [label=\"1\"];")
     })
 
@@ -2079,7 +2079,7 @@ describe("Graph", () => {
         graphName: "MyGraph"
       })
 
-      expect(dot).toContain("digraph MyGraph {")
+      expect(dot).toContain("digraph \"MyGraph\" {")
       expect(dot).toContain("\"0\" [label=\"Alice\"];")
       expect(dot).toContain("\"1\" [label=\"Bob\"];")
       expect(dot).toContain("\"0\" -> \"1\" [label=\"weight: 42\"];")
@@ -2099,9 +2099,10 @@ describe("Graph", () => {
       expect(dot).toContain("\"0\" -> \"1\" [label=\"Edge \\\"1\\\"\"];")
     })
 
-    it("should quote unsafe graph names", () => {
+    it("should quote graph names", () => {
       const graph = Graph.directed<string, string>()
 
+      strictEqual(Graph.toGraphViz(graph, { graphName: "MyGraph" }), "digraph \"MyGraph\" {\n}")
       strictEqual(Graph.toGraphViz(graph, { graphName: "My Graph" }), "digraph \"My Graph\" {\n}")
       strictEqual(Graph.toGraphViz(graph, { graphName: "" }), "digraph \"\" {\n}")
       strictEqual(Graph.toGraphViz(graph, { graphName: "graph" }), "digraph \"graph\" {\n}")
@@ -2121,7 +2122,7 @@ describe("Graph", () => {
       strictEqual(
         dot,
         [
-          "digraph G {",
+          "digraph \"G\" {",
           "  \"0\" [label=\"C:\\\\new\\\\path\"];",
           "  \"1\" [label=\"Line 1\\nLine 2\"];",
           "  \"0\" -> \"1\" [label=\"edge\\\\label\\nnext\"];",
@@ -2151,7 +2152,7 @@ describe("Graph", () => {
       // Uncomment the next line to see the GraphViz output in test console
       // console.log("\nDependency Graph DOT format:\n" + dot)
 
-      expect(dot).toContain("digraph DependencyGraph {")
+      expect(dot).toContain("digraph \"DependencyGraph\" {")
       expect(dot).toContain("\"0\" [label=\"App\"];")
       expect(dot).toContain("\"0\" -> \"1\" [label=\"uses\"];")
       expect(dot).toContain("\"0\" -> \"2\" [label=\"stores\"];")
@@ -2180,7 +2181,7 @@ describe("Graph", () => {
       // Uncomment the next line to see the GraphViz output in test console
       // console.log("\nSocial Network DOT format:\n" + dot)
 
-      expect(dot).toContain("graph SocialNetwork {")
+      expect(dot).toContain("graph \"SocialNetwork\" {")
       expect(dot).toContain("\"0\" [label=\"Alice\"];")
       expect(dot).toContain("\"0\" -- \"1\" [label=\"friends\"];")
       expect(dot).toContain("\"1\" -- \"2\" [label=\"friends\"];")

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -2099,6 +2099,37 @@ describe("Graph", () => {
       expect(dot).toContain("\"0\" -> \"1\" [label=\"Edge \\\"1\\\"\"];")
     })
 
+    it("should quote unsafe graph names", () => {
+      const graph = Graph.directed<string, string>()
+
+      strictEqual(Graph.toGraphViz(graph, { graphName: "My Graph" }), "digraph \"My Graph\" {\n}")
+      strictEqual(Graph.toGraphViz(graph, { graphName: "" }), "digraph \"\" {\n}")
+      strictEqual(Graph.toGraphViz(graph, { graphName: "graph" }), "digraph \"graph\" {\n}")
+      strictEqual(Graph.toGraphViz(graph, { graphName: "Node" }), "digraph \"Node\" {\n}")
+      strictEqual(Graph.toGraphViz(graph, { graphName: "My \"Graph\"" }), "digraph \"My \\\"Graph\\\"\" {\n}")
+    })
+
+    it("should escape labels as literal text", () => {
+      const graph = Graph.directed<string, string>((mutable) => {
+        const nodeA = Graph.addNode(mutable, "C:\\new\\path")
+        const nodeB = Graph.addNode(mutable, "Line 1\nLine 2")
+        Graph.addEdge(mutable, nodeA, nodeB, "edge\\label\nnext")
+      })
+
+      const dot = Graph.toGraphViz(graph)
+
+      strictEqual(
+        dot,
+        [
+          "digraph G {",
+          "  \"0\" [label=\"C:\\\\new\\\\path\"];",
+          "  \"1\" [label=\"Line 1\\nLine 2\"];",
+          "  \"0\" -> \"1\" [label=\"edge\\\\label\\nnext\"];",
+          "}"
+        ].join("\n")
+      )
+    })
+
     it("should demonstrate graph visualization", () => {
       // Create a simple directed graph representing a dependency graph
       const graph = Graph.directed<string, string>((mutable) => {


### PR DESCRIPTION
## Summary
- Always quote DOT graph names in Graph.toGraphViz.
- Escape labels as literal text, including backslashes and physical line breaks.
- Add GraphViz regression tests and a patch changeset.

## Testing
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm check`