### PR TITLE
Fix MutableList filter empty-state handling

### DIFF
--- a/.changeset/fix-mutable-list-empty-filter.md
+++ b/.changeset/fix-mutable-list-empty-filter.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `MutableList.filter` leaving an invalid empty bucket when no values match.

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -899,6 +899,10 @@ export const filter = <A>(self: MutableList<A>, f: (value: A, i: number) => bool
     }
     chunk = chunk.next
   }
+  if (array.length === 0) {
+    clear(self)
+    return
+  }
   self.head = self.tail = {
     array,
     mutable: true,

--- a/packages/effect/test/MutableList.test.ts
+++ b/packages/effect/test/MutableList.test.ts
@@ -46,6 +46,18 @@ describe("MutableList", () => {
     strictEqual(list.length, 2)
   })
 
+  it("filter restores the empty list state when no values match", () => {
+    const list = MutableList.make<number>()
+    MutableList.append(list, 1)
+
+    MutableList.filter(list, () => false)
+
+    strictEqual(list.length, 0)
+    strictEqual(list.head, undefined)
+    strictEqual(list.tail, undefined)
+    strictEqual(MutableList.take(list), MutableList.Empty)
+  })
+
   it("remove deletes all strictly equal values and updates length", () => {
     const list = MutableList.make<string>()
     MutableList.appendAll(list, ["apple", "banana", "apple", "cherry", "apple"])

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -490,6 +490,20 @@ describe("PubSub", () => {
       })
     ))
 
+  it.effect("publish succeeds after interrupting a suspended subscriber", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.dropping<number>(1)
+        const subscription = yield* PubSub.subscribe(pubsub)
+        const fiber = yield* Effect.forkChild(PubSub.take(subscription), { startImmediately: true })
+
+        yield* Fiber.interrupt(fiber)
+
+        assert.isTrue(yield* PubSub.publish(pubsub, 42))
+        assert.strictEqual(yield* PubSub.take(subscription), 42)
+      })
+    ))
+
   it.effect("shutdown interrupts suspended takeAll subscribers", () =>
     Effect.scoped(
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- Restore the canonical empty-list state when `MutableList.filter` removes every value.
- Add regression coverage for empty `MutableList` internals and publishing after interrupting a suspended `PubSub` subscriber.
- Add a patch changeset for the `effect` package.

## Testing

- Added a `MutableList.filter` regression test covering length, head, tail, and `take` behavior.
- Added a `PubSub` regression test verifying publish and take after subscriber interruption.
- Not run (validation results were not provided).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `MutableList.filter` so filtering out all elements leaves the list in a valid empty state.
  * Fixed `PubSub` behavior after interrupting a suspended subscriber, allowing subsequent messages to be published and received correctly.

* **Tests**
  * Added coverage for empty filtered lists and interrupted `PubSub` subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->