### PR TITLE
Preserve accessors with loose object spread

### DIFF
--- a/.changeset/polite-cameras-rest.md
+++ b/.changeset/polite-cameras-rest.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+"@effect/platform-browser": patch
+---
+
+Preserve prototype accessors when code is compiled with loose object spread transforms.

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -471,12 +471,12 @@ export const makeExit = <
   ) => Primitive | Yield
 }): Fn => {
   const Proto = {
-    ...makePrimitiveProto(options),
     [ExitTypeId]: ExitTypeId,
     _tag: options.op,
     get [options.prop](): any {
       return (this as any)[args]
     },
+    ...makePrimitiveProto(options),
     toString(this: any) {
       return `${options.op}(${format(this[args])})`
     },

--- a/packages/effect/src/unstable/ai/Model.ts
+++ b/packages/effect/src/unstable/ai/Model.ts
@@ -84,7 +84,6 @@ export class ModelName extends Context.Service<ModelName, string>()(
 ) {}
 
 const Proto = {
-  ...PipeInspectableProto,
   [TypeId]: TypeId,
   ["~effect/Layer"]: {
     _ROut: identity,
@@ -97,6 +96,7 @@ const Proto = {
       Effect.succeed(Layer.provide(self, Layer.succeedContext(context)))
     )
   },
+  ...PipeInspectableProto,
   toJSON(this: Model<any, any, any>): unknown {
     return {
       _id: "effect/ai/Model",

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -1254,23 +1254,6 @@ const StatementProto: Omit<
   StatementImpl<any>,
   "segments" | "acquirer" | "compiler" | "spanAttributes" | "transformRows"
 > = {
-  ...Effectable.Prototype<StatementImpl<any>>({
-    label: "Statement",
-    evaluate(fiber) {
-      const span = internalEffect.makeSpanUnsafe(fiber, "sql.execute", { kind: "client" })
-      const clock = fiber.getRef(Clock)
-      const timingEnabled = fiber.getRef(TracerTimingEnabled)
-      return Effect.onExit(
-        this.withConnectionSpan(
-          "execute",
-          (connection, sql, params) => connection.execute(sql, params, this.transformRows),
-          false,
-          span
-        ),
-        (exit) => internalEffect.endSpan(span, exit, clock, timingEnabled)
-      )
-    }
-  }),
   [FragmentTypeId]: FragmentTypeId,
   withConnection<XA, E>(
     this: StatementImpl<any>,
@@ -1373,6 +1356,24 @@ const StatementProto: Omit<
       (connection, sql, params) => connection.executeUnprepared(sql, params, self.transformRows)
     )
   },
+
+  ...Effectable.Prototype<StatementImpl<any>>({
+    label: "Statement",
+    evaluate(fiber) {
+      const span = internalEffect.makeSpanUnsafe(fiber, "sql.execute", { kind: "client" })
+      const clock = fiber.getRef(Clock)
+      const timingEnabled = fiber.getRef(TracerTimingEnabled)
+      return Effect.onExit(
+        this.withConnectionSpan(
+          "execute",
+          (connection, sql, params) => connection.execute(sql, params, this.transformRows),
+          false,
+          span
+        ),
+        (exit) => internalEffect.endSpan(span, exit, clock, timingEnabled)
+      )
+    }
+  }),
 
   compile(
     this: StatementImpl<any>,

--- a/packages/platform-browser/src/IndexedDbDatabase.ts
+++ b/packages/platform-browser/src/IndexedDbDatabase.ts
@@ -31,12 +31,6 @@ const SchemaProto = {
   [TypeId]: {
     _A: (_: never) => _
   },
-  ...Effectable.Prototype<IndexedDbSchema<any, any, any>>({
-    label: "IndexedDbSchema",
-    evaluate() {
-      return this.getQueryBuilder
-    }
-  }),
   get getQueryBuilder() {
     const self = this as unknown as IndexedDbSchema<any, any, any>
     return IndexedDbDatabase.useSync(({ database, IDBKeyRange, reactivity }) =>
@@ -48,6 +42,12 @@ const SchemaProto = {
       })
     )
   },
+  ...Effectable.Prototype<IndexedDbSchema<any, any, any>>({
+    label: "IndexedDbSchema",
+    evaluate() {
+      return this.getQueryBuilder
+    }
+  }),
   add<Version extends IndexedDbVersion.AnyWithProps>(
     this: IndexedDbSchema<any, any, any>,
     version: Version,

--- a/packages/platform-browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform-browser/src/IndexedDbQueryBuilder.ts
@@ -1331,7 +1331,6 @@ const FromProto: Omit<
   | "countCache"
   | "deleteCache"
 > = {
-  ...CommonProto,
   select<Index extends IndexedDbDatabase.IndexFromTable<any>>(
     this: IndexedDbQuery.From<any>,
     index?: Index
@@ -1392,7 +1391,8 @@ const FromProto: Omit<
       database: self.database.current,
       table: self.table
     })
-  }
+  },
+  ...CommonProto
 }
 
 const makeFrom = <
@@ -1951,7 +1951,6 @@ const QueryBuilderProto: Omit<
   | "IDBTransaction"
   | "reactivity"
 > = {
-  ...CommonProto,
   use(this: IndexedDbQueryBuilder<any>, f: (database: globalThis.IDBDatabase) => any) {
     return Effect.try({
       try: () => f(this.database.current),
@@ -1979,6 +1978,7 @@ const QueryBuilderProto: Omit<
     const self = this as IndexedDbQueryBuilder<any>
     return applyClearAll({ database: self.database.current })
   },
+  ...CommonProto,
   withTransaction(this: IndexedDbQueryBuilder<any>, options: {
     readonly tables: NonEmptyReadonlyArray<any>
     readonly mode: globalThis.IDBTransactionMode


### PR DESCRIPTION
## Summary

- preserve prototype accessors when packages are compiled with loose object spread transforms
- reorder base prototype spreads in Effect exits, AI models, SQL statements, and IndexedDB APIs
- add patch changesets for `effect` and `@effect/platform-browser`

## Verification

- `pnpm lint`
- `pnpm check`
- `pnpm --filter effect test --run test/Exit.test.ts test/unstable/ai/Model.test.ts test/unstable/sql/Statement.test.ts`
- `pnpm --filter @effect/platform-browser test --run test/IndexedDbDatabase.test.ts test/IndexedDbQueryBuilder.test.ts`
- unmodified Expo reproduction: 9/9 tests pass with the `makeExit` reorder
- repository AST audit: no getter or setter remains after an object spread under `packages/**/src`

A native `Object.getOwnPropertyDescriptor` assertion was not added because it also passes with the broken ordering: standard object spread preserves the accessor in either position, while only Babel's loose transform loses it.

## Consumer Workaround

Until this reaches a release, consumers can run a strict spread transform before `babel-preset-expo`:

```js
plugins: [["@babel/plugin-transform-object-rest-spread", {
  loose: false,
  useBuiltIns: false
}]],
presets: ["babel-preset-expo"]
```

Closes EFF-114
Fixes https://github.com/Effect-TS/effect/issues/6578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where prototype accessors could be overwritten when compiled with loose object spread transforms.
  * Improved consistency and reliability across Effect, browser platform, AI model, SQL statement, and IndexedDB components.
* **Chores**
  * Added patch release entries for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->