### PR TITLE
Fix Schema JSON stringification of undefined

### DIFF
--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -1015,13 +1015,10 @@ type StringifyJsonOptions = {
  * **Details**
  *
  * - Skips `None` inputs.
- * - On thrown stringify failures, such as circular references, fails with
+ * - If `JSON.stringify` throws or returns `undefined`, fails with
  *   `SchemaIssue.InvalidValue`.
  * - Supports optional `replacer` and `space` options, matching
  *   `JSON.stringify`.
- * - If `JSON.stringify` returns `undefined`, such as for `undefined`,
- *   functions, symbols, or a replacer that removes the root value, that
- *   `undefined` result is returned rather than converted into an `Issue`.
  *
  * **Example** (Stringifying JSON)
  *
@@ -1040,7 +1037,13 @@ type StringifyJsonOptions = {
 export function stringifyJson(options?: StringifyJsonOptions): Getter<string, unknown> {
   return onSome((input) =>
     Effect.try({
-      try: () => Option.some(JSON.stringify(input, options?.replacer, options?.space)),
+      try: () => {
+        const output = JSON.stringify(input, options?.replacer, options?.space)
+        if (output === undefined) {
+          throw new TypeError("Value cannot be represented as JSON")
+        }
+        return Option.some(output)
+      },
       catch: (e) => new SchemaIssue.InvalidValue(Option.some(input), { message: globalThis.String(e) })
     })
   )

--- a/packages/effect/test/schema/SchemaGetter.test.ts
+++ b/packages/effect/test/schema/SchemaGetter.test.ts
@@ -18,7 +18,7 @@ describe("SchemaGetter", () => {
   it.effect("stringifyJson fails when JSON.stringify returns undefined", () =>
     SchemaGetter.stringifyJson().run(Option.some(undefined), {}).pipe(
       Effect.flip,
-      Effect.asVoid
+      Effect.map((issue) => assert.strictEqual(issue._tag, "InvalidValue"))
     ))
 
   it("map", () => {

--- a/packages/effect/test/schema/SchemaGetter.test.ts
+++ b/packages/effect/test/schema/SchemaGetter.test.ts
@@ -1,6 +1,5 @@
-import { assert } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { DateTime, Effect, Option, Result, SchemaGetter } from "effect"
-import { describe, it } from "vitest"
 import { assertSome, deepStrictEqual } from "../utils/assert.ts"
 
 function makeAsserts<T, E>(getter: SchemaGetter.Getter<T, E>) {
@@ -16,6 +15,12 @@ function makeAsserts<T, E>(getter: SchemaGetter.Getter<T, E>) {
 }
 
 describe("SchemaGetter", () => {
+  it.effect("stringifyJson fails when JSON.stringify returns undefined", () =>
+    SchemaGetter.stringifyJson().run(Option.some(undefined), {}).pipe(
+      Effect.flip,
+      Effect.asVoid
+    ))
+
   it("map", () => {
     const getter = SchemaGetter.succeed(1).map((t) => t + 1)
     const result = Effect.runSync(getter.run(Option.some(1), {}))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON stringification now consistently reports invalid values when serialization fails or produces no output, including unsupported root values and cases where the root value is removed.

* **Tests**
  * Added coverage to verify that serialization failures (including `undefined` output) correctly produce an `InvalidValue` result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->