### PR TITLE
Fix Chat persistence tests

### DIFF
--- a/packages/effect/test/unstable/ai/Chat.test.ts
+++ b/packages/effect/test/unstable/ai/Chat.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Option, Predicate, Ref, Schema } from "effect"
+import { Effect, Layer, Predicate, Ref, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import { Chat, IdGenerator, Prompt } from "effect/unstable/ai"
 import { Persistence } from "effect/unstable/persistence"
@@ -12,11 +12,11 @@ const withConstantIdGenerator = (id: string) =>
 
 const PersistenceLayer = Layer.provideMerge(
   Chat.layerPersisted({ storeId: "chat" }),
-  Persistence.layerMemory
+  Persistence.layerBackingMemory
 )
 
 describe("Chat", () => {
-  it("should persist chat history to the backing persistence store", () =>
+  it.effect("should persist chat history to the backing persistence store", () =>
     Effect.gen(function*() {
       const storeId = "chat"
       const chatId = "1"
@@ -52,7 +52,7 @@ describe("Chat", () => {
       assert.deepStrictEqual(chatHistory, storedHistory)
     }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
 
-  it("should respect the specified time to live", () =>
+  it.effect("should respect the specified time to live", () =>
     Effect.gen(function*() {
       const storeId = "chat"
       const chatId = "1"
@@ -92,10 +92,10 @@ describe("Chat", () => {
 
       const afterExpiration = yield* store.get(chatId)
 
-      assert.deepStrictEqual(afterExpiration, Option.none())
+      assert.isUndefined(afterExpiration)
     }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
 
-  it("should prefer the message identifier of the most recent assistant message", () =>
+  it.effect("should prefer the message identifier of the most recent assistant message", () =>
     Effect.gen(function*() {
       const storeId = "chat"
       const chatId = "2"
@@ -135,7 +135,7 @@ describe("Chat", () => {
       assert.deepStrictEqual(storedHistory, expectedHistory)
     }).pipe(withConstantIdGenerator("msg_abc123"), Effect.provide(PersistenceLayer)))
 
-  it("should raise an error when retrieving a chat that does not exist", () =>
+  it.effect("should raise an error when retrieving a chat that does not exist", () =>
     Effect.gen(function*() {
       const persistence = yield* Chat.Persistence
 


### PR DESCRIPTION
## Summary

- run all four Chat persistence tests with `it.effect`
- provide the backing persistence layer required by `Chat.layerPersisted`
- correct the TTL assertion to match the backing store's `undefined` miss contract

## Root cause

The tests returned `Effect` values from Vitest's raw `it`, so none of the effects executed. Once enabled, the shared layer supplied `Persistence` instead of `BackingPersistence`, and the TTL test expected `Option.none()` even though an expired backing-store entry is returned as `undefined`.

## Validation

- `pnpm vitest --run packages/effect/test/unstable/ai/Chat.test.ts` (4 passed)
- `pnpm --dir packages/effect check`
- `pnpm exec dprint check packages/effect/test/unstable/ai/Chat.test.ts`
- `pnpm exec oxlint -f unix packages/effect/test/unstable/ai/Chat.test.ts`
- Full `pnpm test --run` attempted; unrelated integration failures occurred because local MySQL/Postgres services were unavailable and a Docker container was stopped. `NodeChildProcessSpawner.test.ts` also failed its process-count assertion before the run stalled.

Closes EFF-38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Chat test scenarios to use effect-aware testing utilities.
  * Revised persistence test setup to validate behavior with a backing memory store.
  * Updated expiration checks to reflect the current retrieval behavior after TTL elapses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->