### PR TITLE
Fix CLI end-of-options operands for subcommands

### DIFF
--- a/.changeset/quiet-clis-parse.md
+++ b/.changeset/quiet-clis-parse.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix unstable CLI subcommands dropping operands after the `--` end-of-options terminator.

--- a/packages/effect/src/unstable/cli/internal/parser.ts
+++ b/packages/effect/src/unstable/cli/internal/parser.ts
@@ -84,7 +84,7 @@ export const parseArgs = (
       }
     }
 
-    const subLex: LexResult = { tokens: result.childTokens, trailingOperands: [] }
+    const subLex: LexResult = { tokens: result.childTokens, trailingOperands: afterEndOfOptions }
     const subParsed = yield* parseArgs(
       subLex,
       result.sub,
@@ -94,7 +94,7 @@ export const parseArgs = (
     const allErrors = [...result.errors, ...(subParsed.errors ?? [])]
     return {
       flags: result.flags,
-      arguments: afterEndOfOptions,
+      arguments: [],
       subcommand: Option.some({ name: result.sub.name, parsedInput: subParsed }),
       ...(allErrors.length > 0 && { errors: allErrors })
     }

--- a/packages/effect/test/unstable/cli/Command.test.ts
+++ b/packages/effect/test/unstable/cli/Command.test.ts
@@ -1289,6 +1289,100 @@ describe("Command", () => {
         assert.deepStrictEqual(captured, [["child", "--value", "x"]])
       }).pipe(Effect.provide(TestLayer)))
 
+    it.effect("should pass trailing operands to the selected subcommand", () =>
+      Effect.gen(function*() {
+        const captured: Array<ReadonlyArray<string>> = []
+
+        const child = Command.make("child", {
+          values: Argument.string("value").pipe(Argument.variadic())
+        }, ({ values }) => Effect.sync(() => captured.push(values)))
+
+        const cli = Command.make("tool").pipe(Command.withSubcommands([child]))
+
+        yield* Command.runWith(cli, { version: "1.0.0" })([
+          "child",
+          "--",
+          "value",
+          "--literal",
+          "-x"
+        ])
+
+        assert.deepStrictEqual(captured, [["value", "--literal", "-x"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should pass trailing operands through nested subcommands", () =>
+      Effect.gen(function*() {
+        const captured: Array<string> = []
+
+        const child = Command.make("child", {
+          value: Argument.string("value")
+        }, ({ value }) => Effect.sync(() => captured.push(value)))
+        const group = Command.make("group").pipe(Command.withSubcommands([child]))
+        const cli = Command.make("tool").pipe(Command.withSubcommands([group]))
+
+        yield* Command.runWith(cli, { version: "1.0.0" })(["group", "child", "--", "-literal"])
+
+        assert.deepStrictEqual(captured, ["-literal"])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should allow no trailing operands after -- for a subcommand", () =>
+      Effect.gen(function*() {
+        let invoked = false
+
+        const child = Command.make("child", {}, () =>
+          Effect.sync(() => {
+            invoked = true
+          }))
+        const cli = Command.make("tool").pipe(Command.withSubcommands([child]))
+
+        yield* Command.runWith(cli, { version: "1.0.0" })(["child", "--"])
+
+        assert.isTrue(invoked)
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should preserve trailing operands for a leaf command", () =>
+      Effect.gen(function*() {
+        const captured: Array<ReadonlyArray<string>> = []
+
+        const command = Command.make("tool", {
+          values: Argument.string("value").pipe(Argument.variadic())
+        }, ({ values }) => Effect.sync(() => captured.push(values)))
+
+        yield* Command.runWith(command, { version: "1.0.0" })(["--", "--literal", "-x"])
+
+        assert.deepStrictEqual(captured, [["--literal", "-x"]])
+      }).pipe(Effect.provide(TestLayer)))
+
+    it.effect("should preserve inherited flags around a subcommand with trailing operands", () =>
+      Effect.gen(function*() {
+        const captured: Array<{ before: boolean; after: boolean; value: string }> = []
+
+        const root = Command.make("tool").pipe(
+          Command.withSharedFlags({
+            before: Flag.boolean("before"),
+            after: Flag.boolean("after")
+          })
+        )
+        const child = Command.make("child", {
+          value: Argument.string("value")
+        }, ({ value }) =>
+          Effect.gen(function*() {
+            const parent = yield* root
+            captured.push({ before: parent.before, after: parent.after, value })
+          }))
+        const cli = root.pipe(Command.withSubcommands([child]))
+
+        yield* Command.runWith(cli, { version: "1.0.0" })([
+          "--before",
+          "child",
+          "--after",
+          "--",
+          "-literal"
+        ])
+
+        assert.deepStrictEqual(captured, [{ before: true, after: true, value: "-literal" }])
+      }).pipe(Effect.provide(TestLayer)))
+
     it.effect("should coerce boolean flags to false when given falsey literals", () =>
       Effect.gen(function*() {
         const captured: Array<boolean> = []


### PR DESCRIPTION
## Why

When an `effect/unstable/cli` subcommand is active, operands after the `--` end-of-options terminator are currently attached to the parent parse record. The child therefore reports required positionals as missing and never receives flag-like operands.

## What

Forward `trailingOperands` through recursive subcommand parsing so the innermost active command receives them, while leaving the parent positional list empty. Add regression coverage and a patch changeset for `effect`.

## Rationale

`scanCommandLevel` can select a subcommand only while awaiting the first positional value. Once a positional is collected, the parser switches permanently to argument collection, so a `Sub` result cannot contain parent positional arguments. This makes `arguments: []` the correct parent representation; the terminator operands belong to the recursively selected child. Forwarding the same list through each recursive level also preserves the rule for multi-level nesting.

## Tests

Added coverage for:

- single-level subcommands with several trailing operands, including `--literal` and `-x`
- multi-level subcommands
- an empty trailing operand list
- leaf-command behavior
- variadic child positionals
- inherited flags both before and after the subcommand name

Before the parser change, the focused regression selection failed 3 tests while both control cases passed. After the change, all 5 focused cases pass, and the full `Command.test.ts` file passes 90/90. `pnpm lint-fix`, `pnpm check`, `pnpm build`, and `pnpm docgen` also pass locally.

Closes #6690

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-scarp |
| `agent_session_id` | 6b78e583-eb90-415e-8bcb-c4fc342cb179 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ph8rlhdj25mg71v81jsfzy6dq4xpcs9m-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/lsykz8x5481xrpbgk280xh3pypk1c5jy-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect/schickling-assistant/2026-07-28-fix-cli-nested-end-of-options |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@3649b53 |
</details>
<!-- agent-footer:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CLI parsing so operands after `--` are preserved instead of being dropped.
  - Ensured these operands are correctly passed to selected and nested subcommands.
  - Preserved trailing operands for commands with variadic positional arguments.
  - Parent command flags continue to apply when `--` is used, including without trailing operands.

- **Tests**
  - Added coverage for `--` handling across subcommands, nested commands, and leaf commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->