### PR TITLE
Fix duplicate chunk handling in ChunkedMessage.join

### DIFF
--- a/.changeset/fix-eventlog-duplicate-chunks.md
+++ b/.changeset/fix-eventlog-duplicate-chunks.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore duplicate chunk indexes when joining event log messages.

--- a/packages/effect/src/unstable/eventlog/EventLogMessage.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogMessage.ts
@@ -225,6 +225,9 @@ export class ChunkedMessage
       }
       map.set(part.id, entry)
     }
+    if (entry.parts[index] !== undefined) {
+      return
+    }
     entry.parts[index] = part.data
     entry.count++
     entry.bytes += part.data.byteLength

--- a/packages/effect/test/unstable/eventlog/EventLogMessage.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLogMessage.test.ts
@@ -1,0 +1,27 @@
+import { assert, describe, it } from "@effect/vitest"
+import { ChunkedMessage } from "effect/unstable/eventlog/EventLogMessage"
+
+describe("EventLogMessage", () => {
+  it("ignores duplicate chunks when joining", () => {
+    const state = ChunkedMessage.initialJoinState()
+    const chunk = new ChunkedMessage({
+      id: 1,
+      part: [0, 2],
+      data: new Uint8Array([1])
+    })
+
+    assert.isUndefined(ChunkedMessage.join(state, chunk))
+    assert.isUndefined(ChunkedMessage.join(state, chunk))
+    assert.deepStrictEqual(
+      ChunkedMessage.join(
+        state,
+        new ChunkedMessage({
+          id: 1,
+          part: [1, 2],
+          data: new Uint8Array([2])
+        })
+      ),
+      new Uint8Array([1, 2])
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- ignore duplicate chunk indexes before updating join bookkeeping
- add a regression test for duplicate delivery followed by successful assembly
- add a patch changeset for `effect`

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/eventlog/EventLogMessage.test.ts --run`
- `pnpm check`

Closes EFF-42
Closes #6612


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate event log chunks from being counted or overwriting existing data.
  * Improved reliability when assembling event log messages from multiple chunks.

* **Tests**
  * Added coverage for duplicate chunks and successful message assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->