### PR TITLE
Avoid timers in synchronous scheduler dispatch

### DIFF
--- a/.changeset/eff-115-sync-scheduler-microtask.md
+++ b/.changeset/eff-115-sync-scheduler-microtask.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use cancellable microtasks when dispatching yielded work from synchronous Effect runs.

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -91,6 +91,16 @@ const setImmediate = "setImmediate" in globalThis
     return (): void => clearTimeout(timer)
   }
 
+const setMicrotask = (f: () => void) => {
+  let cancelled = false
+  queueMicrotask(() => {
+    if (!cancelled) f()
+  })
+  return (): void => {
+    cancelled = true
+  }
+}
+
 class PriorityBuckets {
   buckets: Array<[priority: number, tasks: Array<() => void>]> = []
 
@@ -144,10 +154,10 @@ export class MixedScheduler implements Scheduler {
 
   constructor(
     executionMode: "sync" | "async" = "async",
-    setImmediateFn: (f: () => void) => () => void = setImmediate
+    setImmediateFn?: (f: () => void) => () => void
   ) {
     this.executionMode = executionMode
-    this.setImmediate = setImmediateFn
+    this.setImmediate = setImmediateFn ?? (executionMode === "sync" ? setMicrotask : setImmediate)
   }
 
   /**

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1272,7 +1272,7 @@ export function toStandardSchemaV1<S extends ConstraintDecoder<unknown>>(
   const parseOptions: SchemaAST.ParseOptions = { errors: "all", ...options?.parseOptions }
   const formatter = SchemaIssue.makeFormatterStandardSchemaV1(options)
   const validate: StandardSchemaV1<S["Encoded"], S["Type"]>["~standard"]["validate"] = (value: unknown) => {
-    const scheduler = new Scheduler.MixedScheduler()
+    const scheduler = new Scheduler.MixedScheduler("sync")
     const fiber = Effect.runFork(
       Effect.match(decodeUnknownEffect(value, parseOptions), {
         onFailure: formatter,

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -19,6 +19,26 @@ describe("Scheduler", () => {
     assert.deepStrictEqual(exit, Exit.succeed(1))
   })
 
+  it("runSyncExit does not schedule timers after yielding", () => {
+    const setImmediate = vi.spyOn(globalThis, "setImmediate").mockImplementation(() => {
+      throw new Error("setImmediate is not supported")
+    })
+    const setTimeout = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
+      throw new Error("setTimeout is not supported")
+    })
+
+    try {
+      const exit = Effect.runSyncExit(Effect.as(Effect.yieldNow, 1))
+
+      assert.deepStrictEqual(exit, Exit.succeed(1))
+      assert.strictEqual(setImmediate.mock.calls.length, 0)
+      assert.strictEqual(setTimeout.mock.calls.length, 0)
+    } finally {
+      setImmediate.mockRestore()
+      setTimeout.mockRestore()
+    }
+  })
+
   it.effect("MixedScheduler orders by priority (sync)", () =>
     Effect.sync(() => {
       const scheduler = new Scheduler.MixedScheduler("sync").makeDispatcher()


### PR DESCRIPTION
## Summary

- dispatch yielded sync-mode scheduler work with cancellable microtasks when no custom dispatcher is supplied
- run Standard Schema validation with a sync-mode scheduler
- cover Convex-like environments where timer APIs throw and add a patch changeset

## Testing

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter effect test --run` (232 files passed; 7,162 tests passed; 3 skipped)

Closes EFF-115
Closes EFF-113
Closes #6651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronous effect execution now dispatches yielded work through cancellable microtasks.
  * Synchronous schema validation uses the updated scheduling behavior.
  * Avoids unnecessary timer-based scheduling during synchronous runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->