### PR TITLE
Preserve chained vitest helpers like it.describe.each through the it proxy

### DIFF
--- a/.changeset/fix-vitest-proxy-chained-helpers.md
+++ b/.changeset/fix-vitest-proxy-chained-helpers.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Preserve chained vitest helpers like `it.describe.each` and `it.skip.each` when accessed through the `it` proxy. Previously the proxy returned bound copies of vitest's functions, which stripped their static helper properties and caused `TypeError: it.describe.each is not a function`.

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -64,8 +64,8 @@ const makeItProxy = <Methods extends object>(
       if (property in overrides) {
         return Reflect.get(overrides, property)
       }
-      const value = Reflect.get(target, property, receiver)
-      return typeof value === "function" ? value.bind(target) : value
+      // do not bind: binding would strip vitest's static helpers (e.g. `describe.each`)
+      return Reflect.get(target, property, receiver)
     }
   })
 

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -43,6 +43,17 @@ it.effect.skipIf(false)("effect skipIf (false)", () => Effect.sync(() => expect(
 it.effect.runIf(true)("effect runIf (true)", () => Effect.sync(() => expect(1).toEqual(1)))
 it.effect.runIf(false)("effect runIf (false)", () => Effect.die("not run anyway"))
 
+// chained helpers
+
+it.describe.each(["foo", "bar"] as const)("describe.each %s", (text) => {
+  it.effect("runs an Effect test", () =>
+    Effect.sync(() => {
+      assert.include(["foo", "bar"], text)
+    }))
+})
+
+it.skip.each([1])("skip.each %s", () => assert.fail("skipped anyway"))
+
 // The following test is expected to fail because it simulates a test timeout.
 // Be aware that eventual "failure" of the test is only logged out.
 it.live.fails("interrupts on timeout", (ctx) =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Closes #6348.

`makeItProxy` in `packages/vitest/src/internal/internal.ts` returned `value.bind(target)` for every function property accessed through the `it` proxy. `Function.prototype.bind` produces a fresh function without the original's own properties, and that is exactly where vitest attaches its static helpers (`each`, `skip`, `only`, etc.). As a result, chained access like `it.describe.each(...)` or `it.skip.each(...)` threw `TypeError: it.describe.each is not a function`.

This returns the property as is instead of a bound copy. Removing the bind is safe: vitest's chain functions ignore dynamic `this` and invoke the underlying collector with a context captured in a closure, while the helpers that do read `this` (`each`, `for`, `skipIf`, `runIf`) still resolve correctly because the proxy forwards every lookup it does not override, including vitest's internal context symbol, to the target. Before the proxy was introduced, `makeMethods` used `Object.assign(it, overrides)` on the vitest `it` directly, so chained helpers worked natively; this restores those semantics. As a side effect, property access no longer allocates a bound function each time.

Adds regression tests for `it.describe.each` (the reproduction from the issue, with a nested `it.effect`) and `it.skip.each`, both verified to fail against the previous implementation.

This supersedes Effect-TS/effect-smol#2302 by @truffle-dev, which proposed this same fix, and Effect-TS/effect-smol#2344 by @SAY-5, both closed in the V4 repository migration. Happy to close this in favor of either author if they would prefer to resubmit their own port.
