### PR TITLE
Fix generated SSE event decoding

### DIFF
--- a/.changeset/tidy-sse-events.md
+++ b/.changeset/tidy-sse-events.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Decode Effect SSE event schemas as complete events, including reserved failure events, in generated HTTP clients.

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -605,11 +605,21 @@ const parseOpenApi = (
           }
         }
 
-        const sseResponseSchema = content?.["text/event-stream"]?.schema
+        const sseMediaType = content?.["text/event-stream"]
+        const sseResponseSchema = sseMediaType?.schema
         if (!isHttpApi && Predicate.isUndefined(op.sseSchema) && Predicate.isNotUndefined(sseResponseSchema)) {
           const statusMajorNumber = Number(parsedStatus[0])
           if (!Number.isNaN(statusMajorNumber) && statusMajorNumber < 4) {
-            op.sseSchema = addSchema(`${schemaId}${status}Sse`, sseResponseSchema, op)
+            op.sseSchemaMode = Predicate.isObject(sseMediaType) && getEffectStreamEncoding(sseMediaType) === "sse"
+              ? "event"
+              : "data"
+            op.sseSchema = addSchema(
+              `${schemaId}${status}Sse`,
+              op.sseSchemaMode === "event"
+                ? makeSseEventSchema(resolveReference(sseResponseSchema, resolveRef), sseMediaType)
+                : sseResponseSchema,
+              op
+            )
           }
         }
 
@@ -969,6 +979,60 @@ const getEffectStreamErrorSchema = (mediaType: object): JsonSchema.JsonSchema | 
     return
   }
   return stream.errorSchema as JsonSchema.JsonSchema
+}
+
+const makeSseEventSchema = (
+  input: JsonSchema.JsonSchema,
+  mediaType: object
+): JsonSchema.JsonSchema => {
+  const eventSchema = normalizeSseEventSchema(input)
+  const stream = (mediaType as Record<string, unknown>)["x-effect-stream"]
+  if (!Predicate.isObject(stream) || typeof stream.failureEvent !== "string") {
+    return eventSchema
+  }
+  return {
+    anyOf: [
+      eventSchema,
+      {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          event: { const: stream.failureEvent },
+          data: { type: "string" }
+        },
+        required: ["event", "data"],
+        additionalProperties: false
+      }
+    ]
+  }
+}
+
+const normalizeSseEventSchema = (input: JsonSchema.JsonSchema): JsonSchema.JsonSchema => {
+  const schema = { ...input } as Record<string, any>
+  for (const key of ["allOf", "anyOf", "oneOf"] as const) {
+    if (Array.isArray(schema[key])) {
+      schema[key] = schema[key].map(normalizeSseEventSchema)
+    }
+  }
+  if (
+    schema.type !== "object" ||
+    !Predicate.isObject(schema.properties) ||
+    !Object.hasOwn(schema.properties, "id") ||
+    !Object.hasOwn(schema.properties, "event") ||
+    !Object.hasOwn(schema.properties, "data")
+  ) {
+    return schema as JsonSchema.JsonSchema
+  }
+
+  // OpenAPI represents `undefined` as required nullable; restore the SSE parser's optional wire field.
+  schema.properties = {
+    ...schema.properties,
+    id: { type: "string" }
+  }
+  if (Array.isArray(schema.required)) {
+    schema.required = schema.required.filter((name: unknown) => name !== "id")
+  }
+  return schema as JsonSchema.JsonSchema
 }
 
 const resolveReference = (input: unknown, resolveRef: (ref: string) => unknown): any => {

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -610,13 +610,15 @@ const parseOpenApi = (
         if (!isHttpApi && Predicate.isUndefined(op.sseSchema) && Predicate.isNotUndefined(sseResponseSchema)) {
           const statusMajorNumber = Number(parsedStatus[0])
           if (!Number.isNaN(statusMajorNumber) && statusMajorNumber < 4) {
-            op.sseSchemaMode = Predicate.isObject(sseMediaType) && getEffectStreamEncoding(sseMediaType) === "sse"
-              ? "event"
-              : "data"
+            const effectStream = sseMediaType["x-effect-stream"]
+            op.sseSchemaMode = getEffectStreamEncoding(sseMediaType) === "sse" ? "event" : "data"
             op.sseSchema = addSchema(
               `${schemaId}${status}Sse`,
               op.sseSchemaMode === "event"
-                ? makeSseEventSchema(resolveReference(sseResponseSchema, resolveRef), sseMediaType)
+                ? makeSseEventSchema(
+                  resolveReference(sseResponseSchema, resolveRef),
+                  effectStream?.encoding === "sse" ? effectStream.failureEvent : undefined
+                )
                 : sseResponseSchema,
               op
             )
@@ -983,11 +985,10 @@ const getEffectStreamErrorSchema = (mediaType: object): JsonSchema.JsonSchema | 
 
 const makeSseEventSchema = (
   input: JsonSchema.JsonSchema,
-  mediaType: object
+  failureEvent: string | undefined
 ): JsonSchema.JsonSchema => {
   const eventSchema = normalizeSseEventSchema(input)
-  const stream = (mediaType as Record<string, unknown>)["x-effect-stream"]
-  if (!Predicate.isObject(stream) || typeof stream.failureEvent !== "string") {
+  if (failureEvent === undefined) {
     return eventSchema
   }
   return {
@@ -997,7 +998,7 @@ const makeSseEventSchema = (
         type: "object",
         properties: {
           id: { type: "string" },
-          event: { const: stream.failureEvent },
+          event: { const: failureEvent },
           data: { type: "string" }
         },
         required: ["event", "data"],

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -40,21 +40,30 @@ export class OpenApiTransformer extends Context.Service<
 
 interface ImportRequirements {
   readonly eventStream: boolean
+  readonly eventStreamData: boolean
+  readonly eventStreamSchema: boolean
   readonly octetStream: boolean
 }
 
 const computeImportRequirements = (operations: ReadonlyArray<ParsedOperation>): ImportRequirements => {
   let eventStream = false
+  let eventStreamData = false
+  let eventStreamSchema = false
   let octetStream = false
   for (const op of operations) {
     if (op.sseSchema) {
       eventStream = true
+      if (op.sseSchemaMode === "event") {
+        eventStreamSchema = true
+      } else {
+        eventStreamData = true
+      }
     }
     if (op.binaryResponse) {
       octetStream = true
     }
   }
-  return { eventStream, octetStream }
+  return { eventStream, eventStreamData, eventStreamSchema, octetStream }
 }
 
 const requiresStreaming = (requirements: ImportRequirements): boolean =>
@@ -173,8 +182,11 @@ ${clientErrorSource(name)}`
     const jsdoc = Utils.toComment(operation.description)
     const methodKey = `readonly "${operation.id}Sse"`
     const parameters = args.join(", ")
+    const value = operation.sseSchemaMode === "event"
+      ? `typeof ${operation.sseSchema}.Type`
+      : `{ readonly event: string; readonly id: string | undefined; readonly data: typeof ${operation.sseSchema}.Type }`
     const returnType =
-      `Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: typeof ${operation.sseSchema}.Type }, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof ${operation.sseSchema}.DecodingServices>`
+      `Stream.Stream<${value}, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof ${operation.sseSchema}.DecodingServices>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
@@ -226,8 +238,11 @@ ${clientErrorSource(name)}`
     }
 
     const helpers: Array<string> = [commonSource]
-    if (requirements.eventStream) {
+    if (requirements.eventStreamData) {
       helpers.push(sseRequestSource(importName))
+    }
+    if (requirements.eventStreamSchema) {
+      helpers.push(sseEventRequestSource)
     }
     if (requirements.octetStream) {
       helpers.push(binaryRequestSource)
@@ -370,7 +385,7 @@ export const make = (
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
 
-    pipeline.push(`sseRequest(${operation.sseSchema})`)
+    pipeline.push(`${operation.sseSchemaMode === "event" ? "sseEventRequest" : "sseRequest"}(${operation.sseSchema})`)
 
     return (
       `"${operation.id}Sse": (${params}) => ` +
@@ -931,6 +946,21 @@ const sseRequestSource = (_importName: string) =>
         Stream.unwrap,
         Stream.decodeText(),
         Stream.pipeThroughChannel(Sse.decodeDataSchema(schema))
+      )`
+
+const sseEventRequestSource = `const sseEventRequest = <S extends Sse.EventCodec>(schema: S) =>
+    (
+      request: HttpClientRequest.HttpClientRequest
+    ): Stream.Stream<
+      S["Type"],
+      HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+      S["DecodingServices"]
+    > =>
+      HttpClient.filterStatusOk(httpClient).execute(request).pipe(
+        Effect.map((response) => response.stream),
+        Stream.unwrap,
+        Stream.decodeText(),
+        Stream.pipeThroughChannel(Sse.decodeSchema(schema))
       )`
 
 const binaryRequestSource =

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -221,6 +221,7 @@ export interface ParsedOperation {
   readonly voidSchemas: ReadonlySet<string>
   // SSE streaming response schema (text/event-stream)
   readonly sseSchema?: string
+  readonly sseSchemaMode: "data" | "event"
   // Binary stream response (application/octet-stream)
   readonly binaryResponse: boolean
 }
@@ -273,5 +274,6 @@ export const makeDeepMutable = (options: {
   errorSchemas: new Map(),
   voidSchemas: new Set(),
   paramsOptional: true,
+  sseSchemaMode: "data",
   binaryResponse: false
 })

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -525,6 +525,67 @@ export const TestClientError = <Tag extends string, E>(
         ]
       ))
 
+    it.effect("annotated sse operation decodes the full event schema", () =>
+      assertRuntimeIncludes(
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Test API",
+            version: "1.0.0"
+          },
+          paths: {
+            "/events": {
+              get: {
+                operationId: "streamEvents",
+                parameters: [],
+                responses: {
+                  200: {
+                    description: "Events streamed successfully",
+                    content: {
+                      "text/event-stream": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            id: {
+                              anyOf: [{ type: "string" }, { type: "null" }]
+                            },
+                            event: { const: "message" },
+                            data: { type: "string" }
+                          },
+                          required: ["id", "event", "data"],
+                          additionalProperties: false
+                        },
+                        "x-effect-stream": {
+                          encoding: "sse",
+                          errorSchema: {},
+                          causeSchema: {},
+                          failureEvent: "effect/httpapi/stream/failure"
+                        }
+                      }
+                    }
+                  }
+                },
+                tags: ["Events"],
+                security: []
+              }
+            }
+          },
+          components: {
+            schemas: {},
+            securitySchemes: {}
+          },
+          security: [],
+          tags: []
+        },
+        [
+          `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("message"), "data": Schema.String`,
+          `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("effect/httpapi/stream/failure"), "data": Schema.String`,
+          `readonly "streamEventsSse": () => Stream.Stream<typeof StreamEvents200Sse.Type, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof StreamEvents200Sse.DecodingServices>`,
+          `sseEventRequest(StreamEvents200Sse)`,
+          `Stream.pipeThroughChannel(Sse.decodeSchema(schema))`
+        ]
+      ))
+
     it.effect("form-urlencoded request body generates bodyUrlParams", () =>
       assertRuntimeIncludes(
         {


### PR DESCRIPTION
## Summary

- treat Effect `x-effect-stream` SSE response schemas as complete event codecs and decode them with `Sse.decodeSchema`
- restore the parser-compatible optional `id` field lost when OpenAPI represents `undefined` as `null`
- include the reserved `effect/httpapi/stream/failure` event in generated event schemas while retaining `decodeDataSchema` for unannotated data-only SSE responses

I chose whole-event decoding because `x-effect-stream` explicitly describes its response schema as an `Sse.EventCodec`; data-only decoding remains correct for ordinary unannotated OpenAPI SSE schemas.

## Testing

- `pnpm --filter @effect/openapi-generator test --run test/OpenApiGenerator.test.ts`
- `pnpm --filter effect test --run test/unstable/httpapi/HttpApiClient.test.ts -t "decodes StreamSse reserved failure events as full causes"`
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-214
Closes #6769
