### PR TITLE
Add Deno socket server support

### DIFF
--- a/.changeset/add-deno-socket-server.md
+++ b/.changeset/add-deno-socket-server.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add native Deno TCP, Unix, and TLS socket server adapters.

--- a/packages/platform-deno/src/DenoSocketServer.ts
+++ b/packages/platform-deno/src/DenoSocketServer.ts
@@ -1,0 +1,108 @@
+/**
+ * Native Deno TCP and Unix socket servers for Effect's unstable socket server
+ * API.
+ *
+ * The plain `make` and `layer` names intentionally differ from
+ * `DenoSocket.makeTcp` and `DenoSocket.layerTcp` because this module has only
+ * one server kind. Deno has no standalone WebSocket server, so WebSocket
+ * constructors are omitted, and there is no `IncomingMessage` analogue.
+ * Connections made before `run` starts remain in the kernel backlog instead of
+ * being accepted and buffered as they are by the Node implementation. A second
+ * concurrent `run` waits for the first because listener access is guarded by a
+ * semaphore.
+ *
+ * Deno-native TLS server constructors are included even though the Node socket
+ * server has no corresponding dedicated constructors. TLS is deliberately not
+ * tested here because the repository has no certificate fixture.
+ *
+ * @since 4.0.0
+ */
+import * as Effect from "effect/Effect"
+import * as Function from "effect/Function"
+import * as Layer from "effect/Layer"
+import type * as Scope from "effect/Scope"
+import * as SocketServer from "effect/unstable/socket/SocketServer"
+import { closeListener, fromListener } from "./internal/denoSocketServer.ts"
+
+type ListenOptions =
+  | (Deno.TcpListenOptions & { transport?: "tcp" })
+  | (Deno.UnixListenOptions & { transport: "unix" })
+
+type TlsListenOptions = Deno.ListenTlsOptions & Deno.TlsCertifiedKeyPem
+
+/**
+ * Creates a scoped socket server using a native Deno TCP or Unix listener.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make: (
+  options: ListenOptions
+) => Effect.Effect<
+  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServerError,
+  Scope.Scope
+> = Effect.fnUntraced(function*(options) {
+  const listener = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => options.transport === "unix" ? Deno.listen(options) : Deno.listen(options),
+      catch: openError
+    }),
+    closeListener
+  )
+  return fromListener(listener)
+})
+
+/**
+ * Provides a socket server using a scoped native Deno TCP or Unix listener.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer: (
+  options: ListenOptions
+) => Layer.Layer<SocketServer.SocketServer, SocketServer.SocketServerError> = Function.flow(
+  make,
+  Layer.effect(SocketServer.SocketServer)
+)
+
+/**
+ * Creates a scoped TLS socket server using a native Deno TLS listener.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeTls: (
+  options: TlsListenOptions
+) => Effect.Effect<
+  SocketServer.SocketServer["Service"],
+  SocketServer.SocketServerError,
+  Scope.Scope
+> = Effect.fnUntraced(function*(options) {
+  const listener = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => Deno.listenTls(options),
+      catch: openError
+    }),
+    closeListener
+  )
+  return fromListener(listener)
+})
+
+/**
+ * Provides a TLS socket server using a scoped native Deno TLS listener.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerTls: (
+  options: TlsListenOptions
+) => Layer.Layer<SocketServer.SocketServer, SocketServer.SocketServerError> = Function.flow(
+  makeTls,
+  Layer.effect(SocketServer.SocketServer)
+)
+
+const openError = (cause: unknown) =>
+  new SocketServer.SocketServerError({
+    reason: new SocketServer.SocketServerOpenError({ cause })
+  })

--- a/packages/platform-deno/src/DenoSocketServer.ts
+++ b/packages/platform-deno/src/DenoSocketServer.ts
@@ -24,11 +24,23 @@ import type * as Scope from "effect/Scope"
 import * as SocketServer from "effect/unstable/socket/SocketServer"
 import { closeListener, fromListener } from "./internal/denoSocketServer.ts"
 
-type ListenOptions =
+/**
+ * Native Deno options for listening on a TCP or Unix socket.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ListenOptions =
   | (Deno.TcpListenOptions & { transport?: "tcp" })
   | (Deno.UnixListenOptions & { transport: "unix" })
 
-type TlsListenOptions = Deno.ListenTlsOptions & Deno.TlsCertifiedKeyPem
+/**
+ * Native Deno options and certified key material for listening with TLS.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type TlsListenOptions = Deno.ListenTlsOptions & Deno.TlsCertifiedKeyPem
 
 /**
  * Creates a scoped socket server using a native Deno TCP or Unix listener.

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -62,6 +62,11 @@ export * as DenoSocket from "./DenoSocket.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoSocketServer from "./DenoSocketServer.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoStdio from "./DenoStdio.ts"
 
 /**

--- a/packages/platform-deno/src/internal/denoSocketServer.ts
+++ b/packages/platform-deno/src/internal/denoSocketServer.ts
@@ -1,0 +1,88 @@
+import * as Cause from "effect/Cause"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import { pipe } from "effect/Function"
+import * as References from "effect/References"
+import * as Scope from "effect/Scope"
+import * as Semaphore from "effect/Semaphore"
+import type * as Socket from "effect/unstable/socket/Socket"
+import * as SocketServer from "effect/unstable/socket/SocketServer"
+import * as DenoSocket from "../DenoSocket.ts"
+
+const initialBackoffMillis = 10
+const maximumBackoffMillis = 1_000
+
+type Listener = Deno.Listener<Deno.Conn, Deno.NetAddr | Deno.UnixAddr>
+
+export const fromListener = (listener: Listener): SocketServer.SocketServer["Service"] => {
+  const semaphore = Semaphore.makeUnsafe(1)
+
+  const run = <R, E, _>(handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>) =>
+    semaphore.withPermit(Effect.gen(function*() {
+      const scope = yield* Scope.make()
+      const services = Context.omit(Scope.Scope)(yield* Effect.context<R>()) as Context.Context<R>
+      const trackFiber = Fiber.runIn(scope)
+      let failures = 0
+
+      const loop: Effect.Effect<never> = Effect.suspend(() =>
+        Effect.tryPromise(() => listener.accept()).pipe(
+          Effect.matchEffect({
+            onFailure: (error) => {
+              const cause = error.cause
+              if (isTeardownError(cause)) return Effect.never
+              const backoff = Math.min(initialBackoffMillis * 2 ** failures++, maximumBackoffMillis)
+              return reportUnhandledError(Cause.fail(cause)).pipe(
+                Effect.andThen(Effect.sleep(backoff)),
+                Effect.andThen(loop)
+              )
+            },
+            onSuccess: (conn) => {
+              failures = 0
+              pipe(
+                DenoSocket.fromConn(Effect.acquireRelease(Effect.succeed(conn), closeConn)),
+                Effect.flatMap(handler),
+                Effect.catchCause(reportUnhandledError),
+                Effect.runForkWith(Context.add(services, DenoSocket.Conn, conn)),
+                trackFiber
+              )
+              return loop
+            }
+          })
+        )
+      )
+
+      return yield* loop.pipe(Effect.ensuring(Scope.close(scope, Exit.void)))
+    }))
+
+  const address = listener.addr
+  return SocketServer.SocketServer.of({
+    address: "path" in address
+      ? { _tag: "UnixAddress", path: address.path }
+      : { _tag: "TcpAddress", hostname: address.hostname, port: address.port },
+    run
+  })
+}
+
+export const closeListener = (listener: Listener): Effect.Effect<void> =>
+  Effect.try(() => listener.close()).pipe(
+    Effect.catch(({ cause }) => isTeardownError(cause) ? Effect.void : Effect.die(cause))
+  )
+
+const closeConn = (conn: Deno.Conn): Effect.Effect<void> =>
+  Effect.try(() => conn.close()).pipe(
+    Effect.catch(({ cause }) => isTeardownError(cause) ? Effect.void : Effect.die(cause))
+  )
+
+const isTeardownError = (cause: unknown): boolean =>
+  cause instanceof Deno.errors.BadResource || cause instanceof Deno.errors.Interrupted
+
+const reportUnhandledError = <E>(cause: Cause.Cause<E>) =>
+  Effect.withFiber<void>((fiber) => {
+    const unhandledLogLevel = fiber.getRef(References.UnhandledLogLevel)
+    if (unhandledLogLevel) {
+      return Effect.logWithLevel(unhandledLogLevel)(cause, "Unhandled error in SocketServer")
+    }
+    return Effect.void
+  })

--- a/packages/platform-deno/src/internal/denoSocketServer.ts
+++ b/packages/platform-deno/src/internal/denoSocketServer.ts
@@ -43,6 +43,7 @@ export const fromListener = (listener: Listener): SocketServer.SocketServer["Ser
               pipe(
                 DenoSocket.fromConn(Effect.acquireRelease(Effect.succeed(conn), closeConn)),
                 Effect.flatMap(handler),
+                Effect.ensuring(closeConn(conn)),
                 Effect.catchCause(reportUnhandledError),
                 Effect.runForkWith(Context.add(services, DenoSocket.Conn, conn)),
                 trackFiber

--- a/packages/platform-deno/test/DenoSocketServer.test.ts
+++ b/packages/platform-deno/test/DenoSocketServer.test.ts
@@ -20,14 +20,16 @@ const echo = (socket: Socket.Socket) =>
     })
   )
 
-const makeTestConn = (): Deno.Conn => {
+const makeTestConn = (onClose?: () => void): Deno.Conn => {
   const transform = new TransformStream<Uint8Array>()
   return {
     readable: transform.readable,
     writable: transform.writable,
     read: () => Promise.resolve(null),
     write: (data) => Promise.resolve(data.length),
-    close() {},
+    close() {
+      onClose?.()
+    },
     closeWrite: () => Promise.resolve(),
     ref() {},
     unref() {},
@@ -137,6 +139,24 @@ describe("DenoSocketServer", () => {
 
       assert.isUndefined(runFiber.pollUnsafe())
       yield* Fiber.interrupt(runFiber)
+    }))
+
+  it.effect("closes the connection after its handler completes", () =>
+    Effect.gen(function*() {
+      const called = [Deferred.makeUnsafe<void>(), Deferred.makeUnsafe<void>()]
+      const handled = yield* Deferred.make<void>()
+      const closed = yield* Deferred.make<void>()
+      const listener = makeTestListener([
+        () => Promise.resolve(makeTestConn(() => Deferred.doneUnsafe(closed, Exit.void))),
+        neverAccept
+      ], called)
+      const server = fromListener(listener)
+      yield* server.run(() => Deferred.succeed(handled, undefined)).pipe(Effect.forkChild)
+
+      yield* Deferred.await(handled)
+      yield* Effect.yieldNow
+
+      assert.isTrue(yield* Deferred.isDone(closed))
     }))
 
   it.effect("logs accept failures and continues accepting", () =>

--- a/packages/platform-deno/test/DenoSocketServer.test.ts
+++ b/packages/platform-deno/test/DenoSocketServer.test.ts
@@ -1,0 +1,230 @@
+import * as DenoSocket from "@effect/platform-deno/DenoSocket"
+import * as DenoSocketServer from "@effect/platform-deno/DenoSocketServer"
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Deferred, Effect, Exit, Fiber, Logger, Option, References, Scope } from "effect"
+import * as Stream from "effect/Stream"
+import { TestClock } from "effect/testing"
+import type * as Socket from "effect/unstable/socket/Socket"
+import { fromListener } from "../src/internal/denoSocketServer.ts"
+
+const makeTempDir = Effect.acquireRelease(
+  Effect.promise(() => Deno.makeTempDir()),
+  (path) => Effect.promise(() => Deno.remove(path, { recursive: true }))
+)
+
+const echo = (socket: Socket.Socket) =>
+  Effect.scoped(
+    Effect.gen(function*() {
+      const write = yield* socket.writer
+      yield* socket.run(write)
+    })
+  )
+
+const makeTestConn = (): Deno.Conn => {
+  const transform = new TransformStream<Uint8Array>()
+  return {
+    readable: transform.readable,
+    writable: transform.writable,
+    read: () => Promise.resolve(null),
+    write: (data) => Promise.resolve(data.length),
+    close() {},
+    closeWrite: () => Promise.resolve(),
+    ref() {},
+    unref() {},
+    localAddr: { transport: "tcp", hostname: "127.0.0.1", port: 1 },
+    remoteAddr: { transport: "tcp", hostname: "127.0.0.1", port: 2 },
+    [Symbol.dispose]() {}
+  }
+}
+
+const makeTestListener = (
+  accepts: ReadonlyArray<() => Promise<Deno.Conn>>,
+  called: ReadonlyArray<Deferred.Deferred<void>>
+): Deno.Listener<Deno.Conn, Deno.NetAddr | Deno.UnixAddr> => {
+  let index = 0
+  return {
+    addr: { transport: "tcp", hostname: "127.0.0.1", port: 1 },
+    accept() {
+      Deferred.doneUnsafe(called[index], Exit.void)
+      return accepts[index++]!()
+    },
+    close() {},
+    ref() {},
+    unref() {},
+    [Symbol.dispose]() {}
+  } as unknown as Deno.Listener<Deno.Conn, Deno.NetAddr | Deno.UnixAddr>
+}
+
+const neverAccept = () => new Promise<Deno.Conn>(() => {})
+const settlePromises = Effect.promise(() => Promise.resolve())
+
+describe("DenoSocketServer", () => {
+  it.effect("echoes over TCP and reports its address", () =>
+    Effect.gen(function*() {
+      const server = yield* DenoSocketServer.make({ hostname: "127.0.0.1", port: 0 })
+      const address = server.address
+      assert.strictEqual(address._tag, "TcpAddress")
+      if (address._tag !== "TcpAddress") return
+      assert.strictEqual(address.hostname, "127.0.0.1")
+      assert.notStrictEqual(address.port, 0)
+      yield* server.run(echo).pipe(Effect.forkScoped)
+
+      const output = yield* Stream.make("Hello", "Deno").pipe(
+        Stream.encodeText,
+        Stream.pipeThroughChannel(DenoSocket.makeTcpChannel({
+          hostname: address.hostname,
+          port: address.port
+        })),
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      assert.strictEqual(output, "HelloDeno")
+    }))
+
+  it.effect("echoes over Unix sockets and reports its address", () =>
+    Effect.gen(function*() {
+      const directory = yield* makeTempDir
+      const path = `${directory}/echo.sock`
+      const server = yield* DenoSocketServer.make({ transport: "unix", path })
+      assert.deepStrictEqual(server.address, { _tag: "UnixAddress", path })
+      yield* server.run(echo).pipe(Effect.forkScoped)
+
+      const output = yield* Stream.make("Hello", "Unix").pipe(
+        Stream.encodeText,
+        Stream.pipeThroughChannel(DenoSocket.makeTcpChannel({ transport: "unix", path })),
+        Stream.decodeText(),
+        Stream.mkString
+      )
+
+      assert.strictEqual(output, "HelloUnix")
+    }))
+
+  it.effect("interrupts handler fibers when run is interrupted", () =>
+    Effect.gen(function*() {
+      const server = yield* DenoSocketServer.make({ hostname: "127.0.0.1", port: 0 })
+      const address = server.address
+      assert.strictEqual(address._tag, "TcpAddress")
+      if (address._tag !== "TcpAddress") return
+      const started = yield* Deferred.make<void>()
+      const interrupted = yield* Deferred.make<void>()
+      const runFiber = yield* server.run(() =>
+        Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() => Deferred.succeed(interrupted, undefined))
+        )
+      ).pipe(Effect.forkChild)
+      const conn = yield* Effect.acquireRelease(
+        Effect.promise(() => Deno.connect({ hostname: address.hostname, port: address.port })),
+        (conn) => Effect.sync(() => conn.close())
+      )
+      void conn
+      yield* Deferred.await(started)
+
+      yield* Fiber.interrupt(runFiber)
+
+      assert.isTrue(yield* Deferred.isDone(interrupted))
+    }))
+
+  it.effect("does not surface BadResource when the listener is closed", () =>
+    Effect.gen(function*() {
+      const scope = yield* Scope.make()
+      const server = yield* DenoSocketServer.make({ hostname: "127.0.0.1", port: 0 }).pipe(Scope.provide(scope))
+      const runFiber = yield* server.run(() => Effect.void).pipe(Effect.forkChild)
+
+      yield* Scope.close(scope, Exit.void)
+      yield* Effect.yieldNow
+
+      assert.isUndefined(runFiber.pollUnsafe())
+      yield* Fiber.interrupt(runFiber)
+    }))
+
+  it.effect("logs accept failures and continues accepting", () =>
+    Effect.gen(function*() {
+      const called = [Deferred.makeUnsafe<void>(), Deferred.makeUnsafe<void>(), Deferred.makeUnsafe<void>()]
+      const failure = new Error("accept failed")
+      const handled = yield* Deferred.make<void>()
+      const logs: Array<{ readonly cause: Cause.Cause<unknown>; readonly message: unknown }> = []
+      const logger = Logger.make<unknown, void>((options) =>
+        logs.push({ cause: options.cause, message: options.message })
+      )
+      const listener = makeTestListener([
+        () => Promise.reject(failure),
+        () => Promise.resolve(makeTestConn()),
+        neverAccept
+      ], called)
+      const server = fromListener(listener)
+      yield* server.run(() => Deferred.succeed(handled, undefined)).pipe(
+        Effect.provide(Logger.layer([logger])),
+        Effect.provideService(References.UnhandledLogLevel, "Error"),
+        Effect.forkChild
+      )
+
+      yield* Deferred.await(called[0])
+      yield* settlePromises
+      yield* TestClock.adjust(10)
+      assert.isTrue(yield* Deferred.isDone(handled))
+
+      assert.strictEqual(logs.length, 1)
+      assert.deepStrictEqual(logs[0]!.message, ["Unhandled error in SocketServer"])
+      assert.deepStrictEqual(Cause.findErrorOption(logs[0]!.cause), Option.some(failure))
+    }))
+
+  it.effect("backs off consecutive accept failures", () =>
+    Effect.gen(function*() {
+      const called = [Deferred.makeUnsafe<void>(), Deferred.makeUnsafe<void>(), Deferred.makeUnsafe<void>()]
+      const listener = makeTestListener([
+        () => Promise.reject(new Error("first")),
+        () => Promise.reject(new Error("second")),
+        neverAccept
+      ], called)
+      const server = fromListener(listener)
+      yield* server.run(() => Effect.void).pipe(
+        Effect.provideService(References.UnhandledLogLevel, undefined),
+        Effect.forkChild
+      )
+
+      yield* Deferred.await(called[0])
+      yield* settlePromises
+      yield* TestClock.adjust(9)
+      assert.isFalse(yield* Deferred.isDone(called[1]))
+      yield* TestClock.adjust(1)
+      assert.isTrue(yield* Deferred.isDone(called[1]))
+      yield* settlePromises
+      yield* TestClock.adjust(19)
+      assert.isFalse(yield* Deferred.isDone(called[2]))
+      yield* TestClock.adjust(1)
+      assert.isTrue(yield* Deferred.isDone(called[2]))
+    }))
+
+  it.effect("resets accept backoff after a successful connection", () =>
+    Effect.gen(function*() {
+      const called = [
+        Deferred.makeUnsafe<void>(),
+        Deferred.makeUnsafe<void>(),
+        Deferred.makeUnsafe<void>(),
+        Deferred.makeUnsafe<void>()
+      ]
+      const listener = makeTestListener([
+        () => Promise.reject(new Error("first")),
+        () => Promise.resolve(makeTestConn()),
+        () => Promise.reject(new Error("after success")),
+        neverAccept
+      ], called)
+      const server = fromListener(listener)
+      yield* server.run(() => Effect.void).pipe(
+        Effect.provideService(References.UnhandledLogLevel, undefined),
+        Effect.forkChild
+      )
+
+      yield* Deferred.await(called[0])
+      yield* settlePromises
+      yield* TestClock.adjust(10)
+      assert.isTrue(yield* Deferred.isDone(called[2]))
+      yield* settlePromises
+      yield* TestClock.adjust(9)
+      assert.isFalse(yield* Deferred.isDone(called[3]))
+      yield* TestClock.adjust(1)
+      assert.isTrue(yield* Deferred.isDone(called[3]))
+    }))
+})


### PR DESCRIPTION
Closes EFF-149

## Summary
- add native Deno TCP, Unix, and TLS socket server constructors and layers
- supervise connection handlers and apply resilient accept-loop backoff
- cover TCP/Unix integration and accept-loop edge cases

## Testing
- `nix develop -c deno task test --run packages/platform-deno/test/DenoSocketServer.test.ts`
- `nix develop -c deno check .`
- `nix develop -c pnpm check`
- `nix develop -c pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Deno `SocketServer` support for TCP, Unix, and TLS.
  * Provided scoped server constructors and Layer helpers for easy application integration.
  * Added listen option types for non-TLS and TLS configurations.

* **Bug Fixes**
  * Improved accept-loop resilience with normalized open/accept errors, capped exponential backoff, and backoff reset after success.
  * Ensured connections and server fibers shut down cleanly, including interruption semantics and safe scope teardown.

* **Tests**
  * Added a Deno socket server test suite covering TCP/Unix echo, interruption, cleanup behavior, retry/backoff logic, and connection lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->