### PR TITLE
fix(sql-drizzle): support SQLite batches

### DIFF
--- a/.changeset/small-batches-smile.md
+++ b/.changeset/small-batches-smile.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-drizzle": patch
+---
+
+Support `db.batch` with the SQLite Drizzle integration.

--- a/packages/sql-drizzle/src/Sqlite.ts
+++ b/packages/sql-drizzle/src/Sqlite.ts
@@ -6,12 +6,20 @@ import type { SqlError } from "@effect/sql/SqlError"
 import type { DrizzleConfig } from "drizzle-orm"
 import { QueryPromise } from "drizzle-orm/query-promise"
 import { SQLiteSelectBase } from "drizzle-orm/sqlite-core"
-import type { SqliteRemoteDatabase } from "drizzle-orm/sqlite-proxy"
+import type { AsyncBatchRemoteCallback, AsyncRemoteCallback, SqliteRemoteDatabase } from "drizzle-orm/sqlite-proxy"
 import { drizzle } from "drizzle-orm/sqlite-proxy"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import { makeRemoteCallback, patch } from "./internal/patch.js"
+
+const makeRemoteBatchCallback = (callback: AsyncRemoteCallback): AsyncBatchRemoteCallback => async (queries) => {
+  const results = []
+  for (const query of queries) {
+    results.push(await callback(query.sql, query.params, query.method))
+  }
+  return results
+}
 
 /**
  * @since 1.0.0
@@ -21,7 +29,8 @@ export const make = <TSchema extends Record<string, unknown> = Record<string, ne
   config?: Omit<DrizzleConfig<TSchema>, "logger">
 ): Effect.Effect<SqliteRemoteDatabase<TSchema>, never, Client.SqlClient> =>
   Effect.gen(function*() {
-    const db = drizzle(yield* makeRemoteCallback, config)
+    const callback = yield* makeRemoteCallback
+    const db = drizzle(callback, makeRemoteBatchCallback(callback), config)
     return db
   })
 
@@ -33,7 +42,8 @@ export const makeWithConfig: (config: DrizzleConfig) => Effect.Effect<SqliteRemo
   config
 ) =>
   Effect.gen(function*() {
-    const db = drizzle(yield* makeRemoteCallback, config)
+    const callback = yield* makeRemoteCallback
+    const db = drizzle(callback, makeRemoteBatchCallback(callback), config)
     return db
   })
 

--- a/packages/sql-drizzle/test/Sqlite.test.ts
+++ b/packages/sql-drizzle/test/Sqlite.test.ts
@@ -55,6 +55,23 @@ describe("SqliteDrizzle", () => {
       assert.deepStrictEqual(results, [{ id: 1, name: "Alice", snakeCase: "snake" }])
     }).pipe(Effect.provide(ORM.Client)))
 
+  it.effect("batch", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      const db = yield* SqliteDrizzle.SqliteDrizzle
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, snake_case TEXT)`
+      const results = yield* Effect.promise(() =>
+        db.batch([
+          db.insert(users).values({ name: "Alice", snakeCase: "snake" }).returning(),
+          db.select().from(users)
+        ])
+      )
+      assert.deepStrictEqual(results, [
+        [{ id: 1, name: "Alice", snakeCase: "snake" }],
+        [{ id: 1, name: "Alice", snakeCase: "snake" }]
+      ])
+    }).pipe(Effect.provide(SqliteDrizzleLive)))
+
   it.effect("remote callback", () =>
     Effect.gen(function*() {
       const sql = yield* SqlClient.SqlClient


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The SQLite Drizzle integration supplied only Drizzle's single-query callback. As a result, `db.batch()` attempted to call an undefined batch callback and failed with `TypeError: this.batchCLient is not a function`.

This change supplies an ordered batch callback to both SQLite constructors. Each query is executed through the existing Effect SQL callback, preserving query order and the existing result mapping. A regression test covers an insert followed by a select in one batch.

## Impact

SQLite-backed `@effect/sql-drizzle` users can use `db.batch()` without the runtime failure.

## Related

- Closes #5594

## Validation

- `corepack pnpm --filter @effect/sql-drizzle test -- --run test/Sqlite.test.ts` (13 tests passed)
- `corepack pnpm lint-fix`
- `corepack pnpm check`
- `corepack pnpm build`
- `corepack pnpm docgen`
