### PR TITLE
Fix BrowserCrypto random bytes above Web Crypto limit

### DIFF
--- a/.changeset/eff-162-browser-crypto-chunks.md
+++ b/.changeset/eff-162-browser-crypto-chunks.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": patch
+---
+
+Fix `BrowserCrypto.randomBytes` for requests larger than the Web Crypto per-call limit.

--- a/packages/platform-browser/src/BrowserCrypto.ts
+++ b/packages/platform-browser/src/BrowserCrypto.ts
@@ -60,7 +60,9 @@ export const layer: Layer.Layer<EffectCrypto.Crypto> = Layer.effect(
     }
     const randomBytes = (size: number): Uint8Array => {
       const bytes = new Uint8Array(size)
-      crypto.getRandomValues(bytes)
+      for (let i = 0; i < bytes.length; i += 65_536) {
+        crypto.getRandomValues(bytes.subarray(i, i + 65_536))
+      }
       return bytes
     }
 

--- a/packages/platform-browser/test/BrowserCrypto.test.ts
+++ b/packages/platform-browser/test/BrowserCrypto.test.ts
@@ -18,6 +18,32 @@ const getRandomValues = <T extends ArrayBufferView | null>(array: T): T => {
 }
 
 describe("BrowserCrypto", () => {
+  it.effect("generates random bytes at and above the getRandomValues limit", () => {
+    const chunks: Array<number> = []
+
+    return Effect.gen(function*() {
+      const crypto = yield* Crypto.Crypto
+      for (const size of [65_536, 65_537, 70_000]) {
+        const bytes = yield* crypto.randomBytes(size)
+        assert.strictEqual(bytes.length, size)
+        assert.strictEqual(bytes[0], 0)
+        assert.strictEqual(bytes[size - 1], (size - 1) & 0xff)
+      }
+      assert.deepStrictEqual(chunks, [65_536, 65_536, 1, 65_536, 4_464])
+    }).pipe(Effect.provide(BrowserCrypto.layer.pipe(
+      Layer.provide(Layer.succeed(BrowserCrypto.WebCrypto, {
+        ...crypto,
+        getRandomValues(array) {
+          if (array !== null) {
+            assert.ok(array.byteLength <= 65_536)
+            chunks.push(array.byteLength)
+          }
+          return getRandomValues(array)
+        }
+      }))
+    )))
+  })
+
   it.effect("generates UUIDv4 values from getRandomValues", () =>
     Effect.gen(function*() {
       const crypto = yield* Crypto.Crypto


### PR DESCRIPTION
Chunk BrowserCrypto random byte requests into Web Crypto-compatible views.

Add regression coverage for the 65,536-byte boundary and larger requests.

Closes EFF-162
