### PR TITLE
Fix hydrated atom reactivity initial values

### DIFF
--- a/.changeset/fix-hydrated-atom-reactivity.md
+++ b/.changeset/fix-hydrated-atom-reactivity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix hydrated serializable atoms with reactivity so their invalidation callbacks are registered before mutations.

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -317,6 +317,14 @@ const SerializableTypeId: Atom.SerializableTypeId = "~effect-atom/atom/Atom/Seri
 const atomKey = <A>(atom: Atom.Atom<A>): Atom.Atom<A> | string =>
   SerializableTypeId in atom ? (atom as Atom.Serializable<any>)[SerializableTypeId].key : atom
 
+const initialValueTarget = <A>(atom: Atom.Atom<A>): Atom.Atom<A> => {
+  let target = atom
+  while (target.initialValueTarget) {
+    target = target.initialValueTarget
+  }
+  return target
+}
+
 class RegistryImpl implements AtomRegistry {
   readonly [TypeId]: TypeId
   readonly timeoutResolution: number
@@ -346,11 +354,7 @@ class RegistryImpl implements AtomRegistry {
     }
     if (initialValues !== undefined) {
       for (const [atom, value] of initialValues) {
-        let target = atom
-        while (target.initialValueTarget) {
-          target = target.initialValueTarget
-        }
-        this.ensureNode(target).setInitialValue(value)
+        this.ensureNode(initialValueTarget(atom)).setInitialValue(value)
       }
     }
   }
@@ -435,7 +439,12 @@ class RegistryImpl implements AtomRegistry {
       const encoded = this.preloadedSerializable.get(key)
       this.preloadedSerializable.delete(key)
       const decoded = (atom as any as Atom.Serializable<any>)[SerializableTypeId].decode(encoded)
-      node.setValue(decoded)
+      const target = initialValueTarget(atom)
+      if (target === atom) {
+        node.setInitialValue(decoded)
+      } else {
+        this.ensureNode(target).setInitialValue(decoded)
+      }
     }
     return node
   }

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -70,7 +70,13 @@ export interface AtomRegistry {
   readonly mount: <A>(atom: Atom.Atom<A>) => () => void
   readonly refresh: <A>(atom: Atom.Atom<A>) => void
   readonly set: <R, W>(atom: Atom.Writable<R, W>, value: W) => void
-  readonly setSerializable: (key: string, encoded: unknown) => void
+  readonly setSerializable: (
+    key: string,
+    encoded: unknown,
+    options?: {
+      readonly valueOnly?: boolean | undefined
+    }
+  ) => void
   readonly modify: <R, W, A>(atom: Atom.Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]) => A
   readonly update: <R, W>(atom: Atom.Writable<R, W>, f: (_: R) => W) => void
   readonly subscribe: <A>(atom: Atom.Atom<A>, f: (_: A) => void, options?: {
@@ -360,7 +366,10 @@ class RegistryImpl implements AtomRegistry {
   }
 
   readonly nodes = new Map<Atom.Atom<any> | string, NodeImpl<any>>()
-  readonly preloadedSerializable = new Map<string, unknown>()
+  readonly preloadedSerializable = new Map<string, {
+    readonly encoded: unknown
+    readonly valueOnly: boolean
+  }>()
   readonly timeoutBuckets = new Map<number, readonly [nodes: Set<NodeImpl<any>>, handle: number]>()
   readonly nodeTimeoutBucket = new Map<NodeImpl<any>, number>()
   disposed = false
@@ -377,8 +386,14 @@ class RegistryImpl implements AtomRegistry {
     atom.write(this.ensureNode(atom).writeContext, value)
   }
 
-  setSerializable(key: string, encoded: unknown): void {
-    this.preloadedSerializable.set(key, encoded)
+  setSerializable(
+    key: string,
+    encoded: unknown,
+    options?: {
+      readonly valueOnly?: boolean | undefined
+    }
+  ): void {
+    this.preloadedSerializable.set(key, { encoded, valueOnly: options?.valueOnly === true })
   }
 
   modify<R, W, A>(atom: Atom.Writable<R, W>, f: (_: R) => [returnValue: A, nextValue: W]): A {
@@ -436,14 +451,18 @@ class RegistryImpl implements AtomRegistry {
       this.removeNodeTimeout(node)
     }
     if (typeof key === "string" && this.preloadedSerializable.has(key)) {
-      const encoded = this.preloadedSerializable.get(key)
+      const preloaded = this.preloadedSerializable.get(key)!
       this.preloadedSerializable.delete(key)
-      const decoded = (atom as any as Atom.Serializable<any>)[SerializableTypeId].decode(encoded)
-      const target = initialValueTarget(atom)
-      if (target === atom) {
-        node.setInitialValue(decoded)
+      const decoded = (atom as any as Atom.Serializable<any>)[SerializableTypeId].decode(preloaded.encoded)
+      if (preloaded.valueOnly) {
+        node.setValue(decoded)
       } else {
-        this.ensureNode(target).setInitialValue(decoded)
+        const target = initialValueTarget(atom)
+        if (target === atom) {
+          node.setInitialValue(decoded)
+        } else {
+          this.ensureNode(target).setInitialValue(decoded)
+        }
       }
     }
     return node

--- a/packages/effect/src/unstable/reactivity/Hydration.ts
+++ b/packages/effect/src/unstable/reactivity/Hydration.ts
@@ -130,7 +130,7 @@ export const hydrate = (
   dehydratedState: Iterable<DehydratedAtom>
 ): void => {
   for (const datom of (dehydratedState as Iterable<DehydratedAtomValue>)) {
-    registry.setSerializable(datom.key, datom.value)
+    registry.setSerializable(datom.key, datom.value, { valueOnly: datom.resultPromise !== undefined })
 
     // If there's a resultPromise, it means this was in Initial state when dehydrated
     // and we should wait for it to resolve to a non-Initial state, then update the registry
@@ -148,7 +148,7 @@ export const hydrate = (
         }
       } else {
         // Fallback to setSerializable if node doesn't exist yet
-        registry.setSerializable(datom.key, resolvedValue)
+        registry.setSerializable(datom.key, resolvedValue, { valueOnly: true })
       }
     })
   }

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -15,7 +15,7 @@ import {
 } from "effect"
 import { TestClock } from "effect/testing"
 import { KeyValueStore } from "effect/unstable/persistence"
-import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity"
+import { AsyncResult, Atom, AtomRegistry, Hydration } from "effect/unstable/reactivity"
 
 declare const global: any
 
@@ -2238,6 +2238,43 @@ describe.sequential("Atom", () => {
         }),
         { reactivityKeys: ["counter"] }
       )
+      r.mount(atom)
+
+      assert.strictEqual(r.get(atom), 10)
+      assert.strictEqual(rebuilds, 1)
+
+      value = 11
+      r.set(fn, void 0)
+
+      assert.strictEqual(r.get(atom), 11)
+      assert.strictEqual(rebuilds, 2)
+    })
+
+    it("rebuilds on mutation with a hydrated serializable initial value", async () => {
+      let rebuilds = 0
+      let value = 0
+      const atom = Atom.make(() => {
+        rebuilds++
+        return value
+      }).pipe(
+        Atom.withReactivity(["counter"]),
+        Atom.serializable({ key: "hydrated-counter", schema: Schema.Number }),
+        Atom.keepAlive
+      )
+      const r = AtomRegistry.make()
+      const fn = counterRuntime.fn(
+        Effect.fn(function*() {
+        }),
+        { reactivityKeys: ["counter"] }
+      )
+      const state = [{
+        "~effect/reactivity/DehydratedAtom": true as const,
+        key: "hydrated-counter",
+        value: 10,
+        dehydratedAt: 0
+      }]
+
+      Hydration.hydrate(r, state)
       r.mount(atom)
 
       assert.strictEqual(r.get(atom), 10)


### PR DESCRIPTION
## Summary
- route hydrated serializable atom values through the same initial-value target path used by AtomRegistry initialValues
- keep hydrated nodes stale until first read so withReactivity can register its finalizer before mutations
- add a regression test for hydrated serializable atoms with reactivity

Fixes #6360.

## Tests
- pnpm lint-fix
- pnpm test packages/effect/test/reactivity/Atom.test.ts
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed reactivity for hydrated serializable atoms by ensuring invalidation callbacks are registered before applying mutations.
  - Hydrated serializable atoms now initialize correctly and respond properly to subsequent updates, triggering expected rebuilds.
  - Improved hydration behavior for atoms that derive initial values through target chains.

- **Tests**
  - Added coverage to verify serializable atoms can be hydrated from pre-dehydrated state and still rebuild correctly after reactive updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->