### PR TITLE
Preserve provider metadata in Prompt.fromResponseParts

### DIFF
--- a/.changeset/tidy-lions-think.md
+++ b/.changeset/tidy-lions-think.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai": patch
+---
+
+Preserve provider metadata when converting response parts into prompts.

--- a/packages/ai/ai/src/Prompt.ts
+++ b/packages/ai/ai/src/Prompt.ts
@@ -1570,55 +1570,63 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
   const assistantParts: Array<AssistantMessagePart> = []
   const toolParts: Array<ToolMessagePart> = []
 
-  const activeTextDeltas = new Map<string, { text: string }>()
-  const activeReasoningDeltas = new Map<string, { text: string }>()
+  const activeTextDeltas = new Map<string, { text: string; options: ProviderOptions }>()
+  const activeReasoningDeltas = new Map<string, { text: string; options: ProviderOptions }>()
 
   for (const part of parts) {
     switch (part.type) {
       // Text Parts
       case "text": {
-        assistantParts.push(makePart("text", { text: part.text }))
+        assistantParts.push(makePart("text", { text: part.text, options: part.metadata }))
         break
       }
 
       // Text Parts (streaming)
       case "text-start": {
-        activeTextDeltas.set(part.id, { text: "" })
+        activeTextDeltas.set(part.id, { text: "", options: part.metadata })
         break
       }
       case "text-delta": {
         if (activeTextDeltas.has(part.id)) {
-          activeTextDeltas.get(part.id)!.text += part.delta
+          const active = activeTextDeltas.get(part.id)!
+          active.text += part.delta
+          active.options = { ...active.options, ...part.metadata }
         }
         break
       }
       case "text-end": {
         if (activeTextDeltas.has(part.id)) {
-          assistantParts.push(makePart("text", activeTextDeltas.get(part.id)!))
+          const active = activeTextDeltas.get(part.id)!
+          active.options = { ...active.options, ...part.metadata }
+          assistantParts.push(makePart("text", active))
         }
         break
       }
 
       // Reasoning Parts
       case "reasoning": {
-        assistantParts.push(makePart("reasoning", { text: part.text }))
+        assistantParts.push(makePart("reasoning", { text: part.text, options: part.metadata }))
         break
       }
 
       // Reasoning Parts (streaming)
       case "reasoning-start": {
-        activeReasoningDeltas.set(part.id, { text: "" })
+        activeReasoningDeltas.set(part.id, { text: "", options: part.metadata })
         break
       }
       case "reasoning-delta": {
         if (activeReasoningDeltas.has(part.id)) {
-          activeReasoningDeltas.get(part.id)!.text += part.delta
+          const active = activeReasoningDeltas.get(part.id)!
+          active.text += part.delta
+          active.options = { ...active.options, ...part.metadata }
         }
         break
       }
       case "reasoning-end": {
         if (activeReasoningDeltas.has(part.id)) {
-          assistantParts.push(makePart("reasoning", activeReasoningDeltas.get(part.id)!))
+          const active = activeReasoningDeltas.get(part.id)!
+          active.options = { ...active.options, ...part.metadata }
+          assistantParts.push(makePart("reasoning", active))
         }
         break
       }
@@ -1629,7 +1637,8 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           id: part.id,
           name: part.providerName ?? part.name,
           params: part.params,
-          providerExecuted: part.providerExecuted ?? false
+          providerExecuted: part.providerExecuted ?? false,
+          options: part.metadata
         }))
         break
       }
@@ -1641,7 +1650,8 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
           name: part.providerName ?? part.name,
           isFailure: part.isFailure,
           result: part.encodedResult,
-          providerExecuted: part.providerExecuted ?? false
+          providerExecuted: part.providerExecuted ?? false,
+          options: part.metadata
         })
         if (part.providerExecuted) {
           assistantParts.push(toolPart)

--- a/packages/ai/ai/test/Prompt.test.ts
+++ b/packages/ai/ai/test/Prompt.test.ts
@@ -29,6 +29,102 @@ describe("Prompt", () => {
       ])
       assert.deepStrictEqual(prompt, expected)
     })
+
+    it("preserves metadata on non-streaming response parts", () => {
+      const parts = [
+        Response.makePart("text", {
+          text: "Hello",
+          metadata: { test: { value: "text" } }
+        }),
+        Response.makePart("reasoning", {
+          text: "Thinking",
+          metadata: { test: { value: "reasoning" } }
+        }),
+        Response.makePart("tool-call", {
+          id: "call_1",
+          name: "get_time",
+          params: {},
+          providerExecuted: false,
+          metadata: { test: { value: "tool-call" } }
+        }),
+        Response.makePart("tool-result", {
+          id: "call_1",
+          name: "get_time",
+          isFailure: false,
+          result: "10:30 AM",
+          encodedResult: "10:30 AM",
+          providerExecuted: false,
+          metadata: { test: { value: "tool-result" } }
+        })
+      ]
+
+      const prompt = Prompt.fromResponseParts(parts)
+
+      assert.deepStrictEqual(
+        prompt,
+        Prompt.make([
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Hello", options: { test: { value: "text" } } },
+              { type: "reasoning", text: "Thinking", options: { test: { value: "reasoning" } } },
+              {
+                type: "tool-call",
+                id: "call_1",
+                name: "get_time",
+                params: {},
+                providerExecuted: false,
+                options: { test: { value: "tool-call" } }
+              }
+            ]
+          },
+          {
+            role: "tool",
+            content: [{
+              type: "tool-result",
+              id: "call_1",
+              name: "get_time",
+              isFailure: false,
+              result: "10:30 AM",
+              providerExecuted: false,
+              options: { test: { value: "tool-result" } }
+            }]
+          }
+        ])
+      )
+    })
+
+    it("preserves metadata accumulated from streaming response parts", () => {
+      const parts = [
+        Response.makePart("text-start", {
+          id: "1",
+          metadata: { test: { value: "text" } }
+        }),
+        Response.makePart("text-delta", { id: "1", delta: "Hello" }),
+        Response.makePart("text-end", { id: "1" }),
+        Response.makePart("reasoning-start", { id: "2" }),
+        Response.makePart("reasoning-delta", { id: "2", delta: "Thinking" }),
+        Response.makePart("reasoning-delta", {
+          id: "2",
+          delta: "",
+          metadata: { test: { value: "reasoning" } }
+        }),
+        Response.makePart("reasoning-end", { id: "2" })
+      ]
+
+      const prompt = Prompt.fromResponseParts(parts)
+
+      assert.deepStrictEqual(
+        prompt,
+        Prompt.make([{
+          role: "assistant",
+          content: [
+            { type: "text", text: "Hello", options: { test: { value: "text" } } },
+            { type: "reasoning", text: "Thinking", options: { test: { value: "reasoning" } } }
+          ]
+        }])
+      )
+    })
   })
 
   describe("merge", () => {


### PR DESCRIPTION
## Summary

- preserve response part metadata as prompt provider options for text, reasoning, tool-call, and tool-result parts
- accumulate metadata across streamed text and reasoning parts
- add regression coverage for streaming and non-streaming conversions, plus the required patch changeset

## Problem

`Prompt.fromResponseParts` rebuilt prompt parts without carrying over response metadata. Follow-up requests therefore lost provider data such as Google thought signatures and Anthropic or Bedrock reasoning signatures.

## Assistance

The implementation, tests, validation, and PR text were prepared with OpenAI Codex assistance.

## Validation

- `pnpm test run packages/ai/ai/test/Prompt.test.ts`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Fixes #5954
