### PR TITLE
Construct empty Bun multipart streams per request

### DIFF
--- a/.changeset/eff-170-bun-multipart-stream.md
+++ b/.changeset/eff-170-bun-multipart-stream.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-bun": patch
+---
+
+Construct an empty multipart stream for each bodiless Bun request.

--- a/packages/platform-bun/src/BunMultipart.ts
+++ b/packages/platform-bun/src/BunMultipart.ts
@@ -24,18 +24,17 @@ import * as BunStream from "./BunStream.ts"
  */
 export const stream = (source: Request): Stream.Stream<Multipart.Part, Multipart.MultipartError> =>
   BunStream.fromReadableStream({
-    evaluate: () => source.body ?? emptyReadbleStream,
+    evaluate: () =>
+      source.body ?? new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array())
+          controller.close()
+        }
+      }),
     onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
   }).pipe(
     Stream.pipeThroughChannel(Multipart.makeChannel(Object.fromEntries(source.headers)))
   )
-
-const emptyReadbleStream = new ReadableStream({
-  start(controller) {
-    controller.enqueue(new Uint8Array())
-    controller.close()
-  }
-})
 
 /**
  * Parses and persists multipart data from a Bun `Request`, requiring file-system, path, and scope services.


### PR DESCRIPTION
## Summary

- construct a fresh empty `ReadableStream` for each bodiless Bun multipart request
- add a patch changeset for `@effect/platform-bun`

## Validation

- `pnpm lint-fix`
- `pnpm check`

Closes EFF-170
