### PR TITLE
Make embedding usage input tokens optional

### DIFF
--- a/.changeset/optional-ai-embedding-usage.md
+++ b/.changeset/optional-ai-embedding-usage.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow embedding usage input tokens to be omitted during decoding, including after JSON serialization.

--- a/packages/effect/src/unstable/ai/EmbeddingModel.ts
+++ b/packages/effect/src/unstable/ai/EmbeddingModel.ts
@@ -69,7 +69,7 @@ export class Dimensions extends Context.Service<Dimensions, number>()(
 export class EmbeddingUsage extends Schema.Class<EmbeddingUsage>(
   "effect/ai/EmbeddingModel/EmbeddingUsage"
 )({
-  inputTokens: Schema.UndefinedOr(Schema.Finite)
+  inputTokens: Schema.optional(Schema.Finite)
 }) {}
 
 /**

--- a/packages/effect/test/unstable/ai/EmbeddingModel.test.ts
+++ b/packages/effect/test/unstable/ai/EmbeddingModel.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { EmbeddingModel } from "effect/unstable/ai"
 import * as AiError from "effect/unstable/ai/AiError"
 
@@ -16,6 +16,18 @@ const makeLayer = (
   )
 
 describe("EmbeddingModel", () => {
+  it.effect("round trips usage with undefined input tokens through JSON", () =>
+    Effect.gen(function*() {
+      const usage = new EmbeddingModel.EmbeddingUsage({ inputTokens: undefined })
+
+      const encoded = yield* Schema.encodeEffect(EmbeddingModel.EmbeddingUsage)(usage)
+      const json = JSON.parse(JSON.stringify(encoded))
+      const decoded = yield* Schema.decodeUnknownEffect(EmbeddingModel.EmbeddingUsage)(json)
+
+      assert.deepStrictEqual(json, {}, "encoded JSON")
+      assert.deepStrictEqual(decoded, new EmbeddingModel.EmbeddingUsage({}), "decoded usage")
+    }))
+
   it.effect("embed returns a vector", () => {
     const calls: Array<ReadonlyArray<string>> = []
 


### PR DESCRIPTION
## Summary

- make `EmbeddingUsage.inputTokens` accept an omitted key after JSON serialization by using `Schema.optional`
- add JSON round-trip regression coverage and a patch changeset
- triage all eleven `McpSchema` `payload: Schema.UndefinedOr(...)` occurrences and intentionally leave them unchanged: `Ping` and `ListRoots`; `InitializedNotification`, `ResourceListChangedNotification`, `PromptListChangedNotification`, `ToolListChangedNotification`, and `RootsListChangedNotification`; and `ListResources`, `ListResourceTemplates`, `ListPrompts`, and `ListTools`

The `McpSchema` occurrences are top-level RPC payload schemas, not fields of a serialized struct. The RPC JSON codec maps their `undefined` payload to JSON `null` and decodes `null` back to `undefined`, so they do not have the missing-key failure fixed by `Schema.optional`; changing them would not alter the top-level codec behavior.

## Validation

- `pnpm --filter effect test --run` (229 files passed; 7,094 tests passed; 3 skipped)
- `pnpm check`
- `pnpm lint`
- `pnpm test --run` was also attempted repository-wide: 330 files / 8,305 tests passed; the sole failure was the unrelated `NodeChildProcessSpawner` process-group timing assertion also observed in #6606

Closes EFF-41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Embedding usage data can now be decoded when input token counts are omitted, including after JSON serialization.
  - Preserves compatibility with providers that do not report input token usage.

- **Tests**
  - Added coverage for encoding, serializing, and decoding embedding usage without input token counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->