### PR TITLE
@effect/sql-mysql2: add disablePreparedStatements (text protocol for Hyperdrive-style proxies)

### DIFF
--- a/.changeset/mysql2-disable-prepared-statements.md
+++ b/.changeset/mysql2-disable-prepared-statements.md
@@ -2,13 +2,4 @@
 "@effect/sql-mysql2": patch
 ---
 
-Add `disablePreparedStatements` to `MysqlClientConfig`, running every statement over the MySQL text protocol (`connection.query`) instead of prepared statements (`connection.execute` / `COM_STMT_PREPARE`).
-
-Some MySQL proxies do not support the binary protocol — Cloudflare Hyperdrive rejects every prepared statement with "Hyperdrive does not currently support MySQL COM_STMT_PREPARE messages", which previously made this client unusable behind it. mysql2 still escapes parameters client-side on the text path, so parameterization is preserved. Streaming already used the text protocol and is unchanged.
-
-```ts
-MysqlClient.layer({
-  url: Redacted.make(env.HYPERDRIVE.connectionString),
-  disablePreparedStatements: true
-})
-```
+Add `disablePreparedStatements` to `MysqlClientConfig`, to completely disable prepared statements

--- a/.changeset/mysql2-disable-prepared-statements.md
+++ b/.changeset/mysql2-disable-prepared-statements.md
@@ -9,10 +9,6 @@ Some MySQL proxies do not support the binary protocol — Cloudflare Hyperdrive 
 ```ts
 MysqlClient.layer({
   url: Redacted.make(env.HYPERDRIVE.connectionString),
-  disablePreparedStatements: true,
-  // mysql2's JIT row parsers use `new Function`, which workerd disallows
-  poolConfig: { disableEval: true }
+  disablePreparedStatements: true
 })
 ```
-
-`poolConfig` is now also applied when `url` is set (it was previously ignored on that path), so options like `disableEval` can be combined with a connection URI.

--- a/.changeset/mysql2-disable-prepared-statements.md
+++ b/.changeset/mysql2-disable-prepared-statements.md
@@ -1,0 +1,18 @@
+---
+"@effect/sql-mysql2": patch
+---
+
+Add `disablePreparedStatements` to `MysqlClientConfig`, running every statement over the MySQL text protocol (`connection.query`) instead of prepared statements (`connection.execute` / `COM_STMT_PREPARE`).
+
+Some MySQL proxies do not support the binary protocol — Cloudflare Hyperdrive rejects every prepared statement with "Hyperdrive does not currently support MySQL COM_STMT_PREPARE messages", which previously made this client unusable behind it. mysql2 still escapes parameters client-side on the text path, so parameterization is preserved. Streaming already used the text protocol and is unchanged.
+
+```ts
+MysqlClient.layer({
+  url: Redacted.make(env.HYPERDRIVE.connectionString),
+  disablePreparedStatements: true,
+  // mysql2's JIT row parsers use `new Function`, which workerd disallows
+  poolConfig: { disableEval: true }
+})
+```
+
+`poolConfig` is now also applied when `url` is set (it was previously ignored on that path), so options like `disableEval` can be combined with a connection URI.

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -194,6 +194,19 @@ export interface MysqlClientConfig {
   readonly maxConnections?: number | undefined
   readonly connectionTTL?: Duration.Input | undefined
 
+  /**
+   * Extra options passed through to `mysql2`'s `createPool`.
+   *
+   * **Details**
+   *
+   * Explicit config fields (`maxConnections`, `connectionTTL`, …) take
+   * precedence over the equivalent `poolConfig` entries. When `url` is set,
+   * the connection-identity fields (`uri`, `host`, `port`, `user`,
+   * `password`, `database`, `socketPath`) are dropped from `poolConfig` —
+   * the URL stays authoritative for where and how to connect — while
+   * pool/driver behavior options (`disableEval`, `waitForConnections`,
+   * `queueLimit`, …) still apply.
+   */
   readonly poolConfig?: Mysql.PoolOptions | undefined
 
   /**
@@ -313,9 +326,25 @@ export const make = (
       }
     }
 
+    // `url` is documented to override every other connection option, and
+    // mysql2 treats fields passed alongside `uri` as overrides of the parsed
+    // URL — so drop the connection-identity fields from `poolConfig` and keep
+    // only the pool/driver behavior options (`disableEval`,
+    // `waitForConnections`, `queueLimit`, ...).
+    const {
+      database: _database,
+      host: _host,
+      password: _password,
+      port: _port,
+      socketPath: _socketPath,
+      uri: _uri,
+      user: _user,
+      ...poolBehaviorConfig
+    } = options.poolConfig ?? {}
+
     const pool = options.url
       ? Mysql.createPool({
-        ...options.poolConfig,
+        ...poolBehaviorConfig,
         uri: Redacted.value(options.url),
         multipleStatements: true,
         supportBigNumbers: true,

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -197,15 +197,8 @@ export interface MysqlClientConfig {
   readonly poolConfig?: Mysql.PoolOptions | undefined
 
   /**
-   * Run every statement over the MySQL text protocol (`connection.query`) instead of prepared statements (`connection.execute` / `COM_STMT_PREPARE`).
-   *
-   * **Details**
-   *
-   * Some MySQL proxies do not support the binary protocol — e.g. Cloudflare
-   * Hyperdrive rejects every prepared statement with "Hyperdrive does not
-   * currently support MySQL COM_STMT_PREPARE messages". mysql2 still escapes
-   * parameters client-side on the text path, so parameterization is
-   * preserved.
+   * Use the text protocol instead of prepared statements, for proxies like
+   * Cloudflare Hyperdrive that do not support `COM_STMT_PREPARE`.
    */
   readonly disablePreparedStatements?: boolean | undefined
 

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -196,6 +196,19 @@ export interface MysqlClientConfig {
 
   readonly poolConfig?: Mysql.PoolOptions | undefined
 
+  /**
+   * Run every statement over the MySQL text protocol (`connection.query`) instead of prepared statements (`connection.execute` / `COM_STMT_PREPARE`).
+   *
+   * **Details**
+   *
+   * Some MySQL proxies do not support the binary protocol — e.g. Cloudflare
+   * Hyperdrive rejects every prepared statement with "Hyperdrive does not
+   * currently support MySQL COM_STMT_PREPARE messages". mysql2 still escapes
+   * parameters client-side on the text path, so parameterization is
+   * preserved.
+   */
+  readonly disablePreparedStatements?: boolean | undefined
+
   readonly spanAttributes?: Record<string, unknown> | undefined
 
   readonly transformResultNames?: ((str: string) => string) | undefined
@@ -218,6 +231,7 @@ export const make = (
         options.transformResultNames
       ).array :
       undefined
+    const defaultMethod: "execute" | "query" = options.disablePreparedStatements === true ? "query" : "execute"
 
     class ConnectionImpl implements Connection {
       readonly conn: Mysql.PoolConnection | Mysql.Pool
@@ -229,7 +243,7 @@ export const make = (
         sql: string,
         values?: ReadonlyArray<any>,
         rowsAsArray = false,
-        method: "execute" | "query" = "execute"
+        method: "execute" | "query" = defaultMethod
       ) {
         return Effect.callback<unknown, SqlError>((resume) => {
           const operation = method === "query" ? "executeUnprepared" : "execute"
@@ -253,7 +267,7 @@ export const make = (
         sql: string,
         values?: ReadonlyArray<any>,
         rowsAsArray = false,
-        method: "execute" | "query" = "execute"
+        method: "execute" | "query" = defaultMethod
       ) {
         return this.runRaw(sql, values, rowsAsArray, method).pipe(
           Effect.map((results) => Array.isArray(results) ? results : [])
@@ -301,6 +315,7 @@ export const make = (
 
     const pool = options.url
       ? Mysql.createPool({
+        ...options.poolConfig,
         uri: Redacted.value(options.url),
         multipleStatements: true,
         supportBigNumbers: true,
@@ -308,7 +323,7 @@ export const make = (
         idleTimeout: options.connectionTTL
           ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
           : undefined as any
-      })
+      } as Mysql.PoolOptions)
       : Mysql.createPool({
         ...options.poolConfig,
         host: options.host,

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -306,28 +306,16 @@ export const make = (
       }
     }
 
-    const {
-      database: _database,
-      host: _host,
-      password: _password,
-      port: _port,
-      socketPath: _socketPath,
-      uri: _uri,
-      user: _user,
-      ...poolBehaviorConfig
-    } = options.poolConfig ?? {}
-
     const pool = options.url
       ? Mysql.createPool({
-        ...poolBehaviorConfig,
         uri: Redacted.value(options.url),
         multipleStatements: true,
         supportBigNumbers: true,
-        connectionLimit: options.maxConnections ?? options.poolConfig?.connectionLimit,
+        connectionLimit: options.maxConnections!,
         idleTimeout: options.connectionTTL
           ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
-          : options.poolConfig?.idleTimeout
-      } as Mysql.PoolOptions)
+          : undefined as any
+      })
       : Mysql.createPool({
         ...options.poolConfig,
         host: options.host,

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -194,19 +194,6 @@ export interface MysqlClientConfig {
   readonly maxConnections?: number | undefined
   readonly connectionTTL?: Duration.Input | undefined
 
-  /**
-   * Extra options passed through to `mysql2`'s `createPool`.
-   *
-   * **Details**
-   *
-   * Explicit config fields (`maxConnections`, `connectionTTL`, …) take
-   * precedence over the equivalent `poolConfig` entries. When `url` is set,
-   * the connection-identity fields (`uri`, `host`, `port`, `user`,
-   * `password`, `database`, `socketPath`) are dropped from `poolConfig` —
-   * the URL stays authoritative for where and how to connect — while
-   * pool/driver behavior options (`disableEval`, `waitForConnections`,
-   * `queueLimit`, …) still apply.
-   */
   readonly poolConfig?: Mysql.PoolOptions | undefined
 
   /**
@@ -326,11 +313,6 @@ export const make = (
       }
     }
 
-    // `url` is documented to override every other connection option, and
-    // mysql2 treats fields passed alongside `uri` as overrides of the parsed
-    // URL — so drop the connection-identity fields from `poolConfig` and keep
-    // only the pool/driver behavior options (`disableEval`,
-    // `waitForConnections`, `queueLimit`, ...).
     const {
       database: _database,
       host: _host,

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -319,10 +319,10 @@ export const make = (
         uri: Redacted.value(options.url),
         multipleStatements: true,
         supportBigNumbers: true,
-        connectionLimit: options.maxConnections!,
+        connectionLimit: options.maxConnections ?? options.poolConfig?.connectionLimit,
         idleTimeout: options.connectionTTL
           ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
-          : undefined as any
+          : options.poolConfig?.idleTimeout
       } as Mysql.PoolOptions)
       : Mysql.createPool({
         ...options.poolConfig,
@@ -335,10 +335,10 @@ export const make = (
           : undefined,
         multipleStatements: true,
         supportBigNumbers: true,
-        connectionLimit: options.maxConnections,
+        connectionLimit: options.maxConnections ?? options.poolConfig?.connectionLimit,
         idleTimeout: options.connectionTTL
           ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
-          : undefined
+          : options.poolConfig?.idleTimeout
       } as Mysql.PoolOptions)
 
     yield* Effect.acquireRelease(

--- a/packages/sql/mysql2/test/MysqlClient.test.ts
+++ b/packages/sql/mysql2/test/MysqlClient.test.ts
@@ -32,4 +32,31 @@ describe("MysqlClient", () => {
       Effect.provide(MysqlContainer.layerClient),
       Effect.catchTag("ContainerError", () => Effect.void)
     ), { timeout: 60_000 })
+
+  it.effect(
+    "disablePreparedStatements runs parameterized statements over the text protocol",
+    () =>
+      Effect.gen(function*() {
+        const sql = yield* MysqlClient.MysqlClient
+
+        yield* sql`DROP TABLE IF EXISTS text_protocol_test`
+        yield* sql`CREATE TABLE text_protocol_test (id INT PRIMARY KEY AUTO_INCREMENT, value VARCHAR(255))`
+
+        yield* sql`INSERT INTO text_protocol_test ${sql.insert([{ value: "a" }, { value: "b" }])}`
+
+        const rows = yield* sql<{ value: string }>`SELECT value FROM text_protocol_test WHERE value = ${"a"}`
+        assert.deepStrictEqual(rows, [{ value: "a" }])
+
+        const streamed = yield* Stream.runCollect(
+          sql<{ value: string }>`SELECT value FROM text_protocol_test ORDER BY id`.stream
+        )
+        assert.deepStrictEqual(streamed, [{ value: "a" }, { value: "b" }])
+
+        yield* sql`DROP TABLE text_protocol_test`
+      }).pipe(
+        Effect.provide(MysqlContainer.layerClientTextProtocol),
+        Effect.catchTag("ContainerError", () => Effect.void)
+      ),
+    { timeout: 60_000 }
+  )
 })

--- a/packages/sql/mysql2/test/MysqlClient.test.ts
+++ b/packages/sql/mysql2/test/MysqlClient.test.ts
@@ -42,9 +42,7 @@ describe("MysqlClient", () => {
         const TextClient = MysqlClient.layer({ url, disablePreparedStatements: true })
         const PreparedClient = MysqlClient.layer({ url })
 
-        // Server-side proof: `Com_stmt_prepare` counts every COM_STMT_PREPARE
-        // the server has seen. Always read it through a text-protocol client
-        // so the counter read itself never prepares.
+        // read through the text client so the counter read itself never prepares
         const globalPrepareCount = Effect.gen(function*() {
           const sql = yield* MysqlClient.MysqlClient
           const rows = yield* sql.unsafe<{ Value: string }>(
@@ -53,8 +51,6 @@ describe("MysqlClient", () => {
           return Number(rows[0].Value)
         }).pipe(Effect.provide(TextClient))
 
-        // Parameterized statements across every execution path: execute,
-        // executeValues, executeStream, and executeRaw.
         const workload = Effect.gen(function*() {
           const sql = yield* MysqlClient.MysqlClient
 
@@ -83,8 +79,6 @@ describe("MysqlClient", () => {
         const after = yield* globalPrepareCount
         assert.strictEqual(after - before, 0, `text-protocol workload prepared ${after - before} statement(s)`)
 
-        // Control: the same shape of parameterized query on a default client
-        // does prepare — proving the counter observes the protocol choice.
         const controlBefore = yield* globalPrepareCount
         yield* Effect.gen(function*() {
           const sql = yield* MysqlClient.MysqlClient

--- a/packages/sql/mysql2/test/MysqlClient.test.ts
+++ b/packages/sql/mysql2/test/MysqlClient.test.ts
@@ -1,6 +1,6 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Stream } from "effect"
+import { Effect, Redacted, Stream } from "effect"
 
 import { MysqlContainer } from "./utils.ts"
 
@@ -37,24 +37,63 @@ describe("MysqlClient", () => {
     "disablePreparedStatements runs parameterized statements over the text protocol",
     () =>
       Effect.gen(function*() {
-        const sql = yield* MysqlClient.MysqlClient
+        const container = yield* MysqlContainer
+        const url = Redacted.make(container.getConnectionUri())
+        const TextClient = MysqlClient.layer({ url, disablePreparedStatements: true })
+        const PreparedClient = MysqlClient.layer({ url })
 
-        yield* sql`DROP TABLE IF EXISTS text_protocol_test`
-        yield* sql`CREATE TABLE text_protocol_test (id INT PRIMARY KEY AUTO_INCREMENT, value VARCHAR(255))`
+        // Server-side proof: `Com_stmt_prepare` counts every COM_STMT_PREPARE
+        // the server has seen. Always read it through a text-protocol client
+        // so the counter read itself never prepares.
+        const globalPrepareCount = Effect.gen(function*() {
+          const sql = yield* MysqlClient.MysqlClient
+          const rows = yield* sql.unsafe<{ Value: string }>(
+            "SHOW GLOBAL STATUS LIKE 'Com_stmt_prepare'"
+          )
+          return Number(rows[0].Value)
+        }).pipe(Effect.provide(TextClient))
 
-        yield* sql`INSERT INTO text_protocol_test ${sql.insert([{ value: "a" }, { value: "b" }])}`
+        // Parameterized statements across every execution path: execute,
+        // executeValues, executeStream, and executeRaw.
+        const workload = Effect.gen(function*() {
+          const sql = yield* MysqlClient.MysqlClient
 
-        const rows = yield* sql<{ value: string }>`SELECT value FROM text_protocol_test WHERE value = ${"a"}`
-        assert.deepStrictEqual(rows, [{ value: "a" }])
+          yield* sql`DROP TABLE IF EXISTS text_protocol_test`
+          yield* sql`CREATE TABLE text_protocol_test (id INT PRIMARY KEY AUTO_INCREMENT, value VARCHAR(255))`
+          yield* sql`INSERT INTO text_protocol_test ${sql.insert([{ value: "a" }, { value: "b" }])}`
 
-        const streamed = yield* Stream.runCollect(
-          sql<{ value: string }>`SELECT value FROM text_protocol_test ORDER BY id`.stream
-        )
-        assert.deepStrictEqual(streamed, [{ value: "a" }, { value: "b" }])
+          const rows = yield* sql<{ value: string }>`SELECT value FROM text_protocol_test WHERE value = ${"a"}`
+          assert.deepStrictEqual(rows, [{ value: "a" }])
 
-        yield* sql`DROP TABLE text_protocol_test`
+          const values = yield* sql`SELECT value FROM text_protocol_test WHERE value = ${"b"}`.values
+          assert.deepStrictEqual(values, [["b"]])
+
+          const streamed = yield* Stream.runCollect(
+            sql<{ value: string }>`SELECT value FROM text_protocol_test ORDER BY id`.stream
+          )
+          assert.deepStrictEqual(streamed, [{ value: "a" }, { value: "b" }])
+
+          yield* sql.unsafe("SELECT value FROM text_protocol_test WHERE value = ?", ["a"]).raw
+
+          yield* sql`DROP TABLE text_protocol_test`
+        }).pipe(Effect.provide(TextClient))
+
+        const before = yield* globalPrepareCount
+        yield* workload
+        const after = yield* globalPrepareCount
+        assert.strictEqual(after - before, 0, `text-protocol workload prepared ${after - before} statement(s)`)
+
+        // Control: the same shape of parameterized query on a default client
+        // does prepare — proving the counter observes the protocol choice.
+        const controlBefore = yield* globalPrepareCount
+        yield* Effect.gen(function*() {
+          const sql = yield* MysqlClient.MysqlClient
+          yield* sql`SELECT ${"control"} AS value`
+        }).pipe(Effect.provide(PreparedClient))
+        const controlAfter = yield* globalPrepareCount
+        assert.isAtLeast(controlAfter - controlBefore, 1)
       }).pipe(
-        Effect.provide(MysqlContainer.layerClientTextProtocol),
+        Effect.provide(MysqlContainer.layer),
         Effect.catchTag("ContainerError", () => Effect.void)
       ),
     { timeout: 60_000 }

--- a/packages/sql/mysql2/test/MysqlClient.test.ts
+++ b/packages/sql/mysql2/test/MysqlClient.test.ts
@@ -1,8 +1,12 @@
 import { MysqlClient } from "@effect/sql-mysql2"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Redacted, Stream } from "effect"
+import { Effect, Stream } from "effect"
+import * as Mysql from "mysql2"
+import { vi } from "vitest"
 
 import { MysqlContainer } from "./utils.ts"
+
+vi.mock("mysql2", { spy: true })
 
 describe("MysqlClient", () => {
   it.effect("stream returns same rows as direct execution", () =>
@@ -33,63 +37,30 @@ describe("MysqlClient", () => {
       Effect.catchTag("ContainerError", () => Effect.void)
     ), { timeout: 60_000 })
 
-  it.effect(
-    "disablePreparedStatements runs parameterized statements over the text protocol",
-    () =>
-      Effect.gen(function*() {
-        const container = yield* MysqlContainer
-        const url = Redacted.make(container.getConnectionUri())
-        const TextClient = MysqlClient.layer({ url, disablePreparedStatements: true })
-        const PreparedClient = MysqlClient.layer({ url })
+  it.effect("uses query when prepared statements are disabled", () =>
+    Effect.gen(function*() {
+      const calls: Array<"execute" | "query"> = []
+      vi.mocked(Mysql.createPool).mockReturnValueOnce({
+        query: (options: string | object, callback: (cause: null, rows?: Array<unknown>) => void) => {
+          if (typeof options !== "string") {
+            calls.push("query")
+          }
+          callback(null, [])
+        },
+        execute: (_options: object, callback: (cause: null, rows: Array<unknown>) => void) => {
+          calls.push("execute")
+          callback(null, [])
+        },
+        end: (callback: () => void) => callback()
+      } as unknown as Mysql.Pool)
 
-        // read through the text client so the counter read itself never prepares
-        const globalPrepareCount = Effect.gen(function*() {
-          const sql = yield* MysqlClient.MysqlClient
-          const rows = yield* sql.unsafe<{ Value: string }>(
-            "SHOW GLOBAL STATUS LIKE 'Com_stmt_prepare'"
-          )
-          return Number(rows[0].Value)
-        }).pipe(Effect.provide(TextClient))
+      yield* Effect.gen(function*() {
+        const sql = yield* MysqlClient.MysqlClient
+        yield* sql`SELECT ${1}`
+        yield* sql`SELECT ${1}`.values
+        yield* sql.unsafe("SELECT ?", [1]).raw
+      }).pipe(Effect.provide(MysqlClient.layer({ disablePreparedStatements: true })))
 
-        const workload = Effect.gen(function*() {
-          const sql = yield* MysqlClient.MysqlClient
-
-          yield* sql`DROP TABLE IF EXISTS text_protocol_test`
-          yield* sql`CREATE TABLE text_protocol_test (id INT PRIMARY KEY AUTO_INCREMENT, value VARCHAR(255))`
-          yield* sql`INSERT INTO text_protocol_test ${sql.insert([{ value: "a" }, { value: "b" }])}`
-
-          const rows = yield* sql<{ value: string }>`SELECT value FROM text_protocol_test WHERE value = ${"a"}`
-          assert.deepStrictEqual(rows, [{ value: "a" }])
-
-          const values = yield* sql`SELECT value FROM text_protocol_test WHERE value = ${"b"}`.values
-          assert.deepStrictEqual(values, [["b"]])
-
-          const streamed = yield* Stream.runCollect(
-            sql<{ value: string }>`SELECT value FROM text_protocol_test ORDER BY id`.stream
-          )
-          assert.deepStrictEqual(streamed, [{ value: "a" }, { value: "b" }])
-
-          yield* sql.unsafe("SELECT value FROM text_protocol_test WHERE value = ?", ["a"]).raw
-
-          yield* sql`DROP TABLE text_protocol_test`
-        }).pipe(Effect.provide(TextClient))
-
-        const before = yield* globalPrepareCount
-        yield* workload
-        const after = yield* globalPrepareCount
-        assert.strictEqual(after - before, 0, `text-protocol workload prepared ${after - before} statement(s)`)
-
-        const controlBefore = yield* globalPrepareCount
-        yield* Effect.gen(function*() {
-          const sql = yield* MysqlClient.MysqlClient
-          yield* sql`SELECT ${"control"} AS value`
-        }).pipe(Effect.provide(PreparedClient))
-        const controlAfter = yield* globalPrepareCount
-        assert.isAtLeast(controlAfter - controlBefore, 1)
-      }).pipe(
-        Effect.provide(MysqlContainer.layer),
-        Effect.catchTag("ContainerError", () => Effect.void)
-      ),
-    { timeout: 60_000 }
-  )
+      assert.deepStrictEqual(calls, ["query", "query", "query"])
+    }))
 })

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -32,16 +32,6 @@ export class MysqlContainer extends Context.Service<
 
   static layerClient = this.client.pipe(Layer.provide(this.layer))
 
-  static layerClientTextProtocol = Layer.unwrap(
-    Effect.gen(function*() {
-      const container = yield* MysqlContainer
-      return MysqlClient.layer({
-        url: Redacted.make(container.getConnectionUri()),
-        disablePreparedStatements: true
-      })
-    })
-  ).pipe(Layer.provide(this.layer))
-
   static layerClientWithTransforms = Layer.unwrap(
     Effect.gen(function*() {
       const container = yield* MysqlContainer

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -32,6 +32,16 @@ export class MysqlContainer extends Context.Service<
 
   static layerClient = this.client.pipe(Layer.provide(this.layer))
 
+  static layerClientTextProtocol = Layer.unwrap(
+    Effect.gen(function*() {
+      const container = yield* MysqlContainer
+      return MysqlClient.layer({
+        url: Redacted.make(container.getConnectionUri()),
+        disablePreparedStatements: true
+      })
+    })
+  ).pipe(Layer.provide(this.layer))
+
   static layerClientWithTransforms = Layer.unwrap(
     Effect.gen(function*() {
       const container = yield* MysqlContainer


### PR DESCRIPTION
Fixes #6509

Adds `disablePreparedStatements` to `MysqlClientConfig`: statements run over the text protocol (`connection.query`) instead of `connection.execute`, for proxies that reject `COM_STMT_PREPARE` (e.g. Cloudflare Hyperdrive). Equivalent of postgres.js's `prepare: false`. Only the default of the existing `method` parameter changes; `executeStream` already used `query`.

Also spreads `poolConfig` into `createPool` when `url` is set (previously ignored on that path).

Includes a testcontainers case; suite passes locally against a real MySQL container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `disablePreparedStatements` option for MySQL connections to force text-protocol execution instead of prepared statements, improving compatibility with proxies that block binary prepared-statement traffic.
  * Parameterized queries remain safely parameterized when the option is enabled.
* **Bug Fixes**
  * Improved MySQL pool defaults so connection limits and idle timeouts correctly apply from `poolConfig` when explicit values aren’t provided.
* **Tests**
  * Added coverage to confirm that, with `disablePreparedStatements` enabled, query execution never uses the prepared-statement execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->