### PR TITLE
Configure V3 minor release queue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,9 @@ name: Check
 on:
   workflow_dispatch:
   pull_request:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
   push:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,9 @@ name: Pages
 on:
   workflow_dispatch:
   pull_request:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
   push:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.event.pull_request
         env:
           GITHUB_TOKEN: ${{ secrets.EFFECT_BOT_GH }}
-      - uses: tim-smart/next-release-action@main
+      - uses: Effect-TS/next-release-action@main
         with:
           github_token: ${{ secrets.EFFECT_BOT_GH }}
           packages: effect,@effect/platform

--- a/.github/workflows/release-queue.yml
+++ b/.github/workflows/release-queue.yml
@@ -3,9 +3,9 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
   push:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
 
 permissions: {}
 
@@ -39,5 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.EFFECT_BOT_GH }}
           packages: effect,@effect/platform
+          base_branch: v3
+          eligible_branches: v3/next-minor
           git_user: effect-bot
           git_email: tech-ops@effectful.co

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,7 +1,7 @@
 name: Snapshot
 on:
   pull_request:
-    branches: [v3, next-minor, next-major]
+    branches: [v3, v3/next-minor]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

- anchor the V3 release queue to `v3`
- use `v3/next-minor` as the only staged release branch
- remove the obsolete V3 next-major workflow targets
- use `Effect-TS/next-release-action` with configurable eligible branches

## Validation

- `pnpm lint-fix`
- `pnpm test run` (one MSSQL timeout passed on isolated rerun)
- `pnpm check`
- `pnpm build`
- `pnpm docgen`