### PR TITLE
Fix docgen source links for modules in nested directories

### DIFF
--- a/.changeset/fix-docgen-nested-source-links.md
+++ b/.changeset/fix-docgen-nested-source-links.md
@@ -1,0 +1,7 @@
+---
+"@effect/docgen": patch
+---
+
+Fix source links for modules in nested directories
+
+`[Source]` links in the generated markdown were built from only the file's base name, so modules in subdirectories of `srcDir` (e.g. `src/nested/File.ts`) linked one directory too high. Links now use the module's path relative to `srcDir`, matching how the markdown output paths are computed.

--- a/packages/tools/docgen/src/Printer.ts
+++ b/packages/tools/docgen/src/Printer.ts
@@ -141,7 +141,7 @@ const printOptionalSourceLink = (position?: Domain.Position) => {
     }
     const config = yield* Configuration.Configuration
     const source = yield* Parser.Source
-    const name = source.sourceFile.getBaseName()
+    const name = source.path.slice(1).join("/")
     return `\n\n[Source](${config.srcLink}${name}#L${position.line})`
   })
 }

--- a/packages/tools/docgen/test/Parser.test.ts
+++ b/packages/tools/docgen/test/Parser.test.ts
@@ -195,6 +195,46 @@ declare const foo: "foo"
 
 Since v1.0.0`
         )
+
+        yield* expectMarkdown(
+          Parser.parseModule,
+          `/**
+* This is the direct module.
+*
+* @since 1.0.0
+*/
+import * as assert from 'assert'
+
+/**
+ * This is the foo export.
+ *
+ * @since 1.0.0
+ */
+export const foo = 'foo'`,
+          `## test.ts overview
+
+This is the direct module.
+
+Since v1.0.0
+
+<!-- toc -->
+
+# utils
+
+## foo
+
+This is the foo export.
+
+**Signature**
+
+\`\`\`ts
+declare const foo: "foo"
+\`\`\`
+
+[Source](https://github.com/effect-ts/docgen/blob/main/src/test.ts#L13)
+
+Since v1.0.0`
+        )
       }))
 
     it.effect("should ignore non-JSDoc comments above JSDoc comments", () =>

--- a/packages/tools/docgen/test/Parser.test.ts
+++ b/packages/tools/docgen/test/Parser.test.ts
@@ -46,9 +46,9 @@ const makeSourcefile = (source: string | ast.SourceFile) => {
 
 const makeSource = (source: string | ast.SourceFile) => {
   const sourceFile = makeSourcefile(source)
-  const filename = sourceFile.getBaseName()
+  const segments = sourceFile.getFilePath().split("/").filter((segment) => segment.length > 0)
   return Parser.Source.of({
-    path: [filename],
+    path: ["src", ...segments],
     sourceFile
   })
 }
@@ -70,7 +70,7 @@ const expectMarkdown = Effect.fnUntraced(function*<E>(
     E,
     Parser.Source | Configuration.Configuration | Path.Path
   >,
-  sourceText: string,
+  sourceText: string | ast.SourceFile,
   expected: string,
   config?: Partial<Configuration.ConfigurationShape>
 ) {
@@ -146,6 +146,52 @@ declare const foo: "foo"
 \`\`\`
 
 [Source](https://github.com/effect-ts/docgen/blob/main/src/test.ts#L19)
+
+Since v1.0.0`
+        )
+      }))
+
+    it.effect("should include the path relative to the source directory in source links", () =>
+      Effect.gen(function*() {
+        yield* expectMarkdown(
+          Parser.parseModule,
+          project.createSourceFile(
+            "nested/test.ts",
+            `/**
+* This is the nested module.
+*
+* @since 1.0.0
+*/
+import * as assert from 'assert'
+
+/**
+ * This is the foo export.
+ *
+ * @since 1.0.0
+ */
+export const foo = 'foo'`
+          ),
+          `## test.ts overview
+
+This is the nested module.
+
+Since v1.0.0
+
+<!-- toc -->
+
+# utils
+
+## foo
+
+This is the foo export.
+
+**Signature**
+
+\`\`\`ts
+declare const foo: "foo"
+\`\`\`
+
+[Source](https://github.com/effect-ts/docgen/blob/main/src/nested/test.ts#L13)
 
 Since v1.0.0`
         )


### PR DESCRIPTION
## Summary

`[Source](...)` links in docgen's generated markdown are built from only the file's base name:

```ts
const name = source.sourceFile.getBaseName()
return `\n\n[Source](${config.srcLink}${name}#L${position.line})`
```

For modules in subdirectories of `srcDir` (e.g. `src/frida/FridaRpcClient.ts`), the link drops the subdirectory and points one level too high (`<srcLink>/FridaRpcClient.ts` instead of `<srcLink>/frida/FridaRpcClient.ts`), producing 404s.

This changes the printer to use the module's path relative to `srcDir` (`source.path.slice(1).join("/")`), which is the same convention `getModuleMarkdownOutputPath` already uses for the generated markdown file layout. Links for modules directly under `srcDir` are unchanged.

## Notes

- The `makeSource` test helper previously modeled `Source.path` as `[basename]`, which doesn't match production (`file.path.split(path.sep)` including the `srcDir` prefix). It now derives the path from the source file's actual file path with a `src` prefix, matching what `parseFile` produces.
- Added a regression test covering a module in a nested directory.

Noticed while adopting `@effect/docgen@4.0.0-beta.102` in a project with nested modules: https://github.com/leonitousconforti/efffrida/pull/158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated documentation **Source** links for modules in nested directories.
  - Source links now display and resolve the correct relative folder path and line reference instead of targeting the wrong directory level.

- **Tests**
  - Updated and expanded parser/docgen test coverage to ensure nested in-memory source files produce correctly formed **Source** links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->