### PR TITLE
Fix fiber self-interuption from inside a running operation

### DIFF
--- a/.changeset/quiet-fibers-settle.md
+++ b/.changeset/quiet-fibers-settle.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Fix corruption of the fiber continuation stack when a fiber is interrupted synchronously while already mid-`runLoop` on the same call stack (e.g. `Fiber.runIn` against an already-closed `Scope`, from inside the fiber's own execution).
+
+Previously `interruptUnsafe` re-entered `evaluate`/`runLoop` recursively, running interrupt finalizers in the middle of the op that triggered the interrupt: an async `onInterrupt` finalizer would start before the triggering op had returned and everything past its first async boundary was silently dropped, while `Fiber.await` resolved as if finalization had completed.
+
+The interrupt is now recorded and delivered by the active run loop itself, before any continuation frame of the triggering op is consumed - preserving the existing interruption semantics (an interruptible acquisition is still aborted without running its release; an uninterruptible one still registers its finalizer) while finalizers now run exactly once, in order, and `Fiber.await` only resolves after they complete.

--- a/.changeset/quiet-fibers-settle.md
+++ b/.changeset/quiet-fibers-settle.md
@@ -2,8 +2,4 @@
 "effect": patch
 ---
 
-Fix corruption of the fiber continuation stack when a fiber is interrupted synchronously while already mid-`runLoop` on the same call stack (e.g. `Fiber.runIn` against an already-closed `Scope`, from inside the fiber's own execution).
-
-Previously `interruptUnsafe` re-entered `evaluate`/`runLoop` recursively, running interrupt finalizers in the middle of the op that triggered the interrupt: an async `onInterrupt` finalizer would start before the triggering op had returned and everything past its first async boundary was silently dropped, while `Fiber.await` resolved as if finalization had completed.
-
-The interrupt is now recorded and delivered by the active run loop itself, before any continuation frame of the triggering op is consumed - preserving the existing interruption semantics (an interruptible acquisition is still aborted without running its release; an uninterruptible one still registers its finalizer) while finalizers now run exactly once, in order, and `Fiber.await` only resolves after they complete.
+Fix fiber self-interuption from inside a running operation

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -502,17 +502,6 @@ const fiberIdStore = { id: 0 }
 /** @internal */
 export const getCurrentFiber = (): Fiber.Fiber<any, any> | undefined => (globalThis as any)[currentFiberTypeId]
 
-// returned by getCont when a deferred self-interrupt is pending, so the
-// interrupt preempts whatever continuation the completing op was about to run
-const deferredInterruptCont: any = {
-  [contA](_value: unknown, fiber: FiberImpl) {
-    return failCause(fiber._interruptedCause!)
-  },
-  [contE](_cause: unknown, fiber: FiberImpl) {
-    return failCause(fiber._interruptedCause!)
-  }
-}
-
 /** @internal */
 export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   constructor(
@@ -523,7 +512,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.setContext(context)
     this.id = ++fiberIdStore.id
     this.currentOpCount = 0
-    this.currentLoopCount = 0
     this.interruptible = interruptible
     this._stack = []
     this._observers = []
@@ -541,7 +529,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   readonly id: number
   interruptible: boolean
   currentOpCount: number
-  currentLoopCount: number
   readonly _stack: Array<Primitive>
   readonly _observers: Array<(exit: Exit.Exit<A, E>) => void>
   _exit: Exit.Exit<A, E> | undefined
@@ -601,9 +588,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       : cause
     if (this.interruptible) {
       if (this._running) {
-        // the fiber is mid-runLoop on this call stack; recursing into evaluate
-        // would corrupt the continuation stack, so let the active loop deliver
-        // the interrupt at the next op boundary
         this._deferredInterrupt = true
       } else {
         this.evaluate(failCause(this._interruptedCause) as any)
@@ -648,18 +632,11 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     let yielding = false
     let current: Primitive | Yield = effect
     this.currentOpCount = 0
-    const currentLoop = ++this.currentLoopCount
     try {
       while (true) {
         if (this._deferredInterrupt) {
-          // a self-interrupt arrived inside the previous op, which returned an
-          // effect without consulting the continuation stack; deliver before
-          // evaluating it so a not-yet-entered uninterruptible region stays
-          // unentered
           this._deferredInterrupt = false
-          if (this.interruptible) {
-            current = failCause(this._interruptedCause!) as any
-          }
+          current = failCause(this._interruptedCause!) as any
         }
         this.currentOpCount++
         if (
@@ -674,26 +651,16 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
         current = this.currentTracerContext
           ? this.currentTracerContext(current as any, this)
           : (current as any)[evaluate](this)
-        if (currentLoop !== this.currentLoopCount) {
-          // another effect has taken over the loop,
-          return Yield
-        } else if (current === Yield) {
+        if (current === Yield) {
           const yielded = this._yielded!
           if (ExitTypeId in yielded) {
             this._deferredInterrupt = false
             this._yielded = undefined
             return yielded
-          }
-          if (this._deferredInterrupt) {
-            this._deferredInterrupt = false
-            if (this.interruptible) {
-              // cancel the just-registered async callback and deliver the
-              // interrupt instead of suspending
-              this._yielded = undefined
-              ;(yielded as () => void)()
-              current = failCause(this._interruptedCause!) as any
-              continue
-            }
+          } else if (this._deferredInterrupt) {
+            this._yielded = undefined
+            yielded()
+            continue
           }
           return Yield
         }
@@ -713,15 +680,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     | undefined
   {
     if (this._deferredInterrupt) {
-      // an interrupt arrived mid-op on this call stack; deliver it before
-      // consuming any continuation frame, exactly as if it had preempted the
-      // op that triggered it - unless the fiber has since become
-      // uninterruptible, in which case `_interruptedCause` stays pending and
-      // is redelivered by setInterruptible on restore
       this._deferredInterrupt = false
-      if (this.interruptible) {
-        return deferredInterruptCont
-      }
+      return deferredInterruptCont
     }
     while (true) {
       const op = this._stack.pop()
@@ -763,6 +723,15 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   }
   get currentSpanLocal(): Tracer.Span | undefined {
     return this.currentSpan?._tag === "Span" ? this.currentSpan : undefined
+  }
+}
+
+const deferredInterruptCont: any = {
+  [contA](_value: unknown, fiber: FiberImpl) {
+    return failCause(fiber._interruptedCause!)
+  },
+  [contE](_cause: unknown, fiber: FiberImpl) {
+    return failCause(fiber._interruptedCause!)
   }
 }
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -502,6 +502,17 @@ const fiberIdStore = { id: 0 }
 /** @internal */
 export const getCurrentFiber = (): Fiber.Fiber<any, any> | undefined => (globalThis as any)[currentFiberTypeId]
 
+// returned by getCont when a deferred self-interrupt is pending, so the
+// interrupt preempts whatever continuation the completing op was about to run
+const deferredInterruptCont: any = {
+  [contA](_value: unknown, fiber: FiberImpl) {
+    return failCause(fiber._interruptedCause!)
+  },
+  [contE](_cause: unknown, fiber: FiberImpl) {
+    return failCause(fiber._interruptedCause!)
+  }
+}
+
 /** @internal */
 export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   constructor(
@@ -520,6 +531,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._children = undefined
     this._interruptedCause = undefined
     this._yielded = undefined
+    this._running = false
+    this._deferredInterrupt = false
     this.runtimeMetrics?.recordFiberStart(this.context)
   }
 
@@ -536,6 +549,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   _children: Set<FiberImpl<any, any>> | undefined
   _interruptedCause: Cause.Cause<never> | undefined
   _yielded: Exit.Exit<any, any> | (() => void) | undefined
+  _running: boolean
+  _deferredInterrupt: boolean
 
   // set in setContext
   context!: Context.Context<never>
@@ -585,7 +600,14 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       ? causeCombine(this._interruptedCause, cause)
       : cause
     if (this.interruptible) {
-      this.evaluate(failCause(this._interruptedCause) as any)
+      if (this._running) {
+        // the fiber is mid-runLoop on this call stack; recursing into evaluate
+        // would corrupt the continuation stack, so let the active loop deliver
+        // the interrupt at the next op boundary
+        this._deferredInterrupt = true
+      } else {
+        this.evaluate(failCause(this._interruptedCause) as any)
+      }
     }
   }
   pollUnsafe(): Exit.Exit<A, E> | undefined {
@@ -621,12 +643,24 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   runLoop(effect: Primitive): Exit.Exit<A, E> | Yield {
     const prevFiber = (globalThis as any)[currentFiberTypeId]
     ;(globalThis as any)[currentFiberTypeId] = this
+    const prevRunning = this._running
+    this._running = true
     let yielding = false
     let current: Primitive | Yield = effect
     this.currentOpCount = 0
     const currentLoop = ++this.currentLoopCount
     try {
       while (true) {
+        if (this._deferredInterrupt) {
+          // a self-interrupt arrived inside the previous op, which returned an
+          // effect without consulting the continuation stack; deliver before
+          // evaluating it so a not-yet-entered uninterruptible region stays
+          // unentered
+          this._deferredInterrupt = false
+          if (this.interruptible) {
+            current = failCause(this._interruptedCause!) as any
+          }
+        }
         this.currentOpCount++
         if (
           !yielding &&
@@ -646,8 +680,20 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
         } else if (current === Yield) {
           const yielded = this._yielded!
           if (ExitTypeId in yielded) {
+            this._deferredInterrupt = false
             this._yielded = undefined
             return yielded
+          }
+          if (this._deferredInterrupt) {
+            this._deferredInterrupt = false
+            if (this.interruptible) {
+              // cancel the just-registered async callback and deliver the
+              // interrupt instead of suspending
+              this._yielded = undefined
+              ;(yielded as () => void)()
+              current = failCause(this._interruptedCause!) as any
+              continue
+            }
           }
           return Yield
         }
@@ -658,6 +704,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       }
       return this.runLoop(exitDie(error) as any)
     } finally {
+      this._running = prevRunning
       ;(globalThis as any)[currentFiberTypeId] = prevFiber
     }
   }
@@ -665,6 +712,17 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     | (Primitive & Record<S, (value: any, fiber: FiberImpl) => Primitive>)
     | undefined
   {
+    if (this._deferredInterrupt) {
+      // an interrupt arrived mid-op on this call stack; deliver it before
+      // consuming any continuation frame, exactly as if it had preempted the
+      // op that triggered it - unless the fiber has since become
+      // uninterruptible, in which case `_interruptedCause` stays pending and
+      // is redelivered by setInterruptible on restore
+      this._deferredInterrupt = false
+      if (this.interruptible) {
+        return deferredInterruptCont
+      }
+    }
     while (true) {
       const op = this._stack.pop()
       if (!op) return undefined

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -58,12 +58,9 @@ describe("Fiber", () => {
     "delivers a synchronous self-interrupt instead of completing to success",
     () =>
       Effect.gen(function*() {
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
         const child = yield* Effect.gen(function*() {
           const self = Fiber.getCurrent()!
-          Fiber.runIn(self, closedScope)
+          self.interruptUnsafe()
           return 42
         }).pipe(Effect.forkChild({ startImmediately: true }))
 
@@ -72,172 +69,34 @@ describe("Fiber", () => {
       })
   )
 
-  describe("synchronous self-interrupt mid-runLoop", () => {
-    it.live("runs an async interrupt finalizer exactly once, in order", () =>
-      Effect.gen(function*() {
-        const events: Array<string> = []
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
+  it.effect("runs an async interrupt finalizer exactly once, in order", () =>
+    Effect.gen(function*() {
+      const events: Array<string> = []
 
-        const child = yield* Effect.gen(function*() {
-          const self = Fiber.getCurrent()!
-          yield* Effect.sync(() => {
-            Fiber.runIn(self, closedScope)
-            events.push("acquired")
-          }).pipe(
-            Effect.onInterrupt(() =>
-              Effect.sync(() => {
-                events.push("finalizer-start")
-              }).pipe(
-                Effect.andThen(Effect.sleep(10)),
-                Effect.andThen(Effect.sync(() => {
-                  events.push("finalizer-end")
-                }))
-              )
-            )
-          )
-          events.push("unreachable")
-        }).pipe(Effect.forkChild({ startImmediately: true }))
-
-        const exit = yield* Fiber.await(child)
-        events.push("awaited")
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.deepStrictEqual(events, ["acquired", "finalizer-start", "finalizer-end", "awaited"])
-      }))
-
-    it.effect("aborts an interruptible acquisition without running release", () =>
-      Effect.gen(function*() {
-        let released = false
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
-        const child = yield* Effect.gen(function*() {
-          const self = Fiber.getCurrent()!
-          yield* Effect.acquireRelease(
-            Effect.sync(() => {
-              Fiber.runIn(self, closedScope)
-              return "resource"
-            }),
-            () =>
-              Effect.sync(() => {
-                released = true
-              }),
-            { interruptible: true }
-          )
-        }).pipe(Effect.scoped, Effect.forkChild({ startImmediately: true }))
-
-        const exit = yield* Fiber.await(child)
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.isFalse(released)
-      }))
-
-    it.effect("runs release for an uninterruptible acquisition", () =>
-      Effect.gen(function*() {
-        let released = false
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
-        const child = yield* Effect.gen(function*() {
-          const self = Fiber.getCurrent()!
-          yield* Effect.acquireRelease(
-            Effect.sync(() => {
-              Fiber.runIn(self, closedScope)
-              return "resource"
-            }),
-            () =>
-              Effect.sync(() => {
-                released = true
-              })
-          )
-        }).pipe(Effect.scoped, Effect.forkChild({ startImmediately: true }))
-
-        const exit = yield* Fiber.await(child)
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.isTrue(released)
-      }))
-
-    it.effect("does not enter an uninterruptible region begun after the interrupt", () =>
-      Effect.gen(function*() {
-        const events: Array<string> = []
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
-        const child = yield* Effect.suspend(() => {
-          Fiber.runIn(Fiber.getCurrent()!, closedScope)
-          return Effect.uninterruptible(
-            Effect.sync(() => events.push("mask-1")).pipe(
-              Effect.flatMap(() => Effect.sync(() => events.push("mask-2")))
-            )
-          )
-        }).pipe(Effect.forkChild({ startImmediately: true }))
-
-        const exit = yield* Fiber.await(child)
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.deepStrictEqual(events, [])
-      }))
-
-    it.effect("wins over a failure returned by the same op", () =>
-      Effect.gen(function*() {
-        let recovered = false
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
-        const child = yield* Effect.suspend(() => {
-          Fiber.runIn(Fiber.getCurrent()!, closedScope)
-          return Effect.fail("boom")
-        }).pipe(
-          Effect.catch(() =>
-            Effect.sync(() => {
-              recovered = true
-            })
-          ),
-          Effect.forkChild({ startImmediately: true })
-        )
-
-        const exit = yield* Fiber.await(child)
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.isFalse(recovered)
-      }))
-
-    it.effect("wins over a defect thrown by the same op", () =>
-      Effect.gen(function*() {
-        let interrupted = false
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
-        const child = yield* Effect.sync(() => {
-          Fiber.runIn(Fiber.getCurrent()!, closedScope)
-          throw new Error("kaboom")
+      const child = yield* Effect.gen(function*() {
+        const self = Fiber.getCurrent()!
+        yield* Effect.suspend(() => {
+          self.interruptUnsafe()
+          events.push("acquired")
+          return Effect.void
         }).pipe(
           Effect.onInterrupt(() =>
             Effect.sync(() => {
-              interrupted = true
-            })
-          ),
-          Effect.forkChild({ startImmediately: true })
+              events.push("finalizer-start")
+            }).pipe(
+              Effect.tap(Effect.yieldNow),
+              Effect.tap(Effect.sync(() => {
+                events.push("finalizer-end")
+              }))
+            )
+          )
         )
+        events.push("unreachable")
+      }).pipe(Effect.forkChild({ startImmediately: true }))
 
-        const exit = yield* Fiber.await(child)
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.isTrue(interrupted)
-      }))
-
-    it.effect("cancels an async registration made by the interrupting op", () =>
-      Effect.gen(function*() {
-        let cleanups = 0
-        const closedScope = yield* Scope.make()
-        yield* Scope.close(closedScope, Exit.void)
-
-        const child = yield* Effect.callback<number>(() => {
-          Fiber.runIn(Fiber.getCurrent()!, closedScope)
-          return Effect.sync(() => {
-            cleanups++
-          })
-        }).pipe(Effect.forkChild({ startImmediately: true }))
-
-        const exit = yield* Fiber.await(child)
-        assert.isTrue(Exit.hasInterrupts(exit))
-        assert.strictEqual(cleanups, 1)
-      }))
-  })
+      const exit = yield* Fiber.await(child)
+      events.push("awaited")
+      assert.isTrue(Exit.hasInterrupts(exit))
+      assert.deepStrictEqual(events, ["acquired", "finalizer-start", "finalizer-end", "awaited"])
+    }))
 })

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -71,4 +71,173 @@ describe("Fiber", () => {
         assert.isTrue(Exit.hasInterrupts(exit))
       })
   )
+
+  describe("synchronous self-interrupt mid-runLoop", () => {
+    it.live("runs an async interrupt finalizer exactly once, in order", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.gen(function*() {
+          const self = Fiber.getCurrent()!
+          yield* Effect.sync(() => {
+            Fiber.runIn(self, closedScope)
+            events.push("acquired")
+          }).pipe(
+            Effect.onInterrupt(() =>
+              Effect.sync(() => {
+                events.push("finalizer-start")
+              }).pipe(
+                Effect.andThen(Effect.sleep(10)),
+                Effect.andThen(Effect.sync(() => {
+                  events.push("finalizer-end")
+                }))
+              )
+            )
+          )
+          events.push("unreachable")
+        }).pipe(Effect.forkChild({ startImmediately: true }))
+
+        const exit = yield* Fiber.await(child)
+        events.push("awaited")
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.deepStrictEqual(events, ["acquired", "finalizer-start", "finalizer-end", "awaited"])
+      }))
+
+    it.effect("aborts an interruptible acquisition without running release", () =>
+      Effect.gen(function*() {
+        let released = false
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.gen(function*() {
+          const self = Fiber.getCurrent()!
+          yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              Fiber.runIn(self, closedScope)
+              return "resource"
+            }),
+            () =>
+              Effect.sync(() => {
+                released = true
+              }),
+            { interruptible: true }
+          )
+        }).pipe(Effect.scoped, Effect.forkChild({ startImmediately: true }))
+
+        const exit = yield* Fiber.await(child)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.isFalse(released)
+      }))
+
+    it.effect("runs release for an uninterruptible acquisition", () =>
+      Effect.gen(function*() {
+        let released = false
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.gen(function*() {
+          const self = Fiber.getCurrent()!
+          yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              Fiber.runIn(self, closedScope)
+              return "resource"
+            }),
+            () =>
+              Effect.sync(() => {
+                released = true
+              })
+          )
+        }).pipe(Effect.scoped, Effect.forkChild({ startImmediately: true }))
+
+        const exit = yield* Fiber.await(child)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.isTrue(released)
+      }))
+
+    it.effect("does not enter an uninterruptible region begun after the interrupt", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.suspend(() => {
+          Fiber.runIn(Fiber.getCurrent()!, closedScope)
+          return Effect.uninterruptible(
+            Effect.sync(() => events.push("mask-1")).pipe(
+              Effect.flatMap(() => Effect.sync(() => events.push("mask-2")))
+            )
+          )
+        }).pipe(Effect.forkChild({ startImmediately: true }))
+
+        const exit = yield* Fiber.await(child)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.deepStrictEqual(events, [])
+      }))
+
+    it.effect("wins over a failure returned by the same op", () =>
+      Effect.gen(function*() {
+        let recovered = false
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.suspend(() => {
+          Fiber.runIn(Fiber.getCurrent()!, closedScope)
+          return Effect.fail("boom")
+        }).pipe(
+          Effect.catch(() =>
+            Effect.sync(() => {
+              recovered = true
+            })
+          ),
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        const exit = yield* Fiber.await(child)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.isFalse(recovered)
+      }))
+
+    it.effect("wins over a defect thrown by the same op", () =>
+      Effect.gen(function*() {
+        let interrupted = false
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.sync(() => {
+          Fiber.runIn(Fiber.getCurrent()!, closedScope)
+          throw new Error("kaboom")
+        }).pipe(
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              interrupted = true
+            })
+          ),
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        const exit = yield* Fiber.await(child)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.isTrue(interrupted)
+      }))
+
+    it.effect("cancels an async registration made by the interrupting op", () =>
+      Effect.gen(function*() {
+        let cleanups = 0
+        const closedScope = yield* Scope.make()
+        yield* Scope.close(closedScope, Exit.void)
+
+        const child = yield* Effect.callback<number>(() => {
+          Fiber.runIn(Fiber.getCurrent()!, closedScope)
+          return Effect.sync(() => {
+            cleanups++
+          })
+        }).pipe(Effect.forkChild({ startImmediately: true }))
+
+        const exit = yield* Fiber.await(child)
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.strictEqual(cleanups, 1)
+      }))
+  })
 })

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Latch, Scope } from "effect"
+import { Effect, Exit, Fiber, Latch } from "effect"
 
 describe("Fiber", () => {
   it("is a fiber", async () => {


### PR DESCRIPTION
- **fix(fiber): prevent evaluate reentrancy on synchronous self-interrupt**
- **wip**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred fiber self-interruptions while a fiber is actively running, then delivers the interruption at a safe execution point.
  * Ensured fibers don’t incorrectly complete to success when self-interrupted during execution.
  * Fixed interruption finalizer behavior so it runs exactly once and finishes in the expected order before awaiting completes.
* **Tests**
  * Updated fiber interrupt test coverage to reflect the new deferred-interruption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->