### PR TITLE
Fix worker runner cleanup

### DIFF
--- a/.changeset/fix-worker-runner-cleanup.md
+++ b/.changeset/fix-worker-runner-cleanup.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform-browser": patch
+"@effect/platform-bun": patch
+"@effect/platform-node": patch
+---
+
+Fix worker runner disconnect notifications and event listener cleanup.

--- a/packages/platform-browser/src/BrowserWorkerRunner.ts
+++ b/packages/platform-browser/src/BrowserWorkerRunner.ts
@@ -81,6 +81,7 @@ export const make = (self: MessagePort | Window): WorkerRunner.WorkerRunnerPlatf
                 return Deferred.doneUnsafe(closeLatch, Exit.void)
               }
               ports.delete(portId)
+              Queue.offerUnsafe(disconnects, portId)
               Effect.runFork(Scope.close(port[1], Exit.void))
             }
           }
@@ -122,7 +123,7 @@ export const make = (self: MessagePort | Window): WorkerRunner.WorkerRunnerPlatf
             portScope,
             Effect.sync(() => {
               port.removeEventListener("message", onMsg)
-              port.removeEventListener("messageerror", onError)
+              port.removeEventListener("messageerror", onMessageError)
               port.close()
             })
           ))

--- a/packages/platform-browser/test/BrowserWorkerRunner.test.ts
+++ b/packages/platform-browser/test/BrowserWorkerRunner.test.ts
@@ -1,0 +1,101 @@
+import * as BrowserWorkerRunner from "@effect/platform-browser/BrowserWorkerRunner"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+import * as Queue from "effect/Queue"
+
+type Listener = EventListenerOrEventListenerObject
+
+const makePort = () => {
+  const listeners = new Map<string, Set<Listener>>()
+  const added: Array<readonly [string, Listener]> = []
+  const removed: Array<readonly [string, Listener]> = []
+  const port = {
+    addEventListener(type: string, listener: Listener | null) {
+      if (listener === null) return
+      added.push([type, listener])
+      const eventListeners = listeners.get(type) ?? new Set()
+      eventListeners.add(listener)
+      listeners.set(type, eventListeners)
+    },
+    removeEventListener(type: string, listener: Listener | null) {
+      if (listener === null) return
+      removed.push([type, listener])
+      listeners.get(type)?.delete(listener)
+    },
+    postMessage() {},
+    start() {},
+    close() {}
+  } as unknown as MessagePort
+
+  return {
+    added,
+    removed,
+    port,
+    emit(type: string, data: unknown) {
+      const event = { data } as MessageEvent
+      for (const listener of listeners.get(type) ?? []) {
+        if (typeof listener === "function") {
+          listener(event)
+        } else {
+          listener.handleEvent(event)
+        }
+      }
+    }
+  }
+}
+
+const makeSharedWorker = () => {
+  const worker = {
+    onconnect: null as ((event: MessageEvent) => void) | null,
+    addEventListener() {},
+    removeEventListener() {},
+    close() {}
+  }
+  return {
+    worker: worker as unknown as Window,
+    connect(port: MessagePort) {
+      worker.onconnect?.({ ports: [port] } as unknown as MessageEvent)
+    }
+  }
+}
+
+describe("BrowserWorkerRunner", () => {
+  it.effect("removes the registered messageerror listener", () =>
+    Effect.gen(function*() {
+      const fake = makePort()
+      const runner = yield* BrowserWorkerRunner.make(fake.port).start()
+      const fiber = yield* Effect.forkChild(runner.run<void, never, never>(() => {}))
+      yield* Effect.yieldNow
+
+      fake.emit("message", [1])
+      yield* Fiber.join(fiber)
+
+      const added = fake.added.find(([type]) => type === "messageerror")
+      const removed = fake.removed.find(([type]) => type === "messageerror")
+      assert.isDefined(added)
+      assert.isDefined(removed)
+      assert.strictEqual(removed[1], added[1])
+    }))
+
+  it.effect("emits disconnects for closed SharedWorker ports", () =>
+    Effect.gen(function*() {
+      const sharedWorker = makeSharedWorker()
+      const first = makePort()
+      const second = makePort()
+      const runner = yield* BrowserWorkerRunner.make(sharedWorker.worker).start()
+      const fiber = yield* Effect.forkChild(runner.run<void, never, never>(() => {}))
+      yield* Effect.yieldNow
+
+      sharedWorker.connect(first.port)
+      sharedWorker.connect(second.port)
+      first.emit("message", [1])
+
+      const disconnects = runner.disconnects
+      assert.isDefined(disconnects)
+      assert.strictEqual(yield* Queue.take(disconnects), 0)
+
+      second.emit("message", [1])
+      yield* Fiber.join(fiber)
+    }))
+})

--- a/packages/platform-bun/src/BunWorkerRunner.ts
+++ b/packages/platform-bun/src/BunWorkerRunner.ts
@@ -77,22 +77,11 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
             })
           )
         }
-        function onError(error: MessageEvent) {
-          Deferred.doneUnsafe(
-            closeLatch,
-            new WorkerError({
-              reason: new WorkerReceiveError({
-                message: "received error event",
-                cause: error.data
-              })
-            })
-          )
-        }
         yield* Scope.addFinalizer(
           scope,
           Effect.sync(() => {
             port.removeEventListener("message", onMessage)
-            port.removeEventListener("messageerror", onError)
+            port.removeEventListener("messageerror", onMessageError)
           })
         )
         port.addEventListener("message", onMessage)

--- a/packages/platform-node/src/NodeWorkerRunner.ts
+++ b/packages/platform-node/src/NodeWorkerRunner.ts
@@ -16,6 +16,7 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
 import { WorkerError, WorkerReceiveError, WorkerSpawnError } from "effect/unstable/workers/WorkerError"
 import * as WorkerRunner from "effect/unstable/workers/WorkerRunner"
 import * as WorkerThreads from "node:worker_threads"
@@ -56,7 +57,8 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
               runFork(Effect.logError("unhandled error in worker", exit.cause))
             }
           }
-          ;(WorkerThreads.parentPort ?? process).on("message", (message: WorkerRunner.PlatformMessage<I>) => {
+          const port = WorkerThreads.parentPort ?? process
+          function onMessage(message: WorkerRunner.PlatformMessage<I>) {
             if (message[0] === 0) {
               const result = handler(0, message[1])
               if (Effect.isEffect(result)) {
@@ -72,32 +74,46 @@ export const layer: Layer.Layer<WorkerRunner.WorkerRunnerPlatform> = Layer.succe
               }
               Deferred.doneUnsafe(closeLatch, Exit.void)
             }
-          })
-
-          if (WorkerThreads.parentPort) {
-            WorkerThreads.parentPort.on("messageerror", (cause) => {
-              Deferred.doneUnsafe(
-                closeLatch,
-                new WorkerError({
-                  reason: new WorkerReceiveError({
-                    message: "received messageerror event",
-                    cause
-                  })
-                })
-              )
-            })
-            WorkerThreads.parentPort.on("error", (cause) => {
-              Deferred.doneUnsafe(
-                closeLatch,
-                new WorkerError({
-                  reason: new WorkerReceiveError({
-                    message: "received messageerror event",
-                    cause
-                  })
-                })
-              )
-            })
           }
+          port.on("message", onMessage)
+
+          function onMessageError(cause: unknown) {
+            Deferred.doneUnsafe(
+              closeLatch,
+              new WorkerError({
+                reason: new WorkerReceiveError({
+                  message: "received messageerror event",
+                  cause
+                })
+              })
+            )
+          }
+          function onError(cause: unknown) {
+            Deferred.doneUnsafe(
+              closeLatch,
+              new WorkerError({
+                reason: new WorkerReceiveError({
+                  message: "received error event",
+                  cause
+                })
+              })
+            )
+          }
+          if (WorkerThreads.parentPort) {
+            WorkerThreads.parentPort.on("messageerror", onMessageError)
+            WorkerThreads.parentPort.on("error", onError)
+          }
+
+          yield* Scope.addFinalizer(
+            scope,
+            Effect.sync(() => {
+              port.off("message", onMessage)
+              if (WorkerThreads.parentPort) {
+                WorkerThreads.parentPort.off("messageerror", onMessageError)
+                WorkerThreads.parentPort.off("error", onError)
+              }
+            })
+          )
 
           sendUnsafe(0, [0])
 


### PR DESCRIPTION
## Summary
- clean up the exact browser and Bun messageerror listeners that were registered
- emit browser SharedWorker disconnect IDs and remove Node worker listeners on scope close
- correct the Node error-event diagnostic and add browser lifecycle regression coverage

## Testing
- nix develop -c pnpm lint-fix
- nix develop -c pnpm check
- nix develop -c pnpm --filter @effect/platform-browser test --run test/BrowserWorkerRunner.test.ts

Closes EFF-158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker shutdown handling across browser, Bun, and Node environments.
  * Worker disconnect events are now reported reliably.
  * Corrected cleanup of message and error event handlers to prevent lingering listeners.
  * Improved error reporting for worker communication failures.

* **Tests**
  * Added coverage for worker disconnect notifications and event-listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->