### PR TITLE
Fix Latch stale flush resuming waiters registered after close

### DIFF
--- a/.changeset/fix-latch-stale-flush.md
+++ b/.changeset/fix-latch-stale-flush.md
@@ -1,0 +1,11 @@
+---
+"effect": patch
+---
+
+Fix Latch open/release resuming waiters that registered after a subsequent close.
+
+`Latch.open` and `Latch.release` schedule the waiter flush on the fiber's
+dispatcher. Previously the flush drained whatever waiters existed at flush
+time, so a waiter that registered after the latch was closed again could be
+resumed by the stale flush. The waiters are now snapshotted at schedule time,
+so only waiters covered by an `open`/`release` call are resumed.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5516,9 +5516,6 @@ const succeedFalse = succeed(false)
 
 class Latch implements _Latch.Latch {
   waiters: Array<(_: Effect.Effect<void>) => void> = []
-  // waiters snapshotted at open/release time, awaiting the scheduled flush.
-  // Waiters that register after a subsequent close stay in `waiters` and are
-  // not resumed by a stale flush.
   scheduled: Array<(_: Effect.Effect<void>) => void> | undefined = undefined
   private _isOpen: boolean
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5550,9 +5550,12 @@ class Latch implements _Latch.Latch {
     }
   }
   private flushWaiters() {
-    this.flushScheduled()
+    // swap both arrays out before any resume runs: a resumed waiter can
+    // reentrantly close the latch and register new waiters, which must not
+    // be drained by this flush
     const waiters = this.waiters
     this.waiters = []
+    this.flushScheduled()
     for (let i = 0; i < waiters.length; i++) {
       waiters[i](exitVoid)
     }

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5516,7 +5516,10 @@ const succeedFalse = succeed(false)
 
 class Latch implements _Latch.Latch {
   waiters: Array<(_: Effect.Effect<void>) => void> = []
-  scheduled = false
+  // waiters snapshotted at open/release time, awaiting the scheduled flush.
+  // Waiters that register after a subsequent close stay in `waiters` and are
+  // not resumed by a stale flush.
+  scheduled: Array<(_: Effect.Effect<void>) => void> | undefined = undefined
   private _isOpen: boolean
 
   constructor(isOpen: boolean) {
@@ -5524,15 +5527,30 @@ class Latch implements _Latch.Latch {
   }
 
   private scheduleUnsafe(fiber: Fiber.Fiber<unknown, unknown>) {
-    if (this.scheduled || this.waiters.length === 0) {
+    if (this.waiters.length === 0) {
       return succeedTrue
     }
-    this.scheduled = true
-    fiber.currentDispatcher.scheduleTask(this.flushWaiters, 0)
+    if (this.scheduled === undefined) {
+      this.scheduled = this.waiters
+      fiber.currentDispatcher.scheduleTask(this.flushScheduled, 0)
+    } else {
+      for (let i = 0; i < this.waiters.length; i++) {
+        this.scheduled.push(this.waiters[i])
+      }
+    }
+    this.waiters = []
     return succeedTrue
   }
-  private flushWaiters = () => {
-    this.scheduled = false
+  private flushScheduled = () => {
+    if (this.scheduled === undefined) return
+    const waiters = this.scheduled
+    this.scheduled = undefined
+    for (let i = 0; i < waiters.length; i++) {
+      waiters[i](exitVoid)
+    }
+  }
+  private flushWaiters() {
+    this.flushScheduled()
     const waiters = this.waiters
     this.waiters = []
     for (let i = 0; i < waiters.length; i++) {
@@ -5558,9 +5576,14 @@ class Latch implements _Latch.Latch {
     }
     this.waiters.push(resume)
     return sync(() => {
-      const index = this.waiters.indexOf(resume)
+      let index = this.waiters.indexOf(resume)
       if (index !== -1) {
         this.waiters.splice(index, 1)
+      } else if (this.scheduled !== undefined) {
+        index = this.scheduled.indexOf(resume)
+        if (index !== -1) {
+          this.scheduled.splice(index, 1)
+        }
       }
     })
   })

--- a/packages/effect/test/Latch.test.ts
+++ b/packages/effect/test/Latch.test.ts
@@ -92,6 +92,27 @@ describe("Latch", () => {
       assert.isFalse(latch.isOpen())
     }))
 
+  it.effect("release does not resume waiters registered after the release", () =>
+    Effect.gen(function*() {
+      const latch = yield* Latch.make(false)
+      const covered = yield* Effect.forkChild(
+        Latch.await(latch),
+        { startImmediately: true }
+      )
+
+      yield* latch.release
+      const late = yield* Effect.forkChild(
+        Latch.await(latch),
+        { startImmediately: true }
+      )
+
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+
+      assert.isDefined(covered.pollUnsafe())
+      assert.isUndefined(late.pollUnsafe())
+    }))
+
   it.effect("openUnsafe does not resume waiters registered after a reentrant close", () =>
     Effect.gen(function*() {
       const latch = Latch.makeUnsafe(false)

--- a/packages/effect/test/Latch.test.ts
+++ b/packages/effect/test/Latch.test.ts
@@ -92,6 +92,79 @@ describe("Latch", () => {
       assert.isFalse(latch.isOpen())
     }))
 
+  it.effect("openUnsafe does not resume waiters registered after a reentrant close", () =>
+    Effect.gen(function*() {
+      const latch = Latch.makeUnsafe(false)
+      const tasks: Array<() => void> = []
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: "async",
+        makeDispatcher() {
+          return {
+            scheduleTask(task, _priority) {
+              tasks.push(task)
+            },
+            flush() {
+            }
+          }
+        },
+        shouldYield: () => false
+      }
+
+      let second: Fiber.Fiber<void> | undefined
+      yield* Effect.forkChild(
+        Effect.gen(function*() {
+          yield* Latch.await(latch)
+          latch.closeUnsafe()
+          second = yield* Effect.forkChild(Latch.await(latch), { startImmediately: true })
+          return yield* Effect.never
+        }),
+        { startImmediately: true }
+      )
+
+      yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      latch.openUnsafe()
+      assert.isUndefined(second!.pollUnsafe())
+    }))
+
+  it.effect("interrupting a waiter removes it from a pending flush", () =>
+    Effect.gen(function*() {
+      const latch = yield* Latch.make(false)
+      const tasks: Array<() => void> = []
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: "async",
+        makeDispatcher() {
+          return {
+            scheduleTask(task, _priority) {
+              tasks.push(task)
+            },
+            flush() {
+            }
+          }
+        },
+        shouldYield: () => false
+      }
+
+      const resumed: Array<string> = []
+      const waiter = yield* Effect.forkChild(
+        Effect.gen(function*() {
+          yield* Latch.await(latch)
+          resumed.push("waiter")
+        }),
+        { startImmediately: true }
+      )
+
+      yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      assert.lengthOf(tasks, 1)
+
+      yield* Fiber.interrupt(waiter)
+      const exit = yield* Fiber.await(waiter)
+      assert.isTrue(Exit.hasInterrupts(exit))
+
+      tasks.shift()!()
+      assert.deepStrictEqual(resumed, [])
+      assert.isFalse(latch.isOpen())
+    }))
+
   it.effect("await is interruptible and cleans up interrupted waiters", () =>
     Effect.gen(function*() {
       const latch = yield* Latch.make(false)

--- a/packages/effect/test/Latch.test.ts
+++ b/packages/effect/test/Latch.test.ts
@@ -145,6 +145,9 @@ describe("Latch", () => {
       yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
       latch.openUnsafe()
       assert.isUndefined(second!.pollUnsafe())
+      assert.lengthOf(tasks, 1)
+      tasks.shift()!()
+      assert.isUndefined(second!.pollUnsafe())
     }))
 
   it.effect("interrupting a waiter removes it from a pending flush", () =>

--- a/packages/effect/test/Latch.test.ts
+++ b/packages/effect/test/Latch.test.ts
@@ -32,6 +32,66 @@ describe("Latch", () => {
       assert.isTrue(latch.isOpen())
     }))
 
+  it.effect("open then close does not resume waiters registered after close", () =>
+    Effect.gen(function*() {
+      const latch = Latch.makeUnsafe(false)
+      const before = yield* Effect.forkChild(
+        Latch.await(latch),
+        { startImmediately: true }
+      )
+
+      yield* latch.open
+      yield* latch.close
+      const after = yield* Effect.forkChild(
+        Latch.await(latch),
+        { startImmediately: true }
+      )
+
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+
+      assert.isDefined(before.pollUnsafe())
+      assert.isUndefined(after.pollUnsafe())
+    }))
+
+  it.effect("release while a flush is pending covers the new waiters", () =>
+    Effect.gen(function*() {
+      const latch = yield* Latch.make(false)
+      const tasks: Array<() => void> = []
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: "async",
+        makeDispatcher() {
+          return {
+            scheduleTask(task, _priority) {
+              tasks.push(task)
+            },
+            flush() {
+            }
+          }
+        },
+        shouldYield: () => false
+      }
+
+      const first = yield* Effect.forkChild(
+        Latch.await(latch),
+        { startImmediately: true }
+      )
+      yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      assert.lengthOf(tasks, 1)
+
+      const second = yield* Effect.forkChild(
+        Latch.await(latch),
+        { startImmediately: true }
+      )
+      yield* latch.release.pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      assert.lengthOf(tasks, 1)
+
+      tasks.shift()!()
+      yield* Fiber.join(first)
+      yield* Fiber.join(second)
+      assert.isFalse(latch.isOpen())
+    }))
+
   it.effect("await is interruptible and cleans up interrupted waiters", () =>
     Effect.gen(function*() {
       const latch = yield* Latch.make(false)


### PR DESCRIPTION
## Problem

`Latch.open` / `Latch.release` schedule `flushWaiters` on the fiber dispatcher, which runs on a later macrotask. The flush drained whatever was in the `waiters` array at flush time, with no snapshot and no state check. If the latch was closed again before the flush ran, a waiter that registered **after** the close — never covered by any `open`/`release` — was incorrectly resumed:

```ts
const latch = Latch.makeUnsafe(false)
const w1 = yield* Effect.forkChild(latch.await) // waiters exist, so open() schedules a flush
yield* latch.open   // isOpen = true, flush queued for a later macrotask
yield* latch.close  // isOpen = false before the flush runs
yield* latch.await  // suspends on a CLOSED latch — but the stale flush resumed it
```

This violates the documented contract that `await` on a closed latch suspends until a subsequent `open`/`release`, and gating logic built on `Latch` could observe work proceeding while the gate is closed.

## Fix

Snapshot the waiters at schedule time: `open`/`release` move the current waiters into a pending `scheduled` array, and the scheduled flush resumes only that snapshot. Waiters that register afterwards stay in `waiters` and are untouched by a stale flush.

- A `release` while a flush is already pending extends the snapshot with the newly covered waiters (no extra dispatcher task).
- `await` interruption cleanup also removes the waiter from the pending snapshot.
- `openUnsafe` still flushes everything synchronously (pending snapshot + current waiters).

## Tests

Added two regression tests in `packages/effect/test/Latch.test.ts`:

- `open then close does not resume waiters registered after close` — fails on `main`, passes with the fix.
- `release while a flush is pending covers the new waiters` — exercises the snapshot-extension path with a manual scheduler.

`pnpm check`, oxlint/dprint, and the Latch/Effect/Channel/PubSub/Fiber/SubscriptionRef suites (320 tests) pass.

Closes EFF-52

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed latch wake-up behavior to avoid resuming waiters added after a close from a previously scheduled flush.
  * Wake-ups are now limited to the waiters captured for the related open/release, including reentrant close scenarios.
  * Improved cancellation so interrupted waiters aren’t resumed by queued wake-ups.
* **Tests**
  * Added concurrency and edge-case tests for stale flush prevention, pending flush behavior, repeated releases, reentrant close, and cancellation during queued wake-ups.
* **Documentation**
  * Updated documented latch behavior to reflect the corrected waiter flushing semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->