### PR TITLE
test: assert Effect.race / Effect.raceFirst interrupt the losing side

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1040,6 +1040,64 @@ describe("Effect", () => {
       assert.deepStrictEqual(interrupted, [500, 300, 200])
     }))
 
+  it.effect("race interrupts the loser when the other side succeeds", () =>
+    Effect.gen(function*() {
+      const interrupted: Array<string> = []
+      const onInterrupt = (label: string) =>
+        Effect.onInterrupt(() =>
+          Effect.sync(() => {
+            interrupted.push(label)
+          })
+        )
+      const fiber = yield* Effect.race(
+        Effect.succeed("fast").pipe(Effect.delay(100), onInterrupt("fast")),
+        Effect.succeed("slow").pipe(Effect.delay(500), onInterrupt("slow"))
+      ).pipe(Effect.forkChild)
+      yield* TestClock.adjust("500 millis")
+      const result = yield* Fiber.join(fiber)
+      assert.strictEqual(result, "fast")
+      assert.deepStrictEqual(interrupted, ["slow"])
+    }))
+
+  it.effect("raceFirst interrupts the loser when the other side succeeds", () =>
+    Effect.gen(function*() {
+      const interrupted: Array<string> = []
+      const onInterrupt = (label: string) =>
+        Effect.onInterrupt(() =>
+          Effect.sync(() => {
+            interrupted.push(label)
+          })
+        )
+      const fiber = yield* Effect.raceFirst(
+        Effect.succeed("fast").pipe(Effect.delay(100), onInterrupt("fast")),
+        Effect.succeed("slow").pipe(Effect.delay(500), onInterrupt("slow"))
+      ).pipe(Effect.forkChild)
+      yield* TestClock.adjust("500 millis")
+      const result = yield* Fiber.join(fiber)
+      assert.strictEqual(result, "fast")
+      assert.deepStrictEqual(interrupted, ["slow"])
+    }))
+
+  it.effect("raceFirst interrupts the loser when the other side fails", () =>
+    Effect.gen(function*() {
+      const interrupted: Array<string> = []
+      const fiber = yield* Effect.raceFirst(
+        Effect.fail("boom").pipe(Effect.delay(100)),
+        Effect.succeed("slow").pipe(
+          Effect.delay(500),
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              interrupted.push("slow")
+            })
+          )
+        )
+      ).pipe(Effect.exit, Effect.forkChild)
+      yield* TestClock.adjust("500 millis")
+      const result = yield* Fiber.join(fiber)
+      assert.deepStrictEqual(result, Exit.fail("boom"))
+      assert.deepStrictEqual(interrupted, ["slow"])
+    }))
+
   describe("repeat", () => {
     it.effect("is interruptible", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
Closes EFF-14

From the EFF-8 interruption audit: the binary `Effect.race` and `Effect.raceFirst` had zero tests (only `raceAll`/`raceAllFirst` were covered). This adds loser-interruption coverage to `packages/effect/test/Effect.test.ts`, modeled on the existing `raceAll`/`raceAllFirst` tests (`it.effect` + `TestClock.adjust` + `Effect.onInterrupt` side-effect capture):

- `Effect.race`: when one side succeeds, the loser is interrupted and its `onInterrupt` handler runs
- `Effect.raceFirst`: same assertion for the first-success case
- `Effect.raceFirst`: when the first completion is a failure, the race fails with it and the still-running side is interrupted

Tests-only change, no changeset.

Validation: `pnpm vitest run test/Effect.test.ts` (231 passed), `pnpm lint-fix` (clean), `pnpm check` (clean). Full `packages/effect` suite run: only pre-existing environment failures (EffectKeepAlive, cli Command suggestions, OtlpMetrics) which fail identically on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
