### PR TITLE
Fix Cron alias normalization

### DIFF
--- a/.changeset/cron-locale-independent-aliases.md
+++ b/.changeset/cron-locale-independent-aliases.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Normalize cron month and weekday aliases independently of the host locale.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -1262,7 +1262,7 @@ const splitRange = (input: string, aliases?: Record<string, number>): [number, n
 }
 
 function aliasOrValue(field: string, aliases?: Record<string, number>): number {
-  return aliases?.[field.toLocaleLowerCase()] ?? (decimalRegex.test(field) ? Number(field) : NaN)
+  return aliases?.[String.toLowerCase(field)] ?? (decimalRegex.test(field) ? Number(field) : NaN)
 }
 
 const decimalRegex = /^\d+$/

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, throws } from "@effect/vitest/utils"
 import { Cron, DateTime, Equal, Option, Result } from "effect"
 
@@ -189,26 +189,6 @@ describe("Cron", () => {
 
     const withoutTimeZone = Cron.parseUnsafe("23 0-20/2 * * *")
     assertTrue(Option.isNone(withoutTimeZone.tz))
-  })
-
-  it("normalizes month and weekday aliases without locale-sensitive casing", () => {
-    const toLocaleLowerCase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(() => {
-      throw new Error("Unexpected locale-sensitive normalization")
-    })
-    try {
-      deepStrictEqual(
-        Cron.parse("0 0 * JAN FRI"),
-        Result.succeed(Cron.make({
-          minutes: [0],
-          hours: [0],
-          days: [],
-          months: [1],
-          weekdays: [5]
-        }))
-      )
-    } finally {
-      toLocaleLowerCase.mockRestore()
-    }
   })
 
   it("parseUnsafe", () => {

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest"
+import { describe, it, vi } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, throws } from "@effect/vitest/utils"
 import { Cron, DateTime, Equal, Option, Result } from "effect"
 
@@ -189,6 +189,26 @@ describe("Cron", () => {
 
     const withoutTimeZone = Cron.parseUnsafe("23 0-20/2 * * *")
     assertTrue(Option.isNone(withoutTimeZone.tz))
+  })
+
+  it("normalizes month and weekday aliases without locale-sensitive casing", () => {
+    const toLocaleLowerCase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(() => {
+      throw new Error("Unexpected locale-sensitive normalization")
+    })
+    try {
+      deepStrictEqual(
+        Cron.parse("0 0 * JAN FRI"),
+        Result.succeed(Cron.make({
+          minutes: [0],
+          hours: [0],
+          days: [],
+          months: [1],
+          weekdays: [5]
+        }))
+      )
+    } finally {
+      toLocaleLowerCase.mockRestore()
+    }
   })
 
   it("parseUnsafe", () => {


### PR DESCRIPTION
## Summary

- normalize Cron month and weekday aliases with locale-independent casing
- add a patch changeset for the runtime behavior fix

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cron.test.ts`
- `pnpm check`