### PR TITLE
EFF-22: test Deferred waiter cleanup on interrupt

### DIFF
--- a/packages/effect/test/Deferred.test.ts
+++ b/packages/effect/test/Deferred.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Deferred, Option } from "effect"
+import { Deferred, Fiber, Option } from "effect"
 import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
@@ -96,6 +96,25 @@ describe("Deferred", () => {
         assert.isFalse(yield* Deferred.interrupt(deferred))
         const result = yield* Effect.exit(Deferred.await(deferred))
         assert.deepStrictEqual(result, Exit.failCause(Cause.interrupt(-1)))
+      }))
+
+    it.effect("await - interrupting a suspended waiter removes it", () =>
+      Effect.gen(function*() {
+        const deferred = yield* Deferred.make<number>()
+        const interrupted = yield* Deferred.await(deferred).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+        const live = yield* Deferred.await(deferred).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        assert.strictEqual(deferred.resumes?.length, 2)
+        yield* Fiber.interrupt(interrupted)
+        assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(interrupted)))
+        assert.strictEqual(deferred.resumes?.length, 1)
+
+        assert.isTrue(yield* Deferred.succeed(deferred, 42))
+        assert.strictEqual(yield* Fiber.join(live), 42)
       }))
   })
 


### PR DESCRIPTION
## Summary

- add interruption coverage for a fiber suspended in `Deferred.await`
- assert interrupt cleanup removes only the cancelled resume callback
- verify a later `Deferred.succeed` completes normally and reaches the remaining live waiter

## Validation

- `pnpm vitest run packages/effect/test/Deferred.test.ts` — 14 passed
- `pnpm check`
- `pnpm dprint check packages/effect/test/Deferred.test.ts`
- `pnpm oxlint -f unix packages/effect/test/Deferred.test.ts`
- repository-wide `pnpm vitest run` — 8,111 passed; service-backed SQL/Redis suites timed out locally, plus three unrelated browser/property timing failures

Closes EFF-22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred interruption handling so interrupted waiters are removed correctly.
  * Ensured remaining waiters continue to receive the completed deferred value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->