### PR TITLE
EFF-24: Test blocked Semaphore.withPermits interruption

### DIFF
--- a/packages/effect/test/Semaphore.test.ts
+++ b/packages/effect/test/Semaphore.test.ts
@@ -305,6 +305,33 @@ describe("Semaphore", () => {
       assert.isTrue(Option.isSome(result))
     }))
 
+  it.effect("withPermits interruption does not leak permits", () =>
+    Effect.gen(function*() {
+      const sem = yield* Semaphore.make(1)
+      let acquired = false
+      const waiter = yield* sem.withPermits(2)(
+        Effect.sync(() => {
+          acquired = true
+        })
+      ).pipe(Effect.forkChild)
+
+      yield* Effect.yieldNow
+      assert.isUndefined(waiter.pollUnsafe())
+
+      yield* Fiber.interrupt(waiter)
+      assert.isFalse(acquired)
+
+      const result = yield* sem.withPermitsIfAvailable(1)(Effect.void)
+      assert.isTrue(Option.isSome(result))
+
+      yield* sem.withPermits(1)(
+        Effect.sync(() => {
+          acquired = true
+        })
+      )
+      assert.isTrue(acquired)
+    }))
+
   it.effect("module-level combinators delegate to the instance api", () =>
     Effect.gen(function*() {
       const sem = yield* Semaphore.make(1)


### PR DESCRIPTION
## Summary

- add regression coverage for interrupting a plain `Semaphore.withPermits` acquisition while it is suspended for insufficient permits
- verify the blocked effect never acquires, the existing permit remains immediately available, and a later acquisition completes

This closes a coverage gap identified by the Effect v4 interruption audit and guards waiter cleanup against future regressions.

## Testing

- `pnpm --dir packages/effect test --run test/Semaphore.test.ts` — 16/16 passed
- `pnpm exec dprint check packages/effect/test/Semaphore.test.ts`
- `pnpm exec oxlint packages/effect/test/Semaphore.test.ts` — 0 warnings/errors
- full core suite attempted: 7,050 passed; three unrelated 5-second load-sensitive timeouts outside `Semaphore.test.ts` (Graph and two schema property tests); Graph passed when isolated and the schema tests passed 243/243 with a 30-second timeout
- full workspace suite attempted: 8,115 passed; integration tests requiring SQL/Redis/container services and two unrelated timing-sensitive tests failed locally

Closes EFF-24