### PR TITLE
EFF-954 Clear completed fiber context caches

### DIFF
--- a/.changeset/clear-completed-fiber-caches.md
+++ b/.changeset/clear-completed-fiber-caches.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Clear context-derived services and dispatchers when fibers complete.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -617,14 +617,16 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     }
 
     this._exit = exit
-    this.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
+    const context = this.context
+    const runtimeMetrics = this.runtimeMetrics
+    this._stack.length = 0
+    this._children = undefined
+    this.clearContext()
+    runtimeMetrics?.recordFiberEnd(context, this._exit)
     for (let i = 0; i < this._observers.length; i++) {
       this._observers[i](exit)
     }
     this._observers.length = 0
-    this._stack.length = 0
-    this._children = undefined
-    this.context = Context.empty()
   }
   runLoop(effect: Primitive): Exit.Exit<A, E> | Yield {
     const prevFiber = (globalThis as any)[currentFiberTypeId]
@@ -722,6 +724,13 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.runtimeMetrics = context.mapUnsafe.get(InternalMetric.FiberRuntimeMetricsKey)
     const currentTracer = context.mapUnsafe.get(Tracer.TracerKey)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
+  }
+  private clearContext(): void {
+    // A completed fiber exposes an empty context, all public context-derived
+    // fields reflect that context's defaults, and no private derived references
+    // are retained.
+    this.setContext(Context.empty())
+    this._dispatcher = undefined
   }
   get currentSpanLocal(): Tracer.Span | undefined {
     return this.currentSpan?._tag === "Span" ? this.currentSpan : undefined

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Exit, Fiber, Latch } from "effect"
+import { Cause, Context, Effect, Exit, Fiber, Latch, Metric, References, Scheduler, Tracer } from "effect"
 
 describe("Fiber", () => {
   it("is a fiber", async () => {
@@ -142,4 +142,115 @@ describe("Fiber", () => {
       assert.isTrue(Exit.hasInterrupts(exit))
       assert.deepStrictEqual(events, ["acquired", "finalizer-start", "finalizer-end", "awaited"])
     }))
+
+  it("clears context-derived caches on completion", () => {
+    const dispatcher: Scheduler.SchedulerDispatcher = {
+      scheduleTask() {},
+      flush() {}
+    }
+    const scheduler: Scheduler.Scheduler = {
+      executionMode: "sync",
+      shouldYield: () => false,
+      makeDispatcher: () => dispatcher
+    }
+    const span = Tracer.externalSpan({
+      spanId: "span",
+      traceId: "trace"
+    })
+    const tracerContext: NonNullable<Tracer.Tracer["context"]> = (primitive, fiber) =>
+      primitive["~effect/Effect/evaluate"](fiber)
+    const tracer = Tracer.make({
+      span: () => {
+        throw new Error("unexpected span")
+      },
+      context: tracerContext
+    })
+    let ended = false
+    let endedContext: Context.Context<never> | undefined
+    const metrics: Metric.FiberRuntimeMetricsService = {
+      recordFiberStart() {},
+      recordFiberEnd(context) {
+        ended = true
+        endedContext = context
+      }
+    }
+    const stackFrame: References.StackFrame = {
+      name: "frame",
+      stack: () => undefined,
+      parent: undefined
+    }
+    const context = Context.empty().pipe(
+      Context.add(Scheduler.Scheduler, scheduler),
+      Context.add(Tracer.ParentSpan, span),
+      Context.add(Tracer.Tracer, tracer),
+      Context.add(Metric.FiberRuntimeMetrics, metrics),
+      Context.add(References.CurrentStackFrame, stackFrame)
+    )
+
+    const fiber = Effect.runForkWith(context)(Effect.sync(() => {
+      const current = Fiber.getCurrent()!
+      assert.strictEqual(current.currentDispatcher, dispatcher)
+      assert.strictEqual(current.currentScheduler, scheduler)
+      assert.strictEqual(current.currentSpan, span)
+      assert.strictEqual(current.currentStackFrame, stackFrame)
+    })) as Fiber.Fiber<void> & {
+      readonly _dispatcher: Scheduler.SchedulerDispatcher | undefined
+      readonly currentTracerContext: Tracer.Tracer["context"]
+      readonly runtimeMetrics: Metric.FiberRuntimeMetricsService | undefined
+    }
+
+    assert.isDefined(fiber.pollUnsafe())
+    assert.isTrue(ended)
+    assert.strictEqual(endedContext, context)
+    assert.strictEqual(fiber.context, Context.empty())
+    assert.strictEqual(fiber.currentScheduler, fiber.getRef(Scheduler.Scheduler))
+    assert.notStrictEqual(fiber.currentScheduler, scheduler)
+    assert.notStrictEqual(fiber.getRef(Tracer.Tracer), tracer)
+    assert.isUndefined(fiber.getRef(Metric.FiberRuntimeMetrics))
+    assert.isUndefined(fiber.getRef(References.CurrentStackFrame))
+    assert.isUndefined(fiber.currentSpan)
+    assert.isUndefined(fiber.currentStackFrame)
+    assert.isUndefined(fiber._dispatcher)
+    assert.isUndefined(fiber.currentTracerContext)
+    assert.isUndefined(fiber.runtimeMetrics)
+  })
+
+  it("clears context-derived caches before running completion hooks", () => {
+    const span = Tracer.externalSpan({
+      spanId: "span",
+      traceId: "trace"
+    })
+    const metrics: Metric.FiberRuntimeMetricsService = {
+      recordFiberStart() {},
+      recordFiberEnd() {
+        completionHookRan = true
+        throw new Error("completion hook failed")
+      }
+    }
+    const context = Context.empty().pipe(
+      Context.add(Tracer.ParentSpan, span),
+      Context.add(Metric.FiberRuntimeMetrics, metrics)
+    )
+    let completionHookRan = false
+    let fiber:
+      | (Fiber.Fiber<void> & {
+        readonly runtimeMetrics: Metric.FiberRuntimeMetricsService | undefined
+      })
+      | undefined
+
+    try {
+      Effect.runForkWith(context)(Effect.sync(() => {
+        fiber = Fiber.getCurrent() as typeof fiber
+      }))
+    } catch {
+      // Completion-hook failure handling is outside this teardown invariant.
+    }
+
+    assert.isTrue(completionHookRan)
+    assert.isDefined(fiber)
+    assert.isDefined(fiber.pollUnsafe())
+    assert.strictEqual(fiber.context, Context.empty())
+    assert.isUndefined(fiber.currentSpan)
+    assert.isUndefined(fiber.runtimeMetrics)
+  })
 })


### PR DESCRIPTION
## Summary

- add explicit completed-fiber context teardown that resets public context-derived caches to empty-context defaults
- clear private dispatcher, tracer-context, runtime-metric, span, and stack-frame references before completion hooks and observers run
- preserve the original context for runtime metric completion reporting
- add regression coverage for custom scheduler, dispatcher, span, tracer, metric, and stack-frame retention, including a throwing completion hook
- add a patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Fiber.test.ts packages/effect/test/Effect.test.ts`
- `pnpm check`
- `git diff --check`
