### PR TITLE
Fix Cron.prev weekday wrapping

### DIFF
--- a/.changeset/fix-cron-prev-weekday-wrap.md
+++ b/.changeset/fix-cron-prev-weekday-wrap.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cron.prev` weekday wrapping to always return a matching instant before the input.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -884,7 +884,7 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
             const nextWeekday = table.weekday[currentWeekday]
             if (nextWeekday === undefined) {
               a = reverse ?
-                currentWeekday - 7 + boundary.weekday :
+                boundary.weekday - 7 - currentWeekday :
                 7 - currentWeekday + boundary.weekday
             } else {
               a = nextWeekday - currentWeekday

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -425,6 +425,30 @@ describe("Cron", () => {
     deepStrictEqual(prev(cron, sunday), new Date("2025-10-17T01:00:00.000Z"))
   })
 
+  it("prev wraps a later weekday into the previous week", () => {
+    const cron = Cron.parseUnsafe("0 0 * * SAT", DateTime.zoneMakeNamedUnsafe("UTC"))
+    const thursday = new Date("2025-10-23T12:00:00.000Z")
+    deepStrictEqual(prev(cron, thursday), new Date("2025-10-18T00:00:00.000Z"))
+  })
+
+  it("prev weekday wrapping returns matching instants strictly before the input", () => {
+    const cron = Cron.parseUnsafe("0 0 * * SAT", DateTime.zoneMakeNamedUnsafe("UTC"))
+    for (
+      const input of [
+        new Date("2025-10-19T12:00:00.000Z"),
+        new Date("2025-10-20T12:00:00.000Z"),
+        new Date("2025-10-21T12:00:00.000Z"),
+        new Date("2025-10-22T12:00:00.000Z"),
+        new Date("2025-10-23T12:00:00.000Z"),
+        new Date("2025-10-24T12:00:00.000Z")
+      ]
+    ) {
+      const result = prev(cron, input)
+      assertTrue(result < input)
+      assertTrue(Cron.match(cron, result))
+    }
+  })
+
   it("prev chooses the preferred occurrence in DST fall-back", () => {
     const make = (s: string): DateTime.Zoned => Option.getOrThrow(DateTime.makeZonedFromString(s))
     const cron = Cron.parseUnsafe("0 30 2 * * *", "Europe/Berlin")


### PR DESCRIPTION
## Summary

- fix reverse weekday wrapping in `Cron.prev` so it moves into the previous week
- add a SAT-from-Thursday regression test
- assert wrapped results match the cron and are strictly before the input
- add a patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cron.test.ts`
- `pnpm check`