### PR TITLE
Add D1 batch support

### DIFF
--- a/.changeset/d1-batch-statements.md
+++ b/.changeset/d1-batch-statements.md
@@ -1,5 +1,5 @@
 ---
-"@effect/sql-d1": patch
+"@effect/sql-d1": minor
 ---
 
 Add `D1Client.batch` for executing a collection of SQL statements as a single atomic D1 batch.

--- a/.changeset/d1-batch-statements.md
+++ b/.changeset/d1-batch-statements.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-d1": patch
+---
+
+Add `D1Client.batch` for executing a collection of SQL statements as a single atomic D1 batch.

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -133,61 +133,61 @@ const makeBatch = (options: {
   readonly spanAttributes: ReadonlyArray<readonly [string, unknown]>
   readonly getClient: () => D1Client
 }): D1Client["batch"] =>
-  Effect.fnUntraced(function*<const Statements extends ReadonlyArray<Statement.Statement<any>>>(
-    statements: Statements
-  ) {
-    if (statements.length === 0) {
-      return [] as unknown as BatchResults<Statements>
-    }
-    return yield* Effect.useSpan(
-      "sql.execute",
-      { kind: "client" },
-      (span) =>
-        Effect.withFiber(Effect.fnUntraced(function*(fiber) {
-          const transformer = yield* Statement.CurrentTransformer
-          const prepared: Array<D1PreparedStatement> = []
-          const transforms: Array<TransformRows | undefined> = []
-          const queryTexts: Array<string> = []
+<const Statements extends ReadonlyArray<Statement.Statement<any>>>(
+  statements: Statements
+) => {
+  if (statements.length === 0) {
+    return Effect.succeed([] as unknown as BatchResults<Statements>)
+  }
+  return Effect.useSpan(
+    "sql.execute",
+    { kind: "client" },
+    (span) =>
+      Effect.withFiber(Effect.fnUntraced(function*(fiber) {
+        const transformer = fiber.getRef(Statement.CurrentTransformer)
+        const prepared: Array<D1PreparedStatement> = []
+        const transforms: Array<TransformRows | undefined> = []
+        const queryTexts: Array<string> = []
 
-          for (const original of statements) {
-            const statement = transformer === undefined
-              ? original
-              : yield* transformer(original, options.getClient(), fiber, span)
-            const [sql, params] = statement.compile()
-            queryTexts.push(sql)
-            transforms.push((statement as StatementWithTransformRows).transformRows)
-            prepared.push((yield* Cache.get(options.prepareCache, sql)).bind(...params))
-          }
+        for (const original of statements) {
+          const statement = transformer === undefined
+            ? original
+            : yield* transformer(original, options.getClient(), fiber, span)
+          const [sql, params] = statement.compile()
+          queryTexts.push(sql)
+          transforms.push((statement as StatementWithTransformRows).transformRows)
+          prepared.push((yield* Cache.get(options.prepareCache, sql)).bind(...params))
+        }
 
-          for (const [key, value] of options.spanAttributes) {
-            span.attribute(key, value)
-          }
-          span.attribute(ATTR_DB_OPERATION_NAME, "batch")
-          span.attribute(ATTR_DB_QUERY_TEXT, queryTexts.join("; "))
+        for (const [key, value] of options.spanAttributes) {
+          span.attribute(key, value)
+        }
+        span.attribute(ATTR_DB_OPERATION_NAME, "batch")
+        span.attribute(ATTR_DB_QUERY_TEXT, queryTexts.join("; "))
 
-          // D1 batches execute on the binding directly and intentionally cannot participate in SqlClient transactions.
-          const responses = yield* Effect.tryPromise({
-            try: () =>
-              options.db.batch<Record<string, unknown>>(prepared).then((responses) => {
-                for (const response of responses) {
-                  if (response.error) {
-                    throw response.error
-                  }
+        // D1 batches execute on the binding directly and intentionally cannot participate in SqlClient transactions.
+        const responses = yield* Effect.tryPromise({
+          try: () =>
+            options.db.batch<Record<string, unknown>>(prepared).then((responses) => {
+              for (const response of responses) {
+                if (response.error) {
+                  throw response.error
                 }
-                return responses
-              }),
-            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute batch", "execute") })
-          })
+              }
+              return responses
+            }),
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute batch", "execute") })
+        })
 
-          const results = responses.map((response, index) => {
-            const rows = response.results || []
-            const transformRows = transforms[index]
-            return transformRows ? transformRows(rows) : rows
-          })
-          return results as BatchResults<Statements>
-        }))
-    )
-  })
+        const results = responses.map((response, index) => {
+          const rows = response.results || []
+          const transformRows = transforms[index]
+          return transformRows ? transformRows(rows) : rows
+        })
+        return results as BatchResults<Statements>
+      }))
+  )
+}
 
 /**
  * Creates a scoped Cloudflare D1 SQL client. Prepared statements are cached, while transactions and streaming queries are not supported by this driver.

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -69,8 +69,9 @@ export interface D1Client extends Client.SqlClient {
    *
    * **Gotchas**
    *
-   * Statements should be created by this client so that query and result name
-   * transformations remain consistent.
+   * Each statement uses the query and result name transformations from the
+   * client that created it. Mixing clients can produce differently shaped row
+   * results within the same batch.
    *
    * @since 4.0.0
    */
@@ -115,6 +116,78 @@ export interface D1ClientConfig {
   readonly transformResultNames?: ((str: string) => string) | undefined
   readonly transformQueryNames?: ((str: string) => string) | undefined
 }
+
+type TransformRows = <A extends object>(rows: ReadonlyArray<A>) => ReadonlyArray<A>
+
+type BatchResults<Statements extends ReadonlyArray<Statement.Statement<any>>> = {
+  readonly [K in keyof Statements]: Effect.Success<Statements[K]>
+}
+
+interface StatementWithTransformRows extends Statement.Statement<any> {
+  readonly transformRows: TransformRows | undefined
+}
+
+const makeBatch = (options: {
+  readonly db: D1Database
+  readonly prepareCache: Cache.Cache<string, D1PreparedStatement, SqlError>
+  readonly spanAttributes: ReadonlyArray<readonly [string, unknown]>
+  readonly getClient: () => D1Client
+}): D1Client["batch"] =>
+  Effect.fnUntraced(function*<const Statements extends ReadonlyArray<Statement.Statement<any>>>(
+    statements: Statements
+  ) {
+    if (statements.length === 0) {
+      return [] as unknown as BatchResults<Statements>
+    }
+    return yield* Effect.useSpan(
+      "sql.execute",
+      { kind: "client" },
+      (span) =>
+        Effect.withFiber(Effect.fnUntraced(function*(fiber) {
+          const transformer = yield* Statement.CurrentTransformer
+          const prepared: Array<D1PreparedStatement> = []
+          const transforms: Array<TransformRows | undefined> = []
+          const queryTexts: Array<string> = []
+
+          for (const original of statements) {
+            const statement = transformer === undefined
+              ? original
+              : yield* transformer(original, options.getClient(), fiber, span)
+            const [sql, params] = statement.compile()
+            queryTexts.push(sql)
+            transforms.push((statement as StatementWithTransformRows).transformRows)
+            prepared.push((yield* Cache.get(options.prepareCache, sql)).bind(...params))
+          }
+
+          for (const [key, value] of options.spanAttributes) {
+            span.attribute(key, value)
+          }
+          span.attribute(ATTR_DB_OPERATION_NAME, "batch")
+          span.attribute(ATTR_DB_QUERY_TEXT, queryTexts.join("; "))
+
+          // D1 batches execute on the binding directly and intentionally cannot participate in SqlClient transactions.
+          const responses = yield* Effect.tryPromise({
+            try: () =>
+              options.db.batch<Record<string, unknown>>(prepared).then((responses) => {
+                for (const response of responses) {
+                  if (response.error) {
+                    throw response.error
+                  }
+                }
+                return responses
+              }),
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute batch", "execute") })
+          })
+
+          const results = responses.map((response, index) => {
+            const rows = response.results || []
+            const transformRows = transforms[index]
+            return transformRows ? transformRows(rows) : rows
+          })
+          return results as BatchResults<Statements>
+        }))
+    )
+  })
 
 /**
  * Creates a scoped Cloudflare D1 SQL client. Prepared statements are cached, while transactions and streaming queries are not supported by this driver.
@@ -212,67 +285,6 @@ export const make = (
           catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
         })
 
-      const makeBatch = (
-        transformRows: (<A extends object>(rows: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined,
-        getClient: () => D1Client
-      ) =>
-      <const Statements extends ReadonlyArray<Statement.Statement<any>>>(
-        statements: Statements
-      ): Effect.Effect<
-        {
-          readonly [K in keyof Statements]: Effect.Success<Statements[K]>
-        },
-        SqlError
-      > => {
-        if (statements.length === 0) {
-          return Effect.succeed([]) as any
-        }
-        return Effect.useSpan(
-          "sql.execute",
-          { kind: "client" },
-          (span) =>
-            Effect.gen(function*() {
-              const compiled = yield* Effect.forEach(statements, (statement) =>
-                Effect.withFiber((fiber) => {
-                  const transformer = fiber.getRef(Statement.CurrentTransformer)
-                  if (transformer === undefined) {
-                    return Effect.succeed(statement.compile())
-                  }
-                  return Effect.map(
-                    transformer(statement, getClient(), fiber, span),
-                    (statement) => statement.compile()
-                  )
-                }))
-              for (const [key, value] of spanAttributes) {
-                span.attribute(key, value)
-              }
-              span.attribute(ATTR_DB_OPERATION_NAME, "batch")
-              span.attribute(ATTR_DB_QUERY_TEXT, compiled.map(([sql]) => sql).join("; "))
-
-              const prepared = yield* Effect.forEach(compiled, ([sql]) => Cache.get(prepareCache, sql))
-              const responses = yield* Effect.tryPromise({
-                try: () =>
-                  db.batch(prepared.map((statement, index) => statement.bind(...compiled[index][1]))).then(
-                    (responses) => {
-                      for (const response of responses) {
-                        if (response.error) {
-                          throw response.error
-                        }
-                      }
-                      return responses
-                    }
-                  ),
-                catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute batch", "execute") })
-              })
-
-              return responses.map((response) => {
-                const rows = response.results || []
-                return transformRows ? transformRows(rows as ReadonlyArray<Record<string, unknown>>) : rows
-              }) as any
-            })
-        ) as any
-      }
-
       const connection = identity<Connection>({
         execute(sql, params, transformRows) {
           return transformRows
@@ -297,10 +309,10 @@ export const make = (
           return Stream.die("executeStream not implemented")
         }
       })
-      return { connection, makeBatch } as const
+      return { connection, prepareCache } as const
     })
 
-    const { connection, makeBatch } = yield* makeConnection
+    const { connection, prepareCache } = yield* makeConnection
     const acquirer = Effect.succeed(connection)
     const transactionAcquirer = Effect.die("transactions are not supported in D1")
 
@@ -316,22 +328,37 @@ export const make = (
       {
         [TypeId]: TypeId as TypeId,
         config: options,
-        batch: makeBatch(transformRows, () => client)
+        batch: makeBatch({
+          db: options.db,
+          prepareCache,
+          spanAttributes,
+          getClient: () => client
+        })
       }
     )
 
-    if (transformRows !== undefined) {
-      const withoutTransforms = client.withoutTransforms
+    if (options.transformQueryNames !== undefined || transformRows !== undefined) {
+      const clientWithoutTransformsBase = yield* Client.make({
+        acquirer: Effect.succeed(connection),
+        compiler: compiler.withoutTransform,
+        transactionAcquirer,
+        spanAttributes,
+        transformRows: undefined
+      })
+      let clientWithoutTransforms!: D1Client
+      clientWithoutTransforms = Object.assign(clientWithoutTransformsBase as D1Client, {
+        [TypeId]: TypeId as TypeId,
+        config: options,
+        batch: makeBatch({
+          db: options.db,
+          prepareCache,
+          spanAttributes,
+          getClient: () => clientWithoutTransforms
+        }),
+        withoutTransforms: () => clientWithoutTransforms
+      })
       Object.assign(client, {
-        withoutTransforms: () => {
-          let clientWithoutTransforms!: D1Client
-          clientWithoutTransforms = Object.assign(withoutTransforms.call(client), {
-            [TypeId]: TypeId as TypeId,
-            config: options,
-            batch: makeBatch(undefined, () => clientWithoutTransforms)
-          })
-          return clientWithoutTransforms
-        }
+        withoutTransforms: () => clientWithoutTransforms
       })
     }
 

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -27,6 +27,8 @@ import { SqlError, UnknownError } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const ATTR_DB_OPERATION_NAME = "db.operation.name"
+const ATTR_DB_QUERY_TEXT = "db.query.text"
 
 const classifyError = (cause: unknown, message: string, operation: string) =>
   new UnknownError({ cause, message, operation })
@@ -56,6 +58,30 @@ export type TypeId = "~@effect/sql-d1/D1Client"
 export interface D1Client extends Client.SqlClient {
   readonly [TypeId]: TypeId
   readonly config: D1ClientConfig
+
+  /**
+   * Executes SQL statements as a single atomic D1 batch and returns their row results in order.
+   *
+   * **When to use**
+   *
+   * Use when you have a fixed collection of statements that should run in one
+   * request and roll back together if any statement fails.
+   *
+   * **Gotchas**
+   *
+   * Statements should be created by this client so that query and result name
+   * transformations remain consistent.
+   *
+   * @since 4.0.0
+   */
+  readonly batch: <const Statements extends ReadonlyArray<Statement.Statement<any>>>(
+    statements: Statements
+  ) => Effect.Effect<
+    {
+      readonly [K in keyof Statements]: Effect.Success<Statements[K]>
+    },
+    SqlError
+  >
 
   /** Not supported in d1 */
   readonly updateValues: never
@@ -104,6 +130,10 @@ export const make = (
     const transformRows = options.transformResultNames ?
       Statement.defaultTransforms(options.transformResultNames).array :
       undefined
+    const spanAttributes: Array<readonly [string, unknown]> = [
+      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+      [ATTR_DB_SYSTEM_NAME, "sqlite"]
+    ]
 
     const makeConnection = Effect.gen(function*() {
       const db = options.db
@@ -182,7 +212,68 @@ export const make = (
           catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
         })
 
-      return identity<Connection>({
+      const makeBatch = (
+        transformRows: (<A extends object>(rows: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined,
+        getClient: () => D1Client
+      ) =>
+      <const Statements extends ReadonlyArray<Statement.Statement<any>>>(
+        statements: Statements
+      ): Effect.Effect<
+        {
+          readonly [K in keyof Statements]: Effect.Success<Statements[K]>
+        },
+        SqlError
+      > => {
+        if (statements.length === 0) {
+          return Effect.succeed([]) as any
+        }
+        return Effect.useSpan(
+          "sql.execute",
+          { kind: "client" },
+          (span) =>
+            Effect.gen(function*() {
+              const compiled = yield* Effect.forEach(statements, (statement) =>
+                Effect.withFiber((fiber) => {
+                  const transformer = fiber.getRef(Statement.CurrentTransformer)
+                  if (transformer === undefined) {
+                    return Effect.succeed(statement.compile())
+                  }
+                  return Effect.map(
+                    transformer(statement, getClient(), fiber, span),
+                    (statement) => statement.compile()
+                  )
+                }))
+              for (const [key, value] of spanAttributes) {
+                span.attribute(key, value)
+              }
+              span.attribute(ATTR_DB_OPERATION_NAME, "batch")
+              span.attribute(ATTR_DB_QUERY_TEXT, compiled.map(([sql]) => sql).join("; "))
+
+              const prepared = yield* Effect.forEach(compiled, ([sql]) => Cache.get(prepareCache, sql))
+              const responses = yield* Effect.tryPromise({
+                try: () =>
+                  db.batch(prepared.map((statement, index) => statement.bind(...compiled[index][1]))).then(
+                    (responses) => {
+                      for (const response of responses) {
+                        if (response.error) {
+                          throw response.error
+                        }
+                      }
+                      return responses
+                    }
+                  ),
+                catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute batch", "execute") })
+              })
+
+              return responses.map((response) => {
+                const rows = response.results || []
+                return transformRows ? transformRows(rows as ReadonlyArray<Record<string, unknown>>) : rows
+              }) as any
+            })
+        ) as any
+      }
+
+      const connection = identity<Connection>({
         execute(sql, params, transformRows) {
           return transformRows
             ? Effect.map(runCached(sql, params), transformRows)
@@ -206,28 +297,45 @@ export const make = (
           return Stream.die("executeStream not implemented")
         }
       })
+      return { connection, makeBatch } as const
     })
 
-    const connection = yield* makeConnection
+    const { connection, makeBatch } = yield* makeConnection
     const acquirer = Effect.succeed(connection)
     const transactionAcquirer = Effect.die("transactions are not supported in D1")
 
-    return Object.assign(
+    let client!: D1Client
+    client = Object.assign(
       (yield* Client.make({
         acquirer,
         compiler,
         transactionAcquirer,
-        spanAttributes: [
-          ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [ATTR_DB_SYSTEM_NAME, "sqlite"]
-        ],
+        spanAttributes,
         transformRows
       })) as D1Client,
       {
         [TypeId]: TypeId as TypeId,
-        config: options
+        config: options,
+        batch: makeBatch(transformRows, () => client)
       }
     )
+
+    if (transformRows !== undefined) {
+      const withoutTransforms = client.withoutTransforms
+      Object.assign(client, {
+        withoutTransforms: () => {
+          let clientWithoutTransforms!: D1Client
+          clientWithoutTransforms = Object.assign(withoutTransforms.call(client), {
+            [TypeId]: TypeId as TypeId,
+            config: options,
+            batch: makeBatch(undefined, () => clientWithoutTransforms)
+          })
+          return clientWithoutTransforms
+        }
+      })
+    }
+
+    return client
   })
 
 /**

--- a/packages/sql/d1/test/Client.test.ts
+++ b/packages/sql/d1/test/Client.test.ts
@@ -96,6 +96,43 @@ describe("Client", () => {
           withoutTransforms<{ firstName: string }>`SELECT ${withoutTransforms("firstName")} FROM test`
         ])
         assert.deepStrictEqual(rawRows, [{ firstName: "Jane" }])
+
+        const [rawRowsFromTransformedBatch] = yield* transformed.batch([
+          withoutTransforms<{ first_name: string }>`SELECT ${withoutTransforms("first_name")} FROM test`
+        ])
+        assert.deepStrictEqual(rawRowsFromTransformedBatch, [{ first_name: "John" }])
+
+        const [transformedRowsFromRawBatch] = yield* withoutTransforms.batch([
+          transformed<{ firstName: string }>`SELECT ${transformed("firstName")} FROM test`
+        ])
+        assert.deepStrictEqual(transformedRowsFromRawBatch, [{ firstName: "John" }])
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(Reactivity.layer)
+      )
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should disable query-only transforms", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE test (first_name TEXT, "firstName" TEXT)`
+      yield* sql`INSERT INTO test (first_name, "firstName") VALUES ('John', 'Jane')`
+
+      yield* Effect.gen(function*() {
+        const transformed = yield* D1Client.make({
+          db: sql.config.db,
+          transformQueryNames: (name) => name === "firstName" ? "first_name" : name
+        })
+        const [transformedRows] = yield* transformed.batch([
+          transformed<{ first_name: string }>`SELECT ${transformed("firstName")} FROM test`
+        ])
+        assert.deepStrictEqual(transformedRows, [{ first_name: "John" }])
+
+        const withoutTransforms = transformed.withoutTransforms()
+        const [rawRows] = yield* withoutTransforms.batch([
+          withoutTransforms<{ firstName: string }>`SELECT ${withoutTransforms("firstName")} FROM test`
+        ])
+        assert.deepStrictEqual(rawRows, [{ firstName: "Jane" }])
       }).pipe(
         Effect.scoped,
         Effect.provide(Reactivity.layer)
@@ -149,6 +186,22 @@ describe("Client", () => {
       const sql = yield* D1Client.D1Client
       yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
       const res = yield* sql`INSERT INTO test ${sql.insert({ name: "hello" })}`.pipe(
+        sql.withTransaction,
+        Effect.sandbox,
+        Effect.flip
+      )
+      const rows = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(rows, [])
+      assert.equal(Cause.hasDies(res), true)
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should defect when batching in a transaction", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const res = yield* sql.batch([
+        sql`INSERT INTO test ${sql.insert({ name: "hello" })}`
+      ]).pipe(
         sql.withTransaction,
         Effect.sandbox,
         Effect.flip

--- a/packages/sql/d1/test/Client.test.ts
+++ b/packages/sql/d1/test/Client.test.ts
@@ -2,6 +2,7 @@ import { D1Client } from "@effect/sql-d1"
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { Statement } from "effect/unstable/sql"
 import { D1Miniflare } from "./utils.ts"
 
 describe("Client", () => {
@@ -47,6 +48,100 @@ describe("Client", () => {
       yield* sql`INSERT INTO test ${sql.insert({ name: "hello" })}`
       const rows = yield* sql`SELECT * FROM test WHERE name = ${"hello"}`
       assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should execute statements in a batch", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+
+      const results: readonly [
+        ReadonlyArray<{ id: number; name: string }>,
+        ReadonlyArray<{ id: number; name: string }>,
+        ReadonlyArray<{ count: number }>
+      ] = yield* sql.batch(
+        [
+          sql<{ id: number; name: string }>`INSERT INTO test (name) VALUES (${"hello"}) RETURNING *`,
+          sql<{ id: number; name: string }>`INSERT INTO test (name) VALUES (${"world"}) RETURNING *`,
+          sql<{ count: number }>`SELECT COUNT(*) AS count FROM test`
+        ] as const
+      )
+
+      assert.deepStrictEqual(results, [
+        [{ id: 1, name: "hello" }],
+        [{ id: 2, name: "world" }],
+        [{ count: 2 }]
+      ])
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should apply result transforms to batch results", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE test (first_name TEXT, "firstName" TEXT)`
+      yield* sql`INSERT INTO test (first_name, "firstName") VALUES ('John', 'Jane')`
+
+      yield* Effect.gen(function*() {
+        const transformed = yield* D1Client.make({
+          db: sql.config.db,
+          transformQueryNames: (name) => name === "firstName" ? "first_name" : name,
+          transformResultNames: (name) => name === "first_name" ? "firstName" : name
+        })
+        const [rows] = yield* transformed.batch([
+          transformed<{ firstName: string }>`SELECT ${transformed("firstName")} FROM test`
+        ])
+        assert.deepStrictEqual(rows, [{ firstName: "John" }])
+
+        const withoutTransforms = transformed.withoutTransforms()
+        const [rawRows] = yield* withoutTransforms.batch([
+          withoutTransforms<{ firstName: string }>`SELECT ${withoutTransforms("firstName")} FROM test`
+        ])
+        assert.deepStrictEqual(rawRows, [{ firstName: "Jane" }])
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(Reactivity.layer)
+      )
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should roll back a failed batch", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT UNIQUE)`
+
+      const error = yield* sql.batch([
+        sql`INSERT INTO test (name) VALUES (${"duplicate"})`,
+        sql`INSERT INTO test (name) VALUES (${"duplicate"})`
+      ]).pipe(Effect.flip)
+
+      assert.strictEqual(error.reason._tag, "UnknownError")
+      assert.strictEqual(error.reason.operation, "execute")
+      const rows = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(rows, [])
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should support an empty batch", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      const results: readonly [] = yield* sql.batch([])
+      assert.deepStrictEqual(results, [])
+    }).pipe(Effect.provide(D1Miniflare.layerClient)))
+
+  it.effect("should apply statement transformers in a batch", () =>
+    Effect.gen(function*() {
+      const sql = yield* D1Client.D1Client
+      const queries: Array<string> = []
+
+      const results = yield* sql.batch([
+        sql`SELECT ${1} AS value`,
+        sql`SELECT ${2} AS value`
+      ]).pipe(
+        Effect.provideService(Statement.CurrentTransformer, (statement, sql) =>
+          Effect.sync(() => {
+            queries.push(statement.compile()[0])
+          }).pipe(Effect.as(sql`SELECT ${3} AS value`)))
+      )
+
+      assert.deepStrictEqual(queries, ["SELECT ? AS value", "SELECT ? AS value"])
+      assert.deepStrictEqual(results, [[{ value: 3 }], [{ value: 3 }]])
     }).pipe(Effect.provide(D1Miniflare.layerClient)))
 
   it.effect("should defect on transactions", () =>


### PR DESCRIPTION
## Summary

- Add `D1Client.batch`, backed by native `D1Database.batch`
- Single D1 request for a fixed collection of statements
- Atomic rollback when any statement fails
- Typed heterogeneous tuple results, preserving statement order

## Details

- Reuses the prepared statement cache
- Supports parameter binding
- Applies query/result name transforms and `withoutTransforms()`
- Applies `Statement.CurrentTransformer`
- Adds `sql.execute` tracing with the `batch` operation
- Maps native failures to `SqlError`
- Empty batches return `[]` without calling D1
- Keeps `withTransaction` behavior unchanged
- D1-specific API rather than a generic `SqlClient.batchTx`

Enables a follow-up implementation of `.batch()` in `drizzle-orm/effect-d1`.

## Tests

- Ordered and typed results
- Name transforms and transformer replacement
- Empty batches
- Atomic rollback with Miniflare

## Related

Refs #3888 and #5594. Previous `batchTx` discussion: #3045.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for executing multiple SQL statements as a single atomic D1 batch.
  * Batch results are returned in statement order, including support for empty batches.
  * Query and result transformations are applied consistently to batched statements.

* **Bug Fixes**
  * Batched execution failures now report structured SQL errors and roll back changes to preserve data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->