### PR TITLE
Fix AI provider header redaction

### DIFF
--- a/.changeset/fix-anthropic-header-redaction.md
+++ b/.changeset/fix-anthropic-header-redaction.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Redact the Anthropic API key from client error context.

--- a/.changeset/fix-openai-header-redaction.md
+++ b/.changeset/fix-openai-header-redaction.md
@@ -1,0 +1,6 @@
+---
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+---
+
+Redact OpenAI organization and project headers from client errors.

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -194,6 +194,11 @@ const RedactedAnthropicHeaders = {
   AnthropicApiKey: "x-api-key"
 }
 
+const withRedactedHeaders = Effect.updateService(
+  Headers.CurrentRedactedNames,
+  Array.appendAll(Object.values(RedactedAnthropicHeaders))
+)
+
 /**
  * Creates an Anthropic client service with the given options.
  *
@@ -276,7 +281,8 @@ export const make = Effect.fnUntraced(
           BetaMessagesPost4XX: (error) => Effect.fail(Errors.mapClientError(error, "createMessage")),
           HttpClientError: (error) => Errors.mapHttpClientError(error, "createMessage"),
           SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createMessage"))
-        })
+        }),
+        withRedactedHeaders
       )
 
     const PingEvent = Schema.Struct({
@@ -329,7 +335,8 @@ export const make = Effect.fnUntraced(
         Effect.catchTag(
           "HttpClientError",
           (error) => Errors.mapHttpClientError(error, "createMessageStream")
-        )
+        ),
+        withRedactedHeaders
       )
     }
 
@@ -340,10 +347,7 @@ export const make = Effect.fnUntraced(
       createMessageStream
     })
   },
-  Effect.updateService(
-    Headers.CurrentRedactedNames,
-    Array.appendAll(Object.values(RedactedAnthropicHeaders))
-  )
+  withRedactedHeaders
 )
 
 // =============================================================================

--- a/packages/ai/anthropic/test/AnthropicClient.test.ts
+++ b/packages/ai/anthropic/test/AnthropicClient.test.ts
@@ -1,0 +1,127 @@
+import { AnthropicClient } from "@effect/ai-anthropic"
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Layer, Redacted, type Schema } from "effect"
+import {
+  Headers,
+  HttpClient,
+  type HttpClientError,
+  type HttpClientRequest,
+  HttpClientResponse
+} from "effect/unstable/http"
+
+describe("AnthropicClient", () => {
+  it.effect("redacts the API key in AI error context", () =>
+    Effect.gen(function*() {
+      const client = yield* AnthropicClient.AnthropicClient
+
+      const result = yield* client.createMessage({
+        payload: {
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 1,
+          messages: [{ role: "user", content: "hello" }]
+        }
+      }).pipe(
+        Effect.flip,
+        Effect.updateService(Headers.CurrentRedactedNames, () => [])
+      )
+
+      assert.strictEqual(result.reason._tag, "InvalidRequestError")
+      if (result.reason._tag !== "InvalidRequestError" || result.reason.http === undefined) {
+        return yield* Effect.die(new Error("Expected InvalidRequestError with HTTP context"))
+      }
+      const requests = yield* MockHttpClient.requests
+      assert.include(requests[0]?.url, "/v1/messages")
+      assert.strictEqual(String(result.reason.http.request.headers["x-api-key"]), "<redacted>")
+    }).pipe(Effect.provide(makeTestLayer({
+      _tag: "Json",
+      status: 400,
+      body: {
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "Bad request"
+        },
+        request_id: null
+      }
+    }))))
+})
+
+type MockResponse =
+  | {
+    readonly _tag: "Json"
+    readonly body: Schema.Json
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+  | {
+    readonly _tag: "Sse"
+    readonly events: ReadonlyArray<Schema.Json>
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+
+class MockAnthropicResponse extends Context.Service<MockAnthropicResponse, {
+  readonly response: MockResponse
+}>()("MockAnthropicResponse") {}
+
+class MockHttpClient extends Context.Service<MockHttpClient, {
+  readonly requests: Effect.Effect<ReadonlyArray<HttpClientRequest.HttpClientRequest>>
+}>()("MockHttpClient") {
+  static requests = MockHttpClient.use((client) => client.requests)
+}
+
+const makeHttpClientContext = Effect.gen(function*() {
+  const capturedRequests: Array<HttpClientRequest.HttpClientRequest> = []
+  const mock = yield* MockAnthropicResponse
+
+  const httpClient = HttpClient.makeWith(
+    Effect.fnUntraced(function*(requestEffect) {
+      const request = yield* requestEffect
+      capturedRequests.push(request)
+      return makeResponse(request, mock.response)
+    }),
+    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+  )
+
+  const mockHttpClient: MockHttpClient["Service"] = {
+    requests: Effect.sync(() => capturedRequests)
+  }
+
+  return Context.make(HttpClient.HttpClient, httpClient).pipe(
+    Context.add(MockHttpClient, mockHttpClient)
+  )
+})
+
+const HttpClientLayer = Layer.effectContext(makeHttpClientContext)
+
+const makeTestLayer = (
+  response: MockResponse,
+  options: AnthropicClient.Options = { apiKey: Redacted.make("sk-test-key") }
+) =>
+  AnthropicClient.layer(options).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockAnthropicResponse, { response }))
+  )
+
+const makeResponse = (
+  request: HttpClientRequest.HttpClientRequest,
+  response: MockResponse
+): HttpClientResponse.HttpClientResponse => {
+  const contentType = response._tag === "Json"
+    ? "application/json"
+    : "text/event-stream"
+  const body = response._tag === "Json"
+    ? JSON.stringify(response.body)
+    : response.events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
+
+  return HttpClientResponse.fromWeb(
+    request,
+    new Response(body, {
+      status: response.status ?? 200,
+      headers: {
+        "content-type": contentType,
+        ...response.headers
+      }
+    })
+  )
+}

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -11,7 +11,7 @@ import * as Array from "effect/Array"
 import type * as Config from "effect/Config"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
-import { identity, pipe } from "effect/Function"
+import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
 import * as Redacted from "effect/Redacted"
 import * as Schema from "effect/Schema"
@@ -99,9 +99,14 @@ export type Options = {
 }
 
 const RedactedOpenAiHeaders = {
-  OpenAiOrganization: "OpenAI-Organization",
-  OpenAiProject: "OpenAI-Project"
+  OpenAiOrganization: "openai-organization",
+  OpenAiProject: "openai-project"
 }
+
+const withRedactedHeaders = Effect.updateService(
+  Headers.CurrentRedactedNames,
+  Array.appendAll(Object.values(RedactedOpenAiHeaders))
+)
 
 /**
  * Constructs an OpenAI-compatible client service from explicit options.
@@ -175,24 +180,27 @@ export const make = Effect.fnUntraced(
       [body: CreateResponse200, response: HttpClientResponse.HttpClientResponse],
       AiError.AiError
     > =>
-      Effect.flatMap(resolveHttpClient, (client) =>
-        pipe(
-          HttpClientRequest.post("/chat/completions"),
-          HttpClientRequest.bodyJsonUnsafe(payload),
-          HttpClient.filterStatusOk(client).execute,
-          Effect.flatMap((response) =>
-            Effect.map(decodeResponse(response), (
-              body
-            ): [CreateResponse200, HttpClientResponse.HttpClientResponse] => [
-              body,
-              response
-            ])
-          ),
-          Effect.catchTags({
-            HttpClientError: (error) => Errors.mapHttpClientError(error, "createResponse"),
-            SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createResponse"))
-          })
-        ))
+      resolveHttpClient.pipe(
+        Effect.flatMap((client) =>
+          HttpClientRequest.post("/chat/completions").pipe(
+            HttpClientRequest.bodyJsonUnsafe(payload),
+            HttpClient.filterStatusOk(client).execute,
+            Effect.flatMap((response) =>
+              Effect.map(decodeResponse(response), (
+                body
+              ): [CreateResponse200, HttpClientResponse.HttpClientResponse] => [
+                body,
+                response
+              ])
+            ),
+            Effect.catchTags({
+              HttpClientError: (error) => Errors.mapHttpClientError(error, "createResponse"),
+              SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createResponse"))
+            })
+          )
+        ),
+        withRedactedHeaders
+      )
 
     const buildResponseStream = (
       response: HttpClientResponse.HttpClientResponse
@@ -217,40 +225,46 @@ export const make = Effect.fnUntraced(
     }
 
     const createResponseStream: Service["createResponseStream"] = (payload) =>
-      Effect.flatMap(resolveHttpClient, (client) =>
-        pipe(
-          HttpClientRequest.post("/chat/completions"),
-          HttpClientRequest.bodyJsonUnsafe({
-            ...payload,
-            stream: true,
-            stream_options: {
-              include_usage: true
-            }
-          }),
-          HttpClient.filterStatusOk(client).execute,
-          Effect.map(buildResponseStream),
-          Effect.catchTag(
-            "HttpClientError",
-            (error) => Errors.mapHttpClientError(error, "createResponseStream")
+      resolveHttpClient.pipe(
+        Effect.flatMap((client) =>
+          HttpClientRequest.post("/chat/completions").pipe(
+            HttpClientRequest.bodyJsonUnsafe({
+              ...payload,
+              stream: true,
+              stream_options: {
+                include_usage: true
+              }
+            }),
+            HttpClient.filterStatusOk(client).execute,
+            Effect.map(buildResponseStream),
+            Effect.catchTag(
+              "HttpClientError",
+              (error) => Errors.mapHttpClientError(error, "createResponseStream")
+            )
           )
-        ))
+        ),
+        withRedactedHeaders
+      )
 
     const decodeEmbedding = HttpClientResponse.schemaBodyJson(CreateEmbeddingResponseSchema)
 
     const createEmbedding = (
       payload: CreateEmbeddingRequestJson
     ): Effect.Effect<CreateEmbedding200, AiError.AiError> =>
-      Effect.flatMap(resolveHttpClient, (client) =>
-        pipe(
-          HttpClientRequest.post("/embeddings"),
-          HttpClientRequest.bodyJsonUnsafe(payload),
-          HttpClient.filterStatusOk(client).execute,
-          Effect.flatMap(decodeEmbedding),
-          Effect.catchTags({
-            HttpClientError: (error) => Errors.mapHttpClientError(error, "createEmbedding"),
-            SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createEmbedding"))
-          })
-        ))
+      resolveHttpClient.pipe(
+        Effect.flatMap((client) =>
+          HttpClientRequest.post("/embeddings").pipe(
+            HttpClientRequest.bodyJsonUnsafe(payload),
+            HttpClient.filterStatusOk(client).execute,
+            Effect.flatMap(decodeEmbedding),
+            Effect.catchTags({
+              HttpClientError: (error) => Errors.mapHttpClientError(error, "createEmbedding"),
+              SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createEmbedding"))
+            })
+          )
+        ),
+        withRedactedHeaders
+      )
 
     return OpenAiClient.of({
       client: httpClient,
@@ -259,10 +273,7 @@ export const make = Effect.fnUntraced(
       createEmbedding
     })
   },
-  Effect.updateService(
-    Headers.CurrentRedactedNames,
-    Array.appendAll(Object.values(RedactedOpenAiHeaders))
-  )
+  withRedactedHeaders
 )
 
 /**

--- a/packages/ai/openai-compat/test/OpenAiClient.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiClient.test.ts
@@ -1,65 +1,42 @@
-import * as OpenAiClient from "@effect/ai-openai-compat/OpenAiClient"
+import { OpenAiClient } from "@effect/ai-openai-compat"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Redacted, Stream } from "effect"
-import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { Context, Effect, Layer, Redacted, type Schema, Stream } from "effect"
+import {
+  Headers,
+  HttpClient,
+  type HttpClientError,
+  type HttpClientRequest,
+  HttpClientResponse
+} from "effect/unstable/http"
 
 describe("OpenAiClient", () => {
   describe("request behavior", () => {
     it.effect("sets auth and OpenAI headers on /chat/completions requests", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key"),
-          apiUrl: "https://compat.example.test/v1",
-          organizationId: Redacted.make("org_123"),
-          projectId: Redacted.make("proj_456")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(jsonResponse(request, 200, makeChatCompletion()))
-            })
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         yield* client.createResponse({
           model: "gpt-4o-mini",
           messages: [{ role: "user", content: "hello" }]
         })
 
-        assert.isDefined(capturedRequest)
-        if (capturedRequest === undefined) {
-          return
-        }
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
+        const body = yield* getRequestBody(request)
 
-        assert.isTrue(capturedRequest.url.endsWith("/chat/completions"))
-        assert.isTrue(capturedRequest.url.startsWith("https://compat.example.test/v1"))
-        assert.strictEqual(capturedRequest.headers["authorization"], "Bearer sk-test-key")
-        assert.strictEqual(capturedRequest.headers["openai-organization"], "org_123")
-        assert.strictEqual(capturedRequest.headers["openai-project"], "proj_456")
+        assert.isTrue(request.url.endsWith("/chat/completions"))
+        assert.isTrue(request.url.startsWith("https://compat.example.test/v1"))
+        assert.strictEqual(request.headers["authorization"], "Bearer sk-test-key")
+        assert.strictEqual(request.headers["openai-organization"], "org_123")
+        assert.strictEqual(request.headers["openai-project"], "proj_456")
 
-        const body = yield* getRequestBody(capturedRequest)
         assert.strictEqual(body.messages[0]?.role, "user")
         assert.strictEqual(body.messages[0]?.content, "hello")
-      }))
+      }).pipe(Effect.provide(makeTestLayer())))
 
     it.effect("passes custom chat-completions request properties through", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(jsonResponse(request, 200, makeChatCompletion()))
-            })
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         yield* client.createResponse({
           model: "gpt-4o-mini",
@@ -69,160 +46,110 @@ describe("OpenAiClient", () => {
           }
         })
 
-        assert.isDefined(capturedRequest)
-        if (capturedRequest === undefined) {
-          return
-        }
-
-        const body = yield* getRequestBody(capturedRequest)
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
+        const body = yield* getRequestBody(request)
         assert.deepStrictEqual(body.provider_feature, {
           enabled: true
         })
-      }))
+      }).pipe(Effect.provide(makeTestLayer())))
 
     it.effect("uses /embeddings path and decodes permissive embedding payloads", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key"),
-          apiUrl: "https://compat.example.test/v1"
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(jsonResponse(request, 200, {
-                data: [{
-                  embedding: "YmFzZTY0LWRhdGE=",
-                  index: 0,
-                  object: "embedding",
-                  vendor_payload: { future_field: true }
-                }],
-                model: "my-custom-embedding-model",
-                object: "list",
-                usage: {
-                  prompt_tokens: 5,
-                  total_tokens: 5
-                },
-                unknown_top_level: true
-              }))
-            })
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         const embedding = yield* client.createEmbedding({
           model: "my-custom-embedding-model",
           input: "embed this"
         })
 
-        assert.isDefined(capturedRequest)
-        if (capturedRequest === undefined) {
-          return
-        }
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
 
-        assert.isTrue(capturedRequest.url.endsWith("/embeddings"))
+        assert.isTrue(request.url.endsWith("/embeddings"))
         assert.strictEqual(embedding.model, "my-custom-embedding-model")
         assert.strictEqual(embedding.data[0]?.index, 0)
         assert.strictEqual(typeof embedding.data[0]?.embedding, "string")
-      }))
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Json",
+        body: {
+          data: [{
+            embedding: "YmFzZTY0LWRhdGE=",
+            index: 0,
+            object: "embedding",
+            vendor_payload: { future_field: true }
+          }],
+          model: "my-custom-embedding-model",
+          object: "list",
+          usage: {
+            prompt_tokens: 5,
+            total_tokens: 5
+          },
+          unknown_top_level: true
+        }
+      }))))
 
     it.effect("sets stream=true for createResponseStream and returns chat chunks", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+        const client = yield* OpenAiClient.OpenAiClient
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(sseResponse(request, [
-                {
-                  id: "chatcmpl_test_1",
-                  object: "chat.completion.chunk",
-                  model: "gpt-4o-mini",
-                  created: 1,
-                  future_provider_field: { accepted: true },
-                  choices: [{
-                    index: 0,
-                    delta: { content: "Hello" },
-                    finish_reason: null
-                  }]
-                },
-                {
-                  id: "chatcmpl_test_1",
-                  object: "chat.completion.chunk",
-                  model: "gpt-4o-mini",
-                  created: 1,
-                  usage: {
-                    prompt_tokens: 4,
-                    completion_tokens: 2,
-                    total_tokens: 6,
-                    prompt_tokens_details: { cached_tokens: 1 },
-                    completion_tokens_details: { reasoning_tokens: 1 }
-                  },
-                  choices: [{
-                    index: 0,
-                    delta: {},
-                    finish_reason: "stop"
-                  }]
-                },
-                "[DONE]"
-              ]))
-            })
-          ))
-        )
-
-        const eventsChunk = yield* client.createResponseStream({
+        const events = yield* client.createResponseStream({
           model: "gpt-4o-mini",
           messages: [{ role: "user", content: "hello" }]
         }).pipe(
           Effect.flatMap(([_, stream]) => Stream.runCollect(stream))
         )
 
-        assert.isDefined(capturedRequest)
-        if (capturedRequest === undefined) {
-          return
-        }
-
-        const body = yield* getRequestBody(capturedRequest)
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
+        const body = yield* getRequestBody(request)
         assert.strictEqual(body.stream, true)
         assert.strictEqual(body.stream_options.include_usage, true)
-        assert.isTrue(capturedRequest.url.endsWith("/chat/completions"))
+        assert.isTrue(request.url.endsWith("/chat/completions"))
 
-        const events = globalThis.Array.from(eventsChunk)
-        const firstEvent = events[0]
-        const secondEvent = events[1]
-        assert.isTrue(typeof firstEvent === "object")
-        assert.isTrue(typeof secondEvent === "object")
-        if (
-          typeof firstEvent !== "object" || firstEvent === null || typeof secondEvent !== "object" ||
-          secondEvent === null
-        ) {
-          return
-        }
-        assert.strictEqual(firstEvent.id, "chatcmpl_test_1")
-        assert.strictEqual(secondEvent.id, "chatcmpl_test_1")
+        assert.propertyVal(events[0], "id", "chatcmpl_test_1")
+        assert.propertyVal(events[1], "id", "chatcmpl_test_1")
         assert.strictEqual(events[2], "[DONE]")
-      }))
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Sse",
+        events: [
+          {
+            id: "chatcmpl_test_1",
+            object: "chat.completion.chunk",
+            model: "gpt-4o-mini",
+            created: 1,
+            future_provider_field: { accepted: true },
+            choices: [{
+              index: 0,
+              delta: { content: "Hello" },
+              finish_reason: null
+            }]
+          },
+          {
+            id: "chatcmpl_test_1",
+            object: "chat.completion.chunk",
+            model: "gpt-4o-mini",
+            created: 1,
+            usage: {
+              prompt_tokens: 4,
+              completion_tokens: 2,
+              total_tokens: 6,
+              prompt_tokens_details: { cached_tokens: 1 },
+              completion_tokens_details: { reasoning_tokens: 1 }
+            },
+            choices: [{
+              index: 0,
+              delta: {},
+              finish_reason: "stop"
+            }]
+          },
+          "[DONE]"
+        ]
+      }))))
 
     it.effect("passes chat-completions tool_choice payload through unchanged", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(jsonResponse(request, 200, makeChatCompletion()))
-            })
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         yield* client.createResponse({
           model: "gpt-4o-mini",
@@ -249,30 +176,19 @@ describe("OpenAiClient", () => {
           }]
         })
 
-        assert.isDefined(capturedRequest)
-        if (capturedRequest === undefined) {
-          return
-        }
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
+        const body = yield* getRequestBody(request)
 
-        const body = yield* getRequestBody(capturedRequest)
-        assert.deepStrictEqual(body.tool_choice, { type: "function", function: { name: "TestTool" } })
-      }))
+        assert.deepStrictEqual(body.tool_choice, {
+          type: "function",
+          function: { name: "TestTool" }
+        })
+      }).pipe(Effect.provide(makeTestLayer())))
 
     it.effect("accepts assistant tool-call and tool result chat history", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) => {
-              capturedRequest = request
-              return Effect.succeed(jsonResponse(request, 200, makeChatCompletion()))
-            })
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         yield* client.createResponse({
           model: "gpt-4o-mini",
@@ -303,12 +219,10 @@ describe("OpenAiClient", () => {
           ]
         })
 
-        assert.isDefined(capturedRequest)
-        if (capturedRequest === undefined) {
-          return
-        }
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
+        const body = yield* getRequestBody(request)
 
-        const body = yield* getRequestBody(capturedRequest)
         const assistantMessages = body.messages.filter((message: any) => message.role === "assistant")
         const patchMessage = assistantMessages.find((message: any) =>
           message.tool_calls?.[0]?.function?.name === "apply_patch"
@@ -329,28 +243,41 @@ describe("OpenAiClient", () => {
         const patchOutput = toolMessages.find((message: any) => message.tool_call_id === "patch_call_1")
         assert.isDefined(patchOutput)
         assert.strictEqual(patchOutput.content, "deleted")
-      }))
+      }).pipe(Effect.provide(makeTestLayer())))
+
+    it.effect("redacts OpenAI-specific headers in AI error context", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+
+        const result = yield* client.createResponse({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: "hello" }]
+        }).pipe(Effect.flip)
+
+        const headers = result.reason._tag === "InvalidRequestError"
+          ? result.reason.http?.request.headers ?? Headers.empty
+          : Headers.empty
+
+        assert.strictEqual(String(headers["authorization"]), "<redacted>")
+        assert.strictEqual(String(headers["openai-organization"]), "<redacted>")
+        assert.strictEqual(String(headers["openai-project"]), "<redacted>")
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Json",
+        status: 400,
+        body: {
+          error: {
+            message: "Bad request",
+            type: "invalid_request_error",
+            code: null
+          }
+        }
+      }))))
   })
 
   describe("error mapping", () => {
     it.effect("maps 400 responses to InvalidRequestError", () =>
       Effect.gen(function*() {
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) =>
-              Effect.succeed(jsonResponse(request, 400, {
-                error: {
-                  message: "Bad request",
-                  type: "invalid_request_error",
-                  code: null
-                }
-              }))
-            )
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         const error = yield* client.createResponse({
           model: "gpt-4o-mini",
@@ -360,26 +287,21 @@ describe("OpenAiClient", () => {
         assert.strictEqual(error._tag, "AiError")
         assert.strictEqual(error.method, "createResponse")
         assert.strictEqual(error.reason._tag, "InvalidRequestError")
-      }))
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Json",
+        status: 400,
+        body: {
+          error: {
+            message: "Bad request",
+            type: "invalid_request_error",
+            code: null
+          }
+        }
+      }))))
 
     it.effect("maps insufficient quota errors to QuotaExhaustedError", () =>
       Effect.gen(function*() {
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-key")
-        }).pipe(
-          Effect.provide(Layer.succeed(
-            HttpClient.HttpClient,
-            makeHttpClient((request) =>
-              Effect.succeed(jsonResponse(request, 429, {
-                error: {
-                  message: "You exceeded your current quota",
-                  type: "insufficient_quota",
-                  code: "insufficient_quota"
-                }
-              }))
-            )
-          ))
-        )
+        const client = yield* OpenAiClient.OpenAiClient
 
         const error = yield* client.createResponse({
           model: "gpt-4o-mini",
@@ -389,24 +311,87 @@ describe("OpenAiClient", () => {
         assert.strictEqual(error._tag, "AiError")
         assert.strictEqual(error.method, "createResponse")
         assert.strictEqual(error.reason._tag, "QuotaExhaustedError")
-      }))
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Json",
+        status: 429,
+        body: {
+          error: {
+            message: "You exceeded your current quota",
+            type: "insufficient_quota",
+            code: "insufficient_quota"
+          }
+        }
+      }))))
   })
 })
 
-const makeHttpClient = (
-  handler: (
-    request: HttpClientRequest.HttpClientRequest
-  ) => Effect.Effect<HttpClientResponse.HttpClientResponse, HttpClientError.HttpClientError>
-) =>
-  HttpClient.makeWith(
+type MockResponse =
+  | {
+    readonly _tag: "Json"
+    readonly body: Schema.Json
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+  | {
+    readonly _tag: "Sse"
+    readonly events: ReadonlyArray<Schema.Json>
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+
+class MockOpenAiResponse extends Context.Service<MockOpenAiResponse, {
+  readonly response: MockResponse
+}>()("MockOpenAiResponse") {}
+
+class MockHttpClient extends Context.Service<MockHttpClient, {
+  readonly requests: Effect.Effect<ReadonlyArray<HttpClientRequest.HttpClientRequest>>
+}>()("MockHttpClient") {
+  static requests = MockHttpClient.use((client) => client.requests)
+}
+
+const makeHttpClientContext = Effect.gen(function*() {
+  const capturedRequests: Array<HttpClientRequest.HttpClientRequest> = []
+  const mock = yield* MockOpenAiResponse
+
+  const httpClient = HttpClient.makeWith(
     Effect.fnUntraced(function*(requestEffect) {
       const request = yield* requestEffect
-      return yield* handler(request)
+      capturedRequests.push(request)
+      return makeResponse(request, mock.response)
     }),
     Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
   )
 
-const makeChatCompletion = () => ({
+  const mockHttpClient: MockHttpClient["Service"] = {
+    requests: Effect.sync(() => capturedRequests)
+  }
+
+  return Context.make(HttpClient.HttpClient, httpClient).pipe(
+    Context.add(MockHttpClient, mockHttpClient)
+  )
+})
+
+const HttpClientLayer = Layer.effectContext(makeHttpClientContext)
+
+const makeTestLayer = (response: MockResponse = {
+  _tag: "Json",
+  body: makeCreateResponse()
+}) =>
+  OpenAiClient.layer({
+    apiKey: Redacted.make("sk-test-key"),
+    apiUrl: "https://compat.example.test/v1",
+    organizationId: Redacted.make("org_123"),
+    projectId: Redacted.make("proj_456")
+  }).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockOpenAiResponse, {
+      response
+    }))
+  )
+
+const makeCreateResponse = (
+  overrides: Partial<OpenAiClient.CreateResponse200> = {}
+) => ({
   id: "chatcmpl_test_1",
   object: "chat.completion",
   model: "gpt-4o-mini",
@@ -423,37 +408,32 @@ const makeChatCompletion = () => ({
     prompt_tokens: 1,
     completion_tokens: 1,
     total_tokens: 2
-  }
+  },
+  ...overrides
 })
 
-const jsonResponse = (
+const makeResponse = (
   request: HttpClientRequest.HttpClientRequest,
-  status: number,
-  body: unknown
-): HttpClientResponse.HttpClientResponse =>
-  HttpClientResponse.fromWeb(
-    request,
-    new Response(JSON.stringify(body), {
-      status,
-      headers: {
-        "content-type": "application/json"
-      }
-    })
-  )
+  response: MockResponse
+): HttpClientResponse.HttpClientResponse => {
+  const contentType = response._tag === "Json"
+    ? "application/json"
+    : "text/event-stream"
+  const body = response._tag === "Json"
+    ? JSON.stringify(response.body)
+    : toSseBody(response.events)
 
-const sseResponse = (
-  request: HttpClientRequest.HttpClientRequest,
-  events: ReadonlyArray<unknown>
-): HttpClientResponse.HttpClientResponse =>
-  HttpClientResponse.fromWeb(
+  return HttpClientResponse.fromWeb(
     request,
-    new Response(toSseBody(events), {
-      status: 200,
+    new Response(body, {
+      status: response.status ?? 200,
       headers: {
-        "content-type": "text/event-stream"
+        "content-type": contentType,
+        ...response.headers
       }
     })
   )
+}
 
 const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
   Effect.gen(function*() {
@@ -465,10 +445,8 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
     return yield* Effect.die(new Error("Expected Uint8Array body"))
   })
 
-const toSseBody = (events: ReadonlyArray<unknown>): string =>
+const toSseBody = (events: ReadonlyArray<Schema.Json>): string =>
   events.map((event) => {
-    if (typeof event === "string") {
-      return `data: ${event}\n\n`
-    }
-    return `data: ${JSON.stringify(event)}\n\n`
+    const data = event === "[DONE]" ? event : JSON.stringify(event)
+    return `data: ${data}\n\n`
   }).join("")

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -158,6 +158,11 @@ const RedactedOpenAiHeaders = {
   OpenAiProject: "OpenAI-Project"
 }
 
+const withRedactedHeaders = Effect.updateService(
+  Headers.CurrentRedactedNames,
+  Array.appendAll(Object.values(RedactedOpenAiHeaders))
+)
+
 /**
  * Creates an OpenAI client service with the given options.
  *
@@ -232,25 +237,27 @@ export const make = Effect.fnUntraced(
       [body: typeof OpenAiSchema.Response.Type, response: HttpClientResponse.HttpClientResponse],
       AiError.AiError
     > =>
-      Effect.flatMap(resolveHttpClient, (client) =>
-        client.execute(
-          HttpClientRequest.post("/responses", {
+      resolveHttpClient.pipe(
+        Effect.flatMap((client) =>
+          client.execute(HttpClientRequest.post("/responses", {
             body: HttpBody.jsonUnsafe(payload)
-          })
-        ).pipe(
-          Effect.flatMap((response) =>
-            decodeResponse(response).pipe(
-              Effect.map((body): [typeof OpenAiSchema.Response.Type, HttpClientResponse.HttpClientResponse] => [
-                body,
-                response
-              ])
-            )
-          ),
-          Effect.catchTags({
-            HttpClientError: (error) => Errors.mapHttpClientError(error, "createResponse"),
-            SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createResponse"))
-          })
-        ))
+          })).pipe(
+            Effect.flatMap((response) =>
+              decodeResponse(response).pipe(
+                Effect.map((body): [typeof OpenAiSchema.Response.Type, HttpClientResponse.HttpClientResponse] => [
+                  body,
+                  response
+                ])
+              )
+            ),
+            Effect.catchTags({
+              HttpClientError: (error) => Errors.mapHttpClientError(error, "createResponse"),
+              SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createResponse"))
+            })
+          )
+        ),
+        withRedactedHeaders
+      )
 
     const buildResponseStream = (
       response: HttpClientResponse.HttpClientResponse
@@ -280,18 +287,20 @@ export const make = Effect.fnUntraced(
       Effect.contextWith((services) => {
         const socket = Context.getOrUndefined(services, OpenAiSocket)
         if (socket) return socket.createResponseStream(payload)
-        return Effect.flatMap(resolveHttpClient, (client) =>
-          client.execute(
-            HttpClientRequest.post("/responses", {
+        return resolveHttpClient.pipe(
+          Effect.flatMap((client) =>
+            client.execute(HttpClientRequest.post("/responses", {
               body: HttpBody.jsonUnsafe({ ...payload, stream: true })
-            })
-          ).pipe(
-            Effect.map(buildResponseStream),
-            Effect.catchTag(
-              "HttpClientError",
-              (error) => Errors.mapHttpClientError(error, "createResponseStream")
+            })).pipe(
+              Effect.map(buildResponseStream),
+              Effect.catchTag(
+                "HttpClientError",
+                (error) => Errors.mapHttpClientError(error, "createResponseStream")
+              )
             )
-          ))
+          ),
+          withRedactedHeaders
+        )
       })
 
     const decodeEmbedding = HttpClientResponse.schemaBodyJson(OpenAiSchema.CreateEmbeddingResponse)
@@ -299,18 +308,20 @@ export const make = Effect.fnUntraced(
     const createEmbedding = (
       payload: typeof OpenAiSchema.CreateEmbeddingRequest.Encoded
     ): Effect.Effect<typeof OpenAiSchema.CreateEmbeddingResponse.Type, AiError.AiError> =>
-      Effect.flatMap(resolveHttpClient, (client) =>
-        client.execute(
-          HttpClientRequest.post("/embeddings", {
+      resolveHttpClient.pipe(
+        Effect.flatMap((client) =>
+          client.execute(HttpClientRequest.post("/embeddings", {
             body: HttpBody.jsonUnsafe(payload)
-          })
-        ).pipe(
-          Effect.flatMap(decodeEmbedding),
-          Effect.catchTags({
-            HttpClientError: (error) => Errors.mapHttpClientError(error, "createEmbedding"),
-            SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createEmbedding"))
-          })
-        ))
+          })).pipe(
+            Effect.flatMap(decodeEmbedding),
+            Effect.catchTags({
+              HttpClientError: (error) => Errors.mapHttpClientError(error, "createEmbedding"),
+              SchemaError: (error) => Effect.fail(Errors.mapSchemaError(error, "createEmbedding"))
+            })
+          )
+        ),
+        withRedactedHeaders
+      )
 
     return OpenAiClient.of({
       client: httpClient,
@@ -319,10 +330,7 @@ export const make = Effect.fnUntraced(
       createEmbedding
     })
   },
-  Effect.updateService(
-    Headers.CurrentRedactedNames,
-    Array.appendAll(Object.values(RedactedOpenAiHeaders))
-  )
+  withRedactedHeaders
 )
 
 // =============================================================================

--- a/packages/ai/openai/src/OpenAiClientGenerated.ts
+++ b/packages/ai/openai/src/OpenAiClientGenerated.ts
@@ -74,6 +74,11 @@ const RedactedOpenAiHeaders = {
   OpenAiProject: "OpenAI-Project"
 }
 
+const withRedactedHeaders = Effect.updateService(
+  Headers.CurrentRedactedNames,
+  Array.appendAll(Object.values(RedactedOpenAiHeaders))
+)
+
 // =============================================================================
 // Constructor
 // =============================================================================
@@ -124,10 +129,7 @@ export const make = Effect.fnUntraced(
       })
     })
   },
-  Effect.updateService(
-    Headers.CurrentRedactedNames,
-    Array.appendAll(Object.values(RedactedOpenAiHeaders))
-  )
+  withRedactedHeaders
 )
 
 // =============================================================================

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -1,3 +1,4 @@
+import type { OpenAiSchema } from "@effect/ai-openai"
 import type * as Generated from "@effect/ai-openai/Generated"
 import * as Errors from "@effect/ai-openai/internal/errors"
 import * as OpenAiClient from "@effect/ai-openai/OpenAiClient"
@@ -407,7 +408,7 @@ describe("OpenAiClient", () => {
         assert.strictEqual(result.reason._tag, "InvalidOutputError")
       }).pipe(Effect.provide(makeTestLayer(undefined, {
         _tag: "Json",
-        body: { invalid: "response" }
+        body: { invalid: "response" } as any
       }))))
   })
 
@@ -523,13 +524,19 @@ describe("OpenAiClient", () => {
 type MockResponse =
   | {
     readonly _tag: "Json"
-    readonly body: Schema.Json
+    readonly body: typeof Generated.Response.Encoded | {
+      readonly error: {
+        readonly message: string
+        readonly type?: string
+        readonly code?: string | null
+      }
+    }
     readonly status?: number | undefined
     readonly headers?: Record<string, string> | undefined
   }
   | {
     readonly _tag: "Sse"
-    readonly events: ReadonlyArray<Schema.Json>
+    readonly events: ReadonlyArray<typeof OpenAiSchema.ResponseStreamEvent.Encoded>
     readonly status?: number | undefined
     readonly headers?: Record<string, string> | undefined
   }
@@ -554,7 +561,7 @@ const makeHttpClientContext = Effect.gen(function*() {
       capturedRequests.push(request)
       return makeResponse(request, mock.response)
     }),
-    (request) => Effect.succeed(request)
+    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
   )
 
   const mockHttpClient: MockHttpClient["Service"] = {

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -4,248 +4,107 @@ import * as OpenAiClient from "@effect/ai-openai/OpenAiClient"
 import * as OpenAiClientGenerated from "@effect/ai-openai/OpenAiClientGenerated"
 import * as OpenAiConfig from "@effect/ai-openai/OpenAiConfig"
 import { assert, describe, it } from "@effect/vitest"
-import { Config, ConfigProvider, Effect, Layer, Redacted, Schema, Stream } from "effect"
-import type * as AiError from "effect/unstable/ai/AiError"
+import { Config, ConfigProvider, Context, Effect, Layer, Redacted, Schema, Stream } from "effect"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientError from "effect/unstable/http/HttpClientError"
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 
-// =============================================================================
-// Mock Helpers
-// =============================================================================
-
-const makeMockResponse = (options: {
-  readonly status: number
-  readonly body: unknown
-  readonly request?: HttpClientRequest.HttpClientRequest
-}): HttpClientResponse.HttpClientResponse => {
-  // Always use a plain request for the response to avoid Redacted headers in error contexts
-  const request = HttpClientRequest.get(options.request?.url ?? "/")
-  const json = JSON.stringify(options.body)
-  return HttpClientResponse.fromWeb(
-    request,
-    new Response(json, {
-      status: options.status,
-      headers: { "content-type": "application/json" }
-    })
-  )
-}
-
-const makeMockStreamResponse = (options: {
-  readonly events: ReadonlyArray<unknown>
-  readonly request?: HttpClientRequest.HttpClientRequest
-}): HttpClientResponse.HttpClientResponse => {
-  const request = HttpClientRequest.get(options.request?.url ?? "/")
-  const body = options.events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
-  return HttpClientResponse.fromWeb(
-    request,
-    new Response(body, {
-      status: 200,
-      headers: { "content-type": "text/event-stream" }
-    })
-  )
-}
-
-const makeMockHttpClient = (
-  handler: (
-    request: HttpClientRequest.HttpClientRequest
-  ) => Effect.Effect<HttpClientResponse.HttpClientResponse, HttpClientError.HttpClientError>
-): HttpClient.HttpClient =>
-  HttpClient.makeWith<HttpClientError.HttpClientError, never, HttpClientError.HttpClientError, never>(
-    (effect) =>
-      Effect.flatMap(effect, handler) as Effect.Effect<
-        HttpClientResponse.HttpClientResponse,
-        HttpClientError.HttpClientError,
-        never
-      >,
-    Effect.succeed
-  )
-
-const makeResponseBody = (
-  overrides: Partial<typeof Generated.Response.Encoded> = {}
-): typeof Generated.Response.Encoded => ({
-  id: "resp_test123",
-  object: "response",
-  created_at: 1,
-  model: "gpt-4o-mini",
-  status: "completed",
-  output: [],
-  metadata: null,
-  temperature: null,
-  top_p: null,
-  tools: [],
-  tool_choice: "auto",
-  error: null,
-  incomplete_details: null,
-  instructions: null,
-  parallel_tool_calls: false,
-  ...overrides
-})
-
-// =============================================================================
-// Tests
-// =============================================================================
-
 describe("OpenAiClient", () => {
   describe("make", () => {
     it.effect("sets Bearer token from apiKey", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("sk-test-12345")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        // Call method and ignore response parsing errors - we only care about the request
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
-
-        assert.isDefined(capturedRequest)
-        const authHeader = capturedRequest!.headers["authorization"]
-        assert.strictEqual(authHeader, "Bearer sk-test-12345")
-      }))
+        const requests = yield* MockHttpClient.requests
+        assert.strictEqual(requests[0]?.headers["authorization"], "Bearer sk-test-12345")
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("sk-test-12345")
+      }))))
 
     it.effect("prepends default URL", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
-
-        assert.isDefined(capturedRequest)
-        assert.isTrue(capturedRequest!.url.startsWith("https://api.openai.com/v1"))
-      }))
+        const requests = yield* MockHttpClient.requests
+        assert.isTrue(requests[0]?.url.startsWith("https://api.openai.com/v1"))
+      }).pipe(Effect.provide(makeTestLayer())))
 
     it.effect("uses custom apiUrl when provided", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key"),
-          apiUrl: "https://custom.api.com/v2"
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
-
-        assert.isDefined(capturedRequest)
-        assert.isTrue(capturedRequest!.url.startsWith("https://custom.api.com/v2"))
-      }))
+        const requests = yield* MockHttpClient.requests
+        assert.isTrue(requests[0]?.url.startsWith("https://custom.api.com/v2"))
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        apiUrl: "https://custom.api.com/v2"
+      }))))
 
     it.effect("sets OpenAI-Organization header when organizationId provided", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key"),
-          organizationId: Redacted.make("org-12345")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
-
-        assert.isDefined(capturedRequest)
-        assert.strictEqual(capturedRequest!.headers["openai-organization"], "org-12345")
-      }))
+        const requests = yield* MockHttpClient.requests
+        assert.strictEqual(requests[0]?.headers["openai-organization"], "org-12345")
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        organizationId: Redacted.make("org-12345")
+      }))))
 
     it.effect("sets OpenAI-Project header when projectId provided", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key"),
-          projectId: Redacted.make("proj-67890")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
+        const requests = yield* MockHttpClient.requests
+        assert.strictEqual(requests[0]?.headers["openai-project"], "proj-67890")
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        projectId: Redacted.make("proj-67890")
+      }))))
 
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
-
-        assert.isDefined(capturedRequest)
-        assert.strictEqual(capturedRequest!.headers["openai-project"], "proj-67890")
-      }))
-
-    it.effect("applies transformClient option", () =>
-      Effect.gen(function*() {
-        let transformApplied = false
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key"),
-          transformClient: (client) => {
-            transformApplied = true
-            return client
-          }
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
+    it.effect("applies transformClient option", () => {
+      let transformApplied = false
+      return Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
         assert.isTrue(transformApplied)
-      }))
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        transformClient: (client) => {
+          transformApplied = true
+          return client
+        }
+      })))
+    })
 
     it.effect("exposes transformed HttpClient via client field", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
+        const client = yield* OpenAiClient.OpenAiClient
+        yield* client.client.execute(HttpClientRequest.get("/responses"))
 
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key"),
-          transformClient: (client) =>
-            client.pipe(HttpClient.mapRequest(HttpClientRequest.setHeader("x-client-field", "enabled")))
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
+        const requests = yield* MockHttpClient.requests
+        const request = requests[0]
+        assert.isTrue(request?.url.startsWith("https://api.openai.com/v1"))
+        assert.strictEqual(request?.headers["authorization"], "Bearer test-key")
+        assert.strictEqual(request?.headers["x-client-field"], "enabled")
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        transformClient: (client) =>
+          client.pipe(HttpClient.mapRequest(HttpClientRequest.setHeader("x-client-field", "enabled")))
+      }))))
 
-        yield* client.client.execute(HttpClientRequest.get("/responses")).pipe(Effect.ignore)
+    it.effect("applies OpenAiConfig transformClient after options transformClient", () => {
+      let optionsTransformApplied = false
+      let configTransformApplied = false
 
-        assert.isDefined(capturedRequest)
-        assert.isTrue(capturedRequest!.url.startsWith("https://api.openai.com/v1"))
-        assert.strictEqual(capturedRequest!.headers["authorization"], "Bearer test-key")
-        assert.strictEqual(capturedRequest!.headers["x-client-field"], "enabled")
-      }))
-
-    it.effect("applies OpenAiConfig transformClient after options transformClient", () =>
-      Effect.gen(function*() {
-        let optionsTransformApplied = false
-        let configTransformApplied = false
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: makeResponseBody(), request }))
-        })
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key"),
-          transformClient: (client) => {
-            optionsTransformApplied = true
-            return client.pipe(
-              HttpClient.mapRequest(HttpClientRequest.setHeader("x-openai-transform", "options"))
-            )
-          }
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+      return Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
         yield* client.createResponse({
           model: "gpt-4o",
           input: "test"
@@ -258,87 +117,58 @@ describe("OpenAiClient", () => {
           })
         )
 
+        const requests = yield* MockHttpClient.requests
         assert.isTrue(optionsTransformApplied)
         assert.isTrue(configTransformApplied)
-        assert.isDefined(capturedRequest)
-        assert.strictEqual(capturedRequest!.headers["x-openai-transform"], "config")
-      }))
+        assert.strictEqual(requests[0]?.headers["x-openai-transform"], "config")
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        transformClient: (client) => {
+          optionsTransformApplied = true
+          return client.pipe(
+            HttpClient.mapRequest(HttpClientRequest.setHeader("x-openai-transform", "options"))
+          )
+        }
+      })))
+    })
   })
 
   describe("OpenAiClientGenerated", () => {
     it.effect("sets Bearer token from apiKey", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: makeResponseBody(), request }))
-        })
-
-        const client = yield* OpenAiClientGenerated.make({
-          apiKey: Redacted.make("sk-generated-test")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+        const client = yield* OpenAiClientGenerated.OpenAiClientGenerated
         yield* client.createResponse({
-          payload: {
-            model: "gpt-4o",
-            input: "test"
-          }
+          payload: { model: "gpt-4o", input: "test" }
         })
 
-        assert.isDefined(capturedRequest)
-        assert.strictEqual(capturedRequest!.headers["authorization"], "Bearer sk-generated-test")
-      }))
+        const requests = yield* MockHttpClient.requests
+        assert.strictEqual(requests[0]?.headers["authorization"], "Bearer sk-generated-test")
+      }).pipe(Effect.provide(makeGeneratedTestLayer({
+        apiKey: Redacted.make("sk-generated-test")
+      }))))
 
     it.effect("prepends custom apiUrl", () =>
       Effect.gen(function*() {
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: makeResponseBody(), request }))
-        })
-
-        const client = yield* OpenAiClientGenerated.make({
-          apiKey: Redacted.make("test-key"),
-          apiUrl: "https://generated.example.test/v2"
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+        const client = yield* OpenAiClientGenerated.OpenAiClientGenerated
         yield* client.createResponse({
-          payload: {
-            model: "gpt-4o",
-            input: "test"
-          }
+          payload: { model: "gpt-4o", input: "test" }
         })
 
-        assert.isDefined(capturedRequest)
-        assert.isTrue(capturedRequest!.url.startsWith("https://generated.example.test/v2"))
-      }))
+        const requests = yield* MockHttpClient.requests
+        assert.isTrue(requests[0]?.url.startsWith("https://generated.example.test/v2"))
+      }).pipe(Effect.provide(makeGeneratedTestLayer({
+        apiKey: Redacted.make("test-key"),
+        apiUrl: "https://generated.example.test/v2"
+      }))))
 
-    it.effect("applies OpenAiConfig transformClient after options transformClient", () =>
-      Effect.gen(function*() {
-        let optionsTransformApplied = false
-        let configTransformApplied = false
-        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+    it.effect("applies OpenAiConfig transformClient after options transformClient", () => {
+      let optionsTransformApplied = false
+      let configTransformApplied = false
 
-        const mockClient = makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: makeResponseBody(), request }))
-        })
-
-        const client = yield* OpenAiClientGenerated.make({
-          apiKey: Redacted.make("test-key"),
-          transformClient: (client) => {
-            optionsTransformApplied = true
-            return client.pipe(
-              HttpClient.mapRequest(HttpClientRequest.setHeader("x-openai-transform", "options"))
-            )
-          }
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+      return Effect.gen(function*() {
+        const client = yield* OpenAiClientGenerated.OpenAiClientGenerated
         yield* client.createResponse({
-          payload: {
-            model: "gpt-4o",
-            input: "test"
-          }
+          payload: { model: "gpt-4o", input: "test" }
         }).pipe(
           OpenAiConfig.withClientTransform((client) => {
             configTransformApplied = true
@@ -348,40 +178,30 @@ describe("OpenAiClient", () => {
           })
         )
 
+        const requests = yield* MockHttpClient.requests
         assert.isTrue(optionsTransformApplied)
         assert.isTrue(configTransformApplied)
-        assert.isDefined(capturedRequest)
-        assert.strictEqual(capturedRequest!.headers["x-openai-transform"], "config")
-      }))
+        assert.strictEqual(requests[0]?.headers["x-openai-transform"], "config")
+      }).pipe(Effect.provide(makeGeneratedTestLayer({
+        apiKey: Redacted.make("test-key"),
+        transformClient: (client) => {
+          optionsTransformApplied = true
+          return client.pipe(
+            HttpClient.mapRequest(HttpClientRequest.setHeader("x-openai-transform", "options"))
+          )
+        }
+      })))
+    })
   })
 
   describe("layer", () => {
-    it.effect("creates working service", () => {
-      const HttpClientLayer = Layer.succeed(
-        HttpClient.HttpClient,
-        makeMockHttpClient(() => Effect.succeed(makeMockResponse({ status: 200, body: {} })))
-      )
-
-      const MainLayer = OpenAiClient.layer({
-        apiKey: Redacted.make("test-key")
-      }).pipe(Layer.provide(HttpClientLayer))
-
-      return Effect.gen(function*() {
+    it.effect("creates working service", () =>
+      Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient
         assert.isNotNull(client.client)
-      }).pipe(Effect.provide(MainLayer))
-    })
+      }).pipe(Effect.provide(makeTestLayer())))
 
     it.effect("layerConfig loads from Config", () => {
-      let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
-      const HttpClientLayer = Layer.succeed(
-        HttpClient.HttpClient,
-        makeMockHttpClient((request) => {
-          capturedRequest = request
-          return Effect.succeed(makeMockResponse({ status: 200, body: {}, request }))
-        })
-      )
-
       const configProvider = ConfigProvider.fromEnv({
         env: {
           MY_API_KEY: "sk-config-key",
@@ -389,45 +209,51 @@ describe("OpenAiClient", () => {
         }
       })
 
-      // Use explicit config values to test the layerConfig mechanism
-      // Provide explicit configs that won't fail for optional fields
-      const MainLayer = OpenAiClient.layerConfig({
-        apiKey: Config.redacted("MY_API_KEY"),
-        apiUrl: Config.string("MY_API_URL")
-      }).pipe(
-        Layer.provide(HttpClientLayer),
-        Layer.provide(ConfigProvider.layer(configProvider))
-      )
-
       return Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient
-        yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.ignore)
+        yield* client.createResponse({ model: "gpt-4o", input: "test" })
 
-        assert.isDefined(capturedRequest)
-        assert.strictEqual(capturedRequest!.headers["authorization"], "Bearer sk-config-key")
-        assert.isTrue(capturedRequest!.url.startsWith("https://config.api.com/v1"))
-      }).pipe(Effect.provide(MainLayer))
+        const requests = yield* MockHttpClient.requests
+        assert.strictEqual(requests[0]?.headers["authorization"], "Bearer sk-config-key")
+        assert.isTrue(requests[0]?.url.startsWith("https://config.api.com/v1"))
+      }).pipe(Effect.provide(makeConfigTestLayer(configProvider)))
     })
+  })
+
+  describe("request behavior", () => {
+    it.effect("redacts OpenAI-specific headers in AI error context", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({
+          model: "gpt-4o",
+          input: "test"
+        }).pipe(Effect.flip)
+
+        assert.strictEqual(result.reason._tag, "InvalidRequestError")
+        if (result.reason._tag !== "InvalidRequestError" || result.reason.http === undefined) {
+          return yield* Effect.die(new Error("Expected InvalidRequestError with HTTP context"))
+        }
+        const headers = result.reason.http.request.headers
+        assert.strictEqual(String(headers["authorization"]), "<redacted>")
+        assert.strictEqual(String(headers["openai-organization"]), "<redacted>")
+        assert.strictEqual(String(headers["openai-project"]), "<redacted>")
+      }).pipe(Effect.provide(makeTestLayer({
+        apiKey: Redacted.make("test-key"),
+        organizationId: Redacted.make("org-secret"),
+        projectId: Redacted.make("proj-secret")
+      }, {
+        _tag: "Json",
+        status: 400,
+        body: { error: { message: "Bad request" } }
+      }))))
   })
 
   describe("error mapping", () => {
     it.effect("maps TransportError to NetworkError reason", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient(() =>
-          Effect.fail(
-            new HttpClientError.HttpClientError({
-              reason: new HttpClientError.TransportError({
-                request: HttpClientRequest.get("/"),
-                cause: new Error("Connection refused")
-              })
-            })
-          )
-        )
-
         const client = yield* OpenAiClient.make({
           apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+        })
         const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
           Effect.flip
         )
@@ -436,129 +262,88 @@ describe("OpenAiClient", () => {
         assert.strictEqual(result.module, "OpenAiClient")
         assert.strictEqual(result.method, "createResponse")
         assert.strictEqual(result.reason._tag, "NetworkError")
-      }))
+      }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, makeTransportErrorHttpClient()))))
 
     it.effect("maps 400 status to InvalidRequestError reason", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 400,
-            body: { error: { message: "Bad request" } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.module, "OpenAiClient")
         assert.strictEqual(result.method, "createResponse")
         assert.strictEqual(result.reason._tag, "InvalidRequestError")
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 400,
+        body: { error: { message: "Bad request" } }
+      }))))
 
     it.effect("maps 401 status to AuthenticationError reason", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 401,
-            body: { error: { message: "Invalid API key" } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "AuthenticationError")
-        assert.strictEqual((result.reason as AiError.AuthenticationError).kind, "InvalidKey")
-      }))
+        if (result.reason._tag === "AuthenticationError") {
+          assert.strictEqual(result.reason.kind, "InvalidKey")
+        }
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 401,
+        body: { error: { message: "Invalid API key" } }
+      }))))
 
     it.effect("maps 403 status to AuthenticationError with InsufficientPermissions", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 403,
-            body: { error: { message: "Access denied" } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "AuthenticationError")
-        assert.strictEqual((result.reason as AiError.AuthenticationError).kind, "InsufficientPermissions")
-      }))
+        if (result.reason._tag === "AuthenticationError") {
+          assert.strictEqual(result.reason.kind, "InsufficientPermissions")
+        }
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 403,
+        body: { error: { message: "Access denied" } }
+      }))))
 
     it.effect("maps 429 status to RateLimitError reason", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 429,
-            body: { error: { message: "Rate limit exceeded", type: "rate_limit_error", code: null } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "RateLimitError")
         assert.isTrue(result.isRetryable)
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 429,
+        body: { error: { message: "Rate limit exceeded", type: "rate_limit_error", code: null } }
+      }))))
 
     it.effect("maps 429 with insufficient_quota code to QuotaExhaustedError", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 429,
-            body: {
-              error: {
-                message: "You exceeded your current quota",
-                type: "insufficient_quota",
-                code: "insufficient_quota"
-              }
-            },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "QuotaExhaustedError")
         assert.isFalse(result.isRetryable)
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 429,
+        body: {
+          error: {
+            message: "You exceeded your current quota",
+            type: "insufficient_quota",
+            code: "insufficient_quota"
+          }
+        }
+      }))))
 
     it("mapStatusCodeToReason detects insufficient_quota as QuotaExhaustedError", () => {
       const http = {
@@ -600,66 +385,36 @@ describe("OpenAiClient", () => {
 
     it.effect("maps 5xx status to InternalProviderError reason", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 500,
-            body: { error: { message: "Internal server error" } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "InternalProviderError")
         assert.isTrue(result.isRetryable)
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 500,
+        body: { error: { message: "Internal server error" } }
+      }))))
 
     it.effect("maps schema error to InvalidOutputError reason", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 200,
-            body: { invalid: "response" },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
-        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(
-          Effect.flip
-        )
+        const client = yield* OpenAiClient.OpenAiClient
+        const result = yield* client.createResponse({ model: "gpt-4o", input: "test" }).pipe(Effect.flip)
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.method, "createResponse")
         assert.strictEqual(result.reason._tag, "InvalidOutputError")
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        body: { invalid: "response" }
+      }))))
   })
 
   describe("createEmbedding", () => {
     it.effect("maps 400 error to AiError", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 400,
-            body: { error: { message: "Invalid model" } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+        const client = yield* OpenAiClient.OpenAiClient
         const result = yield* client.createEmbedding({
           model: "invalid-model",
           input: "test"
@@ -668,22 +423,15 @@ describe("OpenAiClient", () => {
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.method, "createEmbedding")
         assert.strictEqual(result.reason._tag, "InvalidRequestError")
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 400,
+        body: { error: { message: "Invalid model" } }
+      }))))
 
     it.effect("maps 429 error to RateLimitError", () =>
       Effect.gen(function*() {
-        const mockClient = makeMockHttpClient((request) =>
-          Effect.succeed(makeMockResponse({
-            status: 429,
-            body: { error: { message: "Rate limit exceeded" } },
-            request
-          }))
-        )
-
-        const client = yield* OpenAiClient.make({
-          apiKey: Redacted.make("test-key")
-        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
-
+        const client = yield* OpenAiClient.OpenAiClient
         const result = yield* client.createEmbedding({
           model: "text-embedding-ada-002",
           input: "test"
@@ -691,47 +439,17 @@ describe("OpenAiClient", () => {
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "RateLimitError")
-      }))
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 429,
+        body: { error: { message: "Rate limit exceeded" } }
+      }))))
   })
 
   describe("createResponseStream", () => {
-    it.effect("accepts keepalive stream events", () => {
-      const mockClient = makeMockHttpClient((request) =>
-        Effect.succeed(makeMockStreamResponse({
-          request,
-          events: [
-            {
-              type: "response.created",
-              sequence_number: 1,
-              response: makeResponseBody({
-                id: "resp_stream",
-                status: "in_progress"
-              })
-            },
-            {
-              type: "keepalive",
-              sequence_number: 2
-            },
-            {
-              type: "response.completed",
-              sequence_number: 3,
-              response: makeResponseBody({
-                id: "resp_stream"
-              })
-            }
-          ]
-        }))
-      )
-
-      const HttpClientLayer = Layer.succeed(HttpClient.HttpClient, mockClient)
-
-      const MainLayer = OpenAiClient.layer({
-        apiKey: Redacted.make("test-key")
-      }).pipe(Layer.provide(HttpClientLayer))
-
-      return Effect.gen(function*() {
+    it.effect("accepts keepalive stream events", () =>
+      Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient
-
         const [_, stream] = yield* client.createResponseStream({
           model: "gpt-4o",
           input: "test"
@@ -761,27 +479,29 @@ describe("OpenAiClient", () => {
             assert.strictEqual(completed.response.id, "resp_stream")
           }
         }
-      }).pipe(Effect.provide(MainLayer))
-    })
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Sse",
+        events: [
+          {
+            type: "response.created",
+            sequence_number: 1,
+            response: makeResponseBody({ id: "resp_stream", status: "in_progress" })
+          },
+          {
+            type: "keepalive",
+            sequence_number: 2
+          },
+          {
+            type: "response.completed",
+            sequence_number: 3,
+            response: makeResponseBody({ id: "resp_stream" })
+          }
+        ]
+      }))))
 
-    it.effect("maps HTTP error before stream starts", () => {
-      const mockClient = makeMockHttpClient((request) =>
-        Effect.succeed(makeMockResponse({
-          status: 500,
-          body: { error: { message: "Server error" } },
-          request
-        }))
-      )
-
-      const HttpClientLayer = Layer.succeed(HttpClient.HttpClient, mockClient)
-
-      const MainLayer = OpenAiClient.layer({
-        apiKey: Redacted.make("test-key")
-      }).pipe(Layer.provide(HttpClientLayer))
-
-      return Effect.gen(function*() {
+    it.effect("maps HTTP error before stream starts", () =>
+      Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient
-
         const result = yield* client.createResponseStream({
           model: "gpt-4o",
           input: "test"
@@ -792,7 +512,152 @@ describe("OpenAiClient", () => {
 
         assert.strictEqual(result._tag, "AiError")
         assert.strictEqual(result.reason._tag, "InternalProviderError")
-      }).pipe(Effect.provide(MainLayer))
-    })
+      }).pipe(Effect.provide(makeTestLayer(undefined, {
+        _tag: "Json",
+        status: 500,
+        body: { error: { message: "Server error" } }
+      }))))
   })
 })
+
+type MockResponse =
+  | {
+    readonly _tag: "Json"
+    readonly body: Schema.Json
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+  | {
+    readonly _tag: "Sse"
+    readonly events: ReadonlyArray<Schema.Json>
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+
+class MockOpenAiResponse extends Context.Service<MockOpenAiResponse, {
+  readonly response: MockResponse
+}>()("MockOpenAiResponse") {}
+
+class MockHttpClient extends Context.Service<MockHttpClient, {
+  readonly requests: Effect.Effect<ReadonlyArray<HttpClientRequest.HttpClientRequest>>
+}>()("MockHttpClient") {
+  static requests = MockHttpClient.use((client) => client.requests)
+}
+
+const makeHttpClientContext = Effect.gen(function*() {
+  const capturedRequests: Array<HttpClientRequest.HttpClientRequest> = []
+  const mock = yield* MockOpenAiResponse
+
+  const httpClient = HttpClient.makeWith(
+    Effect.fnUntraced(function*(requestEffect) {
+      const request = yield* requestEffect
+      capturedRequests.push(request)
+      return makeResponse(request, mock.response)
+    }),
+    (request) => Effect.succeed(request)
+  )
+
+  const mockHttpClient: MockHttpClient["Service"] = {
+    requests: Effect.sync(() => capturedRequests)
+  }
+
+  return Context.make(HttpClient.HttpClient, httpClient).pipe(
+    Context.add(MockHttpClient, mockHttpClient)
+  )
+})
+
+const HttpClientLayer = Layer.effectContext(makeHttpClientContext)
+
+const defaultResponse: MockResponse = {
+  _tag: "Json",
+  body: makeResponseBody()
+}
+
+const makeTestLayer = (
+  options: OpenAiClient.Options = { apiKey: Redacted.make("test-key") },
+  response: MockResponse = defaultResponse
+) =>
+  OpenAiClient.layer(options).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockOpenAiResponse, { response }))
+  )
+
+const makeGeneratedTestLayer = (
+  options: OpenAiClientGenerated.Options,
+  response: MockResponse = defaultResponse
+) =>
+  OpenAiClientGenerated.layer(options).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockOpenAiResponse, { response }))
+  )
+
+const makeConfigTestLayer = (configProvider: ConfigProvider.ConfigProvider) =>
+  OpenAiClient.layerConfig({
+    apiKey: Config.redacted("MY_API_KEY"),
+    apiUrl: Config.string("MY_API_URL")
+  }).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockOpenAiResponse, { response: defaultResponse })),
+    Layer.provide(ConfigProvider.layer(configProvider))
+  )
+
+const makeTransportErrorHttpClient = (): HttpClient.HttpClient =>
+  HttpClient.makeWith<HttpClientError.HttpClientError, never, HttpClientError.HttpClientError, never>(
+    (requestEffect) =>
+      Effect.flatMap(requestEffect, (request) =>
+        Effect.fail(
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause: new Error("Connection refused")
+            })
+          })
+        )),
+    Effect.succeed
+  )
+
+function makeResponseBody(
+  overrides: Partial<typeof Generated.Response.Encoded> = {}
+): typeof Generated.Response.Encoded {
+  return {
+    id: "resp_test123",
+    object: "response",
+    created_at: 1,
+    model: "gpt-4o-mini",
+    status: "completed",
+    output: [],
+    metadata: null,
+    temperature: null,
+    top_p: null,
+    tools: [],
+    tool_choice: "auto",
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    parallel_tool_calls: false,
+    ...overrides
+  }
+}
+
+const makeResponse = (
+  request: HttpClientRequest.HttpClientRequest,
+  response: MockResponse
+): HttpClientResponse.HttpClientResponse => {
+  const contentType = response._tag === "Json"
+    ? "application/json"
+    : "text/event-stream"
+  const body = response._tag === "Json"
+    ? JSON.stringify(response.body)
+    : response.events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
+
+  return HttpClientResponse.fromWeb(
+    request,
+    new Response(body, {
+      status: response.status ?? 200,
+      headers: {
+        "content-type": contentType,
+        ...response.headers
+      }
+    })
+  )
+}

--- a/packages/ai/openrouter/test/OpenRouterClient.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterClient.test.ts
@@ -1,0 +1,113 @@
+import { OpenRouterClient } from "@effect/ai-openrouter"
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Layer, Redacted, type Schema } from "effect"
+import { HttpClient, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+
+describe("OpenRouterClient", () => {
+  it.effect("redacts the API key in AI error context", () =>
+    Effect.gen(function*() {
+      const client = yield* OpenRouterClient.OpenRouterClient
+
+      const result = yield* client.createChatCompletion({
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hello" }]
+      }).pipe(Effect.flip)
+
+      assert.strictEqual(result.reason._tag, "InvalidRequestError")
+      if (result.reason._tag !== "InvalidRequestError" || result.reason.http === undefined) {
+        return yield* Effect.die(new Error("Expected InvalidRequestError with HTTP context"))
+      }
+      const requests = yield* MockHttpClient.requests
+      assert.include(requests[0]?.url, "/chat/completions")
+      assert.strictEqual(String(result.reason.http.request.headers["authorization"]), "<redacted>")
+    }).pipe(Effect.provide(makeTestLayer({
+      _tag: "Json",
+      status: 400,
+      body: {
+        error: {
+          code: 400,
+          message: "Bad request"
+        }
+      }
+    }))))
+})
+
+type MockResponse =
+  | {
+    readonly _tag: "Json"
+    readonly body: Schema.Json
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+  | {
+    readonly _tag: "Sse"
+    readonly events: ReadonlyArray<Schema.Json>
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
+
+class MockOpenRouterResponse extends Context.Service<MockOpenRouterResponse, {
+  readonly response: MockResponse
+}>()("MockOpenRouterResponse") {}
+
+class MockHttpClient extends Context.Service<MockHttpClient, {
+  readonly requests: Effect.Effect<ReadonlyArray<HttpClientRequest.HttpClientRequest>>
+}>()("MockHttpClient") {
+  static requests = MockHttpClient.use((client) => client.requests)
+}
+
+const makeHttpClientContext = Effect.gen(function*() {
+  const capturedRequests: Array<HttpClientRequest.HttpClientRequest> = []
+  const mock = yield* MockOpenRouterResponse
+
+  const httpClient = HttpClient.makeWith(
+    Effect.fnUntraced(function*(requestEffect) {
+      const request = yield* requestEffect
+      capturedRequests.push(request)
+      return makeResponse(request, mock.response)
+    }),
+    (request) => Effect.succeed(request)
+  )
+
+  const mockHttpClient: MockHttpClient["Service"] = {
+    requests: Effect.sync(() => capturedRequests)
+  }
+
+  return Context.make(HttpClient.HttpClient, httpClient).pipe(
+    Context.add(MockHttpClient, mockHttpClient)
+  )
+})
+
+const HttpClientLayer = Layer.effectContext(makeHttpClientContext)
+
+const makeTestLayer = (
+  response: MockResponse,
+  options: OpenRouterClient.Options = { apiKey: Redacted.make("sk-test-key") }
+) =>
+  OpenRouterClient.layer(options).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockOpenRouterResponse, { response }))
+  )
+
+const makeResponse = (
+  request: HttpClientRequest.HttpClientRequest,
+  response: MockResponse
+): HttpClientResponse.HttpClientResponse => {
+  const contentType = response._tag === "Json"
+    ? "application/json"
+    : "text/event-stream"
+  const body = response._tag === "Json"
+    ? JSON.stringify(response.body)
+    : response.events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
+
+  return HttpClientResponse.fromWeb(
+    request,
+    new Response(body, {
+      status: response.status ?? 200,
+      headers: {
+        "content-type": contentType,
+        ...response.headers
+      }
+    })
+  )
+}

--- a/packages/ai/openrouter/test/OpenRouterClient.test.ts
+++ b/packages/ai/openrouter/test/OpenRouterClient.test.ts
@@ -1,7 +1,7 @@
 import { OpenRouterClient } from "@effect/ai-openrouter"
 import { assert, describe, it } from "@effect/vitest"
 import { Context, Effect, Layer, Redacted, type Schema } from "effect"
-import { HttpClient, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("OpenRouterClient", () => {
   it.effect("redacts the API key in AI error context", () =>
@@ -66,7 +66,7 @@ const makeHttpClientContext = Effect.gen(function*() {
       capturedRequests.push(request)
       return makeResponse(request, mock.response)
     }),
-    (request) => Effect.succeed(request)
+    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
   )
 
   const mockHttpClient: MockHttpClient["Service"] = {


### PR DESCRIPTION
## Summary
- apply provider-specific header redaction while OpenAI, OpenAI-compatible, and Anthropic requests and error mapping execute
- refactor OpenAI client tests around shared JSON/SSE response mocks and captured requests
- add focused Anthropic and OpenRouter status-error redaction coverage

## Testing
- `pnpm test packages/ai/openai-compat/test/OpenAiClient.test.ts`
- `pnpm test packages/ai/openai/test/OpenAiClient.test.ts`
- `pnpm test packages/ai/anthropic/test/AnthropicClient.test.ts packages/ai/anthropic/test/AnthropicLanguageModel.test.ts`
- `pnpm test packages/ai/openrouter/test/OpenRouterClient.test.ts packages/ai/openrouter/test/OpenRouterLanguageModel.test.ts`
- targeted package typechecks and oxlint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensitive-header redaction so API keys and OpenAI organization/project headers are no longer exposed in client error context.
  * Ensures redaction is applied consistently across Anthropic, OpenAI, OpenAI compatibility, and OpenRouter for non-streaming, streaming, and embeddings requests.
* **Tests**
  * Added/updated client test coverage to verify outgoing request headers and error redaction, including SSE streaming and embeddings flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->