### PR TITLE
Handle BigInt safely in Inspectable.stringifyCircular

### DIFF
--- a/.changeset/tidy-bigint-inspection.md
+++ b/.changeset/tidy-bigint-inspection.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Handle bigint values in circular JSON serialization.

--- a/packages/effect/src/Inspectable.ts
+++ b/packages/effect/src/Inspectable.ts
@@ -229,6 +229,8 @@ export const stringifyCircular = (obj: unknown, whitespace?: number | string | u
           : cache.push(value) && (redactableState.fiberRefs !== undefined && isRedactable(value)
             ? value[symbolRedactable](redactableState.fiberRefs)
             : value)
+        : typeof value === "bigint"
+        ? String(value) + "n"
         : value,
     whitespace
   )

--- a/packages/effect/test/Inspectable.test.ts
+++ b/packages/effect/test/Inspectable.test.ts
@@ -151,6 +151,12 @@ describe("Inspectable", () => {
     })
   })
 
+  describe("stringifyCircular", () => {
+    it("serializes bigint values", () => {
+      strictEqual(Inspectable.stringifyCircular({ value: 123n }), `{"value":"123n"}`)
+    })
+  })
+
   describe("toString", () => {
     it("primitives", () => {
       strictEqual(Inspectable.format(null), "null")


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Serialize bigint values encountered by `Inspectable.stringifyCircular` as their n-suffixed string representation instead of passing them to `JSON.stringify` unchanged.
- Add a regression test covering a bigint nested in an object.
- Add the required patch changeset for `effect`.

## Related

- Related Issue #4662
- Closes #4662

## Validation

- `pnpm test packages/effect/test/Inspectable.test.ts`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

## AI assistance

The implementation and pull request text were prepared with OpenAI Codex. No human code review was performed before submission.