### PR TITLE
Don’t create a table when it’s not needed

### DIFF
--- a/.changeset/tall-ideas-fix.md
+++ b/.changeset/tall-ideas-fix.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Don’t create a table when it’s not needed

--- a/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
@@ -164,21 +164,25 @@ export const make = Effect.fnUntraced(function*(options: {
         )
       `,
     mysql: () =>
-      sql`
-        CREATE TABLE IF NOT EXISTS ${locksTableSql} (
-          shard_id VARCHAR(50) PRIMARY KEY,
-          address VARCHAR(255) NOT NULL,
-          acquired_at DATETIME NOT NULL
-        )
-      `,
+      disableAdvisoryLocks ?
+        sql`
+          CREATE TABLE IF NOT EXISTS ${locksTableSql} (
+            shard_id VARCHAR(50) PRIMARY KEY,
+            address VARCHAR(255) NOT NULL,
+            acquired_at DATETIME NOT NULL
+          )
+        ` :
+        Effect.void,
     pg: () =>
-      sql`
-        CREATE TABLE IF NOT EXISTS ${locksTableSql} (
-          shard_id VARCHAR(50) PRIMARY KEY,
-          address VARCHAR(255) NOT NULL,
-          acquired_at TIMESTAMP NOT NULL
-        )
-      `,
+      disableAdvisoryLocks ?
+        sql`
+          CREATE TABLE IF NOT EXISTS ${locksTableSql} (
+            shard_id VARCHAR(50) PRIMARY KEY,
+            address VARCHAR(255) NOT NULL,
+            acquired_at TIMESTAMP NOT NULL
+          )
+        ` :
+        Effect.void,
     orElse: () =>
       // sqlite
       sql`


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #5840 (original v3 PR)
- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - PostgreSQL and MySQL no longer create an unnecessary shard locks table when advisory locks are enabled.
  - The locks table continues to be created when advisory locks are disabled.

- **Chores**
  - Added a patch release note for the cluster package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->