### PR TITLE
Fix Stream.asyncPush bounded termination

### DIFF
--- a/.changeset/tidy-stream-push.md
+++ b/.changeset/tidy-stream-push.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.asyncPush` termination with bounded dropping and sliding buffers.

--- a/packages/effect/src/Mailbox.ts
+++ b/packages/effect/src/Mailbox.ts
@@ -9,6 +9,7 @@ import type { Effect } from "./Effect.js"
 import type { Exit } from "./Exit.js"
 import type { Inspectable } from "./Inspectable.js"
 import * as internal from "./internal/mailbox.js"
+import * as internalStream from "./internal/stream.js"
 import type { Option } from "./Option.js"
 import { hasProperty } from "./Predicate.js"
 import type { Scope } from "./Scope.js"
@@ -242,7 +243,7 @@ export const toChannel: <A, E>(self: ReadonlyMailbox<A, E>) => Channel<Chunk<A>,
  * @experimental
  * @category conversions
  */
-export const toStream: <A, E>(self: ReadonlyMailbox<A, E>) => Stream<A, E> = internal.toStream
+export const toStream: <A, E>(self: ReadonlyMailbox<A, E>) => Stream<A, E> = internalStream.mailboxToStream
 
 /**
  * Create a `ReadonlyMailbox` from a `Stream`.
@@ -265,4 +266,4 @@ export const fromStream: {
       readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
     }
   ): Effect<ReadonlyMailbox<A, E>, never, R | Scope>
-} = internal.fromStream
+} = internalStream.mailboxFromStream

--- a/packages/effect/src/internal/mailbox.ts
+++ b/packages/effect/src/internal/mailbox.ts
@@ -13,15 +13,9 @@ import * as Option from "../Option.js"
 import { pipeArguments } from "../Pipeable.js"
 import { hasProperty } from "../Predicate.js"
 import type { Scheduler } from "../Scheduler.js"
-import type { Scope } from "../Scope.js"
-import type { Stream } from "../Stream.js"
 import * as channel from "./channel.js"
-import * as channelExecutor from "./channel/channelExecutor.js"
 import * as coreChannel from "./core-stream.js"
 import * as core from "./core.js"
-import * as circular from "./effect/circular.js"
-import * as fiberRuntime from "./fiberRuntime.js"
-import * as stream from "./stream.js"
 
 /** @internal */
 export const TypeId: Api.TypeId = Symbol.for("effect/Mailbox") as Api.TypeId
@@ -515,47 +509,3 @@ export const toChannel = <A, E>(self: Api.ReadonlyMailbox<A, E>): Channel<Chunk.
       : channel.zipRight(coreChannel.write(messages), loop))
   return loop
 }
-
-/** @internal */
-export const toStream = <A, E>(self: Api.ReadonlyMailbox<A, E>): Stream<A, E> => stream.fromChannel(toChannel(self))
-
-/** @internal */
-export const fromStream: {
-  (options?: {
-    readonly capacity?: number | undefined
-    readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
-  }): <A, E, R>(self: Stream<A, E, R>) => Effect<Api.ReadonlyMailbox<A, E>, never, R | Scope>
-  <A, E, R>(
-    self: Stream<A, E, R>,
-    options?: {
-      readonly capacity?: number | undefined
-      readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
-    }
-  ): Effect<Api.ReadonlyMailbox<A, E>, never, R | Scope>
-} = dual((args) => stream.isStream(args[0]), <A, E, R>(
-  self: Stream<A, E, R>,
-  options?: {
-    readonly capacity?: number | undefined
-    readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
-  }
-): Effect<Api.ReadonlyMailbox<A, E>, never, R | Scope> =>
-  core.tap(
-    fiberRuntime.acquireRelease(
-      make<A, E>(options),
-      (mailbox) => mailbox.shutdown
-    ),
-    (mailbox) => {
-      const writer: Channel<never, Chunk.Chunk<A>, never, E> = coreChannel.readWithCause({
-        onInput: (input: Chunk.Chunk<A>) => coreChannel.flatMap(mailbox.offerAll(input), () => writer),
-        onFailure: (cause: Cause<E>) => mailbox.failCause(cause),
-        onDone: () => mailbox.end
-      })
-      return fiberRuntime.scopeWith((scope) =>
-        stream.toChannel(self).pipe(
-          coreChannel.pipeTo(writer),
-          channelExecutor.runIn(scope),
-          circular.forkIn(scope)
-        )
-      )
-    }
-  ))

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -16,7 +16,7 @@ import type { LazyArg } from "../Function.js"
 import { constTrue, dual, identity, pipe } from "../Function.js"
 import * as internalExecutionPlan from "../internal/executionPlan.js"
 import * as Layer from "../Layer.js"
-import * as Mailbox from "../Mailbox.js"
+import type * as Mailbox from "../Mailbox.js"
 import * as MergeDecision from "../MergeDecision.js"
 import * as Option from "../Option.js"
 import type * as Order from "../Order.js"
@@ -43,7 +43,11 @@ import * as channel from "./channel.js"
 import * as channelExecutor from "./channel/channelExecutor.js"
 import * as MergeStrategy from "./channel/mergeStrategy.js"
 import * as core from "./core-stream.js"
+import * as effectCore from "./core.js"
 import * as doNotation from "./doNotation.js"
+import * as circular from "./effect/circular.js"
+import * as fiberRuntime from "./fiberRuntime.js"
+import * as mailbox from "./mailbox.js"
 import { RingBuffer } from "./ringBuffer.js"
 import * as InternalSchedule from "./schedule.js"
 import * as sink_ from "./sink.js"
@@ -600,9 +604,9 @@ const mailboxFromBufferOptionsPush = <A, E>(
   } | undefined
 ): Effect.Effect<Mailbox.Mailbox<Array<A>, E>> => {
   if (options?.bufferSize === "unbounded" || (options?.bufferSize === undefined && options?.strategy === undefined)) {
-    return Mailbox.make()
+    return mailbox.make()
   }
-  return Mailbox.make({
+  return mailbox.make({
     capacity: options?.bufferSize ?? 16,
     strategy: options?.strategy ?? "dropping"
   })
@@ -3013,6 +3017,51 @@ export const toChannel = <A, E, R>(
     throw new TypeError(`Expected a Stream.`)
   }
 }
+
+/** @internal */
+export const mailboxToStream = <A, E>(self: Mailbox.ReadonlyMailbox<A, E>): Stream.Stream<A, E> =>
+  fromChannel(mailbox.toChannel(self))
+
+/** @internal */
+export const mailboxFromStream: {
+  (options?: {
+    readonly capacity?: number | undefined
+    readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
+  }): <A, E, R>(self: Stream.Stream<A, E, R>) => Effect.Effect<Mailbox.ReadonlyMailbox<A, E>, never, R | Scope.Scope>
+  <A, E, R>(
+    self: Stream.Stream<A, E, R>,
+    options?: {
+      readonly capacity?: number | undefined
+      readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
+    }
+  ): Effect.Effect<Mailbox.ReadonlyMailbox<A, E>, never, R | Scope.Scope>
+} = dual((args) => isStream(args[0]), <A, E, R>(
+  self: Stream.Stream<A, E, R>,
+  options?: {
+    readonly capacity?: number | undefined
+    readonly strategy?: "suspend" | "dropping" | "sliding" | undefined
+  }
+): Effect.Effect<Mailbox.ReadonlyMailbox<A, E>, never, R | Scope.Scope> =>
+  effectCore.tap(
+    fiberRuntime.acquireRelease(
+      mailbox.make<A, E>(options),
+      (mailbox) => mailbox.shutdown
+    ),
+    (mailbox) => {
+      const writer: Channel.Channel<never, Chunk.Chunk<A>, never, E> = core.readWithCause({
+        onInput: (input: Chunk.Chunk<A>) => core.flatMap(mailbox.offerAll(input), () => writer),
+        onFailure: (cause: Cause.Cause<E>) => mailbox.failCause(cause),
+        onDone: () => mailbox.end
+      })
+      return fiberRuntime.scopeWith((scope) =>
+        toChannel(self).pipe(
+          core.pipeTo(writer),
+          channelExecutor.runIn(scope),
+          circular.forkIn(scope)
+        )
+      )
+    }
+  ))
 
 /** @internal */
 export const fromChunk = <A>(chunk: Chunk.Chunk<A>): Stream.Stream<A> =>

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -11,7 +11,6 @@ import * as Equal from "../Equal.js"
 import type { ExecutionPlan } from "../ExecutionPlan.js"
 import * as Exit from "../Exit.js"
 import * as Fiber from "../Fiber.js"
-import * as FiberRef from "../FiberRef.js"
 import type { LazyArg } from "../Function.js"
 import { constTrue, dual, identity, pipe } from "../Function.js"
 import * as internalExecutionPlan from "../internal/executionPlan.js"
@@ -602,7 +601,7 @@ const mailboxFromBufferOptionsPush = <A, E>(
     readonly bufferSize?: number | undefined
     readonly strategy?: "dropping" | "sliding" | undefined
   } | undefined
-): Effect.Effect<Mailbox.Mailbox<Array<A>, E>> => {
+): Effect.Effect<Mailbox.Mailbox<A, E>> => {
   if (options?.bufferSize === "unbounded" || (options?.bufferSize === undefined && options?.strategy === undefined)) {
     return mailbox.make()
   }
@@ -626,22 +625,9 @@ export const asyncPush = <A, E = never, R = never>(
     mailboxFromBufferOptionsPush<A, E>(options),
     (mailbox) => mailbox.shutdown
   ).pipe(
-    Effect.tap((mailbox) =>
-      FiberRef.getWith(
-        FiberRef.currentScheduler,
-        (scheduler) => register(emit.makePush(mailbox, scheduler))
-      )
-    ),
-    Effect.map((mailbox) => {
-      const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E> = core.flatMap(mailbox.takeAll, ([items, done]) => {
-        const values = Chunk.flatMap(items, Chunk.unsafeFromArray)
-        const next = done ? core.void : loop
-        return Chunk.isEmpty(values) ? next : channel.zipRight(core.write(values), next)
-      })
-      return loop
-    }),
-    channel.unwrapScoped,
-    fromChannel
+    Effect.tap((mailbox) => register(emit.makePush(mailbox))),
+    Effect.map(mailboxToStream),
+    unwrapScoped
   )
 
 /** @internal */

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -592,12 +592,12 @@ export const asyncEffect = <A, E = never, R = never>(
     fromChannel
   )
 
-const queueFromBufferOptionsPush = <A, E>(
+const queueFromBufferOptionsPush = <A>(
   options?: { readonly bufferSize: "unbounded" } | {
     readonly bufferSize?: number | undefined
     readonly strategy?: "dropping" | "sliding" | undefined
   } | undefined
-): Effect.Effect<Queue.Queue<Array<A> | Exit.Exit<void, E>>> => {
+): Effect.Effect<Queue.Queue<Array<A>>> => {
   if (options?.bufferSize === "unbounded" || (options?.bufferSize === undefined && options?.strategy === undefined)) {
     return Queue.unbounded()
   }
@@ -620,17 +620,31 @@ export const asyncPush = <A, E = never, R = never>(
   } | undefined
 ): Stream.Stream<A, E, Exclude<R, Scope.Scope>> =>
   Effect.acquireRelease(
-    queueFromBufferOptionsPush<A, E>(options),
-    Queue.shutdown
+    Effect.all([
+      queueFromBufferOptionsPush<A>(options),
+      Queue.dropping<void>(1),
+      Deferred.make<Exit.Exit<void, E>>()
+    ]),
+    ([queue, wakeup]) => Effect.zipRight(Queue.shutdown(queue), Queue.shutdown(wakeup))
   ).pipe(
-    Effect.tap((queue) =>
-      FiberRef.getWith(FiberRef.currentScheduler, (scheduler) => register(emit.makePush(queue, scheduler)))
+    Effect.tap(([queue, wakeup, terminal]) =>
+      FiberRef.getWith(
+        FiberRef.currentScheduler,
+        (scheduler) => register(emit.makePush(queue, wakeup, terminal, scheduler))
+      )
     ),
-    Effect.map((queue) => {
-      const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E> = core.flatMap(Queue.take(queue), (item) =>
-        Exit.isExit(item)
-          ? Exit.isSuccess(item) ? core.void : core.failCause(item.cause)
-          : channel.zipRight(core.write(Chunk.unsafeFromArray(item)), loop))
+    Effect.map(([queue, wakeup, terminal]) => {
+      const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E> = core.flatMap(
+        Effect.race(Queue.take(wakeup), Deferred.await(terminal)),
+        (signal) =>
+          core.flatMap(core.fromEffect(Queue.takeAll(queue)), (items) => {
+            const values = Chunk.flatMap(items, Chunk.unsafeFromArray)
+            const next = Exit.isExit(signal)
+              ? Exit.isSuccess(signal) ? core.void : core.failCause(signal.cause)
+              : loop
+            return Chunk.isEmpty(values) ? next : channel.zipRight(core.write(values), next)
+          })
+      )
       return loop
     }),
     channel.unwrapScoped,

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -634,16 +634,21 @@ export const asyncPush = <A, E = never, R = never>(
       )
     ),
     Effect.map(([queue, wakeup, terminal]) => {
+      const step = Effect.flatMap(Queue.take(wakeup), () =>
+        Effect.flatMap(Deferred.poll(terminal), (exit) =>
+          Effect.map(
+            Queue.takeAll(queue),
+            (items) => [exit, Chunk.flatMap(items, Chunk.unsafeFromArray)] as const
+          )))
       const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E> = core.flatMap(
-        Effect.race(Queue.take(wakeup), Deferred.await(terminal)),
-        (signal) =>
-          core.flatMap(core.fromEffect(Queue.takeAll(queue)), (items) => {
-            const values = Chunk.flatMap(items, Chunk.unsafeFromArray)
-            const next = Exit.isExit(signal)
-              ? Exit.isSuccess(signal) ? core.void : core.failCause(signal.cause)
-              : loop
-            return Chunk.isEmpty(values) ? next : channel.zipRight(core.write(values), next)
-          })
+        step,
+        ([exit, values]) => {
+          const next = Option.isSome(exit)
+            ? core.flatMap(core.fromEffect(exit.value), (exit) =>
+              Exit.isSuccess(exit) ? core.void : core.failCause(exit.cause))
+            : loop
+          return Chunk.isEmpty(values) ? next : channel.zipRight(core.write(values), next)
+        }
       )
       return loop
     }),

--- a/packages/effect/src/internal/stream.ts
+++ b/packages/effect/src/internal/stream.ts
@@ -16,6 +16,7 @@ import type { LazyArg } from "../Function.js"
 import { constTrue, dual, identity, pipe } from "../Function.js"
 import * as internalExecutionPlan from "../internal/executionPlan.js"
 import * as Layer from "../Layer.js"
+import * as Mailbox from "../Mailbox.js"
 import * as MergeDecision from "../MergeDecision.js"
 import * as Option from "../Option.js"
 import type * as Order from "../Order.js"
@@ -592,21 +593,19 @@ export const asyncEffect = <A, E = never, R = never>(
     fromChannel
   )
 
-const queueFromBufferOptionsPush = <A>(
+const mailboxFromBufferOptionsPush = <A, E>(
   options?: { readonly bufferSize: "unbounded" } | {
     readonly bufferSize?: number | undefined
     readonly strategy?: "dropping" | "sliding" | undefined
   } | undefined
-): Effect.Effect<Queue.Queue<Array<A>>> => {
+): Effect.Effect<Mailbox.Mailbox<Array<A>, E>> => {
   if (options?.bufferSize === "unbounded" || (options?.bufferSize === undefined && options?.strategy === undefined)) {
-    return Queue.unbounded()
+    return Mailbox.make()
   }
-  switch (options?.strategy) {
-    case "sliding":
-      return Queue.sliding(options.bufferSize ?? 16)
-    default:
-      return Queue.dropping(options?.bufferSize ?? 16)
-  }
+  return Mailbox.make({
+    capacity: options?.bufferSize ?? 16,
+    strategy: options?.strategy ?? "dropping"
+  })
 }
 
 /** @internal */
@@ -620,36 +619,21 @@ export const asyncPush = <A, E = never, R = never>(
   } | undefined
 ): Stream.Stream<A, E, Exclude<R, Scope.Scope>> =>
   Effect.acquireRelease(
-    Effect.all([
-      queueFromBufferOptionsPush<A>(options),
-      Queue.dropping<void>(1),
-      Deferred.make<Exit.Exit<void, E>>()
-    ]),
-    ([queue, wakeup]) => Effect.zipRight(Queue.shutdown(queue), Queue.shutdown(wakeup))
+    mailboxFromBufferOptionsPush<A, E>(options),
+    (mailbox) => mailbox.shutdown
   ).pipe(
-    Effect.tap(([queue, wakeup, terminal]) =>
+    Effect.tap((mailbox) =>
       FiberRef.getWith(
         FiberRef.currentScheduler,
-        (scheduler) => register(emit.makePush(queue, wakeup, terminal, scheduler))
+        (scheduler) => register(emit.makePush(mailbox, scheduler))
       )
     ),
-    Effect.map(([queue, wakeup, terminal]) => {
-      const step = Effect.flatMap(Queue.take(wakeup), () =>
-        Effect.flatMap(Deferred.poll(terminal), (exit) =>
-          Effect.map(
-            Queue.takeAll(queue),
-            (items) => [exit, Chunk.flatMap(items, Chunk.unsafeFromArray)] as const
-          )))
-      const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E> = core.flatMap(
-        step,
-        ([exit, values]) => {
-          const next = Option.isSome(exit)
-            ? core.flatMap(core.fromEffect(exit.value), (exit) =>
-              Exit.isSuccess(exit) ? core.void : core.failCause(exit.cause))
-            : loop
-          return Chunk.isEmpty(values) ? next : channel.zipRight(core.write(values), next)
-        }
-      )
+    Effect.map((mailbox) => {
+      const loop: Channel.Channel<Chunk.Chunk<A>, unknown, E> = core.flatMap(mailbox.takeAll, ([items, done]) => {
+        const values = Chunk.flatMap(items, Chunk.unsafeFromArray)
+        const next = done ? core.void : loop
+        return Chunk.isEmpty(values) ? next : channel.zipRight(core.write(values), next)
+      })
       return loop
     }),
     channel.unwrapScoped,

--- a/packages/effect/src/internal/stream/emit.ts
+++ b/packages/effect/src/internal/stream/emit.ts
@@ -5,7 +5,6 @@ import * as Exit from "../../Exit.js"
 import { pipe } from "../../Function.js"
 import type * as Mailbox from "../../Mailbox.js"
 import * as Option from "../../Option.js"
-import type * as Scheduler from "../../Scheduler.js"
 import type * as Emit from "../../StreamEmit.js"
 
 /** @internal */
@@ -48,53 +47,23 @@ export const make = <R, E, A, B>(
 }
 
 /** @internal */
-export const makePush = <E, A>(
-  mailbox: Mailbox.Mailbox<Array<A>, E>,
-  scheduler: Scheduler.Scheduler
-): Emit.EmitOpsPush<E, A> => {
+export const makePush = <E, A>(mailbox: Mailbox.Mailbox<A, E>): Emit.EmitOpsPush<E, A> => {
   let finished = false
-  let buffer: Array<A> = []
-  let running = false
   function array(items: ReadonlyArray<A>) {
     if (finished) return false
-    if (items.length <= 50_000) {
-      buffer.push.apply(buffer, items as Array<A>)
-    } else {
-      for (let i = 0; i < items.length; i++) {
-        buffer.push(items[0])
-      }
-    }
-    if (!running) {
-      running = true
-      scheduler.scheduleTask(flush, 0)
-    }
-    return true
-  }
-  function flush() {
-    running = false
-    if (buffer.length > 0) {
-      mailbox.unsafeOffer(buffer)
-      buffer = []
-    }
+    return Chunk.isEmpty(mailbox.unsafeOfferAll(items))
   }
   function done(exit: Exit.Exit<A, E>) {
     if (finished) return
     finished = true
     if (exit._tag === "Success") {
-      buffer.push(exit.value)
+      mailbox.unsafeOffer(exit.value)
     }
-    flush()
     mailbox.unsafeDone(exit._tag === "Success" ? Exit.void : exit)
   }
   return {
     single(value: A) {
-      if (finished) return false
-      buffer.push(value)
-      if (!running) {
-        running = true
-        scheduler.scheduleTask(flush, 0)
-      }
-      return true
+      return finished ? false : mailbox.unsafeOffer(value)
     },
     array,
     chunk(chunk) {
@@ -104,7 +73,6 @@ export const makePush = <E, A>(
     end() {
       if (finished) return
       finished = true
-      flush()
       mailbox.unsafeDone(Exit.void)
     },
     halt(cause: Cause.Cause<E>) {

--- a/packages/effect/src/internal/stream/emit.ts
+++ b/packages/effect/src/internal/stream/emit.ts
@@ -1,5 +1,6 @@
 import * as Cause from "../../Cause.js"
 import * as Chunk from "../../Chunk.js"
+import * as Deferred from "../../Deferred.js"
 import * as Effect from "../../Effect.js"
 import * as Exit from "../../Exit.js"
 import { pipe } from "../../Function.js"
@@ -49,7 +50,9 @@ export const make = <R, E, A, B>(
 
 /** @internal */
 export const makePush = <E, A>(
-  queue: Queue.Queue<Array<A> | Exit.Exit<void, E>>,
+  queue: Queue.Queue<Array<A>>,
+  wakeup: Queue.Queue<void>,
+  terminal: Deferred.Deferred<Exit.Exit<void, E>>,
   scheduler: Scheduler.Scheduler
 ): Emit.EmitOpsPush<E, A> => {
   let finished = false
@@ -73,7 +76,9 @@ export const makePush = <E, A>(
   function flush() {
     running = false
     if (buffer.length > 0) {
-      queue.unsafeOffer(buffer)
+      if (queue.unsafeOffer(buffer)) {
+        wakeup.unsafeOffer(void 0)
+      }
       buffer = []
     }
   }
@@ -84,7 +89,7 @@ export const makePush = <E, A>(
       buffer.push(exit.value)
     }
     flush()
-    queue.unsafeOffer(exit._tag === "Success" ? Exit.void : exit)
+    Deferred.unsafeDone(terminal, Effect.succeed(exit._tag === "Success" ? Exit.void : exit))
   }
   return {
     single(value: A) {
@@ -105,7 +110,7 @@ export const makePush = <E, A>(
       if (finished) return
       finished = true
       flush()
-      queue.unsafeOffer(Exit.void)
+      Deferred.unsafeDone(terminal, Effect.succeed(Exit.void))
     },
     halt(cause: Cause.Cause<E>) {
       return done(Exit.failCause(cause))

--- a/packages/effect/src/internal/stream/emit.ts
+++ b/packages/effect/src/internal/stream/emit.ts
@@ -1,11 +1,10 @@
 import * as Cause from "../../Cause.js"
 import * as Chunk from "../../Chunk.js"
-import * as Deferred from "../../Deferred.js"
 import * as Effect from "../../Effect.js"
 import * as Exit from "../../Exit.js"
 import { pipe } from "../../Function.js"
+import type * as Mailbox from "../../Mailbox.js"
 import * as Option from "../../Option.js"
-import type * as Queue from "../../Queue.js"
 import type * as Scheduler from "../../Scheduler.js"
 import type * as Emit from "../../StreamEmit.js"
 
@@ -50,9 +49,7 @@ export const make = <R, E, A, B>(
 
 /** @internal */
 export const makePush = <E, A>(
-  queue: Queue.Queue<Array<A>>,
-  wakeup: Queue.Queue<void>,
-  terminal: Deferred.Deferred<Exit.Exit<void, E>>,
+  mailbox: Mailbox.Mailbox<Array<A>, E>,
   scheduler: Scheduler.Scheduler
 ): Emit.EmitOpsPush<E, A> => {
   let finished = false
@@ -76,9 +73,7 @@ export const makePush = <E, A>(
   function flush() {
     running = false
     if (buffer.length > 0) {
-      if (queue.unsafeOffer(buffer)) {
-        wakeup.unsafeOffer(void 0)
-      }
+      mailbox.unsafeOffer(buffer)
       buffer = []
     }
   }
@@ -89,8 +84,7 @@ export const makePush = <E, A>(
       buffer.push(exit.value)
     }
     flush()
-    Deferred.unsafeDone(terminal, Effect.succeed(exit._tag === "Success" ? Exit.void : exit))
-    wakeup.unsafeOffer(void 0)
+    mailbox.unsafeDone(exit._tag === "Success" ? Exit.void : exit)
   }
   return {
     single(value: A) {
@@ -111,8 +105,7 @@ export const makePush = <E, A>(
       if (finished) return
       finished = true
       flush()
-      Deferred.unsafeDone(terminal, Effect.succeed(Exit.void))
-      wakeup.unsafeOffer(void 0)
+      mailbox.unsafeDone(Exit.void)
     },
     halt(cause: Cause.Cause<E>) {
       return done(Exit.failCause(cause))

--- a/packages/effect/src/internal/stream/emit.ts
+++ b/packages/effect/src/internal/stream/emit.ts
@@ -90,6 +90,7 @@ export const makePush = <E, A>(
     }
     flush()
     Deferred.unsafeDone(terminal, Effect.succeed(exit._tag === "Success" ? Exit.void : exit))
+    wakeup.unsafeOffer(void 0)
   }
   return {
     single(value: A) {
@@ -111,6 +112,7 @@ export const makePush = <E, A>(
       finished = true
       flush()
       Deferred.unsafeDone(terminal, Effect.succeed(Exit.void))
+      wakeup.unsafeOffer(void 0)
     },
     halt(cause: Cause.Cause<E>) {
       return done(Exit.failCause(cause))

--- a/packages/effect/test/Stream/async.test.ts
+++ b/packages/effect/test/Stream/async.test.ts
@@ -454,15 +454,28 @@ describe("Stream", () => {
     it.effect(`asyncPush - ${strategy} buffer handles done errors after synchronous emission`, () =>
       Effect.gen(function*() {
         const error = new Cause.RuntimeException("boom")
-        const result = yield* Stream.asyncPush<number, Cause.RuntimeException>((emit) => {
+        const values: Array<number> = []
+        const exit = yield* Stream.asyncPush<number, Cause.RuntimeException>((emit) => {
           emit.single(42)
           emit.done(Exit.fail(error))
           return Effect.void
         }, { bufferSize: 1, strategy }).pipe(
-          Stream.runCollect,
+          Stream.runForEach((value) => Effect.sync(() => values.push(value))),
           Effect.exit
         )
-        deepStrictEqual(result, Exit.fail(error))
+        deepStrictEqual(values, [42])
+        deepStrictEqual(exit, Exit.fail(error))
+      }))
+
+    it.effect(`asyncPush - ${strategy} buffer bounds synchronous emissions`, () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.asyncPush<number>((emit) => {
+          emit.single(1)
+          emit.single(2)
+          emit.end()
+          return Effect.void
+        }, { bufferSize: 1, strategy }).pipe(Stream.runCollect)
+        deepStrictEqual(Array.from(result), strategy === "dropping" ? [1] : [2])
       }))
 
     it.effect(`asyncPush - ${strategy} buffer does not exceed its capacity`, () =>

--- a/packages/effect/test/Stream/async.test.ts
+++ b/packages/effect/test/Stream/async.test.ts
@@ -438,6 +438,46 @@ describe("Stream", () => {
       assertTrue(Chunk.isEmpty(result))
     }))
 
+  for (const strategy of ["dropping", "sliding"] as const) {
+    it.effect(`asyncPush - ${strategy} buffer completes after synchronous emission`, () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.asyncPush<number>((emit) => {
+          emit.single(42)
+          emit.end()
+          return Effect.void
+        }, { bufferSize: 1, strategy }).pipe(
+          Stream.runCollect
+        )
+        deepStrictEqual(Array.from(result), [42])
+      }))
+
+    it.effect(`asyncPush - ${strategy} buffer handles done errors after synchronous emission`, () =>
+      Effect.gen(function*() {
+        const error = new Cause.RuntimeException("boom")
+        const result = yield* Stream.asyncPush<number, Cause.RuntimeException>((emit) => {
+          emit.single(42)
+          emit.done(Exit.fail(error))
+          return Effect.void
+        }, { bufferSize: 1, strategy }).pipe(
+          Stream.runCollect,
+          Effect.exit
+        )
+        deepStrictEqual(result, Exit.fail(error))
+      }))
+
+    it.effect(`asyncPush - ${strategy} buffer does not exceed its capacity`, () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.asyncPush<number>((emit) =>
+          Effect.gen(function*() {
+            emit.single(1)
+            yield* Effect.yieldNow({ priority: 1 })
+            emit.single(2)
+            emit.end()
+          }), { bufferSize: 1, strategy }).pipe(Stream.runCollect)
+        assertTrue(result.length === 1)
+      }))
+  }
+
   it.effect("asyncPush - handles errors", () =>
     Effect.gen(function*() {
       const error = new Cause.RuntimeException("boom")

--- a/packages/effect/test/Stream/fromEventListener.test.ts
+++ b/packages/effect/test/Stream/fromEventListener.test.ts
@@ -31,7 +31,10 @@ describe("Stream.fromEventListener", () => {
       )
       const waitForListener = (): Effect.Effect<void> =>
         Effect.suspend(() => target.listening ? Effect.void : Effect.zipRight(Effect.yieldNow(), waitForListener()))
-      yield* waitForListener()
+      yield* Effect.raceFirst(
+        waitForListener(),
+        Fiber.join(fiber).pipe(Effect.flatMap(() => Effect.dieMessage("stream ended before listener registration")))
+      )
       target.emit()
       target.emit()
       target.emit()

--- a/packages/effect/test/Stream/fromEventListener.test.ts
+++ b/packages/effect/test/Stream/fromEventListener.test.ts
@@ -1,7 +1,18 @@
 import { describe, it } from "@effect/vitest"
-import { Effect, pipe, Stream } from "effect"
+import { Effect, Fiber, pipe, Stream } from "effect"
 
 class TestTarget extends EventTarget {
+  listening = false
+
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    super.addEventListener(type, callback, options)
+    this.listening = true
+  }
+
   emit() {
     this.dispatchEvent(new Event("test-event"))
   }
@@ -12,11 +23,19 @@ describe("Stream.fromEventListener", () => {
     Effect.gen(function*() {
       const target = new TestTarget()
 
-      const count = yield* pipe(
+      const fiber = yield* pipe(
         Stream.fromEventListener(target, "test-event"),
-        Stream.interruptWhen(Effect.sync(() => target.emit()).pipe(Effect.repeatN(2))),
-        Stream.runCount
+        Stream.take(3),
+        Stream.runCount,
+        Effect.fork
       )
+      const waitForListener = (): Effect.Effect<void> =>
+        Effect.suspend(() => target.listening ? Effect.void : Effect.zipRight(Effect.yieldNow(), waitForListener()))
+      yield* waitForListener()
+      target.emit()
+      target.emit()
+      target.emit()
+      const count = yield* Fiber.join(fiber)
       ctx.expect(count).toEqual(3)
     }))
 })


### PR DESCRIPTION
## Summary

- use `Mailbox` for `Stream.asyncPush` values and terminal state instead of sharing a Queue between both
- keep dropping/sliding capacity exactly user-configured while guaranteeing completion and failure cannot be dropped
- cover synchronous completion, `done()` failures, and capacity boundaries for both bounded strategies

## Target branch

This targets `v3`, where the bug still reproduces on the current 3.22.0 branch. On `main` / v4, `Stream.asyncPush` has been replaced by `Stream.callback`, and Queue completion is stored separately from buffered values; capacity-1 completion and failure probes pass there.

## Rationale

Increasing the queue to `bufferSize + 1` would make the extra slot available to values, changing dropping/sliding behavior at the boundary, and it would not guarantee termination once multiple flushes fill that slot. v3 `Mailbox` already models completion/failure as state rather than a queued value, exposes `unsafeOffer` and `unsafeDone` for the synchronous callback producer, and enforces the configured dropping/sliding capacity directly.

## Compatibility

The consumer drains all currently available mailbox elements and writes them as one chunk. Element content and order are unchanged, but chunk boundaries can coalesce; this is observable to chunk-granular operators such as `Stream.chunks`.

In released 3.x, `bufferSize` effectively counted flush batches, so a whole synchronous burst occupied one slot; it now counts elements, which is stricter and matches the documented meaning of `bufferSize`.

`emit.single` and `emit.array` now return `false` when an offered value is dropped instead of returning `true` before the later flush discarded it.

The `fromEventListener` test previously dispatched events from `interruptWhen`, requiring delivery to win a scheduler race against interruption. Mailbox can deliver those events on a later scheduler turn without losing them. The test now waits for listener registration, synchronously dispatches three events, and uses `take(3)` to assert all three eventually arrive without assuming synchronous delivery.

## Validation

- `pnpm lint-fix`
- eight bounded dropping/sliding termination and capacity regressions passing, including strengthened values-before-failure assertions
- `pnpm test run packages/effect/test/Stream` (50 files, 483/483 tests)
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-125
Closes #6232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Stream.asyncPush` termination reliability for bounded dropping and sliding buffers.
  * Improved completion and error propagation for synchronous `emit`/`done` scenarios, especially with buffered emission.

* **Tests**
  * Added `asyncPush` test coverage for dropping and sliding buffer strategies, including synchronous completion, synchronous `done()` error handling, and capacity-limit behavior.
  * Updated `Stream.fromEventListener` tests to ensure listener registration is deterministic before emitting events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
