### PR TITLE
fix(cli): remove doubled Expected prefix from InvalidValue messages

### DIFF
--- a/.changeset/fix-invalid-value-doubled-expected.md
+++ b/.changeset/fix-invalid-value-doubled-expected.md
@@ -1,0 +1,25 @@
+---
+"effect": patch
+---
+
+Fix doubled `Expected: Expected ...` prefixes in CLI `InvalidValue` error messages, closes #6312.
+
+`Primitive.choice` now fails with a bare description of the accepted values, and `CliError.InvalidValue` no longer prepends its own `Expected:` label when the underlying failure message (e.g. a schema decode message) already reads as a complete `Expected ...` sentence.
+
+Before:
+
+```
+Invalid value for flag --size: "bogus". Expected: Expected "small" | "medium" | "large", got "bogus"
+```
+
+After:
+
+```
+Invalid value for flag --size: "bogus". Expected: "small" | "medium" | "large"
+```
+
+Schema-backed primitives (`integer`, `float`, `boolean`, `date`) keep their full schema decode sentence, so the decoded actual is still shown after `got`:
+
+```
+Invalid value for flag --count: "3.14". Expected an integer, got 3.14
+```

--- a/.changeset/fix-invalid-value-doubled-expected.md
+++ b/.changeset/fix-invalid-value-doubled-expected.md
@@ -3,23 +3,3 @@
 ---
 
 Fix doubled `Expected: Expected ...` prefixes in CLI `InvalidValue` error messages, closes #6312.
-
-`Primitive.choice` now fails with a bare description of the accepted values, and `CliError.InvalidValue` no longer prepends its own `Expected:` label when the underlying failure message (e.g. a schema decode message) already reads as a complete `Expected ...` sentence.
-
-Before:
-
-```text
-Invalid value for flag --size: "bogus". Expected: Expected "small" | "medium" | "large", got "bogus"
-```
-
-After:
-
-```text
-Invalid value for flag --size: "bogus". Expected: "small" | "medium" | "large"
-```
-
-Schema-backed primitives (`integer`, `float`, `boolean`, `date`) keep their full schema decode sentence, so the decoded actual is still shown after `got`:
-
-```text
-Invalid value for flag --count: "3.14". Expected an integer, got 3.14
-```

--- a/.changeset/fix-invalid-value-doubled-expected.md
+++ b/.changeset/fix-invalid-value-doubled-expected.md
@@ -8,18 +8,18 @@ Fix doubled `Expected: Expected ...` prefixes in CLI `InvalidValue` error messag
 
 Before:
 
-```
+```text
 Invalid value for flag --size: "bogus". Expected: Expected "small" | "medium" | "large", got "bogus"
 ```
 
 After:
 
-```
+```text
 Invalid value for flag --size: "bogus". Expected: "small" | "medium" | "large"
 ```
 
 Schema-backed primitives (`integer`, `float`, `boolean`, `date`) keep their full schema decode sentence, so the decoded actual is still shown after `got`:
 
-```
+```text
 Invalid value for flag --count: "3.14". Expected an integer, got 3.14
 ```

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -359,16 +359,25 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
   /**
    * Formats the invalid flag or argument value with the expected input.
    *
+   * **Details**
+   *
+   * When `expected` is already a complete `Expected ...` sentence (e.g. a
+   * schema decode message), it is appended as-is instead of being prefixed
+   * with another `Expected:` label.
+   *
    * @since 4.0.0
    */
   override get message() {
+    const expectation = this.expected.startsWith("Expected ")
+      ? this.expected
+      : `Expected: ${this.expected}`
     if (this.kind === "argument") {
-      return `Invalid value for argument <${this.option}>: "${this.value}". Expected: ${this.expected}`
+      return `Invalid value for argument <${this.option}>: "${this.value}". ${expectation}`
     }
     if (this.value.length === 0) {
-      return `Missing value for flag --${this.option}. Expected: ${this.expected}`
+      return `Missing value for flag --${this.option}. ${expectation}`
     }
-    return `Invalid value for flag --${this.option}: "${this.value}". Expected: ${this.expected}`
+    return `Invalid value for flag --${this.option}: "${this.value}". ${expectation}`
   }
 }
 

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -359,12 +359,6 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
   /**
    * Formats the invalid flag or argument value with the expected input.
    *
-   * **Details**
-   *
-   * When `expected` is already a complete `Expected ...` sentence (e.g. a
-   * schema decode message), it is appended as-is instead of being prefixed
-   * with another `Expected:` label.
-   *
    * @since 4.0.0
    */
   override get message() {

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -368,7 +368,7 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
    * @since 4.0.0
    */
   override get message() {
-    const expectation = this.expected.startsWith("Expected ")
+    const expectation = this.expected.startsWith("Expected ") || this.expected.startsWith("Expected:")
       ? this.expected
       : `Expected: ${this.expected}`
     if (this.kind === "argument") {

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -304,7 +304,7 @@ export const choice = <A>(
     if (choiceMap.has(value)) {
       return Effect.succeed(choiceMap.get(value)!)
     }
-    return Effect.fail(`Expected ${validChoices}, got ${format(value)}`)
+    return Effect.fail(validChoices)
   })
   return Object.assign(primitive, { choiceKeys: choices.map(([key]) => key) })
 }

--- a/packages/effect/test/unstable/cli/Arguments.test.ts
+++ b/packages/effect/test/unstable/cli/Arguments.test.ts
@@ -156,7 +156,7 @@ describe("Command arguments", () => {
       expect(errorText).toMatchInlineSnapshot(`
         "
         ERROR
-          Invalid value for argument <count>: "not-a-number". Expected: Failed to parse integer: Expected an integer, got NaN"
+          Invalid value for argument <count>: "not-a-number". Expected a string representing a finite number, got "not-a-number""
       `)
     }).pipe(Effect.provide(TestLayer)))
 

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -271,6 +271,27 @@ describe("Command", () => {
         }).pipe(Effect.provide(TestLayer)))
     }
 
+    it.effect("should render invalid choice values without doubling the Expected prefix", () =>
+      Effect.gen(function*() {
+        let invoked = false
+        const command = Command.make("demo", {
+          size: Flag.choice("size", ["small", "medium", "large"])
+        }, () =>
+          Effect.sync(() => {
+            invoked = true
+          }))
+
+        yield* Command.runWith(command, { version: "1.0.0" })(["--size", "bogus"]).pipe(Effect.ignore)
+
+        const stderr = yield* TestConsole.errorLines
+        assert.isFalse(invoked)
+        assert.isTrue(
+          stderr.some((line) =>
+            String(line).includes(`Invalid value for flag --size: "bogus". Expected: "small" | "medium" | "large"`)
+          )
+        )
+      }).pipe(Effect.provide(TestLayer)))
+
     it.effect("should execute handler with parsed config", () =>
       Effect.gen(function*() {
         const path = yield* Path.Path

--- a/packages/effect/test/unstable/cli/Errors.test.ts
+++ b/packages/effect/test/unstable/cli/Errors.test.ts
@@ -188,5 +188,19 @@ describe("Command errors", () => {
         `Invalid value for flag --count: "x". Expected: an integer`
       )
     })
+
+    it("does not double the prefix for a missing flag value", () => {
+      const error = new CliError.InvalidValue({
+        option: "count",
+        value: "",
+        expected: `Expected a string representing a finite number, got ""`,
+        kind: "flag"
+      })
+
+      assert.strictEqual(
+        error.message,
+        `Missing value for flag --count. Expected a string representing a finite number, got ""`
+      )
+    })
   })
 })

--- a/packages/effect/test/unstable/cli/Errors.test.ts
+++ b/packages/effect/test/unstable/cli/Errors.test.ts
@@ -147,4 +147,34 @@ describe("Command errors", () => {
       assert.strictEqual(output, "")
     })
   })
+
+  describe("InvalidValue", () => {
+    it("labels a bare expected description", () => {
+      const error = new CliError.InvalidValue({
+        option: "size",
+        value: "bogus",
+        expected: `"small" | "medium" | "large"`,
+        kind: "flag"
+      })
+
+      assert.strictEqual(
+        error.message,
+        `Invalid value for flag --size: "bogus". Expected: "small" | "medium" | "large"`
+      )
+    })
+
+    it("does not double the prefix for an Expected sentence", () => {
+      const error = new CliError.InvalidValue({
+        option: "count",
+        value: "3.14",
+        expected: "Expected an integer, got 3.14",
+        kind: "argument"
+      })
+
+      assert.strictEqual(
+        error.message,
+        `Invalid value for argument <count>: "3.14". Expected an integer, got 3.14`
+      )
+    })
+  })
 })

--- a/packages/effect/test/unstable/cli/Errors.test.ts
+++ b/packages/effect/test/unstable/cli/Errors.test.ts
@@ -175,6 +175,18 @@ describe("Command errors", () => {
         error.message,
         `Invalid value for argument <count>: "3.14". Expected an integer, got 3.14`
       )
+
+      const labeled = new CliError.InvalidValue({
+        option: "count",
+        value: "x",
+        expected: "Expected: an integer",
+        kind: "flag"
+      })
+
+      assert.strictEqual(
+        labeled.message,
+        `Invalid value for flag --count: "x". Expected: an integer`
+      )
     })
   })
 })

--- a/packages/effect/test/unstable/cli/Primitive.test.ts
+++ b/packages/effect/test/unstable/cli/Primitive.test.ts
@@ -214,9 +214,9 @@ describe("Primitive", () => {
           colorChoice,
           ["yellow", "purple", ""],
           [
-            `Expected "red" | "green" | "blue", got "yellow"`,
-            `Expected "red" | "green" | "blue", got "purple"`,
-            `Expected "red" | "green" | "blue", got ""`
+            `"red" | "green" | "blue"`,
+            `"red" | "green" | "blue"`,
+            `"red" | "green" | "blue"`
           ]
         ))
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`CliError.InvalidValue.message` rendered a doubled `Expected: Expected ...` prefix for values backed by `Primitive.choice` or the schema backed primitives (`integer`, `float`, `boolean`, `date`), and for choices it also repeated the offending value twice.

Before:

```
Invalid value for flag --size: "bogus". Expected: Expected "small" | "medium" | "large", got "bogus"
```

After:

```
Invalid value for flag --size: "bogus". Expected: "small" | "medium" | "large"
Invalid value for argument <count>: "3.14". Expected an integer, got 3.14
```

This combines both directions suggested in the issue:

1. `Primitive.choice` now fails with a bare description of the accepted values. The offending value and the `Expected:` label are added by `InvalidValue.message`, so the value is no longer shown twice.
2. `InvalidValue.message` only prepends its `Expected:` label when `expected` does not already start with `Expected ` or `Expected:`. Failure texts that are already complete sentences (schema decode messages, user supplied strings like the `Param.filter` doc examples) are appended as their own sentence instead of being double labeled.

The schema backed primitives keep their full schema decode sentence. Extracting a bare expected description from a schema issue would mean duplicating the `SchemaIssue` formatter traversal inside the CLI package, because the `AnyOf` branch of the default formatter hardcodes the `Expected X, got Y` sentence and is not reachable through the `leafHook`/`checkHook` extension points. The decoded actual after `got` is also genuinely informative when it differs from the raw input (`got Invalid Date`, `got NaN`).

Tests: updated the `Primitive.choice` assertions, added unit coverage for both `InvalidValue.message` branches, added a test asserting the rendered stderr line through `Command.runWith`, and corrected a stale inline snapshot in `Arguments.test.ts` that encoded wording which no longer exists in the codebase.

## Related

Closes Effect-TS/effect#6312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI invalid-value and missing-value error formatting to avoid duplicated “Expected” prefixes.
  * Improved invalid-choice error output to focus on the allowed options without repeating the invalid “got” framing.
  * Standardized CLI argument/flag validation wording for more consistent messaging.
* **Tests**
  * Expanded CLI test coverage for invalid value, invalid choice, and argument/primitive parsing error messages.
* **Documentation**
  * Updated the release notes entry describing the corrected “Expected” prefix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->