### PR TITLE
EFF-949 Avoid recursive stack overflow from runtime hook defects

### DIFF
--- a/.changeset/eff-949-runtime-hook-defects.md
+++ b/.changeset/eff-949-runtime-hook-defects.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Convert throwing scheduler, tracer, and fiber runtime metric hooks into stable fiber defects without recursive hook retries.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -521,7 +521,14 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._yielded = undefined
     this._running = false
     this._deferredInterrupt = false
-    this.runtimeMetrics?.recordFiberStart(this.context)
+    this._exiting = false
+    this._runtimeHooksDisabled = false
+    try {
+      this.runtimeMetrics?.recordFiberStart(this.context)
+    } catch (error) {
+      this._exit = exitDie(error) as any
+      this.context = Context.empty()
+    }
   }
 
   readonly [FiberTypeId]: Fiber.Fiber.Variance<A, E>
@@ -537,6 +544,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   _yielded: Exit.Exit<any, any> | (() => void) | undefined
   _running: boolean
   _deferredInterrupt: boolean
+  _exiting: boolean
+  _runtimeHooksDisabled: boolean
 
   // set in setContext
   context!: Context.Context<never>
@@ -572,7 +581,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     }
   }
   interruptUnsafe(fiberId?: number | undefined, annotations?: Context.Context<never> | undefined): void {
-    if (this._exit) {
+    if (this._exit || this._exiting) {
       return
     }
     let cause = causeInterrupt(fiberId)
@@ -597,7 +606,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     return this._exit
   }
   evaluate(effect: Primitive): void {
-    if (this._exit) {
+    if (this._exit || this._exiting) {
       return
     } else if (this._yielded !== undefined) {
       const yielded = this._yielded as () => void
@@ -616,10 +625,17 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       return this.evaluate(flatMap(interruptChildren, () => exit) as any)
     }
 
-    this._exit = exit
-    this.runtimeMetrics?.recordFiberEnd(this.context, this._exit)
+    let finalExit = exit
+    this._exiting = true
+    try {
+      this.runtimeMetrics?.recordFiberEnd(this.context, finalExit)
+    } catch (error) {
+      finalExit = exitDie(error) as any
+    }
+    this._exit = finalExit
+    this._exiting = false
     for (let i = 0; i < this._observers.length; i++) {
-      this._observers[i](exit)
+      this._observers[i](finalExit)
     }
     this._observers.length = 0
     this._stack.length = 0
@@ -641,18 +657,37 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
           current = failCause(this._interruptedCause!) as any
         }
         this.currentOpCount++
-        if (
-          !yielding &&
-          !this.currentPreventYield &&
-          this.currentScheduler.shouldYield(this as any)
-        ) {
-          yielding = true
-          const prev = current
-          current = flatMap(yieldNow, () => prev as any) as any
+        if (!this._runtimeHooksDisabled) {
+          try {
+            if (
+              !yielding &&
+              !this.currentPreventYield &&
+              this.currentScheduler.shouldYield(this as any)
+            ) {
+              yielding = true
+              const prev = current
+              current = flatMap(yieldNow, () => prev as any) as any
+            }
+          } catch (error) {
+            this._runtimeHooksDisabled = true
+            current = exitDie(error) as any
+            continue
+          }
         }
-        current = this.currentTracerContext
-          ? this.currentTracerContext(current as any, this)
-          : (current as any)[evaluate](this)
+        const tracerContext = !this._runtimeHooksDisabled ? this.currentTracerContext : undefined
+        try {
+          current = tracerContext
+            ? tracerContext(current as any, this)
+            : (current as any)[evaluate](this)
+        } catch (error) {
+          if (tracerContext) {
+            this._runtimeHooksDisabled = true
+          } else if (!hasProperty(current, evaluate)) {
+            return exitDie(`Fiber.runLoop: Not a valid effect: ${String(current)}`)
+          }
+          current = exitDie(error) as any
+          continue
+        }
         if (current === Yield) {
           const yielded = this._yielded!
           if (ExitTypeId in yielded) {
@@ -667,11 +702,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
           return Yield
         }
       }
-    } catch (error) {
-      if (!hasProperty(current, evaluate)) {
-        return exitDie(`Fiber.runLoop: Not a valid effect: ${String(current)}`)
-      }
-      return this.runLoop(exitDie(error) as any)
     } finally {
       this._running = prevRunning
       ;(globalThis as any)[currentFiberTypeId] = prevFiber
@@ -5189,10 +5219,12 @@ export const forkUnsafe = <FA, FE, A, E, R>(
 ): FiberImpl<A, E> => {
   const interruptible = uninterruptible === "inherit" ? parent.interruptible : !uninterruptible
   const child = new FiberImpl<A, E>(parent.context, interruptible)
-  if (immediate) {
-    child.evaluate(effect as any)
-  } else {
-    parent.currentDispatcher.scheduleTask(() => child.evaluate(effect as any), 0)
+  if (!child._exit) {
+    if (immediate) {
+      child.evaluate(effect as any)
+    } else {
+      parent.currentDispatcher.scheduleTask(() => child.evaluate(effect as any), 0)
+    }
   }
   if (!daemon && !child._exit) {
     parent.children().add(child)

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -13,11 +13,13 @@ import {
   Layer,
   Logger,
   type LogLevel,
+  Metric,
   Option,
   References,
   Result,
   Schedule,
   Scope,
+  Tracer,
   TxRef
 } from "effect"
 import { constFalse, constTrue, pipe } from "effect/Function"
@@ -75,6 +77,95 @@ describe("Effect", () => {
         const trace = Context.getUnsafe(annotations, Cause.StackTrace)
         assert.strictEqual(trace.name, "test span")
       }))
+
+    it.effect("converts a throwing tracer context to the original defect without retrying", () => {
+      const defect = new Error("tracer context")
+      let calls = 0
+      const tracer: Tracer.Tracer = {
+        span: () => {
+          throw new Error("unused")
+        },
+        context: () => {
+          calls++
+          throw defect
+        }
+      }
+
+      return Effect.gen(function*() {
+        const exit = yield* Effect.void.pipe(
+          Effect.provideService(Tracer.Tracer, tracer),
+          Effect.exit
+        )
+        assertExitDefect(exit, defect)
+        assert.strictEqual(calls, 1)
+      })
+    })
+  })
+
+  describe("runtime metric hooks", () => {
+    it.effect("a throwing start hook defects the new fiber without running its body or end hook", () => {
+      const defect = new Error("fiber start")
+      let starts = 0
+      let ends = 0
+      let body = false
+      const metrics: Metric.FiberRuntimeMetricsService = {
+        recordFiberStart: () => {
+          starts++
+          throw defect
+        },
+        recordFiberEnd: () => {
+          ends++
+        }
+      }
+
+      return Effect.gen(function*() {
+        const fiber = yield* Effect.sync(() => {
+          body = true
+        }).pipe(Effect.forkChild)
+        const exit = yield* Fiber.await(fiber)
+        assertExitDefect(exit, defect)
+        assert.isFalse(body)
+        assert.strictEqual(starts, 1)
+        assert.strictEqual(ends, 0)
+      }).pipe(Effect.provideService(Metric.FiberRuntimeMetrics, metrics))
+    })
+
+    it("a throwing end hook replaces the body exit atomically without retrying", async () => {
+      const defect = new Error("fiber end")
+      let starts = 0
+      let ends = 0
+      let body = false
+      let fiber!: Fiber.Fiber<void>
+      let hookPoll: Exit.Exit<void> | undefined
+      let hookObserver: Exit.Exit<void> | undefined
+      const metrics: Metric.FiberRuntimeMetricsService = {
+        recordFiberStart: () => {
+          starts++
+        },
+        recordFiberEnd: () => {
+          ends++
+          hookPoll = fiber.pollUnsafe()
+          fiber.addObserver((exit) => {
+            hookObserver = exit
+          })
+          throw defect
+        }
+      }
+
+      fiber = Effect.runForkWith(Context.make(Metric.FiberRuntimeMetrics, metrics))(
+        Effect.yieldNow.pipe(Effect.andThen(Effect.sync(() => {
+          body = true
+        })))
+      )
+      const exit = await Effect.runPromise(Fiber.await(fiber))
+      assertExitDefect(exit, defect)
+      assert.isUndefined(hookPoll)
+      assert.isDefined(hookObserver)
+      assertExitDefect(hookObserver!, defect)
+      assert.isTrue(body)
+      assert.strictEqual(starts, 1)
+      assert.strictEqual(ends, 1)
+    })
   })
 
   it("callback can branch over sync/async", async () => {

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Exit, Result } from "effect"
 import * as Scheduler from "effect/Scheduler"
 
 describe("Scheduler", () => {
@@ -67,4 +67,26 @@ describe("Scheduler", () => {
       )
       assert.strictEqual(calls, 0)
     }))
+
+  it("converts a throwing shouldYield to the original defect without recursive overflow", () => {
+    const defect = new Error("shouldYield")
+    let calls = 0
+    const scheduler: Scheduler.Scheduler = {
+      executionMode: "sync",
+      shouldYield: () => {
+        calls++
+        throw defect
+      },
+      makeDispatcher: () => ({}) as any
+    }
+
+    const exit = Effect.runFork(Effect.void, { scheduler }).pollUnsafe()
+    assert.isDefined(exit)
+    const result = Exit.findDefect(exit!)
+    assert.isTrue(Result.isSuccess(result))
+    if (Result.isSuccess(result)) {
+      assert.strictEqual(result.success, defect)
+    }
+    assert.strictEqual(calls, 1)
+  })
 })


### PR DESCRIPTION
## Summary

- recover iteratively when scheduler or tracer run-loop hooks throw, disabling the broken per-operation hooks for defect delivery
- convert throwing fiber runtime metric start/end hooks into deterministic fiber defects while preserving the exact thrown value
- publish end-hook failures atomically and avoid scheduling child bodies after start-hook failure
- add regression coverage for scheduler, tracer, start-metric, and end-metric hook failures

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts packages/effect/test/Scheduler.test.ts`
- `pnpm check`
- `git diff --check`
