### PR TITLE
Fix mergeAll outer failure handling

### DIFF
--- a/.changeset/blue-pigs-push.md
+++ b/.changeset/blue-pigs-push.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Channel.mergeAll` to propagate outer failures promptly and interrupt active inner channels.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6030,32 +6030,27 @@ export const mergeAll: {
         yield* Scope.addFinalizer(forkedScope, Queue.shutdown(queue))
 
         const pull = yield* toTransform(channels)(upstream, scope)
-        let pendingChannel: Pull.Success<typeof pull> | undefined
 
         yield* Effect.gen(function*() {
           while (true) {
+            let pullFiber: Fiber.Fiber<Pull.Success<typeof pull>, any> | undefined
             if (semaphore) {
-              const takePermit = semaphore.take(1)
               if (fibers.size < concurrencyN) {
-                yield* takePermit
+                yield* semaphore.take(1)
               } else {
+                pullFiber = yield* Effect.forkChild(pull)
                 yield* Effect.raceFirst(
-                  takePermit,
-                  Effect.uninterruptibleMask((restore) =>
-                    restore(pull).pipe(
-                      Effect.flatMap((channel) =>
-                        Effect.sync(() => {
-                          pendingChannel = channel
-                        })
-                      ),
-                      Effect.andThen(Effect.never)
-                    )
+                  semaphore.take(1),
+                  Effect.flatMap(
+                    Fiber.await(pullFiber),
+                    (exit) => Exit.isSuccess(exit) ? Effect.never : exit
                   )
                 )
               }
             }
-            const channel = pendingChannel ?? (yield* pull)
-            pendingChannel = undefined
+            const channel = pullFiber === undefined
+              ? yield* pull
+              : yield* Effect.flatten(Fiber.await(pullFiber))
             const childScope = Scope.forkUnsafe(forkedScope)
             const childPull = yield* toTransform(channel)(upstream, childScope)
 

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6041,16 +6041,13 @@ export const mergeAll: {
                 pullFiber = yield* Effect.forkChild(pull)
                 yield* Effect.raceFirst(
                   semaphore.take(1),
-                  Effect.flatMap(
-                    Fiber.await(pullFiber),
-                    (exit) => Exit.isSuccess(exit) ? Effect.never : exit
-                  )
+                  Effect.andThen(Fiber.join(pullFiber), Effect.never)
                 )
               }
             }
             const channel = pullFiber === undefined
               ? yield* pull
-              : yield* Effect.flatten(Fiber.await(pullFiber))
+              : yield* Fiber.join(pullFiber)
             const childScope = Scope.forkUnsafe(forkedScope)
             const childPull = yield* toTransform(channel)(upstream, childScope)
 
@@ -6092,7 +6089,6 @@ export const mergeAll: {
             }
             const inFlight = Arr.fromIterable(fibers)
             fibers.clear()
-            doneLatch.openUnsafe()
             return Effect.uninterruptible(Effect.withFiber((parent) => {
               // Signal every child before publishing the failure. The driver's
               // interrupt-children middleware awaits them when the driver exits.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6087,16 +6087,7 @@ export const mergeAll: {
             if (Result.isSuccess(halt)) {
               return doneLatch.whenOpen(Queue.failCause(queue, cause))
             }
-            const inFlight = Arr.fromIterable(fibers)
-            fibers.clear()
-            return Effect.uninterruptible(Effect.withFiber((parent) => {
-              // Signal every child before publishing the failure. The driver's
-              // interrupt-children middleware awaits them when the driver exits.
-              for (const fiber of inFlight) {
-                fiber.interruptUnsafe(parent.id)
-              }
-              return Queue.failCause(queue, cause)
-            }))
+            return Queue.failCause(queue, cause)
           }),
           Effect.forkIn(forkedScope)
         )

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6030,11 +6030,32 @@ export const mergeAll: {
         yield* Scope.addFinalizer(forkedScope, Queue.shutdown(queue))
 
         const pull = yield* toTransform(channels)(upstream, scope)
+        let pendingChannel: Pull.Success<typeof pull> | undefined
 
         yield* Effect.gen(function*() {
           while (true) {
-            const channel = yield* pull
-            if (semaphore) yield* semaphore.take(1)
+            if (semaphore) {
+              const takePermit = semaphore.take(1)
+              if (fibers.size < concurrencyN) {
+                yield* takePermit
+              } else {
+                yield* Effect.raceFirst(
+                  takePermit,
+                  Effect.uninterruptibleMask((restore) =>
+                    restore(pull).pipe(
+                      Effect.flatMap((channel) =>
+                        Effect.sync(() => {
+                          pendingChannel = channel
+                        })
+                      ),
+                      Effect.andThen(Effect.never)
+                    )
+                  )
+                )
+              }
+            }
+            const channel = pendingChannel ?? (yield* pull)
+            pendingChannel = undefined
             const childScope = Scope.forkUnsafe(forkedScope)
             const childPull = yield* toTransform(channel)(upstream, childScope)
 

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6069,7 +6069,23 @@ export const mergeAll: {
             fibers.add(fiber)
           }
         }).pipe(
-          Effect.catchCause((cause) => doneLatch.whenOpen(Queue.failCause(queue, cause))),
+          Effect.catchCause((cause) => {
+            const halt = Pull.filterDone(cause)
+            if (Result.isSuccess(halt)) {
+              return doneLatch.whenOpen(Queue.failCause(queue, cause))
+            }
+            const inFlight = Arr.fromIterable(fibers)
+            fibers.clear()
+            doneLatch.openUnsafe()
+            return Effect.uninterruptible(Effect.withFiber((parent) => {
+              // Signal every child before publishing the failure. The enclosing
+              // scope waits for their finalizers without delaying the queue.
+              for (const fiber of inFlight) {
+                fiber.interruptUnsafe(parent.id)
+              }
+              return Queue.failCause(queue, cause)
+            }))
+          }),
           Effect.forkIn(forkedScope)
         )
 

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6033,8 +6033,8 @@ export const mergeAll: {
 
         yield* Effect.gen(function*() {
           while (true) {
-            if (semaphore) yield* semaphore.take(1)
             const channel = yield* pull
+            if (semaphore) yield* semaphore.take(1)
             const childScope = Scope.forkUnsafe(forkedScope)
             const childPull = yield* toTransform(channel)(upstream, childScope)
 
@@ -6078,8 +6078,8 @@ export const mergeAll: {
             fibers.clear()
             doneLatch.openUnsafe()
             return Effect.uninterruptible(Effect.withFiber((parent) => {
-              // Signal every child before publishing the failure. The enclosing
-              // scope waits for their finalizers without delaying the queue.
+              // Signal every child before publishing the failure. The driver's
+              // interrupt-children middleware awaits them when the driver exits.
               for (const fiber of inFlight) {
                 fiber.interruptUnsafe(parent.id)
               }

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1031,6 +1031,67 @@ describe("Stream", () => {
       }))
   })
 
+  const testOuterFailure = (
+    combinator: "flatMap" | "switchMap",
+    inner: "never" | "slow"
+  ) =>
+    Effect.gen(function*() {
+      const started = yield* Latch.make(false)
+      const failing = yield* Deferred.make<void>()
+      const finalized = yield* Ref.make(0)
+      const outer = Stream.concat(
+        Stream.make(1),
+        Stream.fromEffect(
+          started.await.pipe(
+            Effect.andThen(Deferred.succeed(failing, void 0)),
+            Effect.andThen(Effect.fail("boom"))
+          )
+        )
+      )
+      const makeInner = () => {
+        started.openUnsafe()
+        return (inner === "never" ? Stream.never : Stream.fromEffect(Effect.sleep(Duration.hours(1)))).pipe(
+          Stream.ensuring(Ref.update(finalized, (n) => n + 1))
+        )
+      }
+      const stream = combinator === "flatMap"
+        ? Stream.flatMap(outer, makeInner, { concurrency: 2 })
+        : Stream.switchMap(outer, makeInner)
+      const fiber = yield* stream.pipe(
+        Stream.runDrain,
+        Effect.forkChild
+      )
+      yield* Deferred.await(failing)
+
+      const result = yield* Fiber.await(fiber)
+      assert.deepStrictEqual(result, Exit.fail("boom"))
+      assert.strictEqual(yield* Ref.get(finalized), 1)
+    })
+
+  describe("flatMap", () => {
+    it.effect(
+      "interrupts never-ending inner streams when the outer stream fails",
+      () => testOuterFailure("flatMap", "never")
+    )
+
+    it.effect(
+      "fails promptly and interrupts slow inner streams when the outer stream fails",
+      () => testOuterFailure("flatMap", "slow")
+    )
+  })
+
+  describe("switchMap", () => {
+    it.effect(
+      "interrupts a never-ending inner stream when the outer stream fails",
+      () => testOuterFailure("switchMap", "never")
+    )
+
+    it.effect(
+      "fails promptly and interrupts a slow inner stream when the outer stream fails",
+      () => testOuterFailure("switchMap", "slow")
+    )
+  })
+
   it.effect.prop(
     "rechunk",
     {

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1093,6 +1093,53 @@ describe("Stream", () => {
         assert.strictEqual(yield* Ref.get(finalized), 2)
       }))
 
+    it.effect("releases a permit after a successful saturated pull", () =>
+      Effect.gen(function*() {
+        const gate = yield* Deferred.make<void>()
+        const outer = Stream.concat(
+          Stream.make(1, 2),
+          Stream.fromEffect(Deferred.succeed(gate, void 0).pipe(Effect.as(3)))
+        )
+        const result = yield* Stream.flatMap(
+          outer,
+          (n) => n === 3 ? Stream.make(3) : Stream.fromEffect(Deferred.await(gate).pipe(Effect.as(n))),
+          { concurrency: 2 }
+        ).pipe(Stream.runCollect)
+
+        assert.deepStrictEqual([...result].sort(), [1, 2, 3])
+      }))
+
+    it.effect("preserves an outer element when a permit arrives during a pull", () =>
+      Effect.gen(function*() {
+        const probing = yield* Deferred.make<void>()
+        const gate = yield* Deferred.make<void>()
+        const innerGate = yield* Deferred.make<void>()
+        const outer = Stream.concat(
+          Stream.make(1, 2),
+          Stream.fromEffect(
+            Deferred.succeed(probing, void 0).pipe(
+              Effect.andThen(Deferred.await(gate)),
+              Effect.as(3)
+            )
+          )
+        )
+        const fiber = yield* Stream.flatMap(
+          outer,
+          (n) => n === 3 ? Stream.make(3) : Stream.fromEffect(Deferred.await(innerGate).pipe(Effect.as(n))),
+          { concurrency: 2 }
+        ).pipe(
+          Stream.runCollect,
+          Effect.forkChild
+        )
+        yield* Deferred.await(probing)
+        yield* Deferred.succeed(innerGate, void 0)
+        for (let i = 0; i < 10; i++) yield* Effect.yieldNow
+        yield* Deferred.succeed(gate, void 0)
+
+        const result = yield* Fiber.join(fiber)
+        assert.deepStrictEqual([...result].sort(), [1, 2, 3])
+      }))
+
     it.effect(
       "fails promptly and interrupts slow inner streams when the outer stream fails",
       () => testOuterFailure("flatMap", "slow")

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1069,10 +1069,29 @@ describe("Stream", () => {
     })
 
   describe("flatMap", () => {
-    it.effect(
-      "interrupts never-ending inner streams when the outer stream fails",
-      () => testOuterFailure("flatMap", "never")
-    )
+    it.effect("interrupts all inner streams when the outer fails at the concurrency limit", () =>
+      Effect.gen(function*() {
+        const latch = yield* Latch.make()
+        const finalized = yield* Ref.make(0)
+        const outer = Stream.concat(
+          Stream.make(1, 2),
+          Stream.flatMap(Stream.fromEffect(latch.await), () => Stream.fail("boom"))
+        )
+        const result = yield* Stream.flatMap(
+          outer,
+          () =>
+            Stream.flatMap(Stream.fromEffect(latch.open), () => Stream.never).pipe(
+              Stream.ensuring(Ref.update(finalized, (n) => n + 1))
+            ),
+          { concurrency: 2 }
+        ).pipe(
+          Stream.runDrain,
+          Effect.exit
+        )
+
+        assert.deepStrictEqual(result, Exit.fail("boom"))
+        assert.strictEqual(yield* Ref.get(finalized), 2)
+      }))
 
     it.effect(
       "fails promptly and interrupts slow inner streams when the outer stream fails",

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1114,6 +1114,7 @@ describe("Stream", () => {
         const probing = yield* Deferred.make<void>()
         const gate = yield* Deferred.make<void>()
         const innerGate = yield* Deferred.make<void>()
+        const innerCompleted = yield* Deferred.make<void>()
         const outer = Stream.concat(
           Stream.make(1, 2),
           Stream.fromEffect(
@@ -1125,7 +1126,12 @@ describe("Stream", () => {
         )
         const fiber = yield* Stream.flatMap(
           outer,
-          (n) => n === 3 ? Stream.make(3) : Stream.fromEffect(Deferred.await(innerGate).pipe(Effect.as(n))),
+          (n) =>
+            n === 3
+              ? Stream.make(3)
+              : Stream.fromEffect(Deferred.await(innerGate).pipe(Effect.as(n))).pipe(
+                Stream.ensuring(Deferred.succeed(innerCompleted, void 0))
+              ),
           { concurrency: 2 }
         ).pipe(
           Stream.runCollect,
@@ -1133,7 +1139,7 @@ describe("Stream", () => {
         )
         yield* Deferred.await(probing)
         yield* Deferred.succeed(innerGate, void 0)
-        for (let i = 0; i < 10; i++) yield* Effect.yieldNow
+        yield* Deferred.await(innerCompleted)
         yield* Deferred.succeed(gate, void 0)
 
         const result = yield* Fiber.join(fiber)


### PR DESCRIPTION
## Summary

- preserve permit-before-pull ordering for normal `Channel.mergeAll` operation
- at a saturated concurrency window, run the outer pull in a child fiber and race permit acquisition only against an observer of that fiber; the pull itself is never aborted
- propagate real outer failures immediately through the output queue, while preserving wait-on-normal-`Done` behavior; normal driver teardown interrupts and awaits tracked children
- cover concurrent `Stream.flatMap` at the exact concurrency limit, successful saturated pulls, permit arrival during an in-flight pull, slow finite inners, and the corresponding `Stream.switchMap` failure cases
- include an `effect` patch changeset

## Root cause

The merge driver gated every outer termination cause on `doneLatch`, which is correct only for normal completion. It also could not observe a pending outer failure while every permit was held by never-ending inner channels. Together these behaviors left the stream hung indefinitely.

## Implementation

Normal outer pulls remain guarded by a semaphore permit. When the concurrency window is already full, the driver forks the next pull as a child and races permit acquisition against a `Fiber.await` observer. An outer failure therefore preempts the permit wait. If the permit wins while the pull is still running, only the observer is interrupted; the pull fiber continues and the driver joins its cached exit afterward. This prevents both successful-probe deadlocks and lost elements or failures from an aborted stateful pull.

On a real outer failure, the driver fails the output queue immediately. The queue's first terminal cause is retained while the driver's interrupt-children middleware interrupts and awaits the tracked child fibers during normal teardown, so inner finalizers complete without manual fiber-set mutation.

## Validation

- `pnpm --dir packages/effect test --run` (7,072 passed, 4 skipped)
- the six focused regressions pass
- the saturated outer-failure/cause/finalizer regression passed in 25 repeated runs
- `pnpm --dir packages/effect check`
- `pnpm lint-fix`

Closes EFF-25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent stream/Channel merging so outer failures propagate promptly.
  * When an outer failure occurs, active inner streams are interrupted and non-“done” failures fail the result immediately.
  * Reduced upstream pull latency under saturated concurrency by prefetching pulls when possible.
* **Tests**
  * Added coverage to verify prompt failure propagation, correct finalization behavior, permit release, and interruption timing for `flatMap` and `switchMap` under concurrency edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->