### PR TITLE
test: assert Effect.timeout interrupts the underlying effect

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1418,6 +1418,24 @@ describe("Effect", () => {
         )
         assert.deepStrictEqual(result, new Cause.TimeoutError())
       }))
+    it.effect("timeout interrupts the effect", () =>
+      Effect.gen(function*() {
+        let interrupted = false
+        const fiber = yield* Effect.never.pipe(
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              interrupted = true
+            })
+          ),
+          Effect.timeout(10),
+          Effect.flip,
+          Effect.forkChild
+        )
+        yield* TestClock.adjust(10)
+        const result = yield* Fiber.join(fiber)
+        assert.deepStrictEqual(result, new Cause.TimeoutError())
+        assert.isTrue(interrupted)
+      }))
   })
 
   describe("interruption", () => {


### PR DESCRIPTION
## Summary

From the EFF-8 interruption audit: the existing `Effect.timeout` tests only assert the `Cause.TimeoutError` outcome, not that the timed-out effect is actually interrupted. This adds a test asserting the underlying effect's `onInterrupt` finalizer runs when the timeout fires.

- New `it.effect` test under `describe("timeout")` in `packages/effect/test/Effect.test.ts`, using `TestClock.adjust` per repo conventions: `Effect.never` with an `onInterrupt` finalizer is wrapped in `Effect.timeout(10)`; after the clock advances, the result is `Cause.TimeoutError` and the finalizer has run.

## Testing

- `pnpm vitest run packages/effect` — 228 files, 7053 tests passed.

Closes EFF-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that timed-out effects interrupt their running child operations.
  * Confirmed timeout errors are reported correctly and interruption cleanup is triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->