### PR TITLE
Fix Schema enum codegen type

### DIFF
--- a/packages/effect/src/internal/schema/toCodeDocument.ts
+++ b/packages/effect/src/internal/schema/toCodeDocument.ts
@@ -465,7 +465,7 @@ export function toCodeDocument(
             `typeof ${identifier}`
           )
         })
-        return makeCode(`Schema.Enum(${identifier})`, `typeof ${identifier}`)
+        return makeCode(`Schema.Enum(${identifier})`, identifier)
       }
       case "TemplateLiteral": {
         const parts = representation.parts.map((part, index) => recur(part, [...path, "parts", index], false))

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -628,7 +628,7 @@ describe("toCodeDocument", () => {
           })
         },
         {
-          codes: makeCode(`Schema.Enum(_Enum)`, `typeof _Enum`),
+          codes: makeCode(`Schema.Enum(_Enum)`, `_Enum`),
           artifacts: [{
             _tag: "Enum",
             identifier: "_Enum",
@@ -646,7 +646,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.Enum(_Enum).annotate({ "description": "a" })`,
-            `typeof _Enum`
+            `_Enum`
           ),
           artifacts: [{
             _tag: "Enum",
@@ -666,7 +666,7 @@ describe("toCodeDocument", () => {
           })
         },
         {
-          codes: makeCode(`Schema.Enum(_Enum)`, `typeof _Enum`),
+          codes: makeCode(`Schema.Enum(_Enum)`, `_Enum`),
           artifacts: [{
             _tag: "Enum",
             identifier: "_Enum",
@@ -684,7 +684,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.Enum(_Enum).annotate({ "description": "a" })`,
-            `typeof _Enum`
+            `_Enum`
           ),
           artifacts: [{
             _tag: "Enum",
@@ -704,7 +704,7 @@ describe("toCodeDocument", () => {
           })
         },
         {
-          codes: makeCode(`Schema.Enum(_Enum)`, `typeof _Enum`),
+          codes: makeCode(`Schema.Enum(_Enum)`, `_Enum`),
           artifacts: [{
             _tag: "Enum",
             identifier: "_Enum",
@@ -722,7 +722,7 @@ describe("toCodeDocument", () => {
         {
           codes: makeCode(
             `Schema.Enum(_Enum).annotate({ "description": "a" })`,
-            `typeof _Enum`
+            `_Enum`
           ),
           artifacts: [{
             _tag: "Enum",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated type representations for enum schemas.
  * Enum code output now consistently references the enum identifier while preserving the correct runtime definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->