### PR TITLE
Fix Graph.Walker iterator receiver

### DIFF
--- a/.changeset/graph-walker-iterator-receiver.md
+++ b/.changeset/graph-walker-iterator-receiver.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Graph.Walker` iteration for receiver-sensitive iterables.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4841,7 +4841,8 @@ export class Walker<T, N> implements Iterable<[T, N]> {
     visit: <U>(f: (index: T, data: N) => U) => Iterable<U>
   ) {
     this.visit = visit
-    this[Symbol.iterator] = visit((index, data) => [index, data] as [T, N])[Symbol.iterator]
+    const iterable = visit((index, data) => [index, data] as [T, N])
+    this[Symbol.iterator] = () => iterable[Symbol.iterator]()
   }
 }
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3886,6 +3886,12 @@ describe("Graph", () => {
       expect(Array.from(nodesIterable)).toHaveLength(3)
       expect(Array.from(externalsIterable)).toHaveLength(1) // Only one node with no outgoing edges
     })
+
+    it("should preserve the receiver for iterable iterator methods", () => {
+      const walker = new Graph.Walker<number, string>((f) => new Set([f(0, "A"), f(1, "B")]))
+
+      assert.deepStrictEqual(Array.from(walker), [[0, "A"], [1, "B"]])
+    })
   })
 
   describe("NodeIterable abstraction", () => {


### PR DESCRIPTION
## Summary
- Preserve iterator receivers for `Graph.Walker` entry iteration
- Add a `Set`-backed regression test for receiver-sensitive iterables
- Add an `effect` patch changeset

## Testing
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm lint-fix`
- `pnpm check`