### PR TITLE
clean up more references on fiber exit

### DIFF
--- a/.changeset/whole-pets-build.md
+++ b/.changeset/whole-pets-build.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+clean up more references on fiber exit

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -532,7 +532,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   readonly _stack: Array<Primitive>
   readonly _observers: Array<(exit: Exit.Exit<A, E>) => void>
   _exit: Exit.Exit<A, E> | undefined
-  _currentExit: Exit.Exit<A, E> | undefined
   _children: Set<FiberImpl<any, any>> | undefined
   _interruptedCause: Cause.Cause<never> | undefined
   _yielded: Exit.Exit<any, any> | (() => void) | undefined
@@ -623,6 +622,10 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       this._observers[i](exit)
     }
     this._observers.length = 0
+    this._stack.length = 0
+    this._children = undefined
+    this._dispatcher = undefined
+    this.context = Context.empty()
   }
   runLoop(effect: Primitive): Exit.Exit<A, E> | Yield {
     const prevFiber = (globalThis as any)[currentFiberTypeId]

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -624,7 +624,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._observers.length = 0
     this._stack.length = 0
     this._children = undefined
-    this._dispatcher = undefined
     this.context = Context.empty()
   }
   runLoop(effect: Primitive): Exit.Exit<A, E> | Yield {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fiber cleanup after execution completes by clearing additional retained internal references.
  * Helps reduce unnecessary memory retention and supports more predictable resource handling.

* **Chores**
  * Prepared a patch release for the effect package with a release note about additional cleanup on fiber exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->