### PR TITLE
Fix Config redaction errors on v3

### DIFF
--- a/.changeset/redacted-config-errors.md
+++ b/.changeset/redacted-config-errors.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Redact errors from wrapped config parsers and avoid JSON key path collisions.

--- a/packages/effect/src/internal/config.ts
+++ b/packages/effect/src/internal/config.ts
@@ -39,6 +39,7 @@ export type ConfigPrimitive =
   | MapOrFail
   | Nested
   | Primitive
+  | RedactedConfig
   | Sequence
   | Table
   | Zipped
@@ -122,6 +123,14 @@ export interface Primitive extends
   Op<OpCodes.OP_PRIMITIVE, {
     readonly description: string
     parse(text: string): Either.Either<unknown, ConfigError.ConfigError>
+  }>
+{}
+
+/** @internal */
+export interface RedactedConfig extends
+  Op<OpCodes.OP_REDACTED, {
+    readonly original: Config.Config<unknown>
+    redact(value: unknown): Redacted.Redacted<unknown>
   }>
 {}
 
@@ -475,7 +484,11 @@ export const redacted = <A>(
   nameOrConfig?: string | Config.Config<A>
 ): Config.Config<Redacted.Redacted<A | string>> => {
   const config: Config.Config<A | string> = isConfig(nameOrConfig) ? nameOrConfig : string(nameOrConfig)
-  return map(config, redacted_.make)
+  const redacted = Object.create(proto)
+  redacted._tag = OpCodes.OP_REDACTED
+  redacted.original = config
+  redacted.redact = redacted_.make
+  return redacted
 }
 
 /** @internal */

--- a/packages/effect/src/internal/configProvider.ts
+++ b/packages/effect/src/internal/configProvider.ts
@@ -236,6 +236,18 @@ const appendConfigPath = (path: ReadonlyArray<string>, config: Config.Config<unk
   return path
 }
 
+const RedactedConfigErrorReducer: ConfigError.ConfigErrorReducer<unknown, ConfigError.ConfigError> = {
+  andCase: (_, left, right) => configError.And(left, right),
+  orCase: (_, left, right) => configError.Or(left, right),
+  invalidDataCase: (_, path) => configError.InvalidData(path, "<redacted>"),
+  missingDataCase: (_, path) => configError.MissingData(path, "<redacted>"),
+  sourceUnavailableCase: (_, path, _message, cause) => configError.SourceUnavailable(path, "<redacted>", cause),
+  unsupportedCase: (_, path) => configError.Unsupported(path, "<redacted>")
+}
+
+const redactConfigError = (error: ConfigError.ConfigError): ConfigError.ConfigError =>
+  configError.reduceWithContext(error, void 0, RedactedConfigErrorReducer)
+
 const fromFlatLoop = <A>(
   flat: ConfigProvider.ConfigProvider.Flat,
   prefix: ReadonlyArray<string>,
@@ -317,6 +329,15 @@ const fromFlatLoop = <A>(
               return core.succeed(values)
             })
           )
+        )
+      ) as unknown as Effect.Effect<Array<A>, ConfigError.ConfigError>
+    }
+    case OpCodes.OP_REDACTED: {
+      return core.suspend(() =>
+        pipe(
+          fromFlatLoop(flat, prefix, op.original, split),
+          core.mapError(redactConfigError),
+          core.map(Arr.map(op.redact))
         )
       ) as unknown as Effect.Effect<Array<A>, ConfigError.ConfigError>
     }
@@ -719,7 +740,9 @@ interface JsonArray extends Array<string | number | boolean | null | JsonArray |
 export const fromJson = (json: unknown): ConfigProvider.ConfigProvider => {
   const hiddenDelimiter = "\ufeff"
   const indexedEntries = Arr.map(
-    getIndexedEntries(json as JsonMap),
+    getIndexedEntries(json as JsonMap).filter(([path]) =>
+      path.every((component) => component._tag === "KeyIndex" || !component.name.includes(hiddenDelimiter))
+    ),
     ([key, value]): [string, string] => [configPathToString(key).join(hiddenDelimiter), value]
   )
   return fromMap(new Map(indexedEntries), {

--- a/packages/effect/src/internal/opCodes/config.ts
+++ b/packages/effect/src/internal/opCodes/config.ts
@@ -47,6 +47,12 @@ export type OP_PRIMITIVE = typeof OP_PRIMITIVE
 export const OP_PRIMITIVE = "Primitive" as const
 
 /** @internal */
+export type OP_REDACTED = typeof OP_REDACTED
+
+/** @internal */
+export const OP_REDACTED = "Redacted" as const
+
+/** @internal */
 export type OP_SEQUENCE = typeof OP_SEQUENCE
 
 /** @internal */

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -618,6 +618,39 @@ describe("Config", () => {
       const config = Config.redacted(Config.integer("NUM"))
       assertConfig(config, [["NUM", "2"]], Redacted.make(2))
     })
+
+    it.effect("redacts port parsing errors", () =>
+      Effect.gen(function*() {
+        const secret = "secret-port-value"
+        const configProvider = ConfigProvider.fromMap(new Map([["PORT", secret]]))
+        const error = yield* configProvider.load(Config.redacted(Config.port("PORT"))).pipe(Effect.flip)
+
+        deepStrictEqual(error, ConfigError.InvalidData(["PORT"], "<redacted>"))
+        assertTrue(!String(error).includes(secret))
+      }))
+
+    it.effect("redacts integer parsing errors", () =>
+      Effect.gen(function*() {
+        const secret = "secret-integer-value"
+        const configProvider = ConfigProvider.fromMap(new Map([["INTEGER", secret]]))
+        const error = yield* configProvider.load(Config.redacted(Config.integer("INTEGER"))).pipe(Effect.flip)
+
+        deepStrictEqual(error, ConfigError.InvalidData(["INTEGER"], "<redacted>"))
+        assertTrue(!String(error).includes(secret))
+      }))
+
+    it.effect("does not redact errors outside the wrapper", () =>
+      Effect.gen(function*() {
+        const value = "visible-port-value"
+        const configProvider = ConfigProvider.fromMap(new Map([["PORT", value]]))
+        const error = yield* configProvider.load(Config.port("PORT")).pipe(Effect.flip)
+
+        deepStrictEqual(
+          error,
+          ConfigError.InvalidData(["PORT"], `Expected a network port value but received "${value}"`)
+        )
+        assertTrue(String(error).includes(value))
+      }))
   })
 
   describe("Secret", () => {

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -940,4 +940,14 @@ describe("ConfigProvider", () => {
         hostPorts: Array.from({ length: 3 }, () => ({ host: "localhost", port: 8080 }))
       })
     }))
+
+  it.effect("fromJson - nested paths do not collide with keys containing U+FEFF", () =>
+    Effect.gen(function*() {
+      const result = yield* ConfigProvider.fromJson({
+        a: { b: "nested" },
+        ["a\ufeffb"]: "sibling"
+      }).load(Config.nested(Config.string("b"), "a"))
+
+      strictEqual(result, "nested")
+    }))
 })


### PR DESCRIPTION
## Summary

- replace error details produced inside `Config.redacted` with `<redacted>` while preserving the `ConfigError` shape, path, and type
- reject JSON keys containing the provider's internal path delimiter before flattening
- add regression tests and a patch changeset for `effect`

## Implementation

`Config.redacted` now uses a dedicated internal config operation. This lets the provider rewrite only failures from the wrapped config without adding a broader error-mapping primitive for the v3 maintenance line.

v4/main is unaffected: its `Config.redacted` uses `Schema.Redacted`, which discards wrapped parse issues, and its JSON config provider stores a node tree instead of flattening paths into strings.

## Validation

- `pnpm lint-fix`
- `pnpm test run packages/effect/test/Config.test.ts packages/effect/test/ConfigProvider.test.ts` (105 passed)
- `pnpm check`
- `pnpm build`
- `pnpm docgen`
- full `effect` package run: 6,227 passed; the unrelated existing `clampBigDecimal.test.ts` structural-equality failure reproduces in isolation

Closes EFF-208
Closes EFF-195
