### PR TITLE
Use linear matcher for string template literals

### DIFF
--- a/.changeset/quick-snakes-smile.md
+++ b/.changeset/quick-snakes-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use a linear matcher when decoding template literals containing only string spans.

--- a/packages/effect/src/ParseResult.ts
+++ b/packages/effect/src/ParseResult.ts
@@ -876,6 +876,24 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser => {
     case "Enums":
       return fromRefinement(ast, (u): u is any => ast.enums.some(([_, value]) => value === u))
     case "TemplateLiteral": {
+      if (ast.spans.every((span) => AST.isStringKeyword(span.type))) {
+        return fromRefinement(ast, (u): u is any => {
+          if (!Predicate.isString(u) || !u.startsWith(ast.head)) {
+            return false
+          }
+          let position = ast.head.length
+          for (let i = 0; i < ast.spans.length - 1; i++) {
+            const literal = ast.spans[i].literal
+            const index = u.indexOf(literal, position)
+            if (index === -1) {
+              return false
+            }
+            position = index + literal.length
+          }
+          const literal = ast.spans[ast.spans.length - 1].literal
+          return u.endsWith(literal) && u.length - literal.length >= position
+        })
+      }
       const regex = AST.getTemplateLiteralRegExp(ast)
       return fromRefinement(ast, (u): u is any => Predicate.isString(u) && regex.test(u))
     }

--- a/packages/effect/test/Schema/Schema/TemplateLiteral/TemplateLiteral.test.ts
+++ b/packages/effect/test/Schema/Schema/TemplateLiteral/TemplateLiteral.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@effect/vitest"
-import { deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
+import { assertTrue, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
 import * as A from "effect/Arbitrary"
 import type * as array_ from "effect/Array"
 import * as fc from "effect/FastCheck"
@@ -79,6 +79,59 @@ schema (Union): boolean | symbol`)
       ["-", S.Union(S.TemplateLiteral("a", S.Literal("b", "c")), S.TemplateLiteral("d", S.Literal("e", "f")))],
       "^-(a(b|c)|d(e|f))$"
     )
+  })
+
+  it("StringKeyword matcher is equivalent to getTemplateLiteralRegExp", () => {
+    const schemas: ReadonlyArray<S.Schema.AnyNoContext> = [
+      S.TemplateLiteral(S.String),
+      S.TemplateLiteral("id_", S.String),
+      S.TemplateLiteral(S.String, ".json"),
+      S.TemplateLiteral(S.String, "@", S.String, ".com"),
+      S.TemplateLiteral(S.String, ".", S.String, ".", S.String, ".json"),
+      S.TemplateLiteral("[", S.String, ".*", S.String, "]")
+    ]
+    const inputs = [
+      "",
+      "id_",
+      "id_value",
+      ".json",
+      "file.json",
+      "file.json.extra",
+      "@.com",
+      "a@b.com",
+      "a@@b.com",
+      "a@b@c.com",
+      "...json",
+      "a.b.c.json",
+      "a.b.c.json.extra",
+      "[]",
+      "[.*]",
+      "[a.*b]",
+      "[a.*b.*c]",
+      "[a.*b]extra",
+      "\n",
+      "a\n@b.com"
+    ]
+
+    for (const schema of schemas) {
+      const ast = schema.ast as AST.TemplateLiteral
+      const regex = AST.getTemplateLiteralRegExp(ast)
+      const is = S.is(schema)
+      for (const input of inputs) {
+        strictEqual(is(input), regex.test(input), `${String(ast)} on ${JSON.stringify(input)}`)
+      }
+    }
+  })
+
+  it("decodes adversarial StringKeyword template literals in linear time", () => {
+    const schema = S.TemplateLiteral(S.String, ".", S.String, ".", S.String, ".json")
+    const decode = S.decodeUnknownEither(schema)
+    const start = Date.now()
+    const result = decode(".".repeat(8_000))
+    const elapsed = Date.now() - start
+
+    strictEqual(result._tag, "Left")
+    assertTrue(elapsed < 1_000, `decoding took ${elapsed}ms`)
   })
 
   describe("AST and toString", () => {


### PR DESCRIPTION
## Summary

- use a linear left-to-right matcher when every template literal span is exactly `StringKeyword`
- retain the existing regex fallback for all other span types
- add regex-equivalence coverage, an adversarial performance guard, and an `effect` patch changeset

## Scope

- Union spans containing `StringKeyword` remain on the existing regex path and are not optimized here.
- `getTemplateLiteralCapturingRegExp` is untouched. `TemplateLiteralParser` still uses that capturing regex and may exhibit the same backtracking behavior.

## Validation

- `pnpm lint-fix`
- `pnpm test run packages/effect/test/Schema/Schema/TemplateLiteral/TemplateLiteral.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-209
