### PR TITLE
test: assert acquireUseRelease release runs when use phase is interrupted

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1533,6 +1533,29 @@ describe("Effect", () => {
         assert.isTrue(ref)
       }))
 
+    it.effect("acquireUseRelease release runs when use is interrupted", () =>
+      Effect.gen(function*() {
+        let acquired = false
+        let releaseExit: Exit.Exit<never> | undefined
+        const fiber = yield* Effect.acquireUseRelease(
+          Effect.sync(() => {
+            acquired = true
+            return 123
+          }),
+          () => Effect.never,
+          (resource, exit) =>
+            Effect.sync(() => {
+              assert.strictEqual(resource, 123)
+              releaseExit = exit
+            })
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Fiber.interrupt(fiber)
+        assert.isTrue(acquired)
+        assert.isDefined(releaseExit)
+        assert.isTrue(Exit.hasInterrupts(releaseExit!))
+        assert(Exit.hasInterrupts(fiber.pollUnsafe()!))
+      }))
+
     it.live("async can be uninterruptible", () =>
       Effect.gen(function*() {
         let ref = false


### PR DESCRIPTION
From the EFF-8 interruption audit: no test asserted that the `Effect.acquireUseRelease` release finalizer runs when the **use** phase is interrupted — the existing test only checks the use phase completes under `uninterruptible`, and other coverage is error-path only.

Adds a test to `packages/effect/test/Effect.test.ts` (interruption describe block) that:
- forks an `acquireUseRelease` whose use phase suspends (`Effect.never`)
- interrupts the fiber
- asserts the release finalizer ran with the acquired resource and observed the interrupted exit (`Exit.hasInterrupts`), and the fiber exit is an interrupt

Validation: `pnpm vitest run test/Effect.test.ts` (225 pass), `pnpm lint-fix` (clean), `pnpm check` (clean). The 9 failures in the full `packages/effect` suite (EffectKeepAlive, CLI Command suggestions, metrics delta temporality) reproduce without this change — pre-existing/environment-flaky, unrelated.

Closes EFF-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
