### PR TITLE
Fix Graph curried getter inference

### DIFF
--- a/.changeset/fix-graph-curried-getters.md
+++ b/.changeset/fix-graph-curried-getters.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix standalone data-last `Graph.getNode` and `Graph.getEdge` inference.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1490,9 +1490,9 @@ export const addNode = <N, E, T extends Kind = "directed">(
  * @since 3.18.0
  */
 export const getNode: {
-  <N, E, T extends Kind = "directed">(
-    nodeIndex: NodeIndex
-  ): (graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<N>
+  (nodeIndex: NodeIndex): <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Option.Option<N>
   <N, E, T extends Kind = "directed">(
     graph: Graph<N, E, T> | MutableGraph<N, E, T>,
     nodeIndex: NodeIndex
@@ -2523,9 +2523,9 @@ const removeEdgeInternal = <N, E, T extends Kind = "directed">(
  * @since 3.18.0
  */
 export const getEdge: {
-  <E>(
-    edgeIndex: EdgeIndex
-  ): <N, T extends Kind = "directed">(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => Option.Option<Edge<E>>
+  (edgeIndex: EdgeIndex): <N, E, T extends Kind = "directed">(
+    graph: Graph<N, E, T> | MutableGraph<N, E, T>
+  ) => Option.Option<Edge<E>>
   <N, E, T extends Kind = "directed">(
     graph: Graph<N, E, T> | MutableGraph<N, E, T>,
     edgeIndex: EdgeIndex

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -1,4 +1,4 @@
-import { Graph, hole, pipe } from "effect"
+import { Graph, hole, type Option, pipe } from "effect"
 import { describe, expect, it } from "tstyche"
 
 declare const directed: Graph.DirectedGraph<string, number>
@@ -62,6 +62,21 @@ describe("Graph", () => {
     expect(animalGraph).type.not.toBeAssignableTo<Graph.DirectedGraph<Dog, 1>>()
     expect(dogMutableGraph).type.not.toBeAssignableTo<Graph.MutableDirectedGraph<Animal, number>>()
     expect(animalMutableGraph).type.not.toBeAssignableTo<Graph.MutableDirectedGraph<Dog, 1>>()
+  })
+
+  it("standalone data-last getters", () => {
+    const getNode = Graph.getNode(0)
+    const getEdge = Graph.getEdge(0)
+
+    expect(getNode(directed)).type.toBe<Option.Option<string>>()
+    expect(getNode(undirected)).type.toBe<Option.Option<string>>()
+    expect(getNode(Graph.beginMutation(directed))).type.toBe<Option.Option<string>>()
+    expect(getNode(Graph.beginMutation(undirected))).type.toBe<Option.Option<string>>()
+
+    expect(getEdge(directed)).type.toBe<Option.Option<Graph.Edge<number>>>()
+    expect(getEdge(undirected)).type.toBe<Option.Option<Graph.Edge<number>>>()
+    expect(getEdge(Graph.beginMutation(directed))).type.toBe<Option.Option<Graph.Edge<number>>>()
+    expect(getEdge(Graph.beginMutation(undirected))).type.toBe<Option.Option<Graph.Edge<number>>>()
   })
 
   it("guards", () => {


### PR DESCRIPTION
## Summary

- move graph-derived generics on standalone data-last `Graph.getNode` and `Graph.getEdge` to the returned function
- add focused inference typetests for immutable and mutable directed and undirected graphs
- add an `effect` patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm test-types Graph.tst.ts`
- `pnpm check`