### PR TITLE
Add options to Schema.fromJsonString

### DIFF
--- a/.changeset/internal-json-string-schema.md
+++ b/.changeset/internal-json-string-schema.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Mark `Schema.UnknownFromJsonString` as internal and remove its type-level interface. Use `Schema.fromJsonString(Schema.Unknown)` instead. Add `reviver`, `replacer`, and `space` options to `Schema.fromJsonString`, and make `SchemaTransformation.fromJsonString` a configurable factory.

--- a/.changeset/internal-json-string-schema.md
+++ b/.changeset/internal-json-string-schema.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Mark `Schema.UnknownFromJsonString` as internal and remove its type-level interface. Use `Schema.fromJsonString(Schema.Unknown)` instead. Add `reviver`, `replacer`, and `space` options to `Schema.fromJsonString`, and make `SchemaTransformation.fromJsonString` a configurable factory.
+Mark `Schema.UnknownFromJsonString` as internal and remove its type-level interface. Use `Schema.fromJsonString(Schema.Unknown)` instead. Add `reviver`, callback or array `replacer`, and `space` options to `Schema.fromJsonString`, and make `SchemaTransformation.fromJsonString` a configurable factory.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12415,7 +12415,7 @@ export function fromJsonString<S extends Constraint>(
   schema: S,
   options?: {
     readonly reviver?: Parameters<typeof JSON.parse>[1] | undefined
-    readonly replacer?: Parameters<typeof JSON.stringify>[1] | undefined
+    readonly replacer?: SchemaGetter.JsonReplacer | undefined
     readonly space?: Parameters<typeof JSON.stringify>[2] | undefined
   }
 ): fromJsonString<S> {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -12372,43 +12372,6 @@ const JsonString = String.annotate({
 })
 
 /**
- * Type-level representation of {@link UnknownFromJsonString}.
- *
- * @category models
- * @since 4.0.0
- */
-export interface UnknownFromJsonString extends fromJsonString<Unknown> {
-  readonly "Rebuild": UnknownFromJsonString
-}
-
-/**
- * Schema that decodes a JSON-encoded string into an `unknown` value.
- *
- * **Details**
- *
- * Decoding:
- * - A `string` is decoded as an `unknown` value.
- * - If the string is not valid JSON, decoding fails.
- *
- * Encoding:
- * - Any value is encoded as a JSON string using `JSON.stringify`.
- * - If the value is not a valid JSON value, encoding fails.
- *
- * **Example** (Decoding unknown JSON strings)
- *
- * ```ts
- * import { Schema } from "effect"
- *
- * Schema.decodeUnknownSync(Schema.UnknownFromJsonString)(`{"a":1,"b":2}`)
- * // => { a: 1, b: 2 }
- * ```
- *
- * @category schemas
- * @since 4.0.0
- */
-export const UnknownFromJsonString: UnknownFromJsonString = fromJsonString(Unknown)
-
-/**
  * Type-level representation returned by {@link fromJsonString}.
  *
  * @category models
@@ -12427,27 +12390,40 @@ export interface fromJsonString<S extends Constraint> extends decodeTo<S, String
  * This is useful when working with JSON-encoded strings where the actual
  * structure of the value is known and described by an existing schema.
  *
- * The resulting schema first parses the input string as JSON, and then runs the
- * provided schema on the parsed result.
+ * During decoding, the resulting schema first parses the input string as JSON,
+ * using `reviver` when provided, and then runs the provided schema on the
+ * parsed result. During encoding, it first encodes with the provided schema and
+ * then passes the result to `JSON.stringify` with the optional `replacer` and
+ * `space`.
  *
- * **Example** (Decoding JSON strings with a schema)
+ * **Example** (Formatting encoded JSON)
  *
  * ```ts
  * import { Schema } from "effect"
  *
  * const schema = Schema.Struct({ a: Schema.Number })
- * const schemaFromJsonString = Schema.fromJsonString(schema)
+ * const schemaFromJsonString = Schema.fromJsonString(schema, { space: 2 })
  *
- * Schema.decodeUnknownSync(schemaFromJsonString)(`{"a":1,"b":2}`)
- * // => { a: 1 }
+ * Schema.encodeSync(schemaFromJsonString)({ a: 1 })
+ * // => '{\n  "a": 1\n}'
  * ```
  *
  * @category constructors
  * @since 4.0.0
  */
-export function fromJsonString<S extends Constraint>(schema: S): fromJsonString<S> {
-  return JsonString.pipe(decodeTo(schema, SchemaTransformation.fromJsonString))
+export function fromJsonString<S extends Constraint>(
+  schema: S,
+  options?: {
+    readonly reviver?: Parameters<typeof JSON.parse>[1] | undefined
+    readonly replacer?: Parameters<typeof JSON.stringify>[1] | undefined
+    readonly space?: Parameters<typeof JSON.stringify>[2] | undefined
+  }
+): fromJsonString<S> {
+  return JsonString.pipe(decodeTo(schema, SchemaTransformation.fromJsonString(options)))
 }
+
+/** @internal */
+export const UnknownFromJsonString: fromJsonString<Unknown> = fromJsonString(Unknown)
 
 /**
  * Type-level representation of {@link File}.

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -999,8 +999,19 @@ export function parseJson<E extends string>(options?: ParseJsonOptions | undefin
   )
 }
 
+/**
+ * Replacer function or property allowlist accepted by `JSON.stringify`.
+ *
+ * @category JSON getters
+ * @since 4.0.0
+ */
+export type JsonReplacer =
+  | ((this: any, key: string, value: any) => any)
+  | Array<string | number>
+  | null
+
 type StringifyJsonOptions = {
-  readonly replacer?: Parameters<typeof JSON.stringify>[1]
+  readonly replacer?: JsonReplacer | undefined
   readonly space?: Parameters<typeof JSON.stringify>[2]
 }
 
@@ -1038,7 +1049,7 @@ export function stringifyJson(options?: StringifyJsonOptions): Getter<string, un
   return onSome((input) =>
     Effect.try({
       try: () => {
-        const output = JSON.stringify(input, options?.replacer, options?.space)
+        const output = JSON.stringify(input, options?.replacer as any, options?.space)
         if (output === undefined) {
           throw new TypeError("Value cannot be represented as JSON")
         }

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -1619,7 +1619,7 @@ export const stringFromUriComponent: Transformation<string, string> = new Transf
  */
 export function fromJsonString(options?: {
   readonly reviver?: Parameters<typeof JSON.parse>[1] | undefined
-  readonly replacer?: Parameters<typeof JSON.stringify>[1] | undefined
+  readonly replacer?: SchemaGetter.JsonReplacer | undefined
   readonly space?: Parameters<typeof JSON.stringify>[2] | undefined
 }): Transformation<unknown, string> {
   return new Transformation(

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -1596,8 +1596,10 @@ export const stringFromUriComponent: Transformation<string, string> = new Transf
  *
  * **Details**
  *
- * Decode fails with `InvalidValue` for invalid JSON, and encode can fail with
- * `InvalidValue` when `JSON.stringify` cannot serialize the value.
+ * The `reviver` option is passed to `JSON.parse` during decoding. The
+ * `replacer` and `space` options are passed to `JSON.stringify` during
+ * encoding. Decode fails with `InvalidValue` for invalid JSON, and encode can
+ * fail with `InvalidValue` when `JSON.stringify` cannot serialize the value.
  *
  * **Example** (Parsing JSON)
  *
@@ -1605,7 +1607,7 @@ export const stringFromUriComponent: Transformation<string, string> = new Transf
  * import { Schema, SchemaTransformation } from "effect"
  *
  * const schema = Schema.String.pipe(
- *   Schema.decodeTo(Schema.Unknown, SchemaTransformation.fromJsonString)
+ *   Schema.decodeTo(Schema.Unknown, SchemaTransformation.fromJsonString())
  * )
  * ```
  *
@@ -1615,10 +1617,16 @@ export const stringFromUriComponent: Transformation<string, string> = new Transf
  * @category decoding
  * @since 4.0.0
  */
-export const fromJsonString = new Transformation<unknown, string>(
-  SchemaGetter.parseJson(),
-  SchemaGetter.stringifyJson()
-)
+export function fromJsonString(options?: {
+  readonly reviver?: Parameters<typeof JSON.parse>[1] | undefined
+  readonly replacer?: Parameters<typeof JSON.stringify>[1] | undefined
+  readonly space?: Parameters<typeof JSON.stringify>[2] | undefined
+}): Transformation<unknown, string> {
+  return new Transformation(
+    SchemaGetter.parseJson(options ?? {}),
+    SchemaGetter.stringifyJson(options)
+  )
+}
 
 /**
  * Decodes a `FormData` instance into a nested record using bracket-path keys and

--- a/packages/effect/src/unstable/http/UrlParams.ts
+++ b/packages/effect/src/unstable/http/UrlParams.ts
@@ -522,7 +522,7 @@ export const toReadonlyRecord: (self: UrlParams) => ReadonlyRecord<string, strin
  * @category schemas
  * @since 4.0.0
  */
-export interface schemaJsonField extends Schema.decodeTo<Schema.UnknownFromJsonString, UrlParamsSchema> {}
+export interface schemaJsonField extends Schema.decodeTo<Schema.fromJsonString<Schema.Unknown>, UrlParamsSchema> {}
 
 /**
  * Extracts a JSON value from the first occurrence of the given `field` in the

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5651,7 +5651,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     it("replacer and space options", async () => {
       const schema = Schema.fromJsonString(Schema.Struct({ a: Schema.Number, b: Schema.Number }), {
-        replacer: ["a"],
+        replacer: (key, value) => key === "b" ? undefined : value,
         space: 2
       })
       const encoding = new TestSchema.Asserts(schema).encoding()

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5640,6 +5640,30 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       )
     })
 
+    it("reviver option", async () => {
+      const schema = Schema.fromJsonString(Schema.Struct({ a: Schema.Number }), {
+        reviver: (key, value) => key === "a" ? Number(value) : value
+      })
+      const decoding = new TestSchema.Asserts(schema).decoding()
+
+      await decoding.succeed(`{"a":"1"}`, { a: 1 })
+    })
+
+    it("replacer and space options", async () => {
+      const schema = Schema.fromJsonString(Schema.Struct({ a: Schema.Number, b: Schema.Number }), {
+        replacer: ["a"],
+        space: 2
+      })
+      const encoding = new TestSchema.Asserts(schema).encoding()
+
+      await encoding.succeed(
+        { a: 1, b: 2 },
+        `{
+  "a": 1
+}`
+      )
+    })
+
     it("use case: parse / stringify a nested schema", async () => {
       const schema = Schema.Struct({
         a: Schema.fromJsonString(Schema.Struct({ b: Schema.Number }))

--- a/packages/tools/api-diff/src/Json.ts
+++ b/packages/tools/api-diff/src/Json.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema"
 import { createHash } from "node:crypto"
 
-export const decodeJson = Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)
+export const decodeJson = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown))
 
 export const stableJson = (value: unknown): string => {
   const visit = (input: unknown): unknown => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable JSON string parsing and formatting to `Schema.fromJsonString`.
  * Supports `reviver`, `replacer`, and `space` options for transformation and pretty-printed output.
* **Improvements**
  * Updated internal JSON-decoding usage to rely on `Schema.fromJsonString(Schema.Unknown)`.
  * Added a public `JsonReplacer` type for `stringifyJson` configuration.
* **Documentation**
  * Refined docs and examples to explain parse/decode and encode/stringify flows.
* **Tests**
  * Added coverage for `reviver`, `replacer`, and `space` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->