### PR TITLE
feat(platform-deno): add DenoHttpClient

### DIFF
--- a/.changeset/add-deno-http-client.md
+++ b/.changeset/add-deno-http-client.md
@@ -1,0 +1,7 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add `DenoHttpClient`, re-exporting `effect/unstable/http/FetchHttpClient`
+
+Deno's `fetch` is spec-compliant, so the core fetch-based `HttpClient` works on Deno unmodified. This module mirrors `BunHttpClient` so the platform packages expose a consistent surface.

--- a/packages/platform-deno/src/DenoHttpClient.ts
+++ b/packages/platform-deno/src/DenoHttpClient.ts
@@ -1,0 +1,9 @@
+/**
+ * @since 4.0.0
+ */
+
+/**
+ * @category re-exports
+ * @since 4.0.0
+ */
+export * from "effect/unstable/http/FetchHttpClient"

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -7,6 +7,11 @@
 /**
  * @since 4.0.0
  */
+export * as DenoHttpClient from "./DenoHttpClient.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoKeyValueStore from "./DenoKeyValueStore.ts"
 
 /**


### PR DESCRIPTION
Adds `DenoHttpClient` to `@effect/platform-deno`, re-exporting `effect/unstable/http/FetchHttpClient`.

Deno's `fetch` is spec-compliant and core's `FetchHttpClient` is a pure web-standard implementation (`globalThis.fetch`, `RequestInit`, web streams for stream bodies), so it runs on Deno unmodified. This module exists for package-surface symmetry — it is byte-identical to `packages/platform-bun/src/BunHttpClient.ts` apart from the filename.

### Why no Deno-specific implementation

`Deno.createHttpClient()` (custom CA certs, proxies, unix sockets, HTTP/1-vs-2 selection) is the only Deno-specific candidate, and it was deliberately left out:

- It is gated behind `--unstable-http`.
- Its `client` field is just an extra `RequestInit` key, so it already passes through core's `FetchHttpClient.RequestInit` service today.

If typed ergonomics for it are wanted later, that is a separate change once the API stabilises.

### Notes

- No tests — `platform-bun` has no test directory, and a re-export has no behaviour of its own to cover.
- `src/index.ts` regenerated via `pnpm codegen`, not hand-edited.

### Verification

- `pnpm check` — passes
- `pnpm lint` — passes
- `pnpm exec docgen` in `packages/platform-deno` — passes
- `pnpm test` in `packages/platform-deno` — 8 failures in `RpcWorker.test.ts` / `DenoWorkerRunner.test.ts`, **pre-existing**: identical results on a clean `main` checkout, caused by `deno` not being installed in this environment.

Closes EFF-147
