### PR TITLE
Fix PgClient.makeClient connection acquisition

### DIFF
--- a/.changeset/violet-tips-open.md
+++ b/.changeset/violet-tips-open.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Fix `PgClient.makeClient` to connect the underlying `pg.Client` during resource acquisition.

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -222,47 +222,46 @@ export const makeClient = (
 ): Effect.Effect<PgClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
   fromClient({
     ...options,
-    acquire: Effect.gen(function*() {
-      const client = new Pg.Client({
-        connectionString: options.url ? Redacted.value(options.url) : undefined,
-        user: options.username,
-        host: options.host,
-        database: options.database,
-        password: options.password ? Redacted.value(options.password) : undefined,
-        ssl: options.ssl,
-        port: options.port,
-        ...(options.stream ? { stream: options.stream } : {}),
-        application_name: options.applicationName ?? "@effect/sql-pg",
-        types: options.types
-      })
-      yield* Effect.acquireRelease(
-        Effect.tryPromise({
-          try: () => client.query("SELECT 1"),
-          catch: (cause) => new SqlError({ reason: classifyError(cause, "PgClient: Failed to connect", "connect") })
-        }),
-        () =>
-          Effect.promise(() => client.end()).pipe(
-            Effect.timeoutOption(1000)
-          ),
-        { interruptible: true }
-      ).pipe(
-        Effect.timeoutOrElse({
-          duration: options.connectTimeout ?? Duration.seconds(5),
-          orElse: () =>
-            Effect.fail(
-              new SqlError({
-                reason: new ConnectionError({
-                  cause: new Error("Connection timed out"),
-                  message: "PgClient: Connection timed out",
-                  operation: "connect"
-                })
+    acquire: Effect.acquireRelease(
+      Effect.tryPromise({
+        try: async () => {
+          const client = new Pg.Client({
+            connectionString: options.url ? Redacted.value(options.url) : undefined,
+            user: options.username,
+            host: options.host,
+            database: options.database,
+            password: options.password ? Redacted.value(options.password) : undefined,
+            ssl: options.ssl,
+            port: options.port,
+            ...(options.stream ? { stream: options.stream } : {}),
+            application_name: options.applicationName ?? "@effect/sql-pg",
+            types: options.types
+          })
+          await client.connect()
+          return client
+        },
+        catch: (cause) => new SqlError({ reason: classifyError(cause, "PgClient: Failed to connect", "connect") })
+      }),
+      (client) =>
+        Effect.promise(() => client.end()).pipe(
+          Effect.timeoutOption(1000)
+        ),
+      { interruptible: true }
+    ).pipe(
+      Effect.timeoutOrElse({
+        duration: options.connectTimeout ?? Duration.seconds(5),
+        orElse: () =>
+          Effect.fail(
+            new SqlError({
+              reason: new ConnectionError({
+                cause: new Error("Connection timed out"),
+                message: "PgClient: Connection timed out",
+                operation: "connect"
               })
-            )
-        })
-      )
-
-      return client
-    }),
+            })
+          )
+      })
+    ),
     acquireForStream: options.acquireForStream ?? false
   })
 

--- a/packages/sql/pg/test/Client.test.ts
+++ b/packages/sql/pg/test/Client.test.ts
@@ -252,6 +252,15 @@ it.layer(PgContainer.layerClient, { timeout: "30 seconds" })("PgClient", (it) =>
     }))
 })
 
+it.layer(PgContainer.layerMakeClient, { timeout: "30 seconds" })("PgClient.makeClient", (it) => {
+  it.effect("connects before executing queries", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const rows = yield* sql<{ value: number }>`SELECT 1 AS value`
+      assert.deepStrictEqual(rows, [{ value: 1 }])
+    }))
+})
+
 it.layer(PgContainer.layerClientWithTransforms, { timeout: "30 seconds" })("PgClient transforms", (it) => {
   it.effect("insert helper", () =>
     Effect.gen(function*() {

--- a/packages/sql/pg/test/utils.ts
+++ b/packages/sql/pg/test/utils.ts
@@ -26,6 +26,15 @@ export class PgContainer extends Context.Service<PgContainer>()("test/PgContaine
     })
   ).pipe(Layer.provide(this.layer))
 
+  static layerMakeClient = Layer.unwrap(
+    Effect.gen(function*() {
+      const container = yield* PgContainer
+      return PgClient.layerFrom(PgClient.makeClient({
+        url: Redacted.make(container.getConnectionUri())
+      }))
+    })
+  ).pipe(Layer.provide(this.layer))
+
   static layerClientWithTransforms = Layer.unwrap(
     Effect.gen(function*() {
       const container = yield* PgContainer


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`PgClient.makeClient` created a `pg.Client` and executed a query without calling `client.connect()` first. This caused client acquisition to hang until its timeout.

This change creates the client inside `Effect.acquireRelease` and calls `client.connect()` before returning it.

This follows the existing `listenAcquirer` implementation, which also creates and connects its client during acquisition.

A regression test was added for `PgClient.makeClient`. The test fails without the fix and passes with it.

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm test packages/sql/pg/test`