### PR TITLE
Fix RPC JSON-RPC batch serialization

### DIFF
--- a/.changeset/fix-rpc-batch-serialization.md
+++ b/.changeset/fix-rpc-batch-serialization.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Fix JSON-RPC batch request serialization and response state cleanup.

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -106,11 +106,7 @@ export const jsonRpc = (options?: {
           return decodeJsonRpcRaw(decoded, batches)
         },
         encode: (response) => {
-          if (Array.isArray(response)) {
-            if (response.length === 0) return undefined
-            return JSON.stringify(response.map(encodeJsonRpcMessage))
-          }
-          const encoded = encodeJsonRpcRaw(response as any, batches)
+          const encoded = encodeJsonRpcResponse(response as any, batches)
           return encoded && JSON.stringify(encoded)
         }
       }
@@ -146,10 +142,7 @@ export const ndJsonRpc = (options?: {
           return messages
         },
         encode: (response) => {
-          if (Array.isArray(response)) {
-            return parser.encode(response.map(encodeJsonRpcMessage))
-          }
-          const encoded = encodeJsonRpcRaw(response as any, batches)
+          const encoded = encodeJsonRpcResponse(response as any, batches)
           return encoded && parser.encode(encoded)
         }
       })
@@ -171,6 +164,7 @@ function decodeJsonRpcRaw(
     const messages: Array<RpcMessage.FromClientEncoded | RpcMessage.FromServerEncoded> = []
     for (let i = 0; i < decoded.length; i++) {
       const message = decodeJsonRpcMessage(decoded[i])
+      messages.push(message)
       if (message._tag === "Request") {
         batch.size++
         batches.set(message.id, batch)
@@ -257,6 +251,48 @@ function encodeJsonRpcRaw(
     return undefined
   }
   return encodeJsonRpcMessage(response)
+}
+
+function encodeJsonRpcResponse(
+  response:
+    | RpcMessage.FromServerEncoded
+    | RpcMessage.FromClientEncoded
+    | Array<RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded>,
+  batches: Map<string, {
+    readonly size: number
+    readonly responses: Map<string, RpcMessage.FromServerEncoded>
+  }>
+) {
+  if (Array.isArray(response) === false) {
+    return encodeJsonRpcRaw(response, batches)
+  }
+  if (response.length === 0) {
+    return undefined
+  }
+  const encoded: Array<JsonRpcMessage | Array<JsonRpcMessage>> = []
+  for (let i = 0; i < response.length; i++) {
+    const current = encodeJsonRpcRaw(response[i], batches)
+    if (current !== undefined) {
+      encoded.push(current)
+    }
+  }
+  if (encoded.length === 0) {
+    return undefined
+  }
+  if (encoded.length === 1) {
+    return encoded[0]
+  }
+  const messages: Array<JsonRpcMessage> = []
+  for (let i = 0; i < encoded.length; i++) {
+    const current = encoded[i]
+    if (Array.isArray(current)) {
+      // eslint-disable-next-line no-restricted-syntax
+      messages.push(...current)
+    } else {
+      messages.push(current)
+    }
+  }
+  return messages
 }
 
 function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessage.FromClientEncoded): JsonRpcMessage {

--- a/packages/rpc/test/RpcSerialization.test.ts
+++ b/packages/rpc/test/RpcSerialization.test.ts
@@ -1,7 +1,62 @@
 import { RpcSerialization } from "@effect/rpc"
 import { assert, describe, it } from "@effect/vitest"
 
+const responseExitSuccess = (requestId: string, value: unknown) => ({
+  _tag: "Exit",
+  requestId,
+  exit: {
+    _tag: "Success",
+    value
+  }
+})
+
+const parseResponses = (encoded: string) => {
+  const responses = encoded.trim().split("\n").map((response) => JSON.parse(response))
+  return responses.length === 1 && Array.isArray(responses[0]) ? responses[0] : responses
+}
+
+const assertBatchRoundTrip = (parser: RpcSerialization.Parser, frame: string) => {
+  const decoded = parser.decode(frame)
+  assert.deepStrictEqual(decoded.map((message: any) => message.id), ["1", "2"])
+
+  const encoded = parser.encode([
+    responseExitSuccess("1", "one"),
+    responseExitSuccess("2", "two")
+  ])
+  assert(encoded !== undefined)
+  assert.deepStrictEqual(parseResponses(encoded as string), [
+    { jsonrpc: "2.0", id: 1, result: "one" },
+    { jsonrpc: "2.0", id: 2, result: "two" }
+  ])
+
+  const afterBatch = parser.encode(responseExitSuccess("1", "after batch"))
+  assert(afterBatch !== undefined)
+  assert.deepStrictEqual(parseResponses(afterBatch as string), [{
+    jsonrpc: "2.0",
+    id: 1,
+    result: "after batch"
+  }])
+}
+
 describe("RpcSerialization", () => {
+  describe("jsonRpc", () => {
+    it("dispatches batched requests and clears completed batch state", () => {
+      assertBatchRoundTrip(
+        RpcSerialization.jsonRpc().unsafeMake(),
+        "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"one\"},{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"two\"}]"
+      )
+    })
+  })
+
+  describe("ndJsonRpc", () => {
+    it("dispatches batched requests and clears completed batch state", () => {
+      assertBatchRoundTrip(
+        RpcSerialization.ndJsonRpc().unsafeMake(),
+        "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"one\"},{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"two\"}]\n"
+      )
+    })
+  })
+
   describe("msgPack", () => {
     it("encode and decode correctly", () => {
       const parser = RpcSerialization.msgPack.unsafeMake()


### PR DESCRIPTION
## Summary

- dispatch decoded JSON-RPC batch requests
- route response arrays through batch tracking so completed entries are released
- cover batch dispatch, responses, and cleanup for JSON-RPC and NDJSON transports
- add an `@effect/rpc` patch changeset

Backports the relevant behavior from `61f901d83` to the v3 package layout.

## Testing

- `pnpm lint-fix`
- `pnpm test run packages/rpc/test/RpcSerialization.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-203
