### PR TITLE
Include socket details in RpcClient errors

### DIFF
--- a/.changeset/tidy-sockets-report.md
+++ b/.changeset/tidy-sockets-report.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Include socket error details in RpcClient protocol error messages.

--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -1013,7 +1013,10 @@ export const makeProtocolSocket = (options?: {
         }
         currentError = new RpcClientError({
           reason: "Protocol",
-          message: "Error in socket",
+          message: Option.match(error, {
+            onNone: () => "Error in socket",
+            onSome: (error) => `Socket ${error.message}`
+          }),
           cause: Cause.squash(cause)
         })
         return writeResponse({

--- a/packages/rpc/test/RpcClient.test.ts
+++ b/packages/rpc/test/RpcClient.test.ts
@@ -1,0 +1,39 @@
+import * as Socket from "@effect/platform/Socket"
+import type { RpcClientError } from "@effect/rpc"
+import { RpcClient, RpcSerialization } from "@effect/rpc"
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Schedule } from "effect"
+
+describe("RpcClient", () => {
+  it.effect("includes socket close details in protocol errors", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const socketError = new Socket.SocketCloseError({
+        reason: "Close",
+        code: 1006,
+        closeReason: "connection lost"
+      })
+      const socket: Socket.Socket = {
+        [Socket.TypeId]: Socket.TypeId,
+        run: () => Effect.fail(socketError),
+        runRaw: () => Effect.fail(socketError),
+        writer: Effect.succeed(() => Effect.void)
+      }
+      const errorLatch = yield* Deferred.make<RpcClientError.RpcClientError>()
+      const protocol = yield* RpcClient.makeProtocolSocket({
+        retrySchedule: Schedule.stop
+      }).pipe(
+        Effect.provideService(Socket.Socket, socket),
+        Effect.provideService(RpcSerialization.RpcSerialization, RpcSerialization.json)
+      )
+
+      yield* protocol.run((response) =>
+        response._tag === "ClientProtocolError"
+          ? Deferred.succeed(errorLatch, response.error)
+          : Effect.void
+      ).pipe(Effect.forkScoped)
+
+      const error = yield* Deferred.await(errorLatch)
+      assert.strictEqual(error.message, "Socket Close: 1006: connection lost")
+      assert.strictEqual(error.cause, socketError)
+    })))
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`RpcClient.makeProtocolSocket` currently replaces every socket failure with the hardcoded message `Error in socket`, even though it has already extracted the typed `SocketError` from the cause.

Use the socket error's existing human-readable message when a typed failure is available, while retaining the generic fallback for causes without a socket failure. This surfaces details such as close codes and close reasons without changing the structured `RpcClientError` shape or its cause.

Add a regression test that drives the socket protocol with a `SocketCloseError` and verifies both the detailed message and preserved cause.

Validation:

- `pnpm lint-fix`
- `pnpm test packages/rpc/test/RpcClient.test.ts --run`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

## Related

- Closes #5988
