### PR TITLE
Refactor JsonPatch internals

### DIFF
--- a/packages/effect/src/JsonPatch.ts
+++ b/packages/effect/src/JsonPatch.ts
@@ -7,10 +7,8 @@
  *
  * @since 4.0.0
  */
-import { format } from "./Formatter.ts"
 import * as InternalRecord from "./internal/record.ts"
 import { escapeToken, unescapeToken } from "./JsonPointer.ts"
-import * as Predicate from "./Predicate.ts"
 import type * as Schema from "./Schema.ts"
 
 /**
@@ -181,9 +179,18 @@ export type JsonPatch = ReadonlyArray<JsonPatchOperation>
  * @since 4.0.0
  */
 export function get(oldValue: Schema.Json, newValue: Schema.Json): JsonPatch {
-  if (Object.is(oldValue, newValue)) return []
   const patches: Array<JsonPatchOperation> = []
+  getLoop(oldValue, newValue, "", patches)
+  return patches
+}
 
+function getLoop(
+  oldValue: Schema.Json,
+  newValue: Schema.Json,
+  path: string,
+  patches: Array<JsonPatchOperation>
+): void {
+  if (Object.is(oldValue, newValue)) return
   if (Array.isArray(oldValue) && Array.isArray(newValue)) {
     const len1 = oldValue.length
     const len2 = newValue.length
@@ -191,25 +198,20 @@ export function get(oldValue: Schema.Json, newValue: Schema.Json): JsonPatch {
     // Compare shared prefix by index
     const shared = Math.min(len1, len2)
     for (let i = 0; i < shared; i++) {
-      const path = `/${i}`
-      const patch = get(oldValue[i], newValue[i])
-      for (const op of patch) {
-        prefixPathInPlace(op, path)
-        patches.push(op)
-      }
+      getLoop(oldValue[i], newValue[i], `${path}/${i}`, patches)
     }
 
     // Remove from end to start so later indices do not shift.
     for (let i = len1 - 1; i >= len2; i--) {
-      patches.push({ op: "remove", path: `/${i}` })
+      patches.push({ op: "remove", path: `${path}/${i}` })
     }
 
     // Add from beginning to end.
     for (let i = len1; i < len2; i++) {
-      patches.push({ op: "add", path: `/${i}`, value: newValue[i] })
+      patches.push({ op: "add", path: `${path}/${i}`, value: newValue[i] })
     }
 
-    return patches
+    return
   }
 
   if (isJsonObject(oldValue) && isJsonObject(newValue)) {
@@ -218,29 +220,23 @@ export function get(oldValue: Schema.Json, newValue: Schema.Json): JsonPatch {
     const allKeys = Array.from(new Set([...keys1, ...keys2])).sort()
 
     for (const key of allKeys) {
-      const esc = escapeToken(key)
-      const path = `/${esc}`
+      const keyPath = `${path}/${escapeToken(key)}`
       const hasKey1 = Object.hasOwn(oldValue, key)
       const hasKey2 = Object.hasOwn(newValue, key)
 
       if (hasKey1 && hasKey2) {
-        const patch = get(oldValue[key], newValue[key])
-        for (const op of patch) {
-          prefixPathInPlace(op, path)
-          patches.push(op)
-        }
+        getLoop(oldValue[key], newValue[key], keyPath, patches)
       } else if (!hasKey1 && hasKey2) {
-        patches.push({ op: "add", path, value: newValue[key] })
-      } else if (hasKey1 && !hasKey2) {
-        patches.push({ op: "remove", path })
+        patches.push({ op: "add", path: keyPath, value: newValue[key] })
+      } else {
+        patches.push({ op: "remove", path: keyPath })
       }
     }
 
-    return patches
+    return
   }
 
-  patches.push({ op: "replace", path: "", value: newValue })
-  return patches
+  patches.push({ op: "replace", path, value: newValue })
 }
 
 /**
@@ -289,32 +285,14 @@ export function apply(patch: JsonPatch, oldValue: Schema.Json): Schema.Json {
   let doc = oldValue
 
   for (const op of patch) {
-    switch (op.op) {
-      case "replace": {
-        doc = op.path === "" ? op.value : setAt(doc, op.path, op.value, "replace")
-        break
-      }
-      case "add": {
-        doc = addAt(doc, op.path, op.value)
-        break
-      }
-      case "remove": {
-        doc = setAt(doc, op.path, undefined, "remove")
-        break
-      }
-    }
+    doc = applyOperation(doc, op)
   }
 
   return doc
 }
 
-// Mutates op.path in place for perf; safe because child ops are freshly created and not shared.
-function prefixPathInPlace(op: JsonPatchOperation, parent: string): void {
-  ;(op as any).path = op.path === "" ? parent : parent + op.path
-}
-
 function isJsonObject(value: unknown): value is Schema.JsonObject {
-  return Predicate.isObject(value)
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 /**
@@ -326,7 +304,7 @@ function isJsonObject(value: unknown): value is Schema.JsonObject {
 function tokenize(pointer: string): Array<string> {
   if (pointer === "") return []
   if (pointer.charCodeAt(0) !== 47 /* "/" */) {
-    throw new Error(`Invalid JSON Pointer, it must start with "/": ${format(pointer)}`)
+    throw new Error(`Invalid JSON Pointer, it must start with "/": ${JSON.stringify(pointer)}`)
   }
   return pointer.split("/").slice(1).map(unescapeToken)
 }
@@ -339,72 +317,44 @@ function toIndex(token: string): number {
   return Number(token)
 }
 
-function addAt(doc: Schema.Json, pointer: string, val: Schema.Json): Schema.Json {
-  if (pointer === "") return val
+function applyOperation(doc: Schema.Json, op: JsonPatchOperation): Schema.Json {
+  if (op.path === "") {
+    if (op.op === "remove") throw new Error("Unsupported operation at the root")
+    return op.value
+  }
 
-  const resolved = resolveParent(doc, pointer)
+  const resolved = resolveParent(doc, op.path)
   if (resolved === null) {
-    throw new Error(`Cannot add at "${pointer}" (parent not found or not a container).`)
+    throw new Error(`Cannot ${op.op} at "${op.path}" (parent not found or not a container).`)
   }
 
   const { lastToken, parent, stack } = resolved
 
   if (Array.isArray(parent)) {
-    const idx = lastToken === "-" ? parent.length : toIndex(lastToken)
-    if (idx < 0 || idx > parent.length) throw new Error(`Array index out of bounds at "${pointer}".`)
+    if (lastToken === "-" && op.op !== "add") {
+      throw new Error(`"-" is not valid for ${op.op} at "${op.path}".`)
+    }
+    const index = lastToken === "-" ? parent.length : toIndex(lastToken)
+    const maxIndex = op.op === "add" ? parent.length : parent.length - 1
+    if (index > maxIndex) throw new Error(`Array index out of bounds at "${op.path}".`)
     const updated = parent.slice()
-    updated.splice(idx, 0, val)
+    if (op.op === "add") updated.splice(index, 0, op.value)
+    else if (op.op === "remove") updated.splice(index, 1)
+    else updated[index] = op.value
     return rebuildFromStack(stack, updated)
   }
 
   if (isJsonObject(parent)) {
-    const updated = { ...parent }
-    InternalRecord.assignProperty(updated, lastToken, val)
-    return rebuildFromStack(stack, updated)
-  }
-
-  throw new Error(`Cannot add at "${pointer}" (parent not found or not a container).`)
-}
-
-function setAt(
-  doc: Schema.Json,
-  pointer: string,
-  val: Schema.Json | undefined,
-  mode: "replace" | "remove"
-): Schema.Json {
-  if (pointer === "") {
-    if (mode === "remove" || val === undefined) throw new Error("Unsupported operation at the root")
-    return val
-  }
-
-  const resolved = resolveParent(doc, pointer)
-  if (resolved === null) {
-    throw new Error(`Cannot ${mode} at "${pointer}" (parent not found or not a container).`)
-  }
-
-  const { lastToken, parent, stack } = resolved
-
-  if (Array.isArray(parent)) {
-    if (lastToken === "-") throw new Error(`"-" is not valid for ${mode} at "${pointer}".`)
-    const idx = toIndex(lastToken)
-    if (idx < 0 || idx >= parent.length) throw new Error(`Array index out of bounds at "${pointer}".`)
-    const updated = parent.slice()
-    if (mode === "remove") updated.splice(idx, 1)
-    else updated[idx] = val
-    return rebuildFromStack(stack, updated)
-  }
-
-  if (isJsonObject(parent)) {
-    if (!Object.hasOwn(parent, lastToken)) {
-      throw new Error(`Property "${lastToken}" does not exist at "${pointer}".`)
+    if (op.op !== "add" && !Object.hasOwn(parent, lastToken)) {
+      throw new Error(`Property "${lastToken}" does not exist at "${op.path}".`)
     }
     const updated = { ...parent }
-    if (mode === "remove") delete updated[lastToken]
-    else InternalRecord.assignProperty(updated, lastToken, val!)
+    if (op.op === "remove") delete updated[lastToken]
+    else InternalRecord.assignProperty(updated, lastToken, op.value)
     return rebuildFromStack(stack, updated)
   }
 
-  throw new Error(`Cannot ${mode} at "${pointer}" (parent not found or not a container).`)
+  throw new Error(`Cannot ${op.op} at "${op.path}" (parent not found or not a container).`)
 }
 
 type StackEntry = { readonly container: unknown; readonly token: number | string }
@@ -425,20 +375,18 @@ function resolveParent(
   for (let i = 0; i < tokens.length - 1; i++) {
     const token = tokens[i]
 
-    if (cur == null) return null
-
     if (Array.isArray(cur)) {
       const idx = toIndex(token)
-      if (idx < 0 || idx >= cur.length) return null
+      if (idx >= cur.length) return null
       stack.push({ container: cur, token: idx })
       cur = cur[idx]
       continue
     }
 
-    if (cur && typeof cur === "object") {
+    if (isJsonObject(cur)) {
       if (!Object.hasOwn(cur, token)) return null
       stack.push({ container: cur, token })
-      cur = (cur as any)[token]
+      cur = cur[token]
       continue
     }
 

--- a/packages/effect/test/JsonPatch.test.ts
+++ b/packages/effect/test/JsonPatch.test.ts
@@ -531,6 +531,10 @@ describe("JsonPatch", () => {
           () => JsonPatch.apply([{ op: "replace", path: "/-1", value: 1 }], [1, 2, 3]),
           `Invalid array index`
         )
+        expectMessage(
+          () => JsonPatch.apply([{ op: "add", path: "/items/abc/value", value: 1 }], { items: [] }),
+          `Invalid array index: "abc"`
+        )
       })
 
       it("rejects out-of-bounds array access", () => {

--- a/packages/effect/test/JsonPatch.test.ts
+++ b/packages/effect/test/JsonPatch.test.ts
@@ -166,6 +166,15 @@ describe("JsonPatch", () => {
             { op: "replace", path: "/a~01b", value: 2 }
           ])
         })
+
+        it("treats '__proto__' as an own key", () => {
+          const oldValue = JSON.parse(`{"__proto__":{"value":1}}`)
+          const newValue = JSON.parse(`{"__proto__":{"value":2}}`)
+
+          deepStrictEqual(JsonPatch.get(oldValue, newValue), [
+            { op: "replace", path: "/__proto__/value", value: 2 }
+          ])
+        })
       })
     })
 
@@ -562,6 +571,19 @@ describe("JsonPatch", () => {
         )
       })
 
+      it("does not treat inherited properties as document members", () => {
+        const document = Object.create({ inherited: { value: 1 } }) as Schema.JsonObject
+
+        expectMessage(
+          () => JsonPatch.apply([{ op: "replace", path: "/inherited/value", value: 2 }], document),
+          "Cannot replace at"
+        )
+        expectMessage(
+          () => JsonPatch.apply([{ op: "remove", path: "/inherited" }], document),
+          "does not exist"
+        )
+      })
+
       it("rejects add/replace when the parent is missing or not a container", () => {
         expectMessage(
           () => JsonPatch.apply([{ op: "add", path: "/a/b", value: 1 }], { a: null }),
@@ -585,6 +607,22 @@ describe("JsonPatch", () => {
           () => JsonPatch.apply([{ op: "add", path: "/a/b/c", value: 1 }], { a: { b: "not-object" } }),
           "not a container"
         )
+      })
+
+      it("rejects operations when a nested parent cannot be resolved", () => {
+        const cases: ReadonlyArray<[JsonPatch.JsonPatchOperation, Schema.Json]> = [
+          [{ op: "add", path: "/a/b/c", value: 1 }, { a: null }],
+          [{ op: "add", path: "/a/0/b", value: 1 }, { a: [] }],
+          [{ op: "replace", path: "/a/b", value: 1 }, {}],
+          [{ op: "remove", path: "/a/b" }, {}],
+          [{ op: "remove", path: "/a/b/c" }, { a: "not-object" }]
+        ]
+        for (const [operation, document] of cases) {
+          expectMessage(
+            () => JsonPatch.apply([operation], document),
+            `Cannot ${operation.op} at`
+          )
+        }
       })
 
       it("rejects remove at the root", () => {
@@ -616,6 +654,34 @@ describe("JsonPatch", () => {
 
         JsonPatch.apply(patch, { a: 1 })
         deepStrictEqual(patch, patchCopy)
+      })
+
+      it("preserves references outside the modified path", () => {
+        const unchanged = { value: 1 }
+        const original = { changed: { value: 1 }, unchanged }
+        const result = JsonPatch.apply([{ op: "replace", path: "/changed/value", value: 2 }], original)
+
+        strictEqual((result as any).unchanged, unchanged)
+        deepStrictEqual(original, { changed: { value: 1 }, unchanged: { value: 1 } })
+      })
+
+      it("handles '__proto__' as an own data property", () => {
+        const original = JSON.parse(`{"nested":{"__proto__":{"value":1}}}`)
+        const result = JsonPatch.apply(
+          [
+            { op: "replace", path: "/nested/__proto__/value", value: 2 },
+            { op: "add", path: "/__proto__", value: { value: 3 } }
+          ],
+          original
+        ) as any
+
+        strictEqual(Object.getPrototypeOf(result), Object.prototype)
+        strictEqual(Object.getPrototypeOf(result.nested), Object.prototype)
+        strictEqual(Object.hasOwn(result, "__proto__"), true)
+        strictEqual(Object.hasOwn(result.nested, "__proto__"), true)
+        deepStrictEqual(result.__proto__, { value: 3 })
+        deepStrictEqual(result.nested.__proto__, { value: 2 })
+        deepStrictEqual(original, JSON.parse(`{"nested":{"__proto__":{"value":1}}}`))
       })
     })
 
@@ -765,6 +831,13 @@ describe("JsonPatch", () => {
     })
 
     describe("root operations", () => {
+      it("applies root add", () => {
+        deepStrictEqual(
+          JsonPatch.apply([{ op: "add", path: "", value: { replacement: true } }], { old: true }),
+          { replacement: true }
+        )
+      })
+
       it("applies root replace followed by nested operations", () => {
         const result = JsonPatch.apply(
           [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON Patch generation and application for arrays, objects, and root-level operations.
  * Added stricter validation for invalid JSON Pointer paths, unsupported root `remove`, and array index handling (including correct `-` usage).
  * Properly treats special keys like `__proto__` as normal own properties during patch generation and application.
  * Preserves reference identity for unaffected subtrees and does not mutate the original document.
* **Tests**
  * Expanded coverage for edge cases, error messages, immutability, inherited-properties rejection, and root-level `add` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->