### PR TITLE
Preserve buffered NodeTerminal readLine input

### DIFF
--- a/.changeset/fresh-lines-wait.md
+++ b/.changeset/fresh-lines-wait.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node-shared": patch
+---
+
+NodeTerminal: preserve buffered input across sequential `readLine` calls

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -16,7 +16,8 @@ import * as Option from "effect/Option"
 import { badArgument, type PlatformError } from "effect/PlatformError"
 import * as Predicate from "effect/Predicate"
 import * as Queue from "effect/Queue"
-import * as Scope from "effect/Scope"
+import * as RcRef from "effect/RcRef"
+import type * as Scope from "effect/Scope"
 import * as Terminal from "effect/Terminal"
 import * as readline from "node:readline"
 
@@ -34,59 +35,60 @@ export const make: (
   function*(shouldQuit: (input: Terminal.UserInput) => boolean = defaultShouldQuit) {
     const stdin = process.stdin
     const stdout = process.stdout
-    const scope = yield* Effect.scope
+    const lines = yield* Queue.make<string, Cause.Done>()
 
     // stdin "end" fires once per process, so remember end-of-input for readers
     // created after the event (Bun never sets `readableEnded`).
     let inputEnded = stdin.readableEnded
+    let readlineActive = false
     const onStdinEnd = () => {
       inputEnded = true
+      if (!readlineActive) {
+        Queue.endUnsafe(lines)
+      }
     }
     stdin.once("end", onStdinEnd)
     yield* Effect.addFinalizer(() => Effect.sync(() => stdin.off("end", onStdinEnd)))
 
-    const getLines = yield* Effect.cached(
-      Effect.gen(function*() {
-        const lines = yield* Queue.make<string, Cause.Done>()
-        if (inputEnded) {
-          Queue.endUnsafe(lines)
-          return lines
-        }
+    const rlRef = yield* RcRef.make({
+      acquire: Effect.acquireRelease(
+        Effect.sync(() => {
+          const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
+          const onLine = (line: string) => Queue.offerUnsafe(lines, line)
+          const onClose = () => {
+            readlineActive = false
+            Queue.endUnsafe(lines)
+          }
+          readlineActive = true
+          readline.emitKeypressEvents(stdin, rl)
+          rl.on("line", onLine)
+          rl.once("close", onClose)
 
-        // Keep one readline interface so lines consumed together remain available.
-        yield* Scope.provide(
-          Effect.acquireRelease(
-            Effect.sync(() => {
-              const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
-              readline.emitKeypressEvents(stdin, rl)
-              rl.on("line", (line) => Queue.offerUnsafe(lines, line))
-              rl.once("close", () => Queue.endUnsafe(lines))
-
-              if (stdin.isTTY) {
-                stdin.setRawMode(true)
-              }
-              return rl
-            }),
-            (rl) =>
-              Effect.sync(() => {
-                if (stdin.isTTY) {
-                  stdin.setRawMode(false)
-                }
-                rl.close()
-              })
-          ),
-          scope
-        )
-
-        return lines
-      })
-    )
+          if (stdin.isTTY) {
+            stdin.setRawMode(true)
+          }
+          return { rl, onClose, onLine }
+        }),
+        ({ rl, onClose, onLine }) =>
+          Effect.sync(() => {
+            readlineActive = false
+            rl.off("line", onLine)
+            rl.off("close", onClose)
+            if (stdin.isTTY) {
+              stdin.setRawMode(false)
+            }
+            rl.close()
+            if (inputEnded) {
+              Queue.endUnsafe(lines)
+            }
+          })
+      )
+    })
 
     const columns = Effect.sync(() => stdout.columns ?? 0)
     const rows = Effect.sync(() => stdout.rows ?? 0)
 
     const readInput = Effect.gen(function*() {
-      yield* getLines
       const queue = yield* Queue.make<Terminal.UserInput, Cause.Done>()
       const handleKeypress = (s: string | undefined, k: readline.Key) => {
         const userInput = {
@@ -112,13 +114,20 @@ export const make: (
       if (inputEnded) {
         handleEnd()
       } else {
+        yield* RcRef.get(rlRef)
         stdin.once("end", handleEnd)
       }
       return queue as Queue.Dequeue<Terminal.UserInput, Cause.Done>
     })
 
-    const readLine = Effect.flatMap(getLines, Queue.take).pipe(
-      Effect.mapError(() => new Terminal.QuitError({}))
+    const readLine = Effect.suspend(() =>
+      Queue.poll(lines).pipe(
+        Effect.flatMap(Option.match({
+          onNone: () => Effect.scoped(Effect.andThen(RcRef.get(rlRef), Queue.take(lines))),
+          onSome: Effect.succeed
+        })),
+        Effect.mapError(() => new Terminal.QuitError({}))
+      )
     )
 
     const display = (prompt: string) =>

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -16,7 +16,6 @@ import * as Option from "effect/Option"
 import { badArgument, type PlatformError } from "effect/PlatformError"
 import * as Predicate from "effect/Predicate"
 import * as Queue from "effect/Queue"
-import * as RcRef from "effect/RcRef"
 import type * as Scope from "effect/Scope"
 import * as Terminal from "effect/Terminal"
 import * as readline from "node:readline"
@@ -45,33 +44,34 @@ export const make: (
     stdin.once("end", onStdinEnd)
     yield* Effect.addFinalizer(() => Effect.sync(() => stdin.off("end", onStdinEnd)))
 
-    // Acquire readline interface with TTY setup/cleanup inside the scope
-    const rlRef = yield* RcRef.make({
-      acquire: Effect.acquireRelease(
-        Effect.sync(() => {
-          const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
-          readline.emitKeypressEvents(stdin, rl)
+    const lines = yield* Queue.make<string, Cause.Done>()
 
+    // Keep one readline interface so lines consumed together remain available.
+    yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
+        readline.emitKeypressEvents(stdin, rl)
+        rl.on("line", (line) => Queue.offerUnsafe(lines, line))
+        rl.once("close", () => Queue.endUnsafe(lines))
+
+        if (stdin.isTTY) {
+          stdin.setRawMode(true)
+        }
+        return rl
+      }),
+      (rl) =>
+        Effect.sync(() => {
           if (stdin.isTTY) {
-            stdin.setRawMode(true)
+            stdin.setRawMode(false)
           }
-          return rl
-        }),
-        (rl) =>
-          Effect.sync(() => {
-            if (stdin.isTTY) {
-              stdin.setRawMode(false)
-            }
-            rl.close()
-          })
-      )
-    })
+          rl.close()
+        })
+    )
 
     const columns = Effect.sync(() => stdout.columns ?? 0)
     const rows = Effect.sync(() => stdout.rows ?? 0)
 
     const readInput = Effect.gen(function*() {
-      yield* RcRef.get(rlRef)
       const queue = yield* Queue.make<Terminal.UserInput, Cause.Done>()
       const handleKeypress = (s: string | undefined, k: readline.Key) => {
         const userInput = {
@@ -102,29 +102,8 @@ export const make: (
       return queue as Queue.Dequeue<Terminal.UserInput, Cause.Done>
     })
 
-    const readLine = Effect.suspend(() =>
-      inputEnded ? Effect.fail(new Terminal.QuitError({})) : Effect.scoped(
-        Effect.flatMap(RcRef.get(rlRef), (readlineInterface) =>
-          Effect.callback<string, Terminal.QuitError>((resume) => {
-            const cleanup = () => {
-              readlineInterface.off("line", onLine)
-              readlineInterface.off("close", onClose)
-            }
-            const onLine = (line: string) => {
-              cleanup()
-              resume(Effect.succeed(line))
-            }
-            // readline "close" (rather than stdin "end") so a final line without
-            // a trailing newline still flushes through the "line" event first.
-            const onClose = () => {
-              cleanup()
-              resume(Effect.fail(new Terminal.QuitError({})))
-            }
-            readlineInterface.on("line", onLine)
-            readlineInterface.on("close", onClose)
-            return Effect.sync(cleanup)
-          }))
-      )
+    const readLine = Queue.take(lines).pipe(
+      Effect.mapError(() => new Terminal.QuitError({}))
     )
 
     const display = (prompt: string) =>

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -16,7 +16,7 @@ import * as Option from "effect/Option"
 import { badArgument, type PlatformError } from "effect/PlatformError"
 import * as Predicate from "effect/Predicate"
 import * as Queue from "effect/Queue"
-import type * as Scope from "effect/Scope"
+import * as Scope from "effect/Scope"
 import * as Terminal from "effect/Terminal"
 import * as readline from "node:readline"
 
@@ -34,6 +34,7 @@ export const make: (
   function*(shouldQuit: (input: Terminal.UserInput) => boolean = defaultShouldQuit) {
     const stdin = process.stdin
     const stdout = process.stdout
+    const scope = yield* Effect.scope
 
     // stdin "end" fires once per process, so remember end-of-input for readers
     // created after the event (Bun never sets `readableEnded`).
@@ -44,34 +45,48 @@ export const make: (
     stdin.once("end", onStdinEnd)
     yield* Effect.addFinalizer(() => Effect.sync(() => stdin.off("end", onStdinEnd)))
 
-    const lines = yield* Queue.make<string, Cause.Done>()
-
-    // Keep one readline interface so lines consumed together remain available.
-    yield* Effect.acquireRelease(
-      Effect.sync(() => {
-        const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
-        readline.emitKeypressEvents(stdin, rl)
-        rl.on("line", (line) => Queue.offerUnsafe(lines, line))
-        rl.once("close", () => Queue.endUnsafe(lines))
-
-        if (stdin.isTTY) {
-          stdin.setRawMode(true)
+    const getLines = yield* Effect.cached(
+      Effect.gen(function*() {
+        const lines = yield* Queue.make<string, Cause.Done>()
+        if (inputEnded) {
+          Queue.endUnsafe(lines)
+          return lines
         }
-        return rl
-      }),
-      (rl) =>
-        Effect.sync(() => {
-          if (stdin.isTTY) {
-            stdin.setRawMode(false)
-          }
-          rl.close()
-        })
+
+        // Keep one readline interface so lines consumed together remain available.
+        yield* Scope.provide(
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              const rl = readline.createInterface({ input: stdin, escapeCodeTimeout: 50 })
+              readline.emitKeypressEvents(stdin, rl)
+              rl.on("line", (line) => Queue.offerUnsafe(lines, line))
+              rl.once("close", () => Queue.endUnsafe(lines))
+
+              if (stdin.isTTY) {
+                stdin.setRawMode(true)
+              }
+              return rl
+            }),
+            (rl) =>
+              Effect.sync(() => {
+                if (stdin.isTTY) {
+                  stdin.setRawMode(false)
+                }
+                rl.close()
+              })
+          ),
+          scope
+        )
+
+        return lines
+      })
     )
 
     const columns = Effect.sync(() => stdout.columns ?? 0)
     const rows = Effect.sync(() => stdout.rows ?? 0)
 
     const readInput = Effect.gen(function*() {
+      yield* getLines
       const queue = yield* Queue.make<Terminal.UserInput, Cause.Done>()
       const handleKeypress = (s: string | undefined, k: readline.Key) => {
         const userInput = {
@@ -102,7 +117,7 @@ export const make: (
       return queue as Queue.Dequeue<Terminal.UserInput, Cause.Done>
     })
 
-    const readLine = Queue.take(lines).pipe(
+    const readLine = Effect.flatMap(getLines, Queue.take).pipe(
       Effect.mapError(() => new Terminal.QuitError({}))
     )
 

--- a/packages/platform-node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform-node-shared/test/NodeTerminal.test.ts
@@ -19,6 +19,10 @@ const assertResult = (mode: string, input: string, expected: string) => {
 }
 
 describe("NodeTerminal", () => {
+  it("does not install a readline interface until the terminal is used", () => {
+    assertResult("unused", "", "{\"dataListeners\":0}")
+  })
+
   it("fails a prompt with QuitError after piped input is exhausted", () => {
     assertResult("prompts", "y\n", "{\"first\":true,\"second\":\"QuitError\"}")
   })
@@ -33,5 +37,9 @@ describe("NodeTerminal", () => {
 
   it("preserves lines buffered between sequential readLine calls", () => {
     assertResult("read-lines", "first\nsecond\n", "{\"first\":\"first\",\"second\":\"second\"}")
+  })
+
+  it("fails readLine with QuitError when stdin ended before initialization", () => {
+    assertResult("read-line-after-end", "", "\"QuitError\"")
   })
 })

--- a/packages/platform-node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform-node-shared/test/NodeTerminal.test.ts
@@ -30,4 +30,8 @@ describe("NodeTerminal", () => {
   it("flushes an unterminated line before failing readLine with QuitError at EOF", () => {
     assertResult("read-line", "last line", "{\"first\":\"last line\",\"second\":\"QuitError\"}")
   })
+
+  it("preserves lines buffered between sequential readLine calls", () => {
+    assertResult("read-lines", "first\nsecond\n", "{\"first\":\"first\",\"second\":\"second\"}")
+  })
 })

--- a/packages/platform-node-shared/test/NodeTerminal.test.ts
+++ b/packages/platform-node-shared/test/NodeTerminal.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
-import { spawnSync } from "node:child_process"
+import * as Effect from "effect/Effect"
+import { spawn, spawnSync } from "node:child_process"
 import { join } from "node:path"
 
 const fixture = join(__dirname, "fixtures", "node-terminal.ts")
@@ -17,6 +18,28 @@ const assertResult = (mode: string, input: string, expected: string) => {
   assert.strictEqual(result.status, 0, result.stderr)
   assert.isTrue(result.stderr.includes(`RESULT ${expected}`), result.stderr)
 }
+
+const assertOpenResult = (mode: string, input: string, expected: string) =>
+  Effect.callback<void>((resume) => {
+    const child = spawn(process.execPath, [fixture, mode])
+    let stderr = ""
+    child.stderr.setEncoding("utf8")
+    child.stderr.on("data", (data) => {
+      stderr += data
+      if (stderr.includes("RESULT ")) {
+        child.stdin.end()
+      }
+    })
+    child.on("exit", (code) => {
+      resume(
+        code === 0 && stderr.includes(`RESULT ${expected}`)
+          ? Effect.void
+          : Effect.die(new Error(stderr))
+      )
+    })
+    child.stdin.write(input)
+    return Effect.sync(() => child.kill())
+  })
 
 describe("NodeTerminal", () => {
   it("does not install a readline interface until the terminal is used", () => {
@@ -42,4 +65,7 @@ describe("NodeTerminal", () => {
   it("fails readLine with QuitError when stdin ended before initialization", () => {
     assertResult("read-line-after-end", "", "\"QuitError\"")
   })
+
+  it.effect("disposes readline after readLine completes", () =>
+    assertOpenResult("read-line-disposed", "line\n", "{\"line\":\"line\",\"dataListeners\":0}"))
 })

--- a/packages/platform-node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform-node-shared/test/fixtures/node-terminal.ts
@@ -71,6 +71,12 @@ const readLineAfterEnd = Effect.gen(function*() {
   return error._tag
 })
 
+const readLineDisposed = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  const line = yield* terminal.readLine
+  return { line, dataListeners: process.stdin.listenerCount("data") }
+})
+
 const mode = process.argv[2]
 const program = Effect.gen(function*() {
   if (mode === "prompts") {
@@ -85,6 +91,8 @@ const program = Effect.gen(function*() {
     return yield* unused
   } else if (mode === "read-line-after-end") {
     return yield* readLineAfterEnd
+  } else if (mode === "read-line-disposed") {
+    return yield* readLineDisposed
   }
   return yield* Effect.die(`Unknown mode: ${mode}`)
 })

--- a/packages/platform-node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform-node-shared/test/fixtures/node-terminal.ts
@@ -50,6 +50,27 @@ const readLines = Effect.gen(function*() {
   return { first, second }
 })
 
+const unused = Effect.gen(function*() {
+  yield* Terminal.Terminal
+  return { dataListeners: process.stdin.listenerCount("data") }
+})
+
+const readLineAfterEnd = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  yield* Effect.callback<void>((resume) => {
+    if (process.stdin.readableEnded) {
+      resume(Effect.void)
+      return
+    }
+    const onEnd = () => resume(Effect.void)
+    process.stdin.once("end", onEnd)
+    process.stdin.resume()
+    return Effect.sync(() => process.stdin.off("end", onEnd))
+  })
+  const error = yield* terminal.readLine.pipe(Effect.flip)
+  return error._tag
+})
+
 const mode = process.argv[2]
 const program = Effect.gen(function*() {
   if (mode === "prompts") {
@@ -60,6 +81,10 @@ const program = Effect.gen(function*() {
     return yield* readLine
   } else if (mode === "read-lines") {
     return yield* readLines
+  } else if (mode === "unused") {
+    return yield* unused
+  } else if (mode === "read-line-after-end") {
+    return yield* readLineAfterEnd
   }
   return yield* Effect.die(`Unknown mode: ${mode}`)
 })

--- a/packages/platform-node-shared/test/fixtures/node-terminal.ts
+++ b/packages/platform-node-shared/test/fixtures/node-terminal.ts
@@ -43,6 +43,13 @@ const readLine = Effect.gen(function*() {
   return { first, second: second._tag }
 })
 
+const readLines = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  const first = yield* terminal.readLine
+  const second = yield* terminal.readLine
+  return { first, second }
+})
+
 const mode = process.argv[2]
 const program = Effect.gen(function*() {
   if (mode === "prompts") {
@@ -51,6 +58,8 @@ const program = Effect.gen(function*() {
     return yield* readInput
   } else if (mode === "read-line") {
     return yield* readLine
+  } else if (mode === "read-lines") {
+    return yield* readLines
   }
   return yield* Effect.die(`Unknown mode: ${mode}`)
 })


### PR DESCRIPTION
## Summary

- keep one readline interface for the terminal scope
- buffer line events so sequential `readLine` calls do not drop piped input
- preserve `QuitError` after buffered lines are drained at EOF

## Testing

- `pnpm --filter @effect/platform-node-shared test --run test/NodeTerminal.test.ts`
- `pnpm lint-fix`
- `pnpm check`
- verified the two-line and EOF fixtures with Bun 1.3.13

Closes EFF-135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal input handling so buffered lines are preserved across sequential reads.
  * Improved cleanup when terminal input closes or raw mode is disabled.

* **Tests**
  * Added coverage for reading multiple lines in sequence and returning them in the correct order.

* **Chores**
  * Added a patch release note for the terminal input fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->