### PR TITLE
Refine existing type in Predicate.isTagged

### DIFF
--- a/.changeset/funny-drinks-scream.md
+++ b/.changeset/funny-drinks-scream.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Refine existing type in Predicated.isTagged

--- a/.changeset/funny-drinks-scream.md
+++ b/.changeset/funny-drinks-scream.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Refine existing type in Predicated.isTagged
+Refine existing type in Predicate.isTagged

--- a/packages/effect/src/Predicate.ts
+++ b/packages/effect/src/Predicate.ts
@@ -1164,8 +1164,8 @@ export const hasProperty: {
  * @since 2.0.0
  */
 export const isTagged: {
-  <K extends string>(tag: K): (self: unknown) => self is { _tag: K }
-  <K extends string>(self: unknown, tag: K): self is { _tag: K }
+  <K extends string>(tag: K): <T>(self: T) => self is T extends {} ? Extract<T, { _tag: K }> : T & { _tag: K }
+  <K extends string, T>(self: T, tag: K): self is T extends {} ? Extract<T, { _tag: K }> : T & { _tag: K }
 } = dual(
   2,
   <K extends string>(self: unknown, tag: K): self is { _tag: K } => hasProperty(self, "_tag") && self["_tag"] === tag

--- a/packages/effect/typetest/Predicate.tst.ts
+++ b/packages/effect/typetest/Predicate.tst.ts
@@ -7,6 +7,8 @@ declare const unknowns: ReadonlyArray<unknown>
 declare const numberOrNull: ReadonlyArray<number | null>
 declare const numberOrUndefined: ReadonlyArray<number | undefined>
 declare const numberOrNullOrUndefined: ReadonlyArray<number | null | undefined>
+declare const tags: ReadonlyArray<{ _tag: "a"; a: string } | { _tag: "b"; b: string }>
+declare const tagsOrNumbers: ReadonlyArray<{ _tag: "a"; a: string } | { _tag: "b"; b: string } | number>
 
 describe("Predicate", () => {
   it("isString", () => {
@@ -56,7 +58,11 @@ describe("Predicate", () => {
   })
 
   it("isTagged", () => {
-    expect(anys.filter(Predicate.isTagged("a"))).type.toBe<Array<{ _tag: "a" }>>()
+    expect(anys.filter(Predicate.isTagged("a"))).type.toBe<Array<any>>()
+    expect(unknowns.filter(Predicate.isTagged("a"))).type.toBe<Array<{ _tag: "a" }>>()
+    expect(tags.filter(Predicate.isTagged("a"))).type.toBe<Array<{ _tag: "a"; a: string }>>()
+    expect(tagsOrNumbers.filter(Predicate.isTagged("a"))).type.toBe<Array<{ _tag: "a"; a: string }>>()
+    expect(numberOrNull.filter(Predicate.isTagged("a"))).type.toBe<Array<never>>()
   })
 
   it("isNullish", () => {


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change allows Predicate.isTagged to narrow the type of known tagged structures, rather than turning everything into { _tag: K }. This change does mean that any now remains any, but I can't think of a way around that.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #4785 (original v3 PR)
- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Type Improvements**
  * Refined `Predicate.isTagged` type narrowing to preserve more of the original input shape for tagged unions.
  * Improved inference behavior across tagged, unknown, and mixed (tagged + non-tagged) unions, with tighter results for incompatible inputs.
* **Tests**
  * Expanded type-level coverage for `isTagged` to validate narrowing outcomes across multiple input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->