### PR TITLE
Reject unknown properties in Match.when object patterns

### DIFF
--- a/.changeset/tidy-cats-match.md
+++ b/.changeset/tidy-cats-match.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reject unknown properties in `Match.when` object patterns.

--- a/packages/effect/dtslint/Match.tst.ts
+++ b/packages/effect/dtslint/Match.tst.ts
@@ -84,6 +84,15 @@ describe("Match", () => {
   })
 
   describe("when", () => {
+    it("rejects unknown object pattern properties", () => {
+      pipe(
+        Match.value(hole<{ _tag: "Transfer"; renamedValue: "foo" } | null>()),
+        // @ts-expect-error: Type 'string' is not assignable to type 'never'
+        Match.when({ _tag: "Transfer", value: "foo" }, () => {}),
+        Match.orElse(() => {})
+      )
+    })
+
     it("schema exhaustive-literal", () => {
       expect(
         pipe(

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -132,6 +132,16 @@ export interface ValueMatcher<in Input, out Filters, out Remaining, out Result, 
  */
 export type Case = When | Not
 
+type PatternKeys<A> = A extends object ? keyof A : never
+
+type PatternGuard<A, P> = P extends
+  | Predicate.Predicate<any>
+  | Predicate.Refinement<any, any>
+  | SafeRefinement<any>
+  | ReadonlyArray<any> ? unknown
+  : P extends object ? { readonly [K in Exclude<keyof P, PatternKeys<A>>]: never }
+  : unknown
+
 /**
  * @category Model
  * @since 1.0.0
@@ -371,7 +381,7 @@ export const when: <
   Ret,
   Fn extends (_: Types.WhenMatch<R, P>) => Ret
 >(
-  pattern: P,
+  pattern: P & PatternGuard<R, P>,
   f: Fn
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr, Ret>
@@ -382,7 +392,7 @@ export const when: <
   A | ReturnType<Fn>,
   Pr,
   Ret
-> = internal.when
+> = internal.when as any
 
 /**
  * Matches one of multiple patterns in a single condition.


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Match.when` inferred object patterns through a generic parameter, which bypassed TypeScript's fresh-object excess-property check. A stale property could therefore keep compiling after the matched value type renamed that property, even though the branch could no longer match at runtime.

This adds an object-pattern key guard that accepts keys present on any object variant of the matched input while leaving predicates, refinements, and array patterns unchanged. The regression test covers the reported nullable tagged-union case.

## Related

- Closes #6230

## Validation

- `pnpm test-types Match.tst.ts` — 32 tests, 97 assertions, and 11 expected diagnostics passed
- `pnpm test packages/effect/test/Match.test.ts` — 62 tests passed
- `pnpm lint-fix`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`; the affected `packages/effect` docgen was rerun on the final source
- `git diff --check`

## AI assistance

OpenAI Codex assisted with issue screening, implementation, and validation. No human review is claimed.
