### PR TITLE
EFF-944 Clean up Fiber.joinAll target observers on interruption

### DIFF
--- a/.changeset/clean-fiber-join-all-observers.md
+++ b/.changeset/clean-fiber-join-all-observers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Clean up target fiber observers when an in-progress Fiber.joinAll is interrupted.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -826,21 +826,49 @@ export const fiberJoinAll = <A extends Iterable<Fiber.Fiber<any, any>>>(self: A)
     const cancels = Arr.empty<() => void>()
     let done = 0
     let failed = false
+    let cleaned = false
+    let registering = true
+    let synchronousResult: Effect.Effect<any, any> | undefined
+    const cleanup = () => {
+      if (cleaned) return
+      cleaned = true
+      cancels.forEach((cancel) => cancel())
+    }
     for (let i = 0; i < fibers.length; i++) {
       if (failed) break
-      cancels.push(fibers[i].addObserver((exit) => {
+      const cancel = fibers[i].addObserver((exit) => {
         done++
         if (exit._tag === "Failure") {
           failed = true
-          cancels.forEach((cancel) => cancel())
-          return resume(exit as any)
+          if (registering) {
+            synchronousResult = exit
+          } else {
+            cleanup()
+            resume(exit as any)
+          }
+          return
         }
         out[i] = exit.value
         if (done === fibers.length) {
-          resume(succeed(out))
+          if (registering) {
+            synchronousResult = succeed(out)
+          } else {
+            resume(succeed(out))
+          }
         }
-      }))
+      })
+      if (cleaned) {
+        cancel()
+      } else {
+        cancels.push(cancel)
+      }
     }
+    registering = false
+    if (synchronousResult !== undefined) {
+      cleanup()
+      resume(synchronousResult)
+    }
+    return sync(cleanup)
   })
 
 /** @internal */

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -1,6 +1,37 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Cause, Effect, Exit, Fiber, Latch } from "effect"
 
+const trackObserverCancellation = <A, E>(
+  fiber: Fiber.Fiber<A, E>,
+  onRegister?: () => void
+) => {
+  let registrations = 0
+  let cancellations = 0
+  const addObserver: Fiber.Fiber<A, E>["addObserver"] = (observer) => {
+    onRegister?.()
+    registrations++
+    const cancel = fiber.addObserver(observer)
+    return () => {
+      cancellations++
+      cancel()
+    }
+  }
+  return {
+    fiber: new Proxy(fiber, {
+      get(target, property, receiver) {
+        return property === "addObserver"
+          ? addObserver
+          : Reflect.get(target, property, receiver)
+      }
+    }),
+    registrations: () => registrations,
+    cancellations: () => cancellations
+  }
+}
+
+const observerCount = (fiber: Fiber.Fiber<any, any>) =>
+  (fiber as Fiber.Fiber<any, any> & { readonly _observers: ReadonlyArray<unknown> })._observers.length
+
 describe("Fiber", () => {
   it("is a fiber", async () => {
     const result = Effect.runFork(Effect.succeed(1))
@@ -142,4 +173,164 @@ describe("Fiber", () => {
       assert.isTrue(Exit.hasInterrupts(exit))
       assert.deepStrictEqual(events, ["acquired", "finalizer-start", "finalizer-end", "awaited"])
     }))
+
+  describe("joinAll", () => {
+    it.effect("cleans up when interrupted before the first observer is registered", () =>
+      Effect.gen(function*() {
+        const target = yield* Effect.never.pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const observersBefore = observerCount(target)
+        const tracked = trackObserverCancellation(target, () => {
+          Fiber.getCurrent()!.interruptUnsafe()
+        })
+
+        const joiner = yield* Fiber.joinAll([tracked.fiber]).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const exit = yield* Fiber.await(joiner)
+
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.strictEqual(tracked.registrations(), 1)
+        assert.strictEqual(tracked.cancellations(), 1)
+        assert.strictEqual(observerCount(target), observersBefore)
+      }))
+
+    it.effect("cleans up synchronous registrations when interrupted during setup", () =>
+      Effect.gen(function*() {
+        const targets = yield* Effect.forEach([1, 2, 3], (value) =>
+          Effect.succeed(value).pipe(Effect.forkChild({ startImmediately: true })))
+        const tracked = targets.map((fiber, index) =>
+          trackObserverCancellation(
+            fiber,
+            index === 0
+              ? () =>
+                Fiber.getCurrent()!.interruptUnsafe()
+              : undefined
+          )
+        )
+
+        const joiner = yield* Fiber.joinAll(tracked.map((entry) => entry.fiber)).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const exit = yield* Fiber.await(joiner)
+
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.deepStrictEqual(tracked.map((entry) => entry.registrations()), [1, 1, 1])
+        assert.deepStrictEqual(tracked.map((entry) => entry.cancellations()), [1, 1, 1])
+      }))
+
+    it.effect("cleans up one observer when the joiner is interrupted", () =>
+      Effect.gen(function*() {
+        const target = yield* Effect.never.pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const observersBefore = observerCount(target)
+        const tracked = trackObserverCancellation(target)
+        const joiner = yield* Fiber.joinAll([tracked.fiber]).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.strictEqual(observerCount(target), observersBefore + 1)
+        yield* Fiber.interrupt(joiner)
+
+        assert.strictEqual(tracked.registrations(), 1)
+        assert.strictEqual(tracked.cancellations(), 1)
+        assert.strictEqual(observerCount(target), observersBefore)
+      }))
+
+    it.effect("cleans up idempotently when a target is interrupted", () =>
+      Effect.gen(function*() {
+        const target = yield* Effect.never.pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const tracked = trackObserverCancellation(target)
+        const joiner = yield* Fiber.joinAll([tracked.fiber]).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        target.interruptUnsafe()
+        const exit = yield* Fiber.await(joiner)
+
+        assert.isTrue(Exit.hasInterrupts(exit))
+        assert.strictEqual(tracked.registrations(), 1)
+        assert.strictEqual(tracked.cancellations(), 1)
+        assert.strictEqual(observerCount(target), 0)
+      }))
+
+    it.effect("cleans up many observers when interrupted", () =>
+      Effect.gen(function*() {
+        const targets = yield* Effect.forEach([0, 1, 2], () =>
+          Effect.never.pipe(Effect.forkChild({ startImmediately: true })))
+        const observersBefore = targets.map(observerCount)
+        const tracked = targets.map((fiber) =>
+          trackObserverCancellation(fiber)
+        )
+        const joiner = yield* Fiber.joinAll(tracked.map((entry) => entry.fiber)).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.deepStrictEqual(targets.map(observerCount), observersBefore.map((count) => count + 1))
+        yield* Fiber.interrupt(joiner)
+
+        assert.deepStrictEqual(tracked.map((entry) => entry.registrations()), [1, 1, 1])
+        assert.deepStrictEqual(tracked.map((entry) => entry.cancellations()), [1, 1, 1])
+        assert.deepStrictEqual(targets.map(observerCount), observersBefore)
+      }))
+
+    it.effect("cleans up synchronous and asynchronous target registrations", () =>
+      Effect.gen(function*() {
+        const syncLeft = yield* Effect.succeed(1).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const asyncTarget = yield* Effect.never.pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const syncRight = yield* Effect.succeed(3).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const observersBefore = observerCount(asyncTarget)
+        const tracked = [syncLeft, asyncTarget, syncRight].map((fiber) => trackObserverCancellation(fiber))
+        const joiner = yield* Fiber.joinAll(tracked.map((entry) => entry.fiber)).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.strictEqual(observerCount(asyncTarget), observersBefore + 1)
+        yield* Fiber.interrupt(joiner)
+
+        assert.deepStrictEqual(tracked.map((entry) => entry.registrations()), [1, 1, 1])
+        assert.deepStrictEqual(tracked.map((entry) => entry.cancellations()), [1, 1, 1])
+        assert.strictEqual(observerCount(asyncTarget), observersBefore)
+      }))
+
+    it.effect("cleans up cancellation returned during partial registration", () =>
+      Effect.gen(function*() {
+        const pending = yield* Effect.never.pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const failed = yield* Effect.fail("boom").pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const unvisited = yield* Effect.never.pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const trackedPending = trackObserverCancellation(pending)
+        const trackedFailed = trackObserverCancellation(failed)
+        const trackedUnvisited = trackObserverCancellation(unvisited)
+        const observersBefore = observerCount(pending)
+
+        const joiner = yield* Fiber.joinAll([
+          trackedPending.fiber,
+          trackedFailed.fiber,
+          trackedUnvisited.fiber
+        ]).pipe(Effect.forkChild({ startImmediately: true }))
+        const exit = yield* Fiber.await(joiner)
+
+        assert.isTrue(Exit.isFailure(exit))
+        assert.strictEqual(trackedPending.cancellations(), 1)
+        assert.strictEqual(trackedFailed.cancellations(), 1)
+        assert.strictEqual(trackedUnvisited.registrations(), 0)
+        assert.strictEqual(observerCount(pending), observersBefore)
+      }))
+  })
 })


### PR DESCRIPTION
## Summary
- return an idempotent cancellation effect from `fiberJoinAll` so joiner interruption unregisters every target observer
- handle observer cancellation functions that arrive after synchronous completion or interruption begins
- defer synchronous join completion until registration is complete, ensuring all registrations are owned and cleaned safely
- add regression coverage for interruption after zero, one, and many registrations, never-ending targets, synchronous/async mixes, partial registration, and idempotence
- add an effect patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Fiber.test.ts` (13 tests)
- `pnpm check`
- `git diff --check`

Specification: `.specs/audit.md` F-04.