### PR TITLE
Secure MSSQL transport defaults on v3

### DIFF
--- a/.changeset/eff-213-secure-mssql-transport.md
+++ b/.changeset/eff-213-secure-mssql-transport.md
@@ -1,0 +1,7 @@
+---
+"@effect/sql-mssql": minor
+---
+
+**Breaking:** Secure Microsoft SQL Server connections by default by enabling encryption and validating server certificates.
+
+Users connecting to SQL Server instances without TLS must now explicitly set `encrypt: false`. Users connecting with untrusted or self-signed certificates must explicitly set `trustServer: true`.

--- a/packages/sql-kysely/test/utils.ts
+++ b/packages/sql-kysely/test/utils.ts
@@ -51,7 +51,8 @@ export class MssqlContainer extends Context.Tag("test/MssqlContainer")<
         port: container.getPort(),
         username: container.getUsername(),
         password: Redacted.make(container.getPassword()),
-        database: container.getDatabase()
+        database: container.getDatabase(),
+        trustServer: true
       })
     })
   ).pipe(Layer.provide(this.Live))

--- a/packages/sql-mssql/src/MssqlClient.ts
+++ b/packages/sql-mssql/src/MssqlClient.ts
@@ -78,7 +78,13 @@ export interface MssqlClientConfig {
   readonly domain?: string | undefined
   readonly server: string
   readonly instanceName?: string | undefined
+  /**
+   * Whether to encrypt traffic between the client and server. Defaults to `true`. Setting this to `false` disables transport encryption and transmits credentials in cleartext.
+   */
   readonly encrypt?: boolean | undefined
+  /**
+   * Whether to trust the server certificate without validating it. Defaults to `false`. Setting this to `true` disables TLS certificate validation.
+   */
   readonly trustServer?: boolean | undefined
   readonly port?: number | undefined
   readonly authType?: string | undefined
@@ -148,14 +154,14 @@ export const make = (
         options: {
           port: options.port,
           database: options.database,
-          trustServerCertificate: options.trustServer ?? true,
+          trustServerCertificate: options.trustServer ?? false,
           connectTimeout: options.connectTimeout
             ? Duration.toMillis(Duration.decode(options.connectTimeout))
             : undefined,
           rowCollectionOnRequestCompletion: true,
           useColumnNames: false,
           instanceName: options.instanceName,
-          encrypt: options.encrypt ?? false
+          encrypt: options.encrypt ?? true
         } as ConnectionOptions,
         server: options.server,
         authentication: {


### PR DESCRIPTION
## Summary

- enable SQL Server transport encryption by default
- validate server certificates by default and document both security options
- keep the encrypted MSSQL testcontainer path working by explicitly trusting its self-signed certificate
- add a minor changeset that highlights both explicit opt-outs

## Migration verification

The SQL Kysely MSSQL testcontainer initially failed certificate validation after the default changed, demonstrating the migration described by the changeset. Its test-only client now sets `trustServer: true` for the container's self-signed certificate while keeping TLS enabled.

## Testing

- `pnpm lint-fix`
- `pnpm test run packages/sql-mssql/test/Client.test.ts`
- `pnpm test run packages/sql-kysely/test/Mssql.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-213
