### PR TITLE
docs(agents): run only affected tests, leave the full suite to CI

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -83,12 +83,16 @@ Use the narrowest validation that still covers the change:
 
 | Change type                      | Validation                                                                         |
 | -------------------------------- | ---------------------------------------------------------------------------------- |
-| Code changes                     | `pnpm lint-fix`, targeted `pnpm test <test_file.ts>`, `pnpm check`                 |
-| Tests-only changes               | `pnpm lint-fix`, targeted `pnpm test <test_file.ts>`, `pnpm check`                 |
+| Code changes                     | `pnpm lint-fix`, targeted `pnpm test --run <test_file.ts>`, `pnpm check`           |
+| Tests-only changes               | `pnpm lint-fix`, targeted `pnpm test --run <test_file.ts>`, `pnpm check`           |
 | Type-level/API type changes      | Targeted `pnpm test-types <filename>`, plus `pnpm check` when source types changed |
 | JSDoc text/category/link changes | `pnpm lint`                                                                        |
 | JSDoc example changes            | `pnpm lint`; from the changed package directory, run `pnpm docgen`                 |
 | Docs-only changes                | `pnpm lint-fix`; no tests required unless examples or code changed                 |
+
+Never run the whole test suite. A bare `pnpm test` runs every package in watch mode and will not
+exit; always pass `--run` and the specific test files covering your change. CI runs the full suite
+on push, so leave that to CI.
 
 ## Bundle Size Preview
 
@@ -112,6 +116,9 @@ Read `.patterns/effect.md` before changing Effect code. In particular:
 
 Read `.patterns/testing.md` before writing or changing tests.
 
+- Run only the tests covering the files you changed: `pnpm test --run <path/to/file.test.ts>`.
+  Narrow further with `-t "<test name>"`, or scope to a package with
+  `pnpm --filter <package> exec vitest run`.
 - Test files are located in `packages/*/test/`.
 - Main Effect library tests are in `packages/effect/test/`.
 - Use `it.effect` for Effect-returning tests.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -116,9 +116,10 @@ Read `.patterns/effect.md` before changing Effect code. In particular:
 
 Read `.patterns/testing.md` before writing or changing tests.
 
-- Run only the tests covering the files you changed: `pnpm test --run <path/to/file.test.ts>`.
-  Narrow further with `-t "<test name>"`, or scope to a package with
-  `pnpm --filter <package> exec vitest run`.
+- Run only the tests covering the files you changed.
+- From the repository root, run an affected package with `pnpm --filter effect test --run` only when package-wide coverage is necessary.
+- Prefer a single test file, using a path relative to the package: `pnpm --filter effect test --run test/Option.test.ts`.
+  Replace the package name and test path with those covering your changed files, and narrow further with `-t "<test name>"` when useful.
 - Test files are located in `packages/*/test/`.
 - Main Effect library tests are in `packages/effect/test/`.
 - Use `it.effect` for Effect-returning tests.


### PR DESCRIPTION
Agents working in this repo were running the full test suite on every change (~2 minutes). `.agents/AGENTS.md` already recommended targeted tests, but the guidance was soft and a bare `pnpm test` runs every package in watch mode.

- Requires agents to run only tests covering changed files and leave the full suite to CI.
- Requires `--run` so Vitest never enters watch mode.
- Documents exact package- and file-scoped commands from the repository root.

Verified after `direnv allow`, `corepack install`, and `pnpm install`:

- `pnpm --filter effect test --run` (7,140 passed, 3 skipped)
- `pnpm --filter effect test --run test/Option.test.ts` (58 passed)
- `pnpm lint-fix`

Closes EFF-61
