### PR TITLE
Add `Schema.Natural` for non-negative safe integers and use canonical `Schema.Int`, `Schema.Finite`, and `Schema.Natural` schemas for numeric domain values across Effect, AI protocols, and OpenAPI patches

### DIFF
--- a/.changeset/canonical-number-schemas.md
+++ b/.changeset/canonical-number-schemas.md
@@ -1,0 +1,12 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+"@effect/openapi-generator": patch
+---
+
+Add `Schema.Natural` for non-negative safe integers and use canonical `Schema.Int`, `Schema.Finite`, and `Schema.Natural` schemas for numeric domain values across Effect, AI protocols, and OpenAPI patches.
+
+Update the date, date-time, file, time-zone, cluster, event-log, persistence, socket, SQL, and DevTools schemas to reject invalid non-finite or non-integer values where appropriate. Correct the decoded schema of `Schema.NumberFromString`, and allow `Schema.DurationFromMillis` and `Schema.DurationFromNanos` to represent negative durations.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,8 @@
   "[markdown]": {
     "editor.defaultFormatter": "dprint.dprint"
   },
-  "deno.enable": false,
-  "js/ts.tsdk.path": "node_modules/typescript/lib"
+  "js/ts.tsdk.path": "./node_modules/typescript/bin",
+  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.experimental.useTsgo": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,8 +39,8 @@
   "[markdown]": {
     "editor.defaultFormatter": "dprint.dprint"
   },
-  "js/ts.tsdk.path": "./node_modules/typescript/bin",
-  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
+  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/lib"],
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "js/ts.experimental.useTsgo": true
 }

--- a/LLMS.md
+++ b/LLMS.md
@@ -182,7 +182,7 @@ export class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseErro
 }) {}
 
 export class ReservedPortError extends Schema.TaggedErrorClass<ReservedPortError>()("ReservedPortError", {
-  port: Schema.Number
+  port: Schema.Int
 }) {}
 
 declare const loadPort: (input: string) => Effect.Effect<number, ParseError | ReservedPortError>

--- a/ai-docs/src/01_effect/01_basics/10_creating-effects.ts
+++ b/ai-docs/src/01_effect/01_basics/10_creating-effects.ts
@@ -12,7 +12,7 @@ class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()("InvalidP
 }) {}
 
 class UserLookupError extends Schema.TaggedErrorClass<UserLookupError>()("UserLookupError", {
-  userId: Schema.Number,
+  userId: Schema.Int,
   cause: Schema.Defect()
 }) {}
 

--- a/ai-docs/src/01_effect/02_schema/10_schema-basics.ts
+++ b/ai-docs/src/01_effect/02_schema/10_schema-basics.ts
@@ -13,7 +13,7 @@ import { Effect, Schema } from "effect"
 // The static `Type` and `Encoded` members are available when you need
 // the decoded or encoded TypeScript representation.
 export class User extends Schema.Class<User>("path/to/module/User")({
-  id: Schema.Number,
+  id: Schema.Int,
   name: Schema.NonEmptyString,
   email: Schema.String,
   role: Schema.Literals(["admin", "member"])

--- a/ai-docs/src/01_effect/04_errors/01_error-handling.ts
+++ b/ai-docs/src/01_effect/04_errors/01_error-handling.ts
@@ -12,7 +12,7 @@ export class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseErro
 }) {}
 
 export class ReservedPortError extends Schema.TaggedErrorClass<ReservedPortError>()("ReservedPortError", {
-  port: Schema.Number
+  port: Schema.Int
 }) {}
 
 declare const loadPort: (input: string) => Effect.Effect<number, ParseError | ReservedPortError>

--- a/ai-docs/src/01_effect/04_errors/10_catch-tags.ts
+++ b/ai-docs/src/01_effect/04_errors/10_catch-tags.ts
@@ -11,7 +11,7 @@ export class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
 }) {}
 
 export class NetworkError extends Schema.TaggedErrorClass<NetworkError>()("NetworkError", {
-  statusCode: Schema.Number
+  statusCode: Schema.Int
 }) {}
 
 declare const fetchUser: (id: string) => Effect.Effect<string, ValidationError | NetworkError>

--- a/ai-docs/src/01_effect/04_errors/20_reason-errors.ts
+++ b/ai-docs/src/01_effect/04_errors/20_reason-errors.ts
@@ -9,11 +9,11 @@
 import { Effect, Schema } from "effect"
 
 export class RateLimitError extends Schema.TaggedErrorClass<RateLimitError>()("RateLimitError", {
-  retryAfter: Schema.Number
+  retryAfter: Schema.Finite
 }) {}
 
 export class QuotaExceededError extends Schema.TaggedErrorClass<QuotaExceededError>()("QuotaExceededError", {
-  limit: Schema.Number
+  limit: Schema.Int
 }) {}
 
 export class SafetyBlockedError extends Schema.TaggedErrorClass<SafetyBlockedError>()("SafetyBlockedError", {

--- a/ai-docs/src/03_stream/30_encoding.ts
+++ b/ai-docs/src/03_stream/30_encoding.ts
@@ -11,7 +11,7 @@ import { Msgpack, Ndjson } from "effect/unstable/encoding"
 // with `Msgpack` and using the appropriate channels (`Msgpack.decode()`,
 // `Msgpack.encode()`, etc.).
 export const msgpackDecoder = Msgpack.decodeSchema(Schema.Struct({
-  id: Schema.Number,
+  id: Schema.Int,
   name: Schema.String
 }))
 

--- a/ai-docs/src/04_integration/10_managed-runtime.ts
+++ b/ai-docs/src/04_integration/10_managed-runtime.ts
@@ -7,7 +7,7 @@ import { Context, Effect, Layer, ManagedRuntime, Ref, Schema } from "effect"
 import { Hono } from "hono"
 
 class Todo extends Schema.Class<Todo>("Todo")({
-  id: Schema.Number,
+  id: Schema.Int,
   title: Schema.String,
   completed: Schema.Boolean
 }) {}
@@ -17,7 +17,7 @@ class CreateTodoPayload extends Schema.Class<CreateTodoPayload>("CreateTodoPaylo
 }) {}
 
 class TodoNotFound extends Schema.TaggedErrorClass<TodoNotFound>()("TodoNotFound", {
-  id: Schema.Number
+  id: Schema.Int
 }) {}
 
 export class TodoRepo extends Context.Service<TodoRepo, {

--- a/ai-docs/src/05_batching/10_request-resolver.ts
+++ b/ai-docs/src/05_batching/10_request-resolver.ts
@@ -6,13 +6,13 @@
 import { Context, Effect, Exit, Layer, Request, RequestResolver, Schema, Tracer } from "effect"
 
 export class User extends Schema.Class<User>("User")({
-  id: Schema.Number,
+  id: Schema.Int,
   name: Schema.String,
   email: Schema.String
 }) {}
 
 export class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()("UserNotFound", {
-  id: Schema.Number
+  id: Schema.Int
 }) {}
 
 export class Users extends Context.Service<Users, {

--- a/ai-docs/src/06_schedule/10_schedules.ts
+++ b/ai-docs/src/06_schedule/10_schedules.ts
@@ -63,7 +63,7 @@ export const loadUserWithInferredInput = fetchUserProfile("user-123").pipe(
 
 export class HttpError extends Schema.TaggedErrorClass<HttpError>()("HttpError", {
   message: Schema.String,
-  status: Schema.Number,
+  status: Schema.Int,
   retryable: Schema.Boolean
 }) {}
 

--- a/ai-docs/src/50_http-client/10_basics.ts
+++ b/ai-docs/src/50_http-client/10_basics.ts
@@ -7,8 +7,8 @@ import { Context, Effect, flow, Layer, Schedule, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 class Todo extends Schema.Class<Todo>("Todo")({
-  userId: Schema.Number,
-  id: Schema.Number,
+  userId: Schema.Int,
+  id: Schema.Int,
   title: Schema.String,
   completed: Schema.Boolean
 }) {}

--- a/ai-docs/src/71_ai/20_tools.ts
+++ b/ai-docs/src/71_ai/20_tools.ts
@@ -20,7 +20,7 @@ const ProductId = Schema.String.pipe(Schema.brand("ProductId")).annotate({
 class Product extends Schema.Class<Product>("acme/domain/Product")({
   id: ProductId,
   name: Schema.String,
-  price: Schema.Number
+  price: Schema.Finite
 }) {}
 
 // Each tool has a name, an optional description, a parameters schema that the
@@ -34,7 +34,7 @@ const SearchProducts = Tool.make("SearchProducts", {
       // guidance.
       description: "The search query, e.g. 'wireless headphones'"
     }),
-    maxResults: Schema.Number.pipe(Schema.withDecodingDefault(Effect.succeed(10))).annotate({
+    maxResults: Schema.Int.pipe(Schema.withDecodingDefault(Effect.succeed(10))).annotate({
       description: "The maximum number of results to return"
     })
   }),
@@ -57,7 +57,7 @@ const GetInventory = Tool.make("GetInventory", {
   }),
   success: Schema.Struct({
     productId: ProductId,
-    available: Schema.Number
+    available: Schema.Int
   })
 })
 

--- a/ai-docs/src/71_ai/20_tools.ts
+++ b/ai-docs/src/71_ai/20_tools.ts
@@ -34,7 +34,7 @@ const SearchProducts = Tool.make("SearchProducts", {
       // guidance.
       description: "The search query, e.g. 'wireless headphones'"
     }),
-    maxResults: Schema.Int.pipe(Schema.withDecodingDefault(Effect.succeed(10))).annotate({
+    maxResults: Schema.Natural.pipe(Schema.withDecodingDefault(Effect.succeed(10))).annotate({
       description: "The maximum number of results to return"
     })
   }),
@@ -57,7 +57,7 @@ const GetInventory = Tool.make("GetInventory", {
   }),
   success: Schema.Struct({
     productId: ProductId,
-    available: Schema.Int
+    available: Schema.Natural
   })
 })
 

--- a/ai-docs/src/80_cluster/10_entities.ts
+++ b/ai-docs/src/80_cluster/10_entities.ts
@@ -10,12 +10,12 @@ import { Rpc } from "effect/unstable/rpc"
 import type { SqlClient } from "effect/unstable/sql"
 
 export const Increment = Rpc.make("Increment", {
-  payload: { amount: Schema.Number },
-  success: Schema.Number
+  payload: { amount: Schema.Int },
+  success: Schema.Int
 })
 
 export const GetCount = Rpc.make("GetCount", {
-  success: Schema.Number
+  success: Schema.Int
 })
   // If you want GetCount messages to be persisted, you can annotate the RPC
   // schema with `ClusterSchema.Persisted`.

--- a/packages/ai/anthropic/src/AnthropicTool.ts
+++ b/packages/ai/anthropic/src/AnthropicTool.ts
@@ -483,7 +483,7 @@ export const CodeExecution_20250825 = Tool.providerDefined({
  * @category computer use
  * @since 4.0.0
  */
-export const Coordinate = Schema.Tuple([Schema.Number, Schema.Number])
+export const Coordinate = Schema.Tuple([Schema.Int, Schema.Int])
 /**
  * An `[x, y]` screen coordinate in pixels.
  *
@@ -512,7 +512,7 @@ export type Coordinate = typeof Coordinate.Type
  * @category computer use
  * @since 4.0.0
  */
-export const Region = Schema.Tuple([Schema.Number, Schema.Number, Schema.Number, Schema.Number])
+export const Region = Schema.Tuple([Schema.Int, Schema.Int, Schema.Int, Schema.Int])
 /**
  * An `[x1, y1, x2, y2]` screen region in pixels, from top-left to bottom-right.
  *
@@ -569,19 +569,19 @@ const ComputerUse_20241022_Args = Schema.Struct({
   /**
    * The width of the display being controlled by the model in pixels.
    */
-  displayWidthPx: Schema.Number,
+  displayWidthPx: Schema.Int,
 
   /**
    * The height of the display being controlled by the model in pixels.
    */
-  displayHeightPx: Schema.Number,
+  displayHeightPx: Schema.Int,
 
   /**
    * The display number to control (only relevant for X11 environments). If
    * specified, the tool will be provided a display number in the tool
    * definition.
    */
-  displayNumber: Schema.optional(Schema.Number)
+  displayNumber: Schema.optional(Schema.Int)
 })
 
 const ComputerUse_20251124_Args = Schema.Struct({
@@ -873,7 +873,7 @@ export const ComputerUseHoldKeyAction = Schema.Struct({
   /**
    * The number of seconds to hold the key.
    */
-  duration: Schema.Number
+  duration: Schema.Finite
 })
 /**
  * Computer-use action payload for holding a key for a specified duration.
@@ -1085,7 +1085,7 @@ export type ComputerUseRightClickAction = typeof ComputerUseRightClickAction.Typ
  * **Gotchas**
  *
  * `coordinate` only checks a two-number tuple, and `scroll_amount` is only
- * `Schema.Number`.
+ * `Schema.Int`.
  *
  * @see {@link ComputerUse_20250124} for the tool version that accepts this action
  * @see {@link ScrollDirection} for the accepted direction literals
@@ -1107,7 +1107,7 @@ export const ComputerUseScrollAction = Schema.Struct({
   /**
    * The amount to scroll (in pixels or scroll units).
    */
-  scroll_amount: Schema.Number
+  scroll_amount: Schema.Int
 })
 /**
  * Computer-use action payload for scrolling by a specified amount in a specified direction, optionally from a coordinate.
@@ -1173,8 +1173,8 @@ export type ComputerUseTripleClickAction = typeof ComputerUseTripleClickAction.T
  *
  * **Gotchas**
  *
- * `duration` is only `Schema.Number`; it is not constrained to positive or
- * finite values.
+ * `duration` is only `Schema.Finite`; it is not constrained to positive
+ * values.
  *
  * @see {@link ComputerUseHoldKeyAction} for another duration-based computer-use action
  * @see {@link ComputerUse_20250124} for the tool version that accepts this action
@@ -1187,7 +1187,7 @@ export const ComputerUseWaitAction = Schema.Struct({
   /**
    * The number of seconds to wait.
    */
-  duration: Schema.Number
+  duration: Schema.Finite
 })
 /**
  * Computer-use action payload for pausing for a specified duration.
@@ -1383,7 +1383,7 @@ export const ComputerUse_20251124 = Tool.providerDefined({
  * @category memory
  * @since 4.0.0
  */
-export const ViewRange = Schema.Tuple([Schema.Number, Schema.Number])
+export const ViewRange = Schema.Tuple([Schema.Int, Schema.Int])
 /**
  * A `[start, end]` 1-indexed line range for viewing file contents, using `-1` as the end value to read through the end of the file.
  *
@@ -1478,7 +1478,7 @@ export const MemoryInsertCommand = Schema.Struct({
   /**
    * The line at which the text should be inserted.
    */
-  insert_line: Schema.Number,
+  insert_line: Schema.Int,
   /**
    * The text to insert.
    */
@@ -1804,7 +1804,7 @@ export const TextEditorInsertCommand = Schema.Struct({
   /**
    * The line number after which to insert (0 = beginning, 1-indexed).
    */
-  insert_line: Schema.Number,
+  insert_line: Schema.Int,
   /**
    * The text to insert.
    */
@@ -1879,7 +1879,7 @@ const TextEditor_StrReplaceBasedEdit_Args = Schema.Struct({
    * Maximum number of characters to return when viewing large files.
    * When a file exceeds this limit, it will be truncated.
    */
-  max_characters: Schema.optional(Schema.Number)
+  max_characters: Schema.optional(Schema.Int)
 })
 
 // -----------------------------------------------------------------------------
@@ -2080,7 +2080,7 @@ export const WebSearch_20250305_Args = Schema.Struct({
   /**
    * Maximum number of searches allowed per API request.
    */
-  maxUses: Schema.optional(Schema.Number),
+  maxUses: Schema.optional(Schema.Int),
   /**
    * Restrict search results to only these domains.
    *
@@ -2263,7 +2263,7 @@ export const WebFetch_20250910_Args = Schema.Struct({
   /**
    * Maximum number of fetches allowed per API request.
    */
-  maxUses: Schema.optional(Schema.Number),
+  maxUses: Schema.optional(Schema.Int),
   /**
    * Restrict fetches to only these domains.
    *
@@ -2283,7 +2283,7 @@ export const WebFetch_20250910_Args = Schema.Struct({
   /**
    * Maximum content length in tokens.
    */
-  maxContentTokens: Schema.optional(Schema.Number)
+  maxContentTokens: Schema.optional(Schema.Int)
 })
 /**
  * Configuration arguments for the Anthropic web fetch tool, including usage limits, domain filters, citation settings, and token limits.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -1056,8 +1056,8 @@ export type CreateResponse200 = ChatCompletionResponse
 export type CreateResponse200Sse = ChatCompletionStreamEvent
 
 const EmbeddingSchema = Schema.Struct({
-  embedding: Schema.Union([Schema.Array(Schema.Number), Schema.String]),
-  index: Schema.Number,
+  embedding: Schema.Union([Schema.Array(Schema.Finite), Schema.String]),
+  index: Schema.Int,
   object: Schema.optionalKey(Schema.String)
 })
 
@@ -1066,8 +1066,8 @@ const CreateEmbeddingResponseSchema = Schema.Struct({
   model: Schema.String,
   object: Schema.optionalKey(Schema.Literal("list")),
   usage: Schema.optionalKey(Schema.Struct({
-    prompt_tokens: Schema.Number,
-    total_tokens: Schema.Number
+    prompt_tokens: Schema.Int,
+    total_tokens: Schema.Int
   }))
 })
 
@@ -1086,14 +1086,14 @@ const ChatCompletionToolFunctionDelta = Schema.Struct({
 
 const ChatCompletionToolCall = Schema.Struct({
   id: Schema.optionalKey(Schema.String),
-  index: Schema.optionalKey(Schema.Number),
+  index: Schema.optionalKey(Schema.Int),
   type: Schema.optionalKey(Schema.String),
   function: Schema.optionalKey(ChatCompletionToolFunction)
 })
 
 const ChatCompletionToolCallDelta = Schema.Struct({
   id: Schema.optionalKey(Schema.String),
-  index: Schema.optionalKey(Schema.Number),
+  index: Schema.optionalKey(Schema.Int),
   type: Schema.optionalKey(Schema.String),
   function: Schema.optionalKey(ChatCompletionToolFunctionDelta)
 })
@@ -1115,16 +1115,16 @@ const ChatCompletionDelta = Schema.Struct({
 })
 
 const ChatCompletionChoice = Schema.Struct({
-  index: Schema.Number,
+  index: Schema.Int,
   finish_reason: Schema.optionalKey(Schema.NullOr(Schema.String)),
   message: Schema.optionalKey(ChatCompletionMessage),
   delta: Schema.optionalKey(ChatCompletionDelta)
 })
 
 const ChatCompletionUsage = Schema.Struct({
-  prompt_tokens: Schema.Number,
-  completion_tokens: Schema.Number,
-  total_tokens: Schema.Number,
+  prompt_tokens: Schema.Int,
+  completion_tokens: Schema.Int,
+  total_tokens: Schema.Int,
   prompt_tokens_details: Schema.optionalKey(Schema.Any),
   completion_tokens_details: Schema.optionalKey(Schema.Any)
 })
@@ -1132,7 +1132,7 @@ const ChatCompletionUsage = Schema.Struct({
 const ChatCompletionResponse = Schema.Struct({
   id: Schema.String,
   model: Schema.String,
-  created: Schema.Number,
+  created: Schema.Int,
   choices: Schema.Array(ChatCompletionChoice),
   usage: Schema.optionalKey(Schema.NullOr(ChatCompletionUsage)),
   service_tier: Schema.optionalKey(Schema.String)
@@ -1141,7 +1141,7 @@ const ChatCompletionResponse = Schema.Struct({
 const ChatCompletionChunk = Schema.Struct({
   id: Schema.String,
   model: Schema.String,
-  created: Schema.Number,
+  created: Schema.Int,
   choices: Schema.Array(ChatCompletionChoice),
   usage: Schema.optionalKey(Schema.NullOr(ChatCompletionUsage)),
   service_tier: Schema.optionalKey(Schema.String)

--- a/packages/ai/openai-compat/src/internal/errors.ts
+++ b/packages/ai/openai-compat/src/internal/errors.ts
@@ -22,7 +22,7 @@ export const OpenAiErrorBody = Schema.Struct({
     type: Schema.optional(Schema.NullOr(Schema.String)),
     status: Schema.optional(Schema.NullOr(Schema.String)),
     param: Schema.optional(Schema.NullOr(Schema.String)),
-    code: Schema.optional(Schema.NullOr(Schema.Union([Schema.String, Schema.Number])))
+    code: Schema.optional(Schema.NullOr(Schema.Union([Schema.String, Schema.Finite])))
   })
 })
 const OpenAiErrorBodyJson = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Union([

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -646,7 +646,7 @@ const makeSocket = Effect.gen(function*() {
 
 const ErrorEvent = Schema.Struct({
   type: Schema.Literal("error"),
-  status: Schema.Number.pipe(
+  status: Schema.Int.pipe(
     Schema.withDecodingDefault(Effect.succeed(500))
   ),
   error: Schema.Struct({

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -173,15 +173,15 @@ const ComputerScreenshotContent = Schema.Struct({
 const FileCitationAnnotation = Schema.Struct({
   type: Schema.Literal("file_citation"),
   file_id: Schema.String,
-  index: Schema.Number,
+  index: Schema.Int,
   filename: Schema.String
 })
 
 const UrlCitationAnnotation = Schema.Struct({
   type: Schema.Literal("url_citation"),
   url: Schema.String,
-  start_index: Schema.Number,
-  end_index: Schema.Number,
+  start_index: Schema.Int,
+  end_index: Schema.Int,
   title: Schema.String
 })
 
@@ -189,15 +189,15 @@ const ContainerFileCitationAnnotation = Schema.Struct({
   type: Schema.Literal("container_file_citation"),
   container_id: Schema.String,
   file_id: Schema.String,
-  start_index: Schema.Number,
-  end_index: Schema.Number,
+  start_index: Schema.Int,
+  end_index: Schema.Int,
   filename: Schema.String
 })
 
 const FilePathAnnotation = Schema.Struct({
   type: Schema.Literal("file_path"),
   file_id: Schema.String,
-  index: Schema.Number
+  index: Schema.Int
 })
 
 /**
@@ -654,9 +654,9 @@ export type TextResponseFormatConfiguration = typeof TextResponseFormatConfigura
  */
 export const CreateResponse = Schema.Struct({
   metadata: Schema.optional(Schema.Record(Schema.String, Schema.String)),
-  top_logprobs: Schema.optional(Schema.Number),
-  temperature: Schema.optional(Schema.Number),
-  top_p: Schema.optional(Schema.Number),
+  top_logprobs: Schema.optional(Schema.Int),
+  temperature: Schema.optional(Schema.Finite),
+  top_p: Schema.optional(Schema.Finite),
   user: Schema.optional(Schema.String),
   service_tier: Schema.optional(Schema.String),
   previous_response_id: Schema.optional(Schema.String),
@@ -668,8 +668,8 @@ export const CreateResponse = Schema.Struct({
     generate_summary: Schema.optional(Schema.Literals(["auto", "concise", "detailed"]))
   })),
   background: Schema.optional(Schema.Boolean),
-  max_output_tokens: Schema.optional(Schema.Number),
-  max_tool_calls: Schema.optional(Schema.Number),
+  max_output_tokens: Schema.optional(Schema.Int),
+  max_tool_calls: Schema.optional(Schema.Int),
   text: Schema.optional(
     Schema.Struct({
       format: Schema.optional(TextResponseFormatConfiguration),
@@ -691,7 +691,7 @@ export const CreateResponse = Schema.Struct({
   stream: Schema.optional(Schema.Boolean),
   conversation: Schema.optional(Schema.String),
   modalities: Schema.optional(Schema.Array(Schema.Literals(["text", "audio"]))),
-  seed: Schema.optional(Schema.Number)
+  seed: Schema.optional(Schema.Int)
 })
 
 /**
@@ -716,9 +716,9 @@ export type CreateResponse = typeof CreateResponse.Type
  */
 export const ResponseUsage = Schema.StructWithRest(
   Schema.Struct({
-    input_tokens: Schema.Number,
-    output_tokens: Schema.Number,
-    total_tokens: Schema.Number,
+    input_tokens: Schema.Int,
+    output_tokens: Schema.Int,
+    total_tokens: Schema.Int,
     input_tokens_details: Schema.optionalKey(Schema.Unknown),
     output_tokens_details: Schema.optionalKey(Schema.Unknown)
   }),
@@ -853,7 +853,7 @@ export const Response = Schema.Struct({
   id: Schema.String,
   object: Schema.optionalKey(Schema.Literal("response")),
   model: Schema.String,
-  created_at: Schema.Number,
+  created_at: Schema.Int,
   output: Schema.Array(OutputItem).pipe(
     Schema.withDecodingDefault(Effect.succeed([]))
   ),
@@ -888,141 +888,141 @@ export type Response = typeof Response.Type
 const ResponseCreatedEvent = Schema.Struct({
   type: Schema.Literal("response.created"),
   response: Response,
-  sequence_number: Schema.Number
+  sequence_number: Schema.Int
 })
 
 const ResponseCompletedEvent = Schema.Struct({
   type: Schema.Literal("response.completed"),
   response: Response,
-  sequence_number: Schema.Number
+  sequence_number: Schema.Int
 })
 
 const ResponseIncompleteEvent = Schema.Struct({
   type: Schema.Literal("response.incomplete"),
   response: Response,
-  sequence_number: Schema.Number
+  sequence_number: Schema.Int
 })
 
 const ResponseFailedEvent = Schema.Struct({
   type: Schema.Literal("response.failed"),
   response: Response,
-  sequence_number: Schema.Number
+  sequence_number: Schema.Int
 })
 
 const ResponseOutputItemAddedEvent = Schema.Struct({
   type: Schema.Literal("response.output_item.added"),
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   item: OutputItem
 })
 
 const ResponseOutputItemDoneEvent = Schema.Struct({
   type: Schema.Literal("response.output_item.done"),
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   item: OutputItem
 })
 
 const ResponseOutputTextDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.output_text.delta"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  content_index: Schema.Number,
+  output_index: Schema.Int,
+  content_index: Schema.Int,
   delta: Schema.String,
-  sequence_number: Schema.Number,
+  sequence_number: Schema.Int,
   logprobs: Schema.optionalKey(Schema.Array(Schema.Unknown))
 })
 
 const ResponseOutputTextAnnotationAddedEvent = Schema.Struct({
   type: Schema.Literal("response.output_text.annotation.added"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  content_index: Schema.Number,
-  annotation_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  content_index: Schema.Int,
+  annotation_index: Schema.Int,
+  sequence_number: Schema.Int,
   annotation: Annotation
 })
 
 const ResponseReasoningSummaryPartAddedEvent = Schema.Struct({
   type: Schema.Literal("response.reasoning_summary_part.added"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  summary_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  summary_index: Schema.Int,
+  sequence_number: Schema.Int,
   part: SummaryTextContent
 })
 
 const ResponseReasoningSummaryPartDoneEvent = Schema.Struct({
   type: Schema.Literal("response.reasoning_summary_part.done"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  summary_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  summary_index: Schema.Int,
+  sequence_number: Schema.Int,
   part: SummaryTextContent
 })
 
 const ResponseReasoningSummaryTextDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.reasoning_summary_text.delta"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  summary_index: Schema.Number,
+  output_index: Schema.Int,
+  summary_index: Schema.Int,
   delta: Schema.String,
-  sequence_number: Schema.Number
+  sequence_number: Schema.Int
 })
 
 const ResponseFunctionCallArgumentsDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.function_call_arguments.delta"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   delta: Schema.String
 })
 
 const ResponseFunctionCallArgumentsDoneEvent = Schema.Struct({
   type: Schema.Literal("response.function_call_arguments.done"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   arguments: Schema.String
 })
 
 const ResponseCodeInterpreterCallCodeDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.code_interpreter_call_code.delta"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   delta: Schema.String
 })
 
 const ResponseCodeInterpreterCallCodeDoneEvent = Schema.Struct({
   type: Schema.Literal("response.code_interpreter_call_code.done"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   code: Schema.String
 })
 
 const ResponseApplyPatchCallOperationDiffDeltaEvent = Schema.Struct({
   type: Schema.Literal("response.apply_patch_call_operation_diff.delta"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   delta: Schema.String
 })
 
 const ResponseApplyPatchCallOperationDiffDoneEvent = Schema.Struct({
   type: Schema.Literal("response.apply_patch_call_operation_diff.done"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   delta: Schema.optionalKey(Schema.String)
 })
 
 const ResponseImageGenerationCallPartialImageEvent = Schema.Struct({
   type: Schema.Literal("response.image_generation_call.partial_image"),
   item_id: Schema.String,
-  output_index: Schema.Number,
-  sequence_number: Schema.Number,
+  output_index: Schema.Int,
+  sequence_number: Schema.Int,
   partial_image_b64: Schema.String
 })
 
@@ -1031,8 +1031,8 @@ const ResponseErrorEvent = Schema.Struct({
   code: Schema.NullOr(Schema.String),
   message: Schema.String,
   param: Schema.NullOr(Schema.String),
-  sequence_number: Schema.Number,
-  status: Schema.optionalKey(Schema.Number)
+  sequence_number: Schema.Int,
+  status: Schema.optionalKey(Schema.Int)
 })
 
 const knownResponseStreamEventTypes = new Set([
@@ -1166,10 +1166,10 @@ export type ResponseStreamEvent = typeof ResponseStreamEvent.Type
  */
 export const Embedding = Schema.Struct({
   embedding: Schema.Union([
-    Schema.Array(Schema.Number),
+    Schema.Array(Schema.Finite),
     Schema.String
   ]),
-  index: Schema.Number,
+  index: Schema.Int,
   object: Schema.optionalKey(Schema.String)
 })
 
@@ -1213,12 +1213,12 @@ export const CreateEmbeddingRequest = Schema.Struct({
   input: Schema.Union([
     Schema.String,
     Schema.Array(Schema.String),
-    Schema.Array(Schema.Number),
-    Schema.Array(Schema.Array(Schema.Number))
+    Schema.Array(Schema.Int),
+    Schema.Array(Schema.Array(Schema.Int))
   ]),
   model: Schema.String,
   encoding_format: Schema.optionalKey(Schema.Literals(["float", "base64"])),
-  dimensions: Schema.optionalKey(Schema.Number),
+  dimensions: Schema.optionalKey(Schema.Int),
   user: Schema.optionalKey(Schema.String)
 })
 
@@ -1262,8 +1262,8 @@ export const CreateEmbeddingResponse = Schema.Struct({
   object: Schema.optionalKey(Schema.Literal("list")),
   usage: Schema.optionalKey(
     Schema.Struct({
-      prompt_tokens: Schema.Number,
-      total_tokens: Schema.Number
+      prompt_tokens: Schema.Int,
+      total_tokens: Schema.Int
     })
   )
 })

--- a/packages/ai/openrouter/src/internal/errors.ts
+++ b/packages/ai/openrouter/src/internal/errors.ts
@@ -23,7 +23,7 @@ export const OpenRouterErrorBody = Schema.Struct({
   error: Schema.Struct({
     message: Schema.String,
     type: Schema.optional(Schema.NullOr(Schema.String)),
-    code: Schema.optional(Schema.NullOr(Schema.Union([Schema.String, Schema.Number.check(Schema.isFinite())])))
+    code: Schema.optional(Schema.NullOr(Schema.Union([Schema.String, Schema.Finite])))
   })
 })
 

--- a/packages/effect/benchmark/schema/transformation.ts
+++ b/packages/effect/benchmark/schema/transformation.ts
@@ -18,13 +18,13 @@ const bench = new Bench()
 const schema = Schema.Struct({
   a: Schema.String,
   id: Schema.String,
-  c: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)),
+  c: Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0)),
   d: Schema.String
 }).pipe(Schema.decodeTo(
   Schema.Struct({
     a: Schema.String,
     b: Schema.Struct({ id: Schema.String }),
-    c: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)),
+    c: Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0)),
     d: Schema.String
   }),
   SchemaTransformation.transform({

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -624,7 +624,7 @@ export function revealBottom<S extends Top>(
  * ```ts
  * import { Schema } from "effect"
  *
- * const Age = Schema.Number.pipe(
+ * const Age = Schema.Natural.pipe(
  *   Schema.annotate({
  *     title: "Age",
  *     description: "A non-negative integer representing age in years"
@@ -1232,7 +1232,7 @@ function makeStandardResult<A>(exit: Exit_.Exit<StandardSchemaV1.Result<A>>): St
  * // Create a standard schema from a regular schema
  * const PersonSchema = Schema.Struct({
  *   name: Schema.NonEmptyString,
- *   age: Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 150 }))
+ *   age: Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 150 }))
  * })
  *
  * const standardSchema = Schema.toStandardSchemaV1(PersonSchema, {
@@ -5078,7 +5078,7 @@ export function suspend<S extends Constraint>(f: () => S): suspend<S> {
  * ```ts
  * import { Schema } from "effect"
  *
- * const AgeSchema = Schema.Number.pipe(
+ * const AgeSchema = Schema.Finite.pipe(
  *   Schema.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(120))
  * )
  * ```

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8236,6 +8236,30 @@ export interface Int extends Number {
 export const Int: Int = Number.check(isInt())
 
 /**
+ * Type-level representation of {@link Natural}.
+ *
+ * @category Number
+ * @since 4.0.0
+ */
+export interface Natural extends Int {
+  readonly "Rebuild": Natural
+}
+
+/**
+ * Schema for non-negative safe integers, including zero.
+ *
+ * **When to use**
+ *
+ * Use when you need a count, index, or size that cannot be negative.
+ *
+ * @see {@link Int} for safe integers that may be negative
+ *
+ * @category Number
+ * @since 4.0.0
+ */
+export const Natural: Natural = Int.check(isGreaterThanOrEqualTo(0))
+
+/**
  * Validates that a number is a 32-bit signed integer (range: -2,147,483,648 to
  * 2,147,483,647).
  *
@@ -9002,7 +9026,6 @@ export const isBetweenBigDecimal = makeIsBetween({
   formatter: (bd) => BigDecimal_.format(bd)
 })
 
-const CanonicalLength = Number.check(makeFilter<number>((value) => globalThis.Number.isInteger(value) && value >= 0))
 /**
  * Validates that a value has at least the specified length. Works with strings
  * and arrays.
@@ -9071,7 +9094,7 @@ export const isMinLengthReviver: SchemaRepresentation.FilterReviver<{
   readonly minLength: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isMinLength",
-  Struct({ minLength: CanonicalLength }),
+  Struct({ minLength: Natural }),
   ({ annotations, payload }) => isMinLength(payload.minLength, annotations)
 )
 
@@ -9157,7 +9180,7 @@ export const isMaxLengthReviver: SchemaRepresentation.FilterReviver<{
   readonly maxLength: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isMaxLength",
-  Struct({ maxLength: CanonicalLength }),
+  Struct({ maxLength: Natural }),
   ({ annotations, payload }) => isMaxLength(payload.maxLength, annotations)
 )
 
@@ -9229,7 +9252,7 @@ export const isLengthBetweenReviver: SchemaRepresentation.FilterReviver<{
   readonly maximum: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isLengthBetween",
-  Struct({ minimum: CanonicalLength, maximum: CanonicalLength }),
+  Struct({ minimum: Natural, maximum: Natural }),
   ({ annotations, payload }) => isLengthBetween(payload.minimum, payload.maximum, annotations)
 )
 
@@ -9292,7 +9315,7 @@ export const isMinSizeReviver: SchemaRepresentation.FilterReviver<{
   readonly minSize: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isMinSize",
-  Struct({ minSize: CanonicalLength }),
+  Struct({ minSize: Natural }),
   ({ annotations, payload }) => isMinSize(payload.minSize, annotations)
 )
 
@@ -9355,7 +9378,7 @@ export const isMaxSizeReviver: SchemaRepresentation.FilterReviver<{
   readonly maxSize: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isMaxSize",
-  Struct({ maxSize: CanonicalLength }),
+  Struct({ maxSize: Natural }),
   ({ annotations, payload }) => isMaxSize(payload.maxSize, annotations)
 )
 
@@ -9424,7 +9447,7 @@ export const isSizeBetweenReviver: SchemaRepresentation.FilterReviver<{
   readonly maximum: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isSizeBetween",
-  Struct({ minimum: CanonicalLength, maximum: CanonicalLength }),
+  Struct({ minimum: Natural, maximum: Natural }),
   ({ annotations, payload }) => isSizeBetween(payload.minimum, payload.maximum, annotations)
 )
 
@@ -9487,7 +9510,7 @@ export const isMinPropertiesReviver: SchemaRepresentation.FilterReviver<{
   readonly minProperties: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isMinProperties",
-  Struct({ minProperties: CanonicalLength }),
+  Struct({ minProperties: Natural }),
   ({ annotations, payload }) => isMinProperties(payload.minProperties, annotations)
 )
 
@@ -9549,7 +9572,7 @@ export const isMaxPropertiesReviver: SchemaRepresentation.FilterReviver<{
   readonly maxProperties: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isMaxProperties",
-  Struct({ maxProperties: CanonicalLength }),
+  Struct({ maxProperties: Natural }),
   ({ annotations, payload }) => isMaxProperties(payload.maxProperties, annotations)
 )
 
@@ -9618,7 +9641,7 @@ export const isPropertiesLengthBetweenReviver: SchemaRepresentation.FilterRevive
   readonly maximum: number
 }> = InternalSchema.makeFilterReviver(
   "effect/schema/isPropertiesLengthBetween",
-  Struct({ minimum: CanonicalLength, maximum: CanonicalLength }),
+  Struct({ minimum: Natural, maximum: Natural }),
   ({ annotations, payload }) => isPropertiesLengthBetween(payload.minimum, payload.maximum, annotations)
 )
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12446,26 +12446,24 @@ export interface DurationFromNanos extends decodeTo<Duration, BigInt> {
   readonly "Rebuild": DurationFromNanos
 }
 
-const bigint0 = globalThis.BigInt(0)
-
 /**
- * Schema that decodes a non-negative `bigint` into a
- * `Duration`, treating the bigint as nanoseconds.
+ * Schema that decodes a `bigint` into a `Duration`, treating the bigint as
+ * nanoseconds.
  *
  * **Details**
  *
  * Decoding:
- * A non-negative `bigint` representing nanoseconds is decoded as a `Duration`.
+ * A `bigint` representing nanoseconds is decoded as a `Duration`.
  *
  * Encoding:
- * Finite durations are encoded as a non-negative `bigint` number of nanoseconds.
- * Encoding fails when the duration cannot be represented as nanoseconds, such as
- * `Duration.infinity`.
+ * Finite durations are encoded as a `bigint` number of nanoseconds. Encoding
+ * fails when the duration cannot be represented as nanoseconds, such as
+ * `Duration.infinity` or `Duration.negativeInfinity`.
  *
  * @category Duration
  * @since 3.10.0
  */
-export const DurationFromNanos: DurationFromNanos = BigInt.check(isGreaterThanOrEqualToBigInt(bigint0)).pipe(
+export const DurationFromNanos: DurationFromNanos = BigInt.pipe(
   decodeTo(Duration, SchemaTransformation.durationFromNanos)
 )
 
@@ -12480,24 +12478,25 @@ export interface DurationFromMillis extends decodeTo<Duration, Number> {
 }
 
 /**
- * Schema that decodes a non-negative (possibly infinite)
- * integer into a `Duration`, treating the integer value as the duration in
+ * Schema that decodes a number into a `Duration`, treating the number as
  * milliseconds.
  *
  * **Details**
  *
  * Decoding:
- * - A non-negative (possibly infinite) integer representing milliseconds is
- *   decoded as a `Duration`
+ * - A finite or infinite number is decoded as a `Duration`
  *
  * Encoding:
- * - A `Duration` is encoded to a non-negative (possibly infinite) integer
- *   representing milliseconds
+ * - A `Duration` is encoded to a finite or infinite number of milliseconds
+ *
+ * **Gotchas**
+ *
+ * `NaN` is decoded as `Duration.zero`, matching `Duration.millis`.
  *
  * @category Duration
  * @since 3.10.0
  */
-export const DurationFromMillis: DurationFromMillis = Number.check(isGreaterThanOrEqualTo(0)).pipe(
+export const DurationFromMillis: DurationFromMillis = Number.pipe(
   decodeTo(Duration, SchemaTransformation.durationFromMillis)
 )
 
@@ -13218,7 +13217,7 @@ export function fromURLSearchParams<S extends Constraint>(schema: S): fromURLSea
  * @category Number
  * @since 3.10.0
  */
-export interface NumberFromString extends decodeTo<Finite, String> {
+export interface NumberFromString extends decodeTo<Number, String> {
   readonly "Rebuild": NumberFromString
 }
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12781,7 +12781,7 @@ export const File: File = instanceOf(globalThis.File, {
         data: String.check(isBase64()),
         type: String,
         name: String,
-        lastModified: Number
+        lastModified: Int
       }),
       SchemaTransformation.transformOrFail({
         decode: (e) =>
@@ -13865,7 +13865,7 @@ export const DateTimeUtcFromString: DateTimeUtcFromString = String.annotate({
  * @category DateTime
  * @since 4.0.0
  */
-export interface DateTimeUtcFromMillis extends decodeTo<instanceOf<DateTime.Utc>, Number> {
+export interface DateTimeUtcFromMillis extends decodeTo<instanceOf<DateTime.Utc>, Int> {
   readonly "Rebuild": DateTimeUtcFromMillis
 }
 
@@ -13887,7 +13887,7 @@ export interface DateTimeUtcFromMillis extends decodeTo<instanceOf<DateTime.Utc>
  * @category DateTime
  * @since 4.0.0
  */
-export const DateTimeUtcFromMillis: DateTimeUtcFromMillis = Number.pipe(
+export const DateTimeUtcFromMillis: DateTimeUtcFromMillis = Int.pipe(
   decodeTo(DateTimeUtc, {
     decode: SchemaGetter.dateTimeUtcFromInput(),
     encode: SchemaGetter.transform(DateTime.toEpochMillis)
@@ -13931,7 +13931,7 @@ export const TimeZoneOffset: TimeZoneOffset = declare(
     expected: "DateTime.TimeZone.Offset",
     toCodecJson: () =>
       link<DateTime.TimeZone.Offset>()(
-        Number,
+        Int,
         SchemaTransformation.timeZoneOffsetFromNumber
       ),
     toArbitrary: () => (fc) =>

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8218,6 +8218,24 @@ export const isIntReviver: SchemaRepresentation.FilterReviver<null> = InternalSc
 )
 
 /**
+ * Type-level representation of {@link Int}.
+ *
+ * @category Number
+ * @since 3.10.0
+ */
+export interface Int extends Number {
+  readonly "Rebuild": Int
+}
+
+/**
+ * Schema for integers, rejecting `NaN`, `Infinity`, and `-Infinity`.
+ *
+ * @category Number
+ * @since 3.10.0
+ */
+export const Int: Int = Number.check(isInt())
+
+/**
  * Validates that a number is a 32-bit signed integer (range: -2,147,483,648 to
  * 2,147,483,647).
  *
@@ -12195,7 +12213,7 @@ export const DateFromString: DateFromString = DateString.pipe(decodeTo(Date, Sch
  * @category Date
  * @since 4.0.0
  */
-export interface DateFromMillis extends decodeTo<Date, Number> {
+export interface DateFromMillis extends decodeTo<Date, Int> {
   readonly "Rebuild": DateFromMillis
 }
 
@@ -12210,23 +12228,26 @@ export interface DateFromMillis extends decodeTo<Date, Number> {
  * **Details**
  *
  * Decoding:
- * A number of milliseconds since the Unix epoch is decoded as a `Date`.
+ * A safe integer number of milliseconds since the Unix epoch is decoded as a
+ * `Date`.
  *
  * Encoding:
  * A `Date` is encoded as its millisecond timestamp.
  *
  * **Gotchas**
  *
- * This schema accepts any number, including `NaN`, `Infinity`, and `-Infinity`.
- * Those values decode to invalid `Date` instances.
+ * JavaScript `Date` supports a narrower range than safe integers, so an
+ * out-of-range integer can still decode to an invalid `Date`. Invalid `Date`
+ * instances cannot be encoded because their timestamp is `NaN`.
  *
  * @see {@link DateFromString} for decoding string-encoded dates
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
+ * @see {@link DateValid} for rejecting invalid Date instances
  *
  * @category Date
  * @since 4.0.0
  */
-export const DateFromMillis: DateFromMillis = Number.pipe(
+export const DateFromMillis: DateFromMillis = Int.pipe(
   decodeTo(Date, SchemaTransformation.dateFromMillis)
 )
 
@@ -13167,24 +13188,6 @@ export interface fromURLSearchParams<S extends Constraint> extends decodeTo<S, U
 export function fromURLSearchParams<S extends Constraint>(schema: S): fromURLSearchParams<S> {
   return URLSearchParams.pipe(decodeTo(schema, SchemaTransformation.fromURLSearchParams))
 }
-
-/**
- * Type-level representation of {@link Int}.
- *
- * @category Number
- * @since 3.10.0
- */
-export interface Int extends Number {
-  readonly "Rebuild": Int
-}
-
-/**
- * Schema for integers, rejecting `NaN`, `Infinity`, and `-Infinity`.
- *
- * @category Number
- * @since 3.10.0
- */
-export const Int: Int = Number.check(isInt())
 
 /**
  * Type-level representation of {@link NumberFromString}.

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -307,9 +307,9 @@ export interface UnknownErrorMetadata extends ProviderMetadata {}
  * @since 4.0.0
  */
 export const UsageInfo = Schema.Struct({
-  promptTokens: Schema.optional(Schema.Number),
-  completionTokens: Schema.optional(Schema.Number),
-  totalTokens: Schema.optional(Schema.Number)
+  promptTokens: Schema.optional(Schema.Int),
+  completionTokens: Schema.optional(Schema.Int),
+  totalTokens: Schema.optional(Schema.Int)
 }).annotate({ identifier: "UsageInfo" })
 
 /**

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -100,8 +100,8 @@ export const optional = <S extends Schema.Constraint>(
  */
 export const RequestId: Schema.Union<[
   typeof Schema.String,
-  typeof Schema.Number
-]> = Schema.Union([Schema.String, Schema.Number])
+  typeof Schema.Finite
+]> = Schema.Union([Schema.String, Schema.Finite])
 
 /**
  * Type represented by the JSON-RPC request identifier schema.
@@ -120,8 +120,8 @@ export type RequestId = typeof RequestId.Type
  */
 export const ProgressToken: Schema.Union<[
   typeof Schema.String,
-  typeof Schema.Number
-]> = Schema.Union([Schema.String, Schema.Number])
+  typeof Schema.Finite
+]> = Schema.Union([Schema.String, Schema.Finite])
 
 /**
  * Type represented by the MCP progress token schema.
@@ -299,7 +299,7 @@ export class Annotations extends Schema.Opaque<Annotations>()(Schema.Struct({
    * effectively required, while 0 means "least important," and indicates that
    * the data is entirely optional.
    */
-  priority: optional(Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 1 })))
+  priority: optional(Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 })))
 })) {}
 
 /**
@@ -449,7 +449,7 @@ export class McpErrorBase extends Schema.Class<McpErrorBase>(
   /**
    * The error type that occurred.
    */
-  code: Schema.Number,
+  code: Schema.Int,
   /**
    * A short description of the error. The message SHOULD be limited to a
    * concise single sentence.
@@ -797,11 +797,11 @@ export class ProgressNotification extends Rpc.make("notifications/progress", {
      * The progress thus far. This should increase every time progress is made,
      * even if the total is unknown.
      */
-    progress: optional(Schema.Number),
+    progress: optional(Schema.Finite),
     /**
      * Total number of items to process (or total progress required), if known.
      */
-    total: optional(Schema.Number),
+    total: optional(Schema.Finite),
     /**
      * An optional message describing the current progress.
      */
@@ -855,7 +855,7 @@ export class Resource extends Schema.Class<Resource>(
    * This can be used by Hosts to display file sizes and estimate context
    * window usage.
    */
-  size: optional(Schema.Number),
+  size: optional(Schema.Int),
   /**
    * Optional additional metadata for the client.
    *
@@ -1752,19 +1752,19 @@ export class ModelPreferences extends Schema.Class<ModelPreferences>(
    * is not important, while a value of 1 means cost is the most important
    * factor.
    */
-  costPriority: optional(Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 1 }))),
+  costPriority: optional(Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 }))),
   /**
    * How much to prioritize sampling speed (latency) when selecting a model. A
    * value of 0 means speed is not important, while a value of 1 means speed is
    * the most important factor.
    */
-  speedPriority: optional(Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 1 }))),
+  speedPriority: optional(Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 }))),
   /**
    * How much to prioritize intelligence and capabilities when selecting a
    * model. A value of 0 means intelligence is not important, while a value of 1
    * means intelligence is the most important factor.
    */
-  intelligencePriority: optional(Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 1 })))
+  intelligencePriority: optional(Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 })))
 }) {}
 
 /**
@@ -1831,12 +1831,12 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
      * caller), to be attached to the prompt. The client MAY ignore this request.
      */
     includeContext: optional(Schema.Literals(["none", "thisServer", "allServers"])),
-    temperature: optional(Schema.Number),
+    temperature: optional(Schema.Finite),
     /**
      * The maximum number of tokens to sample, as requested by the server. The
      * client MAY choose to sample fewer tokens than requested.
      */
-    maxTokens: Schema.Number,
+    maxTokens: Schema.Int,
     stopSequences: optional(Schema.Array(Schema.String)),
     /**
      * Optional metadata to pass through to the LLM provider. The format of
@@ -1895,7 +1895,7 @@ export class CompleteResult extends Schema.Opaque<CompleteResult>()(Schema.Struc
      * The total number of completion options available. This can exceed the
      * number of values actually sent in the response.
      */
-    total: optional(Schema.Number),
+    total: optional(Schema.Int),
     /**
      * Indicates whether there are additional completion options beyond those
      * provided in the current response, even if the exact total is unknown.

--- a/packages/effect/src/unstable/ai/Response.ts
+++ b/packages/effect/src/unstable/ai/Response.ts
@@ -2172,7 +2172,7 @@ export const HttpRequestDetails = Schema.Struct({
  * @since 4.0.0
  */
 export const HttpResponseDetails = Schema.Struct({
-  status: Schema.Number,
+  status: Schema.Int,
   headers: Schema.Record(
     Schema.String,
     Schema.Union([
@@ -2368,19 +2368,19 @@ export class Usage extends Schema.Class<Usage>("effect/ai/AiResponse/Usage")({
     /**
      * The number of non-cached input (i.e. prompt) tokens used.
      */
-    uncached: Schema.optional(Schema.Number),
+    uncached: Schema.optional(Schema.Int),
     /**
      * The total of number of input (i.e. prompt) tokens used.
      */
-    total: Schema.optional(Schema.Number),
+    total: Schema.optional(Schema.Int),
     /**
      * The number of cached input (i.e. prompt) tokens read.
      */
-    cacheRead: Schema.optional(Schema.Number),
+    cacheRead: Schema.optional(Schema.Int),
     /**
      * The number of cached input (i.e. prompt) tokens written.
      */
-    cacheWrite: Schema.optional(Schema.Number)
+    cacheWrite: Schema.optional(Schema.Int)
   }),
   /**
    * Information about the output (i.e. response) tokens used.
@@ -2389,15 +2389,15 @@ export class Usage extends Schema.Class<Usage>("effect/ai/AiResponse/Usage")({
     /**
      * The total of number of output (i.e. response) tokens used.
      */
-    total: Schema.optional(Schema.Number),
+    total: Schema.optional(Schema.Int),
     /**
      * The number of text tokens used.
      */
-    text: Schema.optional(Schema.Number),
+    text: Schema.optional(Schema.Int),
     /**
      * The number of reasoning tokens used.
      */
-    reasoning: Schema.optional(Schema.Number)
+    reasoning: Schema.optional(Schema.Int)
   })
 }) {}
 

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -83,7 +83,7 @@ export const make = Effect.gen(function*() {
       | Rpc.Rpc<
         "activity",
         Schema.Struct<
-          { name: typeof Schema.String; attempt: typeof Schema.Number; withTransaction: typeof Schema.Boolean }
+          { name: typeof Schema.String; attempt: typeof Schema.Int; withTransaction: typeof Schema.Boolean }
         >,
         Schema.declare<Workflow.Result<any, any>>
       >
@@ -97,7 +97,7 @@ export const make = Effect.gen(function*() {
       | Rpc.Rpc<"deferred", Schema.Struct<{ name: typeof Schema.String; exit: typeof ExitUnknown }>, typeof ExitUnknown>
       | Rpc.Rpc<
         "activity",
-        Schema.Struct<{ name: typeof Schema.String; attempt: typeof Schema.Number }>,
+        Schema.Struct<{ name: typeof Schema.String; attempt: typeof Schema.Int }>,
         Schema.declare<Workflow.Result<any, any>>
       >
       | Rpc.Rpc<"resume">
@@ -644,7 +644,7 @@ const ExitUnknown = Schema.Exit(AnyOrVoid, AnyOrVoid, Schema.Any)
 const ActivityRpc = Rpc.make("activity", {
   payload: {
     name: Schema.String,
-    attempt: Schema.Number,
+    attempt: Schema.Int,
     withTransaction: Schema.Boolean.pipe(
       Schema.withDecodingDefault(Effect.succeed(false))
     )

--- a/packages/effect/src/unstable/cluster/Reply.ts
+++ b/packages/effect/src/unstable/cluster/Reply.ts
@@ -258,7 +258,7 @@ export class Chunk<R extends Rpc.Any> extends Data.TaggedClass("Chunk")<{
               _tag: Schema.Literal("Chunk"),
               requestId: SnowflakeFromBigInt,
               id: SnowflakeFromBigInt,
-              sequence: Schema.Number,
+              sequence: Schema.Int,
               values: Schema.NonEmptyArray(success)
             }),
             SchemaTransformation.transform({

--- a/packages/effect/src/unstable/cluster/Runner.ts
+++ b/packages/effect/src/unstable/cluster/Runner.ts
@@ -29,7 +29,7 @@ const TypeId = "~effect/cluster/Runner"
 export class Runner extends Schema.Class<Runner>(TypeId)({
   address: RunnerAddress,
   groups: Schema.Array(Schema.String),
-  weight: Schema.Number
+  weight: Schema.Finite
 }) {
   /**
    * Formatter for rendering runner values consistently.

--- a/packages/effect/src/unstable/cluster/RunnerAddress.ts
+++ b/packages/effect/src/unstable/cluster/RunnerAddress.ts
@@ -28,7 +28,7 @@ const TypeId = "~effect/cluster/RunnerAddress"
  */
 export class RunnerAddress extends Schema.Class<RunnerAddress>(TypeId)({
   host: Schema.String,
-  port: Schema.Number
+  port: Schema.Int
 }) {
   /**
    * Marks this value as a cluster runner address for runtime guards.

--- a/packages/effect/src/unstable/cluster/ShardId.ts
+++ b/packages/effect/src/unstable/cluster/ShardId.ts
@@ -49,7 +49,7 @@ export const ShardId = S.declare(isShardId, {
     S.link<ShardId>()(
       S.Struct({
         group: S.String,
-        id: S.Number
+        id: S.Int
       }),
       {
         decode: SchemaGetter.transform(({ group, id }) => make(group, id)),

--- a/packages/effect/src/unstable/devtools/DevToolsSchema.ts
+++ b/packages/effect/src/unstable/devtools/DevToolsSchema.ts
@@ -311,7 +311,7 @@ export type Counter = Schema.Schema.Type<typeof Counter>
 export const Frequency = metric(
   "Frequency",
   Schema.Struct({
-    occurrences: Schema.ReadonlyMap(Schema.String, Schema.Number)
+    occurrences: Schema.ReadonlyMap(Schema.String, Schema.Natural)
   })
 )
 
@@ -370,8 +370,8 @@ export type Gauge = Schema.Schema.Type<typeof Gauge>
 export const Histogram = metric(
   "Histogram",
   Schema.Struct({
-    buckets: Schema.Array(Schema.Tuple([Schema.Number, Schema.Number])),
-    count: Schema.Number,
+    buckets: Schema.Array(Schema.Tuple([Schema.Number, Schema.Natural])),
+    count: Schema.Natural,
     min: Schema.Number,
     max: Schema.Number,
     sum: Schema.Number
@@ -405,8 +405,13 @@ export type Histogram = Schema.Schema.Type<typeof Histogram>
 export const Summary = metric(
   "Summary",
   Schema.Struct({
-    quantiles: Schema.Array(Schema.Tuple([Schema.Number, Schema.UndefinedOr(Schema.Number)])),
-    count: Schema.Number,
+    quantiles: Schema.Array(
+      Schema.Tuple([
+        Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 1 })),
+        Schema.UndefinedOr(Schema.Number)
+      ])
+    ),
+    count: Schema.Natural,
     min: Schema.Number,
     max: Schema.Number,
     sum: Schema.Number

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -345,7 +345,7 @@ export class Entry extends Schema.Class<Entry>("effect/eventlog/EventJournal/Ent
  * @since 4.0.0
  */
 export class RemoteEntry extends Schema.Class<RemoteEntry>("effect/eventlog/EventJournal/RemoteEntry")({
-  remoteSequence: Schema.Number,
+  remoteSequence: Schema.Int,
   entry: Entry
 }) {}
 

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -345,7 +345,7 @@ export class Entry extends Schema.Class<Entry>("effect/eventlog/EventJournal/Ent
  * @since 4.0.0
  */
 export class RemoteEntry extends Schema.Class<RemoteEntry>("effect/eventlog/EventJournal/RemoteEntry")({
-  remoteSequence: Schema.Int,
+  remoteSequence: Schema.Natural,
   entry: Entry
 }) {}
 

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -46,7 +46,7 @@ export interface EncryptedRemoteEntry extends Schema.Schema.Type<typeof Encrypte
  * @since 4.0.0
  */
 export const EncryptedRemoteEntry = Schema.Struct({
-  sequence: Schema.Number,
+  sequence: Schema.Int,
   iv: Transferable.Uint8Array,
   entryId: EntryId,
   encryptedEntry: Transferable.Uint8Array

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -46,7 +46,7 @@ export interface EncryptedRemoteEntry extends Schema.Schema.Type<typeof Encrypte
  * @since 4.0.0
  */
 export const EncryptedRemoteEntry = Schema.Struct({
-  sequence: Schema.Int,
+  sequence: Schema.Natural,
   iv: Transferable.Uint8Array,
   entryId: EntryId,
   encryptedEntry: Transferable.Uint8Array

--- a/packages/effect/src/unstable/eventlog/EventLogMessage.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogMessage.ts
@@ -164,7 +164,11 @@ export class SingleMessage
 export class ChunkedMessage
   extends Schema.TaggedClass<ChunkedMessage>("effect/eventlog/EventLogRemote/ChunkedMessage")("Chunked", {
     id: Schema.Int,
-    part: Schema.Tuple([Schema.Int, Schema.Int]),
+    part: Schema.Tuple([Schema.Natural, Schema.Natural]).check(
+      Schema.makeFilter(([index, total]) => index < total, {
+        expected: "a chunk part with an index less than its total"
+      })
+    ),
     data: Transferable.Uint8Array
   })
 {
@@ -324,7 +328,7 @@ export class ChangesRpc extends Rpc.make("EventLog.Changes", {
   payload: {
     publicKey: Schema.String,
     storeId: StoreId,
-    startSequence: Schema.Int
+    startSequence: Schema.Natural
   },
   success: Schema.Union([SingleMessage, ChunkedMessage]),
   error: EventLogProtocolError,

--- a/packages/effect/src/unstable/eventlog/EventLogMessage.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogMessage.ts
@@ -163,8 +163,8 @@ export class SingleMessage
  */
 export class ChunkedMessage
   extends Schema.TaggedClass<ChunkedMessage>("effect/eventlog/EventLogRemote/ChunkedMessage")("Chunked", {
-    id: Schema.Number,
-    part: Schema.Tuple([Schema.Number, Schema.Number]),
+    id: Schema.Int,
+    part: Schema.Tuple([Schema.Int, Schema.Int]),
     data: Transferable.Uint8Array
   })
 {
@@ -324,7 +324,7 @@ export class ChangesRpc extends Rpc.make("EventLog.Changes", {
   payload: {
     publicKey: Schema.String,
     storeId: StoreId,
-    startSequence: Schema.Number
+    startSequence: Schema.Int
   },
   success: Schema.Union([SingleMessage, ChunkedMessage]),
   error: EventLogProtocolError,

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -345,7 +345,7 @@ const toEntryRow = (entry: EventJournal.Entry): EntryRow => ({
 const RemoteRow = Schema.Struct({
   remote_id: EventJournal.RemoteId,
   entry_id: EventJournal.EntryId,
-  sequence: Schema.Int
+  sequence: Schema.Natural
 })
 
 const RemoteRowArray = Schema.Array(RemoteRow)

--- a/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventJournal.ts
@@ -319,7 +319,7 @@ const EntryRow = Schema.Struct({
   event: Schema.String,
   primary_key: Schema.String,
   payload: Schema.Uint8Array,
-  timestamp: Schema.Number
+  timestamp: Schema.Int
 })
 
 const EntryRowArray = Schema.Array(EntryRow)
@@ -345,7 +345,7 @@ const toEntryRow = (entry: EventJournal.Entry): EntryRow => ({
 const RemoteRow = Schema.Struct({
   remote_id: EventJournal.RemoteId,
   entry_id: EventJournal.EntryId,
-  sequence: Schema.Number
+  sequence: Schema.Int
 })
 
 const RemoteRowArray = Schema.Array(RemoteRow)

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts
@@ -269,7 +269,7 @@ export const makeStorage = (options?: {
   }).pipe(withTracerDisabled)
 
 const EncryptedRemoteEntrySql = Schema.Struct({
-  sequence: Schema.Number,
+  sequence: Schema.Int,
   iv: Schema.Uint8Array,
   entry_id: EntryId,
   encrypted_entry: Schema.Uint8Array

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServerEncrypted.ts
@@ -269,7 +269,7 @@ export const makeStorage = (options?: {
   }).pipe(withTracerDisabled)
 
 const EncryptedRemoteEntrySql = Schema.Struct({
-  sequence: Schema.Int,
+  sequence: Schema.Natural,
   iv: Schema.Uint8Array,
   entry_id: EntryId,
   encrypted_entry: Schema.Uint8Array

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts
@@ -461,7 +461,7 @@ const EntrySql = Schema.Struct({
 
 type EntrySql = Schema.Schema.Type<typeof EntrySql>
 
-const SqlNumber = Schema.Union([Schema.Number, Schema.NumberFromString])
+const SqlNumber = Schema.Union([Schema.Int, Schema.FiniteFromString.check(Schema.isInt())])
 
 const RemoteEntrySql = Schema.Struct({
   ...EntrySql.fields,

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServerUnencrypted.ts
@@ -461,17 +461,20 @@ const EntrySql = Schema.Struct({
 
 type EntrySql = Schema.Schema.Type<typeof EntrySql>
 
-const SqlNumber = Schema.Union([Schema.Int, Schema.FiniteFromString.check(Schema.isInt())])
+const SqlNatural = Schema.Union([
+  Schema.Natural,
+  Schema.FiniteFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))
+])
 
 const RemoteEntrySql = Schema.Struct({
   ...EntrySql.fields,
-  sequence: SqlNumber
+  sequence: SqlNatural
 })
 
 type RemoteEntrySql = Schema.Schema.Type<typeof RemoteEntrySql>
 
 const StoreSequenceSql = Schema.Struct({
-  next_sequence: SqlNumber
+  next_sequence: SqlNatural
 })
 
 const SessionAuthBindingSql = Schema.Struct({

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -362,8 +362,8 @@ export class RateLimitExceeded extends Schema.ErrorClass<RateLimitExceeded>(
   _tag: Schema.tag("RateLimitExceeded"),
   retryAfter: Schema.DurationFromMillis,
   key: Schema.String,
-  limit: Schema.Number,
-  remaining: Schema.Number
+  limit: Schema.Finite,
+  remaining: Schema.Finite
 }) {
   /**
    * Public message used when the rate limiter rejects a request.

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -1010,7 +1010,7 @@ export const Schema = <
     {
       expected: "AsyncResult",
       toCodec([value, cause]) {
-        const Success = Schema_.TaggedStruct("Success", { value, waiting: Schema_.Boolean, timestamp: Schema_.Number })
+        const Success = Schema_.TaggedStruct("Success", { value, waiting: Schema_.Boolean, timestamp: Schema_.Int })
         return Schema_.link<AsyncResult<A["Encoded"], E["Encoded"]>>()(
           Schema_.Union([
             Schema_.TaggedStruct("Initial", { waiting: Schema_.Boolean }),

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -283,7 +283,7 @@ export class SocketOpenError extends Schema.ErrorClass<SocketOpenError>("effect/
  */
 export class SocketCloseError extends Schema.ErrorClass<SocketCloseError>("effect/socket/Socket/SocketCloseError")({
   _tag: Schema.tag("SocketCloseError"),
-  code: Schema.Number,
+  code: Schema.Int,
   closeReason: Schema.optional(Schema.String)
 }) {
   /**

--- a/packages/effect/src/unstable/sql/SqlError.ts
+++ b/packages/effect/src/unstable/sql/SqlError.ts
@@ -575,8 +575,8 @@ export const classifySqliteError = (
  */
 export class ResultLengthMismatch
   extends Schema.TaggedErrorClass<ResultLengthMismatch>("effect/sql/ResultLengthMismatch")("ResultLengthMismatch", {
-    expected: Schema.Int,
-    actual: Schema.Int
+    expected: Schema.Natural,
+    actual: Schema.Natural
   })
 {
   /**

--- a/packages/effect/src/unstable/sql/SqlError.ts
+++ b/packages/effect/src/unstable/sql/SqlError.ts
@@ -575,8 +575,8 @@ export const classifySqliteError = (
  */
 export class ResultLengthMismatch
   extends Schema.TaggedErrorClass<ResultLengthMismatch>("effect/sql/ResultLengthMismatch")("ResultLengthMismatch", {
-    expected: Schema.Number,
-    actual: Schema.Number
+    expected: Schema.Int,
+    actual: Schema.Int
   })
 {
   /**

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5182,11 +5182,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     const decoding = asserts.decoding()
     await decoding.succeed(0n, Duration.zero)
     await decoding.succeed(1000n, Duration.nanos(1000n))
+    await decoding.succeed(-1000n, Duration.nanos(-1000n))
 
     const encoding = asserts.encoding()
     await encoding.succeed(Duration.millis(5), 5_000_000n)
     await encoding.succeed(Duration.nanos(5000n), 5000n)
+    await encoding.succeed(Duration.nanos(-5000n), -5000n)
     await encoding.fail(Duration.infinity, "Unable to encode Infinity into a bigint")
+    await encoding.fail(Duration.negativeInfinity, "Unable to encode -Infinity into a bigint")
   })
 
   it("DurationFromMillis", async () => {
@@ -5199,16 +5202,19 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(Infinity, Duration.infinity)
+    await decoding.succeed(-Infinity, Duration.negativeInfinity)
     await decoding.succeed(0, Duration.millis(0))
+    await decoding.succeed(-1, Duration.millis(-1))
     await decoding.succeed(1000, Duration.seconds(1))
     await decoding.succeed(60 * 1000, Duration.minutes(1))
     await decoding.succeed(0.1, Duration.millis(0.1))
-    await decoding.fail(-1, "Expected a value greater than or equal to 0, got -1")
-    await decoding.fail(NaN, "Expected a value greater than or equal to 0, got NaN")
+    await decoding.succeed(NaN, Duration.zero)
 
     const encoding = asserts.encoding()
     await encoding.succeed(Duration.infinity, Infinity)
+    await encoding.succeed(Duration.negativeInfinity, -Infinity)
     await encoding.succeed(Duration.millis(NaN), 0)
+    await encoding.succeed(Duration.millis(-1), -1)
     await encoding.succeed(Duration.seconds(5), 5000)
     await encoding.succeed(Duration.millis(5000), 5000)
     await encoding.succeed(Duration.millis(0.1), 0.1)

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -9329,6 +9329,34 @@ pointed message
     )
   })
 
+  it("Natural", async () => {
+    const schema = Schema.Natural
+    const asserts = new TestSchema.Asserts(schema)
+
+    if (verifyGeneration) {
+      asserts.arbitrary().verifyGeneration()
+    }
+
+    const decoding = asserts.decoding()
+    await decoding.succeed(0)
+    await decoding.succeed(1)
+    await decoding.fail(
+      -1,
+      `Expected a value greater than or equal to 0, got -1`
+    )
+    await decoding.fail(
+      1.1,
+      `Expected an integer, got 1.1`
+    )
+
+    const encoding = asserts.encoding()
+    await encoding.succeed(0)
+    await encoding.fail(
+      -1,
+      `Expected a value greater than or equal to 0, got -1`
+    )
+  })
+
   it("Capitalize", async () => {
     const schema = Schema.String.pipe(
       Schema.decodeTo(

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -1911,17 +1911,17 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed(0, new Date(0))
-      assertTrue(Schema.decodeSync(schema)(NaN) instanceof Date)
-      assertTrue(Schema.decodeSync(schema)(Infinity) instanceof Date)
-      assertTrue(Schema.decodeSync(schema)(-Infinity) instanceof Date)
+      await decoding.fail(NaN, `Expected an integer, got NaN`)
+      await decoding.fail(Infinity, `Expected an integer, got Infinity`)
+      await decoding.fail(-Infinity, `Expected an integer, got -Infinity`)
       await decoding.fail(null, `Expected number, got null`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(new Date(0), 0)
-      strictEqual(Schema.encodeSync(schema)(new Date("invalid")), NaN)
-      strictEqual(Schema.encodeSync(schema)(new Date(NaN)), NaN)
-      strictEqual(Schema.encodeSync(schema)(new Date(Infinity)), NaN)
-      strictEqual(Schema.encodeSync(schema)(new Date(-Infinity)), NaN)
+      await encoding.fail(new Date("invalid"), `Expected an integer, got NaN`)
+      await encoding.fail(new Date(NaN), `Expected an integer, got NaN`)
+      await encoding.fail(new Date(Infinity), `Expected an integer, got NaN`)
+      await encoding.fail(new Date(-Infinity), `Expected an integer, got NaN`)
     })
 
     it("FiniteFromString", async () => {

--- a/packages/effect/test/schema/representation/builtInRevivers.test.ts
+++ b/packages/effect/test/schema/representation/builtInRevivers.test.ts
@@ -537,7 +537,7 @@ describe("SchemaRepresentation built-in BigInt revivers", () => {
 })
 
 function date(millis: number): Date {
-  return Schema.decodeUnknownSync(Schema.DateFromMillis)(millis)
+  return new globalThis.Date(millis)
 }
 
 const epoch = "1970-01-01T00:00:00.000Z"

--- a/packages/tools/openapi-generator/src/OpenApiPatch.ts
+++ b/packages/tools/openapi-generator/src/OpenApiPatch.ts
@@ -132,7 +132,7 @@ export class JsonPatchApplicationError
   extends Schema.ErrorClass<JsonPatchApplicationError>("JsonPatchApplicationError")({
     _tag: Schema.tag("JsonPatchApplicationError"),
     source: Schema.String,
-    operationIndex: Schema.Int,
+    operationIndex: Schema.Natural,
     operation: Schema.String,
     path: Schema.String,
     reason: Schema.String

--- a/packages/tools/openapi-generator/src/OpenApiPatch.ts
+++ b/packages/tools/openapi-generator/src/OpenApiPatch.ts
@@ -132,7 +132,7 @@ export class JsonPatchApplicationError
   extends Schema.ErrorClass<JsonPatchApplicationError>("JsonPatchApplicationError")({
     _tag: Schema.tag("JsonPatchApplicationError"),
     source: Schema.String,
-    operationIndex: Schema.Number,
+    operationIndex: Schema.Int,
     operation: Schema.String,
     path: Schema.String,
     reason: Schema.String

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,7 +35,6 @@
       "name": "@effect/language-service",
       "namespaceImportPackages": ["effect", "@effect/*"],
       "diagnosticSeverity": {
-        "schemaNumber": "error",
         "globalErrorInEffectFailure": "off" // TODO: Check if we should fix the warnings this reports
       },
       "includeSuggestionsInTsc": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,7 @@
       "name": "@effect/language-service",
       "namespaceImportPackages": ["effect", "@effect/*"],
       "diagnosticSeverity": {
+        "schemaNumber": "error",
         "globalErrorInEffectFailure": "off" // TODO: Check if we should fix the warnings this reports
       },
       "includeSuggestionsInTsc": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Schema.Natural` for non-negative safe integers.
* **Improvements**
  * Standardized numeric validation across Effect core, AI protocol schemas, OpenAPI patches, and related streaming/cluster/persistence/devtools schemas.
  * Integers, finite numbers, and non-finite values are now rejected more consistently.
  * Negative durations are now supported when decoding from milliseconds or nanoseconds.
* **Bug Fixes**
  * Corrected `Schema.NumberFromString` decoding behavior.
* **Documentation**
  * Updated guides and examples to use integer/finite schemas.
* **Tests**
  * Refreshed schema codec and duration/date validation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->