### PR TITLE
Fix Wrangler installation for v4 docs deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,8 +33,7 @@ jobs:
           destination: ./_site
       - name: Deploy to Cloudflare Pages
         if: github.repository_owner == 'Effect-Ts' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./_site --project-name=effect-api-v4 --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm dlx wrangler@4 pages deploy ./_site --project-name=effect-api-v4 --branch=main


### PR DESCRIPTION
## Summary
- replace `cloudflare/wrangler-action` auto-installation with `pnpm dlx wrangler@4`
- keep Cloudflare credentials scoped to the deployment process environment
- avoid pnpm workspace-root mutation during deployment

## Root cause
`wrangler-action` detects the repository pnpm lockfile and runs `pnpm add wrangler@4`. pnpm rejects adding dependencies to a workspace root without `-w`, so deployment fails before Wrangler runs. `pnpm dlx` installs Wrangler in an isolated temporary environment.

## Validation
- `pnpm dlx wrangler@4 --version` (`4.115.0`)
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pages.yml`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cloudflare Pages deployment process while preserving the existing deployment target, branch, and site output.
  * Deployment credentials are now supplied through environment variables during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->