### PR TITLE
Signal Terminal end-of-input at stdin EOF instead of hanging

### DIFF
--- a/.changeset/node-terminal-stdin-eof.md
+++ b/.changeset/node-terminal-stdin-eof.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+NodeTerminal: signal end-of-input at stdin EOF instead of hanging. `readInput` now ends its input queue when stdin ends, so `Prompt.run` fails with `Terminal.QuitError` on piped or closed stdin (buffered keypresses still deliver first), and `readLine` fails with `Terminal.QuitError` when input closes. Also applies to `BunTerminal`, which reuses this implementation.

--- a/.changeset/node-terminal-stdin-eof.md
+++ b/.changeset/node-terminal-stdin-eof.md
@@ -2,4 +2,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-NodeTerminal: signal end-of-input at stdin EOF instead of hanging. `readInput` now ends its input queue when stdin ends, so `Prompt.run` fails with `Terminal.QuitError` on piped or closed stdin (buffered keypresses still deliver first), and `readLine` fails with `Terminal.QuitError` when input closes. Also applies to `BunTerminal`, which reuses this implementation.
+NodeTerminal: end key input and fail `readLine` with `QuitError` at stdin EOF instead of hanging

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -102,24 +102,29 @@ export const make: (
       return queue as Queue.Dequeue<Terminal.UserInput, Cause.Done>
     })
 
-    const readLine = Effect.scoped(
-      Effect.flatMap(RcRef.get(rlRef), (readlineInterface) =>
-        Effect.callback<string, Terminal.QuitError>((resume) => {
-          if (inputEnded) {
-            resume(Effect.fail(new Terminal.QuitError({})))
-            return Effect.void
-          }
-          const onLine = (line: string) => resume(Effect.succeed(line))
-          // readline "close" (rather than stdin "end") so a final line without
-          // a trailing newline still flushes through the "line" event first.
-          const onClose = () => resume(Effect.fail(new Terminal.QuitError({})))
-          readlineInterface.once("line", onLine)
-          readlineInterface.once("close", onClose)
-          return Effect.sync(() => {
-            readlineInterface.off("line", onLine)
-            readlineInterface.off("close", onClose)
-          })
-        }))
+    const readLine = Effect.suspend(() =>
+      inputEnded ? Effect.fail(new Terminal.QuitError({})) : Effect.scoped(
+        Effect.flatMap(RcRef.get(rlRef), (readlineInterface) =>
+          Effect.callback<string, Terminal.QuitError>((resume) => {
+            const cleanup = () => {
+              readlineInterface.off("line", onLine)
+              readlineInterface.off("close", onClose)
+            }
+            const onLine = (line: string) => {
+              cleanup()
+              resume(Effect.succeed(line))
+            }
+            // readline "close" (rather than stdin "end") so a final line without
+            // a trailing newline still flushes through the "line" event first.
+            const onClose = () => {
+              cleanup()
+              resume(Effect.fail(new Terminal.QuitError({})))
+            }
+            readlineInterface.on("line", onLine)
+            readlineInterface.on("close", onClose)
+            return Effect.sync(cleanup)
+          }))
+      )
     )
 
     const display = (prompt: string) =>

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -38,7 +38,7 @@ export const make: (
 
     // stdin "end" fires once per process, so remember end-of-input for readers
     // created after the event (Bun never sets `readableEnded`).
-    let inputEnded = stdin.readableEnded === true
+    let inputEnded = stdin.readableEnded
     const onStdinEnd = () => {
       inputEnded = true
     }
@@ -83,9 +83,7 @@ export const make: (
           Queue.endUnsafe(queue)
         }
       }
-      // End the queue at stdin end-of-input so consumers (e.g. `Prompt.run`)
-      // fail with `QuitError` instead of waiting forever on piped or closed
-      // stdin; keypresses buffered before the end still deliver first.
+      // Without this, consumers (e.g. `Prompt.run`) hang forever on closed stdin.
       const handleEnd = () => {
         Queue.endUnsafe(queue)
       }

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -36,6 +36,15 @@ export const make: (
     const stdin = process.stdin
     const stdout = process.stdout
 
+    // stdin "end" fires once per process, so remember end-of-input for readers
+    // created after the event (Bun never sets `readableEnded`).
+    let inputEnded = stdin.readableEnded === true
+    const onStdinEnd = () => {
+      inputEnded = true
+    }
+    stdin.once("end", onStdinEnd)
+    yield* Effect.addFinalizer(() => Effect.sync(() => stdin.off("end", onStdinEnd)))
+
     // Acquire readline interface with TTY setup/cleanup inside the scope
     const rlRef = yield* RcRef.make({
       acquire: Effect.acquireRelease(
@@ -74,17 +83,44 @@ export const make: (
           Queue.endUnsafe(queue)
         }
       }
-      yield* Effect.addFinalizer(() => Effect.sync(() => stdin.off("keypress", handleKeypress)))
+      // End the queue at stdin end-of-input so consumers (e.g. `Prompt.run`)
+      // fail with `QuitError` instead of waiting forever on piped or closed
+      // stdin; keypresses buffered before the end still deliver first.
+      const handleEnd = () => {
+        Queue.endUnsafe(queue)
+      }
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          stdin.off("keypress", handleKeypress)
+          stdin.off("end", handleEnd)
+        })
+      )
       stdin.on("keypress", handleKeypress)
+      if (inputEnded) {
+        handleEnd()
+      } else {
+        stdin.once("end", handleEnd)
+      }
       return queue as Queue.Dequeue<Terminal.UserInput, Cause.Done>
     })
 
     const readLine = Effect.scoped(
       Effect.flatMap(RcRef.get(rlRef), (readlineInterface) =>
         Effect.callback<string, Terminal.QuitError>((resume) => {
+          if (inputEnded) {
+            resume(Effect.fail(new Terminal.QuitError({})))
+            return Effect.void
+          }
           const onLine = (line: string) => resume(Effect.succeed(line))
+          // readline "close" (rather than stdin "end") so a final line without
+          // a trailing newline still flushes through the "line" event first.
+          const onClose = () => resume(Effect.fail(new Terminal.QuitError({})))
           readlineInterface.once("line", onLine)
-          return Effect.sync(() => readlineInterface.off("line", onLine))
+          readlineInterface.once("close", onClose)
+          return Effect.sync(() => {
+            readlineInterface.off("line", onLine)
+            readlineInterface.off("close", onClose)
+          })
         }))
     )
 

--- a/packages/platform-node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform-node-shared/test/NodeTerminal.test.ts
@@ -1,0 +1,33 @@
+import { assert, describe, it } from "@effect/vitest"
+import { spawnSync } from "node:child_process"
+import { join } from "node:path"
+
+const fixture = join(__dirname, "fixtures", "node-terminal.ts")
+
+const runFixture = (mode: string, input: string) =>
+  spawnSync(process.execPath, [fixture, mode], {
+    encoding: "utf8",
+    input,
+    timeout: 2_000
+  })
+
+const assertResult = (mode: string, input: string, expected: string) => {
+  const result = runFixture(mode, input)
+  assert.isUndefined(result.error)
+  assert.strictEqual(result.status, 0, result.stderr)
+  assert.isTrue(result.stderr.includes(`RESULT ${expected}`), result.stderr)
+}
+
+describe("NodeTerminal", () => {
+  it("fails a prompt with QuitError after piped input is exhausted", () => {
+    assertResult("prompts", "y\n", "{\"first\":true,\"second\":\"QuitError\"}")
+  })
+
+  it("delivers buffered keypresses before ending the input queue", () => {
+    assertResult("read-input", "yn", "{\"first\":\"y\",\"second\":\"n\",\"ended\":true}")
+  })
+
+  it("flushes an unterminated line before failing readLine with QuitError at EOF", () => {
+    assertResult("read-line", "last line", "{\"first\":\"last line\",\"second\":\"QuitError\"}")
+  })
+})

--- a/packages/platform-node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform-node-shared/test/fixtures/node-terminal.ts
@@ -1,0 +1,64 @@
+import * as NodeTerminal from "@effect/platform-node-shared/NodeTerminal"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as FileSystem from "effect/FileSystem"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Path from "effect/Path"
+import * as Queue from "effect/Queue"
+import * as Terminal from "effect/Terminal"
+import { Prompt } from "effect/unstable/cli"
+
+const TerminalLayer = Layer.mergeAll(
+  NodeTerminal.layer,
+  FileSystem.layerNoop({}),
+  Path.layer
+)
+
+const prompts = Effect.gen(function*() {
+  const first = yield* Prompt.run(Prompt.confirm({ message: "First" }))
+  const second = yield* Prompt.run(Prompt.confirm({ message: "Second" })).pipe(Effect.flip)
+  return { first, second: second._tag }
+})
+
+const readInput = Effect.scoped(
+  Effect.gen(function*() {
+    const terminal = yield* Terminal.Terminal
+    const input = yield* terminal.readInput
+    const first = yield* Queue.take(input)
+    const second = yield* Queue.take(input)
+    const end = yield* Effect.exit(Queue.take(input))
+    return {
+      first: Option.getOrNull(first.input),
+      second: Option.getOrNull(second.input),
+      ended: Exit.isFailure(end)
+    }
+  })
+)
+
+const readLine = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  const first = yield* terminal.readLine
+  const second = yield* terminal.readLine.pipe(Effect.flip)
+  return { first, second: second._tag }
+})
+
+const mode = process.argv[2]
+const program = Effect.gen(function*() {
+  if (mode === "prompts") {
+    return yield* prompts
+  } else if (mode === "read-input") {
+    return yield* readInput
+  } else if (mode === "read-line") {
+    return yield* readLine
+  }
+  return yield* Effect.die(`Unknown mode: ${mode}`)
+})
+
+Effect.runPromise(program.pipe(Effect.provide(TerminalLayer))).then(
+  (result) => process.stderr.write(`RESULT ${JSON.stringify(result)}\n`),
+  (cause) => {
+    process.stderr.write(`ERROR ${String(cause)}\n`)
+    process.exitCode = 1
+  }
+)


### PR DESCRIPTION
Closes #4895

## Problem

`NodeTerminal` never observes stdin end-of-input:

- `readInput` ends its `Queue<UserInput, Cause.Done>` only when `shouldQuit` matches a Ctrl+C/Ctrl+D keypress. With piped or closed stdin (`echo y | my-cli login`), any prompt after the buffered keypresses are consumed blocks on `Queue.take` forever — even though `Prompt.run` already maps queue end to `QuitError` and documents that it fails "if terminal input ends".
- `readLine` only listens for the readline `"line"` event, so it hangs the same way at EOF (the original report in #4895).

## Fix

- `make` tracks end-of-input once per terminal (stdin `"end"` fires once per process, and Bun never sets `readableEnded`, so readers created after the event cannot re-detect it from the stream).
- `readInput` ends its queue on stdin `"end"` (or immediately when input already ended). Keypresses buffered before the end still deliver first; `Prompt.run` then fails with `Terminal.QuitError` through the existing `Cause.Done` mapping.
- `readLine` fails with `Terminal.QuitError` when the readline interface closes. Listening to readline `"close"` rather than stdin `"end"` preserves the existing behavior where a final line without a trailing newline still flushes through `"line"` first.

Interactive TTY sessions are unaffected: a TTY stdin does not emit `"end"` during normal use, and Ctrl+C/Ctrl+D in raw mode remain keypresses handled by `shouldQuit`. `BunTerminal` reuses this implementation, so both runtimes are covered.

## Verification

Verified end-to-end in a downstream CLI (Bun runtime) that previously shipped a wrapper Terminal layer implementing exactly this queue-end behavior: with this change applied to the installed package and the wrapper removed, its full CLI test suite passes, including `printf 'y\n' | cli` prompt flows and prompt interruption via closed stdin.

Happy to add a spawned-fixture test for the piped-stdin case if you'd like one — I didn't see existing NodeTerminal coverage to extend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal behavior when standard input reaches end-of-file.
  * Terminal key input and line-reading now end cleanly with `Terminal.QuitError` instead of hanging after input is closed or piped.
  * `readLine` now fails immediately for readers created after input has already ended.
  * Improved listener cleanup so terminal handlers are reliably removed when reads complete.
* **Tests**
  * Added end-to-end coverage for EOF, queued input delivery, and unterminated line handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->