### PR TITLE
Fix useAtomSuspense registry isolation

### DIFF
--- a/.changeset/fix-atom-suspense-registry-cache.md
+++ b/.changeset/fix-atom-suspense-registry-cache.md
@@ -1,0 +1,5 @@
+---
+"@effect/atom-react": patch
+---
+
+Scope `useAtomSuspense` promises to their atom registry so concurrent registries resolve independently.

--- a/packages/atom/react/src/Hooks.ts
+++ b/packages/atom/react/src/Hooks.ts
@@ -293,8 +293,14 @@ export const useAtom = <R, W, const Mode extends "value" | "promise" | "promiseE
 }
 
 const atomPromiseMap = {
-  suspendOnWaiting: new Map<Atom.Atom<any>, Promise<void>>(),
-  default: new Map<Atom.Atom<any>, Promise<void>>()
+  suspendOnWaiting: new WeakMap<
+    AtomRegistry.AtomRegistry,
+    WeakMap<Atom.Atom<any>, Promise<void>>
+  >(),
+  default: new WeakMap<
+    AtomRegistry.AtomRegistry,
+    WeakMap<Atom.Atom<any>, Promise<void>>
+  >()
 }
 
 function atomToPromise<A, E>(
@@ -302,7 +308,12 @@ function atomToPromise<A, E>(
   atom: Atom.Atom<AsyncResult.AsyncResult<A, E>>,
   suspendOnWaiting: boolean
 ) {
-  const map = suspendOnWaiting ? atomPromiseMap.suspendOnWaiting : atomPromiseMap.default
+  const registries = suspendOnWaiting ? atomPromiseMap.suspendOnWaiting : atomPromiseMap.default
+  let map = registries.get(registry)
+  if (map === undefined) {
+    map = new WeakMap()
+    registries.set(registry, map)
+  }
   let promise = map.get(atom)
   if (promise !== undefined) {
     return promise

--- a/packages/atom/react/test/index.test.tsx
+++ b/packages/atom/react/test/index.test.tsx
@@ -135,6 +135,49 @@ describe("atom-react", () => {
 
       expect(screen.getByTestId("loading")).toBeInTheDocument()
     })
+
+    test("suspense subscriptions are isolated per registry", async () => {
+      const atom = Atom.make(AsyncResult.initial<string>())
+      const firstRegistry = AtomRegistry.make()
+      const secondRegistry = AtomRegistry.make()
+
+      function TestComponent({ id }: { readonly id: string }) {
+        const value = useAtomSuspense(atom).value
+        return <div data-testid={`${id}-value`}>{value}</div>
+      }
+
+      render(
+        <RegistryContext.Provider value={firstRegistry}>
+          <Suspense fallback={<div data-testid="first-loading">Loading...</div>}>
+            <TestComponent id="first" />
+          </Suspense>
+        </RegistryContext.Provider>
+      )
+      render(
+        <RegistryContext.Provider value={secondRegistry}>
+          <Suspense fallback={<div data-testid="second-loading">Loading...</div>}>
+            <TestComponent id="second" />
+          </Suspense>
+        </RegistryContext.Provider>
+      )
+
+      act(() => {
+        secondRegistry.set(atom, AsyncResult.success("second"))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("second-value")).toHaveTextContent("second")
+      })
+      expect(screen.getByTestId("first-loading")).toBeInTheDocument()
+
+      act(() => {
+        firstRegistry.set(atom, AsyncResult.success("first"))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("first-value")).toHaveTextContent("first")
+      })
+    })
   })
 
   describe("ScopedAtom", () => {


### PR DESCRIPTION
## Summary

- scope pending `useAtomSuspense` promises to the active `AtomRegistry`
- preserve promise deduplication for the same atom and registry, including the separate `suspendOnWaiting` mode
- add a regression test proving that two registries using the same atom resolve independently

## Root cause

The Suspense promise cache was module-global and keyed only by atom. When two registries rendered the same atom concurrently, the second registry reused the first registry's promise. Its Suspense boundary therefore remained blocked even after its own atom reached a successful result.

Using registry-scoped `WeakMap`s keeps the existing atom-level deduplication without coupling independent registries or retaining disposed registries.

## Validation

- verified the new regression failed before the implementation change
- `pnpm test --run packages/atom/react/test/index.test.tsx`
- focused regression repeated five times
- `pnpm --filter @effect/atom-react check`
- `pnpm --filter @effect/atom-react build`
- `pnpm check`
- `pnpm lint`
- `pnpm test-types --target '>=5.9'`
- `pnpm circular`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useAtomSuspense` so concurrent atom registries resolve independently.
  * Prevented updates in one registry from incorrectly resolving suspense boundaries in another.

* **Tests**
  * Added coverage verifying isolated suspense behavior across separate atom registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->