### PR TITLE
Support Effects in vitest setup hooks

### DIFF
--- a/.changeset/tidy-hooks-run.md
+++ b/.changeset/tidy-hooks-run.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Run Effects returned by `beforeAll` and `beforeEach` hooks.

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -181,6 +181,22 @@ export namespace Vitest {
 export const addEqualityTesters: () => void = internal.addEqualityTesters
 
 /**
+ * Registers a callback before all tests in the current suite. If the callback
+ * returns an `Effect`, the `Effect` is run and awaited.
+ *
+ * @since 1.0.0
+ */
+export const beforeAll: typeof V.beforeAll = internal.beforeAll
+
+/**
+ * Registers a callback before each test in the current suite. If the callback
+ * returns an `Effect`, the `Effect` is run and awaited.
+ *
+ * @since 1.0.0
+ */
+export const beforeEach: typeof V.beforeEach = internal.beforeEach
+
+/**
  * @since 1.0.0
  */
 export const effect: Vitest.Tester<TestServices.TestServices> = internal.effect

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -59,6 +59,14 @@ const runPromise = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A,
 const runTest = (ctx?: Vitest.TestContext) => <E, A>(effect: Effect.Effect<A, E>) => runPromise(ctx)(effect)
 
 /** @internal */
+const runHook = <Args extends Array<unknown>>(hook: (...args: Args) => unknown) => (...args: Args): unknown => {
+  const result = hook(...args)
+  return Effect.isEffect(result)
+    ? runPromise()(result as Effect.Effect<unknown, unknown>)
+    : result
+}
+
+/** @internal */
 const TestEnv = TestEnvironment.TestContext.pipe(
   Layer.provide(Logger.remove(Logger.defaultLogger))
 )
@@ -78,6 +86,12 @@ function customTester(this: TesterContext, a: unknown, b: unknown, customTesters
 export const addEqualityTesters = () => {
   V.expect.addEqualityTesters([customTester])
 }
+
+/** @internal */
+export const beforeAll: typeof V.beforeAll = (fn, timeout) => V.beforeAll(runHook(fn), timeout)
+
+/** @internal */
+export const beforeEach: typeof V.beforeEach = (fn, timeout) => V.beforeEach(runHook(fn), timeout)
 
 /** @internal */
 const testOptions = (timeout?: number | V.TestOptions) => typeof timeout === "number" ? { timeout } : timeout ?? {}

--- a/packages/vitest/test/hooks.test.ts
+++ b/packages/vitest/test/hooks.test.ts
@@ -1,0 +1,28 @@
+import { assert, beforeAll, beforeEach, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("effectful hooks", () => {
+  let initialized = false
+  const prepared = new WeakSet<object>()
+
+  beforeAll(() =>
+    Effect.sync(() => {
+      initialized = true
+    })
+  )
+
+  beforeEach((ctx) =>
+    Effect.sync(() => {
+      prepared.add(ctx)
+    })
+  )
+
+  it("runs an Effect returned by beforeAll", (ctx) => {
+    assert.isTrue(initialized)
+    assert.isTrue(prepared.has(ctx))
+  })
+
+  it("runs an Effect returned by beforeEach", (ctx) => {
+    assert.isTrue(prepared.has(ctx))
+  })
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`@effect/vitest` currently re-exports Vitest's `beforeAll` and `beforeEach` hooks unchanged. Vitest does not recognize a returned `Effect` as asynchronous work, so the Effect remains lazy and the hook body is skipped.

This change explicitly wraps both hooks. When a callback returns an Effect, it is executed and awaited through the package's existing Effect runner; synchronous and Promise-returning callbacks are passed through unchanged. Regression tests cover both suite-level and per-test Effect hooks, including the repository's concurrent test configuration.

Validation:

- `pnpm --filter @effect/vitest test --run` (47 passed, 6 skipped)
- `pnpm --filter @effect/vitest check`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`
- `pnpm changeset status`

## Related

- Closes #6096
