### PR TITLE
Fix HttpRouter web handler context

### DIFF
--- a/.changeset/eff-121-http-router-web-handler.md
+++ b/.changeset/eff-121-http-router-web-handler.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpRouter.toWebHandler` context inference for services provided by the application layer.

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1290,7 +1290,8 @@ export const toWebHandler = <
     | Request<"Error", any>
     | Request<"GlobalError", any>,
   HE,
-  HR = Exclude<Request.Only<"Requires", R> | Request.Only<"GlobalRequires", R>, A>
+  HR = Exclude<Request.Only<"Requires", R> | Request.Only<"GlobalRequires", R>, A>,
+  ReqR = Exclude<HR, A | Scope.Scope | HttpServerRequest.HttpServerRequest>
 >(
   appLayer: Layer.Layer<A, E, R>,
   options?: {
@@ -1319,11 +1320,11 @@ export const toWebHandler = <
     ) => Effect.Effect<HttpServerResponse.HttpServerResponse, HE, HR | GlobalProvided>
   }
 ): {
-  readonly handler: [Exclude<HR, GlobalProvided>] extends [never]
+  readonly handler: [ReqR] extends [never]
     ? ((request: globalThis.Request, context?: Context.Context<never> | undefined) => Promise<Response>)
     : ((
       request: globalThis.Request,
-      context: Context.Context<Exclude<HR, GlobalProvided>>
+      context: Context.Context<ReqR>
     ) => Promise<Response>)
   readonly dispose: () => Promise<void>
 } => {

--- a/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpRouter.tst.ts
@@ -1,4 +1,4 @@
-import { Context, Effect } from "effect"
+import { Context, Effect, Layer } from "effect"
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import { describe, expect, it } from "tstyche"
 
@@ -27,6 +27,28 @@ describe("HttpRouter", () => {
         new Request("http://localhost/"),
         Context.make(CurrentUser, { id: "user-1" })
       )
+    })
+
+    it("excludes services provided by the application layer from the request context", () => {
+      class CurrentUser extends Context.Service<CurrentUser, { readonly id: string }>()("CurrentUser") {}
+
+      const app = Layer.merge(
+        HttpRouter.add(
+          "GET",
+          "/",
+          Effect.map(CurrentUser, (user) => HttpServerResponse.text(user.id))
+        ),
+        Layer.succeed(CurrentUser, { id: "user-1" })
+      )
+      const { handler } = HttpRouter.toWebHandler(app, {
+        disableLogger: true,
+        middleware: (effect) => effect
+      })
+
+      expect(handler).type.toBe<
+        (request: Request, context?: Context.Context<never> | undefined) => Promise<Response>
+      >()
+      expect(handler).type.toBeCallableWith(new Request("http://localhost/"))
     })
   })
 })


### PR DESCRIPTION
## Summary

- align `HttpRouter.toWebHandler` request-context inference with `HttpEffect.toWebHandlerLayerWith`
- exclude services supplied by the application layer and HTTP adapter
- cover identity middleware with an application-provided service in the type tests

## Testing

- `pnpm test-types HttpRouter.tst.ts`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `HttpRouter.toWebHandler` type inference so application-provided services and built-in request/scope services are no longer incorrectly reflected as required in the handler context.
  * Web handlers can now be typed/called with only a request when no extra context is needed.

* **Tests**
  * Added type-level coverage to verify the handler context is optional/absent when services are supplied by the application layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->