### PR TITLE
Render bundle size comments as tables

### DIFF
--- a/.github/workflows/bundle-comment.yml
+++ b/.github/workflows/bundle-comment.yml
@@ -33,14 +33,27 @@ jobs:
         run: |
           max_bytes=48000
           max_lines=500
-          stats_file="bundle-stats/stats.txt"
+          stats_source="bundle-stats/stats.txt"
+          stats_file="$(mktemp)"
+          trap 'rm -f "${stats_file}"' EXIT
+          export LC_ALL=C
+
+          source_valid=true
+          if [ -f "${stats_source}" ] && [ ! -L "${stats_source}" ]; then
+            head -c "$((max_bytes + 1))" "${stats_source}" > "${stats_file}"
+          else
+            source_valid=false
+          fi
+
           byte_count="$(wc -c < "${stats_file}")"
-          line_count="$(awk 'END { print NR }' "${stats_file}")"
+          line_count="$(awk 'END { print NR + 0 }' "${stats_file}")"
           delimiter="EOF_$(openssl rand -hex 16)"
 
           {
             echo "stats<<${delimiter}"
-            if [ "${byte_count}" -gt "${max_bytes}" ] || [ "${line_count}" -gt "${max_lines}" ]; then
+            if [ "${source_valid}" != true ]; then
+              echo "Bundle size report artifact was missing or invalid and was not displayed."
+            elif [ "${byte_count}" -gt "${max_bytes}" ] || [ "${line_count}" -gt "${max_lines}" ]; then
               echo "Bundle size report exceeded ${max_lines} lines or ${max_bytes} bytes and was not displayed."
             elif awk '
               NR == 1 { if ($0 != "| File Name | Current Size | Previous Size | Difference |") exit 1; next }

--- a/.github/workflows/bundle-comment.yml
+++ b/.github/workflows/bundle-comment.yml
@@ -33,26 +33,27 @@ jobs:
         run: |
           max_bytes=48000
           max_lines=500
-          safe_stats="$(mktemp)"
-          tr '\140' '\047' < bundle-stats/stats.txt > "${safe_stats}"
-
-          byte_count="$(wc -c < "${safe_stats}")"
-          line_count="$(awk 'END { print NR }' "${safe_stats}")"
+          stats_file="bundle-stats/stats.txt"
+          byte_count="$(wc -c < "${stats_file}")"
+          line_count="$(awk 'END { print NR }' "${stats_file}")"
           delimiter="EOF_$(openssl rand -hex 16)"
 
           {
             echo "stats<<${delimiter}"
-            echo '```text'
-            head -n "${max_lines}" "${safe_stats}" | head -c "${max_bytes}" | iconv -c -f UTF-8 -t UTF-8 2>/dev/null || true
-            echo
             if [ "${byte_count}" -gt "${max_bytes}" ] || [ "${line_count}" -gt "${max_lines}" ]; then
-              echo "[output truncated at ${max_lines} lines or ${max_bytes} bytes]"
+              echo "Bundle size report exceeded ${max_lines} lines or ${max_bytes} bytes and was not displayed."
+            elif awk '
+              NR == 1 { if ($0 != "| File Name | Current Size | Previous Size | Difference |") exit 1; next }
+              NR == 2 { if ($0 != "|:----------|:------------:|:-------------:|:----------:|") exit 1; next }
+              $0 !~ /^\| `[[:alnum:]_.-]+` \| [0-9]+\.[0-9][0-9] KB \| [0-9]+\.[0-9][0-9] KB \| [+-]?[0-9]+\.[0-9][0-9] KB \([+-]?[0-9]+\.[0-9][0-9]%\) \|$/ { exit 1 }
+              END { if (NR < 2) exit 1 }
+            ' "${stats_file}"; then
+              cat "${stats_file}"
+            else
+              echo "Bundle size report had an invalid format and was not displayed."
             fi
-            echo '```'
             echo "${delimiter}"
           } >> "${GITHUB_OUTPUT}"
-
-          rm "${safe_stats}"
       # https://github.com/orgs/community/discussions/25220#discussioncomment-11300118
       - name: Get PR number
         id: pr-context


### PR DESCRIPTION
## Summary

- stage bundle statistics in a bounded temporary file and validate the same bytes that are emitted
- render validated bundle statistics as a Markdown table instead of a fenced text block
- reject symlinks, non-regular artifacts, unexpected rows, injected content, and oversized reports
- replace invalid artifacts with fixed trusted messages

This preserves the workflow hardening from #6736 while restoring table rendering.

## Validation

- validated the report from the malformed comment through the bounded temporary-file path
- verified an injected HTML/script line is rejected
- parsed `.github/workflows/bundle-comment.yml` with Ruby YAML
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated bundle statistics reporting in comments.
  * Added checks to ensure the stats source is present, valid, and not a symlink.
  * Added byte/line size limits to omit overly large stats with clearer messaging.
  * Added format validation for expected table-like output; show an “invalid format” omission when it doesn’t match.
  * Preserves full valid statistics output without prior truncation or wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->