### PR TITLE
Fix Graph lazy traversal stale node skips

### DIFF
--- a/.changeset/stale-graph-traversal-skips.md
+++ b/.changeset/stale-graph-traversal-skips.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Graph BFS, topological sort, and DFS postorder iterators to skip nodes removed from a MutableGraph without recursive self-calls.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -5379,7 +5379,7 @@ export const bfs: {
             if (Option.isSome(nodeData)) {
               return { done: false, value: f(current, nodeData.value) }
             }
-            return nextMapped()
+            continue
           }
         }
 
@@ -5553,7 +5553,7 @@ export const topo: {
             if (Option.isSome(nodeData)) {
               return { done: false, value: f(current, nodeData.value) }
             }
-            return nextMapped()
+            continue
           }
         }
 
@@ -5675,7 +5675,7 @@ export const dfsPostOrder: {
               if (Option.isSome(nodeData)) {
                 return { done: false, value: f(nodeToEmit, nodeData.value) }
               }
-              return nextMapped()
+              continue
             }
           }
         }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3539,6 +3539,26 @@ describe("Graph", () => {
   })
 
   describe("Iterator Base Methods", () => {
+    const staleTraversalNodeCount = 20000
+
+    const makeSparseMutableGraph = () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        for (let i = 0; i < staleTraversalNodeCount; i++) {
+          Graph.addNode(mutable, String(i))
+        }
+      })
+      return {
+        mutable: Graph.beginMutation(graph),
+        start: Array.from({ length: staleTraversalNodeCount }, (_, index) => index)
+      }
+    }
+
+    const removeNodes = (mutable: Graph.MutableDirectedGraph<string, number>, nodes: Array<Graph.NodeIndex>) => {
+      for (const node of nodes) {
+        Graph.removeNode(mutable, node)
+      }
+    }
+
     it("should provide values() method for DFS iterator", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")
@@ -3597,6 +3617,15 @@ describe("Graph", () => {
       const entries = Array.from(Graph.entries(bfsIterator))
 
       expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
+    })
+
+    it("should skip stale BFS nodes without recursion", () => {
+      const { mutable, start } = makeSparseMutableGraph()
+      const iterator = Graph.indices(Graph.bfs(mutable, { start }))[Symbol.iterator]()
+
+      removeNodes(mutable, start)
+
+      assert.strictEqual(iterator.next().done, true)
     })
 
     it("should limit DFS traversal by radius", () => {
@@ -3687,6 +3716,15 @@ describe("Graph", () => {
 
       const entries = Array.from(Graph.entries(topoIterator))
       expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
+    })
+
+    it("should skip stale topological sort nodes without recursion", () => {
+      const { mutable, start } = makeSparseMutableGraph()
+      const iterator = Graph.indices(Graph.topo(mutable))[Symbol.iterator]()
+
+      removeNodes(mutable, start)
+
+      assert.strictEqual(iterator.next().done, true)
     })
 
     it("should prioritize valid initials and still include all nodes", () => {
@@ -3791,6 +3829,15 @@ describe("Graph", () => {
       const entries = Array.from(Graph.entries(dfsPostIterator))
 
       expect(entries).toEqual([[2, "C"], [1, "B"], [0, "A"]]) // Postorder: children before parents
+    })
+
+    it("should skip stale DFS postorder nodes without recursion", () => {
+      const { mutable, start } = makeSparseMutableGraph()
+      const iterator = Graph.indices(Graph.dfsPostOrder(mutable, { start }))[Symbol.iterator]()
+
+      removeNodes(mutable, start)
+
+      assert.strictEqual(iterator.next().done, true)
     })
 
     it("should traverse undirected edges in reverse storage direction", () => {


### PR DESCRIPTION
## Summary
- Replace recursive stale-node skips in Graph BFS, topological sort, and DFS postorder iterators with iterative loop continues.
- Add MutableGraph regression tests that remove queued nodes after iterator creation.
- Add a patch changeset for effect.

## Validation
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm lint-fix`
- `pnpm check`