### PR TITLE
fix(vitest): preserve schema arbitraries in records

### DIFF
--- a/.changeset/fix-vitest-record-schema-arbitrary.md
+++ b/.changeset/fix-vitest-record-schema-arbitrary.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Fix record-form property tests to convert Schema values to FastCheck arbitraries.

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -148,10 +148,7 @@ const makeTester = <R>(
     const arbs = fc.record(
       Object.keys(arbitraries).reduce(function(result, key) {
         const arb: any = arbitraries[key]
-        if (Schema.isSchema(arb)) {
-          result[key] = Schema.toArbitrary(arb)
-        }
-        result[key] = arb
+        result[key] = Schema.isSchema(arb) ? Schema.toArbitrary(arb) : arb
         return result
       }, {} as Record<string, fc.Arbitrary<any>>)
     )

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, assert, describe, expect, it, layer } from "@effect/vitest"
-import { Clock, Context, Duration, Effect, Fiber, Layer } from "effect"
+import { Clock, Context, Duration, Effect, Fiber, Layer, Schema } from "effect"
 import { FastCheck, TestClock } from "effect/testing"
 
 it.effect(
@@ -197,6 +197,12 @@ it.prop(
   "symmetry with object",
   { a: realNumber, b: FastCheck.integer() },
   ({ a, b }) => a + b === b + a
+)
+
+it.live.prop(
+  "schema with object",
+  { value: Schema.Int },
+  ({ value }) => Effect.sync(() => assert.isTrue(Number.isInteger(value)))
 )
 
 it.effect.prop("symmetry", [realNumber, FastCheck.integer()], ([a, b]) =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Record-form property inputs converted `Schema` values with `Schema.toArbitrary`, but then immediately overwrote the result with the original schema. FastCheck consequently received a `Schema` where it expected an `Arbitrary`, and test collection failed before the property could run.

This change preserves the converted arbitrary for schema values, adds a regression test for `{ value: Schema.Int }`, and adds the required `@effect/vitest` patch changeset.

Validation:

- `pnpm test packages/vitest/test/index.test.ts` — passed (25 passed, 1 expected failure, 4 skipped)
- `pnpm test packages/vitest/test` — passed (34 passed, 1 expected failure, 4 skipped)
- `pnpm check` — passed
- `pnpm lint` — passed
- `git diff --check` — passed

The repository-wide `pnpm test` command was also attempted. It could not complete green in this host because container-backed integration tests had no available container runtime, and the unchanged `NodeChildProcessSpawner` process-tree test observed 1 descendant where it expects at least 7. The changed `@effect/vitest` package remains green as reported above.

Implementation and command execution were performed with OpenAI Codex under the `coyaSONG` GitHub identity; no human-review claim is made.

## Related

- Closes #6413
