### PR TITLE
Optimize Graph pathfinding queues

### DIFF
--- a/.changeset/fast-graph-path-queues.md
+++ b/.changeset/fast-graph-path-queues.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Improve `Graph.dijkstra` and `Graph.astar` priority queue performance.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -72,6 +72,53 @@ export type NodeIndex = number
  */
 export type EdgeIndex = number
 
+interface PriorityQueueEntry {
+  readonly node: NodeIndex
+  readonly priority: number
+  readonly sequence: number
+}
+
+const priorityQueueLessThan = (self: PriorityQueueEntry, that: PriorityQueueEntry): boolean =>
+  self.priority < that.priority || (self.priority === that.priority && self.sequence < that.sequence)
+
+const priorityQueueOffer = (queue: Array<PriorityQueueEntry>, entry: PriorityQueueEntry): void => {
+  let index = queue.length
+  queue.push(entry)
+  while (index > 0) {
+    const parent = (index - 1) >>> 1
+    if (!priorityQueueLessThan(entry, queue[parent])) {
+      break
+    }
+    queue[index] = queue[parent]
+    index = parent
+  }
+  queue[index] = entry
+}
+
+const priorityQueueTake = (queue: Array<PriorityQueueEntry>): PriorityQueueEntry | undefined => {
+  const first = queue[0]
+  const last = queue.pop()
+  if (last === undefined || queue.length === 0) {
+    return first
+  }
+  let index = 0
+  while (true) {
+    const left = index * 2 + 1
+    if (left >= queue.length) {
+      break
+    }
+    const right = left + 1
+    const child = right < queue.length && priorityQueueLessThan(queue[right], queue[left]) ? right : left
+    if (!priorityQueueLessThan(queue[child], last)) {
+      break
+    }
+    queue[index] = queue[child]
+    index = child
+  }
+  queue[index] = last
+  return first
+}
+
 /**
  * Represents edge data containing source, target, and user data.
  *
@@ -4175,21 +4222,12 @@ export const dijkstra: {
     previous.set(node, null)
   }
 
-  // Simple priority queue using array (can be optimized with proper heap)
-  const priorityQueue: Array<{ node: NodeIndex; distance: number }> = [
-    { node: config.source, distance: 0 }
-  ]
+  const priorityQueue: Array<PriorityQueueEntry> = []
+  let sequence = 0
+  priorityQueueOffer(priorityQueue, { node: config.source, priority: 0, sequence: sequence++ })
 
   while (priorityQueue.length > 0) {
-    // Find minimum distance node (priority queue extract-min)
-    let minIndex = 0
-    for (let i = 1; i < priorityQueue.length; i++) {
-      if (priorityQueue[i].distance < priorityQueue[minIndex].distance) {
-        minIndex = i
-      }
-    }
-
-    const current = priorityQueue.splice(minIndex, 1)[0]
+    const current = priorityQueueTake(priorityQueue)!
     const currentNode = current.node
 
     // Skip if already visited (can happen with duplicate entries)
@@ -4226,7 +4264,7 @@ export const dijkstra: {
 
             // Add to priority queue if not visited
             if (!visited.has(neighbor)) {
-              priorityQueue.push({ node: neighbor, distance: newDistance })
+              priorityQueueOffer(priorityQueue, { node: neighbor, priority: newDistance, sequence: sequence++ })
             }
           }
         }
@@ -4596,21 +4634,16 @@ export const astar: {
     fScore.set(config.source, h)
   }
 
-  // Priority queue using f-score (total estimated cost)
-  const openSet: Array<{ node: NodeIndex; fScore: number }> = [
-    { node: config.source, fScore: fScore.get(config.source)! }
-  ]
+  const openSet: Array<PriorityQueueEntry> = []
+  let sequence = 0
+  priorityQueueOffer(openSet, {
+    node: config.source,
+    priority: fScore.get(config.source)!,
+    sequence: sequence++
+  })
 
   while (openSet.length > 0) {
-    // Find node with lowest f-score
-    let minIndex = 0
-    for (let i = 1; i < openSet.length; i++) {
-      if (openSet[i].fScore < openSet[minIndex].fScore) {
-        minIndex = i
-      }
-    }
-
-    const current = openSet.splice(minIndex, 1)[0]
+    const current = priorityQueueTake(openSet)!
     const currentNode = current.node
 
     // Skip if already visited
@@ -4655,7 +4688,7 @@ export const astar: {
 
               // Add to open set if not visited
               if (!visited.has(neighbor)) {
-                openSet.push({ node: neighbor, fScore: f })
+                priorityQueueOffer(openSet, { node: neighbor, priority: f, sequence: sequence++ })
               }
             }
           }

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -72,53 +72,6 @@ export type NodeIndex = number
  */
 export type EdgeIndex = number
 
-interface PriorityQueueEntry {
-  readonly node: NodeIndex
-  readonly priority: number
-  readonly sequence: number
-}
-
-const priorityQueueLessThan = (self: PriorityQueueEntry, that: PriorityQueueEntry): boolean =>
-  self.priority < that.priority || (self.priority === that.priority && self.sequence < that.sequence)
-
-const priorityQueueOffer = (queue: Array<PriorityQueueEntry>, entry: PriorityQueueEntry): void => {
-  let index = queue.length
-  queue.push(entry)
-  while (index > 0) {
-    const parent = (index - 1) >>> 1
-    if (!priorityQueueLessThan(entry, queue[parent])) {
-      break
-    }
-    queue[index] = queue[parent]
-    index = parent
-  }
-  queue[index] = entry
-}
-
-const priorityQueueTake = (queue: Array<PriorityQueueEntry>): PriorityQueueEntry | undefined => {
-  const first = queue[0]
-  const last = queue.pop()
-  if (last === undefined || queue.length === 0) {
-    return first
-  }
-  let index = 0
-  while (true) {
-    const left = index * 2 + 1
-    if (left >= queue.length) {
-      break
-    }
-    const right = left + 1
-    const child = right < queue.length && priorityQueueLessThan(queue[right], queue[left]) ? right : left
-    if (!priorityQueueLessThan(queue[child], last)) {
-      break
-    }
-    queue[index] = queue[child]
-    index = child
-  }
-  queue[index] = last
-  return first
-}
-
 /**
  * Represents edge data containing source, target, and user data.
  *
@@ -4099,6 +4052,53 @@ export interface PathResult<E> {
   readonly costs: Array<E>
 }
 
+interface MinHeapEntry {
+  readonly node: NodeIndex
+  readonly priority: number
+  readonly sequence: number
+}
+
+const minHeapLessThan = (self: MinHeapEntry, that: MinHeapEntry): boolean =>
+  self.priority < that.priority || (self.priority === that.priority && self.sequence < that.sequence)
+
+const minHeapPush = (heap: Array<MinHeapEntry>, entry: MinHeapEntry): void => {
+  let index = heap.length
+  heap.push(entry)
+  while (index > 0) {
+    const parent = (index - 1) >>> 1
+    if (!minHeapLessThan(entry, heap[parent])) {
+      break
+    }
+    heap[index] = heap[parent]
+    index = parent
+  }
+  heap[index] = entry
+}
+
+const minHeapPop = (heap: Array<MinHeapEntry>): MinHeapEntry | undefined => {
+  const first = heap[0]
+  const last = heap.pop()
+  if (last === undefined || heap.length === 0) {
+    return first
+  }
+  let index = 0
+  while (true) {
+    const left = index * 2 + 1
+    if (left >= heap.length) {
+      break
+    }
+    const right = left + 1
+    const child = right < heap.length && minHeapLessThan(heap[right], heap[left]) ? right : left
+    if (!minHeapLessThan(heap[child], last)) {
+      break
+    }
+    heap[index] = heap[child]
+    index = child
+  }
+  heap[index] = last
+  return first
+}
+
 /**
  * Configuration for finding a shortest path with Dijkstra's algorithm.
  *
@@ -4222,12 +4222,12 @@ export const dijkstra: {
     previous.set(node, null)
   }
 
-  const priorityQueue: Array<PriorityQueueEntry> = []
+  const priorityQueue: Array<MinHeapEntry> = []
   let sequence = 0
-  priorityQueueOffer(priorityQueue, { node: config.source, priority: 0, sequence: sequence++ })
+  minHeapPush(priorityQueue, { node: config.source, priority: 0, sequence: sequence++ })
 
   while (priorityQueue.length > 0) {
-    const current = priorityQueueTake(priorityQueue)!
+    const current = minHeapPop(priorityQueue)!
     const currentNode = current.node
 
     // Skip if already visited (can happen with duplicate entries)
@@ -4264,7 +4264,7 @@ export const dijkstra: {
 
             // Add to priority queue if not visited
             if (!visited.has(neighbor)) {
-              priorityQueueOffer(priorityQueue, { node: neighbor, priority: newDistance, sequence: sequence++ })
+              minHeapPush(priorityQueue, { node: neighbor, priority: newDistance, sequence: sequence++ })
             }
           }
         }
@@ -4634,16 +4634,16 @@ export const astar: {
     fScore.set(config.source, h)
   }
 
-  const openSet: Array<PriorityQueueEntry> = []
+  const openSet: Array<MinHeapEntry> = []
   let sequence = 0
-  priorityQueueOffer(openSet, {
+  minHeapPush(openSet, {
     node: config.source,
     priority: fScore.get(config.source)!,
     sequence: sequence++
   })
 
   while (openSet.length > 0) {
-    const current = priorityQueueTake(openSet)!
+    const current = minHeapPop(openSet)!
     const currentNode = current.node
 
     // Skip if already visited
@@ -4688,7 +4688,7 @@ export const astar: {
 
               // Add to open set if not visited
               if (!visited.has(neighbor)) {
-                priorityQueueOffer(openSet, { node: neighbor, priority: f, sequence: sequence++ })
+                minHeapPush(openSet, { node: neighbor, priority: f, sequence: sequence++ })
               }
             }
           }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -2926,6 +2926,50 @@ describe("Graph", () => {
       assertSome(result, { path: [nodeA!, nodeB!, nodeC!], distance: 7, costs: [5, 2] })
     })
 
+    it("should preserve insertion order for equal priorities", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const source = Graph.addNode(mutable, "source")
+        const first = Graph.addNode(mutable, "first")
+        const second = Graph.addNode(mutable, "second")
+        const target = Graph.addNode(mutable, "target")
+        Graph.addEdge(mutable, source, first, 1)
+        Graph.addEdge(mutable, source, second, 1)
+        Graph.addEdge(mutable, first, target, 1)
+        Graph.addEdge(mutable, second, target, 1)
+      })
+
+      const result = Graph.dijkstra(graph, {
+        source: 0,
+        target: 3,
+        cost: (edge) => edge
+      })
+
+      assertSome(result, { path: [0, 1, 3], distance: 2, costs: [1, 1] })
+    })
+
+    it("should skip stale priority queue entries", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const source = Graph.addNode(mutable, "source")
+        const improved = Graph.addNode(mutable, "improved")
+        const shortcut = Graph.addNode(mutable, "shortcut")
+        const middle = Graph.addNode(mutable, "middle")
+        const target = Graph.addNode(mutable, "target")
+        Graph.addEdge(mutable, source, improved, 10)
+        Graph.addEdge(mutable, source, shortcut, 1)
+        Graph.addEdge(mutable, shortcut, improved, 1)
+        Graph.addEdge(mutable, improved, middle, 20)
+        Graph.addEdge(mutable, middle, target, 20)
+      })
+
+      const result = Graph.dijkstra(graph, {
+        source: 0,
+        target: 4,
+        cost: (edge) => edge
+      })
+
+      assertSome(result, { path: [0, 2, 1, 3, 4], distance: 42, costs: [1, 1, 20, 20] })
+    })
+
     it("should return None for unreachable nodes", () => {
       let nodeA: Graph.NodeIndex
       let nodeB: Graph.NodeIndex
@@ -3097,6 +3141,52 @@ describe("Graph", () => {
       })
 
       assertSome(result, { path: [nodeA!, nodeB!, nodeC!], distance: 2, costs: [1, 1] })
+    })
+
+    it("should preserve insertion order for equal priorities", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const source = Graph.addNode(mutable, "source")
+        const first = Graph.addNode(mutable, "first")
+        const second = Graph.addNode(mutable, "second")
+        const target = Graph.addNode(mutable, "target")
+        Graph.addEdge(mutable, source, first, 1)
+        Graph.addEdge(mutable, source, second, 1)
+        Graph.addEdge(mutable, first, target, 1)
+        Graph.addEdge(mutable, second, target, 1)
+      })
+
+      const result = Graph.astar(graph, {
+        source: 0,
+        target: 3,
+        cost: (edge) => edge,
+        heuristic: () => 0
+      })
+
+      assertSome(result, { path: [0, 1, 3], distance: 2, costs: [1, 1] })
+    })
+
+    it("should skip stale open set entries", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const source = Graph.addNode(mutable, "source")
+        const improved = Graph.addNode(mutable, "improved")
+        const shortcut = Graph.addNode(mutable, "shortcut")
+        const middle = Graph.addNode(mutable, "middle")
+        const target = Graph.addNode(mutable, "target")
+        Graph.addEdge(mutable, source, improved, 10)
+        Graph.addEdge(mutable, source, shortcut, 1)
+        Graph.addEdge(mutable, shortcut, improved, 1)
+        Graph.addEdge(mutable, improved, middle, 20)
+        Graph.addEdge(mutable, middle, target, 20)
+      })
+
+      const result = Graph.astar(graph, {
+        source: 0,
+        target: 4,
+        cost: (edge) => edge,
+        heuristic: () => 0
+      })
+
+      assertSome(result, { path: [0, 2, 1, 3, 4], distance: 42, costs: [1, 1, 20, 20] })
     })
 
     it("should return None for unreachable nodes", () => {


### PR DESCRIPTION
## Summary

- replace the linear scanned arrays in `Graph.dijkstra` and `Graph.astar` with a shared private binary min-heap
- preserve deterministic FIFO ordering for equal priorities with insertion sequence numbers
- retain lazy duplicate entries and add regressions for equal-priority paths and stale entries

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts` (258 passed)
- `pnpm test packages/effect/test/Pathfinding.test.ts` (3 passed)
- `pnpm check`

## Bundle

Attempted `pnpm bundle-compare-selected --base origin/main scratchpad/graph-pathfinding.ts`. Both checkouts built and the base fixture measured 5.91 kB, but the comparison process aborted in libuv before producing a current-size delta, so no reliable bundle difference is reported.