### PR TITLE
feat: add MCP protocol adapters

### DIFF
--- a/.changeset/quiet-mice-negotiate.md
+++ b/.changeset/quiet-mice-negotiate.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add adapter-valued MCP server protocol declarations, route requests through the selected protocol before schema decoding, and add built-in support for MCP `2025-06-18`.

--- a/.changeset/quiet-mice-negotiate.md
+++ b/.changeset/quiet-mice-negotiate.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
 Add adapter-valued MCP server protocol declarations, route requests through the selected protocol before schema decoding, and add built-in support for MCP `2025-06-18`.

--- a/packages/effect/MCP.md
+++ b/packages/effect/MCP.md
@@ -12,7 +12,7 @@ Here is an example of a MCP server implementation:
 import { NodeRuntime, NodeSink, NodeStream } from "@effect/platform-node"
 import { Effect, Layer, Logger } from "effect"
 import { Schema } from "effect/schema"
-import { McpServer, Tool, Toolkit } from "effect/unstable/ai"
+import { McpProtocol, McpServer, Tool, Toolkit } from "effect/unstable/ai"
 
 // Define a simple tool
 const DemoTool = Tool.make("DemoTool", {
@@ -58,6 +58,7 @@ const ServerLayer = Layer.mergeAll(
     McpServer.layerStdio({
       name: "Demo MCP Server",
       version: "1.0.0",
+      protocols: [McpProtocol.v2025_06_18],
       stdin: NodeStream.stdin,
       stdout: NodeSink.stdout
     })
@@ -78,8 +79,10 @@ The server exposes three main parts:
 
 The part layers are merged into one layer that has a MCP server implementation as dependency.
 `McpServer.layerStdio` is used to create a standard I/O–based MCP server identified by its name and
-version. Because of the layer architecture the server implementation can be easily exchanged with an
-HTTP based implementation with `McpServer.layerHttp`. Finally, a logging layer is added with
+version. Its ordered, non-empty `protocols` declaration names implemented protocol adapters rather
+than arbitrary version strings. This release supports `McpProtocol.v2025_06_18`. Because of the
+layer architecture the server implementation can be easily exchanged with an HTTP-based implementation
+with `McpServer.layerHttp`. Finally, a logging layer is added with
 `Logger.layer([Logger.consolePretty({ stderr: true })])`, ensuring logs are written to `stderr`.
 This is essential when using stdio, as any output to `stdout` would interfere with the protocol
 communication.
@@ -238,7 +241,7 @@ Here's a complete, copy/pastable MCP server example that combines all the concep
 ```typescript
 import { NodeRuntime, NodeStdio } from "@effect/platform-node"
 import { Effect, Layer, Logger, Schema } from "effect"
-import { McpSchema, McpServer, Tool, Toolkit } from "effect/unstable/ai"
+import { McpProtocol, McpSchema, McpServer, Tool, Toolkit } from "effect/unstable/ai"
 
 // Define tools
 const GreetTool = Tool.make("GreetTool", {
@@ -357,7 +360,8 @@ const ServerLayer = Layer.mergeAll(
   Layer.provide(
     McpServer.layerStdio({
       name: "Demo MCP Server",
-      version: "1.0.0"
+      version: "1.0.0",
+      protocols: [McpProtocol.v2025_06_18]
     })
   ),
   Layer.provide(NodeStdio.layer),

--- a/packages/effect/src/unstable/ai/McpProtocol.ts
+++ b/packages/effect/src/unstable/ai/McpProtocol.ts
@@ -3,6 +3,7 @@
  *
  * @since 4.0.0
  */
+import type * as RpcGroup from "../rpc/RpcGroup.ts"
 import * as Internal from "./internal/mcpProtocol.ts"
 import * as McpSchema from "./McpSchema.ts"
 
@@ -12,7 +13,7 @@ import * as McpSchema from "./McpSchema.ts"
  * @category protocols
  * @since 4.0.0
  */
-export const v2025_06_18 = Internal.make({
+export const v2025_06_18: ProtocolAdapter = Internal.make({
   protocolVersion: "2025-06-18",
   clientRpcs: McpSchema.ClientRpcs,
   clientNotificationRpcs: McpSchema.ClientNotificationRpcs,
@@ -26,7 +27,13 @@ export const v2025_06_18 = Internal.make({
  * @category models
  * @since 4.0.0
  */
-export type ProtocolAdapter = typeof v2025_06_18
+export type ProtocolAdapter = Internal.ProtocolAdapter<
+  "2025-06-18",
+  RpcGroup.Rpcs<typeof McpSchema.ClientRpcs>,
+  RpcGroup.Rpcs<typeof McpSchema.ClientNotificationRpcs>,
+  RpcGroup.Rpcs<typeof McpSchema.ServerRequestRpcs>,
+  RpcGroup.Rpcs<typeof McpSchema.ServerNotificationRpcs>
+>
 
 /**
  * The MCP protocol versions implemented by this release.

--- a/packages/effect/src/unstable/ai/McpProtocol.ts
+++ b/packages/effect/src/unstable/ai/McpProtocol.ts
@@ -1,0 +1,37 @@
+/**
+ * Defines the MCP protocol implementations that an `McpServer` can support.
+ *
+ * @since 4.0.0
+ */
+import * as Internal from "./internal/mcpProtocol.ts"
+import * as McpSchema from "./McpSchema.ts"
+
+/**
+ * The MCP 2025-06-18 protocol implementation.
+ *
+ * @category protocols
+ * @since 4.0.0
+ */
+export const v2025_06_18 = Internal.make({
+  protocolVersion: "2025-06-18",
+  clientRpcs: McpSchema.ClientRpcs,
+  clientNotificationRpcs: McpSchema.ClientNotificationRpcs,
+  serverRequestRpcs: McpSchema.ServerRequestRpcs,
+  serverNotificationRpcs: McpSchema.ServerNotificationRpcs
+})
+
+/**
+ * An implemented MCP protocol that can be supplied to `McpServer`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ProtocolAdapter = typeof v2025_06_18
+
+/**
+ * The MCP protocol versions implemented by this release.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ProtocolVersion = ProtocolAdapter["protocolVersion"]

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -23,6 +23,7 @@ import type * as RpcClient from "../rpc/RpcClient.ts"
 import type { RpcClientError } from "../rpc/RpcClientError.ts"
 import * as RpcGroup from "../rpc/RpcGroup.ts"
 import * as RpcMiddleware from "../rpc/RpcMiddleware.ts"
+import type * as McpProtocol from "./McpProtocol.ts"
 
 /**
  * Schema type returned by `optionalWithDefault`.
@@ -2165,6 +2166,7 @@ export class ElicitationDeclined
  */
 export class McpServerClient extends Context.Service<McpServerClient, {
   readonly clientId: number
+  readonly protocolVersion: McpProtocol.ProtocolVersion
   readonly initializePayload: typeof Initialize.payloadSchema["Type"]
   readonly getClient: Effect.Effect<
     RpcClient.RpcClient<RpcGroup.Rpcs<typeof ServerRequestRpcs>, RpcClientError>,

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -40,9 +40,10 @@ import * as RpcMessage from "../rpc/RpcMessage.ts"
 import * as RpcSerialization from "../rpc/RpcSerialization.ts"
 import * as RpcServer from "../rpc/RpcServer.ts"
 import * as AiError from "./AiError.ts"
+import * as McpProtocolRegistry from "./internal/mcpProtocolRegistry.ts"
+import type * as McpProtocol from "./McpProtocol.ts"
 import {
   CallToolResult,
-  ClientNotificationRpcs,
   ClientRpcs,
   CompleteResult,
   Elicit,
@@ -62,7 +63,6 @@ import {
   Resource,
   ResourceTemplate,
   ServerNotificationRpcs,
-  ServerRequestRpcs,
   TextContent,
   Tool as McpTool
 } from "./McpSchema.ts"
@@ -334,29 +334,32 @@ export class McpServer extends Context.Service<McpServer, {
   static readonly layer: Layer.Layer<McpServer | McpServerClient> = Layer.effect(McpServer)(McpServer.make) as any
 }
 
-const LATEST_PROTOCOL_VERSION = "2025-06-18"
-const SUPPORTED_PROTOCOL_VERSIONS = [
-  LATEST_PROTOCOL_VERSION,
-  "2025-03-26",
-  "2024-11-05",
-  "2024-10-07"
-]
-const MCP_SESSION_ID_HEADER = "mcp-session-id"
-const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+const mcpSessionIdHeader = "mcp-session-id"
+const mcpProtocolVersionHeader = "mcp-protocol-version"
+
+interface Session {
+  readonly initializePayload: typeof Initialize.payloadSchema.Type
+  readonly protocol: McpProtocol.ProtocolAdapter
+}
 
 class McpProtocolState extends Context.Service<McpProtocolState, {
-  readonly clientSessions: Map<string, typeof Initialize.payloadSchema.Type>
-  readonly latestProtocolVersion: string
-  readonly supportedProtocolVersions: ReadonlySet<string>
+  readonly clientSessions: Map<string, Session>
+  readonly protocolRegistry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
 }>()("effect/ai/McpServer/McpProtocolState") {}
 
-const makeMcpProtocolState = (): McpProtocolState["Service"] => ({
-  clientSessions: new Map(),
-  latestProtocolVersion: LATEST_PROTOCOL_VERSION,
-  supportedProtocolVersions: new Set(SUPPORTED_PROTOCOL_VERSIONS)
+const makeMcpProtocolState = Effect.fnUntraced(function*(
+  protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
+) {
+  return McpProtocolState.of({
+    clientSessions: new Map(),
+    protocolRegistry: yield* McpProtocolRegistry.make(protocols)
+  })
 })
 
-const layerMcpProtocolState = Layer.sync(McpProtocolState, makeMcpProtocolState)
+const layerMcpProtocolState = (
+  protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
+): Layer.Layer<McpProtocolState, Cause.IllegalArgumentError> =>
+  Layer.effect(McpProtocolState)(makeMcpProtocolState(protocols))
 
 /**
  * Runs an MCP server over the current `RpcServer.Protocol`.
@@ -373,32 +376,48 @@ const layerMcpProtocolState = Layer.sync(McpProtocolState, makeMcpProtocolState)
 export const run: (options: {
   readonly name: string
   readonly version: string
+  readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }) => Effect.Effect<
   never,
-  never,
+  Cause.IllegalArgumentError,
   McpServer | RpcServer.Protocol
 > = Effect.fnUntraced(function*(options: {
   readonly name: string
   readonly version: string
+  readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }) {
-  const protocolState = Option.getOrElse(
-    yield* Effect.serviceOption(McpProtocolState),
-    makeMcpProtocolState
-  )
+  const protocolStateOption = yield* Effect.serviceOption(McpProtocolState)
+  const protocolState = Option.isSome(protocolStateOption)
+    ? protocolStateOption.value
+    : yield* makeMcpProtocolState(options.protocols)
+  return yield* runWithProtocolState(options, protocolState)
+})
+
+const runWithProtocolState = Effect.fnUntraced(function*(options: {
+  readonly name: string
+  readonly version: string
+  readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
+}, protocolState: McpProtocolState["Service"]) {
+  const protocolRegistry = protocolState.protocolRegistry
   const protocol = yield* RpcServer.Protocol
   const server = yield* McpServer
   const isHttp = Option.isSome(yield* Effect.serviceOption(HttpRouter.HttpRouter))
   const clientSessions = protocolState.clientSessions
-  const handlers = yield* Layer.build(layerHandlers(options)).pipe(
-    Effect.provideService(McpProtocolState, protocolState)
-  )
+  const clientProtocols = new Map<number, McpProtocol.ProtocolAdapter>()
+  const handlers = yield* Layer.build(layerHandlers(options, {
+    clientSessions,
+    protocolRegistry
+  }))
 
   const clients = yield* RcMap.make({
-    lookup: Effect.fnUntraced(function*(clientId: number) {
+    lookup: Effect.fnUntraced(function*(key: string) {
+      const separator = key.indexOf("\0")
+      const clientId = Number(key.slice(0, separator))
+      const selectedProtocol = protocolRegistry.select(key.slice(separator + 1))
       let write!: (message: RpcMessage.FromServerEncoded) => Effect.Effect<void>
-      const client = yield* RpcClient.make(ServerRequestRpcs, {
+      const client = yield* RpcClient.make(selectedProtocol.serverRequestRpcs, {
         spanPrefix: "McpServer/Client"
       }).pipe(
         Effect.provideServiceEffect(
@@ -430,10 +449,10 @@ export const run: (options: {
     idleTimeToLive: 10000
   })
 
-  const clientMiddleware = McpServerClientMiddleware.of((effect, { client, headers, rpc }) => {
-    const initializePayload = getInitializedClient(clientSessions, client.id, headers)
-    const isInitialize = rpc._tag === "initialize"
-    if (!isInitialize && !initializePayload) {
+  const clientMiddleware = McpServerClientMiddleware.of((effect, { client, headers, payload, rpc }) => {
+    const session = getClientSession(clientSessions, client.id, headers)
+    const isInitialize = rpc._tag.endsWith("/initialize")
+    if (!isInitialize && !session) {
       const fiber = Fiber.getCurrent()!
       const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
       if (httpRequest) {
@@ -444,13 +463,15 @@ export const run: (options: {
       }
       return Effect.die(new Error(`Mcp-Session-Id does not exist`))
     }
+    const selectedProtocol = session?.protocol ?? protocolForInternalTag(protocolRegistry, rpc._tag)
     return Effect.provideService(
       effect,
       McpServerClient,
       McpServerClient.of({
         clientId: client.id,
-        initializePayload: initializePayload!,
-        getClient: RcMap.get(clients, client.id).pipe(
+        protocolVersion: selectedProtocol.protocolVersion,
+        initializePayload: session?.initializePayload ?? payload as typeof Initialize.payloadSchema.Type,
+        getClient: RcMap.get(clients, `${client.id}\0${selectedProtocol.protocolVersion}`).pipe(
           Effect.map(({ client }) => client)
         )
       })
@@ -483,44 +504,60 @@ export const run: (options: {
         }
         switch (request._tag) {
           case "Request": {
-            if (httpRequest !== undefined) {
-              const client = getInitializedClient(clientSessions, clientId, httpRequest.headers)
-              if (client) {
+            const headers = isHttp
+              ? Context.getUnsafe(
+                Fiber.getCurrent()!.context,
+                HttpServerRequest.HttpServerRequest
+              ).headers
+              : Headers.fromInput(request.headers)
+            const session = getClientSession(clientSessions, clientId, headers)
+            const selectedProtocol = session?.protocol ??
+              (request.tag === "initialize"
+                ? protocolRegistry.select(getOfferedProtocolVersion(request.payload))
+                : protocolRegistry.protocols[0])
+            clientProtocols.set(clientId, selectedProtocol)
+            if (isHttp) {
+              const fiber = Fiber.getCurrent()!
+              const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
+              if (session) {
                 appendPreResponseHandlerUnsafe(httpRequest, (_, res) =>
                   Effect.succeed(
-                    HttpServerResponse.setHeader(res, MCP_PROTOCOL_VERSION_HEADER, client.protocolVersion)
+                    HttpServerResponse.setHeader(
+                      res,
+                      mcpProtocolVersionHeader,
+                      session.protocol.protocolVersion
+                    )
                   ))
               }
             }
-            const rpc = ClientNotificationRpcs.requests.get(request.tag)
-            if (rpc) {
-              const headers = Headers.fromInput(request.headers)
-              if (!getInitializedClient(clientSessions, clientId, headers)) {
-                if (httpRequest !== undefined) {
-                  appendPreResponseHandlerUnsafe(
-                    httpRequest,
-                    () => Effect.succeed(HttpServerResponse.empty({ status: 404 }))
-                  )
-                }
-                return Effect.void
-              }
-              if (request.tag === "notifications/cancelled") {
-                return f(clientId, {
-                  _tag: "Interrupt",
-                  requestId: String((request.payload as any).requestId)
-                })
-              }
-              const handler = handlers.mapUnsafe.get(request.tag) as Rpc.Handler<string>
-              return handler
-                ? handler.handler(request.payload, {
-                  rpc,
-                  requestId: RpcMessage.RequestId(request.id),
-                  client: new Rpc.ServerClient(clientId),
-                  headers
-                }) as any as Effect.Effect<void>
-                : Effect.void
+            const routedRequest = protocolRegistry.routeClientRequest(selectedProtocol, request)
+            const rpc = protocolRegistry.clientRpcs.requests.get(routedRequest.tag)
+            if (rpc && selectedProtocol.clientNotificationRpcs.requests.has(request.tag)) {
+              const decode = Schema.decodeUnknownEffect(
+                Schema.toCodecJson(rpc.payloadSchema)
+              )(request.payload) as Effect.Effect<unknown, Schema.SchemaError>
+              return decode.pipe(
+                Effect.flatMap((payload) => {
+                  if (request.tag === "notifications/cancelled") {
+                    return f(clientId, {
+                      _tag: "Interrupt",
+                      requestId: String((payload as any).requestId)
+                    })
+                  }
+                  const handler = handlers.mapUnsafe.get(rpc.key) as Rpc.Handler<string> | undefined
+                  return handler
+                    ? handler.handler(payload, {
+                      rpc,
+                      requestId: RpcMessage.RequestId(request.id),
+                      client: new Rpc.ServerClient(clientId),
+                      headers
+                    }) as any as Effect.Effect<void>
+                    : Effect.void
+                }),
+                Effect.catchCause(() => Effect.void)
+              )
             }
-            return f(clientId, request)
+            return f(clientId, routedRequest)
           }
           case "Ping":
           case "Ack":
@@ -532,7 +569,10 @@ export const run: (options: {
           case "Chunk":
           case "ClientProtocolError":
           case "Defect":
-            return RcMap.get(clients, clientId).pipe(
+            return RcMap.get(
+              clients,
+              `${clientId}\0${getProtocolForClient(clientProtocols, clientId, protocolRegistry).protocolVersion}`
+            ).pipe(
               Effect.flatMap(({ write }) => write(request)),
               Effect.scoped
             )
@@ -540,23 +580,30 @@ export const run: (options: {
       })
   })
 
-  const encodeNotification = Schema.encodeUnknownEffect(
-    Schema.Union(Array.from(ServerNotificationRpcs.requests.values(), (rpc) => rpc.payloadSchema))
-  )
   yield* Queue.take(server.notificationsQueue).pipe(
     Effect.flatMap(Effect.fnUntraced(function*(request) {
-      const encoded = yield* encodeNotification(request.payload)
-      const message: RpcMessage.RequestEncoded = {
-        _tag: "Request",
-        tag: request.tag,
-        payload: encoded
-      } as any
       const clientIds = yield* patchedProtocol.clientIds
       for (const clientId of server.initializedClients.keys()) {
         if (!clientIds.has(clientId)) {
           server.initializedClients.delete(clientId)
           continue
         }
+        const selectedProtocol = clientProtocols.get(clientId)
+        if (!selectedProtocol) {
+          continue
+        }
+        const rpc = selectedProtocol.serverNotificationRpcs.requests.get(request.tag)
+        if (!rpc) {
+          continue
+        }
+        const encoded = yield* Schema.encodeUnknownEffect(rpc.payloadSchema)(request.payload)
+        // TODO: Extend RpcServer.Protocol's outbound message contract with server-originated
+        // notifications so MCP does not need to treat this notification as an RPC response.
+        const message: RpcMessage.RequestEncoded = {
+          _tag: "Request",
+          tag: request.tag,
+          payload: encoded
+        } as any
         yield* patchedProtocol.send(clientId, message as any)
       }
     })),
@@ -565,7 +612,7 @@ export const run: (options: {
     Effect.forkScoped
   )
 
-  return yield* RpcServer.make(ClientRpcs, {
+  return yield* RpcServer.make(protocolRegistry.clientRpcs, {
     spanPrefix: "McpServer",
     disableFatalDefects: true
   }).pipe(
@@ -607,10 +654,11 @@ export const run: (options: {
 export const layer = (options: {
   readonly name: string
   readonly version: string
+  readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, RpcServer.Protocol> =>
+}): Layer.Layer<McpServer | McpServerClient, Cause.IllegalArgumentError, RpcServer.Protocol> =>
   layerWithProtocolState(options).pipe(
-    Layer.provide(layerMcpProtocolState)
+    Layer.provide(layerMcpProtocolState(options.protocols))
   )
 
 const layerWithProtocolState = (options: {
@@ -618,7 +666,12 @@ const layerWithProtocolState = (options: {
   readonly version: string
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }): Layer.Layer<McpServer | McpServerClient, never, RpcServer.Protocol | McpProtocolState> =>
-  Layer.effectDiscard(Effect.forkScoped(run(options))).pipe(
+  Layer.effectDiscard(
+    Effect.gen(function*() {
+      const protocolState = yield* McpProtocolState
+      yield* Effect.forkScoped(runWithProtocolState(options, protocolState))
+    })
+  ).pipe(
     Layer.provideMerge(McpServer.layer)
   )
 
@@ -630,7 +683,7 @@ const layerWithProtocolState = (options: {
  * ```ts
  * import { Effect, Layer, Logger, Schema } from "effect"
  * import { NodeRuntime, NodeStdio } from "@effect/platform-node"
- * import { McpSchema, McpServer } from "effect/unstable/ai"
+ * import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai"
  *
  * const idParam = McpSchema.param("id", Schema.Number)
  *
@@ -669,6 +722,7 @@ const layerWithProtocolState = (options: {
  *   Layer.provide(McpServer.layerStdio({
  *     name: "Demo Server",
  *     version: "1.0.0",
+ *     protocols: [McpProtocol.v2025_06_18]
  *   })),
  *   Layer.provide(NodeStdio.layer),
  *   Layer.provide(Layer.succeed(Logger.LogToStderr)(true))
@@ -683,8 +737,9 @@ const layerWithProtocolState = (options: {
 export const layerStdio = (options: {
   readonly name: string
   readonly version: string
+  readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, Stdio> =>
+}): Layer.Layer<McpServer | McpServerClient, Cause.IllegalArgumentError, Stdio> =>
   layer(options).pipe(
     Layer.provide(RpcServer.layerProtocolStdio),
     Layer.provide(RpcSerialization.layerNdJsonRpc())
@@ -713,9 +768,10 @@ export const layerHttp = (options: {
   readonly name: string
   readonly version: string
   readonly path: HttpRouter.PathInput
+  readonly protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, HttpRouter.HttpRouter> => {
-  const protocolState = layerMcpProtocolState
+}): Layer.Layer<McpServer | McpServerClient, Cause.IllegalArgumentError, HttpRouter.HttpRouter> => {
+  const protocolState = layerMcpProtocolState(options.protocols)
   const methodNotAllowedResponse = HttpServerResponse.empty({
     status: 405,
     headers: { allow: "POST" }
@@ -745,10 +801,10 @@ const layerMcpProtocolHttp = (options: {
     const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect
     const router = yield* HttpRouter.HttpRouter
     yield* router.add("POST", options.path, (request) => {
-      const protocolVersion = request.headers[MCP_PROTOCOL_VERSION_HEADER]
+      const protocolVersion = request.headers[mcpProtocolVersionHeader]
       if (
         protocolVersion !== undefined &&
-        !state.supportedProtocolVersions.has(protocolVersion)
+        !state.protocolRegistry.protocols.some((protocol) => protocol.protocolVersion === protocolVersion)
       ) {
         return Effect.succeed(HttpServerResponse.empty({ status: 400 }))
       }
@@ -1386,144 +1442,179 @@ const layerHandlers = (serverInfo: {
   readonly name: string
   readonly version: string
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
+}, options: {
+  readonly clientSessions: Map<string, Session>
+  readonly protocolRegistry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
 }) =>
-  ClientRpcs.toLayer(
+  Layer.effectContext(
     Effect.gen(function*() {
       const server = yield* McpServer
-      const protocolState = yield* McpProtocolState
-      const clientSessions = protocolState.clientSessions
       let currentLogLevel = yield* CurrentLogLevel
+      const contextMap = new Map<string, unknown>()
 
-      return ClientRpcs.of({
-        // Requests
-        ping: () => Effect.succeed({}),
-        initialize(params, { client }) {
-          const requestedVersion = protocolState.supportedProtocolVersions.has(params.protocolVersion)
-            ? params.protocolVersion
-            : protocolState.latestProtocolVersion
-          if (requestedVersion !== params.protocolVersion) {
-            params = {
-              ...params,
-              protocolVersion: requestedVersion
+      for (const protocol of options.protocolRegistry.protocols) {
+        const selectedProtocol = protocol
+        const wireHandlers = ClientRpcs.of({
+          // Requests
+          ping: () => Effect.succeed({}),
+          initialize(params, { client }) {
+            const capabilities: Types.DeepMutable<typeof ServerCapabilities.Type> = {
+              completions: {}
             }
-          }
-          const capabilities: Types.DeepMutable<typeof ServerCapabilities.Type> = {
-            completions: {}
-          }
-          if (server.tools.length > 0) {
-            capabilities.tools = { listChanged: true }
-          }
-          if (server.resources.length > 0 || server.resourceTemplates.length > 0) {
-            capabilities.resources = {
-              listChanged: true,
-              subscribe: false
+            if (server.tools.length > 0) {
+              capabilities.tools = { listChanged: true }
             }
-          }
-          if (server.prompts.length > 0) {
-            capabilities.prompts = { listChanged: true }
-          }
-          if (serverInfo.extensions) {
-            capabilities.extensions = serverInfo.extensions as any
-          }
-          return Effect.withFiber((fiber) => {
-            const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
-            if (httpRequest) {
-              const sessionId = crypto.randomUUID()
-              clientSessions.set(sessionId, params)
-              appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
-                Effect.succeed(HttpServerResponse.setHeaders(res, {
-                  [MCP_SESSION_ID_HEADER]: sessionId,
-                  [MCP_PROTOCOL_VERSION_HEADER]: requestedVersion
-                })))
-            } else {
-              clientSessions.set(String(client.id), params)
+            if (server.resources.length > 0 || server.resourceTemplates.length > 0) {
+              capabilities.resources = {
+                listChanged: true,
+                subscribe: false
+              }
             }
-            return Effect.succeed({
-              capabilities,
-              serverInfo,
-              protocolVersion: requestedVersion
+            if (server.prompts.length > 0) {
+              capabilities.prompts = { listChanged: true }
+            }
+            if (serverInfo.extensions) {
+              capabilities.extensions = serverInfo.extensions as any
+            }
+            return Effect.withFiber((fiber) => {
+              const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
+              const session: Session = {
+                initializePayload: params,
+                protocol: selectedProtocol
+              }
+              if (httpRequest) {
+                const sessionId = crypto.randomUUID()
+                options.clientSessions.set(sessionId, session)
+                appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
+                  Effect.succeed(HttpServerResponse.setHeaders(res, {
+                    [mcpSessionIdHeader]: sessionId,
+                    [mcpProtocolVersionHeader]: selectedProtocol.protocolVersion
+                  })))
+              } else {
+                options.clientSessions.set(String(client.id), session)
+              }
+              return Effect.succeed({
+                capabilities,
+                serverInfo,
+                protocolVersion: selectedProtocol.protocolVersion
+              })
             })
-          })
-        },
-        "completion/complete": (r) =>
-          server.completion(r).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "logging/setLevel": ({ level }) =>
-          Effect.sync(() => {
-            switch (level) {
-              case "notice":
-              case "info":
-                currentLogLevel = "Info"
-                break
-              case "error":
-                currentLogLevel = "Error"
-                break
-              case "debug":
-                currentLogLevel = "Debug"
-                break
-              case "warning":
-                currentLogLevel = "Warn"
-                break
-              case "critical":
-              case "alert":
-              case "emergency":
-                currentLogLevel = "Fatal"
-                break
-            }
-          }),
-        "prompts/get": (r) =>
-          server.getPromptResult(r).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "prompts/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(clientSessions, client.id, headers)
-            return new ListPromptsResult({ prompts: filterByClient(initialized, server.prompts, "prompt") })
-          }),
-        "resources/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(clientSessions, client.id, headers)
-            return new ListResourcesResult({ resources: filterByClient(initialized, server.resources, "resource") })
-          }),
-        "resources/read": ({ uri }) =>
-          server.findResource(uri).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "resources/subscribe": () =>
-          InternalError.notImplemented,
-        "resources/unsubscribe": () =>
-          InternalError.notImplemented,
-        "resources/templates/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(clientSessions, client.id, headers)
-            return new ListResourceTemplatesResult({
-              resourceTemplates: filterByClient(initialized, server.resourceTemplates, "template")
-            })
-          }),
-        "tools/call": (r) =>
-          server.callTool(r).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "tools/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(clientSessions, client.id, headers)
-            return new ListToolsResult({
-              tools: filterByClient(initialized, server.tools, "tool")
-            })
-          }),
+          },
+          "completion/complete": (r) =>
+            server.completion(r).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            ),
+          "logging/setLevel": ({ level }) =>
+            Effect.sync(() => {
+              switch (level) {
+                case "notice":
+                case "info":
+                  currentLogLevel = "Info"
+                  break
+                case "error":
+                  currentLogLevel = "Error"
+                  break
+                case "debug":
+                  currentLogLevel = "Debug"
+                  break
+                case "warning":
+                  currentLogLevel = "Warn"
+                  break
+                case "critical":
+                case "alert":
+                case "emergency":
+                  currentLogLevel = "Fatal"
+                  break
+              }
+            }),
+          "prompts/get": (r) =>
+            server.getPromptResult(r).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            ),
+          "prompts/list": (_, { client, headers }) =>
+            Effect.sync(() => {
+              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              return new ListPromptsResult({ prompts: filterByClient(initialized, server.prompts, "prompt") })
+            }),
+          "resources/list": (_, { client, headers }) =>
+            Effect.sync(() => {
+              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              return new ListResourcesResult({ resources: filterByClient(initialized, server.resources, "resource") })
+            }),
+          "resources/read": ({ uri }) =>
+            server.findResource(uri).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            ),
+          "resources/subscribe": () =>
+            InternalError.notImplemented,
+          "resources/unsubscribe": () =>
+            InternalError.notImplemented,
+          "resources/templates/list": (_, { client, headers }) =>
+            Effect.sync(() => {
+              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              return new ListResourceTemplatesResult({
+                resourceTemplates: filterByClient(initialized, server.resourceTemplates, "template")
+              })
+            }),
+          "tools/call": (r) =>
+            server.callTool(r).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            ),
+          "tools/list": (_, { client, headers }) =>
+            Effect.sync(() => {
+              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              return new ListToolsResult({
+                tools: filterByClient(initialized, server.tools, "tool")
+              })
+            }),
 
-        // Notifications
-        "notifications/cancelled": (_) => Effect.void,
-        "notifications/initialized": (_, { client }) =>
-          Effect.sync(() => {
-            server.initializedClients.add(client.id)
-          }),
-        "notifications/progress": (_) => Effect.void,
-        "notifications/roots/list_changed": (_) => Effect.void
-      })
+          // Notifications
+          "notifications/cancelled": (_) => Effect.void,
+          "notifications/initialized": (_, { client }) =>
+            Effect.sync(() => {
+              server.initializedClients.add(client.id)
+            }),
+          "notifications/progress": (_) => Effect.void,
+          "notifications/roots/list_changed": (_) => Effect.void
+        })
+        yield* addProtocolHandlers(
+          options.protocolRegistry,
+          selectedProtocol,
+          selectedProtocol.clientRpcs,
+          wireHandlers,
+          contextMap
+        )
+      }
+      return Context.makeUnsafe(contextMap)
     })
   )
+
+const addProtocolHandlers = Effect.fnUntraced(function*<
+  ClientRpcs extends Rpc.Any
+>(
+  registry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>,
+  protocol: McpProtocol.ProtocolAdapter,
+  clientRpcs: RpcGroup.RpcGroup<ClientRpcs>,
+  handlers: RpcGroup.HandlersFrom<ClientRpcs>,
+  contextMap: Map<string, unknown>
+) {
+  const handlerContext = yield* clientRpcs.toHandlers(handlers)
+  for (const rpcDefinition of clientRpcs.requests.values()) {
+    const routed = registry.routeClientRequest(protocol, {
+      _tag: "Request",
+      id: 0,
+      tag: rpcDefinition._tag,
+      payload: undefined,
+      headers: []
+    })
+    const namespacedRpc = registry.clientRpcs.requests.get(routed.tag)
+    const handler = handlerContext.mapUnsafe.get(rpcDefinition.key)
+    if (namespacedRpc === undefined || handler === undefined) {
+      return yield* Effect.die(`MCP handler registration invariant failed for ${routed.tag}`)
+    }
+    contextMap.set(namespacedRpc.key, handler)
+  }
+})
 
 const resolveResourceContent = (
   uri: string,
@@ -1571,14 +1662,49 @@ const filterByClient = <
   return out
 }
 
-const getInitializedClient = (
-  sessions: Map<string, typeof Initialize.payloadSchema.Type>,
+const getClientSession = (
+  sessions: Map<string, Session>,
   clientId: number,
   headers: Headers.Headers
 ) => {
-  const sessionId = headers[MCP_SESSION_ID_HEADER]
+  const sessionId = headers[mcpSessionIdHeader]
   if (sessionId === undefined) {
     return sessions.get(String(clientId))
   }
   return sessions.get(sessionId)
 }
+
+const getOfferedProtocolVersion = (payload: unknown): string =>
+  typeof payload === "object" &&
+    payload !== null &&
+    "protocolVersion" in payload &&
+    typeof payload.protocolVersion === "string"
+    ? payload.protocolVersion
+    : ""
+
+const protocolForInternalTag = (
+  registry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>,
+  tag: string
+): McpProtocol.ProtocolAdapter => {
+  for (const protocol of registry.protocols) {
+    const routed = registry.routeClientRequest(protocol, {
+      _tag: "Request",
+      id: 0,
+      tag: "",
+      payload: undefined,
+      headers: []
+    })
+    if (tag.startsWith(routed.tag)) {
+      return protocol
+    }
+  }
+  return registry.protocols[0]
+}
+
+const getProtocolForClient = (
+  clientProtocols: Map<number, McpProtocol.ProtocolAdapter>,
+  clientId: number,
+  registry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
+): McpProtocol.ProtocolAdapter =>
+  clientProtocols.get(clientId) ??
+    registry.protocols[0]

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -334,8 +334,8 @@ export class McpServer extends Context.Service<McpServer, {
   static readonly layer: Layer.Layer<McpServer | McpServerClient> = Layer.effect(McpServer)(McpServer.make) as any
 }
 
-const mcpSessionIdHeader = "mcp-session-id"
-const mcpProtocolVersionHeader = "mcp-protocol-version"
+const MCP_SESSION_ID_HEADER = "mcp-session-id"
+const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 
 interface Session {
   readonly initializePayload: typeof Initialize.payloadSchema.Type
@@ -524,7 +524,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
                   Effect.succeed(
                     HttpServerResponse.setHeader(
                       res,
-                      mcpProtocolVersionHeader,
+                      MCP_PROTOCOL_VERSION_HEADER,
                       session.protocol.protocolVersion
                     )
                   ))
@@ -583,6 +583,15 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   yield* Queue.take(server.notificationsQueue).pipe(
     Effect.flatMap(Effect.fnUntraced(function*(request) {
       const clientIds = yield* patchedProtocol.clientIds
+      for (const clientId of clientProtocols.keys()) {
+        if (!clientIds.has(clientId)) {
+          clientProtocols.delete(clientId)
+          // HTTP client IDs are request-scoped; their UUID sessions outlive them.
+          if (!isHttp) {
+            clientSessions.delete(`client:${clientId}`)
+          }
+        }
+      }
       for (const clientId of server.initializedClients.keys()) {
         if (!clientIds.has(clientId)) {
           server.initializedClients.delete(clientId)
@@ -596,7 +605,9 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
         if (!rpc) {
           continue
         }
-        const encoded = yield* Schema.encodeUnknownEffect(rpc.payloadSchema)(request.payload)
+        const encoded = yield* Schema.encodeUnknownEffect(
+          Schema.toCodecJson(rpc.payloadSchema)
+        )(request.payload)
         // TODO: Extend RpcServer.Protocol's outbound message contract with server-originated
         // notifications so MCP does not need to treat this notification as an RPC response.
         const message: RpcMessage.RequestEncoded = {
@@ -801,7 +812,7 @@ const layerMcpProtocolHttp = (options: {
     const { httpEffect, protocol } = yield* RpcServer.makeProtocolWithHttpEffect
     const router = yield* HttpRouter.HttpRouter
     yield* router.add("POST", options.path, (request) => {
-      const protocolVersion = request.headers[mcpProtocolVersionHeader]
+      const protocolVersion = request.headers[MCP_PROTOCOL_VERSION_HEADER]
       if (
         protocolVersion !== undefined &&
         !state.protocolRegistry.protocols.some((protocol) => protocol.protocolVersion === protocolVersion)
@@ -1484,14 +1495,14 @@ const layerHandlers = (serverInfo: {
               }
               if (httpRequest) {
                 const sessionId = crypto.randomUUID()
-                options.clientSessions.set(sessionId, session)
+                options.clientSessions.set(`session:${sessionId}`, session)
                 appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
                   Effect.succeed(HttpServerResponse.setHeaders(res, {
-                    [mcpSessionIdHeader]: sessionId,
-                    [mcpProtocolVersionHeader]: selectedProtocol.protocolVersion
+                    [MCP_SESSION_ID_HEADER]: sessionId,
+                    [MCP_PROTOCOL_VERSION_HEADER]: selectedProtocol.protocolVersion
                   })))
               } else {
-                options.clientSessions.set(String(client.id), session)
+                options.clientSessions.set(`client:${client.id}`, session)
               }
               return Effect.succeed({
                 capabilities,
@@ -1667,11 +1678,11 @@ const getClientSession = (
   clientId: number,
   headers: Headers.Headers
 ) => {
-  const sessionId = headers[mcpSessionIdHeader]
+  const sessionId = headers[MCP_SESSION_ID_HEADER]
   if (sessionId === undefined) {
-    return sessions.get(String(clientId))
+    return sessions.get(`client:${clientId}`)
   }
-  return sessions.get(sessionId)
+  return sessions.get(`session:${sessionId}`)
 }
 
 const getOfferedProtocolVersion = (payload: unknown): string =>

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -343,13 +343,18 @@ interface Session {
   readonly protocol: McpProtocol.ProtocolAdapter
 }
 
+interface Sessions {
+  readonly bySessionId: Map<string, Session>
+  readonly byClientId: Map<number, Session>
+}
+
 class McpClientKey extends Data.Class<{
   readonly clientId: number
   readonly protocolVersion: string
 }> {}
 
 class McpProtocolState extends Context.Service<McpProtocolState, {
-  readonly clientSessions: Map<string, Session>
+  readonly sessions: Sessions
   readonly protocolRegistry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
 }>()("effect/ai/McpServer/McpProtocolState") {}
 
@@ -357,7 +362,10 @@ const makeMcpProtocolState = Effect.fnUntraced(function*(
   protocols: Arr.NonEmptyReadonlyArray<McpProtocol.ProtocolAdapter>
 ) {
   return McpProtocolState.of({
-    clientSessions: new Map(),
+    sessions: {
+      bySessionId: new Map(),
+      byClientId: new Map()
+    },
     protocolRegistry: yield* McpProtocolRegistry.make(protocols)
   })
 })
@@ -410,10 +418,10 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   const protocol = yield* RpcServer.Protocol
   const server = yield* McpServer
   const isHttp = Option.isSome(yield* Effect.serviceOption(HttpRouter.HttpRouter))
-  const clientSessions = protocolState.clientSessions
+  const sessions = protocolState.sessions
   const clientProtocols = new Map<number, McpProtocol.ProtocolAdapter>()
   const handlers = yield* Layer.build(layerHandlers(options, {
-    clientSessions,
+    sessions,
     protocolRegistry
   }))
 
@@ -454,7 +462,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   })
 
   const clientMiddleware = McpServerClientMiddleware.of((effect, { client, headers, payload, rpc }) => {
-    const session = getClientSession(clientSessions, client.id, headers)
+    const session = getClientSession(sessions, client.id, headers)
     const isInitialize = rpc._tag.endsWith("/initialize")
     if (!isInitialize && !session) {
       const fiber = Fiber.getCurrent()!
@@ -520,7 +528,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
                 HttpServerRequest.HttpServerRequest
               ).headers
               : Headers.fromInput(request.headers)
-            const session = getClientSession(clientSessions, clientId, headers)
+            const session = getClientSession(sessions, clientId, headers)
             const selectedProtocol = session?.protocol ??
               (request.tag === "initialize"
                 ? protocolRegistry.select(getOfferedProtocolVersion(request.payload))
@@ -543,9 +551,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
             const routedRequest = protocolRegistry.routeClientRequest(selectedProtocol, request)
             const rpc = protocolRegistry.clientRpcs.requests.get(routedRequest.tag)
             if (rpc && selectedProtocol.clientNotificationRpcs.requests.has(request.tag)) {
-              const decode = Schema.decodeUnknownEffect(
-                Schema.toCodecJson(rpc.payloadSchema)
-              )(request.payload) as Effect.Effect<unknown, Schema.SchemaError>
+              const decode = selectedProtocol.payloadCodecs(rpc).decode(request.payload)
               return decode.pipe(
                 Effect.flatMap((payload) => {
                   if (request.tag === "notifications/cancelled") {
@@ -601,7 +607,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
           clientProtocols.delete(clientId)
           // HTTP client IDs are request-scoped; their UUID sessions outlive them.
           if (!isHttp) {
-            clientSessions.delete(`client:${clientId}`)
+            sessions.byClientId.delete(clientId)
           }
         }
       }
@@ -618,9 +624,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
         if (!rpc) {
           continue
         }
-        const encoded = yield* Schema.encodeUnknownEffect(
-          Schema.toCodecJson(rpc.payloadSchema)
-        )(request.payload)
+        const encoded = yield* selectedProtocol.payloadCodecs(rpc).encode(request.payload)
         // TODO: Extend RpcServer.Protocol's outbound message contract with server-originated
         // notifications so MCP does not need to treat this notification as an RPC response.
         const message: RpcMessage.RequestEncoded = {
@@ -1467,7 +1471,7 @@ const layerHandlers = (serverInfo: {
   readonly version: string
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
 }, options: {
-  readonly clientSessions: Map<string, Session>
+  readonly sessions: Sessions
   readonly protocolRegistry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
 }) =>
   Layer.effectContext(
@@ -1508,14 +1512,14 @@ const layerHandlers = (serverInfo: {
               }
               if (httpRequest) {
                 const sessionId = crypto.randomUUID()
-                options.clientSessions.set(`session:${sessionId}`, session)
+                options.sessions.bySessionId.set(sessionId, session)
                 appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
                   Effect.succeed(HttpServerResponse.setHeaders(res, {
                     [MCP_SESSION_ID_HEADER]: sessionId,
                     [MCP_PROTOCOL_VERSION_HEADER]: selectedProtocol.protocolVersion
                   })))
               } else {
-                options.clientSessions.set(`client:${client.id}`, session)
+                options.sessions.byClientId.set(client.id, session)
               }
               return Effect.succeed({
                 capabilities,
@@ -1557,12 +1561,12 @@ const layerHandlers = (serverInfo: {
             ),
           "prompts/list": (_, { client, headers }) =>
             Effect.sync(() => {
-              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              const initialized = getClientSession(options.sessions, client.id, headers)?.initializePayload
               return new ListPromptsResult({ prompts: filterByClient(initialized, server.prompts, "prompt") })
             }),
           "resources/list": (_, { client, headers }) =>
             Effect.sync(() => {
-              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              const initialized = getClientSession(options.sessions, client.id, headers)?.initializePayload
               return new ListResourcesResult({ resources: filterByClient(initialized, server.resources, "resource") })
             }),
           "resources/read": ({ uri }) =>
@@ -1575,7 +1579,7 @@ const layerHandlers = (serverInfo: {
             InternalError.notImplemented,
           "resources/templates/list": (_, { client, headers }) =>
             Effect.sync(() => {
-              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              const initialized = getClientSession(options.sessions, client.id, headers)?.initializePayload
               return new ListResourceTemplatesResult({
                 resourceTemplates: filterByClient(initialized, server.resourceTemplates, "template")
               })
@@ -1586,7 +1590,7 @@ const layerHandlers = (serverInfo: {
             ),
           "tools/list": (_, { client, headers }) =>
             Effect.sync(() => {
-              const initialized = getClientSession(options.clientSessions, client.id, headers)?.initializePayload
+              const initialized = getClientSession(options.sessions, client.id, headers)?.initializePayload
               return new ListToolsResult({
                 tools: filterByClient(initialized, server.tools, "tool")
               })
@@ -1687,15 +1691,15 @@ const filterByClient = <
 }
 
 const getClientSession = (
-  sessions: Map<string, Session>,
+  sessions: Sessions,
   clientId: number,
   headers: Headers.Headers
 ) => {
   const sessionId = headers[MCP_SESSION_ID_HEADER]
   if (sessionId === undefined) {
-    return sessions.get(`client:${clientId}`)
+    return sessions.byClientId.get(clientId)
   }
-  return sessions.get(`session:${sessionId}`)
+  return sessions.bySessionId.get(sessionId)
 }
 
 const getOfferedProtocolVersion = (payload: unknown): string =>

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -13,6 +13,7 @@
 import * as Arr from "../../Array.ts"
 import * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
+import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
@@ -342,6 +343,11 @@ interface Session {
   readonly protocol: McpProtocol.ProtocolAdapter
 }
 
+class McpClientKey extends Data.Class<{
+  readonly clientId: number
+  readonly protocolVersion: string
+}> {}
+
 class McpProtocolState extends Context.Service<McpProtocolState, {
   readonly clientSessions: Map<string, Session>
   readonly protocolRegistry: McpProtocolRegistry.ProtocolRegistry<McpProtocol.ProtocolAdapter>
@@ -412,10 +418,8 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
   }))
 
   const clients = yield* RcMap.make({
-    lookup: Effect.fnUntraced(function*(key: string) {
-      const separator = key.indexOf("\0")
-      const clientId = Number(key.slice(0, separator))
-      const selectedProtocol = protocolRegistry.select(key.slice(separator + 1))
+    lookup: Effect.fnUntraced(function*(key: McpClientKey) {
+      const selectedProtocol = protocolRegistry.select(key.protocolVersion)
       let write!: (message: RpcMessage.FromServerEncoded) => Effect.Effect<void>
       const client = yield* RpcClient.make(selectedProtocol.serverRequestRpcs, {
         spanPrefix: "McpServer/Client"
@@ -428,7 +432,7 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
             return {
               send(id, request, _transferables) {
                 cid = id
-                return protocol.send(clientId, {
+                return protocol.send(key.clientId, {
                   ...request,
                   headers: undefined,
                   traceId: undefined,
@@ -471,7 +475,13 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
         clientId: client.id,
         protocolVersion: selectedProtocol.protocolVersion,
         initializePayload: session?.initializePayload ?? payload as typeof Initialize.payloadSchema.Type,
-        getClient: RcMap.get(clients, `${client.id}\0${selectedProtocol.protocolVersion}`).pipe(
+        getClient: RcMap.get(
+          clients,
+          new McpClientKey({
+            clientId: client.id,
+            protocolVersion: selectedProtocol.protocolVersion
+          })
+        ).pipe(
           Effect.map(({ client }) => client)
         )
       })
@@ -571,7 +581,10 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
           case "Defect":
             return RcMap.get(
               clients,
-              `${clientId}\0${getProtocolForClient(clientProtocols, clientId, protocolRegistry).protocolVersion}`
+              new McpClientKey({
+                clientId,
+                protocolVersion: getProtocolForClient(clientProtocols, clientId, protocolRegistry).protocolVersion
+              })
             ).pipe(
               Effect.flatMap(({ write }) => write(request)),
               Effect.scoped

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -551,6 +551,15 @@ const runWithProtocolState = Effect.fnUntraced(function*(options: {
             const routedRequest = protocolRegistry.routeClientRequest(selectedProtocol, request)
             const rpc = protocolRegistry.clientRpcs.requests.get(routedRequest.tag)
             if (rpc && selectedProtocol.clientNotificationRpcs.requests.has(request.tag)) {
+              if (!session) {
+                if (httpRequest) {
+                  appendPreResponseHandlerUnsafe(
+                    httpRequest,
+                    () => Effect.succeed(HttpServerResponse.empty({ status: 404 }))
+                  )
+                }
+                return Effect.void
+              }
               const decode = selectedProtocol.payloadCodecs(rpc).decode(request.payload)
               return decode.pipe(
                 Effect.flatMap((payload) => {

--- a/packages/effect/src/unstable/ai/index.ts
+++ b/packages/effect/src/unstable/ai/index.ts
@@ -37,6 +37,11 @@ export * as LanguageModel from "./LanguageModel.ts"
 /**
  * @since 4.0.0
  */
+export * as McpProtocol from "./McpProtocol.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as McpSchema from "./McpSchema.ts"
 
 /**

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -1,5 +1,13 @@
+import type * as Effect from "../../../Effect.ts"
+import * as Schema from "../../../Schema.ts"
 import type * as Rpc from "../../rpc/Rpc.ts"
 import type * as RpcGroup from "../../rpc/RpcGroup.ts"
+
+/** @internal */
+export interface PayloadCodecs {
+  readonly decode: (input: unknown) => Effect.Effect<unknown, Schema.SchemaError>
+  readonly encode: (input: unknown) => Effect.Effect<unknown, Schema.SchemaError>
+}
 
 /** @internal */
 export interface AnyProtocolAdapter {
@@ -8,6 +16,7 @@ export interface AnyProtocolAdapter {
   readonly clientNotificationRpcs: RpcGroup.Any
   readonly serverRequestRpcs: RpcGroup.Any
   readonly serverNotificationRpcs: RpcGroup.Any
+  readonly payloadCodecs: (rpc: Rpc.AnyWithProps) => PayloadCodecs
 }
 
 /** @internal */
@@ -44,4 +53,22 @@ export const make = <
   ClientNotificationRpcs,
   ServerRequestRpcs,
   ServerNotificationRpcs
-> => options
+> => {
+  const payloadCodecsCache = new WeakMap<Rpc.AnyWithProps, PayloadCodecs>()
+  const payloadCodecs = (rpc: Rpc.AnyWithProps): PayloadCodecs => {
+    let codecs = payloadCodecsCache.get(rpc)
+    if (codecs === undefined) {
+      const schema = Schema.toCodecJson(rpc.payloadSchema)
+      codecs = {
+        decode: Schema.decodeUnknownEffect(schema) as PayloadCodecs["decode"],
+        encode: Schema.encodeUnknownEffect(schema) as PayloadCodecs["encode"]
+      }
+      payloadCodecsCache.set(rpc, codecs)
+    }
+    return codecs
+  }
+  return {
+    ...options,
+    payloadCodecs
+  }
+}

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -14,7 +14,7 @@ export interface AnyProtocolAdapter {
 export interface ProtocolAdapter<
   out Version extends string = string,
   ClientRpcs extends Rpc.Any = Rpc.Any,
-  ClientNotificationRpcs extends Rpc.Any = Rpc.Any,
+  ClientNotificationRpcs extends ClientRpcs = ClientRpcs,
   ServerRequestRpcs extends Rpc.Any = Rpc.Any,
   ServerNotificationRpcs extends Rpc.Any = Rpc.Any
 > extends AnyProtocolAdapter {
@@ -29,7 +29,7 @@ export interface ProtocolAdapter<
 export const make = <
   const Version extends string,
   ClientRpcs extends Rpc.Any,
-  ClientNotificationRpcs extends Rpc.Any,
+  ClientNotificationRpcs extends ClientRpcs,
   ServerRequestRpcs extends Rpc.Any,
   ServerNotificationRpcs extends Rpc.Any
 >(options: {

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -1,0 +1,47 @@
+import type * as Rpc from "../../rpc/Rpc.ts"
+import type * as RpcGroup from "../../rpc/RpcGroup.ts"
+
+/** @internal */
+export interface AnyProtocolAdapter {
+  readonly protocolVersion: string
+  readonly clientRpcs: RpcGroup.Any
+  readonly clientNotificationRpcs: RpcGroup.Any
+  readonly serverRequestRpcs: RpcGroup.Any
+  readonly serverNotificationRpcs: RpcGroup.Any
+}
+
+/** @internal */
+export interface ProtocolAdapter<
+  out Version extends string = string,
+  ClientRpcs extends Rpc.Any = Rpc.Any,
+  ClientNotificationRpcs extends Rpc.Any = Rpc.Any,
+  ServerRequestRpcs extends Rpc.Any = Rpc.Any,
+  ServerNotificationRpcs extends Rpc.Any = Rpc.Any
+> extends AnyProtocolAdapter {
+  readonly protocolVersion: Version
+  readonly clientRpcs: RpcGroup.RpcGroup<ClientRpcs>
+  readonly clientNotificationRpcs: RpcGroup.RpcGroup<ClientNotificationRpcs>
+  readonly serverRequestRpcs: RpcGroup.RpcGroup<ServerRequestRpcs>
+  readonly serverNotificationRpcs: RpcGroup.RpcGroup<ServerNotificationRpcs>
+}
+
+/** @internal */
+export const make = <
+  const Version extends string,
+  ClientRpcs extends Rpc.Any,
+  ClientNotificationRpcs extends Rpc.Any,
+  ServerRequestRpcs extends Rpc.Any,
+  ServerNotificationRpcs extends Rpc.Any
+>(options: {
+  readonly protocolVersion: Version
+  readonly clientRpcs: RpcGroup.RpcGroup<ClientRpcs>
+  readonly clientNotificationRpcs: RpcGroup.RpcGroup<ClientNotificationRpcs>
+  readonly serverRequestRpcs: RpcGroup.RpcGroup<ServerRequestRpcs>
+  readonly serverNotificationRpcs: RpcGroup.RpcGroup<ServerNotificationRpcs>
+}): ProtocolAdapter<
+  Version,
+  ClientRpcs,
+  ClientNotificationRpcs,
+  ServerRequestRpcs,
+  ServerNotificationRpcs
+> => options

--- a/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocol.ts
@@ -3,7 +3,6 @@ import * as Schema from "../../../Schema.ts"
 import type * as Rpc from "../../rpc/Rpc.ts"
 import type * as RpcGroup from "../../rpc/RpcGroup.ts"
 
-/** @internal */
 export interface PayloadCodecs {
   readonly decode: (input: unknown) => Effect.Effect<unknown, Schema.SchemaError>
   readonly encode: (input: unknown) => Effect.Effect<unknown, Schema.SchemaError>
@@ -19,19 +18,19 @@ export interface AnyProtocolAdapter {
   readonly payloadCodecs: (rpc: Rpc.AnyWithProps) => PayloadCodecs
 }
 
-/** @internal */
 export interface ProtocolAdapter<
   out Version extends string = string,
   ClientRpcs extends Rpc.Any = Rpc.Any,
   ClientNotificationRpcs extends ClientRpcs = ClientRpcs,
   ServerRequestRpcs extends Rpc.Any = Rpc.Any,
   ServerNotificationRpcs extends Rpc.Any = Rpc.Any
-> extends AnyProtocolAdapter {
+> {
   readonly protocolVersion: Version
   readonly clientRpcs: RpcGroup.RpcGroup<ClientRpcs>
   readonly clientNotificationRpcs: RpcGroup.RpcGroup<ClientNotificationRpcs>
   readonly serverRequestRpcs: RpcGroup.RpcGroup<ServerRequestRpcs>
   readonly serverNotificationRpcs: RpcGroup.RpcGroup<ServerNotificationRpcs>
+  readonly payloadCodecs: (rpc: Rpc.AnyWithProps) => PayloadCodecs
 }
 
 /** @internal */

--- a/packages/effect/src/unstable/ai/internal/mcpProtocolRegistry.ts
+++ b/packages/effect/src/unstable/ai/internal/mcpProtocolRegistry.ts
@@ -1,0 +1,70 @@
+import type { NonEmptyReadonlyArray } from "../../../Array.ts"
+import * as Cause from "../../../Cause.ts"
+import * as Effect from "../../../Effect.ts"
+import type * as RpcGroup from "../../rpc/RpcGroup.ts"
+import type * as RpcMessage from "../../rpc/RpcMessage.ts"
+import type * as McpProtocol from "./mcpProtocol.ts"
+
+type AnyRpcGroup = RpcGroup.RpcGroup<any>
+
+const prefix = (protocol: McpProtocol.AnyProtocolAdapter): string =>
+  `@effect/mcp/${encodeURIComponent(protocol.protocolVersion)}/`
+
+const asRpcGroup = (group: RpcGroup.Any): AnyRpcGroup => group as unknown as AnyRpcGroup
+
+/** @internal */
+export interface ProtocolRegistry<
+  Protocol extends McpProtocol.AnyProtocolAdapter = McpProtocol.AnyProtocolAdapter
+> {
+  readonly protocols: NonEmptyReadonlyArray<Protocol>
+  readonly clientRpcs: AnyRpcGroup
+  readonly select: (offeredVersion: string) => Protocol
+  readonly routeClientRequest: (
+    protocol: Protocol,
+    request: RpcMessage.RequestEncoded
+  ) => RpcMessage.RequestEncoded
+}
+
+/** @internal */
+export const make = Effect.fnUntraced(function*<
+  const Protocols extends NonEmptyReadonlyArray<McpProtocol.AnyProtocolAdapter>
+>(
+  protocols: Protocols
+) {
+  type Protocol = Protocols[number]
+
+  if (protocols.length === 0) {
+    return yield* new Cause.IllegalArgumentError(
+      "MCP protocol declaration must contain at least one MCP protocol"
+    )
+  }
+
+  const snapshot = Object.freeze(Array.from(protocols)) as NonEmptyReadonlyArray<Protocol>
+  const byVersion = new Map<string, Protocol>()
+  for (const protocol of snapshot) {
+    if (byVersion.has(protocol.protocolVersion)) {
+      return yield* new Cause.IllegalArgumentError(
+        `Duplicate MCP protocol version: ${protocol.protocolVersion}`
+      )
+    }
+    byVersion.set(protocol.protocolVersion, protocol)
+  }
+
+  let clientRpcs = asRpcGroup(snapshot[0].clientRpcs).prefix(prefix(snapshot[0]))
+  for (let i = 1; i < snapshot.length; i++) {
+    clientRpcs = clientRpcs.merge(asRpcGroup(snapshot[i].clientRpcs).prefix(prefix(snapshot[i])))
+  }
+
+  return {
+    protocols: snapshot,
+    clientRpcs,
+    select: (offeredVersion: string) => byVersion.get(offeredVersion) ?? snapshot[0],
+    routeClientRequest: (
+      protocol: Protocol,
+      request: RpcMessage.RequestEncoded
+    ) => ({
+      ...request,
+      tag: `${prefix(protocol)}${request.tag}`
+    })
+  } satisfies ProtocolRegistry<Protocol>
+})

--- a/packages/effect/test/unstable/ai/McpProtocol.test.ts
+++ b/packages/effect/test/unstable/ai/McpProtocol.test.ts
@@ -1,0 +1,138 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import * as McpProtocol from "effect/unstable/ai/internal/mcpProtocol"
+import * as McpProtocolRegistry from "effect/unstable/ai/internal/mcpProtocolRegistry"
+import * as Rpc from "effect/unstable/rpc/Rpc"
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup"
+
+const makeTestProtocol = <
+  const Version extends string,
+  const Discriminator extends string
+>(
+  protocolVersion: Version,
+  discriminator: Discriminator
+) => {
+  const Payload = Schema.Struct({
+    protocol: Schema.Literal(discriminator),
+    value: Schema.String
+  })
+  const TestRequest = Rpc.make("test/shape", {
+    payload: Payload,
+    success: Schema.Struct({
+      protocol: Schema.Literal(protocolVersion),
+      value: Schema.String
+    })
+  })
+
+  return McpProtocol.make({
+    protocolVersion,
+    clientRpcs: RpcGroup.make(TestRequest),
+    clientNotificationRpcs: RpcGroup.make(),
+    serverRequestRpcs: RpcGroup.make(),
+    serverNotificationRpcs: RpcGroup.make()
+  })
+}
+
+const request = (payload: unknown) => ({
+  _tag: "Request" as const,
+  id: 1,
+  tag: "test/shape",
+  payload,
+  headers: []
+})
+
+describe("McpProtocolRegistry", () => {
+  it.effect("should reject an empty declaration when runtime input bypasses the non-empty type", () =>
+    Effect.gen(function*() {
+      const protocols = [] as unknown as Parameters<typeof McpProtocolRegistry.make>[0]
+
+      const error = yield* Effect.flip(McpProtocolRegistry.make(protocols))
+
+      assert.strictEqual(error._tag, "IllegalArgumentError")
+      assert.match(error.message, /at least one MCP protocol/)
+    }))
+
+  it.effect("should reject duplicate versions when distinct adapters declare the same version", () =>
+    Effect.gen(function*() {
+      const first = makeTestProtocol("test-a", "a")
+      const second = makeTestProtocol("test-a", "other-a")
+
+      const error = yield* Effect.flip(McpProtocolRegistry.make([first, second]))
+
+      assert.strictEqual(error._tag, "IllegalArgumentError")
+      assert.match(error.message, /Duplicate MCP protocol version: test-a/)
+    }))
+
+  it.effect("should select the matching adapter when the offered version is declared", () =>
+    Effect.gen(function*() {
+      const first = makeTestProtocol("test-a", "a")
+      const second = makeTestProtocol("test-b", "b")
+      const registry = yield* McpProtocolRegistry.make([first, second])
+      const selected: typeof first | typeof second = registry.select("test-b")
+
+      assert.strictEqual(selected, second)
+    }))
+
+  it.effect("should select the first declared adapter when the offered version is unsupported", () =>
+    Effect.gen(function*() {
+      const first = makeTestProtocol("test-a", "a")
+      const second = makeTestProtocol("test-b", "b")
+      const registry = yield* McpProtocolRegistry.make([first, second])
+
+      assert.strictEqual(registry.select("unsupported"), first)
+    }))
+
+  it.effect("should preserve declaration order when the source array mutates after registry creation", () =>
+    Effect.gen(function*() {
+      const first = makeTestProtocol("test-a", "a")
+      const second = makeTestProtocol("test-b", "b")
+      const protocols: [McpProtocol.AnyProtocolAdapter, McpProtocol.AnyProtocolAdapter] = [
+        first,
+        second
+      ]
+      const registry = yield* McpProtocolRegistry.make(protocols)
+
+      protocols.reverse()
+
+      assert.strictEqual(registry.select("unsupported"), first)
+      assert.strictEqual(registry.select("test-b"), second)
+    }))
+
+  it.effect("should route to only the selected namespace when protocol schemas are incompatible", () =>
+    Effect.gen(function*() {
+      const first = makeTestProtocol("test-a", "a")
+      const second = makeTestProtocol("test-b", "b")
+      const registry = yield* McpProtocolRegistry.make([first, second])
+      const selected = registry.select("test-a")
+
+      const selectedRequest = registry.routeClientRequest(
+        selected,
+        request({ protocol: "b", value: "wrong adapter" })
+      )
+      const unselectedRequest = registry.routeClientRequest(
+        second,
+        request({ protocol: "b", value: "other adapter" })
+      )
+
+      assert.notStrictEqual(selectedRequest.tag, unselectedRequest.tag)
+      assert.notStrictEqual(selectedRequest.tag, "test/shape")
+
+      const selectedRpc = registry.clientRpcs.requests.get(selectedRequest.tag)
+      const unselectedRpc = registry.clientRpcs.requests.get(unselectedRequest.tag)
+      assert.isDefined(selectedRpc)
+      assert.isDefined(unselectedRpc)
+
+      const invalid = yield* Effect.exit(
+        Schema.decodeUnknownEffect(selectedRpc.payloadSchema)(selectedRequest.payload)
+      )
+
+      assert.strictEqual(invalid._tag, "Failure")
+      const valid = yield* Schema.decodeUnknownEffect(unselectedRpc.payloadSchema)(
+        unselectedRequest.payload
+      )
+      assert.deepStrictEqual(valid, {
+        protocol: "b",
+        value: "other adapter"
+      })
+    }))
+})

--- a/packages/effect/test/unstable/ai/McpProtocol.test.ts
+++ b/packages/effect/test/unstable/ai/McpProtocol.test.ts
@@ -123,13 +123,11 @@ describe("McpProtocolRegistry", () => {
       assert.isDefined(unselectedRpc)
 
       const invalid = yield* Effect.exit(
-        Schema.decodeUnknownEffect(selectedRpc.payloadSchema)(selectedRequest.payload)
+        selected.payloadCodecs(selectedRpc).decode(selectedRequest.payload)
       )
 
       assert.strictEqual(invalid._tag, "Failure")
-      const valid = yield* Schema.decodeUnknownEffect(unselectedRpc.payloadSchema)(
-        unselectedRequest.payload
-      )
+      const valid = yield* second.payloadCodecs(unselectedRpc).decode(unselectedRequest.payload)
       assert.deepStrictEqual(valid, {
         protocol: "b",
         value: "other adapter"

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -1,9 +1,16 @@
 import { assert, describe, it } from "@effect/vitest"
 import { assertTrue, strictEqual } from "@effect/vitest/utils"
+import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
+import * as Queue from "effect/Queue"
 import * as Schema from "effect/Schema"
+import * as Sink from "effect/Sink"
+import * as Stdio from "effect/Stdio"
+import * as Stream from "effect/Stream"
 import * as AiError from "effect/unstable/ai/AiError"
+import * as InternalMcpProtocol from "effect/unstable/ai/internal/mcpProtocol"
+import * as McpProtocol from "effect/unstable/ai/McpProtocol"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as McpServer from "effect/unstable/ai/McpServer"
 import * as Tool from "effect/unstable/ai/Tool"
@@ -13,6 +20,7 @@ import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
+import * as Rpc from "effect/unstable/rpc/Rpc"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 import { makeServerLayer, makeWebHandler } from "./McpServer/utils.ts"
 
@@ -129,8 +137,81 @@ const toolResultText = (result: McpSchema.CallToolResult): string => {
   return content.text
 }
 
+const makeTestProtocol = (protocolVersion: string, field: "a" | "b") => {
+  const Ping = Rpc.make("ping", {
+    payload: Schema.Struct({
+      [field]: field === "a" ? Schema.String : Schema.Number
+    }),
+    success: Schema.Struct({})
+  })
+  return InternalMcpProtocol.make({
+    protocolVersion,
+    clientRpcs: McpSchema.ClientRpcs.omit("ping").add(Ping),
+    clientNotificationRpcs: McpSchema.ClientNotificationRpcs,
+    serverRequestRpcs: McpSchema.ServerRequestRpcs,
+    serverNotificationRpcs: McpSchema.ServerNotificationRpcs
+  })
+}
+
+const makeRawHttpServer = (
+  protocols: ReadonlyArray<InternalMcpProtocol.AnyProtocolAdapter>
+) =>
+  Effect.gen(function*() {
+    const serverLayer = McpServer.layerHttp({
+      name: "TestServer",
+      version: "1.0.0",
+      path: "/mcp",
+      protocols: protocols as unknown as [
+        McpProtocol.ProtocolAdapter,
+        ...Array<McpProtocol.ProtocolAdapter>
+      ]
+    })
+    const { dispose, handler } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
+    yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
+
+    const request = (
+      body: unknown,
+      sessionId?: string
+    ) =>
+      Effect.promise(() =>
+        handler(
+          new Request("http://localhost/mcp", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...(sessionId ? { "mcp-session-id": sessionId } : {})
+            },
+            body: JSON.stringify(body)
+          })
+        )
+      )
+
+    const initialize = Effect.fnUntraced(function*(protocolVersion: string, id: number) {
+      const response = yield* request({
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion,
+          capabilities: {},
+          clientInfo: {
+            name: "TestClient",
+            version: "1.0.0"
+          }
+        }
+      })
+      const sessionId = response.headers.get("mcp-session-id")
+      if (sessionId === null) {
+        return yield* Effect.die("MCP initialize response did not include a session id")
+      }
+      return { response, sessionId }
+    })
+
+    return { initialize, request }
+  })
+
 describe("McpServer", () => {
-  it.effect("replays MCP session and negotiated protocol headers after initialize", () =>
+  it.effect("should replay the negotiated protocol header when a session is initialized", () =>
     Effect.gen(function*() {
       const { client, responses } = yield* makeTestClient
 
@@ -146,11 +227,11 @@ describe("McpServer", () => {
       yield* client.ping({})
 
       strictEqual(responses.length, 2)
-      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-03-26")
-      strictEqual(responses[1].headers.get("Mcp-Protocol-Version"), "2025-03-26")
+      strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-06-18")
+      strictEqual(responses[1].headers.get("Mcp-Protocol-Version"), "2025-06-18")
     }))
 
-  it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>
+  it.effect("should return 404 when a non-initialize request omits the MCP session id", () =>
     Effect.gen(function*() {
       const { httpClient } = yield* makeTestClient
 
@@ -161,7 +242,6 @@ describe("McpServer", () => {
 
       strictEqual(response.status, 404)
     }))
-
   describe("registerToolkit", () => {
     it.effect("returns concise parameter-validation errors without invoking the handler", () =>
       Effect.gen(function*() {
@@ -357,13 +437,156 @@ describe("McpServer", () => {
       )
       strictEqual(absentVersionResponse.status, 200)
 
-      for (const protocolVersion of ["2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"]) {
+      for (const protocolVersion of ["2025-03-26", "2024-11-05", "2024-10-07"]) {
         const response = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
           HttpClientRequest.bodyJsonUnsafe(pingBody),
           HttpClientRequest.setHeader("Mcp-Protocol-Version", protocolVersion),
           httpClient.execute
         )
-        strictEqual(response.status, 200)
+        strictEqual(response.status, 400)
       }
+
+      const declaredVersionResponse = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe(pingBody),
+        HttpClientRequest.setHeader("Mcp-Protocol-Version", "2025-06-18"),
+        httpClient.execute
+      )
+      strictEqual(declaredVersionResponse.status, 200)
     }))
+  describe("protocol selection", () => {
+    for (const offeredVersion of ["2025-03-26", "2024-11-05", "2024-10-07"]) {
+      it.effect(`should select June when ${offeredVersion} is offered`, () =>
+        Effect.gen(function*() {
+          const { client, responses } = yield* makeTestClient
+
+          const result = yield* client.initialize({
+            protocolVersion: offeredVersion,
+            capabilities: {},
+            clientInfo: {
+              name: "TestClient",
+              version: "1.0.0"
+            }
+          })
+
+          strictEqual(result.protocolVersion, "2025-06-18")
+          strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-06-18")
+        }))
+    }
+
+    it.effect("should decode with the pinned adapter when sessions use incompatible schemas", () =>
+      Effect.gen(function*() {
+        const protocolA = makeTestProtocol("test-a", "a")
+        const protocolB = makeTestProtocol("test-b", "b")
+        const { initialize, request } = yield* makeRawHttpServer([protocolA, protocolB])
+        const sessionA = yield* initialize("test-a", 1)
+        const sessionB = yield* initialize("test-b", 2)
+
+        const wrongForA = yield* request({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "ping",
+          params: { b: 1 }
+        }, sessionA.sessionId)
+        const validForA = yield* request({
+          jsonrpc: "2.0",
+          id: 4,
+          method: "ping",
+          params: { a: "selected" }
+        }, sessionA.sessionId)
+        const validForB = yield* request({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "ping",
+          params: { b: 1 }
+        }, sessionB.sessionId)
+
+        const invalidBody = (yield* Effect.promise(() => wrongForA.json())) as Record<string, unknown>
+        const validABody = (yield* Effect.promise(() => validForA.json())) as Record<string, unknown>
+        const validBBody = (yield* Effect.promise(() => validForB.json())) as Record<string, unknown>
+        assert.property(invalidBody, "error")
+        assert.deepStrictEqual(validABody, { jsonrpc: "2.0", id: 4, result: {} })
+        assert.deepStrictEqual(validBBody, { jsonrpc: "2.0", id: 5, result: {} })
+      }))
+  })
+
+  describe("stdio", () => {
+    it.effect("should preserve the June wire transcript when requests use stdio", () =>
+      Effect.gen(function*() {
+        const stdin = yield* Queue.unbounded<Uint8Array>()
+        const stdout = yield* Queue.unbounded<string | Uint8Array>()
+        const encoder = new TextEncoder()
+        const decoder = new TextDecoder()
+        const stdioLayer = Stdio.layerTest({
+          stdin: Stream.fromQueue(stdin),
+          stdout: () => Sink.forEach((chunk) => Queue.offer(stdout, chunk))
+        })
+
+        const ready = yield* Deferred.make<void>()
+        yield* Effect.gen(function*() {
+          yield* Layer.build(
+            McpServer.layerStdio({
+              name: "TestServer",
+              version: "1.0.0",
+              protocols: [McpProtocol.v2025_06_18]
+            }).pipe(Layer.provide(stdioLayer))
+          )
+          yield* Deferred.succeed(ready, undefined)
+          return yield* Effect.never
+        }).pipe(
+          Effect.scoped,
+          Effect.forkScoped
+        )
+        yield* Deferred.await(ready)
+
+        const write = (message: unknown) => Queue.offer(stdin, encoder.encode(`${JSON.stringify(message)}\n`))
+        const read = Effect.fnUntraced(function*() {
+          const chunk = yield* Queue.take(stdout)
+          const frame = typeof chunk === "string" ? chunk : decoder.decode(chunk)
+          assert.strictEqual(frame.endsWith("\n"), true)
+          return JSON.parse(frame)
+        })
+
+        yield* write({
+          jsonrpc: "2.0",
+          id: 0,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: {
+              name: "TestClient",
+              version: "1.0.0"
+            }
+          }
+        })
+
+        assert.deepStrictEqual(yield* read(), {
+          jsonrpc: "2.0",
+          id: 0,
+          result: {
+            protocolVersion: "2025-06-18",
+            capabilities: {
+              completions: {}
+            },
+            serverInfo: {
+              name: "TestServer",
+              version: "1.0.0"
+            }
+          }
+        })
+
+        yield* write({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "ping",
+          params: {}
+        })
+
+        assert.deepStrictEqual(yield* read(), {
+          jsonrpc: "2.0",
+          id: 1,
+          result: {}
+        })
+      }))
+  })
 })

--- a/packages/effect/test/unstable/ai/McpServer/Lifecycle.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/Lifecycle.test.ts
@@ -184,16 +184,12 @@ describe("McpServer initialization", () => {
         })
 
         describe("1.1.1 Version Negotiation", () => {
-          it.effect("echoes every requested version supported by the server", () =>
+          it.effect("echoes a requested version supported by the server", () =>
             Effect.gen(function*() {
               const { post } = yield* makeHarness
-              const supportedVersions = ["2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"]
+              const { message } = yield* initialize(post, "2025-06-18")
 
-              for (let i = 0; i < supportedVersions.length; i++) {
-                const protocolVersion = supportedVersions[i]
-                const { message } = yield* initialize(post, protocolVersion, i + 1)
-                assert.strictEqual(message.result.protocolVersion, protocolVersion)
-              }
+              assert.strictEqual(message.result.protocolVersion, "2025-06-18")
             }))
 
           it.effect("negotiates an unsupported requested version to the latest supported version", () =>
@@ -225,14 +221,14 @@ describe("McpServer initialization", () => {
           it.effect("continues to use the version negotiated during initialization", () =>
             Effect.gen(function*() {
               const { post } = yield* makeHarness
-              const initialized = yield* initialize(post, "2025-03-26")
+              const initialized = yield* initialize(post, "2025-06-18")
               const sessionId = initialized.response.headers.get("Mcp-Session-Id")
               assert.isNotNull(sessionId)
 
               const response = yield* post(pingRequest, { "Mcp-Session-Id": sessionId })
 
               assert.strictEqual(response.status, 200)
-              assert.strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-03-26")
+              assert.strictEqual(response.headers.get("Mcp-Protocol-Version"), "2025-06-18")
             }))
         })
       })

--- a/packages/effect/test/unstable/ai/McpServer/utils.ts
+++ b/packages/effect/test/unstable/ai/McpServer/utils.ts
@@ -3,6 +3,7 @@ import { constVoid } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Logger from "effect/Logger"
 import * as References from "effect/References"
+import * as McpProtocol from "effect/unstable/ai/McpProtocol"
 import * as McpServer from "effect/unstable/ai/McpServer"
 import * as HttpRouter from "effect/unstable/http/HttpRouter"
 
@@ -19,6 +20,7 @@ export const makeServerLayer = (options: {
     name: options.name,
     version: options.version ?? "1.0.0",
     path: "/mcp",
+    protocols: [McpProtocol.v2025_06_18],
     extensions: options.extensions
   }).pipe(
     Layer.provideMerge(Layer.succeed(

--- a/packages/effect/test/unstable/ai/McpServer/utils.ts
+++ b/packages/effect/test/unstable/ai/McpServer/utils.ts
@@ -26,7 +26,8 @@ export const makeServerLayer = (options: {
     Layer.provideMerge(Layer.succeed(
       References.CurrentLoggers,
       new Set([noopLogger])
-    ))
+    )),
+    Layer.orDie
   )
 
 export const makeWebHandler = Effect.fnUntraced(function*<A>(

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -1,0 +1,68 @@
+import type * as Cause from "effect/Cause"
+import type * as Effect from "effect/Effect"
+import type * as Layer from "effect/Layer"
+import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai"
+import { describe, expect, it } from "tstyche"
+
+const serverOptions = {
+  name: "TestServer",
+  version: "1.0.0",
+  protocols: [McpProtocol.v2025_06_18]
+} as const
+
+describe("McpServer", () => {
+  describe("protocol configuration", () => {
+    it("should accept a non-empty protocol declaration when constructing any server", () => {
+      expect(McpServer.run).type.toBeCallableWith(serverOptions)
+      expect(McpServer.layer).type.toBeCallableWith(serverOptions)
+      expect(McpServer.layerStdio).type.toBeCallableWith(serverOptions)
+      expect(McpServer.layerHttp).type.toBeCallableWith({
+        ...serverOptions,
+        path: "/mcp"
+      })
+    })
+
+    it("should require a protocol declaration when constructing a server", () => {
+      expect(McpServer.layer).type.not.toBeCallableWith({
+        name: "TestServer",
+        version: "1.0.0"
+      })
+    })
+
+    it("should reject an empty protocol declaration when constructing a server", () => {
+      expect(McpServer.layer).type.not.toBeCallableWith({
+        name: "TestServer",
+        version: "1.0.0",
+        protocols: [] as const
+      })
+    })
+
+    it("should reject version strings when protocol adapter values are required", () => {
+      expect(McpServer.layer).type.not.toBeCallableWith({
+        name: "TestServer",
+        version: "1.0.0",
+        protocols: ["2025-06-18"] as const
+      })
+    })
+
+    it("should expose only June and newer adapters when using the phase one built-ins", () => {
+      expect<keyof typeof McpProtocol>().type.toBe<"v2025_06_18">()
+    })
+
+    it("should expose invalid protocol declarations as typed constructor failures", () => {
+      const run = McpServer.run(serverOptions)
+      const layer = McpServer.layer(serverOptions)
+
+      expect<Effect.Error<typeof run>>().type.toBe<Cause.IllegalArgumentError>()
+      expect<Layer.Error<typeof layer>>().type.toBe<Cause.IllegalArgumentError>()
+    })
+  })
+
+  describe("request context", () => {
+    it("should expose the selected protocol version when a handler reads its client", () => {
+      expect(McpSchema.McpServerClient.useSync((client) => client.protocolVersion)).type.toBe<
+        Effect.Effect<McpProtocol.ProtocolVersion, never, McpSchema.McpServerClient>
+      >()
+    })
+  })
+})

--- a/packages/effect/typetest/unstable/ai/McpServer.tst.ts
+++ b/packages/effect/typetest/unstable/ai/McpServer.tst.ts
@@ -1,7 +1,11 @@
 import type * as Cause from "effect/Cause"
 import type * as Effect from "effect/Effect"
 import type * as Layer from "effect/Layer"
+import * as Schema from "effect/Schema"
 import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai"
+import * as McpProtocolInternal from "effect/unstable/ai/internal/mcpProtocol"
+import * as Rpc from "effect/unstable/rpc/Rpc"
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup"
 import { describe, expect, it } from "tstyche"
 
 const serverOptions = {
@@ -42,6 +46,25 @@ describe("McpServer", () => {
         name: "TestServer",
         version: "1.0.0",
         protocols: ["2025-06-18"] as const
+      })
+    })
+
+    it("should require client notification RPCs to be included in the complete client RPC group", () => {
+      const Request = Rpc.make("request", {
+        payload: Schema.Struct({}),
+        success: Schema.Struct({})
+      })
+      const Notification = Rpc.make("notification", {
+        payload: Schema.Struct({}),
+        success: Schema.Struct({})
+      })
+
+      expect(McpProtocolInternal.make).type.not.toBeCallableWith({
+        protocolVersion: "test",
+        clientRpcs: RpcGroup.make(Request),
+        clientNotificationRpcs: RpcGroup.make(Notification),
+        serverRequestRpcs: RpcGroup.make(),
+        serverNotificationRpcs: RpcGroup.make()
       })
     })
 


### PR DESCRIPTION
## Type

- [x] Refactor
- [x] Feature

## Goal/Scope

Prepare `McpServer` to support multiple incompatible MCP protocol versions through one endpoint without merging their schemas into a permissive shared protocol.

Adds the version-isolation seam and the `2025-06-18` adapter, but does not implement the `2025-11-25` or `2026-07-28` protocols.

## Description

Servers now declare an ordered, non-empty list of implemented adapters:

```text
protocols: [McpProtocol.v2025_06_18]
```

An adapter contains its version and the four RPC groups used for client requests, client notifications, server requests, and server notifications. This prevents a server from advertising support using only a version string.

`ProtocolRegistry` snapshots the declaration, rejects duplicate versions, and selects an exact match or falls back to the first declared adapter. Allowing incoming methods to be routed to versioned internal keys before payload decoding:

```text
tools/call
→ @effect/mcp/2025-06-18/tools/call
```

The internal key selects exactly one adapter's schema and handler. The existing `RpcServer` still owns decoding, middleware, handler execution, and response encoding.

Successful initialization pins the selected adapter to the session. Later requests, reverse client requests, and outbound notifications all reuse that adapter.

## How to Review

1. Start with `McpProtocol.ts` and `internal/mcpProtocol.ts`. Confirm an adapter represents executable support rather than only a version identifier.

2. Review `internal/mcpProtocolRegistry.ts`. Check the declaration snapshot, duplicate rejection, first-adapter fallback, and versioned RPC-group merge.

3. Follow one request through `runWithRegistry` in `McpServer.ts`:

   ```text
   raw initialize
   → inspect protocolVersion
   → select adapter
   → route to versioned key
   → decode and execute through RpcServer
   → store adapter in session
   ```

   The important invariant is that adapter selection happens before schema decoding and is not renegotiated after initialization.

4. Review `layerHandlers` and `addProtocolHandlers`. Shared MCP domain handlers are prepared with `RpcGroup.toHandlers` and registered under each adapter's versioned key.

5. Review the protocol and server tests. They cover registry validation and fallback, incompatible schema isolation, session pinning, the HTTP protocol header, missing sessions, and preservation of the June stdio transcript.

## Comments

Only `McpProtocol.v2025_06_18` is public in this phase. Later versions can introduce distinct schemas and projections without changing the selection boundary.

Server-originated MCP notifications expose an existing mismatch with `RpcServer.Protocol.send`, which only models RPC responses. The narrow cast is retained with a TODO: changing the RPC transport contract is outside this PR.

## Related

- closes #6617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adapter-based MCP protocol support, with built-in support starting at `2025-06-18`.
  * MCP servers now negotiate, pin, and use the correct protocol per session for routing requests and notifications.
  * MCP server client context now exposes the negotiated `protocolVersion`.
* **Bug Fixes**
  * Improved MCP protocol header validation and protocol selection, including rejecting unsupported offered protocol versions.
  * Enhanced protocol-aware decoding; `notifications/cancelled` now behaves as an interrupt.
* **Documentation**
  * Updated MCP server examples to configure `protocols` explicitly and reflect the new support floor.
* **Tests**
  * Expanded MCP protocol/server tests and added type-level validation for the updated server API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->