### PR TITLE
Add core Web Stream interoperability

### DIFF
--- a/.changeset/eff-137-web-stream-interop.md
+++ b/.changeset/eff-137-web-stream-interop.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add Web Stream interoperability for `Channel` and `Sink`, plus byte limiting and `ArrayBuffer` collection for `Stream`.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -1711,38 +1711,7 @@ export const fromReadableStream = <A, E>(options: {
     })
   )
 
-/**
- * Writes values from an upstream pull into a Web `WritableStream`, respecting
- * writer backpressure.
- *
- * **Example** (Writing an existing pull)
- *
- * ```ts
- * import { Channel, Effect, Pull } from "effect"
- *
- * const written: Array<number> = []
- * const writable = new WritableStream<number>({
- *   write(value) {
- *     written.push(value)
- *   }
- * })
- *
- * const program = Effect.scoped(Effect.gen(function*() {
- *   const pull = yield* Channel.toPull(Channel.fromArray([[1, 2] as [number, number]]))
- *   yield* Channel.pullIntoWritableStream({
- *     pull,
- *     writable,
- *     onError: (cause) => new Error(String(cause))
- *   }).pipe(Pull.catchDone(() => Effect.void))
- * }))
- *
- * Effect.runPromise(program).then(() => console.log(written))
- * // Output: [ 1, 2 ]
- * ```
- *
- * @category converting
- * @since 4.0.0
- */
+/** @internal */
 export const pullIntoWritableStream = <A, IE, E>(options: {
   readonly pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, IE, unknown>
   readonly writable: WritableStream<A>

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -26,6 +26,7 @@ import * as Iterable from "./Iterable.ts"
 import * as Latch from "./Latch.ts"
 import * as Layer from "./Layer.ts"
 import type { Severity } from "./LogLevel.ts"
+import * as MutableRef from "./MutableRef.ts"
 import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import { pipeArguments } from "./Pipeable.ts"
@@ -1670,6 +1671,262 @@ export const fromSchedule = <O, E, R>(
   schedule: Schedule.Schedule<O, unknown, E, R>
 ): Channel<O, E, O, unknown, unknown, unknown, R> =>
   fromPull(Effect.map(Schedule.toStepWithSleep(schedule), (step) => step(void 0)))
+
+/**
+ * Creates a channel from a lazily supplied Web `ReadableStream`.
+ *
+ * **Example** (Reading from a Web stream)
+ *
+ * ```ts
+ * import { Channel, Effect } from "effect"
+ *
+ * const channel = Channel.fromReadableStream({
+ *   evaluate: () => new ReadableStream({
+ *     start(controller) {
+ *       controller.enqueue(1)
+ *       controller.close()
+ *     }
+ *   }),
+ *   onError: (cause) => new Error(String(cause))
+ * })
+ *
+ * Effect.runPromise(Channel.runCollect(channel)).then(console.log)
+ * // Output: [ [ 1 ] ]
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromReadableStream = <A, E>(options: {
+  readonly evaluate: LazyArg<ReadableStream<A>>
+  readonly onError: (error: unknown) => E
+  readonly releaseLockOnEnd?: boolean | undefined
+}): Channel<Arr.NonEmptyReadonlyArray<A>, E> =>
+  fromTransform((_, scope) =>
+    readableStreamToPullUnsafe({
+      scope,
+      readable: options.evaluate(),
+      onError: options.onError,
+      releaseLockOnEnd: options.releaseLockOnEnd
+    })
+  )
+
+/**
+ * Writes values from an upstream pull into a Web `WritableStream`, respecting
+ * writer backpressure.
+ *
+ * **Example** (Writing an existing pull)
+ *
+ * ```ts
+ * import { Channel, Effect, Pull } from "effect"
+ *
+ * const written: Array<number> = []
+ * const writable = new WritableStream<number>({
+ *   write(value) {
+ *     written.push(value)
+ *   }
+ * })
+ *
+ * const program = Effect.scoped(Effect.gen(function*() {
+ *   const pull = yield* Channel.toPull(Channel.fromArray([[1, 2] as [number, number]]))
+ *   yield* Channel.pullIntoWritableStream({
+ *     pull,
+ *     writable,
+ *     onError: (cause) => new Error(String(cause))
+ *   }).pipe(Pull.catchDone(() => Effect.void))
+ * }))
+ *
+ * Effect.runPromise(program).then(() => console.log(written))
+ * // Output: [ 1, 2 ]
+ * ```
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const pullIntoWritableStream = <A, IE, E>(options: {
+  readonly pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, IE, unknown>
+  readonly writable: WritableStream<A>
+  readonly onError: (error: unknown) => E
+  readonly closeOnDone?: boolean | undefined
+}): Pull.Pull<never, IE | E, unknown> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => options.writable.getWriter()),
+    (writer) => {
+      const loop = options.pull.pipe(
+        Effect.flatMap((chunk) =>
+          Effect.forEach(
+            chunk,
+            (value) =>
+              Effect.tryPromise({
+                try: () => writer.ready.then(() => writer.write(value)),
+                catch: options.onError
+              }),
+            { discard: true }
+          )
+        ),
+        Effect.forever({ disableYield: true })
+      )
+      const withClose = options.closeOnDone !== false
+        ? Pull.catchDone(loop, (done) =>
+          Effect.andThen(
+            Effect.tryPromise({
+              try: () => writer.close(),
+              catch: options.onError
+            }),
+            Cause.done(done)
+          ))
+        : loop
+      return Effect.onError(
+        withClose,
+        (cause) =>
+          Pull.isDoneCause(cause)
+            ? Effect.void
+            : Effect.promise(() => writer.abort(cause).catch(constVoid))
+      )
+    },
+    (writer) => Effect.sync(() => writer.releaseLock())
+  )
+
+/**
+ * Creates a channel that writes upstream values to a lazily supplied Web
+ * `WritableStream`.
+ *
+ * **Example** (Writing channel input)
+ *
+ * ```ts
+ * import { Channel, Effect } from "effect"
+ *
+ * const written: Array<number> = []
+ * const sink = Channel.fromWritableStream<never, Error, number>({
+ *   evaluate: () => new WritableStream({
+ *     write(value) {
+ *       written.push(value)
+ *     }
+ *   }),
+ *   onError: (cause) => new Error(String(cause))
+ * })
+ *
+ * const program = Channel.fromArray([[1, 2] as [number, number]]).pipe(
+ *   Channel.pipeTo(sink),
+ *   Channel.runDrain
+ * )
+ *
+ * Effect.runPromise(program).then(() => console.log(written))
+ * // Output: [ 1, 2 ]
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromWritableStream = <IE, E, A>(options: {
+  readonly evaluate: LazyArg<WritableStream<A>>
+  readonly onError: (error: unknown) => E
+  readonly closeOnDone?: boolean | undefined
+}): Channel<never, IE | E, void, Arr.NonEmptyReadonlyArray<A>, IE> =>
+  fromTransform((pull: Pull.Pull<Arr.NonEmptyReadonlyArray<A>, IE, unknown>) => {
+    const writable = options.evaluate()
+    return Effect.succeed(pullIntoWritableStream({ ...options, writable, pull }))
+  })
+
+/**
+ * Creates a channel backed by a Web `TransformStream`, writing upstream values
+ * while emitting transformed values from its readable side.
+ *
+ * **Example** (Transforming channel input)
+ *
+ * ```ts
+ * import { Channel, Effect } from "effect"
+ *
+ * const transform = Channel.fromTransformStream<never, number, number, Error>({
+ *   evaluate: () => new TransformStream({
+ *     transform(value, controller) {
+ *       controller.enqueue(value * 2)
+ *     }
+ *   }),
+ *   onError: (cause) => new Error(String(cause))
+ * })
+ *
+ * const program = Channel.fromArray([[1, 2] as [number, number]]).pipe(
+ *   Channel.pipeTo(transform),
+ *   Channel.runCollect
+ * )
+ *
+ * Effect.runPromise(program).then(console.log)
+ * // Output: [ [ 2 ], [ 4 ] ]
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromTransformStream = <IE, I, O, E>(options: {
+  readonly evaluate: LazyArg<TransformStream<I, O>>
+  readonly onError: (error: unknown) => E
+  readonly closeOnDone?: boolean | undefined
+  readonly releaseLockOnEnd?: boolean | undefined
+}): Channel<Arr.NonEmptyReadonlyArray<O>, IE | E, void, Arr.NonEmptyReadonlyArray<I>, IE> =>
+  fromTransform((upstream, scope) => {
+    const transform = options.evaluate()
+    const exit = MutableRef.make<Exit.Exit<never, IE | E | Cause.Done> | undefined>(undefined)
+    return pullIntoWritableStream({
+      pull: upstream,
+      writable: transform.writable,
+      onError: options.onError,
+      closeOnDone: options.closeOnDone
+    }).pipe(
+      Effect.catchCause((cause) => {
+        if (!Pull.isDoneCause(cause)) {
+          exit.current = Exit.failCause(cause as Cause.Cause<IE | E | Cause.Done>)
+        }
+        return Effect.void
+      }),
+      Effect.forkIn(scope),
+      Effect.flatMap(() =>
+        readableStreamToPullUnsafe({
+          scope,
+          exit,
+          readable: transform.readable,
+          onError: options.onError,
+          releaseLockOnEnd: options.releaseLockOnEnd
+        })
+      )
+    )
+  })
+
+const readableStreamToPullUnsafe = <A, E, E2 = never>(options: {
+  readonly scope: Scope.Scope
+  readonly exit?: MutableRef.MutableRef<Exit.Exit<never, E | E2 | Cause.Done> | undefined> | undefined
+  readonly readable: ReadableStream<A>
+  readonly onError: (error: unknown) => E
+  readonly releaseLockOnEnd?: boolean | undefined
+}): Effect.Effect<Pull.Pull<Arr.NonEmptyReadonlyArray<A>, E | E2>, never> => {
+  const reader = options.readable.getReader()
+  const exit = options.exit ?? MutableRef.make(undefined)
+  const pull = Effect.suspend(() => {
+    if (exit.current) return exit.current
+    return Effect.matchCauseEffect(
+      Effect.tryPromise({
+        try: () => reader.read(),
+        catch: options.onError
+      }),
+      {
+        onFailure: (cause) => exit.current ?? Effect.failCause(cause),
+        onSuccess: ({ done, value }) => {
+          if (exit.current) return exit.current
+          return done ? Cause.done() : Effect.succeed(Arr.of(value))
+        }
+      }
+    )
+  })
+  return Effect.as(
+    Scope.addFinalizer(
+      options.scope,
+      options.releaseLockOnEnd
+        ? Effect.sync(() => reader.releaseLock())
+        : Effect.promise(() => reader.cancel().catch(constVoid))
+    ),
+    pull
+  )
+}
 
 /**
  * Creates a channel that pulls values from an `AsyncIterable`.

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -240,6 +240,45 @@ export const fromChannel = <L, In, E, A, R>(
   )
 
 /**
+ * Creates a sink that writes its input to a Web `WritableStream`.
+ *
+ * **Example** (Collecting values in a Web stream)
+ *
+ * ```ts
+ * import { Effect, Sink, Stream } from "effect"
+ *
+ * const written: Array<number> = []
+ * const sink = Sink.fromWritableStream({
+ *   evaluate: () => new WritableStream<number>({
+ *     write(value) {
+ *       written.push(value)
+ *     }
+ *   }),
+ *   onError: (cause) => new Error(String(cause))
+ * })
+ *
+ * const program = Stream.run(Stream.make(1, 2, 3), sink)
+ *
+ * Effect.runPromise(program).then(() => console.log(written))
+ * // Output: [ 1, 2, 3 ]
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromWritableStream = <A, E>(options: {
+  readonly evaluate: LazyArg<WritableStream<A>>
+  readonly onError: (error: unknown) => E
+  readonly closeOnDone?: boolean | undefined
+}): Sink<void, A, never, E> =>
+  fromChannel(
+    Channel.mapDone(
+      Channel.fromWritableStream<never, E, A>(options),
+      (_) => [_]
+    )
+  )
+
+/**
  * Creates a `Sink` from a low-level transform function.
  *
  * **Details**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -22,6 +22,7 @@ import * as Equal from "./Equal.ts"
 import * as ExecutionPlan from "./ExecutionPlan.ts"
 import * as Exit from "./Exit.ts"
 import * as Fiber from "./Fiber.ts"
+import type { SizeInput } from "./FileSystem.ts"
 import type * as Filter from "./Filter.ts"
 import type { LazyArg } from "./Function.ts"
 import { constant, constTrue, constVoid, dual, identity } from "./Function.ts"
@@ -1409,23 +1410,7 @@ export const fromReadableStream = <A, E>(
     readonly onError: (error: unknown) => E
     readonly releaseLockOnEnd?: boolean | undefined
   }
-): Stream<A, E> =>
-  fromChannel(Channel.fromTransform(Effect.fnUntraced(function*(_, scope) {
-    const reader = options.evaluate().getReader()
-    yield* Scope.addFinalizer(
-      scope,
-      options.releaseLockOnEnd
-        ? Effect.sync(() => reader.releaseLock())
-        : Effect.promise(() => reader.cancel().catch(constVoid))
-    )
-    return Effect.flatMap(
-      Effect.tryPromise({
-        try: () => reader.read(),
-        catch: (reason) => options.onError(reason)
-      }),
-      ({ done, value }) => done ? Cause.done() : Effect.succeed(Arr.of(value))
-    )
-  })))
+): Stream<A, E> => fromChannel(Channel.fromReadableStream(options))
 
 /**
  * Creates a stream from an AsyncIterable.
@@ -6336,6 +6321,64 @@ export const take: {
 )
 
 /**
+ * Emits byte chunks until the configured limit would be exceeded, then drops
+ * the crossing chunk and switches to a fallback stream.
+ *
+ * **Example** (Truncating at a byte limit)
+ *
+ * ```ts
+ * import { Effect, Stream } from "effect"
+ *
+ * const program = Stream.make(
+ *   new Uint8Array([1, 2]),
+ *   new Uint8Array([3, 4, 5])
+ * ).pipe(
+ *   Stream.limitBytes(4, () => Stream.empty),
+ *   Stream.runCollect,
+ *   Effect.map((chunks) => chunks.map((chunk) => [...chunk]))
+ * )
+ *
+ * Effect.runPromise(program).then(console.log)
+ * // Output: [ [ 1, 2 ] ]
+ * ```
+ *
+ * @category filtering
+ * @since 4.0.0
+ */
+export const limitBytes: {
+  <E, R>(
+    bytes: SizeInput,
+    onLimitReached: LazyArg<Stream<Uint8Array, E, R>>
+  ): (self: Stream<Uint8Array, E, R>) => Stream<Uint8Array, E, R>
+  <E, R>(
+    self: Stream<Uint8Array, E, R>,
+    bytes: SizeInput,
+    onLimitReached: LazyArg<Stream<Uint8Array, E, R>>
+  ): Stream<Uint8Array, E, R>
+} = dual(3, <E, R>(
+  self: Stream<Uint8Array, E, R>,
+  bytes: SizeInput,
+  onLimitReached: LazyArg<Stream<Uint8Array, E, R>>
+): Stream<Uint8Array, E, R> =>
+  suspend(() => {
+    const limit = BigInt(bytes)
+    let size = BigInt(0)
+    let limitReached = false
+    return concat(
+      takeWhile(self, (chunk) => {
+        const nextSize = size + BigInt(chunk.length)
+        if (nextSize > limit) {
+          limitReached = true
+          return false
+        }
+        size = nextSize
+        return true
+      }),
+      suspend(() => limitReached ? onLimitReached() : empty)
+    )
+  }))
+
+/**
  * Keeps the last `n` elements from this stream.
  *
  * **Example** (Taking elements from the right)
@@ -11070,27 +11113,29 @@ export const mkString = <E, R>(self: Stream<string, E, R>): Effect.Effect<string
   )
 
 /**
- * Concatenates the stream's `Uint8Array` chunks into a single `Uint8Array`.
+ * Concatenates the stream's `Uint8Array` chunks into a single `ArrayBuffer`.
  *
- * **Example** (Joining Uint8Array chunks)
+ * **Example** (Joining byte chunks into an ArrayBuffer)
  *
  * ```ts
- * import { Console, Effect, Stream } from "effect"
+ * import { Effect, Stream } from "effect"
  *
- * const stream = Stream.make(new Uint8Array([1, 2]), new Uint8Array([3, 4]))
- * const program = Effect.gen(function*() {
- *   const bytes = yield* Stream.mkUint8Array(stream)
- *   yield* Console.log([...bytes])
- * })
+ * const program = Stream.make(
+ *   new Uint8Array([1, 2]),
+ *   new Uint8Array([3, 4])
+ * ).pipe(
+ *   Stream.mkArrayBuffer,
+ *   Effect.map((buffer) => [...new Uint8Array(buffer)])
+ * )
  *
- * Effect.runPromise(program)
- * // [1, 2, 3, 4]
+ * Effect.runPromise(program).then(console.log)
+ * // Output: [ 1, 2, 3, 4 ]
  * ```
  *
  * @category destructors
  * @since 4.0.0
  */
-export const mkUint8Array = <E, R>(self: Stream<Uint8Array, E, R>): Effect.Effect<Uint8Array, E, R> =>
+export const mkArrayBuffer = <E, R>(self: Stream<Uint8Array, E, R>): Effect.Effect<ArrayBuffer, E, R> =>
   Effect.map(
     Channel.runFold(
       self.channel,
@@ -11117,9 +11162,33 @@ export const mkUint8Array = <E, R>(self: Stream<Uint8Array, E, R>): Effect.Effec
         result.set(array, offset)
         offset += array.length
       }
-      return result
+      return result.buffer
     }
   )
+
+/**
+ * Concatenates the stream's `Uint8Array` chunks into a single `Uint8Array`.
+ *
+ * **Example** (Joining Uint8Array chunks)
+ *
+ * ```ts
+ * import { Console, Effect, Stream } from "effect"
+ *
+ * const stream = Stream.make(new Uint8Array([1, 2]), new Uint8Array([3, 4]))
+ * const program = Effect.gen(function*() {
+ *   const bytes = yield* Stream.mkUint8Array(stream)
+ *   yield* Console.log([...bytes])
+ * })
+ *
+ * Effect.runPromise(program)
+ * // [1, 2, 3, 4]
+ * ```
+ *
+ * @category destructors
+ * @since 4.0.0
+ */
+export const mkUint8Array = <E, R>(self: Stream<Uint8Array, E, R>): Effect.Effect<Uint8Array, E, R> =>
+  Effect.map(mkArrayBuffer(self), (buffer) => new Uint8Array(buffer))
 
 /**
  * Converts the stream to a `ReadableStream` using the provided services.

--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -119,6 +119,44 @@ describe("Channel", () => {
         assert.deepStrictEqual(resultChunked, [[1, 2, 3, 4], [5]])
       }))
 
+    it.effect("fromReadableStream", () =>
+      Effect.gen(function*() {
+        const result = yield* Channel.fromReadableStream({
+          evaluate: () =>
+            new ReadableStream<number>({
+              start(controller) {
+                controller.enqueue(1)
+                controller.enqueue(2)
+                controller.close()
+              }
+            }),
+          onError: (error) => error
+        }).pipe(Channel.runCollect)
+
+        assert.deepStrictEqual(result, [[1], [2]])
+      }))
+
+    it.effect("fromTransformStream - surfaces write-side errors through the read side", () =>
+      Effect.gen(function*() {
+        const error = new Error("write failed")
+        const channel = Channel.fromTransformStream<never, number, number, Error>({
+          evaluate: () =>
+            new TransformStream<number, number>({
+              transform() {
+                throw error
+              }
+            }),
+          onError: (cause) => cause as Error
+        })
+        const exit = yield* Channel.fromArray([[1] as [number]]).pipe(
+          Channel.pipeTo(channel),
+          Channel.runDrain,
+          Effect.exit
+        )
+
+        assertExitFailure(exit, Cause.fail(error))
+      }))
+
     it.effect("acquireRelease", () =>
       Effect.gen(function*() {
         const acquired = yield* Ref.make(false)

--- a/packages/effect/test/Sink.test.ts
+++ b/packages/effect/test/Sink.test.ts
@@ -7,10 +7,70 @@ import {
   deepStrictEqual,
   strictEqual
 } from "@effect/vitest/utils"
-import { Array, Cause, Effect, Option, Ref, Result, Sink, Stream } from "effect"
+import { Array, Cause, Deferred, Effect, Fiber, Option, Ref, Result, Sink, Stream } from "effect"
 import { constTrue, pipe } from "effect/Function"
 
 describe("Sink", () => {
+  describe("constructors", () => {
+    it.effect("fromWritableStream - aborts instead of closing on upstream failure", () =>
+      Effect.gen(function*() {
+        const error = new Error("upstream failed")
+        let abortReason: unknown = undefined
+        let closes = 0
+        const writable = new WritableStream<number>({
+          close() {
+            closes++
+          },
+          abort(reason) {
+            abortReason = reason
+          }
+        })
+        const exit = yield* Stream.make(1).pipe(
+          Stream.concat(Stream.fail(error)),
+          Stream.run(Sink.fromWritableStream({
+            evaluate: () => writable,
+            onError: (cause) => cause
+          })),
+          Effect.exit
+        )
+
+        assertExitFailure(exit, Cause.fail(error))
+        strictEqual(closes, 0)
+        deepStrictEqual(Cause.squash(abortReason as Cause.Cause<Error>), error)
+      }))
+
+    it.effect("fromWritableStream - aborts instead of closing on interruption", () =>
+      Effect.gen(function*() {
+        const started = yield* Deferred.make<void>()
+        let abortReason: unknown = undefined
+        let closes = 0
+        const writable = new WritableStream<number>({
+          close() {
+            closes++
+          },
+          abort(reason) {
+            abortReason = reason
+          }
+        })
+        const sink = Sink.fromWritableStream({
+          evaluate: () => writable,
+          onError: (cause) => cause
+        })
+        const fiber = yield* Stream.fromEffect(
+          Deferred.succeed(started, void 0).pipe(Effect.andThen(Effect.never))
+        ).pipe(
+          Stream.run(sink),
+          Effect.forkChild
+        )
+
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(fiber)
+
+        strictEqual(closes, 0)
+        strictEqual(abortReason === undefined, false)
+      }))
+  })
+
   describe("reduceWhile", () => {
     it.effect("empty", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -149,6 +149,16 @@ describe("Stream", () => {
         )
       )
 
+    it.effect("mkArrayBuffer - concatenates Uint8Array chunks", () =>
+      Effect.gen(function*() {
+        const buffer = yield* Stream.make(
+          new Uint8Array([1, 2]),
+          new Uint8Array([3, 4])
+        ).pipe(Stream.mkArrayBuffer)
+
+        assert.deepStrictEqual([...new Uint8Array(buffer)], [1, 2, 3, 4])
+      }))
+
     it.effect("runForEachWhile continues across chunk boundaries", () =>
       Effect.gen(function*() {
         const seen: Array<number> = []
@@ -647,6 +657,52 @@ describe("Stream", () => {
   })
 
   describe("taking", () => {
+    it.effect("limitBytes - does not evaluate the fallback below the limit", () =>
+      Effect.gen(function*() {
+        let evaluated = false
+        const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])]
+        const result = yield* Stream.fromIterable(chunks).pipe(
+          Stream.limitBytes(5, () => {
+            evaluated = true
+            return Stream.empty
+          }),
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, chunks)
+        assert.isFalse(evaluated)
+      }))
+
+    it.effect("limitBytes - does not evaluate the fallback at the limit", () =>
+      Effect.gen(function*() {
+        let evaluated = false
+        const chunks = [new Uint8Array([1, 2]), new Uint8Array([3, 4])]
+        const result = yield* Stream.fromIterable(chunks).pipe(
+          Stream.limitBytes(4, () => {
+            evaluated = true
+            return Stream.empty
+          }),
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, chunks)
+        assert.isFalse(evaluated)
+      }))
+
+    it.effect("limitBytes - drops the crossing chunk and switches to the fallback", () =>
+      Effect.gen(function*() {
+        const first = new Uint8Array([1, 2])
+        const crossing = new Uint8Array([3, 4, 5, 6])
+        const after = new Uint8Array([7])
+        const fallback = new Uint8Array([8, 9])
+        const result = yield* Stream.make(first, crossing, after).pipe(
+          Stream.limitBytes(5, () => Stream.succeed(fallback)),
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, [first, fallback])
+      }))
+
     it.effect("take - pulls the first `n` values from a stream", () =>
       Effect.gen(function*() {
         const result = yield* Stream.range(1, 5).pipe(


### PR DESCRIPTION
## Summary
- add Web ReadableStream, WritableStream, and TransformStream adapters to Channel
- add Sink.fromWritableStream with close and abort lifecycle handling
- add Stream.limitBytes and Stream.mkArrayBuffer

## Testing
- pnpm --filter effect test --run test/Channel.test.ts test/Sink.test.ts test/Stream.test.ts
- pnpm check
- pnpm lint-fix
- pnpm docgen (packages/effect)

Closes EFF-137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interoperability with Web `ReadableStream`, `WritableStream`, and `TransformStream` for channels and sinks.
  * Added byte-based stream limiting with configurable fallback behavior.
  * Added support for collecting streamed `Uint8Array` data into an `ArrayBuffer`.
  * Improved stream handling for failures, interruption, backpressure, and resource cleanup.
* **Tests**
  * Added coverage for Web Stream integration, byte limits, buffering, failures, and interruption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->