### PR TITLE
Fix asyncPush bounded buffer termination

### DIFF
--- a/.changeset/tame-streams-end.md
+++ b/.changeset/tame-streams-end.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reserve queue capacity for termination signals in `Stream.asyncPush` with bounded dropping or sliding buffers.

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -603,9 +603,9 @@ const queueFromBufferOptionsPush = <A, E>(
   }
   switch (options?.strategy) {
     case "sliding":
-      return Queue.sliding(options.bufferSize ?? 16)
+      return Queue.sliding((options.bufferSize ?? 16) + 1)
     default:
-      return Queue.dropping(options?.bufferSize ?? 16)
+      return Queue.dropping((options?.bufferSize ?? 16) + 1)
   }
 }
 

--- a/packages/effect/test/Stream/async.test.ts
+++ b/packages/effect/test/Stream/async.test.ts
@@ -438,6 +438,21 @@ describe("Stream", () => {
       assertTrue(Chunk.isEmpty(result))
     }))
 
+  for (const strategy of ["dropping", "sliding"] as const) {
+    it.effect(`asyncPush - signals the end with a bounded ${strategy} buffer`, () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.asyncPush<number>((emit) => {
+          emit.single(42)
+          emit.end()
+          return Effect.void
+        }, { bufferSize: 1, strategy }).pipe(
+          Stream.runCollect,
+          Effect.timeout("1 second")
+        )
+        deepStrictEqual(Array.from(result), [42])
+      }))
+  }
+
   it.effect("asyncPush - handles errors", () =>
     Effect.gen(function*() {
       const error = new Cause.RuntimeException("boom")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

`Stream.asyncPush` can synchronously offer both a buffered element and a termination signal before the stream starts consuming the queue. With a bounded dropping or sliding queue sized exactly to the configured buffer, the termination signal can be lost and the stream waits indefinitely.

This change reserves one additional queue slot for termination, and adds regression coverage for both bounded strategies. The `effect` package also receives a patch changeset.

Validation:

- `pnpm test packages/effect/test/Stream/async.test.ts` (22 tests passed)
- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`
- `git diff --check`

Codex was used to investigate, implement, and validate this change. The exact validation commands and results are listed above.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #6232
- Closes #6232
