### PR TITLE
Route multipart errors to HTTP responses

### DIFF
--- a/.changeset/quiet-pandas-respond.md
+++ b/.changeset/quiet-pandas-respond.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make multipart errors respond with an HTTP status based on their reason and ignore them in the error reporter.

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -16,6 +16,7 @@ import * as Channel from "../../Channel.ts"
 import * as Context from "../../Context.ts"
 import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
+import * as ErrorReporter from "../../ErrorReporter.ts"
 import * as Exit from "../../Exit.ts"
 import * as FileSystem from "../../FileSystem.ts"
 import { constant, dual } from "../../Function.ts"
@@ -31,6 +32,8 @@ import type * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 import * as UndefinedOr from "../../UndefinedOr.ts"
 import * as IncomingMessage from "./HttpIncomingMessage.ts"
+import * as HttpServerRespondable from "./HttpServerRespondable.ts"
+import * as HttpServerResponse from "./HttpServerResponse.ts"
 import * as MP from "./Multipasta.ts"
 
 /**
@@ -199,19 +202,30 @@ export class MultipartErrorReason extends Data.Error<{
   readonly cause?: unknown
 }> {}
 
+const responseStatusByReason = {
+  FileTooLarge: 413,
+  FieldTooLarge: 413,
+  BodyTooLarge: 413,
+  TooManyParts: 413,
+  InternalError: 500,
+  Parse: 400
+} as const satisfies Record<MultipartErrorReason["_tag"], number>
+
 /**
  * Error raised while parsing, streaming, or persisting multipart form data.
  *
  * **Details**
  *
- * The `reason` field contains the concrete `MultipartErrorReason`.
+ * The `reason` field contains the concrete `MultipartErrorReason`. When used as
+ * a server response, parse errors render as `400`, limit errors as `413`, and
+ * internal errors as `500`. Multipart errors are ignored by the error reporter.
  *
  * @category errors
  * @since 4.0.0
  */
 export class MultipartError extends Data.TaggedError("MultipartError")<{
   readonly reason: MultipartErrorReason
-}> {
+}> implements HttpServerRespondable.Respondable {
   /**
    * Creates a multipart error from a reason tag and optional cause.
    *
@@ -227,6 +241,22 @@ export class MultipartError extends Data.TaggedError("MultipartError")<{
    * @since 4.0.0
    */
   readonly [MultipartErrorTypeId] = MultipartErrorTypeId
+
+  override readonly [ErrorReporter.ignore] = true;
+
+  /**
+   * Converts the multipart error into an HTTP response based on its reason.
+   *
+   * **Details**
+   *
+   * Parse errors produce `400`, size and part-count limits produce `413`, and
+   * internal errors produce `500`.
+   *
+   * @since 4.0.0
+   */
+  [HttpServerRespondable.symbol]() {
+    return Effect.succeed(HttpServerResponse.empty({ status: responseStatusByReason[this.reason._tag] }))
+  }
 
   /**
    * Uses the concrete multipart error reason as the public message.

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, identity, Schema, Stream, Unify } from "effect"
+import { Effect, ErrorReporter, identity, Schema, Stream, Unify } from "effect"
 import { Multipart } from "effect/unstable/http"
+import * as HttpServerRespondable from "effect/unstable/http/HttpServerRespondable"
 import { deepStrictEqual, strictEqual } from "node:assert"
 
 describe("Multipart", () => {
@@ -57,6 +58,26 @@ describe("Multipart", () => {
 
       strictEqual(error._tag, "MultipartError")
       strictEqual(error.reason._tag, "TooManyParts")
+    }))
+
+  it.effect("responds based on the reason and is ignored by the ErrorReporter", () =>
+    Effect.gen(function*() {
+      const cases = [
+        ["FileTooLarge", 413],
+        ["FieldTooLarge", 413],
+        ["BodyTooLarge", 413],
+        ["TooManyParts", 413],
+        ["InternalError", 500],
+        ["Parse", 400]
+      ] as const
+
+      for (const [reason, status] of cases) {
+        const error = Multipart.MultipartError.fromReason(reason)
+        const response = yield* HttpServerRespondable.toResponse(error)
+
+        strictEqual(response.status, status)
+        strictEqual(ErrorReporter.isIgnored(error), true)
+      }
     }))
 
   describe("FileSchema", () => {


### PR DESCRIPTION
## Summary
- Map `MultipartError` reasons to HTTP responses: parse failures return `400`, limit-related errors return `413`, and internal errors return `500`.
- Mark multipart errors as ignored by the error reporter so they do not surface as reportable application errors.
- Add coverage for the response status mapping and error-reporter behavior in multipart tests.

## Testing
- `Not run`
- Added unit coverage in `packages/effect/test/unstable/http/Multipart.test.ts` for all multipart error reasons.
- Verified the new change is captured in a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart errors now return HTTP responses with status codes appropriate to their cause, including bad request, payload too large, and internal server error.
  * Multipart errors are no longer reported by the error reporter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->