### PR TITLE
Clarify GenericTag key documentation

### DIFF
--- a/.changeset/clear-tags-key.md
+++ b/.changeset/clear-tags-key.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Clarify that `Context.GenericTag` requires a key.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -165,7 +165,7 @@ export declare namespace Tag {
 }
 
 /**
- * Creates a new `Tag` instance with an optional key parameter.
+ * Creates a new `Tag` instance with the specified key.
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Clarifies the `Context.GenericTag` JSDoc to state that callers must provide a key, matching the function signature and the maintainer clarification on the issue.

This also adds the required patch changeset for `effect`.

OpenAI Codex prepared the documentation change, validation, and PR text. No human review is claimed.

Validation:

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Context.test.ts --run` (16 tests)
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

## Related

- Closes #4656
