### PR TITLE
fix(cli): fail when excess positional arguments are provided

### DIFF
--- a/.changeset/unrecognized-arguments.md
+++ b/.changeset/unrecognized-arguments.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Added UnrecognizedArgument error to effect/cli for excess positional arguments.

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -93,7 +93,7 @@ export type CliError =
   | UnknownSubcommand
   | ShowHelp
   | UserError
-  | ValidationError
+  | UnrecognizedArgument
 
 /**
  * Error thrown when an unrecognized option is encountered.
@@ -491,14 +491,14 @@ export class UserError extends Schema.TaggedErrorClass<UserError>(
 }
 
 /**
- * Error thrown when a validation fails (e.g. excess positional arguments).
+ * Error thrown when an unrecognized argument is encountered.
  *
  * @category models
  * @since 4.0.0
  */
-export class ValidationError extends Schema.TaggedErrorClass<ValidationError>(
-  `${TypeId}/ValidationError`
-)("ValidationError", {
+export class UnrecognizedArgument extends Schema.TaggedErrorClass<UnrecognizedArgument>(
+  `${TypeId}/UnrecognizedArgument`
+)("UnrecognizedArgument", {
   error: Schema.String
 }) {
   /**
@@ -537,6 +537,7 @@ export const NonShowHelpErrors: Schema.Union<
     typeof MissingArgument,
     typeof InvalidValue,
     typeof UnknownSubcommand,
+    typeof UnrecognizedArgument,
     typeof UserError
   ]
 > = Schema.Union([
@@ -546,6 +547,7 @@ export const NonShowHelpErrors: Schema.Union<
   MissingArgument,
   InvalidValue,
   UnknownSubcommand,
+  UnrecognizedArgument,
   UserError
 ])
 

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -93,6 +93,7 @@ export type CliError =
   | UnknownSubcommand
   | ShowHelp
   | UserError
+  | ValidationError
 
 /**
  * Error thrown when an unrecognized option is encountered.
@@ -487,6 +488,34 @@ export class UserError extends Schema.TaggedErrorClass<UserError>(
    * @since 4.0.0
    */
   readonly [TypeId] = TypeId
+}
+
+/**
+ * Error thrown when a validation fails (e.g. excess positional arguments).
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export class ValidationError extends Schema.TaggedErrorClass<ValidationError>(
+  `${TypeId}/ValidationError`
+)("ValidationError", {
+  error: Schema.String
+}) {
+  /**
+   * Marks this value as a CLI parsing error for runtime guards.
+   *
+   * @since 4.0.0
+   */
+  readonly [TypeId] = TypeId
+
+  /**
+   * Retrieves the underlying error.
+   *
+   * @since 4.0.0
+   */
+  override get message() {
+    return this.error
+  }
 }
 
 /**

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -292,7 +292,7 @@ const parseParams: (parsedArgs: Param.ParsedArgs, params: ReadonlyArray<Param.An
   }
 
   if (currentArguments.length > 0) {
-    return yield* new CliError.ValidationError({
+    return yield* new CliError.UnrecognizedArgument({
       error: `Excess arguments: ${currentArguments.join(", ")}`
     })
   }

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -291,6 +291,12 @@ const parseParams: (parsedArgs: Param.ParsedArgs, params: ReadonlyArray<Param.An
     currentArguments = remainingArguments
   }
 
+  if (currentArguments.length > 0) {
+    return yield* new CliError.ValidationError({
+      error: `Excess arguments: ${currentArguments.join(", ")}`
+    })
+  }
+
   return results
 })
 

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -722,6 +722,34 @@ describe("Command", () => {
         const result = yield* Effect.flip(Cli.run(["test-failing", "--input", "test"]))
         assert.strictEqual(result, "Handler error")
       }).pipe(Effect.provide(TestLayer)))
+    it.effect("should fail with UnrecognizedArgument when excess positional arguments are provided to a command with no arguments", () =>
+      Effect.gen(function*() {
+        const command = Command.make("test", {}, () => Effect.void)
+        const runCommand = Command.runWith(command, { version: "1.0.0" })
+        const error = yield* Effect.flip(runCommand(["bogus1", "bogus2"]))
+        assert.strictEqual((error as any)._tag, "UnrecognizedArgument")
+        assert.isTrue(String((error as any).error).includes("Excess arguments: bogus1, bogus2"))
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should fail with UnrecognizedArgument when excess positional arguments are provided to a command with fixed arguments", () =>
+      Effect.gen(function*() {
+        const command = Command.make("test", {
+          arg1: Argument.string("arg1")
+        }, () => Effect.void)
+        const runCommand = Command.runWith(command, { version: "1.0.0" })
+        const error = yield* Effect.flip(runCommand(["valid", "bogus1", "bogus2"]))
+        assert.strictEqual((error as any)._tag, "UnrecognizedArgument")
+        assert.isTrue(String((error as any).error).includes("Excess arguments: bogus1, bogus2"))
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should not fail with UnrecognizedArgument when a command has variadic arguments", () =>
+      Effect.gen(function*() {
+        const command = Command.make("test", {
+          args: Argument.string("args").pipe(Argument.repeated)
+        }, () => Effect.void)
+        const runCommand = Command.runWith(command, { version: "1.0.0" })
+        yield* runCommand(["valid1", "valid2", "valid3"])
+      }).pipe(Effect.provide(TestLayer)))
   })
 
   describe("withSubcommands", () => {


### PR DESCRIPTION
Fixes #6594

This throws a ValidationError when there are unconsumed positional arguments after parsing all parameters. Previously, excess positionals were silently discarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `UnrecognizedArgument` CLI error type for invalid command-line input.
* **Bug Fixes**
  * Commands now error when extra positional arguments remain after parsing.
  * Error messages include the unexpected tokens (e.g., `Excess arguments: ...`).
* **Tests**
  * Added coverage for fixed vs. variadic positional arguments, ensuring excess operands are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->