### PR TITLE
Fix WebSocket handler service requirements

### DIFF
--- a/.changeset/fix-websocket-handler-service.md
+++ b/.changeset/fix-websocket-handler-service.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Socket.makeWebSocket` and `Socket.fromWebSocket` so message handler effects no longer require `Socket.WebSocket`, which is supplied at runtime.

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -764,6 +764,9 @@ export const fromWebSocket = <RO>(
       }))
     const writer = Effect.succeed(write)
 
+    // The cast is sound because `make` derives `run` and `runString` from the
+    // supplied `runRaw`, so every handler runs with the WebSocket service
+    // provided. Passing explicit `run` or `runString` here would break this.
     return Effect.succeed(make({
       runRaw,
       writer

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -549,6 +549,34 @@ export class WebSocket extends Context.Service<WebSocket, globalThis.WebSocket>(
 ) {}
 
 /**
+ * A WebSocket-backed `Socket` that provides the active `WebSocket` service to
+ * message handlers.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WebSocketSocket extends Socket {
+  readonly run: <_, E = never, R = never>(
+    handler: (_: Uint8Array) => Effect.Effect<_, E, R> | void,
+    options?: {
+      readonly onOpen?: Effect.Effect<void> | undefined
+    }
+  ) => Effect.Effect<void, SocketError | E, Exclude<R, WebSocket>>
+  readonly runString: <_, E = never, R = never>(
+    handler: (_: string) => Effect.Effect<_, E, R> | void,
+    options?: {
+      readonly onOpen?: Effect.Effect<void> | undefined
+    }
+  ) => Effect.Effect<void, SocketError | E, Exclude<R, WebSocket>>
+  readonly runRaw: <_, E = never, R = never>(
+    handler: (_: string | Uint8Array) => Effect.Effect<_, E, R> | void,
+    options?: {
+      readonly onOpen?: Effect.Effect<void> | undefined
+    }
+  ) => Effect.Effect<void, SocketError | E, Exclude<R, WebSocket>>
+}
+
+/**
  * Context service for constructing `WebSocket` instances from a URL and
  * optional protocols.
  *
@@ -571,7 +599,7 @@ export const layerWebSocketConstructorGlobal: Layer.Layer<WebSocketConstructor> 
 )
 
 /**
- * Creates a `Socket` backed by a `WebSocketConstructor`, acquiring the
+ * Creates a `WebSocketSocket` backed by a `WebSocketConstructor`, acquiring the
  * WebSocket for each run and using the close-code classifier to decide which
  * closes fail the run.
  *
@@ -582,7 +610,7 @@ export const makeWebSocket = (url: string | Effect.Effect<string>, options?: {
   readonly closeCodeIsError?: ((code: number) => boolean) | undefined
   readonly openTimeout?: Duration.Input | undefined
   readonly protocols?: string | Array<string> | undefined
-}): Effect.Effect<Socket, never, WebSocketConstructor> =>
+}): Effect.Effect<WebSocketSocket, never, WebSocketConstructor> =>
   WebSocketConstructor.use((makeWs) =>
     fromWebSocket(
       Effect.acquireRelease(
@@ -596,9 +624,9 @@ export const makeWebSocket = (url: string | Effect.Effect<string>, options?: {
   )
 
 /**
- * Builds a `Socket` from a scoped WebSocket acquisition effect, waiting for the
- * socket to open, dispatching message handlers in fibers, and translating
- * open, read, and close events into `SocketError` values.
+ * Builds a `WebSocketSocket` from a scoped WebSocket acquisition effect,
+ * waiting for the socket to open, dispatching message handlers in fibers, and
+ * translating open, read, and close events into `SocketError` values.
  *
  * @category constructors
  * @since 4.0.0
@@ -609,16 +637,19 @@ export const fromWebSocket = <RO>(
     readonly closeCodeIsError?: ((code: number) => boolean) | undefined
     readonly openTimeout?: Duration.Input | undefined
   } | undefined
-): Effect.Effect<Socket, never, Exclude<RO, Scope.Scope>> =>
+): Effect.Effect<WebSocketSocket, never, Exclude<RO, Scope.Scope>> =>
   Effect.withFiber((fiber) => {
     let currentWS: globalThis.WebSocket | undefined
     const latch = Latch.makeUnsafe(false)
     const acquireContext = fiber.context as Context.Context<RO>
     const closeCodeIsError = options?.closeCodeIsError ?? defaultCloseCodeIsError
 
-    const runRaw = <_, E, R>(handler: (_: string | Uint8Array) => Effect.Effect<_, E, R> | void, opts?: {
-      readonly onOpen?: Effect.Effect<void> | undefined
-    }) =>
+    const runRaw: WebSocketSocket["runRaw"] = <_, E, R>(
+      handler: (_: string | Uint8Array) => Effect.Effect<_, E, R> | void,
+      opts?: {
+        readonly onOpen?: Effect.Effect<void> | undefined
+      }
+    ) =>
       Effect.scopedWith(Effect.fnUntraced(function*(scope) {
         const fiberSet = yield* FiberSet.make<any, E | SocketError>().pipe(
           Scope.provide(scope)
@@ -715,7 +746,7 @@ export const fromWebSocket = <RO>(
           () => Effect.void
         )
       })).pipe(
-        Effect.updateContext((input: Context.Context<R>) => Context.merge(acquireContext, input)),
+        Effect.updateContext((input: Context.Context<Exclude<R, WebSocket>>) => Context.merge(acquireContext, input)),
         Effect.ensuring(Effect.sync(() => {
           latch.closeUnsafe()
           currentWS = undefined
@@ -736,7 +767,7 @@ export const fromWebSocket = <RO>(
     return Effect.succeed(make({
       runRaw,
       writer
-    }))
+    }) as WebSocketSocket)
   })
 
 /**

--- a/packages/effect/test/unstable/socket/Socket.test.ts
+++ b/packages/effect/test/unstable/socket/Socket.test.ts
@@ -1,0 +1,80 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Fiber, Queue } from "effect"
+import { Socket } from "effect/unstable/socket"
+
+class TestWebSocket extends EventTarget {
+  readonly readyState = 1
+  closeCalls = 0
+
+  send(_data: string | ArrayBufferLike | Blob | ArrayBufferView) {}
+
+  close() {
+    this.closeCalls++
+  }
+
+  emitMessage(data: string | Uint8Array) {
+    this.dispatchEvent(new MessageEvent("message", { data }))
+  }
+
+  emitClose(code: number) {
+    this.dispatchEvent(new CloseEvent("close", { code }))
+  }
+}
+
+describe("Socket", () => {
+  it.effect("provides the acquired WebSocket to raw message handlers", () =>
+    Effect.gen(function*() {
+      const webSocket = new TestWebSocket()
+      const acquired = webSocket as unknown as globalThis.WebSocket
+      const socket = yield* Socket.fromWebSocket(
+        Effect.succeed(acquired),
+        { closeCodeIsError: () => false }
+      )
+      const opened = yield* Deferred.make<void>()
+      const received = yield* Queue.unbounded<readonly [string | Uint8Array, globalThis.WebSocket]>()
+      const fiber = yield* socket.runRaw(
+        (data) =>
+          Effect.gen(function*() {
+            const activeWebSocket = yield* Socket.WebSocket
+            yield* Queue.offer(received, [data, activeWebSocket])
+          }),
+        { onOpen: Deferred.succeed(opened, void 0) }
+      ).pipe(Effect.forkChild)
+
+      yield* Deferred.await(opened)
+
+      webSocket.emitMessage("text")
+      const text = yield* Queue.take(received)
+      assert.strictEqual(text[0], "text")
+      assert.strictEqual(text[1], acquired)
+
+      const bytes = new Uint8Array([1, 2, 3])
+      webSocket.emitMessage(bytes)
+      const binary = yield* Queue.take(received)
+      assert.strictEqual(binary[0], bytes)
+      assert.strictEqual(binary[1], acquired)
+
+      webSocket.emitClose(1000)
+      yield* Fiber.join(fiber)
+    }))
+
+  it.effect("releases the acquired WebSocket when interrupted", () =>
+    Effect.gen(function*() {
+      const webSocket = new TestWebSocket()
+      const socket = yield* Socket.fromWebSocket(
+        Effect.acquireRelease(
+          Effect.succeed(webSocket as unknown as globalThis.WebSocket),
+          () => Effect.sync(() => webSocket.close())
+        )
+      )
+      const opened = yield* Deferred.make<void>()
+      const fiber = yield* socket.runRaw(() => {}, {
+        onOpen: Deferred.succeed(opened, void 0)
+      }).pipe(Effect.forkChild)
+
+      yield* Deferred.await(opened)
+      yield* Fiber.interrupt(fiber)
+
+      assert.strictEqual(webSocket.closeCalls, 1)
+    }))
+})

--- a/packages/effect/typetest/unstable/socket/Socket.tst.ts
+++ b/packages/effect/typetest/unstable/socket/Socket.tst.ts
@@ -1,0 +1,60 @@
+import { Context, Effect } from "effect"
+import { Socket } from "effect/unstable/socket"
+import { describe, expect, it } from "tstyche"
+
+class HandlerService extends Context.Service<HandlerService, string>()("HandlerService") {}
+
+declare const webSocket: globalThis.WebSocket
+declare const makeOptions: Parameters<typeof Socket.make>[0]
+declare const webSocketSocket: Socket.WebSocketSocket
+
+describe("Socket", () => {
+  it("returns WebSocket-backed sockets", () => {
+    expect(Socket.fromWebSocket(Effect.succeed(webSocket))).type.toBe<
+      Effect.Effect<Socket.WebSocketSocket>
+    >()
+    expect(Socket.makeWebSocket("ws://localhost")).type.toBe<
+      Effect.Effect<Socket.WebSocketSocket, never, Socket.WebSocketConstructor>
+    >()
+  })
+
+  it("provides WebSocket to message handlers", () => {
+    const handler = () =>
+      Effect.gen(function*() {
+        const activeWebSocket = yield* Socket.WebSocket
+        activeWebSocket.close()
+        yield* HandlerService
+      })
+
+    expect(webSocketSocket.run(handler)).type.toBe<
+      Effect.Effect<void, Socket.SocketError, HandlerService>
+    >()
+    expect(webSocketSocket.runString(handler)).type.toBe<
+      Effect.Effect<void, Socket.SocketError, HandlerService>
+    >()
+    expect(webSocketSocket.runRaw(handler)).type.toBe<
+      Effect.Effect<void, Socket.SocketError, HandlerService>
+    >()
+  })
+
+  it("excludes WebSocket from generic handler requirements", () => {
+    const runGeneric = <R>(effect: Effect.Effect<void, never, R>) => webSocketSocket.runRaw(() => effect)
+    const webSocketEffect = Effect.gen(function*() {
+      yield* Socket.WebSocket
+    })
+
+    expect(runGeneric(webSocketEffect)).type.toBe<Effect.Effect<void, Socket.SocketError>>()
+  })
+
+  it("does not change the contract of custom sockets", () => {
+    const socket = Socket.make(makeOptions)
+    const program = socket.runRaw(() =>
+      Effect.gen(function*() {
+        yield* Socket.WebSocket
+      })
+    )
+
+    expect(program).type.toBe<Effect.Effect<void, Socket.SocketError, Socket.WebSocket>>()
+    expect(socket).type.not.toBeAssignableTo<Socket.WebSocketSocket>()
+  })
+})


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Socket.fromWebSocket` provides the active `Socket.WebSocket` service while message handlers run, but its returned `Socket` type previously left that service in each handler effect's external requirements.

This change returns a refined `Socket.WebSocketSocket` from `Socket.fromWebSocket` and `Socket.makeWebSocket`. Its `run`, `runString`, and `runRaw` methods exclude the internally provided WebSocket service while preserving every unrelated handler requirement. The base `Socket` and `Socket.make` contracts remain unchanged for implementations that do not provide this service.

Runtime coverage verifies that handlers receive the exact acquired WebSocket for text and binary messages and that interruption still releases it. Type tests cover both WebSocket constructors, all three handler methods, generic handler effects, unrelated requirements, and custom sockets.

## Validation

- `corepack pnpm check`
- `corepack pnpm test-types Socket.tst.ts`
- `corepack pnpm --filter effect test --run test/unstable/socket/Socket.test.ts`
- `corepack pnpm --filter @effect/platform-node test --run test/NodeSocket.test.ts -t "messages"`
- `corepack pnpm --filter @effect/platform-node test --run test/NodeSocket.test.ts -t "close codes are errors by default"`
- `corepack pnpm jsdocs`
- `corepack pnpm exec oxlint -f unix`
- `corepack pnpm exec dprint check`

## Related

- Related Issue: N/A
- Closes: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebSocket message handling so effects no longer require an unnecessary WebSocket environment dependency.
  * Improved WebSocket socket typing so handler requirements are more precise and accurate.
  * Ensured acquired WebSocket instances are released properly when raw message processing is interrupted.
* **Tests**
  * Added coverage for both text and binary message handling, cleanup behavior on interruption, and WebSocket typing expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->