### PR TITLE
Fix Metric max for negative-only observations

### DIFF
--- a/.changeset/fix-metric-negative-max.md
+++ b/.changeset/fix-metric-negative-max.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix histogram and summary maximum values for negative-only observations.

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -1913,7 +1913,7 @@ class HistogramMetric extends Metric$<number, HistogramState> {
     let count = 0
     let sum = 0
     let min = Number.MAX_VALUE
-    let max = Number.MIN_VALUE
+    let max = Number.NEGATIVE_INFINITY
 
     Arr.map(Arr.sort(bounds, Order.Number), (n, i) => {
       boundaries[i] = n
@@ -2000,7 +2000,7 @@ class SummaryMetric extends Metric$<readonly [value: number, timestamp: number],
     let count = 0
     let sum = 0
     let min = Number.MAX_VALUE
-    let max = Number.MIN_VALUE
+    let max = Number.NEGATIVE_INFINITY
 
     const snapshot = (now: number): ReadonlyArray<[number, number | undefined]> => {
       const builder: Array<number> = []

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -1913,7 +1913,7 @@ class HistogramMetric extends Metric$<number, HistogramState> {
     let count = 0
     let sum = 0
     let min = Number.MAX_VALUE
-    let max = Number.NEGATIVE_INFINITY
+    let max = -Number.MAX_VALUE
 
     Arr.map(Arr.sort(bounds, Order.Number), (n, i) => {
       boundaries[i] = n
@@ -2000,7 +2000,7 @@ class SummaryMetric extends Metric$<readonly [value: number, timestamp: number],
     let count = 0
     let sum = 0
     let min = Number.MAX_VALUE
-    let max = Number.NEGATIVE_INFINITY
+    let max = -Number.MAX_VALUE
 
     const snapshot = (now: number): ReadonlyArray<[number, number | undefined]> => {
       const builder: Array<number> = []

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -346,6 +346,26 @@ describe("Metric", () => {
       }))
   })
 
+  it.effect("uses finite extrema for empty histogram and summary states", () =>
+    Effect.gen(function*() {
+      const histogram = Metric.histogram(nextId(), { boundaries: [] })
+      const summary = Metric.summary(nextId(), {
+        maxAge: "1 minute",
+        maxSize: 10,
+        quantiles: []
+      })
+      const histogramState = yield* Metric.value(histogram)
+      const summaryState = yield* Metric.value(summary)
+      assert.deepStrictEqual(
+        { min: histogramState.min, max: histogramState.max },
+        { min: Number.MAX_VALUE, max: -Number.MAX_VALUE }
+      )
+      assert.deepStrictEqual(
+        { min: summaryState.min, max: summaryState.max },
+        { min: Number.MAX_VALUE, max: -Number.MAX_VALUE }
+      )
+    }))
+
   describe("Histogram", () => {
     it.effect("reports the maximum for negative-only observations", () =>
       Effect.gen(function*() {
@@ -353,6 +373,7 @@ describe("Metric", () => {
         yield* Metric.update(histogram, -10)
         yield* Metric.update(histogram, -5)
         const result = yield* Metric.value(histogram)
+        assert.strictEqual(result.min, -10)
         assert.strictEqual(result.max, -5)
       }))
 
@@ -422,6 +443,7 @@ describe("Metric", () => {
         yield* Metric.update(summary, -10)
         yield* Metric.update(summary, -5)
         const result = yield* Metric.value(summary)
+        assert.strictEqual(result.min, -10)
         assert.strictEqual(result.max, -5)
       }))
 

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -347,6 +347,15 @@ describe("Metric", () => {
   })
 
   describe("Histogram", () => {
+    it.effect("reports the maximum for negative-only observations", () =>
+      Effect.gen(function*() {
+        const histogram = Metric.histogram(nextId(), { boundaries: [-10, -5, 0] })
+        yield* Metric.update(histogram, -10)
+        yield* Metric.update(histogram, -5)
+        const result = yield* Metric.value(histogram)
+        assert.strictEqual(result.max, -5)
+      }))
+
     it.effect("custom observe with value", () =>
       Effect.gen(function*() {
         const id = nextId()
@@ -403,6 +412,19 @@ describe("Metric", () => {
   })
 
   describe("Summary", () => {
+    it.effect("reports the maximum for negative-only observations", () =>
+      Effect.gen(function*() {
+        const summary = Metric.summary(nextId(), {
+          maxAge: "1 minute",
+          maxSize: 10,
+          quantiles: [0.5]
+        })
+        yield* Metric.update(summary, -10)
+        yield* Metric.update(summary, -5)
+        const result = yield* Metric.value(summary)
+        assert.strictEqual(result.max, -5)
+      }))
+
     it.effect("custom observe with value", () =>
       Effect.gen(function*() {
         const id = nextId()


### PR DESCRIPTION
## Summary

- initialize histogram and summary maxima with the finite `-Number.MAX_VALUE` sentinel
- cover negative-only observations and finite empty-state bounds with regression tests
- add a patch changeset

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Metric.test.ts --run`
- `pnpm check`

Closes EFF-43
Fixes #6611
