### PR TITLE
Record: make fromIterableBy dual

### DIFF
--- a/.changeset/record-from-iterable-by-dual.md
+++ b/.changeset/record-from-iterable-by-dual.md
@@ -1,0 +1,16 @@
+---
+"effect": patch
+---
+
+Record: make `fromIterableBy` dual, allowing data-last usage in `pipe`
+
+```ts
+import { pipe, Record } from "effect"
+
+const users = [
+  { id: "2", name: "name2" },
+  { id: "1", name: "name1" }
+]
+
+pipe(users, Record.fromIterableBy((user) => user.id))
+```

--- a/packages/effect/src/Record.ts
+++ b/packages/effect/src/Record.ts
@@ -281,10 +281,21 @@ export const fromIterableWith: {
  * @category constructors
  * @since 2.0.0
  */
-export const fromIterableBy = <A, K extends string | symbol>(
-  items: Iterable<A>,
-  f: (a: A) => K
-): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(items, (a) => [f(a), a])
+export const fromIterableBy: {
+  <A, K extends string | symbol>(
+    f: (a: A) => K
+  ): (items: Iterable<A>) => Record<ReadonlyRecord.NonLiteralKey<K>, A>
+  <A, K extends string | symbol>(
+    items: Iterable<A>,
+    f: (a: A) => K
+  ): Record<ReadonlyRecord.NonLiteralKey<K>, A>
+} = dual(
+  2,
+  <A, K extends string | symbol>(
+    items: Iterable<A>,
+    f: (a: A) => K
+  ): Record<ReadonlyRecord.NonLiteralKey<K>, A> => fromIterableWith(items, (a) => [f(a), a])
+)
 
 /**
  * Builds a record from an iterable of key-value pairs.

--- a/packages/effect/test/Record.test.ts
+++ b/packages/effect/test/Record.test.ts
@@ -61,6 +61,11 @@ describe("Record", () => {
       })
 
       deepStrictEqual(Record.fromIterableBy(["a", symA], (s) => s), { a: "a", [symA]: symA })
+
+      deepStrictEqual(pipe(users, Record.fromIterableBy((user) => user.id)), {
+        "2": { id: "2", name: "name2" },
+        "1": { id: "1", name: "name1" }
+      })
     })
 
     it("fromEntries", () => {


### PR DESCRIPTION
Makes `Record.fromIterableBy` dual, so it supports both data-first and data-last (curried) usage:

```ts
// data-first
Record.fromIterableBy(users, (user) => user.id)

// data-last, inside pipe
pipe(users, Record.fromIterableBy((user) => user.id))
```

Previously only the data-first form type-checked, so the curried form failed inside `pipe`. `fromIterableWith` is already dual on `main`, so only `fromIterableBy` needed changing.

Includes a test covering the curried form inside `pipe` and a patch changeset for `effect`.

Closes #6092
Closes EFF-6
