### PR TITLE
Suppress unhandled logs from timeout fibers

### DIFF
--- a/.changeset/quiet-timeout-fibers.md
+++ b/.changeset/quiet-timeout-fibers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Disable unhandled error logging for fibers spawned by `Effect.timeout`.

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -604,26 +604,27 @@ export const timeoutTo = dual<
     core.fiberIdWith((parentFiberId) =>
       core.uninterruptibleMask((restore) =>
         fiberRuntime.raceFibersWith(
-          restore(self),
+          core.exit(restore(self)),
           core.interruptible(effect.sleep(duration)),
           {
             onSelfWin: (winner, loser) =>
               core.flatMap(
                 winner.await,
                 (exit) => {
-                  if (exit._tag === "Success") {
+                  const selfExit = core.exitFlatten(exit)
+                  if (selfExit._tag === "Success") {
                     return core.flatMap(
                       winner.inheritAll,
                       () =>
                         core.as(
                           core.interruptAsFiber(loser, parentFiberId),
-                          onSuccess(exit.value)
+                          onSuccess(selfExit.value)
                         )
                     )
                   } else {
                     return core.flatMap(
                       core.interruptAsFiber(loser, parentFiberId),
-                      () => core.exitFailCause(exit.cause)
+                      () => core.exitFailCause(selfExit.cause)
                     )
                   }
                 }
@@ -651,8 +652,6 @@ export const timeoutTo = dual<
               ),
             otherScope: globalScope
           }
-        ).pipe(
-          core.withUnhandledErrorLogLevel(Option.none())
         )
       )
     )

--- a/packages/effect/src/internal/effect/circular.ts
+++ b/packages/effect/src/internal/effect/circular.ts
@@ -651,6 +651,8 @@ export const timeoutTo = dual<
               ),
             otherScope: globalScope
           }
+        ).pipe(
+          core.withUnhandledErrorLogLevel(Option.none())
         )
       )
     )

--- a/packages/effect/test/Effect/timeout.test.ts
+++ b/packages/effect/test/Effect/timeout.test.ts
@@ -35,14 +35,33 @@ describe("Effect", () => {
         messages.push(message)
       })
 
-      yield* Effect.fail("boom").pipe(
+      const exit = yield* Effect.fail("boom").pipe(
         Effect.timeout(Duration.seconds(1)),
         Effect.exit,
         Effect.provide(Logger.replace(Logger.defaultLogger, logger)),
         Effect.withUnhandledErrorLogLevel(Option.some(LogLevel.Error))
       )
 
+      deepStrictEqual(exit, Exit.fail("boom"))
       deepStrictEqual(messages, [])
+    }))
+  it.effect("preserves the unhandled error log level for user fibers", () =>
+    Effect.gen(function*() {
+      const messages: Array<unknown> = []
+      const logger = Logger.make(({ message }) => {
+        messages.push(message)
+      })
+
+      yield* Effect.gen(function*() {
+        const fiber = yield* Effect.fork(Effect.fail("boom"))
+        yield* Fiber.await(fiber)
+      }).pipe(
+        Effect.timeout(Duration.seconds(1)),
+        Effect.provide(Logger.replace(Logger.defaultLogger, logger)),
+        Effect.withUnhandledErrorLogLevel(Option.some(LogLevel.Error))
+      )
+
+      deepStrictEqual(messages, ["Fiber terminated with an unhandled error"])
     }))
   it.live("timeout a long computation", () =>
     Effect.gen(function*() {

--- a/packages/effect/test/Effect/timeout.test.ts
+++ b/packages/effect/test/Effect/timeout.test.ts
@@ -6,6 +6,9 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { constFalse, pipe } from "effect/Function"
+import * as Logger from "effect/Logger"
+import * as LogLevel from "effect/LogLevel"
+import * as Option from "effect/Option"
 import * as TestClock from "effect/TestClock"
 
 describe("Effect", () => {
@@ -24,6 +27,22 @@ describe("Effect", () => {
           "TimeoutException: Operation timed out after '1s 500ms'"
         )
       )
+    }))
+  it.effect("does not log failures from its fibers as unhandled", () =>
+    Effect.gen(function*() {
+      const messages: Array<unknown> = []
+      const logger = Logger.make(({ message }) => {
+        messages.push(message)
+      })
+
+      yield* Effect.fail("boom").pipe(
+        Effect.timeout(Duration.seconds(1)),
+        Effect.exit,
+        Effect.provide(Logger.replace(Logger.defaultLogger, logger)),
+        Effect.withUnhandledErrorLogLevel(Option.some(LogLevel.Error))
+      )
+
+      deepStrictEqual(messages, [])
     }))
   it.live("timeout a long computation", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- Disable unhandled error logging for fibers spawned by `Effect.timeout`.
- Prevent timeout helper fibers from emitting noisy unhandled failure logs when the wrapped effect fails.
- Add a regression test covering the logging behavior.

## Testing
- Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Effect.timeout` behavior so that failures from timeouts no longer produce unhandled error logs when the underlying fiber errors.
* **Documentation**
  * Added a patch release note for `quiet-timeout-fibers` describing the updated unhandled error-logging behavior for timeout-related fibers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->