### PR TITLE
Fix Schema template literal type codegen

### DIFF
--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -80,31 +80,6 @@ function isSimpleLiveLiteral(
     representation.annotations === undefined
 }
 
-function toTypeParts(parts: ReadonlyArray<SchemaRepresentation.Representation>): ReadonlyArray<string> {
-  let out = [""]
-  for (const part of parts) out = out.flatMap((prefix) => toTypePart(part).map((suffix) => prefix + suffix))
-  return out
-}
-
-function toTypePart(part: SchemaRepresentation.Representation): ReadonlyArray<string> {
-  switch (part._tag) {
-    case "Literal":
-      return [globalThis.String(part.literal)]
-    case "String":
-      return ["${string}"]
-    case "Number":
-      return ["${number}"]
-    case "BigInt":
-      return ["${bigint}"]
-    case "TemplateLiteral":
-      return toTypeParts(part.parts)
-    case "Union":
-      return part.types.flatMap(toTypePart)
-    default:
-      return []
-  }
-}
-
 /** @internal */
 export interface TopologicalSort {
   readonly nonRecursives: ReadonlyArray<{
@@ -398,7 +373,8 @@ export function toCodeDocument(
 
   function recur(
     representation: SchemaRepresentation.Representation,
-    path: Path
+    path: Path,
+    includeTypeBrands: boolean = true
   ): SchemaRepresentation.Code {
     if (representation._tag === "Reference") {
       if (!Object.hasOwn(document.references, representation.$ref)) {
@@ -411,14 +387,18 @@ export function toCodeDocument(
       ) {
         return makeCode(`Schema.suspend((): Schema.Codec<${identifier}> => ${identifier})`, identifier)
       }
-      return makeCode(identifier, identifier)
+      const Type = includeTypeBrands
+        ? identifier
+        : recur(document.references[representation.$ref], ["references", representation.$ref], false).Type
+      return makeCode(identifier, Type)
     }
-    return applyNode(on(representation, path), representation, path)
+    return applyNode(on(representation, path, includeTypeBrands), representation, path, includeTypeBrands)
   }
 
   function on(
     representation: Exclude<SchemaRepresentation.Representation, SchemaRepresentation.Reference>,
-    path: Path
+    path: Path,
+    includeTypeBrands: boolean
   ): SchemaRepresentation.Code {
     switch (representation._tag) {
       case "Declaration": {
@@ -488,8 +468,8 @@ export function toCodeDocument(
         return makeCode(`Schema.Enum(${identifier})`, `typeof ${identifier}`)
       }
       case "TemplateLiteral": {
-        const parts = representation.parts.map((part, index) => recur(part, [...path, "parts", index]))
-        const Type = toTypeParts(representation.parts).map((part) => `\`${part}\``).join(" | ")
+        const parts = representation.parts.map((part, index) => recur(part, [...path, "parts", index], false))
+        const Type = `\`${parts.map((part) => `\${${part.Type}}`).join("")}\``
         return makeCode(`Schema.TemplateLiteral([${parts.map((part) => part.runtime).join(", ")}])`, Type)
       }
       case "Arrays": {
@@ -578,7 +558,9 @@ export function toCodeDocument(
             ? makeCode(`Schema.Literal(${literals[0]})`, literals[0])
             : makeCode(`Schema.Literals([${literals.join(", ")}])`, literals.join(" | "))
         }
-        const types = representation.types.map((type, index) => recur(type, [...path, "types", index]))
+        const types = representation.types.map((type, index) =>
+          recur(type, [...path, "types", index], includeTypeBrands)
+        )
         const mode = representation.mode === "anyOf" ? "" : `, { mode: "oneOf" }`
         return makeCode(
           `Schema.Union([${types.map((type) => type.runtime).join(", ")}]${mode})`,

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -1,6 +1,6 @@
 import { JsonSchema, Schema, SchemaRepresentation } from "effect"
 import { describe, it } from "vitest"
-import { deepStrictEqual, throws } from "../../utils/assert.ts"
+import { assertTrue, deepStrictEqual, strictEqual, throws } from "../../utils/assert.ts"
 
 type Category = {
   readonly name: string
@@ -89,6 +89,7 @@ describe("toCodeDocument", () => {
   }
 
   const makeCode = SchemaRepresentation.makeCode
+  const templateType = (...types: ReadonlyArray<string>) => `\`${types.map((type) => `\${${type}}`).join("")}\``
 
   describe("Declaration", () => {
     it("declaration without a toCode annotation", () => {
@@ -747,7 +748,7 @@ describe("toCodeDocument", () => {
       assertSchema(
         { schema: Schema.TemplateLiteral([Schema.Literal("a")]) },
         {
-          codes: makeCode(`Schema.TemplateLiteral([Schema.Literal("a")])`, "`a`")
+          codes: makeCode(`Schema.TemplateLiteral([Schema.Literal("a")])`, templateType(`"a"`))
         }
       )
     })
@@ -756,7 +757,7 @@ describe("toCodeDocument", () => {
       assertSchema(
         { schema: Schema.TemplateLiteral([Schema.Literal(1)]) },
         {
-          codes: makeCode(`Schema.TemplateLiteral([Schema.Literal(1)])`, "`1`")
+          codes: makeCode(`Schema.TemplateLiteral([Schema.Literal(1)])`, templateType("1"))
         }
       )
     })
@@ -765,7 +766,7 @@ describe("toCodeDocument", () => {
       assertSchema(
         { schema: Schema.TemplateLiteral([Schema.Literal(1n)]) },
         {
-          codes: makeCode(`Schema.TemplateLiteral([Schema.Literal(1n)])`, "`1`")
+          codes: makeCode(`Schema.TemplateLiteral([Schema.Literal(1n)])`, templateType("1n"))
         }
       )
     })
@@ -776,7 +777,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a"), Schema.Literal("b"), Schema.Literal("c")])`,
-            "`abc`"
+            templateType(`"a"`, `"b"`, `"c"`)
           )
         }
       )
@@ -788,7 +789,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a b"), Schema.String])`,
-            "`a b${string}`"
+            templateType(`"a b"`, "string")
           )
         }
       )
@@ -797,10 +798,19 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("\\n"), Schema.String])`,
-            "`\n${string}`"
+            templateType(`"\\n"`, "string")
           )
         }
       )
+
+      for (const literal of ["`", "${number}", "\\"]) {
+        const code = SchemaRepresentation.toCodeDocument(
+          SchemaRepresentation.toRepresentations([
+            Schema.TemplateLiteral([Schema.Literal(literal)]).ast
+          ])
+        ).codes[0]
+        strictEqual(code.Type, templateType(JSON.stringify(literal)))
+      }
     })
 
     it("only schemas", () => {
@@ -839,7 +849,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.String, Schema.Literal("a")])`,
-            "`${string}a`"
+            templateType("string", `"a"`)
           )
         }
       )
@@ -848,7 +858,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Number, Schema.Literal("a")])`,
-            "`${number}a`"
+            templateType("number", `"a"`)
           )
         }
       )
@@ -857,7 +867,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.BigInt, Schema.Literal("a")])`,
-            "`${bigint}a`"
+            templateType("bigint", `"a"`)
           )
         }
       )
@@ -869,7 +879,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a"), Schema.String])`,
-            "`a${string}`"
+            templateType(`"a"`, "string")
           )
         }
       )
@@ -878,7 +888,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a"), Schema.Number])`,
-            "`a${number}`"
+            templateType(`"a"`, "number")
           )
         }
       )
@@ -887,7 +897,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a"), Schema.BigInt])`,
-            "`a${bigint}`"
+            templateType(`"a"`, "bigint")
           )
         }
       )
@@ -899,7 +909,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.String, Schema.Literal("-"), Schema.Number])`,
-            "`${string}-${number}`"
+            templateType("string", `"-"`, "number")
           )
         }
       )
@@ -912,7 +922,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.String, Schema.Literal("-"), Schema.Number]).annotate({ "description": "ad" })`,
-            "`${string}-${number}`"
+            templateType("string", `"-"`, "number")
           )
         }
       )
@@ -929,7 +939,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a"), Schema.TemplateLiteral([Schema.String, Schema.Literals(["-", "+"]), Schema.Number])])`,
-            "`a${string}-${number}` | `a${string}+${number}`"
+            templateType(`"a"`, templateType("string", `"-" | "+"`, "number"))
           )
         }
       )
@@ -943,7 +953,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literal("a"), Schema.Union([Schema.String, Schema.Number])])`,
-            "`a${string}` | `a${number}`"
+            templateType(`"a"`, "string | number")
           )
         }
       )
@@ -957,10 +967,39 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literals(["a", "b"]), Schema.String])`,
-            "`a${string}` | `b${string}`"
+            templateType(`"a" | "b"`, "string")
           )
         }
       )
+    })
+
+    it("uses the encoded type of branded parts", () => {
+      const schema = Schema.TemplateLiteral([
+        Schema.String.pipe(Schema.brand("StringPart")),
+        Schema.Union([
+          Schema.Number.pipe(Schema.brand("NumberPart")),
+          Schema.String.pipe(Schema.brand("OtherStringPart"))
+        ])
+      ])
+      const code = SchemaRepresentation.toCodeDocument(
+        SchemaRepresentation.toRepresentations([schema.ast])
+      ).codes[0]
+
+      strictEqual(
+        code.runtime,
+        `Schema.TemplateLiteral([Schema.String.pipe(Schema.brand("StringPart")), Schema.Union([Schema.Number.pipe(Schema.brand("NumberPart")), Schema.String.pipe(Schema.brand("OtherStringPart"))])])`
+      )
+      strictEqual(code.Type, templateType("string", "number | string"))
+    })
+
+    it("resolves the encoded type of branded references", () => {
+      const part = Schema.String.pipe(Schema.brand("Part")).annotate({ identifier: "Part" })
+      const code = SchemaRepresentation.toCodeDocument(
+        SchemaRepresentation.toRepresentations([Schema.TemplateLiteral([part]).ast])
+      ).codes[0]
+
+      strictEqual(code.runtime, "Schema.TemplateLiteral([Part])")
+      strictEqual(code.Type, templateType("string"))
     })
 
     it("multiple unions", () => {
@@ -975,10 +1014,21 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.TemplateLiteral([Schema.Literals(["a", "b"]), Schema.String, Schema.Union([Schema.Number, Schema.BigInt])])`,
-            "`a${string}${number}` | `a${string}${bigint}` | `b${string}${number}` | `b${string}${bigint}`"
+            templateType(`"a" | "b"`, "string", "number | bigint")
           )
         }
       )
+    })
+
+    it("does not expand combinations of unions", () => {
+      const part = Schema.Literals(["a", "b"])
+      const schema = Schema.TemplateLiteral(Array.from({ length: 20 }, () => part))
+      const Type = SchemaRepresentation.toCodeDocument(
+        SchemaRepresentation.toRepresentations([schema.ast])
+      ).codes[0].Type
+
+      strictEqual(Type, templateType(...Array.from({ length: 20 }, () => `"a" | "b"`)))
+      assertTrue(Type.length < 500)
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated TypeScript types for branded references and intersections.
  * Corrected template-literal type generation, including nested literals, unions, special characters, and branded parts.

* **Tests**
  * Expanded coverage for template-literal and branded type representations.
  * Standardized expected template-literal type assertions for more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->