### PR TITLE
EFF-943 Prevent throwing scheduler tasks from dropping drained work

### DIFF
--- a/.changeset/fix-scheduler-drained-tasks.md
+++ b/.changeset/fix-scheduler-drained-tasks.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure the default scheduler finishes drained task batches before reporting task exceptions.

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -133,7 +133,9 @@ class PriorityBuckets {
  *
  * `MixedScheduler` supports synchronous and asynchronous execution modes, uses
  * operation counts to decide when fibers should yield, and is the default
- * scheduler implementation.
+ * scheduler implementation. A dispatcher runs every task in an already-drained
+ * batch even if tasks throw. After the batch completes, it rethrows a single
+ * exception unchanged or reports multiple exceptions with an `AggregateError`.
  *
  * @category schedulers
  * @since 2.0.0
@@ -213,11 +215,21 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
    */
   runTasks() {
     const buckets = this.tasks.drain()
+    const errors: Array<unknown> = []
     for (let i = 0; i < buckets.length; i++) {
       const toRun = buckets[i][1]
       for (let j = 0; j < toRun.length; j++) {
-        toRun[j]()
+        try {
+          toRun[j]()
+        } catch (error) {
+          errors.push(error)
+        }
       }
+    }
+    if (errors.length === 1) {
+      throw errors[0]
+    } else if (errors.length > 1) {
+      throw new AggregateError(errors, "Multiple scheduler tasks failed")
     }
   }
 

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -41,6 +41,69 @@ describe("Scheduler", () => {
       assert.deepStrictEqual(order, [1, 2, 3])
     }))
 
+  it("MixedScheduler runs the drained batch before rethrowing a task exception", () => {
+    const scheduled: Array<() => void> = []
+    const scheduler = new Scheduler.MixedScheduler("async", (task) => {
+      scheduled.push(task)
+      return () => {}
+    }).makeDispatcher()
+    const error = new Error("task failed")
+    const order: Array<string> = []
+
+    scheduler.scheduleTask(() => {
+      order.push("throwing")
+      scheduler.scheduleTask(() => order.push("next batch"), 0)
+      throw error
+    }, 0)
+    scheduler.scheduleTask(() => order.push("same priority"), 0)
+    scheduler.scheduleTask(() => order.push("different priority"), 1)
+
+    let caught: unknown
+    try {
+      scheduled[0]()
+    } catch (error) {
+      caught = error
+    }
+
+    assert.strictEqual(caught, error)
+    assert.deepStrictEqual(order, ["throwing", "same priority", "different priority"])
+
+    scheduled[1]()
+    assert.deepStrictEqual(order, ["throwing", "same priority", "different priority", "next batch"])
+  })
+
+  it("MixedScheduler aggregates multiple task exceptions after draining", () => {
+    const scheduled: Array<() => void> = []
+    const scheduler = new Scheduler.MixedScheduler("async", (task) => {
+      scheduled.push(task)
+      return () => {}
+    }).makeDispatcher()
+    const first = new Error("first")
+    const second = new Error("second")
+    const order: Array<number> = []
+
+    scheduler.scheduleTask(() => {
+      order.push(1)
+      throw first
+    }, 0)
+    scheduler.scheduleTask(() => {
+      order.push(2)
+      throw second
+    }, 1)
+    scheduler.scheduleTask(() => order.push(3), 2)
+
+    let caught: unknown
+    try {
+      scheduled[0]()
+    } catch (error) {
+      caught = error
+    }
+
+    assert.instanceOf(caught, AggregateError)
+    assert.deepStrictEqual(caught.errors, [first, second])
+    assert.deepStrictEqual(order, [1, 2, 3])
+  })
+
   it.effect("PreventSchedulerYield disables shouldYield checks", () =>
     Effect.gen(function*() {
       let calls = 0


### PR DESCRIPTION
## Summary

- isolate exceptions from tasks in an already-drained MixedScheduler batch so all same- and different-priority work runs
- rethrow a single task exception unchanged and aggregate multiple task exceptions after draining
- verify reentrant follow-up scheduling remains runnable after the host receives an exception
- add a patch changeset documenting the runtime behavior fix

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Scheduler.test.ts`
- `pnpm check`
- `git diff --check`