### PR TITLE
Preserve nested class construction when applying constructor defaults, closes #6491

### DIFF
--- a/.changeset/fix-6491.md
+++ b/.changeset/fix-6491.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve nested class construction when applying constructor defaults, closes #6491.

--- a/packages/effect/src/SchemaParser.ts
+++ b/packages/effect/src/SchemaParser.ts
@@ -23,13 +23,15 @@ import type * as Schema from "./Schema.ts"
 import * as SchemaAST from "./SchemaAST.ts"
 import * as SchemaIssue from "./SchemaIssue.ts"
 
-const recurDefaults = memoize((ast: SchemaAST.AST): SchemaAST.AST => {
+// Converts a type-side AST into its constructor form by recursively restoring
+// constructor encodings for nested classes and fields with constructor defaults.
+const toConstructorAST = memoize((ast: SchemaAST.AST): SchemaAST.AST => {
   switch (ast._tag) {
     case "Declaration": {
       const getLink = ast.annotations?.[SchemaAST.ClassTypeId]
       if (Predicate.isFunction(getLink)) {
         const link = getLink(ast.typeParameters)
-        const to = recurDefaults(link.to)
+        const to = toConstructorAST(link.to)
         return SchemaAST.replaceEncoding(ast, to === link.to ? [link] : [new SchemaAST.Link(to, link.transformation)])
       }
       return ast
@@ -39,12 +41,13 @@ const recurDefaults = memoize((ast: SchemaAST.AST): SchemaAST.AST => {
       return ast.recur((ast) => {
         const defaultValue = ast.context?.defaultValue
         if (defaultValue) {
-          return SchemaAST.replaceEncoding(recurDefaults(ast), defaultValue)
+          const out = toConstructorAST(ast)
+          return SchemaAST.replaceEncoding(out, out.encoding ? [...out.encoding, ...defaultValue] : defaultValue)
         }
-        return recurDefaults(ast)
+        return toConstructorAST(ast)
       })
     case "Suspend":
-      return ast.recur(recurDefaults)
+      return ast.recur(toConstructorAST)
     default:
       return ast
   }
@@ -68,7 +71,7 @@ const recurDefaults = memoize((ast: SchemaAST.AST): SchemaAST.AST => {
  * @since 4.0.0
  */
 export function makeEffect<S extends Schema.Constraint>(schema: S) {
-  const ast = recurDefaults(SchemaAST.toType(schema.ast))
+  const ast = toConstructorAST(SchemaAST.toType(schema.ast))
   const parser = run<S["Type"], never>(ast)
   return (input: S["~type.make.in"], options?: Schema.MakeOptions): Effect.Effect<S["Type"], SchemaIssue.Issue> => {
     return parser(

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3539,6 +3539,16 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
         await make.succeed({}, { a: -1 })
       })
 
+      it("should construct a Class field from a plain object", () => {
+        class A extends Schema.Class<A>("A")({ a: Schema.String }) {}
+        const schema = Schema.Struct({
+          a: A.pipe(Schema.withConstructorDefault(Effect.succeed(A.make({ a: "default" }))))
+        })
+
+        const result = schema.make({ a: { a: "a" } })
+        assertTrue(result.a instanceof A)
+      })
+
       describe("nested defaults", () => {
         it("Struct", async () => {
           const schema = Schema.Struct({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved nested class construction when applying constructor defaults.
  * Schema fields with constructor defaults now correctly produce class instances from plain object input.

* **Tests**
  * Added coverage for constructing nested schema classes with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->