### PR TITLE
Add HttpClient tracer header filter

### DIFF
--- a/.changeset/add-http-client-tracer-header-filter.md
+++ b/.changeset/add-http-client-tracer-header-filter.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add a configurable filter for HTTP client request and response header span attributes.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -690,7 +690,7 @@ export const make = (
             const headerFilter = fiber.getRef(TracerHeaderFilter)
             const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames)
             for (const name in redactedHeaders) {
-              if (!headerFilter(name)) continue
+              if (!headerFilter(name, "request")) continue
               span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]))
             }
             request = fiber.getRef(TracerPropagationEnabled)
@@ -704,7 +704,7 @@ export const make = (
                     span.attribute("http.response.status_code", response.status)
                     const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames)
                     for (const name in redactedHeaders) {
-                      if (!headerFilter(name)) continue
+                      if (!headerFilter(name, "response")) continue
                       span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]))
                     }
 

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -687,8 +687,10 @@ export const make = (
               span.attribute("url.query", query)
             }
             const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames)
+            const headerFilter = fiber.getRef(TracerHeaderFilter)
             const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames)
             for (const name in redactedHeaders) {
+              if (!headerFilter(name)) continue
               span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]))
             }
             request = fiber.getRef(TracerPropagationEnabled)
@@ -702,6 +704,7 @@ export const make = (
                     span.attribute("http.response.status_code", response.status)
                     const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames)
                     for (const name in redactedHeaders) {
+                      if (!headerFilter(name)) continue
                       span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]))
                     }
 
@@ -1506,6 +1509,18 @@ export const TracerDisabledWhen = Context.Reference<
   Predicate.Predicate<HttpClientRequest.HttpClientRequest>
 >("effect/http/HttpClient/TracerDisabledWhen", {
   defaultValue: () => constFalse
+})
+
+/**
+ * Context reference for filtering request and response headers added to client spans.
+ *
+ * @category references
+ * @since 4.0.0
+ */
+export const TracerHeaderFilter = Context.Reference<
+  Predicate.Predicate<string>
+>("effect/http/HttpClient/TracerHeaderFilter", {
+  defaultValue: () => constTrue
 })
 
 /**

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -1518,7 +1518,7 @@ export const TracerDisabledWhen = Context.Reference<
  * @since 4.0.0
  */
 export const TracerHeaderFilter = Context.Reference<
-  Predicate.Predicate<string>
+  (headerName: string, phase: "request" | "response") => boolean
 >("effect/http/HttpClient/TracerHeaderFilter", {
   defaultValue: () => constTrue
 })

--- a/packages/effect/test/unstable/http/HttpClient.test.ts
+++ b/packages/effect/test/unstable/http/HttpClient.test.ts
@@ -107,6 +107,38 @@ describe("HttpClient", () => {
         assert.strictEqual(clientSpan.attributes.get("http.response.header.x-response-drop"), undefined)
         assert.strictEqual(clientSpan.attributes.get("http.response.header.x-response-keep"), "keep")
       }))
+
+    it.effect("filters the same header name independently by phase", () =>
+      Effect.gen(function*() {
+        let clientSpan: Tracer.NativeSpan | undefined
+        const tracer = Tracer.make({
+          span(options) {
+            clientSpan = new Tracer.NativeSpan(options)
+            return clientSpan
+          }
+        })
+        const client = HttpClient.make((request) =>
+          Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(null, {
+                headers: { "x-phase-filter": "response" }
+              })
+            )
+          )
+        )
+
+        yield* client.get("http://test/", {
+          headers: { "x-phase-filter": "request" }
+        }).pipe(
+          Effect.provideService(HttpClient.TracerHeaderFilter, (_name, phase) => phase === "response"),
+          Effect.provideService(Tracer.Tracer, tracer)
+        )
+
+        assert(clientSpan !== undefined)
+        assert.strictEqual(clientSpan.attributes.get("http.request.header.x-phase-filter"), undefined)
+        assert.strictEqual(clientSpan.attributes.get("http.response.header.x-phase-filter"), "response")
+      }))
   })
 
   describe("followRedirects", () => {

--- a/packages/effect/test/unstable/http/HttpClient.test.ts
+++ b/packages/effect/test/unstable/http/HttpClient.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
 import { Clock, Duration, Effect, Fiber, Layer, Ref, Stream } from "effect"
 import { TestClock } from "effect/testing"
+import * as Tracer from "effect/Tracer"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { RateLimiter } from "effect/unstable/persistence"
 
@@ -37,6 +38,77 @@ const makeRedirectClient = Effect.fnUntraced(function*(status: number, location:
 const RateLimiterTestLayer = RateLimiter.layer.pipe(Layer.provide(RateLimiter.layerStoreMemory))
 
 describe("HttpClient", () => {
+  describe("tracer", () => {
+    it.effect("includes request and response headers by default", () =>
+      Effect.gen(function*() {
+        let clientSpan: Tracer.NativeSpan | undefined
+        const tracer = Tracer.make({
+          span(options) {
+            clientSpan = new Tracer.NativeSpan(options)
+            return clientSpan
+          }
+        })
+        const client = HttpClient.make((request) =>
+          Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(null, {
+                headers: { "x-response-default": "response" }
+              })
+            )
+          )
+        )
+
+        yield* client.get("http://test/", {
+          headers: { "x-request-default": "request" }
+        }).pipe(Effect.provideService(Tracer.Tracer, tracer))
+
+        assert(clientSpan !== undefined)
+        assert.strictEqual(clientSpan.attributes.get("http.request.header.x-request-default"), "request")
+        assert.strictEqual(clientSpan.attributes.get("http.response.header.x-response-default"), "response")
+      }))
+
+    it.effect("filters request and response header span attributes", () =>
+      Effect.gen(function*() {
+        let clientSpan: Tracer.NativeSpan | undefined
+        const tracer = Tracer.make({
+          span(options) {
+            clientSpan = new Tracer.NativeSpan(options)
+            return clientSpan
+          }
+        })
+        const client = HttpClient.make((request) =>
+          Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(null, {
+                headers: {
+                  "x-response-drop": "drop",
+                  "x-response-keep": "keep"
+                }
+              })
+            )
+          )
+        )
+
+        yield* client.get("http://test/", {
+          headers: {
+            "x-request-drop": "drop",
+            "x-request-keep": "keep"
+          }
+        }).pipe(
+          Effect.provideService(HttpClient.TracerHeaderFilter, (name) => name.endsWith("-keep")),
+          Effect.provideService(Tracer.Tracer, tracer)
+        )
+
+        assert(clientSpan !== undefined)
+        assert.strictEqual(clientSpan.attributes.get("http.request.header.x-request-drop"), undefined)
+        assert.strictEqual(clientSpan.attributes.get("http.request.header.x-request-keep"), "keep")
+        assert.strictEqual(clientSpan.attributes.get("http.response.header.x-response-drop"), undefined)
+        assert.strictEqual(clientSpan.attributes.get("http.response.header.x-response-keep"), "keep")
+      }))
+  })
+
   describe("followRedirects", () => {
     it.effect("preserves credential headers on same-origin redirects", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Why

`HttpClient` currently emits every request and response header as a span attribute. Value redaction is configurable independently, but there is no way to control which header attributes are included.

Closes #6363.

## What

Add `HttpClient.TracerHeaderFilter`, a context reference that filters request and response header span attributes by normalized header name.

## How

The predicate defaults to `constTrue`, preserving current behavior. Both header attribute loops read the same predicate without mutating transmitted or received headers.

Tests cover unchanged default inclusion and selective suppression on both request and response paths.

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/unstable/http/HttpClient.test.ts`
- `pnpm test-types packages/effect/typetest/unstable/http/HttpClient.tst.ts`
- `pnpm check`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-flame |
| `agent_session_id` | 133b5d2a-3d5d-4f52-8f55-f12a834f6b13 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ph8rlhdj25mg71v81jsfzy6dq4xpcs9m-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/lsykz8x5481xrpbgk280xh3pypk1c5jy-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect/schickling-assistant/2026-07-28-httpclient-header-filter |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@3649b53 |
</details>
<!-- agent-footer:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable filtering for HTTP client request and response headers recorded as tracing span attributes.
  * Headers can now be selectively included while sensitive or unwanted headers remain excluded.
  * Existing behavior continues to record all headers by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->