### PR TITLE
Add extendEnv option to Command.env

### DIFF
--- a/.changeset/calm-commands-rest.md
+++ b/.changeset/calm-commands-rest.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform": patch
+"@effect/platform-node-shared": patch
+"@effect/platform-bun": patch
+---
+
+Add an `extendEnv` option to `Command.env` for spawning commands with a clean environment.

--- a/packages/platform-node-shared/src/internal/commandExecutor.ts
+++ b/packages/platform-node-shared/src/internal/commandExecutor.ts
@@ -68,7 +68,9 @@ const runCommand =
                   ],
                   cwd: Option.getOrElse(command.cwd, constUndefined),
                   shell: command.shell,
-                  env: { ...process.env, ...Object.fromEntries(command.env) },
+                  env: command.extendEnv
+                    ? { ...process.env, ...Object.fromEntries(command.env) }
+                    : Object.fromEntries(command.env),
                   detached: process.platform !== "win32"
                 })
                 handle.on("error", (err) => {

--- a/packages/platform-node-shared/test/CommandExecutor.test.ts
+++ b/packages/platform-node-shared/test/CommandExecutor.test.ts
@@ -328,11 +328,12 @@ describe("Command", () => {
 
   it("should delegate env to all commands", () => {
     const env = { key: "value" }
+    const environment = { ...env, omitted: undefined }
     const command = pipe(
       Command.make("cat"),
       Command.pipeTo(Command.make("sort")),
       Command.pipeTo(Command.make("head", "-2")),
-      Command.env(env, { extendEnv: false })
+      Command.env(environment, { extendEnv: false })
     )
     const commands = Command.flatten(command)
     const envs = commands.map((command) => Object.fromEntries(command.env))

--- a/packages/platform-node-shared/test/CommandExecutor.test.ts
+++ b/packages/platform-node-shared/test/CommandExecutor.test.ts
@@ -6,9 +6,11 @@ import type * as CommandExecutor from "@effect/platform/CommandExecutor"
 import { SystemError } from "@effect/platform/Error"
 import * as FileSystem from "@effect/platform/FileSystem"
 import * as Path from "@effect/platform/Path"
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import * as Array from "effect/Array"
 import * as Chunk from "effect/Chunk"
+import * as Config from "effect/Config"
+import * as ConfigProvider from "effect/ConfigProvider"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
@@ -89,6 +91,25 @@ describe("Command", () => {
       const result = yield* Command.string(command)
       expect(result).toBe("var = myValue")
     })))
+
+  it.effect("should not extend the environment when extendEnv is false", () => {
+    return Effect.gen(function*() {
+      const explicit = yield* Config.string("EXPLICIT")
+      const command = pipe(
+        Command.make(
+          process.execPath,
+          "-e",
+          "process.stdout.write(`${process.env.EXPLICIT ?? ''}:${process.env.PATH ?? ''}`)"
+        ),
+        Command.env({ EXPLICIT: explicit }, { extendEnv: false })
+      )
+      const result = yield* Command.string(command)
+      assert.strictEqual(result, "present:")
+    }).pipe(
+      Effect.withConfigProvider(ConfigProvider.fromMap(new Map([["EXPLICIT", "present"]]))),
+      Effect.provide(TestLive)
+    )
+  })
 
   it("should accept streaming stdin", () =>
     runPromise(Effect.gen(function*() {
@@ -311,10 +332,12 @@ describe("Command", () => {
       Command.make("cat"),
       Command.pipeTo(Command.make("sort")),
       Command.pipeTo(Command.make("head", "-2")),
-      Command.env(env)
+      Command.env(env, { extendEnv: false })
     )
-    const envs = Command.flatten(command).map((command) => Object.fromEntries(command.env))
+    const commands = Command.flatten(command)
+    const envs = commands.map((command) => Object.fromEntries(command.env))
     expect(envs).toEqual([env, env, env])
+    expect(commands.map((command) => command.extendEnv)).toEqual([false, false, false])
   })
 
   it("should delegate workingDirectory to all commands", () => {

--- a/packages/platform/src/Command.ts
+++ b/packages/platform/src/Command.ts
@@ -91,6 +91,7 @@ export interface StandardCommand extends Command.Proto {
   readonly command: string
   readonly args: ReadonlyArray<string>
   readonly env: HashMap<string, string>
+  readonly extendEnv: boolean
   readonly cwd: Option<string>
   readonly shell: boolean | string
   readonly stdin: Command.Input
@@ -122,12 +123,22 @@ export const isCommand: (u: unknown) => u is Command = internal.isCommand
 /**
  * Specify the environment variables that will be used when running this command.
  *
+ * By default, the configured variables extend the parent process environment.
+ * Set `extendEnv` to `false` to use only the configured variables.
+ *
  * @since 1.0.0
  * @category combinators
  */
 export const env: {
-  (environment: Record<string, string | undefined>): (self: Command) => Command
-  (self: Command, environment: Record<string, string | undefined>): Command
+  (
+    environment: Record<string, string | undefined>,
+    options?: { readonly extendEnv?: boolean | undefined }
+  ): (self: Command) => Command
+  (
+    self: Command,
+    environment: Record<string, string | undefined>,
+    options?: { readonly extendEnv?: boolean | undefined }
+  ): Command
 } = internal.env
 
 /**

--- a/packages/platform/src/internal/command.ts
+++ b/packages/platform/src/internal/command.ts
@@ -48,7 +48,7 @@ export const env: {
         extendEnv: options?.extendEnv ?? self.extendEnv,
         env: HashMap.union(
           self.env,
-          HashMap.fromIterable(Object.entries(environment).filter(([v]) => v !== undefined))
+          HashMap.fromIterable(Object.entries(environment).filter(([, value]) => value !== undefined))
         ) as HashMap.HashMap<string, string>
       })
     }

--- a/packages/platform/src/internal/command.ts
+++ b/packages/platform/src/internal/command.ts
@@ -21,16 +21,31 @@ export const isCommand = (u: unknown): u is Command.Command => typeof u === "obj
 
 /** @internal */
 export const env: {
-  (environment: Record<string, string | undefined>): (self: Command.Command) => Command.Command
-  (self: Command.Command, environment: Record<string, string | undefined>): Command.Command
+  (
+    environment: Record<string, string | undefined>,
+    options?: { readonly extendEnv?: boolean | undefined }
+  ): (self: Command.Command) => Command.Command
+  (
+    self: Command.Command,
+    environment: Record<string, string | undefined>,
+    options?: { readonly extendEnv?: boolean | undefined }
+  ): Command.Command
 } = dual<
-  (environment: Record<string, string | undefined>) => (self: Command.Command) => Command.Command,
-  (self: Command.Command, environment: Record<string, string | undefined>) => Command.Command
->(2, (self, environment) => {
+  (
+    environment: Record<string, string | undefined>,
+    options?: { readonly extendEnv?: boolean | undefined }
+  ) => (self: Command.Command) => Command.Command,
+  (
+    self: Command.Command,
+    environment: Record<string, string | undefined>,
+    options?: { readonly extendEnv?: boolean | undefined }
+  ) => Command.Command
+>((args) => isCommand(args[0]), (self, environment, options) => {
   switch (self._tag) {
     case "StandardCommand": {
       return makeStandard({
         ...self,
+        extendEnv: options?.extendEnv ?? self.extendEnv,
         env: HashMap.union(
           self.env,
           HashMap.fromIterable(Object.entries(environment).filter(([v]) => v !== undefined))
@@ -38,7 +53,7 @@ export const env: {
       })
     }
     case "PipedCommand": {
-      return pipeTo(env(self.left, environment), env(self.right, environment))
+      return pipeTo(env(self.left, environment, options), env(self.right, environment, options))
     }
   }
 })
@@ -119,6 +134,7 @@ const StandardProto = {
       command: this.command,
       args: this.args,
       env: Object.fromEntries(this.env),
+      extendEnv: this.extendEnv,
       cwd: this.cwd.toJSON(),
       shell: this.shell,
       gid: this.gid.toJSON(),
@@ -152,6 +168,7 @@ export const make = (command: string, ...args: Array<string>): Command.Command =
     command,
     args,
     env: HashMap.empty(),
+    extendEnv: true,
     cwd: Option.none(),
     shell: false,
     stdin: "pipe",


### PR DESCRIPTION
## Summary
- add an `extendEnv` option to `Command.env`, defaulting to `true`
- allow Node and Bun commands to use only explicitly configured environment variables
- cover clean environments and piped command propagation

## Testing
- `pnpm lint-fix`
- `pnpm test run packages/platform-node-shared/test/CommandExecutor.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes #6643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `extendEnv` option to command environment configuration to control whether spawned processes inherit the current environment.
  * Environment isolation can now be applied consistently across chained/piped and delegated commands.

* **Bug Fixes**
  * Updated command execution so `extendEnv: false` reliably prevents unintended environment variables from being passed through.

* **Tests**
  * Expanded coverage for the isolated-environment behavior.

* **Chores**
  * Updated patch versions for related platform packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->