### PR TITLE
Make AI response fields optional

### DIFF
--- a/.changeset/optional-ai-response-fields.md
+++ b/.changeset/optional-ai-response-fields.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow optional AI response fields to be omitted during decoding, including after JSON serialization.

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -2135,7 +2135,7 @@ export const HttpRequestDetails = Schema.Struct({
   method: Schema.Literals(["GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE"]),
   url: Schema.String,
   urlParams: Schema.Array(Schema.Tuple([Schema.String, Schema.String])),
-  hash: Schema.UndefinedOr(Schema.String),
+  hash: Schema.optional(Schema.String),
   headers: Schema.Record(
     Schema.String,
     Schema.Union([
@@ -2213,19 +2213,19 @@ export interface ResponseMetadataPart extends BasePart<"response-metadata", Resp
   /**
    * Optional unique identifier for this specific response.
    */
-  readonly id: string | undefined
+  readonly id?: string | undefined
   /**
    * Optional identifier of the AI model that generated the response.
    */
-  readonly modelId: string | undefined
+  readonly modelId?: string | undefined
   /**
    * Optional timestamp when the response was generated.
    */
-  readonly timestamp: DateTime.Utc | undefined
+  readonly timestamp?: DateTime.Utc | undefined
   /**
    * Optional HTTP request details for the request made to the AI provider.
    */
-  readonly request: typeof HttpRequestDetails.Type | undefined
+  readonly request?: typeof HttpRequestDetails.Type | undefined
 }
 
 /**
@@ -2272,10 +2272,10 @@ export interface ResponseMetadataPartMetadata extends ProviderMetadata {}
  */
 export const ResponseMetadataPart: Schema.Struct<{
   readonly type: Schema.tag<"response-metadata">
-  readonly id: Schema.UndefinedOr<Schema.String>
-  readonly modelId: Schema.UndefinedOr<Schema.String>
-  readonly timestamp: Schema.UndefinedOr<Schema.DateTimeUtcFromString>
-  readonly request: Schema.UndefinedOr<typeof HttpRequestDetails>
+  readonly id: Schema.optional<Schema.String>
+  readonly modelId: Schema.optional<Schema.String>
+  readonly timestamp: Schema.optional<Schema.DateTimeUtcFromString>
+  readonly request: Schema.optional<typeof HttpRequestDetails>
   readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
@@ -2283,10 +2283,10 @@ export const ResponseMetadataPart: Schema.Struct<{
 }> = Schema.Struct({
   ...BasePart.fields,
   type: Schema.tag("response-metadata"),
-  id: Schema.UndefinedOr(Schema.String),
-  modelId: Schema.UndefinedOr(Schema.String),
-  timestamp: Schema.UndefinedOr(Schema.DateTimeUtcFromString),
-  request: Schema.UndefinedOr(HttpRequestDetails)
+  id: Schema.optional(Schema.String),
+  modelId: Schema.optional(Schema.String),
+  timestamp: Schema.optional(Schema.DateTimeUtcFromString),
+  request: Schema.optional(HttpRequestDetails)
 }).annotate({ identifier: "ResponseMetadataPart" }) satisfies Schema.Codec<
   ResponseMetadataPart,
   ResponseMetadataPartEncoded
@@ -2368,19 +2368,19 @@ export class Usage extends Schema.Class<Usage>("effect/ai/AiResponse/Usage")({
     /**
      * The number of non-cached input (i.e. prompt) tokens used.
      */
-    uncached: Schema.UndefinedOr(Schema.Number),
+    uncached: Schema.optional(Schema.Number),
     /**
      * The total of number of input (i.e. prompt) tokens used.
      */
-    total: Schema.UndefinedOr(Schema.Number),
+    total: Schema.optional(Schema.Number),
     /**
      * The number of cached input (i.e. prompt) tokens read.
      */
-    cacheRead: Schema.UndefinedOr(Schema.Number),
+    cacheRead: Schema.optional(Schema.Number),
     /**
      * The number of cached input (i.e. prompt) tokens written.
      */
-    cacheWrite: Schema.UndefinedOr(Schema.Number)
+    cacheWrite: Schema.optional(Schema.Number)
   }),
   /**
    * Information about the output (i.e. response) tokens used.
@@ -2389,15 +2389,15 @@ export class Usage extends Schema.Class<Usage>("effect/ai/AiResponse/Usage")({
     /**
      * The total of number of output (i.e. response) tokens used.
      */
-    total: Schema.UndefinedOr(Schema.Number),
+    total: Schema.optional(Schema.Number),
     /**
      * The number of text tokens used.
      */
-    text: Schema.UndefinedOr(Schema.Number),
+    text: Schema.optional(Schema.Number),
     /**
      * The number of reasoning tokens used.
      */
-    reasoning: Schema.UndefinedOr(Schema.Number)
+    reasoning: Schema.optional(Schema.Number)
   })
 }) {}
 
@@ -2443,7 +2443,7 @@ export interface FinishPart extends BasePart<"finish", FinishPartMetadata> {
   /**
    * Optional HTTP response details from the AI provider.
    */
-  readonly response: typeof HttpResponseDetails.Type | undefined
+  readonly response?: typeof HttpResponseDetails.Type | undefined
 }
 
 /**
@@ -2500,7 +2500,7 @@ export const FinishPart: Schema.Struct<{
     "unknown"
   ]>
   readonly usage: typeof Usage
-  readonly response: Schema.UndefinedOr<typeof HttpResponseDetails>
+  readonly response: Schema.optional<typeof HttpResponseDetails>
   readonly "~effect/ai/Content/Part": Schema.withDecodingDefaultKey<Schema.tag<"~effect/ai/Content/Part">>
   readonly metadata: Schema.withDecodingDefault<
     Schema.$Record<Schema.String, Schema.Codec<Schema.Json>>
@@ -2510,7 +2510,7 @@ export const FinishPart: Schema.Struct<{
   type: Schema.tag("finish"),
   reason: FinishReason,
   usage: Usage,
-  response: Schema.UndefinedOr(HttpResponseDetails)
+  response: Schema.optional(HttpResponseDetails)
 }).annotate({ identifier: "FinishPart" }) satisfies Schema.Codec<FinishPart, FinishPartEncoded>
 
 // =============================================================================

--- a/packages/effect/test/unstable/ai/Response.test.ts
+++ b/packages/effect/test/unstable/ai/Response.test.ts
@@ -15,6 +15,54 @@ describe("Response", () => {
       deepStrictEqual(decoded, Response.makePart("response-metadata", {}))
     }))
 
+  it.effect("round trips response metadata with undefined optional fields through JSON", () =>
+    Effect.gen(function*() {
+      const part = Response.makePart("response-metadata", {
+        id: undefined,
+        modelId: undefined,
+        timestamp: undefined,
+        request: undefined
+      })
+
+      const encoded = yield* Schema.encodeEffect(Response.ResponseMetadataPart)(part)
+      const json = JSON.parse(JSON.stringify(encoded))
+      const decoded = yield* Schema.decodeUnknownEffect(Response.ResponseMetadataPart)(json)
+
+      deepStrictEqual(json, {
+        metadata: {},
+        type: "response-metadata"
+      }, "encoded JSON")
+      deepStrictEqual(decoded, Response.makePart("response-metadata", {}), "decoded part")
+    }))
+
+  it.effect("round trips HTTP request details with an undefined hash through JSON", () =>
+    Effect.gen(function*() {
+      const request: typeof Response.HttpRequestDetails.Type = {
+        method: "POST",
+        url: "https://example.com/v1/responses",
+        urlParams: [],
+        hash: undefined,
+        headers: {}
+      }
+
+      const encoded = yield* Schema.encodeEffect(Response.HttpRequestDetails)(request)
+      const json = JSON.parse(JSON.stringify(encoded))
+      const decoded = yield* Schema.decodeUnknownEffect(Response.HttpRequestDetails)(json)
+
+      deepStrictEqual(json, {
+        method: "POST",
+        url: "https://example.com/v1/responses",
+        urlParams: [],
+        headers: {}
+      }, "encoded JSON")
+      deepStrictEqual(decoded, {
+        method: "POST",
+        url: "https://example.com/v1/responses",
+        urlParams: [],
+        headers: {}
+      }, "decoded request")
+    }))
+
   it.effect("round trips a finish part with undefined optional fields through JSON", () =>
     Effect.gen(function*() {
       const part = Response.makePart("finish", {

--- a/packages/effect/test/unstable/ai/Response.test.ts
+++ b/packages/effect/test/unstable/ai/Response.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "@effect/vitest"
+import { deepStrictEqual } from "@effect/vitest/utils"
+import { Effect, Schema } from "effect"
+import { Response } from "effect/unstable/ai"
+
+describe("Response", () => {
+  it.effect("decodes response metadata with omitted optional fields", () =>
+    Effect.gen(function*() {
+      const encoded: Response.ResponseMetadataPartEncoded = {
+        type: "response-metadata"
+      }
+
+      const decoded = yield* Schema.decodeUnknownEffect(Response.ResponseMetadataPart)(encoded)
+
+      deepStrictEqual(decoded, Response.makePart("response-metadata", {}))
+    }))
+
+  it.effect("round trips a finish part with undefined optional fields through JSON", () =>
+    Effect.gen(function*() {
+      const part = Response.makePart("finish", {
+        reason: "stop",
+        usage: new Response.Usage({
+          inputTokens: {
+            uncached: undefined,
+            total: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined
+          },
+          outputTokens: {
+            total: undefined,
+            text: undefined,
+            reasoning: undefined
+          }
+        }),
+        response: undefined
+      })
+
+      const encoded = yield* Schema.encodeEffect(Response.FinishPart)(part)
+      const json = JSON.parse(JSON.stringify(encoded))
+      const decoded = yield* Schema.decodeUnknownEffect(Response.FinishPart)(json)
+
+      deepStrictEqual(json, {
+        metadata: {},
+        type: "finish",
+        reason: "stop",
+        usage: {
+          inputTokens: {},
+          outputTokens: {}
+        }
+      }, "encoded JSON")
+      deepStrictEqual(
+        decoded,
+        Response.makePart("finish", {
+          reason: "stop",
+          usage: new Response.Usage({
+            inputTokens: {},
+            outputTokens: {}
+          })
+        }),
+        "decoded part"
+      )
+    }))
+})


### PR DESCRIPTION
## Summary

- make optional `unstable/ai` response fields accept omitted keys by using `Schema.optional`
- apply the same JSON-safe optional semantics to response metadata, HTTP request hashes, usage token details, and finish response details
- add regression coverage for omitted response metadata fields and finish-part JSON round trips

## Validation

- `pnpm --filter effect test --run` (7,090 passed, 4 skipped)
- `pnpm check`
- `pnpm lint`
- `pnpm test --run` was also attempted repository-wide: 315 files / 8,179 tests passed; remaining failures were unavailable SQL/Redis integration services and one unrelated process-supervision timing assertion

Closes EFF-40