### PR TITLE
only interrupt cache lookup when all awaiters are gone

### DIFF
--- a/.changeset/tangy-plants-run.md
+++ b/.changeset/tangy-plants-run.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+only interrupt cache lookup when all awaiters are gone

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -9,7 +9,6 @@
  * @since 4.0.0
  */
 import * as Context from "./Context.ts"
-import * as Deferred from "./Deferred.ts"
 import * as Duration from "./Duration.ts"
 import type * as Effect from "./Effect.ts"
 import type * as Exit from "./Exit.ts"
@@ -129,7 +128,9 @@ export interface Cache<in out Key, in out A, in out E = never, out R = never> ex
  */
 export interface Entry<A, E> {
   expiresAt: number | undefined
-  readonly deferred: Deferred.Deferred<A, E>
+  awaiters: number
+  readonly fiber: Fiber.Fiber<A, E>
+  await(this: Entry<A, E>): Effect.Effect<A, E>
 }
 
 /**
@@ -407,29 +408,47 @@ export const get: {
         // Move the entry to the end of the map to keep it fresh
         MutableHashMap.remove(self.map, key)
         MutableHashMap.set(self.map, key, oentry.value)
-        return Deferred.await(oentry.value.deferred)
+        return oentry.value.await()
       }
-      const deferred = Deferred.makeUnsafe<A, E>()
-      const entry: Entry<A, E> = {
-        expiresAt: undefined,
-        deferred
-      }
-      MutableHashMap.set(self.map, key, entry)
-      if (Number.isFinite(self.capacity)) {
-        checkCapacity(self)
-      }
-      return effect.onExit(self.lookup(key), (exit) => {
-        Deferred.doneUnsafe(deferred, exit)
+      const entry = makeEntry(fiber, self.lookup(key))
+      entry.fiber.addObserver((exit) => {
+        if (effect.exitHasInterrupts(exit)) {
+          MutableHashMap.remove(self.map, key)
+          return
+        }
         const ttl = self.timeToLive(exit, key)
         if (Duration.isFinite(ttl)) {
           entry.expiresAt = fiber.getRef(effect.ClockRef).currentTimeMillisUnsafe() + Duration.toMillis(ttl)
         } else if (Duration.isZero(ttl)) {
           MutableHashMap.remove(self.map, key)
         }
-        return effect.void
       })
+      MutableHashMap.set(self.map, key, entry)
+      if (Number.isFinite(self.capacity)) {
+        checkCapacity(self)
+      }
+      return entry.await()
     })
 )
+
+const makeEntry = <A, E, R>(
+  parent: Fiber.Fiber<unknown, unknown>,
+  valueEffect: Effect.Effect<A, E, R>
+): Entry<A, E> => ({
+  expiresAt: undefined,
+  awaiters: 0,
+  fiber: effect.forkUnsafe(parent, valueEffect, true, true),
+  await() {
+    const exit = this.fiber.pollUnsafe()
+    if (exit) return exit
+    this.awaiters++
+    return effect.onExit(effect.fiberJoin(this.fiber), () => {
+      this.awaiters--
+      if (this.awaiters > 0 || this.fiber.pollUnsafe()) return effect.void
+      return effect.fiberInterrupt(this.fiber)
+    })
+  }
+})
 
 const hasExpired = <A, E>(entry: Entry<A, E>, fiber: Fiber.Fiber<unknown, unknown>): boolean => {
   if (entry.expiresAt === undefined) {
@@ -556,7 +575,7 @@ export const getOption: {
   <Key, A, E, R>(self: Cache<Key, A, E, R>, key: Key): Effect.Effect<Option.Option<A>, E> =>
     core.withFiber((fiber) => {
       const entry = getImpl(self, key, fiber)
-      return entry ? effect.asSome(Deferred.await(entry.deferred)) : effect.succeedNone
+      return entry ? effect.asSome(entry.await()) : effect.succeedNone
     })
 )
 
@@ -602,7 +621,7 @@ export const getSuccess: {
   2,
   <Key, A, E, R>(self: Cache<Key, A, E, R>, key: Key): Effect.Effect<Option.Option<A>> =>
     core.withFiber((fiber) => {
-      const exit = getImpl(self, key, fiber)?.deferred.effect as Exit.Exit<A, E> | undefined
+      const exit = getImpl(self, key, fiber)?.fiber.pollUnsafe()
       if (exit && effect.exitIsSuccess(exit)) {
         return effect.succeedSome(exit.value)
       }
@@ -715,19 +734,16 @@ export const set: {
   <Key, A, E, R>(self: Cache<Key, A, E, R>, key: Key, value: A): Effect.Effect<void> =>
     core.withFiber((fiber) => {
       const exit = core.exitSucceed(value)
-      const deferred = Deferred.makeUnsafe<A, E>()
-      Deferred.doneUnsafe(deferred, exit)
+      const entry = makeEntry(fiber, exit)
       const ttl = self.timeToLive(exit, key)
       if (Duration.isZero(ttl)) {
         MutableHashMap.remove(self.map, key)
         return effect.void
       }
-      MutableHashMap.set(self.map, key, {
-        deferred,
-        expiresAt: Duration.isFinite(ttl)
-          ? fiber.getRef(effect.ClockRef).currentTimeMillisUnsafe() + Duration.toMillis(ttl)
-          : undefined
-      })
+      entry.expiresAt = Duration.isFinite(ttl)
+        ? fiber.getRef(effect.ClockRef).currentTimeMillisUnsafe() + Duration.toMillis(ttl)
+        : undefined
+      MutableHashMap.set(self.map, key, entry)
       checkCapacity(self)
       return effect.void
     })
@@ -963,7 +979,7 @@ export const invalidateWhen: {
       if (oentry === undefined) {
         return effect.succeed(false)
       }
-      return Deferred.await(oentry.deferred).pipe(
+      return oentry.await().pipe(
         effect.map((value) => {
           if (f(value)) {
             MutableHashMap.remove(self.map, key)
@@ -1075,18 +1091,17 @@ export const refresh: {
   2,
   <Key, A, E, R>(self: Cache<Key, A, E, R>, key: Key): Effect.Effect<A, E, R> =>
     core.withFiber((fiber) => {
-      const deferred = Deferred.makeUnsafe<A, E>()
-      const entry: Entry<A, E> = {
-        expiresAt: undefined,
-        deferred
-      }
+      const entry = makeEntry(fiber, self.lookup(key))
       const existing = getImpl(self, key, fiber, false) !== undefined
       if (!existing) {
         MutableHashMap.set(self.map, key, entry)
         checkCapacity(self)
       }
-      return effect.onExit(self.lookup(key), (exit) => {
-        Deferred.doneUnsafe(deferred, exit)
+      entry.fiber.addObserver((exit) => {
+        if (effect.exitHasInterrupts(exit)) {
+          if (!existing) MutableHashMap.remove(self.map, key)
+          return
+        }
         const ttl = self.timeToLive(exit, key)
         if (Duration.isZero(ttl)) {
           MutableHashMap.remove(self.map, key)
@@ -1098,8 +1113,8 @@ export const refresh: {
         if (existing) {
           MutableHashMap.set(self.map, key, entry)
         }
-        return effect.void
       })
+      return entry.await()
     })
 )
 
@@ -1284,10 +1299,10 @@ export const entries = <Key, A, E, R>(self: Cache<Key, A, E, R>): Effect.Effect<
     const now = fiber.getRef(effect.ClockRef).currentTimeMillisUnsafe()
     return effect.succeed(Iterable.filterMap(self.map, ([key, entry]) => {
       if (entry.expiresAt === undefined || entry.expiresAt > now) {
-        const exit = entry.deferred.effect
-        return !core.isExit(exit) || effect.exitIsFailure(exit)
-          ? Result.failVoid
-          : Result.succeed([key, exit.value as A])
+        const exit = entry.fiber.pollUnsafe()
+        return exit && exit._tag === "Success"
+          ? Result.succeed([key, exit.value])
+          : Result.failVoid
       }
       MutableHashMap.remove(self.map, key)
       return Result.failVoid

--- a/packages/effect/src/Cache.ts
+++ b/packages/effect/src/Cache.ts
@@ -410,7 +410,7 @@ export const get: {
         MutableHashMap.set(self.map, key, oentry.value)
         return oentry.value.await()
       }
-      const entry = makeEntry(fiber, self.lookup(key))
+      const entry = new EntryImpl(fiber, self.lookup(key))
       entry.fiber.addObserver((exit) => {
         if (effect.exitHasInterrupts(exit)) {
           MutableHashMap.remove(self.map, key)
@@ -431,14 +431,21 @@ export const get: {
     })
 )
 
-const makeEntry = <A, E, R>(
-  parent: Fiber.Fiber<unknown, unknown>,
-  valueEffect: Effect.Effect<A, E, R>
-): Entry<A, E> => ({
-  expiresAt: undefined,
-  awaiters: 0,
-  fiber: effect.forkUnsafe(parent, valueEffect, true, true),
-  await() {
+class EntryImpl<A, E> implements Entry<A, E> {
+  expiresAt: number | undefined
+  awaiters: number
+  fiber: Fiber.Fiber<A, E>
+
+  constructor(
+    parent: Fiber.Fiber<unknown, unknown>,
+    valueEffect: Effect.Effect<A, E, any>
+  ) {
+    this.fiber = effect.forkUnsafe(parent, valueEffect, true, true)
+    this.awaiters = 0
+    this.expiresAt = undefined
+  }
+
+  await(): Effect.Effect<A, E> {
     const exit = this.fiber.pollUnsafe()
     if (exit) return exit
     this.awaiters++
@@ -448,7 +455,7 @@ const makeEntry = <A, E, R>(
       return effect.fiberInterrupt(this.fiber)
     })
   }
-})
+}
 
 const hasExpired = <A, E>(entry: Entry<A, E>, fiber: Fiber.Fiber<unknown, unknown>): boolean => {
   if (entry.expiresAt === undefined) {
@@ -734,7 +741,7 @@ export const set: {
   <Key, A, E, R>(self: Cache<Key, A, E, R>, key: Key, value: A): Effect.Effect<void> =>
     core.withFiber((fiber) => {
       const exit = core.exitSucceed(value)
-      const entry = makeEntry(fiber, exit)
+      const entry = new EntryImpl(fiber, exit)
       const ttl = self.timeToLive(exit, key)
       if (Duration.isZero(ttl)) {
         MutableHashMap.remove(self.map, key)
@@ -1091,7 +1098,7 @@ export const refresh: {
   2,
   <Key, A, E, R>(self: Cache<Key, A, E, R>, key: Key): Effect.Effect<A, E, R> =>
     core.withFiber((fiber) => {
-      const entry = makeEntry(fiber, self.lookup(key))
+      const entry = new EntryImpl(fiber, self.lookup(key))
       const existing = getImpl(self, key, fiber, false) !== undefined
       if (!existing) {
         MutableHashMap.set(self.map, key, entry)

--- a/packages/effect/test/Cache.test.ts
+++ b/packages/effect/test/Cache.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cache, Context, Data, Deferred, Duration, Effect, Exit, Fiber, Option } from "effect"
+import { Cache, Context, Data, Deferred, Duration, Effect, Exit, Fiber, Latch, MutableHashMap, Option } from "effect"
 import { TestClock } from "effect/testing"
 
 describe("Cache", () => {
@@ -282,6 +282,59 @@ describe("Cache", () => {
           assert.strictEqual(result1, 1)
           assert.strictEqual(result2, 2)
           assert.strictEqual(lookupCount, 2)
+        }))
+
+      it.effect("concurrent access - interrupting the first consumer does not interrupt the second", () =>
+        Effect.gen(function*() {
+          const lookupStarted = yield* Latch.make()
+          const lookupComplete = yield* Latch.make()
+          const cache = yield* Cache.make<string, number>({
+            capacity: 10,
+            lookup: () =>
+              Effect.gen(function*() {
+                yield* lookupStarted.open
+                yield* lookupComplete.await
+                return 42
+              })
+          })
+
+          const first = yield* Cache.get(cache, "K1").pipe(Effect.forkChild({ startImmediately: true }))
+          yield* lookupStarted.await
+          const second = yield* Cache.get(cache, "K1").pipe(Effect.forkChild({ startImmediately: true }))
+          const entry = Option.getOrThrow(MutableHashMap.get(cache.map, "K1"))
+          const third = yield* entry.await().pipe(Effect.forkChild({ startImmediately: true }))
+
+          yield* Fiber.interrupt(first)
+          yield* lookupComplete.open
+
+          assert.deepStrictEqual(yield* Fiber.await(second), Exit.succeed(42))
+          assert.deepStrictEqual(yield* Fiber.await(third), Exit.succeed(42))
+        }))
+
+      it.effect("concurrent access - interrupting the last consumer interrupts the lookup", () =>
+        Effect.gen(function*() {
+          let lookupCount = 0
+          const lookupStarted = yield* Latch.make()
+          const lookupInterrupted = yield* Latch.make()
+          const cache = yield* Cache.make<string, number>({
+            capacity: 10,
+            lookup() {
+              lookupCount++
+              return lookupCount === 1 ?
+                Effect.onInterrupt(
+                  lookupStarted.open.pipe(Effect.andThen(Effect.never)),
+                  () => lookupInterrupted.open
+                ) :
+                Effect.succeed(42)
+            }
+          })
+
+          const fiber = yield* Cache.get(cache, "K1").pipe(Effect.forkChild({ startImmediately: true }))
+          yield* lookupStarted.await
+          yield* Fiber.interrupt(fiber)
+
+          yield* lookupInterrupted.await
+          assert.strictEqual(yield* Cache.get(cache, "K1"), 42)
         }))
     })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache behavior under interruption: ongoing lookups continue when earlier consumers stop waiting.
  * Underlying in-flight lookups are cancelled only after the final consumer stops waiting.
  * Subsequent requests correctly recompute and return fresh results when prior lookups were interrupted.
* **Tests**
  * Added concurrency and interruption scenarios covering multi-consumer cache access.
* **Release**
  * Scheduled a patch release with these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->