### PR TITLE
Pin CI service images and npm toolchain

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -126,7 +126,8 @@ jobs:
           docker pull ghcr.io/tursodatabase/libsql-server:main@sha256:718825e7eea0619b827ff5ee21a17087eb93957470bb73d64735a58d0b121efc &
           docker pull postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15 &
           docker pull mysql:9.7.2@sha256:257388edf9c84dbc04c763625446d5f3fa6ed60d1b0873bc552c614ba0a7ab4e &
-          docker pull vitess/vttestserver:v24.0.2-mysql80@sha256:3f9a449099acd4c1b25fd62a25a01c9b56a306e02cb9651e3b414c7be9cc9181 &
+          # Vitess 25.0.0-SNAPSHOT / MySQL 8.0.43-Vitess
+          docker pull vitess/vttestserver:mysql80@sha256:ba3cc1596a2c3ebe991675e28ee29ebd08de32c01ccf387e8ec073bfa08d23ae &
           docker pull redis:8.8.1-alpine@sha256:8096655e437712b07503796fb64d81359256cfcff0ab29d95a7da72863786efb &
           wait
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -123,11 +123,11 @@ jobs:
       - name: Pre-pull test container images
         run: |
           docker pull testcontainers/ryuk:0.14.0 &
-          docker pull ghcr.io/tursodatabase/libsql-server:main &
-          docker pull postgres:alpine &
-          docker pull mysql:lts &
-          docker pull vitess/vttestserver:mysql80 &
-          docker pull redis:alpine &
+          docker pull ghcr.io/tursodatabase/libsql-server:main@sha256:718825e7eea0619b827ff5ee21a17087eb93957470bb73d64735a58d0b121efc &
+          docker pull postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15 &
+          docker pull mysql:9.7.2@sha256:257388edf9c84dbc04c763625446d5f3fa6ed60d1b0873bc552c614ba0a7ab4e &
+          docker pull vitess/vttestserver:v24.0.2-mysql80@sha256:3f9a449099acd4c1b25fd62a25a01c9b56a306e02cb9651e3b414c7be9cc9181 &
+          docker pull redis:8.8.1-alpine@sha256:8096655e437712b07503796fb64d81359256cfcff0ab29d95a7da72863786efb &
           wait
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/setup
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@11
+        run: npm install -g npm@11.18.0
       - name: Set strip internals config
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json

--- a/packages/platform-deno/test/DenoRedis.test.ts
+++ b/packages/platform-deno/test/DenoRedis.test.ts
@@ -9,7 +9,11 @@ import * as PersistedQueueTest from "../../effect/test/unstable/persistence/Pers
 const RedisLayer = Layer.unwrap(
   Effect.gen(function*() {
     const container = yield* Effect.acquireRelease(
-      Effect.promise(() => new RedisContainer("redis:alpine").start()),
+      Effect.promise(() =>
+        new RedisContainer(
+          "redis:8.8.1-alpine@sha256:8096655e437712b07503796fb64d81359256cfcff0ab29d95a7da72863786efb"
+        ).start()
+      ),
       (container) => Effect.promise(() => container.stop())
     )
     return DenoRedis.layer({

--- a/packages/platform-node/test/NodeRedis.test.ts
+++ b/packages/platform-node/test/NodeRedis.test.ts
@@ -9,7 +9,11 @@ import { PersistedQueue, Persistence } from "effect/unstable/persistence"
 const RedisLayer = Layer.unwrap(
   Effect.gen(function*() {
     const container = yield* Effect.acquireRelease(
-      Effect.promise(() => new RedisContainer("redis:alpine").start()),
+      Effect.promise(() =>
+        new RedisContainer(
+          "redis:8.8.1-alpine@sha256:8096655e437712b07503796fb64d81359256cfcff0ab29d95a7da72863786efb"
+        ).start()
+      ),
       (container) => Effect.promise(() => container.stop())
     )
     return NodeRedis.layer({

--- a/packages/platform-node/test/fixtures/mysql2-utils.ts
+++ b/packages/platform-node/test/fixtures/mysql2-utils.ts
@@ -52,7 +52,7 @@ export class MysqlContainer extends Context.Service<
       Effect.tryPromise({
         try: () =>
           new MySqlContainer(
-            "vitess/vttestserver:v24.0.2-mysql80@sha256:3f9a449099acd4c1b25fd62a25a01c9b56a306e02cb9651e3b414c7be9cc9181"
+            "vitess/vttestserver:mysql80@sha256:ba3cc1596a2c3ebe991675e28ee29ebd08de32c01ccf387e8ec073bfa08d23ae"
           ).withEnvironment({
             KEYSPACES: "test,unsharded",
             NUM_SHARDS: "1,1",

--- a/packages/platform-node/test/fixtures/mysql2-utils.ts
+++ b/packages/platform-node/test/fixtures/mysql2-utils.ts
@@ -14,7 +14,10 @@ export class MysqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: () => new MySqlContainer("mysql:lts").start(),
+        try: () =>
+          new MySqlContainer(
+            "mysql:9.7.2@sha256:257388edf9c84dbc04c763625446d5f3fa6ed60d1b0873bc552c614ba0a7ab4e"
+          ).start(),
         catch: (cause) => new ContainerError({ cause })
       }),
       (container) => Effect.promise(() => container.stop())
@@ -48,7 +51,9 @@ export class MysqlContainer extends Context.Service<
     Effect.acquireRelease(
       Effect.tryPromise({
         try: () =>
-          new MySqlContainer("vitess/vttestserver:mysql80").withEnvironment({
+          new MySqlContainer(
+            "vitess/vttestserver:v24.0.2-mysql80@sha256:3f9a449099acd4c1b25fd62a25a01c9b56a306e02cb9651e3b414c7be9cc9181"
+          ).withEnvironment({
             KEYSPACES: "test,unsharded",
             NUM_SHARDS: "1,1",
             MYSQL_BIND_HOST: "0.0.0.0",

--- a/packages/platform-node/test/fixtures/pg-utils.ts
+++ b/packages/platform-node/test/fixtures/pg-utils.ts
@@ -9,7 +9,10 @@ export class ContainerError extends Data.TaggedError("ContainerError")<{
 export class PgContainer extends Context.Service<PgContainer>()("test/PgContainer", {
   make: Effect.acquireRelease(
     Effect.tryPromise({
-      try: () => new PostgreSqlContainer("postgres:alpine").start(),
+      try: () =>
+        new PostgreSqlContainer(
+          "postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"
+        ).start(),
       catch: (cause) => new ContainerError({ cause })
     }),
     (container) => Effect.promise(() => container.stop())

--- a/packages/sql/libsql/test/util.ts
+++ b/packages/sql/libsql/test/util.ts
@@ -26,7 +26,9 @@ export class LibsqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.promise(async () => {
-        const container = await new GenericContainer("ghcr.io/tursodatabase/libsql-server:main")
+        const container = await new GenericContainer(
+          "ghcr.io/tursodatabase/libsql-server:main@sha256:718825e7eea0619b827ff5ee21a17087eb93957470bb73d64735a58d0b121efc"
+        )
           .withExposedPorts(8080)
           .withEnvironment({ SQLD_NODE: "primary" })
           .withCommand(["sqld", "--no-welcome", "--http-listen-addr", "0.0.0.0:8080"]).start()

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -52,7 +52,7 @@ export class MysqlContainer extends Context.Service<
       Effect.tryPromise({
         try: () =>
           new MySqlContainer(
-            "vitess/vttestserver:v24.0.2-mysql80@sha256:3f9a449099acd4c1b25fd62a25a01c9b56a306e02cb9651e3b414c7be9cc9181"
+            "vitess/vttestserver:mysql80@sha256:ba3cc1596a2c3ebe991675e28ee29ebd08de32c01ccf387e8ec073bfa08d23ae"
           ).withEnvironment({
             KEYSPACES: "test,unsharded",
             NUM_SHARDS: "1,1",

--- a/packages/sql/mysql2/test/utils.ts
+++ b/packages/sql/mysql2/test/utils.ts
@@ -14,7 +14,10 @@ export class MysqlContainer extends Context.Service<
   static readonly layer = Layer.effect(this)(
     Effect.acquireRelease(
       Effect.tryPromise({
-        try: () => new MySqlContainer("mysql:lts").start(),
+        try: () =>
+          new MySqlContainer(
+            "mysql:9.7.2@sha256:257388edf9c84dbc04c763625446d5f3fa6ed60d1b0873bc552c614ba0a7ab4e"
+          ).start(),
         catch: (cause) => new ContainerError({ cause })
       }),
       (container) => Effect.promise(() => container.stop())
@@ -48,7 +51,9 @@ export class MysqlContainer extends Context.Service<
     Effect.acquireRelease(
       Effect.tryPromise({
         try: () =>
-          new MySqlContainer("vitess/vttestserver:mysql80").withEnvironment({
+          new MySqlContainer(
+            "vitess/vttestserver:v24.0.2-mysql80@sha256:3f9a449099acd4c1b25fd62a25a01c9b56a306e02cb9651e3b414c7be9cc9181"
+          ).withEnvironment({
             KEYSPACES: "test,unsharded",
             NUM_SHARDS: "1,1",
             MYSQL_BIND_HOST: "0.0.0.0",

--- a/packages/sql/pg/test/utils.ts
+++ b/packages/sql/pg/test/utils.ts
@@ -9,7 +9,10 @@ export class ContainerError extends Data.TaggedError("ContainerError")<{
 export class PgContainer extends Context.Service<PgContainer>()("test/PgContainer", {
   make: Effect.acquireRelease(
     Effect.tryPromise({
-      try: () => new PostgreSqlContainer("postgres:alpine").start(),
+      try: () =>
+        new PostgreSqlContainer(
+          "postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"
+        ).start(),
       catch: (cause) => new ContainerError({ cause })
     }),
     (container) => Effect.promise(() => container.stop())


### PR DESCRIPTION
## Summary

- pin the currently used CI service image manifests and their Testcontainers references to upstream-resolved digests
- retain human-readable version tags where they resolve to the same current manifest
- pin the release workflow npm upgrade to 11.18.0

`libsql-server:main` and `vitess/vttestserver:mysql80` have no stable aliases for their current manifests, so their existing tags remain alongside immutable digests. The Vitess image contains Vitess 25.0.0-SNAPSHOT and MySQL 8.0.43-Vitess. Moving it to a stable `v<semver>-mysql80` release is a worthwhile follow-up dependency upgrade, separate from this supply-chain hardening change.

## Testing

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter @effect/sql-libsql test --run test/Client.test.ts -t 'should work$'`
- `pnpm --filter @effect/sql-pg test --run test/Client.test.ts`
- `pnpm --filter @effect/sql-mysql2 test --run test/Client.test.ts`
- `pnpm --filter @effect/platform-node test --run test/cluster/SqlRunnerStorage.test.ts -t vitess`
- `pnpm --filter @effect/platform-node test --run test/NodeRedis.test.ts`
- `deno task test --run packages/platform-deno/test/DenoRedis.test.ts -t 'moves exhausted elements'`

Closes EFF-182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Pinned PostgreSQL, MySQL, Redis, Vitess, and libSQL test container images to fixed versions for more consistent test runs.
* **Chores**
  * Updated the release tooling to use npm 11.18.0.
  * Added clarity around container image version pairings in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->