### PR TITLE
Fix FiberHandle.clear race

### DIFF
--- a/.changeset/fix-fiberhandle-clear-race.md
+++ b/.changeset/fix-fiberhandle-clear-race.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix a race where FiberHandle.clear could remove a newer fiber installed while the previous fiber was still interrupting.

--- a/packages/effect/src/FiberHandle.ts
+++ b/packages/effect/src/FiberHandle.ts
@@ -501,10 +501,11 @@ export const clear = <A, E>(self: FiberHandle<A, E>): Effect.Effect<void> =>
     if (self.state._tag === "Closed" || self.state.fiber === undefined) {
       return Effect.void
     }
+    const fiber = self.state.fiber
     return Effect.andThen(
-      restore(Fiber.interruptAs(self.state.fiber, internalFiberId)),
+      restore(Fiber.interruptAs(fiber, internalFiberId)),
       Effect.sync(() => {
-        if (self.state._tag === "Open") {
+        if (self.state._tag === "Open" && self.state.fiber === fiber) {
           self.state.fiber = undefined
         }
       })

--- a/packages/effect/test/FiberHandle.test.ts
+++ b/packages/effect/test/FiberHandle.test.ts
@@ -87,6 +87,26 @@ describe("FiberHandle", () => {
       strictEqual(fiberA.pollUnsafe(), undefined)
     }))
 
+  it.effect("clear does not remove a newer fiber installed while interrupting the previous one", () =>
+    Effect.gen(function*() {
+      const handle = yield* FiberHandle.make()
+      yield* FiberHandle.run(handle, Effect.uninterruptible(Effect.sleep(200)))
+
+      const clearFiber = yield* Effect.forkChild(FiberHandle.clear(handle), { startImmediately: true })
+      yield* TestClock.adjust(50)
+      const nextFiber = yield* FiberHandle.run(handle, Effect.never)
+      yield* TestClock.adjust(200)
+      yield* Fiber.join(clearFiber)
+
+      const current = FiberHandle.getUnsafe(handle)
+      if (Option.isNone(current)) {
+        assert.fail("expected FiberHandle.clear to preserve the newer fiber")
+        return
+      }
+      strictEqual(current.value, nextFiber)
+      strictEqual(nextFiber.pollUnsafe(), undefined)
+    }))
+
   it.effect("runtime onlyIfMissing", () =>
     Effect.gen(function*() {
       const run = yield* FiberHandle.makeRuntime<never>()


### PR DESCRIPTION
## Summary
- capture the fiber being cleared before interrupting it
- only empty the handle if it still points at that same fiber after interruption completes
- add a regression test for installing a newer fiber while clear is waiting for the previous fiber to interrupt

Fixes #5906.

## Tests
- pnpm lint-fix
- pnpm test packages/effect/test/FiberHandle.test.ts
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition where clearing a fiber handle could inadvertently remove a newer fiber installed during the interruption process.
  * Fiber handles now preserve newly installed fibers correctly when clearing a previous fiber.

* **Tests**
  * Added coverage to verify fiber handles retain newer fibers during concurrent interruption and replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->