### PR TITLE
Add manual flush registry to OtlpExporter

### DIFF
--- a/.changeset/add-otlp-manual-flush.md
+++ b/.changeset/add-otlp-manual-flush.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add manual flushing to the OTLP exporters through a shared `Flusher` service exposed by each signal layer. The signal layer output types now include `Flusher`, and `OtlpExporter.make` requires it so custom exporters register unconditionally.

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -58,7 +58,7 @@ const policy = Schedule.forever.pipe(
  * @category flushing
  * @since 4.0.0
  */
-export interface Flusher {
+export class Flusher extends Context.Service<Flusher, {
   /**
    * Drains all registered exporters concurrently and cannot fail.
    *
@@ -86,17 +86,9 @@ export interface Flusher {
    */
   readonly flush: Effect.Effect<void>
   readonly register: (run: Effect.Effect<void>) => Effect.Effect<void, never, Scope.Scope>
-}
-
-/**
- * Context key for the shared exporter flush registry.
- *
- * @category flushing
- * @since 4.0.0
- */
-export const Flusher: Context.Key<Flusher, Flusher> = Context.Service<Flusher>(
+}>()(
   "effect/observability/OtlpExporter/Flusher"
-)
+) {}
 
 /**
  * Provides a `Flusher` backed by a fresh registry.
@@ -110,7 +102,7 @@ export const Flusher: Context.Key<Flusher, Flusher> = Context.Service<Flusher>(
  * layer per call would silently create one registry per signal.
  *
  * Registration is scoped — an exporter is removed from the registry when its
- * own scope closes. Flushing with an empty registry is a debug-logged no-op.
+ * own scope closes. Flushing with an empty registry is a no-op.
  *
  * Note that `flush` cannot await an export that was already in flight when it
  * was called (for example one started by the export interval); it only waits
@@ -124,7 +116,7 @@ export const layerFlusher: Layer.Layer<Flusher> = Layer.sync(Flusher, () => {
   return {
     flush: Effect.suspend(() => {
       if (registry.size === 0) {
-        return Effect.logDebug("Flush requested but no OTLP exporters are registered")
+        return Effect.void
       }
       return Effect.forEach(registry, identity, {
         concurrency: "unbounded",
@@ -224,7 +216,7 @@ export const make: (
   )
 
   const flusher = yield* Flusher
-  yield* Effect.provideService(flusher.register(runExport), Scope.Scope, scope)
+  yield* flusher.register(runExport)
 
   yield* Scope.addFinalizer(
     scope,

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -13,6 +13,8 @@ import * as Context from "../../Context.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
 import * as Fiber from "../../Fiber.ts"
+import { identity } from "../../Function.ts"
+import * as Layer from "../../Layer.ts"
 import * as Num from "../../Number.ts"
 import * as Option from "../../Option.ts"
 import * as Schedule from "../../Schedule.ts"
@@ -42,6 +44,80 @@ const policy = Schedule.forever.pipe(
 )
 
 /**
+ * Registry of exporter flush operations, used to manually drain buffered
+ * telemetry before the surrounding scope closes.
+ *
+ * **Details**
+ *
+ * Every exporter created by `make` registers its export operation here, so a
+ * single `flush` drains all signals sharing the registry. `flush` returns only
+ * after the exports it initiated have settled, cannot fail, and respects each
+ * exporter's temporary-disable window. Wrap it with `Effect.timeoutOption` to
+ * bound its duration at the call site.
+ *
+ * @category flushing
+ * @since 4.0.0
+ */
+export interface Flusher {
+  readonly flush: Effect.Effect<void>
+  readonly register: (run: Effect.Effect<void>) => Effect.Effect<void, never, Scope.Scope>
+}
+
+/**
+ * Context key for the shared exporter flush registry.
+ *
+ * @category flushing
+ * @since 4.0.0
+ */
+export const Flusher: Context.Key<Flusher, Flusher> = Context.Service<Flusher>(
+  "effect/observability/OtlpExporter/Flusher"
+)
+
+/**
+ * Provides a `Flusher` backed by a fresh registry.
+ *
+ * **Details**
+ *
+ * This is intentionally a single module-level constant rather than a factory:
+ * layer memoization is keyed by layer instance, so every signal layer
+ * referencing this same constant shares one registry per layer build, and one
+ * `flush` drains traces, logs and metrics together. A factory returning a new
+ * layer per call would silently create one registry per signal.
+ *
+ * Registration is scoped — an exporter is removed from the registry when its
+ * own scope closes. Flushing with an empty registry is a debug-logged no-op.
+ *
+ * Note that `flush` cannot await an export that was already in flight when it
+ * was called (for example one started by the export interval); it only waits
+ * for the exports it initiates.
+ *
+ * @category flushing
+ * @since 4.0.0
+ */
+export const layerFlusher: Layer.Layer<Flusher> = Layer.sync(Flusher, () => {
+  const registry = new Set<Effect.Effect<void>>()
+  return {
+    flush: Effect.suspend(() => {
+      if (registry.size === 0) {
+        return Effect.logDebug("Flush requested but no OTLP exporters are registered")
+      }
+      return Effect.forEach(registry, identity, {
+        concurrency: "unbounded",
+        discard: true
+      })
+    }),
+    register: (run) =>
+      Effect.flatMap(Scope.Scope, (scope) => {
+        registry.add(run)
+        return Scope.addFinalizer(
+          scope,
+          Effect.sync(() => registry.delete(run))
+        )
+      })
+  }
+})
+
+/**
  * Creates a scoped OTLP batch exporter.
  *
  * **Details**
@@ -67,7 +143,7 @@ export const make: (
 ) => Effect.Effect<
   { readonly push: (data: unknown) => void },
   never,
-  HttpClient.HttpClient | Scope.Scope
+  Flusher | HttpClient.HttpClient | Scope.Scope
 > = Effect.fnUntraced(function*(options) {
   const services = yield* Effect.context<Scope.Scope | HttpClient.HttpClient>()
   const clock = Context.get(services, Clock)
@@ -121,6 +197,9 @@ export const make: (
       module: options.label
     })
   )
+
+  const flusher = yield* Flusher
+  yield* Effect.provideService(flusher.register(runExport), Scope.Scope, scope)
 
   yield* Scope.addFinalizer(
     scope,

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -59,6 +59,31 @@ const policy = Schedule.forever.pipe(
  * @since 4.0.0
  */
 export interface Flusher {
+  /**
+   * Drains all registered exporters concurrently and cannot fail.
+   *
+   * **Details**
+   *
+   * There is no built-in timeout; use `Effect.timeoutOption` to bound the
+   * operation. Exporters in their 60-second `disabledUntil` window are skipped.
+   *
+   * **Example** (Flushing from a Cloudflare Worker)
+   *
+   * ```ts
+   * import { Effect, ManagedRuntime } from "effect"
+   * import { OtlpExporter, OtlpTracer } from "effect/unstable/observability"
+   *
+   * const layer = OtlpTracer.layerFromConfig()
+   * const runtime = ManagedRuntime.make(layer)
+   *
+   * // In the request handler:
+   * ctx.waitUntil(
+   *   runtime.runPromise(
+   *     Effect.flatMap(OtlpExporter.Flusher, (flusher) => flusher.flush)
+   *   )
+   * )
+   * ```
+   */
   readonly flush: Effect.Effect<void>
   readonly register: (run: Effect.Effect<void>) => Effect.Effect<void, never, Scope.Scope>
 }

--- a/packages/effect/src/unstable/observability/OtlpLogger.ts
+++ b/packages/effect/src/unstable/observability/OtlpLogger.ts
@@ -57,7 +57,7 @@ export const make: (
 ) => Effect.Effect<
   Logger.Logger<unknown, void>,
   never,
-  OtlpSerialization | HttpClient.HttpClient | Scope.Scope
+  Exporter.Flusher | OtlpSerialization | HttpClient.HttpClient | Scope.Scope
 > = Effect.fnUntraced(function*(options) {
   const serialization = yield* OtlpSerialization
   const otelResource = yield* OtlpResource.fromConfig(options.resource)
@@ -116,10 +116,10 @@ export const layer = (options: {
   readonly shutdownTimeout?: Duration.Input | undefined
   readonly excludeLogSpans?: boolean | undefined
   readonly mergeWithExisting?: boolean | undefined
-}): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization> =>
+}): Layer.Layer<Exporter.Flusher, never, HttpClient.HttpClient | OtlpSerialization> =>
   Logger.layer([make(options)], {
     mergeWithExisting: options.mergeWithExisting ?? true
-  })
+  }).pipe(Layer.provideMerge(Exporter.layerFlusher))
 
 /**
  * Creates an OTLP logs layer from OpenTelemetry configuration.
@@ -136,7 +136,7 @@ export const layerFromConfig = (options?: {
   readonly headers?: Headers.Input | undefined
   readonly excludeLogSpans?: boolean | undefined
   readonly mergeWithExisting?: boolean | undefined
-}): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization> =>
+}): Layer.Layer<Exporter.Flusher, never, HttpClient.HttpClient | OtlpSerialization> =>
   Effect.gen(function*() {
     const { disabled, endpoint, exporters } = yield* Config.all({
       disabled: Config.boolean("OTEL_SDK_DISABLED").pipe(Config.withDefault(false)),
@@ -145,7 +145,7 @@ export const layerFromConfig = (options?: {
     })
 
     if (disabled || !endpoint || !exporters.includes("otlp")) {
-      return Layer.empty
+      return Exporter.layerFlusher
     }
 
     const { baseTimeout, logsTimeout, exportTimeout, scheduleDelay, maxBatchSize } = yield* Config.all({

--- a/packages/effect/src/unstable/observability/OtlpMetrics.ts
+++ b/packages/effect/src/unstable/observability/OtlpMetrics.ts
@@ -67,6 +67,9 @@ export type AggregationTemporality = "cumulative" | "delta"
  * **Details**
  *
  * The exporter snapshots registered Effect metrics on the configured interval, serializes them with the selected aggregation temporality, and flushes during scope finalization up to `shutdownTimeout`.
+ * Manual flushing also triggers a snapshot. With delta temporality, each
+ * snapshot advances the previous-export state, so frequent flushes narrow the
+ * delta aggregation windows.
  *
  * @category constructors
  * @since 4.0.0

--- a/packages/effect/src/unstable/observability/OtlpMetrics.ts
+++ b/packages/effect/src/unstable/observability/OtlpMetrics.ts
@@ -85,7 +85,7 @@ export const make: (options: {
 }) => Effect.Effect<
   void,
   never,
-  HttpClient.HttpClient | OtlpSerialization | Scope.Scope
+  Exporter.Flusher | HttpClient.HttpClient | OtlpSerialization | Scope.Scope
 > = Effect.fnUntraced(function*(options) {
   const clock = yield* Clock
   const serialization = yield* OtlpSerialization
@@ -464,7 +464,8 @@ export const layer = (options: {
   readonly exportInterval?: Duration.Input | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
   readonly temporality?: AggregationTemporality | undefined
-}): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization> => Layer.effectDiscard(make(options))
+}): Layer.Layer<Exporter.Flusher, never, HttpClient.HttpClient | OtlpSerialization> =>
+  Layer.effectDiscard(make(options)).pipe(Layer.provideMerge(Exporter.layerFlusher))
 
 /**
  * Creates an OTLP metrics layer from OpenTelemetry configuration.
@@ -479,7 +480,7 @@ export const layerFromConfig = (options?: {
     readonly attributes?: Record<string, unknown>
   } | undefined
   readonly headers?: Headers.Input | undefined
-}): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization> =>
+}): Layer.Layer<Exporter.Flusher, never, HttpClient.HttpClient | OtlpSerialization> =>
   Effect.gen(function*() {
     const { disabled, endpoint, exporters } = yield* Config.all({
       disabled: Config.boolean("OTEL_SDK_DISABLED").pipe(Config.withDefault(false)),
@@ -487,7 +488,7 @@ export const layerFromConfig = (options?: {
       exporters: OtlpEnv.exporters("METRICS")
     })
     if (disabled || !endpoint || !exporters.includes("otlp")) {
-      return Layer.empty
+      return Exporter.layerFlusher
     }
 
     const { baseTimeout, metricsTimeout, exportTimeout, exportInterval, temporalityPreference } = yield* Config.all({

--- a/packages/effect/src/unstable/observability/OtlpTracer.ts
+++ b/packages/effect/src/unstable/observability/OtlpTracer.ts
@@ -59,7 +59,7 @@ export const make: (
 ) => Effect.Effect<
   Tracer.Tracer,
   never,
-  OtlpSerialization | HttpClient.HttpClient | Scope.Scope
+  Exporter.Flusher | OtlpSerialization | HttpClient.HttpClient | Scope.Scope
 > = Effect.fnUntraced(function*(options) {
   const otelResource = yield* OtlpResource.fromConfig(options.resource)
   const serialization = yield* OtlpSerialization
@@ -134,7 +134,11 @@ export const layer: (options: {
   readonly maxBatchSize?: number | undefined
   readonly context?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
-}) => Layer.Layer<never, never, OtlpSerialization | HttpClient.HttpClient> = flow(make, Layer.effect(Tracer.Tracer))
+}) => Layer.Layer<Exporter.Flusher, never, OtlpSerialization | HttpClient.HttpClient> = flow(
+  make,
+  Layer.effect(Tracer.Tracer),
+  Layer.provideMerge(Exporter.layerFlusher)
+)
 
 /**
  * Creates an OTLP traces layer from OpenTelemetry configuration.
@@ -150,7 +154,7 @@ export const layerFromConfig = (options?: {
   } | undefined
   readonly headers?: Headers.Input | undefined
   readonly context?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
-}): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization> =>
+}): Layer.Layer<Exporter.Flusher, never, HttpClient.HttpClient | OtlpSerialization> =>
   Effect.gen(function*() {
     const { disabled, endpoint, exporters } = yield* Config.all({
       disabled: Config.boolean("OTEL_SDK_DISABLED").pipe(Config.withDefault(false)),
@@ -159,7 +163,7 @@ export const layerFromConfig = (options?: {
     })
 
     if (disabled || !endpoint || !exporters.includes("otlp")) {
-      return Layer.empty
+      return Exporter.layerFlusher
     }
 
     const { baseTimeout, tracesTimeout, exportTimeout, scheduleDelay, maxBatchSize } = yield* Config.all({

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -1,9 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Ref } from "effect"
+import { Clock, ConfigProvider, Effect, Exit, Fiber, Layer, Metric, Ref, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpBody, HttpClient, HttpClientResponse } from "effect/unstable/http"
 import type { HttpClientError } from "effect/unstable/http"
-import { OtlpExporter } from "effect/unstable/observability"
+import { OtlpExporter, OtlpLogger, OtlpMetrics, OtlpSerialization, OtlpTracer } from "effect/unstable/observability"
 
 const makeHttpClient = Effect.fnUntraced(function*(retryAfter: string | undefined) {
   const attempts = yield* Ref.make(0)
@@ -29,18 +29,38 @@ const makeHttpClient = Effect.fnUntraced(function*(retryAfter: string | undefine
 })
 
 const makeExporter = (httpClient: HttpClient.HttpClient) =>
+  makeExporterRaw().pipe(
+    Effect.provideService(HttpClient.HttpClient, httpClient),
+    Effect.provide(OtlpExporter.layerFlusher)
+  )
+
+const makeExporterRaw = (maxBatchSize: number | "disabled" = 1) =>
   OtlpExporter.make({
     label: "OtlpExporterTest",
     url: "http://localhost:4318/v1/logs",
     headers: undefined,
     exportInterval: "1 hour",
-    maxBatchSize: 1,
+    maxBatchSize,
     body: () => HttpBody.empty,
     shutdownTimeout: "1 second"
-  }).pipe(
-    Effect.provideService(HttpClient.HttpClient, httpClient),
-    Effect.provide(OtlpExporter.layerFlusher)
+  })
+
+const makeStatusHttpClient = Effect.fnUntraced(function*(status: number) {
+  const attempts = yield* Ref.make(0)
+  const urls = yield* Ref.make<ReadonlyArray<string>>([])
+
+  const httpClient = HttpClient.makeWith(
+    Effect.fnUntraced(function*(requestEffect) {
+      const request = yield* requestEffect
+      yield* Ref.update(attempts, (attempts) => attempts + 1)
+      yield* Ref.update(urls, (urls) => [...urls, request.url])
+      return HttpClientResponse.fromWeb(request, new Response(null, { status }))
+    }),
+    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
   )
+
+  return { attempts, httpClient, urls } as const
+})
 
 const yieldNowN = (times: number) =>
   Effect.forEach(Array.from({ length: times }), () => Effect.yieldNow, { discard: true })
@@ -108,4 +128,164 @@ describe("OtlpExporter", () => {
         assert.strictEqual(yield* Ref.get(attempts), 2)
       })
     ))
+
+  describe("flush", () => {
+    it.effect("exports buffered items without advancing to the export interval", () =>
+      Effect.gen(function*() {
+        const { attempts, httpClient } = yield* makeStatusHttpClient(200)
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            const exporter = yield* makeExporterRaw(10)
+            const flusher = yield* OtlpExporter.Flusher
+            const before = yield* Clock.currentTimeMillis
+
+            exporter.push({ value: 1 })
+            yield* flusher.flush
+
+            assert.strictEqual(yield* Clock.currentTimeMillis, before)
+            assert.strictEqual(yield* Ref.get(attempts), 1)
+          }).pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+            Effect.provide(OtlpExporter.layerFlusher)
+          )
+        )
+      }))
+
+    it.effect("shares one registry across traces, logs and metrics", () =>
+      Effect.gen(function*() {
+        const { httpClient, urls } = yield* makeStatusHttpClient(200)
+        const signals = Layer.mergeAll(
+          OtlpTracer.layer({
+            url: "http://localhost:4318/v1/traces",
+            resource: { serviceName: "test" },
+            exportInterval: "1 hour",
+            maxBatchSize: 100
+          }),
+          OtlpLogger.layer({
+            url: "http://localhost:4318/v1/logs",
+            resource: { serviceName: "test" },
+            exportInterval: "1 hour",
+            maxBatchSize: 100,
+            mergeWithExisting: false
+          }),
+          OtlpMetrics.layer({
+            url: "http://localhost:4318/v1/metrics",
+            resource: { serviceName: "test" },
+            exportInterval: "1 hour"
+          })
+        ).pipe(
+          Layer.provide(OtlpSerialization.layerJson),
+          Layer.provideMerge(Layer.succeed(HttpClient.HttpClient, httpClient))
+        )
+
+        yield* Effect.gen(function*() {
+          yield* Effect.log("flush test")
+          yield* Metric.update(Metric.counter("otlp_flush_test"), 1)
+          yield* Effect.void.pipe(Effect.withSpan("flush test"))
+
+          const flusher = yield* OtlpExporter.Flusher
+          yield* flusher.flush
+
+          assert.deepStrictEqual(
+            [...yield* Ref.get(urls)].sort(),
+            [
+              "http://localhost:4318/v1/logs",
+              "http://localhost:4318/v1/metrics",
+              "http://localhost:4318/v1/traces"
+            ]
+          )
+        }).pipe(Effect.provide(signals))
+      }))
+
+    it.effect("is a no-op while the exporter is disabled", () =>
+      Effect.gen(function*() {
+        const { attempts, httpClient } = yield* makeStatusHttpClient(400)
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            const exporter = yield* makeExporterRaw(10)
+            const flusher = yield* OtlpExporter.Flusher
+
+            exporter.push({ value: 1 })
+            yield* flusher.flush
+            assert.strictEqual(yield* Ref.get(attempts), 1)
+
+            exporter.push({ value: 2 })
+            yield* flusher.flush
+            assert.strictEqual(yield* Ref.get(attempts), 1)
+          }).pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+            Effect.provide(OtlpExporter.layerFlusher)
+          )
+        )
+      }))
+
+    it.effect("deregisters an exporter when its scope closes", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          const { attempts, httpClient } = yield* makeStatusHttpClient(200)
+          const flusher = yield* OtlpExporter.Flusher
+          const scope = yield* Scope.make()
+
+          yield* makeExporterRaw("disabled").pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+            Effect.provideService(Scope.Scope, scope)
+          )
+
+          yield* Scope.close(scope, Exit.void)
+          assert.strictEqual(yield* Ref.get(attempts), 1)
+
+          yield* flusher.flush
+          assert.strictEqual(yield* Ref.get(attempts), 1)
+        }).pipe(Effect.provide(OtlpExporter.layerFlusher))
+      ))
+
+    it.effect("succeeds with no registered exporters", () =>
+      Effect.gen(function*() {
+        const flusher = yield* OtlpExporter.Flusher
+        yield* flusher.flush
+      }).pipe(Effect.provide(OtlpExporter.layerFlusher)))
+
+    it.effect("is available when the SDK is disabled", () =>
+      Effect.gen(function*() {
+        const { attempts, httpClient } = yield* makeStatusHttpClient(200)
+        const layer = OtlpTracer.layerFromConfig().pipe(
+          Layer.provide(OtlpSerialization.layerJson),
+          Layer.provideMerge(Layer.succeed(HttpClient.HttpClient, httpClient)),
+          Layer.provideMerge(ConfigProvider.layer(ConfigProvider.fromEnv({
+            env: { OTEL_SDK_DISABLED: "true" }
+          })))
+        )
+
+        yield* Effect.gen(function*() {
+          const flusher = yield* OtlpExporter.Flusher
+          yield* flusher.flush
+        }).pipe(Effect.provide(layer))
+
+        assert.strictEqual(yield* Ref.get(attempts), 0)
+      }))
+
+    it.effect("does not fail when the collector returns 500", () =>
+      Effect.gen(function*() {
+        const { attempts, httpClient } = yield* makeStatusHttpClient(500)
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            const exporter = yield* makeExporterRaw(10)
+            const flusher = yield* OtlpExporter.Flusher
+
+            exporter.push({ value: 1 })
+            const fiber = yield* Effect.forkChild(flusher.flush)
+            yield* yieldNowN(3)
+            yield* TestClock.adjust("3 seconds")
+            yield* Fiber.join(fiber)
+            assert.strictEqual(yield* Ref.get(attempts), 4)
+
+            yield* flusher.flush
+            assert.strictEqual(yield* Ref.get(attempts), 4)
+          }).pipe(
+            Effect.provideService(HttpClient.HttpClient, httpClient),
+            Effect.provide(OtlpExporter.layerFlusher)
+          )
+        )
+      }))
+  })
 })

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -37,7 +37,10 @@ const makeExporter = (httpClient: HttpClient.HttpClient) =>
     maxBatchSize: 1,
     body: () => HttpBody.empty,
     shutdownTimeout: "1 second"
-  }).pipe(Effect.provideService(HttpClient.HttpClient, httpClient))
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, httpClient),
+    Effect.provide(OtlpExporter.layerFlusher)
+  )
 
 const yieldNowN = (times: number) =>
   Effect.forEach(Array.from({ length: times }), () => Effect.yieldNow, { discard: true })


### PR DESCRIPTION
Adds a manual flush mechanism to the OTLP exporters so buffered telemetry can be drained on demand, for example with `ctx.waitUntil` in short-lived serverless invocations where neither the export interval, the batch threshold, nor scope shutdown fires in time.

## Flush registry

- Adds a public `Flusher` service and a module-level `layerFlusher`. Reusing one layer instance lets `Layer.MemoMap` give merged signal layers one shared registry.
- Makes registration unconditional and scoped in `OtlpExporter.make`, preventing missing wiring and removing exporters when their scopes close.
- Runs registered exporters concurrently. `flush` cannot fail, respects the existing 60-second `disabledUntil` circuit breaker, and has no built-in timeout; callers can bound it with `Effect.timeoutOption`.
- Keeps the existing overlap behavior: a flush waits for exports it starts but cannot await an interval export already in flight.

## Signal layers

- Updates `OtlpTracer`, `OtlpLogger`, and `OtlpMetrics` layers to provide and expose the shared `Flusher` with `Layer.provideMerge`.
- Returns `layerFlusher` from disabled `layerFromConfig` branches, so flushing remains an available no-op when telemetry is disabled.
- Changes signal layer output types additively to include `Flusher`; `OtlpExporter.make` now requires `Flusher` for custom exporters.

## Tests and documentation

- Covers immediate flush, registry sharing across traces/logs/metrics, the disabled circuit breaker, scope deregistration, empty and SDK-disabled registries, and collector failures.
- Documents the flush contract and Cloudflare Workers `ctx.waitUntil` call site.
- Documents that metrics flushing takes a snapshot and therefore narrows delta-temporality windows when called frequently.
- Adds a changeset for the public API and type changes.

Validation: `pnpm lint`, `pnpm --dir packages/effect docgen`, and `pnpm check`.

Closes EFF-56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated manual flushing for OTLP batch exporters using a shared flusher service.
  * OTLP logs, metrics, and traces now expose this shared flushing support, including when OTLP export is disabled or unavailable.
  * Flushing drains all registered exporters and exporters are automatically deregistered when their scope ends.
* **Tests**
  * Expanded OTLP exporter test coverage with dedicated flush scenarios (registry sharing, no-op when disabled, scope deregistration, empty-registries, and resilient handling of collector failures).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->