### PR TITLE
Add custom equality detection for atoms

### DIFF
--- a/.changeset/add-atom-equality.md
+++ b/.changeset/add-atom-equality.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+unstable/reactivity Atom: add `withEquality` combinator for customizing how the registry detects value changes

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -68,6 +68,7 @@ export interface Atom<A> extends Pipeable, Inspectable.Inspectable {
   readonly keepAlive: boolean
   readonly lazy: boolean
   readonly read: (get: AtomContext) => A
+  equals(value: A, next: A): boolean
   readonly refresh?: (f: <A>(atom: Atom<A>) => void) => void
   readonly label?: readonly [name: string, stack: string]
   readonly idleTTL?: number
@@ -229,6 +230,7 @@ const removeTtl = setIdleTTL(0)
 
 const AtomProto = {
   [TypeId]: TypeId,
+  equals: Object.is,
   ...PipeInspectableProto,
   toJSON(this: Atom<any>) {
     return {
@@ -1504,6 +1506,44 @@ export const setLazy: {
     ...self,
     lazy
   }))
+
+/**
+ * Returns a copy of an atom that uses a custom equality function to detect
+ * value changes.
+ *
+ * **Details**
+ *
+ * When an atom's value is rebuilt or written, the registry compares the new
+ * value against the current one to decide whether dependents and listeners
+ * should be notified. By default the comparison uses `Object.is`, so a
+ * structurally equal but referentially distinct value still triggers
+ * notifications. Providing an equality function lets the atom skip updates
+ * when the new value is equal to the current one.
+ *
+ * **Example** (Comparing values structurally)
+ *
+ * ```ts
+ * import { Atom } from "effect/unstable/reactivity"
+ *
+ * const point = Atom.make({ x: 0, y: 0 }).pipe(
+ *   Atom.withEquality<{ x: number; y: number }>((a, b) => a.x === b.x && a.y === b.y)
+ * )
+ * ```
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const withEquality: {
+  <A>(equals: (value: A, next: A) => boolean): <T extends Atom<A>>(self: T) => T
+  <T extends Atom<any>>(self: T, equals: (value: Type<T>, next: Type<T>) => boolean): T
+} = dual(
+  2,
+  <T extends Atom<any>>(self: T, equals: (value: Type<T>, next: Type<T>) => boolean): T =>
+    Object.assign(Object.create(Object.getPrototypeOf(self)), {
+      ...self,
+      equals
+    })
+)
 
 /**
  * Attaches a diagnostic label to an atom.

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -685,7 +685,7 @@ class NodeImpl<A> {
     }
 
     this.state = NodeState.valid
-    if (Object.is(this._value, value)) {
+    if (this.atom.equals(this._value, value)) {
       return
     }
 

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -108,6 +108,49 @@ describe.sequential("Atom", () => {
     expect(second).toEqual(1)
   })
 
+  it("withEquality skips notifications for equivalent values", () => {
+    const point = Atom.make({ x: 0, y: 0 }).pipe(
+      Atom.withEquality<{ x: number; y: number }>((a, b) => a.x === b.x && a.y === b.y),
+      Atom.keepAlive
+    )
+    const r = AtomRegistry.make()
+    const initial = r.get(point)
+    let count = 0
+    r.subscribe(point, () => {
+      count++
+    })
+
+    r.set(point, { x: 0, y: 0 })
+    expect(count).toEqual(0)
+    expect(r.get(point)).toBe(initial)
+
+    r.set(point, { x: 1, y: 0 })
+    expect(count).toEqual(1)
+    expect(r.get(point)).toEqual({ x: 1, y: 0 })
+  })
+
+  it("withEquality skips invalidation of derived atoms", () => {
+    const point = Atom.make({ x: 0, y: 0 }).pipe(
+      Atom.withEquality<{ x: number; y: number }>((a, b) => a.x === b.x && a.y === b.y),
+      Atom.keepAlive
+    )
+    let builds = 0
+    const x = Atom.map(point, (p) => {
+      builds++
+      return p.x
+    })
+    const r = AtomRegistry.make()
+    r.subscribe(x, () => {})
+
+    expect(r.get(x)).toEqual(0)
+    expect(builds).toEqual(1)
+    r.set(point, { x: 0, y: 0 })
+    expect(builds).toEqual(1)
+    r.set(point, { x: 2, y: 0 })
+    expect(r.get(x)).toEqual(2)
+    expect(builds).toEqual(2)
+  })
+
   it("searchParam with schema reads initial query value", () => {
     const previousWindow = (globalThis as any).window
     const r = AtomRegistry.make()


### PR DESCRIPTION
## Summary

- Add `Atom.withEquality` for custom value-change detection.
- Use each atom’s equality function when deciding whether to notify listeners and invalidate dependents.
- Add tests for equivalent writes, notifications, and derived atom invalidation.
- Add a patch changeset for `effect`.

## Testing

- Added targeted tests in `packages/effect/test/reactivity/Atom.test.ts`.
- Not run (test results were not provided).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable equality checks for atoms.
  * Added `withEquality` to treat equivalent values as unchanged.
  * Prevents unnecessary subscriber notifications and derived-state recalculations when values are equivalent.

* **Bug Fixes**
  * Atom updates now respect configured equality rules before triggering changes.

* **Tests**
  * Added coverage for notification suppression and derived atom behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->