### PR TITLE
Fix HttpRouter middleware context inference

### DIFF
--- a/.changeset/fuzzy-cats-listen.md
+++ b/.changeset/fuzzy-cats-listen.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpRouter.toWebHandler` middleware inference to exclude request services supplied by the HTTP adapter.

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1316,12 +1316,15 @@ export const toWebHandler = <
         | Request.Only<"Requires", R>
         | Request.Only<"GlobalRequires", R>
       >
-    ) => Effect.Effect<HttpServerResponse.HttpServerResponse, HE, HR>
+    ) => Effect.Effect<HttpServerResponse.HttpServerResponse, HE, HR | GlobalProvided>
   }
 ): {
-  readonly handler: [HR] extends [never]
+  readonly handler: [Exclude<HR, GlobalProvided>] extends [never]
     ? ((request: globalThis.Request, context?: Context.Context<never> | undefined) => Promise<Response>)
-    : ((request: globalThis.Request, context: Context.Context<HR>) => Promise<Response>)
+    : ((
+      request: globalThis.Request,
+      context: Context.Context<Exclude<HR, GlobalProvided>>
+    ) => Promise<Response>)
   readonly dispose: () => Promise<void>
 } => {
   let middleware: any = options?.middleware

--- a/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
@@ -1,0 +1,32 @@
+import { Context, Effect } from "effect"
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { describe, expect, it } from "tstyche"
+
+describe("HttpRouter", () => {
+  describe("toWebHandler", () => {
+    it("excludes adapter services required by middleware from the request context", () => {
+      class CurrentUser extends Context.Service<CurrentUser, { readonly id: string }>()("CurrentUser") {}
+
+      const app = HttpRouter.add(
+        "GET",
+        "/",
+        Effect.gen(function*() {
+          const user = yield* CurrentUser
+          return HttpServerResponse.text(user.id)
+        })
+      )
+      const { handler } = HttpRouter.toWebHandler(app, {
+        disableLogger: true,
+        middleware: (effect) => effect
+      })
+
+      expect(handler).type.toBe<
+        (request: Request, context: Context.Context<CurrentUser>) => Promise<Response>
+      >()
+      expect(handler).type.toBeCallableWith(
+        new Request("http://localhost/"),
+        Context.make(CurrentUser, { id: "user-1" })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Exclude HTTP adapter-provided services from the context required by `toWebHandler` callers.
- Preserve application service requirements when middleware contributes adapter services.
- Add a type test covering middleware context inference and a patch changeset for `effect`.

## Testing

- Added a `tstyche` type test for `HttpRouter.toWebHandler` context inference.
- Not run (PR content generated from the provided diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed web handler type inference so request contexts include only the services your application provides.
  * Middleware-provided adapter services are now excluded from the context required when calling an HTTP web handler.

* **Tests**
  * Added coverage to verify accurate handler context and call signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->