### PR TITLE
EFF-941 Fix pending interrupt delivery across interruptibleMask

### DIFF
--- a/.changeset/fix-pending-interruptible-mask.md
+++ b/.changeset/fix-pending-interruptible-mask.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Deliver pending interrupts when interruptibleMask restores fiber interruptibility.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4261,16 +4261,19 @@ const setInterruptible: (interruptible: boolean) => Primitive = makePrimitive({
 const setInterruptibleTrue = setInterruptible(true)
 const setInterruptibleFalse = setInterruptible(false)
 
+const setFiberInterruptible = (fiber: FiberImpl): Effect.Effect<never> | undefined => {
+  fiber.interruptible = true
+  fiber._stack.push(setInterruptibleFalse)
+  if (fiber._interruptedCause) return failCause(fiber._interruptedCause)
+}
+
 /** @internal */
 export const interruptible = <A, E, R>(
   self: Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> =>
   withFiber((fiber) => {
     if (fiber.interruptible) return self
-    fiber.interruptible = true
-    fiber._stack.push(setInterruptibleFalse)
-    if (fiber._interruptedCause) return failCause(fiber._interruptedCause)
-    return self
+    return setFiberInterruptible(fiber) ?? self
   })
 
 /** @internal */
@@ -4298,9 +4301,9 @@ export const interruptibleMask = <A, E, R>(
 ): Effect.Effect<A, E, R> =>
   withFiber((fiber) => {
     if (fiber.interruptible) return f(identity)
-    fiber.interruptible = true
-    fiber._stack.push(setInterruptibleFalse)
-    return f(uninterruptible)
+    const interrupted = setFiberInterruptible(fiber)
+    const effect = f(uninterruptible)
+    return interrupted ?? effect
   })
 
 /** @internal */

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Latch } from "effect"
+import { Cause, Effect, Exit, Fiber, Latch } from "effect"
 
 describe("Fiber", () => {
   it("is a fiber", async () => {
@@ -68,6 +68,49 @@ describe("Fiber", () => {
         assert.isTrue(Exit.hasInterrupts(exit))
       })
   )
+
+  it.effect("delivers a pending interrupt when interruptibleMask restores interruptibility", () =>
+    Effect.gen(function*() {
+      const masked = yield* Latch.make()
+      const resume = yield* Latch.make()
+      const events: Array<string> = []
+
+      const child = yield* Effect.uninterruptible(
+        Effect.gen(function*() {
+          yield* masked.open
+          yield* resume.await
+          return yield* Effect.interruptibleMask(() => {
+            events.push("interruptibleMask")
+            return Effect.never
+          })
+        })
+      ).pipe(Effect.forkChild({ startImmediately: true }))
+
+      yield* masked.await
+      events.push("masked")
+
+      yield* Effect.sync(() => {
+        child.interruptUnsafe(123)
+        events.push("interrupted")
+      })
+      assert.isUndefined(child.pollUnsafe())
+
+      yield* resume.open
+      events.push("resumed")
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+
+      const exit = child.pollUnsafe()
+      if (exit === undefined) {
+        assert.fail("fiber did not exit after interruptibleMask restored interruptibility")
+      }
+      assert.isTrue(Exit.hasInterrupts(exit))
+      if (exit._tag !== "Failure") {
+        assert.fail("expected interrupted fiber to exit with failure")
+      }
+      assert.deepStrictEqual(Cause.interruptors(exit.cause), new Set([123]))
+      assert.deepStrictEqual(events, ["masked", "interrupted", "resumed", "interruptibleMask"])
+    }))
 
   it.effect("runs an async interrupt finalizer exactly once, in order", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- Centralize restoring fiber interruptibility so pending interrupts are delivered consistently.
- Apply pending interrupt delivery to interruptibleMask before its returned effect can suspend.
- Add a Fiber regression test with a masked/resume handshake that verifies the original interruptor id is delivered without a second signal.
- Add a patch changeset for effect.

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Fiber.test.ts
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pending interrupts are now delivered correctly when interruptibility is restored within `interruptibleMask`.
  - Interruptible effects now immediately fail when an interruption is already pending.
  - Improved consistency in interrupt handling and fiber execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->