### PR TITLE
Prefer explicit OTLP resource configuration

### DIFF
--- a/.changeset/explicit-otel-service-identity.md
+++ b/.changeset/explicit-otel-service-identity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prefer explicit OTLP resource service names and versions over environment configuration.

--- a/.changeset/explicit-otel-service-identity.md
+++ b/.changeset/explicit-otel-service-identity.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Prefer explicit OTLP resource service names and versions over environment configuration.
+Prefer explicit OTLP resource configuration over environment configuration.

--- a/packages/effect/src/unstable/observability/OtlpResource.ts
+++ b/packages/effect/src/unstable/observability/OtlpResource.ts
@@ -80,11 +80,10 @@ export const make = (options: {
  * **Details**
  *
  * Explicit `serviceName` and `serviceVersion` options take precedence over
- * matching explicit attributes and environment variables. Explicit attributes
- * take precedence over `OTEL_SERVICE_NAME`, `OTEL_SERVICE_VERSION`, and
- * `OTEL_RESOURCE_ATTRIBUTES` for service identity. Other attributes from
- * `OTEL_RESOURCE_ATTRIBUTES` override explicit attributes. Missing required
- * configuration is converted to a defect.
+ * matching explicit attributes. Explicit attributes take precedence over
+ * environment variables. `OTEL_SERVICE_NAME` and `OTEL_SERVICE_VERSION` take
+ * precedence over matching attributes in `OTEL_RESOURCE_ATTRIBUTES`. Missing
+ * required configuration is converted to a defect.
  *
  * @category constructors
  * @since 4.0.0
@@ -117,8 +116,8 @@ export const fromConfig: (
     ?? env?.["service.version"] as string | undefined
 
   const attributes = {
-    ...options?.attributes,
-    ...env
+    ...env,
+    ...options?.attributes
   }
 
   delete attributes["service.name"]

--- a/packages/effect/src/unstable/observability/OtlpResource.ts
+++ b/packages/effect/src/unstable/observability/OtlpResource.ts
@@ -70,10 +70,20 @@ export const make = (options: {
  * Creates an OTLP resource from explicit options and OpenTelemetry
  * configuration.
  *
+ * **When to use**
+ *
+ * Use when resource metadata may be configured in code or by the deployment
+ * environment. To let operators set the service identity, omit `serviceName`,
+ * `serviceVersion`, and their matching attributes, then use
+ * `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`.
+ *
  * **Details**
  *
- * `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME`, and
- * `OTEL_SERVICE_VERSION` override explicit options; missing required
+ * Explicit `serviceName` and `serviceVersion` options take precedence over
+ * matching explicit attributes and environment variables. Explicit attributes
+ * take precedence over `OTEL_SERVICE_NAME`, `OTEL_SERVICE_VERSION`, and
+ * `OTEL_RESOURCE_ATTRIBUTES` for service identity. Other attributes from
+ * `OTEL_RESOURCE_ATTRIBUTES` override explicit attributes. Missing required
  * configuration is converted to a defect.
  *
  * @category constructors
@@ -95,16 +105,16 @@ export const fromConfig: (
     "OTEL_RESOURCE_ATTRIBUTES"
   )
 
-  const serviceName = (yield* Config.schema(Schema.UndefinedOr(Schema.String), "OTEL_SERVICE_NAME"))
-    ?? env?.["service.name"] as string | undefined
+  const serviceName = options?.serviceName
     ?? options?.attributes?.["service.name"] as string | undefined
-    ?? options?.serviceName
+    ?? (yield* Config.schema(Schema.UndefinedOr(Schema.String), "OTEL_SERVICE_NAME"))
+    ?? env?.["service.name"] as string | undefined
     ?? (yield* Config.string("OTEL_SERVICE_NAME"))
 
-  const serviceVersion = (yield* Config.schema(Schema.UndefinedOr(Schema.String), "OTEL_SERVICE_VERSION"))
-    ?? env?.["service.version"] as string | undefined
+  const serviceVersion = options?.serviceVersion
     ?? options?.attributes?.["service.version"] as string | undefined
-    ?? options?.serviceVersion
+    ?? (yield* Config.schema(Schema.UndefinedOr(Schema.String), "OTEL_SERVICE_VERSION"))
+    ?? env?.["service.version"] as string | undefined
 
   const attributes = {
     ...options?.attributes,

--- a/packages/effect/test/unstable/observability/OtlpResource.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpResource.test.ts
@@ -7,34 +7,7 @@ const attributesRecord = (resource: OtlpResource.Resource): Record<string, strin
 
 describe("OtlpResource", () => {
   describe("fromConfig", () => {
-    it.effect("uses OTEL service variables before explicit options", () =>
-      Effect.gen(function*() {
-        const resource = yield* OtlpResource.fromConfig({
-          serviceName: "explicit-service",
-          serviceVersion: "explicit-version",
-          attributes: {
-            "custom.attribute": "explicit"
-          }
-        })
-
-        assert.deepStrictEqual(attributesRecord(resource), {
-          "custom.attribute": "explicit",
-          "service.name": "env-service",
-          "service.version": "env-version"
-        })
-      }).pipe(
-        Effect.provideService(
-          ConfigProvider.ConfigProvider,
-          ConfigProvider.fromEnv({
-            env: {
-              OTEL_SERVICE_NAME: "env-service",
-              OTEL_SERVICE_VERSION: "env-version"
-            }
-          })
-        )
-      ))
-
-    it.effect("uses OTEL resource attributes before explicit options", () =>
+    it.effect("uses explicit service options before attributes and environment variables", () =>
       Effect.gen(function*() {
         const resource = yield* OtlpResource.fromConfig({
           serviceName: "explicit-service",
@@ -47,17 +20,68 @@ describe("OtlpResource", () => {
         })
 
         assert.deepStrictEqual(attributesRecord(resource), {
-          "custom.attribute": "env",
-          "service.name": "env-attribute-service",
-          "service.version": "env-attribute-version"
+          "custom.attribute": "explicit",
+          "service.name": "explicit-service",
+          "service.version": "explicit-version"
         })
       }).pipe(
         Effect.provideService(
           ConfigProvider.ConfigProvider,
           ConfigProvider.fromEnv({
             env: {
+              OTEL_SERVICE_NAME: "env-service",
+              OTEL_SERVICE_VERSION: "env-version",
+              OTEL_RESOURCE_ATTRIBUTES: "service.name=env-attribute-service,service.version=env-attribute-version"
+            }
+          })
+        )
+      ))
+
+    it.effect("uses explicit service attributes before environment variables", () =>
+      Effect.gen(function*() {
+        const resource = yield* OtlpResource.fromConfig({
+          attributes: {
+            "custom.attribute": "explicit",
+            "service.name": "explicit-attribute-service",
+            "service.version": "explicit-attribute-version"
+          }
+        })
+
+        assert.deepStrictEqual(attributesRecord(resource), {
+          "custom.attribute": "env",
+          "service.name": "explicit-attribute-service",
+          "service.version": "explicit-attribute-version"
+        })
+      }).pipe(
+        Effect.provideService(
+          ConfigProvider.ConfigProvider,
+          ConfigProvider.fromEnv({
+            env: {
+              OTEL_SERVICE_NAME: "env-service",
+              OTEL_SERVICE_VERSION: "env-version",
               OTEL_RESOURCE_ATTRIBUTES:
                 "service.name=env-attribute-service,service.version=env-attribute-version,custom.attribute=env"
+            }
+          })
+        )
+      ))
+
+    it.effect("uses dedicated service variables before OTEL resource attributes", () =>
+      Effect.gen(function*() {
+        const resource = yield* OtlpResource.fromConfig()
+
+        assert.deepStrictEqual(attributesRecord(resource), {
+          "service.name": "env-service",
+          "service.version": "env-version"
+        })
+      }).pipe(
+        Effect.provideService(
+          ConfigProvider.ConfigProvider,
+          ConfigProvider.fromEnv({
+            env: {
+              OTEL_SERVICE_NAME: "env-service",
+              OTEL_SERVICE_VERSION: "env-version",
+              OTEL_RESOURCE_ATTRIBUTES: "service.name=env-attribute-service,service.version=env-attribute-version"
             }
           })
         )

--- a/packages/effect/test/unstable/observability/OtlpResource.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpResource.test.ts
@@ -37,7 +37,7 @@ describe("OtlpResource", () => {
         )
       ))
 
-    it.effect("uses explicit service attributes before environment variables", () =>
+    it.effect("uses explicit attributes before environment variables", () =>
       Effect.gen(function*() {
         const resource = yield* OtlpResource.fromConfig({
           attributes: {
@@ -48,7 +48,7 @@ describe("OtlpResource", () => {
         })
 
         assert.deepStrictEqual(attributesRecord(resource), {
-          "custom.attribute": "env",
+          "custom.attribute": "explicit",
           "service.name": "explicit-attribute-service",
           "service.version": "explicit-attribute-version"
         })


### PR DESCRIPTION
## Summary

- prefer explicit `serviceName` and `serviceVersion` options over matching resource attributes and OTEL environment configuration
- prefer all explicit resource attributes over `OTEL_RESOURCE_ATTRIBUTES`
- preserve dedicated OTEL service variable precedence over matching attributes in `OTEL_RESOURCE_ATTRIBUTES`
- document that applications should omit explicit resource identity when deployment operators should configure it
- add regression coverage and a patch changeset

## Testing

- `pnpm jsdocs && pnpm exec oxlint -f unix`
- `nix shell nixpkgs#dprint --command dprint check`
- `pnpm --filter effect test --run test/unstable/observability/OtlpResource.test.ts`
- `pnpm check`
- `pnpm exec docgen` from `packages/effect`

Resolves #6742