### PR TITLE
Fix mutable graph topological walkers

### DIFF
--- a/.changeset/fix-graph-mutable-topo.md
+++ b/.changeset/fix-graph-mutable-topo.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix topological walkers silently completing with an incomplete order when a mutable graph becomes cyclic after walker creation.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -5557,6 +5557,10 @@ export const topo: {
           }
         }
 
+        if (remaining.size > 0) {
+          throw new GraphError({ message: "Cannot perform topological sort on cyclic graph" })
+        }
+
         return { done: true, value: undefined } as const
       }
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3727,6 +3727,39 @@ describe("Graph", () => {
       assert.strictEqual(iterator.next().done, true)
     })
 
+    it("should reject cycles introduced before topological iteration", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "A")
+        Graph.addNode(graph, "B")
+      }))
+      const walker = Graph.topo(mutable)
+
+      Graph.addEdge(mutable, 0, 1, 1)
+      Graph.addEdge(mutable, 1, 0, 2)
+
+      assertGraphError(
+        () => Array.from(Graph.indices(walker)),
+        "Cannot perform topological sort on cyclic graph"
+      )
+    })
+
+    it("should use fresh graph state for each topological iteration", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, number>((graph) => {
+        Graph.addNode(graph, "A")
+        Graph.addNode(graph, "B")
+      }))
+      const walker = Graph.topo(mutable)
+
+      assert.deepStrictEqual(Array.from(Graph.indices(walker)), [0, 1])
+      Graph.addEdge(mutable, 0, 1, 1)
+      Graph.addEdge(mutable, 1, 0, 2)
+
+      assertGraphError(
+        () => Array.from(Graph.indices(walker)),
+        "Cannot perform topological sort on cyclic graph"
+      )
+    })
+
     it("should prioritize valid initials and still include all nodes", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")


### PR DESCRIPTION
## Summary

- detect incomplete Kahn traversal when a mutable graph becomes cyclic after topological walker creation
- preserve stale-node skipping by validating remaining traversal nodes rather than emitted values
- add regression coverage for mutation before iteration and repeated walker iteration

## Validation

- 
> @ lint-fix /Users/fubhy/Projects/effect/effect-graph-mutable-topo
> pnpm jsdocs && oxlint --fix && dprint fmt


> @ jsdocs /Users/fubhy/Projects/effect/effect-graph-mutable-topo
> effect-jsdocs

Skipped .data/jsdocs.json
Found 0 warnings and 0 errors.
Finished in 3.1s on 1156 files with 130 rules using 12 threads.
- 
> @ test /Users/fubhy/Projects/effect/effect-graph-mutable-topo
> vitest packages/effect/test/Graph.test.ts


 RUN  v4.1.10 /Users/fubhy/Projects/effect/effect-graph-mutable-topo


 Test Files  1 passed (1)
      Tests  256 passed (256)
   Start at  11:30:28
   Duration  1.63s (transform 895ms, setup 625ms, import 496ms, tests 394ms, environment 0ms)
- 
> @ check /Users/fubhy/Projects/effect/effect-graph-mutable-topo
> tsc -b tsconfig.json