### PR TITLE
Document ChildProcess environment behavior

### DIFF
--- a/.changeset/document-child-process-env.md
+++ b/.changeset/document-child-process-env.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Document that `CommandOptions.extendEnv` defaults to `false` and that providing `env` without enabling it replaces the inherited child environment.

--- a/packages/effect/src/unstable/process/ChildProcess.ts
+++ b/packages/effect/src/unstable/process/ChildProcess.ts
@@ -383,6 +383,11 @@ export interface CommandOptions extends KillOptions {
    * If `extendEnv` is set to `true`, the value of `env` will be merged with
    * the value of `globalThis.process.env`, prioritizing the values in `env`
    * when conflicts exist.
+   *
+   * **Gotchas**
+   *
+   * Without `extendEnv: true`, providing `env` replaces the inherited child
+   * environment. The child will not receive `PATH` unless `env` includes it.
    */
   readonly env?: Record<string, string | undefined> | undefined
   /**
@@ -392,7 +397,9 @@ export interface CommandOptions extends KillOptions {
    *
    * **Details**
    *
-   * If set to `false`, only the value of `env` is used.
+   * If set to `false` and `env` is provided, only the value of `env` is used.
+   *
+   * @default false
    */
   readonly extendEnv?: boolean | undefined
   /**


### PR DESCRIPTION
## Summary

- document that `CommandOptions.extendEnv` defaults to `false`
- warn that providing `env` without `extendEnv: true` replaces inherited variables, including `PATH`
- add an `effect` patch changeset

## Validation

- `pnpm lint`
- `pnpm docgen` from `packages/effect`
- `git diff --check`

Closes #6709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `CommandOptions.extendEnv` defaults to `false`.
  * Documented that providing `env` replaces the inherited child environment unless `extendEnv: true` is enabled.
  * Added guidance on `PATH` inheritance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->