### PR TITLE
EFF-123: Surface unknown OpenAI-compatible stream events

### DIFF
--- a/.changeset/eff-123-openai-compat-unknown-events.md
+++ b/.changeset/eff-123-openai-compat-unknown-events.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Surface parsed chat completion stream events that do not match the expected schema as `UnknownChatCompletionEvent`.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -1201,13 +1201,23 @@ export type ChatCompletionResponse = typeof ChatCompletionResponse.Type
  */
 export type ChatCompletionChunk = typeof ChatCompletionChunk.Type
 /**
- * Streaming chat completion event, including decoded chunks and the `[DONE]`
- * sentinel.
+ * A parsed chat completion event that does not match the expected chunk schema.
  *
  * @category streaming
  * @since 4.0.0
  */
-export type ChatCompletionStreamEvent = ChatCompletionChunk | "[DONE]"
+export interface UnknownChatCompletionEvent {
+  readonly _tag: "UnknownChatCompletionEvent"
+  readonly data: unknown
+}
+/**
+ * Streaming chat completion event, including decoded chunks, unknown parsed
+ * events, and the `[DONE]` sentinel.
+ *
+ * @category streaming
+ * @since 4.0.0
+ */
+export type ChatCompletionStreamEvent = ChatCompletionChunk | UnknownChatCompletionEvent | "[DONE]"
 
 const parseJson = (value: string): unknown => {
   try {
@@ -1226,7 +1236,11 @@ const decodeChatCompletionSseData = (
     return data
   }
   const parsed = parseJson(data)
-  return isChatCompletionChunk(parsed)
-    ? parsed
-    : undefined
+  if (parsed === undefined) {
+    return undefined
+  }
+  return isChatCompletionChunk(parsed) ? parsed : {
+    _tag: "UnknownChatCompletionEvent",
+    data: parsed
+  }
 }

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -48,7 +48,8 @@ import {
   type ReasoningItem,
   type SummaryTextContent,
   type TextResponseFormatConfiguration,
-  type Tool as OpenAiClientTool
+  type Tool as OpenAiClientTool,
+  type UnknownChatCompletionEvent
 } from "./OpenAiClient.ts"
 import { addGenAIAnnotations } from "./OpenAiTelemetry.ts"
 
@@ -1027,6 +1028,11 @@ const buildHttpResponseDetails = (
 
 type ResponseStreamEvent = CreateResponse200Sse
 
+const isUnknownChatCompletionEvent = (
+  event: ResponseStreamEvent
+): event is UnknownChatCompletionEvent =>
+  typeof event !== "string" && "_tag" in event && event._tag === "UnknownChatCompletionEvent"
+
 type ActiveToolCall = {
   readonly id: string
   name: string
@@ -1202,6 +1208,12 @@ const makeStreamResponse = Effect.fnUntraced(
               ? { metadata: { openai: { serviceTier: normalizedServiceTier } } }
               : undefined)
           })
+          return parts
+        }
+
+        // Keep unknown events available to direct client consumers; this layer
+        // cannot translate provider-specific data into portable stream parts.
+        if (isUnknownChatCompletionEvent(event)) {
           return parts
         }
 

--- a/packages/ai/openai-compat/test/OpenAiClient.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiClient.test.ts
@@ -147,6 +147,83 @@ describe("OpenAiClient", () => {
         ]
       }))))
 
+    it.effect("surfaces schema-mismatched chat chunks and continues streaming", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+
+        const events = yield* client.createResponseStream({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: "hello" }]
+        }).pipe(
+          Effect.flatMap(([_, stream]) => Stream.runCollect(stream))
+        )
+
+        assert.deepStrictEqual(events[0], {
+          _tag: "UnknownChatCompletionEvent",
+          data: {
+            type: "provider.chat.completion.delta",
+            provider_payload: { content: "provider-specific" }
+          }
+        })
+        assert.propertyVal(events[1], "id", "chatcmpl_test_2")
+        assert.strictEqual(events[2], "[DONE]")
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "Sse",
+        events: [
+          {
+            type: "provider.chat.completion.delta",
+            provider_payload: { content: "provider-specific" }
+          },
+          {
+            id: "chatcmpl_test_2",
+            object: "chat.completion.chunk",
+            model: "gpt-4o-mini",
+            created: 1,
+            choices: [{
+              index: 0,
+              delta: { content: "Hello" },
+              finish_reason: null
+            }]
+          },
+          "[DONE]"
+        ]
+      }))))
+
+    it.effect("drops invalid JSON and continues streaming", () =>
+      Effect.gen(function*() {
+        const client = yield* OpenAiClient.OpenAiClient
+
+        const events = yield* client.createResponseStream({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: "hello" }]
+        }).pipe(
+          Effect.flatMap(([_, stream]) => Stream.runCollect(stream))
+        )
+
+        assert.strictEqual(events.length, 2)
+        assert.propertyVal(events[0], "id", "chatcmpl_test_3")
+        assert.strictEqual(events[1], "[DONE]")
+      }).pipe(Effect.provide(makeTestLayer({
+        _tag: "RawSse",
+        body: [
+          "data: {invalid-json\n\n",
+          `data: ${
+            JSON.stringify({
+              id: "chatcmpl_test_3",
+              object: "chat.completion.chunk",
+              model: "gpt-4o-mini",
+              created: 1,
+              choices: [{
+                index: 0,
+                delta: { content: "Hello" },
+                finish_reason: null
+              }]
+            })
+          }\n\n`,
+          "data: [DONE]\n\n"
+        ].join("")
+      }))))
+
     it.effect("passes chat-completions tool_choice payload through unchanged", () =>
       Effect.gen(function*() {
         const client = yield* OpenAiClient.OpenAiClient
@@ -338,6 +415,12 @@ type MockResponse =
     readonly status?: number | undefined
     readonly headers?: Record<string, string> | undefined
   }
+  | {
+    readonly _tag: "RawSse"
+    readonly body: string
+    readonly status?: number | undefined
+    readonly headers?: Record<string, string> | undefined
+  }
 
 class MockOpenAiResponse extends Context.Service<MockOpenAiResponse, {
   readonly response: MockResponse
@@ -421,7 +504,9 @@ const makeResponse = (
     : "text/event-stream"
   const body = response._tag === "Json"
     ? JSON.stringify(response.body)
-    : toSseBody(response.events)
+    : response._tag === "Sse"
+    ? toSseBody(response.events)
+    : response.body
 
   return HttpClientResponse.fromWeb(
     request,

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -1064,11 +1064,12 @@ describe("OpenAiLanguageModel", () => {
         assert.deepStrictEqual(toolCall.params, expectedParams)
       }))
 
-    it.effect("streams known events and ignores unknown ones", () =>
+    it.effect("continues after invalid JSON and schema-mismatched events", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
 
         const events = [
+          "{invalid-json",
           {
             id: "chatcmpl_stream_1",
             object: "chat.completion.chunk",
@@ -1079,6 +1080,10 @@ describe("OpenAiLanguageModel", () => {
               delta: { content: "Hello" },
               finish_reason: null
             }]
+          },
+          {
+            type: "provider.chat.completion.delta",
+            provider_payload: { content: "provider-specific" }
           },
           {
             id: "chatcmpl_stream_1",


### PR DESCRIPTION
## Summary

- surface parsed schema-mismatched chat completion SSE payloads as `UnknownChatCompletionEvent`
- continue dropping malformed JSON and explicitly ignore unknown events in the generic language-model layer
- cover malformed JSON, schema mismatch, and continuation behavior

## Testing

- `pnpm --filter @effect/ai-openai-compat test --run test/OpenAiClient.test.ts test/OpenAiLanguageModel.test.ts`
- `pnpm --filter @effect/ai-openai-compat check`
- `pnpm check`
- `pnpm lint`

Closes EFF-123
Closes https://github.com/Effect-TS/effect/issues/6346


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming responses now preserve provider-specific events that don’t match the expected schema.
  * Direct clients can access these events as `UnknownChatCompletionEvent` data.

* **Bug Fixes**
  * Malformed streaming payloads are safely ignored without interrupting the rest of the response stream.
  * Streaming continues correctly through unrecognized events until completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->