### PR TITLE
feat(sql-tursodatabase): add @effect/sql-tursodatabase driver for the Rust Turso engine

### DIFF
--- a/.changeset/add-sql-tursodatabase.md
+++ b/.changeset/add-sql-tursodatabase.md
@@ -1,0 +1,7 @@
+---
+"@effect/sql-tursodatabase": minor
+---
+
+Add `@effect/sql-tursodatabase`, an `@effect/sql` driver for the in-process Rust Turso engine (`@tursodatabase/database`).
+
+Provides `TursoClient` (a `SqlClient` exposing queries as `Effect`, the connection as a composable `Layer`, and typed `SqlError`s via Effect SQL's SQLite error classification) alongside `TursoMigrator`. Mirrors the existing `@effect/sql-libsql` and `@effect/sql-sqlite-node` drivers, including transaction support with savepoints and `SafeIntegers`. Streaming queries are not implemented.

--- a/packages/sql/tursodatabase/LICENSE
+++ b/packages/sql/tursodatabase/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sql/tursodatabase/README.md
+++ b/packages/sql/tursodatabase/README.md
@@ -1,0 +1,7 @@
+# `@effect/sql-tursodatabase`
+
+An `@effect/sql` implementation using the in-process Rust Turso engine (`@tursodatabase/database`).
+
+## Documentation
+
+- **API Reference**: [View the full documentation](https://effect-ts.github.io/effect/docs/sql-tursodatabase).

--- a/packages/sql/tursodatabase/docgen.json
+++ b/packages/sql/tursodatabase/docgen.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../node_modules/@effect/docgen/schema.json",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/tursodatabase/src/",
+  "exclude": ["src/internal/**/*.ts"],
+  "examplesCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ES2022",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rewriteRelativeImportExtensions": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "effect": ["../../../effect/src/index.js"],
+      "effect/*": ["../../../effect/src/*.js"]
+    },
+    "plugins": [
+      { "name": "@effect/language-service", "includeSuggestionsInTsc": false }
+    ]
+  }
+}

--- a/packages/sql/tursodatabase/package.json
+++ b/packages/sql/tursodatabase/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@effect/sql-tursodatabase",
+  "version": "4.0.0-beta.104",
+  "type": "module",
+  "license": "MIT",
+  "description": "A Turso toolkit for Effect",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect.git",
+    "directory": "packages/sql/tursodatabase"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect/issues"
+  },
+  "tags": [
+    "typescript",
+    "sql",
+    "turso",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "sql",
+    "turso",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./index": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./index": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "codegen": "effect-utils codegen",
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json"
+  },
+  "devDependencies": {
+    "effect": "workspace:^"
+  },
+  "peerDependencies": {
+    "effect": "workspace:^"
+  },
+  "dependencies": {
+    "@tursodatabase/database": "^0.7.2",
+    "@tursodatabase/database-common": "^0.7.2"
+  }
+}

--- a/packages/sql/tursodatabase/src/TursoClient.ts
+++ b/packages/sql/tursodatabase/src/TursoClient.ts
@@ -1,0 +1,300 @@
+/**
+ * Turso adapter for Effect SQL, backed by `@tursodatabase/database`.
+ *
+ * This module provides a {@link TursoClient} and the generic SQL client service
+ * for the in-process Rust Turso engine. It uses Effect SQL's SQLite compiler,
+ * supports a managed engine connection or a caller-owned live connection,
+ * classifies Turso and SQLite failures as `SqlError`s, and provides transaction
+ * support with savepoints. Streaming queries are not implemented by this driver.
+ *
+ * @since 4.0.0
+ */
+import { connect } from "@tursodatabase/database"
+import type { DatabaseOpts, DatabasePromise, StatementPromise } from "@tursodatabase/database-common"
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+import { identity } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
+import * as Semaphore from "effect/Semaphore"
+import * as Stream from "effect/Stream"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as Client from "effect/unstable/sql/SqlClient"
+import type { Connection } from "effect/unstable/sql/SqlConnection"
+import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
+import * as Statement from "effect/unstable/sql/Statement"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+
+const classifyError = (cause: unknown, message: string, operation: string) =>
+  classifySqliteError(cause, { message, operation })
+
+/**
+ * Runtime type identifier used to mark `TursoClient` values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-tursodatabase/TursoClient"
+
+/**
+ * Type-level identifier used to mark `TursoClient` values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~@effect/sql-tursodatabase/TursoClient"
+
+/**
+ * Turso-backed SQL client service, extending `SqlClient` with its runtime type marker and client configuration.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface TursoClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId
+  readonly config: TursoClientConfig
+  readonly sdk: DatabasePromise
+}
+
+/**
+ * Service tag for the Turso client service.
+ *
+ * **When to use**
+ *
+ * Use to access or provide a Turso client through the Effect context.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const TursoClient = Context.Service<TursoClient>("@effect/sql-tursodatabase/TursoClient")
+
+/**
+ * Configuration for a Turso client, either by supplying connection options or an existing live connection.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type TursoClientConfig = TursoClientConfig.Full | TursoClientConfig.Live
+
+/**
+ * Namespace containing the configuration variants for `TursoClient`.
+ *
+ * @since 4.0.0
+ */
+export declare namespace TursoClientConfig {
+  /**
+   * Shared Turso client options for span attributes and query/result name transformations.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Base {
+    readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly transformResultNames?: ((str: string) => string) | undefined
+    readonly transformQueryNames?: ((str: string) => string) | undefined
+  }
+
+  /**
+   * Connection-based Turso configuration used to open a managed engine connection.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Full extends Base, DatabaseOpts {
+    /**
+     * The database path.
+     *
+     * **Details**
+     *
+     * The in-process Turso engine opens a local database file by path, or an
+     * in-memory database with `":memory:"`. Unlike libSQL, the engine does not
+     * accept `file:`/`libsql:`/`http:` URLs — pass a filesystem path.
+     */
+    readonly url: string | URL
+  }
+
+  /**
+   * Configuration that uses an existing Turso connection. The supplied `liveClient` is caller-owned and is not closed by the Effect client.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Live extends Base {
+    readonly liveClient: DatabasePromise
+  }
+}
+
+/**
+ * Creates a scoped Turso SQL client with transaction support. When given connection options it opens and closes the engine connection; when given `liveClient`, the caller retains ownership.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = (
+  options: TursoClientConfig
+): Effect.Effect<TursoClient, never, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
+    const transformRows = options.transformResultNames ?
+      Statement.defaultTransforms(
+        options.transformResultNames
+      ).array :
+      undefined
+
+    const spanAttributes: Array<[string, unknown]> = [
+      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+      [ATTR_DB_SYSTEM_NAME, "sqlite"]
+    ]
+
+    const db = "liveClient" in options
+      ? options.liveClient
+      : yield* Effect.acquireRelease(
+        Effect.promise(() => {
+          const { spanAttributes: _s, transformQueryNames: _q, transformResultNames: _r, url, ...opts } = options
+          return connect(url.toString(), opts as DatabaseOpts)
+        }),
+        (db) => Effect.promise(() => db.close())
+      )
+
+    // `@tursodatabase/database` types `prepare` as async, but some engine
+    // versions return the statement synchronously. Wrapping in an async thunk
+    // normalizes both shapes for `Effect.tryPromise`.
+    const prepare = (sql: string) =>
+      Effect.tryPromise({
+        try: async () => db.prepare(sql),
+        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") })
+      })
+
+    const runStatement = (
+      statement: StatementPromise,
+      params: ReadonlyArray<unknown>,
+      raw: boolean
+    ) =>
+      Effect.withFiber<ReadonlyArray<any>, SqlError>((fiber) => {
+        if (Context.get(fiber.context, Client.SafeIntegers)) {
+          statement.safeIntegers(true)
+        }
+        return Effect.tryPromise({
+          try: async () => {
+            if (statement.reader) {
+              return await statement.all(...params)
+            }
+            const result = await statement.run(...params)
+            return raw ? result as unknown as ReadonlyArray<any> : []
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+        })
+      })
+
+    const runValues = (
+      statement: StatementPromise,
+      params: ReadonlyArray<unknown>
+    ) =>
+      Effect.tryPromise({
+        try: async () => {
+          if (statement.reader) {
+            return await statement.raw(true).all(...params) as ReadonlyArray<ReadonlyArray<unknown>>
+          }
+          await statement.run(...params)
+          return []
+        },
+        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+      })
+
+    const run = (sql: string, params: ReadonlyArray<unknown>, raw = false) =>
+      Effect.flatMap(prepare(sql), (statement) => runStatement(statement, params, raw))
+
+    const connection = identity<Connection>({
+      execute(sql, params, transformRows) {
+        return transformRows
+          ? Effect.map(run(sql, params), transformRows)
+          : run(sql, params)
+      },
+      executeRaw(sql, params) {
+        return run(sql, params, true)
+      },
+      executeValues(sql, params) {
+        return Effect.flatMap(prepare(sql), (statement) => runValues(statement, params))
+      },
+      executeValuesUnprepared(sql, params) {
+        return Effect.flatMap(prepare(sql), (statement) => runValues(statement, params))
+      },
+      executeUnprepared(sql, params, transformRows) {
+        return transformRows
+          ? Effect.map(run(sql, params), transformRows)
+          : run(sql, params)
+      },
+      executeStream(_sql, _params) {
+        return Stream.die("executeStream not implemented")
+      }
+    })
+
+    const semaphore = yield* Semaphore.make(1)
+
+    const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
+    const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
+      const fiber = Fiber.getCurrent()!
+      const scope = Context.getUnsafe(fiber.context, Scope.Scope)
+      return Effect.as(
+        Effect.tap(
+          restore(semaphore.take(1)),
+          () => Scope.addFinalizer(scope, semaphore.release(1))
+        ),
+        connection
+      )
+    })
+
+    return Object.assign(
+      yield* Client.make({
+        acquirer,
+        compiler,
+        transactionAcquirer,
+        spanAttributes,
+        transformRows
+      }),
+      {
+        [TypeId]: TypeId as TypeId,
+        config: options,
+        sdk: db
+      }
+    )
+  })
+
+/**
+ * Creates a layer from a `Config`-wrapped Turso client configuration, providing both `TursoClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerConfig = (
+  config: Config.Wrap<TursoClientConfig>
+): Layer.Layer<TursoClient | Client.SqlClient, Config.ConfigError> =>
+  Layer.effectContext(
+    Config.unwrap(config).pipe(
+      Effect.flatMap(make),
+      Effect.map((client) =>
+        Context.make(TursoClient, client).pipe(
+          Context.add(Client.SqlClient, client)
+        )
+      )
+    )
+  ).pipe(Layer.provide(Reactivity.layer))
+
+/**
+ * Creates a layer from a concrete Turso client configuration, providing both `TursoClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = (
+  config: TursoClientConfig
+): Layer.Layer<TursoClient | Client.SqlClient> =>
+  Layer.effectContext(
+    Effect.map(make(config), (client) =>
+      Context.make(TursoClient, client).pipe(
+        Context.add(Client.SqlClient, client)
+      ))
+  ).pipe(Layer.provide(Reactivity.layer))

--- a/packages/sql/tursodatabase/src/TursoClient.ts
+++ b/packages/sql/tursodatabase/src/TursoClient.ts
@@ -135,7 +135,7 @@ export declare namespace TursoClientConfig {
  */
 export const make = (
   options: TursoClientConfig
-): Effect.Effect<TursoClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<TursoClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames ?
@@ -152,9 +152,12 @@ export const make = (
     const db = "liveClient" in options
       ? options.liveClient
       : yield* Effect.acquireRelease(
-        Effect.promise(() => {
-          const { spanAttributes: _s, transformQueryNames: _q, transformResultNames: _r, url, ...opts } = options
-          return connect(url.toString(), opts as DatabaseOpts)
+        Effect.tryPromise({
+          try: () => {
+            const { spanAttributes: _s, transformQueryNames: _q, transformResultNames: _r, url, ...opts } = options
+            return connect(url.toString(), opts as DatabaseOpts)
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to open database", "openDatabase") })
         }),
         (db) => Effect.promise(() => db.close())
       )
@@ -193,15 +196,20 @@ export const make = (
       statement: StatementPromise,
       params: ReadonlyArray<unknown>
     ) =>
-      Effect.tryPromise({
-        try: async () => {
-          if (statement.reader) {
-            return await statement.raw(true).all(...params) as ReadonlyArray<ReadonlyArray<unknown>>
-          }
-          await statement.run(...params)
-          return []
-        },
-        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+      Effect.withFiber<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>((fiber) => {
+        if (Context.get(fiber.context, Client.SafeIntegers)) {
+          statement.safeIntegers(true)
+        }
+        return Effect.tryPromise({
+          try: async () => {
+            if (statement.reader) {
+              return await statement.raw(true).all(...params) as ReadonlyArray<ReadonlyArray<unknown>>
+            }
+            await statement.run(...params)
+            return []
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+        })
       })
 
     const run = (sql: string, params: ReadonlyArray<unknown>, raw = false) =>
@@ -271,7 +279,7 @@ export const make = (
  */
 export const layerConfig = (
   config: Config.Wrap<TursoClientConfig>
-): Layer.Layer<TursoClient | Client.SqlClient, Config.ConfigError> =>
+): Layer.Layer<TursoClient | Client.SqlClient, Config.ConfigError | SqlError> =>
   Layer.effectContext(
     Config.unwrap(config).pipe(
       Effect.flatMap(make),
@@ -291,7 +299,7 @@ export const layerConfig = (
  */
 export const layer = (
   config: TursoClientConfig
-): Layer.Layer<TursoClient | Client.SqlClient> =>
+): Layer.Layer<TursoClient | Client.SqlClient, SqlError> =>
   Layer.effectContext(
     Effect.map(make(config), (client) =>
       Context.make(TursoClient, client).pipe(

--- a/packages/sql/tursodatabase/src/TursoMigrator.ts
+++ b/packages/sql/tursodatabase/src/TursoMigrator.ts
@@ -1,0 +1,47 @@
+/**
+ * Runs database migrations for Turso projects that use Effect SQL.
+ *
+ * This module re-exports the shared migration loaders and errors, then provides
+ * `run` and `layer` helpers that apply pending migration files with the current
+ * `SqlClient`. Migration execution is handled by the shared SQL migrator.
+ *
+ * @since 4.0.0
+ */
+import type * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Migrator from "effect/unstable/sql/Migrator"
+import type * as Client from "effect/unstable/sql/SqlClient"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+
+/**
+ * @since 4.0.0
+ */
+export * from "effect/unstable/sql/Migrator"
+
+/**
+ * Runs SQL migrations for a Turso database using the shared `Migrator` implementation and the current `SqlClient`.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const run: <R2 = never>(
+  options: Migrator.MigratorOptions<R2>
+) => Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  Client.SqlClient | R2
+> = Migrator.make({})
+
+/**
+ * Creates a layer that runs the configured Turso migrations during layer construction and provides no services.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const layer = <R>(
+  options: Migrator.MigratorOptions<R>
+): Layer.Layer<
+  never,
+  Migrator.MigrationError | SqlError,
+  Client.SqlClient | R
+> => Layer.effectDiscard(run(options))

--- a/packages/sql/tursodatabase/src/TursoMigrator.ts
+++ b/packages/sql/tursodatabase/src/TursoMigrator.ts
@@ -35,7 +35,7 @@ export const run: <R2 = never>(
 /**
  * Creates a layer that runs the configured Turso migrations during layer construction and provides no services.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/tursodatabase/src/index.ts
+++ b/packages/sql/tursodatabase/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @since 4.0.0
+ */
+
+// @barrel: Auto-generated exports. Do not edit manually.
+
+/**
+ * @since 4.0.0
+ */
+export * as TursoClient from "./TursoClient.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as TursoMigrator from "./TursoMigrator.ts"

--- a/packages/sql/tursodatabase/test/Client.test.ts
+++ b/packages/sql/tursodatabase/test/Client.test.ts
@@ -1,0 +1,95 @@
+import { TursoClient } from "@effect/sql-tursodatabase"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+
+const makeClient = TursoClient.make({
+  url: ":memory:"
+}).pipe(Effect.provide(Reactivity.layer))
+
+describe("Client", () => {
+  it.effect("should work", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      let response
+      response = yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      assert.deepStrictEqual(response, [])
+      response = yield* sql`INSERT INTO test (name) VALUES ('hello')`
+      assert.deepStrictEqual(response, [])
+      response = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(response, [{ id: 1, name: "hello" }])
+      response = yield* sql`SELECT * FROM test`.values
+      assert.deepStrictEqual(response, [[1, "hello"]])
+      response = yield* sql`INSERT INTO test (name) VALUES ('world')`.pipe(sql.withTransaction)
+      assert.deepStrictEqual(response, [])
+      response = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(response, [
+        { id: 1, name: "hello" },
+        { id: 2, name: "world" }
+      ])
+    }))
+
+  it.effect("should work with raw", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      let response
+      response = yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`.raw
+      assert.deepStrictEqual(response, { changes: 0, lastInsertRowid: 0 })
+      response = yield* sql`INSERT INTO test (name) VALUES ('hello')`.raw
+      assert.deepStrictEqual(response, { changes: 1, lastInsertRowid: 1 })
+      response = yield* sql`SELECT * FROM test`.raw
+      assert.deepStrictEqual(response, [{ id: 1, name: "hello" }])
+      response = yield* sql`INSERT INTO test (name) VALUES ('world')`.raw.pipe(sql.withTransaction)
+      assert.deepStrictEqual(response, { changes: 1, lastInsertRowid: 2 })
+      response = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(response, [
+        { id: 1, name: "hello" },
+        { id: 2, name: "world" }
+      ])
+    }))
+
+  it.effect("withTransaction", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql.withTransaction(sql`INSERT INTO test (name) VALUES ('hello')`)
+      const rows = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+    }))
+
+  it.effect("withTransaction rollback", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql`INSERT INTO test (name) VALUES ('hello')`.pipe(
+        Effect.andThen(Effect.fail("boom")),
+        sql.withTransaction,
+        Effect.ignore
+      )
+      const rows = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(rows, [])
+    }))
+
+  it.effect("withTransaction nested", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const stmt = sql`INSERT INTO test (name) VALUES ('hello')`
+      yield* stmt.pipe(Effect.andThen(() => stmt.pipe(sql.withTransaction)), sql.withTransaction)
+      const rows = yield* sql<{ total_rows: number }>`select count(*) as total_rows FROM test`
+      assert.deepStrictEqual(rows.at(0)?.total_rows, 2)
+    }))
+
+  it.effect("withTransaction nested rollback", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const stmt = sql`INSERT INTO test (name) VALUES ('hello')`
+      yield* stmt.pipe(
+        Effect.andThen(() => stmt.pipe(Effect.andThen(Effect.fail("boom")), sql.withTransaction, Effect.ignore)),
+        sql.withTransaction
+      )
+      const rows = yield* sql<{ total_rows: number }>`select count(*) as total_rows FROM test`
+      assert.deepStrictEqual(rows.at(0)?.total_rows, 1)
+    }))
+})

--- a/packages/sql/tursodatabase/test/Client.test.ts
+++ b/packages/sql/tursodatabase/test/Client.test.ts
@@ -2,6 +2,7 @@ import { TursoClient } from "@effect/sql-tursodatabase"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import { Reactivity } from "effect/unstable/reactivity"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
 
 const makeClient = TursoClient.make({
   url: ":memory:"
@@ -92,4 +93,13 @@ describe("Client", () => {
       const rows = yield* sql<{ total_rows: number }>`select count(*) as total_rows FROM test`
       assert.deepStrictEqual(rows.at(0)?.total_rows, 1)
     }))
+
+  it.effect("honors SafeIntegers for .values queries", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, big INTEGER)`
+      yield* sql`INSERT INTO test (big) VALUES (9007199254740993)`
+      const rows = yield* sql`SELECT big FROM test`.values
+      assert.deepStrictEqual(rows, [[9007199254740993n]])
+    }).pipe(Effect.provideService(SqlClient.SafeIntegers, true)))
 })

--- a/packages/sql/tursodatabase/tsconfig.json
+++ b/packages/sql/tursodatabase/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,19 @@ importers:
         specifier: workspace:^
         version: link:../../effect
 
+  packages/sql/tursodatabase:
+    dependencies:
+      '@tursodatabase/database':
+        specifier: ^0.7.2
+        version: 0.7.2
+      '@tursodatabase/database-common':
+        specifier: ^0.7.2
+        version: 0.7.2
+    devDependencies:
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+
   packages/tools/ai-codegen:
     dependencies:
       '@effect/openapi-generator':
@@ -3128,6 +3141,32 @@ packages:
 
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+
+  '@tursodatabase/database-common@0.7.2':
+    resolution: {integrity: sha512-c4uWaA5m7nyDemUrjvX6lQQ89cBxv1jCv7nmwq5JoagyXgbMxDeBfLcY7N5kn0oEcnD0Y+cf09S0wKEXKFKbfg==}
+
+  '@tursodatabase/database-darwin-arm64@0.7.2':
+    resolution: {integrity: sha512-pDYbrPnmsqzWsf21bQXXGKmGhcLdfQQVjx+yrpC/IboCue5o/h9fDZ1QFzQEP6CHRXXoc+pwQCyF8KBntI8fdA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tursodatabase/database-linux-arm64-gnu@0.7.2':
+    resolution: {integrity: sha512-/Blz7cRssWh7dk8vGs7Cq3kupHOnI0GROAg+u9J4MD5U5ABAabJGN7iW5YQ16jZW35Bv2AkmJAyjvsCWdTyfTg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tursodatabase/database-linux-x64-gnu@0.7.2':
+    resolution: {integrity: sha512-rXxInfTxKRPG3XeOAZvzJuX4wF+m9t9BjLbFnKU83Ad8ob2z88r1x+EV7IBzEFhz2FbvrRgriH7PhIEZ7Lx5ug==}
+    cpu: [x64]
+    os: [linux]
+
+  '@tursodatabase/database-win32-x64-msvc@0.7.2':
+    resolution: {integrity: sha512-AUvN3KO1bZOpsXVofRIMM2+MJ6OghUhgK62t8/3Bsb0Zzt6PztaMvJrtaWI6u5Olx0WCfGdhaVKyegcjYPNAeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tursodatabase/database@0.7.2':
+    resolution: {integrity: sha512-B84QicyDYnKt97qxgb7861cQQC26kuv/LkUlCnpxGs4tuGT9zgS2z/Mt+BkG/wOo1fB4rsSycOgGCbi0xU0YOQ==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -8775,6 +8814,29 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
       tinyglobby: 0.2.17
+
+  '@tursodatabase/database-common@0.7.2': {}
+
+  '@tursodatabase/database-darwin-arm64@0.7.2':
+    optional: true
+
+  '@tursodatabase/database-linux-arm64-gnu@0.7.2':
+    optional: true
+
+  '@tursodatabase/database-linux-x64-gnu@0.7.2':
+    optional: true
+
+  '@tursodatabase/database-win32-x64-msvc@0.7.2':
+    optional: true
+
+  '@tursodatabase/database@0.7.2':
+    dependencies:
+      '@tursodatabase/database-common': 0.7.2
+    optionalDependencies:
+      '@tursodatabase/database-darwin-arm64': 0.7.2
+      '@tursodatabase/database-linux-arm64-gnu': 0.7.2
+      '@tursodatabase/database-linux-x64-gnu': 0.7.2
+      '@tursodatabase/database-win32-x64-msvc': 0.7.2
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -30,6 +30,7 @@
     { "path": "packages/sql/sqlite-node" },
     { "path": "packages/sql/sqlite-react-native" },
     { "path": "packages/sql/sqlite-wasm" },
+    { "path": "packages/sql/tursodatabase" },
     { "path": "packages/tools/ai-codegen" },
     { "path": "packages/tools/api-diff" },
     { "path": "packages/tools/bundle" },

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -75,6 +75,8 @@
       "@effect/sql-sqlite-react-native/*": ["./packages/sql/sqlite-react-native/src/*.ts"],
       "@effect/sql-sqlite-wasm": ["./packages/sql/sqlite-wasm/src/index.ts"],
       "@effect/sql-sqlite-wasm/*": ["./packages/sql/sqlite-wasm/src/*.ts"],
+      "@effect/sql-tursodatabase": ["./packages/sql/tursodatabase/src/index.ts"],
+      "@effect/sql-tursodatabase/*": ["./packages/sql/tursodatabase/src/*.ts"],
       "@effect/ai-codegen": ["./packages/tools/ai-codegen/src/index.ts"],
       "@effect/ai-codegen/*": ["./packages/tools/ai-codegen/src/*.ts"],
       "@effect/api-diff": ["./packages/tools/api-diff/src/Cli.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -184,6 +184,7 @@ export default defineConfig({
       ...project("@effect/sql-sqlite-node", "packages/sql/sqlite-node", !isDeno),
       ...project("@effect/sql-sqlite-react-native", "packages/sql/sqlite-react-native"),
       ...project("@effect/sql-sqlite-wasm", "packages/sql/sqlite-wasm"),
+      ...project("@effect/sql-tursodatabase", "packages/sql/tursodatabase", isNode),
       ...project("@effect/api-diff", "packages/tools/api-diff"),
       ...project("@effect/bundle", "packages/tools/bundle"),
       ...project("@effect/doctest", "packages/tools/doctest"),


### PR DESCRIPTION
Adds `@effect/sql-tursodatabase`, an `@effect/sql` implementation backed by the in-process Rust Turso engine (`@tursodatabase/database`), modeled on `@effect/sql-libsql`.

This is the migration of Effect-TS/effect-smol#2509 (closed because V4 development moved here). See that PR for the original discussion and review history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `@effect/sql-tursodatabase` for SQL access via the in-process Turso engine.
  * Introduced a composable client layer with typed SQL error handling.
  * Added transaction support, including nested transactions and rollback behavior.
  * Added migration helpers for running and layering database migrations (streaming queries not included).

* **Tests**
  * Added integration tests covering query execution, raw results, transactions, nested transactions, and rollbacks.

* **Documentation**
  * Added package README and documentation generation configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->