### PR TITLE
Fix empty struct union candidate selection

### DIFF
--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2459,7 +2459,7 @@ function getCandidateTypes(ast: AST): ReadonlyArray<Type> {
     case "Objects":
       return ast.propertySignatures.length || ast.indexSignatures.length
         ? ["object"]
-        : ["object", "array"]
+        : ["string", "number", "boolean", "symbol", "bigint", "object", "array", "function"]
     case "Enum":
       return Array.from(new Set(ast.enums.map(([, v]) => typeof v)))
     case "Literal":

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -4271,15 +4271,26 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.fail("a", `Expected exactly one member to match the input "a"`)
     })
 
-    it("{} & Literal", async () => {
+    it("Struct({}) preserves its semantics in a union", async () => {
       const schema = Schema.Union([
         Schema.Struct({}),
-        Schema.Literal("a")
+        Schema.Null
       ])
       const asserts = new TestSchema.Asserts(schema)
 
       const decoding = asserts.decoding()
+      const symbol = Symbol()
+      const fn = () => {}
+      await decoding.succeed("a")
+      await decoding.succeed(1)
+      await decoding.succeed(true)
+      await decoding.succeed(symbol)
+      await decoding.succeed(1n)
+      await decoding.succeed(fn)
+      await decoding.succeed({})
       await decoding.succeed([])
+      await decoding.succeed(null)
+      await decoding.fail(undefined, `Expected object | array | null, got undefined`)
     })
 
     describe("should exclude members based on failed sentinels", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected schema handling for empty object structures in unions.
  * Empty object schemas now correctly accept all non-nullish values while continuing to reject `undefined`.

* **Tests**
  * Expanded coverage across primitive values, objects, arrays, functions, symbols, bigints, and `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->