### PR TITLE
Add Deno Redis integration

### DIFF
--- a/.changeset/eff-151-deno-redis.md
+++ b/.changeset/eff-151-deno-redis.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add a native Deno Redis integration backed by `@db/redis`.

--- a/packages/platform-deno/package.json
+++ b/packages/platform-deno/package.json
@@ -61,6 +61,7 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
+    "@db/redis": "jsr:^0.41.2",
     "@std/path": "jsr:^1.1.6"
   },
   "peerDependencies": {
@@ -69,6 +70,7 @@
   "devDependencies": {
     "@types/deno": "^2.7.0",
     "@std/assert": "jsr:^1.0.16",
+    "@testcontainers/redis": "^11.14.0",
     "effect": "workspace:^"
   }
 }

--- a/packages/platform-deno/src/DenoRedis.ts
+++ b/packages/platform-deno/src/DenoRedis.ts
@@ -15,6 +15,8 @@ import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
+import * as Predicate from "effect/Predicate"
+import * as Record from "effect/Record"
 import * as Redis from "effect/unstable/persistence/Redis"
 
 /**
@@ -46,27 +48,12 @@ const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
     Effect.tryPromise({
       try: () => {
         const { url, ...connectOptions } = options
-        const resolved = url === undefined ? { hostname: "localhost" } : parseURL(url)
-        if (url !== undefined) {
-          if (resolved.name !== undefined) resolved.username = resolved.name
-          delete resolved.name
-        }
-        if (connectOptions.hostname !== undefined) resolved.hostname = connectOptions.hostname
-        if (connectOptions.port !== undefined) resolved.port = connectOptions.port
-        if (connectOptions.tls !== undefined) resolved.tls = connectOptions.tls
-        if (connectOptions.caCerts !== undefined) resolved.caCerts = connectOptions.caCerts
-        if (connectOptions.db !== undefined) resolved.db = connectOptions.db
-        if (connectOptions.password !== undefined) resolved.password = connectOptions.password
-        if (connectOptions.username !== undefined) resolved.username = connectOptions.username
-        if (connectOptions.name !== undefined) resolved.name = connectOptions.name
-        if (connectOptions.maxRetryCount !== undefined) resolved.maxRetryCount = connectOptions.maxRetryCount
-        if (connectOptions.backoff !== undefined) resolved.backoff = connectOptions.backoff
-        if (connectOptions.healthCheckInterval !== undefined) {
-          resolved.healthCheckInterval = connectOptions.healthCheckInterval
-        }
-        if (connectOptions.signal !== undefined) resolved.signal = connectOptions.signal
-        if (connectOptions.noDelay !== undefined) resolved.noDelay = connectOptions.noDelay
-        return connect(resolved)
+        const { name, ...parsed } = url === undefined ? { hostname: "localhost" } : parseURL(url)
+        return connect({
+          ...parsed,
+          ...(name === undefined ? {} : { username: name }),
+          ...Record.filter(connectOptions, Predicate.isNotUndefined)
+        })
       },
       catch: (cause) => new Redis.RedisError({ cause })
     }),

--- a/packages/platform-deno/src/DenoRedis.ts
+++ b/packages/platform-deno/src/DenoRedis.ts
@@ -29,14 +29,6 @@ export type RedisOptions = Omit<RedisConnectOptions, "hostname"> & {
   readonly url?: string
 }
 
-const withoutUndefined = <A extends object>(options: A): Partial<A> =>
-  Object.fromEntries(
-    Reflect.ownKeys(options).flatMap((key) => {
-      const value = Reflect.get(options, key)
-      return value === undefined ? [] : [[key, value]]
-    })
-  ) as Partial<A>
-
 /**
  * Service tag for Deno Redis integration, exposing the raw `@db/redis` client
  * and a `use` helper that maps client promise failures to `RedisError`.
@@ -54,14 +46,27 @@ const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
     Effect.tryPromise({
       try: () => {
         const { url, ...connectOptions } = options
-        if (url === undefined) {
-          return connect({ hostname: "localhost", ...withoutUndefined(connectOptions) })
+        const resolved = url === undefined ? { hostname: "localhost" } : parseURL(url)
+        if (url !== undefined) {
+          if (resolved.name !== undefined) resolved.username = resolved.name
+          delete resolved.name
         }
-        const { name: username, ...parsed } = parseURL(url)
-        return connect({
-          ...withoutUndefined({ ...parsed, username }),
-          ...withoutUndefined(connectOptions)
-        } as RedisConnectOptions)
+        if (connectOptions.hostname !== undefined) resolved.hostname = connectOptions.hostname
+        if (connectOptions.port !== undefined) resolved.port = connectOptions.port
+        if (connectOptions.tls !== undefined) resolved.tls = connectOptions.tls
+        if (connectOptions.caCerts !== undefined) resolved.caCerts = connectOptions.caCerts
+        if (connectOptions.db !== undefined) resolved.db = connectOptions.db
+        if (connectOptions.password !== undefined) resolved.password = connectOptions.password
+        if (connectOptions.username !== undefined) resolved.username = connectOptions.username
+        if (connectOptions.name !== undefined) resolved.name = connectOptions.name
+        if (connectOptions.maxRetryCount !== undefined) resolved.maxRetryCount = connectOptions.maxRetryCount
+        if (connectOptions.backoff !== undefined) resolved.backoff = connectOptions.backoff
+        if (connectOptions.healthCheckInterval !== undefined) {
+          resolved.healthCheckInterval = connectOptions.healthCheckInterval
+        }
+        if (connectOptions.signal !== undefined) resolved.signal = connectOptions.signal
+        if (connectOptions.noDelay !== undefined) resolved.noDelay = connectOptions.noDelay
+        return connect(resolved)
       },
       catch: (cause) => new Redis.RedisError({ cause })
     }),

--- a/packages/platform-deno/src/DenoRedis.ts
+++ b/packages/platform-deno/src/DenoRedis.ts
@@ -1,0 +1,104 @@
+/**
+ * Deno Redis integration backed by `@db/redis`.
+ *
+ * This module creates a scoped, native Deno Redis client and exposes it as
+ * both the portable `Redis` service and the Deno-specific {@link DenoRedis}
+ * service for direct access to the raw client. Unlike Bun's built-in client,
+ * `@db/redis` connects eagerly using RESP2, so layer construction can fail
+ * with a `RedisError`.
+ *
+ * @since 4.0.0
+ */
+import { connect, parseURL, type Redis as RedisClient, type RedisConnectOptions } from "@db/redis"
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Fn from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
+import * as Redis from "effect/unstable/persistence/Redis"
+
+type RedisOptions = Omit<RedisConnectOptions, "hostname"> & {
+  readonly hostname?: string
+  readonly url?: string
+}
+
+/**
+ * Service tag for Deno Redis integration, exposing the raw `@db/redis` client
+ * and a `use` helper that maps client promise failures to `RedisError`.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export class DenoRedis extends Context.Service<DenoRedis, {
+  readonly client: RedisClient
+  readonly use: <A>(f: (client: RedisClient) => Promise<A>) => Effect.Effect<A, Redis.RedisError>
+}>()("@effect/platform-deno/DenoRedis") {}
+
+const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
+  const client = yield* Effect.tryPromise({
+    try: () => {
+      const { url, ...connectOptions } = options
+      const parsed = url === undefined ? undefined : parseURL(url)
+      return connect({
+        ...parsed,
+        ...connectOptions,
+        hostname: connectOptions.hostname ?? parsed?.hostname ?? "localhost"
+      })
+    },
+    catch: (cause) => new Redis.RedisError({ cause })
+  })
+  const scope = yield* Effect.scope
+  yield* Scope.addFinalizer(scope, Effect.sync(() => client.close()))
+
+  const use = <A>(f: (client: RedisClient) => Promise<A>) =>
+    Effect.tryPromise({
+      try: () => f(client),
+      catch: (cause) => new Redis.RedisError({ cause })
+    })
+
+  const redis = yield* Redis.make({
+    send: <A = unknown>(command: string, ...args: ReadonlyArray<string>) =>
+      Effect.tryPromise({
+        try: () => client.sendCommand(command, args as Array<string>) as Promise<A>,
+        catch: (cause) => new Redis.RedisError({ cause })
+      })
+  })
+
+  const denoRedis = Fn.identity<DenoRedis["Service"]>({
+    client,
+    use
+  })
+
+  return Context.make(DenoRedis, denoRedis).pipe(
+    Context.add(Redis.Redis, redis)
+  )
+})
+
+/**
+ * Provides `Redis` and `DenoRedis` services backed by an `@db/redis` client,
+ * closing the client when the layer scope ends. URL-derived options can be
+ * overridden by other supplied options.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = (
+  options?: RedisOptions | undefined
+): Layer.Layer<Redis.Redis | DenoRedis, Redis.RedisError> => Layer.effectContext(make(options))
+
+/**
+ * Provides `Redis` and `DenoRedis` services from `Config`-backed options,
+ * closing the client when the layer scope ends.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerConfig = (
+  options: Config.Wrap<RedisOptions>
+): Layer.Layer<Redis.Redis | DenoRedis, Redis.RedisError | Config.ConfigError> =>
+  Layer.effectContext(
+    Config.unwrap(options).pipe(
+      Effect.flatMap(make)
+    )
+  )

--- a/packages/platform-deno/src/DenoRedis.ts
+++ b/packages/platform-deno/src/DenoRedis.ts
@@ -15,13 +15,27 @@ import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Fn from "effect/Function"
 import * as Layer from "effect/Layer"
-import * as Scope from "effect/Scope"
 import * as Redis from "effect/unstable/persistence/Redis"
 
-type RedisOptions = Omit<RedisConnectOptions, "hostname"> & {
+/**
+ * Options for connecting to Redis, including a Redis URL or individual
+ * connection settings. Explicit settings override values from the URL.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type RedisOptions = Omit<RedisConnectOptions, "hostname"> & {
   readonly hostname?: string
   readonly url?: string
 }
+
+const withoutUndefined = <A extends object>(options: A): Partial<A> =>
+  Object.fromEntries(
+    Reflect.ownKeys(options).flatMap((key) => {
+      const value = Reflect.get(options, key)
+      return value === undefined ? [] : [[key, value]]
+    })
+  ) as Partial<A>
 
 /**
  * Service tag for Deno Redis integration, exposing the raw `@db/redis` client
@@ -36,20 +50,23 @@ export class DenoRedis extends Context.Service<DenoRedis, {
 }>()("@effect/platform-deno/DenoRedis") {}
 
 const make = Effect.fnUntraced(function*(options: RedisOptions = {}) {
-  const client = yield* Effect.tryPromise({
-    try: () => {
-      const { url, ...connectOptions } = options
-      const parsed = url === undefined ? undefined : parseURL(url)
-      return connect({
-        ...parsed,
-        ...connectOptions,
-        hostname: connectOptions.hostname ?? parsed?.hostname ?? "localhost"
-      })
-    },
-    catch: (cause) => new Redis.RedisError({ cause })
-  })
-  const scope = yield* Effect.scope
-  yield* Scope.addFinalizer(scope, Effect.sync(() => client.close()))
+  const client = yield* Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () => {
+        const { url, ...connectOptions } = options
+        if (url === undefined) {
+          return connect({ hostname: "localhost", ...withoutUndefined(connectOptions) })
+        }
+        const { name: username, ...parsed } = parseURL(url)
+        return connect({
+          ...withoutUndefined({ ...parsed, username }),
+          ...withoutUndefined(connectOptions)
+        } as RedisConnectOptions)
+      },
+      catch: (cause) => new Redis.RedisError({ cause })
+    }),
+    (client) => Effect.sync(() => client.close())
+  )
 
   const use = <A>(f: (client: RedisClient) => Promise<A>) =>
     Effect.tryPromise({

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -27,6 +27,11 @@ export * as DenoPath from "./DenoPath.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoRedis from "./DenoRedis.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoRuntime from "./DenoRuntime.ts"
 
 /**

--- a/packages/platform-deno/test/DenoRedis.test.ts
+++ b/packages/platform-deno/test/DenoRedis.test.ts
@@ -1,4 +1,4 @@
-import { DenoRedis } from "@effect/platform-deno"
+import * as DenoRedis from "@effect/platform-deno/DenoRedis"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
 import { Deferred, Effect, Fiber, Layer, Schema } from "effect"

--- a/packages/platform-deno/test/DenoRedis.test.ts
+++ b/packages/platform-deno/test/DenoRedis.test.ts
@@ -1,7 +1,7 @@
 import { DenoRedis } from "@effect/platform-deno"
 import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Effect, Layer, Schema } from "effect"
+import { Deferred, Effect, Fiber, Layer, Schema } from "effect"
 import { PersistedQueue, Persistence } from "effect/unstable/persistence"
 import * as PersistedCacheTest from "../../effect/test/unstable/persistence/PersistedCacheTest.ts"
 import * as PersistedQueueTest from "../../effect/test/unstable/persistence/PersistedQueueTest.ts"
@@ -73,6 +73,78 @@ it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
   }
 )
 
+it.effect("closes the connection when interrupted during acquisition", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const listener = yield* makeListener
+    const authReceived = yield* Deferred.make<void>()
+    const sendAuthReply = yield* Deferred.make<void>()
+    const server = yield* Effect.gen(function*() {
+      const connection = yield* accept(listener)
+      yield* read(connection)
+      yield* Deferred.succeed(authReceived, void 0)
+      yield* Deferred.await(sendAuthReply)
+      yield* write(connection, "+OK\r\n")
+      return yield* read(connection)
+    }).pipe(Effect.forkChild)
+
+    const port = (listener.addr as Deno.NetAddr).port
+    const layerFiber = yield* Layer.build(DenoRedis.layer({
+      url: `redis://:secret@127.0.0.1:${port}`
+    })).pipe(Effect.forkChild({ startImmediately: true }))
+
+    yield* Deferred.await(authReceived)
+    const interruptFiber = yield* Fiber.interrupt(layerFiber).pipe(
+      Effect.forkChild({ startImmediately: true })
+    )
+    yield* Deferred.succeed(sendAuthReply, void 0)
+    yield* Fiber.join(interruptFiber)
+
+    assert.isNull(yield* Fiber.join(server))
+  })))
+
+it.effect("uses the URL username for two-argument AUTH", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const listener = yield* makeListener
+    const server = yield* Effect.gen(function*() {
+      const connection = yield* accept(listener)
+      const request = yield* read(connection)
+      yield* write(connection, "+OK\r\n")
+      return request
+    }).pipe(Effect.forkChild)
+
+    const port = (listener.addr as Deno.NetAddr).port
+    yield* Layer.build(DenoRedis.layer({
+      url: `redis://alice:secret@127.0.0.1:${port}`
+    }))
+
+    assert.strictEqual(
+      yield* Fiber.join(server),
+      "*3\r\n$4\r\nAUTH\r\n$5\r\nalice\r\n$6\r\nsecret\r\n"
+    )
+  })))
+
 const RedisItem = Schema.Struct({
   n: Schema.Number
 })
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+const makeListener = Effect.acquireRelease(
+  Effect.sync(() => Deno.listen({ hostname: "127.0.0.1", port: 0 })),
+  (listener) => Effect.sync(() => listener.close())
+)
+
+const accept = (listener: Deno.TcpListener) =>
+  Effect.acquireRelease(
+    Effect.promise(() => listener.accept()),
+    (connection) => Effect.sync(() => connection.close())
+  )
+
+const read = (connection: Deno.TcpConn) =>
+  Effect.promise(() => {
+    const buffer = new Uint8Array(256)
+    return connection.read(buffer).then((size) => size === null ? null : decoder.decode(buffer.subarray(0, size)))
+  })
+
+const write = (connection: Deno.TcpConn, value: string) => Effect.promise(() => connection.write(encoder.encode(value)))

--- a/packages/platform-deno/test/DenoRedis.test.ts
+++ b/packages/platform-deno/test/DenoRedis.test.ts
@@ -1,0 +1,78 @@
+import { DenoRedis } from "@effect/platform-deno"
+import { assert, it } from "@effect/vitest"
+import { RedisContainer } from "@testcontainers/redis"
+import { Effect, Layer, Schema } from "effect"
+import { PersistedQueue, Persistence } from "effect/unstable/persistence"
+import * as PersistedCacheTest from "../../effect/test/unstable/persistence/PersistedCacheTest.ts"
+import * as PersistedQueueTest from "../../effect/test/unstable/persistence/PersistedQueueTest.ts"
+
+const RedisLayer = Layer.unwrap(
+  Effect.gen(function*() {
+    const container = yield* Effect.acquireRelease(
+      Effect.promise(() => new RedisContainer("redis:alpine").start()),
+      (container) => Effect.promise(() => container.stop())
+    )
+    return DenoRedis.layer({
+      url: `redis://${container.getHost()}:${container.getMappedPort(6379)}`
+    })
+  }).pipe(
+    Effect.catchCause(() => Effect.fail(new PersistedCacheTest.TransientError()))
+  )
+)
+
+PersistedCacheTest.suite(
+  "DenoRedis",
+  Persistence.layerRedis.pipe(Layer.provide(RedisLayer))
+)
+
+PersistedQueueTest.suite(
+  "DenoRedis",
+  // short intervals so the periodic reset runs while the suite's takes are
+  // in flight
+  PersistedQueue.layerStoreRedis({
+    pollInterval: "50 millis",
+    lockRefreshInterval: "100 millis"
+  }).pipe(Layer.provide(RedisLayer))
+)
+
+const PersistedQueueRedisLayer = Layer.mergeAll(
+  RedisLayer,
+  PersistedQueue.layer.pipe(
+    Layer.provideMerge(
+      PersistedQueue.layerStoreRedis().pipe(Layer.provide(RedisLayer))
+    )
+  )
+)
+
+it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
+  "PersistedQueue (DenoRedis)",
+  (it) => {
+    it.effect("moves exhausted elements to the failed list", () =>
+      Effect.gen(function*() {
+        const redis = yield* DenoRedis.DenoRedis
+        const queueName = "test-redis-failed"
+
+        const queue = yield* PersistedQueue.make({
+          name: queueName,
+          schema: RedisItem
+        })
+        const id = yield* queue.offer({ n: 42 })
+        const error = yield* queue.take(() => Effect.fail("boom"), { maxAttempts: 1 }).pipe(Effect.flip)
+        assert.strictEqual(error, "boom")
+
+        const failed = yield* redis.use((client) => client.lrange(`effectq:${queueName}:failed`, 0, -1))
+        assert.strictEqual(failed.length, 1)
+        const failedItem = JSON.parse(failed[0])
+        assert.strictEqual(failedItem.id, id)
+        assert.deepStrictEqual(failedItem.element, { n: 42 })
+        assert.strictEqual(failedItem.attempts, 1)
+
+        const pending = yield* redis.use((client) => client.hlen(`effectq:${queueName}:pending`))
+        assert.strictEqual(pending, 0)
+      }))
+  }
+)
+
+const RedisItem = Schema.Struct({
+  n: Schema.Number
+})

--- a/packages/platform-deno/test/DenoRedis.test.ts
+++ b/packages/platform-deno/test/DenoRedis.test.ts
@@ -114,12 +114,36 @@ it.effect("uses the URL username for two-argument AUTH", () =>
 
     const port = (listener.addr as Deno.NetAddr).port
     yield* Layer.build(DenoRedis.layer({
-      url: `redis://alice:secret@127.0.0.1:${port}`
+      url: `redis://alice:secret@127.0.0.1:${port}`,
+      password: undefined
     }))
 
     assert.strictEqual(
       yield* Fiber.join(server),
       "*3\r\n$4\r\nAUTH\r\n$5\r\nalice\r\n$6\r\nsecret\r\n"
+    )
+  })))
+
+it.effect("prefers explicit credentials over URL credentials", () =>
+  Effect.scoped(Effect.gen(function*() {
+    const listener = yield* makeListener
+    const server = yield* Effect.gen(function*() {
+      const connection = yield* accept(listener)
+      const request = yield* read(connection)
+      yield* write(connection, "+OK\r\n")
+      return request
+    }).pipe(Effect.forkChild)
+
+    const port = (listener.addr as Deno.NetAddr).port
+    yield* Layer.build(DenoRedis.layer({
+      url: `redis://alice:secret@127.0.0.1:${port}`,
+      username: "bob",
+      password: "other"
+    }))
+
+    assert.strictEqual(
+      yield* Fiber.join(server),
+      "*3\r\n$4\r\nAUTH\r\n$3\r\nbob\r\n$5\r\nother\r\n"
     )
   })))
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,6 +468,9 @@ importers:
 
   packages/platform-deno:
     dependencies:
+      '@db/redis':
+        specifier: jsr:^0.41.2
+        version: '@jsr/db__redis@0.41.2'
       '@std/path':
         specifier: jsr:^1.1.6
         version: '@jsr/std__path@1.1.6'
@@ -475,6 +478,9 @@ importers:
       '@std/assert':
         specifier: jsr:^1.0.16
         version: '@jsr/std__assert@1.0.19'
+      '@testcontainers/redis':
+        specifier: ^11.14.0
+        version: 11.14.0
       '@types/deno':
         specifier: ^2.7.0
         version: 2.7.0
@@ -2321,14 +2327,35 @@ packages:
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
 
+  '@jsr/db__redis@0.41.2':
+    resolution: {integrity: sha512-pDHlF3sQaU5+VDwDH3jRkETBSD9gAIqdoaC3j0B4nrffr+H/Kh0Pbw7i/p5eD+9W5j38l8yRqZGbo4xgohYttg==, tarball: https://npm.jsr.io/~/11/@jsr/db__redis/0.41.2.tgz}
+
   '@jsr/std__assert@1.0.19':
     resolution: {integrity: sha512-pEj6RPkGbqlgRmyKwATp4cUs6+ijxtdrv3bq8v1d2I2CEcMEyPaO8cVKro61wGRDH4cNg8Zx6haztvK/9m7gkA==, tarball: https://npm.jsr.io/~/11/@jsr/std__assert/1.0.19.tgz}
+
+  '@jsr/std__async@1.5.0':
+    resolution: {integrity: sha512-I2Qekl1oQYM+dpI2RQUCKi1TBuaA7Od3LNzxcqls9s1e2ytiZyREL4403qHJ6UbLNAwbqO2ZhdWAWDUQAajyiA==, tarball: https://npm.jsr.io/~/11/@jsr/std__async/1.5.0.tgz}
+
+  '@jsr/std__bytes@1.0.6':
+    resolution: {integrity: sha512-St6yKggjFGhxS52IFLJWvkchRFbAKg2Xh8UxA4S1EGz7GJ2Ui+ssDDldj/w2c8vCxvl6qgR0HaYbKeFJNqujmA==, tarball: https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.6.tgz}
+
+  '@jsr/std__collections@1.3.0':
+    resolution: {integrity: sha512-oJ5V5ZvsWyO5VLdGk3TaRHaVibfVKHvDC8KJdgmxIucHN2QzAXlMt36ApyTUBncfrhXdN/5Q3yMNvloAKym8RA==, tarball: https://npm.jsr.io/~/11/@jsr/std__collections/1.3.0.tgz}
+
+  '@jsr/std__data-structures@1.1.1':
+    resolution: {integrity: sha512-ceWGRdAPq3oD2If4k/JvgL/bskN5VohnM6wINlJhYLz4yCW9cmHFcGsrhRgh9HbD9xhXi9sEQoiHQG5B9caHEg==, tarball: https://npm.jsr.io/~/11/@jsr/std__data-structures/1.1.1.tgz}
 
   '@jsr/std__internal@1.0.14':
     resolution: {integrity: sha512-JT8b/t40WcR9q0GDwRZUooY7aXeXnFal8iidE/5TckdAFtvpVAsaJ71/Xgf1SfoChs41s6CZkuCYM8toaNgdvA==, tarball: https://npm.jsr.io/~/11/@jsr/std__internal/1.0.14.tgz}
 
+  '@jsr/std__io@0.224.5':
+    resolution: {integrity: sha512-1Y8ZWIjFiQKkaSJwbt7NM/9esDtO0ieKS4vcT929dFArG2ADk7ZKVAV4KluYYh4+kF5VgkOcvJkEm84KeBpqFA==, tarball: https://npm.jsr.io/~/11/@jsr/std__io/0.224.5.tgz}
+
   '@jsr/std__path@1.1.6':
     resolution: {integrity: sha512-H1Cmg6z8jFyIsQbVV+vZB4eOx4k6Qg8lyUM6l7nZysj5MZumg89kb0M1bsPBTGQis3fw6mJFkJELo5+AK6oCFA==, tarball: https://npm.jsr.io/~/11/@jsr/std__path/1.1.6.tgz}
+
+  '@jsr/std__random@0.1.0':
+    resolution: {integrity: sha512-gt+pI83ha04zLv2+5kSf/i6uPT4c8QEwscpATrYe2IKfOkCVpL++NrFcH7pWHc0vgm2fDGC8aY6OI2Mz7tEHhQ==, tarball: https://npm.jsr.io/~/11/@jsr/std__random/0.1.0.tgz}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -3837,6 +3864,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  cluster-key-slot@1.1.0:
+    resolution: {integrity: sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==}
+    engines: {node: '>=0.10.0'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -8171,15 +8202,42 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
+  '@jsr/db__redis@0.41.2':
+    dependencies:
+      '@jsr/std__async': 1.5.0
+      '@jsr/std__bytes': 1.0.6
+      '@jsr/std__collections': 1.3.0
+      '@jsr/std__io': 0.224.5
+      '@jsr/std__random': 0.1.0
+      cluster-key-slot: 1.1.0
+
   '@jsr/std__assert@1.0.19':
     dependencies:
       '@jsr/std__internal': 1.0.14
 
+  '@jsr/std__async@1.5.0':
+    dependencies:
+      '@jsr/std__data-structures': 1.1.1
+
+  '@jsr/std__bytes@1.0.6': {}
+
+  '@jsr/std__collections@1.3.0': {}
+
+  '@jsr/std__data-structures@1.1.1':
+    dependencies:
+      '@jsr/std__assert': 1.0.19
+
   '@jsr/std__internal@1.0.14': {}
+
+  '@jsr/std__io@0.224.5':
+    dependencies:
+      '@jsr/std__bytes': 1.0.6
 
   '@jsr/std__path@1.1.6':
     dependencies:
       '@jsr/std__internal': 1.0.14
+
+  '@jsr/std__random@0.1.0': {}
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -9697,6 +9755,8 @@ snapshots:
       shallow-clone: 3.0.1
 
   clone@1.0.4: {}
+
+  cluster-key-slot@1.1.0: {}
 
   cluster-key-slot@1.1.2: {}
 


### PR DESCRIPTION
## Summary

- add a scoped Deno Redis integration backed by `@db/redis`
- support URL-based and explicit connection options
- mirror Redis persistence and queue integration coverage under Deno

## Testing

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter @effect/platform-deno check`
- `deno task test --run packages/platform-deno/test/DenoRedis.test.ts`

Closes EFF-151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Redis integration for Deno applications via new `DenoRedis` support.
  * Configure Redis using a URL or explicit connection details (explicit credentials override URL) via `layer` and `layerConfig`.
  * Enables Redis-backed cache and queue persistence with improved error handling.
* **Bug Fixes**
  * Improved queue failure handling by moving exhausted items to the failed queue.
* **Tests**
  * Added Deno Redis integration coverage for cache/queue persistence, connection lifecycle, and correct `AUTH` credential behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->