### PR TITLE
Rename Schema error class constructors

### DIFF
--- a/.changeset/eff-172-schema-error.md
+++ b/.changeset/eff-172-schema-error.md
@@ -1,0 +1,5 @@
+---
+"effect": major
+---
+
+Rename `Schema.ErrorClass` to the overloaded `Schema.Error` constructor and rename `Schema.TaggedErrorClass` to `Schema.TaggedError`.

--- a/LLMS.md
+++ b/LLMS.md
@@ -42,8 +42,8 @@ Effect.gen(function*() {
   })
 )
 
-// Use Schema.TaggedErrorClass to define a custom error
-export class FileProcessingError extends Schema.TaggedErrorClass<FileProcessingError>()("FileProcessingError", {
+// Use Schema.TaggedError to define a custom error
+export class FileProcessingError extends Schema.TaggedError<FileProcessingError>()("FileProcessingError", {
   message: Schema.String
 }) {}
 ```
@@ -82,8 +82,8 @@ export const effectFunction = Effect.fn("effectFunction")(
   })
 )
 
-// Use Schema.TaggedErrorClass to define a custom error
-export class SomeError extends Schema.TaggedErrorClass<SomeError>()("SomeError", {
+// Use Schema.TaggedError to define a custom error
+export class SomeError extends Schema.TaggedError<SomeError>()("SomeError", {
   message: Schema.String
 }) {}
 ```
@@ -150,7 +150,7 @@ export class Database extends Context.Service<Database, {
   )
 }
 
-export class DatabaseError extends Schema.TaggedErrorClass<DatabaseError>()("DatabaseError", {
+export class DatabaseError extends Schema.TaggedError<DatabaseError>()("DatabaseError", {
   cause: Schema.Defect()
 }) {}
 
@@ -175,13 +175,13 @@ Defining custom errors and handling them with Effect.catch and Effect.catchTag.
 ```ts
 import { Effect, Schema } from "effect"
 
-// Define custom errors using Schema.TaggedErrorClass
-export class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseError", {
+// Define custom errors using Schema.TaggedError
+export class ParseError extends Schema.TaggedError<ParseError>()("ParseError", {
   input: Schema.String,
   message: Schema.String
 }) {}
 
-export class ReservedPortError extends Schema.TaggedErrorClass<ReservedPortError>()("ReservedPortError", {
+export class ReservedPortError extends Schema.TaggedError<ReservedPortError>()("ReservedPortError", {
   port: Schema.Int
 }) {}
 

--- a/ai-docs/src/01_effect/01_basics/01_effect-gen.ts
+++ b/ai-docs/src/01_effect/01_basics/01_effect-gen.ts
@@ -24,7 +24,7 @@ Effect.gen(function*() {
   })
 )
 
-// Use Schema.TaggedErrorClass to define a custom error
-export class FileProcessingError extends Schema.TaggedErrorClass<FileProcessingError>()("FileProcessingError", {
+// Use Schema.TaggedError to define a custom error
+export class FileProcessingError extends Schema.TaggedError<FileProcessingError>()("FileProcessingError", {
   message: Schema.String
 }) {}

--- a/ai-docs/src/01_effect/01_basics/02_effect-fn.ts
+++ b/ai-docs/src/01_effect/01_basics/02_effect-fn.ts
@@ -33,7 +33,7 @@ export const effectFunction = Effect.fn("effectFunction")(
   })
 )
 
-// Use Schema.TaggedErrorClass to define a custom error
-export class SomeError extends Schema.TaggedErrorClass<SomeError>()("SomeError", {
+// Use Schema.TaggedError to define a custom error
+export class SomeError extends Schema.TaggedError<SomeError>()("SomeError", {
   message: Schema.String
 }) {}

--- a/ai-docs/src/01_effect/01_basics/10_creating-effects.ts
+++ b/ai-docs/src/01_effect/01_basics/10_creating-effects.ts
@@ -6,17 +6,17 @@
  */
 import { Effect, Schema } from "effect"
 
-class InvalidPayload extends Schema.TaggedErrorClass<InvalidPayload>()("InvalidPayload", {
+class InvalidPayload extends Schema.TaggedError<InvalidPayload>()("InvalidPayload", {
   input: Schema.String,
   cause: Schema.Defect()
 }) {}
 
-class UserLookupError extends Schema.TaggedErrorClass<UserLookupError>()("UserLookupError", {
+class UserLookupError extends Schema.TaggedError<UserLookupError>()("UserLookupError", {
   userId: Schema.Int,
   cause: Schema.Defect()
 }) {}
 
-class MissingWorkspaceId extends Schema.TaggedErrorClass<MissingWorkspaceId>()("MissingWorkspaceId", {}) {}
+class MissingWorkspaceId extends Schema.TaggedError<MissingWorkspaceId>()("MissingWorkspaceId", {}) {}
 
 // Some request fields are optional and may be absent.
 const requestHeaders = new Map<string, string>([

--- a/ai-docs/src/01_effect/02_schema/10_schema-basics.ts
+++ b/ai-docs/src/01_effect/02_schema/10_schema-basics.ts
@@ -32,7 +32,7 @@ export type UserEncoded = typeof User["Encoded"]
 export const decodeUser = Schema.decodeUnknownEffect(User)
 export const encodeUser = Schema.encodeEffect(User)
 
-export class InvalidUserPayload extends Schema.TaggedErrorClass<InvalidUserPayload>()("InvalidUserPayload", {
+export class InvalidUserPayload extends Schema.TaggedError<InvalidUserPayload>()("InvalidUserPayload", {
   message: Schema.String
 }) {}
 

--- a/ai-docs/src/01_effect/03_services/01_service.ts
+++ b/ai-docs/src/01_effect/03_services/01_service.ts
@@ -37,7 +37,7 @@ export class Database extends Context.Service<Database, {
   )
 }
 
-export class DatabaseError extends Schema.TaggedErrorClass<DatabaseError>()("DatabaseError", {
+export class DatabaseError extends Schema.TaggedError<DatabaseError>()("DatabaseError", {
   cause: Schema.Defect()
 }) {}
 

--- a/ai-docs/src/01_effect/03_services/20_layer-composition.ts
+++ b/ai-docs/src/01_effect/03_services/20_layer-composition.ts
@@ -17,7 +17,7 @@ export const SqlClientLayer: Layer.Layer<
   url: Config.redacted("DATABASE_URL")
 })
 
-export class UserRespositoryError extends Schema.TaggedErrorClass<UserRespositoryError>()("UserRespositoryError", {
+export class UserRespositoryError extends Schema.TaggedError<UserRespositoryError>()("UserRespositoryError", {
   reason: SqlError.SqlError
 }) {}
 

--- a/ai-docs/src/01_effect/03_services/20_layer-unwrap.ts
+++ b/ai-docs/src/01_effect/03_services/20_layer-unwrap.ts
@@ -5,7 +5,7 @@
  */
 import { Config, Context, Effect, Layer, Schema } from "effect"
 
-export class MessageStoreError extends Schema.TaggedErrorClass<MessageStoreError>()("MessageStoreError", {
+export class MessageStoreError extends Schema.TaggedError<MessageStoreError>()("MessageStoreError", {
   cause: Schema.Defect()
 }) {}
 

--- a/ai-docs/src/01_effect/04_errors/01_error-handling.ts
+++ b/ai-docs/src/01_effect/04_errors/01_error-handling.ts
@@ -5,13 +5,13 @@
  */
 import { Effect, Schema } from "effect"
 
-// Define custom errors using Schema.TaggedErrorClass
-export class ParseError extends Schema.TaggedErrorClass<ParseError>()("ParseError", {
+// Define custom errors using Schema.TaggedError
+export class ParseError extends Schema.TaggedError<ParseError>()("ParseError", {
   input: Schema.String,
   message: Schema.String
 }) {}
 
-export class ReservedPortError extends Schema.TaggedErrorClass<ReservedPortError>()("ReservedPortError", {
+export class ReservedPortError extends Schema.TaggedError<ReservedPortError>()("ReservedPortError", {
   port: Schema.Int
 }) {}
 

--- a/ai-docs/src/01_effect/04_errors/10_catch-tags.ts
+++ b/ai-docs/src/01_effect/04_errors/10_catch-tags.ts
@@ -6,11 +6,11 @@
 
 import { Effect, Schema } from "effect"
 
-export class ValidationError extends Schema.TaggedErrorClass<ValidationError>()("ValidationError", {
+export class ValidationError extends Schema.TaggedError<ValidationError>()("ValidationError", {
   message: Schema.String
 }) {}
 
-export class NetworkError extends Schema.TaggedErrorClass<NetworkError>()("NetworkError", {
+export class NetworkError extends Schema.TaggedError<NetworkError>()("NetworkError", {
   statusCode: Schema.Int
 }) {}
 

--- a/ai-docs/src/01_effect/04_errors/20_reason-errors.ts
+++ b/ai-docs/src/01_effect/04_errors/20_reason-errors.ts
@@ -8,19 +8,19 @@
 
 import { Effect, Schema } from "effect"
 
-export class RateLimitError extends Schema.TaggedErrorClass<RateLimitError>()("RateLimitError", {
+export class RateLimitError extends Schema.TaggedError<RateLimitError>()("RateLimitError", {
   retryAfter: Schema.Finite
 }) {}
 
-export class QuotaExceededError extends Schema.TaggedErrorClass<QuotaExceededError>()("QuotaExceededError", {
+export class QuotaExceededError extends Schema.TaggedError<QuotaExceededError>()("QuotaExceededError", {
   limit: Schema.Int
 }) {}
 
-export class SafetyBlockedError extends Schema.TaggedErrorClass<SafetyBlockedError>()("SafetyBlockedError", {
+export class SafetyBlockedError extends Schema.TaggedError<SafetyBlockedError>()("SafetyBlockedError", {
   category: Schema.String
 }) {}
 
-export class AiError extends Schema.TaggedErrorClass<AiError>()("AiError", {
+export class AiError extends Schema.TaggedError<AiError>()("AiError", {
   reason: Schema.Union([RateLimitError, QuotaExceededError, SafetyBlockedError])
 }) {}
 

--- a/ai-docs/src/01_effect/05_resources/10_acquire-release.ts
+++ b/ai-docs/src/01_effect/05_resources/10_acquire-release.ts
@@ -8,7 +8,7 @@
 import { Config, Context, Effect, Layer, Redacted, Schema } from "effect"
 import * as NodeMailer from "nodemailer"
 
-export class SmtpError extends Schema.ErrorClass<SmtpError>("SmtpError")({
+export class SmtpError extends Schema.Error<SmtpError>("SmtpError")({
   cause: Schema.Defect()
 }) {}
 
@@ -70,7 +70,7 @@ export class Smtp extends Context.Service<Smtp, {
 // We can then use the `Smtp` service in another service, and the transporter
 // will be properly managed by the Layer system.
 
-export class MailerError extends Schema.TaggedErrorClass<MailerError>()("MailerError", {
+export class MailerError extends Schema.TaggedError<MailerError>()("MailerError", {
   reason: SmtpError
 }) {}
 

--- a/ai-docs/src/01_effect/05_resources/30_layer-map.ts
+++ b/ai-docs/src/01_effect/05_resources/30_layer-map.ts
@@ -6,7 +6,7 @@
  */
 import { Context, Effect, Layer, LayerMap, Schema } from "effect"
 
-class DatabaseQueryError extends Schema.TaggedErrorClass<DatabaseQueryError>()("DatabaseQueryError", {
+class DatabaseQueryError extends Schema.TaggedError<DatabaseQueryError>()("DatabaseQueryError", {
   tenantId: Schema.String,
   cause: Schema.Defect()
 }) {}

--- a/ai-docs/src/03_stream/10_creating-streams.ts
+++ b/ai-docs/src/03_stream/10_creating-streams.ts
@@ -49,7 +49,7 @@ export const fetchJobsPage = Stream.paginate(
   })
 )
 
-class LetterError extends Schema.TaggedErrorClass<LetterError>()("LetterError", {
+class LetterError extends Schema.TaggedError<LetterError>()("LetterError", {
   cause: Schema.Defect()
 }) {}
 
@@ -88,7 +88,7 @@ export const callbackStream = Stream.callback<PointerEvent>(Effect.fn(function*(
   )
 }))
 
-export class NodeStreamError extends Schema.TaggedErrorClass<NodeStreamError>()("NodeStreamError", {
+export class NodeStreamError extends Schema.TaggedError<NodeStreamError>()("NodeStreamError", {
   cause: Schema.Defect()
 }) {}
 

--- a/ai-docs/src/04_integration/10_managed-runtime.ts
+++ b/ai-docs/src/04_integration/10_managed-runtime.ts
@@ -16,7 +16,7 @@ class CreateTodoPayload extends Schema.Class<CreateTodoPayload>("CreateTodoPaylo
   title: Schema.String
 }) {}
 
-class TodoNotFound extends Schema.TaggedErrorClass<TodoNotFound>()("TodoNotFound", {
+class TodoNotFound extends Schema.TaggedError<TodoNotFound>()("TodoNotFound", {
   id: Schema.Int
 }) {}
 

--- a/ai-docs/src/05_batching/10_request-resolver.ts
+++ b/ai-docs/src/05_batching/10_request-resolver.ts
@@ -11,7 +11,7 @@ export class User extends Schema.Class<User>("User")({
   email: Schema.String
 }) {}
 
-export class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()("UserNotFound", {
+export class UserNotFound extends Schema.TaggedError<UserNotFound>()("UserNotFound", {
   id: Schema.Int
 }) {}
 

--- a/ai-docs/src/06_schedule/10_schedules.ts
+++ b/ai-docs/src/06_schedule/10_schedules.ts
@@ -61,7 +61,7 @@ export const loadUserWithInferredInput = fetchUserProfile("user-123").pipe(
   Effect.orDie
 )
 
-export class HttpError extends Schema.TaggedErrorClass<HttpError>()("HttpError", {
+export class HttpError extends Schema.TaggedError<HttpError>()("HttpError", {
   message: Schema.String,
   status: Schema.Int,
   retryable: Schema.Boolean

--- a/ai-docs/src/50_http-client/10_basics.ts
+++ b/ai-docs/src/50_http-client/10_basics.ts
@@ -97,6 +97,6 @@ export class JsonPlaceholder extends Context.Service<JsonPlaceholder, {
   )
 }
 
-export class JsonPlaceholderError extends Schema.TaggedErrorClass<JsonPlaceholderError>()("JsonPlaceholderError", {
+export class JsonPlaceholderError extends Schema.TaggedError<JsonPlaceholderError>()("JsonPlaceholderError", {
   cause: Schema.Defect()
 }) {}

--- a/ai-docs/src/51_http-server/fixtures/api/Authorization.ts
+++ b/ai-docs/src/51_http-server/fixtures/api/Authorization.ts
@@ -4,7 +4,7 @@ import type { User } from "../domain/User.ts"
 
 export class CurrentUser extends Context.Service<CurrentUser, User>()("acme/HttpApi/Authorization/CurrentUser") {}
 
-export class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
+export class Unauthorized extends Schema.TaggedError<Unauthorized>()(
   "Unauthorized",
   {
     message: Schema.String

--- a/ai-docs/src/51_http-server/fixtures/domain/UserErrors.ts
+++ b/ai-docs/src/51_http-server/fixtures/domain/UserErrors.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
 
-export class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
+export class UserNotFound extends Schema.TaggedError<UserNotFound>()(
   "UserNotFound",
   {},
   // You can specify the status code for this error inline
@@ -8,7 +8,7 @@ export class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
 ) {}
 
 export class SearchQueryTooShort
-  extends Schema.TaggedErrorClass<SearchQueryTooShort>()("SearchQueryTooShort", {}, { httpApiStatus: 422 })
+  extends Schema.TaggedError<SearchQueryTooShort>()("SearchQueryTooShort", {}, { httpApiStatus: 422 })
 {
   static readonly minimumLength = 2
 }
@@ -17,6 +17,6 @@ export class SearchQueryTooShort
 //
 // This prevents adding too many error types to services / endpoint definitions.
 //
-export class UsersError extends Schema.TaggedErrorClass<UsersError>()("UsersError", {
+export class UsersError extends Schema.TaggedError<UsersError>()("UsersError", {
   reason: Schema.Union([UserNotFound, SearchQueryTooShort])
 }) {}

--- a/ai-docs/src/51_http-server/fixtures/server/Users/http.ts
+++ b/ai-docs/src/51_http-server/fixtures/server/Users/http.ts
@@ -23,7 +23,7 @@ export const UsersApiHandlers = HttpApiBuilder.group(
         Effect.fn(function*({ payload }) {
           if (payload.search === "bad-request") {
             // You can use the built in error types like any other
-            // Schema.TaggedErrorClass
+            // Schema.TaggedError
             return yield* new HttpApiError.RequestTimeout()
           }
           return yield* users.list(payload.search).pipe(

--- a/ai-docs/src/60_child-process/10_working-with-child-processes.ts
+++ b/ai-docs/src/60_child-process/10_working-with-child-processes.ts
@@ -7,7 +7,7 @@ import { NodeServices } from "@effect/platform-node"
 import { Console, Context, Effect, Layer, Schema, Stream, String } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 
-export class DevToolsError extends Schema.TaggedErrorClass<DevToolsError>()("DevToolsError", {
+export class DevToolsError extends Schema.TaggedError<DevToolsError>()("DevToolsError", {
   cause: Schema.Defect()
 }) {}
 

--- a/ai-docs/src/71_ai/10_language-model.ts
+++ b/ai-docs/src/71_ai/10_language-model.ts
@@ -26,7 +26,7 @@ const OpenAiClientLayer = OpenAiClient.layerConfig({
   Layer.provide(FetchHttpClient.layer)
 )
 
-export class AiWriterError extends Schema.TaggedErrorClass<AiWriterError>()("AiWriterError", {
+export class AiWriterError extends Schema.TaggedError<AiWriterError>()("AiWriterError", {
   // AiErrorReason is a Schema, so we can include it directly in our custom
   // error schema.
   reason: AiError.AiErrorReason

--- a/ai-docs/src/71_ai/20_tools.ts
+++ b/ai-docs/src/71_ai/20_tools.ts
@@ -104,7 +104,7 @@ const OpenAiClientLayer = OpenAiClient.layerConfig({
   apiKey: Config.redacted("OPENAI_API_KEY")
 }).pipe(Layer.provide(FetchHttpClient.layer))
 
-export class ProductAssistantError extends Schema.TaggedErrorClass<ProductAssistantError>()(
+export class ProductAssistantError extends Schema.TaggedError<ProductAssistantError>()(
   "ProductAssistantError",
   { reason: AiError.AiErrorReason }
 ) {}

--- a/ai-docs/src/71_ai/30_chat.ts
+++ b/ai-docs/src/71_ai/30_chat.ts
@@ -43,7 +43,7 @@ const ToolsLayer = Tools.toLayer(Effect.gen(function*() {
 // Service that wraps Chat for a domain use-case
 // ---------------------------------------------------------------------------
 
-export class AiAssistantError extends Schema.TaggedErrorClass<AiAssistantError>()("AiAssistantError", {
+export class AiAssistantError extends Schema.TaggedError<AiAssistantError>()("AiAssistantError", {
   reason: AiError.AiErrorReason
 }) {
   static fromAiError(error: AiError.AiError) {

--- a/migration/annotations/effect__Schema.yaml
+++ b/migration/annotations/effect__Schema.yaml
@@ -1133,11 +1133,11 @@ effect/Schema#TaggedClass:
   replacement: Schema.TaggedClass
   note: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
 effect/Schema#TaggedError:
-  replacement: Schema.TaggedErrorClass
-  note: Rename the tagged error class constructor.
+  replacement: Schema.TaggedError
+  note: The tagged error class constructor retains its v3 name.
 effect/Schema#TaggedErrorClass:
-  replacement: Schema.TaggedErrorClass
-  note: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
+  replacement: Schema.TaggedError
+  note: Rename the tagged error class constructor.
 effect/Schema#TaggedRequest:
   replacement: effect/unstable/rpc/Rpc.make
   note: The Schema request/serialization protocol was removed; migrate RPC requests to the v4 Rpc APIs.

--- a/migration/annotations/effect__platform__Error.yaml
+++ b/migration/annotations/effect__platform__Error.yaml
@@ -14,5 +14,5 @@
   replacement: "none"
   note: "The PlatformError runtime marker is internal in v4; use the PlatformError class/tag."
 "@effect/platform/Error#TypeIdError":
-  replacement: "Data.TaggedError or Schema.ErrorClass"
+  replacement: "Data.TaggedError or Schema.Error"
   note: "The platform-specific error-class factory was removed; define tagged data errors or schema-backed error classes directly."

--- a/migration/annotations/effect__platform__HttpApiSchema.yaml
+++ b/migration/annotations/effect__platform__HttpApiSchema.yaml
@@ -29,14 +29,14 @@
   replacement: "effect/unstable/httpapi/HttpApiSchema#Empty"
   note: "The API remains and returns Schema.Void annotated with the supplied status."
 "@effect/platform/HttpApiSchema#EmptyError":
-  replacement: "effect/Schema#ErrorClass"
+  replacement: "effect/Schema#Error"
   note: "Define a normal schema error with httpApiStatus, then derive its no-content wire schema with asNoContent."
 "@effect/platform/HttpApiSchema#EmptyErrorClass":
-  replacement: "effect/Schema#ErrorClass"
-  note: "The class and no-content codec are separate in v4; combine ErrorClass with HttpApiSchema.asNoContent."
+  replacement: "effect/Schema#Error"
+  note: "The class and no-content codec are separate in v4; combine Schema.Error with HttpApiSchema.asNoContent."
 "@effect/platform/HttpApiSchema#EmptyErrorUnify":
   replacement: "none"
-  note: "Removed with EmptyError; Schema.ErrorClass instances already support yieldable-error behavior."
+  note: "Removed with EmptyError; Schema.Error instances already support yieldable-error behavior."
 "@effect/platform/HttpApiSchema#EmptyErrorUnifyIgnore":
   replacement: "none"
   note: "Removed with EmptyError; do not recreate the old Unify marker."

--- a/migration/schema.md
+++ b/migration/schema.md
@@ -31,7 +31,7 @@ This document maps v3 Schema APIs to their v4 equivalents. Simple renames and ar
 | `EitherFromSelf`                                | `Result`                                                                      | rename            |
 | `DateFromNumber`                                | `DateFromMillis`                                                              | rename            |
 | `Date`                                          | `DateFromString`                                                              | restructure       |
-| `TaggedError`                                   | `TaggedErrorClass`                                                            | rename            |
+| `TaggedError`                                   | `TaggedError`                                                                 | unchanged         |
 | `decodeUnknown`                                 | `decodeUnknownEffect`                                                         | rename            |
 | `decode`                                        | `decodeEffect`                                                                | rename            |
 | `decodeUnknownEither`                           | `decodeUnknownExit`                                                           | rename            |

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -6417,7 +6417,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Error.TypeId` -> `none`: The PlatformError runtime marker is internal in v4; use the PlatformError class/tag.
 
-- `Error.TypeIdError` -> `Data.TaggedError or Schema.ErrorClass`: The platform-specific error-class factory was removed; define tagged data errors or schema-backed error classes directly.
+- `Error.TypeIdError` -> `Data.TaggedError or Schema.Error`: The platform-specific error-class factory was removed; define tagged data errors or schema-backed error classes directly.
 
 - `Error.isPlatformError` -> `value instanceof PlatformError.PlatformError`: PlatformError is a class in v4; use an instanceof check or match its PlatformError tag.
 
@@ -6729,11 +6729,11 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `HttpApiSchema.Empty` -> `effect/unstable/httpapi/HttpApiSchema#Empty`: The API remains and returns Schema.Void annotated with the supplied status.
 
-- `HttpApiSchema.EmptyError` -> `effect/Schema#ErrorClass`: Define a normal schema error with httpApiStatus, then derive its no-content wire schema with asNoContent.
+- `HttpApiSchema.EmptyError` -> `effect/Schema#Error`: Define a normal schema error with httpApiStatus, then derive its no-content wire schema with asNoContent.
 
-- `HttpApiSchema.EmptyErrorClass` -> `effect/Schema#ErrorClass`: The class and no-content codec are separate in v4; combine ErrorClass with HttpApiSchema.asNoContent.
+- `HttpApiSchema.EmptyErrorClass` -> `effect/Schema#Error`: The class and no-content codec are separate in v4; combine Schema.Error with HttpApiSchema.asNoContent.
 
-- `HttpApiSchema.EmptyErrorUnify` -> `none`: Removed with EmptyError; Schema.ErrorClass instances already support yieldable-error behavior.
+- `HttpApiSchema.EmptyErrorUnify` -> `none`: Removed with EmptyError; Schema.Error instances already support yieldable-error behavior.
 
 - `HttpApiSchema.EmptyErrorUnifyIgnore` -> `none`: Removed with EmptyError; do not recreate the old Unify marker.
 
@@ -13804,9 +13804,9 @@ Schema.toFormatter(schema)
 
 - `Schema.TaggedClass` -> `Schema.TaggedClass`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
 
-- `Schema.TaggedError` -> `Schema.TaggedErrorClass`: Rename the tagged error class constructor.
+- `Schema.TaggedError` -> `Schema.TaggedError`: The tagged error class constructor retains its v3 name.
 
-- `Schema.TaggedErrorClass` -> `Schema.TaggedErrorClass`: The API remains public in v4, but its type/value declaration was consolidated; use the v4 declaration and update inferred types/signature as needed.
+- `Schema.TaggedErrorClass` -> `Schema.TaggedError`: Rename the tagged error class constructor.
 
 - `Schema.TaggedRequest` -> `effect/unstable/rpc/Rpc.make`: The Schema request/serialization protocol was removed; migrate RPC requests to the v4 Rpc APIs.
 

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -2024,7 +2024,7 @@ import {
 import { createServer } from "node:http"
 
 // Define a custom error for validation failures
-class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
+class ValidationError extends Schema.TaggedError<ValidationError>()(
   "ValidationError",
   {
     message: Schema.String
@@ -2263,7 +2263,7 @@ import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware, HttpApiSecur
 class User extends Schema.Class<User>("User")({ id: Schema.Finite }) {}
 
 // Define a schema for the "Unauthorized" error
-class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
+class Unauthorized extends Schema.TaggedError<Unauthorized>()(
   "Unauthorized",
   {},
   // Specify the HTTP status code for unauthorized errors
@@ -2322,7 +2322,7 @@ import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi"
 
 class User extends Schema.Class<User>("User")({ id: Schema.Finite }) {}
 
-class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
+class Unauthorized extends Schema.TaggedError<Unauthorized>()(
   "Unauthorized",
   {},
   // Specify the HTTP status code for unauthorized errors
@@ -2378,7 +2378,7 @@ import { HttpApiMiddleware, HttpApiSecurity, OpenApi } from "effect/unstable/htt
 
 class User extends Schema.Class<User>("User")({ id: Schema.Finite }) {}
 
-class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
+class Unauthorized extends Schema.TaggedError<Unauthorized>()(
   "Unauthorized",
   {},
   // Specify the HTTP status code for unauthorized errors

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -4418,19 +4418,21 @@ console.log(Schema.decodeUnknownSync(Animal)({ _tag: "Cat", lives: 9 }))
 
 All features from `Class` are available: `extend`, `annotate`, `check`, branded classes, and recursive definitions.
 
-### ErrorClass
+### Error
+
+`Error` is overloaded: pass optional error options to create a schema for JavaScript `Error` values, or pass a string identifier to define a schema-backed yieldable error class.
 
 ```ts
 import { Schema } from "effect"
 
-class E extends Schema.ErrorClass<E>("E")({
+class E extends Schema.Error<E>("E")({
   id: Schema.Number
 }) {}
 ```
 
-### TaggedErrorClass
+### TaggedError
 
-`TaggedErrorClass` combines `ErrorClass` with an automatic `_tag` field, giving you a tagged error that can be caught with `Effect.catchTag`.
+`TaggedError` combines `Error` with an automatic `_tag` field, giving you a tagged error that can be caught with `Effect.catchTag`.
 
 Like `TaggedClass`, the tag value doubles as the identifier by default, and you can pass an explicit identifier as the first argument to override it.
 
@@ -4439,7 +4441,7 @@ Like `TaggedClass`, the tag value doubles as the identifier by default, and you 
 ```ts
 import { Effect, Schema } from "effect"
 
-class HttpError extends Schema.TaggedErrorClass<HttpError>()("HttpError", {
+class HttpError extends Schema.TaggedError<HttpError>()("HttpError", {
   status: Schema.Number,
   message: Schema.String
 }) {}
@@ -4458,11 +4460,11 @@ const recovered = program.pipe(
 ```ts
 import { Effect, Schema } from "effect"
 
-class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
   path: Schema.String
 }) {}
 
-class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()("Unauthorized", {
+class Unauthorized extends Schema.TaggedError<Unauthorized>()("Unauthorized", {
   reason: Schema.String
 }) {}
 
@@ -4483,7 +4485,7 @@ const recovered = program.pipe(
 )
 ```
 
-All features from `ErrorClass` are available: `extend`, `annotate`, and `check`.
+All features from `Error` classes are available: `extend`, `annotate`, and `check`.
 
 # Serialization
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -10627,22 +10627,101 @@ const getErrorOptions = (key: ErrorOptionsKey): NormalizedErrorOptions | undefin
 
 const errorSchemaCache: Array<Error | undefined> = []
 
+const errorClassImpl: {
+  <Self = never, Brand = {}>(identifier: string): {
+    <const Fields extends Struct.Fields>(
+      fields: Fields,
+      annotations?: Annotations.Declaration<Self, readonly [Struct<Fields>]>
+    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.Error">
+      : Class<Self, Struct<Fields>, Cause_.YieldableError & Brand>
+    <S extends Struct<Struct.Fields>>(
+      schema: S,
+      annotations?: Annotations.Declaration<Self, readonly [S]>
+    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.Error"> : Class<Self, S, Cause_.YieldableError & Brand>
+  }
+} = <Self, Brand = {}>(identifier: string) =>
+(
+  schema: Struct.Fields | Struct<Struct.Fields>,
+  annotations?: Annotations.Declaration<Self, readonly [Struct<Struct.Fields>]>
+): [Self] extends [never] ? MissingSelfGeneric<"Schema.Error">
+  : Class<Self, Struct<Struct.Fields>, Cause_.YieldableError & Brand> =>
+{
+  const struct = isStruct(schema) ? schema : Struct(schema)
+  const self = makeClass(
+    core.Error,
+    identifier,
+    struct,
+    annotations,
+    (identifier) => ({
+      name: identifier
+    })
+  )
+  return self
+}
+
 /**
- * Schema for JavaScript `Error` objects.
+ * Creates either a schema for JavaScript `Error` objects or a schema-backed,
+ * yieldable error class.
+ *
+ * **When to use**
+ *
+ * Use when you need either a schema for `globalThis.Error` values or a typed,
+ * schema-backed error class. Call `Schema.Error()` with optional
+ * {@link ErrorOptions} for the instance schema, or call
+ * `Schema.Error<Self>(identifier)` with a string identifier for the error class.
  *
  * **Details**
  *
- * Default JSON serializer:
+ * The instance schema encodes an `Error` as an object with `message`, optional
+ * `name`, and optional `cause` properties, and decodes that object back into an
+ * `Error`. Stack traces are omitted by default for security. Pass
+ * `{ includeStack: true }` to include stack traces, or
+ * `{ excludeCause: true }` to omit causes.
  *
- * Encodes an `Error` as an object with `message`, optional `name`, and optional
- * `cause` properties, and decodes that object back into an `Error`. Stack
- * traces are omitted by default for security. Pass `{ includeStack: true }` to
- * include stack traces, or `{ excludeCause: true }` to omit causes.
+ * The class constructor combines {@link Class} validation with the
+ * `YieldableError` interface, so instances can be yielded directly inside
+ * `Effect.gen`.
+ *
+ * **Example** (JavaScript error schema)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const ErrorSchema = Schema.Error({ includeStack: true })
+ * ```
+ *
+ * **Example** (Schema-backed error class)
+ *
+ * ```ts
+ * import { Effect, Schema } from "effect"
+ *
+ * class NotFound extends Schema.Error<NotFound>("NotFound")({
+ *   id: Schema.Number
+ * }) {}
+ *
+ * const program = Effect.gen(function*() {
+ *   yield* new NotFound({ id: 1 })
+ * })
+ * ```
  *
  * @category constructors
  * @since 4.0.0
  */
-export function Error(options?: ErrorOptions): Error {
+export const Error: {
+  (options?: ErrorOptions): Error
+  <Self = never, Brand = {}>(identifier: string): {
+    <const Fields extends Struct.Fields>(
+      fields: Fields,
+      annotations?: Annotations.Declaration<Self, readonly [Struct<Fields>]>
+    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.Error">
+      : Class<Self, Struct<Fields>, Cause_.YieldableError & Brand>
+    <S extends Struct<Struct.Fields>>(
+      schema: S,
+      annotations?: Annotations.Declaration<Self, readonly [S]>
+    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.Error"> : Class<Self, S, Cause_.YieldableError & Brand>
+  }
+} = function Error(options?: ErrorOptions | string): any {
+  if (Predicate.isString(options)) return errorClassImpl(options)
   const key = getErrorOptionsKey(options)
   const cached = errorSchemaCache[key]
   if (cached !== undefined) {
@@ -14255,8 +14334,8 @@ type MissingSelfGeneric<Usage extends string> =
  * ```
  *
  * @see {@link TaggedClass} for adding a `_tag` literal field to the class schema
- * @see {@link ErrorClass} for defining schema-backed error classes
- * @see {@link TaggedErrorClass} for defining tagged schema-backed error classes
+ * @see {@link Error} for defining schema-backed error classes
+ * @see {@link TaggedError} for defining tagged schema-backed error classes
  *
  * @category constructors
  * @since 3.10.0
@@ -14357,61 +14436,6 @@ export const TaggedClass: {
 }
 
 /**
- * Creates a schema-backed error class that can be used as a typed,
- * yieldable error in Effect programs. Combines {@link Class} validation with
- * the `YieldableError` interface so instances can be yielded directly inside
- * `Effect.gen`.
- *
- * **Example** (Schema-backed error)
- *
- * ```ts
- * import { Effect, Schema } from "effect"
- *
- * class NotFound extends Schema.ErrorClass<NotFound>("NotFound")({
- *   id: Schema.Number
- * }) {}
- *
- * const program = Effect.gen(function*() {
- *   yield* new NotFound({ id: 1 })
- * })
- * ```
- *
- * @category constructors
- * @since 4.0.0
- */
-export const ErrorClass: {
-  <Self = never, Brand = {}>(identifier: string): {
-    <const Fields extends Struct.Fields>(
-      fields: Fields,
-      annotations?: Annotations.Declaration<Self, readonly [Struct<Fields>]>
-    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.ErrorClass">
-      : Class<Self, Struct<Fields>, Cause_.YieldableError & Brand>
-    <S extends Struct<Struct.Fields>>(
-      schema: S,
-      annotations?: Annotations.Declaration<Self, readonly [S]>
-    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.ErrorClass"> : Class<Self, S, Cause_.YieldableError & Brand>
-  }
-} = <Self, Brand = {}>(identifier: string) =>
-(
-  schema: Struct.Fields | Struct<Struct.Fields>,
-  annotations?: Annotations.Declaration<Self, readonly [Struct<Struct.Fields>]>
-): [Self] extends [never] ? MissingSelfGeneric<"Schema.ErrorClass">
-  : Class<Self, Struct<Struct.Fields>, Cause_.YieldableError & Brand> =>
-{
-  const struct = isStruct(schema) ? schema : Struct(schema)
-  const self = makeClass(
-    core.Error,
-    identifier,
-    struct,
-    annotations,
-    (identifier) => ({
-      name: identifier
-    })
-  )
-  return self
-}
-
-/**
  * Defines a schema-backed yieldable error class with an automatically populated
  * `_tag` field.
  *
@@ -14425,7 +14449,7 @@ export const ErrorClass: {
  * ```ts
  * import { Effect, Schema } from "effect"
  *
- * class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+ * class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
  *   id: Schema.Number
  * }) {}
  *
@@ -14437,13 +14461,13 @@ export const ErrorClass: {
  * @category constructors
  * @since 3.10.0
  */
-export const TaggedErrorClass: {
+export const TaggedError: {
   <Self = never, Brand = {}>(identifier?: string): {
     <Tag extends string, const Fields extends Struct.Fields>(
       tag: Tag,
       fields: Fields,
       annotations?: Annotations.Declaration<Self, readonly [TaggedStruct<Tag, Fields>]>
-    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.TaggedErrorClass">
+    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.TaggedError">
       : Class<Self, TaggedStruct<Tag, Fields>, Cause_.YieldableError & Brand>
     <Tag extends string, S extends Struct<Struct.Fields>>(
       tag: Tag,
@@ -14452,7 +14476,7 @@ export const TaggedErrorClass: {
         Self,
         readonly [Struct<Simplify<{ readonly _tag: tag<Tag> } & S["fields"]>>]
       >
-    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.TaggedErrorClass">
+    ): [Self] extends [never] ? MissingSelfGeneric<"Schema.TaggedError">
       : Class<Self, Struct<Simplify<{ readonly _tag: tag<Tag> } & S["fields"]>>, Cause_.YieldableError & Brand>
   }
 } = (identifier?: string) => {
@@ -14466,7 +14490,7 @@ export const TaggedErrorClass: {
         unsafePreserveChecks: true
       }) :
       TaggedStruct(tagValue, schema)
-    return ErrorClass<any, {}>(identifier ?? tagValue)(
+    return errorClassImpl<any, {}>(identifier ?? tagValue)(
       struct,
       annotations as Annotations.Declaration<any, readonly [typeof struct]>
     )

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -10682,6 +10682,10 @@ const errorClassImpl: {
  * `YieldableError` interface, so instances can be yielded directly inside
  * `Effect.gen`.
  *
+ * When passing `Schema.Error` to a generic higher-order function, wrap the call
+ * (for example, `(options) => Schema.Error(options)`) because TypeScript infers
+ * a bare overloaded function value from its last overload.
+ *
  * **Example** (JavaScript error schema)
  *
  * ```ts

--- a/packages/effect/src/Terminal.ts
+++ b/packages/effect/src/Terminal.ts
@@ -121,7 +121,7 @@ const QuitErrorTypeId = "effect/platform/Terminal/QuitError"
  * @category QuitError
  * @since 4.0.0
  */
-export class QuitError extends Schema.ErrorClass<QuitError>("QuitError")({
+export class QuitError extends Schema.Error<QuitError>("QuitError")({
   _tag: Schema.tag("QuitError")
 }) {
   /**

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -78,7 +78,7 @@ const redactHeaders = (headers: Record<string, string>): Record<string, string> 
  * @category reason
  * @since 4.0.0
  */
-export class NetworkError extends Schema.ErrorClass<NetworkError>(
+export class NetworkError extends Schema.Error<NetworkError>(
   "effect/ai/AiError/NetworkError"
 )({
   _tag: Schema.tag("NetworkError"),
@@ -366,7 +366,7 @@ export const HttpContext = Schema.Struct({
  * @category reason
  * @since 4.0.0
  */
-export class RateLimitError extends Schema.ErrorClass<RateLimitError>(
+export class RateLimitError extends Schema.Error<RateLimitError>(
   "effect/ai/AiError/RateLimitError"
 )({
   _tag: Schema.tag("RateLimitError"),
@@ -419,7 +419,7 @@ export class RateLimitError extends Schema.ErrorClass<RateLimitError>(
  * @category reason
  * @since 4.0.0
  */
-export class QuotaExhaustedError extends Schema.ErrorClass<QuotaExhaustedError>(
+export class QuotaExhaustedError extends Schema.Error<QuotaExhaustedError>(
   "effect/ai/AiError/QuotaExhaustedError"
 )({
   _tag: Schema.tag("QuotaExhaustedError"),
@@ -474,7 +474,7 @@ export class QuotaExhaustedError extends Schema.ErrorClass<QuotaExhaustedError>(
  * @category reason
  * @since 4.0.0
  */
-export class AuthenticationError extends Schema.ErrorClass<AuthenticationError>(
+export class AuthenticationError extends Schema.Error<AuthenticationError>(
   "effect/ai/AiError/AuthenticationError"
 )({
   _tag: Schema.tag("AuthenticationError"),
@@ -534,7 +534,7 @@ export class AuthenticationError extends Schema.ErrorClass<AuthenticationError>(
  * @category reason
  * @since 4.0.0
  */
-export class ContentPolicyError extends Schema.ErrorClass<ContentPolicyError>(
+export class ContentPolicyError extends Schema.Error<ContentPolicyError>(
   "effect/ai/AiError/ContentPolicyError"
 )({
   _tag: Schema.tag("ContentPolicyError"),
@@ -589,7 +589,7 @@ export class ContentPolicyError extends Schema.ErrorClass<ContentPolicyError>(
  * @category reason
  * @since 4.0.0
  */
-export class InvalidRequestError extends Schema.ErrorClass<InvalidRequestError>(
+export class InvalidRequestError extends Schema.Error<InvalidRequestError>(
   "effect/ai/AiError/InvalidRequestError"
 )({
   _tag: Schema.tag("InvalidRequestError"),
@@ -648,7 +648,7 @@ export class InvalidRequestError extends Schema.ErrorClass<InvalidRequestError>(
  * @category reason
  * @since 4.0.0
  */
-export class InternalProviderError extends Schema.ErrorClass<InternalProviderError>(
+export class InternalProviderError extends Schema.Error<InternalProviderError>(
   "effect/ai/AiError/InternalProviderError"
 )({
   _tag: Schema.tag("InternalProviderError"),
@@ -701,7 +701,7 @@ export class InternalProviderError extends Schema.ErrorClass<InternalProviderErr
  * @category reason
  * @since 4.0.0
  */
-export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
+export class InvalidOutputError extends Schema.Error<InvalidOutputError>(
   "effect/ai/AiError/InvalidOutputError"
 )({
   _tag: Schema.tag("InvalidOutputError"),
@@ -778,7 +778,7 @@ export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
  * @category reason
  * @since 4.0.0
  */
-export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputError>(
+export class StructuredOutputError extends Schema.Error<StructuredOutputError>(
   "effect/ai/AiError/StructuredOutputError"
 )({
   _tag: Schema.tag("StructuredOutputError"),
@@ -858,7 +858,7 @@ export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputErr
  * @category reason
  * @since 4.0.0
  */
-export class UnsupportedSchemaError extends Schema.ErrorClass<UnsupportedSchemaError>(
+export class UnsupportedSchemaError extends Schema.Error<UnsupportedSchemaError>(
   "effect/ai/AiError/UnsupportedSchemaError"
 )({
   _tag: Schema.tag("UnsupportedSchemaError"),
@@ -910,7 +910,7 @@ export class UnsupportedSchemaError extends Schema.ErrorClass<UnsupportedSchemaE
  * @category reason
  * @since 4.0.0
  */
-export class UnknownError extends Schema.ErrorClass<UnknownError>(
+export class UnknownError extends Schema.Error<UnknownError>(
   "effect/ai/AiError/UnknownError"
 )({
   _tag: Schema.tag("UnknownError"),
@@ -969,7 +969,7 @@ export class UnknownError extends Schema.ErrorClass<UnknownError>(
  * @category reason
  * @since 4.0.0
  */
-export class ToolNotFoundError extends Schema.ErrorClass<ToolNotFoundError>(
+export class ToolNotFoundError extends Schema.Error<ToolNotFoundError>(
   "effect/ai/AiError/ToolNotFoundError"
 )({
   _tag: Schema.tag("ToolNotFoundError"),
@@ -1025,7 +1025,7 @@ export class ToolNotFoundError extends Schema.ErrorClass<ToolNotFoundError>(
  * @category reason
  * @since 4.0.0
  */
-export class ToolParameterValidationError extends Schema.ErrorClass<ToolParameterValidationError>(
+export class ToolParameterValidationError extends Schema.Error<ToolParameterValidationError>(
   "effect/ai/AiError/ToolParameterValidationError"
 )({
   _tag: Schema.tag("ToolParameterValidationError"),
@@ -1081,7 +1081,7 @@ export class ToolParameterValidationError extends Schema.ErrorClass<ToolParamete
  * @category reason
  * @since 4.0.0
  */
-export class InvalidToolResultError extends Schema.ErrorClass<InvalidToolResultError>(
+export class InvalidToolResultError extends Schema.Error<InvalidToolResultError>(
   "effect/ai/AiError/InvalidToolResultError"
 )({
   _tag: Schema.tag("InvalidToolResultError"),
@@ -1136,7 +1136,7 @@ export class InvalidToolResultError extends Schema.ErrorClass<InvalidToolResultE
  * @category reason
  * @since 4.0.0
  */
-export class ToolResultEncodingError extends Schema.ErrorClass<ToolResultEncodingError>(
+export class ToolResultEncodingError extends Schema.Error<ToolResultEncodingError>(
   "effect/ai/AiError/ToolResultEncodingError"
 )({
   _tag: Schema.tag("ToolResultEncodingError"),
@@ -1191,7 +1191,7 @@ export class ToolResultEncodingError extends Schema.ErrorClass<ToolResultEncodin
  * @category reason
  * @since 4.0.0
  */
-export class ToolConfigurationError extends Schema.ErrorClass<ToolConfigurationError>(
+export class ToolConfigurationError extends Schema.Error<ToolConfigurationError>(
   "effect/ai/AiError/ToolConfigurationError"
 )({
   _tag: Schema.tag("ToolConfigurationError"),
@@ -1244,7 +1244,7 @@ export class ToolConfigurationError extends Schema.ErrorClass<ToolConfigurationE
  * @category reason
  * @since 4.0.0
  */
-export class ToolkitRequiredError extends Schema.ErrorClass<ToolkitRequiredError>(
+export class ToolkitRequiredError extends Schema.Error<ToolkitRequiredError>(
   "effect/ai/AiError/ToolkitRequiredError"
 )({
   _tag: Schema.tag("ToolkitRequiredError"),
@@ -1299,7 +1299,7 @@ export class ToolkitRequiredError extends Schema.ErrorClass<ToolkitRequiredError
  * @category reason
  * @since 4.0.0
  */
-export class InvalidUserInputError extends Schema.ErrorClass<InvalidUserInputError>(
+export class InvalidUserInputError extends Schema.Error<InvalidUserInputError>(
   "effect/ai/AiError/InvalidUserInputError"
 )({
   _tag: Schema.tag("InvalidUserInputError"),
@@ -1459,7 +1459,7 @@ const TypeId = "~effect/unstable/ai/AiError/AiError" as const
  * @category schemas
  * @since 4.0.0
  */
-export class AiError extends Schema.ErrorClass<AiError>(
+export class AiError extends Schema.Error<AiError>(
   "effect/ai/AiError/AiError"
 )({
   _tag: Schema.tag("AiError"),

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -664,7 +664,7 @@ export const fromJson = (data: string): Effect.Effect<
  * @category errors
  * @since 4.0.0
  */
-export class ChatNotFoundError extends Schema.ErrorClass<ChatNotFoundError>(
+export class ChatNotFoundError extends Schema.Error<ChatNotFoundError>(
   "effect/ai/Chat/ChatNotFoundError"
 )({
   _tag: Schema.tag("ChatNotFoundError"),

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -540,7 +540,7 @@ export const PARSE_ERROR_CODE = -32700 as const
  * @category errors
  * @since 4.0.0
  */
-export class ParseError extends Schema.ErrorClass<ParseError>("effect/ai/McpSchema/ParseError")({
+export class ParseError extends Schema.Error<ParseError>("effect/ai/McpSchema/ParseError")({
   ...McpErrorBase.fields,
   _tag: Schema.tag("ParseError"),
   code: Schema.tag(PARSE_ERROR_CODE)
@@ -561,7 +561,7 @@ export class ParseError extends Schema.ErrorClass<ParseError>("effect/ai/McpSche
  * @category errors
  * @since 4.0.0
  */
-export class InvalidRequest extends Schema.ErrorClass<InvalidRequest>("effect/ai/McpSchema/InvalidRequest")({
+export class InvalidRequest extends Schema.Error<InvalidRequest>("effect/ai/McpSchema/InvalidRequest")({
   ...McpErrorBase.fields,
   _tag: Schema.tag("InvalidRequest"),
   code: Schema.tag(INVALID_REQUEST_ERROR_CODE)
@@ -581,7 +581,7 @@ export class InvalidRequest extends Schema.ErrorClass<InvalidRequest>("effect/ai
  * @category errors
  * @since 4.0.0
  */
-export class MethodNotFound extends Schema.ErrorClass<MethodNotFound>("effect/ai/McpSchema/MethodNotFound")({
+export class MethodNotFound extends Schema.Error<MethodNotFound>("effect/ai/McpSchema/MethodNotFound")({
   ...McpErrorBase.fields,
   _tag: Schema.tag("MethodNotFound"),
   code: Schema.tag(METHOD_NOT_FOUND_ERROR_CODE)
@@ -602,7 +602,7 @@ export class MethodNotFound extends Schema.ErrorClass<MethodNotFound>("effect/ai
  * @category errors
  * @since 4.0.0
  */
-export class InvalidParams extends Schema.ErrorClass<InvalidParams>("effect/ai/McpSchema/InvalidParams")({
+export class InvalidParams extends Schema.Error<InvalidParams>("effect/ai/McpSchema/InvalidParams")({
   ...McpErrorBase.fields,
   _tag: Schema.tag("InvalidParams"),
   code: Schema.tag(INVALID_PARAMS_ERROR_CODE)
@@ -624,7 +624,7 @@ export class InvalidParams extends Schema.ErrorClass<InvalidParams>("effect/ai/M
  * @category errors
  * @since 4.0.0
  */
-export class InternalError extends Schema.ErrorClass<InternalError>("effect/ai/McpSchema/InternalError")({
+export class InternalError extends Schema.Error<InternalError>("effect/ai/McpSchema/InternalError")({
   ...McpErrorBase.fields,
   _tag: Schema.tag("InternalError"),
   code: Schema.tag(INTERNAL_ERROR_CODE)
@@ -2141,13 +2141,11 @@ export class Elicit extends Rpc.make("elicitation/create", {
  * @category elicitation
  * @since 4.0.0
  */
-export class ElicitationDeclined
-  extends Schema.ErrorClass<ElicitationDeclined>("@effect/ai/McpSchema/ElicitationDeclined")({
-    _tag: Schema.tag("ElicitationDeclined"),
-    request: Elicit.payloadSchema,
-    cause: optional(Schema.Defect())
-  })
-{}
+export class ElicitationDeclined extends Schema.Error<ElicitationDeclined>("@effect/ai/McpSchema/ElicitationDeclined")({
+  _tag: Schema.tag("ElicitationDeclined"),
+  request: Elicit.payloadSchema,
+  cause: optional(Schema.Defect())
+}) {}
 
 // =============================================================================
 // McpServerClient

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -128,7 +128,7 @@ export type CliError =
  * @category models
  * @since 4.0.0
  */
-export class UnrecognizedOption extends Schema.TaggedErrorClass<UnrecognizedOption>(
+export class UnrecognizedOption extends Schema.TaggedError<UnrecognizedOption>(
   `${TypeId}/UnrecognizedOption`
 )("UnrecognizedOption", {
   option: Schema.String,
@@ -180,7 +180,7 @@ export class UnrecognizedOption extends Schema.TaggedErrorClass<UnrecognizedOpti
  * @category models
  * @since 4.0.0
  */
-export class DuplicateOption extends Schema.TaggedErrorClass<DuplicateOption>(
+export class DuplicateOption extends Schema.TaggedError<DuplicateOption>(
   `${TypeId}/DuplicateOption`
 )("DuplicateOption", {
   option: Schema.String,
@@ -235,7 +235,7 @@ export class DuplicateOption extends Schema.TaggedErrorClass<DuplicateOption>(
  * @category models
  * @since 4.0.0
  */
-export class MissingOption extends Schema.TaggedErrorClass<MissingOption>(
+export class MissingOption extends Schema.TaggedError<MissingOption>(
   `${TypeId}/MissingOption`
 )("MissingOption", {
   option: Schema.String
@@ -286,7 +286,7 @@ export class MissingOption extends Schema.TaggedErrorClass<MissingOption>(
  * @category models
  * @since 4.0.0
  */
-export class MissingArgument extends Schema.TaggedErrorClass<MissingArgument>(
+export class MissingArgument extends Schema.TaggedError<MissingArgument>(
   `${TypeId}/MissingArgument`
 )("MissingArgument", {
   argument: Schema.String
@@ -328,7 +328,7 @@ export class MissingArgument extends Schema.TaggedErrorClass<MissingArgument>(
  * @category models
  * @since 4.0.0
  */
-export class UnexpectedArgument extends Schema.TaggedErrorClass<UnexpectedArgument>(
+export class UnexpectedArgument extends Schema.TaggedError<UnexpectedArgument>(
   `${TypeId}/UnexpectedArgument`
 )("UnexpectedArgument", {
   arguments: Schema.Array(Schema.String)
@@ -385,7 +385,7 @@ export class UnexpectedArgument extends Schema.TaggedErrorClass<UnexpectedArgume
  * @category models
  * @since 4.0.0
  */
-export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
+export class InvalidValue extends Schema.TaggedError<InvalidValue>(
   `${TypeId}/InvalidValue`
 )("InvalidValue", {
   option: Schema.String,
@@ -455,7 +455,7 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
  * @category models
  * @since 4.0.0
  */
-export class UnknownSubcommand extends Schema.TaggedErrorClass<UnknownSubcommand>(
+export class UnknownSubcommand extends Schema.TaggedError<UnknownSubcommand>(
   `${TypeId}/UnknownSubcommand`
 )("UnknownSubcomand", {
   subcommand: Schema.String,
@@ -520,7 +520,7 @@ export class UnknownSubcommand extends Schema.TaggedErrorClass<UnknownSubcommand
  * @category models
  * @since 4.0.0
  */
-export class UserError extends Schema.TaggedErrorClass<UserError>(
+export class UserError extends Schema.TaggedError<UserError>(
   `${TypeId}/UserError`
 )("UserError", {
   cause: Schema.Defect()
@@ -592,7 +592,7 @@ export type NonShowHelpErrors = typeof NonShowHelpErrors.Type
  * @category models
  * @since 4.0.0
  */
-export class ShowHelp extends Schema.TaggedErrorClass<ShowHelp>(
+export class ShowHelp extends Schema.TaggedError<ShowHelp>(
   `${TypeId}/ShowHelp`
 )("ShowHelp", {
   commandPath: Schema.Array(Schema.String),

--- a/packages/effect/src/unstable/cluster/ClusterError.ts
+++ b/packages/effect/src/unstable/cluster/ClusterError.ts
@@ -26,7 +26,7 @@ const TypeId = "~effect/cluster/ClusterError"
  * @since 4.0.0
  */
 export class EntityNotAssignedToRunner
-  extends Schema.ErrorClass<EntityNotAssignedToRunner>(`${TypeId}/EntityNotAssignedToRunner`)({
+  extends Schema.Error<EntityNotAssignedToRunner>(`${TypeId}/EntityNotAssignedToRunner`)({
     _tag: Schema.tag("EntityNotAssignedToRunner"),
     address: EntityAddress
   })
@@ -60,7 +60,7 @@ export class EntityNotAssignedToRunner
  * @category errors
  * @since 4.0.0
  */
-export class MalformedMessage extends Schema.ErrorClass<MalformedMessage>(`${TypeId}/MalformedMessage`)({
+export class MalformedMessage extends Schema.Error<MalformedMessage>(`${TypeId}/MalformedMessage`)({
   _tag: Schema.tag("MalformedMessage"),
   cause: Schema.Defect()
 }) {
@@ -99,7 +99,7 @@ export class MalformedMessage extends Schema.ErrorClass<MalformedMessage>(`${Typ
  * @category errors
  * @since 4.0.0
  */
-export class PersistenceError extends Schema.ErrorClass<PersistenceError>(`${TypeId}/PersistenceError`)({
+export class PersistenceError extends Schema.Error<PersistenceError>(`${TypeId}/PersistenceError`)({
   _tag: Schema.tag("PersistenceError"),
   cause: Schema.Defect()
 }) {
@@ -127,7 +127,7 @@ export class PersistenceError extends Schema.ErrorClass<PersistenceError>(`${Typ
  * @category errors
  * @since 4.0.0
  */
-export class RunnerNotRegistered extends Schema.ErrorClass<RunnerNotRegistered>(`${TypeId}/RunnerNotRegistered`)({
+export class RunnerNotRegistered extends Schema.Error<RunnerNotRegistered>(`${TypeId}/RunnerNotRegistered`)({
   _tag: Schema.tag("RunnerNotRegistered"),
   address: RunnerAddress
 }) {
@@ -145,7 +145,7 @@ export class RunnerNotRegistered extends Schema.ErrorClass<RunnerNotRegistered>(
  * @category errors
  * @since 4.0.0
  */
-export class RunnerUnavailable extends Schema.ErrorClass<RunnerUnavailable>(`${TypeId}/RunnerUnavailable`)({
+export class RunnerUnavailable extends Schema.Error<RunnerUnavailable>(`${TypeId}/RunnerUnavailable`)({
   _tag: Schema.tag("RunnerUnavailable"),
   address: RunnerAddress
 }) {
@@ -181,7 +181,7 @@ export class RunnerUnavailable extends Schema.ErrorClass<RunnerUnavailable>(`${T
  * @category errors
  * @since 4.0.0
  */
-export class MailboxFull extends Schema.ErrorClass<MailboxFull>(`${TypeId}/MailboxFull`)({
+export class MailboxFull extends Schema.Error<MailboxFull>(`${TypeId}/MailboxFull`)({
   _tag: Schema.tag("MailboxFull"),
   address: EntityAddress
 }) {
@@ -214,7 +214,7 @@ export class MailboxFull extends Schema.ErrorClass<MailboxFull>(`${TypeId}/Mailb
  * @since 4.0.0
  */
 export class AlreadyProcessingMessage
-  extends Schema.ErrorClass<AlreadyProcessingMessage>(`${TypeId}/AlreadyProcessingMessage`)({
+  extends Schema.Error<AlreadyProcessingMessage>(`${TypeId}/AlreadyProcessingMessage`)({
     _tag: Schema.tag("AlreadyProcessingMessage"),
     envelopeId: SnowflakeFromString,
     address: EntityAddress

--- a/packages/effect/src/unstable/eventlog/EventLogMessage.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogMessage.ts
@@ -63,7 +63,7 @@ export const StoreId = Schema.String.pipe(Schema.brand(StoreIdTypeId))
  * @category protocols
  * @since 4.0.0
  */
-export class EventLogProtocolError extends Schema.TaggedErrorClass<EventLogProtocolError>(
+export class EventLogProtocolError extends Schema.TaggedError<EventLogProtocolError>(
   "effect/eventlog/EventLogRemote/ProtocolError"
 )("EventLogProtocolError", {
   requestTag: Schema.String,

--- a/packages/effect/src/unstable/http/HttpClientError.ts
+++ b/packages/effect/src/unstable/http/HttpClientError.ts
@@ -299,7 +299,7 @@ export type HttpClientErrorReason = RequestError | ResponseError
  * @category schemas
  * @since 4.0.0
  */
-export class HttpClientErrorSchema extends Schema.ErrorClass<HttpClientErrorSchema>(TypeId)({
+export class HttpClientErrorSchema extends Schema.Error<HttpClientErrorSchema>(TypeId)({
   _tag: Schema.tag("HttpError"),
   kind: Schema.Literals(
     [

--- a/packages/effect/src/unstable/httpapi/HttpApiError.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiError.ts
@@ -1,7 +1,7 @@
 /**
  * Built-in error schemas for common HTTP API failure responses.
  *
- * This module provides reusable `Schema.ErrorClass` values for common HTTP
+ * This module provides reusable `Schema.Error` values for common HTTP
  * status codes, plus `HttpApiSchemaError` for request decoding failures raised
  * by the HTTP API runtime. The status errors can be used in endpoint or
  * middleware error declarations and are understood by builders, generated
@@ -39,7 +39,7 @@ const serviceUnavailableResponse = HttpServerResponse.empty({ status: 503 })
  * @category errors
  * @since 4.0.0
  */
-export class BadRequest extends Schema.ErrorClass<BadRequest>("effect/HttpApiError/BadRequest")({
+export class BadRequest extends Schema.Error<BadRequest>("effect/HttpApiError/BadRequest")({
   _tag: Schema.tag("BadRequest")
 }, {
   description: "BadRequest",
@@ -70,7 +70,7 @@ export const BadRequestNoContent = BadRequest.pipe(HttpApiSchema.asNoContent({
  * @category errors
  * @since 4.0.0
  */
-export class Unauthorized extends Schema.ErrorClass<Unauthorized>("effect/HttpApiError/Unauthorized")({
+export class Unauthorized extends Schema.Error<Unauthorized>("effect/HttpApiError/Unauthorized")({
   _tag: Schema.tag("Unauthorized")
 }, {
   description: "Unauthorized",
@@ -100,7 +100,7 @@ export const UnauthorizedNoContent = Unauthorized.pipe(HttpApiSchema.asNoContent
  * @category errors
  * @since 4.0.0
  */
-export class Forbidden extends Schema.ErrorClass<Forbidden>("effect/HttpApiError/Forbidden")({
+export class Forbidden extends Schema.Error<Forbidden>("effect/HttpApiError/Forbidden")({
   _tag: Schema.tag("Forbidden")
 }, {
   description: "Forbidden",
@@ -130,7 +130,7 @@ export const ForbiddenNoContent = Forbidden.pipe(HttpApiSchema.asNoContent({
  * @category errors
  * @since 4.0.0
  */
-export class NotFound extends Schema.ErrorClass<NotFound>("effect/HttpApiError/NotFound")({
+export class NotFound extends Schema.Error<NotFound>("effect/HttpApiError/NotFound")({
   _tag: Schema.tag("NotFound")
 }, {
   description: "NotFound",
@@ -160,7 +160,7 @@ export const NotFoundNoContent = NotFound.pipe(HttpApiSchema.asNoContent({
  * @category errors
  * @since 4.0.0
  */
-export class MethodNotAllowed extends Schema.ErrorClass<MethodNotAllowed>("effect/HttpApiError/MethodNotAllowed")({
+export class MethodNotAllowed extends Schema.Error<MethodNotAllowed>("effect/HttpApiError/MethodNotAllowed")({
   _tag: Schema.tag("MethodNotAllowed")
 }, {
   description: "MethodNotAllowed",
@@ -190,7 +190,7 @@ export const MethodNotAllowedNoContent = MethodNotAllowed.pipe(HttpApiSchema.asN
  * @category errors
  * @since 4.0.0
  */
-export class NotAcceptable extends Schema.ErrorClass<NotAcceptable>("effect/HttpApiError/NotAcceptable")({
+export class NotAcceptable extends Schema.Error<NotAcceptable>("effect/HttpApiError/NotAcceptable")({
   _tag: Schema.tag("NotAcceptable")
 }, {
   description: "NotAcceptable",
@@ -220,7 +220,7 @@ export const NotAcceptableNoContent = NotAcceptable.pipe(HttpApiSchema.asNoConte
  * @category errors
  * @since 4.0.0
  */
-export class RequestTimeout extends Schema.ErrorClass<RequestTimeout>("effect/HttpApiError/RequestTimeout")({
+export class RequestTimeout extends Schema.Error<RequestTimeout>("effect/HttpApiError/RequestTimeout")({
   _tag: Schema.tag("RequestTimeout")
 }, {
   description: "RequestTimeout",
@@ -250,7 +250,7 @@ export const RequestTimeoutNoContent = RequestTimeout.pipe(HttpApiSchema.asNoCon
  * @category errors
  * @since 4.0.0
  */
-export class Conflict extends Schema.ErrorClass<Conflict>("effect/HttpApiError/Conflict")({
+export class Conflict extends Schema.Error<Conflict>("effect/HttpApiError/Conflict")({
   _tag: Schema.tag("Conflict")
 }, {
   description: "Conflict",
@@ -280,7 +280,7 @@ export const ConflictNoContent = Conflict.pipe(HttpApiSchema.asNoContent({
  * @category errors
  * @since 4.0.0
  */
-export class Gone extends Schema.ErrorClass<Gone>("effect/HttpApiError/Gone")({
+export class Gone extends Schema.Error<Gone>("effect/HttpApiError/Gone")({
   _tag: Schema.tag("Gone")
 }, {
   description: "Gone",
@@ -310,14 +310,12 @@ export const GoneNoContent = Gone.pipe(HttpApiSchema.asNoContent({
  * @category errors
  * @since 4.0.0
  */
-export class UnprocessableEntity
-  extends Schema.ErrorClass<UnprocessableEntity>("effect/HttpApiError/UnprocessableEntity")({
-    _tag: Schema.tag("UnprocessableEntity")
-  }, {
-    description: "UnprocessableEntity",
-    httpApiStatus: 422
-  })
-{
+export class UnprocessableEntity extends Schema.Error<UnprocessableEntity>("effect/HttpApiError/UnprocessableEntity")({
+  _tag: Schema.tag("UnprocessableEntity")
+}, {
+  description: "UnprocessableEntity",
+  httpApiStatus: 422
+}) {
   override readonly [ErrorReporter.ignore] = true;
   [HttpServerRespondable.symbol]() {
     return Effect.succeed(unprocessableEntityResponse)
@@ -342,14 +340,12 @@ export const UnprocessableEntityNoContent = UnprocessableEntity.pipe(HttpApiSche
  * @category errors
  * @since 4.0.0
  */
-export class InternalServerError
-  extends Schema.ErrorClass<InternalServerError>("effect/HttpApiError/InternalServerError")({
-    _tag: Schema.tag("InternalServerError")
-  }, {
-    description: "InternalServerError",
-    httpApiStatus: 500
-  })
-{
+export class InternalServerError extends Schema.Error<InternalServerError>("effect/HttpApiError/InternalServerError")({
+  _tag: Schema.tag("InternalServerError")
+}, {
+  description: "InternalServerError",
+  httpApiStatus: 500
+}) {
   [HttpServerRespondable.symbol]() {
     return Effect.succeed(internalServerErrorResponse)
   }
@@ -373,7 +369,7 @@ export const InternalServerErrorNoContent = InternalServerError.pipe(HttpApiSche
  * @category errors
  * @since 4.0.0
  */
-export class NotImplemented extends Schema.ErrorClass<NotImplemented>("effect/HttpApiError/NotImplemented")({
+export class NotImplemented extends Schema.Error<NotImplemented>("effect/HttpApiError/NotImplemented")({
   _tag: Schema.tag("NotImplemented")
 }, {
   description: "NotImplemented",
@@ -402,14 +398,12 @@ export const NotImplementedNoContent = NotImplemented.pipe(HttpApiSchema.asNoCon
  * @category errors
  * @since 4.0.0
  */
-export class ServiceUnavailable
-  extends Schema.ErrorClass<ServiceUnavailable>("effect/HttpApiError/ServiceUnavailable")({
-    _tag: Schema.tag("ServiceUnavailable")
-  }, {
-    description: "ServiceUnavailable",
-    httpApiStatus: 503
-  })
-{
+export class ServiceUnavailable extends Schema.Error<ServiceUnavailable>("effect/HttpApiError/ServiceUnavailable")({
+  _tag: Schema.tag("ServiceUnavailable")
+}, {
+  description: "ServiceUnavailable",
+  httpApiStatus: 503
+}) {
   [HttpServerRespondable.symbol]() {
     return Effect.succeed(serviceUnavailableResponse)
   }

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -398,7 +398,7 @@ function getError(error: ErrorConstraint | undefined): ReadonlySet<Schema.Top> {
  * import { Effect, Schema } from "effect"
  * import { HttpApiMiddleware } from "effect/unstable/httpapi"
  *
- * export class CustomError extends Schema.TaggedErrorClass<CustomError>()("CustomError", {}) {}
+ * export class CustomError extends Schema.TaggedError<CustomError>()("CustomError", {}) {}
  *
  * export class ErrorHandler extends HttpApiMiddleware.Service<ErrorHandler>()("api/ErrorHandler", {
  *   error: CustomError

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -217,7 +217,7 @@ export type ErrorTypeId = "~@effect/experimental/PersistedQueue/PersistedQueueEr
  * @category errors
  * @since 4.0.0
  */
-export class PersistedQueueError extends Schema.ErrorClass<PersistedQueueError>(
+export class PersistedQueueError extends Schema.Error<PersistedQueueError>(
   "effect/persistence/PersistedQueue/PersistedQueueError"
 )({
   _tag: Schema.tag("PersistedQueueError"),

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -33,7 +33,7 @@ const ErrorTypeId = "~effect/persistence/Persistence/PersistenceError" as const
  * @category errors
  * @since 4.0.0
  */
-export class PersistenceError extends Schema.ErrorClass<PersistenceError>(ErrorTypeId)({
+export class PersistenceError extends Schema.Error<PersistenceError>(ErrorTypeId)({
   _tag: Schema.tag("PersistenceError"),
   message: Schema.String,
   cause: Schema.optional(Schema.Defect())

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -356,7 +356,7 @@ export type ErrorTypeId = "~@effect/experimental/RateLimiter/RateLimiterError"
  * @category errors
  * @since 4.0.0
  */
-export class RateLimitExceeded extends Schema.ErrorClass<RateLimitExceeded>(
+export class RateLimitExceeded extends Schema.Error<RateLimitExceeded>(
   "effect/persistence/RateLimiter/RateLimitExceeded"
 )({
   _tag: Schema.tag("RateLimitExceeded"),
@@ -381,7 +381,7 @@ export class RateLimitExceeded extends Schema.ErrorClass<RateLimitExceeded>(
  * @category errors
  * @since 4.0.0
  */
-export class RateLimitStoreError extends Schema.ErrorClass<RateLimitStoreError>(
+export class RateLimitStoreError extends Schema.Error<RateLimitStoreError>(
   "effect/persistence/RateLimiter/RateLimitStoreError"
 )({
   _tag: Schema.tag("RateLimitStoreError"),
@@ -415,7 +415,7 @@ export const RateLimiterErrorReason: Schema.Union<[
  * @category errors
  * @since 4.0.0
  */
-export class RateLimiterError extends Schema.ErrorClass<RateLimiterError>(ErrorTypeId)({
+export class RateLimiterError extends Schema.Error<RateLimiterError>(ErrorTypeId)({
   _tag: Schema.tag("RateLimiterError"),
   reason: RateLimiterErrorReason
 }) {

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -100,7 +100,7 @@ const ErrorTypeId: ErrorTypeId = "~effect/persistence/Redis/RedisError"
  * @category errors
  * @since 4.0.0
  */
-export class RedisError extends Schema.ErrorClass<RedisError>(ErrorTypeId)({
+export class RedisError extends Schema.Error<RedisError>(ErrorTypeId)({
   _tag: Schema.tag("RedisError"),
   cause: Schema.Defect()
 }) {

--- a/packages/effect/src/unstable/rpc/RpcClientError.ts
+++ b/packages/effect/src/unstable/rpc/RpcClientError.ts
@@ -22,7 +22,7 @@ const TypeId = "~effect/rpc/RpcClientError"
  * @category errors
  * @since 4.0.0
  */
-export class RpcClientDefect extends Schema.ErrorClass<RpcClientDefect>("effect/rpc/RpcClientError/RpcClientDefect")({
+export class RpcClientDefect extends Schema.Error<RpcClientDefect>("effect/rpc/RpcClientError/RpcClientDefect")({
   _tag: Schema.tag("RpcClientDefect"),
   message: Schema.String,
   cause: Schema.Defect()
@@ -35,7 +35,7 @@ export class RpcClientDefect extends Schema.ErrorClass<RpcClientDefect>("effect/
  * @category errors
  * @since 4.0.0
  */
-export class RpcClientError extends Schema.ErrorClass<RpcClientError>(TypeId)({
+export class RpcClientError extends Schema.Error<RpcClientError>(TypeId)({
   _tag: Schema.tag("RpcClientError"),
   reason: Schema.Union([
     WorkerErrorReason,

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -220,7 +220,7 @@ export const isSocketError = (u: unknown): u is SocketError => Predicate.hasProp
  * @category errors
  * @since 4.0.0
  */
-export class SocketReadError extends Schema.ErrorClass<SocketReadError>("effect/socket/Socket/SocketReadError")({
+export class SocketReadError extends Schema.Error<SocketReadError>("effect/socket/Socket/SocketReadError")({
   _tag: Schema.tag("SocketReadError"),
   cause: Schema.Defect()
 }) {
@@ -238,7 +238,7 @@ export class SocketReadError extends Schema.ErrorClass<SocketReadError>("effect/
  * @category errors
  * @since 4.0.0
  */
-export class SocketWriteError extends Schema.ErrorClass<SocketWriteError>("effect/socket/Socket/SocketWriteError")({
+export class SocketWriteError extends Schema.Error<SocketWriteError>("effect/socket/Socket/SocketWriteError")({
   _tag: Schema.tag("SocketWriteError"),
   cause: Schema.Defect()
 }) {
@@ -257,7 +257,7 @@ export class SocketWriteError extends Schema.ErrorClass<SocketWriteError>("effec
  * @category errors
  * @since 4.0.0
  */
-export class SocketOpenError extends Schema.ErrorClass<SocketOpenError>("effect/socket/Socket/SocketOpenError")({
+export class SocketOpenError extends Schema.Error<SocketOpenError>("effect/socket/Socket/SocketOpenError")({
   _tag: Schema.tag("SocketOpenError"),
   kind: Schema.Literals(["Unknown", "Timeout"]),
   cause: Schema.Defect()
@@ -281,7 +281,7 @@ export class SocketOpenError extends Schema.ErrorClass<SocketOpenError>("effect/
  * @category errors
  * @since 4.0.0
  */
-export class SocketCloseError extends Schema.ErrorClass<SocketCloseError>("effect/socket/Socket/SocketCloseError")({
+export class SocketCloseError extends Schema.Error<SocketCloseError>("effect/socket/Socket/SocketCloseError")({
   _tag: Schema.tag("SocketCloseError"),
   code: Schema.Int,
   closeReason: Schema.optional(Schema.String)
@@ -339,7 +339,7 @@ export type SocketErrorReason =
  * @category errors
  * @since 4.0.0
  */
-export class SocketError extends Schema.TaggedErrorClass<SocketError>(SocketErrorTypeId)("SocketError", {
+export class SocketError extends Schema.TaggedError<SocketError>(SocketErrorTypeId)("SocketError", {
   _tag: Schema.tag("SocketError"),
   reason: SocketErrorReason
 }) {

--- a/packages/effect/src/unstable/sql/SqlError.ts
+++ b/packages/effect/src/unstable/sql/SqlError.ts
@@ -28,7 +28,7 @@ const ReasonFields = {
  * @category errors
  * @since 4.0.0
  */
-export class ConnectionError extends Schema.TaggedErrorClass<ConnectionError>("effect/sql/SqlError/ConnectionError")(
+export class ConnectionError extends Schema.TaggedError<ConnectionError>("effect/sql/SqlError/ConnectionError")(
   "ConnectionError",
   ReasonFields
 ) {
@@ -56,7 +56,7 @@ export class ConnectionError extends Schema.TaggedErrorClass<ConnectionError>("e
  * @category errors
  * @since 4.0.0
  */
-export class AuthenticationError extends Schema.TaggedErrorClass<AuthenticationError>(
+export class AuthenticationError extends Schema.TaggedError<AuthenticationError>(
   "effect/sql/SqlError/AuthenticationError"
 )("AuthenticationError", ReasonFields) {
   /**
@@ -83,7 +83,7 @@ export class AuthenticationError extends Schema.TaggedErrorClass<AuthenticationE
  * @category errors
  * @since 4.0.0
  */
-export class AuthorizationError extends Schema.TaggedErrorClass<AuthorizationError>(
+export class AuthorizationError extends Schema.TaggedError<AuthorizationError>(
   "effect/sql/SqlError/AuthorizationError"
 )("AuthorizationError", ReasonFields) {
   /**
@@ -109,7 +109,7 @@ export class AuthorizationError extends Schema.TaggedErrorClass<AuthorizationErr
  * @category errors
  * @since 4.0.0
  */
-export class SqlSyntaxError extends Schema.TaggedErrorClass<SqlSyntaxError>("effect/sql/SqlError/SqlSyntaxError")(
+export class SqlSyntaxError extends Schema.TaggedError<SqlSyntaxError>("effect/sql/SqlError/SqlSyntaxError")(
   "SqlSyntaxError",
   ReasonFields
 ) {
@@ -142,7 +142,7 @@ const UniqueViolationFields = {
  * @category errors
  * @since 4.0.0
  */
-export class UniqueViolation extends Schema.TaggedErrorClass<UniqueViolation>("effect/sql/SqlError/UniqueViolation")(
+export class UniqueViolation extends Schema.TaggedError<UniqueViolation>("effect/sql/SqlError/UniqueViolation")(
   "UniqueViolation",
   UniqueViolationFields
 ) {
@@ -169,7 +169,7 @@ export class UniqueViolation extends Schema.TaggedErrorClass<UniqueViolation>("e
  * @category errors
  * @since 4.0.0
  */
-export class ConstraintError extends Schema.TaggedErrorClass<ConstraintError>("effect/sql/SqlError/ConstraintError")(
+export class ConstraintError extends Schema.TaggedError<ConstraintError>("effect/sql/SqlError/ConstraintError")(
   "ConstraintError",
   ReasonFields
 ) {
@@ -196,7 +196,7 @@ export class ConstraintError extends Schema.TaggedErrorClass<ConstraintError>("e
  * @category errors
  * @since 4.0.0
  */
-export class DeadlockError extends Schema.TaggedErrorClass<DeadlockError>("effect/sql/SqlError/DeadlockError")(
+export class DeadlockError extends Schema.TaggedError<DeadlockError>("effect/sql/SqlError/DeadlockError")(
   "DeadlockError",
   ReasonFields
 ) {
@@ -224,7 +224,7 @@ export class DeadlockError extends Schema.TaggedErrorClass<DeadlockError>("effec
  * @category errors
  * @since 4.0.0
  */
-export class SerializationError extends Schema.TaggedErrorClass<SerializationError>(
+export class SerializationError extends Schema.TaggedError<SerializationError>(
   "effect/sql/SqlError/SerializationError"
 )("SerializationError", ReasonFields) {
   /**
@@ -251,7 +251,7 @@ export class SerializationError extends Schema.TaggedErrorClass<SerializationErr
  * @category errors
  * @since 4.0.0
  */
-export class LockTimeoutError extends Schema.TaggedErrorClass<LockTimeoutError>("effect/sql/SqlError/LockTimeoutError")(
+export class LockTimeoutError extends Schema.TaggedError<LockTimeoutError>("effect/sql/SqlError/LockTimeoutError")(
   "LockTimeoutError",
   ReasonFields
 ) {
@@ -278,7 +278,7 @@ export class LockTimeoutError extends Schema.TaggedErrorClass<LockTimeoutError>(
  * @category errors
  * @since 4.0.0
  */
-export class StatementTimeoutError extends Schema.TaggedErrorClass<StatementTimeoutError>(
+export class StatementTimeoutError extends Schema.TaggedError<StatementTimeoutError>(
   "effect/sql/SqlError/StatementTimeoutError"
 )("StatementTimeoutError", ReasonFields) {
   /**
@@ -304,7 +304,7 @@ export class StatementTimeoutError extends Schema.TaggedErrorClass<StatementTime
  * @category errors
  * @since 4.0.0
  */
-export class UnknownError extends Schema.TaggedErrorClass<UnknownError>("effect/sql/SqlError/UnknownError")(
+export class UnknownError extends Schema.TaggedError<UnknownError>("effect/sql/SqlError/UnknownError")(
   "UnknownError",
   ReasonFields
 ) {
@@ -384,7 +384,7 @@ export const SqlErrorReason: Schema.Union<[
  * @category errors
  * @since 4.0.0
  */
-export class SqlError extends Schema.TaggedErrorClass<SqlError>("effect/sql/SqlError")("SqlError", {
+export class SqlError extends Schema.TaggedError<SqlError>("effect/sql/SqlError")("SqlError", {
   reason: SqlErrorReason
 }) {
   /**
@@ -574,7 +574,7 @@ export const classifySqliteError = (
  * @since 4.0.0
  */
 export class ResultLengthMismatch
-  extends Schema.TaggedErrorClass<ResultLengthMismatch>("effect/sql/ResultLengthMismatch")("ResultLengthMismatch", {
+  extends Schema.TaggedError<ResultLengthMismatch>("effect/sql/ResultLengthMismatch")("ResultLengthMismatch", {
     expected: Schema.Natural,
     actual: Schema.Natural
   })

--- a/packages/effect/src/unstable/workers/WorkerError.ts
+++ b/packages/effect/src/unstable/workers/WorkerError.ts
@@ -34,7 +34,7 @@ export const isWorkerError = (u: unknown): u is WorkerError => hasProperty(u, Ty
  * @category models
  * @since 4.0.0
  */
-export class WorkerSpawnError extends Schema.ErrorClass<WorkerSpawnError>(
+export class WorkerSpawnError extends Schema.Error<WorkerSpawnError>(
   "effect/workers/WorkerError/WorkerSpawnError"
 )({
   _tag: Schema.tag("WorkerSpawnError"),
@@ -48,7 +48,7 @@ export class WorkerSpawnError extends Schema.ErrorClass<WorkerSpawnError>(
  * @category models
  * @since 4.0.0
  */
-export class WorkerSendError extends Schema.ErrorClass<WorkerSendError>(
+export class WorkerSendError extends Schema.Error<WorkerSendError>(
   "effect/workers/WorkerError/WorkerSendError"
 )({
   _tag: Schema.tag("WorkerSendError"),
@@ -63,7 +63,7 @@ export class WorkerSendError extends Schema.ErrorClass<WorkerSendError>(
  * @category models
  * @since 4.0.0
  */
-export class WorkerReceiveError extends Schema.ErrorClass<WorkerReceiveError>(
+export class WorkerReceiveError extends Schema.Error<WorkerReceiveError>(
   "effect/workers/WorkerError/WorkerReceiveError"
 )({
   _tag: Schema.tag("WorkerReceiveError"),
@@ -77,7 +77,7 @@ export class WorkerReceiveError extends Schema.ErrorClass<WorkerReceiveError>(
  * @category models
  * @since 4.0.0
  */
-export class WorkerUnknownError extends Schema.ErrorClass<WorkerUnknownError>(
+export class WorkerUnknownError extends Schema.Error<WorkerUnknownError>(
   "effect/workers/WorkerError/WorkerUnknownError"
 )({
   _tag: Schema.tag("WorkerUnknownError"),
@@ -122,7 +122,7 @@ export const WorkerErrorReason: Schema.Union<[
  * @category models
  * @since 4.0.0
  */
-export class WorkerError extends Schema.ErrorClass<WorkerError>(TypeId)({
+export class WorkerError extends Schema.Error<WorkerError>(TypeId)({
   _tag: Schema.tag("WorkerError"),
   reason: WorkerErrorReason
 }) {

--- a/packages/effect/test/Formatter.test.ts
+++ b/packages/effect/test/Formatter.test.ts
@@ -161,8 +161,8 @@ describe("Formatter", () => {
       strictEqual(format(new A({ a: "a" })), `A({"a":"a"})`)
     })
 
-    it("Schema.ErrorClass", () => {
-      class E extends Schema.ErrorClass<E>("E")({
+    it("Schema.Error", () => {
+      class E extends Schema.Error<E>("E")({
         a: Schema.String
       }) {}
       strictEqual(format(new E({ a: "a" })), `E`)

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -391,7 +391,7 @@ const TestWorkflowEngine = ClusterWorkflowEngine.layer.pipe(
   Layer.provide(TestShardingConfig)
 )
 
-class SendEmailError extends Schema.ErrorClass<SendEmailError>("SendEmailError")({
+class SendEmailError extends Schema.Error<SendEmailError>("SendEmailError")({
   _tag: Schema.tag("SendEmailError"),
   message: Schema.String
 }) {}

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3127,7 +3127,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       assertFalse(schema({ excludeCause: true }) === schema({ includeStack: true, excludeCause: true }))
     }
 
-    assertMemoized(Schema.Error)
+    assertMemoized((options) => Schema.Error(options))
     assertMemoized(Schema.Defect)
   })
 
@@ -6947,16 +6947,16 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
   })
 
-  describe("ErrorClass", () => {
+  describe("Error", () => {
     it("make with void input", () => {
-      class E extends Schema.ErrorClass<E>("E")({}) {}
+      class E extends Schema.Error<E>("E")({}) {}
       deepStrictEqual(E.make(), new E())
       deepStrictEqual(E.makeOption(), Option.some(new E()))
       deepStrictEqual(Effect.runSync(E.makeEffect()), new E())
     })
 
     it("fields argument", async () => {
-      class E extends Schema.ErrorClass<E>("E")({
+      class E extends Schema.Error<E>("E")({
         id: Schema.Number
       }) {}
       const asserts = new TestSchema.Asserts(E)
@@ -6973,7 +6973,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("constructor ignores excess properties by default", () => {
-      class E extends Schema.ErrorClass<E>("E")({
+      class E extends Schema.Error<E>("E")({
         message: Schema.String,
         cause: Schema.optionalKey(Schema.Unknown),
         code: Schema.Number
@@ -6989,7 +6989,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("constructor preserves excess properties when requested", () => {
-      class E extends Schema.ErrorClass<E>("E")({
+      class E extends Schema.Error<E>("E")({
         message: Schema.String,
         code: Schema.Number
       }) {}
@@ -7004,7 +7004,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("Struct argument", async () => {
-      class E extends Schema.ErrorClass<E>("E")(Schema.Struct({
+      class E extends Schema.Error<E>("E")(Schema.Struct({
         id: Schema.Number
       })) {}
       const asserts = new TestSchema.Asserts(E)
@@ -7025,7 +7025,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("extend", async () => {
-      class A extends Schema.ErrorClass<A>("A")({
+      class A extends Schema.Error<A>("A")({
         a: Schema.String
       }) {
         readonly _a = 1
@@ -7061,7 +7061,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("extended constructor ignores excess properties by default", () => {
-      class A extends Schema.ErrorClass<A>("A")({
+      class A extends Schema.Error<A>("A")({
         message: Schema.String
       }) {}
       class B extends A.extend<B>("B")({
@@ -7076,7 +7076,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("extended constructor does not treat subclass fields as excess properties", () => {
-      class A extends Schema.ErrorClass<A>("A")({
+      class A extends Schema.Error<A>("A")({
         message: Schema.String
       }) {}
       class B extends A.extend<B>("B")({
@@ -7092,7 +7092,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("`toString` to match native `Error` output format", async () => {
-      class E extends Schema.ErrorClass<E>("E")({
+      class E extends Schema.Error<E>("E")({
         message: Schema.String
       }) {}
       const err = new E({ message: "my message" })
@@ -7100,16 +7100,16 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
   })
 
-  describe("TaggedErrorClass", () => {
+  describe("TaggedError", () => {
     it("make with void input", () => {
-      class E extends Schema.TaggedErrorClass<E>()("E", {}) {}
+      class E extends Schema.TaggedError<E>()("E", {}) {}
       deepStrictEqual(E.make(), new E())
       deepStrictEqual(E.makeOption(), Option.some(new E()))
       deepStrictEqual(Effect.runSync(E.makeEffect()), new E())
     })
 
     it("fields argument", async () => {
-      class E extends Schema.TaggedErrorClass<E>()("E", {
+      class E extends Schema.TaggedError<E>()("E", {
         id: Schema.Number
       }) {}
       const asserts = new TestSchema.Asserts(E)
@@ -7131,7 +7131,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("constructor ignores excess properties by default", () => {
-      class E extends Schema.TaggedErrorClass<E>()("E", {
+      class E extends Schema.TaggedError<E>()("E", {
         id: Schema.Number
       }) {}
 
@@ -7143,7 +7143,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("Struct argument", async () => {
-      class E extends Schema.TaggedErrorClass<E>()(
+      class E extends Schema.TaggedError<E>()(
         "E",
         Schema.Struct({
           id: Schema.Number
@@ -7157,7 +7157,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("name matches tag", () => {
-      class E extends Schema.TaggedErrorClass<E>()("TaggedErrorName", {
+      class E extends Schema.TaggedError<E>()("TaggedErrorName", {
         id: Schema.Number
       }) {}
 
@@ -7166,7 +7166,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("name matches identifier", () => {
-      class E extends Schema.TaggedErrorClass<E>("A")("B", {
+      class E extends Schema.TaggedError<E>("A")("B", {
         a: Schema.Number
       }) {}
 
@@ -7175,7 +7175,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("name matches identifier after extend", () => {
-      class E extends Schema.TaggedErrorClass<E>("A")("B", {
+      class E extends Schema.TaggedError<E>("A")("B", {
         a: Schema.Number
       }) {}
       class E2 extends E.extend<E2>("C")({
@@ -7186,8 +7186,8 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       strictEqual(err.name, "C")
     })
 
-    it("zero-field TaggedErrorClass allows omitting props argument", () => {
-      class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("NotFoundError", {}) {}
+    it("zero-field TaggedError allows omitting props argument", () => {
+      class NotFoundError extends Schema.TaggedError<NotFoundError>()("NotFoundError", {}) {}
 
       // new NotFoundError() should work without passing {}
       const a = new NotFoundError()
@@ -7201,7 +7201,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("extend", async () => {
-      class A extends Schema.TaggedErrorClass<A>()("A", {
+      class A extends Schema.TaggedError<A>()("A", {
         a: Schema.String
       }) {}
       class B extends A.extend<B>("B")({
@@ -7214,7 +7214,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("extended constructor ignores excess properties by default", () => {
-      class A extends Schema.TaggedErrorClass<A>()("A", {
+      class A extends Schema.TaggedError<A>()("A", {
         a: Schema.String
       }) {}
       class B extends A.extend<B>("B")({
@@ -7230,7 +7230,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     })
 
     it("extended constructor does not treat subclass fields as excess properties", () => {
-      class A extends Schema.TaggedErrorClass<A>()("A", {
+      class A extends Schema.TaggedError<A>()("A", {
         a: Schema.String
       }) {}
       class B extends A.extend<B>("B")({

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -286,8 +286,8 @@ describe("SchemaAST", () => {
       deepStrictEqual(SchemaAST.collectSentinels(ast), [{ key: "_tag", literal: "A" }])
     })
 
-    it("ErrorClass", () => {
-      class E extends Schema.ErrorClass<E>("E")({
+    it("Error", () => {
+      class E extends Schema.Error<E>("E")({
         type: Schema.Literal("E"),
         e: Schema.String
       }) {}
@@ -295,8 +295,8 @@ describe("SchemaAST", () => {
       deepStrictEqual(SchemaAST.collectSentinels(ast), [{ key: "type", literal: "E" }])
     })
 
-    it("TaggedErrorClass", () => {
-      class E extends Schema.TaggedErrorClass<E>()("E", {
+    it("TaggedError", () => {
+      class E extends Schema.TaggedError<E>()("E", {
         e: Schema.String
       }) {}
       const ast = E.ast

--- a/packages/effect/test/schema/toCodec.test.ts
+++ b/packages/effect/test/schema/toCodec.test.ts
@@ -999,8 +999,8 @@ describe("Serializers", () => {
         await decoding.succeed({ a: 0 }, new A({ a: 0 }))
       })
 
-      it("ErrorClass", async () => {
-        class E extends Schema.ErrorClass<E>("E")({
+      it("Error", async () => {
+        class E extends Schema.Error<E>("E")({
           a: Schema.Finite
         }) {}
         const asserts = new TestSchema.Asserts(Schema.toCodecJson(Schema.toType(E)))
@@ -1488,7 +1488,7 @@ describe("Serializers", () => {
       })
 
       it("Error", async () => {
-        class E extends Schema.ErrorClass<E>("E")({
+        class E extends Schema.Error<E>("E")({
           a: FiniteFromDate
         }) {}
         const asserts = new TestSchema.Asserts(Schema.toCodecJson(E))
@@ -2557,8 +2557,8 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await decoding.succeed({ a: "0" }, new A({ a: 0 }))
       })
 
-      it("ErrorClass", async () => {
-        class E extends Schema.ErrorClass<E>("E")({
+      it("Error", async () => {
+        class E extends Schema.Error<E>("E")({
           a: Schema.Finite
         }) {}
         const asserts = new TestSchema.Asserts(Schema.toCodecStringTree(Schema.toType(E)))

--- a/packages/effect/test/schema/toDifferJsonPatch.test.ts
+++ b/packages/effect/test/schema/toDifferJsonPatch.test.ts
@@ -231,7 +231,7 @@ describe("Schema.toDifferJsonPatch", () => {
       class B extends Schema.Class<B>("B")({ a: A }) {}
       roundtrip(B)
 
-      class E extends Schema.ErrorClass<E>("E")({ message: Schema.String }) {}
+      class E extends Schema.Error<E>("E")({ message: Schema.String }) {}
       roundtrip(E)
     })
   })

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3686,8 +3686,8 @@ describe("toJsonSchemaDocument", () => {
     )
   })
 
-  it("ErrorClass preserves its identifier as a canonical reference", () => {
-    class E extends Schema.ErrorClass<E>("E")({
+  it("Error preserves its identifier as a canonical reference", () => {
+    class E extends Schema.Error<E>("E")({
       a: Schema.String
     }) {}
     assertJsonSchemaDocument(E, {

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -475,7 +475,7 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
 
   it.effect("does not try another security scheme after the handler fails", () =>
     Effect.gen(function*() {
-      class HandlerFailure extends Schema.TaggedErrorClass<HandlerFailure>()("HandlerFailure", {
+      class HandlerFailure extends Schema.TaggedError<HandlerFailure>()("HandlerFailure", {
         message: Schema.String
       }, { httpApiStatus: 418 }) {}
 

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -552,7 +552,7 @@ const Events = Schema.Struct({
   data: Schema.String
 })
 
-class EndpointError extends Schema.TaggedErrorClass<EndpointError>()("EndpointError", {
+class EndpointError extends Schema.TaggedError<EndpointError>()("EndpointError", {
   message: Schema.String
 }, { httpApiStatus: 400 }) {}
 

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -332,16 +332,16 @@ describe("Schema", () => {
       })
     })
 
-    describe("ErrorClass", () => {
+    describe("Error", () => {
       it("make with void input", () => {
-        class E extends Schema.ErrorClass<E>("E")({}) {}
+        class E extends Schema.Error<E>("E")({}) {}
         expect(E.make).type.toBe<Make<void | {}, E>>()
       })
     })
 
-    describe("TaggedErrorClass", () => {
+    describe("TaggedError", () => {
       it("make with void input", () => {
-        class E extends Schema.TaggedErrorClass<E>()("E", {}) {}
+        class E extends Schema.TaggedError<E>()("E", {}) {}
         expect(E.make).type.toBe<Make<void | { readonly _tag?: "E" }, E>>()
       })
     })
@@ -1434,8 +1434,13 @@ describe("Schema", () => {
     })
 
     describe("Error", () => {
+      it("instance schema overload", () => {
+        expect(Schema.Error()).type.toBe<Schema.Error>()
+        expect(Schema.Error({ includeStack: true })).type.toBe<Schema.Error>()
+      })
+
       it("extend Fields", () => {
-        class E extends Schema.ErrorClass<E>("E")({
+        class E extends Schema.Error<E>("E")({
           a: Schema.String
         }) {}
 
@@ -1449,7 +1454,7 @@ describe("Schema", () => {
       })
 
       it("extend Struct", () => {
-        class E extends Schema.ErrorClass<E>("E")(Schema.Struct({
+        class E extends Schema.Error<E>("E")(Schema.Struct({
           a: Schema.String
         })) {}
 
@@ -1463,7 +1468,7 @@ describe("Schema", () => {
       })
 
       it("should reject non existing props", () => {
-        class E extends Schema.ErrorClass<E>("E")({
+        class E extends Schema.Error<E>("E")({
           a: Schema.String
         }) {}
 
@@ -1472,7 +1477,7 @@ describe("Schema", () => {
       })
 
       it("mutable field", () => {
-        class E extends Schema.ErrorClass<E>("E")({
+        class E extends Schema.Error<E>("E")({
           a: Schema.String.pipe(Schema.mutableKey)
         }) {}
 
@@ -1500,15 +1505,15 @@ describe("Schema", () => {
         )
       })
 
-      it("ErrorClass", () => {
-        expect(Schema.ErrorClass("A")({})).type.toBe(
-          "Missing `Self` generic - use `class Self extends Schema.ErrorClass<Self>(...)`"
+      it("Error", () => {
+        expect(Schema.Error("A")({})).type.toBe(
+          "Missing `Self` generic - use `class Self extends Schema.Error<Self>(...)`"
         )
       })
 
-      it("TaggedErrorClass", () => {
-        expect(Schema.TaggedErrorClass("A")("A", {})).type.toBe(
-          "Missing `Self` generic - use `class Self extends Schema.TaggedErrorClass<Self>(...)`"
+      it("TaggedError", () => {
+        expect(Schema.TaggedError("A")("A", {})).type.toBe(
+          "Missing `Self` generic - use `class Self extends Schema.TaggedError<Self>(...)`"
         )
       })
     })

--- a/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from "tstyche"
 describe("HttpApiBuilder", () => {
   describe("group", () => {
     it("does not require unknown services for status annotations piped onto errors", () => {
-      class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {}) {}
+      class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {}) {}
       const Api = HttpApi.make("api").add(
         HttpApiGroup.make("group").add(
           HttpApiEndpoint.get("get", "/", {

--- a/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
@@ -843,7 +843,7 @@ describe("HttpApiClient", () => {
     })
 
     it("preserves custom client errors when normalizing HttpClientError", () => {
-      class CustomClientError extends Schema.ErrorClass<CustomClientError>("CustomClientError")({
+      class CustomClientError extends Schema.Error<CustomClientError>("CustomClientError")({
         _tag: Schema.tag("CustomClientError")
       }) {}
 
@@ -957,10 +957,10 @@ describe("HttpApiClient", () => {
     })
 
     it("selects within the requested group when endpoint identifiers overlap", () => {
-      class UsersEndpointError extends Schema.TaggedErrorClass<UsersEndpointError>()("UsersEndpointError", {}) {}
-      class AdminsEndpointError extends Schema.TaggedErrorClass<AdminsEndpointError>()("AdminsEndpointError", {}) {}
-      class UsersClientError extends Schema.TaggedErrorClass<UsersClientError>()("UsersClientError", {}) {}
-      class AdminsClientError extends Schema.TaggedErrorClass<AdminsClientError>()("AdminsClientError", {}) {}
+      class UsersEndpointError extends Schema.TaggedError<UsersEndpointError>()("UsersEndpointError", {}) {}
+      class AdminsEndpointError extends Schema.TaggedError<AdminsEndpointError>()("AdminsEndpointError", {}) {}
+      class UsersClientError extends Schema.TaggedError<UsersClientError>()("UsersClientError", {}) {}
+      class AdminsClientError extends Schema.TaggedError<AdminsClientError>()("AdminsClientError", {}) {}
 
       class UsersMiddleware extends HttpApiMiddleware.Service<UsersMiddleware, {
         clientError: UsersClientError
@@ -1117,7 +1117,7 @@ describe("HttpApiClient", () => {
         readonly customService: "customService"
       }
 
-      class CustomClientError extends Schema.ErrorClass<CustomClientError>("CustomClientError")({
+      class CustomClientError extends Schema.Error<CustomClientError>("CustomClientError")({
         _tag: Schema.tag("CustomClientError")
       }) {}
 
@@ -1159,11 +1159,11 @@ describe("HttpApiClient", () => {
 
   describe("client middleware", () => {
     it("requires layers and includes errors for required client middleware", () => {
-      class RequiredClientError extends Schema.ErrorClass<RequiredClientError>("RequiredClientError")({
+      class RequiredClientError extends Schema.Error<RequiredClientError>("RequiredClientError")({
         _tag: Schema.tag("RequiredClientError")
       }) {}
 
-      class OptionalClientError extends Schema.ErrorClass<OptionalClientError>("OptionalClientError")({
+      class OptionalClientError extends Schema.Error<OptionalClientError>("OptionalClientError")({
         _tag: Schema.tag("OptionalClientError")
       }) {}
 
@@ -1212,7 +1212,7 @@ describe("HttpApiClient", () => {
     })
 
     it("enforces required middleware for makeWith, group, and endpoint", () => {
-      class RequiredClientError extends Schema.ErrorClass<RequiredClientError>("RequiredClientError")({
+      class RequiredClientError extends Schema.Error<RequiredClientError>("RequiredClientError")({
         _tag: Schema.tag("RequiredClientError")
       }) {}
 

--- a/packages/effect/typetest/unstable/httpapi/HttpApiMiddleware.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiMiddleware.tst.ts
@@ -30,7 +30,7 @@ describe("HttpApiMiddleware", () => {
     })
 
     it("preserves error services for status annotations used with pipe", () => {
-      class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {}) {}
+      class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {}) {}
       class M extends HttpApiMiddleware.Service<M>()("Http/Logger", {
         error: NotFound.pipe(HttpApiSchema.status(404))
       }) {}

--- a/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "tstyche"
 describe("HttpApiSchema", () => {
   describe("status", () => {
     it("preserves schema services when used with pipe", () => {
-      class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {}) {}
+      class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {}) {}
 
       const schema = NotFound.pipe(HttpApiSchema.status(404))
 

--- a/packages/effect/typetest/unstable/reactivity/AtomHttpApi.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/AtomHttpApi.tst.ts
@@ -4,15 +4,15 @@ import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware } from "effec
 import { type Atom, AtomHttpApi } from "effect/unstable/reactivity"
 import { describe, expect, it } from "tstyche"
 
-class EndpointError extends Schema.ErrorClass<EndpointError>("EndpointError")({
+class EndpointError extends Schema.Error<EndpointError>("EndpointError")({
   _tag: Schema.tag("EndpointError")
 }) {}
 
-class MiddlewareError extends Schema.ErrorClass<MiddlewareError>("MiddlewareError")({
+class MiddlewareError extends Schema.Error<MiddlewareError>("MiddlewareError")({
   _tag: Schema.tag("MiddlewareError")
 }) {}
 
-class MiddlewareClientError extends Schema.ErrorClass<MiddlewareClientError>("MiddlewareClientError")({
+class MiddlewareClientError extends Schema.Error<MiddlewareClientError>("MiddlewareClientError")({
   _tag: Schema.tag("MiddlewareClientError")
 }) {}
 

--- a/packages/platform-browser/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-browser/test/fixtures/rpc-schemas.ts
@@ -20,7 +20,7 @@ class StreamUsers extends Rpc.make("StreamUsers", {
 
 class CurrentUser extends Context.Service<CurrentUser, User>()("CurrentUser") {}
 
-class Unauthorized extends Schema.ErrorClass<Unauthorized>("Unauthorized")({
+class Unauthorized extends Schema.Error<Unauthorized>("Unauthorized")({
   _tag: Schema.tag("Unauthorized")
 }) {}
 

--- a/packages/platform-deno/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-deno/test/fixtures/rpc-schemas.ts
@@ -20,7 +20,7 @@ class StreamUsers extends Rpc.make("StreamUsers", {
 
 class CurrentUser extends Context.Service<CurrentUser, User>()("CurrentUser") {}
 
-class Unauthorized extends Schema.ErrorClass<Unauthorized>("Unauthorized")({
+class Unauthorized extends Schema.Error<Unauthorized>("Unauthorized")({
   _tag: Schema.tag("Unauthorized")
 }) {}
 

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -307,7 +307,7 @@ describe("HttpApi", () => {
     })
 
     it.effect("required client middleware can fail with typed clientError", () => {
-      class ClientFailure extends Schema.ErrorClass<ClientFailure>("ClientFailure")({
+      class ClientFailure extends Schema.Error<ClientFailure>("ClientFailure")({
         _tag: Schema.tag("ClientFailure")
       }) {}
 
@@ -1421,7 +1421,7 @@ describe("HttpApi", () => {
     })
 
     it.effect("error from plain text", () => {
-      class RateLimitError extends Schema.ErrorClass<RateLimitError>("RateLimitError")({
+      class RateLimitError extends Schema.Error<RateLimitError>("RateLimitError")({
         _tag: Schema.tag("RateLimitError"),
         message: Schema.String
       }) {}
@@ -1488,17 +1488,17 @@ describe("HttpApi", () => {
   })
 })
 
-class UserError extends Schema.ErrorClass<UserError>("UserError")({
+class UserError extends Schema.Error<UserError>("UserError")({
   _tag: Schema.tag("UserError")
 }, {
   httpApiStatus: 400
 }) {}
-class GroupError extends Schema.ErrorClass<GroupError>("GroupError")({
+class GroupError extends Schema.Error<GroupError>("GroupError")({
   _tag: Schema.tag("GroupError")
 }, {
   httpApiStatus: 418
 }) {}
-class NoStatusError extends Schema.ErrorClass<NoStatusError>("NoStatusError")({
+class NoStatusError extends Schema.Error<NoStatusError>("NoStatusError")({
   _tag: Schema.tag("NoStatusError")
 }) {}
 

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -586,7 +586,7 @@ describe("HttpServer", () => {
   describe("HttpServerRespondable", () => {
     it.effect("error/schema", () =>
       Effect.gen(function*() {
-        class CustomError extends Schema.ErrorClass<CustomError>("CustomError")({
+        class CustomError extends Schema.Error<CustomError>("CustomError")({
           _tag: Schema.tag("CustomError"),
           name: Schema.String
         }) {

--- a/packages/platform-node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-node/test/fixtures/rpc-schemas.ts
@@ -20,7 +20,7 @@ class StreamUsers extends Rpc.make("StreamUsers", {
 
 class CurrentUser extends Context.Service<CurrentUser, User>()("CurrentUser") {}
 
-class Unauthorized extends Schema.ErrorClass<Unauthorized>("Unauthorized")({
+class Unauthorized extends Schema.Error<Unauthorized>("Unauthorized")({
   _tag: Schema.tag("Unauthorized")
 }) {}
 

--- a/packages/tools/api-diff/src/Error.ts
+++ b/packages/tools/api-diff/src/Error.ts
@@ -1,6 +1,6 @@
 import * as Schema from "effect/Schema"
 
-export class ApiDiffError extends Schema.TaggedErrorClass<ApiDiffError>()("ApiDiffError", {
+export class ApiDiffError extends Schema.TaggedError<ApiDiffError>()("ApiDiffError", {
   message: Schema.String,
   cause: Schema.optional(Schema.Defect())
 }) {}

--- a/packages/tools/api-diff/src/Snapshot.ts
+++ b/packages/tools/api-diff/src/Snapshot.ts
@@ -701,7 +701,7 @@ export interface ExtractSnapshotOptions {
   readonly modules?: ReadonlyArray<string>
 }
 
-export class SnapshotExtractionError extends Schema.TaggedErrorClass<SnapshotExtractionError>()(
+export class SnapshotExtractionError extends Schema.TaggedError<SnapshotExtractionError>()(
   "SnapshotExtractionError",
   {
     message: Schema.String,

--- a/packages/tools/openapi-generator/src/OpenApiPatch.ts
+++ b/packages/tools/openapi-generator/src/OpenApiPatch.ts
@@ -50,7 +50,7 @@ import * as Yaml from "yaml"
  * @category errors
  * @since 4.0.0
  */
-export class JsonPatchParseError extends Schema.ErrorClass<JsonPatchParseError>("JsonPatchParseError")({
+export class JsonPatchParseError extends Schema.Error<JsonPatchParseError>("JsonPatchParseError")({
   _tag: Schema.tag("JsonPatchParseError"),
   source: Schema.String,
   reason: Schema.String
@@ -88,7 +88,7 @@ export class JsonPatchParseError extends Schema.ErrorClass<JsonPatchParseError>(
  * @category errors
  * @since 4.0.0
  */
-export class JsonPatchValidationError extends Schema.ErrorClass<JsonPatchValidationError>("JsonPatchValidationError")({
+export class JsonPatchValidationError extends Schema.Error<JsonPatchValidationError>("JsonPatchValidationError")({
   _tag: Schema.tag("JsonPatchValidationError"),
   source: Schema.String,
   reason: Schema.String
@@ -128,16 +128,14 @@ export class JsonPatchValidationError extends Schema.ErrorClass<JsonPatchValidat
  * @category errors
  * @since 4.0.0
  */
-export class JsonPatchApplicationError
-  extends Schema.ErrorClass<JsonPatchApplicationError>("JsonPatchApplicationError")({
-    _tag: Schema.tag("JsonPatchApplicationError"),
-    source: Schema.String,
-    operationIndex: Schema.Natural,
-    operation: Schema.String,
-    path: Schema.String,
-    reason: Schema.String
-  })
-{
+export class JsonPatchApplicationError extends Schema.Error<JsonPatchApplicationError>("JsonPatchApplicationError")({
+  _tag: Schema.tag("JsonPatchApplicationError"),
+  source: Schema.String,
+  operationIndex: Schema.Natural,
+  operation: Schema.String,
+  path: Schema.String,
+  reason: Schema.String
+}) {
   override get message() {
     return `Failed to apply patch from ${this.source}: operation ${this.operationIndex} ` +
       `(${this.operation} at ${this.path}): ${this.reason}`
@@ -183,7 +181,7 @@ export class JsonPatchApplicationError
  * @category errors
  * @since 4.0.0
  */
-export class JsonPatchAggregateError extends Schema.ErrorClass<JsonPatchAggregateError>("JsonPatchAggregateError")({
+export class JsonPatchAggregateError extends Schema.Error<JsonPatchAggregateError>("JsonPatchAggregateError")({
   _tag: Schema.tag("JsonPatchAggregateError"),
   errors: Schema.Array(Schema.Unknown)
 }) {


### PR DESCRIPTION
## Summary

- overload `Schema.Error` for both JavaScript error schemas and schema-backed yieldable error classes
- rename `Schema.TaggedErrorClass` to `Schema.TaggedError` and migrate call sites and documentation
- add overload-selection coverage and a breaking changeset

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm check-recursive`
- `pnpm test-types packages/effect/typetest/schema/Schema.tst.ts`
- 1,160 affected runtime tests across `effect` and `@effect/platform-node`
- effect package doc generation and `pnpm ai-docgen`

The repository instructions prohibit running the bare whole-suite test command locally; the full suite is delegated to CI.

Closes EFF-172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Replaced `Schema.ErrorClass` with the enhanced `Schema.Error` API.
  * Renamed `Schema.TaggedErrorClass` to `Schema.TaggedError`.
  * Existing code using the removed constructors must be updated.

* **Documentation**
  * Updated migration guidance, API documentation, and examples to reflect the new error APIs.
  * Clarified related platform-error and HTTP API migration patterns.

* **Maintenance**
  * Updated tests and type checks across error schemas, tagged errors, HTTP APIs, RPC, AI, SQL, and other integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->