### PR TITLE
Add Effect.updateServiceScoped

### DIFF
--- a/.changeset/add-update-service-scoped.md
+++ b/.changeset/add-update-service-scoped.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add `Effect.updateServiceScoped` for updating a context service until the current scope closes.
+Add `Effect.updateServiceScoped` for updating a context service until the current scope closes, with customizable reset behavior.

--- a/.changeset/add-update-service-scoped.md
+++ b/.changeset/add-update-service-scoped.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.updateServiceScoped` for updating a context service until the current scope closes.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6253,7 +6253,13 @@ export const updateService: {
  *   const before = yield* CurrentNumber
  *   const during = yield* Effect.scoped(
  *     Effect.gen(function*() {
- *       yield* Effect.updateServiceScoped(CurrentNumber, (value) => value + 1)
+ *       yield* Effect.updateServiceScoped(
+ *         CurrentNumber,
+ *         (value) => value + 1,
+ *         // Preserve a value installed after this scoped update
+ *         (original, updated, current) =>
+ *           current === updated ? original : current
+ *       )
  *       return yield* CurrentNumber
  *     })
  *   )

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6274,9 +6274,7 @@ export const updateService: {
 export const updateServiceScoped: <I, A>(
   service: Context.Key<I, A>,
   f: (value: A) => A,
-  options?: {
-    readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
-  } | undefined
+  reset?: ((original: A, updated: A, current: A) => A) | undefined
 ) => Effect<void, never, I | Scope> = internal.updateServiceScoped
 
 /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6256,9 +6256,8 @@ export const updateService: {
  *       yield* Effect.updateServiceScoped(
  *         CurrentNumber,
  *         (value) => value + 1,
- *         // Preserve a value installed after this scoped update
- *         (original, updated, current) =>
- *           current === updated ? original : current
+ *         // Install a different value when the scope closes
+ *         () => 100
  *       )
  *       return yield* CurrentNumber
  *     })
@@ -6266,7 +6265,7 @@ export const updateService: {
  *   const after = yield* CurrentNumber
  *
  *   console.log([before, during, after])
- *   // [1, 2, 1]
+ *   // [1, 2, 100]
  * })
  *
  * Effect.runPromise(program)

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6256,9 +6256,11 @@ export const updateService: {
  *       yield* Effect.updateServiceScoped(
  *         CurrentNumber,
  *         (value) => value + 1,
- *         // Optional: when omitted, the original value is restored
- *         (original, updated, current) =>
- *           Math.max(original, updated, current) + 1
+ *         {
+ *           // Optional: when omitted, the original value is restored
+ *           reset: (original, updated, current) =>
+ *             Math.max(original, updated, current) + 1
+ *         }
  *       )
  *       return yield* CurrentNumber
  *     })
@@ -6280,7 +6282,9 @@ export const updateService: {
 export const updateServiceScoped: <I, A>(
   service: Context.Key<I, A>,
   f: (value: A) => A,
-  reset?: ((original: A, updated: A, current: A) => A) | undefined
+  options?: {
+    readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
+  } | undefined
 ) => Effect<void, never, I | Scope> = internal.updateServiceScoped
 
 /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6235,7 +6235,10 @@ export const updateService: {
  * The updater receives the currently visible service value. A
  * `Context.Service` remains in the requirements, while a `Context.Reference`
  * uses its default when no override is present and adds no service requirement.
- * The returned effect always requires `Scope`.
+ * The returned effect always requires `Scope`. The optional `reset` function
+ * receives the original, updated, and current values when the scope closes,
+ * allowing changes to be merged during restoration. It defaults to returning
+ * the original value.
  *
  * **Example** (Updating a reference within a scope)
  *
@@ -6270,7 +6273,10 @@ export const updateService: {
  */
 export const updateServiceScoped: <I, A>(
   service: Context.Key<I, A>,
-  f: (value: A) => A
+  f: (value: A) => A,
+  options?: {
+    readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
+  } | undefined
 ) => Effect<void, never, I | Scope> = internal.updateServiceScoped
 
 /**

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6256,8 +6256,9 @@ export const updateService: {
  *       yield* Effect.updateServiceScoped(
  *         CurrentNumber,
  *         (value) => value + 1,
- *         // Install a different value when the scope closes
- *         () => 100
+ *         // Optional: when omitted, the original value is restored
+ *         (original, updated, current) =>
+ *           Math.max(original, updated, current) + 1
  *       )
  *       return yield* CurrentNumber
  *     })
@@ -6265,7 +6266,7 @@ export const updateService: {
  *   const after = yield* CurrentNumber
  *
  *   console.log([before, during, after])
- *   // [1, 2, 100]
+ *   // [1, 2, 3]
  * })
  *
  * Effect.runPromise(program)

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6222,6 +6222,58 @@ export const updateService: {
 } = internal.updateService
 
 /**
+ * Updates a service for the lifetime of the current scope and restores its
+ * previous value when the scope closes.
+ *
+ * **When to use**
+ *
+ * Use when you need a setup effect to change a service for subsequent effects
+ * in the same scope.
+ *
+ * **Details**
+ *
+ * The updater receives the currently visible service value. A
+ * `Context.Service` remains in the requirements, while a `Context.Reference`
+ * uses its default when no override is present and adds no service requirement.
+ * The returned effect always requires `Scope`.
+ *
+ * **Example** (Updating a reference within a scope)
+ *
+ * ```ts
+ * import { Context, Effect } from "effect"
+ *
+ * const CurrentNumber = Context.Reference<number>("CurrentNumber", {
+ *   defaultValue: () => 1
+ * })
+ *
+ * const program = Effect.gen(function*() {
+ *   const before = yield* CurrentNumber
+ *   const during = yield* Effect.scoped(
+ *     Effect.gen(function*() {
+ *       yield* Effect.updateServiceScoped(CurrentNumber, (value) => value + 1)
+ *       return yield* CurrentNumber
+ *     })
+ *   )
+ *   const after = yield* CurrentNumber
+ *
+ *   console.log([before, during, after])
+ *   // [1, 2, 1]
+ * })
+ *
+ * Effect.runPromise(program)
+ * ```
+ *
+ * @see {@link updateService} for updating a service only within a wrapped effect
+ *
+ * @category context
+ * @since 4.0.0
+ */
+export const updateServiceScoped: <I, A>(
+  service: Context.Key<I, A>,
+  f: (value: A) => A
+) => Effect<void, never, I | Scope> = internal.updateServiceScoped
+
+/**
  * Provides one concrete service implementation to an effect.
  *
  * **When to use**

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2115,19 +2115,19 @@ export const updateService: {
 export const updateServiceScoped = <I, A>(
   service: Context.Key<I, A>,
   f: (value: A) => A,
-  options?: {
-    readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
-  } | undefined
+  reset?: ((original: A, updated: A, current: A) => A) | undefined
 ): Effect.Effect<void, never, I | Scope.Scope> =>
   uninterruptible(withFiber((fiber) => {
     const original = Context.getUnsafe(fiber.context, service)
     const updated = f(original)
     fiber.setContext(Context.add(fiber.context, service, updated))
     return scopeAddFinalizerExit(Context.getUnsafe(fiber.context, scopeTag), (_) => {
-      const current = Context.getUnsafe(fiber.context, service)
-      const reset = options?.reset
       fiber.setContext(
-        Context.add(fiber.context, service, reset === undefined ? original : reset(original, updated, current))
+        Context.add(
+          fiber.context,
+          service,
+          reset === undefined ? original : reset(original, updated, Context.getUnsafe(fiber.context, service))
+        )
       )
       return void_
     })

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2114,13 +2114,21 @@ export const updateService: {
 /** @internal */
 export const updateServiceScoped = <I, A>(
   service: Context.Key<I, A>,
-  f: (value: A) => A
+  f: (value: A) => A,
+  options?: {
+    readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
+  } | undefined
 ): Effect.Effect<void, never, I | Scope.Scope> =>
   uninterruptible(withFiber((fiber) => {
-    const prev = Context.getUnsafe(fiber.context, service)
-    fiber.setContext(Context.add(fiber.context, service, f(prev)))
+    const original = Context.getUnsafe(fiber.context, service)
+    const updated = f(original)
+    fiber.setContext(Context.add(fiber.context, service, updated))
     return scopeAddFinalizerExit(Context.getUnsafe(fiber.context, scopeTag), (_) => {
-      fiber.setContext(Context.add(fiber.context, service, prev))
+      const current = Context.getUnsafe(fiber.context, service)
+      const reset = options?.reset
+      fiber.setContext(
+        Context.add(fiber.context, service, reset === undefined ? original : reset(original, updated, current))
+      )
       return void_
     })
   }))

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2112,6 +2112,20 @@ export const updateService: {
 )
 
 /** @internal */
+export const updateServiceScoped = <I, A>(
+  service: Context.Key<I, A>,
+  f: (value: A) => A
+): Effect.Effect<void, never, I | Scope.Scope> =>
+  uninterruptible(withFiber((fiber) => {
+    const prev = Context.getUnsafe(fiber.context, service)
+    fiber.setContext(Context.add(fiber.context, service, f(prev)))
+    return scopeAddFinalizerExit(Context.getUnsafe(fiber.context, scopeTag), (_) => {
+      fiber.setContext(Context.add(fiber.context, service, prev))
+      return void_
+    })
+  }))
+
+/** @internal */
 export const context = <R = never>(): Effect.Effect<Context.Context<R>> => getContext as any
 const getContext = withFiber((fiber) => succeed(fiber.context))
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2114,21 +2114,26 @@ export const updateService: {
 /** @internal */
 export const updateServiceScoped = <I, A>(
   service: Context.Key<I, A>,
-  f: (value: A) => A,
-  reset?: ((original: A, updated: A, current: A) => A) | undefined
+  update: (value: A) => A,
+  options?: {
+    readonly reset?: ((original: A, updated: A, current: A) => A) | undefined
+  } | undefined
 ): Effect.Effect<void, never, I | Scope.Scope> =>
   uninterruptible(withFiber((fiber) => {
     const original = Context.getUnsafe(fiber.context, service)
-    const updated = f(original)
+    const updated = update(original)
     fiber.setContext(Context.add(fiber.context, service, updated))
     return scopeAddFinalizerExit(Context.getUnsafe(fiber.context, scopeTag), (_) => {
-      fiber.setContext(
-        Context.add(
-          fiber.context,
-          service,
-          reset === undefined ? original : reset(original, updated, Context.getUnsafe(fiber.context, service))
-        )
-      )
+      const current = Context.getUnsafe(fiber.context, service)
+      // Check if the service was modified later in the program - avoid resetting
+      // the service to its original value unless an explicit reset method is specified
+      if (options?.reset === undefined && current !== updated) {
+        return void_
+      }
+      const next = options?.reset === undefined
+        ? original
+        : options.reset(original, updated, current)
+      fiber.setContext(Context.add(fiber.context, service, next))
       return void_
     })
   }))

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2125,14 +2125,13 @@ export const updateServiceScoped = <I, A>(
     fiber.setContext(Context.add(fiber.context, service, updated))
     return scopeAddFinalizerExit(Context.getUnsafe(fiber.context, scopeTag), (_) => {
       const current = Context.getUnsafe(fiber.context, service)
-      // Check if the service was modified later in the program - avoid resetting
-      // the service to its original value unless an explicit reset method is specified
-      if (options?.reset === undefined && current !== updated) {
-        return void_
+      let next: A
+      if (options?.reset === undefined) {
+        if (current !== updated) return void_
+        next = original
+      } else {
+        next = options.reset(original, updated, current)
       }
-      const next = options?.reset === undefined
-        ? original
-        : options.reset(original, updated, current)
       fiber.setContext(Context.add(fiber.context, service, next))
       return void_
     })

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3083,9 +3083,11 @@ describe("Effect", () => {
           yield* Effect.updateServiceScoped(
             CurrentValues,
             (values) => [...values, "scoped"],
-            (original, updated, current) => {
-              resetValues = [original, updated, current]
-              return [...original, ...current.filter((value) => !updated.includes(value))]
+            {
+              reset: (original, updated, current) => {
+                resetValues = [original, updated, current]
+                return [...original, ...current.filter((value) => !updated.includes(value))]
+              }
             }
           )
           yield* Effect.withFiber((fiber) =>

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3083,11 +3083,9 @@ describe("Effect", () => {
           yield* Effect.updateServiceScoped(
             CurrentValues,
             (values) => [...values, "scoped"],
-            {
-              reset: (original, updated, current) => {
-                resetValues = [original, updated, current]
-                return [...original, ...current.filter((value) => !updated.includes(value))]
-              }
+            (original, updated, current) => {
+              resetValues = [original, updated, current]
+              return [...original, ...current.filter((value) => !updated.includes(value))]
             }
           )
           yield* Effect.withFiber((fiber) =>

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3035,6 +3035,42 @@ describe("Effect", () => {
       }))
   })
 
+  describe("updateServiceScoped", () => {
+    class CurrentNumber extends Context.Service<CurrentNumber, number>()("CurrentNumber") {}
+
+    const CurrentNumberReference = Context.Reference<number>("CurrentNumberReference", {
+      defaultValue: () => 1
+    })
+
+    it.effect("updates a Context.Service until the scope closes", () =>
+      Effect.gen(function*() {
+        const before = yield* CurrentNumber
+        const during = yield* Effect.scoped(
+          Effect.gen(function*() {
+            yield* Effect.updateServiceScoped(CurrentNumber, (value) => value + 1)
+            return yield* CurrentNumber
+          })
+        )
+        const after = yield* CurrentNumber
+
+        assert.deepStrictEqual([before, during, after], [1, 2, 1])
+      }).pipe(Effect.provideService(CurrentNumber, 1)))
+
+    it.effect("updates a Context.Reference until the scope closes", () =>
+      Effect.gen(function*() {
+        const before = yield* CurrentNumberReference
+        const during = yield* Effect.scoped(
+          Effect.gen(function*() {
+            yield* Effect.updateServiceScoped(CurrentNumberReference, (value) => value + 1)
+            return yield* CurrentNumberReference
+          })
+        )
+        const after = yield* CurrentNumberReference
+
+        assert.deepStrictEqual([before, during, after], [1, 2, 1])
+      }))
+  })
+
   describe("provide", () => {
     class MyNumber extends Context.Service<MyNumber, number>()("MyNumber") {}
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -3042,6 +3042,10 @@ describe("Effect", () => {
       defaultValue: () => 1
     })
 
+    const CurrentValues = Context.Reference<ReadonlyArray<string>>("CurrentValues", {
+      defaultValue: () => []
+    })
+
     it.effect("updates a Context.Service until the scope closes", () =>
       Effect.gen(function*() {
         const before = yield* CurrentNumber
@@ -3068,6 +3072,35 @@ describe("Effect", () => {
         const after = yield* CurrentNumberReference
 
         assert.deepStrictEqual([before, during, after], [1, 2, 1])
+      }))
+
+    it.effect("supports merging the current value on reset", () =>
+      Effect.gen(function*() {
+        const scope = Scope.makeUnsafe()
+        let resetValues: ReadonlyArray<ReadonlyArray<string>> | undefined
+
+        const result = yield* Effect.gen(function*() {
+          yield* Effect.updateServiceScoped(
+            CurrentValues,
+            (values) => [...values, "scoped"],
+            {
+              reset: (original, updated, current) => {
+                resetValues = [original, updated, current]
+                return [...original, ...current.filter((value) => !updated.includes(value))]
+              }
+            }
+          )
+          yield* Effect.withFiber((fiber) =>
+            Effect.sync(() => {
+              fiber.setContext(Context.add(fiber.context, CurrentValues, ["scoped", "external"]))
+            })
+          )
+          yield* Scope.close(scope, Exit.void)
+          return yield* CurrentValues
+        }).pipe(Effect.provideService(Scope.Scope, scope))
+
+        assert.deepStrictEqual(resetValues, [[], ["scoped"], ["scoped", "external"]])
+        assert.deepStrictEqual(result, ["external"])
       }))
   })
 

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -623,13 +623,11 @@ describe("Effect.updateServiceScoped", () => {
     const result = Effect.updateServiceScoped(
       UpdateServiceScopedService,
       (value) => value + 1,
-      {
-        reset: (original, updated, current) => {
-          expect(original).type.toBe<number>()
-          expect(updated).type.toBe<number>()
-          expect(current).type.toBe<number>()
-          return current
-        }
+      (original, updated, current) => {
+        expect(original).type.toBe<number>()
+        expect(updated).type.toBe<number>()
+        expect(current).type.toBe<number>()
+        return current
       }
     )
     expect(result).type.toBe<Effect.Effect<void, never, UpdateServiceScopedService | Scope.Scope>>()

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -74,6 +74,14 @@ class AcquireReleaseDependency extends Context.Service<AcquireReleaseDependency,
   "AcquireReleaseDependency"
 ) {}
 
+class UpdateServiceScopedService extends Context.Service<UpdateServiceScopedService, number>()(
+  "UpdateServiceScopedService"
+) {}
+
+const UpdateServiceScopedReference = Context.Reference<number>("UpdateServiceScopedReference", {
+  defaultValue: () => 0
+})
+
 describe("Types", () => {
   describe("ReasonOf", () => {
     it("extracts reason type", () => {
@@ -596,6 +604,18 @@ describe("Effect.annotateLogsScoped", () => {
 
   it("returns a scoped effect for record input", () => {
     const result = Effect.annotateLogsScoped({ requestId: "req-123", attempt: 1 })
+    expect(result).type.toBe<Effect.Effect<void, never, Scope.Scope>>()
+  })
+})
+
+describe("Effect.updateServiceScoped", () => {
+  it("adds a Context.Service to the requirements", () => {
+    const result = Effect.updateServiceScoped(UpdateServiceScopedService, (value) => value + 1)
+    expect(result).type.toBe<Effect.Effect<void, never, UpdateServiceScopedService | Scope.Scope>>()
+  })
+
+  it("does not add a Context.Reference to the requirements", () => {
+    const result = Effect.updateServiceScoped(UpdateServiceScopedReference, (value) => value + 1)
     expect(result).type.toBe<Effect.Effect<void, never, Scope.Scope>>()
   })
 })

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -618,6 +618,22 @@ describe("Effect.updateServiceScoped", () => {
     const result = Effect.updateServiceScoped(UpdateServiceScopedReference, (value) => value + 1)
     expect(result).type.toBe<Effect.Effect<void, never, Scope.Scope>>()
   })
+
+  it("types the reset values from the service", () => {
+    const result = Effect.updateServiceScoped(
+      UpdateServiceScopedService,
+      (value) => value + 1,
+      {
+        reset: (original, updated, current) => {
+          expect(original).type.toBe<number>()
+          expect(updated).type.toBe<number>()
+          expect(current).type.toBe<number>()
+          return current
+        }
+      }
+    )
+    expect(result).type.toBe<Effect.Effect<void, never, UpdateServiceScopedService | Scope.Scope>>()
+  })
 })
 
 describe("Effect.forkScoped", () => {

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -623,11 +623,13 @@ describe("Effect.updateServiceScoped", () => {
     const result = Effect.updateServiceScoped(
       UpdateServiceScopedService,
       (value) => value + 1,
-      (original, updated, current) => {
-        expect(original).type.toBe<number>()
-        expect(updated).type.toBe<number>()
-        expect(current).type.toBe<number>()
-        return current
+      {
+        reset: (original, updated, current) => {
+          expect(original).type.toBe<number>()
+          expect(updated).type.toBe<number>()
+          expect(current).type.toBe<number>()
+          return current
+        }
       }
     )
     expect(result).type.toBe<Effect.Effect<void, never, UpdateServiceScopedService | Scope.Scope>>()


### PR DESCRIPTION
## Summary
- add `Effect.updateServiceScoped` to update a context service until scope closure
- restore the previous service value by default, with a custom `reset(original, updated, current)` hook for merge strategies
- cover `Context.Service` and `Context.Reference` runtime and requirement inference
- test reset merging that preserves changes made after the scoped update
- document the API and add a patch changeset

## Testing
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types Effect.tst.ts`
- `pnpm check` (from `packages/effect`)
- targeted `oxlint`, `dprint check`, and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Effect.updateServiceScoped` to temporarily update a context service for the lifetime of the current scope.
  * The previous value is restored when the scope closes; a `reset` option lets you customize the restoration behavior.
  * Updated typings so scoped updates require `Scope` only.
* **Documentation**
  * Added docs and a scoped usage example for `Effect.updateServiceScoped`.
* **Tests**
  * Added tests covering scoped visibility, restoration after scope exit, `reset` callback arguments/behavior, and type inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->