### PR TITLE
Fix streaming tool call concurrency

### DIFF
--- a/.changeset/fix-language-model-stream-concurrency.md
+++ b/.changeset/fix-language-model-stream-concurrency.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `LanguageModel.streamText` to apply the configured concurrency limit to tool call resolution, including approval checks.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -23,6 +23,7 @@ import * as Queue from "../../Queue.ts"
 import { CurrentConcurrency } from "../../References.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
+import * as Semaphore from "../../Semaphore.ts"
 import * as Sink from "../../Sink.ts"
 import * as Stream from "../../Stream.ts"
 import type { Span } from "../../Tracer.ts"
@@ -1007,6 +1008,8 @@ export const make: (params: {
   ) {
     const tracker = Option.getOrUndefined(yield* Effect.serviceOption(ResponseIdTracker.ResponseIdTracker))
     const toolChoice = options.toolChoice ?? "auto"
+    const concurrency = yield* resolveToolCallConcurrency(options.concurrency)
+    providerOptions.span.attribute("concurrency", concurrency)
 
     const generateWithNonIncrementalFallback = () => {
       const requestOptions: ProviderOptions = {
@@ -1124,7 +1127,7 @@ export const make: (params: {
       const approvedResults = yield* executeApprovedToolCalls(
         approved,
         toolkit,
-        options.concurrency
+        concurrency
       )
       const deniedResults = createDenialResults(denied)
       const preResolvedResults = [...approvedResults, ...deniedResults]
@@ -1192,7 +1195,7 @@ export const make: (params: {
       rawContent,
       toolkit,
       providerOptions.prompt.content,
-      options.concurrency
+      concurrency
     ).pipe(
       Stream.filter(
         (result) =>
@@ -1242,6 +1245,8 @@ export const make: (params: {
   ) {
     const tracker = Option.getOrUndefined(yield* Effect.serviceOption(ResponseIdTracker.ResponseIdTracker))
     const toolChoice = options.toolChoice ?? "auto"
+    const concurrency = yield* resolveToolCallConcurrency(options.concurrency)
+    providerOptions.span.attribute("concurrency", concurrency)
 
     const streamWithNonIncrementalFallback = () => {
       const requestOptions: ProviderOptions = {
@@ -1382,7 +1387,7 @@ export const make: (params: {
       const approvedResults = yield* executeApprovedToolCalls(
         pendingApproved,
         toolkit,
-        options.concurrency
+        concurrency
       )
       const deniedResults = createDenialResults(pendingDenied)
       const preResolvedResults = [...approvedResults, ...deniedResults]
@@ -1489,6 +1494,9 @@ export const make: (params: {
 
     // FiberSet to track concurrent tool call handlers
     const toolCallFibers = yield* FiberSet.make<void, AiError.AiError>()
+    const toolCallSemaphore = concurrency === "unbounded"
+      ? undefined
+      : yield* Semaphore.make(concurrency)
 
     // Helper function to handle tool calls with approval logic
     const handleToolCall = Effect.fnUntraced(function*(part: Response.ToolCallPartEncoded) {
@@ -1553,7 +1561,11 @@ export const make: (params: {
           // Fork tool call handlers - use the raw chunk for encoded params
           for (const part of chunk) {
             if (part.type === "tool-call" && part.providerExecuted !== true) {
-              yield* FiberSet.run(toolCallFibers, handleToolCall(part))
+              const effect = handleToolCall(part)
+              yield* FiberSet.run(
+                toolCallFibers,
+                toolCallSemaphore ? toolCallSemaphore.withPermit(effect) : effect
+              )
             }
           }
         })
@@ -1954,10 +1966,19 @@ const isApprovalNeeded = Effect.fnUntraced(function*<T extends Tool.Any>(
   return tool.needsApproval
 }, Effect.orElseSucceed(constFalse))
 
+type ResolvedConcurrency = Exclude<Concurrency, "inherit">
+
+const resolveToolCallConcurrency = (
+  concurrency: Concurrency | undefined
+): Effect.Effect<ResolvedConcurrency> =>
+  concurrency === "inherit"
+    ? Effect.service(CurrentConcurrency)
+    : Effect.succeed(concurrency ?? "unbounded")
+
 const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
   approvals: ReadonlyArray<ApprovalResult>,
   toolkit: Toolkit.WithHandler<Tools>,
-  concurrency: Concurrency | undefined
+  concurrency: ResolvedConcurrency
 ): Effect.Effect<
   Array<Prompt.ToolResultPart>,
   Tool.HandlerError<Tools[keyof Tools]> | AiError.AiError,
@@ -2007,14 +2028,8 @@ const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
     })
   })
 
-  return Effect.gen(function*() {
-    const resolveConcurrency = concurrency === "inherit"
-      ? yield* Effect.service(CurrentConcurrency)
-      : (concurrency ?? "unbounded")
-
-    return yield* Effect.forEach(approvals, executeTool, {
-      concurrency: resolveConcurrency
-    })
+  return Effect.forEach(approvals, executeTool, {
+    concurrency
   })
 }
 
@@ -2053,7 +2068,7 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
   content: ReadonlyArray<Response.AllPartsEncoded>,
   toolkit: Toolkit.WithHandler<Tools>,
   messages: ReadonlyArray<Prompt.Message>,
-  concurrency: Concurrency | undefined
+  concurrency: ResolvedConcurrency
 ): Stream.Stream<
   ToolResolutionResult<Tools>,
   Tool.HandlerError<Tools[keyof Tools]> | AiError.AiError,
@@ -2142,14 +2157,7 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
     }).pipe(Stream.unwrap)
   )
 
-  const resolveConcurrency = concurrency === "inherit"
-    ? Effect.service(CurrentConcurrency)
-    : Effect.succeed(concurrency ?? "unbounded")
-
-  return resolveConcurrency.pipe(
-    Effect.map((concurrency) => Stream.mergeAll(streams, { concurrency })),
-    Stream.unwrap
-  )
+  return Stream.mergeAll(streams, { concurrency })
 }
 
 // =============================================================================

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -156,7 +156,7 @@ describe("LanguageModel", () => {
         strictEqual(parts[2]?.type, "finish")
       }))
 
-    it("runs tool handlers sequentially with concurrency: 1", () =>
+    it.effect("runs tool handlers sequentially with concurrency: 1", () =>
       Effect.gen(function*() {
         const active = yield* Ref.make(0)
         const maxActive = yield* Ref.make(0)
@@ -217,7 +217,7 @@ describe("LanguageModel", () => {
         strictEqual(yield* Ref.get(maxActive), 1)
       }))
 
-    it("allows tool handler overlap up to a bounded concurrency", () =>
+    it.effect("allows tool handler overlap up to a bounded concurrency", () =>
       Effect.gen(function*() {
         const active = yield* Ref.make(0)
         const maxActive = yield* Ref.make(0)
@@ -280,7 +280,7 @@ describe("LanguageModel", () => {
         strictEqual(yield* Ref.get(maxActive), 2)
       }))
 
-    it("bounds needsApproval evaluation with the tool handler concurrency", () =>
+    it.effect("bounds needsApproval evaluation with the tool handler concurrency", () =>
       Effect.gen(function*() {
         const active = yield* Ref.make(0)
         const maxActive = yield* Ref.make(0)

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertDefined, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Effect, Latch, Option, Schema, Stream } from "effect"
+import { Effect, Fiber, Latch, Option, Ref, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { AiError, LanguageModel, Prompt, Response, ResponseIdTracker, Tool, Toolkit } from "effect/unstable/ai"
 import * as TestUtils from "./utils.ts"
@@ -154,6 +154,191 @@ describe("LanguageModel", () => {
         strictEqual(parts[0]?.type, "tool-call")
         strictEqual(parts[1]?.type, "tool-result")
         strictEqual(parts[2]?.type, "finish")
+      }))
+
+    it("runs tool handlers sequentially with concurrency: 1", () =>
+      Effect.gen(function*() {
+        const active = yield* Ref.make(0)
+        const maxActive = yield* Ref.make(0)
+        const started = yield* Latch.make()
+        const release = yield* Latch.make()
+
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Effect.gen(function*() {
+              const current = yield* Ref.updateAndGet(active, (n) => n + 1)
+              yield* Ref.update(maxActive, (n) => Math.max(n, current))
+              yield* started.open
+              yield* release.await
+              return { testSuccess: "test-success" }
+            }).pipe(Effect.ensuring(Ref.update(active, (n) => n - 1)))
+        })
+
+        const fiber = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit,
+          concurrency: 1
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-1",
+                name: "MyTool",
+                params: { testParam: "test-1" }
+              },
+              {
+                type: "tool-call",
+                id: "tool-2",
+                name: "MyTool",
+                params: { testParam: "test-2" }
+              },
+              {
+                type: "tool-call",
+                id: "tool-3",
+                name: "MyTool",
+                params: { testParam: "test-3" }
+              }
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.forkScoped
+        )
+
+        yield* started.await
+        strictEqual(yield* Ref.get(active), 1)
+        strictEqual(yield* Ref.get(maxActive), 1)
+
+        yield* release.open
+        yield* Fiber.join(fiber)
+
+        strictEqual(yield* Ref.get(active), 0)
+        strictEqual(yield* Ref.get(maxActive), 1)
+      }))
+
+    it("allows tool handler overlap up to a bounded concurrency", () =>
+      Effect.gen(function*() {
+        const active = yield* Ref.make(0)
+        const maxActive = yield* Ref.make(0)
+        const twoStarted = yield* Latch.make()
+        const release = yield* Latch.make()
+
+        const handlers = MyToolkit.toLayer({
+          MyTool: () =>
+            Effect.gen(function*() {
+              const current = yield* Ref.updateAndGet(active, (n) => n + 1)
+              yield* Ref.update(maxActive, (n) => Math.max(n, current))
+              if (current === 2) {
+                yield* twoStarted.open
+              }
+              yield* release.await
+              return { testSuccess: "test-success" }
+            }).pipe(Effect.ensuring(Ref.update(active, (n) => n - 1)))
+        })
+
+        const fiber = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit,
+          concurrency: 2
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-1",
+                name: "MyTool",
+                params: { testParam: "test-1" }
+              },
+              {
+                type: "tool-call",
+                id: "tool-2",
+                name: "MyTool",
+                params: { testParam: "test-2" }
+              },
+              {
+                type: "tool-call",
+                id: "tool-3",
+                name: "MyTool",
+                params: { testParam: "test-3" }
+              }
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.forkScoped
+        )
+
+        yield* twoStarted.await
+        strictEqual(yield* Ref.get(active), 2)
+        strictEqual(yield* Ref.get(maxActive), 2)
+
+        yield* release.open
+        yield* Fiber.join(fiber)
+
+        strictEqual(yield* Ref.get(active), 0)
+        strictEqual(yield* Ref.get(maxActive), 2)
+      }))
+
+    it("bounds needsApproval evaluation with the tool handler concurrency", () =>
+      Effect.gen(function*() {
+        const active = yield* Ref.make(0)
+        const maxActive = yield* Ref.make(0)
+        const started = yield* Latch.make()
+        const release = yield* Latch.make()
+
+        const tool = Tool.make("ApprovalConcurrencyTool", {
+          parameters: Schema.Struct({ input: Schema.String }),
+          success: Schema.Struct({ output: Schema.String }),
+          needsApproval: () =>
+            Effect.gen(function*() {
+              const current = yield* Ref.updateAndGet(active, (n) => n + 1)
+              yield* Ref.update(maxActive, (n) => Math.max(n, current))
+              yield* started.open
+              yield* release.await
+              return false
+            }).pipe(Effect.ensuring(Ref.update(active, (n) => n - 1)))
+        })
+        const toolkit = Toolkit.make(tool)
+        const handlers = toolkit.toLayer({
+          ApprovalConcurrencyTool: () => Effect.succeed({ output: "done" })
+        })
+
+        const fiber = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit,
+          concurrency: 1
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-1",
+                name: "ApprovalConcurrencyTool",
+                params: { input: "test-1" }
+              },
+              {
+                type: "tool-call",
+                id: "tool-2",
+                name: "ApprovalConcurrencyTool",
+                params: { input: "test-2" }
+              }
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.forkScoped
+        )
+
+        yield* started.await
+        strictEqual(yield* Ref.get(active), 1)
+        strictEqual(yield* Ref.get(maxActive), 1)
+
+        yield* release.open
+        yield* Fiber.join(fiber)
+
+        strictEqual(yield* Ref.get(active), 0)
+        strictEqual(yield* Ref.get(maxActive), 1)
       }))
   })
 


### PR DESCRIPTION
## Summary

- share one concurrency resolver between `generateText` and `streamText`, including the default and `"inherit"` mappings
- bound the complete streaming `handleToolCall` effect so approval checks and handlers both respect the configured concurrency
- record the resolved concurrency on language-model spans and add a patch changeset
- cover sequential execution, bounded overlap, and bounded `needsApproval` evaluation

## Root cause

`generateText` merged tool-call streams with its resolved concurrency, while `streamText` forked every tool call directly into an unbounded `FiberSet`. As a result, streaming ignored `GenerateTextOptions.concurrency`, including during dynamic approval checks.

## Validation

- the three new `it.effect` tests pass with this fix (3 passed, 29 filtered)
- with only `LanguageModel.ts` restored to the pre-PR source, all three regression tests fail at their concurrency assertions; after restoring the fixed source, all three pass again
- full `LanguageModel.test.ts`: 32 passed
- `pnpm --dir packages/effect check`
- `pnpm lint`

The initial `Test (1/2, Deno)` failure is unrelated to this change: it is a 30-second timeout in `@effect/sql-mysql2`'s `PersistedCache (sql-mysql2-multi) > smoke test`. The PR changes only AI language-model code/tests, the exact base commit passes that MySQL file in isolation (11/11), and recent `main` Deno runs show the same pre-existing SQL/test-container timing failure class.

Closes EFF-29