### PR TITLE
Optimize unchanged FiberRefs updates

### DIFF
--- a/.changeset/fuzzy-spiders-smile.md
+++ b/.changeset/fuzzy-spiders-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Avoid copying all FiberRefs when an update keeps the current fiber's value unchanged.

--- a/packages/effect/src/internal/fiberRefs.ts
+++ b/packages/effect/src/internal/fiberRefs.ts
@@ -210,13 +210,46 @@ export const updateAs = dual<
   readonly fiberRef: FiberRef.FiberRef<A>
   readonly value: A
 }) => {
+  const newStack = updatedStack(self.locals, fiberId, fiberRef, value)
+  if (newStack === undefined) {
+    return self
+  }
   if (self.locals.size === 0) {
-    return new FiberRefsImpl(new Map([[fiberRef, [[fiberId, value] as const]]]))
+    return new FiberRefsImpl(new Map([[fiberRef, newStack]]))
   }
   const locals = new Map(self.locals)
-  unsafeUpdateAs(locals, fiberId, fiberRef, value)
+  locals.set(fiberRef, newStack)
   return new FiberRefsImpl(locals)
 })
+
+const updatedStack = (
+  locals: Map<FiberRef.FiberRef<any>, Arr.NonEmptyReadonlyArray<readonly [FiberId.Single, any]>>,
+  fiberId: FiberId.Single,
+  fiberRef: FiberRef.FiberRef<any>,
+  value: any
+): Arr.NonEmptyReadonlyArray<readonly [FiberId.Single, any]> | undefined => {
+  const oldStack: ReadonlyArray<readonly [FiberId.Single, any]> = locals.get(fiberRef) ?? []
+  if (Arr.isNonEmptyReadonlyArray(oldStack)) {
+    const [currentId, currentValue] = Arr.headNonEmpty(oldStack)
+    if (currentId[Equal.symbol](fiberId)) {
+      if (Equal.equals(currentValue, value)) {
+        return undefined
+      } else {
+        return [
+          [fiberId, value] as const,
+          ...oldStack.slice(1)
+        ]
+      }
+    } else {
+      return [
+        [fiberId, value] as const,
+        ...oldStack
+      ]
+    }
+  }
+
+  return [[fiberId, value] as const]
+}
 
 const unsafeUpdateAs = (
   locals: Map<FiberRef.FiberRef<any>, Arr.NonEmptyReadonlyArray<readonly [FiberId.Single, any]>>,
@@ -224,31 +257,10 @@ const unsafeUpdateAs = (
   fiberRef: FiberRef.FiberRef<any>,
   value: any
 ) => {
-  const oldStack: ReadonlyArray<readonly [FiberId.Single, any]> = locals.get(fiberRef) ?? []
-  let newStack: Arr.NonEmptyReadonlyArray<readonly [FiberId.Single, any]> | undefined
-
-  if (Arr.isNonEmptyReadonlyArray(oldStack)) {
-    const [currentId, currentValue] = Arr.headNonEmpty(oldStack)
-    if (currentId[Equal.symbol](fiberId)) {
-      if (Equal.equals(currentValue, value)) {
-        return
-      } else {
-        newStack = [
-          [fiberId, value] as const,
-          ...oldStack.slice(1)
-        ]
-      }
-    } else {
-      newStack = [
-        [fiberId, value] as const,
-        ...oldStack
-      ]
-    }
-  } else {
-    newStack = [[fiberId, value] as const]
+  const newStack = updatedStack(locals, fiberId, fiberRef, value)
+  if (newStack !== undefined) {
+    locals.set(fiberRef, newStack)
   }
-
-  locals.set(fiberRef, newStack)
 }
 
 /** @internal */

--- a/packages/effect/test/FiberRefs.test.ts
+++ b/packages/effect/test/FiberRefs.test.ts
@@ -33,6 +33,32 @@ describe("FiberRefs", () => {
     deepStrictEqual(FiberRefs.get(newParentFiberRefs, FiberRef.interruptedCause), Option.some(Cause.empty))
   })
 
+  it("updateAs reuses unchanged FiberRefs for the same fiber", () => {
+    const fiberId = FiberId.make(1, 0) as FiberId.Runtime
+    const childId = FiberId.make(2, 1) as FiberId.Runtime
+    const fiberRef = FiberRef.unsafeMake(0)
+    const fiberRefs = FiberRefs.updateAs(FiberRefs.empty(), {
+      fiberId,
+      fiberRef,
+      value: 1
+    })
+
+    const unchanged = FiberRefs.updateAs(fiberRefs, {
+      fiberId,
+      fiberRef,
+      value: 1
+    })
+    strictEqual(unchanged, fiberRefs)
+
+    const childFiberRefs = FiberRefs.updateAs(fiberRefs, {
+      fiberId: childId,
+      fiberRef,
+      value: 1
+    })
+    assertTrue(childFiberRefs !== fiberRefs)
+    strictEqual(childFiberRefs.locals.get(fiberRef)?.length, 2)
+  })
+
   describe("currentLogAnnotations", () => {
     it("doesnt leak", () => {
       Effect.void.pipe(Effect.annotateLogs("test", "abc"), Effect.runSync)


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

`FiberRefs.updateAs` cloned the complete `locals` map before `unsafeUpdateAs` could discover that the current fiber already held an equal value. Repeated unchanged `FiberRef` updates therefore remained O(R) in the number of unrelated refs.

This change computes the replacement stack first and returns the original `FiberRefs` when the same fiber's value is unchanged. Updates from a different fiber still append a history entry, and changed values still copy the map to preserve immutable snapshots.

A local 7-sample median microbenchmark with 500 populated refs and 20,000 unchanged updates measured the map-cloning baseline at 476.9 ms and the optimized path at 0.69 ms (about 691x faster).

Implementation and validation were assisted by OpenAI Codex. No independent human review is claimed.

Validation:

- `corepack pnpm lint-fix`
- `corepack pnpm vitest packages/effect/test/FiberRefs.test.ts packages/effect/test/FiberRef.test.ts --run` (40 tests)
- `corepack pnpm check`
- `corepack pnpm build`
- `corepack pnpm docgen`
- `git diff --check`

## Related

- Related Issue #6306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved FiberRefs updates to avoid unnecessary copying when a value remains unchanged.

- **Bug Fixes**
  - Preserved existing FiberRefs instances for no-op updates while correctly creating updated instances when changes affect another fiber.

- **Tests**
  - Added coverage for instance reuse and child-fiber update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->