### PR TITLE
Fix Graph shortest-path edge weight validation

### DIFF
--- a/.changeset/fix-graph-finite-edge-weights.md
+++ b/.changeset/fix-graph-finite-edge-weights.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reject non-finite edge weights in Graph shortest-path algorithms.

--- a/.changeset/fix-graph-finite-edge-weights.md
+++ b/.changeset/fix-graph-finite-edge-weights.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Reject non-finite edge weights in Graph shortest-path algorithms.
+Reject `NaN` and `-Infinity` edge weights in Graph shortest-path algorithms.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4038,7 +4038,7 @@ export const stronglyConnectedComponents = <N, E>(
  * `costs` contains original edge data, not the numeric output of the cost
  * function unless the edge data is numeric.
  *
- * @see {@link dijkstra} for shortest paths with non-negative edge costs
+ * @see {@link dijkstra} for shortest paths with finite non-negative edge costs
  * @see {@link astar} for heuristic shortest-path search
  * @see {@link bellmanFord} for shortest paths that may include negative edge weights
  * @see {@link AllPairsResult} for the all-pairs shortest-path result shape
@@ -4058,17 +4058,17 @@ export interface PathResult<E> {
  * **When to use**
  *
  * Use when configuring `dijkstra` to find a shortest path between two existing
- * node indices with non-negative edge costs.
+ * node indices with finite non-negative edge costs.
  *
  * **Details**
  *
  * Specifies the source and target node indices, plus a cost function that maps
- * each edge's data to a non-negative numeric weight.
+ * each edge's data to a finite non-negative numeric weight.
  *
  * **Gotchas**
  *
  * `dijkstra` throws a `GraphError` when either endpoint does not exist or when
- * the cost function returns a negative weight.
+ * the cost function returns a negative or non-finite weight.
  *
  * @see {@link dijkstra} for the algorithm that consumes this configuration
  * @see {@link AstarConfig} for heuristic shortest-path search
@@ -4083,17 +4083,19 @@ export interface DijkstraConfig<E> {
   cost: (edgeData: E) => number
 }
 
-const validateNonNegativeEdgeWeights = <N, E, T extends Kind = "directed">(
+const validateEdgeWeights = <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
   cost: (edgeData: E) => number,
-  algorithm: string
+  algorithm: string,
+  options: { readonly allowNegative: boolean }
 ): Map<EdgeIndex, number> => {
   const impl = graphImpl(graph)
   const edgeWeights = new Map<EdgeIndex, number>()
+  const message = `${algorithm} requires finite${options.allowNegative ? "" : " non-negative"} edge weights`
   for (const [edgeIndex, edgeData] of impl.edges) {
     const weight = cost(edgeData.data)
-    if (weight < 0 || Number.isNaN(weight)) {
-      throw new GraphError({ message: `${algorithm} requires non-negative edge weights` })
+    if (!Number.isFinite(weight) || (!options.allowNegative && weight < 0)) {
+      throw new GraphError({ message })
     }
     edgeWeights.set(edgeIndex, weight)
   }
@@ -4106,9 +4108,9 @@ const validateNonNegativeEdgeWeights = <N, E, T extends Kind = "directed">(
  *
  * **Details**
  *
- * Edge costs must be non-negative. Returns `Option.none()` when the target is
- * not reachable, and throws a `GraphError` when either endpoint is missing or a
- * negative edge cost is encountered.
+ * Edge costs must be finite and non-negative. Returns `Option.none()` when the
+ * target is not reachable, and throws a `GraphError` when either endpoint is
+ * missing or an edge cost is negative or non-finite.
  *
  * **Example** (Finding shortest paths with Dijkstra)
  *
@@ -4160,7 +4162,7 @@ export const dijkstra: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = validateNonNegativeEdgeWeights(graph, config.cost, "Dijkstra's algorithm")
+  const edgeWeights = validateEdgeWeights(graph, config.cost, "Dijkstra's algorithm", { allowNegative: false })
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -4304,8 +4306,9 @@ export interface AllPairsResult<E> {
  * **Details**
  *
  * Computes distances, reconstructed node paths, and edge-data paths for every
- * source and target pair in O(V^3) time. Negative edge weights are allowed, but
- * a `GraphError` is thrown if any negative cycle is detected.
+ * source and target pair in O(V^3) time. Finite negative edge weights are
+ * allowed, but a `GraphError` is thrown if any edge weight is non-finite or if
+ * any negative cycle is detected.
  *
  * **Example** (Finding all-pairs shortest paths)
  *
@@ -4342,6 +4345,7 @@ export const floydWarshall: {
   cost: (edgeData: E) => number
 ): AllPairsResult<E> => {
   const impl = graphImpl(graph)
+  const edgeWeights = validateEdgeWeights(graph, cost, "Floyd-Warshall algorithm", { allowNegative: true })
   // Get all nodes for Floyd-Warshall algorithm (needs array for nested iteration)
   const allNodes = Array.from(impl.nodes.keys())
 
@@ -4362,8 +4366,8 @@ export const floydWarshall: {
   }
 
   // Set edge weights
-  for (const [, edgeData] of impl.edges) {
-    const weight = cost(edgeData.data)
+  for (const [edgeIndex, edgeData] of impl.edges) {
+    const weight = edgeWeights.get(edgeIndex)!
     const i = edgeData.source
     const j = edgeData.target
 
@@ -4469,8 +4473,9 @@ export const floydWarshall: {
  *
  * **Details**
  *
- * Specifies the source and target node indices, an edge-cost function, and a
- * heuristic that estimates the remaining cost from a node to the target.
+ * Specifies the source and target node indices, an edge-cost function that maps
+ * edge data to finite non-negative weights, and a heuristic that estimates the
+ * remaining cost from a node to the target.
  *
  * @see {@link astar} for the algorithm that consumes this configuration
  * @see {@link DijkstraConfig} for shortest paths without a heuristic
@@ -4492,10 +4497,10 @@ export interface AstarConfig<E, N> {
  *
  * **Details**
  *
- * The edge-cost function must return non-negative weights, and the heuristic
- * should be consistent to preserve shortest-path guarantees. Returns
+ * The edge-cost function must return finite non-negative weights, and the
+ * heuristic should be consistent to preserve shortest-path guarantees. Returns
  * `Option.none()` when the target is not reachable, and throws a `GraphError`
- * when either endpoint is missing or a negative edge cost is encountered.
+ * when either endpoint is missing or an edge cost is negative or non-finite.
  *
  * **Example** (Finding shortest paths with A-star)
  *
@@ -4553,7 +4558,7 @@ export const astar: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = validateNonNegativeEdgeWeights(graph, config.cost, "A* algorithm")
+  const edgeWeights = validateEdgeWeights(graph, config.cost, "A* algorithm", { allowNegative: false })
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -4699,10 +4704,10 @@ export const astar: {
  * **Details**
  *
  * Specifies the source and target node indices, plus a cost function that maps
- * each edge's data to a numeric weight.
+ * each edge's data to a finite numeric weight.
  *
  * @see {@link bellmanFord} for the algorithm that consumes this configuration
- * @see {@link DijkstraConfig} for non-negative edge costs
+ * @see {@link DijkstraConfig} for finite non-negative edge costs
  * @see {@link AstarConfig} for heuristic shortest-path search
  *
  * @category models
@@ -4720,9 +4725,10 @@ export interface BellmanFordConfig<E> {
  *
  * **Details**
  *
- * Negative edge weights are allowed. Returns `Option.none()` when the target is
- * unreachable or when a negative cycle affects the path to the target. Throws a
- * `GraphError` when either endpoint is missing.
+ * Finite negative edge weights are allowed. Returns `Option.none()` when the
+ * target is unreachable or when a negative cycle affects the path to the target.
+ * Throws a `GraphError` when either endpoint is missing or an edge weight is
+ * non-finite.
  *
  * **Example** (Finding shortest paths with Bellman-Ford)
  *
@@ -4774,6 +4780,8 @@ export const bellmanFord: {
     throw missingNode(config.target)
   }
 
+  const edgeWeights = validateEdgeWeights(graph, config.cost, "Bellman-Ford algorithm", { allowNegative: true })
+
   // Initialize distances and predecessors
   const distances = new Map<NodeIndex, number>()
   const previous = new Map<NodeIndex, { node: NodeIndex; edgeData: E } | null>()
@@ -4786,8 +4794,8 @@ export const bellmanFord: {
 
   // Collect all edges for relaxation
   const edges: Array<{ source: NodeIndex; target: NodeIndex; weight: number; edgeData: E }> = []
-  for (const [, edgeData] of impl.edges) {
-    const weight = config.cost(edgeData.data)
+  for (const [edgeIndex, edgeData] of impl.edges) {
+    const weight = edgeWeights.get(edgeIndex)!
     edges.push({
       source: edgeData.source,
       target: edgeData.target,

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4083,20 +4083,14 @@ export interface DijkstraConfig<E> {
   cost: (edgeData: E) => number
 }
 
-const validateEdgeWeights = <N, E, T extends Kind = "directed">(
+const collectEdgeWeights = <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
-  cost: (edgeData: E) => number,
-  algorithm: string,
-  options: { readonly allowNegative: boolean }
+  cost: (edgeData: E) => number
 ): Map<EdgeIndex, number> => {
   const impl = graphImpl(graph)
   const edgeWeights = new Map<EdgeIndex, number>()
-  const message = `${algorithm} requires finite${options.allowNegative ? "" : " non-negative"} edge weights`
   for (const [edgeIndex, edgeData] of impl.edges) {
     const weight = cost(edgeData.data)
-    if (!Number.isFinite(weight) || (!options.allowNegative && weight < 0)) {
-      throw new GraphError({ message })
-    }
     edgeWeights.set(edgeIndex, weight)
   }
   return edgeWeights
@@ -4162,7 +4156,13 @@ export const dijkstra: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = validateEdgeWeights(graph, config.cost, "Dijkstra's algorithm", { allowNegative: false })
+  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
+    const weight = config.cost(edgeData)
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new GraphError({ message: "Dijkstra's algorithm requires finite non-negative edge weights" })
+    }
+    return weight
+  })
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -4345,7 +4345,13 @@ export const floydWarshall: {
   cost: (edgeData: E) => number
 ): AllPairsResult<E> => {
   const impl = graphImpl(graph)
-  const edgeWeights = validateEdgeWeights(graph, cost, "Floyd-Warshall algorithm", { allowNegative: true })
+  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
+    const weight = cost(edgeData)
+    if (!Number.isFinite(weight)) {
+      throw new GraphError({ message: "Floyd-Warshall algorithm requires finite edge weights" })
+    }
+    return weight
+  })
   // Get all nodes for Floyd-Warshall algorithm (needs array for nested iteration)
   const allNodes = Array.from(impl.nodes.keys())
 
@@ -4558,7 +4564,13 @@ export const astar: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = validateEdgeWeights(graph, config.cost, "A* algorithm", { allowNegative: false })
+  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
+    const weight = config.cost(edgeData)
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new GraphError({ message: "A* algorithm requires finite non-negative edge weights" })
+    }
+    return weight
+  })
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -4780,7 +4792,13 @@ export const bellmanFord: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = validateEdgeWeights(graph, config.cost, "Bellman-Ford algorithm", { allowNegative: true })
+  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
+    const weight = config.cost(edgeData)
+    if (!Number.isFinite(weight)) {
+      throw new GraphError({ message: "Bellman-Ford algorithm requires finite edge weights" })
+    }
+    return weight
+  })
 
   // Initialize distances and predecessors
   const distances = new Map<NodeIndex, number>()

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4084,19 +4084,6 @@ export interface DijkstraConfig<E> {
   cost: (edgeData: E) => number
 }
 
-const collectEdgeWeights = <N, E, T extends Kind = "directed">(
-  graph: Graph<N, E, T> | MutableGraph<N, E, T>,
-  cost: (edgeData: E) => number
-): Map<EdgeIndex, number> => {
-  const impl = graphImpl(graph)
-  const edgeWeights = new Map<EdgeIndex, number>()
-  for (const [edgeIndex, edgeData] of impl.edges) {
-    const weight = cost(edgeData.data)
-    edgeWeights.set(edgeIndex, weight)
-  }
-  return edgeWeights
-}
-
 /**
  * Finds the shortest path from the configured source node to the target node
  * using Dijkstra's algorithm.
@@ -4158,13 +4145,14 @@ export const dijkstra: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
-    const weight = config.cost(edgeData)
+  const edgeWeights = new Map<EdgeIndex, number>()
+  for (const [edgeIndex, edgeData] of impl.edges) {
+    const weight = config.cost(edgeData.data)
     if (Number.isNaN(weight) || weight < 0) {
       throw new GraphError({ message: "Dijkstra's algorithm requires non-negative edge weights" })
     }
-    return weight
-  })
+    edgeWeights.set(edgeIndex, weight)
+  }
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -4347,13 +4335,6 @@ export const floydWarshall: {
   cost: (edgeData: E) => number
 ): AllPairsResult<E> => {
   const impl = graphImpl(graph)
-  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
-    const weight = cost(edgeData)
-    if (Number.isNaN(weight) || weight === -Infinity) {
-      throw new GraphError({ message: "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights" })
-    }
-    return weight
-  })
   // Get all nodes for Floyd-Warshall algorithm (needs array for nested iteration)
   const allNodes = Array.from(impl.nodes.keys())
 
@@ -4374,8 +4355,11 @@ export const floydWarshall: {
   }
 
   // Set edge weights
-  for (const [edgeIndex, edgeData] of impl.edges) {
-    const weight = edgeWeights.get(edgeIndex)!
+  for (const [, edgeData] of impl.edges) {
+    const weight = cost(edgeData.data)
+    if (Number.isNaN(weight) || weight === -Infinity) {
+      throw new GraphError({ message: "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights" })
+    }
     const i = edgeData.source
     const j = edgeData.target
 
@@ -4567,13 +4551,14 @@ export const astar: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
-    const weight = config.cost(edgeData)
+  const edgeWeights = new Map<EdgeIndex, number>()
+  for (const [edgeIndex, edgeData] of impl.edges) {
+    const weight = config.cost(edgeData.data)
     if (Number.isNaN(weight) || weight < 0) {
       throw new GraphError({ message: "A* algorithm requires non-negative edge weights" })
     }
-    return weight
-  })
+    edgeWeights.set(edgeIndex, weight)
+  }
 
   // Early return if source equals target
   if (config.source === config.target) {
@@ -4795,14 +4780,6 @@ export const bellmanFord: {
     throw missingNode(config.target)
   }
 
-  const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
-    const weight = config.cost(edgeData)
-    if (Number.isNaN(weight) || weight === -Infinity) {
-      throw new GraphError({ message: "Bellman-Ford algorithm does not support NaN or -Infinity edge weights" })
-    }
-    return weight
-  })
-
   // Initialize distances and predecessors
   const distances = new Map<NodeIndex, number>()
   const previous = new Map<NodeIndex, { node: NodeIndex; edgeData: E } | null>()
@@ -4815,8 +4792,11 @@ export const bellmanFord: {
 
   // Collect all edges for relaxation
   const edges: Array<{ source: NodeIndex; target: NodeIndex; weight: number; edgeData: E }> = []
-  for (const [edgeIndex, edgeData] of impl.edges) {
-    const weight = edgeWeights.get(edgeIndex)!
+  for (const [, edgeData] of impl.edges) {
+    const weight = config.cost(edgeData.data)
+    if (Number.isNaN(weight) || weight === -Infinity) {
+      throw new GraphError({ message: "Bellman-Ford algorithm does not support NaN or -Infinity edge weights" })
+    }
     edges.push({
       source: edgeData.source,
       target: edgeData.target,

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4038,7 +4038,7 @@ export const stronglyConnectedComponents = <N, E>(
  * `costs` contains original edge data, not the numeric output of the cost
  * function unless the edge data is numeric.
  *
- * @see {@link dijkstra} for shortest paths with finite non-negative edge costs
+ * @see {@link dijkstra} for shortest paths with non-negative edge costs
  * @see {@link astar} for heuristic shortest-path search
  * @see {@link bellmanFord} for shortest paths that may include negative edge weights
  * @see {@link AllPairsResult} for the all-pairs shortest-path result shape
@@ -4058,17 +4058,18 @@ export interface PathResult<E> {
  * **When to use**
  *
  * Use when configuring `dijkstra` to find a shortest path between two existing
- * node indices with finite non-negative edge costs.
+ * node indices with non-negative edge costs.
  *
  * **Details**
  *
  * Specifies the source and target node indices, plus a cost function that maps
- * each edge's data to a finite non-negative numeric weight.
+ * each edge's data to a non-negative numeric weight. `Infinity` is allowed and
+ * behaves like an impassable edge.
  *
  * **Gotchas**
  *
  * `dijkstra` throws a `GraphError` when either endpoint does not exist or when
- * the cost function returns a negative or non-finite weight.
+ * the cost function returns a negative weight or `NaN`.
  *
  * @see {@link dijkstra} for the algorithm that consumes this configuration
  * @see {@link AstarConfig} for heuristic shortest-path search
@@ -4102,9 +4103,10 @@ const collectEdgeWeights = <N, E, T extends Kind = "directed">(
  *
  * **Details**
  *
- * Edge costs must be finite and non-negative. Returns `Option.none()` when the
- * target is not reachable, and throws a `GraphError` when either endpoint is
- * missing or an edge cost is negative or non-finite.
+ * Edge costs must be non-negative and not `NaN`. `Infinity` is allowed and
+ * behaves like an impassable edge. Returns `Option.none()` when the target is
+ * not reachable, and throws a `GraphError` when either endpoint is missing or an
+ * edge cost is negative or `NaN`.
  *
  * **Example** (Finding shortest paths with Dijkstra)
  *
@@ -4158,8 +4160,8 @@ export const dijkstra: {
 
   const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
     const weight = config.cost(edgeData)
-    if (!Number.isFinite(weight) || weight < 0) {
-      throw new GraphError({ message: "Dijkstra's algorithm requires finite non-negative edge weights" })
+    if (Number.isNaN(weight) || weight < 0) {
+      throw new GraphError({ message: "Dijkstra's algorithm requires non-negative edge weights" })
     }
     return weight
   })
@@ -4306,9 +4308,9 @@ export interface AllPairsResult<E> {
  * **Details**
  *
  * Computes distances, reconstructed node paths, and edge-data paths for every
- * source and target pair in O(V^3) time. Finite negative edge weights are
- * allowed, but a `GraphError` is thrown if any edge weight is non-finite or if
- * any negative cycle is detected.
+ * source and target pair in O(V^3) time. Negative edge weights are allowed, and
+ * `Infinity` behaves like an impassable edge. A `GraphError` is thrown if any
+ * edge weight is `NaN` or `-Infinity`, or if any negative cycle is detected.
  *
  * **Example** (Finding all-pairs shortest paths)
  *
@@ -4347,8 +4349,8 @@ export const floydWarshall: {
   const impl = graphImpl(graph)
   const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
     const weight = cost(edgeData)
-    if (!Number.isFinite(weight)) {
-      throw new GraphError({ message: "Floyd-Warshall algorithm requires finite edge weights" })
+    if (Number.isNaN(weight) || weight === -Infinity) {
+      throw new GraphError({ message: "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights" })
     }
     return weight
   })
@@ -4480,7 +4482,7 @@ export const floydWarshall: {
  * **Details**
  *
  * Specifies the source and target node indices, an edge-cost function that maps
- * edge data to finite non-negative weights, and a heuristic that estimates the
+ * edge data to non-negative weights, and a heuristic that estimates the
  * remaining cost from a node to the target.
  *
  * @see {@link astar} for the algorithm that consumes this configuration
@@ -4503,10 +4505,11 @@ export interface AstarConfig<E, N> {
  *
  * **Details**
  *
- * The edge-cost function must return finite non-negative weights, and the
- * heuristic should be consistent to preserve shortest-path guarantees. Returns
+ * The edge-cost function must return non-negative weights and not `NaN`.
+ * `Infinity` is allowed and behaves like an impassable edge. The heuristic
+ * should be consistent to preserve shortest-path guarantees. Returns
  * `Option.none()` when the target is not reachable, and throws a `GraphError`
- * when either endpoint is missing or an edge cost is negative or non-finite.
+ * when either endpoint is missing or an edge cost is negative or `NaN`.
  *
  * **Example** (Finding shortest paths with A-star)
  *
@@ -4566,8 +4569,8 @@ export const astar: {
 
   const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
     const weight = config.cost(edgeData)
-    if (!Number.isFinite(weight) || weight < 0) {
-      throw new GraphError({ message: "A* algorithm requires finite non-negative edge weights" })
+    if (Number.isNaN(weight) || weight < 0) {
+      throw new GraphError({ message: "A* algorithm requires non-negative edge weights" })
     }
     return weight
   })
@@ -4716,10 +4719,10 @@ export const astar: {
  * **Details**
  *
  * Specifies the source and target node indices, plus a cost function that maps
- * each edge's data to a finite numeric weight.
+ * each edge's data to a numeric weight.
  *
  * @see {@link bellmanFord} for the algorithm that consumes this configuration
- * @see {@link DijkstraConfig} for finite non-negative edge costs
+ * @see {@link DijkstraConfig} for non-negative edge costs
  * @see {@link AstarConfig} for heuristic shortest-path search
  *
  * @category models
@@ -4737,10 +4740,10 @@ export interface BellmanFordConfig<E> {
  *
  * **Details**
  *
- * Finite negative edge weights are allowed. Returns `Option.none()` when the
- * target is unreachable or when a negative cycle affects the path to the target.
- * Throws a `GraphError` when either endpoint is missing or an edge weight is
- * non-finite.
+ * Negative edge weights are allowed, and `Infinity` behaves like an impassable
+ * edge. Returns `Option.none()` when the target is unreachable or when a
+ * negative cycle affects the path to the target. Throws a `GraphError` when
+ * either endpoint is missing or an edge weight is `NaN` or `-Infinity`.
  *
  * **Example** (Finding shortest paths with Bellman-Ford)
  *
@@ -4794,8 +4797,8 @@ export const bellmanFord: {
 
   const edgeWeights = collectEdgeWeights(graph, (edgeData) => {
     const weight = config.cost(edgeData)
-    if (!Number.isFinite(weight)) {
-      throw new GraphError({ message: "Bellman-Ford algorithm requires finite edge weights" })
+    if (Number.isNaN(weight) || weight === -Infinity) {
+      throw new GraphError({ message: "Bellman-Ford algorithm does not support NaN or -Infinity edge weights" })
     }
     return weight
   })

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -19,6 +19,24 @@ const makeReversedUndirectedPath = () =>
     Graph.addEdge(mutable, c, b, 1)
   })
 
+const makeSingleEdgeGraph = (weight: number) =>
+  Graph.directed<string, number>((mutable) => {
+    const source = Graph.addNode(mutable, "source")
+    const target = Graph.addNode(mutable, "target")
+    Graph.addEdge(mutable, source, target, weight)
+  })
+
+const nonFiniteEdgeWeights = [NaN, Infinity, -Infinity] as const
+
+const assertGraphError = (thunk: () => void, message: string) => {
+  throws(thunk, (error) => {
+    strictEqual(error instanceof Graph.GraphError, true)
+    if (error instanceof Graph.GraphError) {
+      strictEqual(error.message, message)
+    }
+  })
+}
+
 type SetNode = { readonly id: string; readonly label: string }
 
 class SetNodeKey implements Equal.Equal {
@@ -2963,8 +2981,24 @@ describe("Graph", () => {
           cost: (edge) => edge
         })
       ).toThrow(
-        "Dijkstra's algorithm requires non-negative edge weights"
+        "Dijkstra's algorithm requires finite non-negative edge weights"
       )
+    })
+
+    it("should throw for non-finite weights", () => {
+      for (const weight of nonFiniteEdgeWeights) {
+        const graph = makeSingleEdgeGraph(weight)
+
+        assertGraphError(
+          () =>
+            Graph.dijkstra(graph, {
+              source: 0,
+              target: 1,
+              cost: (edge) => edge
+            }),
+          "Dijkstra's algorithm requires finite non-negative edge weights"
+        )
+      }
     })
 
     it("should throw for negative weights before early target termination", () => {
@@ -2983,7 +3017,7 @@ describe("Graph", () => {
           target: 1,
           cost: (edge) => edge
         })
-      ).toThrow("Dijkstra's algorithm requires non-negative edge weights")
+      ).toThrow("Dijkstra's algorithm requires finite non-negative edge weights")
     })
 
     it("should validate weights before returning same source and target", () => {
@@ -2998,7 +3032,7 @@ describe("Graph", () => {
           target: 0,
           cost: (edge) => edge
         })
-      ).toThrow("Dijkstra's algorithm requires non-negative edge weights")
+      ).toThrow("Dijkstra's algorithm requires finite non-negative edge weights")
     })
 
     it("should throw for non-existent nodes", () => {
@@ -3109,7 +3143,24 @@ describe("Graph", () => {
           cost: (edge) => edge,
           heuristic
         })
-      ).toThrow("A* algorithm requires non-negative edge weights")
+      ).toThrow("A* algorithm requires finite non-negative edge weights")
+    })
+
+    it("should throw for non-finite weights", () => {
+      for (const weight of nonFiniteEdgeWeights) {
+        const graph = makeSingleEdgeGraph(weight)
+
+        assertGraphError(
+          () =>
+            Graph.astar(graph, {
+              source: 0,
+              target: 1,
+              cost: (edge) => edge,
+              heuristic: () => 0
+            }),
+          "A* algorithm requires finite non-negative edge weights"
+        )
+      }
     })
 
     it("should throw for negative weights before early target termination", () => {
@@ -3129,7 +3180,7 @@ describe("Graph", () => {
           cost: (edge) => edge,
           heuristic: () => 0
         })
-      ).toThrow("A* algorithm requires non-negative edge weights")
+      ).toThrow("A* algorithm requires finite non-negative edge weights")
     })
 
     it("should validate weights before returning same source and target", () => {
@@ -3145,7 +3196,7 @@ describe("Graph", () => {
           cost: (edge) => edge,
           heuristic: () => 0
         })
-      ).toThrow("A* algorithm requires non-negative edge weights")
+      ).toThrow("A* algorithm requires finite non-negative edge weights")
     })
 
     it("should traverse undirected edges in reverse storage direction", () => {
@@ -3212,6 +3263,22 @@ describe("Graph", () => {
       })
 
       assertSome(result, { path: [0], distance: 0, costs: [] })
+    })
+
+    it("should throw for non-finite weights", () => {
+      for (const weight of nonFiniteEdgeWeights) {
+        const graph = makeSingleEdgeGraph(weight)
+
+        assertGraphError(
+          () =>
+            Graph.bellmanFord(graph, {
+              source: 0,
+              target: 1,
+              cost: (edge) => edge
+            }),
+          "Bellman-Ford algorithm requires finite edge weights"
+        )
+      }
     })
 
     it("should detect a directed negative self-loop when source equals target", () => {
@@ -3344,6 +3411,17 @@ describe("Graph", () => {
       expect(result.distances.get(0)?.get(0)).toBe(0)
       expect(result.paths.get(0)?.get(0)).toEqual([0])
       expect(result.costs.get(0)?.get(0)).toEqual([])
+    })
+
+    it("should throw for non-finite weights", () => {
+      for (const weight of nonFiniteEdgeWeights) {
+        const graph = makeSingleEdgeGraph(weight)
+
+        assertGraphError(
+          () => Graph.floydWarshall(graph, (edge) => edge),
+          "Floyd-Warshall algorithm requires finite edge weights"
+        )
+      }
     })
 
     it("should preserve null edge data in direct paths", () => {

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -26,7 +26,7 @@ const makeSingleEdgeGraph = (weight: number) =>
     Graph.addEdge(mutable, source, target, weight)
   })
 
-const nonFiniteEdgeWeights = [NaN, Infinity, -Infinity] as const
+const unsupportedEdgeWeights = [NaN, -Infinity] as const
 
 const assertGraphError = (thunk: () => void, message: string) => {
   throws(thunk, (error) => {
@@ -2981,12 +2981,12 @@ describe("Graph", () => {
           cost: (edge) => edge
         })
       ).toThrow(
-        "Dijkstra's algorithm requires finite non-negative edge weights"
+        "Dijkstra's algorithm requires non-negative edge weights"
       )
     })
 
-    it("should throw for non-finite weights", () => {
-      for (const weight of nonFiniteEdgeWeights) {
+    it("should throw for NaN and negative infinity weights", () => {
+      for (const weight of unsupportedEdgeWeights) {
         const graph = makeSingleEdgeGraph(weight)
 
         assertGraphError(
@@ -2996,9 +2996,21 @@ describe("Graph", () => {
               target: 1,
               cost: (edge) => edge
             }),
-          "Dijkstra's algorithm requires finite non-negative edge weights"
+          "Dijkstra's algorithm requires non-negative edge weights"
         )
       }
+    })
+
+    it("should treat infinity weights as unreachable", () => {
+      const graph = makeSingleEdgeGraph(Infinity)
+
+      const result = Graph.dijkstra(graph, {
+        source: 0,
+        target: 1,
+        cost: (edge) => edge
+      })
+
+      assertNone(result)
     })
 
     it("should throw for negative weights before early target termination", () => {
@@ -3017,7 +3029,7 @@ describe("Graph", () => {
           target: 1,
           cost: (edge) => edge
         })
-      ).toThrow("Dijkstra's algorithm requires finite non-negative edge weights")
+      ).toThrow("Dijkstra's algorithm requires non-negative edge weights")
     })
 
     it("should validate weights before returning same source and target", () => {
@@ -3032,7 +3044,7 @@ describe("Graph", () => {
           target: 0,
           cost: (edge) => edge
         })
-      ).toThrow("Dijkstra's algorithm requires finite non-negative edge weights")
+      ).toThrow("Dijkstra's algorithm requires non-negative edge weights")
     })
 
     it("should throw for non-existent nodes", () => {
@@ -3143,11 +3155,11 @@ describe("Graph", () => {
           cost: (edge) => edge,
           heuristic
         })
-      ).toThrow("A* algorithm requires finite non-negative edge weights")
+      ).toThrow("A* algorithm requires non-negative edge weights")
     })
 
-    it("should throw for non-finite weights", () => {
-      for (const weight of nonFiniteEdgeWeights) {
+    it("should throw for NaN and negative infinity weights", () => {
+      for (const weight of unsupportedEdgeWeights) {
         const graph = makeSingleEdgeGraph(weight)
 
         assertGraphError(
@@ -3158,9 +3170,22 @@ describe("Graph", () => {
               cost: (edge) => edge,
               heuristic: () => 0
             }),
-          "A* algorithm requires finite non-negative edge weights"
+          "A* algorithm requires non-negative edge weights"
         )
       }
+    })
+
+    it("should treat infinity weights as unreachable", () => {
+      const graph = makeSingleEdgeGraph(Infinity)
+
+      const result = Graph.astar(graph, {
+        source: 0,
+        target: 1,
+        cost: (edge) => edge,
+        heuristic: () => 0
+      })
+
+      assertNone(result)
     })
 
     it("should throw for negative weights before early target termination", () => {
@@ -3180,7 +3205,7 @@ describe("Graph", () => {
           cost: (edge) => edge,
           heuristic: () => 0
         })
-      ).toThrow("A* algorithm requires finite non-negative edge weights")
+      ).toThrow("A* algorithm requires non-negative edge weights")
     })
 
     it("should validate weights before returning same source and target", () => {
@@ -3196,7 +3221,7 @@ describe("Graph", () => {
           cost: (edge) => edge,
           heuristic: () => 0
         })
-      ).toThrow("A* algorithm requires finite non-negative edge weights")
+      ).toThrow("A* algorithm requires non-negative edge weights")
     })
 
     it("should traverse undirected edges in reverse storage direction", () => {
@@ -3265,8 +3290,8 @@ describe("Graph", () => {
       assertSome(result, { path: [0], distance: 0, costs: [] })
     })
 
-    it("should throw for non-finite weights", () => {
-      for (const weight of nonFiniteEdgeWeights) {
+    it("should throw for NaN and negative infinity weights", () => {
+      for (const weight of unsupportedEdgeWeights) {
         const graph = makeSingleEdgeGraph(weight)
 
         assertGraphError(
@@ -3276,9 +3301,21 @@ describe("Graph", () => {
               target: 1,
               cost: (edge) => edge
             }),
-          "Bellman-Ford algorithm requires finite edge weights"
+          "Bellman-Ford algorithm does not support NaN or -Infinity edge weights"
         )
       }
+    })
+
+    it("should treat infinity weights as unreachable", () => {
+      const graph = makeSingleEdgeGraph(Infinity)
+
+      const result = Graph.bellmanFord(graph, {
+        source: 0,
+        target: 1,
+        cost: (edge) => edge
+      })
+
+      assertNone(result)
     })
 
     it("should detect a directed negative self-loop when source equals target", () => {
@@ -3413,15 +3450,25 @@ describe("Graph", () => {
       expect(result.costs.get(0)?.get(0)).toEqual([])
     })
 
-    it("should throw for non-finite weights", () => {
-      for (const weight of nonFiniteEdgeWeights) {
+    it("should throw for NaN and negative infinity weights", () => {
+      for (const weight of unsupportedEdgeWeights) {
         const graph = makeSingleEdgeGraph(weight)
 
         assertGraphError(
           () => Graph.floydWarshall(graph, (edge) => edge),
-          "Floyd-Warshall algorithm requires finite edge weights"
+          "Floyd-Warshall algorithm does not support NaN or -Infinity edge weights"
         )
       }
+    })
+
+    it("should treat infinity weights as unreachable", () => {
+      const graph = makeSingleEdgeGraph(Infinity)
+
+      const result = Graph.floydWarshall(graph, (edge) => edge)
+
+      expect(result.distances.get(0)?.get(1)).toBe(Infinity)
+      expect(result.paths.get(0)?.get(1)).toBeNull()
+      expect(result.costs.get(0)?.get(1)).toEqual([])
     })
 
     it("should preserve null edge data in direct paths", () => {


### PR DESCRIPTION
## Summary
- reject `NaN` and `-Infinity` edge weights in Graph shortest-path algorithms
- keep Dijkstra/A* rejecting negative edge weights while allowing `Infinity` as an impassable edge
- document the numeric-domain policy and add regression tests for unsupported and infinite edge weights

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Graph.test.ts
- pnpm check