### PR TITLE
Fix Stream.haltWhen for synchronous streams

### DIFF
--- a/.changeset/fix-stream-haltwhen.md
+++ b/.changeset/fix-stream-haltwhen.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.haltWhen` to observe halt effects at pull boundaries for synchronous streams.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6915,17 +6915,16 @@ export const haltWhen: {
 ): Channel<OutElem, OutErr | OutErr2, OutDone | OutDone2, InElem, InErr, InDone, Env2 | Env> =>
   fromTransformBracket(Effect.fnUntraced(function*(upstream, scope, forkedScope) {
     const pull = yield* toTransform(self)(upstream, scope)
-    let haltCause: Cause.Cause<OutErr2 | Cause.Done<OutDone2>> | undefined = undefined
-    yield* effect.pipe(
-      Effect.catchCause((cause) => {
-        haltCause = cause
-        return Effect.void
-      }),
-      Effect.forkIn(forkedScope)
-    )
-    return Effect.suspend((): Pull.Pull<OutElem, OutErr | OutErr2, OutDone | OutDone2> =>
-      haltCause ? Effect.failCause(haltCause) : pull
-    )
+    const fiber = yield* Effect.forkIn(effect, forkedScope, { startImmediately: true })
+    return Effect.suspend((): Pull.Pull<OutElem, OutErr | OutErr2, OutDone | OutDone2> => {
+      const exit = fiber.pollUnsafe()
+      return exit === undefined
+        ? pull
+        : Exit.match(exit, {
+          onFailure: Effect.failCause,
+          onSuccess: Cause.done
+        })
+    })
   })))
 
 /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -9721,7 +9721,7 @@ export const interruptWhen: {
 )
 
 /**
- * Stops a stream after the current element when an effect completes.
+ * Stops a stream after the current pull when an effect completes.
  *
  * **When to use**
  *
@@ -9734,8 +9734,10 @@ export const interruptWhen: {
  *
  * **Gotchas**
  *
- * This does not interrupt an in-progress pull. Use {@link interruptWhen} when
- * the stream should be interrupted immediately.
+ * This does not interrupt or truncate an in-progress pull. A pull may emit
+ * multiple elements in a single chunk, in which case the entire chunk is
+ * emitted. Use {@link interruptWhen} when the stream should be interrupted
+ * immediately.
  *
  * **Example** (Halting a stream after an effect completes)
  *

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -3421,6 +3421,28 @@ describe("Stream", () => {
   })
 
   describe("haltWhen", () => {
+    it.effect("halts after the current element in the documentation example", () =>
+      Effect.gen(function*() {
+        const halt = yield* Deferred.make<void>()
+        const values = yield* Stream.fromArray([1, 2, 3]).pipe(
+          Stream.tap((value) => value === 2 ? Deferred.succeed(halt, void 0) : Effect.void),
+          Stream.haltWhen(Deferred.await(halt)),
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(values, [1, 2])
+      }))
+
+    it.effect("halts a synchronous upstream before the next chunk", () =>
+      Effect.gen(function*() {
+        const halt = yield* Deferred.make<void>()
+        const values = yield* Stream.fromArrays([1], [2], [3], [4]).pipe(
+          Stream.tap((value) => value === 2 ? Deferred.succeed(halt, void 0) : Effect.void),
+          Stream.haltWhen(Deferred.await(halt)),
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(values, [1, 2])
+      }))
+
     it.effect("halts after the current element", () =>
       Effect.gen(function*() {
         const ref = yield* Ref.make(false)


### PR DESCRIPTION
## Summary

- start the `Channel.haltWhen` signal fiber immediately and inspect its exit at each pull boundary
- preserve the current pull while deterministically observing successful or failed halt effects before the next pull
- clarify `Stream.haltWhen` pull/chunk granularity
- cover the documentation example and a synchronous multi-chunk upstream

## Root cause

The halt effect was forked without being started immediately, while a mutable flag was checked before each pull. A fully synchronous upstream could finish before the watcher fiber was ever scheduled. Successful completion also did not populate the halt cause, so the halt could be missed entirely.

## Validation

- `pnpm --dir packages/effect test --run` (7,060 passed, 4 skipped)
- `pnpm --dir packages/effect check`
- `pnpm lint`

Closes EFF-26