### PR TITLE
EFF-945 Prevent raceAllFirst daemon leaks

### DIFF
--- a/.changeset/eff-945-race-all-first-cleanup.md
+++ b/.changeset/eff-945-race-all-first-cleanup.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Interrupt and await raceAllFirst workers when iterable mechanics or synchronous winner callbacks throw.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -571,6 +571,19 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       }
     }
   }
+  addObserverFirst(cb: (exit: Exit.Exit<A, E>) => void): () => void {
+    if (this._exit) {
+      cb(this._exit)
+      return constVoid
+    }
+    this._observers.unshift(cb)
+    return () => {
+      const index = this._observers.indexOf(cb)
+      if (index >= 0) {
+        this._observers.splice(index, 1)
+      }
+    }
+  }
   interruptUnsafe(fiberId?: number | undefined, annotations?: Context.Context<never> | undefined): void {
     if (this._exit) {
       return
@@ -1528,35 +1541,63 @@ export const raceAllFirst = <Eff extends Effect.Effect<any, any, any>>(
   Effect.Services<Eff>
 > =>
   withFiber((parent) =>
-    callback((resume) => {
+    suspend(() => {
       let done = false
-      const fibers = new Set<Fiber.Fiber<any, any>>()
-      const onExit = (exit: Exit.Exit<any, any>) => {
+      const fibers = new Set<FiberImpl<any, any>>()
+      const cleanup = withFiber((fiber) => {
         done = true
-        resume(
-          fibers.size === 0
-            ? exit
-            : flatMap(uninterruptible(fiberInterruptAll(fibers)), () => exit)
-        )
-      }
-
-      let i = 0
-      for (const effect of all) {
-        if (done) break
-        const index = i++
-        const fiber = forkUnsafe(parent, effect, true, true, false)
-        fibers.add(fiber)
-        fiber.addObserver((exit) => {
-          fibers.delete(fiber)
-          const isWinner = !done
-          onExit(exit)
-          if (isWinner && options?.onWinner) {
-            options.onWinner({ fiber, index, parentFiber: parent })
-          }
+        const owned = Array.from(fibers)
+        if (owned.length === 0) return void_
+        const annotations = fiberStackAnnotations(fiber)
+        return callback<void>((resume) => {
+          fiber.currentDispatcher.scheduleTask(() => {
+            let resumed = false
+            const complete = () => {
+              if (resumed || owned.some((fiber) => fiber.pollUnsafe() === undefined)) return
+              resumed = true
+              resume(void_)
+            }
+            for (const fiber of owned) {
+              if (fiber.pollUnsafe() !== undefined) continue
+              fiber.addObserverFirst(() => complete())
+            }
+            for (const child of owned) {
+              try {
+                child.interruptUnsafe(fiber.id, annotations)
+              } catch {
+                // A public observer may throw while the fiber is completing.
+              }
+            }
+            complete()
+          }, 0)
         })
-      }
-
-      return fiberInterruptAll(fibers)
+      })
+      return onExitPrimitive(
+        callback((resume) => {
+          const onExit = (exit: Exit.Exit<any, any>) => {
+            if (done) return
+            done = true
+            resume(exit)
+          }
+          let index = 0
+          for (const effect of all) {
+            if (done) break
+            const fiber = new FiberImpl(parent.context)
+            fibers.add(fiber)
+            fiber.evaluate(effect as any)
+            const currentIndex = index++
+            fiber.addObserver((exit) => {
+              fibers.delete(fiber)
+              const isWinner = !done
+              onExit(exit)
+              if (isWinner && options?.onWinner) {
+                options.onWinner({ fiber, index: currentIndex, parentFiber: parent })
+              }
+            })
+          }
+        }),
+        () => cleanup
+      )
     })
   )
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -17,6 +17,7 @@ import {
   References,
   Result,
   Schedule,
+  Scheduler,
   Scope,
   TxRef
 } from "effect"
@@ -981,6 +982,219 @@ describe("Effect", () => {
       assert.deepStrictEqual(result, Exit.fail("boom"))
       // 100 doesn't start because 0 finishes the race first
       assert.deepStrictEqual(interrupted, [500, 300, 200])
+    }))
+
+  it.effect("raceAllFirst preserves an iterable defect before the first fork", () =>
+    Effect.gen(function*() {
+      const defect = new Error("iterator defect")
+      const iterable: Iterable<Effect.Effect<void>> = {
+        [Symbol.iterator]() {
+          throw defect
+        }
+      }
+      const exit = yield* Effect.raceAllFirst(iterable).pipe(Effect.exit)
+
+      assertExitDefect(exit, defect)
+    }))
+
+  it.effect("raceAllFirst interrupts and awaits workers when iteration throws", () =>
+    Effect.gen(function*() {
+      const interruptStarted = yield* Deferred.make<void>()
+      const releaseFinalizer = yield* Deferred.make<void>()
+      const defect = new Error("iterator defect")
+      let workerFiber: Fiber.Fiber<never, never> | undefined
+      const worker = Effect.fiber.pipe(
+        Effect.tap((fiber) =>
+          Effect.sync(() => {
+            workerFiber = fiber as Fiber.Fiber<never, never>
+          })
+        ),
+        Effect.andThen(Effect.never),
+        Effect.onInterrupt(() =>
+          Deferred.succeed(interruptStarted, void 0).pipe(
+            Effect.andThen(Deferred.await(releaseFinalizer))
+          )
+        )
+      )
+      const iterable: Iterable<Effect.Effect<never>> = {
+        [Symbol.iterator]() {
+          let first = true
+          return {
+            next() {
+              if (first) {
+                first = false
+                return { done: false, value: worker }
+              }
+              throw defect
+            }
+          }
+        }
+      }
+      const parent = yield* Effect.raceAllFirst(iterable).pipe(
+        Effect.forkChild({ startImmediately: true })
+      )
+
+      yield* Effect.yieldNow
+      const workerStarted = workerFiber !== undefined
+      const parentAwaitingCleanup = parent.pollUnsafe() === undefined
+      yield* Deferred.await(interruptStarted)
+      yield* Deferred.succeed(releaseFinalizer, void 0)
+      const exit = yield* Fiber.await(parent)
+
+      assert.isTrue(workerStarted)
+      assert.isTrue(parentAwaitingCleanup)
+      assertExitDefect(exit, defect)
+      assert.isDefined(workerFiber!.pollUnsafe())
+      assert.isTrue(Exit.hasInterrupts(workerFiber!.pollUnsafe()!))
+    }))
+
+  it.effect("raceAllFirst owns workers before their first scheduler step", () =>
+    Effect.gen(function*() {
+      const defect = new Error("iterator defect")
+      let shouldYield = true
+      let workerFiber: Fiber.Fiber<never, never> | undefined
+      const scheduler = new Scheduler.MixedScheduler()
+      const iterable: Iterable<Effect.Effect<never>> = {
+        [Symbol.iterator]() {
+          let first = true
+          return {
+            next() {
+              if (first) {
+                first = false
+                return {
+                  done: false,
+                  value: Effect.fiber.pipe(
+                    Effect.tap((fiber) =>
+                      Effect.sync(() => {
+                        workerFiber = fiber as Fiber.Fiber<never, never>
+                      })
+                    ),
+                    Effect.andThen(Effect.never)
+                  )
+                }
+              }
+              throw defect
+            }
+          }
+        }
+      }
+      const exit = yield* Effect.raceAllFirst(iterable).pipe(
+        Effect.provideService(References.Scheduler, {
+          executionMode: scheduler.executionMode,
+          makeDispatcher: () => scheduler.makeDispatcher(),
+          shouldYield: () => {
+            const result = shouldYield
+            shouldYield = false
+            return result
+          }
+        }),
+        Effect.exit
+      )
+
+      assertExitDefect(exit, defect)
+      assert.isDefined(workerFiber)
+      assert.isTrue(Exit.hasInterrupts(workerFiber!.pollUnsafe()!))
+    }))
+
+  it.effect("raceAllFirst interrupts every worker when public observers throw", () =>
+    Effect.gen(function*() {
+      const defect = new Error("iterator defect")
+      const workerFibers: Array<Fiber.Fiber<never, never>> = []
+      const worker = Effect.fiber.pipe(
+        Effect.tap((fiber) =>
+          Effect.sync(() => {
+            workerFibers.push(fiber as Fiber.Fiber<never, never>)
+            fiber.addObserver(() => {
+              throw new Error("observer defect")
+            })
+          })
+        ),
+        Effect.andThen(Effect.never)
+      )
+      const iterable: Iterable<Effect.Effect<never>> = {
+        [Symbol.iterator]() {
+          let index = 0
+          return {
+            next() {
+              if (index++ < 2) return { done: false, value: worker }
+              throw defect
+            }
+          }
+        }
+      }
+      const exit = yield* Effect.raceAllFirst(iterable).pipe(Effect.exit)
+
+      assertExitDefect(exit, defect)
+      assert.strictEqual(workerFibers.length, 2)
+      assert.isTrue(workerFibers.every((fiber) => Exit.hasInterrupts(fiber.pollUnsafe()!)))
+    }))
+
+  it.effect("raceAllFirst cleans up when onWinner interrupts the parent reentrantly", () =>
+    Effect.gen(function*() {
+      const interruptStarted = yield* Deferred.make<void>()
+      const releaseFinalizer = yield* Deferred.make<void>()
+      let workerFiber: Fiber.Fiber<never, never> | undefined
+      const worker = Effect.fiber.pipe(
+        Effect.tap((fiber) =>
+          Effect.sync(() => {
+            workerFiber = fiber as Fiber.Fiber<never, never>
+          })
+        ),
+        Effect.andThen(Effect.never),
+        Effect.onInterrupt(() =>
+          Deferred.succeed(interruptStarted, void 0).pipe(
+            Effect.andThen(Deferred.await(releaseFinalizer))
+          )
+        )
+      )
+      const parent = yield* Effect.raceAllFirst([worker, Effect.succeed(1)], {
+        onWinner({ parentFiber }) {
+          parentFiber.interruptUnsafe()
+        }
+      }).pipe(Effect.forkChild({ startImmediately: true }))
+
+      yield* Effect.yieldNow
+      const parentAwaitingCleanup = parent.pollUnsafe() === undefined
+      yield* Deferred.await(interruptStarted)
+      yield* Deferred.succeed(releaseFinalizer, void 0)
+      const exit = yield* Fiber.await(parent)
+
+      assert.isTrue(parentAwaitingCleanup)
+      assert.isTrue(Exit.hasInterrupts(exit))
+      assert.isTrue(Exit.hasInterrupts(workerFiber!.pollUnsafe()!))
+    }))
+
+  it.effect("raceAllFirst preserves a synchronous onWinner defect", () =>
+    Effect.gen(function*() {
+      const defect = new Error("onWinner defect")
+      const exit = yield* Effect.raceAllFirst([Effect.succeed(1)], {
+        onWinner() {
+          throw defect
+        }
+      }).pipe(Effect.exit)
+
+      assertExitDefect(exit, defect)
+    }))
+
+  it.effect("raceAllFirst preserves an iterator close defect after a synchronous winner", () =>
+    Effect.gen(function*() {
+      const defect = new Error("iterator close defect")
+      const iterable: Iterable<Effect.Effect<number>> = {
+        [Symbol.iterator]() {
+          let index = 0
+          return {
+            next() {
+              return { done: false, value: index++ === 0 ? Effect.succeed(1) : Effect.never }
+            },
+            return() {
+              throw defect
+            }
+          }
+        }
+      }
+      const exit = yield* Effect.raceAllFirst(iterable).pipe(Effect.exit)
+
+      assertExitDefect(exit, defect)
     }))
 
   describe("repeat", () => {


### PR DESCRIPTION
## Summary
- establish raceAllFirst worker ownership before candidate evaluation
- run registration under uninterruptible exit cleanup so iterator and callback defects interrupt and await owned daemons
- preserve synchronous race completion and registration-defect precedence
- add regressions for pre/post-fork iterable failures, gated finalizers, scheduler yields, reentrant interruption, and synchronous registration callbacks

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check