### PR TITLE
Fix Graph.isAcyclic for parallel undirected edges

### DIFF
--- a/.changeset/graph-acyclic-parallel-undirected-edges.md
+++ b/.changeset/graph-acyclic-parallel-undirected-edges.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Graph.isAcyclic` to detect cycles formed by parallel undirected edges.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -3578,17 +3578,17 @@ export const isAcyclic = <N, E, T extends Kind = "directed">(
       }
 
       visited.add(startNode)
-      const stack: Array<{ node: NodeIndex; parentEdge: EdgeIndex | null }> = [{ node: startNode, parentEdge: null }]
+      const stack: Array<{ node: NodeIndex; incoming: EdgeIndex | null }> = [{ node: startNode, incoming: null }]
 
       while (stack.length > 0) {
-        const { node, parentEdge } = stack.pop()!
+        const { node, incoming } = stack.pop()!
         const adjacencyList = impl.adjacency.get(node)
         if (adjacencyList === undefined) {
           continue
         }
 
         for (const edgeIndex of adjacencyList) {
-          if (edgeIndex === parentEdge) {
+          if (edgeIndex === incoming) {
             continue
           }
           const edge = impl.edges.get(edgeIndex)
@@ -3598,7 +3598,7 @@ export const isAcyclic = <N, E, T extends Kind = "directed">(
           const neighbor = getTraversableNeighbor(graph, node, edge)
           if (!visited.has(neighbor)) {
             visited.add(neighbor)
-            stack.push({ node: neighbor, parentEdge: edgeIndex })
+            stack.push({ node: neighbor, incoming: edgeIndex })
           } else {
             impl.acyclic = Option.some(false)
             return false

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -3529,7 +3529,8 @@ export type TraversalDirection = Direction | "undirected"
  *
  * Uses depth-first search to detect back edges, which indicate cycles.
  * For directed graphs, any back edge creates a cycle. For undirected graphs,
- * a back edge that doesn't go to the immediate parent creates a cycle.
+ * a back edge that doesn't use the same edge used to enter the current node
+ * creates a cycle.
  *
  * **Example** (Checking cycles)
  *
@@ -3577,17 +3578,28 @@ export const isAcyclic = <N, E, T extends Kind = "directed">(
       }
 
       visited.add(startNode)
-      const stack: Array<{ node: NodeIndex; parent: NodeIndex | null }> = [{ node: startNode, parent: null }]
+      const stack: Array<{ node: NodeIndex; parentEdge: EdgeIndex | null }> = [{ node: startNode, parentEdge: null }]
 
       while (stack.length > 0) {
-        const { node, parent } = stack.pop()!
-        const nodeNeighbors = getUndirectedNeighbors(graph as any, node)
+        const { node, parentEdge } = stack.pop()!
+        const adjacencyList = impl.adjacency.get(node)
+        if (adjacencyList === undefined) {
+          continue
+        }
 
-        for (const neighbor of nodeNeighbors) {
+        for (const edgeIndex of adjacencyList) {
+          if (edgeIndex === parentEdge) {
+            continue
+          }
+          const edge = impl.edges.get(edgeIndex)
+          if (edge === undefined) {
+            continue
+          }
+          const neighbor = getTraversableNeighbor(graph, node, edge)
           if (!visited.has(neighbor)) {
             visited.add(neighbor)
-            stack.push({ node: neighbor, parent: node })
-          } else if (neighbor !== parent) {
+            stack.push({ node: neighbor, parentEdge: edgeIndex })
+          } else {
             impl.acyclic = Option.some(false)
             return false
           }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -2629,6 +2629,36 @@ describe("Graph", () => {
       expect(Graph.isAcyclic(graph)).toBe(true)
     })
 
+    it("should treat a single undirected edge as acyclic", () => {
+      const graph = Graph.undirected<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, 1)
+      })
+
+      strictEqual(Graph.isAcyclic(graph), true)
+    })
+
+    it("should detect parallel undirected edges as a cycle", () => {
+      const graph = Graph.undirected<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, a, b, 2)
+      })
+
+      strictEqual(Graph.isAcyclic(graph), false)
+    })
+
+    it("should detect undirected self-loops as cycles", () => {
+      const graph = Graph.undirected<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        Graph.addEdge(mutable, a, a, 1)
+      })
+
+      strictEqual(Graph.isAcyclic(graph), false)
+    })
+
     it("should detect cycles in undirected graphs", () => {
       const graph = Graph.undirected<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")


### PR DESCRIPTION
## Summary
- make undirected `Graph.isAcyclic` skip only the parent edge rather than all edges to the parent node
- add regression coverage for single edges, parallel undirected edges, and self-loops
- add a patch changeset

## Testing
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm check`