### PR TITLE
Escape control characters in CLI errors

### DIFF
--- a/.changeset/eff-220-cli-control-characters.md
+++ b/.changeset/eff-220-cli-control-characters.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Escape terminal control characters in unstable CLI error output.

--- a/packages/effect/src/unstable/cli/CliOutput.ts
+++ b/packages/effect/src/unstable/cli/CliOutput.ts
@@ -269,6 +269,11 @@ export const Formatter: Context.Reference<Formatter> = Context.Reference(
  */
 export const layer = (formatter: Formatter): Layer.Layer<never> => Layer.succeed(Formatter)(formatter)
 
+const escapeControlCharacters = (text: string): string =>
+  // oxlint-disable-next-line no-control-regex
+  text.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, (character) =>
+    `\\x${character.charCodeAt(0).toString(16).padStart(2, "0")}`)
+
 /**
  * Creates a default formatter with configurable options.
  *
@@ -349,14 +354,14 @@ export const defaultFormatter = (options?: { colors?: boolean }): Formatter => {
 
   return {
     formatHelpDoc: (doc: HelpDoc): string => formatHelpDocImpl(doc, colors),
-    formatCliError: (error): string => error.message,
+    formatCliError: (error): string => escapeControlCharacters(error.message),
     formatError: (error): string => {
-      return `\n${bold}${red}ERROR${reset}\n  ${error.message}${reset}`
+      return `\n${bold}${red}ERROR${reset}\n  ${escapeControlCharacters(error.message)}${reset}`
     },
     formatErrors: (errors): string => {
       if (errors.length === 0) return ""
       if (errors.length === 1) {
-        return `\n${bold}${red}ERROR${reset}\n  ${errors[0].message}${reset}`
+        return `\n${bold}${red}ERROR${reset}\n  ${escapeControlCharacters(errors[0].message)}${reset}`
       }
 
       // Group errors by _tag
@@ -373,7 +378,7 @@ export const defaultFormatter = (options?: { colors?: boolean }): Formatter => {
 
       for (const [, group] of grouped) {
         for (const error of group) {
-          sections.push(`  ${error.message}${reset}`)
+          sections.push(`  ${escapeControlCharacters(error.message)}${reset}`)
         }
       }
 

--- a/packages/effect/test/unstable/cli/Errors.test.ts
+++ b/packages/effect/test/unstable/cli/Errors.test.ts
@@ -167,7 +167,94 @@ describe("Command errors", () => {
       }).pipe(Effect.provide(TestLayer)))
   })
 
-  describe("formatErrors", () => {
+  describe("error formatting", () => {
+    it("escapes control characters in an unrecognized flag", () => {
+      const formatter = CliOutput.defaultFormatter({ colors: false })
+      const error = new CliError.UnrecognizedOption({
+        option: "--foo\x1b]52;c;bWFsaWNpb3Vz\x07",
+        suggestions: []
+      })
+
+      assert.strictEqual(
+        formatter.formatCliError(error),
+        "Unrecognized flag: --foo\\x1b]52;c;bWFsaWNpb3Vz\\x07"
+      )
+    })
+
+    it("escapes control characters in an unknown subcommand with colors enabled", () => {
+      const formatter = CliOutput.defaultFormatter({ colors: true })
+      const error = new CliError.UnknownSubcommand({
+        subcommand: "deplyo\x1b]8;;https://example.com\x07",
+        suggestions: []
+      })
+
+      assert.strictEqual(
+        formatter.formatError(error),
+        `\n\x1b[1m\x1b[31mERROR\x1b[0m\n  Unknown subcommand "deplyo\\x1b]8;;https://example.com\\x07"\x1b[0m`
+      )
+    })
+
+    it("escapes control characters in an invalid argument value without colors", () => {
+      const formatter = CliOutput.defaultFormatter({ colors: false })
+      const error = new CliError.InvalidValue({
+        option: "count",
+        value: "12\x1b]52;c;bWFsaWNpb3Vz\x07\x7f",
+        expected: "an integer",
+        kind: "argument"
+      })
+
+      assert.strictEqual(
+        formatter.formatErrors([error]),
+        `\nERROR\n  Invalid value for argument <count>: "12\\x1b]52;c;bWFsaWNpb3Vz\\x07\\x7f". Expected: an integer`
+      )
+    })
+
+    it("preserves multi-line suggestion blocks", () => {
+      const formatter = CliOutput.defaultFormatter({ colors: false })
+      const errors = [
+        new CliError.UnrecognizedOption({
+          option: "--deplyo",
+          suggestions: ["--deploy"]
+        }),
+        new CliError.UnknownSubcommand({
+          subcommand: "usrs",
+          parent: ["app"],
+          suggestions: ["users"]
+        })
+      ]
+
+      assert.strictEqual(
+        formatter.formatErrors(errors),
+        [
+          "",
+          "ERRORS",
+          "  Unrecognized flag: --deplyo",
+          "",
+          "  Did you mean this?",
+          "    --deploy",
+          "  Unknown subcommand \"usrs\" for \"app\"",
+          "",
+          "  Did you mean this?",
+          "    users"
+        ].join("\n")
+      )
+    })
+
+    it("preserves line feeds and tabs in error messages", () => {
+      const formatter = CliOutput.defaultFormatter({ colors: false })
+      const error = new CliError.InvalidValue({
+        option: "count",
+        value: "twelve",
+        expected: "one line\n\tcontinuation",
+        kind: "argument"
+      })
+
+      assert.strictEqual(
+        formatter.formatCliError(error),
+        "Invalid value for argument <count>: \"twelve\". Expected: one line\n\tcontinuation"
+      )
+    })
+
     it("formats single error with ERROR header", () => {
       const formatter = CliOutput.defaultFormatter({ colors: false })
       const error = new CliError.MissingOption({ option: "value" })


### PR DESCRIPTION
## Summary
- escape C0 controls except line feed and tab, plus DEL, as visible \xNN sequences
- sanitize bare, colored, and grouped CLI error formatter output
- cover OSC payloads, no-color mode, and multi-line suggestion formatting

## Verification
- pnpm lint-fix
- pnpm --filter effect test --run test/unstable/cli/Errors.test.ts
- pnpm check

Closes EFF-220