### PR TITLE
EFF-956 Make awaitAllChildren child selection linear

### DIFF
--- a/.changeset/eff-956-await-all-children.md
+++ b/.changeset/eff-956-await-all-children.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make awaitAllChildren child selection linear in the number of fibers.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5233,7 +5233,7 @@ export const awaitAllChildren = <A, E, R>(
   self: Effect.Effect<A, E, R>
 ): Effect.Effect<A, E, R> =>
   withFiber((fiber) => {
-    const initialChildren = fiber._children && Arr.fromIterable(fiber._children)
+    const initialChildren = fiber._children && new Set(fiber._children)
     return onExit(
       self,
       (_) => {
@@ -5243,7 +5243,7 @@ export const awaitAllChildren = <A, E, R>(
         } else if (initialChildren) {
           children = Iterable.filter(
             children,
-            (child: FiberImpl<any, any>) => !initialChildren.includes(child)
+            (child: FiberImpl<any, any>) => !initialChildren.has(child)
           ) as Set<FiberImpl<any, any>>
         }
         return asVoid(fiberAwaitAll(children))

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1569,6 +1569,12 @@ describe("Effect", () => {
   })
 
   describe("awaitAllChildren", () => {
+    it.effect("completes immediately when no children are forked", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.succeed(1).pipe(Effect.awaitAllChildren)
+        assert.strictEqual(result, 1)
+      }))
+
     it.effect("awaits children forked by the wrapped effect", () =>
       Effect.gen(function*() {
         const latch = yield* Deferred.make<void>()
@@ -1595,6 +1601,14 @@ describe("Effect", () => {
         )
         yield* Effect.yieldNow
         assert.deepStrictEqual(fiber.pollUnsafe(), Exit.succeed(1))
+        yield* Fiber.interrupt(preexisting)
+      }))
+
+    it.effect("does not await preexisting children", () =>
+      Effect.gen(function*() {
+        const preexisting = yield* Effect.never.pipe(Effect.forkChild({ startImmediately: true }))
+        const result = yield* Effect.succeed(1).pipe(Effect.awaitAllChildren)
+        assert.strictEqual(result, 1)
         yield* Fiber.interrupt(preexisting)
       }))
 


### PR DESCRIPTION
## Summary

- snapshot pre-existing children in a `Set` inside `awaitAllChildren`
- use expected O(1) membership checks when selecting newly-created children to await
- add focused coverage for empty and same-fiber pre-existing child snapshots
- add a patch changeset for the runtime performance improvement

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Fiber.test.ts packages/effect/test/Effect.test.ts` (226 tests)
- `pnpm check`
- `git diff --check`
