### PR TITLE
EFF-957 Document and benchmark scheduler priority cardinality

### DIFF
--- a/packages/effect/benchmark/scheduler/priorityBuckets.ts
+++ b/packages/effect/benchmark/scheduler/priorityBuckets.ts
@@ -1,0 +1,31 @@
+import * as Scheduler from "effect/Scheduler"
+import { Bench } from "tinybench"
+
+const taskCount = 4_096
+const priorityCounts = [1, 8, 64, 4_096] as const
+const task = () => {}
+
+// Repeating ascending priorities exercises lookup across the sorted bucket
+// array while keeping the total number of scheduled tasks fixed.
+const priorities = new Map(
+  priorityCounts.map((priorityCount) => [
+    priorityCount,
+    Array.from({ length: taskCount }, (_, index) => index % priorityCount)
+  ])
+)
+
+const bench = new Bench()
+
+for (const priorityCount of priorityCounts) {
+  bench.add(taskCount + " tasks / " + priorityCount + " distinct priorities", () => {
+    const dispatcher = new Scheduler.MixedScheduler("sync", () => () => {}).makeDispatcher()
+    const workload = priorities.get(priorityCount)!
+    for (let index = 0; index < workload.length; index++) {
+      dispatcher.scheduleTask(task, workload[index])
+    }
+  })
+}
+
+await bench.run()
+
+console.table(bench.table())

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -133,7 +133,11 @@ class PriorityBuckets {
  *
  * `MixedScheduler` supports synchronous and asynchronous execution modes, uses
  * operation counts to decide when fibers should yield, and is the default
- * scheduler implementation.
+ * scheduler implementation. Its priority queue is optimized for a small set of
+ * priorities reused across tasks in each queued batch. Dynamic finite numeric
+ * priorities are ordered correctly, but high-cardinality priority sets are not
+ * a performance target because task insertion scans the queued priority buckets
+ * linearly.
  *
  * @category schedulers
  * @since 2.0.0


### PR DESCRIPTION
## Summary

- document that `MixedScheduler` is optimized for a small set of priorities reused within each queued batch
- clarify that finite dynamic priorities remain correctly ordered, while high-cardinality priority sets are not a performance target
- add a Tinybench workload comparing 4,096 scheduled tasks across 1, 8, 64, and 4,096 distinct priorities

## Benchmark

Local Node 24 run (latency per 4,096-task scheduling workload):

| Distinct priorities | Average latency |
| ---: | ---: |
| 1 | 21 µs |
| 8 | 33 µs |
| 64 | 246 µs |
| 4,096 | 28 ms |

Run with:

`pnpm --dir packages/effect exec node benchmark/scheduler/priorityBuckets.ts`

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Scheduler.test.ts`
- `pnpm check`
- `git diff --check`