### PR TITLE
add platform literal to HttpPlatform

### DIFF
--- a/.changeset/clever-maps-care.md
+++ b/.changeset/clever-maps-care.md
@@ -1,0 +1,8 @@
+---
+"@effect/platform-deno": patch
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+"effect": patch
+---
+
+add platform literal to HttpPlatform

--- a/packages/effect/src/unstable/http/HttpPlatform.ts
+++ b/packages/effect/src/unstable/http/HttpPlatform.ts
@@ -29,6 +29,7 @@ import * as Response from "./HttpServerResponse.ts"
  * @since 4.0.0
  */
 export class HttpPlatform extends Context.Service<HttpPlatform, {
+  readonly platform: "deno" | "node" | "bun" | "web"
   readonly fileResponse: (
     path: string,
     options?: Response.Options.WithContent & {
@@ -54,6 +55,7 @@ export class HttpPlatform extends Context.Service<HttpPlatform, {
  * @since 4.0.0
  */
 export const make: (impl: {
+  readonly platform: "deno" | "node" | "bun" | "web"
   readonly fileResponse: (
     path: string,
     status: number,
@@ -83,6 +85,7 @@ export const make: (impl: {
   const etagGen = yield* Etag.Generator
 
   return HttpPlatform.of({
+    platform: impl.platform,
     fileResponse: Effect.fnUntraced(function*(path, options) {
       const info = yield* fs.stat(path)
       const etag = yield* etagGen.fromFileInfo(info)
@@ -143,6 +146,7 @@ export const make: (impl: {
 export const layer = Layer.effect(HttpPlatform)(
   Effect.flatMap(FileSystem.FileSystem, (fs) =>
     make({
+      platform: "web",
       fileResponse(path, status, statusText, headers, start, end, contentLength) {
         return Response.stream(
           fs.stream(path, {

--- a/packages/platform-bun/src/BunHttpPlatform.ts
+++ b/packages/platform-bun/src/BunHttpPlatform.ts
@@ -26,6 +26,7 @@ const make: Effect.Effect<
   never,
   FileSystem | Etag.Generator
 > = Platform.make({
+  platform: "bun",
   fileResponse(path, status, statusText, headers, start, end, _contentLength) {
     let file = Bun.file(path)
     if (start > 0 || end !== undefined) {

--- a/packages/platform-deno/src/DenoHttpPlatform.ts
+++ b/packages/platform-deno/src/DenoHttpPlatform.ts
@@ -28,6 +28,7 @@ import * as DenoFileSystem from "./DenoFileSystem.ts"
  * @since 4.0.0
  */
 export const make = Platform.make({
+  platform: "deno",
   fileResponse(path, status, statusText, headers, start, end, contentLength) {
     let body: ReadableStream<Uint8Array>
     if (contentLength === 0) {

--- a/packages/platform-node/src/NodeHttpPlatform.ts
+++ b/packages/platform-node/src/NodeHttpPlatform.ts
@@ -27,6 +27,7 @@ import * as NodeFileSystem from "./NodeFileSystem.ts"
  * @since 4.0.0
  */
 export const make = Platform.make({
+  platform: "node",
   fileResponse(path, status, statusText, headers, start, end, contentLength) {
     const stream = contentLength === 0
       ? Readable.from([])

--- a/packages/platform-node/test/HttpStaticServerConditional.test.ts
+++ b/packages/platform-node/test/HttpStaticServerConditional.test.ts
@@ -61,6 +61,7 @@ const makeHandler = async () => {
   })
 
   const httpPlatform = HttpPlatform.HttpPlatform.of({
+    platform: "node",
     fileResponse: (_path, options) =>
       Effect.succeed(HttpServerResponse.text(fileBody, {
         status: options?.status,
@@ -100,6 +101,7 @@ const makeFailingApp = async (options: {
   })
 
   const httpPlatform = HttpPlatform.HttpPlatform.of({
+    platform: "node",
     fileResponse: (_path, fileOptions) => {
       if (options.fileResponseError !== undefined) {
         return Effect.fail(options.fileResponseError)
@@ -137,6 +139,7 @@ const makeLayerHandler = (options: {
     }
   })
   const httpPlatform = HttpPlatform.HttpPlatform.of({
+    platform: "node",
     fileResponse: () =>
       options.fileResponseError !== undefined
         ? Effect.fail(options.fileResponseError)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP platform services now expose a runtime `platform` identifier (Web, Node, Deno, or Bun).
  * HTTP platform creation now requires specifying the matching `platform` value for the implementation, with the default set to Web.
* **Tests**
  * Updated HTTP static server conditional tests to explicitly provide the Node `platform` value.
* **Chores**
  * Bumped relevant platform/effect package versions via a patch changeset.
* **Documentation**
  * Added release-notes guidance to include a platform literal for `HttpPlatform`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->