### PR TITLE
Expose tool call IDs to AI handlers

### DIFF
--- a/.changeset/fix-ai-tool-call-id.md
+++ b/.changeset/fix-ai-tool-call-id.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Expose the tool call ID to AI tool handlers and `Toolkit.WithHandler.handle` wrappers.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1520,7 +1520,7 @@ export const make: (params: {
         return
       }
 
-      yield* toolkit.handle(part.name, part.params as any).pipe(
+      yield* toolkit.handle(part.name, part.params as any, part.id).pipe(
         Stream.unwrap,
         Stream.runForEach((result) => {
           const toolResultPart = Response.makePart("tool-result", {
@@ -2006,7 +2006,8 @@ const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
 
     const resultStream = yield* toolkit.handle(
       toolCall.name,
-      toolCall.params as any
+      toolCall.params as any,
+      approval.toolCallId
     )
 
     const terminalResult = yield* resultStream.pipe(
@@ -2116,7 +2117,7 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
       }
 
       if (approvedToolCallIds.has(toolCall.id)) {
-        return toolkit.handle(toolCall.name, toolCall.params as any).pipe(
+        return toolkit.handle(toolCall.name, toolCall.params as any, toolCall.id).pipe(
           Stream.unwrap,
           Stream.map(
             (result) =>
@@ -2142,7 +2143,7 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
         )
       }
 
-      return toolkit.handle(toolCall.name, toolCall.params as any).pipe(
+      return toolkit.handle(toolCall.name, toolCall.params as any, toolCall.id).pipe(
         Stream.unwrap,
         Stream.map(
           (result) =>

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -107,6 +107,10 @@ export interface Toolkit<in out Tools extends Record<string, Tool.Any>> extends
  */
 export interface HandlerContext<Tool extends Tool.Any> {
   /**
+   * The unique identifier of the tool call, when available.
+   */
+  readonly toolCallId?: string | undefined
+  /**
    * Emit a preliminary result during long-running tool calls.
    *
    * **Details**
@@ -200,7 +204,11 @@ export interface WithHandler<in out Tools extends Record<string, Tool.Any>> {
     /**
      * Parameters to pass to the tool handler.
      */
-    params: Tool.Parameters<Tools[Name]>
+    params: Tool.Parameters<Tools[Name]>,
+    /**
+     * The unique identifier of the tool call.
+     */
+    toolCallId?: string
   ) => Effect.Effect<
     Stream.Stream<
       Tool.HandlerResult<Tools[Name]>,
@@ -258,7 +266,7 @@ const Proto = {
         return schemas
       }
 
-      const handle = Effect.fnUntraced(function*(name: string, params: unknown) {
+      const handle = Effect.fnUntraced(function*(name: string, params: unknown, toolCallId?: string) {
         const tool = Object.hasOwn(tools, name) ? tools[name] : undefined
 
         yield* Effect.annotateCurrentSpan({
@@ -303,6 +311,7 @@ const Proto = {
           readonly preliminary: boolean
         }, Cause.Done>()
         const context: HandlerContext<any> = {
+          toolCallId,
           preliminary: (result) =>
             Effect.asVoid(Queue.offer(queue, {
               result,

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -286,6 +286,58 @@ describe("LanguageModel", () => {
         strictEqual(yield* Ref.get(maxActive), 2)
       }))
 
+    it.effect("provides tool call IDs to concurrent identical tool handlers", () =>
+      Effect.gen(function*() {
+        const toolCallIds = yield* Ref.make<Array<string>>([])
+        const twoStarted = yield* Latch.make()
+        const release = yield* Latch.make()
+
+        const handlers = MyToolkit.toLayer({
+          MyTool: (_, context) =>
+            Effect.gen(function*() {
+              const toolCallId = context.toolCallId
+              assertDefined(toolCallId)
+              const ids = yield* Ref.updateAndGet(toolCallIds, (ids) => [...ids, toolCallId])
+              if (ids.length === 2) {
+                yield* twoStarted.open
+              }
+              yield* release.await
+              return { testSuccess: "test-success" }
+            })
+        })
+
+        const fiber = yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          Stream.runDrain,
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-1",
+                name: "MyTool",
+                params: { testParam: "identical" }
+              },
+              {
+                type: "tool-call",
+                id: "tool-2",
+                name: "MyTool",
+                params: { testParam: "identical" }
+              }
+            ]
+          }),
+          Effect.provide(handlers),
+          Effect.forkScoped
+        )
+
+        yield* twoStarted.await
+        deepStrictEqual((yield* Ref.get(toolCallIds)).sort(), ["tool-1", "tool-2"])
+
+        yield* release.open
+        yield* Fiber.join(fiber)
+      }))
+
     it.effect("bounds needsApproval evaluation with the tool handler concurrency", () =>
       Effect.gen(function*() {
         const active = yield* Ref.make(0)


### PR DESCRIPTION
## Summary

- expose an optional `toolCallId` argument on `Toolkit.WithHandler.handle` and provide it to `HandlerContext`
- thread tool call IDs through streaming, approved, and non-streaming language model execution paths
- cover concurrent identical tool calls with distinct handler context IDs

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts`
- `pnpm check`
- `pnpm changeset status`

Closes EFF-44
Fixes #6597


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI tool handlers can now access the identifier for each tool call.
  * Tool call identifiers are preserved during both streaming and non-streaming execution.
  * Supports distinguishing concurrent calls to the same tool.

* **Tests**
  * Added coverage verifying tool call identifiers remain available during concurrent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->