### PR TITLE
TIM-5: Add HttpClientRequest.updateHeaders and removeHeader

### DIFF
--- a/.changeset/add-http-client-request-update-headers.md
+++ b/.changeset/add-http-client-request-update-headers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+unstable/http HttpClientRequest: add `updateHeaders` and `removeHeader` combinators for transforming or removing request headers, closes #6271

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -328,6 +328,39 @@ export const setHeaders: {
   ))
 
 /**
+ * Transforms the request headers with the provided function, returning a new request.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const updateHeaders: {
+  (f: (headers: Headers.Headers) => Headers.Headers): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, f: (headers: Headers.Headers) => Headers.Headers): HttpClientRequest
+} = dual(2, (self: HttpClientRequest, f: (headers: Headers.Headers) => Headers.Headers): HttpClientRequest =>
+  makeWith(
+    self.method,
+    self.url,
+    self.urlParams,
+    self.hash,
+    f(self.headers),
+    self.body
+  ))
+
+/**
+ * Removes a single request header by name, returning a new request.
+ *
+ * @category combinators
+ * @since 4.0.0
+ */
+export const removeHeader: {
+  (key: string): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, key: string): HttpClientRequest
+} = dual(
+  2,
+  (self: HttpClientRequest, key: string): HttpClientRequest => updateHeaders(self, Headers.remove(key))
+)
+
+/**
  * Sets the `Authorization` header using HTTP Basic authentication credentials.
  *
  * @category combinators

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -128,6 +128,13 @@ describe("HttpClientRequest", () => {
       assertTrue(HttpClientRequest.isHttpClientRequest(request))
       strictEqual(request.headers["x-test"], "ok")
     })
+
+    it("supports the data-first overload", () => {
+      const request = HttpClientRequest.get("/")
+      const updated = HttpClientRequest.updateHeaders(request, Headers.set("X-Test", "ok"))
+
+      strictEqual(updated.headers["x-test"], "ok")
+    })
   })
 
   describe("hash", () => {

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "@effect/vitest"
-import { assertNone, assertSome, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { assertNone, assertSome, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Effect, Stream } from "effect"
 import * as Option from "effect/Option"
-import { HttpClientRequest } from "effect/unstable/http"
+import { Headers, HttpClientRequest } from "effect/unstable/http"
 
 describe("HttpClientRequest", () => {
   describe("appendUrl", () => {
@@ -79,6 +79,54 @@ describe("HttpClientRequest", () => {
 
       strictEqual(request.headers["content-type"], undefined)
       strictEqual(request.headers["content-length"], undefined)
+    })
+  })
+
+  describe("removeHeader", () => {
+    it("removes an existing header", () => {
+      const request = HttpClientRequest.get("/").pipe(
+        HttpClientRequest.setHeader("X-Test", "ok"),
+        HttpClientRequest.removeHeader("X-Test")
+      )
+
+      strictEqual(request.headers["x-test"], undefined)
+    })
+
+    it("no-ops on a missing header", () => {
+      const request = HttpClientRequest.get("/").pipe(
+        HttpClientRequest.setHeader("X-Test", "ok")
+      )
+      const removed = HttpClientRequest.removeHeader(request, "X-Missing")
+
+      deepStrictEqual(removed.headers, request.headers)
+    })
+
+    it("preserves the request prototype", () => {
+      const request = HttpClientRequest.get("/").pipe(
+        HttpClientRequest.removeHeader("X-Test")
+      )
+
+      assertTrue(HttpClientRequest.isHttpClientRequest(request))
+    })
+  })
+
+  describe("updateHeaders", () => {
+    it("transforms the header collection", () => {
+      const request = HttpClientRequest.get("/").pipe(
+        HttpClientRequest.setHeaders({ "X-A": "a", "X-B": "b" }),
+        HttpClientRequest.updateHeaders((headers) => Headers.set(Headers.remove(headers, "X-A"), "X-C", "c"))
+      )
+
+      deepStrictEqual(request.headers, Headers.fromInput({ "x-b": "b", "x-c": "c" }))
+    })
+
+    it("preserves the request prototype", () => {
+      const request = HttpClientRequest.get("/").pipe(
+        HttpClientRequest.updateHeaders(Headers.set("X-Test", "ok"))
+      )
+
+      assertTrue(HttpClientRequest.isHttpClientRequest(request))
+      strictEqual(request.headers["x-test"], "ok")
     })
   })
 


### PR DESCRIPTION
Closes #6271

Adds two header combinators to `effect/unstable/http` `HttpClientRequest`:

- `updateHeaders` — the fundamental primitive: transforms the whole header set with a `(headers: Headers.Headers) => Headers.Headers` function.
- `removeHeader` — removes a single header by name, implemented as `updateHeaders(Headers.remove(key))`.

Both use dual (data-first / data-last) signatures consistent with the existing `setHeader` / `setHeaders` combinators and delegate to the `Headers` module, so header-name normalization (lowercasing) is inherited.

This gives a public escape hatch for cases like the motivating bug in #6271, where a `content-length` header written by `setBody` needs to be dropped before handing the request to `FetchHttpClient` / undici:

```ts
HttpClientRequest.post(url).pipe(
  HttpClientRequest.bodyUint8Array(body, contentType),
  HttpClientRequest.removeHeader("content-length")
)
```

Tests cover removing an existing header, removing a missing header (no-op), an `updateHeaders` transformation, and that the request prototype/TypeId is preserved.

Validation: `pnpm lint-fix`, `pnpm test packages/effect/test/unstable/http/HttpClientRequest.test.ts` (18 passed), `pnpm check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-header utilities to update existing headers or remove a specific header from HTTP client requests.
  * Header updates/removals preserve the request’s existing behavior and structure.

* **Tests**
  * Added coverage for updating headers, removing existing or missing headers, and ensuring request compatibility is preserved.

* **Release**
  * Scheduled a patch release for these HTTP client request enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->