### PR TITLE
Harden ConfigFile file name handling

### DIFF
--- a/.changeset/tough-files-smile.md
+++ b/.changeset/tough-files-smile.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Reject path separators and `..` segments in `ConfigFile` file names.

--- a/packages/cli/src/ConfigFile.ts
+++ b/packages/cli/src/ConfigFile.ts
@@ -44,6 +44,9 @@ export interface ConfigFileError extends YieldableError {
 export const ConfigFileError: (message: string) => ConfigFileError = Internal.ConfigFileError
 
 /**
+ * `fileName` must be a static application-defined value and must not be derived
+ * from untrusted input.
+ *
  * @since 2.0.0
  * @category constructors
  */
@@ -58,6 +61,9 @@ export const makeProvider: (
 ) => Effect<ConfigProvider, ConfigFileError, Path | FileSystem> = Internal.makeProvider
 
 /**
+ * `fileName` must be a static application-defined value and must not be derived
+ * from untrusted input.
+ *
  * @since 2.0.0
  * @category layers
  */

--- a/packages/cli/src/internal/configFile.ts
+++ b/packages/cli/src/internal/configFile.ts
@@ -25,6 +25,9 @@ export const makeProvider = (fileName: string, options?: {
   readonly searchPaths?: ReadonlyArray<string>
 }): Effect.Effect<ConfigProvider.ConfigProvider, ConfigFile.ConfigFileError, Path.Path | FileSystem.FileSystem> =>
   Effect.gen(function*() {
+    if (fileName === ".." || fileName.includes("/") || fileName.includes("\\")) {
+      return yield* Effect.fail(ConfigFileError("fileName must not contain path separators or '..' segments"))
+    }
     const path = yield* Path.Path
     const fs = yield* FileSystem.FileSystem
     const searchPaths = options?.searchPaths && options.searchPaths.length ? options.searchPaths : ["."]

--- a/packages/cli/test/ConfigFile.test.ts
+++ b/packages/cli/test/ConfigFile.test.ts
@@ -11,6 +11,15 @@ const runEffect = <E, A>(
 ): Promise<A> => Effect.provide(self, NodeContext.layer).pipe(Effect.runPromise)
 
 describe("ConfigFile", () => {
+  it("rejects file names containing path separators or '..' segments", () =>
+    Effect.gen(function*() {
+      for (const fileName of ["../config", "config\\file", ".."]) {
+        const error = yield* Effect.flip(ConfigFile.makeProvider(fileName))
+        assert.strictEqual(error._tag, "ConfigFileError")
+        assert.strictEqual(error.message, "fileName must not contain path separators or '..' segments")
+      }
+    }).pipe(runEffect))
+
   it("loads json files", () =>
     Effect.gen(function*() {
       const path = yield* Path.Path
@@ -24,6 +33,25 @@ describe("ConfigFile", () => {
         }))
       )
       assert.deepStrictEqual(result, [true, "baz"])
+    }).pipe(runEffect))
+
+  it("supports relative, absolute, and '..'-containing search paths", () =>
+    Effect.gen(function*() {
+      const path = yield* Path.Path
+      const fixtures = path.join(__dirname, "fixtures")
+      const searchPaths = [
+        path.relative(".", fixtures),
+        fixtures,
+        `${fixtures}${path.sep}..${path.sep}fixtures`
+      ]
+      const results = yield* Effect.forEach(searchPaths, (searchPath) =>
+        Config.boolean("foo").pipe(
+          Effect.provide(ConfigFile.layer("config", {
+            searchPaths: [searchPath],
+            formats: ["json"]
+          }))
+        ))
+      assert.deepStrictEqual(results, [true, true, true])
     }).pipe(runEffect))
 
   it("loads yaml", () =>


### PR DESCRIPTION
## Summary

- reject path separators and `..` segments in `ConfigFile` file names before filesystem access
- preserve relative, absolute, and `..`-containing search paths
- document that file names must be static application-defined values
- add an `@effect/cli` patch changeset

## Testing

- `pnpm lint-fix`
- `pnpm test run packages/cli/test/ConfigFile.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-202
Closes EFF-187
