### PR TITLE
Add direct tests for Effect.uninterruptibleMask

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -10,6 +10,7 @@ import {
   Exit,
   Fiber,
   type Filter,
+  Latch,
   Layer,
   Logger,
   type LogLevel,
@@ -1636,6 +1637,142 @@ describe("Effect", () => {
         yield* Fiber.interrupt(fiber)
         assert.strictEqual(signal!.aborted, true)
       }))
+
+    describe("uninterruptibleMask", () => {
+      it.effect("defers a pending interrupt until the masked region completes", () =>
+        Effect.gen(function*() {
+          const masked = yield* Latch.make()
+          const resume = yield* Latch.make()
+          const events: Array<string> = []
+
+          const child = yield* Effect.uninterruptibleMask(() =>
+            Effect.gen(function*() {
+              yield* masked.open
+              yield* resume.await
+              events.push("masked region completed")
+            })
+          ).pipe(Effect.forkChild({ startImmediately: true }))
+
+          yield* masked.await
+          events.push("masked")
+
+          yield* Effect.sync(() => {
+            child.interruptUnsafe(123)
+            events.push("interrupted")
+          })
+          assert.isUndefined(child.pollUnsafe())
+
+          yield* resume.open
+          events.push("resumed")
+          yield* Effect.yieldNow
+          yield* Effect.yieldNow
+
+          const exit = child.pollUnsafe()
+          if (exit === undefined) {
+            return assert.fail("fiber did not exit after the masked region completed")
+          }
+          assert.isTrue(Exit.hasInterrupts(exit))
+          if (exit._tag !== "Failure") {
+            return assert.fail("expected interrupted fiber to exit with failure")
+          }
+          assert.deepStrictEqual(Cause.interruptors(exit.cause), new Set([123]))
+          assert.deepStrictEqual(events, ["masked", "interrupted", "resumed", "masked region completed"])
+        }))
+
+      it.effect("delivers a pending interrupt when restore re-enables interruptibility", () =>
+        Effect.gen(function*() {
+          const masked = yield* Latch.make()
+          const resume = yield* Latch.make()
+          const events: Array<string> = []
+
+          const child = yield* Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function*() {
+              yield* masked.open
+              yield* resume.await
+              // the pending interrupt is delivered at the restore boundary, so
+              // the restored effect never runs
+              return yield* restore(Effect.suspend(() => {
+                events.push("restored")
+                return Effect.never
+              }))
+            })
+          ).pipe(Effect.forkChild({ startImmediately: true }))
+
+          yield* masked.await
+          events.push("masked")
+
+          yield* Effect.sync(() => {
+            child.interruptUnsafe(123)
+            events.push("interrupted")
+          })
+          assert.isUndefined(child.pollUnsafe())
+
+          yield* resume.open
+          events.push("resumed")
+          yield* Effect.yieldNow
+          yield* Effect.yieldNow
+
+          const exit = child.pollUnsafe()
+          if (exit === undefined) {
+            return assert.fail("fiber did not exit after restore re-enabled interruptibility")
+          }
+          assert.isTrue(Exit.hasInterrupts(exit))
+          if (exit._tag !== "Failure") {
+            return assert.fail("expected interrupted fiber to exit with failure")
+          }
+          assert.deepStrictEqual(Cause.interruptors(exit.cause), new Set([123]))
+          assert.deepStrictEqual(events, ["masked", "interrupted", "resumed"])
+        }))
+
+      it.effect("region after a restored section stays uninterruptible", () =>
+        Effect.gen(function*() {
+          const afterRestore = yield* Latch.make()
+          const resume = yield* Latch.make()
+          const events: Array<string> = []
+
+          const child = yield* Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function*() {
+              yield* restore(Effect.sync(() => {
+                events.push("restored section completed")
+              }))
+              yield* afterRestore.open
+              yield* resume.await
+              events.push("masked region completed")
+            })
+          ).pipe(Effect.forkChild({ startImmediately: true }))
+
+          yield* afterRestore.await
+          events.push("after restore")
+
+          yield* Effect.sync(() => {
+            child.interruptUnsafe(123)
+            events.push("interrupted")
+          })
+          assert.isUndefined(child.pollUnsafe())
+
+          yield* resume.open
+          events.push("resumed")
+          yield* Effect.yieldNow
+          yield* Effect.yieldNow
+
+          const exit = child.pollUnsafe()
+          if (exit === undefined) {
+            return assert.fail("fiber did not exit after the masked region completed")
+          }
+          assert.isTrue(Exit.hasInterrupts(exit))
+          if (exit._tag !== "Failure") {
+            return assert.fail("expected interrupted fiber to exit with failure")
+          }
+          assert.deepStrictEqual(Cause.interruptors(exit.cause), new Set([123]))
+          assert.deepStrictEqual(events, [
+            "restored section completed",
+            "after restore",
+            "interrupted",
+            "resumed",
+            "masked region completed"
+          ])
+        }))
+    })
   })
 
   describe("awaitAllChildren", () => {


### PR DESCRIPTION
## Summary

From the EFF-8 interruption audit: `Effect.uninterruptibleMask` had no direct test — only `interruptibleMask` was covered (`packages/effect/test/Fiber.test.ts`). This adds a `describe("uninterruptibleMask")` block to the `interruption` suite in `packages/effect/test/Effect.test.ts`, modeled on the existing `interruptibleMask` pending-interrupt test, covering:

1. **Mask defers interrupts** — a pending interrupt fired inside the masked region is deferred; the masked work runs to completion and the interrupt is delivered at the region boundary (exit has interrupts, interruptor recorded).
2. **`restore` re-enables interruptibility** — a pending interrupt is delivered at the `restore` boundary, before the restored effect's body even evaluates.
3. **Outer region stays masked after a restored section** — after a `restore` section completes normally, the remainder of the mask is still uninterruptible; an interrupt fired there is deferred until the region completes.

All three assert the exit via `Exit.hasInterrupts` and `Cause.interruptors`, and verify event ordering.

## Validation

- `pnpm lint-fix` — clean
- `pnpm vitest run test/Effect.test.ts` — 231 passed
- `pnpm check` — clean
- Full `packages/effect` suite: 7037 passed; the 18 failures (EffectKeepAlive, cli/Command, OtlpMetrics, schema, cluster) reproduce identically on a clean checkout without this change (pre-existing/environmental).

Closes EFF-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
