### PR TITLE
Use it.effect for KeyValueStore tests

### DIFF
--- a/packages/effect/test/unstable/persistence/KeyValueStore.test.ts
+++ b/packages/effect/test/unstable/persistence/KeyValueStore.test.ts
@@ -89,7 +89,7 @@ export const testLayer = <E>(layer: Layer.Layer<KeyValueStore.KeyValueStore, E>)
 describe("KeyValueStore / layerMemory", () => testLayer(KeyValueStore.layerMemory))
 
 describe("KeyValueStore / prefix", () => {
-  it("prefixes the keys", () =>
+  it.effect("prefixes the keys", () =>
     Effect.gen(function*() {
       const store = yield* (KeyValueStore.KeyValueStore)
       const prefixed = KeyValueStore.prefix(store, "prefix/")
@@ -103,8 +103,7 @@ describe("KeyValueStore / prefix", () => {
       strictEqual(yield* (store.get("prefix/foo")), "barbar")
       assertTrue(yield* (store.has("prefix/foo")))
     }).pipe(
-      Effect.provide(KeyValueStore.layerMemory),
-      Effect.runPromise
+      Effect.provide(KeyValueStore.layerMemory)
     ))
 })
 
@@ -114,7 +113,7 @@ describe("toSchemaStore", () => {
     age: Schema.Number
   }) {}
 
-  it("encodes & decodes", () =>
+  it.effect("encodes & decodes", () =>
     Effect.gen(function*() {
       const store = yield* KeyValueStore.KeyValueStore
       const schemaStore = KeyValueStore.toSchemaStore(store, User)
@@ -126,11 +125,10 @@ describe("toSchemaStore", () => {
       strictEqual(value.value.name, "foo")
       strictEqual(value.value.age, 43)
     }).pipe(
-      Effect.provide(KeyValueStore.layerMemory),
-      Effect.runPromise
+      Effect.provide(KeyValueStore.layerMemory)
     ))
 
-  it("prefix", () =>
+  it.effect("prefix", () =>
     Effect.gen(function*() {
       const store = yield* KeyValueStore.KeyValueStore
       const schemaStore = KeyValueStore.toSchemaStore(store, User)
@@ -142,11 +140,10 @@ describe("toSchemaStore", () => {
         strictEqual(value.value.age, 42)
       }
     }).pipe(
-      Effect.provide(KeyValueStore.layerMemory),
-      Effect.runPromise
+      Effect.provide(KeyValueStore.layerMemory)
     ))
 
-  it("json compliant", () =>
+  it.effect("json compliant", () =>
     Effect.gen(function*() {
       const store = yield* KeyValueStore.KeyValueStore
       const schema = Schema.Struct({
@@ -158,7 +155,6 @@ describe("toSchemaStore", () => {
       assertTrue(Option.isSome(value))
       deepStrictEqual(value.value.a, new Date(0))
     }).pipe(
-      Effect.provide(KeyValueStore.layerMemory),
-      Effect.runPromise
+      Effect.provide(KeyValueStore.layerMemory)
     ))
 })


### PR DESCRIPTION
## Summary

- migrate the four scoped `KeyValueStore` tests to `it.effect`
- return the provided `Effect` directly so the Effect-aware Vitest adapter executes and observes each test
- leave the existing Promise-wrapped `testLayer` tests unchanged

No genuine `KeyValueStore` bug surfaced; all newly Effect-managed tests pass without production changes.

## Validation

- `pnpm --filter effect test --run test/unstable/persistence/KeyValueStore.test.ts` (10 passed)
- `pnpm --filter effect test --run` (228 files passed; 7,088 tests passed, 4 skipped)
- `pnpm check`
- `pnpm exec dprint check packages/effect/test/unstable/persistence/KeyValueStore.test.ts`
- `pnpm exec oxlint -f unix packages/effect/test/unstable/persistence/KeyValueStore.test.ts`

Closes EFF-39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated persistence tests to use the standard effect-aware test execution pattern.
  - Preserved coverage for key-value storage prefixes, schema encoding and decoding, and JSON-compatible values.
  - Simplified in-memory store setup while maintaining the existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->