### PR TITLE
Add test: onExit callback observes interrupt exit

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1986,6 +1986,21 @@ describe("Effect", () => {
         )
         assert.isTrue(ref)
       }))
+
+    it.effect("onExit - callback observes interrupt exit when the fiber is interrupted", () =>
+      Effect.gen(function*() {
+        let observedInterrupt = false
+        const fiber = yield* Effect.never.pipe(
+          Effect.onExit((exit) =>
+            Effect.sync(() => {
+              observedInterrupt = Exit.hasInterrupts(exit)
+            })
+          ),
+          Effect.forkChild({ startImmediately: true })
+        )
+        yield* Fiber.interrupt(fiber)
+        assert.isTrue(observedInterrupt)
+      }))
   })
 
   describe("Effect.ignore", () => {


### PR DESCRIPTION
## Summary

From the EFF-8 interruption audit: `Effect.onExit` had test coverage for die/failure exits only — no test asserted the callback observes an **interrupt** exit when the fiber running the wrapped effect is interrupted.

This adds a test under the existing `onExit` coverage in the `finalization` describe block: it forks `Effect.never` wrapped in `Effect.onExit` via `Effect.forkChild({ startImmediately: true })`, interrupts it with `Fiber.interrupt`, and asserts the callback received an exit for which `Exit.hasInterrupts` is true.

Tests-only change; no changeset needed.

## Validation

- `pnpm vitest run test/Effect.test.ts` — 229 passed
- `pnpm lint-fix` — clean
- `pnpm check` — clean
- Full `packages/effect` suite run: the only failures were pre-existing flaky property-based schema tests and cluster tests that also fail intermittently without this change and pass in isolation on a clean tree.

Closes EFF-15
