### PR TITLE
Fix Graph Walker repeatability

### DIFF
--- a/.changeset/fix-graph-walker-repeatability.md
+++ b/.changeset/fix-graph-walker-repeatability.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Graph.Walker` to create a fresh iterable for each direct iteration.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -5009,8 +5009,7 @@ export class Walker<T, N> implements Iterable<[T, N]> {
     visit: <U>(f: (index: T, data: N) => U) => Iterable<U>
   ) {
     this.visit = visit
-    const iterable = visit((index, data) => [index, data] as [T, N])
-    this[Symbol.iterator] = () => iterable[Symbol.iterator]()
+    this[Symbol.iterator] = () => visit((index, data) => [index, data] as [T, N])[Symbol.iterator]()
   }
 }
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -4219,6 +4219,37 @@ describe("Graph", () => {
 
       assert.deepStrictEqual(Array.from(walker), [[0, "A"], [1, "B"]])
     })
+
+    it("should create fresh iterators for generator-backed walkers", () => {
+      const walker = new Graph.Walker<number, string>(function*(f) {
+        yield f(0, "A")
+        yield f(1, "B")
+      })
+
+      const assertRepeated = <A>(iterable: Iterable<A>, expected: Array<A>) => {
+        assert.deepStrictEqual(Array.from(iterable), expected)
+        assert.deepStrictEqual(Array.from(iterable), expected)
+      }
+
+      assertRepeated(walker, [[0, "A"], [1, "B"]])
+      assert.deepStrictEqual(Array.from(walker.visit((index, data) => `${index}:${data}`)), ["0:A", "1:B"])
+      assert.deepStrictEqual(Array.from(walker.visit((index, data) => `${index}:${data}`)), ["0:A", "1:B"])
+      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
+      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
+      assert.deepStrictEqual(Array.from(Graph.values(walker)), ["A", "B"])
+      assert.deepStrictEqual(Array.from(Graph.values(walker)), ["A", "B"])
+      assert.deepStrictEqual(Array.from(Graph.entries(walker)), [[0, "A"], [1, "B"]])
+      assert.deepStrictEqual(Array.from(Graph.entries(walker)), [[0, "A"], [1, "B"]])
+
+      const left = walker[Symbol.iterator]()
+      const right = walker[Symbol.iterator]()
+      assert.deepStrictEqual(left.next(), { done: false, value: [0, "A"] })
+      assert.deepStrictEqual(right.next(), { done: false, value: [0, "A"] })
+      assert.deepStrictEqual(left.next(), { done: false, value: [1, "B"] })
+      assert.deepStrictEqual(right.next(), { done: false, value: [1, "B"] })
+      assert.deepStrictEqual(left.next(), { done: true, value: undefined })
+      assert.deepStrictEqual(right.next(), { done: true, value: undefined })
+    })
   })
 
   describe("NodeIterable abstraction", () => {


### PR DESCRIPTION
## Summary

- create a fresh mapped iterable whenever a public `Graph.Walker` is iterated
- cover generator-backed walkers across direct iteration and public views
- verify concurrent iterators maintain independent state

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm check`