### PR TITLE
Fix OpenRouter dynamic tools sending an empty parameters schema

### DIFF
--- a/.changeset/beige-goats-sin.md
+++ b/.changeset/beige-goats-sin.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Fix dynamic tools defined with a raw JSON schema sending empty parameter schema to OpenRouter

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -1612,7 +1612,7 @@ const prepareTools = Effect.fnUntraced(
 
     for (const tool of options.tools) {
       const description = Tool.getDescription(tool)
-      const parameters = yield* tryJsonSchema(tool.parametersSchema, "prepareTools", transformer)
+      const parameters = yield* tryToolJsonSchema(tool, "prepareTools", transformer)
       const strict = Tool.getStrictMode(tool) ?? null
 
       tools.push({
@@ -1773,6 +1773,12 @@ const tryJsonSchema = <S extends Schema.Constraint>(
 ) =>
   Effect.try({
     try: () => Tool.getJsonSchemaFromSchema(schema, { transformer }),
+    catch: (error) => unsupportedSchemaError(error, method)
+  })
+
+const tryToolJsonSchema = <T extends Tool.Any>(tool: T, method: string, transformer: LanguageModel.CodecTransformer) =>
+  Effect.try({
+    try: () => Tool.getJsonSchema(tool, { transformer }),
     catch: (error) => unsupportedSchemaError(error, method)
   })
 

--- a/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts
@@ -2,7 +2,7 @@ import { Generated, OpenRouterClient, OpenRouterLanguageModel } from "@effect/ai
 import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Array, Context, Effect, Layer, Redacted, Ref, Schema } from "effect"
-import { LanguageModel, Prompt } from "effect/unstable/ai"
+import { LanguageModel, Prompt, Tool, Toolkit } from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("OpenRouterLanguageModel", () => {
@@ -171,6 +171,42 @@ describe("OpenRouterLanguageModel", () => {
             }])
           }).pipe(Effect.provide(makeTestLayer())))
       })
+    })
+
+    describe("tool preparation", () => {
+      it.effect("passes raw JSON schema for dynamic tools", () =>
+        Effect.gen(function*() {
+          const inputSchema = {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              limit: { type: "number" }
+            },
+            required: ["query"],
+            additionalProperties: false
+          } as const
+
+          const DynamicTool = Tool.dynamic("DynamicTool", {
+            description: "A dynamic tool",
+            parameters: inputSchema
+          })
+
+          yield* LanguageModel.generateText({
+            prompt: "Use the dynamic tool",
+            toolkit: Toolkit.make(DynamicTool),
+            disableToolCallResolution: true
+          }).pipe(Effect.provide(OpenRouterLanguageModel.model("google/gemini-2.5-flash")))
+
+          const requests = yield* MockHttpClient.requests
+          const body = yield* getRequestBody(requests[0])
+
+          const tool = body.tools?.find((entry: any) =>
+            entry.type === "function" && entry.function.name === "DynamicTool"
+          )
+          assert.isDefined(tool)
+          strictEqual(tool.function.description, "A dynamic tool")
+          deepStrictEqual(tool.function.parameters, inputSchema)
+        }).pipe(Effect.provide(makeTestLayer())))
     })
   })
 })


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a bug in the `@effect/ai-openrouter` package where dynamic tools were sending an empty parameters schema to Openrouter. The `@effect/ai-openai` package already has this working as expected, the logic is just copied over.

## Tests

- Added a regression test on par with the `@effect/ai-openai` one
- Verified the new test fails without the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic tools defined with raw JSON schemas so their parameter schemas are correctly sent to OpenRouter.
  * Improved tool handling during text generation to preserve expected function descriptions and parameters.

* **Release**
  * Included in a patch release for the OpenRouter integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->