### PR TITLE
Fix undirected Graph equality

### DIFF
--- a/.changeset/graph-undirected-edge-equality.md
+++ b/.changeset/graph-undirected-edge-equality.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix undirected `Graph` equality and hashing to ignore stored edge endpoint orientation.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -321,11 +321,11 @@ export type MutableUndirectedGraph<N, E> = MutableGraph<N, E, "undirected">
 
 /** @internal */
 const edgeEquals = (type: Kind, self: Edge<any>, that: Edge<any>): boolean =>
-  Equal.equals(self.data, that.data) &&
   (type === "directed"
     ? self.source === that.source && self.target === that.target
     : (self.source === that.source && self.target === that.target) ||
-      (self.source === that.target && self.target === that.source))
+      (self.source === that.target && self.target === that.source)) &&
+  Equal.equals(self.data, that.data)
 
 /** @internal */
 const edgeHash = (type: Kind, edge: Edge<any>): number =>

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -320,6 +320,20 @@ export type MutableUndirectedGraph<N, E> = MutableGraph<N, E, "undirected">
 // =============================================================================
 
 /** @internal */
+const edgeEquals = (type: Kind, self: Edge<any>, that: Edge<any>): boolean =>
+  Equal.equals(self.data, that.data) &&
+  (type === "directed"
+    ? self.source === that.source && self.target === that.target
+    : (self.source === that.source && self.target === that.target) ||
+      (self.source === that.target && self.target === that.source))
+
+/** @internal */
+const edgeHash = (type: Kind, edge: Edge<any>): number =>
+  type === "directed"
+    ? Hash.hash(edge)
+    : Hash.optimize(Hash.hash(edge.data) ^ (Hash.hash(edge.source) + Hash.hash(edge.target)))
+
+/** @internal */
 const ProtoGraph = {
   [TypeId]: {
     _N: (_: never) => _,
@@ -357,7 +371,7 @@ const ProtoGraph = {
           return false
         }
         const otherEdge = thatImpl.edges.get(edgeIndex)!
-        if (!Equal.equals(edgeData, otherEdge)) {
+        if (!edgeEquals(this.type, edgeData, otherEdge)) {
           return false
         }
       }
@@ -374,7 +388,7 @@ const ProtoGraph = {
       hash = hash ^ (Hash.hash(nodeIndex) + Hash.hash(nodeData))
     }
     for (const [edgeIndex, edgeData] of this.edges) {
-      hash = hash ^ (Hash.hash(edgeIndex) + Hash.hash(edgeData))
+      hash = hash ^ (Hash.hash(edgeIndex) + edgeHash(this.type, edgeData))
     }
     return hash
   },

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -105,6 +105,69 @@ describe("Graph", () => {
     })
   })
 
+  describe("equality and hashing", () => {
+    const makeGraph = (
+      type: Graph.Kind,
+      edges: ReadonlyArray<readonly [Graph.NodeIndex, Graph.NodeIndex, string]>
+    ) =>
+      Graph.make(type)<string, string>((mutable) => {
+        Graph.addNode(mutable, "A")
+        Graph.addNode(mutable, "B")
+        for (const [source, target, data] of edges) {
+          Graph.addEdge(mutable, source, target, data)
+        }
+      })
+
+    it("treats undirected edge endpoints as unordered", () => {
+      const left = makeGraph("undirected", [[0, 1, "edge"]])
+      const right = makeGraph("undirected", [[1, 0, "edge"]])
+
+      strictEqual(Equal.equals(left, right), true)
+      strictEqual(Equal.equals(right, left), true)
+      strictEqual(Hash.hash(left), Hash.hash(right))
+    })
+
+    it("keeps directed edge endpoints ordered", () => {
+      const left = makeGraph("directed", [[0, 1, "edge"]])
+      const right = makeGraph("directed", [[1, 0, "edge"]])
+
+      strictEqual(Equal.equals(left, right), false)
+      strictEqual(Equal.equals(right, left), false)
+    })
+
+    it("compares undirected edge data", () => {
+      const left = makeGraph("undirected", [[0, 1, "left"]])
+      const right = makeGraph("undirected", [[1, 0, "right"]])
+
+      strictEqual(Equal.equals(left, right), false)
+    })
+
+    it("keeps parallel edges paired by edge index", () => {
+      const left = makeGraph("undirected", [[0, 1, "first"], [0, 1, "second"]])
+      const reversed = makeGraph("undirected", [[1, 0, "first"], [1, 0, "second"]])
+      const reordered = makeGraph("undirected", [[1, 0, "second"], [1, 0, "first"]])
+
+      strictEqual(Equal.equals(left, reversed), true)
+      strictEqual(Hash.hash(left), Hash.hash(reversed))
+      strictEqual(Equal.equals(left, reordered), false)
+    })
+
+    it("handles undirected self-loops", () => {
+      const left = makeGraph("undirected", [[0, 0, "loop"]])
+      const right = makeGraph("undirected", [[0, 0, "loop"]])
+
+      strictEqual(Equal.equals(left, right), true)
+      strictEqual(Hash.hash(left), Hash.hash(right))
+    })
+
+    it("keeps Graph.Edge endpoint equality ordered", () => {
+      const left = new Graph.Edge({ source: 0, target: 1, data: "edge" })
+      const right = new Graph.Edge({ source: 1, target: 0, data: "edge" })
+
+      strictEqual(Equal.equals(left, right), false)
+    })
+  })
+
   describe("set operations", () => {
     const makeLeft = () =>
       Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {


### PR DESCRIPTION
## Summary

- treat reversed endpoint storage as equivalent when comparing undirected graph edges
- hash undirected edge endpoints commutatively while preserving directed graph and public `Graph.Edge` semantics
- cover edge-indexed parallel edges, self-loops, payload differences, and the equality/hash contract

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts` (263 tests)
- `pnpm check`