### PR TITLE
test: Effect.all / zip / zipWith with concurrency interrupt in-flight siblings on failure

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -732,6 +732,35 @@ describe("Effect", () => {
           c: Result.succeed(true)
         })
       }))
+
+    it.effect("concurrency interrupts started siblings on failure", () =>
+      Effect.gen(function*() {
+        const started: Array<number> = []
+        const interrupted: Array<number> = []
+        const make = (i: number) =>
+          Effect.suspend(() => {
+            started.push(i)
+            return Effect.sleep(500)
+          }).pipe(
+            Effect.as(i),
+            Effect.onInterrupt(() =>
+              Effect.sync(() => {
+                interrupted.push(i)
+              })
+            )
+          )
+        const fiber = yield* Effect.all([
+          make(1),
+          Effect.fail("boom").pipe(Effect.delay(100)),
+          make(3),
+          make(4)
+        ], { concurrency: 3 }).pipe(Effect.forkChild)
+        yield* TestClock.adjust(100)
+        const result = yield* Fiber.await(fiber)
+        assert.deepStrictEqual(result, Exit.fail("boom"))
+        assert.deepStrictEqual(started, [1, 3])
+        assert.deepStrictEqual(interrupted, [1, 3])
+      }))
   })
 
   describe("partition", () => {
@@ -2234,6 +2263,20 @@ describe("Effect", () => {
         assert.deepStrictEqual(executionOrder, ["task2", "task1"])
       })
     })
+    it.effect("concurrent: true interrupts the other side on failure", () => {
+      const interrupted: Array<string> = []
+      const task1 = Effect.never.pipe(
+        Effect.onInterrupt(() => Effect.sync(() => interrupted.push("task1")))
+      )
+      const task2 = Effect.fail("boom").pipe(Effect.delay(10))
+      return Effect.gen(function*() {
+        const fiber = yield* Effect.forkChild(Effect.zip(task1, task2, { concurrent: true }))
+        yield* TestClock.adjust(10)
+        const result = yield* Fiber.await(fiber)
+        assert.deepStrictEqual(result, Exit.fail("boom"))
+        assert.deepStrictEqual(interrupted, ["task1"])
+      })
+    })
   })
 
   describe("zipWith", () => {
@@ -2271,6 +2314,22 @@ describe("Effect", () => {
         const result = yield* Fiber.join(fiber)
         assert.deepStrictEqual(result, "a1")
         assert.deepStrictEqual(executionOrder, ["task2", "task1"])
+      })
+    })
+    it.effect("concurrent: true interrupts the other side on failure", () => {
+      const interrupted: Array<string> = []
+      const task1 = Effect.fail("boom").pipe(Effect.delay(10))
+      const task2 = Effect.never.pipe(
+        Effect.onInterrupt(() => Effect.sync(() => interrupted.push("task2")))
+      )
+      return Effect.gen(function*() {
+        const fiber = yield* Effect.forkChild(
+          Effect.zipWith(task1, task2, (a, b) => `${a}${b}`, { concurrent: true })
+        )
+        yield* TestClock.adjust(10)
+        const result = yield* Fiber.await(fiber)
+        assert.deepStrictEqual(result, Exit.fail("boom"))
+        assert.deepStrictEqual(interrupted, ["task2"])
       })
     })
   })


### PR DESCRIPTION
Adds the interruption coverage identified by the EFF-8 audit for `Effect.all` and concurrent `zip`/`zipWith` — previously all failure-with-concurrency interruption tests lived under `describe("forEach")` only.

New tests in `packages/effect/test/Effect.test.ts`:

- **`all` › "concurrency interrupts started siblings on failure"** — `Effect.all` with `{ concurrency: 3 }` where one member fails: the started siblings are interrupted (observed via `Effect.onInterrupt`) and the queued member never starts.
- **`zip` › "concurrent: true interrupts the other side on failure"** — one side fails, the other (an `Effect.never`) is interrupted.
- **`zipWith` › "concurrent: true interrupts the other side on failure"** — same assertion for `zipWith`.

Modeled on the existing `forEach` interruption tests (`it.effect` + `TestClock.adjust` + `onInterrupt` side-effect capture).

Test-only change, no runtime code touched. `test/Effect.test.ts` passes (226/226); the full suite has 6 pre-existing failures on `main` (EffectKeepAlive, CLI suggestions, OtlpMetrics) that are unrelated and unchanged by this PR.

Closes EFF-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for concurrent effects to verify that sibling operations are interrupted when one fails.
  * Expanded validation for concurrent `Effect.all`, `Effect.zip`, and `Effect.zipWith` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->