### PR TITLE
Deploy v3 API docs to Cloudflare Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Pages
+name: API Reference
 on:
   workflow_dispatch:
   pull_request:
@@ -17,6 +17,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -27,84 +29,10 @@ jobs:
         with:
           source: ./docs
           destination: ./_site
-      - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+      - name: Deploy to Cloudflare Pages
+        if: github.repository_owner == 'Effect-Ts' && github.event_name != 'pull_request' && github.ref == 'refs/heads/v3'
+        uses: cloudflare/wrangler-action@v4
         with:
-          name: pages-v3
-          path: ./_site
-          include-hidden-files: true
-
-  publish:
-    if: github.repository_owner == 'Effect-Ts' && github.event_name == 'push' && github.ref == 'refs/heads/v3'
-    name: Publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: build
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download site artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: pages-v3
-          path: site
-      - name: Check out publication branch
-        run: |
-          if git fetch origin gh-pages:refs/remotes/origin/gh-pages; then
-            git worktree add --detach publication refs/remotes/origin/gh-pages
-            git -C publication switch -c gh-pages
-          else
-            git worktree add --detach publication
-            git -C publication switch --orphan gh-pages
-          fi
-      - name: Publish v3 documentation
-        run: |
-          git -C publication config user.name github-actions[bot]
-          git -C publication config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          for attempt in 1 2 3 4 5; do
-            if git fetch origin gh-pages:refs/remotes/origin/gh-pages; then
-              git -C publication reset --hard refs/remotes/origin/gh-pages
-            fi
-            mkdir -p publication/v3
-            rsync -a --delete site/ publication/v3/
-            git -C publication add --all
-            if git -C publication diff --cached --quiet; then
-              exit 0
-            fi
-            git -C publication commit -m "Publish v3 API documentation"
-            if git -C publication push origin HEAD:gh-pages; then
-              exit 0
-            fi
-            test "$attempt" -lt 5 || exit 1
-            sleep $((attempt * 2))
-          done
-
-  deploy:
-    if: github.repository_owner == 'Effect-Ts' && github.event_name == 'push' && github.ref == 'refs/heads/v3'
-    name: Deploy
-    needs: publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    concurrency:
-      group: github-pages-deployment
-      cancel-in-progress: false
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: publication
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: publication
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./_site --project-name=effect-api-v3 --branch=v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,28 +23,64 @@ jobs:
         uses: ./.github/actions/setup
       - run: pnpm docgen
       - name: Build pages Jekyll
-        if: github.repository_owner == 'Effect-Ts' && github.event_name == 'push' && github.ref == 'refs/heads/v3'
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
-      - name: Upload pages artifact
-        if: github.repository_owner == 'Effect-Ts' && github.event_name == 'push' && github.ref == 'refs/heads/v3'
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-v3
+          path: ./_site
+          include-hidden-files: true
 
-  deploy:
+  publish:
     if: github.repository_owner == 'Effect-Ts' && github.event_name == 'push' && github.ref == 'refs/heads/v3'
-    name: Deploy
+    name: Publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
+    concurrency:
+      group: github-pages-publication
+      cancel-in-progress: false
     permissions:
-      pages: write # To deploy to GitHub Pages
-      id-token: write # To verify the deployment originates from an appropriate source
+      contents: write
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pages-v3
+          path: site
+      - name: Check out publication branch
+        run: |
+          if git fetch origin gh-pages:refs/heads/gh-pages; then
+            git worktree add publication gh-pages
+          else
+            git worktree add --detach publication
+            git -C publication switch --orphan gh-pages
+          fi
+      - name: Update v3 documentation
+        run: |
+          mkdir -p publication/v3
+          rsync -a --delete site/ publication/v3/
+          test -e publication/index.html || cp site/index.html publication/index.html
+      - name: Push publication branch
+        run: |
+          git -C publication config user.name github-actions[bot]
+          git -C publication config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C publication add --all
+          git -C publication diff --cached --quiet || git -C publication commit -m "Publish v3 API documentation"
+          git -C publication push origin HEAD:gh-pages
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: publication
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: github-pages-deployment
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,16 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
-    concurrency:
-      group: github-pages-publication
-      cancel-in-progress: false
     permissions:
       contents: write
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Download site artifact
@@ -59,24 +51,56 @@ jobs:
           path: site
       - name: Check out publication branch
         run: |
-          if git fetch origin gh-pages:refs/heads/gh-pages; then
-            git worktree add publication gh-pages
+          if git fetch origin gh-pages:refs/remotes/origin/gh-pages; then
+            git worktree add --detach publication refs/remotes/origin/gh-pages
+            git -C publication switch -c gh-pages
           else
             git worktree add --detach publication
             git -C publication switch --orphan gh-pages
           fi
-      - name: Update v3 documentation
-        run: |
-          mkdir -p publication/v3
-          rsync -a --delete site/ publication/v3/
-          test -e publication/index.html || cp site/index.html publication/index.html
-      - name: Push publication branch
+      - name: Publish v3 documentation
         run: |
           git -C publication config user.name github-actions[bot]
           git -C publication config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git -C publication add --all
-          git -C publication diff --cached --quiet || git -C publication commit -m "Publish v3 API documentation"
-          git -C publication push origin HEAD:gh-pages
+          for attempt in 1 2 3 4 5; do
+            if git fetch origin gh-pages:refs/remotes/origin/gh-pages; then
+              git -C publication reset --hard refs/remotes/origin/gh-pages
+            fi
+            mkdir -p publication/v3
+            rsync -a --delete site/ publication/v3/
+            git -C publication add --all
+            if git -C publication diff --cached --quiet; then
+              exit 0
+            fi
+            git -C publication commit -m "Publish v3 API documentation"
+            if git -C publication push origin HEAD:gh-pages; then
+              exit 0
+            fi
+            test "$attempt" -lt 5 || exit 1
+            sleep $((attempt * 2))
+          done
+
+  deploy:
+    if: github.repository_owner == 'Effect-Ts' && github.event_name == 'push' && github.ref == 'refs/heads/v3'
+    name: Deploy
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: github-pages-deployment
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: publication
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,6 @@
 remote_theme: mikearnaldi/just-the-docs
+url: https://effect-ts.github.io
+baseurl: /effect/v3
 search_enabled: true
 aux_links:
   "GitHub":

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 remote_theme: mikearnaldi/just-the-docs
-url: https://effect-ts.github.io
-baseurl: /effect/v3
+url: https://v3.api.effect.website
+baseurl: ""
 search_enabled: true
 aux_links:
   "GitHub":

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ For detailed information and usage examples, visit the [Effect website](https://
 
 ## API Reference
 
-For a complete API reference of the core package `effect`, see the [Effect API documentation](https://effect-ts.github.io/effect/).
+For a complete API reference of the core package `effect`, see the [Effect API documentation]({{ "/" | relative_url }}).
 
 ## Introduction to Effect
 


### PR DESCRIPTION
## Summary
- build the v3 API reference exclusively from the `v3` branch and toolchain
- validate the generated Jekyll site on pull requests
- deploy production builds directly to the `effect-api-v3` Cloudflare Pages project
- configure root-relative links for `https://v3.api.effect.website`

## Cloudflare setup required before merge
- create the `effect-api-v3` Pages project with production branch `v3`
- attach the custom domain `v3.api.effect.website`
- add repository secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
- grant the API token permission to deploy to Cloudflare Pages

Existing README links remain on the live GitHub Pages deployment until the Cloudflare domain is provisioned and verified. They should be migrated in a cutover follow-up.

## Validation
- `npx --yes --package=node@23.7.0 -- pnpm docgen`
- `npx --yes --package=node@23.7.0 -- pnpm lint-fix`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pages.yml`
- Pages `Build` CI job, including the Docker-based Jekyll build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation site URL and base path for the v3 API reference.
  - Adjusted the API reference link to use a relative site root.
- **Deployment**
  - Updated the documentation publishing workflow to deploy to Cloudflare Pages.
  - Renamed the workflow and tightened build permissions.
  - Scoped deployments to non–pull request events on the v3 branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->