### PR TITLE
Optimize schema union derivation

### DIFF
--- a/.changeset/schema-union-type-derivation.md
+++ b/.changeset/schema-union-type-derivation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Precompile union formatters and equivalences, select transformed union members using their decoded type, and allow deriving an equivalence for `Never`.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -14732,14 +14732,17 @@ export function toFormatter<S extends Constraint>(schema: S, options?: {
         }
       }
       case "Union": {
-        const getCandidates = (t: any) => SchemaAST.getCandidates(t, ast.types)
+        const types = SchemaAST.toType(ast).types
+        const getCandidates = (t: any) => SchemaAST.getCandidates(t, types)
+        const compiled = new Map(
+          types.map((candidate) => [candidate, [SchemaParser._is(candidate), recur(candidate)] as const] as const)
+        )
         return (t) => {
           const candidates = getCandidates(t)
-          const refinements = candidates.map(SchemaParser._is)
           for (let i = 0; i < candidates.length; i++) {
-            const is = refinements[i]
+            const [is, formatter] = compiled.get(candidates[i])!
             if (is(t)) {
-              return recur(candidates[i])(t)
+              return formatter(t)
             }
           }
           return format(t)

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -14735,7 +14735,7 @@ export function toFormatter<S extends Constraint>(schema: S, options?: {
         const types = SchemaAST.toType(ast).types
         const getCandidates = (t: any) => SchemaAST.getCandidates(t, types)
         const compiled = new Map(
-          types.map((candidate) => [candidate, [SchemaParser._is(candidate), recur(candidate)] as const] as const)
+          types.map((candidate, i) => [candidate, [SchemaParser._is(candidate), recur(ast.types[i])] as const] as const)
         )
         return (t) => {
           const candidates = getCandidates(t)

--- a/packages/effect/src/internal/schema/toEquivalence.ts
+++ b/packages/effect/src/internal/schema/toEquivalence.ts
@@ -135,7 +135,9 @@ function recur(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): Equivalenc
     case "Union": {
       const types = SchemaAST.toType(ast).types
       const compiled = new Map(
-        types.map((candidate) => [candidate, [SchemaParser._is(candidate), recur(candidate, path)] as const] as const)
+        types.map((candidate, i) =>
+          [candidate, [SchemaParser._is(candidate), recur(ast.types[i], path)] as const] as const
+        )
       )
       return Equivalence.make((a, b) => {
         const candidates = SchemaAST.getCandidates(a, types)

--- a/packages/effect/src/internal/schema/toEquivalence.ts
+++ b/packages/effect/src/internal/schema/toEquivalence.ts
@@ -5,7 +5,6 @@ import * as Predicate from "../../Predicate.ts"
 import type * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
 import * as SchemaParser from "../../SchemaParser.ts"
-import { errorWithPath } from "../errors.ts"
 import * as InternalAnnotations from "./annotations.ts"
 
 /** @internal */
@@ -25,7 +24,7 @@ function recur(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): Equivalenc
   }
   switch (ast._tag) {
     case "Never":
-      throw errorWithPath(`Unsupported AST ${ast._tag}`, path)
+      return Equivalence.strictEqual()
     case "Declaration":
     case "Null":
     case "Undefined":
@@ -133,18 +132,22 @@ function recur(ast: SchemaAST.AST, path: ReadonlyArray<PropertyKey>): Equivalenc
         return true
       })
     }
-    case "Union":
+    case "Union": {
+      const types = SchemaAST.toType(ast).types
+      const compiled = new Map(
+        types.map((candidate) => [candidate, [SchemaParser._is(candidate), recur(candidate, path)] as const] as const)
+      )
       return Equivalence.make((a, b) => {
-        const candidates = SchemaAST.getCandidates(a, ast.types)
-        const types = candidates.map(SchemaParser._is)
+        const candidates = SchemaAST.getCandidates(a, types)
         for (let i = 0; i < candidates.length; i++) {
-          const is = types[i]
+          const [is, equivalence] = compiled.get(candidates[i])!
           if (is(a) && is(b)) {
-            return recur(candidates[i], path)(a, b)
+            return equivalence(a, b)
           }
         }
         return false
       })
+    }
     case "Suspend": {
       const get = SchemaAST.memoizeThunk(() => recur(ast.thunk(), path))
       return Equivalence.make((a, b) => get()(a, b))

--- a/packages/effect/test/schema/toEquivalence.test.ts
+++ b/packages/effect/test/schema/toEquivalence.test.ts
@@ -378,6 +378,19 @@ describe("toEquivalence", () => {
     assertFalse(equivalence({ value: "a" }, { value: "b" }))
   })
 
+  it("preserves Union member equivalence annotations", () => {
+    const member = Schema.String.pipe(
+      Schema.flip,
+      Schema.check(Schema.makeFilter(() => true)),
+      Schema.flip,
+      Schema.overrideToEquivalence(() => Equivalence.make((a, b) => a[0] === b[0]))
+    )
+    const equivalence = Schema.toEquivalence(Schema.Union([member, Schema.Number]))
+
+    assertTrue(equivalence("ab", "ac"))
+    assertFalse(equivalence("ab", "bc"))
+  })
+
   it("Date", () => {
     const schema = Schema.Date
     const equivalence = Schema.toEquivalence(schema)

--- a/packages/effect/test/schema/toEquivalence.test.ts
+++ b/packages/effect/test/schema/toEquivalence.test.ts
@@ -1,6 +1,17 @@
-import { BigDecimal, DateTime, Duration, Equivalence, HashMap, Option, Redacted, Result, Schema } from "effect"
+import {
+  BigDecimal,
+  DateTime,
+  Duration,
+  Equivalence,
+  HashMap,
+  Option,
+  Redacted,
+  Result,
+  Schema,
+  SchemaGetter
+} from "effect"
 import { describe, it } from "vitest"
-import { assertFalse, assertTrue, throws } from "../utils/assert.ts"
+import { assertFalse, assertTrue, strictEqual } from "../utils/assert.ts"
 
 const Modulo2 = Schema.Number.annotate({
   toEquivalence: (): Equivalence.Equivalence<number> => Equivalence.make((a, b) => a % 2 === b % 2)
@@ -12,22 +23,11 @@ const Modulo3 = Schema.Number.annotate({
 
 describe("toEquivalence", () => {
   it("Never", () => {
-    throws(
-      () =>
-        Schema.toEquivalence(Schema.Struct({
-          a: Schema.Never
-        })),
-      `Unsupported AST Never
-  at ["a"]`
-    )
-    throws(
-      () =>
-        Schema.toEquivalence(Schema.Tuple([
-          Schema.Never
-        ])),
-      `Unsupported AST Never
-  at [0]`
-    )
+    const equivalence = Schema.toEquivalence(Schema.Never)
+    const value = {} as never
+
+    assertTrue(equivalence(value, value))
+    assertFalse(equivalence({} as never, {} as never))
   })
 
   it("String", () => {
@@ -341,6 +341,41 @@ describe("toEquivalence", () => {
         })
       )
     })
+  })
+
+  it("precompiles Union members", () => {
+    let derivations = 0
+    const member = Schema.Struct({
+      tag: Schema.Literal("a"),
+      value: Schema.String
+    }).pipe(
+      Schema.overrideToEquivalence(() => {
+        derivations++
+        return Equivalence.make((a, b) => a.value === b.value)
+      })
+    )
+    const equivalence = Schema.toEquivalence(Schema.Union([member, Schema.Never]))
+
+    strictEqual(derivations, 1)
+    assertTrue(equivalence({ tag: "a", value: "a" }, { tag: "a", value: "a" }))
+    assertFalse(equivalence({ tag: "a", value: "a" }, { tag: "a", value: "b" }))
+    strictEqual(derivations, 1)
+  })
+
+  it("selects transformed Union members on the Type side", () => {
+    const Target = Schema.Struct({ value: Schema.String }).pipe(
+      Schema.overrideToEquivalence(() => Equivalence.make((a, b) => a.value === b.value))
+    )
+    const Transformed = Schema.String.pipe(
+      Schema.decodeTo(Target, {
+        decode: SchemaGetter.transform((s) => ({ value: s })),
+        encode: SchemaGetter.transform((a) => a.value)
+      })
+    )
+    const equivalence = Schema.toEquivalence(Schema.Union([Transformed, Schema.Boolean]))
+
+    assertTrue(equivalence({ value: "a" }, { value: "a" }))
+    assertFalse(equivalence({ value: "a" }, { value: "b" }))
   })
 
   it("Date", () => {

--- a/packages/effect/test/schema/toFormatter.test.ts
+++ b/packages/effect/test/schema/toFormatter.test.ts
@@ -1,4 +1,4 @@
-import { BigDecimal, DateTime, Duration, HashMap, Option, Redacted, Result, Schema } from "effect"
+import { BigDecimal, DateTime, Duration, HashMap, Option, Redacted, Result, Schema, SchemaGetter } from "effect"
 import { describe, it } from "vitest"
 import { strictEqual } from "../utils/assert.ts"
 
@@ -150,6 +150,37 @@ describe("toFormatter", () => {
     const format = Schema.toFormatter(Schema.Union([Schema.String, Schema.Number]))
     strictEqual(format("a"), `"a"`)
     strictEqual(format(1), "1")
+  })
+
+  it("precompiles Union members", () => {
+    let derivations = 0
+    const String = Schema.String.pipe(
+      Schema.overrideToFormatter(() => {
+        derivations++
+        return (s) => s.toUpperCase()
+      })
+    )
+    const format = Schema.toFormatter(Schema.Union([String, Schema.Number, Schema.Never]))
+
+    strictEqual(derivations, 1)
+    strictEqual(format("a"), "A")
+    strictEqual(format("b"), "B")
+    strictEqual(derivations, 1)
+  })
+
+  it("selects transformed Union members on the Type side", () => {
+    const Target = Schema.Struct({ value: Schema.String }).pipe(
+      Schema.overrideToFormatter(() => (a) => `formatted:${a.value}`)
+    )
+    const Transformed = Schema.String.pipe(
+      Schema.decodeTo(Target, {
+        decode: SchemaGetter.transform((s) => ({ value: s })),
+        encode: SchemaGetter.transform((a) => a.value)
+      })
+    )
+    const format = Schema.toFormatter(Schema.Union([Transformed, Schema.Boolean]))
+
+    strictEqual(format({ value: "a" }), "formatted:a")
   })
 
   describe("Tuple", () => {

--- a/packages/effect/test/schema/toFormatter.test.ts
+++ b/packages/effect/test/schema/toFormatter.test.ts
@@ -183,6 +183,32 @@ describe("toFormatter", () => {
     strictEqual(format({ value: "a" }), "formatted:a")
   })
 
+  it("preserves Union member formatter annotations", () => {
+    const member = Schema.String.pipe(
+      Schema.flip,
+      Schema.check(Schema.makeFilter(() => true)),
+      Schema.flip,
+      Schema.overrideToFormatter(() => (s) => s.toUpperCase())
+    )
+    const format = Schema.toFormatter(Schema.Union([member, Schema.Number]))
+
+    strictEqual(format("a"), "A")
+  })
+
+  it("preserves Union member encoding metadata for onBefore", () => {
+    const member = Schema.String.pipe(
+      Schema.decode({
+        decode: SchemaGetter.transform((s) => s),
+        encode: SchemaGetter.transform((s) => s)
+      })
+    )
+    const format = Schema.toFormatter(Schema.Union([member, Schema.Number]), {
+      onBefore: (ast) => ast.encoding ? () => "transformed" : undefined
+    })
+
+    strictEqual(format("a"), "transformed")
+  })
+
   describe("Tuple", () => {
     it("empty", () => {
       const format = Schema.toFormatter(Schema.Tuple([]))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatter and equivalence behavior for union schemas, including correct branch selection for transformed members.
  * Equivalence derivation for `Never` is now supported without throwing.
  * Unsupported schema cases now fall back to strict equality rather than failing.
* **Performance**
  * Union formatter and equivalence matching is now precompiled and reused across calls.
* **Tests**
  * Added/updated union and `Never` coverage to verify precompilation and preservation of member annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->