### PR TITLE
Remove Effect.withConcurrency and "inherit" concurrency

### DIFF
--- a/.changeset/remove-with-concurrency.md
+++ b/.changeset/remove-with-concurrency.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove `Effect.withConcurrency`, the `References.CurrentConcurrency` reference backing it, and the `"inherit"` option from `Types.Concurrency`. Use an explicit `number` or `"unbounded"` concurrency value instead.

--- a/migration/fiberref.md
+++ b/migration/fiberref.md
@@ -11,7 +11,6 @@ from `References` and related modules.
 
 | v3 FiberRef                         | v4 Reference                       |
 | ----------------------------------- | ---------------------------------- |
-| `FiberRef.currentConcurrency`       | `References.CurrentConcurrency`    |
 | `FiberRef.currentLogLevel`          | `References.CurrentLogLevel`       |
 | `FiberRef.currentMinimumLogLevel`   | `References.MinimumLogLevel`       |
 | `FiberRef.currentLogAnnotations`    | `References.CurrentLogAnnotations` |
@@ -88,8 +87,8 @@ set via `Effect.provideService`, which scopes the value to the provided effect.
 import { Effect, FiberRef } from "effect"
 
 const program = Effect.gen(function*() {
-  yield* FiberRef.set(FiberRef.currentConcurrency, 10)
-  // subsequent code sees concurrency = 10
+  yield* FiberRef.set(FiberRef.currentMaxOpsBeforeYield, 500)
+  // subsequent code sees maxOpsBeforeYield = 500
 })
 ```
 
@@ -100,10 +99,10 @@ import { Effect, References } from "effect"
 
 const program = Effect.provideService(
   Effect.gen(function*() {
-    const concurrency = yield* References.CurrentConcurrency
-    console.log(concurrency) // 10
+    const maxOps = yield* References.MaxOpsBeforeYield
+    console.log(maxOps) // 500
   }),
-  References.CurrentConcurrency,
-  10
+  References.MaxOpsBeforeYield,
+  500
 )
 ```

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6426,52 +6426,6 @@ export const provideServiceEffect: {
 } = internal.provideServiceEffect
 
 // -----------------------------------------------------------------------------
-// References
-// -----------------------------------------------------------------------------
-
-/**
- * Sets the concurrency level for parallel operations within an effect.
- *
- * **Example** (Setting local concurrency)
- *
- * ```ts
- * import { Console, Effect } from "effect"
- *
- * const task = (id: number) =>
- *   Effect.gen(function*() {
- *     yield* Console.log(`Task ${id} starting`)
- *     yield* Effect.sleep("100 millis")
- *     yield* Console.log(`Task ${id} completed`)
- *     return id
- *   })
- *
- * // Run tasks with limited concurrency (max 2 at a time)
- * const program = Effect.gen(function*() {
- *   const tasks = [1, 2, 3, 4, 5].map(task)
- *   return yield* Effect.all(tasks, { concurrency: 2 })
- * }).pipe(
- *   Effect.withConcurrency(2)
- * )
- *
- * Effect.runPromise(program).then(console.log)
- * // Tasks will run with max 2 concurrent operations
- * // [1, 2, 3, 4, 5]
- * ```
- *
- * @category references
- * @since 2.0.0
- */
-export const withConcurrency: {
-  (
-    concurrency: number | "unbounded"
-  ): <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, R>
-  <A, E, R>(
-    self: Effect<A, E, R>,
-    concurrency: number | "unbounded"
-  ): Effect<A, E, R>
-} = internal.withConcurrency
-
-// -----------------------------------------------------------------------------
 // Resource management & finalization
 // -----------------------------------------------------------------------------
 

--- a/packages/effect/src/References.ts
+++ b/packages/effect/src/References.ts
@@ -125,52 +125,6 @@ export {
 }
 
 /**
- * Context reference for controlling the current concurrency limit. Can be set to "unbounded"
- * for unlimited concurrency or a specific number to limit concurrent operations.
- *
- * **When to use**
- *
- * Use to configure the default concurrency limit for operations that read
- * concurrency from the current context.
- *
- * **Example** (Setting current concurrency)
- *
- * ```ts
- * import { Effect, References } from "effect"
- *
- * const limitConcurrency = Effect.gen(function*() {
- *   // Get current setting
- *   const current = yield* References.CurrentConcurrency
- *   console.log(current) // "unbounded" (default)
- *
- *   // Run with limited concurrency
- *   yield* Effect.provideService(
- *     Effect.gen(function*() {
- *       const limited = yield* References.CurrentConcurrency
- *       console.log(limited) // 10
- *     }),
- *     References.CurrentConcurrency,
- *     10
- *   )
- *
- *   // Run with unlimited concurrency
- *   yield* Effect.provideService(
- *     Effect.gen(function*() {
- *       const unlimited = yield* References.CurrentConcurrency
- *       console.log(unlimited) // "unbounded"
- *     }),
- *     References.CurrentConcurrency,
- *     "unbounded"
- *   )
- * })
- * ```
- *
- * @category references
- * @since 4.0.0
- */
-export const CurrentConcurrency: Context.Reference<number | "unbounded"> = references.CurrentConcurrency
-
-/**
  * Context reference for managing log annotations that are automatically added to all log entries.
  * These annotations provide contextual metadata that appears in every log message.
  *

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -421,7 +421,6 @@ export type MergeRight<Target, Source> = Simplify<
  *
  * - `number` — run at most N effects concurrently.
  * - `"unbounded"` — run all effects concurrently with no limit.
- * - `"inherit"` — inherit the concurrency from the surrounding context.
  *
  * **Example** (Setting concurrency values)
  *
@@ -431,13 +430,12 @@ export type MergeRight<Target, Source> = Simplify<
  * const sequential: Types.Concurrency = 1
  * const limited: Types.Concurrency = 5
  * const unbounded: Types.Concurrency = "unbounded"
- * const inherit: Types.Concurrency = "inherit"
  * ```
  *
  * @category models
  * @since 2.0.0
  */
-export type Concurrency = number | "unbounded" | "inherit"
+export type Concurrency = number | "unbounded"
 
 /**
  * Removes `readonly` from all properties of `T`. Supports arrays, tuples,

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -85,7 +85,6 @@ import * as doNotation from "./doNotation.ts"
 import * as InternalMetric from "./metric.ts"
 import * as InternalRecord from "./record.ts"
 import {
-  CurrentConcurrency,
   CurrentErrorReporters,
   CurrentLogAnnotations,
   CurrentLogLevel,
@@ -2248,17 +2247,6 @@ export const provideServiceEffect: {
   ): Effect.Effect<A, E | E2, Exclude<R, I> | R2> =>
     flatMap(acquire, (implementation) => provideService(self, service, implementation))
 )
-
-/** @internal */
-export const withConcurrency: {
-  (
-    concurrency: "unbounded" | number
-  ): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
-  <A, E, R>(
-    self: Effect.Effect<A, E, R>,
-    concurrency: "unbounded" | number
-  ): Effect.Effect<A, E, R>
-} = provideService(CurrentConcurrency)
 
 // ----------------------------------------------------------------------------
 // zipping
@@ -4642,10 +4630,8 @@ export const forEach: {
     readonly discard?: boolean | undefined
   }
 ): Effect.Effect<any, E, R> =>
-  withFiber((parent) => {
-    const concurrencyOption = options?.concurrency === "inherit"
-      ? parent.getRef(CurrentConcurrency)
-      : (options?.concurrency ?? 1)
+  suspend(() => {
+    const concurrencyOption = options?.concurrency ?? 1
     const concurrency = concurrencyOption === "unbounded"
       ? Number.POSITIVE_INFINITY
       : Math.max(1, concurrencyOption)

--- a/packages/effect/src/internal/references.ts
+++ b/packages/effect/src/internal/references.ts
@@ -7,11 +7,6 @@ import type { StackFrame } from "../References.ts"
 import type { SpanLink } from "../Tracer.ts"
 
 /** @internal */
-export const CurrentConcurrency = Context.Reference<"unbounded" | number>("effect/References/CurrentConcurrency", {
-  defaultValue: () => "unbounded"
-})
-
-/** @internal */
 export const CurrentErrorReporters = Context.Reference<ReadonlySet<ErrorReporter>>(
   "effect/ErrorReporter/CurrentErrorReporters",
   { defaultValue: () => new Set() }

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -20,7 +20,6 @@ import type * as JsonSchema from "../../JsonSchema.ts"
 import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Queue from "../../Queue.ts"
-import { CurrentConcurrency } from "../../References.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
 import * as Semaphore from "../../Semaphore.ts"
@@ -1008,7 +1007,7 @@ export const make: (params: {
   ) {
     const tracker = Option.getOrUndefined(yield* Effect.serviceOption(ResponseIdTracker.ResponseIdTracker))
     const toolChoice = options.toolChoice ?? "auto"
-    const concurrency = yield* resolveToolCallConcurrency(options.concurrency)
+    const concurrency = options.concurrency ?? "unbounded"
     providerOptions.span.attribute("concurrency", concurrency)
 
     const generateWithNonIncrementalFallback = () => {
@@ -1245,7 +1244,7 @@ export const make: (params: {
   ) {
     const tracker = Option.getOrUndefined(yield* Effect.serviceOption(ResponseIdTracker.ResponseIdTracker))
     const toolChoice = options.toolChoice ?? "auto"
-    const concurrency = yield* resolveToolCallConcurrency(options.concurrency)
+    const concurrency = options.concurrency ?? "unbounded"
     providerOptions.span.attribute("concurrency", concurrency)
 
     const streamWithNonIncrementalFallback = () => {
@@ -1966,19 +1965,10 @@ const isApprovalNeeded = Effect.fnUntraced(function*<T extends Tool.Any>(
   return tool.needsApproval
 }, Effect.orElseSucceed(constFalse))
 
-type ResolvedConcurrency = Exclude<Concurrency, "inherit">
-
-const resolveToolCallConcurrency = (
-  concurrency: Concurrency | undefined
-): Effect.Effect<ResolvedConcurrency> =>
-  concurrency === "inherit"
-    ? Effect.service(CurrentConcurrency)
-    : Effect.succeed(concurrency ?? "unbounded")
-
 const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
   approvals: ReadonlyArray<ApprovalResult>,
   toolkit: Toolkit.WithHandler<Tools>,
-  concurrency: ResolvedConcurrency
+  concurrency: Concurrency
 ): Effect.Effect<
   Array<Prompt.ToolResultPart>,
   Tool.HandlerError<Tools[keyof Tools]> | AiError.AiError,
@@ -2069,7 +2059,7 @@ const resolveToolCalls = <Tools extends Record<string, Tool.Any>>(
   content: ReadonlyArray<Response.AllPartsEncoded>,
   toolkit: Toolkit.WithHandler<Tools>,
   messages: ReadonlyArray<Prompt.Message>,
-  concurrency: ResolvedConcurrency
+  concurrency: Concurrency
 ): Stream.Stream<
   ToolResolutionResult<Tools>,
   Tool.HandlerError<Tools[keyof Tools]> | AiError.AiError,

--- a/packages/effect/src/unstable/http/Template.ts
+++ b/packages/effect/src/unstable/http/Template.ts
@@ -154,7 +154,7 @@ export function make<A extends ReadonlyArray<Interpolated>>(
             values[index] = primitiveToString(value)
           })),
       {
-        concurrency: "inherit",
+        concurrency: "unbounded",
         discard: true
       }
     ),

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -483,18 +483,6 @@ describe("Effect", () => {
         assert.deepStrictEqual(results, [1, 2, 3, 4, 5])
       }))
 
-    it.effect("inherit unbounded", () =>
-      Effect.gen(function*() {
-        const handle = yield* Effect.forEach([1, 2, 3], (_) => Effect.succeed(_).pipe(Effect.delay(50)), {
-          concurrency: "inherit"
-        }).pipe(
-          Effect.withConcurrency("unbounded"),
-          Effect.forkChild
-        )
-        yield* TestClock.adjust(90)
-        assert.deepStrictEqual(handle.pollUnsafe(), Exit.succeed([1, 2, 3]))
-      }))
-
     it.effect("sequential interrupt", () =>
       Effect.gen(function*() {
         const done: Array<number> = []

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -1,12 +1,14 @@
 import { describe, test } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Context, Effect, References, Stream } from "effect"
+import { Context, Effect, Stream } from "effect"
 import * as Layer from "effect/Layer"
 import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import {
   appendPreResponseHandlerUnsafe,
   requestPreResponseHandlers
 } from "effect/unstable/http/internal/preResponseHandler"
+
+const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpEffect", () => {
   describe("toWebHandler", () => {
@@ -84,9 +86,9 @@ describe("HttpEffect", () => {
 
     test("stream runtime", async () => {
       const handler = Effect.succeed(HttpServerResponse.stream(
-        Stream.fromEffect(References.CurrentConcurrency).pipe(Stream.map(String), Stream.encodeText)
+        Stream.fromEffect(TestValue).pipe(Stream.map(String), Stream.encodeText)
       )).pipe(
-        HttpEffect.toWebHandlerWith(References.CurrentConcurrency.context(420))
+        HttpEffect.toWebHandlerWith(TestValue.context(420))
       )
       const response = await handler(new Request("http://localhost:3000/"))
       strictEqual(await response.text(), "420")
@@ -95,13 +97,13 @@ describe("HttpEffect", () => {
     test("stream layer", async () => {
       const { handler } = HttpEffect.toWebHandlerLayer(
         Effect.succeed(HttpServerResponse.stream(
-          References.CurrentConcurrency.pipe(
+          TestValue.pipe(
             Stream.fromEffect,
             Stream.map(String),
             Stream.encodeText
           )
         )),
-        Layer.succeed(References.CurrentConcurrency, 420)
+        Layer.succeed(TestValue, 420)
       )
       const response = await handler(new Request("http://localhost:3000/"))
       strictEqual(await response.text(), "420")

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -1,6 +1,8 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, References, Stream } from "effect"
+import { Context, Effect, Stream } from "effect"
 import { HttpClientRequest, HttpClientResponse, HttpServerResponse } from "effect/unstable/http"
+
+const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpServerResponse", () => {
   it.effect("fromClientResponse preserves status, headers, cookies, and json", () =>
@@ -29,7 +31,7 @@ describe("HttpServerResponse", () => {
     Effect.gen(function*() {
       const clientResponse = HttpServerResponse.toClientResponse(
         HttpServerResponse.stream(
-          Stream.fromEffect(References.CurrentConcurrency).pipe(
+          Stream.fromEffect(TestValue).pipe(
             Stream.map(String),
             Stream.encodeText
           )
@@ -39,7 +41,7 @@ describe("HttpServerResponse", () => {
       const response = HttpServerResponse.fromClientResponse(clientResponse)
       const roundTrip = HttpServerResponse.toClientResponse(response)
       const text = yield* roundTrip.text.pipe(
-        Effect.provideService(References.CurrentConcurrency, 420)
+        Effect.provideService(TestValue, 420)
       )
 
       assert.strictEqual(text, "420")

--- a/packages/tools/docgen/src/Core.ts
+++ b/packages/tools/docgen/src/Core.ts
@@ -69,7 +69,7 @@ const readSourceFiles = Effect.gen(function*() {
     Effect.map(
       fs.readFileString(path),
       (content) => new Domain.File(path, content, false)
-    ), { concurrency: "inherit" })
+    ), { concurrency: "unbounded" })
 })
 
 /**

--- a/packages/tools/utils/src/commands/codegen.ts
+++ b/packages/tools/utils/src/commands/codegen.ts
@@ -38,7 +38,7 @@ export const codegen = Command.make("codegen", {
     const files = yield* generator.discoverFiles(config.pattern, path.resolve(config.cwd))
 
     yield* Effect.forEach(files, (file) => generator.processFile(file), {
-      concurrency: "inherit",
+      concurrency: "unbounded",
       discard: true
     })
   })).pipe(Command.provide(CodegenLayer))


### PR DESCRIPTION
Removes `Effect.withConcurrency`, the `References.CurrentConcurrency` fiber reference backing it, and all `"inherit"` concurrency handling.

## Changes

- **`Effect.ts`**: removed the `Effect.withConcurrency` export (and the now-empty "References" section header).
- **`internal/effect.ts`**: removed the internal `withConcurrency` combinator and the `"inherit"` branch in `forEach` concurrency resolution (now `options?.concurrency ?? 1`; `withFiber` downgraded to `suspend` since the parent fiber is no longer needed).
- **`internal/references.ts` / `References.ts`**: removed the `CurrentConcurrency` reference and its public re-export.
- **`Types.ts`**: `Concurrency` is now `number | "unbounded"`.
- **`unstable/ai/LanguageModel.ts`**: dropped `resolveToolCallConcurrency` / `ResolvedConcurrency`; tool-call concurrency is now `options.concurrency ?? "unbounded"`.
- **`unstable/http/Template.ts`, `tools/utils` codegen, `tools/docgen`**: internal `concurrency: "inherit"` call sites now use `"unbounded"` (the former default of the removed reference).
- **Tests**: removed the `forEach` "inherit unbounded" test; HTTP tests that used `CurrentConcurrency` as an arbitrary context-propagation probe now use a locally defined `Context.Reference`.
- Added a changeset.

The `"inherit"` value for `uninterruptible` fork options and ChildProcess stdio `"inherit"` are unrelated and untouched.

## Verification

- `pnpm check` (tsc) passes
- `pnpm build` passes
- `pnpm lint` passes
- `pnpm test-types` passes (1946 passed)
- `pnpm vitest run`: 8387 passed; the single failure (`NodeChildProcessSpawner.test.ts` "isAtLeast(beforeKill, 7)") also fails on pristine `origin/main` — pre-existing, unrelated to this change.

Closes EFF-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Removed the `Effect.withConcurrency` API and `References.CurrentConcurrency`.
  - Removed the `"inherit"` concurrency option; concurrency now supports only an explicit number or `"unbounded"`.
- **Behavior Changes**
  - Updated concurrent execution, AI tool-call handling, template evaluation, and streaming logic to use explicit concurrency defaults/options instead of inheriting.
  - Updated doc generation and code generation to run with `"unbounded"` concurrency.
- **Documentation / Tests**
  - Refreshed migration guidance for concurrency-related built-in references.
  - Updated affected concurrency tests to match the new model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->