### PR TITLE
Add Deno Crypto implementation

### DIFF
--- a/.changeset/eff-140-deno-crypto.md
+++ b/.changeset/eff-140-deno-crypto.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add a Deno Web Crypto implementation of the `Crypto` service.

--- a/packages/platform-deno/src/DenoCrypto.ts
+++ b/packages/platform-deno/src/DenoCrypto.ts
@@ -1,12 +1,11 @@
 /**
  * Deno-backed implementation of Effect's Crypto service.
  *
- * This module uses Deno's global Web Crypto API. Unlike the browser
- * implementation, random byte requests are split into chunks of at most 65,536
- * bytes so they support the full size range accepted by `Crypto.make`. Deno's
- * supported runtime versions always provide `globalThis.crypto` and
- * `crypto.subtle`, so this implementation does not include browser availability
- * guards.
+ * This module uses Deno's global Web Crypto API. Random byte requests are split
+ * into chunks of at most 65,536 bytes so they support the full size range
+ * accepted by `Crypto.make`. Unlike browser runtimes, Deno's supported runtime
+ * versions always provide `globalThis.crypto` and `crypto.subtle`, so this
+ * implementation does not include availability guards.
  *
  * @since 4.0.0
  */
@@ -39,7 +38,7 @@ export const layer: Layer.Layer<EffectCrypto.Crypto> = Layer.effect(
     const randomBytes = (size: number): Uint8Array => {
       const bytes = new Uint8Array(size)
       for (let offset = 0; offset < bytes.length; offset += 65_536) {
-        crypto.getRandomValues(bytes.subarray(offset, Math.min(offset + 65_536, bytes.length)))
+        crypto.getRandomValues(bytes.subarray(offset, offset + 65_536))
       }
       return bytes
     }

--- a/packages/platform-deno/src/DenoCrypto.ts
+++ b/packages/platform-deno/src/DenoCrypto.ts
@@ -1,11 +1,7 @@
 /**
  * Deno-backed implementation of Effect's Crypto service.
  *
- * This module uses Deno's global Web Crypto API. Random byte requests are split
- * into chunks of at most 65,536 bytes so they support the full size range
- * accepted by `Crypto.make`. Unlike browser runtimes, Deno's supported runtime
- * versions always provide `globalThis.crypto` and `crypto.subtle`, so this
- * implementation does not include availability guards.
+ * This module uses Deno's global Web Crypto API.
  *
  * @since 4.0.0
  */

--- a/packages/platform-deno/src/DenoCrypto.ts
+++ b/packages/platform-deno/src/DenoCrypto.ts
@@ -1,0 +1,68 @@
+/**
+ * Deno-backed implementation of Effect's Crypto service.
+ *
+ * This module uses Deno's global Web Crypto API. Unlike the browser
+ * implementation, random byte requests are split into chunks of at most 65,536
+ * bytes so they support the full size range accepted by `Crypto.make`. Deno's
+ * supported runtime versions always provide `globalThis.crypto` and
+ * `crypto.subtle`, so this implementation does not include browser availability
+ * guards.
+ *
+ * @since 4.0.0
+ */
+import * as Context from "effect/Context"
+import * as EffectCrypto from "effect/Crypto"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as PlatformError from "effect/PlatformError"
+
+/**
+ * Provides the Web Crypto API used by the Crypto service implementation.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const WebCrypto = Context.Reference<Crypto>("@effect/platform-deno/Crypto/WebCrypto", {
+  defaultValue: () => globalThis.crypto
+})
+
+/**
+ * A layer that provides Effect's Crypto service using Deno's Web Crypto API.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer: Layer.Layer<EffectCrypto.Crypto> = Layer.effect(
+  EffectCrypto.Crypto,
+  Effect.gen(function*() {
+    const crypto = yield* WebCrypto
+    const randomBytes = (size: number): Uint8Array => {
+      const bytes = new Uint8Array(size)
+      for (let offset = 0; offset < bytes.length; offset += 65_536) {
+        crypto.getRandomValues(bytes.subarray(offset, Math.min(offset + 65_536, bytes.length)))
+      }
+      return bytes
+    }
+
+    const digest: EffectCrypto.Crypto["digest"] = (algorithm, data) =>
+      Effect.map(
+        Effect.tryPromise({
+          try: () => crypto.subtle.digest(algorithm, new Uint8Array(data)),
+          catch: (cause) =>
+            PlatformError.systemError({
+              module: "Crypto",
+              method: "digest",
+              _tag: "Unknown",
+              description: "Could not compute digest",
+              cause
+            })
+        }),
+        (buffer) => new Uint8Array(buffer)
+      )
+
+    return EffectCrypto.make({
+      randomBytes,
+      digest
+    })
+  })
+)

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -7,6 +7,11 @@
 /**
  * @since 4.0.0
  */
+export * as DenoCrypto from "./DenoCrypto.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoKeyValueStore from "./DenoKeyValueStore.ts"
 
 /**

--- a/packages/platform-deno/test/DenoCrypto.test.ts
+++ b/packages/platform-deno/test/DenoCrypto.test.ts
@@ -1,0 +1,37 @@
+import * as DenoCrypto from "@effect/platform-deno/DenoCrypto"
+import { assert, describe, it } from "@effect/vitest"
+import * as Crypto from "effect/Crypto"
+import * as Effect from "effect/Effect"
+
+const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+const uuidV7Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+const hex = (bytes: Uint8Array): string => Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
+
+describe("DenoCrypto", () => {
+  it.effect("computes SHA-256 digests", () =>
+    Effect.gen(function*() {
+      const crypto = yield* Crypto.Crypto
+      const digest = yield* crypto.digest("SHA-256", new TextEncoder().encode("hello"))
+      assert.strictEqual(hex(digest), "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+    }).pipe(Effect.provide(DenoCrypto.layer)))
+
+  it.effect("generates random bytes larger than the Web Crypto quota", () =>
+    Effect.gen(function*() {
+      const crypto = yield* Crypto.Crypto
+      const bytes = yield* crypto.randomBytes(70_000)
+      assert.strictEqual(bytes.length, 70_000)
+    }).pipe(Effect.provide(DenoCrypto.layer)))
+
+  it.effect("generates UUIDv4 values", () =>
+    Effect.gen(function*() {
+      const crypto = yield* Crypto.Crypto
+      assert.match(yield* crypto.randomUUIDv4, uuidV4Regex)
+    }).pipe(Effect.provide(DenoCrypto.layer)))
+
+  it.effect("generates UUIDv7 values", () =>
+    Effect.gen(function*() {
+      const crypto = yield* Crypto.Crypto
+      assert.match(yield* crypto.randomUUIDv7, uuidV7Regex)
+    }).pipe(Effect.provide(DenoCrypto.layer)))
+})


### PR DESCRIPTION
## Summary

- add a Deno Web Crypto-backed `Crypto` layer and overridable `WebCrypto` reference
- chunk random byte requests at the Web Crypto 65,536-byte limit
- export the module from `@effect/platform-deno`

## Testing

- `pnpm lint-fix`
- `pnpm --filter @effect/platform-deno test --run test/DenoCrypto.test.ts`
- `deno task test --run packages/platform-deno/test/DenoCrypto.test.ts`
- `pnpm check`
- `deno check .`

The Deno tests intentionally differ from `BrowserCrypto.test.ts`: they use the real runtime Web Crypto implementation for SHA-256, a 70,000-byte random request, and UUID shape checks. They do not port the browser suite's fake-injection tests because those fakes replace the adapter's primitive operations and primarily retest `Crypto.make`, which is already covered in `packages/effect`.

Closes EFF-140
