### PR TITLE
Add Deno HTTP platform

### DIFF
--- a/.changeset/eff-148-deno-http-platform.md
+++ b/.changeset/eff-148-deno-http-platform.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add a native Deno `HttpPlatform` layer with resource-backed file responses.

--- a/packages/platform-deno/package.json
+++ b/packages/platform-deno/package.json
@@ -66,7 +66,9 @@
     "@db/redis": "jsr:^0.41.2",
     "@effect/platform-node-shared": "workspace:^",
     "@std/fs": "jsr:^1.0.24",
-    "@std/path": "jsr:^1.1.6"
+    "@std/media-types": "jsr:^1.1.0",
+    "@std/path": "jsr:^1.1.6",
+    "@std/streams": "jsr:^1.1.1"
   },
   "peerDependencies": {
     "effect": "workspace:^"

--- a/packages/platform-deno/src/DenoHttpPlatform.ts
+++ b/packages/platform-deno/src/DenoHttpPlatform.ts
@@ -1,0 +1,79 @@
+/**
+ * Deno implementation of the Effect HTTP platform service.
+ *
+ * File responses use `Deno.FsFile.readable` directly so full-file responses
+ * retain Deno's resource-backed fast path. Deno closes the file after the body
+ * is sent, but server adapters must cancel a raw body when they do not send it,
+ * including when handling `HEAD` requests.
+ *
+ * The provided layer uses strong ETags, unlike the portable `HttpPlatform`
+ * layer, which uses weak ETags.
+ *
+ * @since 4.0.0
+ */
+import { contentType } from "@std/media-types"
+import { extname } from "@std/path"
+import { ByteSliceStream } from "@std/streams"
+import * as Layer from "effect/Layer"
+import * as Etag from "effect/unstable/http/Etag"
+import * as Platform from "effect/unstable/http/HttpPlatform"
+import * as Response from "effect/unstable/http/HttpServerResponse"
+import * as DenoFileSystem from "./DenoFileSystem.ts"
+
+/**
+ * Creates the Deno `HttpPlatform`, serving file responses from resource-backed
+ * readable streams and adding content type and content length headers.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = Platform.make({
+  fileResponse(path, status, statusText, headers, start, end, contentLength) {
+    let body: ReadableStream<Uint8Array>
+    if (contentLength === 0) {
+      body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close()
+        }
+      })
+    } else {
+      const file = Deno.openSync(path)
+      file.seekSync(start, Deno.SeekMode.Start)
+      body = end === undefined
+        ? file.readable
+        : file.readable.pipeThrough(new ByteSliceStream(0, contentLength - 1))
+    }
+    return Response.raw(body, {
+      headers: {
+        ...headers,
+        "content-type": headers["content-type"] ?? contentType(extname(path)) ?? "application/octet-stream",
+        "content-length": contentLength.toString()
+      },
+      status,
+      statusText
+    })
+  },
+  fileWebResponse(file, status, statusText, headers, _options) {
+    return Response.raw(file, {
+      headers: {
+        ...headers,
+        "content-type": file.type,
+        "content-length": file.size.toString()
+      },
+      status,
+      statusText
+    })
+  }
+})
+
+/**
+ * Provides the Deno `HttpPlatform` together with its filesystem and strong ETag
+ * services.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer: Layer.Layer<Platform.HttpPlatform> = Layer.effect(Platform.HttpPlatform)(make).pipe(
+  Layer.provide(DenoFileSystem.layer),
+  Layer.provide(Etag.layer)
+)

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -27,6 +27,11 @@ export * as DenoHttpClient from "./DenoHttpClient.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoHttpPlatform from "./DenoHttpPlatform.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoKeyValueStore from "./DenoKeyValueStore.ts"
 
 /**

--- a/packages/platform-deno/test/DenoHttpPlatform.test.ts
+++ b/packages/platform-deno/test/DenoHttpPlatform.test.ts
@@ -1,0 +1,45 @@
+import * as DenoHttpPlatform from "@effect/platform-deno/DenoHttpPlatform"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import type * as HttpBody from "effect/unstable/http/HttpBody"
+import * as HttpPlatform from "effect/unstable/http/HttpPlatform"
+
+const fixture = `${import.meta.dirname}/fixtures/text.txt`
+
+const readStream = (stream: ReadableStream<Uint8Array>) => Effect.promise(() => new globalThis.Response(stream).text())
+
+describe("DenoHttpPlatform", () => {
+  it.effect("fileResponse reads exact bytesToRead", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const response = yield* platform.fileResponse(fixture, {
+        offset: 6,
+        bytesToRead: 5
+      })
+
+      assert.strictEqual(response.headers["content-length"], "5")
+      assert.strictEqual(response.body._tag, "Raw")
+      const body = (response.body as HttpBody.Raw).body
+      assert(body instanceof ReadableStream)
+
+      const text = yield* readStream(body)
+      assert.strictEqual(text, "ipsum")
+    }).pipe(Effect.provide(DenoHttpPlatform.layer)))
+
+  it.effect("fileResponse supports zero bytesToRead", () =>
+    Effect.gen(function*() {
+      const platform = yield* HttpPlatform.HttpPlatform
+      const response = yield* platform.fileResponse(fixture, {
+        offset: 6,
+        bytesToRead: 0
+      })
+
+      assert.strictEqual(response.headers["content-length"], "0")
+      assert.strictEqual(response.body._tag, "Raw")
+      const body = (response.body as HttpBody.Raw).body
+      assert(body instanceof ReadableStream)
+
+      const text = yield* readStream(body)
+      assert.strictEqual(text, "")
+    }).pipe(Effect.provide(DenoHttpPlatform.layer)))
+})

--- a/packages/platform-deno/test/fixtures/text.txt
+++ b/packages/platform-deno/test/fixtures/text.txt
@@ -1,0 +1,1 @@
+lorem ipsum dolar sit amet

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,9 +471,15 @@ importers:
       '@std/fs':
         specifier: jsr:^1.0.24
         version: '@jsr/std__fs@1.0.24'
+      '@std/media-types':
+        specifier: jsr:^1.1.0
+        version: '@jsr/std__media-types@1.1.0'
       '@std/path':
         specifier: jsr:^1.1.6
         version: '@jsr/std__path@1.1.6'
+      '@std/streams':
+        specifier: jsr:^1.1.1
+        version: '@jsr/std__streams@1.1.1'
     devDependencies:
       '@std/assert':
         specifier: jsr:^1.0.16
@@ -2263,11 +2269,17 @@ packages:
   '@jsr/std__io@0.224.5':
     resolution: {integrity: sha512-1Y8ZWIjFiQKkaSJwbt7NM/9esDtO0ieKS4vcT929dFArG2ADk7ZKVAV4KluYYh4+kF5VgkOcvJkEm84KeBpqFA==, tarball: https://npm.jsr.io/~/11/@jsr/std__io/0.224.5.tgz}
 
+  '@jsr/std__media-types@1.1.0':
+    resolution: {integrity: sha512-dHvaxHL7ENWnltgL653uo3KnKFse3ZbopZop2gqsT7yrscx7irZEClu5Cba7gMPPRk4Lg1FbriNcaBViM2RSBw==, tarball: https://npm.jsr.io/~/11/@jsr/std__media-types/1.1.0.tgz}
+
   '@jsr/std__path@1.1.6':
     resolution: {integrity: sha512-H1Cmg6z8jFyIsQbVV+vZB4eOx4k6Qg8lyUM6l7nZysj5MZumg89kb0M1bsPBTGQis3fw6mJFkJELo5+AK6oCFA==, tarball: https://npm.jsr.io/~/11/@jsr/std__path/1.1.6.tgz}
 
   '@jsr/std__random@0.1.0':
     resolution: {integrity: sha512-gt+pI83ha04zLv2+5kSf/i6uPT4c8QEwscpATrYe2IKfOkCVpL++NrFcH7pWHc0vgm2fDGC8aY6OI2Mz7tEHhQ==, tarball: https://npm.jsr.io/~/11/@jsr/std__random/0.1.0.tgz}
+
+  '@jsr/std__streams@1.1.1':
+    resolution: {integrity: sha512-V9auR/i6gJz6SR1+h5wc4EN42IC5+ObBjXu/h7Buef7UOE0GtX4vRSx+3MJywEiBcJqQC+lCnf+wBAodvBL1SA==, tarball: https://npm.jsr.io/~/11/@jsr/std__streams/1.1.1.tgz}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -8201,11 +8213,17 @@ snapshots:
     dependencies:
       '@jsr/std__bytes': 1.0.6
 
+  '@jsr/std__media-types@1.1.0': {}
+
   '@jsr/std__path@1.1.6':
     dependencies:
       '@jsr/std__internal': 1.0.14
 
   '@jsr/std__random@0.1.0': {}
+
+  '@jsr/std__streams@1.1.1':
+    dependencies:
+      '@jsr/std__bytes': 1.0.6
 
   '@kwsites/file-exists@1.1.1':
     dependencies:


### PR DESCRIPTION
## Summary

- add a native Deno `HttpPlatform` backed by `Deno.FsFile.readable`
- preserve the raw full-file fast path while bounding range responses with `ByteSliceStream`
- add MIME and content-length headers, Deno-local tests, generated exports, and a changeset

## Testing

- `pnpm lint-fix`
- `deno check` in `packages/platform-deno`
- Deno Vitest with explicit read permission for `DenoHttpPlatform.test.ts`
- Node Vitest for `NodeHttpPlatform.test.ts`
- `pnpm check`

Closes EFF-148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a native Deno HTTP platform integration.
  - Added support for streaming file-backed responses, including partial and empty file responses.
  - Automatically sets content type and content length for file responses.
  - Added support for responses backed by Deno file objects.
  - Exported the new Deno HTTP platform for easy integration.

- **Bug Fixes**
  - Ensured zero-byte file responses produce an empty body with the correct length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->