### PR TITLE
Fix HTML escaping in API docs

### DIFF
--- a/.changeset/secure-api-docs-html.md
+++ b/.changeset/secure-api-docs-html.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Fix a security issue in HTML escaping for generated Scalar and Swagger API documentation.

--- a/packages/platform/src/HttpApiScalar.ts
+++ b/packages/platform/src/HttpApiScalar.ts
@@ -129,12 +129,12 @@ const makeHandler = (options: {
     ${
     !spec.info.description
       ? ""
-      : `<meta name="description" content="${Html.escape(spec.info.description)}"/>`
+      : `<meta name="description" content="${Html.escapeAttribute(spec.info.description)}"/>`
   }
     ${
     !spec.info.description
       ? ""
-      : `<meta name="og:description" content="${Html.escape(spec.info.description)}"/>`
+      : `<meta name="og:description" content="${Html.escapeAttribute(spec.info.description)}"/>`
   }
     <meta
       name="viewport"
@@ -149,9 +149,13 @@ const makeHandler = (options: {
     </script>
     ${
     source._tag === "Cdn"
-      ? `<script src="${`https://cdn.jsdelivr.net/npm/@scalar/api-reference@${
-        source.version ?? "latest"
-      }/dist/browser/standalone.min.js`}" crossorigin></script>`
+      ? `<script src="${
+        Html.escapeAttribute(
+          `https://cdn.jsdelivr.net/npm/@scalar/api-reference@${
+            source.version ?? "latest"
+          }/dist/browser/standalone.min.js`
+        )
+      }" crossorigin></script>`
       : `<script>${source.source}</script>`
   }
   </body>

--- a/packages/platform/src/internal/html.ts
+++ b/packages/platform/src/internal/html.ts
@@ -1,5 +1,5 @@
-// Regex to find closing </script> tags in JSON to prevent breaking out of script context
-const ESCAPE_SCRIPT_END = /<\/script>/gi
+// Regex to find script data delimiters in JSON to prevent breaking out of script context
+const ESCAPE_SCRIPT_DATA = /</g
 
 // Regex to find Unicode line terminators that are valid JSON but break JS string literals
 const ESCAPE_LINE_TERMS = /[\u2028\u2029]/g
@@ -8,19 +8,19 @@ const ESCAPE_LINE_TERMS = /[\u2028\u2029]/g
  * Safely serialize an object to a JSON string
  * and escape any sequences that could break <script> blocks.
  *
- * - Replaces `</script>` with `<\/script>` to avoid premature tag closing.
+ * - Escapes `<` as `\u003c` to avoid premature tag closing.
  * - Escapes U+2028 and U+2029 as literal \u2028 / \u2029.
  *
  * @internal
  */
 export function escapeJson(spec: unknown): string {
   return JSON.stringify(spec)
-    .replace(ESCAPE_SCRIPT_END, "<\\/script>")
+    .replace(ESCAPE_SCRIPT_DATA, "\\u003c")
     .replace(ESCAPE_LINE_TERMS, (c) => c === "\u2028" ? "\\u2028" : "\\u2029")
 }
 
 /**
- * HTML-escape text content to prevent injection in text nodes or attributes.
+ * HTML-escape text content to prevent injection in text nodes.
  *
  * @internal
  */
@@ -29,4 +29,11 @@ export function escape(str: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
+}
+
+/** @internal */
+export function escapeAttribute(str: string): string {
+  return escape(str)
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
 }

--- a/packages/platform/test/HttpApiDocs.test.ts
+++ b/packages/platform/test/HttpApiDocs.test.ts
@@ -1,0 +1,31 @@
+import { HttpApi, HttpApiScalar, HttpApiSwagger, HttpLayerRouter, OpenApi } from "@effect/platform"
+import { assert, describe, test } from "@effect/vitest"
+
+describe("HttpApi docs", () => {
+  test("escapes quotes in Scalar description attributes", async () => {
+    const api = HttpApi.make("Api").annotate(OpenApi.Description, `A "quoted" and 'single-quoted' description`)
+    const { handler } = HttpLayerRouter.toWebHandler(
+      HttpApiScalar.layerHttpLayerRouter({ api, path: "/docs" })
+    )
+
+    const response = await handler(new Request("http://localhost/docs"))
+    const body = await response.text()
+
+    assert.include(body, `content="A &quot;quoted&quot; and &#39;single-quoted&#39; description"`)
+  })
+
+  test("escapes script end tag variants in Swagger JSON", async () => {
+    const variants = ["</script ", "</script/", "</script\n", "</script\t"]
+    const api = HttpApi.make("Api").annotate(OpenApi.Description, variants.join("|"))
+    const { handler } = HttpLayerRouter.toWebHandler(
+      HttpApiSwagger.layerHttpLayerRouter({ api, path: "/docs" })
+    )
+
+    const response = await handler(new Request("http://localhost/docs"))
+    const body = await response.text()
+
+    for (const variant of ["\\u003c/script ", "\\u003c/script/", "\\u003c/script\\n", "\\u003c/script\\t"]) {
+      assert.include(body, variant)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- add context-specific attribute escaping to generated Scalar documentation
- escape script-data delimiters in embedded JSON
- cover Scalar and Swagger rendering regressions and add a patch changeset

## Testing

- `pnpm lint-fix`
- `pnpm test run packages/platform/test`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-204
