### PR TITLE
Make schema tree validation stack safe

### DIFF
--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3909,6 +3909,86 @@ export const resolveTitle: (ast: AST) => string | undefined = InternalAnnotation
  */
 export const resolveDescription: (ast: AST) => string | undefined = InternalAnnotations.resolveDescription
 
+type TreeFrame = {
+  readonly value: object
+  readonly keys: ReadonlyArray<string> | undefined
+  index: number
+  readonly length: number
+}
+
+function isJsonLeaf(u: unknown): boolean {
+  return u === null || typeof u === "string" || typeof u === "boolean" ||
+    typeof u === "number" && globalThis.Number.isFinite(u)
+}
+
+function isStringTreeLeaf(u: unknown): boolean {
+  return u === undefined || typeof u === "string"
+}
+
+function isTree(u: unknown, isLeaf: (u: unknown) => boolean): boolean {
+  const cache = new WeakMap<object, boolean>()
+  const stack: Array<TreeFrame> = []
+  outer: while (true) {
+    if (typeof u !== "object" || u === null) {
+      if (!isLeaf(u)) {
+        return false
+      }
+    } else {
+      const value = u
+      const cached = cache.get(value)
+      // `false` marks a node on the current path, while `true` marks a fully
+      // validated node that can be safely reused by a DAG.
+      if (cached === false) {
+        return false
+      }
+      if (cached === undefined) {
+        const isArray = Array.isArray(value)
+        if (!isArray) {
+          const prototype = Object.getPrototypeOf(value)
+          // A plain object from another realm has a different Object.prototype,
+          // but that prototype still has a null prototype.
+          if (
+            prototype !== null &&
+            prototype !== Object.prototype &&
+            Object.getPrototypeOf(prototype) !== null
+          ) {
+            return false
+          }
+        }
+        cache.set(value, false)
+        stack.push({
+          value,
+          keys: isArray ? undefined : Object.keys(value),
+          index: 0,
+          // Snapshot the length so getters cannot extend the traversal.
+          length: isArray ? value.length : 0
+        })
+      }
+    }
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]
+      if (frame.keys !== undefined) {
+        if (frame.index < frame.keys.length) {
+          u = (frame.value as Record<string, unknown>)[frame.keys[frame.index++]]
+          continue outer
+        }
+      } else {
+        const value = frame.value as ReadonlyArray<unknown>
+        if (frame.index < frame.length) {
+          // A sparse slot is read as `undefined`; the leaf predicate determines
+          // whether that is valid for the current tree.
+          u = value[frame.index++]
+          continue outer
+        }
+      }
+      cache.set(frame.value, true)
+      stack.pop()
+    }
+    return true
+  }
+}
+
 /**
  * Returns true if the value is a JSON value.
  *
@@ -3917,45 +3997,7 @@ export const resolveDescription: (ast: AST) => string | undefined = InternalAnno
  * @internal
  */
 export function isJson(u: unknown): u is Schema.Json {
-  const cache = new WeakMap<object, boolean>()
-  return recur(u)
-
-  function recur(u: unknown): boolean {
-    if (u === null || typeof u === "string" || typeof u === "boolean") {
-      return true
-    }
-    if (typeof u === "number") {
-      return globalThis.Number.isFinite(u)
-    }
-    if (typeof u !== "object" || u === undefined) {
-      return false
-    }
-    const cached = cache.get(u)
-    if (cached !== undefined) {
-      return cached
-    }
-    const isArray = Array.isArray(u)
-    if (!isArray) {
-      const prototype = Object.getPrototypeOf(u)
-      if (prototype !== null && Object.getPrototypeOf(prototype) !== null) {
-        return false
-      }
-    }
-    cache.set(u, false)
-    let ok = true
-    if (isArray) {
-      for (let index = 0; index < u.length; index++) {
-        if (!Object.hasOwn(u, index) || !recur(u[index])) {
-          ok = false
-          break
-        }
-      }
-    } else {
-      ok = Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
-    }
-    cache.set(u, ok)
-    return ok
-  }
+  return isTree(u, isJsonLeaf)
 }
 
 /** @internal */
@@ -4008,27 +4050,7 @@ export const objectKeywordToJson = new Link(
  * @internal
  */
 export function isStringTree(u: unknown): u is Schema.StringTree {
-  const cache = new WeakMap<object, boolean>()
-  return recur(u)
-
-  function recur(u: unknown): boolean {
-    if (u === undefined || typeof u === "string") {
-      return true
-    }
-    if (typeof u !== "object" || u === null) {
-      return false
-    }
-    const cached = cache.get(u)
-    if (cached !== undefined) {
-      return cached
-    }
-    cache.set(u, false)
-    const ok = Array.isArray(u)
-      ? u.every(recur)
-      : Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
-    cache.set(u, ok)
-    return ok
-  }
+  return isTree(u, isStringTreeLeaf)
 }
 
 const StringTree = new Declaration(

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3911,9 +3911,9 @@ export const resolveDescription: (ast: AST) => string | undefined = InternalAnno
 
 type TreeFrame = {
   readonly value: object
-  readonly keys: ReadonlyArray<string> | undefined
+  // Object keys or an array length snapshot.
+  readonly keys: ReadonlyArray<string> | number
   index: number
-  readonly length: number
 }
 
 function isJsonLeaf(u: unknown): boolean {
@@ -3958,29 +3958,25 @@ function isTree(u: unknown, isLeaf: (u: unknown) => boolean): boolean {
         cache.set(value, false)
         stack.push({
           value,
-          keys: isArray ? undefined : Object.keys(value),
-          index: 0,
-          // Snapshot the length so getters cannot extend the traversal.
-          length: isArray ? value.length : 0
+          keys: isArray ? value.length : Object.keys(value),
+          index: 0
         })
       }
     }
 
     while (stack.length > 0) {
       const frame = stack[stack.length - 1]
-      if (frame.keys !== undefined) {
-        if (frame.index < frame.keys.length) {
-          u = (frame.value as Record<string, unknown>)[frame.keys[frame.index++]]
-          continue outer
-        }
-      } else {
-        const value = frame.value as ReadonlyArray<unknown>
-        if (frame.index < frame.length) {
+      const keys = frame.keys
+      if (typeof keys === "number") {
+        if (frame.index < keys) {
           // A sparse slot is read as `undefined`; the leaf predicate determines
           // whether that is valid for the current tree.
-          u = value[frame.index++]
+          u = (frame.value as ReadonlyArray<unknown>)[frame.index++]
           continue outer
         }
+      } else if (frame.index < keys.length) {
+        u = (frame.value as Record<string, unknown>)[keys[frame.index++]]
+        continue outer
       }
       cache.set(frame.value, true)
       stack.pop()

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -70,6 +70,17 @@ describe("SchemaAST", () => {
     strictEqual(SchemaAST.isJson(deeper), true)
   })
 
+  it("isJson is stack safe", () => {
+    let valid: unknown = null
+    let invalid: unknown = undefined
+    for (let i = 0; i < 25_000; i++) {
+      valid = [valid]
+      invalid = [invalid]
+    }
+    strictEqual(SchemaAST.isJson(valid), true)
+    strictEqual(SchemaAST.isJson(invalid), false)
+  })
+
   it("Schema.toCodecJson rejects non-JSON objects", () => {
     const encode = Schema.encodeUnknownExit(Schema.toCodecJson(Schema.Unknown))
     strictEqual(encode(new Map([["a", 1]]))._tag, "Failure")
@@ -88,10 +99,22 @@ describe("SchemaAST", () => {
     strictEqual(SchemaAST.isStringTree(["a"]), true)
     strictEqual(SchemaAST.isStringTree(["a", undefined]), true)
     strictEqual(SchemaAST.isStringTree(["a", 1]), false)
+    strictEqual(SchemaAST.isStringTree(new Array(1)), true)
+    const sparseWithInheritedValue = new Array(1)
+    const arrayPrototype = Object.create(Array.prototype)
+    arrayPrototype[0] = 1
+    Object.setPrototypeOf(sparseWithInheritedValue, arrayPrototype)
+    strictEqual(SchemaAST.isStringTree(sparseWithInheritedValue), false)
     strictEqual(SchemaAST.isStringTree({}), true)
     strictEqual(SchemaAST.isStringTree({ a: "b" }), true)
     strictEqual(SchemaAST.isStringTree({ a: undefined }), true)
     strictEqual(SchemaAST.isStringTree({ a: "b", c: 1 }), false)
+    strictEqual(SchemaAST.isStringTree(new Map([["a", "b"]])), false)
+    strictEqual(SchemaAST.isStringTree(new Date(0)), false)
+    class A {
+      readonly a = "a"
+    }
+    strictEqual(SchemaAST.isStringTree(new A()), false)
     // nested
     strictEqual(SchemaAST.isStringTree({ a: { b: "c" } }), true)
     strictEqual(SchemaAST.isStringTree({ a: ["b", { c: "d" }] }), true)
@@ -103,6 +126,17 @@ describe("SchemaAST", () => {
     const circular: Record<string, unknown> = {}
     circular.self = circular
     strictEqual(SchemaAST.isStringTree(circular), false)
+  })
+
+  it("isStringTree is stack safe", () => {
+    let valid: unknown = "value"
+    let invalid: unknown = 1
+    for (let i = 0; i < 25_000; i++) {
+      valid = { value: valid }
+      invalid = { value: invalid }
+    }
+    strictEqual(SchemaAST.isStringTree(valid), true)
+    strictEqual(SchemaAST.isStringTree(invalid), false)
   })
 
   describe("toType", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of deeply nested JSON and string-tree structures to avoid stack overflows.
  * Strengthened detection and rejection of cyclic references, sparse arrays, inherited/prototypal values, and non-plain object shapes.
  * Enhanced consistency across edge cases including arrays, maps, dates, and class instances.
  * Added regression tests covering deep nesting and additional tricky invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->