### PR TITLE
Fix PartitionedSemaphore permit leak on interruption

### DIFF
--- a/.changeset/eff-51-partitioned-semaphore-interruption.md
+++ b/.changeset/eff-51-partitioned-semaphore-interruption.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `PartitionedSemaphore.take` leaking partially acquired permits when interrupted.

--- a/packages/effect/src/PartitionedSemaphore.ts
+++ b/packages/effect/src/PartitionedSemaphore.ts
@@ -193,7 +193,6 @@ export const makeUnsafe = <K = unknown>(options: {
       }
 
       const needed = permits - totalPermits
-      const taken = permits - needed
       if (totalPermits > 0) {
         totalPermits = 0
       }
@@ -228,9 +227,7 @@ export const makeUnsafe = <K = unknown>(options: {
       return Effect.sync(() => {
         cleanup()
         waitingPermits -= entry.permits
-        if (taken > 0) {
-          releaseUnsafe(taken)
-        }
+        releaseUnsafe(permits - entry.permits)
       })
     })
   }

--- a/packages/effect/test/PartitionedSemaphore.test.ts
+++ b/packages/effect/test/PartitionedSemaphore.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Option, PartitionedSemaphore } from "effect"
+import { Effect, Fiber, Option, PartitionedSemaphore } from "effect"
 
 describe("PartitionedSemaphore", () => {
   it.effect("module-level combinators delegate to the instance api", () =>
@@ -70,5 +70,21 @@ describe("PartitionedSemaphore", () => {
 
       assert.deepStrictEqual(result, Option.none())
       assert.isFalse(executed)
+    }))
+
+  it.effect("interrupting a partially satisfied waiter releases all acquired permits", () =>
+    Effect.gen(function*() {
+      const sem = yield* PartitionedSemaphore.make<string>({ permits: 4 })
+
+      yield* PartitionedSemaphore.take(sem, "a", 3)
+      const waiter = yield* PartitionedSemaphore.take(sem, "b", 3).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+
+      yield* PartitionedSemaphore.release(sem, 1)
+      yield* Fiber.interrupt(waiter)
+      yield* PartitionedSemaphore.release(sem, 2)
+
+      assert.strictEqual(yield* PartitionedSemaphore.available(sem), 4)
+      yield* PartitionedSemaphore.take(sem, "c", 4)
     }))
 })

--- a/packages/effect/test/PartitionedSemaphore.test.ts
+++ b/packages/effect/test/PartitionedSemaphore.test.ts
@@ -81,7 +81,9 @@ describe("PartitionedSemaphore", () => {
       yield* Effect.yieldNow
 
       yield* PartitionedSemaphore.release(sem, 1)
+      assert.strictEqual(yield* PartitionedSemaphore.available(sem), 0)
       yield* Fiber.interrupt(waiter)
+      assert.strictEqual(yield* PartitionedSemaphore.available(sem), 2)
       yield* PartitionedSemaphore.release(sem, 2)
 
       assert.strictEqual(yield* PartitionedSemaphore.available(sem), 4)


### PR DESCRIPTION
## Summary

- restore permits drip-fed to an interrupted `PartitionedSemaphore` waiter
- add a regression test covering partial waiter satisfaction and full-capacity reacquisition
- add a patch changeset for `effect`

## Testing

- `pnpm test packages/effect/test/PartitionedSemaphore.test.ts`
- `pnpm test packages/effect/test/Semaphore.test.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where interrupting a semaphore `take` that had partially acquired permits could temporarily leave permits unavailable.
  * Ensured surplus/partially acquired permits are correctly released on interruption.
  * Added test coverage to verify availability is fully restored after interrupted partial acquisitions, including a final successful `take` for all permits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->