### PR TITLE
fix(openapi-generator): handle recursive schema forward references

### DIFF
--- a/.changeset/common-mammals-tickle.md
+++ b/.changeset/common-mammals-tickle.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Fix generation order for recursive schemas referenced by earlier recursive definitions, closes #6357.

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -285,12 +285,24 @@ function collectForwardReferencedRecursives(
   recursives: ReadonlyArray<readonly [string, SchemaRepresentation.Code]>
 ): Set<string> {
   const recursiveNames = new Set(recursives.map(([name]) => name))
+  const recursiveIndexes = new Map(recursives.map(([name], index) => [name, index]))
   const referenced = new Set<string>()
 
   for (const { code } of nonRecursives) {
     for (const token of code.runtime.matchAll(tokenPattern)) {
       const identifier = token[0]
       if (recursiveNames.has(identifier)) {
+        referenced.add(identifier)
+      }
+    }
+  }
+
+  for (let index = 0; index < recursives.length; index++) {
+    const [, code] = recursives[index]
+    for (const token of code.runtime.matchAll(tokenPattern)) {
+      const identifier = token[0]
+      const referencedIndex = recursiveIndexes.get(identifier)
+      if (referencedIndex !== undefined && referencedIndex > index) {
         referenced.add(identifier)
       }
     }

--- a/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts
@@ -115,6 +115,47 @@ export const A = B
 `)
   })
 
+  it("hoists recursive definitions referenced by earlier recursive definitions", () => {
+    const generator = JsonSchemaGenerator.make()
+    generator.addSchema("A", { $ref: "#/components/schemas/ResourcesNetworkCard" })
+    const definitions = {
+      ResourcesNetworkCard: {
+        type: "object",
+        properties: {
+          sriov: {
+            $ref: "#/components/schemas/ResourcesNetworkCardSRIOV"
+          }
+        },
+        additionalProperties: false
+      },
+      ResourcesNetworkCardSRIOV: {
+        type: "object",
+        properties: {
+          vfs: {
+            type: "array",
+            items: {
+              $ref: "#/components/schemas/ResourcesNetworkCard"
+            }
+          }
+        },
+        additionalProperties: false
+      }
+    }
+
+    const result = generator.generate("openapi-3.1", definitions, false)
+    const recursiveDeclaration =
+      "export const ResourcesNetworkCardSRIOV = Schema.suspend((): Schema.Codec<ResourcesNetworkCardSRIOV> => __recursive_ResourcesNetworkCardSRIOV)"
+
+    expect(result).toContain(recursiveDeclaration)
+    expect(result).toContain("const __recursive_ResourcesNetworkCardSRIOV =")
+    expect(result.indexOf(recursiveDeclaration)).toBeLessThan(
+      result.indexOf("export const ResourcesNetworkCard =")
+    )
+    expect(result.indexOf("export const ResourcesNetworkCard =")).toBeLessThan(
+      result.indexOf("const __recursive_ResourcesNetworkCardSRIOV =")
+    )
+  })
+
   it("renders recursive definitions before non-recursive references for runtime generation", () => {
     const generator = JsonSchemaGenerator.make()
     generator.addSchema("A", { $ref: "#/components/schemas/ErrorResponse" })


### PR DESCRIPTION
Fixes `@effect/openapi-generator` output for mutually recursive schemas where an earlier recursive definition eagerly references a later recursive definition during module initialization.

Extends the existing forward-reference handling to also account for references between recursive definitions, avoiding import-time `ReferenceError`s.

Closes #6357.

Migrated from Effect-TS/effect-smol#2165, which contains the original discussion and review history

Tested with:

- `pnpm lint-fix`
- `pnpm test packages/tools/openapi-generator/test/JsonSchemaGenerator.test.ts`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAPI schema generation ordering for recursive definitions, ensuring dependencies referenced by earlier recursive schemas are generated in the correct order.

* **Tests**
  * Added coverage for mutually related recursive schemas and verified their generated declaration order.

* **Release**
  * Scheduled a patch release for the OpenAPI generator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->