### PR TITLE
Add Tool.setNeedsApproval combinator

### DIFF
--- a/.changeset/add-tool-set-needs-approval.md
+++ b/.changeset/add-tool-set-needs-approval.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Tool.setNeedsApproval` for replacing the approval policy of an existing tool.

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -274,6 +274,13 @@ export interface Tool<
   readonly needsApproval?: boolean | NeedsApprovalFunction<any> | undefined
 
   /**
+   * Set whether user approval is required before executing this tool.
+   */
+  setNeedsApproval(
+    needsApproval: NeedsApproval<Config["parameters"]>
+  ): Tool<Name, Config, Requirements>
+
+  /**
    * Adds a _request-level_ dependency which must be provided before the tool
    * call handler can be executed.
    *
@@ -1050,6 +1057,9 @@ const Proto = {
   },
   setFailure(this: Any, failureSchema: Schema.Constraint) {
     return clone(this, { failureSchema })
+  },
+  setNeedsApproval(this: Any, needsApproval: NeedsApproval<any>) {
+    return clone(this, { needsApproval })
   },
   annotate<I, S>(this: Any, tag: Context.Key<I, S>, value: S) {
     return clone(this, { annotations: Context.add(this.annotations, tag, value) })

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -1048,6 +1048,34 @@ const HandlerRequired = Tool.providerDefined({
   })
 })
 
+describe("setNeedsApproval", () => {
+  it("sets a static approval requirement without mutating the original tool", () => {
+    const tool = Tool.make("TestTool", { needsApproval: true })
+    const updated = tool.setNeedsApproval(false)
+
+    strictEqual(tool.needsApproval, true)
+    strictEqual(updated.needsApproval, false)
+  })
+
+  it("sets a dynamic approval requirement", () => {
+    const needsApproval = (params: { readonly dangerous: boolean }) => params.dangerous
+    const tool = Tool.make("TestTool", {
+      parameters: Schema.Struct({ dangerous: Schema.Boolean })
+    }).setNeedsApproval(needsApproval)
+
+    strictEqual(tool.needsApproval, needsApproval)
+  })
+
+  it("preserves dynamic tool identity", () => {
+    const tool = Tool.dynamic("TestTool", {
+      parameters: { type: "object", properties: {} }
+    }).setNeedsApproval(true)
+
+    assertTrue(Tool.isDynamic(tool))
+    strictEqual(tool.needsApproval, true)
+  })
+})
+
 describe("Dynamic", () => {
   describe("isDynamic", () => {
     it.effect("returns true for dynamic tools with Effect Schema", () =>


### PR DESCRIPTION
## Summary

- add `Tool.setNeedsApproval` to immutably replace static or dynamic approval policies
- preserve the original tool kind through the existing clone helper
- cover static, dynamic, and dynamic-tool cloning behavior and add a patch changeset

## Testing

- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/ai/Tool.test.ts`
- `pnpm test-types Tool.tst.ts`
- `pnpm check`

Closes EFF-45

Related to Effect-TS/effect#6600
