### PR TITLE
Fix mutable Graph hashing

### DIFF
--- a/.changeset/fix-graph-mutable-hash.md
+++ b/.changeset/fix-graph-mutable-hash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix mutable Graph equality and hashing to use reference identity while preserving structural semantics for immutable graphs.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -512,7 +512,7 @@ export const make =
     }
 
     graph.mutable = true
-    const mutable = graph as unknown as MutableGraph<N, E, T>
+    const mutable = Equal.byReferenceUnsafe(graph as unknown as MutableGraph<N, E, T>)
     return mutateScoped(mutable, mutate)
   }
 
@@ -604,7 +604,7 @@ export const beginMutation = <N, E, T extends Kind = "directed">(
   mutable.acyclic = source.acyclic
   mutable.mutable = true
 
-  return mutable as unknown as MutableGraph<N, E, T>
+  return Equal.byReferenceUnsafe(mutable as unknown as MutableGraph<N, E, T>)
 }
 
 /**

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -166,6 +166,42 @@ describe("Graph", () => {
 
       strictEqual(Equal.equals(left, right), false)
     })
+
+    it("uses stable reference equality and hashing for mutable graphs", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, string>())
+      const initialHash = Hash.hash(mutable)
+
+      strictEqual(Equal.equals(mutable, mutable), true)
+      const source = Graph.addNode(mutable, "A")
+      const target = Graph.addNode(mutable, "B")
+      Graph.addEdge(mutable, source, target, "edge")
+
+      strictEqual(Hash.hash(mutable), initialHash)
+      strictEqual(Equal.equals(mutable, mutable), true)
+    })
+
+    it("does not structurally compare independently constructed mutable graphs", () => {
+      const graph = makeGraph("directed", [[0, 1, "edge"]])
+      const left = Graph.beginMutation(graph)
+      const right = Graph.beginMutation(graph)
+
+      strictEqual(Equal.equals(left, right), false)
+      strictEqual(Equal.equals(right, left), false)
+    })
+
+    it("restores structural equality and hashing after finalization", () => {
+      const mutable = Graph.beginMutation(Graph.directed<string, string>())
+      Hash.hash(mutable)
+      const source = Graph.addNode(mutable, "A")
+      const target = Graph.addNode(mutable, "B")
+      Graph.addEdge(mutable, source, target, "edge")
+
+      const graph = Graph.endMutation(mutable)
+      const expected = makeGraph("directed", [[0, 1, "edge"]])
+
+      strictEqual(Equal.equals(graph, expected), true)
+      strictEqual(Hash.hash(graph), Hash.hash(expected))
+    })
   })
 
   describe("set operations", () => {


### PR DESCRIPTION
## Summary

- mark mutable Graph handles for reference equality before they escape constructor and mutation scopes
- keep mutable hashes stable across in-place changes while preserving structural equality and hashing for finalized immutable graphs
- add focused regression coverage and an effect patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm check`