### PR TITLE
Fix Cron timezone equality

### DIFF
--- a/.changeset/fix-cron-timezone-hash.md
+++ b/.changeset/fix-cron-timezone-hash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make Cron equality and hashing include the optional timezone consistently.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -997,8 +997,7 @@ export const sequence = function*(cron: Cron, now?: DateTime.DateTime.Input): It
 }
 
 /**
- * Equivalence instance for comparing the field restrictions of two `Cron`
- * schedules.
+ * Equivalence instance for comparing two `Cron` schedules.
  *
  * **When to use**
  *
@@ -1007,8 +1006,8 @@ export const sequence = function*(cron: Cron, now?: DateTime.DateTime.Input): It
  *
  * **Details**
  *
- * This comparison checks seconds, minutes, hours, days, months, and weekdays.
- * It does not compare the optional timezone.
+ * This comparison checks the optional timezone, day matching mode, seconds,
+ * minutes, hours, days, months, and weekdays.
  *
  * **Example** (Comparing schedules with equivalence)
  *
@@ -1040,6 +1039,7 @@ export const sequence = function*(cron: Cron, now?: DateTime.DateTime.Input): It
  * @since 2.0.0
  */
 export const Equivalence: Equ.Equivalence<Cron> = Equ.make((self, that) =>
+  Equal.equals(self.tz, that.tz) &&
   self.and === that.and &&
   restrictionsEquals(self.seconds, that.seconds) &&
   restrictionsEquals(self.minutes, that.minutes) &&
@@ -1054,17 +1054,17 @@ const restrictionsEquals = (self: ReadonlySet<number>, that: ReadonlySet<number>
   restrictionsArrayEquals(Arr.fromIterable(self), Arr.fromIterable(that))
 
 /**
- * Checks whether two `Cron` instances have the same field restrictions.
+ * Checks whether two `Cron` instances have equal timezone values and field
+ * restrictions.
  *
  * **When to use**
  *
- * Use to directly compare whether two cron schedules have the same field
- * restrictions.
+ * Use to directly compare two cron schedules, including their timezones.
  *
  * **Details**
  *
- * The comparison checks seconds, minutes, hours, days, months, and weekdays.
- * It does not compare the optional timezone.
+ * The comparison checks the optional timezone, day matching mode, seconds,
+ * minutes, hours, days, months, and weekdays.
  *
  * **Example** (Checking schedule equality)
  *

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
-import { assertFalse, assertTrue, deepStrictEqual, throws } from "@effect/vitest/utils"
-import { Cron, DateTime, Equal, Option, Result } from "effect"
+import { assertFalse, assertTrue, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
+import { Cron, DateTime, Equal, Hash, HashSet, Option, Result } from "effect"
 
 const match = (input: Cron.Cron | string, date: DateTime.DateTime.Input) =>
   Cron.match(Cron.isCron(input) ? input : Cron.parseUnsafe(input), date)
@@ -494,8 +494,20 @@ describe("Cron", () => {
 
   it("equal", () => {
     const cron = Cron.parseUnsafe("23 0-20/2 * * 0")
+    const utc = Cron.parseUnsafe("23 0-20/2 * * 0", "UTC")
+    const anotherUtc = Cron.parseUnsafe("23 0-20/2 * * 0", "UTC")
+    const berlin = Cron.parseUnsafe("23 0-20/2 * * 0", "Europe/Berlin")
     assertTrue(Equal.equals(cron, cron))
     assertTrue(Equal.equals(cron, Cron.parseUnsafe("23 0-20/2 * * 0")))
+    assertTrue(Cron.equals(utc, anotherUtc))
+    assertTrue(Cron.Equivalence(utc, anotherUtc))
+    assertTrue(Equal.equals(utc, anotherUtc))
+    strictEqual(Hash.hash(utc), Hash.hash(anotherUtc))
+    strictEqual(HashSet.size(HashSet.make(cron, utc, anotherUtc, berlin)), 3)
+    assertFalse(Cron.equals(cron, utc))
+    assertFalse(Cron.Equivalence(utc, berlin))
+    assertFalse(Equal.equals(cron, utc))
+    assertFalse(Equal.equals(utc, berlin))
     assertFalse(Equal.equals(cron, Cron.parseUnsafe("23 0-20/2 * * 1")))
     assertFalse(Equal.equals(cron, Cron.parseUnsafe("23 0-20/2 * * 0-6")))
     assertFalse(Equal.equals(cron, Cron.parseUnsafe("23 0-20/2 1 * 0")))


### PR DESCRIPTION
## Summary

- include the optional timezone in `Cron.Equivalence` and `Cron.equals`
- keep protocol equality and hashing consistent for timezone-aware Cron values
- cover equal and differing zones, equal hashes, and `HashSet` behavior

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cron.test.ts`
- `pnpm check`