### PR TITLE
Interrupt Stream async iterable pulls on iterator close

### DIFF
--- a/.changeset/curly-streams-stop.md
+++ b/.changeset/curly-streams-stop.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Interrupt in-flight stream pulls when closing an async iterator.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -11341,11 +11341,9 @@ export const toAsyncIterableWith: {
       let pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E, void, R> | undefined
       let currentIter: Iterator<A> | undefined
       let currentFiber: Fiber.Fiber<Arr.NonEmptyReadonlyArray<A>, E | Cause.Done<void>> | undefined
-      let closed = false
       let closePromise: Promise<IteratorResult<A>> | undefined
       const close = (exit: Exit.Exit<unknown, unknown>): Promise<IteratorResult<A>> => {
         if (closePromise) return closePromise
-        closed = true
         const fiber = currentFiber
         closePromise = runPromise(Effect.as(
           Effect.andThen(
@@ -11365,7 +11363,7 @@ export const toAsyncIterableWith: {
       }
       return {
         async next(): Promise<IteratorResult<A>> {
-          if (closed) return closePromise!
+          if (closePromise) return closePromise
           if (currentIter) {
             const next = currentIter.next()
             if (!next.done) return next
@@ -11389,8 +11387,8 @@ export const toAsyncIterableWith: {
           } else if (Pull.isDoneCause(exit.cause)) {
             return close(Exit.void)
           }
-          if (closed && Cause.hasInterruptsOnly(exit.cause)) {
-            return closePromise!
+          if (closePromise && Cause.hasInterruptsOnly(exit.cause)) {
+            return closePromise
           }
           await closeAndReportError(exit)
           throw Cause.squash(exit.cause)

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -11358,7 +11358,7 @@ export const toAsyncIterableWith: {
       }
       return {
         async next(): Promise<IteratorResult<A>> {
-          if (closed) return { done: true, value: undefined }
+          if (closed) return closePromise!
           if (currentIter) {
             const next = currentIter.next()
             if (!next.done) return next
@@ -11381,6 +11381,9 @@ export const toAsyncIterableWith: {
             return currentIter.next()
           } else if (Pull.isDoneCause(exit.cause)) {
             return close()
+          }
+          if (closed && Cause.hasInterruptsOnly(exit.cause)) {
+            return closePromise!
           }
           await close()
           throw Cause.squash(exit.cause)

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -11343,18 +11343,25 @@ export const toAsyncIterableWith: {
       let currentFiber: Fiber.Fiber<Arr.NonEmptyReadonlyArray<A>, E | Cause.Done<void>> | undefined
       let closed = false
       let closePromise: Promise<IteratorResult<A>> | undefined
-      const close = (): Promise<IteratorResult<A>> => {
+      const close = (exit: Exit.Exit<unknown, unknown>): Promise<IteratorResult<A>> => {
         if (closePromise) return closePromise
         closed = true
         const fiber = currentFiber
         closePromise = runPromise(Effect.as(
           Effect.andThen(
             fiber ? Fiber.interrupt(fiber) : Effect.void,
-            Scope.close(scope, Exit.void)
+            Scope.close(scope, exit)
           ),
           { done: true, value: undefined }
         ))
         return closePromise
+      }
+      const closeAndReportError = async (exit: Exit.Exit<unknown, unknown>): Promise<void> => {
+        try {
+          await close(exit)
+        } catch (error) {
+          await runPromise(Effect.logError("Suppressed error while closing Stream async iterator", error))
+        }
       }
       return {
         async next(): Promise<IteratorResult<A>> {
@@ -11380,19 +11387,19 @@ export const toAsyncIterableWith: {
             currentIter = exit.value[Symbol.iterator]()
             return currentIter.next()
           } else if (Pull.isDoneCause(exit.cause)) {
-            return close()
+            return close(Exit.void)
           }
           if (closed && Cause.hasInterruptsOnly(exit.cause)) {
             return closePromise!
           }
-          await close()
+          await closeAndReportError(exit)
           throw Cause.squash(exit.cause)
         },
         return() {
-          return close()
+          return close(Exit.void)
         },
         async throw(error) {
-          await close()
+          await closeAndReportError(Exit.die(error))
           throw error
         }
       }

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -11336,32 +11336,61 @@ export const toAsyncIterableWith: {
   ): AsyncIterable<A> => ({
     [Symbol.asyncIterator]() {
       const runPromise = Effect.runPromiseWith(context)
-      const runPromiseExit = Effect.runPromiseExitWith(context)
+      const runFork = Effect.runForkWith(context)
       const scope = Scope.makeUnsafe()
       let pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E, void, R> | undefined
       let currentIter: Iterator<A> | undefined
+      let currentFiber: Fiber.Fiber<Arr.NonEmptyReadonlyArray<A>, E | Cause.Done<void>> | undefined
+      let closed = false
+      let closePromise: Promise<IteratorResult<A>> | undefined
+      const close = (): Promise<IteratorResult<A>> => {
+        if (closePromise) return closePromise
+        closed = true
+        const fiber = currentFiber
+        closePromise = runPromise(Effect.as(
+          Effect.andThen(
+            fiber ? Fiber.interrupt(fiber) : Effect.void,
+            Scope.close(scope, Exit.void)
+          ),
+          { done: true, value: undefined }
+        ))
+        return closePromise
+      }
       return {
         async next(): Promise<IteratorResult<A>> {
+          if (closed) return { done: true, value: undefined }
           if (currentIter) {
             const next = currentIter.next()
             if (!next.done) return next
             currentIter = undefined
           }
-          pull ??= await runPromise(Channel.toPullScoped(self.channel, scope))
-          const exit = await runPromiseExit(pull)
+          const fiber = runFork(
+            pull ??
+              Effect.flatMap(Channel.toPullScoped(self.channel, scope), (nextPull) => {
+                pull = nextPull
+                return nextPull
+              })
+          )
+          currentFiber = fiber
+          const exit = await runPromise(Fiber.await(fiber))
+          if (currentFiber === fiber) {
+            currentFiber = undefined
+          }
           if (Exit.isSuccess(exit)) {
             currentIter = exit.value[Symbol.iterator]()
             return currentIter.next()
           } else if (Pull.isDoneCause(exit.cause)) {
-            return { done: true, value: undefined }
+            return close()
           }
+          await close()
           throw Cause.squash(exit.cause)
         },
-        return(_) {
-          return runPromise(Effect.as(
-            Scope.close(scope, Exit.void),
-            { done: true, value: undefined }
-          ))
+        return() {
+          return close()
+        },
+        async throw(error) {
+          await close()
+          throw error
         }
       }
     }

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -181,10 +181,34 @@ describe("Stream", () => {
           )
         )[Symbol.asyncIterator]()
 
-        const pending = iterator.next().catch(constVoid)
+        const pending = iterator.next()
         yield* Deferred.await(started)
         const result = yield* Effect.promise(() => iterator.return!(undefined))
-        yield* Effect.promise(() => pending)
+        const pendingResult = yield* Effect.promise(() => pending)
+
+        assert.deepStrictEqual(result, { done: true, value: undefined })
+        assert.deepStrictEqual(pendingResult, { done: true, value: undefined })
+        assert.isTrue(interrupted)
+      }))
+
+    it.effect("toAsyncIterable - return does not reject an unawaited in-flight next", () =>
+      Effect.gen(function*() {
+        let interrupted = false
+        const iterator = Stream.toAsyncIterable(
+          Stream.fromEffect(
+            Effect.never.pipe(
+              Effect.onInterrupt(() =>
+                Effect.sync(() => {
+                  interrupted = true
+                })
+              )
+            )
+          )
+        )[Symbol.asyncIterator]()
+
+        iterator.next()
+        const result = yield* Effect.promise(() => iterator.return!(undefined))
+        yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 0)))
 
         assert.deepStrictEqual(result, { done: true, value: undefined })
         assert.isTrue(interrupted)
@@ -250,12 +274,13 @@ describe("Stream", () => {
         )[Symbol.asyncIterator]()
         const error = new Error("boom")
 
-        const pending = iterator.next().catch(constVoid)
+        const pending = iterator.next()
         yield* Deferred.await(started)
         const thrown = yield* Effect.promise(() => iterator.throw!(error).catch((error) => error))
-        yield* Effect.promise(() => pending)
+        const pendingResult = yield* Effect.promise(() => pending)
 
         assert.strictEqual(thrown, error)
+        assert.deepStrictEqual(pendingResult, { done: true, value: undefined })
         assert.isTrue(interrupted)
       }))
   })

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -4,6 +4,7 @@ import { assertExitFailure, assertSuccess, assertTrue, deepStrictEqual, strictEq
 import {
   Array,
   Cause,
+  Channel,
   Clock,
   Context,
   Data,
@@ -22,6 +23,7 @@ import {
   References,
   Result,
   Schedule,
+  Scope,
   Sink,
   Stream,
   String as Str
@@ -134,6 +136,19 @@ describe("Stream", () => {
   })
 
   describe("destructors", () => {
+    const withScopeFinalizer = <A, E, R>(
+      self: Stream.Stream<A, E, R>,
+      finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<unknown>
+    ): Stream.Stream<A, E, R> =>
+      Stream.fromChannel(
+        Channel.fromTransform((upstream, scope) =>
+          Effect.andThen(
+            Scope.addFinalizerExit(scope, finalizer),
+            Channel.toTransform(Stream.toChannel(self))(upstream, scope)
+          )
+        )
+      )
+
     it.effect("runForEachWhile continues across chunk boundaries", () =>
       Effect.gen(function*() {
         const seen: Array<number> = []
@@ -252,6 +267,89 @@ describe("Stream", () => {
         assert.deepStrictEqual(first, { done: true, value: undefined })
         assert.deepStrictEqual(second, { done: true, value: undefined })
         assert.deepStrictEqual(next, { done: true, value: undefined })
+      }))
+
+    it.effect("toAsyncIterable - natural completion closes the scope with a successful exit", () =>
+      Effect.gen(function*() {
+        const finalizerExits: Array<Exit.Exit<unknown, unknown>> = []
+        const stream = withScopeFinalizer(
+          Stream.make(1, 2),
+          (exit) =>
+            Effect.sync(() => {
+              finalizerExits.push(exit)
+            })
+        )
+        const values = yield* Effect.promise(async () => {
+          const values: Array<number> = []
+          for await (const value of Stream.toAsyncIterable(stream)) {
+            values.push(value)
+          }
+          return values
+        })
+
+        assert.deepStrictEqual(values, [1, 2])
+        assert.deepStrictEqual(finalizerExits, [Exit.void])
+      }))
+
+    it.effect("toAsyncIterable - stream failure is forwarded to the scope", () =>
+      Effect.gen(function*() {
+        const streamError = new Error("stream failure")
+        const finalizerError = new Error("finalizer failure")
+        const finalizerExits: Array<Exit.Exit<unknown, unknown>> = []
+        const capturedLogs: Array<unknown> = []
+        const testLogger = Logger.make<unknown, void>((options) => {
+          capturedLogs.push(options.message)
+        })
+        const stream = withScopeFinalizer(
+          Stream.fail(streamError),
+          (exit) =>
+            Effect.andThen(
+              Effect.sync(() => {
+                finalizerExits.push(exit)
+              }),
+              Effect.die(finalizerError)
+            )
+        )
+
+        const thrown = yield* Effect.gen(function*() {
+          const iterable = yield* Stream.toAsyncIterableEffect(stream)
+          return yield* Effect.promise(() => iterable[Symbol.asyncIterator]().next().catch((error) => error))
+        }).pipe(Effect.withLogger(testLogger))
+
+        assert.strictEqual(thrown, streamError)
+        assert.deepStrictEqual(finalizerExits, [Exit.fail(streamError)])
+        assert.strictEqual(capturedLogs.length, 1)
+      }))
+
+    it.effect("toAsyncIterable - throw forwards a failure exit and preserves its error", () =>
+      Effect.gen(function*() {
+        const thrownError = new Error("thrown failure")
+        const finalizerError = new Error("finalizer failure")
+        const finalizerExits: Array<Exit.Exit<unknown, unknown>> = []
+        const capturedLogs: Array<unknown> = []
+        const testLogger = Logger.make<unknown, void>((options) => {
+          capturedLogs.push(options.message)
+        })
+        const stream = withScopeFinalizer(
+          Stream.make(1),
+          (exit) =>
+            Effect.andThen(
+              Effect.sync(() => {
+                finalizerExits.push(exit)
+              }),
+              Effect.die(finalizerError)
+            )
+        )
+
+        const thrown = yield* Effect.gen(function*() {
+          const iterator = (yield* Stream.toAsyncIterableEffect(stream))[Symbol.asyncIterator]()
+          yield* Effect.promise(() => iterator.next())
+          return yield* Effect.promise(() => iterator.throw!(thrownError).catch((error) => error))
+        }).pipe(Effect.withLogger(testLogger))
+
+        assert.strictEqual(thrown, thrownError)
+        assert.deepStrictEqual(finalizerExits, [Exit.die(thrownError)])
+        assert.strictEqual(capturedLogs.length, 1)
       }))
 
     it.effect("toAsyncIterable - throw interrupts an in-flight pull", () =>

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -161,6 +161,103 @@ describe("Stream", () => {
         )
         assert.deepStrictEqual(seen, [1, 2, 3])
       }))
+
+    it.effect("toAsyncIterable - return interrupts an in-flight pull", () =>
+      Effect.gen(function*() {
+        const started = yield* Deferred.make<void>()
+        let interrupted = false
+        const iterator = Stream.toAsyncIterable(
+          Stream.fromEffect(
+            Effect.andThen(
+              Deferred.succeed(started, void 0),
+              Effect.never
+            ).pipe(
+              Effect.onInterrupt(() =>
+                Effect.sync(() => {
+                  interrupted = true
+                })
+              )
+            )
+          )
+        )[Symbol.asyncIterator]()
+
+        const pending = iterator.next().catch(constVoid)
+        yield* Deferred.await(started)
+        const result = yield* Effect.promise(() => iterator.return!(undefined))
+        yield* Effect.promise(() => pending)
+
+        assert.deepStrictEqual(result, { done: true, value: undefined })
+        assert.isTrue(interrupted)
+      }))
+
+    it.effect("toAsyncIterable - early for await exit interrupts the producer", () =>
+      Effect.gen(function*() {
+        let interrupted = false
+        const iterable = Stream.toAsyncIterable(
+          Stream.callback<number>((queue) =>
+            Effect.andThen(
+              Queue.offer(queue, 1),
+              Effect.never
+            ).pipe(
+              Effect.onInterrupt(() =>
+                Effect.sync(() => {
+                  interrupted = true
+                })
+              )
+            )
+          )
+        )
+
+        yield* Effect.promise(async () => {
+          for await (const _ of iterable) {
+            break
+          }
+        })
+
+        assert.isTrue(interrupted)
+      }))
+
+    it.effect("toAsyncIterable - return is idempotent without an in-flight pull", () =>
+      Effect.gen(function*() {
+        const iterator = Stream.toAsyncIterable(Stream.make(1))[Symbol.asyncIterator]()
+
+        const first = yield* Effect.promise(() => iterator.return!(undefined))
+        const second = yield* Effect.promise(() => iterator.return!(undefined))
+        const next = yield* Effect.promise(() => iterator.next())
+
+        assert.deepStrictEqual(first, { done: true, value: undefined })
+        assert.deepStrictEqual(second, { done: true, value: undefined })
+        assert.deepStrictEqual(next, { done: true, value: undefined })
+      }))
+
+    it.effect("toAsyncIterable - throw interrupts an in-flight pull", () =>
+      Effect.gen(function*() {
+        const started = yield* Deferred.make<void>()
+        let interrupted = false
+        const iterator = Stream.toAsyncIterable(
+          Stream.fromEffect(
+            Effect.andThen(
+              Deferred.succeed(started, void 0),
+              Effect.never
+            ).pipe(
+              Effect.onInterrupt(() =>
+                Effect.sync(() => {
+                  interrupted = true
+                })
+              )
+            )
+          )
+        )[Symbol.asyncIterator]()
+        const error = new Error("boom")
+
+        const pending = iterator.next().catch(constVoid)
+        yield* Deferred.await(started)
+        const thrown = yield* Effect.promise(() => iterator.throw!(error).catch((error) => error))
+        yield* Effect.promise(() => pending)
+
+        assert.strictEqual(thrown, error)
+        assert.isTrue(interrupted)
+      }))
   })
 
   describe("constructors", () => {


### PR DESCRIPTION
## Summary

- run async-iterable pull setup and each pull in a tracked fiber
- make `return()` idempotently interrupt and await an active pull before closing its scope
- resolve a racing pending `next()` as done after iterator cleanup instead of surfacing an interruption rejection
- forward the terminal exit to the iterator scope so exit-aware finalizers observe real stream failures
- implement `throw()` through the same cleanup path and close scopes on terminal stream exits
- add regression coverage for cancellation races, natural completion, exit-aware finalizers, cleanup defects, and the unawaited-pending-`next()` reproduction
- add an `effect` patch changeset

## Root cause

`toAsyncIterableWith` ran pulls through `runPromiseExitWith` and discarded the underlying fiber, so iterator cleanup could close the scope but could not interrupt or await a live pull. Once pulls were tracked, interruption from iterator closure also needed to be distinguished from real stream failures so a concurrent `next()` would settle as done rather than reject. Scope closure also needs the actual pull failure exit; using `Exit.void` for every close incorrectly told exit-aware finalizers that failed streams succeeded.

## Cleanup semantics

The first caller to close the iterator still wins and memoizes both cleanup and its exit. Natural completion and explicit `return()` use `Exit.void`; a real stream failure forwards its exact `Exit`. `throw(error)` uses `Exit.die(error)` because it represents consumer-side exceptional termination rather than a value in the stream's typed error channel, while still telling transactional finalizers to roll back.

If scope cleanup defects while a stream failure or caller-provided `throw()` error is already being propagated, the original error remains the rejection and the suppressed cleanup error is emitted through Effect's logger. Explicit `return()` has no competing error, so cleanup defects continue to reject it normally.

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm test packages/effect/test/Stream.test.ts --run` (306 passed, 1 skipped)
- `pnpm test --run` (330 files passed; 8,297 tests passed, 1 expected failure, 9 skipped)

Closes EFF-28