### PR TITLE
Remove version.ts

### DIFF
--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -12,7 +12,6 @@ import type * as Context from "./Context.ts"
 import type { Effect } from "./Effect.ts"
 import type { Exit } from "./Exit.ts"
 import * as effect from "./internal/effect.ts"
-import { version } from "./internal/version.ts"
 import type { LogLevel } from "./LogLevel.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
@@ -22,7 +21,7 @@ import type { Scope } from "./Scope.ts"
 import type { AnySpan } from "./Tracer.ts"
 import type { Covariant } from "./Types.ts"
 
-const TypeId = `~effect/Fiber/${version}`
+const TypeId = "~effect/Fiber"
 
 /**
  * A runtime fiber is a lightweight thread that executes Effects. Fibers are

--- a/packages/effect/src/TxPubSub.ts
+++ b/packages/effect/src/TxPubSub.ts
@@ -638,14 +638,14 @@ export const shutdown = <A>(self: TxPubSub<A>): Effect.Effect<void> =>
  * **Example** (Waiting for shutdown)
  *
  * ```ts
- * import { Effect, TxPubSub } from "effect"
+ * import { Effect, Fiber, TxPubSub } from "effect"
  *
  * const program = Effect.gen(function*() {
  *   const hub = yield* TxPubSub.unbounded<number>()
  *
  *   const fiber = yield* Effect.forkChild(TxPubSub.awaitShutdown(hub))
  *   yield* TxPubSub.shutdown(hub)
- *   yield* fiber.await
+ *   yield* Fiber.await(fiber)
  * })
  * ```
  *

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -98,7 +98,6 @@ import {
 } from "./references.ts"
 import { getStackTraceLimit, setStackTraceLimit } from "./stackTraceLimit.ts"
 import { addSpanStackTrace, makeStackCleaner } from "./tracer.ts"
-import { version } from "./version.ts"
 
 // ----------------------------------------------------------------------------
 // Cause
@@ -490,7 +489,7 @@ const renderErrorCause = (cause: Error, prefix: string) => {
 // ----------------------------------------------------------------------------
 
 /** @internal */
-export const FiberTypeId = `~effect/Fiber/${version}` as const
+export const FiberTypeId = "~effect/Fiber" as const
 
 const fiberVariance = {
   _A: identity,
@@ -5204,16 +5203,17 @@ export const forkUnsafe = <FA, FE, A, E, R>(
   daemon = false,
   uninterruptible: boolean | "inherit" = false
 ): FiberImpl<A, E> => {
-  const interruptible = uninterruptible === "inherit" ? parent.interruptible : !uninterruptible
-  const child = new FiberImpl<A, E>(parent.context, interruptible)
+  const parentRuntime = parent as FiberImpl<FA, FE>
+  const interruptible = uninterruptible === "inherit" ? parentRuntime.interruptible : !uninterruptible
+  const child = new FiberImpl<A, E>(parentRuntime.context, interruptible)
   if (immediate) {
     child.evaluate(effect as any)
   } else {
-    parent.currentDispatcher.scheduleTask(() => child.evaluate(effect as any), 0)
+    parentRuntime.currentDispatcher.scheduleTask(() => child.evaluate(effect as any), 0)
   }
   if (!daemon && !child._exit) {
-    parent.children().add(child)
-    child.addObserver(() => parent._children!.delete(child))
+    parentRuntime.children().add(child)
+    child.addObserver(() => parentRuntime._children!.delete(child))
   }
   return child
 }

--- a/packages/effect/src/internal/version.ts
+++ b/packages/effect/src/internal/version.ts
@@ -1,2 +1,0 @@
-export const version: version = "dev"
-export type version = "dev"

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -1202,7 +1202,7 @@ const make = Effect.gen(function*() {
               if (!options.discard) {
                 const entry: ClientRequestEntry = {
                   rpc: rpc as any,
-                  context: fiber.currentContext,
+                  context: fiber.context,
                   message
                 }
                 clientRequests.set(id, entry)

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,9 +1,0 @@
-import * as Fs from "node:fs"
-import Package from "../packages/effect/package.json" with { type: "json" }
-
-const tpl = Fs.readFileSync("./scripts/version.template.txt").toString("utf8")
-
-Fs.writeFileSync(
-  "packages/effect/src/internal/version.ts",
-  tpl.replace(/VERSION/g, Package.version)
-)

--- a/scripts/version.template.txt
+++ b/scripts/version.template.txt
@@ -1,2 +1,0 @@
-export const version: version = "VERSION"
-export type version = "VERSION"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized fiber type identification using a fixed identifier.
  * Removed the internal version contract and the script/template previously used to generate it.
* **Bug Fixes**
  * Corrected which fiber context is stored for in-flight client request entries, improving the context used for outgoing replies.
  * Improved consistency in how child fibers inherit interruptibility and parent/child tracking during forking.
* **Documentation**
  * Updated the `TxPubSub.awaitShutdown` JSDoc example to use `Fiber.await(...)` when awaiting forked fibers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->