### PR TITLE
Avoid direct @vitest/runner import

### DIFF
--- a/.changeset/fix-vitest-runner-import.md
+++ b/.changeset/fix-vitest-runner-import.md
@@ -2,4 +2,4 @@
 "@effect/vitest": patch
 ---
 
-Declare the directly imported `@vitest/runner` package as a peer dependency so it shares Vitest's runner instance.
+Import suite state through the Vitest peer instead of relying on a separately resolved `@vitest/runner` instance.

--- a/.changeset/fix-vitest-runner-import.md
+++ b/.changeset/fix-vitest-runner-import.md
@@ -2,4 +2,4 @@
 "@effect/vitest": patch
 ---
 
-Import suite state through the Vitest peer instead of relying on a separately resolved `@vitest/runner` instance.
+Read suite state from the Vitest peer, using `TestRunner` when available and a lazy compatibility fallback for older versions.

--- a/.changeset/fix-vitest-runner-import.md
+++ b/.changeset/fix-vitest-runner-import.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Declare the directly imported `@vitest/runner` package as a runtime dependency instead of relying on Vitest's transitive installation.

--- a/.changeset/fix-vitest-runner-import.md
+++ b/.changeset/fix-vitest-runner-import.md
@@ -2,4 +2,4 @@
 "@effect/vitest": patch
 ---
 
-Declare the directly imported `@vitest/runner` package as a runtime dependency instead of relying on Vitest's transitive installation.
+Declare the directly imported `@vitest/runner` package as a peer dependency so it shares Vitest's runner instance.

--- a/.changeset/fix-vitest-runner-import.md
+++ b/.changeset/fix-vitest-runner-import.md
@@ -1,5 +1,5 @@
 ---
-"@effect/vitest": patch
+"@effect/vitest": minor
 ---
 
-Import suite state through the Vitest peer instead of relying on a separately resolved `@vitest/runner` instance.
+Require Vitest 4.1 or later and read suite state from `TestRunner`, removing the direct `@vitest/runner` import and support for Vitest 3 and 4.0.

--- a/.changeset/fix-vitest-runner-import.md
+++ b/.changeset/fix-vitest-runner-import.md
@@ -2,4 +2,4 @@
 "@effect/vitest": patch
 ---
 
-Read suite state from the Vitest peer, using `TestRunner` when available and a lazy compatibility fallback for older versions.
+Import suite state through the Vitest peer instead of relying on a separately resolved `@vitest/runner` instance.

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "effect": "workspace:^",
-    "vitest": "^3.0.0 || ^4.0.0"
+    "vitest": "^4.1.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -46,15 +46,14 @@
     "test": "vitest",
     "coverage": "vitest --coverage"
   },
-  "dependencies": {
-    "@vitest/runner": "4.1.10"
-  },
   "peerDependencies": {
+    "@vitest/runner": "^3.0.0 || ^4.0.0",
     "effect": "workspace:^",
     "vitest": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
+    "@vitest/runner": "4.1.10",
     "effect": "workspace:^",
     "vitest": "4.1.10"
   }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -46,13 +46,15 @@
     "test": "vitest",
     "coverage": "vitest --coverage"
   },
+  "dependencies": {
+    "@vitest/runner": "4.1.10"
+  },
   "peerDependencies": {
     "effect": "workspace:^",
     "vitest": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@vitest/runner": "4.1.10",
     "effect": "workspace:^",
     "vitest": "4.1.10"
   }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -47,13 +47,11 @@
     "coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "@vitest/runner": "^3.0.0 || ^4.0.0",
     "effect": "workspace:^",
     "vitest": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@vitest/runner": "4.1.10",
     "effect": "workspace:^",
     "vitest": "4.1.10"
   }

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -17,8 +17,9 @@ import * as fc from "effect/testing/FastCheck"
 import * as TestClock from "effect/testing/TestClock"
 import * as TestConsole from "effect/testing/TestConsole"
 import * as V from "vitest"
-import { getCurrentSuite } from "vitest/suite"
 import type * as Vitest from "../index.ts"
+
+const getCurrentSuite = V.TestRunner?.getCurrentSuite ?? (await import("vitest/suite")).getCurrentSuite
 
 const runPromise: <E, A>(
   _: Effect.Effect<A, E, never>,

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -2,7 +2,6 @@
  * @since 4.0.0
  */
 
-import { getCurrentSuite } from "@vitest/runner"
 import * as Cause from "effect/Cause"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -18,6 +17,7 @@ import * as fc from "effect/testing/FastCheck"
 import * as TestClock from "effect/testing/TestClock"
 import * as TestConsole from "effect/testing/TestConsole"
 import * as V from "vitest"
+import { getCurrentSuite } from "vitest/suite"
 import type * as Vitest from "../index.ts"
 
 const runPromise: <E, A>(

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -17,8 +17,9 @@ import * as fc from "effect/testing/FastCheck"
 import * as TestClock from "effect/testing/TestClock"
 import * as TestConsole from "effect/testing/TestConsole"
 import * as V from "vitest"
-import { getCurrentSuite } from "vitest/suite"
 import type * as Vitest from "../index.ts"
+
+const getCurrentSuite = V.TestRunner.getCurrentSuite
 
 const runPromise: <E, A>(
   _: Effect.Effect<A, E, never>,

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -17,9 +17,8 @@ import * as fc from "effect/testing/FastCheck"
 import * as TestClock from "effect/testing/TestClock"
 import * as TestConsole from "effect/testing/TestConsole"
 import * as V from "vitest"
+import { getCurrentSuite } from "vitest/suite"
 import type * as Vitest from "../index.ts"
-
-const getCurrentSuite = V.TestRunner?.getCurrentSuite ?? (await import("vitest/suite")).getCurrentSuite
 
 const runPromise: <E, A>(
   _: Effect.Effect<A, E, never>,

--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -1,6 +1,10 @@
 import { mergeConfig, type ViteUserConfig } from "vitest/config"
 import shared from "../../vitest.shared.ts"
 
-const config: ViteUserConfig = {}
+const config: ViteUserConfig = {
+  esbuild: {
+    target: "es2022"
+  }
+}
 
 export default mergeConfig(shared, config)

--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -1,10 +1,6 @@
 import { mergeConfig, type ViteUserConfig } from "vitest/config"
 import shared from "../../vitest.shared.ts"
 
-const config: ViteUserConfig = {
-  esbuild: {
-    target: "es2022"
-  }
-}
+const config: ViteUserConfig = {}
 
 export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -908,14 +908,13 @@ importers:
         version: 26.1.1
 
   packages/vitest:
-    dependencies:
-      '@vitest/runner':
-        specifier: 4.1.10
-        version: 4.1.10
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@vitest/runner':
+        specifier: 4.1.10
+        version: 4.1.10
       effect:
         specifier: workspace:^
         version: link:../effect

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,9 +912,6 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
-      '@vitest/runner':
-        specifier: 4.1.10
-        version: 4.1.10
       effect:
         specifier: workspace:^
         version: link:../effect

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -908,13 +908,14 @@ importers:
         version: 26.1.1
 
   packages/vitest:
+    dependencies:
+      '@vitest/runner':
+        specifier: 4.1.10
+        version: 4.1.10
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
-      '@vitest/runner':
-        specifier: 4.1.10
-        version: 4.1.10
       effect:
         specifier: workspace:^
         version: link:../effect


### PR DESCRIPTION
## Summary

- remove the direct `@vitest/runner` import and development dependency
- require Vitest 4.1 or later and read suite state from `TestRunner.getCurrentSuite`
- ensure `@effect/vitest` observes the runner instance owned by the consumer's Vitest installation
- add a minor changeset documenting the dropped Vitest 3 and 4.0 support

## Reproduction

Declaring `@vitest/runner` separately does not fix npm's Vitest-only install. With Vitest 4.0.18, npm installed runner 4.1.10 for `@effect/vitest`, while Vitest resolved its nested runner 4.0.18. Resolution from the two packages returned distinct physical paths.

The final implementation has no runner declaration or subpath import. Collector state comes from the main Vitest entry's `TestRunner`, so it uses the running Vitest instance by construction and emits no `vitest/suite` deprecation warning.

## Validation

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter @effect/vitest build`
- `pnpm test --run`: 343 files passed; 8,416 tests passed, 1 expected failure, 8 skipped

Closes EFF-124
Closes #6666
