### PR TITLE
Clean up stale package references

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -345,7 +345,7 @@ Build http clients with the `HttpClient` module.
 
 ## Working with child processes
 
-Use the `effect/unstable/process` modules to define child processes and run them with `ChildProcessSpawner.
+Use the `effect/unstable/process` modules to define child processes and run them with `ChildProcessSpawner`.
 
 - **[Working with child processes](./ai-docs/src/60_child-process/10_working-with-child-processes.ts)**: This example shows how to collect process output, compose pipelines, and stream long-running command output.
 

--- a/ai-docs/src/60_child-process/index.md
+++ b/ai-docs/src/60_child-process/index.md
@@ -1,3 +1,3 @@
 ## Working with child processes
 
-Use the `effect/unstable/process` modules to define child processes and run them with `ChildProcessSpawner.
+Use the `effect/unstable/process` modules to define child processes and run them with `ChildProcessSpawner`.

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -49,5 +49,3 @@ The `effect` package provides a collection of modules designed for functional pr
 | Schedule | A module for defining retry and repeat policies with composable schedules.                                                 |
 | Scope    | Manages the lifecycle of resources, ensuring proper acquisition and release.                                               |
 | Schema   | A powerful library for defining, validating, and transforming structured data with type-safe encoding and decoding.        |
-
-For a comparison between `effect/Schema` and `zod`, see [Schema vs Zod](https://github.com/Effect-TS/effect/tree/main/packages/effect/schema-vs-zod.md).

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -62,8 +62,7 @@ export interface SqlClient extends Constructor {
   readonly transactionService: Context.Service<TransactionConnection, TransactionConnection.Service>
 
   /**
-   * Use the Reactivity service from @effect/experimental to create a reactive
-   * query.
+   * Use the Reactivity service to create a reactive query.
    */
   readonly reactive: <A, E, R>(
     keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>,

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -1,6 +1,6 @@
 # `@effect/platform-bun`
 
-Provides Bun-specific implementations for the abstractions defined in [`@effect/platform`](https://github.com/Effect-TS/effect/tree/main/packages/platform), allowing you to write platform-independent code that runs smoothly in Bun environments.
+Provides Bun-specific implementations for Effect's platform abstractions, allowing you to write platform-independent code that runs smoothly in Bun environments.
 
 ## Documentation
 

--- a/packages/platform-bun/src/BunChildProcessSpawner.ts
+++ b/packages/platform-bun/src/BunChildProcessSpawner.ts
@@ -1,5 +1,5 @@
 /**
- * Node.js implementation of `ChildProcessSpawner`.
+ * Bun implementation of `ChildProcessSpawner`.
  *
  * @since 4.0.0
  */

--- a/packages/platform-node-shared/README.md
+++ b/packages/platform-node-shared/README.md
@@ -1,7 +1,7 @@
-# `@effect/platform-node`
+# `@effect/platform-node-shared`
 
-Provides Node.js-specific implementations for the abstractions defined in [`@effect/platform`](https://github.com/Effect-TS/effect/tree/main/packages/platform), allowing you to write platform-independent code that integrates smoothly with Node.js.
+Provides shared Node.js-compatible implementations used by the Effect Node.js and Bun platform packages.
 
 ## Documentation
 
-- **API Reference**: [View the full documentation](https://effect-ts.github.io/effect/docs/platform-node).
+- **API Reference**: [View the full documentation](https://effect-ts.github.io/effect/docs/platform-node-shared).

--- a/packages/platform-node-shared/docgen.json
+++ b/packages/platform-node-shared/docgen.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
-  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/platform-node/src/",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/platform-node-shared/src/",
   "exclude": ["src/internal/**/*.ts"],
   "examplesCompilerOptions": {
     "noEmit": true,
@@ -14,21 +14,7 @@
     "allowImportingTsExtensions": true,
     "paths": {
       "effect": ["../../../effect/src/index.js"],
-      "effect/*": ["../../../effect/src/*.js"],
-      "@effect/cluster": ["../../../cluster/src/index.js"],
-      "@effect/cluster/*": ["../../../cluster/src/*.js"],
-      "@effect/experimental": ["../../../experimental/src/index.js"],
-      "@effect/experimental/*": ["../../../experimental/src/*.js"],
-      "@effect/platform": ["../../../platform/src/index.js"],
-      "@effect/platform/*": ["../../../platform/src/*.js"],
-      "@effect/platform-node": ["../../../platform-node/src/index.js"],
-      "@effect/platform-node/*": ["../../../platform-node/src/*.js"],
-      "@effect/platform-node-shared": ["../../../platform-node-shared/src/index.js"],
-      "@effect/platform-node-shared/*": ["../../../platform-node-shared/src/*.js"],
-      "@effect/rpc": ["../../../rpc/src/index.js"],
-      "@effect/rpc/*": ["../../../rpc/src/*.js"],
-      "effect/unstable/sql": ["../../../sql/src/index.js"],
-      "effect/unstable/sql/*": ["../../../sql/src/*.js"]
+      "effect/*": ["../../../effect/src/*.js"]
     },
     "plugins": [
       { "name": "@effect/language-service", "includeSuggestionsInTsc": false }

--- a/packages/platform-node/README.md
+++ b/packages/platform-node/README.md
@@ -1,6 +1,6 @@
 # `@effect/platform-node`
 
-Provides Node.js-specific implementations for the abstractions defined in [`@effect/platform`](https://github.com/Effect-TS/effect/tree/main/packages/platform), allowing you to write platform-independent code that integrates smoothly with Node.js.
+Provides Node.js-specific implementations for Effect's platform abstractions, allowing you to write platform-independent code that integrates smoothly with Node.js.
 
 ## Documentation
 

--- a/packages/sql/clickhouse/README.md
+++ b/packages/sql/clickhouse/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-clickhouse`
 
-An `@effect/sql` implementation for [ClickHouse](https://clickhouse.com/).
+An Effect SQL implementation for [ClickHouse](https://clickhouse.com/).
 
 ## Documentation
 

--- a/packages/sql/d1/README.md
+++ b/packages/sql/d1/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-d1`
 
-An `@effect/sql` implementation for [Cloudflare D1](https://developers.cloudflare.com/d1/).
+An Effect SQL implementation for [Cloudflare D1](https://developers.cloudflare.com/d1/).
 
 ## Documentation
 

--- a/packages/sql/libsql/README.md
+++ b/packages/sql/libsql/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-libsql`
 
-An `@effect/sql` implementation using the `@libsql/client` library.
+An Effect SQL implementation using the `@libsql/client` library.
 
 ## Documentation
 

--- a/packages/sql/mssql/README.md
+++ b/packages/sql/mssql/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-mssql`
 
-An `@effect/sql` implementation using the mssql `tedious` library.
+An Effect SQL implementation using the mssql `tedious` library.
 
 ## Documentation
 

--- a/packages/sql/mssql/docgen.json
+++ b/packages/sql/mssql/docgen.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
-  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/d1/src/",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/mssql/src/",
   "exclude": ["src/internal/**/*.ts"],
   "examplesCompilerOptions": {
     "noEmit": true,

--- a/packages/sql/mysql2/README.md
+++ b/packages/sql/mysql2/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-mysql2`
 
-An `@effect/sql` implementation using the `mysql2` library.
+An Effect SQL implementation using the `mysql2` library.
 
 ## Documentation
 

--- a/packages/sql/pg/README.md
+++ b/packages/sql/pg/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-pg`
 
-An `@effect/sql` implementation using the `pg` library.
+An Effect SQL implementation using the `pg` library.
 
 ## Documentation
 

--- a/packages/sql/pglite/README.md
+++ b/packages/sql/pglite/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-pglite`
 
-An `@effect/sql` implementation using the `@electric-sql/pglite` library.
+An Effect SQL implementation using the `@electric-sql/pglite` library.
 
 ## Documentation
 

--- a/packages/sql/sqlite-bun/README.md
+++ b/packages/sql/sqlite-bun/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-sqlite-bun`
 
-An `@effect/sql` implementation using the `bun:sqlite` library.
+An Effect SQL implementation using the `bun:sqlite` library.
 
 ## Documentation
 

--- a/packages/sql/sqlite-do/README.md
+++ b/packages/sql/sqlite-do/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-sqlite-do`
 
-An `@effect/sql` implementation for Cloudflare Durable Objects sqlite storage.
+An Effect SQL implementation for Cloudflare Durable Objects SQLite storage.
 
 ## Documentation
 

--- a/packages/sql/sqlite-do/docgen.json
+++ b/packages/sql/sqlite-do/docgen.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
-  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/do/src/",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/sqlite-do/src/",
   "exclude": ["src/internal/**/*.ts"],
   "examplesCompilerOptions": {
     "noEmit": true,

--- a/packages/sql/sqlite-node/README.md
+++ b/packages/sql/sqlite-node/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-sqlite-node`
 
-An `@effect/sql` implementation using Node.js' built-in `node:sqlite` module.
+An Effect SQL implementation using Node.js' built-in `node:sqlite` module.
 
 ## Documentation
 

--- a/packages/sql/sqlite-react-native/README.md
+++ b/packages/sql/sqlite-react-native/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-sqlite-react-native`
 
-An `@effect/sql` implementation using the `@op-engineering/op-sqlite` library.
+An Effect SQL implementation using the `@op-engineering/op-sqlite` library.
 
 ## Documentation
 

--- a/packages/sql/sqlite-wasm/README.md
+++ b/packages/sql/sqlite-wasm/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-sqlite-wasm`
 
-An `@effect/sql` implementation using the `@sqlite.org/sqlite-wasm` library.
+An Effect SQL implementation using the `@sqlite.org/sqlite-wasm` library.
 
 ## Documentation
 

--- a/packages/sql/sqlite-wasm/docgen.json
+++ b/packages/sql/sqlite-wasm/docgen.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
-  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/do/src/",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/sqlite-wasm/src/",
   "exclude": ["src/internal/**/*.ts"],
   "examplesCompilerOptions": {
     "noEmit": true,

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -6,7 +6,7 @@ In this guide, we'll walk you through setting up the necessary dependencies and 
 
 # Requirements
 
-First, ensure you have [`vitest`](https://vitest.dev/guide/) installed (version `1.6.0` or later).
+First, ensure you have a supported [`vitest`](https://vitest.dev/guide/) version installed (`^3.0.0` or `^4.0.0`).
 
 ```sh
 pnpm add -D vitest


### PR DESCRIPTION
## Summary

- remove stale package-era references from active documentation and JSDoc
- correct copied package descriptions, broken documentation text, and Vitest version guidance
- fix docgen source links and remove obsolete path aliases
- preserve intentional historical references and compatibility-sensitive runtime identifiers

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm ai-docgen`
- targeted `pnpm docgen` for affected packages