### PR TITLE
EFF-950 Apply RunOptions before initial root evaluation

### DIFF
--- a/.changeset/apply-run-options-before-evaluation.md
+++ b/.changeset/apply-run-options-before-evaluation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Apply `runFork` abort signals and fiber-start hooks before evaluating the root effect.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -8842,7 +8842,8 @@ export const fiberId: Effect<number> = internal.fiberId
  *
  * `signal` interrupts the fiber, `scheduler` provides the scheduler service,
  * `uninterruptible` starts the fiber uninterruptibly, and `onFiberStart`
- * receives the created fiber.
+ * receives the created fiber. Signal handling is installed and `onFiberStart`
+ * is invoked before the root effect begins evaluation.
  *
  * @see {@link runFork} for starting a fiber with these options
  * @see {@link runCallback} for callback-based running with these options

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5337,20 +5337,32 @@ export const runForkWith = <R>(context: Context.Context<R>) =>
     options?.scheduler ? Context.add(context, Scheduler.Scheduler, options.scheduler) : context,
     options?.uninterruptible !== true
   )
-  fiber.evaluate(effect as any)
-  if (fiber._exit) return fiber
 
-  if (options?.signal) {
-    if (options.signal.aborted) {
-      fiber.interruptUnsafe()
+  const signal = options?.signal
+  let preAborted = false
+  if (signal) {
+    if (signal.aborted) {
+      preAborted = true
     } else {
       const abort = () => fiber.interruptUnsafe()
-      options.signal.addEventListener("abort", abort, { once: true })
-      fiber.addObserver(() => options.signal!.removeEventListener("abort", abort))
+      signal.addEventListener("abort", abort, { once: true })
+      fiber.addObserver(() => signal.removeEventListener("abort", abort))
     }
   }
+  const start = () => {
+    if (preAborted) {
+      fiber.interruptUnsafe()
+    }
+    fiber.evaluate(effect as any)
+  }
   if (options?.onFiberStart) {
-    options.onFiberStart(fiber)
+    try {
+      options.onFiberStart(fiber)
+    } finally {
+      start()
+    }
+  } else {
+    start()
   }
   return fiber
 }

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -98,6 +98,111 @@ describe("Effect", () => {
     assert.strictEqual(result, 1)
   })
 
+  describe("runFork RunOptions", () => {
+    it("does not evaluate a synchronous root with a pre-aborted signal", () => {
+      const controller = new AbortController()
+      controller.abort()
+      let evaluated = false
+
+      const fiber = Effect.runFork(
+        Effect.sync(() => {
+          evaluated = true
+        }),
+        { signal: controller.signal }
+      )
+
+      assert.isFalse(evaluated)
+      assert.isTrue(Exit.hasInterrupts(fiber.pollUnsafe()!))
+    })
+
+    it("does not evaluate a yielding root with a pre-aborted signal", () => {
+      const controller = new AbortController()
+      controller.abort()
+      let evaluated = false
+
+      const fiber = Effect.runFork(
+        Effect.gen(function*() {
+          evaluated = true
+          yield* Effect.yieldNow
+        }),
+        { signal: controller.signal }
+      )
+
+      assert.isFalse(evaluated)
+      assert.isTrue(Exit.hasInterrupts(fiber.pollUnsafe()!))
+    })
+
+    it("allows a pre-aborted uninterruptible root to complete", () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      const fiber = Effect.runFork(Effect.succeed(1), {
+        signal: controller.signal,
+        uninterruptible: true
+      })
+
+      assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(1))
+    })
+
+    it("delivers an abort during the initial synchronous segment", () => {
+      const controller = new AbortController()
+
+      const fiber = Effect.runFork(
+        Effect.sync(() => {
+          controller.abort()
+        }),
+        { signal: controller.signal }
+      )
+
+      assert.isTrue(Exit.hasInterrupts(fiber.pollUnsafe()!))
+    })
+
+    it("invokes onFiberStart before synchronous completion", () => {
+      const events: Array<string> = []
+      let startedFiber: Fiber.Fiber<void> | undefined
+
+      const fiber = Effect.runFork(
+        Effect.sync(() => {
+          events.push("effect")
+        }),
+        {
+          onFiberStart: (fiber) => {
+            events.push("start")
+            startedFiber = fiber as Fiber.Fiber<void>
+            assert.isUndefined(fiber.pollUnsafe())
+          }
+        }
+      )
+
+      assert.strictEqual(startedFiber, fiber)
+      assert.deepStrictEqual(events, ["start", "effect"])
+    })
+
+    it.effect("invokes onFiberStart before asynchronous completion", () =>
+      Effect.gen(function*() {
+        const events: Array<string> = []
+        let startedFiber: Fiber.Fiber<void> | undefined
+
+        const fiber = Effect.runFork(
+          Effect.gen(function*() {
+            events.push("effect")
+            yield* Effect.yieldNow
+          }),
+          {
+            onFiberStart: (fiber) => {
+              events.push("start")
+              startedFiber = fiber as Fiber.Fiber<void>
+              assert.isUndefined(fiber.pollUnsafe())
+            }
+          }
+        )
+
+        yield* Fiber.await(fiber)
+        assert.strictEqual(startedFiber, fiber)
+        assert.deepStrictEqual(events, ["start", "effect"])
+      }))
+  })
+
   it("acquireUseRelease interrupt", async () => {
     let acquire = false
     let use = false


### PR DESCRIPTION
## Summary

- install runFork AbortSignal handling before root evaluation
- invoke onFiberStart before synchronous or asynchronous root work begins
- preserve uninterruptible-root masking for pre-aborted signals
- document the boundary and add regression coverage for pre-aborted, initial-abort, and lifecycle-hook cases
- add an effect patch changeset

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts packages/effect/test/Fiber.test.ts
- pnpm check
- git diff --check