### PR TITLE
Make schemas directly extendable as classes

### DIFF
--- a/.changeset/schema-direct-class-extension.md
+++ b/.changeset/schema-direct-class-extension.md
@@ -1,0 +1,22 @@
+---
+"effect": patch
+---
+
+Schema: make schemas directly extendable as classes with static method support
+and remove `Schema.asClass`.
+
+`Bottom` and `BottomLazy` now include the class-compatible `new` signature,
+while `BottomWithoutNew` and `BottomLazyWithoutNew` expose the schema protocol
+without it for schema types that define a specialized construct signature.
+
+**Example**
+
+```ts
+import { Schema } from "effect"
+
+class MyString extends Schema.String {
+  static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
+}
+
+MyString.decodeUnknownSync("a") // "a"
+```

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -3838,7 +3838,7 @@ g(A.make({ a: "a" })) // error: Argument of type 'A' is not assignable to parame
 
 ## Schema as a Class
 
-`Schema.asClass` turns any schema into a class that can be extended with `extends`. The resulting class inherits the full schema API (e.g. `annotate`) and supports static methods that reference `this`.
+Any schema can be extended directly with `extends`. The resulting class inherits the full schema API (e.g. `annotate`) and supports static methods that reference `this`.
 
 Unlike `Schema.Opaque`, it does **not** make the decoded type nominally distinct, and unlike `Schema.Class`, it does **not** create prototype-backed instances with methods or constructors. It is a lightweight way to attach custom static helpers to a schema.
 
@@ -3847,7 +3847,7 @@ Unlike `Schema.Opaque`, it does **not** make the decoded type nominally distinct
 ```ts
 import { Schema } from "effect"
 
-class MyString extends Schema.asClass(Schema.String) {
+class MyString extends Schema.String {
   static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
 }
 
@@ -3860,9 +3860,7 @@ console.log(MyString.decodeUnknownSync("a"))
 ```ts
 import { Schema } from "effect"
 
-class MyStruct extends Schema.asClass(
-  Schema.Struct({ name: Schema.String })
-) {
+class MyStruct extends Schema.Struct({ name: Schema.String }) {
   static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
 }
 
@@ -3872,12 +3870,12 @@ console.log(MyStruct.decodeUnknownSync({ name: "a" }))
 
 ### Subclassing
 
-You can extend an `asClass` class to layer on more static helpers:
+You can extend a schema class to layer on more static helpers:
 
 ```ts
 import { Schema } from "effect"
 
-class MyString extends Schema.asClass(Schema.FiniteFromString) {
+class MyString extends Schema.FiniteFromString {
   static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
 }
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -6422,9 +6422,7 @@ export interface Opaque<Self, S extends Top, Brand> extends
  */
 export function Opaque<Self, Brand = {}>() {
   return <S extends Top>(schema: S): Opaque<Self, S, Brand> & Omit<S, keyof Top> => {
-    // oxlint-disable-next-line @typescript-eslint/no-extraneous-class
-    class Opaque {}
-    return Object.setPrototypeOf(Opaque, schema)
+    return schema as any
   }
 }
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -109,8 +109,8 @@ export type ConstructorDefault = "no-default" | "with-default"
  * Use when passing `disableChecks: true` to skip validation when you trust the data.
  * - Pass `parseOptions` to control error reporting behavior.
  *
- * @see {@link Bottom.makeEffect}
- * @see {@link Bottom.make}
+ * @see {@link BottomWithoutNew.makeEffect}
+ * @see {@link BottomWithoutNew.make}
  *
  * @category options
  * @since 3.13.4
@@ -133,19 +133,19 @@ export interface MakeOptions {
 }
 
 /**
- * The fully-parameterized base interface for all schemas. Exposes all 14 type
- * parameters controlling type inference, mutability, optionality, services, and
- * transformation behavior.
+ * The fully-parameterized schema interface without a construct signature.
+ * Exposes all 14 type parameters controlling type inference, mutability,
+ * optionality, services, and transformation behavior.
  *
  * **When to use**
  *
- * Use when you are writing advanced generic schema utilities or performing
- *   schema introspection.
+ * Use as the base for schema interfaces that provide a specialized construct
+ * signature.
  *
  * @category models
  * @since 4.0.0
  */
-export interface Bottom<
+export interface BottomWithoutNew<
   out T,
   out E,
   out RD,
@@ -207,8 +207,8 @@ export interface Bottom<
    * Causes that contain defects, interruptions, or other non-schema reasons
    * throw with the underlying `Cause` attached instead.
    *
-   * @see {@link Bottom.makeOption} — construct synchronously and discard validation details
-   * @see {@link Bottom.makeEffect} — construct through `Effect` when validation failure should stay in the error channel
+   * @see {@link BottomWithoutNew.makeOption} — construct synchronously and discard validation details
+   * @see {@link BottomWithoutNew.makeEffect} — construct through `Effect` when validation failure should stay in the error channel
    */
   make(input: this["~type.make.in"], options?: MakeOptions): this["Type"]
   /**
@@ -231,8 +231,8 @@ export interface Bottom<
    * that contain defects, interruptions, or other non-schema reasons throw
    * instead.
    *
-   * @see {@link Bottom.make} — construct synchronously when validation failure should throw
-   * @see {@link Bottom.makeEffect} — construct through `Effect` when validation details should stay in the error channel
+   * @see {@link BottomWithoutNew.make} — construct synchronously when validation failure should throw
+   * @see {@link BottomWithoutNew.makeEffect} — construct through `Effect` when validation details should stay in the error channel
    */
   makeOption(input: this["~type.make.in"], options?: MakeOptions): Option_.Option<this["Type"]>
   /**
@@ -244,38 +244,95 @@ export interface Bottom<
    * Use when constructor input may fail validation and you want to
    * compose that failure with other `Effect` operations instead of throwing.
    *
-   * @see {@link Bottom.make} — construct synchronously when validation failure should throw
-   * @see {@link Bottom.makeOption} — construct synchronously and discard validation details
+   * @see {@link BottomWithoutNew.make} — construct synchronously when validation failure should throw
+   * @see {@link BottomWithoutNew.makeOption} — construct synchronously and discard validation details
    */
   makeEffect(input: this["~type.make.in"], options?: MakeOptions): Effect.Effect<this["Type"], SchemaError>
 }
 
 /**
- * Lazy `Bottom` variant for schema implementations that compute their public
- * views on demand.
+ * Fully-parameterized base interface for schemas that can be extended directly
+ * by TypeScript classes.
  *
  * **When to use**
  *
- * Use as an implementation base for schema interfaces that must expose
- * `Bottom` behavior without forcing TypeScript to eagerly evaluate expensive
- * `Type`, `Encoded`, or service views.
+ * Use as the base for concrete schema interfaces whose runtime values support
+ * `class ... extends schema`.
+ *
+ * **Details**
+ *
+ * Extends {@link BottomWithoutNew} with a construct signature that accepts `never`. The
+ * signature enables class extension without making ordinary schemas directly
+ * constructible.
+ *
+ * @see {@link BottomWithoutNew} for the schema protocol without a construct signature
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export interface Bottom<
+  out T,
+  out E,
+  out RD,
+  out RE,
+  out Ast extends SchemaAST.AST,
+  out Rebuild extends Top,
+  out TypeMakeIn = T,
+  out Iso = T,
+  in out TypeParameters extends ReadonlyArray<Constraint> = readonly [],
+  out TypeMake = TypeMakeIn,
+  out TypeMutability extends Mutability = "readonly",
+  out TypeOptionality extends Optionality = "required",
+  out TypeConstructorDefault extends ConstructorDefault = "no-default",
+  out EncodedMutability extends Mutability = "readonly",
+  out EncodedOptionality extends Optionality = "required"
+> extends
+  BottomWithoutNew<
+    T,
+    E,
+    RD,
+    RE,
+    Ast,
+    Rebuild,
+    TypeMakeIn,
+    Iso,
+    TypeParameters,
+    TypeMake,
+    TypeMutability,
+    TypeOptionality,
+    TypeConstructorDefault,
+    EncodedMutability,
+    EncodedOptionality
+  >
+{
+  new(_: never): {}
+}
+
+/**
+ * Lazy `BottomWithoutNew` variant for schema implementations that
+ * compute their public views on demand.
+ *
+ * **When to use**
+ *
+ * Use as the base for lazy schema interfaces that provide a specialized
+ * construct signature.
  *
  * **Details**
  *
  * The laziness is purely type-level; runtime behavior is unchanged.
- * `BottomLazy` keeps the structural operations inherited from `Bottom`, but
- * erases the expensive schema views to `unknown`. Concrete schema interfaces can
- * then redeclare the precise views they expose. This keeps wide schemas such as
- * `Struct` and `Union` cheaper when generic code reads a single view, while
- * preserving their exact public types.
+ * `BottomLazyWithoutNew` keeps the structural operations inherited from
+ * `BottomWithoutNew`, but erases the expensive schema views to
+ * `unknown`. Concrete schema interfaces can then redeclare the precise views
+ * they expose. This keeps wide schemas such as `Struct` and `Union` cheaper when
+ * generic code reads a single view, while preserving their exact public types.
  *
- * @see {@link Bottom} for the fully parameterized schema interface when every
+ * @see {@link BottomWithoutNew} for the fully parameterized schema interface when every
  * view must be supplied directly.
  *
  * @category utility types
  * @since 4.0.0
  */
-export interface BottomLazy<
+export interface BottomLazyWithoutNew<
   out Ast extends SchemaAST.AST,
   out Rebuild extends Top,
   in out TypeParameters extends ReadonlyArray<Constraint> = readonly [],
@@ -285,7 +342,7 @@ export interface BottomLazy<
   out EncodedMutability extends Mutability = "readonly",
   out EncodedOptionality extends Optionality = "required"
 > extends
-  Bottom<
+  BottomWithoutNew<
     unknown,
     unknown,
     unknown,
@@ -303,6 +360,50 @@ export interface BottomLazy<
     EncodedOptionality
   >
 {}
+
+/**
+ * Lazy `Bottom` variant for schemas that can be extended directly by TypeScript
+ * classes.
+ *
+ * **When to use**
+ *
+ * Use as the base for concrete lazy schema interfaces whose runtime values
+ * support `class ... extends schema`.
+ *
+ * **Details**
+ *
+ * Extends {@link BottomLazyWithoutNew} with a construct signature that accepts `never`.
+ * The signature enables class extension without making ordinary schemas
+ * directly constructible.
+ *
+ * @see {@link BottomLazyWithoutNew} for the lazy schema protocol without a construct signature
+ *
+ * @category utility types
+ * @since 4.0.0
+ */
+export interface BottomLazy<
+  out Ast extends SchemaAST.AST,
+  out Rebuild extends Top,
+  in out TypeParameters extends ReadonlyArray<Constraint> = readonly [],
+  out TypeMutability extends Mutability = "readonly",
+  out TypeOptionality extends Optionality = "required",
+  out TypeConstructorDefault extends ConstructorDefault = "no-default",
+  out EncodedMutability extends Mutability = "readonly",
+  out EncodedOptionality extends Optionality = "required"
+> extends
+  BottomLazyWithoutNew<
+    Ast,
+    Rebuild,
+    TypeParameters,
+    TypeMutability,
+    TypeOptionality,
+    TypeConstructorDefault,
+    EncodedMutability,
+    EncodedOptionality
+  >
+{
+  new(_: never): {}
+}
 
 /**
  * Type-level representation returned by {@link declareConstructor}.
@@ -2225,33 +2326,6 @@ export const encodeSync: <S extends ConstraintEncoder<unknown>>(
  * @since 3.10.0
  */
 export const make: <S extends Constraint>(ast: S["ast"], options?: object) => S = InternalSchema.make
-
-/**
- * Transforms a schema into a class that can be extended with `extends`. The
- * resulting class inherits the full schema API (e.g. `annotate`) and can define
- * static methods that reference `this`.
- *
- * **Example** (Wrapping a primitive schema)
- *
- * ```ts
- * import { Schema } from "effect"
- *
- * class MyString extends Schema.asClass(Schema.String) {
- *   static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
- * }
- *
- * console.log(MyString.decodeUnknownSync("a"))
- * // "a"
- * ```
- *
- * @category constructors
- * @since 4.0.0
- */
-export function asClass<S extends Top>(schema: S): S & { new(_: never): {} } {
-  // oxlint-disable-next-line @typescript-eslint/no-extraneous-class
-  class Class {}
-  return Object.setPrototypeOf(Class, schema)
-}
 
 /**
  * Checks whether a value is a `Schema`.
@@ -6301,7 +6375,7 @@ export function TaggedUnion<const CasesByTag extends Record<string, Struct.Field
  * @since 4.0.0
  */
 export interface Opaque<Self, S extends Top, Brand> extends
-  BottomLazy<
+  BottomLazyWithoutNew<
     S["ast"],
     S["Rebuild"],
     S["~type.parameters"],
@@ -14209,17 +14283,18 @@ export const DateTimeZonedFromString: DateTimeZonedFromString = DateTimeZonedStr
  * @category models
  * @since 3.10.0
  */
-export interface Class<Self, S extends Constraint & { readonly fields: Struct.Fields }, Inherited> extends
-  BottomLazy<
-    SchemaAST.Declaration,
-    decodeTo<declareConstructor<Self, S["Encoded"], readonly [S], S["Iso"]>, S>,
-    readonly [S],
-    S["~type.mutability"],
-    S["~type.optionality"],
-    S["~type.constructor.default"],
-    S["~encoded.mutability"],
-    S["~encoded.optionality"]
-  >
+export interface Class<Self, S extends Constraint & { readonly fields: Struct.Fields }, Inherited>
+  extends
+    BottomLazyWithoutNew<
+      SchemaAST.Declaration,
+      decodeTo<declareConstructor<Self, S["Encoded"], readonly [S], S["Iso"]>, S>,
+      readonly [S],
+      S["~type.mutability"],
+      S["~type.optionality"],
+      S["~type.constructor.default"],
+      S["~encoded.mutability"],
+      S["~encoded.optionality"]
+    >
 {
   readonly "Type": Self
   readonly "Encoded": S["Encoded"]

--- a/packages/effect/src/internal/schema/schema.ts
+++ b/packages/effect/src/internal/schema/schema.ts
@@ -68,7 +68,11 @@ const SchemaProto = {
 
 /** @internal */
 export function make<S extends Schema.Constraint>(ast: S["ast"], options?: object): S {
-  const self = Object.setPrototypeOf({ ...options }, SchemaProto)
+  function Schema() {}
+  const self = Object.defineProperties(
+    Object.setPrototypeOf(Schema, SchemaProto),
+    Object.getOwnPropertyDescriptors({ ...options })
+  )
   self.ast = ast
   self.rebuild = (ast: SchemaAST.AST) => make(ast, options)
   const makeEffect = SchemaParser.makeEffect(self)

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -15,7 +15,6 @@ import * as InternalRecord from "../../internal/record.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
-import type * as SchemaAST from "../../SchemaAST.ts"
 import * as Struct_ from "../../Struct.ts"
 
 /**
@@ -264,19 +263,7 @@ export interface Class<
   S extends Schema.Top & {
     readonly fields: Schema.Struct.Fields
   }
-> extends
-  Schema.BottomLazy<
-    SchemaAST.Declaration,
-    Schema.decodeTo<Schema.declareConstructor<Self, S["Encoded"], readonly [S], S["Iso"]>, S>,
-    readonly [S],
-    S["~type.mutability"],
-    S["~type.optionality"],
-    S["~type.constructor.default"],
-    S["~encoded.mutability"],
-    S["~encoded.optionality"]
-  >,
-  Struct<Struct_.Simplify<Fields>>
-{
+> extends Schema.Class<Self, S, {}>, Struct<Struct_.Simplify<Fields>> {
   readonly "Type": Self
   readonly "Encoded": S["Encoded"]
   readonly "DecodingServices": S["DecodingServices"]

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5100,6 +5100,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
   })
 
   describe("Opaque", () => {
+    it("returns the original schema", () => {
+      const schema = Schema.Struct({ a: Schema.String })
+
+      strictEqual(Schema.Opaque<{ readonly a: string }>()(schema), schema)
+    })
+
     it("Struct", () => {
       class A extends Schema.Opaque<A>()(Schema.Struct({ a: Schema.String })) {}
 

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3336,6 +3336,21 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       strictEqual((schema as any)["__proto__"], value)
     })
 
+    it("preserves name and length as options", () => {
+      const schema = Schema.make<Schema.String>(Schema.String.ast, {
+        name: "CustomSchema",
+        length: 2
+      })
+
+      strictEqual((schema as any).name, "CustomSchema")
+      strictEqual((schema as any).length, 2)
+
+      const rebuilt = schema.annotate({})
+
+      strictEqual((rebuilt as any).name, "CustomSchema")
+      strictEqual((rebuilt as any).length, 2)
+    })
+
     it("should throw an error when the cause contains both a schema issue and a defect", () => {
       const cause = Cause.combine(
         Cause.fail(new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" }))),
@@ -9733,15 +9748,33 @@ Missing key
     )
   })
 
-  describe("asClass", () => {
+  describe("class extension", () => {
     it("wrapping a primitive schema", () => {
-      class A extends Schema.asClass(Schema.String) {}
+      class A extends Schema.String {}
 
       strictEqual(Schema.decodeUnknownSync(A)("a"), "a")
     })
 
+    it("inherits the schema protocol", () => {
+      class A extends Schema.String {}
+
+      assertTrue(Schema.isSchema(A))
+      strictEqual(A.make("a"), "a")
+
+      const annotated = A.annotate({ title: "A" })
+      assertTrue(Schema.isSchema(annotated))
+      strictEqual(Schema.resolveAnnotations(annotated)?.title, "A")
+    })
+
+    it("extending a rebuilt schema", () => {
+      class A extends Schema.Struct({ name: Schema.String }).annotate({ title: "A" }) {}
+
+      deepStrictEqual(Schema.decodeUnknownSync(A)({ name: "a" }), { name: "a" })
+      strictEqual(Schema.resolveAnnotations(A)?.title, "A")
+    })
+
     it("static getter using this", () => {
-      class A extends Schema.asClass(Schema.String) {
+      class A extends Schema.String {
         static get decodeUnknownSync() {
           return Schema.decodeUnknownSync(this)
         }
@@ -9751,7 +9784,7 @@ Missing key
     })
 
     it("static property", () => {
-      class A extends Schema.asClass(Schema.String) {
+      class A extends Schema.String {
         static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
       }
 
@@ -9759,7 +9792,7 @@ Missing key
     })
 
     it("static property using Schema.suspend", () => {
-      class A extends Schema.asClass(Schema.String) {
+      class A extends Schema.String {
         static readonly decodeUnknownSync = Schema.decodeUnknownSync(Schema.suspend(() => this))
       }
 
@@ -9770,7 +9803,7 @@ Missing key
       const struct = Schema.Struct({
         name: Schema.String
       })
-      class A extends Schema.asClass(struct) {
+      class A extends struct {
         static get decodeUnknownSync() {
           return Schema.decodeUnknownSync(this)
         }
@@ -9780,8 +9813,17 @@ Missing key
       strictEqual(A.fields, struct.fields)
     })
 
-    it("subclassing (double wrap)", () => {
-      class A extends Schema.asClass(Schema.FiniteFromString) {
+    it("does not create class instances", () => {
+      class A extends Schema.Struct({ name: Schema.String }) {}
+
+      const value = A.make({ name: "a" })
+
+      assertFalse(value instanceof A)
+      deepStrictEqual(value, { name: "a" })
+    })
+
+    it("subclassing", () => {
+      class A extends Schema.FiniteFromString {
         static get decodeUnknownSync() {
           return Schema.decodeUnknownSync(this)
         }

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -18,6 +18,25 @@ describe("VariantSchema", () => {
     assert.deepStrictEqual(Object.keys(Test.extract(struct, "b").fields), ["common", "onlyB", "exceptC"])
     assert.deepStrictEqual(Object.keys(Test.extract(struct, "c").fields), ["common"])
   })
+
+  it("Class preserves class and variant schema behavior", () => {
+    const Test = VariantSchema.make({
+      variants: ["a", "b"],
+      defaultVariant: "a"
+    })
+    class User extends Test.Class<User>("User")({
+      id: Test.FieldOnly(["a"])(Schema.Number),
+      name: Schema.String
+    }) {}
+
+    const user = User.make({ id: 1, name: "Alice" })
+
+    assert.isTrue(user instanceof User)
+    assert.deepStrictEqual(user, new User({ id: 1, name: "Alice" }))
+    assert.deepStrictEqual(Schema.decodeSync(User)({ id: 1, name: "Alice" }), user)
+    assert.deepStrictEqual(Schema.decodeSync(User.b)({ name: "Alice" }), { name: "Alice" })
+    assert.deepStrictEqual(Object.keys(User.fields), ["id", "name"])
+  })
 })
 
 describe("Model", () => {

--- a/packages/effect/typetest/VariantSchema.tst.ts
+++ b/packages/effect/typetest/VariantSchema.tst.ts
@@ -30,6 +30,29 @@ describe("VariantSchema", () => {
     expect(Test.Union).type.toBeCallableWith([first, second])
     expect(Test.Union).type.not.toBeCallableWith(first, second)
   })
+
+  it("Class preserves constructor and variant schema types", () => {
+    const Test = VariantSchema.make({
+      variants: ["a", "b"],
+      defaultVariant: "a"
+    })
+    class User extends Test.Class<User>("User")({
+      id: Test.FieldOnly(["a"])(Schema.Number),
+      name: Schema.String
+    }) {}
+
+    expect(User).type.toBeConstructableWith({ id: 1, name: "Alice" })
+    expect(User).type.not.toBeConstructableWith({ name: "Alice" })
+    expect(User.make({ id: 1, name: "Alice" })).type.toBe<User>()
+    expect<Schema.Schema.Type<typeof User>>().type.toBe<User>()
+    expect<Schema.Codec.Encoded<typeof User>>().type.toBe<
+      { readonly id: number; readonly name: string }
+    >()
+    expect<Schema.Schema.Type<typeof User.a>>().type.toBe<
+      { readonly id: number; readonly name: string }
+    >()
+    expect<Schema.Schema.Type<typeof User.b>>().type.toBe<{ readonly name: string }>()
+  })
 })
 
 describe("Model", () => {

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -1846,26 +1846,115 @@ describe("Schema", () => {
     })
   })
 
-  describe("asClass", () => {
-    it("preserves schema Type", () => {
-      class A extends Schema.asClass(Schema.String) {}
-      expect(Schema.revealCodec(A)).type.toBe<Schema.Codec<string, string, never, never>>()
-
-      class B extends Schema.asClass(Schema.Struct({ name: Schema.String })) {}
-      expect(Schema.revealCodec(B)).type.toBe<
-        Schema.Codec<{ readonly name: string }, { readonly name: string }, never, never>
+  describe("class extension", () => {
+    it("keeps protocol bases constructor-free", () => {
+      const bottomWithoutNew: Schema.BottomWithoutNew<
+        string,
+        string,
+        never,
+        never,
+        (typeof Schema.String)["ast"],
+        Schema.String
+      > = Schema.String
+      expect(bottomWithoutNew).type.not.toBeAssignableTo<
+        abstract new(...args: Array<any>) => unknown
       >()
+
+      const struct = Schema.Struct({ name: Schema.String })
+      const bottomLazyWithoutNew: Schema.BottomLazyWithoutNew<
+        (typeof struct)["ast"],
+        (typeof struct)["Rebuild"]
+      > = struct
+      expect(bottomLazyWithoutNew).type.not.toBeAssignableTo<
+        abstract new(...args: Array<any>) => unknown
+      >()
+    })
+
+    it("keeps class-compatible bases extendable", () => {
+      const bottom: Schema.Bottom<
+        string,
+        string,
+        never,
+        never,
+        (typeof Schema.String)["ast"],
+        Schema.String
+      > = Schema.String
+      class A extends bottom {}
+
+      const struct = Schema.Struct({ name: Schema.String })
+      const bottomLazy: Schema.BottomLazy<
+        (typeof struct)["ast"],
+        (typeof struct)["Rebuild"]
+      > = struct
+      class B extends bottomLazy {}
+
+      expect(Schema.revealCodec(A)).type.toBe<Schema.Codec<string>>()
+      expect(B).type.toBeAssignableTo<Schema.Top>()
+    })
+
+    it("keeps Opaque assignable to Top", () => {
+      class A extends Schema.Opaque<A>()(Schema.Struct({ name: Schema.String })) {}
+
+      expect(A).type.toBeAssignableTo<Schema.Top>()
+    })
+
+    it("keeps Schema.Class assignable to Top", () => {
+      class A extends Schema.Class<A>("A")({ name: Schema.String }) {}
+
+      expect(A).type.toBeAssignableTo<Schema.Top>()
+    })
+
+    it("preserves codec parameters", () => {
+      interface DecodingService {
+        readonly DecodingService: unique symbol
+      }
+      interface EncodingService {
+        readonly EncodingService: unique symbol
+      }
+
+      const schema = Schema.FiniteFromString.pipe(
+        Schema.middlewareDecoding((effect) =>
+          Effect.andThen(
+            Effect.context<DecodingService>(),
+            effect
+          )
+        ),
+        Schema.middlewareEncoding((effect) =>
+          Effect.andThen(
+            Effect.context<EncodingService>(),
+            effect
+          )
+        )
+      )
+
+      class A extends schema {}
+
+      expect(Schema.revealCodec(A)).type.toBe<
+        Schema.Codec<number, string, DecodingService, EncodingService>
+      >()
+    })
+
+    it("preserves Struct fields", () => {
+      class B extends Schema.Struct({ name: Schema.String }) {}
+
       expect(B.fields).type.toBe<{ readonly name: Schema.String }>()
     })
 
+    it("cannot be constructed", () => {
+      class A extends Schema.String {}
+
+      expect(A).type.not.toBeConstructableWith()
+      expect(A).type.not.toBeConstructableWith("a")
+    })
+
     it("annotate returns the original schema type", () => {
-      class A extends Schema.asClass(Schema.String) {}
+      class A extends Schema.String {}
 
       expect(A.annotate({})).type.toBe<Schema.String>()
     })
 
     it("should support static methods", () => {
-      class A extends Schema.asClass(Schema.FiniteFromString) {
+      class A extends Schema.FiniteFromString {
         static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
         static get encodeSync() {
           return Schema.encodeSync(this)


### PR DESCRIPTION
**Example**

```ts
import { Schema } from "effect"

class MyString extends Schema.String {
  static readonly decodeUnknownSync = Schema.decodeUnknownSync(this)
}

MyString.decodeUnknownSync("a") // "a"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schemas can now be extended directly using standard class syntax, keeping the full schema API and related static helpers.
  * Variant schemas now preserve normal class construction behavior alongside variant-specific decoding.
* **Breaking Changes**
  * The `Schema.asClass` helper has been removed—migrate to direct class extension.
* **Documentation**
  * Updated schema documentation and examples to reflect the new class-extension approach.
* **Tests**
  * Expanded runtime and TypeScript test coverage for class/variant behavior, annotation and metadata preservation, and correct decode/encode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->