### PR TITLE
Add Queue.take interruption test

### DIFF
--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -130,6 +130,22 @@ describe("Queue", () => {
       assert.deepStrictEqual(result, [5])
     }))
 
+  it.effect("take can be interrupted without losing offers", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<number>()
+      const interruptedFiber = yield* Queue.take(queue).pipe(Effect.forkChild)
+
+      yield* Effect.yieldNow
+      yield* Fiber.interrupt(interruptedFiber)
+      assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(interruptedFiber)))
+
+      const liveFiber = yield* Queue.take(queue).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* Queue.offer(queue, 1)
+
+      assert.strictEqual(yield* Fiber.join(liveFiber), 1)
+    }))
+
   it.effect("done completes takes", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number, Cause.Done>(2)


### PR DESCRIPTION
## Summary

- add regression coverage for interrupting a fiber suspended in `Queue.take`
- assert the interrupted fiber exits with an interruption
- verify a later offer skips the dead waiter and reaches the next live waiter without losing the item

## Validation

- `pnpm test --run packages/effect/test/Queue.test.ts` — 22 tests passed
- `pnpm --filter effect check` — passed
- `pnpm exec dprint check packages/effect/test/Queue.test.ts` — passed
- `pnpm test --run` — full monorepo run completed with 309 files / 8,116 tests passing, but 21 unrelated files / 35 tests failed locally in external-service and timing-heavy suites (SQL, Redis, browser worker, process supervision, and property-test timeouts); the modified Queue suite remained green

Closes EFF-21