### PR TITLE
Fix Graph.floydWarshall null edge costs

### DIFF
--- a/.changeset/floyd-warshall-null-edge-data.md
+++ b/.changeset/floyd-warshall-null-edge-data.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve null edge data in Graph.floydWarshall costs.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4345,7 +4345,7 @@ export const floydWarshall: {
   // Initialize distance matrix
   const distances = new Map<NodeIndex, Map<NodeIndex, number>>()
   const next = new Map<NodeIndex, Map<NodeIndex, NodeIndex | null>>()
-  const edgeMatrix = new Map<NodeIndex, Map<NodeIndex, E | null>>()
+  const edgeMatrix = new Map<NodeIndex, Map<NodeIndex, E>>()
 
   // Initialize with infinity for all pairs
   for (const i of allNodes) {
@@ -4356,7 +4356,6 @@ export const floydWarshall: {
     for (const j of allNodes) {
       distances.get(i)!.set(j, i === j ? 0 : Infinity)
       next.get(i)!.set(j, null)
-      edgeMatrix.get(i)!.set(j, null)
     }
   }
 
@@ -4433,9 +4432,9 @@ export const floydWarshall: {
           const nextNode = next.get(current)!.get(j)!
           if (nextNode === null) break
 
-          const edgeData = edgeMatrix.get(current)!.get(nextNode)!
-          if (edgeData !== null) {
-            weights.push(edgeData)
+          const edgeRow = edgeMatrix.get(current)!
+          if (edgeRow.has(nextNode)) {
+            weights.push(edgeRow.get(nextNode) as E)
           }
 
           current = nextNode

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4344,7 +4344,7 @@ export const floydWarshall: {
 
   // Initialize distance matrix
   const distances = new Map<NodeIndex, Map<NodeIndex, number>>()
-  const next = new Map<NodeIndex, Map<NodeIndex, NodeIndex | null>>()
+  const next = new Map<NodeIndex, Map<NodeIndex, NodeIndex>>()
   const edgeMatrix = new Map<NodeIndex, Map<NodeIndex, E>>()
 
   // Initialize with infinity for all pairs
@@ -4355,7 +4355,6 @@ export const floydWarshall: {
 
     for (const j of allNodes) {
       distances.get(i)!.set(j, i === j ? 0 : Infinity)
-      next.get(i)!.set(j, null)
     }
   }
 
@@ -4392,8 +4391,11 @@ export const floydWarshall: {
         const distIJ = distances.get(i)!.get(j)!
 
         if (distIK !== Infinity && distKJ !== Infinity && distIK + distKJ < distIJ) {
-          distances.get(i)!.set(j, distIK + distKJ)
-          next.get(i)!.set(j, next.get(i)!.get(k)!)
+          const nextIK = next.get(i)!.get(k)
+          if (nextIK !== undefined) {
+            distances.get(i)!.set(j, distIK + distKJ)
+            next.get(i)!.set(j, nextIK)
+          }
         }
       }
     }
@@ -4429,8 +4431,8 @@ export const floydWarshall: {
 
         path.push(current)
         while (current !== j) {
-          const nextNode = next.get(current)!.get(j)!
-          if (nextNode === null) break
+          const nextNode = next.get(current)!.get(j)
+          if (nextNode === undefined) break
 
           const edgeRow = edgeMatrix.get(current)!
           if (edgeRow.has(nextNode)) {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3308,6 +3308,39 @@ describe("Graph", () => {
       expect(result.costs.get(0)?.get(0)).toEqual([])
     })
 
+    it("should preserve null edge data in direct paths", () => {
+      const graph = Graph.directed<string, null>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, null)
+      })
+
+      const result = Graph.floydWarshall(graph, () => 1)
+
+      assert.strictEqual(result.distances.get(0)?.get(1), 1)
+      assert.deepStrictEqual(result.paths.get(0)?.get(1), [0, 1])
+      assert.deepStrictEqual(result.costs.get(0)?.get(1), [null])
+    })
+
+    it("should preserve null edge data in multihop paths", () => {
+      type EdgeData = null | { readonly weight: number }
+
+      const graph = Graph.directed<string, EdgeData>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        Graph.addEdge(mutable, a, b, null)
+        Graph.addEdge(mutable, b, c, null)
+        Graph.addEdge(mutable, a, c, { weight: 10 })
+      })
+
+      const result = Graph.floydWarshall(graph, (edge) => edge === null ? 1 : edge.weight)
+
+      assert.strictEqual(result.distances.get(0)?.get(2), 2)
+      assert.deepStrictEqual(result.paths.get(0)?.get(2), [0, 1, 2])
+      assert.deepStrictEqual(result.costs.get(0)?.get(2), [null, null])
+    })
+
     it("should detect negative cycles", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")


### PR DESCRIPTION
## Summary
- make Graph.floydWarshall edge data lookup sparse and presence-based
- preserve legitimate null edge data in returned costs
- add direct and multihop null edge regressions

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Graph.test.ts
- pnpm check