### PR TITLE
Add discriminants to Schema.toTaggedUnion

### DIFF
--- a/.changeset/add-schema-tagged-union-discriminants.md
+++ b/.changeset/add-schema-tagged-union-discriminants.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+---
+
+Add a `discriminants` tuple to schemas augmented with `Schema.toTaggedUnion` and reject duplicate discriminant
+property keys.

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -1996,7 +1996,7 @@ The result is a tagged union schema with built-in helpers based on the tag value
 
 ### Augmenting Tagged Unions
 
-The `asTaggedUnion` function enhances a tagged union schema by adding helper methods for working with its members.
+The `toTaggedUnion` function enhances a tagged union schema by adding helper methods for working with its members.
 
 You need to specify the name of the tag field used to differentiate between variants.
 
@@ -2022,6 +2022,8 @@ This helper has some advantages over a dedicated constructor:
 - You can choose among multiple possible tag fields if present.
 - It supports unions that include nested unions.
 
+Each member must have a unique discriminant property key. `toTaggedUnion` throws when it encounters a duplicate. Numeric and string values that resolve to the same property key, such as `1` and `"1"`, are considered duplicates.
+
 **Note**. If the tag is the standard `_tag` field, you can use `Schema.TaggedUnion` instead.
 
 #### Accessing Members by Tag
@@ -2034,6 +2036,18 @@ The `cases` property gives direct access to each member schema of the union.
 const A = tagged.cases.A
 const B = tagged.cases.B
 const C = tagged.cases.C
+```
+
+#### Accessing Discriminant Values
+
+The `discriminants` property contains the decoded discriminant values in the same order as the flattened union members. Its type preserves the exact tuple of values.
+
+**Example** (Deriving a literal schema from discriminants)
+
+```ts
+const Tags = Schema.Literals(tagged.discriminants)
+
+// Schema.Literals<readonly ["A", "B", "C"]>
 ```
 
 #### Checking Membership in a Subset of Tags

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -35,6 +35,7 @@ import { identity, memoize } from "./Function.ts"
 import * as HashMap_ from "./HashMap.ts"
 import * as HashSet_ from "./HashSet.ts"
 import * as core from "./internal/core.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as InternalAnnotations from "./internal/schema/annotations.ts"
 import * as InternalArbitrary from "./internal/schema/arbitrary.ts"
 import * as InternalEquivalence from "./internal/schema/equivalence.ts"
@@ -6089,6 +6090,10 @@ type TaggedUnionUtils<
     Members
   >
 > = {
+  /**
+   * Discriminant values in flattened member order.
+   */
+  readonly discriminants: { readonly [I in keyof Flattened]: Flattened[I]["Type"][Tag] }
   readonly cases: Simplify<{ [M in Flattened[number] as M["Type"][Tag]]: M }>
   readonly isAnyOf: <const Keys>(
     keys: ReadonlyArray<Keys>
@@ -6123,7 +6128,12 @@ export type toTaggedUnion<
 > = Union<Members> & TaggedUnionUtils<Tag, Members>
 
 /**
- * Augments an existing {@link Union} of tagged structs with utility methods keyed by the discriminant field.
+ * Augments an existing {@link Union} of tagged structs with utility methods and an ordered tuple of discriminant
+ * values.
+ *
+ * **Gotchas**
+ *
+ * Throws if multiple members use the same discriminant property key.
  *
  * **Example** (Adding tagged-union utilities to an existing union)
  *
@@ -6151,12 +6161,14 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
     self: Union<Members>
   ): toTaggedUnion<Tag, Members> => {
     const cases: Record<PropertyKey, unknown> = {}
+    const discriminants: Array<PropertyKey> = []
+    const discriminantKeys = new Set<string | symbol>()
     const guards: Record<PropertyKey, (u: unknown) => boolean> = {}
     const isAnyOf = (keys: ReadonlyArray<PropertyKey>) => (value: Members[number]["Type"]) => keys.includes(value[tag])
 
     walk(self)
 
-    return Object.assign(self, { cases, isAnyOf, guards, match }) as any
+    return Object.assign(self, { cases, discriminants, isAnyOf, guards, match }) as any
 
     function walk(schema: Constraint) {
       const ast = schema.ast
@@ -6172,8 +6184,14 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
       if (sentinels.length > 0) {
         const literal = sentinels.find((s) => s.key === tag)?.literal
         if (Predicate.isPropertyKey(literal)) {
-          cases[literal] = schema
-          guards[literal] = is(toType(schema))
+          const key = typeof literal === "number" ? globalThis.String(literal) : literal
+          if (discriminantKeys.has(key)) {
+            throw new globalThis.Error(`Duplicate discriminant: ${globalThis.String(literal)}`)
+          }
+          discriminantKeys.add(key)
+          discriminants.push(literal)
+          InternalRecord.set(cases, literal, schema)
+          InternalRecord.set(guards, literal, is(toType(schema)))
           return
         }
       }

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -19,7 +19,7 @@ import * as Exit from "./Exit.ts"
 import { format, formatPropertyKey } from "./Formatter.ts"
 import { memoize } from "./Function.ts"
 import { effectIsExit, iterateEager } from "./internal/effect.ts"
-import * as internalRecord from "./internal/record.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as InternalAnnotations from "./internal/schema/annotations.ts"
 import * as InternalSchemaCause from "./internal/schema/cause.ts"
 import * as Option from "./Option.ts"
@@ -2131,9 +2131,9 @@ export class Objects extends Base {
             const v2 = exitValue.value.value
             if (is.merge && is.merge.decode && Object.hasOwn(s.out, k2)) {
               const [k, v] = is.merge.decode.combine([k2, s.out[k2]], [k2, v2])
-              internalRecord.set(s.out, k, v)
+              InternalRecord.set(s.out, k, v)
             } else {
-              internalRecord.set(s.out, k2, v2)
+              InternalRecord.set(s.out, k2, v2)
             }
           }
         }),
@@ -2189,7 +2189,7 @@ export class Objects extends Base {
               }
             } else {
               // preserve key
-              internalRecord.set(out, key, input[key])
+              InternalRecord.set(out, key, input[key])
             }
           }
         }
@@ -2229,7 +2229,7 @@ export class Objects extends Base {
         const preserved: Record<PropertyKey, unknown> = {}
         for (const key of keys) {
           if (Object.hasOwn(out, key)) {
-            internalRecord.set(preserved, key, out[key])
+            InternalRecord.set(preserved, key, out[key])
           }
         }
         return Option.some(preserved)
@@ -2320,7 +2320,7 @@ const parseProperties = iterateEager<{
     if (exit._tag === "Failure") {
       return wrapPropertyKeyIssue(s, s.ast, p.name, exit)
     } else if (exit.value._tag === "Some") {
-      internalRecord.set(s.out, p.name, exit.value.value)
+      InternalRecord.set(s.out, p.name, exit.value.value)
     } else if (!isOptional(p.type)) {
       const issue = new SchemaIssue.Pointer([p.name], new SchemaIssue.MissingKey(p.type.context?.annotations))
       if (s.options.errors === "all") {

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -14,7 +14,7 @@
 import * as DateTime from "./DateTime.ts"
 import * as Effect from "./Effect.ts"
 import * as Encoding from "./Encoding.ts"
-import * as internalRecord from "./internal/record.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as Option from "./Option.ts"
 import * as Pipeable from "./Pipeable.ts"
 import * as Predicate from "./Predicate.ts"
@@ -1714,7 +1714,7 @@ function getOrCreateContainer(
     return current
   }
   const container = shouldBeArray ? [] : {}
-  internalRecord.set(self, key, container)
+  InternalRecord.set(self, key, container)
   return container
 }
 
@@ -1789,9 +1789,9 @@ export function makeTreeRecord<A>(
         if (hasOwn && Array.isArray(cur[token])) {
           cur[token].push(value)
         } else if (hasOwn) {
-          internalRecord.set(cur, token, [cur[token], value])
+          InternalRecord.set(cur, token, [cur[token], value])
         } else {
-          internalRecord.set(cur, token, value)
+          InternalRecord.set(cur, token, value)
         }
       } else {
         const next = tokens[i + 1]

--- a/packages/effect/src/unstable/httpapi/HttpApi.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApi.ts
@@ -10,7 +10,7 @@
  */
 import type { NonEmptyReadonlyArray } from "../../Array.ts"
 import * as Context from "../../Context.ts"
-import * as internalRecord from "../../internal/record.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Record from "../../Record.ts"
@@ -145,7 +145,7 @@ const Proto = {
   ) {
     const groups = { ...this.groups }
     for (const group of toAdd) {
-      internalRecord.set(groups, group.identifier, group)
+      InternalRecord.set(groups, group.identifier, group)
     }
     return makeProto({
       ...optionsFromApi(this),
@@ -159,7 +159,7 @@ const Proto = {
     const newGroups = { ...this.groups }
     for (const key in api.groups) {
       const group = api.groups[key]
-      internalRecord.set(
+      InternalRecord.set(
         newGroups,
         key,
         group.annotateMerge(Context.merge(api.annotations, group.annotations))

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -15,7 +15,7 @@ import * as Cause from "../../Cause.ts"
 import type * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import { identity } from "../../Function.ts"
-import * as internalRecord from "../../internal/record.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
@@ -520,10 +520,10 @@ export const makeWith = <ApiId extends string, Groups extends HttpApiGroup.Const
     ...options,
     onGroup({ group }) {
       if (group.topLevel) return
-      internalRecord.set(client, group.identifier, {})
+      InternalRecord.set(client, group.identifier, {})
     },
     onEndpoint({ endpoint, endpointFn, group }) {
-      internalRecord.set(
+      InternalRecord.set(
         group.topLevel ? client : client[group.identifier],
         endpoint.identifier,
         endpointFn
@@ -565,7 +565,7 @@ export const group = <
     ...options,
     predicate: ({ group }) => group.identifier === options.group,
     onEndpoint({ endpoint, endpointFn }) {
-      internalRecord.set(client, endpoint.identifier, endpointFn)
+      InternalRecord.set(client, endpoint.identifier, endpointFn)
     }
   }).pipe(Effect.map(() => client)) as any
 }
@@ -662,7 +662,7 @@ export const urlBuilder = <Api extends HttpApi.Constraint>(api: Api, options?: {
   HttpApi.reflect(api as unknown as HttpApi.Top, {
     onGroup({ group }) {
       if (group.topLevel) return
-      internalRecord.set(builder, group.identifier, {})
+      InternalRecord.set(builder, group.identifier, {})
     },
     onEndpoint({ group, endpoint }) {
       const makeUrl = compilePath(endpoint.path)
@@ -688,7 +688,7 @@ export const urlBuilder = <Api extends HttpApi.Constraint>(api: Api, options?: {
         const url = query === "" ? path : `${path}?${query}`
         return options?.baseUrl === undefined ? url : new URL(url, options.baseUrl.toString()).toString()
       }
-      internalRecord.set(
+      InternalRecord.set(
         group.topLevel ? builder : builder[group.identifier],
         endpoint.identifier,
         endpointBuilder

--- a/packages/effect/src/unstable/httpapi/HttpApiGroup.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiGroup.ts
@@ -12,7 +12,7 @@
  */
 import type { NonEmptyReadonlyArray } from "../../Array.ts"
 import * as Context from "../../Context.ts"
-import * as internalRecord from "../../internal/record.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Record from "../../Record.ts"
@@ -308,7 +308,7 @@ const Proto = {
   add(this: Top, ...toAdd: NonEmptyReadonlyArray<HttpApiEndpoint.Top>) {
     const endpoints = { ...this.endpoints }
     for (const endpoint of toAdd) {
-      internalRecord.set(endpoints, endpoint.identifier, endpoint)
+      InternalRecord.set(endpoints, endpoint.identifier, endpoint)
     }
     return makeProto({
       ...optionsFromGroup(this),

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -13,7 +13,7 @@ import type { NonEmptyArray } from "../../Array.ts"
 import * as Context from "../../Context.ts"
 import * as Equal from "../../Equal.ts"
 import { constFalse } from "../../Function.ts"
-import * as internalRecord from "../../internal/record.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as JsonPatch from "../../JsonPatch.ts"
 import { escapeToken } from "../../JsonPointer.ts"
 import * as JsonSchema from "../../JsonSchema.ts"
@@ -483,7 +483,7 @@ export function fromApi<Id extends string, Groups extends HttpApiGroup.Constrain
       ) {
         const scheme = makeSecurityScheme(security)
         if (!Object.hasOwn(spec.components.securitySchemes, name)) {
-          internalRecord.set(spec.components.securitySchemes, name, scheme)
+          InternalRecord.set(spec.components.securitySchemes, name, scheme)
           return
         }
         if (

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -8703,6 +8703,8 @@ pointed message
           ])
         ]).pipe(Schema.toTaggedUnion("_tag"))
 
+        deepStrictEqual(schema.discriminants, ["A", b, 1, "D"])
+
         // cases
         deepStrictEqual(schema.cases.A, schema.members[0])
         deepStrictEqual(schema.cases[b], schema.members[1])
@@ -8777,6 +8779,44 @@ pointed message
         // cases
         deepStrictEqual(schema.cases.TypeA, schema.members[0])
         deepStrictEqual(schema.cases.TypeB, schema.members[1])
+      })
+
+      it("should throw on duplicate discriminants", () => {
+        throws(
+          () =>
+            Schema.Union([
+              Schema.Struct({ event: Schema.Literal("A"), a: Schema.String }),
+              Schema.Union([
+                Schema.Struct({ event: Schema.Literal("B"), b: Schema.String }),
+                Schema.Struct({ event: Schema.Literal("A"), c: Schema.String })
+              ])
+            ]).pipe(Schema.toTaggedUnion("event")),
+          "Duplicate discriminant: A"
+        )
+        throws(
+          () =>
+            Schema.Union([
+              Schema.Struct({ event: Schema.Literal(1) }),
+              Schema.Struct({ event: Schema.Literal("1") })
+            ]).pipe(Schema.toTaggedUnion("event")),
+          "Duplicate discriminant: 1"
+        )
+      })
+
+      it("should collect no discriminants from an empty union", () => {
+        const schema = Schema.Union([]).pipe(Schema.toTaggedUnion("event"))
+
+        deepStrictEqual(schema.discriminants, [])
+      })
+
+      it("should support __proto__ as a discriminant", () => {
+        const member = Schema.Struct({ event: Schema.Literal("__proto__"), value: Schema.String })
+        const schema = Schema.Union([member]).pipe(Schema.toTaggedUnion("event"))
+
+        assertTrue(Object.hasOwn(schema.cases, "__proto__"))
+        strictEqual(schema.cases["__proto__"], member)
+        assertTrue(Object.hasOwn(schema.guards, "__proto__"))
+        assertTrue(schema.guards["__proto__"]({ event: "__proto__", value: "a" }))
       })
 
       it("should augment a union of classes", () => {

--- a/packages/effect/typetest/schema/Union.tst.ts
+++ b/packages/effect/typetest/schema/Union.tst.ts
@@ -121,6 +121,8 @@ describe("Union", () => {
 
         const schema = original.pipe(Schema.toTaggedUnion("_tag"))
 
+        expect(schema.discriminants).type.toBe<readonly ["A", "C", "B"]>()
+
         expect(Schema.revealCodec(schema)).type.toBe<
           Schema.Codec<
             | { readonly _tag: "A"; readonly a: string }
@@ -159,6 +161,25 @@ describe("Union", () => {
             | { readonly kind: "b"; readonly b: string }
           >()
         }
+      })
+
+      it("should flatten discriminants", () => {
+        const schema = Schema.Union([
+          Schema.Struct({ event: Schema.Literal("A") }),
+          Schema.Union([
+            Schema.Struct({ event: Schema.Literal("B") }),
+            Schema.Struct({ event: Schema.Literal("C") })
+          ])
+        ]).pipe(Schema.toTaggedUnion("event"))
+
+        expect(schema.discriminants).type.toBe<readonly ["A", "B", "C"]>()
+        expect(Schema.Literals(schema.discriminants)).type.toBe<Schema.Literals<readonly ["A", "B", "C"]>>()
+      })
+
+      it("should support empty unions", () => {
+        const schema = Schema.Union([]).pipe(Schema.toTaggedUnion("event"))
+
+        expect(schema.discriminants).type.toBe<readonly []>()
       })
     })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tagged unions now expose an ordered `discriminants` collection containing the decoded discriminant values.
  - Discriminants remain correctly typed and ordered when unions are nested or empty.
  - Support includes symbol, numeric, string, and special keys such as `__proto__`.

- **Bug Fixes**
  - Duplicate discriminant keys are now detected and rejected, including numeric and string values that resolve to the same key.

- **Documentation**
  - Updated tagged-union guidance with discriminant access examples and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->