### PR TITLE
Fix stateful Schema.isPattern validation

### DIFF
--- a/.changeset/fix-schema-pattern-state.md
+++ b/.changeset/fix-schema-pattern-state.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make `Schema.isPattern` deterministic for regular expressions with global or sticky flags.

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3166,14 +3166,16 @@ export const finite = appendChecks(number, [isFinite()])
  * **Details**
  *
  * The filter can be used with `Schema.filter` or attached directly to a
- * `String` AST node through checks. The regular expression source is stored in
- * annotations for serialization and arbitrary generation.
+ * `String` AST node through checks. The regular expression is cloned and its
+ * `lastIndex` is reset before each test, so global and sticky expressions are
+ * deterministic and the provided regular expression is not mutated. The
+ * regular expression source is stored in annotations for serialization and
+ * arbitrary generation.
  *
  * **Gotchas**
  *
- * Use a non-global, non-sticky regular expression, or reset `lastIndex`
- * yourself, because `RegExp.test` is stateful for expressions with the `g` or
- * `y` flag.
+ * When deriving an arbitrary, only `regExp.source` is used. Regular expression
+ * flags are ignored because fast-check does not support them.
  *
  * **Example** (Validating an email pattern)
  *
@@ -3189,8 +3191,12 @@ export const finite = appendChecks(number, [isFinite()])
  */
 export function isPattern(regExp: globalThis.RegExp, annotations?: Schema.Annotations.Filter) {
   const source = regExp.source
+  const pattern = new globalThis.RegExp(source, regExp.flags)
   return makeFilter(
-    (s: string) => regExp.test(s),
+    (s: string) => {
+      pattern.lastIndex = 0
+      return pattern.test(s)
+    },
     {
       expected: `a string matching the RegExp ${source}`,
       representation: {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -1247,6 +1247,17 @@ Expected a string including "c", got "ab"`
         )
       })
 
+      it("isPattern with stateful RegExp flags", async () => {
+        for (const regExp of [/^a/g, /^a/y]) {
+          const schema = Schema.String.check(Schema.isPattern(regExp))
+          const decoding = new TestSchema.Asserts(schema).decoding()
+
+          await decoding.succeed("a")
+          await decoding.succeed("a")
+          strictEqual(regExp.lastIndex, 0)
+        }
+      })
+
       it("isStartsWith", async () => {
         const schema = Schema.String.check(Schema.isStartsWith("a"))
         const asserts = new TestSchema.Asserts(schema)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made schema pattern validation deterministic when using global or sticky regular expressions.
  * Prevented regular expression state from leaking between validation runs.
* **Tests**
  * Added coverage confirming repeated validations succeed and regular expression state is reset consistently.
* **Documentation**
  * Clarified pattern-matching behavior and how regular expression flags are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->