### PR TITLE
Fix dynamic record property assignment

### DIFF
--- a/.changeset/fix-proto-record-assignment.md
+++ b/.changeset/fix-proto-record-assignment.md
@@ -1,0 +1,16 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+"@effect/docgen": patch
+"@effect/openapi-generator": patch
+"@effect/opentelemetry": patch
+"@effect/sql-mssql": patch
+"@effect/sql-sqlite-do": patch
+"@effect/sql-sqlite-wasm": patch
+"@effect/vitest": patch
+---
+
+Add `Record.assignProperty` and safely handle dynamic record keys such as `__proto__` and inherited property names.

--- a/.patterns/dynamic-records.md
+++ b/.patterns/dynamic-records.md
@@ -1,0 +1,41 @@
+# Dynamic Record Safety
+
+An **open key** comes from external data or is determined at runtime. A key is
+**closed** only when selected from an explicit internal list; TypeScript types
+do not close external input at runtime.
+
+## Rules
+
+1. **Owned internal dictionary:** use
+   `Object.create(null) as Record<string, Value>` (or `Map` without record/JSON
+   interop). Direct open-key reads and writes are safe. Use `Object.hasOwn` when
+   stored `undefined` must differ from absence.
+2. **External record:** use `Object.hasOwn(record, key)` for presence. Never use
+   `in`, truthiness, or `record[key] !== undefined`. Enumerate with
+   `Object.keys` / `values` / `entries`, never `for...in`.
+3. **Normal object or instance:** write open keys with
+   `Record.assignProperty(target, key, value)`. It protects only writes;
+   presence checks still require `Object.hasOwn`.
+4. **Existing public API:** preserve its output prototype. Build with a
+   null-prototype dictionary, then return `{ ...internalMap }` when a normal
+   object is required.
+
+## `Object.assign`
+
+| Case                                 | Policy                                                |
+| ------------------------------------ | ----------------------------------------------------- |
+| Null-rooted target + open source     | `Object.assign` allowed                               |
+| New normal target + open source      | Use `{ ...source }`                                   |
+| New custom-prototype object          | Use `Object.setPrototypeOf({ ...source }, Proto)`     |
+| Existing normal target + open source | Copy own enumerable keys with `Record.assignProperty` |
+| Normal target + closed source        | `Object.assign` allowed                               |
+
+Therefore `Object.assign({}, openSource)` is forbidden. A source is closed only
+when constructed internally with explicit properties, for example
+`{ name: options.name }`; passing `options` directly is not closed.
+Use `Reflect.ownKeys` plus an enumerable check when symbols must be copied.
+
+## Property Syntax
+
+- Safe: `{ [key]: value }` and `{ ...source }`; both create own data properties.
+- Unsafe for data: `{ __proto__: value }`; it changes the literal's prototype.

--- a/packages/ai/anthropic/src/internal/utilities.ts
+++ b/packages/ai/anthropic/src/internal/utilities.ts
@@ -15,7 +15,7 @@ export const resolveFinishReason = (
   finishReason: string,
   isJsonResponse: boolean = false
 ): Response.FinishReason => {
-  const reason = finishReasonMap[finishReason]
+  const reason = Object.hasOwn(finishReasonMap, finishReason) ? finishReasonMap[finishReason] : undefined
   if (Predicate.isUndefined(reason)) {
     return "unknown"
   }

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -16,6 +16,7 @@ import { dual } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
+import * as Rec from "effect/Record"
 import * as Redactable from "effect/Redactable"
 import type * as Schema from "effect/Schema"
 import * as AST from "effect/SchemaAST"
@@ -828,7 +829,7 @@ const prepareMessages = Effect.fnUntraced(
         }
 
         case "assistant": {
-          const reasoningMessages: Record<string, DeepMutable<ReasoningItem>> = {}
+          const reasoningMessages: Record<string, DeepMutable<ReasoningItem>> = Object.create(null)
 
           for (const part of message.content) {
             switch (part.type) {
@@ -1541,7 +1542,7 @@ const extractCustomRequestProperties = (payload: CreateResponse): Record<string,
   const customProperties: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(payload)) {
     if (!createResponseKnownProperties.has(key)) {
-      customProperties[key] = value
+      Rec.assignProperty(customProperties, key, value)
     }
   }
   return customProperties

--- a/packages/ai/openai-compat/src/internal/utilities.ts
+++ b/packages/ai/openai-compat/src/internal/utilities.ts
@@ -16,7 +16,7 @@ export const resolveFinishReason = (
   if (finishReason == null) {
     return hasToolCalls ? "tool-calls" : "stop"
   }
-  const reason = finishReasonMap[finishReason]
+  const reason = Object.hasOwn(finishReasonMap, finishReason) ? finishReasonMap[finishReason] : undefined
   if (reason == null) {
     return hasToolCalls ? "tool-calls" : "unknown"
   }

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -548,7 +548,11 @@ const makeSocket = Effect.gen(function*() {
                 method: "createResponseStream",
                 reason: AiError.reasonFromHttpStatus({
                   description: json,
-                  status: isNaN(status) ? errorTypeToStatus[error.type] ?? 500 : status,
+                  status: isNaN(status) ?
+                    Object.hasOwn(errorTypeToStatus, error.type)
+                      ? errorTypeToStatus[error.type]
+                      : 500 :
+                    status,
                   metadata: error as any,
                   http: {
                     body: json,

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -885,7 +885,8 @@ const prepareMessages = Effect.fnUntraced(
         }
 
         case "assistant": {
-          const reasoningMessages: Record<string, DeepMutable<typeof OpenAiSchema.ReasoningItem.Encoded>> = {}
+          const reasoningMessages: Record<string, DeepMutable<typeof OpenAiSchema.ReasoningItem.Encoded>> = Object
+            .create(null)
 
           for (const part of message.content) {
             switch (part.type) {
@@ -1682,7 +1683,7 @@ const makeStreamResponse = Effect.fnUntraced(
     }
 
     // Track active reasoning items with state machine for proper concluding logic
-    const activeReasoning: Record<string, ReasoningPart> = {}
+    const activeReasoning: Record<string, ReasoningPart> = Object.create(null)
 
     const getOrCreateReasoningPart = (
       itemId: string,

--- a/packages/ai/openai/src/internal/utilities.ts
+++ b/packages/ai/openai/src/internal/utilities.ts
@@ -19,7 +19,7 @@ export const resolveFinishReason = (
   if (finishReason == null) {
     return hasToolCalls ? "tool-calls" : "stop"
   }
-  const reason = finishReasonMap[finishReason]
+  const reason = Object.hasOwn(finishReasonMap, finishReason) ? finishReasonMap[finishReason] : undefined
   if (reason == null) {
     return hasToolCalls ? "tool-calls" : "unknown"
   }

--- a/packages/ai/openrouter/src/internal/utilities.ts
+++ b/packages/ai/openrouter/src/internal/utilities.ts
@@ -14,10 +14,12 @@ const finishReasonMap: Record<string, Response.FinishReason> = {
 /** @internal */
 export const resolveFinishReason = (
   finishReason: string | null | undefined
-): Response.FinishReason =>
-  Predicate.isNotNullish(finishReason)
-    ? finishReasonMap[finishReason]
-    : "other"
+): Response.FinishReason => {
+  if (Predicate.isNullish(finishReason)) {
+    return "other"
+  }
+  return Object.hasOwn(finishReasonMap, finishReason) ? finishReasonMap[finishReason] : "unknown"
+}
 
 /**
  * Tracks ReasoningDetailUnion entries and deduplicates them based

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -16,6 +16,7 @@ import { dual, identity } from "./Function.ts"
 import type { TypeLambda } from "./HKT.ts"
 import * as internalArray from "./internal/array.ts"
 import * as internalDoNotation from "./internal/doNotation.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as moduleIterable from "./Iterable.ts"
 import * as Option from "./Option.ts"
 import * as Order from "./Order.ts"
@@ -3073,7 +3074,7 @@ export const groupBy: {
     if (Object.hasOwn(out, k)) {
       out[k].push(a)
     } else {
-      out[k] = [a]
+      InternalRecord.assignProperty(out, k, [a])
     }
   }
   return out

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -12,6 +12,7 @@ import * as ConfigProvider from "./ConfigProvider.ts"
 import * as Effect from "./Effect.ts"
 import * as Effectable from "./Effectable.ts"
 import { dual } from "./Function.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as LogLevel_ from "./LogLevel.ts"
 import * as Option from "./Option.ts"
 import * as Predicate from "./Predicate.ts"
@@ -508,7 +509,7 @@ const dump: (
       const out: Record<string, Schema.StringTree> = {}
       for (const key of stat.keys) {
         const child = yield* dump(provider, [...path, key])
-        if (child !== undefined) out[key] = child
+        if (child !== undefined) InternalRecord.assignProperty(out, key, child)
       }
       return out
     }
@@ -538,7 +539,7 @@ const recur: (
           const name = ps.name
           if (typeof name === "string") {
             const value = yield* recur(ps.type, provider, [...path, name])
-            if (value !== undefined) out[name] = value
+            if (value !== undefined) InternalRecord.assignProperty(out, name, value)
           }
         }
         if (ast.indexSignatures.length > 0) {
@@ -548,7 +549,7 @@ const recur: (
               for (const key of stat.keys) {
                 if (!Object.hasOwn(out, key) && matches(key)) {
                   const value = yield* recur(is.type, provider, [...path, key])
-                  if (value !== undefined) out[key] = value
+                  if (value !== undefined) InternalRecord.assignProperty(out, key, value)
                 }
               }
             }

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -874,8 +874,8 @@ function buildEnvTrie(env: Record<string, string | undefined>): EnvTrieNode {
 
     let node = trie
     for (const seg of segments) {
-      node.children ??= {}
-      node = node.children[seg] ??= {}
+      const children = node.children ??= Object.create(null)
+      node = children[seg] ??= {}
     }
   }
 
@@ -891,7 +891,7 @@ function nodeAtEnv(
   preserveEmptyStrings: boolean
 ): Node | undefined {
   const key = path.map(String).join("_")
-  const leafValue = emptyStringAsMissing(env[key], preserveEmptyStrings)
+  const leafValue = emptyStringAsMissing(Object.hasOwn(env, key) ? env[key] : undefined, preserveEmptyStrings)
 
   const trieNode = trieNodeAt(trie, path)
   const children = trieNode?.children ? Object.keys(trieNode.children) : []
@@ -979,7 +979,7 @@ const DOT_ENV_LINE =
   /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg
 
 function parseDotEnvContents(lines: string): Record<string, string> {
-  const obj: Record<string, string> = {}
+  const obj: Record<string, string> = Object.create(null)
 
   // Convert line breaks to same format
   lines = lines.replace(/\r\n?/gm, "\n")
@@ -1014,9 +1014,9 @@ function parseDotEnvContents(lines: string): Record<string, string> {
 }
 
 function dotEnvExpand(parsed: Record<string, string>): Record<string, string> {
-  const newParsed: Record<string, string> = {}
+  const newParsed: Record<string, string> = Object.create(null)
 
-  for (const configKey in parsed) {
+  for (const configKey of Object.keys(parsed)) {
     // resolve escape sequences
     newParsed[configKey] = interpolate(parsed[configKey], parsed).replace(/\\\$/g, "$")
   }
@@ -1054,7 +1054,7 @@ function interpolate(envValue: string, parsed: Record<string, string>): string {
     const [_, group, variableName, defaultValue] = match
 
     return interpolate(
-      envValue.replace(group, defaultValue || parsed[variableName] || ""),
+      envValue.replace(group, defaultValue || (Object.hasOwn(parsed, variableName) ? parsed[variableName] : "")),
       parsed
     )
   }

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -10,6 +10,7 @@
  */
 import type * as Cause from "./Cause.ts"
 import * as core from "./internal/core.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as Pipeable from "./Pipeable.ts"
 import * as Predicate from "./Predicate.ts"
 import type * as Types from "./Types.ts"
@@ -51,10 +52,10 @@ import type { Unify } from "./Unify.ts"
 export const Class: new<A extends Record<string, any> = {}>(
   args: Types.VoidIfEmpty<{ readonly [P in keyof A]: A[P] }>
 ) => Readonly<A> & Pipeable.Pipeable = class extends Pipeable.Class {
-  constructor(props: any) {
+  constructor(props: object | undefined) {
     super()
     if (props) {
-      Object.assign(this, props)
+      InternalRecord.assignProperties(this, props)
     }
   }
 } as any

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -26,6 +26,7 @@ import * as core from "./internal/core.ts"
 import * as internal from "./internal/effect.ts"
 import * as internalExecutionPlan from "./internal/executionPlan.ts"
 import * as internalLayer from "./internal/layer.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as internalRequest from "./internal/request.ts"
 import * as internalSchedule from "./internal/schedule.ts"
 import type * as Layer from "./Layer.ts"
@@ -14114,11 +14115,11 @@ export const annotateLogs = dual<
     ...args: [Record<string, unknown>] | [key: string, value: unknown]
   ): Effect<A, E, R> =>
     internal.updateService(effect, CurrentLogAnnotations, (annotations) => {
-      const newAnnotations = { ...annotations }
+      const newAnnotations = args.length === 1 ? { ...annotations, ...args[0] } : { ...annotations }
       if (args.length === 1) {
-        Object.assign(newAnnotations, args[0])
+        return newAnnotations
       } else {
-        newAnnotations[args[0]] = args[1]
+        InternalRecord.assignProperty(newAnnotations, args[0], args[1])
       }
       return newAnnotations
     })

--- a/packages/effect/src/Iterable.ts
+++ b/packages/effect/src/Iterable.ts
@@ -12,6 +12,7 @@
 import type { NonEmptyArray } from "./Array.ts"
 import * as Equal from "./Equal.ts"
 import { dual } from "./Function.ts"
+import * as InternalRecord from "./internal/record.ts"
 import type { Option } from "./Option.ts"
 import * as O from "./Option.ts"
 import { isBoolean } from "./Predicate.ts"
@@ -1366,7 +1367,7 @@ export const groupBy: {
     if (Object.hasOwn(out, k)) {
       out[k].push(a)
     } else {
-      out[k] = [a]
+      InternalRecord.assignProperty(out, k, [a])
     }
   }
   return out

--- a/packages/effect/src/JsonPatch.ts
+++ b/packages/effect/src/JsonPatch.ts
@@ -8,6 +8,7 @@
  * @since 4.0.0
  */
 import { format } from "./Formatter.ts"
+import * as InternalRecord from "./internal/record.ts"
 import { escapeToken, unescapeToken } from "./JsonPointer.ts"
 import * as Predicate from "./Predicate.ts"
 import type * as Schema from "./Schema.ts"
@@ -358,7 +359,7 @@ function addAt(doc: Schema.Json, pointer: string, val: Schema.Json): Schema.Json
 
   if (isJsonObject(parent)) {
     const updated = { ...parent }
-    updated[lastToken] = val
+    InternalRecord.assignProperty(updated, lastToken, val)
     return rebuildFromStack(stack, updated)
   }
 
@@ -399,7 +400,7 @@ function setAt(
     }
     const updated = { ...parent }
     if (mode === "remove") delete updated[lastToken]
-    else updated[lastToken] = val!
+    else InternalRecord.assignProperty(updated, lastToken, val!)
     return rebuildFromStack(stack, updated)
   }
 
@@ -460,7 +461,7 @@ function rebuildFromStack(stack: ReadonlyArray<StackEntry>, newParent: Schema.Js
       acc = copy
     } else {
       const copy = { ...(container as Schema.JsonObject) }
-      copy[token as string] = acc
+      InternalRecord.assignProperty(copy, token as string, acc)
       acc = copy
     }
   }

--- a/packages/effect/src/JsonSchema.ts
+++ b/packages/effect/src/JsonSchema.ts
@@ -9,6 +9,7 @@
  * @since 4.0.0
  */
 import * as Arr from "./Array.ts"
+import * as InternalRecord from "./internal/record.ts"
 import { unescapeToken } from "./JsonPointer.ts"
 import * as Predicate from "./Predicate.ts"
 import * as Rec from "./Record.ts"
@@ -745,11 +746,11 @@ function rewrite_refs(node: unknown, f: ($ref: string) => string): unknown {
     const v = node[k]
 
     if (k === "$ref") {
-      out[k] = typeof v === "string" ? f(v) : v
+      InternalRecord.assignProperty(out, k, typeof v === "string" ? f(v) : v)
     } else if (Array.isArray(v) || Predicate.isObject(v)) {
-      out[k] = rewrite_refs(v, f)
+      InternalRecord.assignProperty(out, k, rewrite_refs(v, f))
     } else {
-      out[k] = v
+      InternalRecord.assignProperty(out, k, v)
     }
   }
 
@@ -762,7 +763,7 @@ function walk_object(
 ): Record<string, unknown> | undefined {
   if (!Predicate.isObject(value)) return undefined
   const out: Record<string, unknown> = {}
-  for (const k of Object.keys(value)) out[k] = walk(value[k], false)
+  for (const k of Object.keys(value)) InternalRecord.assignProperty(out, k, walk(value[k], false))
   return out
 }
 
@@ -776,15 +777,15 @@ function normalize_OpenApi3_0_to_Draft07(node: unknown): unknown {
   for (const k of Object.keys(src)) {
     const v = src[k]
     if (k === "$ref" && typeof v === "string") {
-      out[k] = v.replace(RE_COMPONENTS_SCHEMAS, "#/definitions")
+      InternalRecord.assignProperty(out, k, v.replace(RE_COMPONENTS_SCHEMAS, "#/definitions"))
     } else if (k === "example") {
       if (src.examples === undefined) {
         out.examples = [v]
       }
     } else if (Array.isArray(v) || Predicate.isObject(v)) {
-      out[k] = normalize_OpenApi3_0_to_Draft07(v)
+      InternalRecord.assignProperty(out, k, normalize_OpenApi3_0_to_Draft07(v))
     } else {
-      out[k] = v
+      InternalRecord.assignProperty(out, k, v)
     }
   }
 
@@ -895,10 +896,7 @@ export function resolve$ref($ref: string, definitions: Definitions): JsonSchema 
   const tokens = $ref.split("/")
   if (tokens.length > 0) {
     const identifier = unescapeToken(tokens[tokens.length - 1])
-    const definition = definitions[identifier]
-    if (definition !== undefined) {
-      return definition
-    }
+    if (Object.hasOwn(definitions, identifier)) return definitions[identifier]
   }
 }
 

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -20,6 +20,7 @@ import * as Formatter from "./Formatter.ts"
 import { dual } from "./Function.ts"
 import { isEffect, withFiber } from "./internal/core.ts"
 import * as effect from "./internal/effect.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as Layer from "./Layer.ts"
 import type * as LogLevel from "./LogLevel.ts"
 import type { Pipeable } from "./Pipeable.ts"
@@ -637,13 +638,13 @@ export const formatStructured: Logger<unknown, {
 
   const annotations = fiber.getRef(CurrentLogAnnotations)
   for (const [key, value] of Object.entries(annotations)) {
-    annotationsObj[key] = effect.structuredMessage(value)
+    InternalRecord.assignProperty(annotationsObj, key, effect.structuredMessage(value))
   }
 
   const now = date.getTime()
   const spans = fiber.getRef(CurrentLogSpans)
   for (const [label, timestamp] of spans) {
-    spansObj[label] = now - timestamp
+    InternalRecord.assignProperty(spansObj, label, now - timestamp)
   }
 
   const messageArr = Array.ensure(message)

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -19,6 +19,7 @@ import type { Exit } from "./Exit.ts"
 import { constUndefined, dual } from "./Function.ts"
 import * as InternalEffect from "./internal/effect.ts"
 import * as InternalMetric from "./internal/metric.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as Layer from "./Layer.ts"
 import * as Order from "./Order.ts"
 import type { Pipeable } from "./Pipeable.ts"
@@ -4041,7 +4042,7 @@ function mergeAttributes(
 function attributesToRecord(attributes?: Metric.Attributes): Metric.AttributeSet | undefined {
   if (Predicate.isNotUndefined(attributes) && Array.isArray(attributes)) {
     return attributes.reduce((acc, [key, value]) => {
-      acc[key] = value
+      InternalRecord.assignProperty(acc, key, value)
       return acc
     }, {} as Metric.AttributeSet)
   }

--- a/packages/effect/src/Optic.ts
+++ b/packages/effect/src/Optic.ts
@@ -14,6 +14,7 @@
 
 import { format } from "./Formatter.ts"
 import { identity, memoize } from "./Function.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as Option from "./Option.ts"
 import * as Predicate from "./Predicate.ts"
 import * as Result from "./Result.ts"
@@ -1072,7 +1073,7 @@ class OptionalImpl<S, A> implements Optional<S, A> {
                 delete copy[key]
               }
             } else {
-              copy[key] = a
+              InternalRecord.assignProperty(copy, key, a)
             }
             return copy
           }
@@ -1110,7 +1111,7 @@ class OptionalImpl<S, A> implements Optional<S, A> {
           (a, s) => {
             if (Object.hasOwn(s, key)) {
               const copy = cloneShallow(s)
-              copy[key] = a
+              InternalRecord.assignProperty(copy, key, a)
               return Result.succeed(copy)
             } else {
               return err
@@ -1283,12 +1284,12 @@ const recur = memoize((node: Node): Op => {
           let i = 0
           for (; i < path.length - 1; i++) {
             const key = path[i]
-            current[key] = cloneShallow(current[key])
+            InternalRecord.assignProperty(current, key, cloneShallow(current[key]))
             current = current[key]
           }
 
           const finalKey = path[i]
-          current[finalKey] = a
+          InternalRecord.assignProperty(current, finalKey, a)
 
           return out
         }

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -20,6 +20,7 @@ import type { TypeLambda } from "./HKT.ts"
 import type { Inspectable } from "./Inspectable.ts"
 import * as doNotation from "./internal/doNotation.ts"
 import * as option from "./internal/option.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as result from "./internal/result.ts"
 import type { Order } from "./Order.ts"
 import * as order from "./Order.ts"
@@ -1758,7 +1759,7 @@ export const all: <const I extends Iterable<Option<any>> | Record<string, Option
       if (isNone(o)) {
         return none()
       }
-      out[key] = o.value
+      InternalRecord.assignProperty(out, key, o.value)
     }
     return some(out)
   }

--- a/packages/effect/src/Record.ts
+++ b/packages/effect/src/Record.ts
@@ -15,6 +15,7 @@ import * as Equal from "./Equal.ts"
 import type { Equivalence } from "./Equivalence.ts"
 import { dual, identity } from "./Function.ts"
 import type { TypeLambda } from "./HKT.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as Option from "./Option.ts"
 import * as Reducer from "./Reducer.ts"
 import type { Result } from "./Result.ts"
@@ -248,7 +249,7 @@ export const fromIterableWith: {
     const out: Record<string, B> = empty()
     for (const a of self) {
       const [k, b] = f(a)
-      out[k] = b
+      InternalRecord.assignProperty(out, k, b)
     }
     return out
   }
@@ -438,7 +439,7 @@ export const get: {
 } = dual(
   2,
   <K extends string | symbol, A>(self: ReadonlyRecord<K, A>, key: NoInfer<K>): Option.Option<A> =>
-    has(self, key) ? Option.some(self[key]) : Option.none()
+    Object.hasOwn(self, key) ? Option.some(self[key]) : Option.none()
 )
 
 /**
@@ -624,7 +625,7 @@ export const map: {
   <K extends string, A, B>(self: ReadonlyRecord<K, A>, f: (a: A, key: NoInfer<K>) => B): Record<K, B> => {
     const out: Record<K, B> = { ...self } as any
     for (const key of keys(self)) {
-      out[key] = f(self[key], key)
+      InternalRecord.assignProperty(out, key, f(self[key], key))
     }
     return out
   }
@@ -665,7 +666,7 @@ export const mapKeys: {
     const out: Record<K2, A> = {} as any
     for (const key of keys(self)) {
       const a = self[key]
-      out[f(key, a)] = a
+      InternalRecord.assignProperty(out, f(key, a), a)
     }
     return out
   }
@@ -706,7 +707,7 @@ export const mapEntries: {
     const out = {} as Record<K2, B>
     for (const key of keys(self)) {
       const [k, b] = f(self[key], key)
-      out[k] = b
+      InternalRecord.assignProperty(out, k, b)
     }
     return out
   }
@@ -748,7 +749,7 @@ export const filterMap: {
     for (const key of keys(self)) {
       const result = f(self[key], key)
       if (R.isSuccess(result)) {
-        out[key] = result.success
+        InternalRecord.assignProperty(out, key, result.success)
       }
     }
     return out
@@ -795,7 +796,7 @@ export const filter: {
     const out: Record<string, A> = empty()
     for (const key of keys(self)) {
       if (predicate(self[key], key)) {
-        out[key] = self[key]
+        InternalRecord.assignProperty(out, key, self[key])
       }
     }
     return out
@@ -830,7 +831,7 @@ export const getSomes: <K extends string, A>(
   for (const key of keys(self)) {
     const option = self[key]
     if (Option.isSome(option)) {
-      out[key] = option.value
+      InternalRecord.assignProperty(out, key, option.value)
     }
   }
   return out
@@ -866,7 +867,7 @@ export const getFailures = <K extends string, A, E>(
   for (const key of keys(self)) {
     const value = self[key]
     if (R.isFailure(value)) {
-      out[key] = value.failure
+      InternalRecord.assignProperty(out, key, value.failure)
     }
   }
 
@@ -903,7 +904,7 @@ export const getSuccesses = <K extends string, A, E>(
   for (const key of keys(self)) {
     const value = self[key]
     if (R.isSuccess(value)) {
-      out[key] = value.success
+      InternalRecord.assignProperty(out, key, value.success)
     }
   }
 
@@ -954,9 +955,9 @@ export const partition: {
     for (const key of keys(self)) {
       const e = f(self[key], key)
       if (R.isFailure(e)) {
-        left[key] = e.failure
+        InternalRecord.assignProperty(left, key, e.failure)
       } else {
-        right[key] = e.success
+        InternalRecord.assignProperty(right, key, e.success)
       }
     }
     return [left, right]
@@ -1057,6 +1058,44 @@ export const set: {
     return { ...self, [key]: value } as any
   }
 )
+
+/**
+ * Mutates a record by assigning a value to a property.
+ *
+ * **When to use**
+ *
+ * Use when incrementally constructing a new record and copying it for every
+ * property would be unnecessary.
+ *
+ * **Gotchas**
+ *
+ * This function mutates `self`. When `key` is `"__proto__"`, it creates an
+ * own data property instead of changing the object's prototype.
+ *
+ * **Example** (Assigning an external key safely)
+ *
+ * ```ts
+ * import { Record } from "effect"
+ * import * as assert from "node:assert"
+ *
+ * const key: string = "__proto__" // Assume this comes from external input
+ * const value = { polluted: true }
+ *
+ * const unsafe: Record<string, unknown> = {}
+ * unsafe[key] = value
+ * assert.strictEqual(Object.getPrototypeOf(unsafe), value)
+ *
+ * const safe: Record<string, unknown> = {}
+ * Record.assignProperty(safe, key, value)
+ * assert.strictEqual(Object.getPrototypeOf(safe), Object.prototype)
+ * assert.strictEqual(safe[key], value)
+ * ```
+ *
+ * @see {@link set} for an immutable update
+ * @category mutations
+ * @since 4.0.0
+ */
+export const assignProperty: (self: object, key: PropertyKey, value: unknown) => void = InternalRecord.assignProperty
 
 /**
  * Checks whether all the keys and values in one record are also found in another record.
@@ -1292,14 +1331,14 @@ export const union: {
     const out: Record<string, A | B | C> = empty()
     for (const key of keys(self)) {
       if (has(that, key as any)) {
-        out[key] = combine(self[key], that[key as unknown as K1])
+        InternalRecord.assignProperty(out, key, combine(self[key], that[key as unknown as K1]))
       } else {
-        out[key] = self[key]
+        InternalRecord.assignProperty(out, key, self[key])
       }
     }
     for (const key of keys(that)) {
       if (!has(out, key)) {
-        out[key] = that[key]
+        InternalRecord.assignProperty(out, key, that[key])
       }
     }
     return out
@@ -1348,7 +1387,7 @@ export const intersection: {
     }
     for (const key of keys(self)) {
       if (has(that, key as any)) {
-        out[key] = combine(self[key], that[key as unknown as K1])
+        InternalRecord.assignProperty(out, key, combine(self[key], that[key as unknown as K1]))
       }
     }
     return out
@@ -1395,12 +1434,12 @@ export const difference: {
   const out = {} as Record<K0 | K1, A | B>
   for (const key of keys(self)) {
     if (!has(that, key as any)) {
-      out[key] = self[key]
+      InternalRecord.assignProperty(out, key, self[key])
     }
   }
   for (const key of keys(that)) {
     if (!has(self, key as any)) {
-      out[key] = that[key]
+      InternalRecord.assignProperty(out, key, that[key])
     }
   }
   return out

--- a/packages/effect/src/Request.ts
+++ b/packages/effect/src/Request.ts
@@ -17,6 +17,7 @@ import type * as Exit from "./Exit.ts"
 import { dual } from "./Function.ts"
 import * as core from "./internal/core.ts"
 import * as internalEffect from "./internal/effect.ts"
+import * as InternalRecord from "./internal/record.ts"
 import { hasProperty } from "./Predicate.ts"
 import type * as Types from "./Types.ts"
 
@@ -280,7 +281,7 @@ export const isRequest = (u: unknown): u is Request<unknown, unknown, unknown> =
  * @since 2.0.0
  */
 export const of = <R extends Request<any, any, any>>(): Constructor<R> => (args) =>
-  Object.assign(Object.create(RequestPrototype), args)
+  Object.setPrototypeOf({ ...(args as R) }, RequestPrototype)
 
 /**
  * Creates a constructor function for a tagged Request type. The tag is automatically
@@ -328,10 +329,7 @@ export const tagged = <R extends Request<any, any, any> & { _tag: string }>(
   tag: R["_tag"]
 ): Constructor<R, "_tag"> =>
 (args) => {
-  const request = Object.create(RequestPrototype)
-  if (args) Object.assign(request, args)
-  request._tag = tag
-  return request
+  return Object.setPrototypeOf({ ...(args as R), _tag: tag }, RequestPrototype)
 }
 
 /**
@@ -364,9 +362,9 @@ export const Class: new<A extends Record<string, any>, Success, Error = never, C
   args: Types.Equals<Omit<A, keyof Request<unknown, unknown>>, {}> extends true ? void
     : { readonly [P in keyof A as P extends keyof Request<any, any, any> ? never : P]: A[P] }
 ) => Request<Success, Error, Context> & Readonly<A> = (function() {
-  function Class(this: any, args: any) {
+  function Class(this: object, args: object | undefined) {
     if (args) {
-      Object.assign(this, args)
+      InternalRecord.assignProperties(this, args)
     }
   }
   Class.prototype = RequestPrototype

--- a/packages/effect/src/Result.ts
+++ b/packages/effect/src/Result.ts
@@ -17,6 +17,7 @@ import type { TypeLambda } from "./HKT.ts"
 import type { Inspectable } from "./Inspectable.ts"
 import * as doNotation from "./internal/doNotation.ts"
 import * as option_ from "./internal/option.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as result from "./internal/result.ts"
 import type { Option } from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
@@ -1481,7 +1482,7 @@ export const all: <const I extends Iterable<Result<any, any>> | Record<string, R
       if (isFailure(e)) {
         return e
       }
-      out[key] = e.success
+      InternalRecord.assignProperty(out, key, e.success)
     }
     return succeed(out)
   }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3554,8 +3554,8 @@ export function encodeKeys<
 >(mapping: M) {
   return function(self: S): encodeKeys<S, M> {
     const fields: any = {}
-    const appliedMapping: any = {}
-    const reverseMapping: any = {}
+    const appliedMapping: any = Object.create(null)
+    const reverseMapping: any = Object.create(null)
     const seenEncodedKeys = new Set<string | symbol>()
     for (const k of Reflect.ownKeys(self.fields)) {
       const encoded = toEncoded(self.fields[k])
@@ -3566,7 +3566,7 @@ export function encodeKeys<
         throw new globalThis.Error(`Duplicate encoded keys: ${formatPropertyKey(encodedKey)}`)
       }
       seenEncodedKeys.add(canonical)
-      fields[encodedKey] = encoded
+      InternalRecord.assignProperty(fields, encodedKey, encoded)
       if (hasMapping) {
         appliedMapping[k] = encodedKey
         reverseMapping[encodedKey] = k
@@ -3633,7 +3633,7 @@ export function extendTo<S extends Struct<Struct.Fields>, const Fields extends S
             const f = derive[k]
             const o = f(input)
             if (Option_.isSome(o)) {
-              out[k] = o.value
+              InternalRecord.assignProperty(out, k, o.value)
             }
           }
           return out
@@ -6191,8 +6191,8 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
           }
           discriminantKeys.add(key)
           discriminants.push(literal)
-          InternalRecord.set(cases, literal, schema)
-          InternalRecord.set(guards, literal, is(toType(schema)))
+          InternalRecord.assignProperty(cases, literal, schema)
+          InternalRecord.assignProperty(guards, literal, is(toType(schema)))
           return
         }
       }
@@ -6204,12 +6204,16 @@ export function toTaggedUnion<const Tag extends PropertyKey>(tag: Tag) {
       if (arguments.length === 1) {
         const cases = arguments[0]
         return function(value: any) {
-          return cases[value[tag]](value)
+          const key = value[tag]
+          const handler = Object.hasOwn(cases, key) ? cases[key] : undefined
+          return handler(value)
         }
       }
       const value = arguments[0]
       const cases = arguments[1]
-      return cases[value[tag]](value)
+      const key = value[tag]
+      const handler = Object.hasOwn(cases, key) ? cases[key] : undefined
+      return handler(value)
     }
   }
 }
@@ -6281,7 +6285,9 @@ export function TaggedUnion<const CasesByTag extends Record<string, Struct.Field
   const cases: any = {}
   const members: any = []
   for (const key of Object.keys(casesByTag)) {
-    members.push(cases[key] = TaggedStruct(key, casesByTag[key]))
+    const member = TaggedStruct(key, casesByTag[key])
+    InternalRecord.assignProperty(cases, key, member)
+    members.push(member)
   }
   const union = Union(members)
   const { guards, isAnyOf, match } = toTaggedUnion("_tag")(union)

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2143,9 +2143,9 @@ export class Objects extends Base {
             const v2 = exitValue.value.value
             if (is.merge && is.merge.decode && Object.hasOwn(s.out, k2)) {
               const [k, v] = is.merge.decode.combine([k2, s.out[k2]], [k2, v2])
-              InternalRecord.set(s.out, k, v)
+              InternalRecord.assignProperty(s.out, k, v)
             } else {
-              InternalRecord.set(s.out, k2, v2)
+              InternalRecord.assignProperty(s.out, k2, v2)
             }
           }
         }),
@@ -2201,7 +2201,7 @@ export class Objects extends Base {
               }
             } else {
               // preserve key
-              InternalRecord.set(out, key, input[key])
+              InternalRecord.assignProperty(out, key, input[key])
             }
           }
         }
@@ -2241,7 +2241,7 @@ export class Objects extends Base {
         const preserved: Record<PropertyKey, unknown> = {}
         for (const key of keys) {
           if (Object.hasOwn(out, key)) {
-            InternalRecord.set(preserved, key, out[key])
+            InternalRecord.assignProperty(preserved, key, out[key])
           }
         }
         return Option.some(preserved)
@@ -2332,7 +2332,7 @@ const parseProperties = iterateEager<{
     if (exit._tag === "Failure") {
       return wrapPropertyKeyIssue(s, s.ast, p.name, exit)
     } else if (exit.value._tag === "Some") {
-      InternalRecord.set(s.out, p.name, exit.value.value)
+      InternalRecord.assignProperty(s.out, p.name, exit.value.value)
     } else if (!isOptional(p.type)) {
       const issue = new SchemaIssue.Pointer([p.name], new SchemaIssue.MissingKey(p.type.context?.annotations))
       if (s.options.errors === "all") {

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -1085,7 +1085,7 @@ export function splitKeyValue<E extends string>(options?: {
     input.split(separator).reduce((acc, pair) => {
       const [key, value] = pair.split(keyValueSeparator)
       if (key && value) {
-        acc[key] = value
+        InternalRecord.assignProperty(acc, key, value)
       }
       return acc
     }, {} as Record<string, string>)
@@ -1714,7 +1714,7 @@ function getOrCreateContainer(
     return current
   }
   const container = shouldBeArray ? [] : {}
-  InternalRecord.set(self, key, container)
+  InternalRecord.assignProperty(self, key, container)
   return container
 }
 
@@ -1789,9 +1789,9 @@ export function makeTreeRecord<A>(
         if (hasOwn && Array.isArray(cur[token])) {
           cur[token].push(value)
         } else if (hasOwn) {
-          InternalRecord.set(cur, token, [cur[token], value])
+          InternalRecord.assignProperty(cur, token, [cur[token], value])
         } else {
-          InternalRecord.set(cur, token, value)
+          InternalRecord.assignProperty(cur, token, value)
         }
       } else {
         const next = tokens[i + 1]

--- a/packages/effect/src/SchemaRepresentation.ts
+++ b/packages/effect/src/SchemaRepresentation.ts
@@ -839,7 +839,7 @@ function pruneAnnotations(
   const out: Record<string, Schema.Json> = {}
   for (const [key, value] of Object.entries(annotations)) {
     if (SchemaAST.isJson(value)) {
-      InternalRecord.set(out, key, value)
+      InternalRecord.assignProperty(out, key, value)
     }
   }
   return Object.keys(out).length === 0 ? Option.none() : Option.some(out)

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -5733,7 +5733,8 @@ export const catchReasons: {
     }[keyof Cases]
   >
 } = dual((args) => isStream(args[0]), (self, errorTag, cases, orElse) => {
-  const handlers: Record<string, (reason: any, error: any) => Channel.Channel<any, any, any, any, any, any, any>> = {}
+  const handlers: Record<string, (reason: any, error: any) => Channel.Channel<any, any, any, any, any, any, any>> =
+    Object.create(null)
   for (const key of Object.keys(cases)) {
     const handler = (cases as any)[key]
     handlers[key] = (reason, error) => handler(reason, error).channel

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -14,6 +14,7 @@
 import * as Combiner from "./Combiner.ts"
 import * as Equivalence from "./Equivalence.ts"
 import { dual } from "./Function.ts"
+import * as InternalRecord from "./internal/record.ts"
 import * as order from "./Order.ts"
 import * as Reducer from "./Reducer.ts"
 
@@ -836,7 +837,7 @@ function buildStruct<
     const res = f(k, source[k])
     if (res) {
       const [nk, nv] = res
-      out[nk] = nv
+      InternalRecord.assignProperty(out, nk, nv)
     }
   }
   return out
@@ -888,7 +889,7 @@ export function makeCombiner<A>(
     for (const key of keys) {
       const merge = combiners[key].combine(self[key], that[key])
       if (omitKeyWhen(merge)) continue
-      out[key] = merge
+      InternalRecord.assignProperty(out as object, key, merge)
     }
     return out
   })
@@ -943,7 +944,7 @@ export function makeReducer<A>(
   for (const key of Reflect.ownKeys(reducers) as Array<keyof A>) {
     const iv = reducers[key].initialValue
     if (options?.omitKeyWhen?.(iv)) continue
-    initialValue[key] = iv
+    InternalRecord.assignProperty(initialValue as object, key, iv)
   }
   return Reducer.make(combine, initialValue)
 }
@@ -973,7 +974,7 @@ export function Record<const Keys extends ReadonlyArray<string | symbol>, Value>
 ): Record<Keys[number], Value> {
   const out: any = {}
   for (const key of keys) {
-    out[key] = value
+    InternalRecord.assignProperty(out, key, value)
   }
   return out
 }

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -13,6 +13,7 @@ import type { StackFrame } from "../References.ts"
 import type * as Types from "../Types.ts"
 import { SingleShotGen } from "../Utils.ts"
 import type { FiberImpl } from "./effect.ts"
+import * as InternalRecord from "./record.ts"
 
 /** @internal */
 export const EffectTypeId = `~effect/Effect` as const
@@ -587,10 +588,10 @@ export const Error: new<A extends Record<string, any> = {}>(
 ) => Cause.YieldableError & Readonly<A> = (function() {
   const plainArgsSymbol = Symbol.for("effect/Data/Error/plainArgs")
   return class Base extends YieldableError {
-    constructor(args: any) {
+    constructor(args: Record<string, any> | undefined) {
       super(args?.message, args?.cause ? { cause: args.cause } : undefined)
       if (args) {
-        Object.assign(this, args)
+        InternalRecord.assignProperties(this, args)
         // @effect-diagnostics-next-line floatingEffect:off
         Object.defineProperty(this, plainArgsSymbol, {
           value: args,

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -83,6 +83,7 @@ import {
 } from "./core.ts"
 import * as doNotation from "./doNotation.ts"
 import * as InternalMetric from "./metric.ts"
+import * as InternalRecord from "./record.ts"
 import {
   CurrentConcurrency,
   CurrentErrorReporters,
@@ -4353,7 +4354,7 @@ export const all = <
         Object.entries(arg),
         ([key, effect]) =>
           map(options?.mode === "result" ? result(effect) : effect, (value) => {
-            out[key] = value
+            InternalRecord.assignProperty(out, key, value)
           }),
         {
           discard: true,
@@ -5885,11 +5886,11 @@ export const annotateSpans: {
     ...args: [Record<string, unknown>] | [key: string, value: unknown]
   ): Effect.Effect<A, E, R> =>
     updateService(effect, TracerSpanAnnotations, (annotations) => {
-      const newAnnotations = { ...annotations }
+      const newAnnotations = args.length === 1 ? { ...annotations, ...args[0] } : { ...annotations }
       if (args.length === 1) {
-        Object.assign(newAnnotations, args[0])
+        return newAnnotations
       } else {
-        newAnnotations[args[0]] = args[1]
+        InternalRecord.assignProperty(newAnnotations, args[0], args[1])
       }
       return newAnnotations
     })
@@ -6160,7 +6161,7 @@ export const annotateLogsScoped: {
     const next = { ...prev }
     for (let i = 0; i < entries.length; i++) {
       const [key, value] = entries[i]
-      next[key] = value
+      InternalRecord.assignProperty(next, key, value)
     }
     fiber.setContext(Context.add(fiber.context, CurrentLogAnnotations, next))
     return scopeAddFinalizerExit(Context.getUnsafe(fiber.context, scopeTag), (_) => {
@@ -6169,8 +6170,8 @@ export const annotateLogsScoped: {
       for (let i = 0; i < entries.length; i++) {
         const [key, value] = entries[i]
         if (current[key] !== value) continue
-        if (key in prev) {
-          next[key] = prev[key]
+        if (Object.hasOwn(prev, key)) {
+          InternalRecord.assignProperty(next, key, prev[key])
         } else {
           delete next[key]
         }
@@ -6514,7 +6515,7 @@ export const tracerLogger = loggerMake<unknown, void>(({ cause, fiber, logLevel,
   if (span === undefined || span._tag === "ExternalSpan") return
   const attributes: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(annotations)) {
-    attributes[key] = value
+    InternalRecord.assignProperty(attributes, key, value)
   }
   attributes["effect.fiberId"] = fiber.id
   attributes["effect.logLevel"] = logLevel.toUpperCase()

--- a/packages/effect/src/internal/matcher.ts
+++ b/packages/effect/src/internal/matcher.ts
@@ -396,7 +396,7 @@ export const discriminators = <D extends string>(field: D) =>
   fields: P
 ) => {
   const predicate = makeWhen(
-    (arg: any) => arg != null && arg[field] in fields,
+    (arg: any) => arg != null && Object.hasOwn(fields, arg[field]),
     (data: any) => (fields as any)[data[field]](data)
   )
 

--- a/packages/effect/src/internal/record.ts
+++ b/packages/effect/src/internal/record.ts
@@ -1,9 +1,5 @@
-/**
- * @since 4.0.0
- */
-
 /** @internal */
-export function set<K extends PropertyKey, A>(self: Record<K, A>, key: K, value: A): Record<K, A> {
+export function assignProperty(self: object, key: PropertyKey, value: unknown): void {
   if (key === "__proto__") {
     Object.defineProperty(self, key, {
       value,
@@ -12,7 +8,15 @@ export function set<K extends PropertyKey, A>(self: Record<K, A>, key: K, value:
       configurable: true
     })
   } else {
-    self[key] = value
+    ;(self as any)[key] = value
   }
-  return self
+}
+
+/** @internal */
+export function assignProperties(self: object, source: object): void {
+  for (const key of Reflect.ownKeys(source)) {
+    if (Object.prototype.propertyIsEnumerable.call(source, key)) {
+      assignProperty(self, key, (source as any)[key])
+    }
+  }
 }

--- a/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/fromJsonSchemaDocument.ts
@@ -891,7 +891,7 @@ function translateJsonSchemaMultiDocument(
 
   const references: Record<string, Representation> = {}
   for (const key of Object.keys(document.definitions)) {
-    InternalRecord.set(references, key, unknownJsonSchemas(translateDefinition(key, ["definitions", key])))
+    InternalRecord.assignProperty(references, key, unknownJsonSchemas(translateDefinition(key, ["definitions", key])))
   }
   const representations = document.schemas.map((schema, index) =>
     unknownJsonSchemas(recur(schema, singleRoot ? ["schema"] : ["schemas", index]))

--- a/packages/effect/src/internal/schema/fromRepresentation.ts
+++ b/packages/effect/src/internal/schema/fromRepresentation.ts
@@ -295,7 +295,7 @@ function revivePersisted(
           if (property.isMutable) {
             schema = Schema.mutableKey(schema)
           }
-          InternalRecord.set(fields, property.name, schema)
+          InternalRecord.assignProperty(fields, property.name, schema)
         }
         const records = representation.indexSignatures.map((indexSignature, index) =>
           Schema.Record(
@@ -319,7 +319,7 @@ function revivePersisted(
 
   const definitions: Record<string, Schema.Top> = {}
   for (const key of referenceKeys) {
-    InternalRecord.set(definitions, key, resolveReference(key, ["references", key]))
+    InternalRecord.assignProperty(definitions, key, resolveReference(key, ["references", key]))
   }
 
   const schemas = representations.map((representation, index) =>

--- a/packages/effect/src/internal/schema/schema.ts
+++ b/packages/effect/src/internal/schema/schema.ts
@@ -68,10 +68,7 @@ const SchemaProto = {
 
 /** @internal */
 export function make<S extends Schema.Constraint>(ast: S["ast"], options?: object): S {
-  const self = Object.create(SchemaProto)
-  if (options) {
-    Object.assign(self, options)
-  }
+  const self = Object.setPrototypeOf({ ...options }, SchemaProto)
   self.ast = ast
   self.rebuild = (ast: SchemaAST.AST) => make(ast, options)
   const makeEffect = SchemaParser.makeEffect(self)

--- a/packages/effect/src/internal/schema/toArbitrary.ts
+++ b/packages/effect/src/internal/schema/toArbitrary.ts
@@ -13,6 +13,7 @@ import * as Struct from "../../Struct.ts"
 import type * as FastCheck from "../../testing/FastCheck.ts"
 import * as UndefinedOr from "../../UndefinedOr.ts"
 import { errorWithPath } from "../errors.ts"
+import * as InternalRecord from "../record.ts"
 import * as InternalAnnotations from "./annotations.ts"
 
 const arbitraryMemoMap = new WeakMap<SchemaAST.AST, LazyArbitraryWithContext<any>>()
@@ -288,7 +289,7 @@ function objectWithOptionalCount(
     const out: Record<PropertyKey, any> = {}
     for (const name of orderedNames) {
       if (keep.has(name)) {
-        out[name] = base[name]
+        InternalRecord.assignProperty(out, name, base[name])
       }
     }
     return out
@@ -771,7 +772,7 @@ function base(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): LazyArbitra
             return undefined
           }
           requiredKeys.push(name)
-          pss[name] = out
+          InternalRecord.assignProperty(pss, name, out)
         }
         let optionalCount = Math.max(0, (ctx.constraint?.minLength ?? 0) - requiredKeys.length)
         for (const [name, out] of optionals) {
@@ -780,7 +781,7 @@ function base(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): LazyArbitra
           }
           optionalCount--
           requiredKeys.push(name)
-          pss[name] = out
+          InternalRecord.assignProperty(pss, name, out)
         }
         if (optionalCount > 0 && ast.indexSignatures.length === 0) {
           return undefined
@@ -826,7 +827,7 @@ function base(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): LazyArbitra
           } else {
             requiredKeys.push(name)
           }
-          pss[name] = arbitrary(fc, reset, recursionStack)
+          InternalRecord.assignProperty(pss, name, arbitrary(fc, reset, recursionStack))
         }
         // When property-count constraints must be satisfied by selecting
         // optional keys (no index signatures are available to fill the gap),

--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -237,7 +237,7 @@ export function topologicalSort(
     }
   }
   const recursives: Record<string, SchemaRepresentation.Representation> = {}
-  for (const identifier of recursive) InternalRecord.set(recursives, identifier, references[identifier])
+  for (const identifier of recursive) InternalRecord.assignProperty(recursives, identifier, references[identifier])
   return { nonRecursives, recursives }
 }
 
@@ -262,7 +262,7 @@ export function toCodeDocument(
   const recursives: Record<string, SchemaRepresentation.Code> = {}
   for (const [$ref, representation] of Object.entries(sorted.recursives)) {
     compilingRecursiveDefinition = true
-    InternalRecord.set(recursives, ensureUniqueIdentifier($ref), recur(representation, ["references", $ref]))
+    InternalRecord.assignProperty(recursives, ensureUniqueIdentifier($ref), recur(representation, ["references", $ref]))
     compilingRecursiveDefinition = false
   }
   const codes = document.representations.map((representation, index) =>

--- a/packages/effect/src/internal/schema/toJsonSchemaDocument.ts
+++ b/packages/effect/src/internal/schema/toJsonSchemaDocument.ts
@@ -59,7 +59,7 @@ function collectJsonSchemaAnnotations(
       ) {
         continue
       }
-      if (SchemaAST.isJson(value)) out[key] = value
+      if (SchemaAST.isJson(value)) InternalRecord.assignProperty(out, key, value)
     }
   }
 
@@ -143,7 +143,7 @@ function compileJsonSchema(
 ): JsonSchema.MultiDocument<"draft-2020-12"> {
   const definitions: Record<string, JsonSchema.JsonSchema> = {}
   for (const key of Object.keys(references)) {
-    InternalRecord.set(definitions, key, recur(references[key], ["references", key]))
+    InternalRecord.assignProperty(definitions, key, recur(references[key], ["references", key]))
   }
   const schemas = Arr.map(representations, (representation, index) => recur(representation, rootPaths[index]))
   return { dialect: "draft-2020-12", schemas, definitions }
@@ -306,7 +306,11 @@ function compileJsonSchema(
           const name = property.name
           const compiled = recur(property.type, [...path, "propertySignatures", index, "type"])
           const annotations = collectJsonSchemaAnnotations(property.annotations, options)
-          properties[name] = annotations === undefined ? compiled : appendJsonSchema(compiled, annotations)
+          InternalRecord.assignProperty(
+            properties,
+            name,
+            annotations === undefined ? compiled : appendJsonSchema(compiled, annotations)
+          )
           if (!property.isOptional) required.push(name)
         }
         if (representation.propertySignatures.length > 0) out.properties = properties
@@ -328,7 +332,7 @@ function compileJsonSchema(
           if (patterns.length === 0) {
             out.additionalProperties = type
           } else {
-            for (const pattern of patterns) patternProperties[pattern] = type
+            for (const pattern of patterns) InternalRecord.assignProperty(patternProperties, pattern, type)
           }
         }
         if (Object.keys(patternProperties).length > 0) {

--- a/packages/effect/src/internal/schema/toRepresentation.ts
+++ b/packages/effect/src/internal/schema/toRepresentation.ts
@@ -104,7 +104,7 @@ function lowerASTs(
   const representations = Arr.map(asts, (ast) => recur(ast))
 
   for (const definition of externalDefinitions) {
-    InternalRecord.set(references, definition.key, recur(definition.body, definition.key))
+    InternalRecord.assignProperty(references, definition.key, recur(definition.body, definition.key))
   }
 
   return { representations, references }
@@ -184,7 +184,7 @@ function lowerASTs(
       const reference = getReference(referenceIdentifier, ast)
       referenceMap.set(ast, reference)
       if (!Object.hasOwn(references, reference) && !externalReferences.has(reference)) {
-        InternalRecord.set(references, reference, on(ast))
+        InternalRecord.assignProperty(references, reference, on(ast))
       }
       return { _tag: "Reference", $ref: reference }
     }
@@ -192,7 +192,7 @@ function lowerASTs(
     if (ownedReference === undefined && shared.has(ast)) {
       const reference = generateReference(`${ast._tag}_`, ast)
       referenceMap.set(ast, reference)
-      InternalRecord.set(references, reference, on(ast))
+      InternalRecord.assignProperty(references, reference, on(ast))
       return { _tag: "Reference", $ref: reference }
     }
 
@@ -208,7 +208,7 @@ function lowerASTs(
 
     const reference = referenceMap.get(ast)
     if (reference !== undefined && reference !== ownedReference) {
-      InternalRecord.set(references, reference, representation)
+      InternalRecord.assignProperty(references, reference, representation)
       return { _tag: "Reference", $ref: reference }
     }
 

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -225,7 +225,7 @@ const SleepOrder = Order.flip(Order.Struct({
 export const make = Effect.fnUntraced(function*(
   options?: TestClock.Options
 ) {
-  const config = Object.assign({}, defaultOptions, options)
+  const config = { ...defaultOptions, ...options }
   let sequence = 0
   const sleeps: Array<{
     readonly sequence: number

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -13,6 +13,7 @@
  */
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import { redact } from "../../Redactable.ts"
@@ -34,7 +35,7 @@ const redactHeaders = (headers: Record<string, string>): Record<string, string> 
   const result: Record<string, string> = {}
   for (const key in redacted) {
     const value = redacted[key]
-    result[key] = Redacted.isRedacted(value) ? value.toString() : value
+    InternalRecord.assignProperty(result, key, Redacted.isRedacted(value) ? value.toString() : value)
   }
   return result
 }

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -909,7 +909,9 @@ export const registerResource: {
       uriTemplate: uriPath,
       annotations: options!
     })
-    const completions: Record<string, (input: string) => Effect.Effect<CompleteResult, InternalError>> = {}
+    const completions: Record<string, (input: string) => Effect.Effect<CompleteResult, InternalError>> = Object.create(
+      null
+    )
     for (const [param, handle] of Object.entries(options.completion ?? {})) {
       const encodeArray = Schema.encodeUnknownEffect(Schema.Array(params[param]))
       const handler = (input: string) =>
@@ -1079,7 +1081,7 @@ export const registerPrompt = <
     const completions: Record<
       string,
       (input: string) => Effect.Effect<CompleteResult, InternalError, McpServerClient>
-    > = {}
+    > = Object.create(null)
     for (const [param, handle] of Object.entries(completion)) {
       const encodeArray = Schema.encodeEffect(Schema.Array(props[param]))
       const handler = (input: string) =>
@@ -1244,7 +1246,7 @@ const makeUriMatcher = <A>() => {
 const compileUriTemplate = (segments: TemplateStringsArray, ...schemas: ReadonlyArray<Schema.Constraint>) => {
   let routerPath = segments[0].replace(":", "::")
   let uriPath = segments[0]
-  const params: Record<string, Schema.Top> = {}
+  const params: Record<string, Schema.Top> = Object.create(null)
   let pathSchema = Schema.Tuple([]) as Schema.Top
   if (schemas.length > 0) {
     const arr: Array<Schema.Top> = []

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -15,6 +15,7 @@ import * as Effect from "../../Effect.ts"
 import * as Effectable from "../../Effectable.ts"
 import * as Fiber from "../../Fiber.ts"
 import { identity } from "../../Function.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Layer from "../../Layer.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Queue from "../../Queue.ts"
@@ -258,7 +259,7 @@ const Proto = {
       }
 
       const handle = Effect.fnUntraced(function*(name: string, params: unknown) {
-        const tool = tools[name]
+        const tool = Object.hasOwn(tools, name) ? tools[name] : undefined
 
         yield* Effect.annotateCurrentSpan({
           tool: name,
@@ -390,8 +391,10 @@ const Proto = {
       const handlers = Effect.isEffect(build) ? yield* build : build
       const context = new Map<string, unknown>()
       for (const [name, handler] of Object.entries(handlers)) {
-        const tool = this.tools[name]!
-        context.set(tool.id, { name, handler, context: services })
+        const tool = Object.hasOwn(this.tools, name) ? this.tools[name] : undefined
+        if (tool !== undefined) {
+          context.set(tool.id, { name, handler, context: services })
+        }
       }
       return Context.makeUnsafe(context)
     })
@@ -418,7 +421,7 @@ const resolveInput = <Tools extends ReadonlyArray<Tool.Any>>(
 ): Record<string, Tools[number]> => {
   const output = {} as Record<string, Tools[number]>
   for (const tool of tools) {
-    output[tool.name] = tool
+    InternalRecord.assignProperty(output, tool.name, tool)
   }
   return output
 }
@@ -547,7 +550,7 @@ export const merge = <const Toolkits extends ReadonlyArray<Any>>(
   const tools = {} as Record<string, any>
   for (const toolkit of toolkits) {
     for (const [name, tool] of Object.entries(toolkit.tools)) {
-      tools[name] = tool
+      InternalRecord.assignProperty(tools, name, tool)
     }
   }
   return makeProto(tools) as any

--- a/packages/effect/src/unstable/ai/internal/structured-output.ts
+++ b/packages/effect/src/unstable/ai/internal/structured-output.ts
@@ -1,4 +1,5 @@
 import * as Arr from "../../../Array.ts"
+import * as InternalRecord from "../../../internal/record.ts"
 import type * as JsonSchema from "../../../JsonSchema.ts"
 import * as Option from "../../../Option.ts"
 import * as Predicate from "../../../Predicate.ts"
@@ -402,31 +403,39 @@ export function walkJsonSchema(
         if (isJsonSchema(value)) {
           const properties: Record<string, unknown> = {}
           for (const [name, property] of Object.entries(value)) {
-            properties[name] = isJsonSchema(property) ? walkJsonSchema(property, visitor) : property
+            InternalRecord.assignProperty(
+              properties,
+              name,
+              isJsonSchema(property) ? walkJsonSchema(property, visitor) : property
+            )
           }
-          out[key] = properties
+          InternalRecord.assignProperty(out, key, properties)
         } else {
-          out[key] = value
+          InternalRecord.assignProperty(out, key, value)
         }
         break
       }
       case "additionalProperties":
       case "items":
       case "propertyNames": {
-        out[key] = isJsonSchema(value) ? walkJsonSchema(value, visitor) : value
+        InternalRecord.assignProperty(out, key, isJsonSchema(value) ? walkJsonSchema(value, visitor) : value)
         break
       }
       case "prefixItems":
       case "allOf":
       case "anyOf":
       case "oneOf": {
-        out[key] = Array.isArray(value)
-          ? value.map((member) => isJsonSchema(member) ? walkJsonSchema(member, visitor) : member)
-          : value
+        InternalRecord.assignProperty(
+          out,
+          key,
+          Array.isArray(value)
+            ? value.map((member) => isJsonSchema(member) ? walkJsonSchema(member, visitor) : member)
+            : value
+        )
         break
       }
       default:
-        out[key] = value
+        InternalRecord.assignProperty(out, key, value)
         break
     }
   }

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -755,7 +755,7 @@ export const withSubcommands: {
 
     const context = yield* impl.parseContext(raw)
     const result = yield* sub.parse(raw.subcommand.value.parsedInput)
-    return Object.assign({}, context, { [SubcommandStateSymbol]: { name: sub.name, result } }) as NextInput
+    return { ...context, [SubcommandStateSymbol]: { name: sub.name, result } } as NextInput
   })
 
   const handle = Effect.fnUntraced(function*(input: NextInput, path: ReadonlyArray<string>) {
@@ -859,13 +859,13 @@ export const withSharedFlags: {
     const parse = Effect.fnUntraced(function*(raw: ParsedTokens) {
       const base = yield* impl.parse(raw)
       const shared = yield* parseShared(raw)
-      return Object.assign({}, base, shared) as NextInput
+      return { ...(base as object), ...(shared as object) } as NextInput
     })
 
     const parseContext = Effect.fnUntraced(function*(raw: ParsedTokens) {
       const base = yield* impl.parseContext(raw)
       const shared = yield* parseShared(raw)
-      return Object.assign({}, base, shared) as NextContextInput
+      return { ...(base as object), ...(shared as object) } as NextContextInput
     })
 
     const handle = (

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -343,14 +343,14 @@ export const makeSingle = <const Kind extends ParamKind, A>(params: {
     params.kind === argumentKind
       ? parsePositional(params.name, params.primitiveType, args)
       : parseFlag(params.name, params.primitiveType, args)
-  return Object.assign(Object.create(Proto), {
+  return Object.setPrototypeOf({
     _tag: "Single",
     ...params,
     description: params.description ?? Option.none(),
     aliases: params.aliases ?? [],
     hidden: params.hidden ?? false,
     parse
-  })
+  }, Proto)
 }
 
 /**
@@ -865,7 +865,7 @@ export const keyValuePair = <Kind extends ParamKind>(
       }),
       { min: 1 }
     ),
-    (objects) => Object.assign({}, ...objects)
+    (objects) => Object.fromEntries(objects.flatMap(Object.entries))
   )
 
 /**

--- a/packages/effect/src/unstable/cli/internal/config.ts
+++ b/packages/effect/src/unstable/cli/internal/config.ts
@@ -46,6 +46,7 @@
  * 1. Flat iteration over all params for parsing/validation
  * 2. Reconstruction of original nested shape for handler input
  */
+import * as InternalRecord from "../../../internal/record.ts"
 import * as Param from "../Param.ts"
 
 /* ========================================================================== */
@@ -135,8 +136,8 @@ export const parseConfig = (config: Config): ConfigInternal => {
   const args: Array<Param.AnyArgument> = []
 
   function parse(config: Config): ConfigInternal.Tree {
-    const tree: ConfigInternal.Tree = {}
-    for (const key in config) {
+    const tree: ConfigInternal.Tree = Object.create(null)
+    for (const key of Object.keys(config)) {
       tree[key] = parseValue(config[key])
     }
     return tree
@@ -202,8 +203,8 @@ const shiftNodeIndexes = (node: ConfigInternal.Node, offset: number): ConfigInte
 }
 
 const shiftTreeIndexes = (tree: ConfigInternal.Tree, offset: number): ConfigInternal.Tree => {
-  const output: ConfigInternal.Tree = {}
-  for (const key in tree) {
+  const output: ConfigInternal.Tree = Object.create(null)
+  for (const key of Object.keys(tree)) {
     output[key] = shiftNodeIndexes(tree[key], offset)
   }
   return output
@@ -220,10 +221,7 @@ export const mergeConfig = (
     flags: [...left.flags, ...right.flags],
     arguments: [...left.arguments, ...right.arguments],
     orderedParams: [...left.orderedParams, ...right.orderedParams],
-    tree: {
-      ...left.tree,
-      ...shiftTreeIndexes(right.tree, offset)
-    }
+    tree: Object.assign(Object.create(null), left.tree, shiftTreeIndexes(right.tree, offset))
   }
 }
 
@@ -245,8 +243,8 @@ export const reconstructTree = (
 ): Record<string, any> => {
   const output: Record<string, any> = {}
 
-  for (const key in tree) {
-    output[key] = nodeValue(tree[key])
+  for (const key of Object.keys(tree)) {
+    InternalRecord.assignProperty(output, key, nodeValue(tree[key]))
   }
 
   return output

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -349,7 +349,7 @@ const Proto = {
           ),
           Stream.unwrap
         )
-      const handlers: Record<string, any> = {}
+      const handlers: Record<string, any> = Object.create(null)
       for (const rpc_ of this.protocol.requests.values()) {
         const rpc = rpc_ as any as Rpc.AnyWithProps
         handlers[rpc._tag] = RpcSchema.isStreamSchema(rpc.successSchema) ? streamHandler : handler

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -23,6 +23,7 @@ import * as Fiber from "../../Fiber.ts"
 import * as FiberMap from "../../FiberMap.ts"
 import { constant, flow } from "../../Function.ts"
 import * as HashRing from "../../HashRing.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Latch from "../../Latch.ts"
 import * as Layer from "../../Layer.ts"
 import * as MutableHashMap from "../../MutableHashMap.ts"
@@ -1167,12 +1168,14 @@ const make = Effect.gen(function*() {
             return entity.protocol.requests.has(p as string)
           },
           get(target, p) {
-            if (p in target) {
+            if (Object.hasOwn(target, p)) {
               return target[p]
             } else if (!entity.protocol.requests.has(p as string)) {
               return undefined
             }
-            return target[p] = (payload: any, options?: {}) => clientFn(p as string, payload, options)
+            const method = (payload: any, options?: {}) => clientFn(p as string, payload, options)
+            InternalRecord.assignProperty(target, p, method)
+            return method
           }
         })
       }

--- a/packages/effect/src/unstable/eventlog/EventLog.ts
+++ b/packages/effect/src/unstable/eventlog/EventLog.ts
@@ -13,6 +13,7 @@ import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import * as FiberMap from "../../FiberMap.ts"
 import { constant, identity } from "../../Function.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Layer from "../../Layer.ts"
 import type { Pipeable } from "../../Pipeable.ts"
 import { pipeArguments } from "../../Pipeable.ts"
@@ -159,7 +160,9 @@ export const layerRegistry = Layer.effect(
       },
       registerReactivity: (keys) =>
         Effect.sync(() => {
-          Object.assign(reactivityKeys, keys)
+          for (const [key, value] of Object.entries(keys)) {
+            InternalRecord.assignProperty(reactivityKeys, key, value)
+          }
         }),
       reactivityKeys
     })
@@ -498,7 +501,7 @@ const handlersProto = {
       handlers: {
         ...this.handlers,
         [tag]: {
-          event: this.group.events[tag],
+          event: Object.hasOwn(this.group.events, tag) ? this.group.events[tag] : undefined!,
           context: this.context,
           handler
         }
@@ -547,7 +550,7 @@ export const group = <Events extends Event.Any, Return>(
       const handlers = Effect.isEffect(result)
         ? (yield* (result as unknown as Effect.Effect<Handlers<any>>))
         : (result as unknown as Handlers<any>)
-      for (const tag in handlers.handlers) {
+      for (const tag of Object.keys(handlers.handlers)) {
         registry.registerHandlerUnsafe({ event: tag, handler: handlers.handlers[tag] })
       }
     })
@@ -584,7 +587,7 @@ export const groupCompaction = <Events extends Event.Any, R>(
       yield* registry.registerCompaction({
         events: Object.keys(group.events),
         effect: Effect.fnUntraced(function*({ entries, write }): Effect.fn.Return<void> {
-          const isEventTag = (tag: string): tag is Event.Tag<Events> => tag in group.events
+          const isEventTag = (tag: string): tag is Event.Tag<Events> => Object.hasOwn(group.events, tag)
           const decodePayload = <Tag extends Event.Tag<Events>>(tag: Tag, payload: Uint8Array) =>
             Schema.decodeUnknownEffect(group.events[tag].payloadMsgPack)(payload).pipe(
               Effect.updateContext((input) => Context.merge(services, input)),
@@ -595,7 +598,7 @@ export const groupCompaction = <Events extends Event.Any, R>(
             tag: Tag,
             payload: Event.PayloadWithTag<Events, Tag>
           ): Effect.fn.Return<void, never, Event.PayloadSchemaWithTag<Events, Tag>["EncodingServices"]> {
-            const event = group.events[tag]
+            const event = Object.hasOwn(group.events, tag) ? group.events[tag] : undefined!
             const entry = new Entry({
               id: makeEntryIdUnsafe({ msecs: timestamp }),
               event: tag,
@@ -674,8 +677,8 @@ export const groupReactivity = <Events extends Event.Any>(
       yield* registry.registerReactivity(keys as Record.ReadonlyRecord<string, ReadonlyArray<string>>)
       return
     }
-    const obj: Record<string, ReadonlyArray<string>> = {}
-    for (const tag in group.events) {
+    const obj: Record<string, ReadonlyArray<string>> = Object.create(null)
+    for (const tag of Object.keys(group.events)) {
       obj[tag] = keys
     }
     yield* registry.registerReactivity(obj)
@@ -741,7 +744,9 @@ export const makeReplayFromRemote = (options: {
         Effect.asVoid
       ) as any
 
-      const keys = options.reactivityKeys[entry.event]
+      const keys = Object.hasOwn(options.reactivityKeys, entry.event)
+        ? options.reactivityKeys[entry.event]
+        : undefined
       if (keys) {
         for (const key of keys) {
           options.reactivity.invalidateUnsafe({
@@ -780,7 +785,9 @@ const make = Effect.gen(function*() {
   const invalidateReactivityEntries = (entries: ReadonlyArray<Entry>) =>
     Effect.sync(() => {
       for (const entry of entries) {
-        const keys = registry.reactivityKeys[entry.event]
+        const keys = Object.hasOwn(registry.reactivityKeys, entry.event)
+          ? registry.reactivityKeys[entry.event]
+          : undefined
         if (!keys) {
           continue
         }
@@ -903,8 +910,11 @@ const make = Effect.gen(function*() {
           Effect.updateContext((input) => Context.merge(handler.context, input)),
           Effect.provideService(Identity, identity),
           Effect.tap(() => {
-            if (registry.reactivityKeys[entry.event]) {
-              for (const key of registry.reactivityKeys[entry.event]) {
+            const keys = Object.hasOwn(registry.reactivityKeys, entry.event)
+              ? registry.reactivityKeys[entry.event]
+              : undefined
+            if (keys) {
+              for (const key of keys) {
                 reactivity.invalidateUnsafe({
                   [key]: [entry.primaryKey]
                 })

--- a/packages/effect/src/unstable/http/Cookies.ts
+++ b/packages/effect/src/unstable/http/Cookies.ts
@@ -13,6 +13,7 @@ import * as Data from "../../Data.ts"
 import * as Duration from "../../Duration.ts"
 import { dual } from "../../Function.ts"
 import * as Inspectable from "../../Inspectable.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Option from "../../Option.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
@@ -252,7 +253,7 @@ export const fromReadonlyRecord = (cookies: Record.ReadonlyRecord<string, Cookie
 export const fromIterable = (cookies: Iterable<Cookie>): Cookies => {
   const record: Record<string, Cookie> = {}
   for (const cookie of cookies) {
-    record[cookie.name] = cookie
+    InternalRecord.assignProperty(record, cookie.name, cookie)
   }
   return fromReadonlyRecord(record)
 }
@@ -527,7 +528,7 @@ export const setAllCookie: {
 } = dual(2, (self: Cookies, cookies: Iterable<Cookie>) => {
   const record = { ...self.cookies }
   for (const cookie of cookies) {
-    record[cookie.name] = cookie
+    InternalRecord.assignProperty(record, cookie.name, cookie)
   }
   return fromReadonlyRecord(record)
 })
@@ -569,7 +570,8 @@ export const get: {
   (self: Cookies, name: string): Option.Option<Cookie>
 } = dual(
   (args) => isCookies(args[0]),
-  (self: Cookies, name: string): Option.Option<Cookie> => Option.fromUndefinedOr(self.cookies[name])
+  (self: Cookies, name: string): Option.Option<Cookie> =>
+    Option.fromUndefinedOr(Object.hasOwn(self.cookies, name) ? self.cookies[name] : undefined)
 )
 
 /**
@@ -743,7 +745,7 @@ export const setAll: {
       if (Result.isFailure(result)) {
         return result as Result.Failure<never, CookiesError>
       }
-      record[name] = result.success
+      InternalRecord.assignProperty(record, name, result.success)
     }
     return Result.succeed(fromReadonlyRecord(record))
   }
@@ -866,7 +868,7 @@ export const toRecord = (self: Cookies): Record<string, string> => {
   const cookies = Object.values(self.cookies)
   for (let index = 0; index < cookies.length; index++) {
     const cookie = cookies[index]
-    record[cookie.name] = cookie.value
+    InternalRecord.assignProperty(record, cookie.name, cookie.value)
   }
   return record
 }
@@ -927,14 +929,16 @@ export function parseHeader(header: string): Record<string, string> {
     }
 
     const key = header.substring(pos, eqIdx++).trim()
-    if (result[key] === undefined) {
+    if (!Object.hasOwn(result, key)) {
       const val = header.charCodeAt(eqIdx) === 0x22
         ? header.substring(eqIdx + 1, terminatorPos - 1).trim()
         : header.substring(eqIdx, terminatorPos).trim()
 
-      result[key] = !(val.indexOf("%") === -1)
-        ? tryDecodeURIComponent(val)
-        : val
+      InternalRecord.assignProperty(
+        result,
+        key,
+        !(val.indexOf("%") === -1) ? tryDecodeURIComponent(val) : val
+      )
     }
 
     pos = terminatorPos + 1

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -16,6 +16,7 @@ import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import type * as FileSystem from "../../FileSystem.ts"
 import * as Inspectable from "../../Inspectable.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Option from "../../Option.ts"
 import type * as Path from "../../Path.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
@@ -145,15 +146,15 @@ export class ParsedSearchParams extends Context.Service<
 export const searchParamsFromURL = (url: URL): ReadonlyRecord<string, string | Array<string>> => {
   const out: Record<string, string | Array<string>> = {}
   for (const [key, value] of url.searchParams.entries()) {
-    const entry = out[key]
-    if (entry !== undefined) {
+    if (Object.hasOwn(out, key)) {
+      const entry = out[key]
       if (Array.isArray(entry)) {
         entry.push(value)
       } else {
-        out[key] = [entry, value]
+        InternalRecord.assignProperty(out, key, [entry, value])
       }
     } else {
-      out[key] = value
+      InternalRecord.assignProperty(out, key, value)
     }
   }
   return out

--- a/packages/effect/src/unstable/http/UrlParams.ts
+++ b/packages/effect/src/unstable/http/UrlParams.ts
@@ -16,6 +16,7 @@ import { dual } from "../../Function.ts"
 import * as Hash from "../../Hash.ts"
 import type { Inspectable } from "../../Inspectable.ts"
 import { PipeInspectableProto } from "../../internal/core.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Option from "../../Option.ts"
 import type { Pipeable } from "../../Pipeable.ts"
 import { hasProperty } from "../../Predicate.ts"
@@ -487,13 +488,15 @@ export const toString = (input: Input): string => new URLSearchParams(fromInput(
 export const toRecord = (self: UrlParams): Record<string, string | Arr.NonEmptyArray<string>> => {
   const out: Record<string, string | Arr.NonEmptyArray<string>> = {}
   for (const [k, value] of self.params) {
-    const curr = out[k]
-    if (curr === undefined) {
-      out[k] = value
-    } else if (typeof curr === "string") {
-      out[k] = [curr, value]
+    if (!Object.hasOwn(out, k)) {
+      InternalRecord.assignProperty(out, k, value)
     } else {
-      curr.push(value)
+      const current = out[k]
+      if (typeof current === "string") {
+        InternalRecord.assignProperty(out, k, [current, value])
+      } else {
+        current.push(value)
+      }
     }
   }
   return out

--- a/packages/effect/src/unstable/httpapi/HttpApi.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApi.ts
@@ -157,7 +157,7 @@ const Proto = {
     api: Top
   ) {
     const newGroups = { ...this.groups }
-    for (const key in api.groups) {
+    for (const key of Object.keys(api.groups)) {
       const group = api.groups[key]
       InternalRecord.assignProperty(
         newGroups,

--- a/packages/effect/src/unstable/httpapi/HttpApi.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApi.ts
@@ -145,7 +145,7 @@ const Proto = {
   ) {
     const groups = { ...this.groups }
     for (const group of toAdd) {
-      InternalRecord.set(groups, group.identifier, group)
+      InternalRecord.assignProperty(groups, group.identifier, group)
     }
     return makeProto({
       ...optionsFromApi(this),
@@ -159,7 +159,7 @@ const Proto = {
     const newGroups = { ...this.groups }
     for (const key in api.groups) {
       const group = api.groups[key]
-      InternalRecord.set(
+      InternalRecord.assignProperty(
         newGroups,
         key,
         group.annotateMerge(Context.merge(api.annotations, group.annotations))

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -520,10 +520,10 @@ export const makeWith = <ApiId extends string, Groups extends HttpApiGroup.Const
     ...options,
     onGroup({ group }) {
       if (group.topLevel) return
-      InternalRecord.set(client, group.identifier, {})
+      InternalRecord.assignProperty(client, group.identifier, {})
     },
     onEndpoint({ endpoint, endpointFn, group }) {
-      InternalRecord.set(
+      InternalRecord.assignProperty(
         group.topLevel ? client : client[group.identifier],
         endpoint.identifier,
         endpointFn
@@ -565,7 +565,7 @@ export const group = <
     ...options,
     predicate: ({ group }) => group.identifier === options.group,
     onEndpoint({ endpoint, endpointFn }) {
-      InternalRecord.set(client, endpoint.identifier, endpointFn)
+      InternalRecord.assignProperty(client, endpoint.identifier, endpointFn)
     }
   }).pipe(Effect.map(() => client)) as any
 }
@@ -662,7 +662,7 @@ export const urlBuilder = <Api extends HttpApi.Constraint>(api: Api, options?: {
   HttpApi.reflect(api as unknown as HttpApi.Top, {
     onGroup({ group }) {
       if (group.topLevel) return
-      InternalRecord.set(builder, group.identifier, {})
+      InternalRecord.assignProperty(builder, group.identifier, {})
     },
     onEndpoint({ group, endpoint }) {
       const makeUrl = compilePath(endpoint.path)
@@ -688,7 +688,7 @@ export const urlBuilder = <Api extends HttpApi.Constraint>(api: Api, options?: {
         const url = query === "" ? path : `${path}?${query}`
         return options?.baseUrl === undefined ? url : new URL(url, options.baseUrl.toString()).toString()
       }
-      InternalRecord.set(
+      InternalRecord.assignProperty(
         group.topLevel ? builder : builder[group.identifier],
         endpoint.identifier,
         endpointBuilder

--- a/packages/effect/src/unstable/httpapi/HttpApiGroup.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiGroup.ts
@@ -308,7 +308,7 @@ const Proto = {
   add(this: Top, ...toAdd: NonEmptyReadonlyArray<HttpApiEndpoint.Top>) {
     const endpoints = { ...this.endpoints }
     for (const endpoint of toAdd) {
-      InternalRecord.set(endpoints, endpoint.identifier, endpoint)
+      InternalRecord.assignProperty(endpoints, endpoint.identifier, endpoint)
     }
     return makeProto({
       ...optionsFromGroup(this),

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -338,6 +338,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
         tag.externalDocs = externalDocs
       })
       processAnnotation(group.annotations, Override, (override) => {
+        // OpenAPI documents are JSON, so symbol keys are intentionally ignored.
         for (const [key, value] of Object.entries(override)) {
           InternalRecord.assignProperty(tag as any, key, value)
         }
@@ -574,6 +575,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       )
 
       processAnnotation(endpoint.annotations, Override, (override) => {
+        // OpenAPI documents are JSON, so symbol keys are intentionally ignored.
         for (const [key, value] of Object.entries(override)) {
           InternalRecord.assignProperty(op as any, key, value)
         }
@@ -652,6 +654,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
   })
 
   processAnnotation(api.annotations, Override, (override) => {
+    // OpenAPI documents are JSON, so symbol keys are intentionally ignored.
     for (const [key, value] of Object.entries(override)) {
       InternalRecord.assignProperty(spec as any, key, value)
     }

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -338,7 +338,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
         tag.externalDocs = externalDocs
       })
       processAnnotation(group.annotations, Override, (override) => {
-        Object.assign(tag, override)
+        for (const [key, value] of Object.entries(override)) {
+          InternalRecord.assignProperty(tag as any, key, value)
+        }
       })
       processAnnotation(group.annotations, Transform, (transformFn) => {
         tag = transformFn(tag) as OpenAPISpecTag
@@ -368,9 +370,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       function processResponseBodies(bodies: ResponseBodies, defaultDescription: () => string) {
         for (const [status, { content, descriptions, streamContent }] of bodies) {
           const description = descriptions.size > 0 ? Array.from(descriptions).join(" | ") : defaultDescription()
-          op.responses[status] = {
+          InternalRecord.assignProperty(op.responses, status, {
             description
-          }
+          })
           if (content !== undefined) {
             content.forEach((map, encoding) => {
               map.forEach((schemas, contentType) => {
@@ -383,9 +385,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
                   path: ["paths", path, method, "responses", String(status), "content", contentType, "schema"]
                 })
                 op.responses[status].content ??= {}
-                op.responses[status].content[contentType] = {
+                InternalRecord.assignProperty(op.responses[status].content, contentType, {
                   schema: {}
-                }
+                })
               })
             })
           }
@@ -428,7 +430,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
                     "errorSchema"
                   ]
                 })
-                op.responses[status].content[contentType] = {
+                InternalRecord.assignProperty(op.responses[status].content, contentType, {
                   schema: {},
                   "x-effect-stream": {
                     encoding: "sse",
@@ -436,9 +438,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
                     errorSchema: {},
                     failureEvent: reservedStreamFailureEvent
                   }
-                }
+                })
               } else {
-                op.responses[status].content[contentType] = {
+                InternalRecord.assignProperty(op.responses[status].content, contentType, {
                   schema: {
                     type: "string",
                     format: "binary"
@@ -446,7 +448,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
                   "x-effect-stream": {
                     encoding: "uint8array"
                   }
-                }
+                })
               }
             })
           }
@@ -503,7 +505,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       ) {
         const scheme = makeSecurityScheme(security)
         if (!Object.hasOwn(spec.components.securitySchemes, name)) {
-          InternalRecord.set(spec.components.securitySchemes, name, scheme)
+          InternalRecord.assignProperty(spec.components.securitySchemes, name, scheme)
           return
         }
         if (
@@ -542,9 +544,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
               ast: toEncodingAST(ast, encoding._tag),
               path: ["paths", path, method, "requestBody", "content", contentType, "schema"]
             })
-            content[contentType] = {
+            InternalRecord.assignProperty(content, contentType, {
               schema: {}
-            }
+            })
           }
           op.requestBody = { content, required: true }
         }
@@ -572,7 +574,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       )
 
       processAnnotation(endpoint.annotations, Override, (override) => {
-        Object.assign(op, override)
+        for (const [key, value] of Object.entries(override)) {
+          InternalRecord.assignProperty(op as any, key, value)
+        }
       })
       processAnnotation(endpoint.annotations, Transform, (transformFn) => {
         op = transformFn(op) as OpenAPISpecOperation
@@ -590,8 +594,8 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
         operationIds.add(operationId)
       }
       pathOperations.add(pathOperation)
-      if (!spec.paths[path]) {
-        spec.paths[path] = {}
+      if (!Object.hasOwn(spec.paths, path)) {
+        InternalRecord.assignProperty(spec.paths, path, {})
       }
       spec.paths[path][method] = op
     }
@@ -601,10 +605,10 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
     componentSchemas.forEach((componentSchema) => {
       const identifier = SchemaAST.resolveIdentifier(componentSchema.ast)
       if (identifier !== undefined) {
-        if (identifier in spec.components.schemas) {
+        if (Object.hasOwn(spec.components.schemas, identifier)) {
           throw new globalThis.Error(`Duplicate component schema identifier: ${identifier}`)
         }
-        spec.components.schemas[identifier] = {}
+        InternalRecord.assignProperty(spec.components.schemas, identifier, {})
         pathOps.push({
           _tag: "schema",
           ast: componentSchema.ast,
@@ -648,7 +652,9 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
   })
 
   processAnnotation(api.annotations, Override, (override) => {
-    Object.assign(spec, override)
+    for (const [key, value] of Object.entries(override)) {
+      InternalRecord.assignProperty(spec as any, key, value)
+    }
   })
   processAnnotation(api.annotations, Transform, (transformFn) => {
     spec = transformFn(spec) as OpenAPISpec

--- a/packages/effect/src/unstable/persistence/Persistable.ts
+++ b/packages/effect/src/unstable/persistence/Persistable.ts
@@ -10,6 +10,7 @@
 import type * as Duration from "../../Duration.ts"
 import type * as Effect from "../../Effect.ts"
 import type * as Exit from "../../Exit.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as PrimaryKey from "../../PrimaryKey.ts"
 import * as Request from "../../Request.ts"
 import * as Schema from "../../Schema.ts"
@@ -179,10 +180,10 @@ export const Class = <
     | ("requires" extends keyof Config ? Config["requires"] : never)
   > =>
 {
-  function Persistable(this: any, props: any) {
+  function Persistable(this: any, props: object | undefined) {
     this._tag = tag
     if (props) {
-      Object.assign(this, props)
+      InternalRecord.assignProperties(this, props)
     }
   }
   Persistable.prototype = {

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -186,8 +186,8 @@ export const script = <Params extends ReadonlyArray<any>>(
   params: Params
   result: void
 }> =>
-  Object.assign(Object.create(ScriptProto), {
+  Object.setPrototypeOf({
     ...options,
     params: f,
     numberOfKeys: typeof options.numberOfKeys === "number" ? constant(options.numberOfKeys) : options.numberOfKeys
-  })
+  }, ScriptProto)

--- a/packages/effect/src/unstable/process/ChildProcessSpawner.ts
+++ b/packages/effect/src/unstable/process/ChildProcessSpawner.ts
@@ -200,7 +200,7 @@ const HandleProto = {
  * @since 4.0.0
  */
 export const makeHandle = (params: Omit<ChildProcessHandle, typeof HandleTypeId>): ChildProcessHandle =>
-  Object.assign(Object.create(HandleProto), params)
+  Object.setPrototypeOf({ ...params }, HandleProto)
 
 /**
  * Creates a `ChildProcessSpawner` service from a `spawn` function, deriving

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -17,6 +17,7 @@ import * as Exit from "../../Exit.ts"
 import type { LazyArg } from "../../Function.ts"
 import { constTrue, dual, identity } from "../../Function.ts"
 import * as Hash from "../../Hash.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Option from "../../Option.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import type { Predicate, Refinement } from "../../Predicate.ts"
@@ -694,12 +695,12 @@ export const all = <const Arg extends Iterable<any> | Record<string, any>>(
   for (let i = 0; i < entries.length; i++) {
     const [key, result] = entries[i]
     if (!isAsyncResult(result)) {
-      successes[key] = result
+      InternalRecord.assignProperty(successes, key, result)
       continue
     } else if (!isSuccess(result)) {
       return result as any
     }
-    successes[key] = result.value
+    InternalRecord.assignProperty(successes, key, result.value)
     if (result.waiting) {
       waiting = true
     }

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -18,6 +18,7 @@ import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
 import { constVoid, dual, flow, identity } from "../../Function.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import * as Latch from "../../Latch.ts"
 import * as Layer from "../../Layer.ts"
 import * as Option from "../../Option.ts"
@@ -608,7 +609,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
   } else {
     client = {}
     group.requests.forEach((rpc) => {
-      client[rpc._tag] = onRequest(rpc as any)
+      InternalRecord.assignProperty(client, rpc._tag, onRequest(rpc as any))
     })
   }
 

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -11,6 +11,7 @@
 import type { Brand } from "../../Brand.ts"
 import * as Effect from "../../Effect.ts"
 import { dual } from "../../Function.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
@@ -214,9 +215,9 @@ const extract: {
       readonly isDefault?: boolean | undefined
     }
   ): Extract<V, A> => {
-    const cache = self[cacheSymbol] ?? (self[cacheSymbol] = {})
+    const cache = self[cacheSymbol] ?? (self[cacheSymbol] = Object.create(null))
     const cacheKey = options?.isDefault === true ? "__default" : variant
-    if (cache[cacheKey] !== undefined) {
+    if (Object.hasOwn(cache, cacheKey)) {
       return cache[cacheKey] as any
     }
     const fields: Record<string, any> = {}
@@ -224,19 +225,21 @@ const extract: {
       const value = self[TypeId][key]
       if (TypeId in value) {
         if (options?.isDefault === true && Schema.isSchema(value)) {
-          fields[key] = value
+          InternalRecord.assignProperty(fields, key, value)
         } else {
-          fields[key] = extract(value, variant)
+          InternalRecord.assignProperty(fields, key, extract(value, variant))
         }
       } else if (FieldTypeId in value) {
-        if (variant in value.schemas) {
-          fields[key] = value.schemas[variant]
+        if (Object.hasOwn(value.schemas, variant)) {
+          InternalRecord.assignProperty(fields, key, value.schemas[variant])
         }
       } else {
-        fields[key] = value
+        InternalRecord.assignProperty(fields, key, value)
       }
     }
-    return cache[cacheKey] = Schema.Struct(fields) as any
+    const schema = Schema.Struct(fields)
+    cache[cacheKey] = schema
+    return schema as any
   }
 )
 
@@ -462,7 +465,7 @@ export const make = <
     return function<S extends Schema.Top>(schema: S) {
       const obj: Record<string, S> = {}
       for (const key of keys) {
-        obj[key] = schema
+        InternalRecord.assignProperty(obj, key, schema)
       }
       return Field(obj)
     }
@@ -472,7 +475,7 @@ export const make = <
       const obj: Record<string, S> = {}
       for (const variant of options.variants) {
         if (!keys.includes(variant)) {
-          obj[variant] = schema
+          InternalRecord.assignProperty(obj, variant, schema)
         }
       }
       return Field(obj)

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -17,6 +17,7 @@ import * as Effectable from "../../Effectable.ts"
 import type * as Fiber from "../../Fiber.ts"
 import { constUndefined } from "../../Function.ts"
 import * as internalEffect from "../../internal/effect.ts"
+import * as InternalRecord from "../../internal/record.ts"
 import { hasProperty } from "../../Predicate.ts"
 import { TracerTimingEnabled } from "../../References.ts"
 import * as Stream from "../../Stream.ts"
@@ -1147,7 +1148,7 @@ export const defaultTransforms = (
   const transformObject = (obj: Record<string, any>): any => {
     const newObj: Record<string, any> = {}
     for (const key in obj) {
-      newObj[transformer(key)] = transformValue(obj[key])
+      InternalRecord.assignProperty(newObj, transformer(key), transformValue(obj[key]))
     }
     return newObj
   }
@@ -1163,7 +1164,7 @@ export const defaultTransforms = (
       } else {
         const obj: any = {}
         for (const key in row) {
-          obj[transformer(key)] = transformValue(row[key])
+          InternalRecord.assignProperty(obj, transformer(key), transformValue(row[key]))
         }
         newRows[i] = obj
       }
@@ -1182,7 +1183,7 @@ export const defaultTransforms = (
       } else {
         const obj: any = {}
         for (const key in row) {
-          obj[transformer(key)] = row[key]
+          InternalRecord.assignProperty(obj, transformer(key), row[key])
         }
         newRows[i] = obj
       }

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -1163,9 +1163,8 @@ export const defaultTransforms = (
         newRows[i] = transformArrayNested(row) as any
       } else {
         const obj: any = {}
-        const record = row as Record<string, any>
-        for (const key of Object.keys(record)) {
-          InternalRecord.assignProperty(obj, transformer(key), transformValue(record[key]))
+        for (const [key, value] of Object.entries(row)) {
+          InternalRecord.assignProperty(obj, transformer(key), transformValue(value))
         }
         newRows[i] = obj
       }
@@ -1183,9 +1182,8 @@ export const defaultTransforms = (
         newRows[i] = transformArray(row) as any
       } else {
         const obj: any = {}
-        const record = row as Record<string, any>
-        for (const key of Object.keys(record)) {
-          InternalRecord.assignProperty(obj, transformer(key), record[key])
+        for (const [key, value] of Object.entries(row)) {
+          InternalRecord.assignProperty(obj, transformer(key), value)
         }
         newRows[i] = obj
       }

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -1147,7 +1147,7 @@ export const defaultTransforms = (
 
   const transformObject = (obj: Record<string, any>): any => {
     const newObj: Record<string, any> = {}
-    for (const key in obj) {
+    for (const key of Object.keys(obj)) {
       InternalRecord.assignProperty(newObj, transformer(key), transformValue(obj[key]))
     }
     return newObj
@@ -1163,8 +1163,9 @@ export const defaultTransforms = (
         newRows[i] = transformArrayNested(row) as any
       } else {
         const obj: any = {}
-        for (const key in row) {
-          InternalRecord.assignProperty(obj, transformer(key), transformValue(row[key]))
+        const record = row as Record<string, any>
+        for (const key of Object.keys(record)) {
+          InternalRecord.assignProperty(obj, transformer(key), transformValue(record[key]))
         }
         newRows[i] = obj
       }
@@ -1182,8 +1183,9 @@ export const defaultTransforms = (
         newRows[i] = transformArray(row) as any
       } else {
         const obj: any = {}
-        for (const key in row) {
-          InternalRecord.assignProperty(obj, transformer(key), row[key])
+        const record = row as Record<string, any>
+        for (const key of Object.keys(record)) {
+          InternalRecord.assignProperty(obj, transformer(key), record[key])
         }
         newRows[i] = obj
       }

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -203,6 +203,21 @@ describe("ConfigProvider", () => {
       await assertSuccess(provider, ["missing"], undefined)
     })
 
+    it("does not read inherited environment properties", async () => {
+      const provider = ConfigProvider.fromEnv({ env: {} })
+      await assertSuccess(provider, ["constructor"], undefined)
+    })
+
+    it("does not traverse inherited trie properties", async () => {
+      delete (Object as any).children
+      const provider = ConfigProvider.fromEnv({ env: { constructor_X: "value" } })
+      const polluted = Object.hasOwn(Object, "children")
+      delete (Object as any).children
+
+      deepStrictEqual(polluted, false)
+      await assertSuccess(provider, ["constructor", "X"], ConfigProvider.makeValue("value"))
+    })
+
     it("treats empty string values as missing while preserving structure by default", async () => {
       const env = { A: "", B: "value1" }
       const provider = ConfigProvider.fromEnv({ env })
@@ -676,6 +691,13 @@ DB_PASS=$PASSWORD
       await assertSuccess(provider, [], ConfigProvider.makeRecord(new Set(["PASSWORD", "DB"])))
       await assertSuccess(provider, ["PASSWORD"], ConfigProvider.makeValue("value"))
       await assertSuccess(provider, ["DB_PASS"], ConfigProvider.makeValue("value"))
+    })
+
+    it("does not expand missing inherited variables", async () => {
+      const provider = ConfigProvider.fromDotEnvContents("VALUE=$constructor", {
+        expandVariables: true
+      })
+      await assertSuccess(provider, ["VALUE"], undefined)
     })
   })
 

--- a/packages/effect/test/JsonSchema.test.ts
+++ b/packages/effect/test/JsonSchema.test.ts
@@ -3,6 +3,20 @@ import { deepStrictEqual } from "@effect/vitest/utils"
 import * as JsonSchema from "effect/JsonSchema"
 
 describe("JsonSchema", () => {
+  describe("resolve$ref", () => {
+    it("ignores inherited definitions", () => {
+      deepStrictEqual(JsonSchema.resolve$ref("#/$defs/constructor", {}), undefined)
+    })
+
+    it("resolves __proto__ when it is an own definition", () => {
+      const definition: JsonSchema.JsonSchema = { type: "string" }
+      deepStrictEqual(
+        JsonSchema.resolve$ref("#/$defs/__proto__", { ["__proto__"]: definition }),
+        definition
+      )
+    })
+  })
+
   describe("sanitizeOpenApiComponentsKey", () => {
     const sanitizeOpenApiComponentsKey = JsonSchema.sanitizeOpenApiComponentsSchemasKey
 

--- a/packages/effect/test/Record.test.ts
+++ b/packages/effect/test/Record.test.ts
@@ -1,4 +1,4 @@
-import { assertFalse, assertNone, assertSome, assertTrue, deepStrictEqual } from "@effect/vitest/utils"
+import { assertFalse, assertNone, assertSome, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Equivalence, Number as Num, Option, Record, Result } from "effect"
 import { pipe } from "effect/Function"
 import { describe, it } from "vitest"
@@ -156,6 +156,20 @@ describe("Record", () => {
         deepStrictEqual(Record.set(stringRecord, "c", 3), { a: 1, [symA]: null, c: 3 })
 
         deepStrictEqual(Record.set(symbolRecord, symC, 3), { [symA]: 1, [symB]: 2, [symC]: 3 })
+      })
+    })
+
+    describe("assignProperty", () => {
+      it("preserves __proto__ as an own property", () => {
+        const record: Record<string, unknown> = {}
+        const prototype = Object.getPrototypeOf(record)
+        const value = { polluted: true }
+
+        Record.assignProperty(record, "__proto__", value)
+
+        strictEqual(Object.getPrototypeOf(record), prototype)
+        assertTrue(Object.hasOwn(record, "__proto__"))
+        strictEqual(record["__proto__"], value)
       })
     })
 

--- a/packages/effect/test/Request.test.ts
+++ b/packages/effect/test/Request.test.ts
@@ -133,6 +133,26 @@ const provideEnv = flow(
 )
 
 describe.sequential("Request", () => {
+  it("preserves __proto__ as an own constructor property", () => {
+    interface ProtoRequest extends Request.Request<void> {
+      readonly "__proto__": { readonly polluted: boolean }
+    }
+    const make = Request.of<ProtoRequest>()
+    const value = { polluted: true }
+    const request = make({ ["__proto__"]: value })
+
+    assert.isTrue(Request.isRequest(request))
+    assert.isTrue(Object.hasOwn(request, "__proto__"))
+    assert.strictEqual(request["__proto__"], value)
+  })
+
+  it("copies enumerable symbol properties in Class", () => {
+    const key = Symbol()
+    class SymbolRequest extends Request.Class<{ readonly [key]: string }, void> {}
+
+    assert.strictEqual(new SymbolRequest({ [key]: "value" })[key], "value")
+  })
+
   it("compares StructuralProto values when hashes collide", () => {
     class Req extends Request.Class<{ id: string; account: string }, string> {}
 

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3325,6 +3325,17 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
   })
 
   describe("make", () => {
+    it("preserves __proto__ as an own option", () => {
+      const value = { polluted: true }
+      const schema = Schema.make(Schema.String.ast, {
+        ["__proto__"]: value
+      })
+
+      assertTrue(Schema.isSchema(schema))
+      assertTrue(Object.hasOwn(schema, "__proto__"))
+      strictEqual((schema as any)["__proto__"], value)
+    })
+
     it("should throw an error when the cause contains both a schema issue and a defect", () => {
       const cause = Cause.combine(
         Cause.fail(new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" }))),

--- a/packages/effect/test/unstable/cli/Param.test.ts
+++ b/packages/effect/test/unstable/cli/Param.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Config, ConfigProvider, Effect, FileSystem, Layer, Option, Path, Ref, Stdio } from "effect"
 import { TestConsole } from "effect/testing"
-import { Argument, CliError, Flag, Prompt } from "effect/unstable/cli"
+import { Argument, CliError, Flag, Param, Primitive, Prompt } from "effect/unstable/cli"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import * as MockTerminal from "./services/MockTerminal.ts"
 
@@ -25,6 +25,20 @@ const TestLayer = Layer.mergeAll(
 )
 
 describe("Param", () => {
+  it("preserves __proto__ as an own makeSingle option", () => {
+    const value = { polluted: true }
+    const param = Param.makeSingle({
+      ["__proto__"]: value,
+      kind: Param.flagKind,
+      name: "name",
+      primitiveType: Primitive.string
+    } as any)
+
+    assert.isTrue(Param.isParam(param))
+    assert.isTrue(Object.hasOwn(param, "__proto__"))
+    assert.strictEqual((param as any)["__proto__"], value)
+  })
+
   describe("optional", () => {
     it.effect("returns none when an optional boolean flag is omitted", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/unstable/http/Cookies.test.ts
+++ b/packages/effect/test/unstable/http/Cookies.test.ts
@@ -76,5 +76,6 @@ describe("Cookies", () => {
     assertSome(Cookies.getValue(cookies, "session"), "abc")
     assertNone(Cookies.get(cookies, "missing"))
     assertNone(Cookies.getValue(cookies, "missing"))
+    assertNone(Cookies.get(Cookies.empty, "constructor"))
   })
 })

--- a/packages/effect/test/unstable/httpapi/HttpApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApi.test.ts
@@ -51,6 +51,17 @@ describe("HttpApi", () => {
     assert.strictEqual(Context.getUnsafe(parent.groups.users.annotations, OpenApi.Description), "Child API")
   })
 
+  it("does not add inherited groups", () => {
+    const inherited = HttpApiGroup.make("inherited")
+    const child = HttpApi.make("Child").add(HttpApiGroup.make("own"))
+    Object.setPrototypeOf(child.groups, { inherited })
+
+    const parent = HttpApi.make("Parent").addHttpApi(child)
+
+    assert.isTrue(Object.hasOwn(parent.groups, "own"))
+    assert.isFalse(Object.hasOwn(parent.groups, "inherited"))
+  })
+
   it("keeps annotations from API variants isolated", () => {
     const group = HttpApiGroup.make("users").annotate(OpenApi.Title, "Users")
     const child = HttpApi.make("Child").add(group)

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -3,6 +3,18 @@ import { Effect } from "effect"
 import { Redis } from "effect/unstable/persistence"
 
 describe("Redis", () => {
+  it("preserves __proto__ as an own script option", () => {
+    const value = { polluted: true }
+    const script = Redis.script(() => [], {
+      ["__proto__"]: value,
+      lua: "return nil",
+      numberOfKeys: 0
+    } as any)
+
+    assert.isTrue(Object.hasOwn(script, "__proto__"))
+    assert.strictEqual((script as any)["__proto__"], value)
+  })
+
   it.effect("retries script loading when SCRIPT LOAD fails", () =>
     Effect.gen(function*() {
       const commands: Array<readonly [command: string, args: ReadonlyArray<string>]> = []

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -6,11 +6,12 @@ describe("Statement", () => {
     const row = Object.create({ inherited: 1 })
     row.own = 2
 
-    const nested = Statement.defaultTransforms((key) => key)
-    const flat = Statement.defaultTransforms((key) => key, false)
+    const nested = Statement.defaultTransforms((key) => key.toUpperCase())
+    const flat = Statement.defaultTransforms((key) => key.toUpperCase(), false)
 
-    assert.deepStrictEqual(nested.object(row), { own: 2 })
-    assert.deepStrictEqual(nested.array([row]), [{ own: 2 }])
-    assert.deepStrictEqual(flat.array([row]), [{ own: 2 }])
+    assert.deepStrictEqual(nested.object(row), { OWN: 2 })
+    assert.deepStrictEqual(nested.array([row]), [{ OWN: 2 }])
+    assert.deepStrictEqual(nested.array([[row]]), [[{ OWN: 2 }]])
+    assert.deepStrictEqual(flat.array([row]), [{ OWN: 2 }])
   })
 })

--- a/packages/effect/test/unstable/sql/Statement.test.ts
+++ b/packages/effect/test/unstable/sql/Statement.test.ts
@@ -1,0 +1,16 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Statement from "effect/unstable/sql/Statement"
+
+describe("Statement", () => {
+  it("defaultTransforms ignores inherited properties", () => {
+    const row = Object.create({ inherited: 1 })
+    row.own = 2
+
+    const nested = Statement.defaultTransforms((key) => key)
+    const flat = Statement.defaultTransforms((key) => key, false)
+
+    assert.deepStrictEqual(nested.object(row), { own: 2 })
+    assert.deepStrictEqual(nested.array([row]), [{ own: 2 }])
+    assert.deepStrictEqual(flat.array([row]), [{ own: 2 }])
+  })
+})

--- a/packages/opentelemetry/src/OtelLogger.ts
+++ b/packages/opentelemetry/src/OtelLogger.ts
@@ -21,6 +21,7 @@ import * as Layer from "effect/Layer"
 import * as Logger from "effect/Logger"
 import type * as LogLevel from "effect/LogLevel"
 import * as Predicate from "effect/Predicate"
+import * as Rec from "effect/Record"
 import * as References from "effect/References"
 import * as Tracer from "effect/Tracer"
 import { nanosToHrTime, unknownToAttributeValue } from "./internal/attributes.ts"
@@ -98,7 +99,7 @@ export const make: Effect.Effect<
     }
 
     for (const [key, value] of Object.entries(options.fiber.getRef(References.CurrentLogAnnotations))) {
-      attributes[key] = unknownToAttributeValue(value)
+      Rec.assignProperty(attributes, key, unknownToAttributeValue(value))
     }
     const now = options.date.getTime()
     for (const [label, startTime] of options.fiber.getRef(References.CurrentLogSpans)) {

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -129,12 +129,10 @@ export const layerFromEnv = (
       if (serviceName._tag === "Some") {
         attributes[OtelSemConv.ATTR_SERVICE_NAME] = serviceName.value
       }
-      if (additionalAttributes) {
-        for (const [key, value] of Object.entries(additionalAttributes)) {
-          Rec.assignProperty(attributes, key, value)
-        }
-      }
-      return Resources.resourceFromAttributes(attributes)
+      return Resources.resourceFromAttributes({
+        ...attributes,
+        ...additionalAttributes
+      })
     }).pipe(Effect.orDie)
   )
 

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -18,6 +18,7 @@ import * as Config from "effect/Config"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
+import * as Rec from "effect/Record"
 
 /**
  * Service tag for OpenTelemetry metadata attached to emitted telemetry.
@@ -120,7 +121,7 @@ export const layerFromEnv = (
             if (parts.length !== 2) {
               return acc
             }
-            acc[parts[0].trim()] = parts[1].trim()
+            Rec.assignProperty(acc, parts[0].trim(), parts[1].trim())
             return acc
           })
         })
@@ -129,7 +130,9 @@ export const layerFromEnv = (
         attributes[OtelSemConv.ATTR_SERVICE_NAME] = serviceName.value
       }
       if (additionalAttributes) {
-        Object.assign(attributes, additionalAttributes)
+        for (const [key, value] of Object.entries(additionalAttributes)) {
+          Rec.assignProperty(attributes, key, value)
+        }
       }
       return Resources.resourceFromAttributes(attributes)
     }).pipe(Effect.orDie)

--- a/packages/opentelemetry/src/internal/attributes.ts
+++ b/packages/opentelemetry/src/internal/attributes.ts
@@ -1,5 +1,6 @@
 import type * as Otel from "@opentelemetry/api"
 import * as Inspectable from "effect/Inspectable"
+import * as Rec from "effect/Record"
 
 const bigint1e9 = BigInt(1_000_000_000)
 
@@ -12,7 +13,7 @@ export const nanosToHrTime = (timestamp: bigint): Otel.HrTime => {
 export const recordToAttributes = (record: Record<string, unknown>): Otel.Attributes => {
   const attributes: Otel.Attributes = {}
   for (const [key, value] of Object.entries(record)) {
-    attributes[key] = unknownToAttributeValue(value)
+    Rec.assignProperty(attributes, key, unknownToAttributeValue(value))
   }
   return attributes
 }

--- a/packages/opentelemetry/src/internal/metrics.ts
+++ b/packages/opentelemetry/src/internal/metrics.ts
@@ -13,6 +13,7 @@ import type { InstrumentDescriptor } from "@opentelemetry/sdk-metrics/build/src/
 import * as Arr from "effect/Array"
 import type * as Context from "effect/Context"
 import * as Metric from "effect/Metric"
+import * as Rec from "effect/Record"
 import type * as Metrics from "../OtelMetrics.ts"
 
 const sdkName = "@effect/opentelemetry/Metrics"
@@ -94,7 +95,7 @@ export class MetricProducerImpl implements MetricProducer {
       const state = snapshot[i]
       const attributes = state.attributes
         ? Arr.reduce(Object.entries(state.attributes), {} as Record<string, string>, (acc, [key, value]) => {
-          acc[key] = String(value)
+          Rec.assignProperty(acc, key, String(value))
           return acc
         })
         : {}

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -19,6 +19,7 @@ import * as Effect from "effect/Effect"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Pool from "effect/Pool"
+import * as Rec from "effect/Record"
 import * as Redacted from "effect/Redacted"
 import * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
@@ -409,7 +410,7 @@ export const make = (
           }
 
           req.on("returnValue", (name, value) => {
-            result[name] = value
+            Rec.assignProperty(result, name, value)
           })
 
           conn.cancel()
@@ -738,7 +739,7 @@ function rowsToObjects(rows: ReadonlyArray<any>) {
     const newRow: any = {}
     for (let j = 0, columnLen = row.length; j < columnLen; j++) {
       const column = row[j]
-      newRow[column.metadata.colName] = column.value
+      Rec.assignProperty(newRow, column.metadata.colName, column.value)
     }
     newRows[i] = newRow
   }

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -28,6 +28,7 @@ import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
+import * as Rec from "effect/Record"
 import * as Scope from "effect/Scope"
 import * as Semaphore from "effect/Semaphore"
 import * as Stream from "effect/Stream"
@@ -199,7 +200,7 @@ export const make = (
           const obj: any = {}
           for (let i = 0; i < columns.length; i++) {
             const value = result[i]
-            obj[columns[i]] = value instanceof ArrayBuffer ? new Uint8Array(value) : value
+            Rec.assignProperty(obj, columns[i], value instanceof ArrayBuffer ? new Uint8Array(value) : value)
           }
           yield obj
         }

--- a/packages/sql/sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteClient.ts
@@ -24,6 +24,7 @@ import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
+import * as Rec from "effect/Record"
 import * as Scope from "effect/Scope"
 import * as ScopedRef from "effect/ScopedRef"
 import * as Semaphore from "effect/Semaphore"
@@ -183,7 +184,7 @@ export const makeMemory = (
                 if (rowMode === "object") {
                   const obj: Record<string, any> = {}
                   for (let i = 0; i < columns.length; i++) {
-                    obj[columns[i]] = row[i]
+                    Rec.assignProperty(obj, columns[i], row[i])
                   }
                   results.push(obj)
                 } else {
@@ -224,7 +225,7 @@ export const makeMemory = (
                 const row = sqlite3.row(stmt)
                 const obj: Record<string, any> = {}
                 for (let i = 0; i < columns.length; i++) {
-                  obj[columns[i]] = row[i]
+                  Rec.assignProperty(obj, columns[i], row[i])
                 }
                 yield obj
               }
@@ -456,7 +457,7 @@ export const make = (
 function rowToObject(columns: Array<string>, row: Array<any>) {
   const obj: Record<string, any> = {}
   for (let i = 0; i < columns.length; i++) {
-    obj[columns[i]] = row[i]
+    Rec.assignProperty(obj, columns[i], row[i])
   }
   return obj
 }

--- a/packages/tools/docgen/src/Domain.ts
+++ b/packages/tools/docgen/src/Domain.ts
@@ -8,6 +8,7 @@ import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Order from "effect/Order"
+import * as Rec from "effect/Record"
 import * as String from "effect/String"
 import type * as Parser from "./Parser.ts"
 
@@ -319,7 +320,7 @@ export class Process extends Context.Service<Process, {
     env: Effect.sync(() => {
       const env: Record<string, string> = {}
       for (const [key, value] of Object.entries(process.env)) {
-        if (value !== undefined) env[key] = value
+        if (value !== undefined) Rec.assignProperty(env, key, value)
       }
       return env
     })

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -54,10 +54,10 @@ export function make() {
 }
 
 function makeWithRepresentation() {
-  const store: Record<string, JsonSchema.JsonSchema> = {}
+  const store = Object.create(null) as Record<string, JsonSchema.JsonSchema>
 
   function addSchema(name: string, schema: JsonSchema.JsonSchema): string {
-    if (name in store) {
+    if (Object.hasOwn(store, name)) {
       throw new Error(`Schema ${name} already exists`)
     }
     store[name] = schema

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -745,14 +745,14 @@ const buildParameterSchema = <
 
       for (const [name, propertySchema] of Object.entries(paramSchema.properties)) {
         const adjustedName = `${parameter.name}[${name}]`
-        schema.properties[adjustedName] = propertySchema as JsonSchema.JsonSchema
+        Rec.assignProperty(schema.properties, adjustedName, propertySchema as JsonSchema.JsonSchema)
         if (required.includes(name)) {
           schema.required.push(adjustedName)
         }
         added.push(adjustedName)
       }
     } else {
-      schema.properties[parameter.name] = parameter.schema as JsonSchema.JsonSchema
+      Rec.assignProperty(schema.properties, parameter.name, parameter.schema as JsonSchema.JsonSchema)
       if (parameter.required) {
         schema.required.push(parameter.name)
       }
@@ -875,7 +875,7 @@ const transformMultipartSchema = (
 
     const out: Record<string, unknown> = {}
     for (const [key, current] of Object.entries(value)) {
-      out[key] = visit(current)
+      Rec.assignProperty(out, key, visit(current))
     }
 
     if (isMultipartBinaryFiles(out, singleFileRef)) {

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -10,6 +10,7 @@ import * as Exit from "effect/Exit"
 import { flow, pipe } from "effect/Function"
 import * as Layer from "effect/Layer"
 import { isObject } from "effect/Predicate"
+import * as Rec from "effect/Record"
 import * as Schedule from "effect/Schedule"
 import * as Schema from "effect/Schema"
 import * as Scope from "effect/Scope"
@@ -61,7 +62,7 @@ const makeItProxy = <Methods extends object>(
       return Reflect.apply(target, thisArg, argArray)
     },
     get(target, property, receiver) {
-      if (property in overrides) {
+      if (Object.hasOwn(overrides, property)) {
         return Reflect.get(overrides, property)
       }
       // do not bind: binding would strip vitest's static helpers (e.g. `describe.each`)
@@ -148,7 +149,7 @@ const makeTester = <R>(
     const arbs = fc.record(
       Object.keys(arbitraries).reduce(function(result, key) {
         const arb: any = arbitraries[key]
-        result[key] = Schema.isSchema(arb) ? Schema.toArbitrary(arb) : arb
+        Rec.assignProperty(result, key, Schema.isSchema(arb) ? Schema.toArbitrary(arb) : arb)
         return result
       }, {} as Record<string, fc.Arbitrary<any>>)
     )
@@ -194,7 +195,7 @@ export const prop: Vitest.Vitest.Methods["prop"] = (name, arbitraries, self, tim
       if (Schema.isSchema(arb)) {
         throw new Error("Schemas are not supported yet")
       }
-      result[key] = arb
+      Rec.assignProperty(result, key, arb)
       return result
     }, {} as Record<string, fc.Arbitrary<any>>)
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Record.assignProperty` for safely assigning dynamic keys, including `__proto__` and inherited property names.
* **Bug Fixes**
  * Improved prototype-safety across dynamic record writes and internal lookups (own-key checks), affecting configuration, schemas, requests, cookies, HTTP params, OpenAPI generation, and AI finish-reason handling.
* **Documentation**
  * Added guidance on safely working with dynamic/open-key records.
* **Tests**
  * Added regression coverage for prototype-key handling and inherited-property avoidance across records, schemas, config, requests, cookies, CLI, persistence, and SQL/HTTP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->