### PR TITLE
Validate Cron.make field restrictions

### DIFF
--- a/.changeset/fix-cron-make-validation.md
+++ b/.changeset/fix-cron-make-validation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Validate `Cron.make` field constraints and treat weekday `7` as Sunday consistently with cron parsing.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -365,12 +365,12 @@ export const make = (values: {
   readonly tz?: DateTime.TimeZone | undefined
 }): Cron => {
   const o: Mutable<Cron> = Object.create(CronProto)
-  o.seconds = makeRestrictions("seconds", values.seconds ?? [0], 0, 59)
-  o.minutes = makeRestrictions("minutes", values.minutes, 0, 59)
-  o.hours = makeRestrictions("hours", values.hours, 0, 23)
-  o.days = makeRestrictions("days", values.days, 1, 31)
-  o.months = makeRestrictions("months", values.months, 1, 12)
-  o.weekdays = makeRestrictions("weekdays", values.weekdays, 0, 7, (value) => value === 7 ? 0 : value)
+  o.seconds = restrictions.seconds(values.seconds ?? [0])
+  o.minutes = restrictions.minutes(values.minutes)
+  o.hours = restrictions.hours(values.hours)
+  o.days = restrictions.days(values.days)
+  o.months = restrictions.months(values.months)
+  o.weekdays = restrictions.weekdays(values.weekdays)
   o.and = values.and === true
   o.tz = Option.fromUndefinedOr(values.tz)
 
@@ -400,21 +400,21 @@ export const make = (values: {
   }
 
   o.next = {
-    second: lookupTable(seconds, 60, "next"),
-    minute: lookupTable(minutes, 60, "next"),
-    hour: lookupTable(hours, 24, "next"),
-    day: lookupTable(days, 32, "next"),
-    month: lookupTable(months, 13, "next"),
-    weekday: lookupTable(weekdays, 7, "next")
+    second: lookup.next.second(seconds),
+    minute: lookup.next.minute(minutes),
+    hour: lookup.next.hour(hours),
+    day: lookup.next.day(days),
+    month: lookup.next.month(months),
+    weekday: lookup.next.weekday(weekdays)
   }
 
   o.prev = {
-    second: lookupTable(seconds, 60, "prev"),
-    minute: lookupTable(minutes, 60, "prev"),
-    hour: lookupTable(hours, 24, "prev"),
-    day: lookupTable(days, 32, "prev"),
-    month: lookupTable(months, 13, "prev"),
-    weekday: lookupTable(weekdays, 7, "prev")
+    second: lookup.prev.second(seconds),
+    minute: lookup.prev.minute(minutes),
+    hour: lookup.prev.hour(hours),
+    day: lookup.prev.day(days),
+    month: lookup.prev.month(months),
+    weekday: lookup.prev.weekday(weekdays)
   }
 
   return o
@@ -422,26 +422,35 @@ export const make = (values: {
 
 const makeRestrictions = (
   field: string,
-  values: Iterable<number>,
   min: number,
   max: number,
   normalize: (value: number) => number = (value) => value
-): Set<number> => {
+): (values: Iterable<number>) => Set<number> =>
+(values) => {
   const restrictions: Array<number> = []
   for (const value of values) {
     if (!Number.isInteger(value) || value < min || value > max) {
-      throw new RangeError(`Cron.make: ${field} must contain only integers between ${min} and ${max}`)
+      throw new RangeError(`${field} must contain only integers between ${min} and ${max}`)
     }
     restrictions.push(normalize(value))
   }
   return new Set(Arr.sort(restrictions, N.Order))
 }
 
-const lookupTable = (
-  values: ReadonlyArray<number>,
+const restrictions = {
+  seconds: makeRestrictions("seconds", 0, 59),
+  minutes: makeRestrictions("minutes", 0, 59),
+  hours: makeRestrictions("hours", 0, 23),
+  days: makeRestrictions("days", 1, 31),
+  months: makeRestrictions("months", 1, 12),
+  weekdays: makeRestrictions("weekdays", 0, 7, (value) => value === 7 ? 0 : value)
+}
+
+const makeLookupTable = (
   size: number,
   dir: "next" | "prev"
-): Array<number | undefined> => {
+): (values: ReadonlyArray<number>) => Array<number | undefined> =>
+(values) => {
   const result = new Array(size).fill(undefined)
   if (values.length === 0) {
     return result
@@ -468,6 +477,25 @@ const lookupTable = (
   }
 
   return result
+}
+
+const lookup = {
+  prev: {
+    second: makeLookupTable(60, "prev"),
+    minute: makeLookupTable(60, "prev"),
+    hour: makeLookupTable(24, "prev"),
+    day: makeLookupTable(32, "prev"),
+    month: makeLookupTable(13, "prev"),
+    weekday: makeLookupTable(7, "prev")
+  },
+  next: {
+    second: makeLookupTable(60, "next"),
+    minute: makeLookupTable(60, "next"),
+    hour: makeLookupTable(24, "next"),
+    day: makeLookupTable(32, "next"),
+    month: makeLookupTable(13, "next"),
+    weekday: makeLookupTable(7, "next")
+  }
 }
 
 const CronParseErrorTypeId = "~effect/time/Cron/CronParseError"

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -257,7 +257,9 @@ export const isCron = (u: unknown): u is Cron => hasProperty(u, TypeId)
  * days, months, and weekdays the schedule should match. Empty arrays mean
  * "match all" for that time unit. When both days and weekdays are restricted,
  * the default matches either field; set `and: true` to require both fields to
- * match.
+ * match. Weekdays range from `0` (Sunday) to `7` (also Sunday). The constructor
+ * throws a `RangeError` when a field contains a non-integer or out-of-range
+ * value.
  *
  * **Example** (Creating schedules from constraints)
  *
@@ -363,12 +365,12 @@ export const make = (values: {
   readonly tz?: DateTime.TimeZone | undefined
 }): Cron => {
   const o: Mutable<Cron> = Object.create(CronProto)
-  o.seconds = new Set(Arr.sort(values.seconds ?? [0], N.Order))
-  o.minutes = new Set(Arr.sort(values.minutes, N.Order))
-  o.hours = new Set(Arr.sort(values.hours, N.Order))
-  o.days = new Set(Arr.sort(values.days, N.Order))
-  o.months = new Set(Arr.sort(values.months, N.Order))
-  o.weekdays = new Set(Arr.sort(values.weekdays, N.Order))
+  o.seconds = makeRestrictions("seconds", values.seconds ?? [0], 0, 59)
+  o.minutes = makeRestrictions("minutes", values.minutes, 0, 59)
+  o.hours = makeRestrictions("hours", values.hours, 0, 23)
+  o.days = makeRestrictions("days", values.days, 1, 31)
+  o.months = makeRestrictions("months", values.months, 1, 12)
+  o.weekdays = makeRestrictions("weekdays", values.weekdays, 0, 7, (value) => value === 7 ? 0 : value)
   o.and = values.and === true
   o.tz = Option.fromUndefinedOr(values.tz)
 
@@ -416,6 +418,23 @@ export const make = (values: {
   }
 
   return o
+}
+
+const makeRestrictions = (
+  field: string,
+  values: Iterable<number>,
+  min: number,
+  max: number,
+  normalize: (value: number) => number = (value) => value
+): Set<number> => {
+  const restrictions: Array<number> = []
+  for (const value of values) {
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new RangeError(`Cron.make: ${field} must contain only integers between ${min} and ${max}`)
+    }
+    restrictions.push(normalize(value))
+  }
+  return new Set(Arr.sort(restrictions, N.Order))
 }
 
 const lookupTable = (

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -235,6 +235,75 @@ describe("Cron", () => {
     deepStrictEqual(Cron.next(andCron, new Date("2024-01-02T00:00:00.000Z")), new Date("2024-04-01T00:00:00.000Z"))
   })
 
+  it("make validates field values and normalizes weekday 7", () => {
+    const make = (field: string, value: number) =>
+      Cron.make({
+        minutes: field === "minutes" ? [value] : [],
+        hours: field === "hours" ? [value] : [],
+        days: field === "days" ? [value] : [],
+        months: field === "months" ? [value] : [],
+        weekdays: field === "weekdays" ? [value] : [],
+        seconds: field === "seconds" ? [value] : []
+      })
+
+    for (
+      const [field, value] of [
+        ["seconds", 60],
+        ["minutes", -1],
+        ["hours", 24],
+        ["days", 0],
+        ["months", 13],
+        ["weekdays", 8],
+        ["seconds", 0.5],
+        ["minutes", NaN]
+      ] as const
+    ) {
+      throws(() => make(field, value), (error) => {
+        assertTrue(error instanceof RangeError)
+        return undefined
+      })
+    }
+
+    deepStrictEqual(
+      Cron.make({
+        minutes: [],
+        hours: [],
+        days: [],
+        months: [],
+        weekdays: [7]
+      }).weekdays,
+      new Set([0])
+    )
+  })
+
+  it("make treats weekday 7 as Sunday when matching", () => {
+    const cron = Cron.make({
+      minutes: [0],
+      hours: [0],
+      days: [],
+      months: [],
+      weekdays: [7],
+      tz: DateTime.zoneMakeNamedUnsafe("UTC")
+    })
+
+    assertTrue(Cron.match(cron, new Date("2024-01-07T00:00:00.000Z")))
+    assertFalse(Cron.match(cron, new Date("2024-01-08T00:00:00.000Z")))
+  })
+
+  it("make treats weekday 7 as Sunday when stepping", () => {
+    const cron = Cron.make({
+      minutes: [0],
+      hours: [0],
+      days: [],
+      months: [],
+      weekdays: [7],
+      tz: DateTime.zoneMakeNamedUnsafe("UTC")
+    })
+
+    deepStrictEqual(Cron.next(cron, new Date("2024-01-05T00:00:00.000Z")), new Date("2024-01-07T00:00:00.000Z"))
+    deepStrictEqual(Cron.prev(cron, new Date("2024-01-08T00:00:00.000Z")), new Date("2024-01-07T00:00:00.000Z"))
+  })
+
   it("match", () => {
     assertTrue(match("5 0 * 8 *", new Date("2024-08-01 00:05:00")))
     assertFalse(match("5 0 * 8 *", new Date("2024-09-01 00:05:00")))

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -264,16 +264,15 @@ describe("Cron", () => {
       })
     }
 
-    deepStrictEqual(
-      Cron.make({
-        minutes: [],
-        hours: [],
-        days: [],
-        months: [],
-        weekdays: [7]
-      }).weekdays,
-      new Set([0])
-    )
+    const normalized = Cron.make({
+      minutes: [],
+      hours: [],
+      days: [],
+      months: [],
+      weekdays: [7]
+    })
+    deepStrictEqual(normalized.seconds, new Set([0]))
+    deepStrictEqual(normalized.weekdays, new Set([0]))
   })
 
   it("make treats weekday 7 as Sunday when matching", () => {


### PR DESCRIPTION
## Summary

- validate explicit Cron field restrictions before building lookup tables
- normalize weekday `7` to Sunday (`0`) consistently with parsing
- add focused constructor, matching, and stepping coverage

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cron.test.ts`
- `pnpm check`