### PR TITLE
EFF-955 Avoid runSyncExit dispatcher allocation

### DIFF
--- a/.changeset/eff-955-run-sync-dispatcher.md
+++ b/.changeset/eff-955-run-sync-dispatcher.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Avoid allocating a scheduler dispatcher when `runSyncExit` completes without yielding.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5456,9 +5456,9 @@ export const runSyncExitWith = <R>(context: Context.Context<R>) => {
   return <A, E>(effect: Effect.Effect<A, E, R>): Exit.Exit<A, E> => {
     if (effectIsExit(effect)) return effect
     const scheduler = new Scheduler.MixedScheduler("sync")
-    const fiber = runFork(effect, { scheduler })
-    fiber.currentDispatcher?.flush()
-    return (fiber as FiberImpl<A, E>)._exit ?? exitDie(new AsyncFiberError(fiber))
+    const fiber = runFork(effect, { scheduler }) as FiberImpl<A, E>
+    fiber._dispatcher?.flush()
+    return fiber._exit ?? exitDie(new AsyncFiberError(fiber))
   }
 }
 

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -1,8 +1,24 @@
-import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { assert, describe, it, vi } from "@effect/vitest"
+import { Effect, Exit } from "effect"
 import * as Scheduler from "effect/Scheduler"
 
 describe("Scheduler", () => {
+  it("runSyncExit does not create a dispatcher for synchronous effects", () => {
+    const makeDispatcher = vi.spyOn(Scheduler.MixedScheduler.prototype, "makeDispatcher")
+    const exit = Effect.runSyncExit(Effect.sync(() => 1))
+    const calls = makeDispatcher.mock.calls.length
+    makeDispatcher.mockRestore()
+
+    assert.deepStrictEqual(exit, Exit.succeed(1))
+    assert.strictEqual(calls, 0)
+  })
+
+  it("runSyncExit flushes dispatcher work after yielding", () => {
+    const exit = Effect.runSyncExit(Effect.as(Effect.yieldNow, 1))
+
+    assert.deepStrictEqual(exit, Exit.succeed(1))
+  })
+
   it.effect("MixedScheduler orders by priority (sync)", () =>
     Effect.sync(() => {
       const scheduler = new Scheduler.MixedScheduler("sync").makeDispatcher()


### PR DESCRIPTION
## Summary

- flush only a dispatcher already created while evaluating `runSyncExit`
- avoid `MixedSchedulerDispatcher` allocation for purely synchronous effects
- add regressions for the allocation-free fast path and yielded dispatcher flushing
- add a patch changeset

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts packages/effect/test/Scheduler.test.ts`
- `pnpm check`
- `git diff --check`

Specification: `.specs/audit.md` F-14.