### PR TITLE
Add Deno cluster socket support

### DIFF
--- a/.changeset/eff-155-deno-cluster-socket.md
+++ b/.changeset/eff-155-deno-cluster-socket.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-deno": patch
+---
+
+Add native Deno socket layers for Effect Cluster runners.

--- a/packages/effect/src/unstable/http/FetchHttpClient.ts
+++ b/packages/effect/src/unstable/http/FetchHttpClient.ts
@@ -53,7 +53,9 @@ export class RequestInit extends Context.Service<RequestInit, globalThis.Request
 const fetch: HttpClient.HttpClient = HttpClient.make((request, url, signal, fiber) => {
   const fetch = fiber.getRef(Fetch)
   const options: globalThis.RequestInit = fiber.context.mapUnsafe.get(RequestInit.key) ?? {}
-  let headers = options.headers ? Headers.merge(Headers.fromInput(options.headers), request.headers) : request.headers
+  let headers = options.headers
+    ? Headers.merge(Headers.fromInput(options.headers as Headers.Input), request.headers)
+    : request.headers
   if (headers["content-length"]) {
     headers = Headers.remove(headers, "content-length")
   }

--- a/packages/platform-deno/src/DenoClusterSocket.ts
+++ b/packages/platform-deno/src/DenoClusterSocket.ts
@@ -1,0 +1,194 @@
+/**
+ * Native Deno socket layers for Effect Cluster runners.
+ *
+ * The main `layer` builds a sharding layer for socket transport, choosing
+ * serialization, runner health checks, runner storage, message storage, and
+ * optional client-only mode from the supplied options. Unlike Node sockets,
+ * Deno connections have no native idle-timeout option, so peer connections use
+ * only the one-second open timeout.
+ *
+ * @since 4.0.0
+ */
+import type * as Config from "effect/Config"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as K8sHttpClient from "effect/unstable/cluster/K8sHttpClient"
+import * as MessageStorage from "effect/unstable/cluster/MessageStorage"
+import * as RunnerHealth from "effect/unstable/cluster/RunnerHealth"
+import * as Runners from "effect/unstable/cluster/Runners"
+import * as RunnerStorage from "effect/unstable/cluster/RunnerStorage"
+import type { Sharding } from "effect/unstable/cluster/Sharding"
+import * as ShardingConfig from "effect/unstable/cluster/ShardingConfig"
+import * as SocketRunner from "effect/unstable/cluster/SocketRunner"
+import * as SqlMessageStorage from "effect/unstable/cluster/SqlMessageStorage"
+import * as SqlRunnerStorage from "effect/unstable/cluster/SqlRunnerStorage"
+import * as RpcClient from "effect/unstable/rpc/RpcClient"
+import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization"
+import { Socket } from "effect/unstable/socket/Socket"
+import type * as SocketServer from "effect/unstable/socket/SocketServer"
+import type { SqlClient } from "effect/unstable/sql/SqlClient"
+import * as DenoCrypto from "./DenoCrypto.ts"
+import * as DenoFileSystem from "./DenoFileSystem.ts"
+import * as DenoHttpClient from "./DenoHttpClient.ts"
+import * as DenoSocket from "./DenoSocket.ts"
+import * as DenoSocketServer from "./DenoSocketServer.ts"
+
+/**
+ * Provides the cluster `RpcClientProtocol` using native Deno TCP sockets.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerClientProtocol: Layer.Layer<
+  Runners.RpcClientProtocol,
+  never,
+  RpcSerialization.RpcSerialization
+> = Layer.effect(Runners.RpcClientProtocol)(
+  Effect.gen(function*() {
+    const serialization = yield* RpcSerialization.RpcSerialization
+    return Effect.fnUntraced(function*(address) {
+      const socket = yield* DenoSocket.makeTcp({
+        openTimeout: 1000,
+        hostname: address.host,
+        port: address.port
+      })
+      return yield* RpcClient.makeProtocolSocket().pipe(
+        Effect.provideService(Socket, socket),
+        Effect.provideService(RpcSerialization.RpcSerialization, serialization)
+      )
+    }, Effect.orDie)
+  })
+)
+
+/**
+ * Provides the native Deno socket server used by cluster runners, listening on
+ * `ShardingConfig.runnerListenAddress` or `runnerAddress`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerSocketServer: Layer.Layer<
+  SocketServer.SocketServer,
+  SocketServer.SocketServerError,
+  ShardingConfig.ShardingConfig
+> = Effect.gen(function*() {
+  const config = yield* ShardingConfig.ShardingConfig
+  const listenAddress = Option.orElse(config.runnerListenAddress, () => config.runnerAddress)
+  if (Option.isNone(listenAddress)) {
+    return yield* Effect.die("layerSocketServer: ShardingConfig.runnerListenAddress is None")
+  }
+  return DenoSocketServer.layer({
+    hostname: listenAddress.value.host,
+    port: listenAddress.value.port
+  })
+}).pipe(Layer.unwrap)
+
+/**
+ * Creates Deno socket cluster layers, configuring serialization, storage,
+ * runner health, and optional client-only mode.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = <
+  const ClientOnly extends boolean = false,
+  const Storage extends "local" | "sql" | "byo" = never
+>(
+  options?: {
+    readonly serialization?: "msgpack" | "ndjson" | undefined
+    readonly clientOnly?: ClientOnly | undefined
+    readonly storage?: Storage | undefined
+    readonly runnerHealth?: "ping" | "k8s" | undefined
+    readonly runnerHealthK8s?: {
+      readonly namespace?: string | undefined
+      readonly labelSelector?: string | undefined
+    } | undefined
+    readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Service"]> | undefined
+  }
+): ClientOnly extends true ? Layer.Layer<
+    Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),
+    Config.ConfigError,
+    "local" extends Storage ? never
+      : "byo" extends Storage ? (MessageStorage.MessageStorage | RunnerStorage.RunnerStorage)
+      : SqlClient
+  > :
+  Layer.Layer<
+    Sharding | Runners.Runners | ("byo" extends Storage ? never : MessageStorage.MessageStorage),
+    SocketServer.SocketServerError | Config.ConfigError,
+    "local" extends Storage ? never
+      : "byo" extends Storage ? (MessageStorage.MessageStorage | RunnerStorage.RunnerStorage)
+      : SqlClient
+  > =>
+{
+  const layer: Layer.Layer<any, any, any> = options?.clientOnly
+    ? Layer.provide(SocketRunner.layerClientOnly, layerClientProtocol)
+    : Layer.provide(SocketRunner.layer, [layerSocketServer, layerClientProtocol])
+
+  const runnerHealth: Layer.Layer<any, any, any> = options?.clientOnly
+    ? Layer.empty as any
+    : options?.runnerHealth === "k8s"
+    ? RunnerHealth.layerK8s(options.runnerHealthK8s).pipe(
+      Layer.provide(layerK8sHttpClient)
+    )
+    : RunnerHealth.layerPing.pipe(
+      Layer.provide(Runners.layerRpc),
+      Layer.provide(layerClientProtocol)
+    )
+
+  return layer.pipe(
+    Layer.provide(runnerHealth),
+    Layer.provideMerge(
+      options?.storage === "local"
+        ? MessageStorage.layerNoop
+        : options?.storage === "byo"
+        ? Layer.empty
+        : Layer.orDie(SqlMessageStorage.layer).pipe(Layer.provide(DenoCrypto.layer))
+    ),
+    Layer.provide(
+      options?.storage === "local"
+        ? RunnerStorage.layerMemory
+        : options?.storage === "byo"
+        ? Layer.empty
+        : Layer.orDie(SqlRunnerStorage.layer)
+    ),
+    Layer.provide(ShardingConfig.layerFromEnv(options?.shardingConfig)),
+    Layer.provide(
+      options?.serialization === "ndjson" ? RpcSerialization.layerNdjson : RpcSerialization.layerMsgPack
+    )
+  ) as any
+}
+
+/**
+ * Layer that provides `K8sHttpClient`, using a scoped native Deno HTTP client
+ * with the Kubernetes service-account CA certificate when it is available.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerK8sHttpClient: Layer.Layer<K8sHttpClient.K8sHttpClient> = K8sHttpClient.layer.pipe(
+  Layer.provide(
+    Layer.fresh(DenoHttpClient.layer).pipe(
+      Layer.provide(Layer.effect(
+        DenoHttpClient.Fetch,
+        Effect.gen(function*() {
+          const fs = yield* FileSystem.FileSystem
+          const caCertOption = yield* fs.readFileString("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt").pipe(
+            Effect.option
+          )
+          if (Option.isNone(caCertOption)) {
+            return globalThis.fetch
+          }
+
+          const client = yield* Effect.acquireRelease(
+            Effect.sync(() => Deno.createHttpClient({ caCerts: [caCertOption.value] })),
+            (client) => Effect.sync(() => client.close())
+          )
+          return ((input, init) => globalThis.fetch(input, { ...init, client } as any)) as typeof globalThis.fetch
+        })
+      ))
+    )
+  ),
+  Layer.provide(DenoFileSystem.layer)
+)

--- a/packages/platform-deno/src/index.ts
+++ b/packages/platform-deno/src/index.ts
@@ -12,6 +12,11 @@ export * as DenoChildProcessSpawner from "./DenoChildProcessSpawner.ts"
 /**
  * @since 4.0.0
  */
+export * as DenoClusterSocket from "./DenoClusterSocket.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as DenoCrypto from "./DenoCrypto.ts"
 
 /**

--- a/packages/platform-deno/test/cluster/SocketRunner.test.ts
+++ b/packages/platform-deno/test/cluster/SocketRunner.test.ts
@@ -1,0 +1,165 @@
+import { DenoClusterSocket } from "@effect/platform-deno"
+import { assert, describe, it } from "@effect/vitest"
+import { BigDecimal, Cause, Effect, Exit, Fiber, Layer, Option, PrimaryKey, Schema } from "effect"
+import type { Sharding } from "effect/unstable/cluster"
+import {
+  ClusterSchema,
+  Entity,
+  MessageStorage,
+  RunnerAddress,
+  RunnerHealth,
+  RunnerStorage,
+  ShardingConfig,
+  SocketRunner
+} from "effect/unstable/cluster"
+import { Rpc, RpcSerialization } from "effect/unstable/rpc"
+
+class TestPayload extends Schema.Class<TestPayload>("TestPayload")({
+  id: Schema.String,
+  amount: Schema.BigDecimal
+}) {
+  [PrimaryKey.symbol]() {
+    return this.id
+  }
+}
+
+const TestEntity = Entity
+  .make("TestEntity", [
+    Rpc.make("Process", {
+      payload: TestPayload,
+      success: Schema.Void
+    })
+  ])
+  .annotateRpcs(ClusterSchema.Persisted, true)
+  .annotateRpcs(ClusterSchema.Uninterruptible, true)
+
+const TestEntityLayer = TestEntity.toLayer(
+  Effect.succeed({
+    Process: () => Effect.void
+  })
+)
+
+const RUNNER_PORT = 50_125
+const SharedStorage = Layer.mergeAll(
+  RunnerStorage.layerMemory,
+  MessageStorage.layerMemory
+).pipe(
+  Layer.provide(ShardingConfig.layerDefaults)
+)
+
+const makeRunnerLayer = (port: number, entities: Layer.Layer<never, never, Sharding.Sharding>) =>
+  entities.pipe(
+    Layer.provideMerge(SocketRunner.layer),
+    Layer.provide(RunnerHealth.layerNoop),
+    Layer.provide(DenoClusterSocket.layerSocketServer),
+    Layer.provide(DenoClusterSocket.layerClientProtocol),
+    Layer.provide(ShardingConfig.layer({
+      runnerAddress: Option.some(RunnerAddress.make("127.0.0.1", port)),
+      entityTerminationTimeout: 0,
+      entityMessagePollInterval: 5000,
+      sendRetryInterval: 100
+    })),
+    Layer.provide(RpcSerialization.layerMsgPack)
+  )
+
+const makeClientLayer = (port: number) =>
+  SocketRunner.layerClientOnly.pipe(
+    Layer.provide(DenoClusterSocket.layerClientProtocol),
+    Layer.provide(ShardingConfig.layer({
+      runnerAddress: Option.some(RunnerAddress.make("127.0.0.1", port)),
+      runnerListenAddress: Option.some(RunnerAddress.make("127.0.0.1", port)),
+      entityTerminationTimeout: 0,
+      entityMessagePollInterval: 5000,
+      sendRetryInterval: 100
+    })),
+    Layer.provide(RpcSerialization.layerMsgPack)
+  )
+
+const IsolationEntity = Entity
+  .make("IsolationEntity", [
+    Rpc.make("BadReply", {
+      payload: { id: Schema.Number },
+      success: Schema.Int
+    }),
+    Rpc.make("Slow", {
+      success: Schema.String
+    })
+  ])
+  .annotateRpcs(ClusterSchema.Persisted, false)
+
+const IsolationEntityLayer = IsolationEntity.toLayer(
+  Effect.succeed({
+    BadReply: () => Effect.succeed(1.5),
+    Slow: () => Effect.as(Effect.sleep("2 seconds"), "done")
+  })
+)
+
+const ISOLATION_PORT = 50_126
+
+describe("SocketRunner", () => {
+  it.live(
+    "entity call with BigDecimal and discard should not stack overflow",
+    () =>
+      Effect.gen(function*() {
+        yield* Layer.launch(makeRunnerLayer(RUNNER_PORT, TestEntityLayer)).pipe(Effect.forkScoped)
+
+        yield* Effect.sleep("2 seconds")
+        yield* Effect.gen(function*() {
+          yield* Effect.sleep("2 seconds")
+          const makeClient = yield* TestEntity.client
+          yield* Effect.sleep("3 seconds")
+          const client = makeClient("entity-1")
+
+          const amount = BigDecimal.fromStringUnsafe("123.45")
+          yield* client.Process(
+            TestPayload.make({ id: "req-1", amount }),
+            { discard: true }
+          )
+        }).pipe(
+          Effect.provide(makeClientLayer(RUNNER_PORT)),
+          Effect.scoped
+        )
+      }).pipe(Effect.provide(SharedStorage)),
+    30_000
+  )
+
+  it.live(
+    "a reply serialization failure fails only its own request",
+    () =>
+      Effect.gen(function*() {
+        yield* Layer.launch(makeRunnerLayer(ISOLATION_PORT, IsolationEntityLayer)).pipe(Effect.forkScoped)
+        yield* Effect.sleep("2 seconds")
+
+        yield* Effect.gen(function*() {
+          const makeClient = yield* IsolationEntity.client
+          yield* Effect.sleep("3 seconds")
+
+          const slowFiber = yield* makeClient("slow-entity").Slow().pipe(Effect.forkChild)
+          yield* Effect.sleep("300 millis")
+
+          const badExit = yield* makeClient("bad-entity").BadReply({ id: 1 }).pipe(Effect.exit)
+          assert.isTrue(Exit.isFailure(badExit), "the unencodable reply must fail the request")
+          const failure = Exit.isFailure(badExit) ? String(Cause.squash(badExit.cause)) : ""
+          assert.include(failure, "MalformedMessage", "the caller must receive the real encode error")
+          assert.notInclude(
+            failure,
+            "AlreadyProcessingMessage",
+            "the request must not be re-sent into the entity's dedup guard"
+          )
+
+          const slowExit = yield* Fiber.await(slowFiber)
+          assert.isTrue(
+            Exit.isSuccess(slowExit),
+            "a sibling in-flight request on the same connection must be unaffected"
+          )
+          if (Exit.isSuccess(slowExit)) {
+            assert.strictEqual(slowExit.value, "done")
+          }
+        }).pipe(
+          Effect.provide(makeClientLayer(ISOLATION_PORT)),
+          Effect.scoped
+        )
+      }).pipe(Effect.provide(SharedStorage)),
+    30_000
+  )
+})


### PR DESCRIPTION
## Summary

- add native Deno client and server layers for Effect Cluster socket runners
- compose storage, serialization, runner health, and Kubernetes HTTP layers without Node compatibility modules
- mirror the Node cluster socket regression coverage under the Deno runtime
- accept Deno's standards-compatible `HeadersInit` type in the shared fetch client

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm --filter @effect/platform-deno check`
- `deno run -A npm:vitest --run test/cluster/SocketRunner.test.ts`

Closes EFF-155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native Deno socket support for Effect Cluster runners.
  - Added configurable client and server runner layers with local, SQL, or custom storage options.
  - Added NDJSON and MessagePack serialization choices.
  - Added optional Kubernetes-based runner health checks and HTTP client support.
  - Exported the new Deno Cluster Socket functionality publicly.

- **Bug Fixes**
  - Improved request header handling for fetch-based HTTP requests.
  - Isolated serialization failures to the affected request without disrupting concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->