### PR TITLE
Support HttpApiSchema.StreamUint8Array request payloads in HttpApiClient

### DIFF
--- a/.changeset/httpapi-client-stream-request-payloads.md
+++ b/.changeset/httpapi-client-stream-request-payloads.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Support `HttpApiSchema.StreamUint8Array` request payloads in `HttpApiClient`
+
+Previously, declaring an endpoint with `payload: HttpApiSchema.StreamUint8Array()` type-checked (the client accepted a `Stream<Uint8Array>`), but the payload encoder had no stream case and fell back to Json encoding, sending `JSON.stringify(stream)` — the literal body `null` — over the wire. Stream payload schemas are now preserved through endpoint construction and encoded as streamed request bodies with the schema's content type.

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -1000,6 +1000,21 @@ function getEncodePayloadSchemaFromBody(
   if (cached !== undefined) {
     return cached
   }
+  if (HttpApiSchema.isStreamUint8Array(schema)) {
+    const out = $HttpBody.pipe(Schema.decodeTo(
+      schema,
+      SchemaTransformation.transformOrFail<Stream.Stream<Uint8Array, unknown>, HttpBody.HttpBody>({
+        decode(httpBody) {
+          return Effect.fail(new SchemaIssue.Forbidden(Option.some(httpBody), { message: "Encode only schema" }))
+        },
+        encode(stream) {
+          return Effect.succeed(HttpBody.stream(stream, schema.contentType))
+        }
+      })
+    ))
+    bodyFromPayloadCache.set(ast, out)
+    return out
+  }
   const encoding = HttpApiSchema.getPayloadEncoding(ast, method)
   const out = $HttpBody.pipe(Schema.decodeTo(
     schema,

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -991,16 +991,19 @@ function getEncodePayloadSchema(
 
 const bodyFromPayloadCache = new WeakMap<SchemaAST.AST, Schema.Top>()
 
+// Stream schemas share a single AST, with the content type carried on the
+// schema object itself, so their encoders are cached by schema identity
+const streamBodyFromPayloadCache = new WeakMap<HttpApiSchema.StreamUint8Array, Schema.Top>()
+
 function getEncodePayloadSchemaFromBody(
   schema: Schema.Constraint,
   method: HttpMethod.HttpMethod
 ): Schema.Top {
-  const ast = schema.ast
-  const cached = bodyFromPayloadCache.get(ast)
-  if (cached !== undefined) {
-    return cached
-  }
   if (HttpApiSchema.isStreamUint8Array(schema)) {
+    const cachedStream = streamBodyFromPayloadCache.get(schema)
+    if (cachedStream !== undefined) {
+      return cachedStream
+    }
     const out = $HttpBody.pipe(Schema.decodeTo(
       schema,
       SchemaTransformation.transformOrFail<Stream.Stream<Uint8Array, unknown>, HttpBody.HttpBody>({
@@ -1012,8 +1015,13 @@ function getEncodePayloadSchemaFromBody(
         }
       })
     ))
-    bodyFromPayloadCache.set(ast, out)
+    streamBodyFromPayloadCache.set(schema, out)
     return out
+  }
+  const ast = schema.ast
+  const cached = bodyFromPayloadCache.get(ast)
+  if (cached !== undefined) {
+    return cached
   }
   const encoding = HttpApiSchema.getPayloadEncoding(ast, method)
   const out = $HttpBody.pipe(Schema.decodeTo(

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1287,6 +1287,12 @@ function transformResponse(schema: Schema.Top): Schema.Top {
 }
 
 function transformPayload(schema: Schema.Top, method: HttpMethod): Schema.Top {
+  // Stream schemas carry their metadata on the schema object itself, so they
+  // must be preserved as-is for the client to detect them when encoding the
+  // request body
+  if (HttpApiSchema.isStreamSchema(schema)) {
+    return schema
+  }
   const encoding = HttpApiSchema.getPayloadEncoding(schema.ast, method)
   switch (encoding._tag) {
     case "Json":

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -233,6 +233,26 @@ describe("HttpApiClient", () => {
         const textDecoder = new TextDecoder()
         strictEqual(chunks.map((chunk) => textDecoder.decode(chunk, { stream: true })).join(""), "hello world")
       }))
+
+    it.effect("preserves each endpoint's stream content type", () =>
+      Effect.gen(function*() {
+        const captured: Array<HttpBody.HttpBody> = []
+        const client = yield* HttpApiClient.makeWith(UploadApi, {
+          baseUrl: "http://test",
+          httpClient: HttpClient.make((request) => {
+            captured.push(request.body)
+            return Effect.succeed(HttpClientResponse.fromWeb(request, new Response(undefined, { status: 200 })))
+          })
+        })
+
+        yield* client.test.upload({ payload: Stream.make(textEncoder.encode("a")) })
+        yield* client.test.uploadCustom({ payload: Stream.make(textEncoder.encode("b")) })
+
+        assert.strictEqual(captured[0]?._tag, "Stream")
+        assert.strictEqual((captured[0] as HttpBody.Stream).contentType, "application/octet-stream")
+        assert.strictEqual(captured[1]?._tag, "Stream")
+        assert.strictEqual((captured[1] as HttpBody.Stream).contentType, "application/vnd.custom")
+      }))
   })
 
   describe("error responses", () => {
@@ -681,6 +701,11 @@ const UploadApi = HttpApi.make("UploadApi").add(
   HttpApiGroup.make("test").add(
     HttpApiEndpoint.post("upload", "/upload", {
       payload: HttpApiSchema.StreamUint8Array(),
+      success: HttpApiSchema.Empty(200)
+    })
+  ).add(
+    HttpApiEndpoint.post("uploadCustom", "/uploadCustom", {
+      payload: HttpApiSchema.StreamUint8Array({ contentType: "application/vnd.custom" }),
       success: HttpApiSchema.Empty(200)
     })
   )

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
 import { Cause, Effect, Schema, Stream } from "effect"
 import { Sse } from "effect/unstable/encoding"
+import type { HttpBody } from "effect/unstable/http"
 import { HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { HttpApi, HttpApiClient, HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "effect/unstable/httpapi"
 
@@ -206,6 +207,31 @@ describe("HttpApiClient", () => {
         }
         const events = yield* Stream.runCollect(stream)
         assert.deepStrictEqual(events, [{ text: "hello" }])
+      }))
+  })
+
+  describe("streaming request payloads", () => {
+    it.effect("sends StreamUint8Array payloads as streamed bodies", () =>
+      Effect.gen(function*() {
+        let captured: HttpBody.HttpBody | undefined
+        const client = yield* HttpApiClient.makeWith(UploadApi, {
+          baseUrl: "http://test",
+          httpClient: HttpClient.make((request) => {
+            captured = request.body
+            return Effect.succeed(HttpClientResponse.fromWeb(request, new Response(undefined, { status: 200 })))
+          })
+        })
+
+        yield* client.test.upload({
+          payload: Stream.make(textEncoder.encode("hello "), textEncoder.encode("world"))
+        })
+
+        assert.strictEqual(captured?._tag, "Stream")
+        const body = captured as HttpBody.Stream
+        assert.strictEqual(body.contentType, "application/octet-stream")
+        const chunks = yield* Stream.runCollect(body.stream)
+        const textDecoder = new TextDecoder()
+        strictEqual(chunks.map((chunk) => textDecoder.decode(chunk, { stream: true })).join(""), "hello world")
       }))
   })
 
@@ -649,6 +675,15 @@ const ErrorContentTypeApi = HttpApi.make("ErrorContentTypeApi").add(
         error: [FirstJsonResponseError, SecondJsonResponseError]
       })
     )
+)
+
+const UploadApi = HttpApi.make("UploadApi").add(
+  HttpApiGroup.make("test").add(
+    HttpApiEndpoint.post("upload", "/upload", {
+      payload: HttpApiSchema.StreamUint8Array(),
+      success: HttpApiSchema.Empty(200)
+    })
+  )
 )
 
 const clientFromResponse = (response: () => Response): HttpClient.HttpClient =>


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP API streaming request payloads to be transmitted as streamed binary data (not JSON).
  * Preserved the declared content type for streamed request bodies across endpoints.
* **Tests**
  * Added coverage ensuring streamed payloads are sent correctly, including chunked data content and content-type handling.
* **Documentation**
  * Documented the streaming request payload fix and its impact on request encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->