### PR TITLE
Harden JSON-RPC message classification against inherited properties

### DIFF
--- a/.changeset/tough-rpcs-own.md
+++ b/.changeset/tough-rpcs-own.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Harden JSON-RPC wire message classification against inherited properties.

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -182,7 +182,7 @@ function decodeJsonRpcRaw(
 }
 
 function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEncoded | RpcMessage.FromServerEncoded {
-  if ("method" in decoded) {
+  if (isJsonRpcRequest(decoded)) {
     if (!decoded.id && decoded.method.startsWith("@effect/rpc/")) {
       const tag = decoded.method.slice("@effect/rpc/".length) as
         | RpcMessage.FromServerEncoded["_tag"]
@@ -205,12 +205,12 @@ function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEnc
       spanId: decoded.spanId,
       sampled: decoded.sampled
     }
-  } else if (decoded.error && decoded.error._tag === "Defect") {
+  } else if (Object.hasOwn(decoded, "error") && decoded.error && decoded.error._tag === "Defect") {
     return {
       _tag: "Defect",
       defect: decoded.error.data
     }
-  } else if (decoded.chunk === true) {
+  } else if (Object.hasOwn(decoded, "chunk") && decoded.chunk === true) {
     return {
       _tag: "Chunk",
       requestId: String(decoded.id),
@@ -220,7 +220,7 @@ function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEnc
   return {
     _tag: "Exit",
     requestId: String(decoded.id),
-    exit: decoded.error != null ?
+    exit: Object.hasOwn(decoded, "error") && decoded.error != null ?
       {
         _tag: "Failure",
         cause: decoded.error._tag === "Cause" ?
@@ -235,6 +235,10 @@ function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEnc
         value: decoded.result
       }
   }
+}
+
+function isJsonRpcRequest(decoded: JsonRpcMessage): decoded is JsonRpcRequest {
+  return Object.hasOwn(decoded, "method")
 }
 
 function encodeJsonRpcRaw(

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -29,7 +29,6 @@ import * as Layer from "effect/Layer"
 import * as Mailbox from "effect/Mailbox"
 import * as Option from "effect/Option"
 import { type ParseError, TreeFormatter } from "effect/ParseResult"
-import * as Predicate from "effect/Predicate"
 import * as Runtime from "effect/Runtime"
 import * as RuntimeFlags from "effect/RuntimeFlags"
 import * as Schedule from "effect/Schedule"
@@ -653,7 +652,7 @@ export const make: <Rpcs extends Rpc.Any>(
 
     switch (request._tag) {
       case "Request": {
-        const tag = Predicate.hasProperty(request, "tag") ? request.tag as string : ""
+        const tag = Object.hasOwn(request, "tag") ? request.tag as string : ""
         const rpc = group.requests.get(tag)
         if (!rpc) {
           return sendDefect(client, `Unknown request tag: ${tag}`)

--- a/packages/rpc/test/RpcSerialization.test.ts
+++ b/packages/rpc/test/RpcSerialization.test.ts
@@ -1,5 +1,23 @@
 import { RpcSerialization } from "@effect/rpc"
-import { assert, describe, it } from "@effect/vitest"
+import { afterEach, assert, describe, it } from "@effect/vitest"
+
+const prototypeDescriptors = new Map<PropertyKey, PropertyDescriptor | undefined>()
+
+const polluteObjectPrototype = (property: PropertyKey, value: unknown) => {
+  prototypeDescriptors.set(property, Object.getOwnPropertyDescriptor(Object.prototype, property))
+  Object.defineProperty(Object.prototype, property, { configurable: true, value })
+}
+
+afterEach(() => {
+  for (const [property, descriptor] of prototypeDescriptors) {
+    if (descriptor) {
+      Object.defineProperty(Object.prototype, property, descriptor)
+    } else {
+      Reflect.deleteProperty(Object.prototype, property)
+    }
+  }
+  prototypeDescriptors.clear()
+})
 
 describe("RpcSerialization", () => {
   describe("msgPack", () => {
@@ -56,6 +74,45 @@ describe("RpcSerialization", () => {
       const decoded = parser.decode(encoded as Uint8Array)
       assert.strictEqual(decoded.length, 1)
       assert.deepStrictEqual(decoded[0], payload)
+    })
+  })
+
+  describe("jsonRpc", () => {
+    const response = JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" })
+    const expected = {
+      _tag: "Exit",
+      requestId: "1",
+      exit: { _tag: "Success", value: "ok" }
+    }
+
+    it("decodes a success response", () => {
+      const decoded = RpcSerialization.jsonRpc().unsafeMake().decode(response)
+
+      assert.deepStrictEqual(decoded, [expected])
+    })
+
+    it("ignores an inherited method", () => {
+      polluteObjectPrototype("method", "attacker.evil")
+
+      const decoded = RpcSerialization.jsonRpc().unsafeMake().decode(response)
+
+      assert.deepStrictEqual(decoded, [expected])
+    })
+
+    it("ignores an inherited chunk marker", () => {
+      polluteObjectPrototype("chunk", true)
+
+      const decoded = RpcSerialization.jsonRpc().unsafeMake().decode(response)
+
+      assert.deepStrictEqual(decoded, [expected])
+    })
+
+    it("ignores an inherited error", () => {
+      polluteObjectPrototype("error", { _tag: "Defect", data: "pwn" })
+
+      const decoded = RpcSerialization.jsonRpc().unsafeMake().decode(response)
+
+      assert.deepStrictEqual(decoded, [expected])
     })
   })
 })


### PR DESCRIPTION
## Summary

- classify JSON-RPC requests, errors, chunks, and exits using own properties
- reject inherited request tags in the server dispatch path
- cover clean and polluted-prototype response decoding
- add a patch changeset for `@effect/rpc`

## Testing

- `pnpm lint-fix`
- `pnpm test run packages/rpc/test/RpcSerialization.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-207
