### PR TITLE
EFF-942 Make fiber completion notification atomic and observer-safe

### DIFF
--- a/.changeset/fix-fiber-completion-observers.md
+++ b/.changeset/fix-fiber-completion-observers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make fiber completion teardown and observer notification safe against observer cancellation and throwing metric, observer, or error reporter callbacks.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -6,6 +6,7 @@ import * as Context from "../Context.ts"
 import * as Duration from "../Duration.ts"
 import type * as Effect from "../Effect.ts"
 import * as Equal from "../Equal.ts"
+import type * as ErrorReporter from "../ErrorReporter.ts"
 import type * as Exit from "../Exit.ts"
 import type * as Fiber from "../Fiber.ts"
 import * as Filter from "../Filter.ts"
@@ -58,6 +59,7 @@ import {
   contA,
   contAll,
   contE,
+  Die,
   evaluate,
   exitDie,
   exitFail,
@@ -502,6 +504,28 @@ const fiberIdStore = { id: 0 }
 /** @internal */
 export const getCurrentFiber = (): Fiber.Fiber<any, any> | undefined => (globalThis as any)[currentFiberTypeId]
 
+const reportCompletionCallbackErrors = (
+  fiber: Fiber.Fiber<unknown, unknown>,
+  errors: ReadonlyArray<unknown>,
+  reporters: ReadonlySet<ErrorReporter.ErrorReporter>,
+  clock: Clock.Clock
+): void => {
+  try {
+    if (reporters.size === 0) return
+    const cause = causeFromReasons(errors.map((error) => new Die(error)))
+    const options = { cause, fiber, timestamp: clock.currentTimeNanosUnsafe() }
+    for (const reporter of reporters) {
+      try {
+        reporter.report(options)
+      } catch {
+        // Completion must not be corrupted by a failing reporter.
+      }
+    }
+  } catch {
+    // Completion must not be corrupted by a failing reporting dependency.
+  }
+}
+
 /** @internal */
 export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   constructor(
@@ -617,14 +641,31 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     }
 
     this._exit = exit
-    this.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
-    for (let i = 0; i < this._observers.length; i++) {
-      this._observers[i](exit)
-    }
-    this._observers.length = 0
+    const context = this.context
+    const observers = this._observers.splice(0)
+    const runtimeMetrics = this.runtimeMetrics
+    const reporters = this.getRef(CurrentErrorReporters)
+    const clock = this.getRef(ClockRef)
     this._stack.length = 0
     this._children = undefined
     this.context = Context.empty()
+
+    let callbackErrors: Array<unknown> | undefined
+    try {
+      runtimeMetrics?.recordFiberEnd(context, exit)
+    } catch (error) {
+      ;(callbackErrors ??= []).push(error)
+    }
+    for (let i = 0; i < observers.length; i++) {
+      try {
+        observers[i](exit)
+      } catch (error) {
+        ;(callbackErrors ??= []).push(error)
+      }
+    }
+    if (callbackErrors !== undefined) {
+      reportCompletionCallbackErrors(this, callbackErrors, reporters, clock)
+    }
   }
   runLoop(effect: Primitive): Exit.Exit<A, E> | Yield {
     const prevFiber = (globalThis as any)[currentFiberTypeId]

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -1,5 +1,22 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Exit, Fiber, Latch } from "effect"
+import { Effect, ErrorReporter, Exit, Fiber, Latch, Metric } from "effect"
+
+const forkYielded = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+  Effect.andThen(Effect.yieldNow, self).pipe(
+    Effect.forkDetach({ startImmediately: true })
+  )
+
+const assertCompletionStateCleared = <A, E>(fiber: Fiber.Fiber<A, E>) => {
+  const state = fiber as Fiber.Fiber<A, E> & {
+    readonly _observers: ReadonlyArray<unknown>
+    readonly _stack: ReadonlyArray<unknown>
+    readonly _children: ReadonlySet<unknown> | undefined
+  }
+  assert.strictEqual(state._observers.length, 0)
+  assert.strictEqual(state._stack.length, 0)
+  assert.isUndefined(state._children)
+  assert.strictEqual(fiber.context.mapUnsafe.size, 0)
+}
 
 describe("Fiber", () => {
   it("is a fiber", async () => {
@@ -99,4 +116,183 @@ describe("Fiber", () => {
       assert.isTrue(Exit.hasInterrupts(exit))
       assert.deepStrictEqual(events, ["acquired", "finalizer-start", "finalizer-end", "awaited"])
     }))
+
+  describe("completion observers", () => {
+    it.effect("notifies all detached observers when one cancels itself", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(Effect.succeed(1))
+        let cancelSelf: () => void = () => {}
+        cancelSelf = fiber.addObserver(() => {
+          events.push("self")
+          cancelSelf()
+        })
+        fiber.addObserver(() => events.push("later"))
+
+        yield* Fiber.await(fiber)
+
+        assert.deepStrictEqual(events, ["self", "later"])
+      }))
+
+    it.effect("notifies all detached observers when one cancels an earlier observer", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(Effect.succeed(1))
+        const cancelEarlier = fiber.addObserver(() => events.push("earlier"))
+        fiber.addObserver(() => {
+          events.push("cancelling")
+          cancelEarlier()
+        })
+        fiber.addObserver(() => events.push("later"))
+
+        yield* Fiber.await(fiber)
+
+        assert.deepStrictEqual(events, ["earlier", "cancelling", "later"])
+      }))
+
+    it.effect("notifies all detached observers when one cancels a later observer", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(Effect.succeed(1))
+        let cancelLater: () => void = () => {}
+        fiber.addObserver(() => {
+          events.push("cancelling")
+          cancelLater()
+        })
+        fiber.addObserver(() => events.push("middle"))
+        cancelLater = fiber.addObserver(() => events.push("later"))
+
+        yield* Fiber.await(fiber)
+
+        assert.deepStrictEqual(events, ["cancelling", "middle", "later"])
+      }))
+
+    it.effect("does not strand await behind a failing joinAll observer", () =>
+      Effect.gen(function*() {
+        const target = yield* forkYielded(Effect.fail("boom"))
+        const joiner = yield* Fiber.joinAll([target]).pipe(
+          Effect.forkDetach({ startImmediately: true })
+        )
+        const waiter = yield* Fiber.await(target).pipe(
+          Effect.forkDetach({ startImmediately: true })
+        )
+
+        const joinExit = yield* Fiber.await(joiner)
+        const awaitExit = yield* Fiber.await(waiter)
+
+        assert.isTrue(Exit.isFailure(joinExit))
+        assert.deepStrictEqual(awaitExit, Exit.succeed(Exit.fail("boom")))
+      }))
+
+    it.effect("notifies later observers and tears down when the first observer throws", () => {
+      const reported: Array<string> = []
+      const reporter = ErrorReporter.make(({ error, fiber }) => {
+        reported.push(error.message)
+        assert.strictEqual(fiber.context.mapUnsafe.size, 0)
+      })
+
+      return Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(
+          Effect.forkChild(Effect.never).pipe(Effect.as(1))
+        )
+        fiber.addObserver(() => {
+          events.push("first")
+          throw new Error("first observer")
+        })
+        fiber.addObserver(() => events.push("later"))
+
+        const exit = yield* Fiber.await(fiber)
+        yield* Effect.yieldNow
+
+        assert.deepStrictEqual(exit, Exit.succeed(1))
+        assert.deepStrictEqual(events, ["first", "later"])
+        assert.deepStrictEqual(reported, ["first observer"])
+        assertCompletionStateCleared(fiber)
+      }).pipe(
+        Effect.provideService(ErrorReporter.CurrentErrorReporters, new Set([reporter]))
+      )
+    })
+
+    it.effect("notifies later observers when a middle observer throws", () => {
+      const reported: Array<string> = []
+      const reporter = ErrorReporter.make(({ error }) => {
+        reported.push(error.message)
+      })
+
+      return Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(Effect.succeed(1))
+        fiber.addObserver(() => events.push("first"))
+        fiber.addObserver(() => {
+          events.push("middle")
+          throw new Error("middle observer")
+        })
+        fiber.addObserver(() => events.push("last"))
+
+        yield* Fiber.await(fiber)
+        yield* Effect.yieldNow
+
+        assert.deepStrictEqual(events, ["first", "middle", "last"])
+        assert.deepStrictEqual(reported, ["middle observer"])
+      }).pipe(
+        Effect.provideService(ErrorReporter.CurrentErrorReporters, new Set([reporter]))
+      )
+    })
+
+    it.effect("notifies observers and tears down when the metric end hook throws", () => {
+      const reported: Array<string> = []
+      const throwingReporter = ErrorReporter.make(() => {
+        throw new Error("reporter failure")
+      })
+      const reporter = ErrorReporter.make(({ error }) => {
+        reported.push(error.message)
+      })
+      const metrics: Metric.FiberRuntimeMetricsService = {
+        recordFiberStart: () => {},
+        recordFiberEnd: () => {
+          throw new Error("metric end")
+        }
+      }
+
+      return Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(Effect.succeed(1))
+        fiber.addObserver(() => events.push("observer"))
+
+        const exit = yield* Fiber.await(fiber)
+        yield* Effect.yieldNow
+
+        assert.deepStrictEqual(exit, Exit.succeed(1))
+        assert.deepStrictEqual(events, ["observer"])
+        assert.deepStrictEqual(reported, ["metric end"])
+        assertCompletionStateCleared(fiber)
+      }).pipe(
+        Effect.provideService(Metric.FiberRuntimeMetrics, metrics),
+        Effect.provideService(
+          ErrorReporter.CurrentErrorReporters,
+          new Set([throwingReporter, reporter])
+        )
+      )
+    })
+
+    it.effect("invokes an observer added during completion synchronously", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        const fiber = yield* forkYielded(Effect.succeed(1))
+        fiber.addObserver((exit) => {
+          events.push("outer start")
+          fiber.addObserver((reentrantExit) => {
+            assert.strictEqual(reentrantExit, exit)
+            events.push("reentrant")
+          })
+          events.push("outer end")
+        })
+        fiber.addObserver(() => events.push("later"))
+
+        yield* Fiber.await(fiber)
+
+        assert.deepStrictEqual(events, ["outer start", "reentrant", "outer end", "later"])
+      }))
+  })
 })


### PR DESCRIPTION
## Summary
- atomically publish fiber exits, detach observers, and tear down lifecycle state before invoking completion hooks
- isolate metric and observer failures, report them as defects through captured error reporters, and swallow reporter failures
- add regressions for observer cancellation/reentrancy, joinAll/await ordering, throwing observers, throwing metric hooks, and completion cleanup
- add an effect patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm lint`
- `pnpm test packages/effect/test/Fiber.test.ts`
- `pnpm check`
- `git diff --check`

Specification: `.specs/audit.md` F-02 and fiber-completion portion of F-03.