### PR TITLE
Fix Cron.prev month day rollover

### DIFF
--- a/.changeset/fix-cron-prev-month-rollover.md
+++ b/.changeset/fix-cron-prev-month-rollover.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cron.prev` day-of-month rollover across shorter months and non-leap years.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -897,15 +897,19 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
             if (nextDay === undefined) {
               if (reverse) {
                 const previous = new Date(current)
-                while (true) {
+                let day: number | undefined
+                for (let i = 0; i < 2; i++) {
                   previous.setUTCDate(0)
-                  const day = table.day[previous.getUTCDate()]
+                  day = table.day[previous.getUTCDate()]
                   if (day !== undefined) {
-                    previous.setUTCDate(day)
-                    b = (previous.getTime() - current.getTime()) / 86_400_000
                     break
                   }
                 }
+                if (day === undefined) {
+                  throw new Error("Unable to find " + direction + " cron date")
+                }
+                previous.setUTCDate(day)
+                b = (previous.getTime() - current.getTime()) / 86_400_000
               } else {
                 b = daysInMonth(current) - currentDay + boundary.day
               }

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -897,6 +897,8 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
             if (nextDay === undefined) {
               if (reverse) {
                 const previous = new Date(current)
+                // Day zero is the previous month's last day. These two probes cover every
+                // valid day-of-month.
                 previous.setUTCDate(0)
                 let day = table.day[previous.getUTCDate()]
                 if (day === undefined) {

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -897,16 +897,14 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
             if (nextDay === undefined) {
               if (reverse) {
                 const previous = new Date(current)
-                let day: number | undefined
-                for (let i = 0; i < 2; i++) {
+                previous.setUTCDate(0)
+                let day = table.day[previous.getUTCDate()]
+                if (day === undefined) {
                   previous.setUTCDate(0)
                   day = table.day[previous.getUTCDate()]
-                  if (day !== undefined) {
-                    break
-                  }
                 }
                 if (day === undefined) {
-                  throw new Error("Unable to find " + direction + " cron date")
+                  throw new Error("Unable to find prev cron date")
                 }
                 previous.setUTCDate(day)
                 b = (previous.getTime() - current.getTime()) / 86_400_000

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -896,22 +896,15 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
             const nextDay = table.day[currentDay]
             if (nextDay === undefined) {
               if (reverse) {
-                let year = current.getUTCFullYear()
-                let month = current.getUTCMonth() - 1
-                let daysBack = currentDay
+                const previous = new Date(current)
                 while (true) {
-                  if (month < 0) {
-                    year--
-                    month = 11
-                  }
-                  const monthDays = daysInMonth(new Date(Date.UTC(year, month, 1)))
-                  const day = table.day[monthDays]
+                  previous.setUTCDate(0)
+                  const day = table.day[previous.getUTCDate()]
                   if (day !== undefined) {
-                    b = -(daysBack + monthDays - day)
+                    previous.setUTCDate(day)
+                    b = (previous.getTime() - current.getTime()) / 86_400_000
                     break
                   }
-                  daysBack += monthDays
-                  month--
                 }
               } else {
                 b = daysInMonth(current) - currentDay + boundary.day

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -796,6 +796,8 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
   const tick = reverse ? -1 : 1
   const table = cron[direction]
   const boundary = reverse ? cron.last : cron.first
+  const lastMatchingDayInMonth = (year: number, month: number): number | undefined =>
+    table.day[daysInMonth(new Date(Date.UTC(year, month, 1)))]
 
   const needsStep = reverse ?
     (next: number, current: number) => next < current :
@@ -896,10 +898,23 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
             const nextDay = table.day[currentDay]
             if (nextDay === undefined) {
               if (reverse) {
-                const prevMonthDays = daysInMonth(
-                  new Date(Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 0))
-                )
-                b = -(currentDay + (prevMonthDays - boundary.day))
+                let year = current.getUTCFullYear()
+                let month = current.getUTCMonth() - 1
+                let daysBack = currentDay
+                while (true) {
+                  if (month < 0) {
+                    year--
+                    month = 11
+                  }
+                  const monthDays = daysInMonth(new Date(Date.UTC(year, month, 1)))
+                  const day = table.day[monthDays]
+                  if (day !== undefined) {
+                    b = -(daysBack + monthDays - day)
+                    break
+                  }
+                  daysBack += monthDays
+                  month--
+                }
               } else {
                 b = daysInMonth(current) - currentDay + boundary.day
               }
@@ -925,6 +940,35 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
       if (cron.months.size !== 0) {
         const currentMonth = current.getUTCMonth() + 1
         const nextMonth = table.month[currentMonth]
+        if (reverse && cron.days.size !== 0 && cron.weekdays.size === 0 && nextMonth !== currentMonth) {
+          let year = current.getUTCFullYear()
+          let month = nextMonth === undefined ? boundary.month : nextMonth - 1
+          if (nextMonth === undefined) {
+            year--
+          }
+          let found = false
+          for (let i = 0; i < 400 * cron.months.size; i++) {
+            const day = lastMatchingDayInMonth(year, month)
+            if (day !== undefined) {
+              current.setUTCFullYear(year, month, day)
+              current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
+              adjustDst(current)
+              found = true
+              break
+            }
+            do {
+              month--
+              if (month < 0) {
+                year--
+                month = 11
+              }
+            } while (!cron.months.has(month + 1))
+          }
+          if (!found) {
+            throw new Error("Unable to find " + direction + " cron date")
+          }
+          continue
+        }
         const clampBoundaryDay = (targetMonthIndex: number): number => {
           if (cron.days.size !== 0 && cron.weekdays.size === 0) {
             return boundary.day

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -796,8 +796,6 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
   const tick = reverse ? -1 : 1
   const table = cron[direction]
   const boundary = reverse ? cron.last : cron.first
-  const lastMatchingDayInMonth = (year: number, month: number): number | undefined =>
-    table.day[daysInMonth(new Date(Date.UTC(year, month, 1)))]
 
   const needsStep = reverse ?
     (next: number, current: number) => next < current :
@@ -940,40 +938,11 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
       if (cron.months.size !== 0) {
         const currentMonth = current.getUTCMonth() + 1
         const nextMonth = table.month[currentMonth]
-        if (reverse && cron.days.size !== 0 && cron.weekdays.size === 0 && nextMonth !== currentMonth) {
-          let year = current.getUTCFullYear()
-          let month = nextMonth === undefined ? boundary.month : nextMonth - 1
-          if (nextMonth === undefined) {
-            year--
-          }
-          let found = false
-          for (let i = 0; i < 400 * cron.months.size; i++) {
-            const day = lastMatchingDayInMonth(year, month)
-            if (day !== undefined) {
-              current.setUTCFullYear(year, month, day)
-              current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
-              adjustDst(current)
-              found = true
-              break
-            }
-            do {
-              month--
-              if (month < 0) {
-                year--
-                month = 11
-              }
-            } while (!cron.months.has(month + 1))
-          }
-          if (!found) {
-            throw new Error("Unable to find " + direction + " cron date")
-          }
-          continue
-        }
         const clampBoundaryDay = (targetMonthIndex: number): number => {
-          if (cron.days.size !== 0 && cron.weekdays.size === 0) {
-            return boundary.day
-          }
           const maxDayInMonth = daysInMonth(new Date(Date.UTC(current.getUTCFullYear(), targetMonthIndex + 1, 0)))
+          if (cron.days.size !== 0 && cron.weekdays.size === 0) {
+            return reverse ? table.day[maxDayInMonth] ?? maxDayInMonth : boundary.day
+          }
           return reverse ? maxDayInMonth : 1
         }
         if (nextMonth === undefined) {

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -906,7 +906,7 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
                   day = table.day[previous.getUTCDate()]
                 }
                 if (day === undefined) {
-                  throw new Error("Unable to find prev cron date")
+                  throw new Error("Unable to find cron date")
                 }
                 previous.setUTCDate(day)
                 b = (previous.getTime() - current.getTime()) / 86_400_000
@@ -961,7 +961,7 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
       return
     }
 
-    throw new Error("Unable to find " + direction + " cron date")
+    throw new Error("Unable to find cron date")
   })
 
   return dateTime.toDateUtc(result)

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -468,6 +468,40 @@ describe("Cron", () => {
     deepStrictEqual(prev(cron, from), new Date("2024-01-31T00:00:00.000Z"))
   })
 
+  it("prev skips an invalid day in the immediately preceding month", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 31 * *", tz)
+    const from = new Date("2024-03-15T00:00:00.000Z")
+    deepStrictEqual(prev(cron, from), new Date("2024-01-31T00:00:00.000Z"))
+  })
+
+  it("prev finds the previous leap day", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 29 2 *", tz)
+    const from = new Date("2024-01-01T00:00:00.000Z")
+    deepStrictEqual(prev(cron, from), new Date("2020-02-29T00:00:00.000Z"))
+  })
+
+  it("prev day-of-month rollovers preserve match and ordering invariants", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cases = [
+      [Cron.parseUnsafe("0 0 31 * *", tz), new Date("2024-03-15T00:00:00.000Z")],
+      [Cron.parseUnsafe("0 0 29 2 *", tz), new Date("2024-01-01T00:00:00.000Z")]
+    ] as const
+
+    for (const [cron, from] of cases) {
+      const result = prev(cron, from)
+      assertTrue(Cron.match(cron, result))
+      assertTrue(result < from)
+    }
+  })
+
+  it("prev terminates for an impossible day and month combination", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 30 2 *", tz)
+    throws(() => prev(cron, new Date("2024-03-01T00:00:00.000Z")))
+  })
+
   it("prev clamps to the last valid day when rolling back a month with only month constraints", () => {
     const tz = DateTime.zoneMakeNamedUnsafe("UTC")
     const cron = Cron.parseUnsafe("0 0 0 * FEB *", tz)


### PR DESCRIPTION
## Summary

- skip invalid day-of-month values while traversing shorter previous months
- find previous restricted month/day combinations across non-leap years
- preserve strict ordering and matching invariants, with bounded handling for impossible combinations
- add a patch changeset for the runtime fix

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cron.test.ts`
- `pnpm check`