### PR TITLE
Make Schema.Date reject invalid dates

### DIFF
--- a/.changeset/schema-date-valid.md
+++ b/.changeset/schema-date-valid.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Make `Schema.Date` reject invalid dates and remove the redundant `Schema.DateValid`, `Schema.isDateValid`, and `Schema.isDateValidReviver` APIs.
+
+`Schema.DateFromString` and `Schema.DateFromMillis` now fail decoding when their input would produce an invalid date.
+
+Remove `Schema.Annotations.ToArbitrary.GenerationConstraint.valid`; `Schema.Date` arbitraries now generate only valid dates by default.

--- a/migration/schema.md
+++ b/migration/schema.md
@@ -30,7 +30,7 @@ This document maps v3 Schema APIs to their v4 equivalents. Simple renames and ar
 | `Redacted`                                      | `RedactedFromValue`                                                           | rename            |
 | `EitherFromSelf`                                | `Result`                                                                      | rename            |
 | `DateFromNumber`                                | `DateFromMillis`                                                              | rename            |
-| `Date`                                          | `DateFromString.check(isDateValid())`                                         | restructure       |
+| `Date`                                          | `DateFromString`                                                              | restructure       |
 | `TaggedError`                                   | `TaggedErrorClass`                                                            | rename            |
 | `decodeUnknown`                                 | `decodeUnknownEffect`                                                         | rename            |
 | `decode`                                        | `decodeEffect`                                                                | rename            |
@@ -92,7 +92,7 @@ The following `*FromSelf` schemas have been renamed to drop the suffix:
 
 **Migration: restructure**
 
-In v3, `Schema.Date` decoded an ISO date string to a `Date` and rejected invalid dates. In v4, `Schema.Date` is the renamed `Schema.DateFromSelf`, so it expects a `Date` as its encoded value. Existing code can still type-check after upgrading while no longer accepting the same input.
+In v3, `Schema.Date` decoded an ISO date string to a `Date` and rejected invalid dates. In v4, `Schema.Date` is the renamed `Schema.DateFromSelf`, so it expects a valid `Date` as its encoded value. Existing code can still type-check after upgrading while no longer accepting the same input.
 
 v3
 
@@ -107,10 +107,10 @@ v4
 ```ts
 import { Schema } from "effect"
 
-const DateFromIsoString = Schema.DateFromString.check(Schema.isDateValid())
+const DateFromIsoString = Schema.DateFromString
 ```
 
-`Schema.DateFromString` preserves the string-to-`Date` transformation, while `Schema.isDateValid()` restores the validity check from the v3 schema.
+`Schema.DateFromString` preserves the string-to-`Date` transformation and rejects strings that produce invalid dates.
 
 ### Filter renames
 

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -244,9 +244,8 @@ Schema.BigInt.check(isNonPositive)
 
 ## Dates
 
-The `Schema.Date` schema matches `Date` objects (even invalid dates).
-
-If you want to validate only valid dates, use `Schema.DateValid` instead.
+The `Schema.Date` schema matches valid `Date` objects and rejects invalid dates
+such as `new Date(NaN)`.
 
 ## Template literals
 

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -1339,7 +1339,7 @@ export function url(name?: string) {
  *
  * **Details**
  *
- * Shortcut for `Config.schema(Schema.DateValid, name)`.
+ * Shortcut for `Config.schema(Schema.Date, name)`.
  *
  * **Gotchas**
  *
@@ -1361,7 +1361,7 @@ export function url(name?: string) {
  * @since 2.0.0
  */
 export function date(name?: string) {
-  return schema(Schema.DateValid, name)
+  return schema(Schema.Date, name)
 }
 
 /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8338,63 +8338,6 @@ function formatDateRuntime(date: globalThis.Date): string {
 }
 
 /**
- * Validates that a Date object represents a valid date (not an invalid date
- * like `new Date("invalid")`).
- *
- * **Details**
- *
- * JSON Schema:
- *
- * This check does not have a direct JSON Schema equivalent, as JSON Schema
- * validates date strings, not Date objects.
- *
- * Arbitrary:
- *
- * When generating test data with fast-check, this applies a `valid: true`
- * constraint to ensure generated Date objects are valid.
- *
- * @category Date checks
- * @since 4.0.0
- */
-export function isDateValid(annotations?: Annotations.Filter) {
-  return makeFilter<globalThis.Date>(
-    (date) => !isNaN(date.getTime()),
-    {
-      expected: "a valid date",
-      representation: {
-        id: "effect/schema/isDateValid",
-        payload: null
-      },
-      toCode: () => ({ runtime: "Schema.isDateValid()" }),
-      arbitrary: {
-        constraint: {
-          valid: true
-        }
-      },
-      ...annotations
-    }
-  )
-}
-
-/**
- * Reviver for persisted `isDateValid` checks.
- *
- * **When to use**
- *
- * Use when reconstructing documents that may contain checks created by {@link isDateValid}.
- *
- * @see {@link isDateValid} for creating the corresponding check
- *
- * @category Date checks
- * @since 4.0.0
- */
-export const isDateValidReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
-  "effect/schema/isDateValid",
-  Null,
-  ({ annotations }) => isDateValid(annotations)
-)
-
-/**
  * Validates that a Date is greater than the specified value (exclusive).
  *
  * **Details**
@@ -12079,25 +12022,16 @@ export const URLFromString: URLFromString = URLString.pipe(decodeTo(URL, SchemaT
  * @category Date
  * @since 4.0.0
  */
-export interface Date extends instanceOf<globalThis.Date> {
+export interface Date extends declare<globalThis.Date> {
   readonly "Rebuild": Date
 }
 
-type DateArbitraryConstraints = FastCheck.DateConstraints & {
-  readonly valid?: boolean | undefined
-}
-
 function dateArbitraryConstraints<T = globalThis.Date>(
-  constraint: Annotations.ToArbitrary.GenerationConstraint | undefined,
   ordered: Annotations.ToArbitrary.OrderedConstraint<T> | undefined,
-  base?: DateArbitraryConstraints | undefined,
+  base?: FastCheck.DateConstraints | undefined,
   toDate?: (value: T) => globalThis.Date
 ): FastCheck.DateConstraints {
   const out: FastCheck.DateConstraints = { ...base }
-  delete (out as any).valid
-  if (base?.valid || constraint?.valid) {
-    out.noInvalidDate = true
-  }
   if (ordered?.minimum !== undefined) {
     const minimum = toDate === undefined ? ordered.minimum as globalThis.Date : toDate(ordered.minimum)
     const nextMin = ordered.exclusiveMinimum ? new globalThis.Date(minimum.getTime() + 1) : minimum
@@ -12115,21 +12049,20 @@ function dateArbitraryConstraints<T = globalThis.Date>(
   return out
 }
 
-const DateString = String.annotate({ expected: "a string in ISO 8601 format that will be decoded as a Date" })
+const DateString = String.annotate({ expected: "a string that will be decoded as a Date" })
 
 /**
- * Schema for JavaScript `Date` objects.
+ * Schema for valid JavaScript `Date` objects.
  *
  * **When to use**
  *
- * Use to validate in-memory values that must already be JavaScript date
+ * Use to validate in-memory values that must already be valid JavaScript date
  * objects.
  *
  * **Details**
  *
- * This schema accepts any `Date` instance, including invalid dates. The default
- * JSON serializer encodes valid dates as ISO 8601 strings; invalid dates encode
- * as `"Invalid Date"`.
+ * This schema accepts `Date` instances whose timestamp is not `NaN`. The
+ * default JSON serializer encodes dates as ISO 8601 strings.
  *
  * **Example** (Defining a Date schema)
  *
@@ -12140,15 +12073,14 @@ const DateString = String.annotate({ expected: "a string in ISO 8601 format that
  * // => Date { 2024-01-01T00:00:00.000Z }
  * ```
  *
- * @see {@link DateValid} for accepting only valid Date instances
  * @see {@link DateFromString} for decoding strings into Date instances
  * @see {@link DateFromMillis} for decoding epoch milliseconds into Date instances
  *
  * @category Date
  * @since 4.0.0
  */
-export const Date: Date = instanceOf(
-  globalThis.Date,
+export const Date: Date = declare(
+  (input): input is globalThis.Date => input instanceof globalThis.Date && !globalThis.Number.isNaN(input.getTime()),
   {
     representation: {
       id: "effect/schema/Date",
@@ -12158,7 +12090,7 @@ export const Date: Date = instanceOf(
       runtime: `Schema.Date`,
       Type: `globalThis.Date`
     }),
-    expected: "Date",
+    expected: "a valid Date",
     toCodecJson: () =>
       link<globalThis.Date>()(
         DateString,
@@ -12166,8 +12098,8 @@ export const Date: Date = instanceOf(
       ),
     toArbitrary: () => (fc, ctx) =>
       fc.date(dateArbitraryConstraints(
-        ctx?.constraint,
-        ctx?.constraint?.ordered?.order === Order.Date ? ctx.constraint.ordered : undefined
+        ctx?.constraint?.ordered?.order === Order.Date ? ctx.constraint.ordered : undefined,
+        { noInvalidDate: true }
       ))
   }
 )
@@ -12213,17 +12145,13 @@ export interface DateFromString extends decodeTo<Date, String> {
  * The string is passed to JavaScript `Date` construction.
  *
  * Encoding:
- * A valid `Date` is encoded as an ISO string; an invalid `Date` is encoded as
- * `"Invalid Date"`.
+ * A `Date` is encoded as an ISO string.
  *
- * **Gotchas**
- *
- * Invalid date strings can decode to invalid `Date` instances.
+ * Invalid date strings fail decoding.
  *
  * @see {@link DateFromMillis} for decoding epoch milliseconds into Date instances
  * @see {@link DateTimeUtcFromString} for decoding date-time strings into UTC values
  * @see {@link Date} for accepting Date instances directly
- * @see {@link DateValid} for rejecting invalid Date instances
  *
  * @category Date
  * @since 3.10.0
@@ -12259,13 +12187,11 @@ export interface DateFromMillis extends decodeTo<Date, Int> {
  *
  * **Gotchas**
  *
- * JavaScript `Date` supports a narrower range than safe integers, so an
- * out-of-range integer can still decode to an invalid `Date`. Invalid `Date`
- * instances cannot be encoded because their timestamp is `NaN`.
+ * JavaScript `Date` supports a narrower range than safe integers, so integers
+ * outside the supported `Date` range fail decoding.
  *
  * @see {@link DateFromString} for decoding string-encoded dates
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
- * @see {@link DateValid} for rejecting invalid Date instances
  *
  * @category Date
  * @since 4.0.0
@@ -12273,29 +12199,6 @@ export interface DateFromMillis extends decodeTo<Date, Int> {
 export const DateFromMillis: DateFromMillis = Int.pipe(
   decodeTo(Date, SchemaTransformation.dateFromMillis)
 )
-
-/**
- * Type-level representation of {@link DateValid}.
- *
- * @category Date
- * @since 4.0.0
- */
-export interface DateValid extends Date {
-  readonly "Rebuild": DateValid
-}
-
-/**
- * Schema for **valid** JavaScript `Date` objects.
- *
- * **Details**
- *
- * This schema accepts `Date` instances but rejects invalid dates (such as `new
- * Date("invalid")`).
- *
- * @category Date
- * @since 4.0.0
- */
-export const DateValid: DateValid = Date.check(isDateValid())
 
 /**
  * Type-level representation of {@link Duration}.
@@ -13775,9 +13678,8 @@ export const DateTimeUtc: DateTimeUtc = declare(
       ),
     toArbitrary: () => (fc, ctx) =>
       fc.date(dateArbitraryConstraints(
-        ctx?.constraint,
         ctx?.constraint?.ordered?.order === DateTime.Order ? ctx.constraint.ordered : undefined,
-        { valid: true },
+        { noInvalidDate: true },
         DateTime.toDateUtc
       ))
         .map((date) => DateTime.fromDateUnsafe(date)),
@@ -13832,12 +13734,12 @@ export interface DateTimeUtcFromDate extends decodeTo<DateTimeUtc, Date> {
  * @see {@link DateTimeUtc} for validating values that are already `DateTime.Utc`
  * @see {@link DateTimeUtcFromString} for decoding date-time strings into UTC values
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
- * @see {@link DateValid} for validating Date instances without converting them
+ * @see {@link Date} for validating Date instances without converting them
  *
  * @category DateTime
  * @since 3.12.0
  */
-export const DateTimeUtcFromDate: DateTimeUtcFromDate = DateValid.pipe(
+export const DateTimeUtcFromDate: DateTimeUtcFromDate = Date.pipe(
   decodeTo(DateTimeUtc, {
     decode: SchemaGetter.dateTimeUtcFromInput(),
     encode: SchemaGetter.transform(DateTime.toDateUtc)
@@ -14235,12 +14137,11 @@ export const DateTimeZoned: DateTimeZoned = declare(
     toArbitrary: () => (fc, ctx) =>
       fc.tuple(
         fc.date(dateArbitraryConstraints(
-          ctx?.constraint,
           ctx?.constraint?.ordered?.order === DateTime.Order ? ctx.constraint.ordered : undefined,
           {
             max: new globalThis.Date(8640000000000000 - 14 * 60 * 60 * 1000),
             min: new globalThis.Date(-8640000000000000 + 14 * 60 * 60 * 1000),
-            valid: true
+            noInvalidDate: true
           },
           DateTime.toDateUtc
         )),
@@ -16566,7 +16467,7 @@ export declare namespace Annotations {
      * length for strings, array length for arrays, final own-property count for
      * objects, and final size/cardinality for sets, maps, hash collections, and
      * chunks. `patterns` are concatenated and used by string generators.
-     * `integer`, `noNaN`, `noInfinity`, `valid`, and `unique` are true when any
+     * `integer`, `noNaN`, `noInfinity`, and `unique` are true when any
      * contributing filter sets them. Range bounds live in `ordered` so ordered
      * values can share the same representation.
      *
@@ -16580,7 +16481,6 @@ export declare namespace Annotations {
       readonly integer?: boolean | undefined
       readonly noInfinity?: boolean | undefined
       readonly noNaN?: boolean | undefined
-      readonly valid?: boolean | undefined
       readonly unique?: boolean | undefined
       readonly ordered?: OrderedConstraint<any> | undefined
     }

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -852,8 +852,8 @@ export const bigintFromString = new Transformation(
  *
  * **When to use**
  *
- * Use when you need a schema transformation to parse ISO 8601 date strings from
- * APIs or user input.
+ * Use when you need a schema transformation to parse date strings from APIs or
+ * user input.
  *
  * **Details**
  *

--- a/packages/effect/src/internal/schema/toArbitrary.ts
+++ b/packages/effect/src/internal/schema/toArbitrary.ts
@@ -132,8 +132,7 @@ const combiner: Combiner.Combiner<any> = Struct.makeCombiner({
   noInfinity: or,
   noNaN: or,
   patterns: concat,
-  unique: or,
-  valid: or
+  unique: or
 }, {
   omitKeyWhen: Predicate.isUndefined
 })

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -236,7 +236,7 @@ export const integer: Primitive<number> = makeSchemaPrimitive(
  */
 export const date: Primitive<Date> = makeSchemaPrimitive(
   "Date",
-  Schema.DateValid
+  Schema.Date
 )
 
 /**

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -159,7 +159,7 @@ describe("Config", () => {
       await assertFailure(
         Config.date("b"),
         provider,
-        `Expected a valid date, got Invalid Date
+        `Expected a valid Date, got Invalid Date
   at ["b"]`
       )
     })

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -1897,9 +1897,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed("2021-01-01T00:00:00.000Z", new Date("2021-01-01T00:00:00.000Z"))
+      await decoding.fail("invalid", `Expected a valid Date, got Invalid Date`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(new Date("2021-01-01T00:00:00.000Z"), "2021-01-01T00:00:00.000Z")
+      await encoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
     })
 
     it("DateFromMillis", async () => {
@@ -1915,13 +1917,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.fail(Infinity, `Expected an integer, got Infinity`)
       await decoding.fail(-Infinity, `Expected an integer, got -Infinity`)
       await decoding.fail(null, `Expected number, got null`)
+      await decoding.fail(8640000000000001, `Expected a valid Date, got Invalid Date`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(new Date(0), 0)
-      await encoding.fail(new Date("invalid"), `Expected an integer, got NaN`)
-      await encoding.fail(new Date(NaN), `Expected an integer, got NaN`)
-      await encoding.fail(new Date(Infinity), `Expected an integer, got NaN`)
-      await encoding.fail(new Date(-Infinity), `Expected an integer, got NaN`)
+      await encoding.fail(new Date("invalid"), `Expected a valid Date, got Invalid Date`)
+      await encoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
+      await encoding.fail(new Date(Infinity), `Expected a valid Date, got Invalid Date`)
+      await encoding.fail(new Date(-Infinity), `Expected a valid Date, got Invalid Date`)
     })
 
     it("FiniteFromString", async () => {
@@ -4812,17 +4815,13 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new Date("2021-01-01"))
-    await decoding.fail(null, `Expected Date, got null`)
-    await decoding.fail(0, `Expected Date, got 0`)
-  })
+    await decoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
+    await decoding.fail(null, `Expected a valid Date, got null`)
+    await decoding.fail(0, `Expected a valid Date, got 0`)
 
-  it("DateValid", async () => {
-    const schema = Schema.DateValid
-    const asserts = new TestSchema.Asserts(schema)
-
-    if (verifyGeneration) {
-      asserts.arbitrary().verifyGeneration()
-    }
+    const encoding = asserts.encoding()
+    await encoding.succeed(new Date("2021-01-01"))
+    await encoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
   })
 
   it("DateTimeUtc", async () => {
@@ -4850,7 +4849,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new Date("2021-01-01T00:00:00.000Z"), DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"))
-    await decoding.fail(new Date("invalid date"), `Expected a valid date, got Invalid Date`)
+    await decoding.fail(new Date("invalid date"), `Expected a valid Date, got Invalid Date`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"), new Date("2021-01-01T00:00:00.000Z"))

--- a/packages/effect/test/schema/representation/builtInRevivers.test.ts
+++ b/packages/effect/test/schema/representation/builtInRevivers.test.ts
@@ -543,18 +543,6 @@ function date(millis: number): Date {
 const epoch = "1970-01-01T00:00:00.000Z"
 
 describe("SchemaRepresentation built-in Date revivers", () => {
-  it("revives isDateValid", () => {
-    assertFilterReviver({
-      schema: Schema.Any.check(Schema.isDateValid()),
-      id: "effect/schema/isDateValid",
-      payload: null,
-      reviver: Schema.isDateValidReviver,
-      valid: date(0),
-      invalid: date(Number.NaN),
-      hasToJsonSchema: false
-    })
-  })
-
   it("revives isGreaterThanDate", () => {
     assertFilterReviver({
       schema: Schema.Any.check(Schema.isGreaterThanDate(date(0))),

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -1623,15 +1623,6 @@ describe("toCodeDocument", () => {
     })
 
     describe("checks", () => {
-      it("isDateValid", () => {
-        assertSchema(
-          { schema: Schema.Date.check(Schema.isDateValid()) },
-          {
-            codes: makeCode(`Schema.Date.check(Schema.isDateValid())`, "globalThis.Date")
-          }
-        )
-      })
-
       it("isGreaterThanDate", () => {
         assertSchema(
           { schema: Schema.Date.check(Schema.isGreaterThanDate(new Date(0))) },

--- a/packages/effect/test/schema/toArbitrary.test.ts
+++ b/packages/effect/test/schema/toArbitrary.test.ts
@@ -1154,10 +1154,6 @@ describe("Arbitrary generation", () => {
       })))
     })
 
-    it("DateValid", () => {
-      verifyGeneration(Schema.DateValid)
-    })
-
     it("isGreaterThanOrEqualToBigInt", () => {
       verifyGeneration(Schema.BigInt.check(Schema.isGreaterThanOrEqualToBigInt(BigInt(0))))
     })
@@ -1221,7 +1217,7 @@ describe("Arbitrary generation", () => {
 
     it("non-natural Date order", () => {
       const order = Order.flip(Order.Date)
-      verifyGeneration(Schema.DateValid.check(Schema.makeIsGreaterThan({ order })(new Date(0))))
+      verifyGeneration(Schema.Date.check(Schema.makeIsGreaterThan({ order })(new Date(0))))
     })
 
     it("non-natural BigInt order", () => {
@@ -1530,17 +1526,9 @@ describe("Arbitrary generation", () => {
       })))
     })
 
-    it("isValidDate", () => {
-      verifyGeneration(Schema.Date.check(Schema.isDateValid()))
-    })
-
-    it("isValidDate & isGreaterThanOrEqualToDate", () => {
-      verifyGeneration(Schema.Date.check(Schema.isDateValid(), Schema.isGreaterThanOrEqualToDate(new Date(0))))
-    })
-
     it("Date with non-natural order", () => {
       const order = Order.flip(Order.Date)
-      verifyGeneration(Schema.DateValid.check(Schema.makeIsGreaterThan({ order })(new Date(0))))
+      verifyGeneration(Schema.Date.check(Schema.makeIsGreaterThan({ order })(new Date(0))))
     })
 
     it("isGreaterThanOrEqualToBigInt", () => {

--- a/packages/effect/test/schema/toDifferJsonPatch.test.ts
+++ b/packages/effect/test/schema/toDifferJsonPatch.test.ts
@@ -97,12 +97,12 @@ describe("Schema.toDifferJsonPatch", () => {
       deepStrictEqual(differ.patch(-0, [{ op: "replace", path: "", value: 0 }]), 0)
     })
 
-    it("Date: encodes invalid Date as a string on diff", () => {
+    it("Date: rejects an invalid Date on diff", () => {
       const differ = Schema.toDifferJsonPatch(Schema.Date)
 
-      deepStrictEqual(
-        differ.diff(new Date("1970-01-01T00:00:00.000Z"), new Date(NaN)),
-        [{ op: "replace", path: "", value: "Invalid Date" }]
+      throws(
+        () => differ.diff(new Date("1970-01-01T00:00:00.000Z"), new Date(NaN)),
+        "Expected a valid Date, got Invalid Date"
       )
     })
 
@@ -218,7 +218,6 @@ describe("Schema.toDifferJsonPatch", () => {
       roundtrip(Schema.RegExp)
       roundtrip(Schema.Duration)
       roundtrip(Schema.DateTimeUtc)
-      roundtrip(Schema.DateValid)
       roundtrip(Schema.Uint8Array)
       roundtrip(Schema.PropertyKey)
       roundtrip(Schema.Option(Schema.String))

--- a/packages/effect/test/schema/toIso.test.ts
+++ b/packages/effect/test/schema/toIso.test.ts
@@ -15,7 +15,7 @@ import { describe, it } from "vitest"
 import { assertNone, assertSome, deepStrictEqual, strictEqual, throws } from "../utils/assert.ts"
 
 class Value extends Schema.Class<Value, { readonly brand: unique symbol }>("Value")({
-  a: Schema.DateValid
+  a: Schema.Date
 }) {}
 
 function addOne(date: Date): Date {

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -540,15 +540,6 @@ describe("toJsonSchemaDocument", () => {
       })
     })
 
-    it("DateValid", () => {
-      const schema = Schema.DateValid
-      assertJsonSchemaDocument(schema, {
-        schema: {
-          "type": "string"
-        }
-      })
-    })
-
     it("URL", () => {
       const schema = Schema.URL
       assertJsonSchemaDocument(schema, {

--- a/packages/effect/test/unstable/cli/Primitive.test.ts
+++ b/packages/effect/test/unstable/cli/Primitive.test.ts
@@ -145,7 +145,7 @@ describe("Primitive", () => {
         ]))
 
       it.effect("should fail for invalid values", () =>
-        expectInvalidValues(Primitive.date, ["not-a-date"], [`Expected a valid date, got Invalid Date`]))
+        expectInvalidValues(Primitive.date, ["not-a-date"], [`Expected a valid Date, got Invalid Date`]))
 
       it("should have correct _tag", () => {
         assert.strictEqual(Primitive.date._tag, "Date")

--- a/packages/effect/typetest/schema/SchemaBuiltInDateRevivers.tst.ts
+++ b/packages/effect/typetest/schema/SchemaBuiltInDateRevivers.tst.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "tstyche"
 describe("Schema built-in Date revivers", () => {
   it("composes every Date check reviver without casts", () => {
     const revivers: ReadonlyArray<SchemaRepresentation.AnyReviver> = [
-      Schema.isDateValidReviver,
       Schema.isGreaterThanDateReviver,
       Schema.isGreaterThanOrEqualToDateReviver,
       Schema.isLessThanDateReviver,

--- a/packages/effect/typetest/schema/toIso.tst.ts
+++ b/packages/effect/typetest/schema/toIso.tst.ts
@@ -3,7 +3,7 @@ import { Data, Schema, SchemaUtils } from "effect"
 import { describe, expect, it } from "tstyche"
 
 class Value extends Schema.Class<Value, { readonly brand: unique symbol }>("Value")({
-  a: Schema.DateValid
+  a: Schema.Date
 }) {}
 
 describe("toIso", () => {

--- a/packages/platform-browser/src/IndexedDb.ts
+++ b/packages/platform-browser/src/IndexedDb.ts
@@ -40,7 +40,7 @@ export const IndexedDb: Context.Service<IndexedDb, IndexedDb> = Context.Service<
 const IDBFlatKey = Schema.Union([
   Schema.String,
   Schema.Number.check(Schema.makeFilter((input) => !Number.isNaN(input))),
-  Schema.DateValid,
+  Schema.Date,
   Schema.declare(
     (input): input is BufferSource =>
       input instanceof ArrayBuffer ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date validation now consistently rejects invalid `Date` values across schemas, configuration, CLI parsing, and IndexedDB keys.
  * Date strings and millisecond values that produce invalid dates now fail decoding.
  * Generated dates are valid by default.

* **Breaking Changes**
  * Removed the separate `DateValid` schema and related date-validation helpers.

* **Documentation**
  * Updated date validation and migration guidance to reflect the simplified API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->