### PR TITLE
EFF-948 Guarantee run-loop progress after scheduler yields

### DIFF
--- a/.changeset/curly-spiders-yield.md
+++ b/.changeset/curly-spiders-yield.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Guarantee fiber progress after scheduler-requested yields and normalize invalid operation budgets.

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -250,6 +250,11 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  * fairness by helping prevent long-running fibers from monopolizing the
  * execution thread.
  *
+ * Values are normalized when installed on a fiber. Finite values are rounded
+ * down and clamped to a minimum of `1`. `NaN` and positive or negative
+ * infinity use the default value of `2048`. Use {@link PreventSchedulerYield}
+ * instead when cooperative yielding should be disabled.
+ *
  * @see {@link PreventSchedulerYield} for bypassing scheduler yield checks entirely rather than tuning the operation budget
  *
  * @category references

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -519,6 +519,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._children = undefined
     this._interruptedCause = undefined
     this._yielded = undefined
+    this._schedulerYieldTarget = undefined
     this._running = false
     this._deferredInterrupt = false
     this.runtimeMetrics?.recordFiberStart(this.context)
@@ -535,6 +536,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   _children: Set<FiberImpl<any, any>> | undefined
   _interruptedCause: Cause.Cause<never> | undefined
   _yielded: Exit.Exit<any, any> | (() => void) | undefined
+  _schedulerYieldTarget: Primitive | undefined
   _running: boolean
   _deferredInterrupt: boolean
 
@@ -589,6 +591,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       if (this._running) {
         this._deferredInterrupt = true
       } else {
+        this._schedulerYieldTarget = undefined
         this.evaluate(failCause(this._interruptedCause) as any)
       }
     }
@@ -631,28 +634,32 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     ;(globalThis as any)[currentFiberTypeId] = this
     const prevRunning = this._running
     this._running = true
-    let yielding = false
     let current: Primitive | Yield = effect
     this.currentOpCount = 0
     try {
       while (true) {
         if (this._deferredInterrupt) {
           this._deferredInterrupt = false
+          this._schedulerYieldTarget = undefined
           current = failCause(this._interruptedCause!) as any
         }
         this.currentOpCount++
         if (
-          !yielding &&
+          this._schedulerYieldTarget === undefined &&
           !this.currentPreventYield &&
           this.currentScheduler.shouldYield(this as any)
         ) {
-          yielding = true
           const prev = current
-          current = flatMap(yieldNow, () => prev as any) as any
+          this._schedulerYieldTarget = prev as Primitive
+          current = flatMap(schedulerYieldNow(), () => prev as any) as any
         }
+        const evaluated = current
         current = this.currentTracerContext
           ? this.currentTracerContext(current as any, this)
           : (current as any)[evaluate](this)
+        if (evaluated === this._schedulerYieldTarget) {
+          this._schedulerYieldTarget = undefined
+        }
         if (current === Yield) {
           const yielded = this._yielded!
           if (ExitTypeId in yielded) {
@@ -668,6 +675,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
         }
       }
     } catch (error) {
+      this._schedulerYieldTarget = undefined
       if (!hasProperty(current, evaluate)) {
         return exitDie(`Fiber.runLoop: Not a valid effect: ${String(current)}`)
       }
@@ -717,7 +725,10 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = context.mapUnsafe.get(CurrentStackFrame.key)
-    this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
+    const maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
+    this.maxOpsBeforeYield = Number.isFinite(maxOpsBeforeYield)
+      ? Math.max(1, Math.floor(maxOpsBeforeYield))
+      : Scheduler.MaxOpsBeforeYield.defaultValue()
     this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
     this.runtimeMetrics = context.mapUnsafe.get(InternalMetric.FiberRuntimeMetricsKey)
     const currentTracer = context.mapUnsafe.get(Tracer.TracerKey)
@@ -976,6 +987,21 @@ export const yieldNowWith: (priority?: number) => Effect.Effect<void> = makePrim
 
 /** @internal */
 export const yieldNow: Effect.Effect<void> = yieldNowWith(0)
+
+const schedulerYieldNow: () => Effect.Effect<void> = makePrimitive({
+  op: "Yield",
+  [evaluate](fiber) {
+    let resumed = false
+    const resume = exitSucceed(undefined)
+    fiber.currentDispatcher.scheduleTask(() => {
+      if (resumed) return
+      fiber.evaluate(resume as any)
+    }, 0)
+    return fiber.yieldWith(() => {
+      resumed = true
+    })
+  }
+})
 
 /** @internal */
 export const succeedSome = <A>(a: A): Effect.Effect<Option.Option<A>> => succeed(Option.some(a))

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -2,6 +2,37 @@ import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as Scheduler from "effect/Scheduler"
 
+const makeQueuedScheduler = (shouldYield?: Scheduler.Scheduler["shouldYield"]) => {
+  const tasks: Array<() => void> = []
+  const mixed = new Scheduler.MixedScheduler("sync", (task) => {
+    let active = true
+    tasks.push(() => {
+      if (active) task()
+    })
+    return () => {
+      active = false
+    }
+  })
+  const scheduler: Scheduler.Scheduler = shouldYield
+    ? {
+      executionMode: "sync",
+      shouldYield,
+      makeDispatcher: () => mixed.makeDispatcher()
+    }
+    : mixed
+  return {
+    scheduler,
+    drain: (limit = 100) => {
+      let count = 0
+      while (tasks.length > 0 && count < limit) {
+        tasks.shift()!()
+        count++
+      }
+      return tasks.length
+    }
+  }
+}
+
 describe("Scheduler", () => {
   it.effect("MixedScheduler orders by priority (sync)", () =>
     Effect.sync(() => {
@@ -67,4 +98,101 @@ describe("Scheduler", () => {
       )
       assert.strictEqual(calls, 0)
     }))
+
+  it("normalizes MaxOpsBeforeYield and makes progress with aggressive budgets", () => {
+    const cases = [
+      [0, 1],
+      [1, 1],
+      [2, 2],
+      [3, 3],
+      [Number.NaN, 2048],
+      [Number.POSITIVE_INFINITY, 2048],
+      [Number.NEGATIVE_INFINITY, 2048],
+      [2.75, 2],
+      [-2.75, 1]
+    ] as const
+
+    for (const [budget, expected] of cases) {
+      const queued = makeQueuedScheduler()
+      let actual: number | undefined
+      const fiber = Effect.withFiber((fiber) =>
+        Effect.sync(() => {
+          actual = fiber.maxOpsBeforeYield
+        })
+      ).pipe(
+        Effect.provideService(Scheduler.MaxOpsBeforeYield, budget),
+        Effect.provideService(Scheduler.Scheduler, queued.scheduler),
+        Effect.runFork
+      )
+
+      assert.strictEqual(queued.drain(), 0, `budget: ${budget}`)
+      assert.strictEqual(actual, expected, `budget: ${budget}`)
+      assert.isDefined(fiber.pollUnsafe(), `budget: ${budget}`)
+    }
+  })
+
+  it("makes progress when a custom scheduler always requests a yield", () => {
+    const queued = makeQueuedScheduler(() => true)
+    let operations = 0
+    const fiber = Effect.sync(() => {
+      operations++
+    }).pipe(
+      Effect.provideService(Scheduler.Scheduler, queued.scheduler),
+      Effect.runFork
+    )
+
+    assert.strictEqual(queued.drain(), 0)
+    assert.strictEqual(operations, 1)
+    assert.isDefined(fiber.pollUnsafe())
+  })
+
+  it("makes progress when an always-yield scheduler captures an explicit yield", () => {
+    const queued = makeQueuedScheduler(() => true)
+    const fiber = Effect.yieldNow.pipe(
+      Effect.provideService(Scheduler.Scheduler, queued.scheduler),
+      Effect.runFork
+    )
+
+    assert.strictEqual(queued.drain(), 0)
+    assert.isDefined(fiber.pollUnsafe())
+  })
+
+  it("restores yield checks when interruption replaces the pending operation", () => {
+    const tasks: Array<() => void> = []
+    let calls = 0
+    let finalized = false
+    let yieldRequested = false
+    const scheduler: Scheduler.Scheduler = {
+      executionMode: "sync",
+      shouldYield: () => {
+        calls++
+        if (!yieldRequested) return false
+        yieldRequested = false
+        return true
+      },
+      makeDispatcher: () => ({
+        scheduleTask: (task) => tasks.push(task),
+        flush() {
+          while (tasks.length > 0) tasks.shift()!()
+        }
+      })
+    }
+    const fiber = Effect.sync(() => {
+      yieldRequested = true
+    }).pipe(
+      Effect.andThen(Effect.never),
+      Effect.ensuring(Effect.sync(() => {
+        finalized = true
+      })),
+      Effect.provideService(Scheduler.Scheduler, scheduler),
+      Effect.runFork
+    )
+
+    assert.strictEqual(tasks.length, 1)
+    const callsBeforeInterrupt = calls
+    fiber.interruptUnsafe()
+    assert.strictEqual(calls > callsBeforeInterrupt, true)
+    assert.strictEqual(finalized, true)
+    assert.isDefined(fiber.pollUnsafe())
+  })
 })


### PR DESCRIPTION
## Summary

- persist scheduler-yield grace until the captured primitive executes, including always-yield schedulers and explicit yields
- normalize `MaxOpsBeforeYield` to a documented positive integer contract with a default fallback for non-finite values
- add bounded regression coverage for aggressive budgets, always-yield schedulers, explicit yields, and interruption replacing pending work
- add a patch changeset for the runtime behavior fix

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Scheduler.test.ts packages/effect/test/Effect.test.ts` (221 tests)
- `pnpm check`