### PR TITLE
Label pull requests by target branch

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,32 @@
+name: Label Pull Requests
+
+on:
+  pull_request_target:
+    branches: [main, v3]
+    types: [opened, reopened, synchronize, edited]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 1
+    steps:
+      - name: Add Version Label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = {
+              main: "4.0",
+              v3: "3.0"
+            }
+            const label = labels[context.payload.pull_request.base.ref]
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label]
+            })

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -12,7 +12,7 @@ jobs:
     name: Label
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     timeout-minutes: 1
     steps:
       - name: Add Version Label
@@ -24,9 +24,16 @@ jobs:
               v3: "3.0"
             }
             const label = labels[context.payload.pull_request.base.ref]
-
-            await github.rest.issues.addLabels({
+            const issue = {
               ...context.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: [label]
-            })
+              issue_number: context.payload.pull_request.number
+            }
+            const labelsToRemove = context.payload.pull_request.labels
+              .map(({ name }) => name)
+              .filter((name) => Object.values(labels).includes(name) && name !== label)
+
+            for (const name of labelsToRemove) {
+              await github.rest.issues.removeLabel({ ...issue, name })
+            }
+
+            await github.rest.issues.addLabels({ ...issue, labels: [label] })


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow for pull requests targeting `main` or `v3`.
- Apply the `4.0` label to `main` pull requests and the `3.0` label to `v3` pull requests.
- Run labeling when pull requests are opened, reopened, synchronized, or edited.

## Testing

- Not run (GitHub Actions workflow-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests targeting supported branches are now automatically labeled with the corresponding release version.
  * Labels are applied when pull requests are opened, reopened, synchronized, or edited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->