### PR TITLE
fix: accept image generation lifecycle statuses

### DIFF
--- a/.changeset/fresh-images-generate.md
+++ b/.changeset/fresh-images-generate.md
@@ -2,4 +2,4 @@
 "@effect/ai-openai": patch
 ---
 
-Accept image generation-specific lifecycle statuses in OpenAI response items.
+Accept image generation-specific lifecycle statuses and nullable results in OpenAI response items.

--- a/.changeset/fresh-images-generate.md
+++ b/.changeset/fresh-images-generate.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Accept image generation-specific lifecycle statuses in OpenAI response items.

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -778,7 +778,7 @@ const FileSearchCall = Schema.Struct({
 const ImageGenerationCall = Schema.Struct({
   id: Schema.String,
   type: Schema.Literal("image_generation_call"),
-  result: Schema.optionalKey(Schema.String),
+  result: Schema.optionalKey(Schema.NullOr(Schema.String)),
   status: Schema.optionalKey(Schema.Literals(["in_progress", "completed", "generating", "failed"]))
 })
 

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -779,7 +779,7 @@ const ImageGenerationCall = Schema.Struct({
   id: Schema.String,
   type: Schema.Literal("image_generation_call"),
   result: Schema.optionalKey(Schema.String),
-  status: Schema.optionalKey(MessageStatus)
+  status: Schema.optionalKey(Schema.Literals(["in_progress", "completed", "generating", "failed"]))
 })
 
 const McpCall = Schema.Struct({

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -77,6 +77,24 @@ describe("OpenAiSchema", () => {
     }
   })
 
+  it("decodes image generation lifecycle statuses", () => {
+    for (const status of ["generating", "failed"]) {
+      const decoded = Schema.decodeUnknownSync(OpenAiSchema.Response)({
+        ...makeResponse(),
+        output: [{
+          id: "image_1",
+          type: "image_generation_call",
+          status
+        }]
+      })
+
+      assert.strictEqual(decoded.output[0].type, "image_generation_call")
+      if (decoded.output[0].type === "image_generation_call") {
+        assert.strictEqual(decoded.output[0].status, status)
+      }
+    }
+  })
+
   it("decodes required stream events", () => {
     const response = makeResponse({ status: "in_progress" })
     const applyPatchItem = {

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -84,7 +84,8 @@ describe("OpenAiSchema", () => {
         output: [{
           id: "image_1",
           type: "image_generation_call",
-          status
+          status,
+          result: null
         }]
       })
 


### PR DESCRIPTION
## Summary

- Accept OpenAI image generation-specific `generating` and `failed` lifecycle statuses without widening shared message statuses.
- Align the handwritten response schema with the generated OpenAI schema.
- Add regression coverage and a patch changeset for `@effect/ai-openai`.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/ai/openai/test/OpenAiSchema.test.ts`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI image generation responses now correctly support lifecycle statuses, including “in progress,” “generating,” “completed,” and “failed.”
  * Image generation results now properly handle nullable outcomes, improving decoding and compatibility for intermediate and failure responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->