### PR TITLE
Fix Graph async mutation callbacks

### DIFF
--- a/.changeset/graph-sync-mutation-callbacks.md
+++ b/.changeset/graph-sync-mutation-callbacks.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Reject asynchronous `Graph` mutation callbacks and finalize scoped mutable handles when callbacks fail.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -19,7 +19,7 @@ import * as MutableHashMap from "./MutableHashMap.ts"
 import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { pipeArguments } from "./Pipeable.ts"
-import { hasProperty, isPromiseLike } from "./Predicate.ts"
+import { hasProperty } from "./Predicate.ts"
 import type { Covariant, Invariant, Mutable } from "./Types.ts"
 
 const TypeId = "~effect/collections/Graph"
@@ -639,13 +639,11 @@ export const endMutation = <N, E, T extends Kind = "directed">(
 /** @internal */
 const mutateScoped = <N, E, T extends Kind>(
   mutable: MutableGraph<N, E, T>,
-  f: (mutable: MutableGraph<N, E, T>) => unknown
+  f: (mutable: MutableGraph<N, E, T>) => undefined
 ): Graph<N, E, T> => {
   let graph: Graph<N, E, T>
   try {
-    if (isPromiseLike(f(mutable))) {
-      throw new GraphError({ message: "Graph mutation callbacks must be synchronous" })
-    }
+    f(mutable)
   } finally {
     graph = endMutation(mutable)
   }

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -19,7 +19,7 @@ import * as MutableHashMap from "./MutableHashMap.ts"
 import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { pipeArguments } from "./Pipeable.ts"
-import { hasProperty } from "./Predicate.ts"
+import { hasProperty, isPromiseLike } from "./Predicate.ts"
 import type { Covariant, Invariant, Mutable } from "./Types.ts"
 
 const TypeId = "~effect/collections/Graph"
@@ -481,7 +481,7 @@ export const isGraph = <N = unknown, E = unknown, T extends Kind = Kind, U = nev
  * @since 4.0.0
  */
 export const make =
-  <T extends Kind>(type: T) => <N, E>(mutate?: (mutable: MutableGraph<N, E, T>) => void): Graph<N, E, T> => {
+  <T extends Kind>(type: T) => <N, E>(mutate?: (mutable: MutableGraph<N, E, T>) => undefined): Graph<N, E, T> => {
     const graph: Mutable<GraphImpl<N, E, T>> = Object.create(ProtoGraph)
     graph.type = type
     graph.nodes = new Map()
@@ -499,8 +499,7 @@ export const make =
 
     graph.mutable = true
     const mutable = graph as unknown as MutableGraph<N, E, T>
-    mutate(mutable)
-    return endMutation(mutable)
+    return mutateScoped(mutable, mutate)
   }
 
 /**
@@ -525,7 +524,7 @@ export const make =
  * @since 3.18.0
  */
 export const directed: <N, E>(
-  mutate?: (mutable: MutableDirectedGraph<N, E>) => void
+  mutate?: (mutable: MutableDirectedGraph<N, E>) => undefined
 ) => DirectedGraph<N, E> = make("directed")
 
 /**
@@ -550,7 +549,7 @@ export const directed: <N, E>(
  * @since 3.18.0
  */
 export const undirected: <N, E>(
-  mutate?: (mutable: MutableUndirectedGraph<N, E>) => void
+  mutate?: (mutable: MutableUndirectedGraph<N, E>) => undefined
 ) => UndirectedGraph<N, E> = make("undirected")
 
 // =============================================================================
@@ -637,6 +636,22 @@ export const endMutation = <N, E, T extends Kind = "directed">(
   return graph as unknown as Graph<N, E, T>
 }
 
+/** @internal */
+const mutateScoped = <N, E, T extends Kind>(
+  mutable: MutableGraph<N, E, T>,
+  f: (mutable: MutableGraph<N, E, T>) => unknown
+): Graph<N, E, T> => {
+  let graph: Graph<N, E, T>
+  try {
+    if (isPromiseLike(f(mutable))) {
+      throw new GraphError({ message: "Graph mutation callbacks must be synchronous" })
+    }
+  } finally {
+    graph = endMutation(mutable)
+  }
+  return graph
+}
+
 /**
  * Performs scoped mutations on a graph, automatically managing the mutation lifecycle.
  *
@@ -661,19 +676,18 @@ export const endMutation = <N, E, T extends Kind = "directed">(
  */
 export const mutate: {
   <N, E, T extends Kind = "directed">(
-    f: (mutable: MutableGraph<N, E, T>) => void
+    f: (mutable: MutableGraph<N, E, T>) => undefined
   ): (graph: Graph<N, E, T>) => Graph<N, E, T>
   <N, E, T extends Kind = "directed">(
     graph: Graph<N, E, T>,
-    f: (mutable: MutableGraph<N, E, T>) => void
+    f: (mutable: MutableGraph<N, E, T>) => undefined
   ): Graph<N, E, T>
 } = dual(2, <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T>,
-  f: (mutable: MutableGraph<N, E, T>) => void
+  f: (mutable: MutableGraph<N, E, T>) => undefined
 ): Graph<N, E, T> => {
   const mutable = beginMutation(graph)
-  f(mutable)
-  return endMutation(mutable)
+  return mutateScoped(mutable, f)
 })
 
 // =============================================================================

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -863,21 +863,6 @@ describe("Graph", () => {
       expect(Graph.edgeCount(result)).toBe(0)
     })
 
-    it("should reject PromiseLike callbacks and finalize the mutable graph", () => {
-      let mutable: Graph.MutableDirectedGraph<string, number> | undefined
-      const callback = ((graph: Graph.MutableDirectedGraph<string, number>) => {
-        mutable = graph
-        /* oxlint-disable-next-line no-thenable */
-        return { then() {} }
-      }) as unknown as (graph: Graph.MutableDirectedGraph<string, number>) => undefined
-
-      assertGraphError(
-        () => Graph.mutate(Graph.directed<string, number>(), callback),
-        "Graph mutation callbacks must be synchronous"
-      )
-      assertGraphError(() => Graph.addNode(mutable!, "late"), "Graph is not mutable")
-    })
-
     it("should finalize the mutable graph when the callback throws", () => {
       let mutable: Graph.MutableDirectedGraph<string, number> | undefined
       const error = new Error("boom")

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -862,6 +862,38 @@ describe("Graph", () => {
       expect(Graph.nodeCount(result)).toBe(0)
       expect(Graph.edgeCount(result)).toBe(0)
     })
+
+    it("should reject PromiseLike callbacks and finalize the mutable graph", () => {
+      let mutable: Graph.MutableDirectedGraph<string, number> | undefined
+      const callback = ((graph: Graph.MutableDirectedGraph<string, number>) => {
+        mutable = graph
+        /* oxlint-disable-next-line no-thenable */
+        return { then() {} }
+      }) as unknown as (graph: Graph.MutableDirectedGraph<string, number>) => undefined
+
+      assertGraphError(
+        () => Graph.mutate(Graph.directed<string, number>(), callback),
+        "Graph mutation callbacks must be synchronous"
+      )
+      assertGraphError(() => Graph.addNode(mutable!, "late"), "Graph is not mutable")
+    })
+
+    it("should finalize the mutable graph when the callback throws", () => {
+      let mutable: Graph.MutableDirectedGraph<string, number> | undefined
+      const error = new Error("boom")
+
+      throws(
+        () =>
+          Graph.mutate(Graph.directed<string, number>(), (graph) => {
+            mutable = graph
+            throw error
+          }),
+        (cause) => {
+          strictEqual(cause, error)
+        }
+      )
+      assertGraphError(() => Graph.addNode(mutable!, "late"), "Graph is not mutable")
+    })
   })
 
   describe("addNode", () => {

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -36,6 +36,26 @@ describe("Graph", () => {
         expect(mutable).type.toBe<Graph.MutableUndirectedGraph<string, number>>()
       })
     ).type.toBe<Graph.UndirectedGraph<string, number>>()
+
+    expect(Graph.make("directed")<string, number>).type.not.toBeCallableWith(async () => {})
+    expect(Graph.make("undirected")<string, number>).type.not.toBeCallableWith(() => Promise.resolve())
+  })
+
+  it("mutation callbacks must be synchronous", () => {
+    expect(Graph.directed<string, number>).type.not.toBeCallableWith(async () => {})
+    expect(Graph.undirected<string, number>).type.not.toBeCallableWith(() => Promise.resolve())
+    expect(Graph.mutate).type.not.toBeCallableWith(directed, async () => {})
+    expect(Graph.mutate).type.not.toBeCallableWith(async () => {})
+
+    expect(Graph.mutate(directed, (mutable) => {
+      expect(mutable).type.toBe<Graph.MutableDirectedGraph<string, number>>()
+    })).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(pipe(
+      directed,
+      Graph.mutate((mutable) => {
+        expect(mutable).type.toBe<Graph.MutableDirectedGraph<string, number>>()
+      })
+    )).type.toBe<Graph.DirectedGraph<string, number>>()
   })
 
   it("opaque interface", () => {


### PR DESCRIPTION
## Summary

- require `Graph` constructor and scoped mutation callbacks to return `undefined`, preventing directly supplied async callbacks from type-checking
- always finalize scoped mutable handles when callbacks throw, reusing the finalization behavior from #6417
- rely on the public callback types rather than runtime inspection of ignored callback results

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm test-types Graph.tst.ts`
- `pnpm check`