### PR TITLE
fix(ai): respect failureMode when tool-call parameter decoding fails

### DIFF
--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1167,7 +1167,7 @@ export const make: (params: {
 
     // Construct the response schema with the tools from the toolkit
     const ResponseSchema = Schema.mutable(
-      Schema.Array(Response.Part(toolkit))
+      Schema.Array(Response.Part(toolkit, { relaxParams: true }))
     )
 
     // If tool call resolution is disabled, return the response without
@@ -1469,7 +1469,7 @@ export const make: (params: {
       >
     }
 
-    const ResponseSchema = Schema.NonEmptyArray(Response.StreamPart(toolkit))
+    const ResponseSchema = Schema.NonEmptyArray(Response.StreamPart(toolkit, { relaxParams: true }))
     const decodeParts = Schema.decodeEffect(ResponseSchema)
 
     // Queue for decoded parts and tool results

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -263,7 +263,8 @@ export type PartEncoded =
  * @since 4.0.0
  */
 export const Part = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
-  toolkit: T
+  toolkit: T,
+  options?: { readonly relaxParams?: boolean }
 ): Schema.Codec<
   Part<T extends Toolkit.Any ? Toolkit.Tools<T> : Toolkit.WithHandlerTools<T>>,
   PartEncoded,
@@ -273,7 +274,7 @@ export const Part = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
   const toolCalls: Array<Schema.Top> = []
   const toolResults: Array<Schema.Top> = []
   for (const tool of Object.values(toolkit.tools as Record<string, Tool.Any>)) {
-    const toolCall = ToolCallPart(tool.name, tool.parametersSchema)
+    const toolCall = ToolCallPart(tool.name, options?.relaxParams === true ? Schema.Unknown : tool.parametersSchema)
     const toolResult = ToolResultPart(tool.name, tool.successSchema, tool.failureSchema)
     toolCalls.push(toolCall)
     toolResults.push(toolResult)
@@ -355,7 +356,8 @@ export type StreamPartEncoded =
  * @since 4.0.0
  */
 export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
-  toolkit: T
+  toolkit: T,
+  options?: { readonly relaxParams?: boolean }
 ): Schema.Codec<
   StreamPart<T extends Toolkit.Any ? Toolkit.Tools<T> : Toolkit.WithHandlerTools<T>>,
   StreamPartEncoded,
@@ -365,7 +367,7 @@ export const StreamPart = <T extends Toolkit.Any | Toolkit.WithHandler<any>>(
   const toolCalls: Array<Schema.Top> = []
   const toolResults: Array<Schema.Top> = []
   for (const tool of Object.values(toolkit.tools as Record<string, Tool.Any>)) {
-    const toolCall = ToolCallPart(tool.name, tool.parametersSchema)
+    const toolCall = ToolCallPart(tool.name, options?.relaxParams === true ? Schema.Unknown : tool.parametersSchema)
     const toolResult = ToolResultPart(tool.name, tool.successSchema, tool.failureSchema)
     toolCalls.push(toolCall)
     toolResults.push(toolResult)

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -293,7 +293,8 @@ const Proto = {
         // Fetch cached schemas / handlers for the tool
         const schemas = getSchemas(tool)
 
-        // Decode the tool call parameters which will be passed to the handler
+        // Decode the tool call parameters which will be passed to the handler.
+        // When decoding fails, respect the tool's failureMode before propagating.
         const decodedParams = yield* schemas.decodeParameters(params).pipe(
           Effect.mapError((cause) =>
             AiError.make({
@@ -305,8 +306,26 @@ const Proto = {
                 description: cause.message
               })
             })
-          )
+          ),
+          Effect.matchEffect({
+            onFailure: (error) =>
+              tool.failureMode === "error"
+                ? Effect.fail(error)
+                : schemas.encodeResult(error).pipe(
+                  Effect.map((encodedResult) =>
+                    Stream.succeed({ result: error, encodedResult, isFailure: true, preliminary: false }) as Stream.Stream<
+                      { readonly result: any; readonly encodedResult: any; readonly isFailure: boolean; readonly preliminary: boolean },
+                      never
+                    >
+                  ),
+                  Effect.orDie
+                ),
+            onSuccess: Effect.succeed
+          })
         )
+        if (Stream.isStream(decodedParams)) {
+          return decodedParams
+        }
 
         // Setup the handler context
         const queue = yield* Queue.make<{

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -158,7 +158,7 @@ describe("Tool", () => {
         deepStrictEqual(response, toolResult)
       }))
 
-    it.effect("should raise an error when tool call parameters are invalid", () =>
+    it.effect("should return a tool-result with isFailure when tool call parameters are invalid", () =>
       Effect.gen(function*() {
         const toolkit = Toolkit.make(FailureModeReturn)
 
@@ -182,22 +182,40 @@ describe("Tool", () => {
               params: {}
             }]
           }),
-          Effect.provide(handlers),
-          Effect.flip
+          Effect.provide(handlers)
         )
 
-        deepStrictEqual(
-          response,
-          AiError.make({
-            module: "Toolkit",
-            method: "FailureModeReturn.handle",
-            reason: new AiError.ToolParameterValidationError({
-              toolName: "FailureModeReturn",
-              toolParams: {},
-              description: `Missing key\n  at ["testParam"]`
-            })
+        const validationError = AiError.make({
+          module: "Toolkit",
+          method: "FailureModeReturn.handle",
+          reason: new AiError.ToolParameterValidationError({
+            toolName: "FailureModeReturn",
+            toolParams: {},
+            description: `Missing key\n  at ["testParam"]`
           })
-        )
+        })
+
+        deepStrictEqual(response.toolResults, [
+          Response.toolResultPart({
+            id: toolCallId,
+            name: toolName,
+            isFailure: true,
+            providerExecuted: false,
+            preliminary: false,
+            result: validationError,
+            encodedResult: {
+              _tag: "AiError",
+              module: "Toolkit",
+              method: "FailureModeReturn.handle",
+              reason: {
+                _tag: "ToolParameterValidationError",
+                toolName: "FailureModeReturn",
+                toolParams: {},
+                description: `Missing key\n  at ["testParam"]`
+              }
+            }
+          })
+        ])
       }))
 
     it.effect("should return AiError when user returns an AiErrorReason when failure mode is return", () =>
@@ -870,7 +888,7 @@ describe("Tool", () => {
         deepStrictEqual(response, toolResult)
       }))
 
-    it.effect("should raise an error when tool call parameters are invalid", () =>
+    it.effect("should return a tool-result with isFailure when tool call parameters are invalid", () =>
       Effect.gen(function*() {
         const tool = HandlerRequired({
           failureMode: "return",
@@ -902,22 +920,40 @@ describe("Tool", () => {
               }
             ]
           }),
-          Effect.provide(handlers),
-          Effect.flip
+          Effect.provide(handlers)
         )
 
-        deepStrictEqual(
-          response,
-          AiError.make({
-            module: "Toolkit",
-            method: "HandlerRequired.handle",
-            reason: new AiError.ToolParameterValidationError({
-              toolName: "HandlerRequired",
-              toolParams: {},
-              description: `Missing key\n  at ["testParam"]`
-            })
+        const validationError = AiError.make({
+          module: "Toolkit",
+          method: "HandlerRequired.handle",
+          reason: new AiError.ToolParameterValidationError({
+            toolName: "HandlerRequired",
+            toolParams: {},
+            description: `Missing key\n  at ["testParam"]`
           })
-        )
+        })
+
+        deepStrictEqual(response.toolResults, [
+          Response.toolResultPart({
+            id: toolCallId,
+            name: tool.name,
+            isFailure: true,
+            providerExecuted: false,
+            preliminary: false,
+            result: validationError,
+            encodedResult: {
+              _tag: "AiError",
+              module: "Toolkit",
+              method: "HandlerRequired.handle",
+              reason: {
+                _tag: "ToolParameterValidationError",
+                toolName: "HandlerRequired",
+                toolParams: {},
+                description: `Missing key\n  at ["testParam"]`
+              }
+            }
+          })
+        ])
       }))
 
     describe("addDependency", () => {


### PR DESCRIPTION
## Summary

Closes #6335

When a language model returns tool-call parameters that fail schema validation, the decode error was thrown before the handler queue was set up, bypassing the `failureMode` gate entirely. This meant `failureMode: "return"` had no effect for parameter errors — the effect always propagated the failure.

### Root cause

Two decode sites were responsible:

1. **`LanguageModel.ts`** — The `Response.StreamPart` / `Response.Part` decoders were applied to the raw LLM output *before* routing to `Toolkit.handle`. A parameter schema mismatch here caused an immediate effect failure, skipping `handle` completely.

2. **`Toolkit.ts`** — Inside `handle`, `decodeParameters` failed with an uncaught error before the queue existed, so the `failureMode` check in `Stream.catch` was never reached.

### Fix

**Site 1**: Pass `{ relaxParams: true }` to `Response.StreamPart`/`Response.Part` for the tool-resolution decode pass. This substitutes `Schema.Unknown` for `tool.parametersSchema`, allowing raw params through to `handle` regardless of shape.

**Site 2**: Wrap `decodeParameters` in `Effect.matchEffect`. On failure, check `tool.failureMode`:
- `"error"` → propagate via `Effect.fail` (existing behavior)
- `"return"` → encode the `AiError` via `schemas.encodeResult` and emit it as a tool-result stream with `{ result, encodedResult, isFailure: true, preliminary: false }`

### Tests updated

Two existing tests asserted the old broken behavior (expecting `Effect.flip` to yield an `AiError` for parameter errors on `failureMode: "return"` tools). Updated them to assert the correct behavior: the effect succeeds and `response.toolResults` contains a part with `isFailure: true` and the encoded validation error.