### PR TITLE
EFF-947 Preserve Cause immutability in concurrent traversal

### DIFF
--- a/.changeset/eff-947-cause-immutability.md
+++ b/.changeset/eff-947-cause-immutability.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve reusable causes when aggregating concurrent traversal failures.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4770,7 +4770,7 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
                 for (const reason of exit.cause.reasons) {
                   if (reason._tag === "Interrupt") continue
                   else if (terminal._tag === "Failure") {
-                    ;(terminal.cause.reasons as Array<any>).push(reason)
+                    terminal = exitFailCause(causeFromReasons(terminal.cause.reasons.concat(reason)))
                   } else {
                     terminal = exitFailCause(causeFromReasons([reason]))
                   }

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -532,6 +532,26 @@ describe("Effect", () => {
         assert.deepStrictEqual(done, [1, 2, 3])
       }))
 
+    it.effect("does not mutate reusable failures during concurrent aggregation", () =>
+      Effect.gen(function*() {
+        const primary = Exit.fail("primary")
+        const cleanup = Effect.never.pipe(Effect.ensuring(Effect.die("cleanup")))
+        const effects: ReadonlyArray<Effect.Effect<never, string>> = [cleanup, primary]
+
+        const result = yield* Effect.forEach(effects, (effect) => effect, {
+          concurrency: 2
+        }).pipe(Effect.exit)
+
+        assert.deepStrictEqual(
+          result,
+          Exit.failCause(Cause.combine(Cause.fail("primary"), Cause.die("cleanup")))
+        )
+        assert.deepStrictEqual(primary, Exit.fail("primary"))
+
+        const rerun = yield* Effect.exit(primary)
+        assert.deepStrictEqual(rerun, Exit.fail("primary"))
+      }))
+
     it("length = 0", () =>
       Effect.gen(function*() {
         const results = yield* Effect.forEach([], (_) => Effect.succeed(_))


### PR DESCRIPTION
## Summary

- rebuild the terminal failure cause when aggregating non-interrupt sibling cleanup reasons instead of mutating its readonly reasons array
- add regression coverage proving a reusable failure remains unchanged after aggregation and on rerun
- add a patch changeset for the runtime behavior fix

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts` (215 tests)
- `pnpm check`
- `git diff --check`