### PR TITLE
Add `Effect.reduce`

### DIFF
--- a/.changeset/port-effect-reduce.md
+++ b/.changeset/port-effect-reduce.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Port `Effect.reduce` from Effect v3.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -566,6 +566,50 @@ export const partition: {
 } = internal.partition
 
 /**
+ * Reduces elements from left to right with an effectful accumulator function.
+ *
+ * **When to use**
+ *
+ * Use when each accumulation step is effectful and must run sequentially in
+ * iteration order.
+ *
+ * **Details**
+ *
+ * The accumulator function receives the current accumulator, the current
+ * element, and its zero-based index. An empty iterable succeeds with `zero`.
+ * If a step fails, remaining elements are not processed.
+ *
+ * **Example** (Summing values sequentially)
+ *
+ * ```ts
+ * import { Console, Effect } from "effect"
+ *
+ * const program = Effect.reduce(
+ *   [1, 2, 3],
+ *   0,
+ *   (total, value, index) =>
+ *     Console.log(`Adding ${value} at index ${index}`).pipe(
+ *       Effect.as(total + value)
+ *     )
+ * )
+ *
+ * Effect.runPromise(program).then(console.log)
+ * // Output:
+ * // Adding 1 at index 0
+ * // Adding 2 at index 1
+ * // Adding 3 at index 2
+ * // 6
+ * ```
+ *
+ * @category collecting
+ * @since 2.0.0
+ */
+export const reduce: {
+  <Z, A, E, R>(zero: Z, f: (z: Z, a: A, i: number) => Effect<Z, E, R>): (elements: Iterable<A>) => Effect<Z, E, R>
+  <A, Z, E, R>(elements: Iterable<A>, zero: Z, f: (z: Z, a: A, i: number) => Effect<Z, E, R>): Effect<Z, E, R>
+} = internal.reduce
+
+/**
  * Applies an effectful function to each element and accumulates all failures.
  *
  * **Details**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -576,8 +576,9 @@ export const partition: {
  * **Details**
  *
  * The accumulator function receives the current accumulator, the current
- * element, and its zero-based index. An empty iterable succeeds with `zero`.
- * If a step fails, remaining elements are not processed.
+ * element, and its zero-based index. The `zero` function is evaluated each
+ * time the effect runs. An empty iterable succeeds with its result. If a step
+ * fails, remaining elements are not processed.
  *
  * **Example** (Summing values sequentially)
  *
@@ -586,7 +587,7 @@ export const partition: {
  *
  * const program = Effect.reduce(
  *   [1, 2, 3],
- *   0,
+ *   () => 0,
  *   (total, value, index) =>
  *     Console.log(`Adding ${value} at index ${index}`).pipe(
  *       Effect.as(total + value)
@@ -605,8 +606,15 @@ export const partition: {
  * @since 2.0.0
  */
 export const reduce: {
-  <Z, A, E, R>(zero: Z, f: (z: Z, a: A, i: number) => Effect<Z, E, R>): (elements: Iterable<A>) => Effect<Z, E, R>
-  <A, Z, E, R>(elements: Iterable<A>, zero: Z, f: (z: Z, a: A, i: number) => Effect<Z, E, R>): Effect<Z, E, R>
+  <Z, A, E, R>(
+    zero: LazyArg<Z>,
+    f: (z: Z, a: A, i: number) => Effect<Z, E, R>
+  ): (elements: Iterable<A>) => Effect<Z, E, R>
+  <A, Z, E, R>(
+    elements: Iterable<A>,
+    zero: LazyArg<Z>,
+    f: (z: Z, a: A, i: number) => Effect<Z, E, R>
+  ): Effect<Z, E, R>
 } = internal.reduce
 
 /**

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4383,6 +4383,44 @@ export const partition: {
 )
 
 /** @internal */
+export const reduce: {
+  <Z, A, E, R>(
+    zero: Z,
+    f: (z: Z, a: A, i: number) => Effect.Effect<Z, E, R>
+  ): (elements: Iterable<A>) => Effect.Effect<Z, E, R>
+  <A, Z, E, R>(
+    elements: Iterable<A>,
+    zero: Z,
+    f: (z: Z, a: A, i: number) => Effect.Effect<Z, E, R>
+  ): Effect.Effect<Z, E, R>
+} = dual(
+  3,
+  <A, Z, E, R>(
+    elements: Iterable<A>,
+    zero: Z,
+    f: (z: Z, a: A, i: number) => Effect.Effect<Z, E, R>
+  ) => {
+    const arr = Arr.fromIterable(elements)
+    if (arr.length === 0) return succeed(zero)
+    return suspend(() => {
+      let index = 0
+      let state = zero
+      return map(
+        whileLoop({
+          while: () => index < arr.length,
+          body: () => f(state, arr[index], index),
+          step(next) {
+            state = next
+            index++
+          }
+        }),
+        () => state
+      )
+    })
+  }
+)
+
+/** @internal */
 export const validate: {
   <A, B, E, R>(
     f: (a: A, i: number) => Effect.Effect<B, E, R>,

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4385,26 +4385,26 @@ export const partition: {
 /** @internal */
 export const reduce: {
   <Z, A, E, R>(
-    zero: Z,
+    zero: LazyArg<Z>,
     f: (z: Z, a: A, i: number) => Effect.Effect<Z, E, R>
   ): (elements: Iterable<A>) => Effect.Effect<Z, E, R>
   <A, Z, E, R>(
     elements: Iterable<A>,
-    zero: Z,
+    zero: LazyArg<Z>,
     f: (z: Z, a: A, i: number) => Effect.Effect<Z, E, R>
   ): Effect.Effect<Z, E, R>
 } = dual(
   3,
   <A, Z, E, R>(
     elements: Iterable<A>,
-    zero: Z,
+    zero: LazyArg<Z>,
     f: (z: Z, a: A, i: number) => Effect.Effect<Z, E, R>
   ) => {
     const arr = Arr.fromIterable(elements)
-    if (arr.length === 0) return succeed(zero)
+    if (arr.length === 0) return sync(zero)
     return suspend(() => {
       let index = 0
-      let state = zero
+      let state = zero()
       return map(
         whileLoop({
           while: () => index < arr.length,

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -693,7 +693,7 @@ describe("Effect", () => {
     it.effect("runs sequentially from left to right and passes the index", () =>
       Effect.gen(function*() {
         const visited: Array<string> = []
-        const result = yield* Effect.reduce([1, 2, 3, 4, 5], 0, (acc, value, index) =>
+        const result = yield* Effect.reduce([1, 2, 3, 4, 5], () => 0, (acc, value, index) =>
           Effect.sync(() => {
             visited.push(`${index}:${value}`)
             return acc + value
@@ -708,7 +708,7 @@ describe("Effect", () => {
         const visited: Array<number> = []
         const result = yield* pipe(
           [1, 2, 3, 4, 5],
-          Effect.reduce(0, (acc, value) =>
+          Effect.reduce(() => 0, (acc, value) =>
             Effect.sync(() => visited.push(value)).pipe(
               Effect.andThen(value === 3 ? Effect.fail("fail") : Effect.succeed(acc + value))
             )),
@@ -721,8 +721,22 @@ describe("Effect", () => {
 
     it.effect("returns zero for an empty iterable", () =>
       Effect.gen(function*() {
-        const result = yield* Effect.reduce([], 42, (acc, value: number) => Effect.succeed(acc + value))
+        const result = yield* Effect.reduce([], () => 42, (acc, value: number) => Effect.succeed(acc + value))
         assert.strictEqual(result, 42)
+      }))
+
+    it.effect("evaluates zero lazily for each run", () =>
+      Effect.gen(function*() {
+        let evaluations = 0
+        const reduced = Effect.reduce([1], () => {
+          evaluations++
+          return [] as Array<number>
+        }, (acc, value) => Effect.succeed([...acc, value]))
+
+        assert.strictEqual(evaluations, 0)
+        assert.deepStrictEqual(yield* reduced, [1])
+        assert.deepStrictEqual(yield* reduced, [1])
+        assert.strictEqual(evaluations, 2)
       }))
   })
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -689,6 +689,43 @@ describe("Effect", () => {
       }))
   })
 
+  describe("reduce", () => {
+    it.effect("runs sequentially from left to right and passes the index", () =>
+      Effect.gen(function*() {
+        const visited: Array<string> = []
+        const result = yield* Effect.reduce([1, 2, 3, 4, 5], 0, (acc, value, index) =>
+          Effect.sync(() => {
+            visited.push(`${index}:${value}`)
+            return acc + value
+          }))
+
+        assert.strictEqual(result, 15)
+        assert.deepStrictEqual(visited, ["0:1", "1:2", "2:3", "3:4", "4:5"])
+      }))
+
+    it.effect("stops at the first failure", () =>
+      Effect.gen(function*() {
+        const visited: Array<number> = []
+        const result = yield* pipe(
+          [1, 2, 3, 4, 5],
+          Effect.reduce(0, (acc, value) =>
+            Effect.sync(() => visited.push(value)).pipe(
+              Effect.andThen(value === 3 ? Effect.fail("fail") : Effect.succeed(acc + value))
+            )),
+          Effect.exit
+        )
+
+        assert.deepStrictEqual(result, Exit.fail("fail"))
+        assert.deepStrictEqual(visited, [1, 2, 3])
+      }))
+
+    it.effect("returns zero for an empty iterable", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.reduce([], 42, (acc, value: number) => Effect.succeed(acc + value))
+        assert.strictEqual(result, 42)
+      }))
+  })
+
   describe("validate", () => {
     it.effect("collects successes when all effects succeed", () =>
       Effect.gen(function*() {

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -797,7 +797,7 @@ describe("Effect.reduce", () => {
   it("data-first", () => {
     const result = Effect.reduce(
       [1, 2, 3],
-      "",
+      () => "",
       (acc, n) => string.pipe(Effect.map((value) => `${acc}${value}${n}`))
     )
     expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1">>()
@@ -806,7 +806,7 @@ describe("Effect.reduce", () => {
   it("data-last", () => {
     const result = pipe(
       [1, 2, 3],
-      Effect.reduce("", (acc, n) => string.pipe(Effect.map((value) => `${acc}${value}${n}`)))
+      Effect.reduce(() => "", (acc, n) => string.pipe(Effect.map((value) => `${acc}${value}${n}`)))
     )
     expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1">>()
   })

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -793,6 +793,25 @@ describe("Effect.partition", () => {
   })
 })
 
+describe("Effect.reduce", () => {
+  it("data-first", () => {
+    const result = Effect.reduce(
+      [1, 2, 3],
+      "",
+      (acc, n) => string.pipe(Effect.map((value) => `${acc}${value}${n}`))
+    )
+    expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1">>()
+  })
+
+  it("data-last", () => {
+    const result = pipe(
+      [1, 2, 3],
+      Effect.reduce("", (acc, n) => string.pipe(Effect.map((value) => `${acc}${value}${n}`)))
+    )
+    expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1">>()
+  })
+})
+
 describe("Effect.findFirst", () => {
   it("data-first", () => {
     const result = Effect.findFirst(


### PR DESCRIPTION
## Summary
- Ported `Effect.reduce` from Effect v3 into `packages/effect`.
- Added a sequential, effectful left-to-right reduction with data-first and data-last overloads.
- Covered runtime behavior for ordered execution, early failure, and empty iterables.
- Added type tests to verify inference in both calling styles.

## Testing
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types packages/effect/typetest/Effect.tst.ts`
- Not run: full repository `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Effect.reduce` for sequential, left-to-right reduction over iterable data.
  * Supports both data-first and data-last call styles.
  * Provides the initial accumulator for empty inputs and short-circuits after the first failure (including element index support).
* **Tests**
  * Added runtime and type-level coverage for ordering, index tracking, empty inputs, error short-circuiting, and type inference.
* **Documentation**
  * Added an entry for this patch release in the changeset notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->