### PR TITLE
Add interruption test: Effect.callback register cleanup runs on interrupt

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1696,6 +1696,18 @@ describe("Effect", () => {
         assert.strictEqual(signal!.aborted, true)
       }))
 
+    it.effect("callback cleanup effect runs on interrupt", () =>
+      Effect.gen(function*() {
+        let cleanedUp = false
+        const fiber = yield* Effect.callback<void>((_resume) =>
+          Effect.sync(() => {
+            cleanedUp = true
+          })
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Fiber.interrupt(fiber)
+        assert.isTrue(cleanedUp)
+      }))
+
     describe("uninterruptibleMask", () => {
       it.effect("defers a pending interrupt until the masked region completes", () =>
         Effect.gen(function*() {


### PR DESCRIPTION
## Summary

Adds a test asserting that the cleanup Effect returned by an `Effect.callback` register function runs when the suspended fiber is interrupted (the documented `clearTimeout` pattern).

From the EFF-8 interruption audit: existing callback tests only covered `signal.aborted` and resume-after-interrupt; the cleanup-on-interrupt path had no permanent coverage.

Test-only change — no changeset needed.

## Validation

- `pnpm vitest run packages/effect/test/Effect.test.ts` — 224 passed
- `pnpm lint-fix` — clean
- `pnpm check` — clean

Closes EFF-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that cleanup actions run when an active callback is interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->