### PR TITLE
Preserve reactive query metadata

### DIFF
--- a/.changeset/fix-reactive-query-metadata.md
+++ b/.changeset/fix-reactive-query-metadata.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve serialization and retention metadata on reactive `AtomRpc` and `AtomHttpApi` queries.

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -266,6 +266,9 @@ export const Service =
           HttpClientError.HttpClientError | SchemaError
         >)
       }))
+      if (opts.reactivityKeys) {
+        atom = self.runtime.factory.withReactivity(opts.reactivityKeys)(atom)
+      }
       if (opts.responseMode === "decoded-only" && opts.serializationKey) {
         const endpoint = groups[opts.group].endpoints[opts.endpoint]
         atom = Atom.serializable(atom, {
@@ -281,9 +284,7 @@ export const Service =
           ? Atom.setIdleTTL(atom, opts.timeToLive)
           : Atom.keepAlive(atom)
       }
-      return opts.reactivityKeys
-        ? self.runtime.factory.withReactivity(opts.reactivityKeys)(atom)
-        : atom
+      return atom
     })
 
     self.query = ((

--- a/packages/effect/src/unstable/reactivity/AtomRpc.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRpc.ts
@@ -234,6 +234,9 @@ export const Service = <Self>() =>
         : self.runtime.atom(
           self.use((client) => client(tag, payload, { headers } as any)) as any
         )
+      if (reactivityKeys) {
+        atom = self.runtime.factory.withReactivity(reactivityKeys)(atom)
+      }
       if (!isStream && key.serializationKey) {
         atom = Atom.serializable(atom, {
           key: `AtomRpc:${key.tag}:${key.serializationKey}`,
@@ -248,9 +251,7 @@ export const Service = <Self>() =>
           ? Atom.setIdleTTL(atom, timeToLive)
           : Atom.keepAlive(atom)
       }
-      return reactivityKeys
-        ? self.runtime.factory.withReactivity(reactivityKeys)(atom)
-        : atom
+      return atom
     }
   )
 

--- a/packages/effect/test/reactivity/AtomHttpApi.test.ts
+++ b/packages/effect/test/reactivity/AtomHttpApi.test.ts
@@ -63,6 +63,23 @@ describe("AtomHttpApi", () => {
           serializable: true
         }
       )
+      const keepAliveAtom = Client.query("group", "get", {
+        params: { id: 2 },
+        query: { page: 3 },
+        reactivityKeys: ["users"],
+        timeToLive: "Infinity",
+        serializationKey: "keep-alive"
+      })
+      assert.deepStrictEqual(
+        {
+          keepAlive: keepAliveAtom.keepAlive,
+          serializable: Atom.isSerializable(keepAliveAtom)
+        },
+        {
+          keepAlive: true,
+          serializable: true
+        }
+      )
       if (!Atom.isSerializable(atom)) {
         assert.fail("expected query atom to be serializable")
       }

--- a/packages/effect/test/reactivity/AtomHttpApi.test.ts
+++ b/packages/effect/test/reactivity/AtomHttpApi.test.ts
@@ -19,7 +19,7 @@ const Api = HttpApi.make("api").add(
 )
 
 describe("AtomHttpApi", () => {
-  it.effect("query creates a serializable atom that encodes the request and decodes the response", () =>
+  it.effect("query creates a serializable atom with reactivity and retention that encodes the request", () =>
     Effect.gen(function*() {
       const requestRef = yield* Ref.make<
         {
@@ -48,9 +48,21 @@ describe("AtomHttpApi", () => {
       const atom = Client.query("group", "get", {
         params: { id: 1 },
         query: { page: 2 },
+        reactivityKeys: ["users"],
+        timeToLive: "1 minute",
         serializationKey: `1:2`
       })
 
+      assert.deepStrictEqual(
+        {
+          idleTTL: atom.idleTTL,
+          serializable: Atom.isSerializable(atom)
+        },
+        {
+          idleTTL: 60_000,
+          serializable: true
+        }
+      )
       if (!Atom.isSerializable(atom)) {
         assert.fail("expected query atom to be serializable")
       }
@@ -59,6 +71,8 @@ describe("AtomHttpApi", () => {
       const atomFromEncodedInput = Client.query("group", "get", {
         params: { id: 1 },
         query: { page: 2 },
+        reactivityKeys: ["users"],
+        timeToLive: "1 minute",
         serializationKey: `1:2`
       })
       if (!Atom.isSerializable(atomFromEncodedInput)) {

--- a/packages/effect/test/reactivity/AtomRpc.test.ts
+++ b/packages/effect/test/reactivity/AtomRpc.test.ts
@@ -16,7 +16,7 @@ const Group = RpcGroup.make(
 )
 
 describe("AtomRpc", () => {
-  it.effect("query creates a serializable atom", () =>
+  it.effect("query creates a serializable atom with reactivity and retention", () =>
     Effect.gen(function*() {
       const Client = AtomRpc.Service()("Client", {
         group: Group,
@@ -38,9 +38,21 @@ describe("AtomRpc", () => {
         headers: {
           "x-id": "abc"
         },
+        reactivityKeys: ["users"],
+        timeToLive: "1 minute",
         serializationKey: "1"
       })
 
+      assert.deepStrictEqual(
+        {
+          idleTTL: atom.idleTTL,
+          serializable: Atom.isSerializable(atom)
+        },
+        {
+          idleTTL: 60_000,
+          serializable: true
+        }
+      )
       if (!Atom.isSerializable(atom)) {
         assert.fail("expected query atom to be serializable")
       }
@@ -50,6 +62,8 @@ describe("AtomRpc", () => {
         headers: {
           "x-id": "abc"
         },
+        reactivityKeys: ["users"],
+        timeToLive: "1 minute",
         serializationKey: "1"
       })
       assert(Atom.isSerializable(atomFromEncodedPayload), "expected query atom from encoded payload to be serializable")

--- a/packages/effect/test/reactivity/AtomRpc.test.ts
+++ b/packages/effect/test/reactivity/AtomRpc.test.ts
@@ -53,6 +53,21 @@ describe("AtomRpc", () => {
           serializable: true
         }
       )
+      const keepAliveAtom = Client.query("getUser", { id: 2 }, {
+        reactivityKeys: ["users"],
+        timeToLive: "Infinity",
+        serializationKey: "keep-alive"
+      })
+      assert.deepStrictEqual(
+        {
+          keepAlive: keepAliveAtom.keepAlive,
+          serializable: Atom.isSerializable(keepAliveAtom)
+        },
+        {
+          keepAlive: true,
+          serializable: true
+        }
+      )
       if (!Atom.isSerializable(atom)) {
         assert.fail("expected query atom to be serializable")
       }


### PR DESCRIPTION
## Summary

- compose `AtomRpc` and `AtomHttpApi` query reactivity before serialization and retention metadata
- preserve `serializationKey`, finite `timeToLive`, and `keepAlive` behavior on the query atom returned to callers
- extend both query regressions to cover reactivity, retention, serialization, and dehydration together

## Root cause

Both query constructors attached serialization and retention metadata to the base atom and then returned a new atom from `withReactivity`. `withReactivity` is implemented as a transform, so the returned atom intentionally starts with fresh metadata. Enabling `reactivityKeys` therefore changed an explicitly serializable query with a one-minute TTL into a non-serializable atom with `idleTTL` set to `0`.

The query constructors own the complete composition pipeline, so this change applies the behavioral transform first and then attaches serialization and retention to the final public atom. It does not change the generic semantics of `Atom.transform`, `withReactivity`, hydration, or the registry.

## Red-before / green-after proof

With the regression changes applied to unmodified `main`, both focused tests failed with the same result:

```text
actual:   { idleTTL: 0, serializable: false }
expected: { idleTTL: 60000, serializable: true }
```

After reordering the query composition, both tests pass and continue to verify request execution and dehydration.

## Validation

- `pnpm lint-fix`
- `pnpm --filter effect test --run test/reactivity/AtomRpc.test.ts test/reactivity/AtomHttpApi.test.ts`
- `pnpm check`
- `pnpm lint`
- `pnpm --filter effect build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reactive query atoms now preserve reactivity settings consistently, alongside serialization and retention/TTL behavior.
  - Reconstructed queries retain the same serialization and time-to-live configuration.
- **Tests**
  - Strengthened assertions for reactive queries to verify serializability and TTL behavior for both “1 minute” (idleTTL) and “Infinity” (keepAlive), including reconstruction parity.
- **Chores**
  - Published a patch-level update for the corrected reactive query metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->