### PR TITLE
EFF-953 Store interruptor stack frames separately

### DIFF
--- a/.changeset/eff-953-interruptor-stack-trace.md
+++ b/.changeset/eff-953-interruptor-stack-trace.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Store interrupting fiber stack frames separately from interrupted target stack frames.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -746,7 +746,7 @@ const fiberMiddleware = {
 const fiberStackAnnotations = (fiber: Fiber.Fiber<any, any>) => {
   if (!fiber.currentStackFrame) return undefined
   const annotations = new Map<string, unknown>()
-  annotations.set(CauseStackTrace.key, fiber.currentStackFrame)
+  annotations.set(InterruptorStackTrace.key, fiber.currentStackFrame)
   return Context.makeUnsafe(annotations)
 }
 

--- a/packages/effect/test/Fiber.test.ts
+++ b/packages/effect/test/Fiber.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Exit, Fiber, Latch } from "effect"
+import { Cause, Context, Effect, Exit, Fiber, Latch, References } from "effect"
 
 describe("Fiber", () => {
   it("is a fiber", async () => {
@@ -68,6 +68,37 @@ describe("Fiber", () => {
         assert.isTrue(Exit.hasInterrupts(exit))
       })
   )
+
+  it.effect("retains distinct target and interruptor stack frames", () =>
+    Effect.gen(function*() {
+      const targetFrame: References.StackFrame = {
+        name: "target-frame",
+        stack: () => "at target-call-site.ts:1:1",
+        parent: undefined
+      }
+      const interruptorFrame: References.StackFrame = {
+        name: "interruptor-frame",
+        stack: () => "at interruptor-call-site.ts:2:2",
+        parent: undefined
+      }
+      const target = yield* Effect.never.pipe(
+        Effect.provideService(References.CurrentStackFrame, targetFrame),
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* Fiber.interrupt(target).pipe(
+        Effect.provideService(References.CurrentStackFrame, interruptorFrame)
+      )
+
+      const exit = yield* Fiber.await(target)
+      if (exit._tag !== "Failure") {
+        return assert.fail("expected interrupted fiber to exit with failure")
+      }
+      const annotations = Cause.reasonAnnotations(exit.cause.reasons[0])
+      assert.strictEqual(Context.getUnsafe(annotations, Cause.StackTrace), targetFrame)
+      assert.strictEqual(Context.getUnsafe(annotations, Cause.InterruptorStackTrace), interruptorFrame)
+      assert.isTrue(Cause.pretty(exit.cause).includes("interruptor-call-site.ts:2:2"))
+    }))
 
   it.effect("delivers a pending interrupt when interruptibleMask restores interruptibility", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- store interrupting fiber frames under `Cause.InterruptorStackTrace` instead of colliding with the target's `Cause.StackTrace`
- add regression coverage proving both framed call sites remain available under distinct annotations
- verify pretty interruption diagnostics include the interruptor call site
- add a patch changeset for the diagnostic behavior fix

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Cause.test.ts packages/effect/test/Fiber.test.ts`
- `pnpm check`