### PR TITLE
Allow enabling websocket compression in NodeHttpServer and BunHttpServer

### DIFF
--- a/.changeset/http-server-websocket-options.md
+++ b/.changeset/http-server-websocket-options.md
@@ -1,0 +1,24 @@
+---
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+---
+
+Allow configuring the WebSocket server in `NodeHttpServer` and `BunHttpServer`.
+
+The HTTP server layers previously hardcoded their WebSocket wiring — `NodeHttpServer` always constructed `new WebSocketServer({ noServer: true })`, and `BunHttpServer` overwrote any `websocket` key in the serve options with its own handlers. There was no way to enable `permessage-deflate` compression (which browsers offer on every connection) or tune payload limits.
+
+Both servers now accept a `websocket` option that is forwarded to the underlying implementation, with the wiring/lifecycle options the server manages excluded from the type:
+
+```ts
+// Node: forwarded to the `ws` WebSocketServer
+NodeHttpServer.layer(() => createServer(), {
+  port: 3000,
+  websocket: { perMessageDeflate: true }
+})
+
+// Bun: merged into Bun.serve's websocket handler
+BunHttpServer.layer({
+  port: 3000,
+  websocket: { perMessageDeflate: true }
+})
+```

--- a/.changeset/http-server-websocket-options.md
+++ b/.changeset/http-server-websocket-options.md
@@ -5,8 +5,6 @@
 
 Allow configuring the WebSocket server in `NodeHttpServer` and `BunHttpServer`.
 
-The HTTP server layers previously hardcoded their WebSocket wiring — `NodeHttpServer` always constructed `new WebSocketServer({ noServer: true })`, and `BunHttpServer` overwrote any `websocket` key in the serve options with its own handlers. There was no way to enable `permessage-deflate` compression (which browsers offer on every connection) or tune payload limits.
-
 Both servers now accept a `websocket` option that is forwarded to the underlying implementation, with the wiring/lifecycle options the server manages excluded from the type:
 
 ```ts

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -67,6 +67,25 @@ export type ServeOptions<R extends string> =
   & { readonly routes?: Bun.Serve.Routes<WebSocketContext, R> }
 
 /**
+ * WebSocket tuning options forwarded to `Bun.serve`'s `websocket` handler.
+ *
+ * **Details**
+ *
+ * The lifecycle handlers (`open`, `message`, `close`, ...) are managed by the
+ * server and cannot be overridden; everything else — such as
+ * `perMessageDeflate` compression, payload limits, and idle timeouts — passes
+ * through, e.g.
+ * `BunHttpServer.layer({ port: 3000, websocket: { perMessageDeflate: true } })`.
+ *
+ * @category options
+ * @since 4.0.0
+ */
+export type WebSocketOptions = Omit<
+  Bun.WebSocketHandler<WebSocketContext>,
+  "open" | "message" | "close" | "drain" | "ping" | "pong" | "data"
+>
+
+/**
  * Creates a scoped Bun `HttpServer` from `Bun.serve` options, stopping the server on scope finalization with optional graceful shutdown settings.
  *
  * @category constructors
@@ -77,6 +96,7 @@ export const make = Effect.fnUntraced(
     options: ServeOptions<R> & {
       readonly disablePreemptiveShutdown?: boolean | undefined
       readonly gracefulShutdownTimeout?: Duration.Input | undefined
+      readonly websocket?: WebSocketOptions | undefined
     }
   ) {
     const scope = yield* Effect.scope
@@ -90,6 +110,7 @@ export const make = Effect.fnUntraced(
       ...options as ServeOptions<R>,
       fetch: handlerStack[0],
       websocket: {
+        ...options.websocket,
         open(ws) {
           Deferred.doneUnsafe(ws.data.deferred, Exit.succeed(ws))
         },
@@ -233,6 +254,7 @@ export const layerServer: <R extends string>(
   options: ServeOptions<R> & {
     readonly disablePreemptiveShutdown?: boolean | undefined
     readonly gracefulShutdownTimeout?: Duration.Input | undefined
+    readonly websocket?: WebSocketOptions | undefined
   }
 ) => Layer.Layer<Server.HttpServer> = flow(make, Layer.effect(Server.HttpServer)) as any
 
@@ -262,6 +284,7 @@ export const layer = <R extends string>(
   options: ServeOptions<R> & {
     readonly disablePreemptiveShutdown?: boolean | undefined
     readonly gracefulShutdownTimeout?: Duration.Input | undefined
+    readonly websocket?: WebSocketOptions | undefined
   }
 ): Layer.Layer<
   | Server.HttpServer
@@ -296,6 +319,7 @@ export const layerConfig = <R extends string>(
     ServeOptions<R> & {
       readonly disablePreemptiveShutdown?: boolean | undefined
       readonly gracefulShutdownTimeout?: Duration.Input | undefined
+      readonly websocket?: WebSocketOptions | undefined
     }
   >
 ): Layer.Layer<

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -82,7 +82,7 @@ export type ServeOptions<R extends string> =
  */
 export type WebSocketOptions = Omit<
   Bun.WebSocketHandler<WebSocketContext>,
-  "open" | "message" | "close" | "drain" | "ping" | "pong" | "data"
+  "open" | "message" | "close" | "drain" | "ping" | "pong" | "data" | "binaryType"
 >
 
 /**

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -63,6 +63,27 @@ import * as NodeServices from "./NodeServices.ts"
 import { NodeWS } from "./NodeSocket.ts"
 
 /**
+ * Options accepted by the Node `HttpServer` constructors and layers.
+ *
+ * **Details**
+ *
+ * `websocket` is forwarded to the underlying `ws` `WebSocketServer`, minus the
+ * wiring options the server manages itself. Use it to enable
+ * `permessage-deflate` compression or tune payload limits, e.g.
+ * `NodeHttpServer.layer(() => createServer(), { port: 3000, websocket: { perMessageDeflate: true } })`.
+ *
+ * @category options
+ * @since 4.0.0
+ */
+export interface Options extends Net.ListenOptions {
+  readonly disablePreemptiveShutdown?: boolean | undefined
+  readonly gracefulShutdownTimeout?: Duration.Input | undefined
+  readonly websocket?:
+    | Omit<NodeWS.ServerOptions, "noServer" | "server" | "host" | "port" | "path">
+    | undefined
+}
+
+/**
  * Creates a scoped `HttpServer` from a Node `http.Server`, starts listening
  * with the supplied options, registers request and upgrade handling, and closes
  * the server during scope finalization with optional graceful-shutdown control.
@@ -72,10 +93,7 @@ import { NodeWS } from "./NodeSocket.ts"
  */
 export const make = Effect.fnUntraced(function*(
   evaluate: LazyArg<Http.Server>,
-  options: Net.ListenOptions & {
-    readonly disablePreemptiveShutdown?: boolean | undefined
-    readonly gracefulShutdownTimeout?: Duration.Input | undefined
-  }
+  options: Options
 ) {
   const scope = yield* Effect.scope
   const server = evaluate()
@@ -116,7 +134,7 @@ export const make = Effect.fnUntraced(function*(
   const address = server.address()!
 
   const wss = yield* Effect.acquireRelease(
-    Effect.sync(() => new NodeWS.WebSocketServer({ noServer: true })),
+    Effect.sync(() => new NodeWS.WebSocketServer({ ...options.websocket, noServer: true })),
     (wss) =>
       Effect.callback<void>((resume) => {
         wss.close(() => resume(Effect.void))
@@ -397,10 +415,7 @@ class ServerRequestImpl extends NodeHttpIncomingMessage<HttpServerError> impleme
  */
 export const layerServer: (
   evaluate: LazyArg<Http.Server<typeof Http.IncomingMessage, typeof Http.ServerResponse>>,
-  options: Net.ListenOptions & {
-    readonly disablePreemptiveShutdown?: boolean | undefined
-    readonly gracefulShutdownTimeout?: Duration.Input | undefined
-  }
+  options: Options
 ) => Layer.Layer<HttpServer.HttpServer, ServeError> = flow(make, Layer.effect(HttpServer.HttpServer))
 
 /**
@@ -427,10 +442,7 @@ export const layerHttpServices: Layer.Layer<
  */
 export const layer = (
   evaluate: LazyArg<Http.Server>,
-  options: Net.ListenOptions & {
-    readonly disablePreemptiveShutdown?: boolean | undefined
-    readonly gracefulShutdownTimeout?: Duration.Input | undefined
-  }
+  options: Options
 ): Layer.Layer<
   HttpServer.HttpServer | NodeServices.NodeServices | HttpPlatform.HttpPlatform | Etag.Generator,
   ServeError
@@ -450,12 +462,7 @@ export const layer = (
  */
 export const layerConfig = (
   evaluate: LazyArg<Http.Server>,
-  options: Config.Wrap<
-    Net.ListenOptions & {
-      readonly disablePreemptiveShutdown?: boolean | undefined
-      readonly gracefulShutdownTimeout?: Duration.Input | undefined
-    }
-  >
+  options: Config.Wrap<Options>
 ): Layer.Layer<
   HttpServer.HttpServer | NodeServices.NodeServices | HttpPlatform.HttpPlatform | Etag.Generator,
   ServeError | Config.ConfigError

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -65,19 +65,18 @@ import { NodeWS } from "./NodeSocket.ts"
 /**
  * Options accepted by the Node `HttpServer` constructors and layers.
  *
- * **Details**
- *
- * `websocket` is forwarded to the underlying `ws` `WebSocketServer`, minus the
- * wiring options the server manages itself. Use it to enable
- * `permessage-deflate` compression or tune payload limits, e.g.
- * `NodeHttpServer.layer(() => createServer(), { port: 3000, websocket: { perMessageDeflate: true } })`.
- *
  * @category options
  * @since 4.0.0
  */
 export interface Options extends Net.ListenOptions {
   readonly disablePreemptiveShutdown?: boolean | undefined
   readonly gracefulShutdownTimeout?: Duration.Input | undefined
+  /**
+   * Options forwarded to the underlying `ws` `WebSocketServer`, minus the
+   * wiring options the server manages itself. Use this to enable
+   * `permessage-deflate` compression or tune payload limits, e.g.
+   * `websocket: { perMessageDeflate: true }`.
+   */
   readonly websocket?:
     | Omit<NodeWS.ServerOptions, "noServer" | "server" | "host" | "port" | "path">
     | undefined

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -1,5 +1,6 @@
 /** @effect-diagnostics preferSchemaOverJson:skip-file */
 import { NodeHttpServer } from "@effect/platform-node"
+import { NodeWS } from "@effect/platform-node/NodeSocket"
 import { assert, describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as Duration from "effect/Duration"
@@ -673,7 +674,57 @@ describe("HttpServer", () => {
       )
       expect(root).toEqual("root")
     }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+
+  it.effect("websocket options are forwarded to the WebSocketServer", () =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add(
+        "GET",
+        "/ws",
+        Effect.gen(function*() {
+          const request = yield* HttpServerRequest.HttpServerRequest
+          const socket = yield* Effect.orDie(request.upgrade)
+          yield* Effect.orDie(socket.run(() => Effect.void))
+          return HttpServerResponse.empty()
+        })
+      ).pipe(
+        HttpRouter.serve,
+        Layer.build
+      )
+      const server = yield* HttpServer.HttpServer
+      const port = (server.address as HttpServer.TcpAddress).port
+
+      const connect = (perMessageDeflate: boolean) =>
+        Effect.acquireRelease(
+          Effect.callback<NodeWS.WebSocket, Error>((resume) => {
+            const ws = new NodeWS.WebSocket(`ws://127.0.0.1:${port}/ws`, { perMessageDeflate })
+            ws.on("open", () => resume(Effect.succeed(ws)))
+            ws.on("error", (error) => resume(Effect.fail(error)))
+          }),
+          (ws) => Effect.sync(() => ws.close())
+        )
+
+      // layerTest configures websocket: { perMessageDeflate: true }, so the
+      // server accepts the extension when the client offers it...
+      const compressed = yield* connect(true)
+      expect(compressed.extensions).toContain("permessage-deflate")
+
+      // ...and clients that do not offer it still connect uncompressed.
+      const plain = yield* connect(false)
+      expect(plain.extensions).not.toContain("permessage-deflate")
+    }).pipe(Effect.scoped, Effect.provide(layerTestWebsocket)))
 })
+
+const layerTestWebsocket = HttpServer.layerTestClient.pipe(
+  Layer.provide(
+    Layer.fresh(FetchHttpClient.layer).pipe(
+      Layer.provide(Layer.succeed(FetchHttpClient.RequestInit)({ keepalive: false }))
+    )
+  ),
+  Layer.provideMerge(NodeHttpServer.layer(Http.createServer, {
+    port: 0,
+    websocket: { perMessageDeflate: true }
+  }))
+)
 
 const tcpPort = (server: Http.Server): number => {
   const address = server.address()


### PR DESCRIPTION
tl;dr - I want to add compression to websockets in T3 Code. It will [help cut data transferred on T3 Code by as much as 80%](https://github.com/pingdotgg/t3code/pull/4705)

Happy to talk more about this. Figured the patch was simple enough to file a PR quick - no hard feelings if this gets closed :)

---- FROM HERE DOWN IS AI SLOP ----

Browsers offer `permessage-deflate` on every WebSocket connection, but an Effect HTTP server has no way to accept it. `NodeHttpServer` hardcodes `new WebSocketServer({ noServer: true })`, and `BunHttpServer` overwrites any `websocket` key in the serve options with its own handlers — so there is no way to enable compression or tune payload limits without patching the packages.

For apps streaming JSON over websockets this leaves a lot on the table: measured on real production traffic (small ~500B-1KB frames with repeated keys and UUIDs, raw TCP byte counts), accepting `permessage-deflate` with context takeover cuts wire bytes by **4x**.

## Solution

Both servers accept an optional `websocket` field in their existing options, forwarded to the underlying implementation. The wiring/lifecycle options the server manages (`noServer`, `open`/`message`/`close`, etc.) are excluded from the type so they cannot be overridden.

```ts
// Node: forwarded to the ws WebSocketServer
NodeHttpServer.layer(() => createServer(), {
  port: 3000,
  websocket: { perMessageDeflate: true }
})

// Bun: merged into Bun.serve's websocket handler
BunHttpServer.layer({
  port: 3000,
  websocket: { perMessageDeflate: true }
})
```

Omitting the option keeps today's behavior exactly; clients that don't offer the extension keep uncompressed frames on their connection.

Includes a test asserting the server accepts `permessage-deflate` when configured and offered, and that clients not offering it still connect uncompressed. `tsc -b` on both packages, oxlint, dprint, and jsdocs are clean; a changeset is included.

🤖 Drafted with [Claude Code](https://claude.com/claude-code) (Fable 5), reviewed and filed by a human.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable `websocket` option to both Node.js and Bun HTTP servers.
  * Enables forwarding WebSocket configuration (for example, per-message deflate settings) while keeping connection lifecycle behavior managed by the servers.
* **Bug Fixes**
  * Preserved and applied user-provided WebSocket settings instead of overriding them with fixed defaults.
* **Tests**
  * Added coverage to verify WebSocket option forwarding, including per-message compression behavior.  
* **Documentation**
  * Updated release documentation with usage examples for Node.js and Bun.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->