### PR TITLE
Update Deno CI to fix native transform flake

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/setup
         with:
-          deno-version: v2.8.3
+          deno-version: v2.9.4
       - name: Set strip internals config
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json
@@ -143,7 +143,7 @@ jobs:
         if: matrix.runtime == 'Deno'
         uses: ./.github/actions/setup
         with:
-          deno-version: v2.8.3
+          deno-version: v2.9.4
       - name: Test
         if: matrix.runtime == 'Deno'
         run: deno task test --shard ${{ matrix.shard }}


### PR DESCRIPTION
## Summary

- update Deno CI jobs from 2.8.3 to 2.9.4
- pick up denoland/deno#35212, which fixes the exact intermittent N-API `TsconfigCache` recovery failure
- keep the Deno type-check and test jobs on the same runtime version

The pnpm graph contains a single `rolldown@1.1.5` and matching native binding, so dependency overrides cannot address this failure. Deno 2.8.3 predates the upstream runtime fix, which first shipped in Deno 2.9.0.

## Verification

- `deno task test --run packages/tools/openapi-generator/test/OpenApiGeneratorCli.test.ts` using Deno 2.9.4
- `git diff --check`

Closes EFF-171
