### PR TITLE
Fix published pre-response handler types

### DIFF
--- a/.changeset/fix-http-pre-response-handler-types.md
+++ b/.changeset/fix-http-pre-response-handler-types.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the published declaration for `HttpEffect.appendPreResponseHandlerUnsafe`.

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -25,7 +25,10 @@ import { HttpServerRequest } from "./HttpServerRequest.ts"
 import * as Request from "./HttpServerRequest.ts"
 import type { HttpServerResponse } from "./HttpServerResponse.ts"
 import * as Response from "./HttpServerResponse.ts"
-import { appendPreResponseHandlerUnsafe, requestPreResponseHandlers } from "./internal/preResponseHandler.ts"
+import {
+  appendPreResponseHandlerUnsafe as appendPreResponseHandlerUnsafeInternal,
+  requestPreResponseHandlers
+} from "./internal/preResponseHandler.ts"
 
 /**
  * Runs an HTTP server effect, sends the produced response with the supplied handler, and converts failures into HTTP responses.
@@ -192,15 +195,16 @@ export const appendPreResponseHandler = (handler: PreResponseHandler): Effect.Ef
     return Effect.void
   })
 
-export {
-  /**
-   * Registers a pre-response handler for the supplied HTTP server request.
-   *
-   * @category fiber refs
-   * @since 4.0.0
-   */
-  appendPreResponseHandlerUnsafe
-}
+/**
+ * Registers a pre-response handler for the supplied HTTP server request.
+ *
+ * @category fiber refs
+ * @since 4.0.0
+ */
+export const appendPreResponseHandlerUnsafe: (
+  request: HttpServerRequest,
+  handler: PreResponseHandler
+) => void = appendPreResponseHandlerUnsafeInternal
 
 /**
  * Runs an effect after registering a pre-response handler for the current HTTP server request.

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -25,10 +25,7 @@ import { HttpServerRequest } from "./HttpServerRequest.ts"
 import * as Request from "./HttpServerRequest.ts"
 import type { HttpServerResponse } from "./HttpServerResponse.ts"
 import * as Response from "./HttpServerResponse.ts"
-import {
-  appendPreResponseHandlerUnsafe as appendPreResponseHandlerUnsafeInternal,
-  requestPreResponseHandlers
-} from "./internal/preResponseHandler.ts"
+import * as preResponseHandler from "./internal/preResponseHandler.ts"
 
 /**
  * Runs an HTTP server effect, sends the produced response with the supplied handler, and converts failures into HTTP responses.
@@ -49,7 +46,7 @@ export const toHandled = <E, R, EH, RH>(
       const fiber = Fiber.getCurrent()!
       reportCauseUnsafe(fiber, cause)
       const request = Context.getUnsafe(fiber.context, HttpServerRequest)
-      const handler = requestPreResponseHandlers.get(request.source)
+      const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
       const cont = cause.reasons.length === 0 ? Effect.succeed(response) : Effect.failCause(cause)
       if (handler === undefined) {
         ;(request as any)[handledSymbol] = true
@@ -72,7 +69,7 @@ export const toHandled = <E, R, EH, RH>(
     onSuccess: (response) => {
       const fiber = Fiber.getCurrent()!
       const request = Context.getUnsafe(fiber.context, HttpServerRequest)
-      const handler = requestPreResponseHandlers.get(request.source)
+      const handler = preResponseHandler.requestPreResponseHandlers.get(request.source)
       if (handler === undefined) {
         ;(request as any)[handledSymbol] = true
         return Effect.mapEager(handleResponse(request, response), () => response)
@@ -204,7 +201,7 @@ export const appendPreResponseHandler = (handler: PreResponseHandler): Effect.Ef
 export const appendPreResponseHandlerUnsafe: (
   request: HttpServerRequest,
   handler: PreResponseHandler
-) => void = appendPreResponseHandlerUnsafeInternal
+) => void = preResponseHandler.appendPreResponseHandlerUnsafe
 
 /**
  * Runs an effect after registering a pre-response handler for the current HTTP server request.

--- a/packages/effect/src/unstable/http/internal/preResponseHandler.ts
+++ b/packages/effect/src/unstable/http/internal/preResponseHandler.ts
@@ -5,6 +5,7 @@ import type { HttpServerRequest } from "../HttpServerRequest.ts"
 /** @internal */
 export const requestPreResponseHandlers = new WeakMap<object, PreResponseHandler>()
 
+/** @internal */
 export const appendPreResponseHandlerUnsafe = (request: HttpServerRequest, handler: PreResponseHandler): void => {
   const prev = requestPreResponseHandlers.get(request.source)
   const next: PreResponseHandler = prev ?

--- a/packages/effect/src/unstable/http/internal/preResponseHandler.ts
+++ b/packages/effect/src/unstable/http/internal/preResponseHandler.ts
@@ -5,7 +5,6 @@ import type { HttpServerRequest } from "../HttpServerRequest.ts"
 /** @internal */
 export const requestPreResponseHandlers = new WeakMap<object, PreResponseHandler>()
 
-/** @internal */
 export const appendPreResponseHandlerUnsafe = (request: HttpServerRequest, handler: PreResponseHandler): void => {
   const prev = requestPreResponseHandlers.get(request.source)
   const next: PreResponseHandler = prev ?

--- a/packages/tools/oxc/src/oxlint/rules/no-unused-internal.ts
+++ b/packages/tools/oxc/src/oxlint/rules/no-unused-internal.ts
@@ -286,6 +286,33 @@ function getExports(
   return fileInfos.get(fileName)?.internalExports.get(exportName) ?? []
 }
 
+function getReExportedInternals(
+  fileInfos: ReadonlyMap<string, FileInfo>,
+  fileInfo: FileInfo,
+  workspacePackages: ReadonlyMap<string, string>,
+  specifier: ts.ExportSpecifier
+): ReadonlyArray<InternalExport> {
+  const exportDeclaration = specifier.parent.parent
+  const importedName = (specifier.propertyName ?? specifier.name).text
+  if (
+    exportDeclaration.moduleSpecifier !== undefined &&
+    ts.isStringLiteral(exportDeclaration.moduleSpecifier)
+  ) {
+    const importedFile = resolveModule(
+      exportDeclaration.moduleSpecifier.text,
+      fileInfo.sourceFile.fileName,
+      workspacePackages
+    )
+    return getExports(fileInfos, importedFile, importedName)
+  }
+
+  const imported = fileInfo.imports.get(importedName)
+  return [
+    ...(fileInfo.internalExports.get(importedName) ?? []),
+    ...getExports(fileInfos, imported?.fileName, imported?.importedName ?? "")
+  ]
+}
+
 function markUsed(exports: ReadonlyArray<InternalExport>, node: ts.Node) {
   for (const internal of exports) {
     if (!isInside(node, internal.declaration)) {
@@ -348,6 +375,17 @@ function collectFileInfo(
       continue
     }
 
+    if (
+      !isInternalFile &&
+      ts.isExportDeclaration(statement) &&
+      !hasInternalApiJSDoc(statement) &&
+      statement.exportClause !== undefined &&
+      ts.isNamedExports(statement.exportClause)
+    ) {
+      fileInfo.publicDeclarations.push(statement)
+      continue
+    }
+
     if (!hasExportModifier(statement)) continue
 
     const names = getTopLevelDeclarationNameNodes(statement)
@@ -385,9 +423,15 @@ function markNamespaceReference(
   markUsed(getExports(fileInfos, importedFile, name.text), name)
 }
 
-function scanUsage(fileInfos: ReadonlyMap<string, FileInfo>, fileInfo: FileInfo) {
+function scanUsage(
+  fileInfos: ReadonlyMap<string, FileInfo>,
+  fileInfo: FileInfo,
+  workspacePackages: ReadonlyMap<string, string>
+) {
   const visit = (node: ts.Node) => {
-    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && ts.isIdentifier(node.name)) {
+    if (ts.isExportSpecifier(node)) {
+      markUsed(getReExportedInternals(fileInfos, fileInfo, workspacePackages, node), node)
+    } else if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && ts.isIdentifier(node.name)) {
       markNamespaceReference(fileInfos, fileInfo, node.expression, node.name)
     } else if (ts.isQualifiedName(node) && ts.isIdentifier(node.left)) {
       markNamespaceReference(fileInfos, fileInfo, node.left, node.right)
@@ -529,7 +573,8 @@ function scanPublicSignature(
   fileInfos: ReadonlyMap<string, FileInfo>,
   fileInfo: FileInfo,
   diagnostics: Array<Diagnostic>,
-  node: ts.Node
+  node: ts.Node,
+  workspacePackages: ReadonlyMap<string, string>
 ) {
   if (ts.isFunctionDeclaration(node)) {
     scanFunctionLikeSignature(fileInfos, fileInfo, diagnostics, node)
@@ -562,6 +607,21 @@ function scanPublicSignature(
     for (const member of node.members) {
       scanClassMemberSignature(fileInfos, fileInfo, diagnostics, member)
     }
+  } else if (
+    ts.isExportDeclaration(node) &&
+    node.exportClause !== undefined &&
+    ts.isNamedExports(node.exportClause)
+  ) {
+    for (const specifier of node.exportClause.elements) {
+      for (const internal of getReExportedInternals(fileInfos, fileInfo, workspacePackages, specifier)) {
+        const name = specifier.propertyName ?? specifier.name
+        diagnostics.push({
+          fileName: fileInfo.fileName,
+          range: [name.getStart(), name.getEnd()],
+          message: `Do not re-export @internal export "${internal.name}" from a public module`
+        })
+      }
+    }
   }
 }
 
@@ -579,7 +639,7 @@ function analyze(cwd: string): Analysis {
   }
 
   for (const fileInfo of fileInfos.values()) {
-    scanUsage(fileInfos, fileInfo)
+    scanUsage(fileInfos, fileInfo, workspacePackages)
   }
 
   const diagnosticsByFile = new Map<string, Array<Diagnostic>>()
@@ -587,7 +647,7 @@ function analyze(cwd: string): Analysis {
   for (const fileInfo of fileInfos.values()) {
     const diagnostics: Array<Diagnostic> = []
     for (const declaration of fileInfo.publicDeclarations) {
-      scanPublicSignature(fileInfos, fileInfo, diagnostics, declaration)
+      scanPublicSignature(fileInfos, fileInfo, diagnostics, declaration, workspacePackages)
     }
     for (const diagnostic of diagnostics) {
       addFileDiagnostic(diagnosticsByFile, diagnostic)
@@ -619,7 +679,7 @@ const rule: CreateRule = {
   meta: {
     type: "problem",
     docs: {
-      description: "Disallow unused @internal exports and references to @internal exports from public type signatures"
+      description: "Disallow unused @internal exports, public re-exports, and references from public type signatures"
     }
   },
   create(context) {

--- a/packages/tools/oxc/test/no-unused-internal.test.ts
+++ b/packages/tools/oxc/test/no-unused-internal.test.ts
@@ -86,6 +86,23 @@ export interface Public {
     expect(run(cwd, "packages/foo/src/Internal.ts")).toEqual([])
   })
 
+  it("reports public re-exports of @internal exports", () => {
+    const cwd = writeFixture({
+      "packages/foo/src/Internal.ts": `/** @internal */
+export const internal = 1
+`,
+      "packages/foo/src/Public.ts": `import { internal } from "./Internal.ts"
+
+export { internal }
+`
+    })
+
+    expect(run(cwd, "packages/foo/src/Public.ts")).toEqual([
+      `Do not re-export @internal export "internal" from a public module`
+    ])
+    expect(run(cwd, "packages/foo/src/Internal.ts")).toEqual([])
+  })
+
   it("ignores @internal class member type signatures", () => {
     const cwd = writeFixture({
       "packages/foo/src/Internal.ts": `/** @internal */

--- a/packages/tools/oxc/test/no-unused-internal.test.ts
+++ b/packages/tools/oxc/test/no-unused-internal.test.ts
@@ -91,9 +91,7 @@ export interface Public {
       "packages/foo/src/Internal.ts": `/** @internal */
 export const internal = 1
 `,
-      "packages/foo/src/Public.ts": `import { internal } from "./Internal.ts"
-
-export { internal }
+      "packages/foo/src/Public.ts": `export { internal } from "./Internal.ts"
 `
     })
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Preserve `appendPreResponseHandlerUnsafe` in release declaration output. `HttpEffect` publicly re-exports this function, but its implementation declaration was tagged `@internal`. Release builds enable `stripInternal`, so the symbol disappeared from `internal/preResponseHandler.d.ts` while `HttpEffect.d.ts` still imported and re-exported it. Consumers using strict library checking then received TS2305.

This change removes the erroneous internal marker, extends the existing lint rule to flag public named re-exports of `@internal` symbols, adds regression coverage, and includes a patch changeset.

Validation:

- `pnpm lint-fix`
- `pnpm --dir packages/tools/oxc test --run` (51 tests)
- `pnpm vitest run packages/effect/test/unstable/http/HttpEffect.test.ts` (17 tests)
- `pnpm check`
- release-style declaration emit with `--stripInternal true` (the internal file now declares `appendPreResponseHandlerUnsafe` instead of emitting `export {}`)

Prepared with OpenAI Codex assistance; repository guidance, scope, diff, and validation results were checked before publication.

## Related

- Related Issue #6431
- Closes #6431


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type declarations for the HTTP pre-response handler API.
  * Improved handling of pre-response handlers for both successful and failed HTTP responses.
  * Enhanced detection of internal exports unintentionally re-exported from public modules.

* **Developer Experience**
  * Added clearer diagnostics for invalid public re-exports of internal APIs.

* **Tests**
  * Added coverage for detecting internal exports re-exported by public modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->