### PR TITLE
Add Deno services aggregate

### DIFF
--- a/.changeset/eff-145-deno-services.md
+++ b/.changeset/eff-145-deno-services.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add the aggregate Deno platform services layer.

--- a/packages/platform-deno/src/DenoServices.ts
+++ b/packages/platform-deno/src/DenoServices.ts
@@ -1,0 +1,49 @@
+/**
+ * Aggregate Deno platform services layer.
+ *
+ * This module defines the `DenoServices` union and a single `layer` that
+ * provides Deno-backed child process spawning, crypto, filesystem, path, stdio,
+ * and terminal services. Use the layer when a Deno program wants the standard
+ * platform services from one place.
+ *
+ * @since 4.0.0
+ */
+import type { Crypto } from "effect/Crypto"
+import type { FileSystem } from "effect/FileSystem"
+import * as Layer from "effect/Layer"
+import type { Path } from "effect/Path"
+import type { Stdio } from "effect/Stdio"
+import type { Terminal } from "effect/Terminal"
+import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import * as DenoChildProcessSpawner from "./DenoChildProcessSpawner.ts"
+import * as DenoCrypto from "./DenoCrypto.ts"
+import * as DenoFileSystem from "./DenoFileSystem.ts"
+import * as DenoPath from "./DenoPath.ts"
+import * as DenoStdio from "./DenoStdio.ts"
+import * as DenoTerminal from "./DenoTerminal.ts"
+
+/**
+ * The union of core services provided by the Deno platform layer, including
+ * child process spawning, filesystem, path, stdio, and terminal services.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type DenoServices = ChildProcessSpawner | Crypto | FileSystem | Path | Terminal | Stdio
+
+/**
+ * Provides the default Deno implementations for child process spawning,
+ * filesystem, path, stdio, and terminal services.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer: Layer.Layer<DenoServices> = DenoChildProcessSpawner.layer.pipe(
+  Layer.provideMerge(Layer.mergeAll(
+    DenoFileSystem.layer,
+    DenoCrypto.layer,
+    DenoPath.layer,
+    DenoStdio.layer,
+    DenoTerminal.layer
+  ))
+)

--- a/packages/platform-deno/src/DenoServices.ts
+++ b/packages/platform-deno/src/DenoServices.ts
@@ -24,7 +24,7 @@ import * as DenoTerminal from "./DenoTerminal.ts"
 
 /**
  * The union of core services provided by the Deno platform layer, including
- * child process spawning, filesystem, path, stdio, and terminal services.
+ * child process spawning, crypto, filesystem, path, stdio, and terminal services.
  *
  * @category models
  * @since 4.0.0
@@ -33,7 +33,7 @@ export type DenoServices = ChildProcessSpawner | Crypto | FileSystem | Path | Te
 
 /**
  * Provides the default Deno implementations for child process spawning,
- * filesystem, path, stdio, and terminal services.
+ * crypto, filesystem, path, stdio, and terminal services.
  *
  * @category layers
  * @since 4.0.0

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -47,6 +47,11 @@ export * as DenoRuntime from "./DenoRuntime.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoServices from "./DenoServices.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoStdio from "./DenoStdio.ts"
 
 /**


### PR DESCRIPTION
## Summary

- add the aggregate `DenoServices` type and layer
- export `DenoServices` from the generated platform-deno barrel
- add a patch changeset for the new public API

## Validation

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter @effect/platform-deno check`
- Deno runtime smoke test resolving every service from `DenoServices.layer`

`pnpm --filter @effect/platform-deno test --run` is currently hosted by Node and fails existing native-Deno tests because the `Deno` global is unavailable.

Closes EFF-145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an aggregate Deno “platform services” layer that bundles child process spawning, cryptography, filesystem, path utilities, terminal, and stdio into a single integration point.
  * Re-exported this new Deno services module from the platform package to simplify consumption and composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->