### PR TITLE
Correct SQL combinator README examples

### DIFF
--- a/.changeset/curvy-dates-listen.md
+++ b/.changeset/curvy-dates-listen.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql": patch
+---
+
+Correct the SQL combinator examples in the README.

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -236,7 +236,7 @@ export const make = (names: string[], cursor: string) =>
       sql.in("name", names),
       sql`created_at < ${cursor}`
     ])}`
-    // SELECT * FROM people WHERE ("name" IN (?,?,?) AND created_at < ?)
+    // SELECT * FROM people WHERE ("name" IN ($1,$2,$3) AND created_at < $4)
   })
 ```
 
@@ -254,7 +254,7 @@ export const make = (names: string[], cursor: Date) =>
       sql.in("name", names),
       sql`created_at < ${cursor}`
     ])}`
-    // SELECT * FROM people WHERE ("name" IN (?,?,?) OR created_at < ?)
+    // SELECT * FROM people WHERE ("name" IN ($1,$2,$3) OR created_at < $4)
   })
 ```
 
@@ -270,9 +270,9 @@ export const make = (names: string[], afterCursor: Date, beforeCursor: Date) =>
 
     const statement = sql`SELECT * FROM people WHERE ${sql.or([
       sql.in("name", names),
-      sql.and([`created_at > ${afterCursor}`, `created_at < ${beforeCursor}`])
+      sql.and([sql`created_at > ${afterCursor}`, sql`created_at < ${beforeCursor}`])
     ])}`
-    // SELECT * FROM people WHERE ("name" IN (?,?,?) OR (created_at > ? AND created_at < ?))
+    // SELECT * FROM people WHERE ("name" IN ($1,$2,$3) OR (created_at > $4 AND created_at < $5))
   })
 ```
 


### PR DESCRIPTION
## Summary

- use SQL fragments for the mixed `sql.and` example
- align the combinator output comments with PostgreSQL placeholders
- add a patch changeset for `@effect/sql`

## Validation

- `pnpm lint-fix`
- `pnpm test run packages/sql-pg/test/Client.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-206
