### PR TITLE
Fix Graph.bellmanFord self cycle detection

### DIFF
--- a/.changeset/fix-graph-bellman-ford-self-cycle.md
+++ b/.changeset/fix-graph-bellman-ford-self-cycle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Graph.bellmanFord` to detect reachable negative cycles when the source and target are the same node.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4774,15 +4774,6 @@ export const bellmanFord: {
     throw missingNode(config.target)
   }
 
-  // Early return if source equals target
-  if (config.source === config.target) {
-    return Option.some({
-      path: [config.source],
-      distance: 0,
-      costs: []
-    })
-  }
-
   // Initialize distances and predecessors
   const distances = new Map<NodeIndex, number>()
   const previous = new Map<NodeIndex, { node: NodeIndex; edgeData: E } | null>()

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3214,6 +3214,36 @@ describe("Graph", () => {
       assertSome(result, { path: [0], distance: 0, costs: [] })
     })
 
+    it("should detect a directed negative self-loop when source equals target", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const node = Graph.addNode(mutable, "A")
+        Graph.addEdge(mutable, node, node, -1)
+      })
+
+      const result = Graph.bellmanFord(graph, {
+        source: 0,
+        target: 0,
+        cost: (edge) => edge
+      })
+
+      assertNone(result)
+    })
+
+    it("should detect an undirected negative self-loop when source equals target", () => {
+      const graph = Graph.undirected<string, number>((mutable) => {
+        const node = Graph.addNode(mutable, "A")
+        Graph.addEdge(mutable, node, node, -1)
+      })
+
+      const result = Graph.bellmanFord(graph, {
+        source: 0,
+        target: 0,
+        cost: (edge) => edge
+      })
+
+      assertNone(result)
+    })
+
     it("should detect negative cycles", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")


### PR DESCRIPTION
## Summary
- Remove the Bellman-Ford same-node fast path so reachable negative cycles are checked first
- Add directed and undirected negative self-loop regressions for source equals target
- Add a patch changeset for the runtime behavior fix

## Testing
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm lint-fix`
- `pnpm check`