### PR TITLE
Fix Graph.isGraph predicate narrowing

### DIFF
--- a/.changeset/graph-guard-predicates.md
+++ b/.changeset/graph-guard-predicates.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix Graph.isGraph narrowing and add directed and undirected graph guards.
+Fix Graph.isGraph narrowing for mutable and undirected graphs.

--- a/.changeset/graph-guard-predicates.md
+++ b/.changeset/graph-guard-predicates.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Graph.isGraph narrowing and add directed and undirected graph guards.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -435,11 +435,36 @@ function assertMutable<N, E, T extends Kind = "directed">(
 
 /**
  * Returns `true` if a value has the graph runtime type identifier, narrowing
- * it to a `Graph`.
+ * it to an immutable or mutable graph.
  *
  * **When to use**
  *
  * Use to narrow an unknown value before treating it as a graph value.
+ *
+ * **Gotchas**
+ *
+ * This guard checks the shared graph runtime type identifier and does not
+ * distinguish immutable graphs from mutable graphs or directed graphs from
+ * undirected graphs.
+ *
+ * @category guards
+ * @since 4.0.0
+ */
+export function isGraph<N = unknown, E = unknown, T extends Kind = Kind, U = never>(
+  u: U | Graph<N, E, T> | MutableGraph<N, E, T>
+): u is Graph<N, E, T> | MutableGraph<N, E, T>
+export function isGraph(u: unknown): boolean {
+  return hasProperty(u, TypeId)
+}
+
+/**
+ * Returns `true` if a value has the graph runtime type identifier and is
+ * directed.
+ *
+ * **When to use**
+ *
+ * Use to narrow an unknown graph value before relying on directed graph
+ * semantics.
  *
  * **Gotchas**
  *
@@ -449,7 +474,36 @@ function assertMutable<N, E, T extends Kind = "directed">(
  * @category guards
  * @since 4.0.0
  */
-export const isGraph = (u: unknown): u is Graph<unknown, unknown> => hasProperty(u, TypeId)
+export function isDirectedGraph<N = unknown, E = unknown, U = never>(
+  u: U | Graph<N, E, Kind> | MutableGraph<N, E, Kind>
+): u is Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
+export function isDirectedGraph(u: unknown): boolean {
+  return isGraph(u) && u.type === "directed"
+}
+
+/**
+ * Returns `true` if a value has the graph runtime type identifier and is
+ * undirected.
+ *
+ * **When to use**
+ *
+ * Use to narrow an unknown graph value before relying on undirected graph
+ * semantics.
+ *
+ * **Gotchas**
+ *
+ * This guard checks the shared graph runtime type identifier and does not
+ * distinguish immutable graphs from mutable graphs.
+ *
+ * @category guards
+ * @since 4.0.0
+ */
+export function isUndirectedGraph<N = unknown, E = unknown, U = never>(
+  u: U | Graph<N, E, Kind> | MutableGraph<N, E, Kind>
+): u is Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
+export function isUndirectedGraph(u: unknown): boolean {
+  return isGraph(u) && u.type === "undirected"
+}
 
 /**
  * Creates a graph constructor for the specified graph kind.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -458,54 +458,6 @@ export function isGraph(u: unknown): boolean {
 }
 
 /**
- * Returns `true` if a value has the graph runtime type identifier and is
- * directed.
- *
- * **When to use**
- *
- * Use to narrow an unknown graph value before relying on directed graph
- * semantics.
- *
- * **Gotchas**
- *
- * This guard checks the shared graph runtime type identifier and does not
- * distinguish immutable graphs from mutable graphs.
- *
- * @category guards
- * @since 4.0.0
- */
-export function isDirectedGraph<N = unknown, E = unknown, U = never>(
-  u: U | Graph<N, E, Kind> | MutableGraph<N, E, Kind>
-): u is Graph<N, E, "directed"> | MutableGraph<N, E, "directed">
-export function isDirectedGraph(u: unknown): boolean {
-  return isGraph(u) && u.type === "directed"
-}
-
-/**
- * Returns `true` if a value has the graph runtime type identifier and is
- * undirected.
- *
- * **When to use**
- *
- * Use to narrow an unknown graph value before relying on undirected graph
- * semantics.
- *
- * **Gotchas**
- *
- * This guard checks the shared graph runtime type identifier and does not
- * distinguish immutable graphs from mutable graphs.
- *
- * @category guards
- * @since 4.0.0
- */
-export function isUndirectedGraph<N = unknown, E = unknown, U = never>(
-  u: U | Graph<N, E, Kind> | MutableGraph<N, E, Kind>
-): u is Graph<N, E, "undirected"> | MutableGraph<N, E, "undirected">
-export function isUndirectedGraph(u: unknown): boolean {
-  return isGraph(u) && u.type === "undirected"
-}
-
-/**
  * Creates a graph constructor for the specified graph kind.
  *
  * **When to use**

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -450,12 +450,9 @@ function assertMutable<N, E, T extends Kind = "directed">(
  * @category guards
  * @since 4.0.0
  */
-export function isGraph<N = unknown, E = unknown, T extends Kind = Kind, U = never>(
+export const isGraph = <N = unknown, E = unknown, T extends Kind = Kind, U = never>(
   u: U | Graph<N, E, T> | MutableGraph<N, E, T>
-): u is Graph<N, E, T> | MutableGraph<N, E, T>
-export function isGraph(u: unknown): boolean {
-  return hasProperty(u, TypeId)
-}
+): u is Graph<N, E, T> | MutableGraph<N, E, T> => hasProperty(u, TypeId)
 
 /**
  * Creates a graph constructor for the specified graph kind.

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -471,17 +471,51 @@ describe("Graph", () => {
       const directedGraph = Graph.directed<string, number>()
       const undirectedGraph = Graph.undirected<string, number>()
 
-      expect(Graph.isGraph(directedGraph)).toBe(true)
-      expect(Graph.isGraph(undirectedGraph)).toBe(true)
+      strictEqual(Graph.isGraph(directedGraph), true)
+      strictEqual(Graph.isGraph(undirectedGraph), true)
+    })
+
+    it("should return true for mutable graph instances", () => {
+      const directedGraph = Graph.beginMutation(Graph.directed<string, number>())
+      const undirectedGraph = Graph.beginMutation(Graph.undirected<string, number>())
+
+      strictEqual(Graph.isGraph(directedGraph), true)
+      strictEqual(Graph.isGraph(undirectedGraph), true)
     })
 
     it("should return false for non-graph values", () => {
-      expect(Graph.isGraph({})).toBe(false)
-      expect(Graph.isGraph(null)).toBe(false)
-      expect(Graph.isGraph(undefined)).toBe(false)
-      expect(Graph.isGraph("string")).toBe(false)
-      expect(Graph.isGraph(42)).toBe(false)
-      expect(Graph.isGraph([])).toBe(false)
+      strictEqual(Graph.isGraph({}), false)
+      strictEqual(Graph.isGraph(null), false)
+      strictEqual(Graph.isGraph(undefined), false)
+      strictEqual(Graph.isGraph("string"), false)
+      strictEqual(Graph.isGraph(42), false)
+      strictEqual(Graph.isGraph([]), false)
+    })
+
+    it("should identify directed graphs", () => {
+      const directedGraph = Graph.directed<string, number>()
+      const undirectedGraph = Graph.undirected<string, number>()
+      const mutableDirectedGraph = Graph.beginMutation(directedGraph)
+      const mutableUndirectedGraph = Graph.beginMutation(undirectedGraph)
+
+      strictEqual(Graph.isDirectedGraph(directedGraph), true)
+      strictEqual(Graph.isDirectedGraph(mutableDirectedGraph), true)
+      strictEqual(Graph.isDirectedGraph(undirectedGraph), false)
+      strictEqual(Graph.isDirectedGraph(mutableUndirectedGraph), false)
+      strictEqual(Graph.isDirectedGraph({}), false)
+    })
+
+    it("should identify undirected graphs", () => {
+      const directedGraph = Graph.directed<string, number>()
+      const undirectedGraph = Graph.undirected<string, number>()
+      const mutableDirectedGraph = Graph.beginMutation(directedGraph)
+      const mutableUndirectedGraph = Graph.beginMutation(undirectedGraph)
+
+      strictEqual(Graph.isUndirectedGraph(directedGraph), false)
+      strictEqual(Graph.isUndirectedGraph(mutableDirectedGraph), false)
+      strictEqual(Graph.isUndirectedGraph(undirectedGraph), true)
+      strictEqual(Graph.isUndirectedGraph(mutableUndirectedGraph), true)
+      strictEqual(Graph.isUndirectedGraph({}), false)
     })
 
     it("should be iterable using for...of syntax", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -492,32 +492,6 @@ describe("Graph", () => {
       strictEqual(Graph.isGraph([]), false)
     })
 
-    it("should identify directed graphs", () => {
-      const directedGraph = Graph.directed<string, number>()
-      const undirectedGraph = Graph.undirected<string, number>()
-      const mutableDirectedGraph = Graph.beginMutation(directedGraph)
-      const mutableUndirectedGraph = Graph.beginMutation(undirectedGraph)
-
-      strictEqual(Graph.isDirectedGraph(directedGraph), true)
-      strictEqual(Graph.isDirectedGraph(mutableDirectedGraph), true)
-      strictEqual(Graph.isDirectedGraph(undirectedGraph), false)
-      strictEqual(Graph.isDirectedGraph(mutableUndirectedGraph), false)
-      strictEqual(Graph.isDirectedGraph({}), false)
-    })
-
-    it("should identify undirected graphs", () => {
-      const directedGraph = Graph.directed<string, number>()
-      const undirectedGraph = Graph.undirected<string, number>()
-      const mutableDirectedGraph = Graph.beginMutation(directedGraph)
-      const mutableUndirectedGraph = Graph.beginMutation(undirectedGraph)
-
-      strictEqual(Graph.isUndirectedGraph(directedGraph), false)
-      strictEqual(Graph.isUndirectedGraph(mutableDirectedGraph), false)
-      strictEqual(Graph.isUndirectedGraph(undirectedGraph), true)
-      strictEqual(Graph.isUndirectedGraph(mutableUndirectedGraph), true)
-      strictEqual(Graph.isUndirectedGraph({}), false)
-    })
-
     it("should be iterable using for...of syntax", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         Graph.addNode(mutable, "Node A")

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -72,27 +72,27 @@ describe("Graph", () => {
       >()
     }
 
-    const directedInput = hole<unknown>()
-    if (Graph.isDirectedGraph(directedInput)) {
-      expect(directedInput).type.toBe<
-        Graph.Graph<unknown, unknown, "directed"> | Graph.MutableGraph<unknown, unknown, "directed">
-      >()
-    }
-
-    const undirectedInput = hole<unknown>()
-    if (Graph.isUndirectedGraph(undirectedInput)) {
-      expect(undirectedInput).type.toBe<
-        Graph.Graph<unknown, unknown, "undirected"> | Graph.MutableGraph<unknown, unknown, "undirected">
-      >()
-    }
-
     const known = hole<
       | Graph.UndirectedGraph<string, number>
       | Graph.MutableUndirectedGraph<string, number>
       | { readonly _tag: "other" }
     >()
-    if (Graph.isUndirectedGraph(known)) {
+    if (Graph.isGraph(known)) {
       expect(known).type.toBe<Graph.UndirectedGraph<string, number> | Graph.MutableUndirectedGraph<string, number>>()
+    }
+
+    const mixed = hole<
+      | Graph.DirectedGraph<string, number>
+      | Graph.UndirectedGraph<string, number>
+      | Graph.MutableDirectedGraph<string, number>
+      | Graph.MutableUndirectedGraph<string, number>
+      | { readonly _tag: "other" }
+    >()
+    if (Graph.isGraph(mixed)) {
+      expect(mixed.type).type.toBe<Graph.Kind>()
+      if (mixed.type === "undirected") {
+        expect(mixed.type).type.toBe<"undirected">()
+      }
     }
   })
 

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -1,4 +1,4 @@
-import { Graph, pipe } from "effect"
+import { Graph, hole, pipe } from "effect"
 import { describe, expect, it } from "tstyche"
 
 declare const directed: Graph.DirectedGraph<string, number>
@@ -62,6 +62,38 @@ describe("Graph", () => {
     expect(animalGraph).type.not.toBeAssignableTo<Graph.DirectedGraph<Dog, 1>>()
     expect(dogMutableGraph).type.not.toBeAssignableTo<Graph.MutableDirectedGraph<Animal, number>>()
     expect(animalMutableGraph).type.not.toBeAssignableTo<Graph.MutableDirectedGraph<Dog, 1>>()
+  })
+
+  it("guards", () => {
+    const input = hole<unknown>()
+    if (Graph.isGraph(input)) {
+      expect(input).type.toBe<
+        Graph.Graph<unknown, unknown, Graph.Kind> | Graph.MutableGraph<unknown, unknown, Graph.Kind>
+      >()
+    }
+
+    const directedInput = hole<unknown>()
+    if (Graph.isDirectedGraph(directedInput)) {
+      expect(directedInput).type.toBe<
+        Graph.Graph<unknown, unknown, "directed"> | Graph.MutableGraph<unknown, unknown, "directed">
+      >()
+    }
+
+    const undirectedInput = hole<unknown>()
+    if (Graph.isUndirectedGraph(undirectedInput)) {
+      expect(undirectedInput).type.toBe<
+        Graph.Graph<unknown, unknown, "undirected"> | Graph.MutableGraph<unknown, unknown, "undirected">
+      >()
+    }
+
+    const known = hole<
+      | Graph.UndirectedGraph<string, number>
+      | Graph.MutableUndirectedGraph<string, number>
+      | { readonly _tag: "other" }
+    >()
+    if (Graph.isUndirectedGraph(known)) {
+      expect(known).type.toBe<Graph.UndirectedGraph<string, number> | Graph.MutableUndirectedGraph<string, number>>()
+    }
   })
 
   it("compose", () => {


### PR DESCRIPTION
## Summary
- fix Graph.isGraph to narrow to immutable or mutable graphs across both graph kinds
- keep kind-specific checks as direct .type refinements instead of adding helper guards
- add runtime and type-level coverage for mutable and undirected graph narrowing

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Graph.test.ts
- pnpm test-types Graph.tst.ts
- pnpm check