### PR TITLE
Add Deno terminal support

### DIFF
--- a/.changeset/eff-142-deno-terminal.md
+++ b/.changeset/eff-142-deno-terminal.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-deno": patch
+"@effect/platform-node-shared": patch
+---
+
+Add a Deno `Terminal` implementation and keep `NodeTerminal` input readers alive until stdin ends under Deno.

--- a/packages/platform-deno/package.json
+++ b/packages/platform-deno/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@db/redis": "jsr:^0.41.2",
+    "@effect/platform-node-shared": "workspace:^",
     "@std/fs": "jsr:^1.0.24",
     "@std/path": "jsr:^1.1.6"
   },

--- a/packages/platform-deno/src/DenoTerminal.ts
+++ b/packages/platform-deno/src/DenoTerminal.ts
@@ -1,0 +1,32 @@
+/**
+ * Deno-backed implementation of Effect's `Terminal` service.
+ *
+ * This module reuses the shared Node terminal implementation for Deno. `make`
+ * creates a scoped process-backed `Terminal` service, and `layer` provides the
+ * default terminal service with the standard quit behavior for key input.
+ *
+ * @since 4.0.0
+ */
+import * as NodeTerminal from "@effect/platform-node-shared/NodeTerminal"
+import type { Effect } from "effect/Effect"
+import type { Layer } from "effect/Layer"
+import type { Scope } from "effect/Scope"
+import type { Terminal, UserInput } from "effect/Terminal"
+
+/**
+ * Creates a scoped `Terminal` service backed by process stdin/stdout, using the
+ * optional predicate to decide when key input should end the input stream.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make: (shouldQuit?: (input: UserInput) => boolean) => Effect<Terminal, never, Scope> = NodeTerminal.make
+
+/**
+ * Provides the default process-backed `Terminal` service, ending key input on
+ * the default quit keys.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer: Layer<Terminal> = NodeTerminal.layer

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -52,6 +52,11 @@ export * as DenoStdio from "./DenoStdio.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoTerminal from "./DenoTerminal.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoWorker from "./DenoWorker.ts"
 
 /**

--- a/packages/platform-deno/test/DenoTerminal.test.ts
+++ b/packages/platform-deno/test/DenoTerminal.test.ts
@@ -1,0 +1,96 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import { spawn, spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const fixture = fileURLToPath(new URL("fixtures/deno-terminal.ts", import.meta.url))
+
+const runFixture = (mode: string, input: string) =>
+  spawnSync(Deno.execPath(), [fixture, mode], {
+    encoding: "utf8",
+    input,
+    timeout: 2_000
+  })
+
+const assertResult = (mode: string, input: string, expected: string) => {
+  const result = runFixture(mode, input)
+  assert.isUndefined(result.error)
+  assert.strictEqual(result.status, 0, result.stderr)
+  assert.isTrue(result.stderr.includes(`RESULT ${expected}`), result.stderr)
+}
+
+const assertOpenResult = (mode: string, input: string, expected: string) =>
+  Effect.callback<void>((resume) => {
+    const child = spawn(Deno.execPath(), [fixture, mode])
+    let stderr = ""
+    child.stderr.setEncoding("utf8")
+    child.stderr.on("data", (data) => {
+      stderr += data
+      if (stderr.includes("RESULT ")) {
+        child.stdin.end()
+      }
+    })
+    child.on("exit", (code) => {
+      resume(
+        code === 0 && stderr.includes(`RESULT ${expected}`)
+          ? Effect.void
+          : Effect.die(new Error(stderr))
+      )
+    })
+    child.stdin.write(input)
+    return Effect.sync(() => child.kill())
+  })
+
+const assertInteropResult = Effect.callback<void>((resume) => {
+  const child = spawn(Deno.execPath(), [fixture, "interop"])
+  let stderr = ""
+  let sentTerminalInput = false
+  child.stderr.setEncoding("utf8")
+  child.stderr.on("data", (data) => {
+    stderr += data
+    if (!sentTerminalInput && stderr.includes("READY")) {
+      sentTerminalInput = true
+      child.stdin.end("terminal\n")
+    }
+  })
+  child.on("exit", (code) => {
+    resume(
+      code === 0 && stderr.includes("RESULT {\"stdio\":\"stdio\",\"terminal\":\"terminal\"}")
+        ? Effect.void
+        : Effect.die(new Error(stderr))
+    )
+  })
+  child.stdin.write("stdio\n")
+  return Effect.sync(() => child.kill())
+})
+
+describe("DenoTerminal", () => {
+  it("does not install a readline interface until the terminal is used", () => {
+    assertResult("unused", "", "{\"dataListeners\":0}")
+  })
+
+  it("fails a prompt with QuitError after piped input is exhausted", () => {
+    assertResult("prompts", "y\n", "{\"first\":true,\"second\":\"QuitError\"}")
+  })
+
+  it("delivers buffered keypresses before ending the input queue", () => {
+    assertResult("read-input", "yn", "{\"first\":\"y\",\"second\":\"n\",\"ended\":true}")
+  })
+
+  it("flushes an unterminated line before failing readLine with QuitError at EOF", () => {
+    assertResult("read-line", "last line", "{\"first\":\"last line\",\"second\":\"QuitError\"}")
+  })
+
+  it("preserves lines buffered between sequential readLine calls", () => {
+    assertResult("read-lines", "first\nsecond\n", "{\"first\":\"first\",\"second\":\"second\"}")
+  })
+
+  it("fails readLine with QuitError when stdin ended before initialization", () => {
+    assertResult("read-line-after-end", "", "\"QuitError\"")
+  })
+
+  it.effect("disposes readline after readLine completes", () =>
+    assertOpenResult("read-line-disposed", "line\n", "{\"line\":\"line\",\"dataListeners\":0}"))
+
+  it.effect("interoperates with DenoStdio on stdin", () => assertInteropResult)
+})

--- a/packages/platform-deno/test/fixtures/deno-terminal.ts
+++ b/packages/platform-deno/test/fixtures/deno-terminal.ts
@@ -1,0 +1,125 @@
+import * as DenoStdio from "@effect/platform-deno/DenoStdio"
+import * as DenoTerminal from "@effect/platform-deno/DenoTerminal"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as FileSystem from "effect/FileSystem"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Path from "effect/Path"
+import * as Queue from "effect/Queue"
+import * as Stdio from "effect/Stdio"
+import * as Stream from "effect/Stream"
+import * as Terminal from "effect/Terminal"
+import { Prompt } from "effect/unstable/cli"
+
+const TerminalLayer = Layer.mergeAll(
+  DenoStdio.layer,
+  DenoTerminal.layer,
+  FileSystem.layerNoop({}),
+  Path.layer
+)
+
+const prompts = Effect.gen(function*() {
+  const first = yield* Prompt.run(Prompt.confirm({ message: "First" }))
+  const second = yield* Prompt.run(Prompt.confirm({ message: "Second" })).pipe(Effect.flip)
+  return { first, second: second._tag }
+})
+
+const readInput = Effect.scoped(
+  Effect.gen(function*() {
+    const terminal = yield* Terminal.Terminal
+    const input = yield* terminal.readInput
+    const first = yield* Queue.take(input)
+    const second = yield* Queue.take(input)
+    const end = yield* Effect.exit(Queue.take(input))
+    return {
+      first: Option.getOrNull(first.input),
+      second: Option.getOrNull(second.input),
+      ended: Exit.isFailure(end)
+    }
+  })
+)
+
+const readLine = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  const first = yield* terminal.readLine
+  const second = yield* terminal.readLine.pipe(Effect.flip)
+  return { first, second: second._tag }
+})
+
+const readLines = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  const first = yield* terminal.readLine
+  const second = yield* terminal.readLine
+  return { first, second }
+})
+
+const unused = Effect.gen(function*() {
+  yield* Terminal.Terminal
+  return { dataListeners: process.stdin.listenerCount("data") }
+})
+
+const readLineAfterEnd = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  yield* Effect.callback<void>((resume) => {
+    if (process.stdin.readableEnded) {
+      resume(Effect.void)
+      return
+    }
+    const onEnd = () => resume(Effect.void)
+    process.stdin.once("end", onEnd)
+    process.stdin.resume()
+    return Effect.sync(() => process.stdin.off("end", onEnd))
+  })
+  const error = yield* terminal.readLine.pipe(Effect.flip)
+  return error._tag
+})
+
+const readLineDisposed = Effect.gen(function*() {
+  const terminal = yield* Terminal.Terminal
+  const line = yield* terminal.readLine
+  return { line, dataListeners: process.stdin.listenerCount("data") }
+})
+
+const interop = Effect.gen(function*() {
+  const stdio = yield* Stdio.Stdio
+  const terminal = yield* Terminal.Terminal
+  const line = yield* stdio.stdin.pipe(
+    Stream.decodeText(),
+    Stream.splitLines,
+    Stream.runHead
+  )
+  yield* Effect.sync(() => process.stderr.write("READY\n"))
+  const terminalLine = yield* terminal.readLine
+  return { stdio: Option.getOrNull(line), terminal: terminalLine }
+})
+
+const mode = process.argv[2]
+const program = Effect.gen(function*() {
+  if (mode === "prompts") {
+    return yield* prompts
+  } else if (mode === "read-input") {
+    return yield* readInput
+  } else if (mode === "read-line") {
+    return yield* readLine
+  } else if (mode === "read-lines") {
+    return yield* readLines
+  } else if (mode === "unused") {
+    return yield* unused
+  } else if (mode === "read-line-after-end") {
+    return yield* readLineAfterEnd
+  } else if (mode === "read-line-disposed") {
+    return yield* readLineDisposed
+  } else if (mode === "interop") {
+    return yield* interop
+  }
+  return yield* Effect.die(`Unknown mode: ${mode}`)
+})
+
+Effect.runPromise(program.pipe(Effect.provide(TerminalLayer))).then(
+  (result) => process.stderr.write(`RESULT ${JSON.stringify(result)}\n`),
+  (cause) => {
+    process.stderr.write(`ERROR ${String(cause)}\n`)
+    process.exitCode = 1
+  }
+)

--- a/packages/platform-deno/tsconfig.json
+++ b/packages/platform-deno/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "references": [
-    { "path": "../effect" }
+    { "path": "../effect" },
+    { "path": "../platform-node-shared" }
   ],
   "compilerOptions": {
     "types": ["deno"]

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -100,12 +100,18 @@ export const make: (
           Queue.endUnsafe(queue)
         }
       }
+      // Deno's `process.stdin` shim does not keep the event loop alive, so a
+      // program blocked on input can exit before `end` is ever delivered. A
+      // timer holds the loop open for as long as this reader is active.
+      const keepAlive = setInterval(() => {}, 2147483647)
       // Without this, consumers (e.g. `Prompt.run`) hang forever on closed stdin.
       const handleEnd = () => {
+        clearInterval(keepAlive)
         Queue.endUnsafe(queue)
       }
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
+          clearInterval(keepAlive)
           stdin.off("keypress", handleKeypress)
           stdin.off("end", handleEnd)
         })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       '@db/redis':
         specifier: jsr:^0.41.2
         version: '@jsr/db__redis@0.41.2'
+      '@effect/platform-node-shared':
+        specifier: workspace:^
+        version: link:../platform-node-shared
       '@std/fs':
         specifier: jsr:^1.0.24
         version: '@jsr/std__fs@1.0.24'


### PR DESCRIPTION
## Summary

- add `DenoTerminal` backed by the shared Node terminal implementation
- keep `NodeTerminal.readInput` alive until stdin ends under Deno
- port the seven terminal cases and add `DenoStdio` interoperability coverage

## Testing

- `pnpm lint`
- `pnpm check`
- `deno check .`
- `deno task test --run test/DenoTerminal.test.ts`
- `pnpm vitest run --root packages/platform-node-shared test/NodeTerminal.test.ts`
- `bun run vitest run --root packages/platform-node-shared test/NodeTerminal.test.ts`

Closes EFF-142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal support for Deno, including prompts, key input, and line reading.
  * Exported the Deno terminal functionality for use by applications.
  * Added interoperability between Deno standard input and terminal operations.

* **Bug Fixes**
  * Improved handling of closed or exhausted standard input to prevent terminal reads from hanging.
  * Ensured buffered input is delivered and terminal resources are released correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->