### PR TITLE
fix(ai): encode system messages as input text

### DIFF
--- a/.changeset/fix-openai-system-input-text.md
+++ b/.changeset/fix-openai-system-input-text.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Encode OpenAI Responses API system messages as typed input text content.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -816,7 +816,7 @@ const prepareMessages = Effect.fnUntraced(
         case "system": {
           messages.push({
             role: getSystemMessageMode(config.model as string),
-            content: message.content
+            content: [{ type: "input_text", text: message.content }]
           })
           break
         }

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -46,7 +46,10 @@ describe("OpenAiLanguageModel", () => {
 
             const systemMessage = body.input.find((m: any) => m.role === "system")
             assert.isDefined(systemMessage)
-            strictEqual(systemMessage.content, "You are a helpful assistant")
+            deepStrictEqual(systemMessage.content, [{
+              type: "input_text",
+              text: "You are a helpful assistant"
+            }])
           }).pipe(Effect.provide(makeTestLayer())))
 
         it.effect("uses developer role for reasoning models", () =>
@@ -63,7 +66,10 @@ describe("OpenAiLanguageModel", () => {
 
             const devMessage = body.input.find((m: any) => m.role === "developer")
             assert.isDefined(devMessage)
-            strictEqual(devMessage.content, "You are a helpful assistant")
+            deepStrictEqual(devMessage.content, [{
+              type: "input_text",
+              text: "You are a helpful assistant"
+            }])
           }).pipe(Effect.provide(makeTestLayer({ body: { model: "o1" } }))))
 
         it.effect("uses developer role for gpt-5 models", () =>


### PR DESCRIPTION
Fixes #6342

## Summary
- encode OpenAI Responses API system/developer messages as typed input_text content
- keep existing role selection for reasoning models
- update request-shape tests for both system and developer roles

## Tests
- pnpm test packages/ai/openai/test/OpenAiLanguageModel.test.ts
- pnpm lint-fix
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System messages sent through the OpenAI Responses API are now encoded in the expected typed input-text format.
  * Improved compatibility for both standard and reasoning models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->