### PR TITLE
Update v3 to v4 migration reference

### DIFF
--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `v3` (`3d390f232bdbc3f0d3d6a2ae3c775084f494b547`)
 
-Head: `main` (`797111ae7630edde7f4f801d1e6a86fc32d15eed`)
+Head: `main` (`96ced895a07f89b2dd03c3e470884f7e25063696`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 


### PR DESCRIPTION
## Summary

- inspect `main` changes since `797111ae7630edde7f4f801d1e6a86fc32d15eed`
- regenerate the v3-to-v4 migration reference at `96ced895a07f89b2dd03c3e470884f7e25063696`
- confirm the seven affected module-level guidance entries remain fully annotated

## Validation

- `pnpm api-diff --write-doc migration/v3-to-v4.md --check`
- `pnpm api-diff --check`
- `pnpm lint-fix`

Closes EFF-120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration documentation metadata to reference the current source revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->