### PR TITLE
Fix Schema numeric index key matching

### DIFF
--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3682,7 +3682,7 @@ export const STRING_PATTERN = "[\\s\\S]*?"
 
 const isStringFiniteRegExp = new globalThis.RegExp(`^${FINITE_PATTERN}$`)
 
-const isStringNumberRegExp = new globalThis.RegExp(`(?:${FINITE_PATTERN}|Infinity|-Infinity|NaN)`)
+const isStringNumberRegExp = new globalThis.RegExp(`^(?:${FINITE_PATTERN}|Infinity|-Infinity|NaN)$`)
 
 /** @internal */
 export function isStringFinite(annotations?: Schema.Annotations.Filter) {

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -414,7 +414,7 @@ describe("SchemaAST", () => {
     })
 
     it("Number", () => {
-      const input = { "1": 1, "1.5": 2, "-2": 3, a: 4, NaN: 5 }
+      const input = { "1": 1, "1.5": 2, "-2": 3, a: 4, NaN: 5, x1: 6, "1x": 7 }
       deepStrictEqual(SchemaAST.getIndexSignatureKeys(input, Schema.Number.ast, SchemaAST.defaultParseOptions), [
         "1",
         "1.5",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for numeric object keys so only complete, valid numeric strings are accepted.
  * Non-numeric-like keys are now correctly ignored when identifying numeric index keys.

* **Tests**
  * Expanded coverage for objects containing additional non-numeric property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->