### PR TITLE
Simplify the displayed `Type`, `Encoded`, and `Iso` types of required readonly `Schema.Struct` fields, closes #6521

### DIFF
--- a/.changeset/fix-6521.md
+++ b/.changeset/fix-6521.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Simplify the displayed `Type`, `Encoded`, and `Iso` types of required readonly `Schema.Struct` fields, closes #6521.

--- a/.patterns/testing.md
+++ b/.patterns/testing.md
@@ -42,3 +42,31 @@ Run targeted type-level tests with:
 ```sh
 pnpm test-types <filename>
 ```
+
+### Testing Displayed Types
+
+Ordinary Tstyche assertions such as `toBe` compare types structurally. They cannot
+catch regressions where a public type is semantically correct but TypeScript
+displays an internal alias or an unsimplified intersection in editor quick info.
+
+To test the displayed form, deliberately produce an assignment error and use
+Tstyche's checked `@ts-expect-error` message to match a distinctive substring of
+the rendered type:
+
+```typescript
+it("simplifies the displayed type", () => {
+  const value = null as unknown as PublicType
+
+  // @ts-expect-error Type '{ readonly value: string; }'
+  const displayed: never = value
+
+  void displayed
+})
+```
+
+Before accepting the test, temporarily restore the broken type and confirm that
+the diagnostic-message match fails. Keep the expected substring as small as
+possible while still distinguishing the desired public type from the leaked
+implementation type, because diagnostic wording can change between TypeScript
+versions. Run the targeted test against every TypeScript version configured by
+`pnpm test-types`.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3246,7 +3246,7 @@ export declare namespace Struct {
     S extends Side,
     O extends keyof F = SideOptionalKeys<F, S>,
     M extends keyof F = SideMutableKeys<F, S>
-  > = [O | M] extends [never] ? ReadonlySide<F, S>
+  > = [O | M] extends [never] ? Simplify<ReadonlySide<F, S>>
     : [M] extends [never] ? Simplify<SetOptional<ReadonlySide<F, S>, O>>
     : [O] extends [never] ? Simplify<SetMutable<ReadonlySide<F, S>, M>>
     : Simplify<

--- a/packages/effect/typetest/schema/Struct.tst.ts
+++ b/packages/effect/typetest/schema/Struct.tst.ts
@@ -46,6 +46,22 @@ describe("Struct", () => {
       >()
     })
 
+    it("simplifies readonly & required views", () => {
+      const schema = Schema.Union([
+        Schema.Struct({ name: Schema.Literal("a"), a: Schema.String }),
+        Schema.Struct({ name: Schema.Literal("b"), b: Schema.Finite })
+      ])
+
+      // @ts-expect-error Type '{ readonly name: "a"; readonly a: string; } | { readonly name: "b"; readonly b: number; }'
+      const type: never = null as unknown as typeof schema.Type
+      // @ts-expect-error Type '{ readonly name: "a"; readonly a: string; } | { readonly name: "b"; readonly b: number; }'
+      const encoded: never = null as unknown as typeof schema.Encoded
+      // @ts-expect-error Type '{ readonly name: "a"; readonly a: string; } | { readonly name: "b"; readonly b: number; }'
+      const iso: never = null as unknown as typeof schema.Iso
+
+      void [type, encoded, iso]
+    })
+
     it("readonly & optionalKey field", () => {
       const schema = Schema.Struct({
         a: Schema.optionalKey(Schema.String)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified the displayed `Type`, `Encoded`, and `Iso` types for required readonly `Schema.Struct` fields, improving editor/quick-info output without changing runtime behavior.
- **Tests**
  - Added a type-level check to ensure readonly + required `Schema.Struct` views stay simplified.
- **Documentation**
  - Documented how to validate displayed/public TypeScript types using targeted compiler error assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->