### PR TITLE
Fix eager forward references in recursive OpenAPI schemas

### DIFF
--- a/.changeset/fix-openapi-recursive-forward-refs.md
+++ b/.changeset/fix-openapi-recursive-forward-refs.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Suspend forward references between mutually recursive generated schemas, closes #6357.

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -284,13 +284,23 @@ function collectForwardReferencedRecursives(
   }>,
   recursives: ReadonlyArray<readonly [string, SchemaRepresentation.Code]>
 ): Set<string> {
-  const recursiveNames = new Set(recursives.map(([name]) => name))
+  const recursiveIndexes = new Map(recursives.map(([name], index) => [name, index]))
   const referenced = new Set<string>()
 
   for (const { code } of nonRecursives) {
     for (const token of code.runtime.matchAll(tokenPattern)) {
       const identifier = token[0]
-      if (recursiveNames.has(identifier)) {
+      if (recursiveIndexes.has(identifier)) {
+        referenced.add(identifier)
+      }
+    }
+  }
+
+  for (const [index, [, code]] of recursives.entries()) {
+    for (const token of code.runtime.matchAll(tokenPattern)) {
+      const identifier = token[0]
+      const referencedIndex = recursiveIndexes.get(identifier)
+      if (referencedIndex !== undefined && referencedIndex > index) {
         referenced.add(identifier)
       }
     }

--- a/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
@@ -1,5 +1,5 @@
 import * as JsonSchemaGenerator from "@effect/openapi-generator/JsonSchemaGenerator"
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 
 describe("JsonSchemaGenerator", () => {
   it("schema & no definitions", () => {
@@ -168,6 +168,46 @@ export const A = B
     expect(httpApiResult).toContain("const __recursive_ErrorDetails =")
     expect(httpApiResult.indexOf(recursiveDeclaration)).toBeLessThan(
       httpApiResult.indexOf("export const ErrorResponse =")
+    )
+  })
+
+  it("declares mutually recursive forward references before runtime initialization", () => {
+    const generator = JsonSchemaGenerator.make()
+    generator.addSchema("Root", { $ref: "#/components/schemas/ResourcesNetworkCard" })
+    const definitions = {
+      ResourcesNetworkCard: {
+        type: "object",
+        properties: {
+          sriov: { $ref: "#/components/schemas/ResourcesNetworkCardSRIOV" }
+        },
+        additionalProperties: false
+      },
+      ResourcesNetworkCardSRIOV: {
+        type: "object",
+        properties: {
+          vfs: {
+            type: "array",
+            items: { $ref: "#/components/schemas/ResourcesNetworkCard" }
+          }
+        },
+        additionalProperties: false
+      }
+    }
+    const recursiveDeclaration =
+      "export const ResourcesNetworkCardSRIOV = Schema.suspend((): Schema.Codec<ResourcesNetworkCardSRIOV> => __recursive_ResourcesNetworkCardSRIOV)"
+
+    const runtimeResult = generator.generate("openapi-3.1", definitions, false)
+    assert.include(runtimeResult, recursiveDeclaration)
+    assert.isBelow(
+      runtimeResult.indexOf(recursiveDeclaration),
+      runtimeResult.indexOf("export const ResourcesNetworkCard =")
+    )
+
+    const httpApiResult = generator.generateHttpApi("openapi-3.1", definitions)
+    assert.include(httpApiResult, recursiveDeclaration)
+    assert.isBelow(
+      httpApiResult.indexOf(recursiveDeclaration),
+      httpApiResult.indexOf("export const ResourcesNetworkCard =")
     )
   })
 })


### PR DESCRIPTION
## Summary

- detect forward references between mutually recursive schema definitions
- emit a suspended declaration before the earlier runtime initializer
- cover both standard and HttpApi schema generation

## Why

When one recursive schema referenced another recursive schema declared later, the generator emitted a direct runtime reference. Importing the generated module then failed in the temporal dead zone before the later declaration was initialized.

The existing suspended declaration path now also covers forward references within the recursive definition list, so generated modules initialize safely. Closes #6357.

## Validation

- `corepack pnpm lint-fix`
- `corepack pnpm test packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts` (8 tests)
- `corepack pnpm check`
