### PR TITLE
Fix Schema StringTree DAG validation

### DIFF
--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3917,14 +3917,7 @@ export const resolveDescription: (ast: AST) => string | undefined = InternalAnno
  * @internal
  */
 export function isJson(u: unknown): u is Schema.Json {
-  // `onPath` is the current recursion stack: nodes between the root and the
-  // one being visited. A hit here means we looped back to an ancestor — a
-  // real cycle, not a DAG — so the value is not JSON.
-  const onPath = new Set<unknown>()
-  // `validated` memoizes subtrees we've already fully checked. Without it, a
-  // diamond-shaped DAG (same node reached through multiple parents) would be
-  // re-traversed once per parent, which is exponential in the nesting depth.
-  const validated = new Set<unknown>()
+  const cache = new WeakMap<object, boolean>()
   return recur(u)
 
   function recur(u: unknown): boolean {
@@ -3937,11 +3930,9 @@ export function isJson(u: unknown): u is Schema.Json {
     if (typeof u !== "object" || u === undefined) {
       return false
     }
-    if (onPath.has(u)) {
-      return false
-    }
-    if (validated.has(u)) {
-      return true
+    const cached = cache.get(u)
+    if (cached !== undefined) {
+      return cached
     }
     const isArray = Array.isArray(u)
     if (!isArray) {
@@ -3950,7 +3941,7 @@ export function isJson(u: unknown): u is Schema.Json {
         return false
       }
     }
-    onPath.add(u)
+    cache.set(u, false)
     let ok = true
     if (isArray) {
       for (let index = 0; index < u.length; index++) {
@@ -3962,12 +3953,7 @@ export function isJson(u: unknown): u is Schema.Json {
     } else {
       ok = Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
     }
-    // Pop on exit so siblings reaching the same node via a different path
-    // don't see it as an ancestor (that would reject valid DAGs).
-    onPath.delete(u)
-    if (ok) {
-      validated.add(u)
-    }
+    cache.set(u, ok)
     return ok
   }
 }
@@ -4022,7 +4008,7 @@ export const objectKeywordToJson = new Link(
  * @internal
  */
 export function isStringTree(u: unknown): u is Schema.StringTree {
-  const seen = new Set<unknown>()
+  const cache = new WeakMap<object, boolean>()
   return recur(u)
 
   function recur(u: unknown): boolean {
@@ -4032,14 +4018,16 @@ export function isStringTree(u: unknown): u is Schema.StringTree {
     if (typeof u !== "object" || u === null) {
       return false
     }
-    if (seen.has(u)) {
-      return false
+    const cached = cache.get(u)
+    if (cached !== undefined) {
+      return cached
     }
-    seen.add(u)
-    if (Array.isArray(u)) {
-      return u.every(recur)
-    }
-    return Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
+    cache.set(u, false)
+    const ok = Array.isArray(u)
+      ? u.every(recur)
+      : Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
+    cache.set(u, ok)
+    return ok
   }
 }
 

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -96,6 +96,9 @@ describe("SchemaAST", () => {
     strictEqual(SchemaAST.isStringTree({ a: { b: "c" } }), true)
     strictEqual(SchemaAST.isStringTree({ a: ["b", { c: "d" }] }), true)
     strictEqual(SchemaAST.isStringTree({ a: { b: 1 } }), false)
+    // DAG
+    const shared = { value: "a" }
+    strictEqual(SchemaAST.isStringTree({ left: shared, right: shared }), true)
     // circular reference
     const circular: Record<string, unknown> = {}
     circular.self = circular


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of JSON-like and string-tree data structures.
  * Correctly handles shared object references while still rejecting cyclic structures.

* **Tests**
  * Added coverage confirming that valid graphs with shared substructures are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->