### PR TITLE
Fix Cron DST stepping

### DIFF
--- a/.changeset/fix-cron-dst-stepping.md
+++ b/.changeset/fix-cron-dst-stepping.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Cron.next` and `Cron.prev` to preserve strict ordering and return only matching occurrences across named time zone gaps and folds.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -801,21 +801,36 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
     (next: number, current: number) => next < current :
     (next: number, current: number) => next > current
 
-  const utc = tz !== undefined && dateTime.isTimeZoneNamed(tz) && tz.id === "UTC"
-  const adjustDst = utc ? constVoid : (current: Date) => {
-    const adjusted = dateTime.makeZonedUnsafe(current, {
+  const start = dateTime.toEpochMillis(zoned)
+  const result = dateTime.mutate(zoned, (current) => {
+    const earlier = dateTime.makeZonedUnsafe(current, {
       timeZone: zoned.zone,
       adjustForTimeZone: true,
-      disambiguation: reverse ? "later" : undefined
-    }).pipe(dateTime.toDate)
-
-    const drift = current.getTime() - adjusted.getTime()
-    if (reverse ? drift !== 0 : drift > 0) {
-      current.setTime(reverse ? adjusted.getTime() : current.getTime() + drift)
+      disambiguation: "earlier"
+    })
+    const later = dateTime.makeZonedUnsafe(current, {
+      timeZone: zoned.zone,
+      adjustForTimeZone: true,
+      disambiguation: "later"
+    })
+    const earlierTime = dateTime.toEpochMillis(earlier)
+    const laterTime = dateTime.toEpochMillis(later)
+    if (earlierTime !== laterTime && start === laterTime) {
+      const laterOffset = dateTime.zonedOffset(later)
+      let low = earlierTime
+      let high = laterTime
+      while (low + 1 < high) {
+        const middle = Math.floor((low + high) / 2)
+        const offset = dateTime.makeZonedUnsafe(middle, { timeZone: zoned.zone }).pipe(dateTime.zonedOffset)
+        if (offset === laterOffset) {
+          high = middle
+        } else {
+          low = middle
+        }
+      }
+      const foldStart = dateTime.makeZonedUnsafe(high, { timeZone: zoned.zone }).pipe(dateTime.toDate)
+      current.setTime(foldStart.getTime() + laterTime - earlierTime - (reverse ? 0 : 1_000))
     }
-  }
-
-  const result = dateTime.mutate(zoned, (current) => {
     current.setUTCSeconds(current.getUTCSeconds() + tick, 0)
 
     for (let i = 0; i < 10_000; i++) {
@@ -824,12 +839,10 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
         const nextSecond = table.second[currentSecond]
         if (nextSecond === undefined) {
           current.setUTCMinutes(current.getUTCMinutes() + tick, boundary.second)
-          adjustDst(current)
           continue
         }
         if (needsStep(nextSecond, currentSecond)) {
           current.setUTCSeconds(nextSecond)
-          adjustDst(current)
           continue
         }
       }
@@ -839,12 +852,10 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
         const nextMinute = table.minute[currentMinute]
         if (nextMinute === undefined) {
           current.setUTCHours(current.getUTCHours() + tick, boundary.minute, boundary.second)
-          adjustDst(current)
           continue
         }
         if (needsStep(nextMinute, currentMinute)) {
           current.setUTCMinutes(nextMinute, boundary.second)
-          adjustDst(current)
           continue
         }
       }
@@ -855,12 +866,10 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
         if (nextHour === undefined) {
           current.setUTCDate(current.getUTCDate() + tick)
           current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
-          adjustDst(current)
           continue
         }
         if (needsStep(nextHour, currentHour)) {
           current.setUTCHours(nextHour, boundary.minute, boundary.second)
-          adjustDst(current)
           continue
         }
       }
@@ -872,7 +881,6 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
           if (!matchesDay || !matchesWeekday) {
             current.setUTCDate(current.getUTCDate() + tick)
             current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
-            adjustDst(current)
             continue
           }
         } else {
@@ -916,7 +924,6 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
           if (addDays !== 0) {
             current.setUTCDate(current.getUTCDate() + addDays)
             current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
-            adjustDst(current)
             continue
           }
         }
@@ -936,19 +943,37 @@ const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, directio
           current.setUTCFullYear(current.getUTCFullYear() + tick)
           current.setUTCMonth(boundary.month, clampBoundaryDay(boundary.month))
           current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
-          adjustDst(current)
           continue
         }
         if (needsStep(nextMonth, currentMonth)) {
           const targetMonthIndex = nextMonth - 1
           current.setUTCMonth(targetMonthIndex, clampBoundaryDay(targetMonthIndex))
           current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
-          adjustDst(current)
           continue
         }
       }
 
-      return
+      const candidate = dateTime.makeZonedUnsafe(current, {
+        timeZone: zoned.zone,
+        adjustForTimeZone: true,
+        disambiguation: "earlier"
+      })
+      const candidateWallTime = dateTime.toDate(candidate).getTime()
+      if (candidateWallTime !== current.getTime()) {
+        const adjusted = reverse ? candidate : dateTime.makeZonedUnsafe(current, {
+          timeZone: zoned.zone,
+          adjustForTimeZone: true,
+          disambiguation: "later"
+        })
+        current.setTime(dateTime.toDate(adjusted).getTime())
+        continue
+      }
+
+      const candidateTime = dateTime.toEpochMillis(candidate)
+      if ((reverse ? candidateTime < start : candidateTime > start) && match(cron, candidate)) {
+        return
+      }
+      current.setUTCSeconds(current.getUTCSeconds() + tick, 0)
     }
 
     throw new Error("Unable to find " + direction + " cron date")

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -562,6 +562,75 @@ describe("Cron", () => {
     deepStrictEqual(next().pipe(DateTime.formatIsoZoned), e.pipe(DateTime.formatIsoZoned))
   })
 
+  it("skips nonexistent occurrences in named time zones", () => {
+    const cron = Cron.parseUnsafe("0 30 2 * * *", "Europe/Berlin")
+    const after = new Date("2024-03-30T02:30:00.000+01:00")
+    const result = next(cron, after)
+
+    deepStrictEqual(result, new Date("2024-04-01T02:30:00.000+02:00"))
+    assertTrue(result > after)
+    assertTrue(Cron.match(cron, result))
+  })
+
+  it("next remains strict when started in the second fall-back occurrence", () => {
+    const cron = Cron.parseUnsafe("0 30 2 * * *", "Europe/Berlin")
+    const after = new Date("2024-10-27T02:00:00.000+01:00")
+    const result = next(cron, after)
+
+    deepStrictEqual(result, new Date("2024-10-28T02:30:00.000+01:00"))
+    assertTrue(result > after)
+    assertTrue(Cron.match(cron, result))
+  })
+
+  it("prev finds preferred occurrences before the second fall-back occurrence", () => {
+    const cron = Cron.parseUnsafe("0 30 2 * * *", "Europe/Berlin")
+    const before = new Date("2024-10-27T02:00:00.000+01:00")
+    const result = prev(cron, before)
+
+    deepStrictEqual(result, new Date("2024-10-27T02:30:00.000+02:00"))
+    assertTrue(result < before)
+    assertTrue(Cron.match(cron, result))
+  })
+
+  it("prev skips nonexistent occurrences when traversing a spring gap", () => {
+    const cron = Cron.parseUnsafe("0 30 2 * * *", "Europe/Berlin")
+    const before = new Date("2024-03-31T03:00:00.000+02:00")
+    const result = prev(cron, before)
+
+    deepStrictEqual(result, new Date("2024-03-30T02:30:00.000+01:00"))
+    assertTrue(result < before)
+    assertTrue(Cron.match(cron, result))
+  })
+
+  it("handles large named-zone gaps and folds", () => {
+    const apia = Cron.parseUnsafe("0 0 12 * * *", "Pacific/Apia")
+    const beforeApiaGap = new Date("2011-12-29T12:00:00.000-10:00")
+    const afterApiaGap = new Date("2011-12-31T12:00:00.000+14:00")
+    const apiaNext = next(apia, beforeApiaGap)
+    const apiaPrev = prev(apia, afterApiaGap)
+
+    deepStrictEqual(apiaNext, afterApiaGap)
+    deepStrictEqual(apiaPrev, beforeApiaGap)
+    assertTrue(apiaNext > beforeApiaGap)
+    assertTrue(apiaPrev < afterApiaGap)
+    assertTrue(Cron.match(apia, apiaNext))
+    assertTrue(Cron.match(apia, apiaPrev))
+
+    const kwajalein = Cron.parseUnsafe("0 0 12 * * *", "Pacific/Kwajalein")
+    const secondFoldOccurrence = new Date("1969-09-30T01:00:00.000-12:00")
+    const kwajaleinNext = next(kwajalein, secondFoldOccurrence)
+
+    deepStrictEqual(kwajaleinNext, new Date("1969-10-01T12:00:00.000-12:00"))
+    assertTrue(kwajaleinNext > secondFoldOccurrence)
+    assertTrue(Cron.match(kwajalein, kwajaleinNext))
+
+    const everySecond = Cron.parseUnsafe("* * * * * *", "Pacific/Kwajalein")
+    const afterFold = next(everySecond, secondFoldOccurrence)
+    deepStrictEqual(afterFold, new Date("1969-10-01T00:00:00.000-12:00"))
+    assertTrue(afterFold > secondFoldOccurrence)
+    assertTrue(Cron.match(everySecond, afterFold))
+  })
+
   it("handles utc timezone", () => {
     const utc = DateTime.zoneMakeNamedUnsafe("UTC")
     const make = (date: string): DateTime.Zoned => Option.getOrThrow(DateTime.makeZonedFromString(date))


### PR DESCRIPTION
## Summary

- preserve strict instant ordering for `Cron.next` and `Cron.prev` across named-zone gaps and folds
- reject normalized wall times that do not match the schedule while retaining the preferred earlier fold occurrence
- handle starts in the second fold occurrence, including large historical offset transitions
- add focused Berlin, Apia, and Kwajalein regression and invariant coverage

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cron.test.ts`
- `pnpm check`