### PR TITLE
Fix zero-capacity Mailbox rendezvous

### DIFF
--- a/.changeset/fix-mailbox-zero-capacity.md
+++ b/.changeset/fix-mailbox-zero-capacity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix zero-capacity `Mailbox` rendezvous behavior for `take` and `takeN`.

--- a/packages/effect/src/internal/mailbox.ts
+++ b/packages/effect/src/internal/mailbox.ts
@@ -255,7 +255,10 @@ class MailboxImpl<A, E> extends Effectable.Class<readonly [messages: Chunk.Chunk
         return core.exitAs(this.state.exit, constDone)
       } else if (n <= 0) {
         return core.succeed([empty, false])
-      } else if (this.capacity <= 0 && this.state.offers.size > 0) {
+      } else if (
+        this.capacity <= 0 && this.messages.length === 0 && this.messagesChunk.length === 0 &&
+        this.state.offers.size > 0
+      ) {
         this.capacity = 1
         this.releaseCapacity()
         this.capacity = 0

--- a/packages/effect/src/internal/mailbox.ts
+++ b/packages/effect/src/internal/mailbox.ts
@@ -255,8 +255,14 @@ class MailboxImpl<A, E> extends Effectable.Class<readonly [messages: Chunk.Chunk
         return core.exitAs(this.state.exit, constDone)
       } else if (n <= 0) {
         return core.succeed([empty, false])
+      } else if (this.capacity <= 0 && this.state.offers.size > 0) {
+        this.capacity = 1
+        this.releaseCapacity()
+        this.capacity = 0
+        const messages = Chunk.of(this.messages.pop()!)
+        return core.succeed([messages, this.releaseCapacity()])
       }
-      n = Math.min(n, this.capacity)
+      n = Math.min(n, this.capacity || 1)
       let messages: Chunk.Chunk<A>
       if (n <= this.messagesChunk.length) {
         messages = Chunk.take(this.messagesChunk, n)
@@ -288,7 +294,9 @@ class MailboxImpl<A, E> extends Effectable.Class<readonly [messages: Chunk.Chunk
       this.capacity = 1
       this.releaseCapacity()
       this.capacity = 0
-      return this.messages.length > 0 ? core.exitSucceed(this.messages.pop()!) : undefined
+      const message = this.messages.pop()!
+      this.releaseCapacity()
+      return core.exitSucceed(message)
     } else {
       return undefined
     }

--- a/packages/effect/test/Mailbox.test.ts
+++ b/packages/effect/test/Mailbox.test.ts
@@ -182,4 +182,39 @@ describe("Mailbox", () => {
       result = yield* Fiber.join(fiber)
       strictEqual(result, 2)
     }))
+
+  it.effect("bounded 0 capacity take finalizes after end", () =>
+    Effect.gen(function*() {
+      const mailbox = yield* Mailbox.make<number>(0)
+      const offerFiber = yield* mailbox.offer(1).pipe(Effect.fork)
+      yield* Effect.yieldNow({ priority: 1 })
+
+      yield* mailbox.end
+      const awaitFiber = yield* mailbox.await.pipe(Effect.fork)
+      strictEqual(yield* mailbox.take, 1)
+      yield* Effect.yieldNow({ priority: 1 })
+
+      deepStrictEqual(awaitFiber.unsafePoll(), Exit.void)
+      assertTrue(yield* Fiber.join(offerFiber))
+    }))
+
+  it.effect("bounded 0 capacity takeN rendezvous", () =>
+    Effect.gen(function*() {
+      const pendingOffer = yield* Mailbox.make<number>(0)
+      const offerFiber = yield* pendingOffer.offer(1).pipe(Effect.fork)
+      yield* Effect.yieldNow({ priority: 1 })
+
+      const [first] = yield* pendingOffer.takeN(1)
+      deepStrictEqual(Chunk.toReadonlyArray(first), [1])
+      assertTrue(yield* Fiber.join(offerFiber))
+
+      const pendingTake = yield* Mailbox.make<number>(0)
+      const takeFiber = yield* pendingTake.takeN(1).pipe(Effect.fork)
+      yield* Effect.yieldNow({ priority: 1 })
+      strictEqual(takeFiber.unsafePoll(), null)
+
+      assertTrue(yield* pendingTake.offer(2))
+      const [second] = yield* Fiber.join(takeFiber)
+      deepStrictEqual(Chunk.toReadonlyArray(second), [2])
+    }))
 })

--- a/packages/effect/test/Mailbox.test.ts
+++ b/packages/effect/test/Mailbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertFalse, assertNone, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Chunk, Effect, Exit, Fiber, Mailbox, Stream } from "effect"
+import { Chunk, Effect, Exit, Fiber, Mailbox, Scheduler, Stream } from "effect"
 
 describe("Mailbox", () => {
   it.effect("offerAll with capacity", () =>
@@ -216,5 +216,24 @@ describe("Mailbox", () => {
       assertTrue(yield* pendingTake.offer(2))
       const [second] = yield* Fiber.join(takeFiber)
       deepStrictEqual(Chunk.toReadonlyArray(second), [2])
+    }))
+
+  it.effect("bounded 0 capacity takeN preserves buffered order", () =>
+    Effect.gen(function*() {
+      const scheduler = new Scheduler.ControlledScheduler()
+      const mailbox = yield* Mailbox.make<number>(0).pipe(Effect.withScheduler(scheduler))
+      const taker1 = yield* mailbox.take.pipe(Effect.fork)
+      const taker2 = yield* mailbox.take.pipe(Effect.fork)
+      yield* Effect.yieldNow({ priority: 1 })
+
+      const offerFiber = yield* mailbox.offerAll([1, 2, 3]).pipe(Effect.fork)
+      yield* Effect.yieldNow({ priority: 1 })
+      strictEqual(offerFiber.unsafePoll(), null)
+      yield* Fiber.interrupt(taker1)
+      yield* Fiber.interrupt(taker2)
+
+      const [messages] = yield* mailbox.takeN(1)
+      deepStrictEqual(Chunk.toReadonlyArray(messages), [1])
+      deepStrictEqual(yield* Fiber.join(offerFiber), Chunk.empty())
     }))
 })


### PR DESCRIPTION
## Summary

- finalize zero-capacity mailboxes after `take` consumes the last suspended offer
- make zero-capacity `takeN` rendezvous with producer-first and consumer-first offers
- add focused regressions and a patch changeset

## Comparison

Backported the two v4 zero-capacity behavioral fixes because they map directly onto v3 internals.

Skipped the v4 `collect` duplication fix because v3 `Mailbox` has no equivalent API. Also skipped scheduler-without-takers changes because they are performance-only, and v4 completion/shutdown changes because they rely on v4's `Done`/`Pull` contract.

## Validation

- `pnpm lint-fix`
- `pnpm test run packages/effect/test/Mailbox.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zero-capacity mailbox rendezvous behavior for `take` and `takeN`, including correct handling when capacity is 0 and offers arrive while receives are pending.
  * Improved reliability so `take`, `takeN`, and mailbox `end` complete blocked operations as expected.
  * Preserved expected buffered ordering for `takeN` in zero-capacity scenarios.
* **Tests**
  * Added coverage for zero-capacity `Mailbox` behaviors, including rendezvous and ordering cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->