### PR TITLE
Fix reactivity for hydrated atoms

### DIFF
--- a/.changeset/eff-117-hydration-reactivity.md
+++ b/.changeset/eff-117-hydration-reactivity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix hydrated atoms with `Atom.withReactivity` to refresh after reactive mutations.

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -435,7 +435,15 @@ class RegistryImpl implements AtomRegistry {
       const encoded = this.preloadedSerializable.get(key)
       this.preloadedSerializable.delete(key)
       const decoded = (atom as any as Atom.Serializable<any>)[SerializableTypeId].decode(encoded)
-      node.setValue(decoded)
+      let target = atom
+      while (target.initialValueTarget) {
+        target = target.initialValueTarget
+      }
+      if (target === atom) {
+        node.setValue(decoded)
+      } else {
+        this.ensureNode(target).setInitialValue(decoded)
+      }
     }
     return node
   }

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -15,7 +15,7 @@ import {
 } from "effect"
 import { TestClock } from "effect/testing"
 import { KeyValueStore } from "effect/unstable/persistence"
-import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity"
+import { AsyncResult, Atom, AtomRegistry, Hydration } from "effect/unstable/reactivity"
 
 declare const global: any
 
@@ -2281,6 +2281,42 @@ describe.sequential("Atom", () => {
         }),
         { reactivityKeys: ["counter"] }
       )
+      r.mount(atom)
+
+      assert.strictEqual(r.get(atom), 10)
+      assert.strictEqual(rebuilds, 1)
+
+      value = 11
+      r.set(fn, void 0)
+
+      assert.strictEqual(r.get(atom), 11)
+      assert.strictEqual(rebuilds, 2)
+    })
+
+    it("rebuilds on mutation with a hydrated value", async () => {
+      let rebuilds = 0
+      let value = 0
+      const atom = Atom.make(() => {
+        rebuilds++
+        return value
+      }).pipe(
+        Atom.withReactivity(["counter"]),
+        Atom.serializable({ key: "hydrated-counter", schema: Schema.Number }),
+        Atom.keepAlive
+      )
+      const r = AtomRegistry.make()
+      const fn = counterRuntime.fn(
+        Effect.fn(function*() {
+        }),
+        { reactivityKeys: ["counter"] }
+      )
+      const dehydratedState: Array<Hydration.DehydratedAtomValue> = [{
+        "~effect/reactivity/DehydratedAtom": true,
+        key: "hydrated-counter",
+        value: 10,
+        dehydratedAt: 0
+      }]
+      Hydration.hydrate(r, dehydratedState)
       r.mount(atom)
 
       assert.strictEqual(r.get(atom), 10)


### PR DESCRIPTION
## Summary

- seed transformed hydration targets as initial values so atom setup logic runs before the hydrated value is preserved
- keep direct hydration for ordinary serializable atoms, avoiding duplicate execution during streaming hydration
- add a hydration reactivity regression test and an `effect` patch changeset

## Tests

- `pnpm --filter effect test --run test/reactivity/Atom.test.ts`
- `pnpm --filter @effect/atom-react test --run test/index.test.tsx -t "hydration streaming with resultPromise"`
- `pnpm lint`
- `pnpm check`

Closes EFF-117
Closes #6360
