### PR TITLE
Fix error names in JSDocs

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4500,8 +4500,8 @@ export const firstSuccessOf: <Eff extends Effect<any, any, any>>(
  *
  * The `timeout` function allows you to specify a time limit for an
  * effect's execution. If the effect does not complete within the given time, a
- * `TimeoutException` is raised. This can be useful for controlling how long
- * your program waits for a task to finish, ensuring that it doesn't hang
+ * `TimeoutError` is raised. This can be useful for controlling how long your
+ * program waits for a task to finish, ensuring that it doesn't hang
  * indefinitely if the task takes too long.
  *
  * **Gotchas**
@@ -4520,7 +4520,7 @@ export const firstSuccessOf: <Eff extends Effect<any, any, any>>(
  *   return "Result"
  * })
  *
- * // Output will show a TimeoutException as the task takes longer
+ * // Output will show a TimeoutError as the task takes longer
  * // than the specified timeout duration
  * const timedEffect = task.pipe(Effect.timeout("1 second"))
  *
@@ -4533,7 +4533,7 @@ export const firstSuccessOf: <Eff extends Effect<any, any, any>>(
  * //   cause: {
  * //     _id: 'Cause',
  * //     _tag: 'Fail',
- * //     failure: { _tag: 'TimeoutException' }
+ * //     failure: { _tag: 'TimeoutError' }
  * //   }
  * // }
  * ```
@@ -4597,7 +4597,7 @@ export const timeout: {
  * // ]
  * ```
  *
- * @see {@link timeout} for a version that raises a `TimeoutException`.
+ * @see {@link timeout} for a version that raises a `TimeoutError`.
  * @see {@link timeoutOrElse} for a version that allows specifying both success and timeout handlers.
  *
  * @category delays & timeouts
@@ -4658,7 +4658,7 @@ export const timeoutOption: {
  * // Cached result
  * ```
  *
- * @see {@link timeout} for failing with a `TimeoutException`.
+ * @see {@link timeout} for failing with a `TimeoutError`.
  * @see {@link timeoutOption} for returning `Option.none` on timeout.
  *
  * @category delays & timeouts


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated timeout-related documentation to consistently refer to `TimeoutError`.
  * Revised explanatory text, examples, and cross-references for timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->