### PR TITLE
fix(ai-openai): remove stale web search patch

### DIFF
--- a/packages/ai/openai/codegen.yaml
+++ b/packages/ai/openai/codegen.yaml
@@ -13,7 +13,6 @@ patches:
   - '[{"op":"add","path":"/components/schemas/ModelResponseProperties/properties/prompt_cache_key/nullable","value":true}]'
   - '[{"op":"add","path":"/components/schemas/Response/allOf/2/properties/usage/nullable","value":true}]'
   - '[{"op":"remove","path":"/components/schemas/ResponseFunctionCallArgumentsDoneEvent/required/2"}]'
-  - '[{"op":"remove","path":"/components/schemas/WebSearchActionSearch/required/1"}]'
   - '[{"op":"add","path":"/components/schemas/ModelResponseProperties/properties/prompt_cache_retention/anyOf/0/enum/1","value":"in_memory"}]'
   - '[{"op":"add","path":"/components/schemas/PromptCacheRetentionEnum/enum/1","value":"in-memory"}]'
   - '[{"op":"replace","path":"/components/schemas/OpenAIFile/properties/expires_at","value":{"anyOf":[{"type":"integer","format":"unixtime","description":"The Unix timestamp (in seconds) for when the file will expire."},{"type":"null"}]}}]'


### PR DESCRIPTION
## Summary

- remove the obsolete index-based patch for `WebSearchActionSearch.required`
- allow OpenAI generation to use the upstream schema, where only `type` is now required

## Verification

- `node packages/tools/ai-codegen/src/bin.ts generate` (openrouter, openai, anthropic)

Closes EFF-111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new streaming events, including keepalive updates and incremental patch-application tool outputs.
  * Added support for in-memory prompt cache retention.
* **Bug Fixes**
  * Improved compatibility with nullable response fields, file expiration values, status details, and function-call events.
  * Updated response schemas to better reflect current OpenAI API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->