### PR TITLE
Add DateTime.toEpochSeconds

### DIFF
--- a/.changeset/add-datetime-epoch-seconds.md
+++ b/.changeset/add-datetime-epoch-seconds.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `DateTime.toEpochSeconds` for whole Unix timestamps.

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -939,6 +939,14 @@ export const zonedOffsetIso: (self: Zoned) => string = Internal.zonedOffsetIso
 export const toEpochMillis: (self: DateTime) => number = Internal.toEpochMillis
 
 /**
+ * Get the whole seconds since the Unix epoch of a `DateTime`.
+ *
+ * @since 3.22.0
+ * @category conversions
+ */
+export const toEpochSeconds: (self: DateTime) => number = Internal.toEpochSeconds
+
+/**
  * Remove the time aspect of a `DateTime`, first adjusting for the time
  * zone. It will return a `DateTime.Utc` only containing the date.
  *

--- a/packages/effect/src/internal/dateTime.ts
+++ b/packages/effect/src/internal/dateTime.ts
@@ -614,6 +614,9 @@ export const zonedOffsetIso = (self: DateTime.Zoned): string => offsetToString(z
 export const toEpochMillis = (self: DateTime.DateTime): number => self.epochMillis
 
 /** @internal */
+export const toEpochSeconds = (self: DateTime.DateTime): number => Math.floor(self.epochMillis / 1000)
+
+/** @internal */
 export const removeTime = (self: DateTime.DateTime): DateTime.Utc =>
   withDate(self, (date) => {
     date.setUTCHours(0, 0, 0, 0)

--- a/packages/effect/test/DateTime.test.ts
+++ b/packages/effect/test/DateTime.test.ts
@@ -368,6 +368,16 @@ describe("DateTime", () => {
       ))
   })
 
+  describe("toEpochSeconds", () => {
+    it("converts milliseconds to whole seconds", () => {
+      strictEqual(DateTime.toEpochSeconds(DateTime.unsafeMake(1_999)), 1)
+    })
+
+    it("floors timestamps before the Unix epoch", () => {
+      strictEqual(DateTime.toEpochSeconds(DateTime.unsafeMake(-1)), -1)
+    })
+  })
+
   describe("removeTime", () => {
     it("removes time", () => {
       const dt = DateTime.unsafeMakeZoned("2024-01-01T01:00:00Z", {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `DateTime.toEpochSeconds` for obtaining whole seconds since the Unix epoch. The conversion floors the millisecond timestamp so instants before the epoch retain the conventional Unix timestamp semantics (for example, `-1` millisecond becomes `-1` second rather than `0`).

The change includes regression coverage for fractional positive and pre-epoch timestamps, along with the required patch changeset. It was validated with:

- `pnpm vitest packages/effect/test/DateTime.test.ts --run`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`
- `git diff --check`

Implementation prepared with OpenAI Codex. No human code review has been performed.

## Related

- Closes #6148
