### PR TITLE
Preserve OpenAI Responses cache write token usage

### DIFF
--- a/.changeset/small-pandas-cache.md
+++ b/.changeset/small-pandas-cache.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Preserve OpenAI Responses API cache write token usage in language model responses.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -3053,15 +3053,16 @@ const getUsage = (usage: OpenAiSchema.ResponseUsage | null | undefined): Respons
 
   const inputTokens = usage.input_tokens
   const outputTokens = usage.output_tokens
-  const cachedTokens = getUsageTokenDetail(usage.input_tokens_details, "cached_tokens")
-  const reasoningTokens = getUsageTokenDetail(usage.output_tokens_details, "reasoning_tokens")
+  const cachedTokens = getUsageTokenDetail(usage.input_tokens_details, "cached_tokens") ?? 0
+  const cacheWriteTokens = getUsageTokenDetail(usage.input_tokens_details, "cache_write_tokens")
+  const reasoningTokens = getUsageTokenDetail(usage.output_tokens_details, "reasoning_tokens") ?? 0
 
   return {
     inputTokens: {
       uncached: inputTokens - cachedTokens,
       total: inputTokens,
       cacheRead: cachedTokens,
-      cacheWrite: undefined
+      cacheWrite: cacheWriteTokens
     },
     outputTokens: {
       total: outputTokens,
@@ -3092,8 +3093,8 @@ const toServiceTier = (value: string | undefined): {
   }
 }
 
-const getUsageTokenDetail = (details: unknown, key: string): number =>
-  Predicate.hasProperty(details, key) && typeof details[key] === "number" ? details[key] : 0
+const getUsageTokenDetail = (details: unknown, key: string): number | undefined =>
+  Predicate.hasProperty(details, key) && typeof details[key] === "number" ? details[key] : undefined
 
 const transformToolCallParams = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Tool.Any>>(
   tools: Tools,

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -1,4 +1,4 @@
-import { Generated, OpenAiClient, OpenAiLanguageModel, OpenAiTool } from "@effect/ai-openai"
+import { type Generated, OpenAiClient, OpenAiLanguageModel, OpenAiSchema, OpenAiTool } from "@effect/ai-openai"
 import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Array, Context, Effect, Layer, Redacted, Ref, Schema, Stream } from "effect"
@@ -799,17 +799,22 @@ describe("OpenAiLanguageModel", () => {
           assert.isDefined(finishPart)
           if (finishPart?.type === "finish") {
             deepStrictEqual(finishPart.usage.inputTokens, {
-              uncached: 10,
+              uncached: 7,
               total: 10,
-              cacheRead: 0,
-              cacheWrite: undefined
+              cacheRead: 3,
+              cacheWrite: 4
             })
             deepStrictEqual(finishPart.usage.outputTokens, { total: 20, text: 20, reasoning: 0 })
           }
         }).pipe(Effect.provide(makeTestLayer({
           body: {
             output: [makeTextOutput("Hello")],
-            usage: makeUsage()
+            usage: makeUsage({
+              input_tokens_details: {
+                cached_tokens: 3,
+                cache_write_tokens: 4
+              }
+            })
           }
         }))))
 
@@ -902,6 +907,48 @@ describe("OpenAiLanguageModel", () => {
   })
 
   describe("streamText", () => {
+    it.effect("extracts usage information", () =>
+      Effect.gen(function*() {
+        const streamEvents = [
+          {
+            type: "response.created",
+            sequence_number: 1,
+            response: makeDefaultResponse({ status: "in_progress" })
+          },
+          {
+            type: "response.completed",
+            sequence_number: 2,
+            response: makeDefaultResponse({
+              usage: makeUsage({
+                input_tokens_details: {
+                  cached_tokens: 3,
+                  cache_write_tokens: 4
+                }
+              })
+            })
+          }
+        ] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "Hello"
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer(streamEvents))
+        )
+
+        const finishPart = globalThis.Array.from(partsChunk).find((part) => part.type === "finish")
+        assert.isDefined(finishPart)
+        if (finishPart?.type === "finish") {
+          deepStrictEqual(finishPart.usage.inputTokens, {
+            uncached: 7,
+            total: 10,
+            cacheRead: 3,
+            cacheWrite: 4
+          })
+        }
+      }))
+
     it.effect("emits valid apply_patch tool params JSON for update_file diffs", () =>
       Effect.gen(function*() {
         const diff = "@@ -1 +1 @@\n-old\n+new\n"
@@ -1322,7 +1369,7 @@ class MockHttpClient extends Context.Service<MockHttpClient, {
   )
 }
 
-const encodeResponse = Schema.encodeEffect(Generated.Response)
+const encodeResponse = Schema.encodeUnknownEffect(OpenAiSchema.Response)
 
 const makeHttpClient = Effect.gen(function*() {
   const capturedRequests = yield* Ref.make<ReadonlyArray<HttpClientRequest.HttpClientRequest>>([])
@@ -1498,9 +1545,16 @@ const makeReasoningOutput = (
   ...overrides
 })
 
+type TestResponseUsage = Omit<Generated.ResponseUsage, "input_tokens_details"> & {
+  readonly input_tokens_details: {
+    readonly cached_tokens: number
+    readonly cache_write_tokens?: number
+  }
+}
+
 const makeUsage = (
-  overrides: Partial<Generated.ResponseUsage> = {}
-): Generated.ResponseUsage => ({
+  overrides: Partial<TestResponseUsage> = {}
+): TestResponseUsage => ({
   input_tokens: 10,
   output_tokens: 20,
   total_tokens: 30,


### PR DESCRIPTION
## Summary

- preserve `usage.input_tokens_details.cache_write_tokens` in `Response.Usage.inputTokens.cacheWrite`
- cover positive cache write counts in both streamed and non-streamed Responses API results
- add a patch changeset for `@effect/ai-openai`

## Root cause

The OpenAI Responses usage adapter read cached and reasoning token details, but always assigned `undefined` to `cacheWrite`. Once normalized into `Response.Usage`, downstream consumers could not recover the provider-reported cache write count.

## Impact

Provider-reported cache write usage is now preserved. The adapter leaves `cacheWrite` undefined when OpenAI omits the field and does not infer costs or token counts.

## Validation

- `pnpm lint-fix`
- `pnpm test packages/ai/openai/test/OpenAiLanguageModel.test.ts` (52 tests)
- `pnpm check`
- `git diff --check`

Closes #6504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved OpenAI Responses API cache-write token usage in language model responses.
  * Improved usage reporting when cached, cache-write, or reasoning token details are missing.
  * Updated text generation and streaming usage breakdowns to accurately include cached and cache-write tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->