### PR TITLE
Fix Graph.topo directed graph types

### DIFF
--- a/.changeset/fix-graph-topo-types.md
+++ b/.changeset/fix-graph-topo-types.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Restrict `Graph.topo` to directed graphs at the type level while retaining runtime validation for unsafe undirected inputs.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -5465,8 +5465,11 @@ export interface TopoConfig {
 export const topo: {
   (
     config?: TopoConfig
-  ): <N, E, T extends Kind = "directed">(graph: Graph<N, E, T> | MutableGraph<N, E, T>) => NodeWalker<N>
-  <N, E, T extends Kind = "directed">(graph: Graph<N, E, T> | MutableGraph<N, E, T>, config?: TopoConfig): NodeWalker<N>
+  ): <N, E>(graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">) => NodeWalker<N>
+  <N, E>(
+    graph: Graph<N, E, "directed"> | MutableGraph<N, E, "directed">,
+    config?: TopoConfig
+  ): NodeWalker<N>
 } = dual((args) => isGraph(args[0]), <N, E, T extends Kind = "directed">(
   graph: Graph<N, E, T> | MutableGraph<N, E, T>,
   config: TopoConfig = {}

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3799,7 +3799,7 @@ describe("Graph", () => {
     it("should throw for undirected graphs", () => {
       const graph = makeReversedUndirectedPath()
 
-      expect(() => Graph.topo(graph)).toThrow("Cannot perform topological sort on undirected graph")
+      expect(() => Graph.topo(graph as any)).toThrow("Cannot perform topological sort on undirected graph")
     })
 
     it("should handle corrupted graph state during topological sort", () => {

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from "tstyche"
 
 declare const directed: Graph.DirectedGraph<string, number>
 declare const undirected: Graph.UndirectedGraph<string, number>
+declare const mutableDirected: Graph.MutableDirectedGraph<string, number>
+declare const mutableUndirected: Graph.MutableUndirectedGraph<string, number>
+declare const unknownKind: Graph.Graph<string, number, Graph.Kind>
+declare const mixedKind: Graph.DirectedGraph<string, number> | Graph.UndirectedGraph<string, number>
 
 interface Node {
   readonly id: string
@@ -212,6 +216,31 @@ describe("Graph", () => {
     expect(Graph.dfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
     expect(Graph.bfs(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
     expect(Graph.dfsPostOrder(directed, { direction: "undirected", radius: 1 })).type.toBe<Graph.NodeWalker<string>>()
+  })
+
+  it("topo", () => {
+    expect(Graph.topo(directed)).type.toBe<Graph.NodeWalker<string>>()
+    expect(Graph.topo(directed, { initials: [0] })).type.toBe<Graph.NodeWalker<string>>()
+    expect(Graph.topo(mutableDirected)).type.toBe<Graph.NodeWalker<string>>()
+
+    expect(pipe(directed, Graph.topo())).type.toBe<Graph.NodeWalker<string>>()
+    expect(pipe(directed, Graph.topo({ initials: [0] }))).type.toBe<Graph.NodeWalker<string>>()
+    expect(pipe(mutableDirected, Graph.topo())).type.toBe<Graph.NodeWalker<string>>()
+
+    // @ts-expect-error! Topological sorting requires a directed graph
+    Graph.topo(undirected)
+    // @ts-expect-error! Topological sorting requires a directed graph
+    Graph.topo(mutableUndirected)
+    // @ts-expect-error! Topological sorting requires a directed graph
+    pipe(undirected, Graph.topo())
+    // @ts-expect-error! Topological sorting requires a directed graph
+    pipe(mutableUndirected, Graph.topo({ initials: [0] }))
+    // @ts-expect-error! The graph kind must first be narrowed to directed
+    Graph.topo(unknownKind)
+
+    if (mixedKind.type === "directed") {
+      expect(Graph.topo(mixedKind)).type.toBe<Graph.NodeWalker<string>>()
+    }
   })
 
   it("sum", () => {


### PR DESCRIPTION
## Summary
- restrict both `Graph.topo` public overloads to directed immutable and mutable graphs
- retain the broad implementation signature and runtime guard for unsafe inputs
- add direct, data-last, mutable, broad-kind, and narrowing typetests
- preserve runtime guard coverage through an unsafe cast

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm test-types Graph.tst.ts`
- `pnpm check`