### PR TITLE
Add HttpClientRequest header combinators

### DIFF
--- a/.changeset/calm-headers-transform.md
+++ b/.changeset/calm-headers-transform.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Add `HttpClientRequest.removeHeader` and `HttpClientRequest.updateHeaders`.

--- a/packages/platform/src/HttpClientRequest.ts
+++ b/packages/platform/src/HttpClientRequest.ts
@@ -168,6 +168,24 @@ export const setHeaders: {
  * @since 1.0.0
  * @category combinators
  */
+export const updateHeaders: {
+  (f: (headers: Headers.Headers) => Headers.Headers): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, f: (headers: Headers.Headers) => Headers.Headers): HttpClientRequest
+} = internal.updateHeaders
+
+/**
+ * @since 1.0.0
+ * @category combinators
+ */
+export const removeHeader: {
+  (key: string): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, key: string): HttpClientRequest
+} = internal.removeHeader
+
+/**
+ * @since 1.0.0
+ * @category combinators
+ */
 export const basicAuth: {
   (username: string | Redacted, password: string | Redacted): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, username: string | Redacted, password: string | Redacted): HttpClientRequest

--- a/packages/platform/src/internal/httpClientRequest.ts
+++ b/packages/platform/src/internal/httpClientRequest.ts
@@ -167,6 +167,31 @@ export const setHeaders = dual<
     self.body
   ))
 
+/** @internal */
+export const updateHeaders = dual<
+  (
+    f: (headers: Headers.Headers) => Headers.Headers
+  ) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
+  (
+    self: ClientRequest.HttpClientRequest,
+    f: (headers: Headers.Headers) => Headers.Headers
+  ) => ClientRequest.HttpClientRequest
+>(2, (self, f) =>
+  makeInternal(
+    self.method,
+    self.url,
+    self.urlParams,
+    self.hash,
+    f(self.headers),
+    self.body
+  ))
+
+/** @internal */
+export const removeHeader = dual<
+  (key: string) => (self: ClientRequest.HttpClientRequest) => ClientRequest.HttpClientRequest,
+  (self: ClientRequest.HttpClientRequest, key: string) => ClientRequest.HttpClientRequest
+>(2, (self, key) => updateHeaders(self, Headers.remove(key)))
+
 const stringOrRedacted = (value: string | Redacted.Redacted): string =>
   typeof value === "string" ? value : Redacted.value(value)
 

--- a/packages/platform/test/HttpClient.test.ts
+++ b/packages/platform/test/HttpClient.test.ts
@@ -246,6 +246,37 @@ describe("HttpClient", () => {
     })
   })
 
+  describe("ClientRequest headers", () => {
+    it("removeHeader removes a header without mutating the original request", () => {
+      const original = HttpClientRequest.get("https://example.com").pipe(
+        HttpClientRequest.setHeaders({
+          "Content-Length": "5",
+          "X-Test": "ok"
+        })
+      )
+      const request = original.pipe(HttpClientRequest.removeHeader("CONTENT-LENGTH"))
+
+      deepStrictEqual({ ...request.headers }, { "x-test": "ok" })
+      deepStrictEqual({ ...original.headers }, { "content-length": "5", "x-test": "ok" })
+    })
+
+    it("updateHeaders transforms the complete header set", () => {
+      const original = HttpClientRequest.get("https://example.com").pipe(
+        HttpClientRequest.setHeaders({
+          "Content-Length": "5",
+          "X-Test": "ok"
+        })
+      )
+      const request = HttpClientRequest.updateHeaders(
+        original,
+        (headers) => pipe(headers, Headers.remove("content-length"), Headers.set("x-next", "yes"))
+      )
+
+      deepStrictEqual({ ...request.headers }, { "x-test": "ok", "x-next": "yes" })
+      deepStrictEqual({ ...original.headers }, { "content-length": "5", "x-test": "ok" })
+    })
+  })
+
   it.effect("matchStatus", () =>
     Effect.gen(function*() {
       const jp = yield* JsonPlaceholder


### PR DESCRIPTION
## Summary

- add dual `HttpClientRequest.removeHeader` and `HttpClientRequest.updateHeaders` combinators
- preserve the original request while allowing the complete header set to be transformed
- add regression coverage and a patch changeset for `@effect/platform`

## Testing

- `pnpm lint-fix`
- `pnpm test packages/platform/test/HttpClient.test.ts` (31 tests)
- `pnpm check`

Closes #6271
