### PR TITLE
Expose runtime schemas for prompt parts

### DIFF
--- a/.changeset/expose-ai-prompt-part-schemas.md
+++ b/.changeset/expose-ai-prompt-part-schemas.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Expose runtime schemas for AI prompt parts and message-specific part unions.

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -952,7 +952,17 @@ export const toolApprovalRequestPart = (
  * @category schemas
  * @since 4.0.0
  */
-export const Part: Schema.Codec<Part, PartEncoded> = Schema.Union([
+export const Part: Schema.Union<
+  readonly [
+    typeof TextPart,
+    typeof ReasoningPart,
+    typeof FilePart,
+    typeof ToolCallPart,
+    typeof ToolResultPart,
+    typeof ToolApprovalResponsePart,
+    typeof ToolApprovalRequestPart
+  ]
+> = Schema.Union([
   TextPart,
   ReasoningPart,
   FilePart,
@@ -1263,7 +1273,7 @@ export type UserMessagePartEncoded = TextPartEncoded | FilePartEncoded
  * @category schemas
  * @since 4.0.0
  */
-export const UserMessagePart: Schema.Codec<UserMessagePart, UserMessagePartEncoded> = Schema.Union([
+export const UserMessagePart: Schema.Union<readonly [typeof TextPart, typeof FilePart]> = Schema.Union([
   TextPart,
   FilePart
 ])
@@ -1460,7 +1470,16 @@ export type AssistantMessagePartEncoded =
  * @category schemas
  * @since 4.0.0
  */
-export const AssistantMessagePart: Schema.Codec<AssistantMessagePart, AssistantMessagePartEncoded> = Schema.Union([
+export const AssistantMessagePart: Schema.Union<
+  readonly [
+    typeof TextPart,
+    typeof FilePart,
+    typeof ReasoningPart,
+    typeof ToolCallPart,
+    typeof ToolResultPart,
+    typeof ToolApprovalRequestPart
+  ]
+> = Schema.Union([
   TextPart,
   FilePart,
   ReasoningPart,
@@ -1644,7 +1663,9 @@ export type ToolMessagePartEncoded = ToolResultPartEncoded | ToolApprovalRespons
  * @category schemas
  * @since 4.0.0
  */
-export const ToolMessagePart: Schema.Codec<ToolMessagePart, ToolMessagePartEncoded> = Schema.Union([
+export const ToolMessagePart: Schema.Union<
+  readonly [typeof ToolResultPart, typeof ToolApprovalResponsePart]
+> = Schema.Union([
   ToolResultPart,
   ToolApprovalResponsePart
 ])

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -946,6 +946,22 @@ export const toolApprovalRequestPart = (
   params: PartConstructorParams<ToolApprovalRequestPart>
 ): ToolApprovalRequestPart => makePart("tool-approval-request", params as any)
 
+/**
+ * Schema for validation and encoding of content parts.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const Part: Schema.Codec<Part, PartEncoded> = Schema.Union([
+  TextPart,
+  ReasoningPart,
+  FilePart,
+  ToolCallPart,
+  ToolResultPart,
+  ToolApprovalResponsePart,
+  ToolApprovalRequestPart
+])
+
 // =============================================================================
 // Base Message
 // =============================================================================
@@ -1242,6 +1258,17 @@ export interface UserMessageEncoded extends BaseMessageEncoded<"user", UserMessa
 export type UserMessagePartEncoded = TextPartEncoded | FilePartEncoded
 
 /**
+ * Schema for validation and encoding of user message content parts.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const UserMessagePart: Schema.Codec<UserMessagePart, UserMessagePartEncoded> = Schema.Union([
+  TextPart,
+  FilePart
+])
+
+/**
  * Represents provider-specific options that can be associated with a
  * `UserMessage` through module augmentation.
  *
@@ -1428,6 +1455,21 @@ export type AssistantMessagePartEncoded =
   | ToolApprovalRequestPartEncoded
 
 /**
+ * Schema for validation and encoding of assistant message content parts.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const AssistantMessagePart: Schema.Codec<AssistantMessagePart, AssistantMessagePartEncoded> = Schema.Union([
+  TextPart,
+  FilePart,
+  ReasoningPart,
+  ToolCallPart,
+  ToolResultPart,
+  ToolApprovalRequestPart
+])
+
+/**
  * Represents provider-specific options that can be associated with a
  * `AssistantMessage` through module augmentation.
  *
@@ -1595,6 +1637,17 @@ export interface ToolMessageEncoded extends BaseMessageEncoded<"tool", ToolMessa
  * @since 4.0.0
  */
 export type ToolMessagePartEncoded = ToolResultPartEncoded | ToolApprovalResponsePartEncoded
+
+/**
+ * Schema for validation and encoding of tool message content parts.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const ToolMessagePart: Schema.Codec<ToolMessagePart, ToolMessagePartEncoded> = Schema.Union([
+  ToolResultPart,
+  ToolApprovalResponsePart
+])
 
 /**
  * Represents provider-specific options that can be associated with a

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -1,7 +1,30 @@
 import { assert, describe, it } from "@effect/vitest"
+import { Schema } from "effect"
 import { Prompt, Response } from "effect/unstable/ai"
 
 describe("Prompt", () => {
+  describe("part schemas", () => {
+    it("exports schemas for all parts and message-specific parts", () => {
+      assert.strictEqual(Schema.decodeUnknownExit(Prompt.Part)({ type: "text", text: "hello" })._tag, "Success")
+      assert.strictEqual(
+        Schema.decodeUnknownExit(Prompt.UserMessagePart)({ type: "file", mediaType: "text/plain", data: "hello" })._tag,
+        "Success"
+      )
+      assert.strictEqual(
+        Schema.decodeUnknownExit(Prompt.AssistantMessagePart)({ type: "reasoning", text: "thinking" })._tag,
+        "Success"
+      )
+      assert.strictEqual(
+        Schema.decodeUnknownExit(Prompt.ToolMessagePart)({
+          type: "tool-approval-response",
+          approvalId: "approval-1",
+          approved: true
+        })._tag,
+        "Success"
+      )
+    })
+  })
+
   describe("fromResponseParts", () => {
     it("folds streamed text and reasoning deltas into an assistant message", () => {
       const parts = [

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -5,23 +5,52 @@ import { Prompt, Response } from "effect/unstable/ai"
 describe("Prompt", () => {
   describe("part schemas", () => {
     it("exports schemas for all parts and message-specific parts", () => {
-      assert.strictEqual(Schema.decodeUnknownExit(Prompt.Part)({ type: "text", text: "hello" })._tag, "Success")
-      assert.strictEqual(
-        Schema.decodeUnknownExit(Prompt.UserMessagePart)({ type: "file", mediaType: "text/plain", data: "hello" })._tag,
-        "Success"
-      )
-      assert.strictEqual(
-        Schema.decodeUnknownExit(Prompt.AssistantMessagePart)({ type: "reasoning", text: "thinking" })._tag,
-        "Success"
-      )
-      assert.strictEqual(
-        Schema.decodeUnknownExit(Prompt.ToolMessagePart)({
+      const parts = {
+        text: { type: "text", text: "hello" },
+        reasoning: { type: "reasoning", text: "thinking" },
+        file: { type: "file", mediaType: "text/plain", data: "hello" },
+        toolCall: { type: "tool-call", id: "call-1", name: "tool", params: {} },
+        toolResult: { type: "tool-result", id: "call-1", name: "tool", isFailure: false, result: "done" },
+        toolApprovalResponse: {
           type: "tool-approval-response",
           approvalId: "approval-1",
           approved: true
-        })._tag,
-        "Success"
-      )
+        },
+        toolApprovalRequest: {
+          type: "tool-approval-request",
+          approvalId: "approval-1",
+          toolCallId: "call-1"
+        }
+      } as const
+
+      const decodePart = Schema.decodeUnknownExit(Prompt.Part)
+      for (const part of Object.values(parts)) {
+        assert.strictEqual(decodePart(part)._tag, "Success")
+      }
+
+      const decodeUserMessagePart = Schema.decodeUnknownExit(Prompt.UserMessagePart)
+      for (const part of [parts.text, parts.file]) {
+        assert.strictEqual(decodeUserMessagePart(part)._tag, "Success")
+      }
+
+      const decodeAssistantMessagePart = Schema.decodeUnknownExit(Prompt.AssistantMessagePart)
+      for (
+        const part of [
+          parts.text,
+          parts.file,
+          parts.reasoning,
+          parts.toolCall,
+          parts.toolResult,
+          parts.toolApprovalRequest
+        ]
+      ) {
+        assert.strictEqual(decodeAssistantMessagePart(part)._tag, "Success")
+      }
+
+      const decodeToolMessagePart = Schema.decodeUnknownExit(Prompt.ToolMessagePart)
+      for (const part of [parts.toolResult, parts.toolApprovalResponse]) {
+        assert.strictEqual(decodeToolMessagePart(part)._tag, "Success")
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

- expose runtime schemas for all prompt parts
- expose runtime schemas for user, assistant, and tool message parts
- preserve the existing type aliases under the same names

## Testing

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/unstable/ai/Prompt.test.ts`
- `pnpm check`

Closes EFF-132
Closed #6671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed runtime schemas for AI prompt parts and message-specific content variants.
  * Added public unions covering supported parts for prompts, including user, assistant, and tool message content shapes.

* **Tests**
  * Added coverage to decode and validate text, file, reasoning, tool-call, tool-result, and tool-approval variants using the new schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->