### PR TITLE
EFF-946 Prevent concurrent traversal daemon leaks

### DIFF
--- a/.changeset/eff-946-concurrent-traversal-cleanup.md
+++ b/.changeset/eff-946-concurrent-traversal-cleanup.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Interrupt and await concurrent traversal workers when mapper or refill callbacks throw.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4698,6 +4698,16 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
     let nextIndex = index
     const exits: Array<Exit.Exit<X, E> | undefined> | undefined = orderedStep ? new Array(end) : undefined
 
+    const failDefect = (error: unknown): Effect.Effect<void, E | E2, R> => {
+      const defect = exitDie(error)
+      terminal = defect
+      done = true
+      interrupted = true
+      return fibers && fibers.size > 0
+        ? flatMap(uninterruptible(fiberInterruptAll(Array.from(fibers))), () => defect)
+        : defect
+    }
+
     const runStep = (item: A, exit: Exit.Exit<X, E>, currentIndex: number): Exit.Exit<void, E | E2> | void => {
       if (!orderedStep) return step(state, item, exit, currentIndex)
       if (terminal) return terminal
@@ -4735,9 +4745,15 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
         } else if (!parentFiber) {
           return callback((cb) => {
             parentFiber = getCurrentFiber()!
+            fibers = new Set()
             effect = eff
             resume = cb
-            const result = go()
+            let result: Effect.Effect<void, E | E2, R> | undefined
+            try {
+              result = go()
+            } catch (error) {
+              return cb(failDefect(error))
+            }
             if (result) return cb(result)
             return suspend(() => {
               terminal = exitVoid
@@ -4759,43 +4775,46 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
           }
 
           // Add the fiber to the Set
-          if (fibers) fibers.add(fiber)
-          else fibers = new Set([fiber])
+          fibers!.add(fiber)
 
           const currentIndex = index
           fiber.addObserver((exit) => {
             fibers!.delete(fiber)
-            if (terminal) {
-              if (!interrupted && exit._tag === "Failure") {
-                for (const reason of exit.cause.reasons) {
-                  if (reason._tag === "Interrupt") continue
-                  else if (terminal._tag === "Failure") {
-                    ;(terminal.cause.reasons as Array<any>).push(reason)
-                  } else {
-                    terminal = exitFailCause(causeFromReasons([reason]))
+            try {
+              if (terminal) {
+                if (!interrupted && exit._tag === "Failure") {
+                  for (const reason of exit.cause.reasons) {
+                    if (reason._tag === "Interrupt") continue
+                    else if (terminal._tag === "Failure") {
+                      ;(terminal.cause.reasons as Array<any>).push(reason)
+                    } else {
+                      terminal = exitFailCause(causeFromReasons([reason]))
+                    }
                   }
                 }
+              } else {
+                const result = runStep(item, exit, currentIndex)
+                if (result) {
+                  terminal = result._tag === "Failure"
+                    ? exitFailCause(causeFromReasons(result.cause.reasons.slice()))
+                    : result
+                  go()
+                }
               }
-            } else {
-              const result = runStep(item, exit, currentIndex)
-              if (result) {
-                terminal = result._tag === "Failure"
-                  ? exitFailCause(causeFromReasons(result.cause.reasons.slice()))
-                  : result
-                go()
-              }
-            }
 
-            if (paused) {
-              const eff = go()
-              if (eff) resume!(eff)
-            } else if (done && fibers!.size === 0) {
-              resume!(terminal ?? void_)
+              if (paused) {
+                const eff = go()
+                if (eff) resume!(eff)
+              } else if (done && fibers!.size === 0) {
+                resume!(terminal ?? void_)
+              }
+            } catch (error) {
+              resume!(failDefect(error))
             }
           })
 
           // Check if we have reached the concurrency limit
-          if (fibers.size < concurrency) continue
+          if (fibers!.size < concurrency) continue
           paused = true
           index++
           return

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -532,6 +532,62 @@ describe("Effect", () => {
         assert.deepStrictEqual(done, [1, 2, 3])
       }))
 
+    it.effect("interrupts started workers when the mapper throws during initial pumping", () =>
+      Effect.gen(function*() {
+        const interruptStarted = yield* Deferred.make<void>()
+        const interruptFinished = yield* Deferred.make<void>()
+        const defect = new Error("mapper defect")
+        const fiber = yield* Effect.forEach([0, 1], (i) => {
+          if (i === 0) {
+            return Effect.never.pipe(
+              Effect.onInterrupt(() =>
+                Deferred.succeed(interruptStarted, void 0).pipe(
+                  Effect.andThen(Deferred.await(interruptFinished))
+                )
+              )
+            )
+          }
+          throw defect
+        }, { concurrency: 2 }).pipe(Effect.forkChild({ startImmediately: true }))
+
+        assert.isTrue(yield* Deferred.isDone(interruptStarted))
+        assert.isUndefined(fiber.pollUnsafe())
+        yield* Deferred.succeed(interruptFinished, void 0)
+        const exit = fiber.pollUnsafe()
+        assert.isDefined(exit)
+        assertExitDefect(exit!, defect)
+      }))
+
+    it.effect("interrupts started workers when observer-driven refill throws", () =>
+      Effect.gen(function*() {
+        const release = yield* Deferred.make<void>()
+        const interruptStarted = yield* Deferred.make<void>()
+        const interruptFinished = yield* Deferred.make<void>()
+        const defect = new Error("refill defect")
+        const fiber = yield* Effect.forEach([0, 1, 2], (i) => {
+          if (i === 0) return Deferred.await(release)
+          if (i === 1) {
+            return Effect.never.pipe(
+              Effect.onInterrupt(() =>
+                Deferred.succeed(interruptStarted, void 0).pipe(
+                  Effect.andThen(Deferred.await(interruptFinished))
+                )
+              )
+            )
+          }
+          throw defect
+        }, { concurrency: 2 }).pipe(Effect.forkChild({ startImmediately: true }))
+
+        assert.isUndefined(fiber.pollUnsafe())
+        yield* Deferred.succeed(release, void 0)
+        assert.isTrue(yield* Deferred.isDone(interruptStarted))
+        assert.isUndefined(fiber.pollUnsafe())
+        yield* Deferred.succeed(interruptFinished, void 0)
+        const exit = fiber.pollUnsafe()
+        assert.isDefined(exit)
+        assertExitDefect(exit!, defect)
+      }))
+
     it("length = 0", () =>
       Effect.gen(function*() {
         const results = yield* Effect.forEach([], (_) => Effect.succeed(_))


### PR DESCRIPTION
## Summary

- establish eager concurrent traversal worker ownership before launching the first daemon
- convert mapper, step, item-access, and observer refill throws into terminal defects that interrupt and await owned workers
- add gated regressions proving initial-pump and observer-refill exceptions do not complete the parent before worker interruption finalizers finish
- add a patch changeset for the runtime behavior fix

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm check`
- `git diff --check origin/audit...HEAD`