### PR TITLE
ManagedRuntime: add Symbol.asyncDispose

### DIFF
--- a/.changeset/managed-runtime-async-dispose.md
+++ b/.changeset/managed-runtime-async-dispose.md
@@ -1,0 +1,14 @@
+---
+"effect": patch
+---
+
+ManagedRuntime: add `Symbol.asyncDispose`, enabling `await using` syntax
+
+```ts
+import { Effect, Layer, ManagedRuntime } from "effect"
+
+await using runtime = ManagedRuntime.make(Layer.empty)
+
+await runtime.runPromise(Effect.log("Hello, world!"))
+// runtime is disposed automatically at the end of the scope
+```

--- a/packages/effect/src/ManagedRuntime.ts
+++ b/packages/effect/src/ManagedRuntime.ts
@@ -212,6 +212,16 @@ export interface ManagedRuntime<in R, out ER> {
    *
    * **When to use**
    *
+   * Use with the `await using` syntax to automatically dispose the runtime
+   * when it goes out of scope.
+   */
+  readonly [Symbol.asyncDispose]: () => Promise<void>
+
+  /**
+   * Dispose of the resources associated with the runtime.
+   *
+   * **When to use**
+   *
    * Use to release this runtime's layer resources from an `Effect` workflow.
    */
   readonly disposeEffect: Effect.Effect<void, never, never>
@@ -323,6 +333,9 @@ export const make = <R, ER>(
     },
     dispose(): Promise<void> {
       return Effect.runPromise(self.disposeEffect)
+    },
+    [Symbol.asyncDispose](): Promise<void> {
+      return self.dispose()
     },
     disposeEffect: Effect.suspend(() => {
       ;(self as Mutable<ManagedRuntime<R, ER>>).contextEffect = Effect.die("ManagedRuntime disposed")

--- a/packages/effect/test/ManagedRuntime.test.ts
+++ b/packages/effect/test/ManagedRuntime.test.ts
@@ -47,6 +47,21 @@ describe("ManagedRuntime", () => {
     strictEqual(result, "test")
   })
 
+  test("supports await using", async () => {
+    let count = 0
+    const layer = Layer.effectDiscard(Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        count++
+      })
+    ))
+    {
+      await using runtime = ManagedRuntime.make(layer)
+      await runtime.runPromise(Effect.void)
+      strictEqual(count, 0)
+    }
+    strictEqual(count, 1)
+  })
+
   it("fibers are interrupted on dispose", async () => {
     const runtime = ManagedRuntime.make(Layer.empty)
     const fiber = runtime.runFork(Effect.never)


### PR DESCRIPTION
Adds `Symbol.asyncDispose` to `ManagedRuntime` as an alias for the existing `dispose` method, enabling the `await using` explicit resource management syntax:

```ts
await using runtime = ManagedRuntime.make(layer)
// disposed automatically at the end of the scope
```

Closes #5990
Closes EFF-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
