### PR TITLE
Add Deno socket support

### DIFF
--- a/.changeset/add-deno-socket.md
+++ b/.changeset/add-deno-socket.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add native Deno TCP, Unix, and WebSocket integrations for Effect sockets.

--- a/packages/platform-deno/src/DenoSocket.ts
+++ b/packages/platform-deno/src/DenoSocket.ts
@@ -189,9 +189,8 @@ export const fromConn = <RO>(
             return Effect.void
           }
           const { conn, writer } = current
-          return Effect.sync(() => writer.releaseLock()).pipe(
-            Effect.andThen(closeWrite(conn))
-          )
+          writer.releaseLock()
+          return closeWrite(conn)
         })
     )
 

--- a/packages/platform-deno/src/DenoSocket.ts
+++ b/packages/platform-deno/src/DenoSocket.ts
@@ -12,7 +12,6 @@
 import type { Array } from "effect"
 import * as Channel from "effect/Channel"
 import * as Context from "effect/Context"
-import * as Data from "effect/Data"
 import * as Deferred from "effect/Deferred"
 import type * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -23,40 +22,26 @@ import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import * as Socket from "effect/unstable/socket/Socket"
 
-type ConnectOptions = (Deno.ConnectOptions | Deno.UnixConnectOptions) & {
+/**
+ * Options for opening a TCP or Unix connection.
+ *
+ * @category types
+ * @since 4.0.0
+ */
+export type ConnectOptions = (Deno.ConnectOptions | Deno.UnixConnectOptions) & {
   readonly noDelay?: boolean | undefined
   readonly keepAlive?: boolean | undefined
 }
 
-type TcpOptions = ConnectOptions & {
+/**
+ * Options for opening a TCP or Unix connection.
+ *
+ * @category types
+ * @since 4.0.0
+ */
+export type TcpOptions = ConnectOptions & {
   readonly openTimeout?: Duration.Input | undefined
 }
-
-const encoder = new TextEncoder()
-
-class DenoError extends Data.TaggedError("DenoError")<{
-  readonly cause: unknown
-}> {}
-
-const isBadResource = (cause: unknown): cause is Deno.errors.BadResource => cause instanceof Deno.errors.BadResource
-
-const isTeardownError = (cause: unknown): boolean => cause instanceof Deno.errors.Interrupted || isBadResource(cause)
-
-const close = (conn: Deno.Conn): Effect.Effect<void> =>
-  Effect.try({
-    try: () => conn.close(),
-    catch: (cause) => new DenoError({ cause })
-  }).pipe(
-    Effect.catch((error) => isBadResource(error.cause) ? Effect.void : Effect.die(error.cause))
-  )
-
-const closeWrite = (conn: Deno.Conn): Effect.Effect<void> =>
-  Effect.tryPromise({
-    try: () => conn.closeWrite(),
-    catch: (cause) => new DenoError({ cause })
-  }).pipe(
-    Effect.catch((error) => isBadResource(error.cause) ? Effect.void : Effect.die(error.cause))
-  )
 
 /**
  * Service tag for the underlying Deno connection.
@@ -116,10 +101,9 @@ export const fromConn = <RO>(
         }
         latch.openUnsafe()
 
-        const read = Effect.tryPromise({
-          try: () => reader.read(),
-          catch: (cause) => new DenoError({ cause })
-        }).pipe(
+        const read = Effect.tryPromise(
+          () => reader.read()
+        ).pipe(
           Effect.catchIf(
             (error) => tearingDown && isTeardownError(error.cause),
             () => Effect.succeed({ done: true, value: undefined } as ReadableStreamReadDoneResult<Uint8Array>)
@@ -316,3 +300,19 @@ export const layerWebSocket = (url: string, options?: {
  */
 export const layerWebSocketConstructor: Layer.Layer<Socket.WebSocketConstructor> =
   Socket.layerWebSocketConstructorGlobal
+
+const encoder = new TextEncoder()
+
+const isBadResource = (cause: unknown): cause is Deno.errors.BadResource => cause instanceof Deno.errors.BadResource
+
+const isTeardownError = (cause: unknown): boolean => cause instanceof Deno.errors.Interrupted || isBadResource(cause)
+
+const close = (conn: Deno.Conn): Effect.Effect<void> =>
+  Effect.try(() => conn.close()).pipe(
+    Effect.catch(({ cause }) => isBadResource(cause) ? Effect.void : Effect.die(cause))
+  )
+
+const closeWrite = (conn: Deno.Conn): Effect.Effect<void> =>
+  Effect.tryPromise(() => conn.closeWrite()).pipe(
+    Effect.catch((error) => isBadResource(error) ? Effect.void : Effect.die(error))
+  )

--- a/packages/platform-deno/src/DenoSocket.ts
+++ b/packages/platform-deno/src/DenoSocket.ts
@@ -184,8 +184,10 @@ export const fromConn = <RO>(
       }),
       () =>
         Effect.suspend(() => {
-          writeClosed = true
-          if (current === undefined) return Effect.void
+          if (current === undefined) {
+            writeClosed = true
+            return Effect.void
+          }
           const { conn, writer } = current
           return Effect.sync(() => writer.releaseLock()).pipe(
             Effect.andThen(closeWrite(conn))

--- a/packages/platform-deno/src/DenoSocket.ts
+++ b/packages/platform-deno/src/DenoSocket.ts
@@ -1,0 +1,317 @@
+/**
+ * Native Deno socket adapters for Effect sockets.
+ *
+ * This module uses Deno-specific names: `makeTcp`, `makeTcpChannel`,
+ * `layerTcp`, and `fromConn` correspond to the Node platform's net and duplex
+ * APIs. Deno does not support `keepAliveInitialDelay`, and the `noDelay` and
+ * `keepAlive` options have no effect on Unix connections. A `CloseEvent` always
+ * closes gracefully because Deno has no equivalent of Node's reset-on-close.
+ *
+ * @since 4.0.0
+ */
+import type { Array } from "effect"
+import * as Channel from "effect/Channel"
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+import * as Deferred from "effect/Deferred"
+import type * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as FiberSet from "effect/FiberSet"
+import * as Function from "effect/Function"
+import * as Latch from "effect/Latch"
+import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
+import * as Socket from "effect/unstable/socket/Socket"
+
+type ConnectOptions = (Deno.ConnectOptions | Deno.UnixConnectOptions) & {
+  readonly noDelay?: boolean | undefined
+  readonly keepAlive?: boolean | undefined
+}
+
+type TcpOptions = ConnectOptions & {
+  readonly openTimeout?: Duration.Input | undefined
+}
+
+const encoder = new TextEncoder()
+
+class DenoError extends Data.TaggedError("DenoError")<{
+  readonly cause: unknown
+}> {}
+
+const isBadResource = (cause: unknown): cause is Deno.errors.BadResource => cause instanceof Deno.errors.BadResource
+
+const isTeardownError = (cause: unknown): boolean => cause instanceof Deno.errors.Interrupted || isBadResource(cause)
+
+const close = (conn: Deno.Conn): Effect.Effect<void> =>
+  Effect.try({
+    try: () => conn.close(),
+    catch: (cause) => new DenoError({ cause })
+  }).pipe(
+    Effect.catch((error) => isBadResource(error.cause) ? Effect.void : Effect.die(error.cause))
+  )
+
+const closeWrite = (conn: Deno.Conn): Effect.Effect<void> =>
+  Effect.tryPromise({
+    try: () => conn.closeWrite(),
+    catch: (cause) => new DenoError({ cause })
+  }).pipe(
+    Effect.catch((error) => isBadResource(error.cause) ? Effect.void : Effect.die(error.cause))
+  )
+
+/**
+ * Service tag for the underlying Deno connection.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export class Conn extends Context.Service<Conn, Deno.Conn>()(
+  "@effect/platform-deno/DenoSocket/Conn"
+) {}
+
+/**
+ * Adapts a Deno connection into an Effect socket.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromConn = <RO>(
+  open: Effect.Effect<Deno.Conn, Socket.SocketError, RO>
+): Effect.Effect<Socket.Socket, never, Exclude<RO, Scope.Scope>> =>
+  Effect.withFiber<Socket.Socket, never, Exclude<RO, Scope.Scope>>((fiber) => {
+    let current: {
+      readonly conn: Deno.Conn
+      readonly writer: WritableStreamDefaultWriter<Uint8Array>
+    } | undefined
+    let tearingDown = false
+    let writeClosed = false
+    const latch = Latch.makeUnsafe(false)
+    const openServices = fiber.context as Context.Context<RO>
+
+    const run = <R, E, _>(handler: (_: Uint8Array) => Effect.Effect<_, E, R> | void, options?: {
+      readonly onOpen?: Effect.Effect<void> | undefined
+    }) =>
+      Effect.scopedWith(Effect.fnUntraced(function*(scope) {
+        const fiberSet = yield* FiberSet.make<any, E | Socket.SocketError>().pipe(
+          Scope.provide(scope)
+        )
+        let conn: Deno.Conn | undefined
+        yield* Scope.addFinalizer(
+          scope,
+          Effect.suspend(() => {
+            tearingDown = true
+            return conn === undefined ? Effect.void : close(conn)
+          })
+        )
+        conn = yield* Scope.provide(open, scope)
+        const reader = conn.readable.getReader()
+        const writer = conn.writable.getWriter()
+        const runFork = yield* Effect.provideService(FiberSet.runtime(fiberSet)<R>(), Conn, conn)
+
+        current = { conn, writer }
+        tearingDown = false
+        if (writeClosed) {
+          writeClosed = false
+          writer.releaseLock()
+          yield* closeWrite(conn)
+        }
+        latch.openUnsafe()
+
+        const read = Effect.tryPromise({
+          try: () => reader.read(),
+          catch: (cause) => new DenoError({ cause })
+        }).pipe(
+          Effect.catchIf(
+            (error) => tearingDown && isTeardownError(error.cause),
+            () => Effect.succeed({ done: true, value: undefined } as ReadableStreamReadDoneResult<Uint8Array>)
+          ),
+          Effect.mapError((error) =>
+            new Socket.SocketError({
+              reason: new Socket.SocketReadError({ cause: error.cause })
+            })
+          )
+        )
+        const readLoop: Effect.Effect<void, Socket.SocketError> = Effect.suspend(() =>
+          Effect.flatMap(read, ({ done, value }) => {
+            if (done) {
+              Deferred.doneUnsafe(fiberSet.deferred, Effect.void)
+              return Effect.void
+            }
+            const result = handler(value)
+            if (Effect.isEffect(result)) {
+              runFork(result)
+            }
+            return readLoop
+          })
+        )
+        yield* FiberSet.run(fiberSet, readLoop)
+
+        if (options?.onOpen) {
+          yield* options.onOpen
+        }
+        return yield* FiberSet.join(fiberSet)
+      })).pipe(
+        Effect.updateContext((input: Context.Context<R>) => Context.merge(openServices, input)),
+        Effect.onExit(() =>
+          Effect.sync(() => {
+            tearingDown = true
+            latch.closeUnsafe()
+            current = undefined
+          })
+        )
+      )
+
+    const write = (chunk: Uint8Array | string | Socket.CloseEvent) =>
+      latch.whenOpen(Effect.suspend(() => {
+        const { conn, writer } = current!
+        if (Socket.isCloseEvent(chunk)) {
+          tearingDown = true
+          return close(conn)
+        }
+        const bytes = typeof chunk === "string" ? encoder.encode(chunk) : chunk
+        return Effect.tryPromise({
+          try: () => writer.ready.then(() => writer.write(bytes)),
+          catch: (cause) =>
+            new Socket.SocketError({
+              reason: new Socket.SocketWriteError({ cause })
+            })
+        })
+      }))
+
+    const writer = Effect.acquireRelease(
+      Effect.sync(() => {
+        writeClosed = false
+        return write
+      }),
+      () =>
+        Effect.suspend(() => {
+          writeClosed = true
+          if (current === undefined) return Effect.void
+          const { conn, writer } = current
+          return Effect.sync(() => writer.releaseLock()).pipe(
+            Effect.andThen(closeWrite(conn))
+          )
+        })
+    )
+
+    return Effect.succeed(Socket.make({
+      run,
+      runRaw: run,
+      writer
+    }))
+  })
+
+/**
+ * Opens a native Deno TCP or Unix connection as an Effect socket.
+ *
+ * **Details**
+ *
+ * An `openTimeout` interrupts acquisition but cannot cancel the in-flight
+ * `Deno.connect` promise. The scope finalizer closes a connection that arrives
+ * after the timeout.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeTcp = (options: TcpOptions): Effect.Effect<Socket.Socket> => {
+  const { keepAlive, noDelay, openTimeout, ...connectOptions } = options
+  const acquire = Effect.contextWith((context: Context.Context<Scope.Scope>) => {
+    let conn: Deno.Conn | undefined
+    let finalized = false
+    return Scope.addFinalizer(
+      Context.get(context, Scope.Scope),
+      Effect.suspend(() => {
+        finalized = true
+        return conn === undefined ? Effect.void : close(conn)
+      })
+    ).pipe(
+      Effect.andThen(Effect.tryPromise({
+        try: () => {
+          const connecting = connectOptions.transport === "unix"
+            ? Deno.connect(connectOptions)
+            : Deno.connect(connectOptions)
+          return connecting.then((connection) => {
+            conn = connection
+            if (finalized) connection.close()
+            return connection
+          })
+        },
+        catch: (cause) =>
+          new Socket.SocketError({
+            reason: new Socket.SocketOpenError({ kind: "Unknown", cause })
+          })
+      })),
+      Effect.tap((connection) =>
+        Effect.sync(() => {
+          if ("setNoDelay" in connection && noDelay !== undefined) {
+            connection.setNoDelay(noDelay)
+          }
+          if ("setKeepAlive" in connection && keepAlive !== undefined) {
+            connection.setKeepAlive(keepAlive)
+          }
+        })
+      )
+    )
+  }).pipe(
+    openTimeout === undefined
+      ? Function.identity
+      : Effect.timeoutOrElse({
+        duration: openTimeout,
+        orElse: () =>
+          Effect.fail(
+            new Socket.SocketError({
+              reason: new Socket.SocketOpenError({ kind: "Timeout", cause: new Error("Connection timed out") })
+            })
+          )
+      })
+  )
+  return fromConn(acquire)
+}
+
+/**
+ * Creates a channel over a native Deno TCP or Unix connection.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeTcpChannel = <IE = never>(
+  options: ConnectOptions
+): Channel.Channel<
+  Array.NonEmptyReadonlyArray<Uint8Array>,
+  Socket.SocketError | IE,
+  void,
+  Array.NonEmptyReadonlyArray<Uint8Array | string | Socket.CloseEvent>,
+  IE
+> => Channel.unwrap(Effect.map(makeTcp(options), Socket.toChannelWith<IE>()))
+
+/**
+ * Provides a socket by opening a native Deno TCP or Unix connection.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerTcp: (options: ConnectOptions) => Layer.Layer<
+  Socket.Socket,
+  Socket.SocketError
+> = Function.flow(makeTcp, Layer.effect(Socket.Socket))
+
+/**
+ * Creates a socket layer connected to a URL with Deno's global WebSocket.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerWebSocket = (url: string, options?: {
+  readonly closeCodeIsError?: (code: number) => boolean
+}): Layer.Layer<Socket.Socket> =>
+  Layer.effect(Socket.Socket, Socket.makeWebSocket(url, options)).pipe(
+    Layer.provide(layerWebSocketConstructor)
+  )
+
+/**
+ * Provides the WebSocket constructor backed by `globalThis.WebSocket`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerWebSocketConstructor: Layer.Layer<Socket.WebSocketConstructor> =
+  Socket.layerWebSocketConstructorGlobal

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -57,6 +57,11 @@ export * as DenoServices from "./DenoServices.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoSocket from "./DenoSocket.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoStdio from "./DenoStdio.ts"
 
 /**

--- a/packages/platform-deno/test/DenoSocket.test.ts
+++ b/packages/platform-deno/test/DenoSocket.test.ts
@@ -19,6 +19,69 @@ const runEchoServer = (listener: Deno.Listener) =>
     Effect.promise(() => listener.accept().then((conn) => conn.readable.pipeTo(conn.writable)))
   )
 
+const makeTestConn = (options?: {
+  readonly data?: Uint8Array | undefined
+  readonly pendingRead?: boolean | undefined
+  readonly closeReadableOnCloseWrite?: boolean | undefined
+  readonly setNoDelay?: ((value?: boolean) => void) | undefined
+  readonly setKeepAlive?: ((value?: boolean) => void) | undefined
+}) => {
+  let controller!: ReadableStreamDefaultController<Uint8Array>
+  let readableClosed = false
+  let closeWrites = 0
+  const readable = new ReadableStream<Uint8Array>({
+    start(value) {
+      controller = value
+      if (options?.data) value.enqueue(options.data)
+      if (options?.pendingRead !== true) {
+        readableClosed = true
+        value.close()
+      }
+    }
+  })
+  const conn = {
+    readable,
+    writable: new WritableStream<Uint8Array>(),
+    read: () => Promise.resolve(null),
+    write: (data: Uint8Array) => Promise.resolve(data.length),
+    close() {
+      if (readableClosed) return
+      readableClosed = true
+      controller.close()
+    },
+    closeWrite() {
+      closeWrites++
+      if (options?.closeReadableOnCloseWrite && !readableClosed) {
+        readableClosed = true
+        controller.close()
+      }
+      return Promise.resolve()
+    },
+    ref() {},
+    unref() {},
+    localAddr: { transport: "tcp", hostname: "127.0.0.1", port: 0 },
+    remoteAddr: { transport: "tcp", hostname: "127.0.0.1", port: 0 },
+    [Symbol.dispose]() {
+      this.close()
+    },
+    ...(options?.setNoDelay ? { setNoDelay: options.setNoDelay } : {}),
+    ...(options?.setKeepAlive ? { setKeepAlive: options.setKeepAlive } : {})
+  } as Deno.Conn
+  return { conn, closeWrites: () => closeWrites }
+}
+
+const replaceDenoConnect = (
+  connect: (options: Deno.ConnectOptions | Deno.UnixConnectOptions) => Promise<Deno.Conn>
+) =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const descriptor = Object.getOwnPropertyDescriptor(Deno, "connect")!
+      Object.defineProperty(Deno, "connect", { ...descriptor, value: connect })
+      return descriptor
+    }),
+    (descriptor) => Effect.sync(() => Object.defineProperty(Deno, "connect", descriptor))
+  )
+
 describe("DenoSocket", () => {
   it.effect("echoes over TCP", () =>
     Effect.gen(function*() {
@@ -100,6 +163,83 @@ describe("DenoSocket", () => {
       )
 
       assert.strictEqual(output, "Closed")
+    }))
+
+  it.effect("does not carry a consumed half-close into a second run", () =>
+    Effect.gen(function*() {
+      const encoder = new TextEncoder()
+      const first = makeTestConn({ pendingRead: true, closeReadableOnCloseWrite: true })
+      const second = makeTestConn({ data: encoder.encode("Second") })
+      const connections = [first.conn, second.conn]
+      let index = 0
+      const socket = yield* DenoSocket.fromConn(Effect.sync(() => connections[index++]!))
+      const opened = yield* Deferred.make<void>()
+
+      const firstRun = yield* socket.run(() => {}, {
+        onOpen: Deferred.succeed(opened, undefined)
+      }).pipe(Effect.forkChild)
+      yield* Deferred.await(opened)
+      yield* Effect.scoped(socket.writer)
+      yield* Fiber.join(firstRun)
+
+      const received: Array<Uint8Array> = []
+      yield* socket.run((chunk) => Effect.sync(() => received.push(chunk)))
+
+      assert.deepStrictEqual(received, [encoder.encode("Second")])
+      assert.strictEqual(first.closeWrites(), 1)
+      assert.strictEqual(second.closeWrites(), 0)
+    }))
+
+  it.effect("maps connection refusal to SocketOpenError", () =>
+    Effect.gen(function*() {
+      const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 })
+      const address = listener.addr as Deno.NetAddr
+      listener.close()
+      const socket = yield* DenoSocket.makeTcp({ hostname: address.hostname, port: address.port })
+
+      const error = yield* socket.run(() => {}).pipe(Effect.flip)
+
+      assert.instanceOf(error, Socket.SocketError)
+      assert.strictEqual(error.reason._tag, "SocketOpenError")
+      if (error.reason._tag === "SocketOpenError") {
+        assert.strictEqual(error.reason.kind, "Unknown")
+        assert.instanceOf(error.reason.cause, Deno.errors.ConnectionRefused)
+      }
+    }))
+
+  it.effect("applies TCP tuning options and ignores them for Unix", () =>
+    Effect.gen(function*() {
+      const noDelay: Array<boolean | undefined> = []
+      const keepAlive: Array<boolean | undefined> = []
+      const tcp = makeTestConn({
+        setNoDelay: (value) => noDelay.push(value),
+        setKeepAlive: (value) => keepAlive.push(value)
+      })
+      const unix = makeTestConn()
+      const connections = [tcp.conn, unix.conn]
+      const connectOptions: Array<Deno.ConnectOptions | Deno.UnixConnectOptions> = []
+      let index = 0
+      yield* replaceDenoConnect((options) => {
+        connectOptions.push(options)
+        return Promise.resolve(connections[index++]!)
+      })
+
+      const tcpSocket = yield* DenoSocket.makeTcp({ port: 1, noDelay: false, keepAlive: true })
+      yield* tcpSocket.run(() => {})
+      const unixSocket = yield* DenoSocket.makeTcp({
+        transport: "unix",
+        path: "/unused.sock",
+        noDelay: true,
+        keepAlive: false
+      })
+      yield* unixSocket.run(() => {})
+
+      assert.deepStrictEqual(noDelay, [false])
+      assert.deepStrictEqual(keepAlive, [true])
+      assert.deepStrictEqual(connectOptions, [
+        { port: 1 },
+        { transport: "unix", path: "/unused.sock" }
+      ])
     }))
 
   it.effect("echoes over Unix sockets", () =>

--- a/packages/platform-deno/test/DenoSocket.test.ts
+++ b/packages/platform-deno/test/DenoSocket.test.ts
@@ -1,0 +1,192 @@
+import * as DenoSocket from "@effect/platform-deno/DenoSocket"
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Fiber, Queue } from "effect"
+import * as Stream from "effect/Stream"
+import * as Socket from "effect/unstable/socket/Socket"
+
+const makeTcpServer = Effect.acquireRelease(
+  Effect.sync(() => Deno.listen({ hostname: "127.0.0.1", port: 0 })),
+  (listener) => Effect.sync(() => listener.close())
+)
+
+const makeTempDir = Effect.acquireRelease(
+  Effect.promise(() => Deno.makeTempDir()),
+  (path) => Effect.promise(() => Deno.remove(path, { recursive: true }))
+)
+
+const runEchoServer = (listener: Deno.Listener) =>
+  Effect.forever(
+    Effect.promise(() => listener.accept().then((conn) => conn.readable.pipeTo(conn.writable)))
+  )
+
+describe("DenoSocket", () => {
+  it.effect("echoes over TCP", () =>
+    Effect.gen(function*() {
+      const listener = yield* makeTcpServer
+      yield* runEchoServer(listener).pipe(Effect.forkScoped)
+      const address = listener.addr as Deno.NetAddr
+
+      const output = yield* Stream.make("Hello", "World").pipe(
+        Stream.encodeText,
+        Stream.pipeThroughChannel(DenoSocket.makeTcpChannel({ hostname: address.hostname, port: address.port })),
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      assert.strictEqual(output, "HelloWorld")
+    }))
+
+  it.effect("keeps reading after the write side closes", () =>
+    Effect.gen(function*() {
+      const listener = yield* makeTcpServer
+      const address = listener.addr as Deno.NetAddr
+      const writeClosed = yield* Deferred.make<void>()
+      const encoder = new TextEncoder()
+      const decoder = new TextDecoder()
+
+      yield* Effect.gen(function*() {
+        const conn = yield* Effect.promise(() => listener.accept())
+        const chunks: Array<string> = []
+        const read: Effect.Effect<void> = Effect.suspend(() => {
+          const buffer = new Uint8Array(5)
+          return Effect.promise(() => conn.read(buffer)).pipe(
+            Effect.flatMap((size) => {
+              if (size === null) return Effect.void
+              chunks.push(decoder.decode(buffer.subarray(0, size)))
+              return read
+            })
+          )
+        })
+        yield* read
+        assert.strictEqual(chunks.join(""), "Hello")
+        yield* Deferred.succeed(writeClosed, undefined)
+        const writer = conn.writable.getWriter()
+        yield* Effect.promise(() => writer.ready.then(() => writer.write(encoder.encode("Hello"))))
+        writer.releaseLock()
+        yield* Effect.promise(() => conn.closeWrite())
+      }).pipe(Effect.forkScoped)
+
+      const socket = yield* DenoSocket.makeTcp({ hostname: address.hostname, port: address.port })
+      const messages = yield* Queue.unbounded<Uint8Array>()
+      const runFiber = yield* socket.run((chunk) => Queue.offer(messages, chunk)).pipe(Effect.forkChild)
+      yield* Effect.scoped(
+        socket.writer.pipe(Effect.flatMap((write) => write(encoder.encode("Hello"))))
+      )
+      yield* Deferred.await(writeClosed)
+
+      assert.deepStrictEqual(yield* Queue.take(messages), encoder.encode("Hello"))
+      yield* Fiber.join(runFiber)
+    }))
+
+  it.effect("half-closes an empty channel input", () =>
+    Effect.gen(function*() {
+      const listener = yield* makeTcpServer
+      const address = listener.addr as Deno.NetAddr
+      const encoder = new TextEncoder()
+
+      yield* Effect.gen(function*() {
+        const conn = yield* Effect.promise(() => listener.accept())
+        assert.strictEqual(yield* Effect.promise(() => conn.read(new Uint8Array(1))), null)
+        const writer = conn.writable.getWriter()
+        yield* Effect.promise(() => writer.write(encoder.encode("Closed")))
+        writer.releaseLock()
+        yield* Effect.promise(() => conn.closeWrite())
+      }).pipe(Effect.forkScoped)
+
+      const output = yield* Stream.empty.pipe(
+        Stream.pipeThroughChannel(DenoSocket.makeTcpChannel({ hostname: address.hostname, port: address.port })),
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      assert.strictEqual(output, "Closed")
+    }))
+
+  it.effect("echoes over Unix sockets", () =>
+    Effect.gen(function*() {
+      const directory = yield* makeTempDir
+      const path = `${directory}/echo.sock`
+      const listener = yield* Effect.acquireRelease(
+        Effect.sync(() => Deno.listen({ transport: "unix", path })),
+        (listener) => Effect.sync(() => listener.close())
+      )
+      yield* runEchoServer(listener).pipe(Effect.forkScoped)
+
+      const output = yield* Stream.make("Hello", "Unix").pipe(
+        Stream.encodeText,
+        Stream.pipeThroughChannel(DenoSocket.makeTcpChannel({ transport: "unix", path })),
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      assert.strictEqual(output, "HelloUnix")
+    }))
+
+  it.effect("uses Deno's native WebSocket", () =>
+    Effect.gen(function*() {
+      const server = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Deno.serve(
+            { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+            (request) => {
+              const { response, socket } = Deno.upgradeWebSocket(request)
+              socket.onmessage = (event) => socket.send(event.data)
+              return response
+            }
+          )
+        ),
+        (server) => Effect.promise(() => server.shutdown())
+      )
+      const address = server.addr as Deno.NetAddr
+      const messages = yield* Queue.unbounded<Uint8Array>()
+
+      yield* Effect.gen(function*() {
+        const socket = yield* Socket.Socket
+        const runFiber = yield* socket.run((chunk) => Queue.offer(messages, chunk)).pipe(Effect.forkChild)
+        const write = yield* socket.writer
+        yield* write("Hello WebSocket")
+
+        assert.deepStrictEqual(yield* Queue.take(messages), new TextEncoder().encode("Hello WebSocket"))
+        yield* Fiber.interrupt(runFiber)
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(DenoSocket.layerWebSocket(`ws://${address.hostname}:${address.port}`, {
+          closeCodeIsError: () => false
+        }))
+      )
+    }))
+
+  it.effect("adapts a TransformStream", () =>
+    Effect.gen(function*() {
+      const readable = Stream.make("A", "B", "C").pipe(
+        Stream.tap(() => Effect.sleep(50)),
+        Stream.toReadableStream()
+      )
+      const decoder = new TextDecoder()
+      const chunks: Array<string> = []
+      const writable = new WritableStream<Uint8Array>({
+        write(chunk) {
+          chunks.push(decoder.decode(chunk))
+        }
+      })
+
+      const socket = yield* Socket.fromTransformStream(
+        Effect.succeed({ readable, writable }),
+        { closeCodeIsError: () => false }
+      )
+      yield* socket.writer.pipe(
+        Effect.tap((write) => write("Hello").pipe(Effect.andThen(write("World")))),
+        Effect.scoped,
+        Effect.forkChild
+      )
+      const received: Array<string> = []
+      yield* socket.run((chunk) =>
+        Effect.sync(() => {
+          received.push(decoder.decode(chunk))
+        })
+      ).pipe(Effect.scoped)
+
+      assert.deepStrictEqual(chunks, ["Hello", "World"])
+      assert.deepStrictEqual(received, ["A", "B", "C"])
+    }))
+})


### PR DESCRIPTION
## Summary

- add a native Deno TCP and Unix socket adapter with scoped half-close semantics
- provide TCP channel/layer and native WebSocket layers
- cover TCP, Unix, half-close, empty input, sequential socket reuse, connection refusal, transport tuning, native WebSocket, and TransformStream behavior

## Testing

- `deno task test --run packages/platform-deno/test/DenoSocket.test.ts`
- `pnpm --filter @effect/platform-deno check`
- `pnpm check`
- `pnpm lint`

## Known Gaps

The deliberately excluded error-path cases are `openTimeout`, connection reset, broken-pipe writes, `CloseEvent`, and teardown-time `Interrupted` / `BadResource`. These can be added independently without expanding this PR.

Closes EFF-146
