### PR TITLE
Restrict nightly AI codegen to Effect-Ts repositories

### DIFF
--- a/.github/workflows/ai-codegen.yml
+++ b/.github/workflows/ai-codegen.yml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   codegen:
     name: AI Codegen
+    if: github.repository_owner == 'Effect-Ts'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Restrict the AI codegen job to repositories owned by the `Effect-Ts` organization.
- Prevent the nightly workflow from running in forks or repositories under other owners.

## Testing

- Not run (workflow-only conditional change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted nightly AI code generation to repositories owned by Effect-Ts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->