### PR TITLE
Add Deno multipart support

### DIFF
--- a/.changeset/add-deno-multipart.md
+++ b/.changeset/add-deno-multipart.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add web-standard multipart request parsing helpers for Deno.

--- a/packages/platform-deno/src/DenoMultipart.ts
+++ b/packages/platform-deno/src/DenoMultipart.ts
@@ -24,18 +24,17 @@ import * as Multipart from "effect/unstable/http/Multipart"
  */
 export const stream = (source: Request): Stream.Stream<Multipart.Part, Multipart.MultipartError> =>
   Stream.fromReadableStream({
-    evaluate: () => source.body ?? emptyReadableStream,
+    evaluate: () =>
+      source.body ?? new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array())
+          controller.close()
+        }
+      }),
     onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
   }).pipe(
     Stream.pipeThroughChannel(Multipart.makeChannel(Object.fromEntries(source.headers)))
   )
-
-const emptyReadableStream = new ReadableStream({
-  start(controller) {
-    controller.enqueue(new Uint8Array())
-    controller.close()
-  }
-})
 
 /**
  * Parses and persists multipart data from a web `Request`, requiring file-system, path, and scope services.

--- a/packages/platform-deno/src/DenoMultipart.ts
+++ b/packages/platform-deno/src/DenoMultipart.ts
@@ -1,0 +1,54 @@
+/**
+ * Web-standard helpers for parsing HTTP `multipart/form-data` request bodies.
+ *
+ * This module mirrors `BunMultipart`, adapting a web `Request` body and headers
+ * into the shared `Multipart` model. `stream` returns multipart parts as a
+ * `Stream`, while `persisted` collects the form and writes file parts to scoped
+ * temporary files through the current `FileSystem`, `Path`, and `Scope`
+ * services.
+ *
+ * @since 4.0.0
+ */
+import type * as Effect from "effect/Effect"
+import type { FileSystem } from "effect/FileSystem"
+import type { Path } from "effect/Path"
+import type * as Scope from "effect/Scope"
+import * as Stream from "effect/Stream"
+import * as Multipart from "effect/unstable/http/Multipart"
+
+/**
+ * Parses a web `Request` body as multipart data and returns a stream of multipart parts.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const stream = (source: Request): Stream.Stream<Multipart.Part, Multipart.MultipartError> =>
+  Stream.fromReadableStream({
+    evaluate: () => source.body ?? emptyReadableStream,
+    onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
+  }).pipe(
+    Stream.pipeThroughChannel(Multipart.makeChannel(Object.fromEntries(source.headers)))
+  )
+
+const emptyReadableStream = new ReadableStream({
+  start(controller) {
+    controller.enqueue(new Uint8Array())
+    controller.close()
+  }
+})
+
+/**
+ * Parses and persists multipart data from a web `Request`, requiring file-system, path, and scope services.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const persisted = (
+  source: Request
+): Effect.Effect<
+  Multipart.Persisted,
+  Multipart.MultipartError,
+  | FileSystem
+  | Path
+  | Scope.Scope
+> => Multipart.toPersisted(stream(source))

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -37,6 +37,11 @@ export * as DenoKeyValueStore from "./DenoKeyValueStore.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoMultipart from "./DenoMultipart.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoPath from "./DenoPath.ts"
 
 /**


### PR DESCRIPTION
## Summary
- add web-standard multipart request streaming and persistence helpers for Deno
- preserve BunMultipart's null-body single-empty-chunk behavior
- export DenoMultipart from the generated platform-deno barrel

## Validation
- pnpm lint-fix
- pnpm --dir packages/platform-deno check
- pnpm check

Closes EFF-150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multipart form-data parsing helpers for Deno and web-standard `Request` objects.
  - Added support for streaming multipart parts and persisting uploaded data.
  - Exposed the new functionality through the Deno platform package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->