### PR TITLE
Add Latch await interruption coverage

### DIFF
--- a/packages/effect/test/Latch.test.ts
+++ b/packages/effect/test/Latch.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Latch } from "effect"
+import { Effect, Exit, Fiber, Latch } from "effect"
+import * as Scheduler from "effect/Scheduler"
 
 describe("Latch", () => {
   it.effect("release wakes current waiters and keeps the latch closed", () =>
@@ -29,5 +30,61 @@ describe("Latch", () => {
       yield* Effect.yieldNow
 
       assert.isTrue(latch.isOpen())
+    }))
+
+  it.effect("await is interruptible and cleans up interrupted waiters", () =>
+    Effect.gen(function*() {
+      const latch = yield* Latch.make(false)
+      const tasks: Array<() => void> = []
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: "async",
+        makeDispatcher() {
+          return {
+            scheduleTask(task, _priority) {
+              tasks.push(task)
+            },
+            flush() {
+            }
+          }
+        },
+        shouldYield: () => false
+      }
+      const resumed: Array<string> = []
+      const interrupted = yield* Effect.forkChild(
+        Effect.gen(function*() {
+          yield* Latch.await(latch)
+          resumed.push("interrupted")
+        }),
+        { startImmediately: true }
+      )
+
+      assert.isUndefined(interrupted.pollUnsafe())
+
+      yield* Fiber.interrupt(interrupted)
+      const exit = yield* Fiber.await(interrupted)
+      assert.isTrue(Exit.hasInterrupts(exit))
+
+      yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      assert.lengthOf(tasks, 0)
+
+      const live = yield* Effect.forkChild(
+        Effect.gen(function*() {
+          yield* Latch.await(latch)
+          resumed.push("live")
+        }),
+        { startImmediately: true }
+      )
+
+      assert.isUndefined(live.pollUnsafe())
+
+      yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      assert.lengthOf(tasks, 1)
+      assert.isUndefined(live.pollUnsafe())
+
+      tasks.shift()!()
+      yield* Fiber.join(live)
+
+      assert.deepStrictEqual(resumed, ["live"])
+      assert.isFalse(latch.isOpen())
     }))
 })


### PR DESCRIPTION
## Summary

- add regression coverage for interrupting a fiber suspended in `Latch.await`
- verify the interrupted exit and that the cancelled waiter schedules no later release work
- verify a subsequent live waiter is released normally while the latch remains closed

## Testing

- `pnpm vitest run packages/effect/test/Latch.test.ts` — 3 passed
- `pnpm --dir packages/effect check` — passed
- `pnpm dprint check packages/effect/test/Latch.test.ts` — passed
- `pnpm exec oxlint -f unix packages/effect/test/Latch.test.ts` — passed
- `pnpm test --run` — 8,113 passed; 38 unrelated failures across unavailable SQL/Redis services, platform integration timing, and schema timeouts
- `pnpm --dir packages/effect test --run` — 7,037 passed; 16 unrelated cluster/schema timeouts

Closes EFF-23