### PR TITLE
Distribute HttpApiBuilder handler Requires markers per service

### DIFF
--- a/.changeset/httpapi-distribute-requires-markers.md
+++ b/.changeset/httpapi-distribute-requires-markers.md
@@ -1,0 +1,11 @@
+---
+"effect": patch
+---
+
+HttpApiBuilder: distribute handler `Requires` markers per service.
+
+`HandlerRequirements` emitted a single combined `HttpRouter.Request<"Requires", A | B>`
+marker when a handler needed multiple services. `HttpRouter` middleware layers provide
+distributed per-service markers (`Request.From<"Requires", Provides>`), so the combined
+marker could never be eliminated by `Layer.provide` and leaked into the route layer's
+requirements. Emitting `Request.From<"Requires", R>` restores the distributed shape.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -171,7 +171,7 @@ type HandlerRequirements<
 > =
   | HttpApiEndpoint.Middleware<Endpoint>
   | HttpApiEndpoint.MiddlewareServices<Endpoint>
-  | ([R] extends [never] ? never : HttpRouter.Request<"Requires", R>)
+  | HttpRouter.Request.From<"Requires", R>
 
 interface HandlerOptions {
   readonly uninterruptible?: boolean | undefined

--- a/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
@@ -110,6 +110,41 @@ describe("HttpApiBuilder", () => {
 
         expect<Layer.Services<typeof handlers>>().type.toBe<HttpRouterRequest<"Requires", UserRepository>>()
       })
+
+      it("distributes multi-service handler requirements into per-service markers", () => {
+        class UserRepository extends Context.Service<UserRepository, {}>()("UserRepository") {}
+        class UserPreferences extends Context.Service<UserPreferences, {}>()("UserPreferences") {}
+        const Api = HttpApi.make("api").add(
+          HttpApiGroup.make("users").add(
+            HttpApiEndpoint.get("getUser", "/users/:id", {
+              success: Schema.String
+            })
+          )
+        )
+
+        const handlers = HttpApiBuilder.group(
+          Api,
+          "users",
+          (handlers) =>
+            handlers.handle(
+              "getUser",
+              Effect.fnUntraced(function*() {
+                yield* UserRepository
+                yield* UserPreferences
+                return "user"
+              })
+            )
+        )
+
+        // A single combined marker would not be eliminated by middleware layers,
+        // which provide per-service markers via `Request.From<"Requires", Provides>`.
+        type Requirements =
+          | HttpRouterRequest<"Requires", UserRepository>
+          | HttpRouterRequest<"Requires", UserPreferences>
+
+        expect<Layer.Services<typeof handlers>>().type.toBeAssignableTo<Requirements>()
+        expect<Layer.Services<typeof handlers>>().type.toBeAssignableFrom<Requirements>()
+      })
     })
 
     describe("handleAll", () => {


### PR DESCRIPTION
Closes #6464.

## Summary

Since the `HttpApiBuilder` type-level rework (Effect-TS/effect-smol#2476, shipped in `effect@4.0.0-beta.98`), a handler that needs **multiple** services emits a single combined requirement marker:

```ts
HttpRouter.Request<"Requires", AuthDb | CurrentSession>
```

`HttpRouter` middleware layers, however, provide **distributed** per-service markers — `Middleware["layer"]` outputs `Request.From<"Requires", Provides>`, i.e. `Request<"Requires", AuthDb> | Request<"Requires", CurrentSession>`. `Layer.provide` can therefore never eliminate the combined marker, and it leaks into the route layer's requirements.

### Reproduction

```ts
const handlers = HttpApiBuilder.group(Api, "Images", (handlers) =>
  handlers.handle("uploadImage", ({ payload }) => handleUploadImage(payload)) // needs AuthDb and CurrentSession
)

HttpApiBuilder.layer(Api).pipe(
  Layer.provide(handlers),
  Layer.provide(authMiddleware.combine(servicesMiddleware).layer) // provides AuthDb and CurrentSession
)
// beta.97: Layer<never, never, HttpRouter>
// beta.98: Layer<never, never, HttpRouter | Request<"Requires", AuthDb | CurrentSession>>  ← leak
```

In beta.97, `handle` distributed the leftover requirements into per-service markers (via an unbracketed conditional over the inferred union), which matched what middleware layers provide.

### Fix

Emit `HttpRouter.Request.From<"Requires", R>` in `HandlerRequirements`, restoring the distributed shape. `Request.From` already resolves to `never` for `R = never`, so the previous `[R] extends [never]` guard is subsumed.

### Test

Added a typetest covering a handler that requires two services; it fails against current `main` (combined marker) and passes with the fix.

Found while validating the `beta.97 → beta.98` upgrade of a production Workers codebase, where every `HttpApiBuilder` group behind multi-service middleware stopped typechecking.

