### PR TITLE
Fix Graph allocator equality

### DIFF
--- a/.changeset/fix-graph-allocator-equality.md
+++ b/.changeset/fix-graph-allocator-equality.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix immutable Graph equality and hashing to include future node and edge identifier allocation.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -351,6 +351,8 @@ const ProtoGraph = {
       if (
         this.nodes.size !== thatImpl.nodes.size ||
         this.edges.size !== thatImpl.edges.size ||
+        this.nextNodeIndex !== thatImpl.nextNodeIndex ||
+        this.nextEdgeIndex !== thatImpl.nextEdgeIndex ||
         this.type !== thatImpl.type
       ) {
         return false
@@ -384,6 +386,8 @@ const ProtoGraph = {
     hash = hash ^ Hash.string(this.type)
     hash = hash ^ Hash.number(this.nodes.size)
     hash = hash ^ Hash.number(this.edges.size)
+    hash = hash ^ Hash.number(this.nextNodeIndex)
+    hash = hash ^ Hash.number(this.nextEdgeIndex)
     for (const [nodeIndex, nodeData] of this.nodes) {
       hash = hash ^ (Hash.hash(nodeIndex) + Hash.hash(nodeData))
     }

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -167,6 +167,73 @@ describe("Graph", () => {
       strictEqual(Equal.equals(left, right), false)
     })
 
+    it("compares future node allocation", () => {
+      const left = Graph.directed<string, string>()
+      const right = Graph.directed<string, string>((mutable) => {
+        const node = Graph.addNode(mutable, "removed")
+        Graph.removeNode(mutable, node)
+      })
+
+      strictEqual(Graph.nodeCount(left), Graph.nodeCount(right))
+      strictEqual(Graph.edgeCount(left), Graph.edgeCount(right))
+      strictEqual(Equal.equals(left, right), false)
+      strictEqual(Hash.hash(left) === Hash.hash(right), false)
+
+      let leftNode: Graph.NodeIndex | undefined
+      let rightNode: Graph.NodeIndex | undefined
+      Graph.mutate(left, (mutable) => {
+        leftNode = Graph.addNode(mutable, "next")
+      })
+      Graph.mutate(right, (mutable) => {
+        rightNode = Graph.addNode(mutable, "next")
+      })
+
+      strictEqual(leftNode, 0)
+      strictEqual(rightNode, 1)
+    })
+
+    it("compares future edge allocation", () => {
+      const left = makeGraph("directed", [])
+      const right = Graph.directed<string, string>((mutable) => {
+        const source = Graph.addNode(mutable, "A")
+        const target = Graph.addNode(mutable, "B")
+        const edge = Graph.addEdge(mutable, source, target, "removed")
+        Graph.removeEdge(mutable, edge)
+      })
+
+      assert.deepStrictEqual(Array.from(left), Array.from(right))
+      assert.deepStrictEqual(Array.from(Graph.edges(left)), Array.from(Graph.edges(right)))
+      strictEqual(Equal.equals(left, right), false)
+      strictEqual(Hash.hash(left) === Hash.hash(right), false)
+
+      let leftEdge: Graph.EdgeIndex | undefined
+      let rightEdge: Graph.EdgeIndex | undefined
+      Graph.mutate(left, (mutable) => {
+        leftEdge = Graph.addEdge(mutable, 0, 1, "next")
+      })
+      Graph.mutate(right, (mutable) => {
+        rightEdge = Graph.addEdge(mutable, 0, 1, "next")
+      })
+
+      strictEqual(leftEdge, 0)
+      strictEqual(rightEdge, 1)
+    })
+
+    it("preserves allocator equality and hashing through an empty mutation", () => {
+      const graph = Graph.directed<string, string>((mutable) => {
+        const source = Graph.addNode(mutable, "A")
+        const target = Graph.addNode(mutable, "B")
+        const removed = Graph.addNode(mutable, "removed")
+        Graph.removeNode(mutable, removed)
+        const edge = Graph.addEdge(mutable, source, target, "removed")
+        Graph.removeEdge(mutable, edge)
+      })
+      const clone = Graph.mutate(graph, () => {})
+
+      strictEqual(Equal.equals(graph, clone), true)
+      strictEqual(Hash.hash(graph), Hash.hash(clone))
+    })
+
     it("uses stable reference equality and hashing for mutable graphs", () => {
       const mutable = Graph.beginMutation(Graph.directed<string, string>())
       const initialHash = Hash.hash(mutable)


### PR DESCRIPTION
## Summary

- include immutable Graph node and edge allocator state in structural equality and hashing
- preserve mutable Graph reference equality and hashing from #6461
- cover divergent node and edge allocation histories plus allocator-preserving clones

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Graph.test.ts`
- `pnpm check`