### PR TITLE
Fix OpenAI compat parallel tool calls

### DIFF
--- a/.changeset/openai-compat-parallel-tool-calls.md
+++ b/.changeset/openai-compat-parallel-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Group consecutive tool calls into one assistant message when using Chat Completions APIs.

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1676,11 +1676,15 @@ const toChatMessages = (
           tool_calls: [...previous.tool_calls, toolCall]
         }
       } else {
-        messages.push({ role: "assistant", content: null, tool_calls: [toolCall] })
+        messages.push({
+          role: "assistant",
+          content: null,
+          tool_calls: [toolCall]
+        })
       }
-      continue
+    } else {
+      messages.push(...toChatMessagesFromItem(item))
     }
-    messages.push(...toChatMessagesFromItem(item))
   }
 
   return messages

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -36,6 +36,7 @@ import * as InternalUtilities from "./internal/utilities.ts"
 import {
   type Annotation,
   type ChatCompletionContentPart,
+  type ChatCompletionRequestToolCall,
   type CreateResponse,
   type CreateResponse200,
   type CreateResponse200Sse,
@@ -1666,6 +1667,19 @@ const toChatMessages = (
   const messages: Array<CreateResponseRequestJson["messages"][number]> = []
 
   for (const item of input) {
+    if (Predicate.hasProperty(item, "type") && item.type === "function_call") {
+      const previous = messages.at(-1)
+      const toolCall = toChatToolCall(item)
+      if (previous?.role === "assistant" && previous.tool_calls !== undefined) {
+        messages[messages.length - 1] = {
+          ...previous,
+          tool_calls: [...previous.tool_calls, toolCall]
+        }
+      } else {
+        messages.push({ role: "assistant", content: null, tool_calls: [toolCall] })
+      }
+      continue
+    }
     messages.push(...toChatMessagesFromItem(item))
   }
 
@@ -1694,14 +1708,7 @@ const toChatMessagesFromItem = (
       return [{
         role: "assistant",
         content: null,
-        tool_calls: [{
-          id: item.call_id,
-          type: "function",
-          function: {
-            name: item.name,
-            arguments: item.arguments
-          }
-        }]
+        tool_calls: [toChatToolCall(item)]
       }]
     }
 
@@ -1718,6 +1725,17 @@ const toChatMessagesFromItem = (
     }
   }
 }
+
+const toChatToolCall = (
+  item: Extract<InputItem, { readonly type: "function_call" }>
+): ChatCompletionRequestToolCall => ({
+  id: item.call_id,
+  type: "function",
+  function: {
+    name: item.name,
+    arguments: item.arguments
+  }
+})
 
 const toAssistantChatMessageContent = (
   content: ReadonlyArray<{

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -329,6 +329,94 @@ describe("OpenAiLanguageModel", () => {
         assert.strictEqual(functionTool.function.strict, true)
       }))
 
+    it.effect("groups parallel tool calls into one assistant message", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, makeChatCompletion()))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({
+          prompt: Prompt.make([
+            { role: "user", content: "use both tools" },
+            {
+              role: "assistant",
+              content: [
+                Prompt.toolCallPart({
+                  id: "call_1",
+                  name: "TestTool",
+                  params: { input: "first" },
+                  providerExecuted: false
+                }),
+                Prompt.toolCallPart({
+                  id: "call_2",
+                  name: "TestTool",
+                  params: { input: "second" },
+                  providerExecuted: false
+                })
+              ]
+            },
+            {
+              role: "tool",
+              content: [
+                Prompt.toolResultPart({
+                  id: "call_1",
+                  name: "TestTool",
+                  isFailure: false,
+                  result: { output: "first" }
+                }),
+                Prompt.toolResultPart({
+                  id: "call_2",
+                  name: "TestTool",
+                  isFailure: false,
+                  result: { output: "second" }
+                })
+              ]
+            }
+          ]),
+          toolkit: TestToolkit
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(TestToolkitLayer),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const requestBody = yield* getRequestBody(capturedRequest)
+        assert.deepStrictEqual(requestBody.messages, [
+          { role: "user", content: "use both tools" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "TestTool", arguments: JSON.stringify({ input: "first" }) }
+              },
+              {
+                id: "call_2",
+                type: "function",
+                function: { name: "TestTool", arguments: JSON.stringify({ input: "second" }) }
+              }
+            ]
+          },
+          { role: "tool", tool_call_id: "call_1", content: JSON.stringify({ output: "first" }) },
+          { role: "tool", tool_call_id: "call_2", content: JSON.stringify({ output: "second" }) }
+        ])
+      }))
+
     it.effect("converts dynamic tools to function type", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined


### PR DESCRIPTION
Fixes #6702

Groups consecutive function calls into a single assistant message before emitting their tool outputs, matching strict Chat Completions message ordering requirements.

Adds a regression test covering two parallel tool calls and their adjacent outputs.

## Testing

- `pnpm --filter @effect/ai-openai-compat test --run test/OpenAiLanguageModel.test.ts`
- `pnpm --filter @effect/ai-openai-compat check`
- `pnpm lint-fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Chat Completions APIs by grouping consecutive parallel tool calls into a single assistant message.
  * Preserved correct tool call identifiers and responses when multiple tools are invoked together.

* **Tests**
  * Added coverage verifying parallel tool calls are encoded and returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->