### PR TITLE
EFF-952 Preserve stack annotations for terminal root failures

### DIFF
--- a/.changeset/eff-952-terminal-failure-stack.md
+++ b/.changeset/eff-952-terminal-failure-stack.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve current stack frame annotations on terminal root failures.

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -541,7 +541,7 @@ export const exitFailCause: <E>(cause: Cause.Cause<E>) => Exit.Exit<never, E> = 
     }
     return cont
       ? cont[contE](cause, fiber, annotated ? undefined : this)
-      : fiber.yieldWith(annotated ? this : exitFailCause(cause))
+      : fiber.yieldWith(annotated ? exitFailCause(cause) : this)
   }
 })
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -64,7 +64,24 @@ describe("Effect", () => {
   })
 
   describe("tracing", () => {
-    it.effect("failCause captures stack frame", () =>
+    it("terminal root failure captures stack frame", () => {
+      const frame: References.StackFrame = {
+        name: "root frame",
+        stack: () => undefined,
+        parent: undefined
+      }
+      const failure = Exit.fail("boom")
+      const exit = Effect.runForkWith(Context.make(References.CurrentStackFrame, frame))(failure).pollUnsafe()
+
+      assert.isDefined(exit)
+      assert.isTrue(Exit.isFailure(exit!))
+      if (Exit.isFailure(exit!)) {
+        const trace = Context.getOrUndefined(Cause.annotations(exit.cause), Cause.StackTrace)
+        assert.strictEqual(trace, frame)
+      }
+    })
+
+    it.effect("caught sandboxed failure captures stack frame", () =>
       Effect.gen(function*() {
         const cause = yield* Effect.failCause(Cause.die(new Error("boom"))).pipe(
           Effect.withSpan("test span"),
@@ -75,6 +92,17 @@ describe("Effect", () => {
         const trace = Context.getUnsafe(annotations, Cause.StackTrace)
         assert.strictEqual(trace.name, "test span")
       }))
+
+    it("failure without a current frame has no stack annotation and reuses the original exit", () => {
+      const failure = Exit.fail("boom")
+      const exit = Effect.runFork(failure).pollUnsafe()
+
+      assert.strictEqual(exit, failure)
+      assert.isTrue(Exit.isFailure(exit!))
+      if (Exit.isFailure(exit!)) {
+        assert.isUndefined(Context.getOrUndefined(Cause.annotations(exit.cause), Cause.StackTrace))
+      }
+    })
   })
 
   it("callback can branch over sync/async", async () => {


### PR DESCRIPTION
## Summary

- return the annotated failure exit for terminal root failures
- reuse the original failure exit when no current stack frame is available
- add direct Cause.StackTrace regression assertions for terminal, caught/sandboxed, and frameless failures
- add a patch changeset for the corrected runtime diagnostics

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/Cause.test.ts packages/effect/test/Effect.test.ts
- pnpm check
- git diff --check