### PR TITLE
Use Node 26 for Corepack

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
         packages = with pkgs; [
           bun
           deno
-          corepack
+          (corepack.override {nodejs-slim = nodejs-slim_26;})
           nodejs_26
           python3
         ];


### PR DESCRIPTION
Corepack currently embeds Node 24 even though the dev shell exposes Node 26. The affected Nix Node 24 build has broken worker-thread file descriptor tracking, causing pnpm installs to emit repeated unmanaged file descriptor warnings.

Override Corepack's `nodejs-slim` input so pnpm and its package extraction workers run on Node 26.

Validation:
- `nix flake check --no-build`
- Confirmed `pnpm` uses `nodejs-slim-26.4.0` and reports `node/v26.4.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the packaged Corepack environment to use Node.js 26.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->