### PR TITLE
Fix OpenAI stable web search action parameters

### DIFF
--- a/.changeset/fix-openai-web-search-action.md
+++ b/.changeset/fix-openai-web-search-action.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Fix OpenAI stable web search response decoding by preserving the provider action in tool call parameters.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1615,7 +1615,9 @@ const makeResponse = Effect.fnUntraced(
             type: "tool-call",
             id: part.id,
             name: toolName,
-            params: {},
+            params: webSearchTool?.name === "OpenAiWebSearchPreview"
+              ? {}
+              : { action: part.action },
             providerExecuted: true
           })
           parts.push({
@@ -1943,6 +1945,9 @@ const makeStreamResponse = Effect.fnUntraced(
                   id: event.item.id,
                   name: toolName
                 }
+                if (webSearchTool?.name === "OpenAiWebSearch") {
+                  break
+                }
                 parts.push({
                   type: "tool-params-start",
                   id: event.item.id,
@@ -2256,6 +2261,15 @@ const makeStreamResponse = Effect.fnUntraced(
                 const toolName = toolNameMapper.getCustomName(
                   webSearchTool?.name ?? "web_search"
                 )
+                if (webSearchTool?.name === "OpenAiWebSearch") {
+                  parts.push({
+                    type: "tool-call",
+                    id: event.item.id,
+                    name: toolName,
+                    params: { action: event.item.action },
+                    providerExecuted: true
+                  })
+                }
                 parts.push({
                   type: "tool-result",
                   id: event.item.id,

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -752,6 +752,39 @@ describe("OpenAiLanguageModel", () => {
           }
         }))))
 
+      for (const model of ["gpt-4.1", "gpt-5.6"] as const) {
+        it.effect(`maps stable web search action to tool call parameters with ${model}`, () =>
+          Effect.gen(function*() {
+            const toolkit = Toolkit.make(OpenAiTool.WebSearch({}))
+            const result = yield* LanguageModel.generateText({
+              prompt: "Search the web",
+              toolkit
+            }).pipe(Effect.provide(OpenAiLanguageModel.model(model)))
+
+            const toolCall = result.content.find((part) => part.type === "tool-call")
+            assert.isDefined(toolCall)
+            if (toolCall?.type === "tool-call") {
+              deepStrictEqual(toolCall.params, {
+                action: { type: "search", query: "Effect TypeScript" }
+              })
+            }
+
+            const toolResult = result.content.find((part) => part.type === "tool-result")
+            assert.isDefined(toolResult)
+            if (toolResult?.type === "tool-result") {
+              deepStrictEqual(toolResult.result, {
+                action: { type: "search", query: "Effect TypeScript" },
+                status: "completed"
+              })
+            }
+          }).pipe(Effect.provide(makeTestLayer({
+            body: {
+              model,
+              output: [makeWebSearchCall()]
+            }
+          }))))
+      }
+
       it.effect("uses canonical OpenAiMcp name for mcp_approval_request", () =>
         Effect.gen(function*() {
           const result = yield* LanguageModel.generateText({
@@ -1097,6 +1130,64 @@ describe("OpenAiLanguageModel", () => {
 
         const toolParamsEnd = parts.find((part) => part.type === "tool-params-end" && part.id === "call_1")
         assert.isDefined(toolParamsEnd)
+      }))
+
+    it.effect("waits for the stable streamed web search action before emitting the tool call", () =>
+      Effect.gen(function*() {
+        const toolkit = Toolkit.make(OpenAiTool.WebSearch({}))
+        const streamEvents = [
+          {
+            type: "response.created",
+            sequence_number: 1,
+            response: makeDefaultResponse({ status: "in_progress" })
+          },
+          {
+            type: "response.output_item.added",
+            sequence_number: 2,
+            output_index: 0,
+            item: {
+              type: "web_search_call",
+              id: "ws_123",
+              status: "in_progress"
+            }
+          },
+          {
+            type: "response.output_item.done",
+            sequence_number: 3,
+            output_index: 0,
+            item: makeWebSearchCall()
+          }
+        ] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "Search the web",
+          toolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer(streamEvents))
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        const toolCalls = parts.filter((part) => part.type === "tool-call")
+        strictEqual(toolCalls.length, 1)
+        const toolCall = toolCalls[0]
+        assert.isDefined(toolCall)
+        if (toolCall?.type === "tool-call") {
+          deepStrictEqual(toolCall.params, {
+            action: { type: "search", query: "Effect TypeScript" }
+          })
+        }
+
+        const toolResult = parts.find((part) => part.type === "tool-result")
+        assert.isDefined(toolResult)
+        if (toolResult?.type === "tool-result") {
+          deepStrictEqual(toolResult.result, {
+            action: { type: "search", query: "Effect TypeScript" },
+            status: "completed"
+          })
+        }
       }))
 
     it.effect("handles reasoning summary events when reasoning state is missing", () =>
@@ -1509,6 +1600,16 @@ const makeFunctionCall = (
   name,
   arguments: JSON.stringify(args),
   status: "completed",
+  ...overrides
+})
+
+const makeWebSearchCall = (
+  overrides: Partial<Generated.WebSearchToolCall> = {}
+): Generated.WebSearchToolCall => ({
+  type: "web_search_call",
+  id: "ws_123",
+  status: "completed",
+  action: { type: "search", query: "Effect TypeScript" },
   ...overrides
 })
 

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -752,38 +752,37 @@ describe("OpenAiLanguageModel", () => {
           }
         }))))
 
-      for (const model of ["gpt-4.1", "gpt-5.6"] as const) {
-        it.effect(`maps stable web search action to tool call parameters with ${model}`, () =>
-          Effect.gen(function*() {
-            const toolkit = Toolkit.make(OpenAiTool.WebSearch({}))
-            const result = yield* LanguageModel.generateText({
-              prompt: "Search the web",
-              toolkit
-            }).pipe(Effect.provide(OpenAiLanguageModel.model(model)))
+      it.each(["gpt-4.1", "gpt-5.6"] as const)(
+        "maps stable web search action to tool call parameters with %s",
+        (model) =>
+          Effect.runPromise(
+            Effect.gen(function*() {
+              const toolkit = Toolkit.make(OpenAiTool.WebSearch({}))
+              const result = yield* LanguageModel.generateText({
+                prompt: "Search the web",
+                toolkit
+              }).pipe(Effect.provide(OpenAiLanguageModel.model(model)))
 
-            const toolCall = result.content.find((part) => part.type === "tool-call")
-            assert.isDefined(toolCall)
-            if (toolCall?.type === "tool-call") {
-              deepStrictEqual(toolCall.params, {
+              const toolCall = result.content.find((part) => part.type === "tool-call")
+              assert.isDefined(toolCall)
+              assert.deepStrictEqual(toolCall.params, {
                 action: { type: "search", query: "Effect TypeScript" }
               })
-            }
 
-            const toolResult = result.content.find((part) => part.type === "tool-result")
-            assert.isDefined(toolResult)
-            if (toolResult?.type === "tool-result") {
-              deepStrictEqual(toolResult.result, {
+              const toolResult = result.content.find((part) => part.type === "tool-result")
+              assert.isDefined(toolResult)
+              assert.deepStrictEqual(toolResult.result, {
                 action: { type: "search", query: "Effect TypeScript" },
                 status: "completed"
               })
-            }
-          }).pipe(Effect.provide(makeTestLayer({
-            body: {
-              model,
-              output: [makeWebSearchCall()]
-            }
-          }))))
-      }
+            }).pipe(Effect.provide(makeTestLayer({
+              body: {
+                model,
+                output: [makeWebSearchCall()]
+              }
+            })))
+          )
+      )
 
       it.effect("uses canonical OpenAiMcp name for mcp_approval_request", () =>
         Effect.gen(function*() {
@@ -1159,7 +1158,7 @@ describe("OpenAiLanguageModel", () => {
           }
         ] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
 
-        const partsChunk = yield* LanguageModel.streamText({
+        const parts = yield* LanguageModel.streamText({
           prompt: "Search the web",
           toolkit,
           disableToolCallResolution: true
@@ -1169,25 +1168,20 @@ describe("OpenAiLanguageModel", () => {
           Effect.provide(makeStreamTestLayer(streamEvents))
         )
 
-        const parts = globalThis.Array.from(partsChunk)
         const toolCalls = parts.filter((part) => part.type === "tool-call")
         strictEqual(toolCalls.length, 1)
         const toolCall = toolCalls[0]
         assert.isDefined(toolCall)
-        if (toolCall?.type === "tool-call") {
-          deepStrictEqual(toolCall.params, {
-            action: { type: "search", query: "Effect TypeScript" }
-          })
-        }
+        assert.deepStrictEqual(toolCall.params, {
+          action: { type: "search", query: "Effect TypeScript" }
+        })
 
         const toolResult = parts.find((part) => part.type === "tool-result")
         assert.isDefined(toolResult)
-        if (toolResult?.type === "tool-result") {
-          deepStrictEqual(toolResult.result, {
-            action: { type: "search", query: "Effect TypeScript" },
-            status: "completed"
-          })
-        }
+        assert.deepStrictEqual(toolResult.result, {
+          action: { type: "search", query: "Effect TypeScript" },
+          status: "completed"
+        })
       }))
 
     it.effect("handles reasoning summary events when reasoning state is missing", () =>


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Stable OpenAI `web_search` responses currently become Effect tool calls with `params: {}`, while `OpenAiTool.WebSearch` requires `params.action`. A successful provider response therefore fails Effect response decoding with `InvalidOutputError: Missing key at ["params"]["action"]`.

This change preserves the existing public tool schema and maps the completed provider action into stable web search tool-call parameters. For streaming responses, the initial `response.output_item.added` event may not contain `action`, so the stable tool call is emitted when `response.output_item.done` provides the completed action. `WebSearchPreview` keeps its existing empty-parameter behavior.

## OpenAI API Reference

OpenAI documents that Responses API web search output includes “a `web_search_call` output item with the ID of the search call, along with the action taken in `web_search_call.action`.”

https://platform.openai.com/docs/guides/tools-web-search#output-and-citations

The documented response shape includes:

```json
{
  "type": "web_search_call",
  "id": "ws_...",
  "status": "completed",
  "action": {
    "type": "search",
    "query": "latest news about AI"
  }
}
```

## Testing

- Added deterministic non-streaming coverage with `gpt-4.1` and `gpt-5.6` model configurations.
- Added streaming coverage where the partial item omits `action` and the completed item supplies it.
- Verified the provider action remains available in both tool-call parameters and the tool result.
- `pnpm test --run`: 96 tests passed.
- `pnpm check`: passed.
- `pnpm build`: passed.
- dprint, oxlint, and `git diff --check`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAI web search responses so search actions are correctly preserved in tool calls and results.
  * Improved streamed web search handling by waiting for complete action details before emitting tool-call events.
  * Ensured stable web search actions include the expected search type and query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->