### PR TITLE
Harden file-backed key-value store keys on v3

### DIFF
--- a/.changeset/eff-219-key-value-store-file-keys.md
+++ b/.changeset/eff-219-key-value-store-file-keys.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform": patch
+---
+
+Reject empty, `.` and `..` keys in file-backed key-value stores.

--- a/packages/platform-node-shared/test/KeyValueStore.test.ts
+++ b/packages/platform-node-shared/test/KeyValueStore.test.ts
@@ -1,8 +1,50 @@
+import * as NodeFileSystem from "@effect/platform-node-shared/NodeFileSystem"
 import * as KvN from "@effect/platform-node-shared/NodeKeyValueStore"
-import { describe } from "@effect/vitest"
+import * as PlatformError from "@effect/platform/Error"
+import * as FileSystem from "@effect/platform/FileSystem"
+import * as KeyValueStore from "@effect/platform/KeyValueStore"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
 // @ts-ignore
 import { testLayer } from "../../platform/test/KeyValueStore.test.js"
 
 const KeyValueLive = KvN.layerFileSystem(`${__dirname}/fixtures/kv`)
 
 describe.sequential("KeyValueStore / layerFileSystem", () => testLayer(KeyValueLive))
+
+it.effect("rejects invalid keys without modifying the file system", () =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const root = yield* fs.makeTempDirectoryScoped()
+    const directory = `${root}/store`
+    const sibling = `${root}/sibling.txt`
+    yield* fs.makeDirectory(directory)
+    yield* fs.writeFileString(sibling, "sibling")
+
+    yield* Effect.gen(function*() {
+      const store = yield* KeyValueStore.KeyValueStore
+
+      for (const key of ["", ".", ".."]) {
+        const operations = [
+          ["get", Effect.asVoid(store.get(key))],
+          ["getUint8Array", Effect.asVoid(store.getUint8Array(key))],
+          ["set", Effect.asVoid(store.set(key, "value"))],
+          ["remove", Effect.asVoid(store.remove(key))],
+          ["has", Effect.asVoid(store.has(key))]
+        ] as const
+
+        for (const [method, operation] of operations) {
+          const error = yield* Effect.flip(operation)
+          assert.instanceOf(error, PlatformError.BadArgument)
+          assert.strictEqual(error.method, method)
+        }
+      }
+    }).pipe(Effect.provide(KvN.layerFileSystem(directory)))
+
+    assert.isTrue(yield* fs.exists(directory))
+    assert.deepStrictEqual(yield* fs.readDirectory(directory), [])
+    assert.strictEqual(yield* fs.readFileString(sibling), "sibling")
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(NodeFileSystem.layer)
+  ))

--- a/packages/platform/src/KeyValueStore.ts
+++ b/packages/platform/src/KeyValueStore.ts
@@ -139,6 +139,15 @@ export const prefix: {
 } = internal.prefix
 
 /**
+ * Provides a file-backed key-value store in the specified directory.
+ *
+ * Keys are percent-encoded as single file names. Empty keys, `.` and `..` are
+ * rejected. Keys are only guaranteed to be distinct on case-sensitive file
+ * systems.
+ *
+ * `clear` removes the directory recursively, so it must not be shared with
+ * unrelated data.
+ *
  * @since 1.0.0
  * @category layers
  */

--- a/packages/platform/src/internal/keyValueStore.ts
+++ b/packages/platform/src/internal/keyValueStore.ts
@@ -197,7 +197,20 @@ export const layerFileSystem = (directory: string) =>
     Effect.gen(function*() {
       const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
-      const keyPath = (key: string) => path.join(directory, encodeURIComponent(key))
+      const withKeyPath = <A>(
+        method: string,
+        key: string,
+        f: (path: string) => Effect.Effect<A, PlatformError.PlatformError>
+      ): Effect.Effect<A, PlatformError.PlatformError> =>
+        key.length === 0 || key === "." || key === ".."
+          ? Effect.fail(
+            new PlatformError.BadArgument({
+              module: "KeyValueStore",
+              method,
+              description: "Key must not be empty, . or .."
+            })
+          )
+          : f(path.join(directory, encodeURIComponent(key)))
 
       if (!(yield* fs.exists(directory))) {
         yield* fs.makeDirectory(directory, { recursive: true })
@@ -205,25 +218,30 @@ export const layerFileSystem = (directory: string) =>
 
       return make({
         get: (key: string) =>
-          pipe(
-            Effect.map(fs.readFileString(keyPath(key)), Option.some),
-            Effect.catchTag(
-              "SystemError",
-              (sysError) => sysError.reason === "NotFound" ? Effect.succeed(Option.none()) : Effect.fail(sysError)
-            )
-          ),
+          withKeyPath("get", key, (path) =>
+            pipe(
+              Effect.map(fs.readFileString(path), Option.some),
+              Effect.catchTag(
+                "SystemError",
+                (sysError) => sysError.reason === "NotFound" ? Effect.succeed(Option.none()) : Effect.fail(sysError)
+              )
+            )),
         getUint8Array: (key: string) =>
-          pipe(
-            Effect.map(fs.readFile(keyPath(key)), Option.some),
-            Effect.catchTag(
-              "SystemError",
-              (sysError) => sysError.reason === "NotFound" ? Effect.succeed(Option.none()) : Effect.fail(sysError)
-            )
-          ),
+          withKeyPath("getUint8Array", key, (path) =>
+            pipe(
+              Effect.map(fs.readFile(path), Option.some),
+              Effect.catchTag(
+                "SystemError",
+                (sysError) => sysError.reason === "NotFound" ? Effect.succeed(Option.none()) : Effect.fail(sysError)
+              )
+            )),
         set: (key: string, value: string | Uint8Array) =>
-          typeof value === "string" ? fs.writeFileString(keyPath(key), value) : fs.writeFile(keyPath(key), value),
-        remove: (key: string) => fs.remove(keyPath(key)),
-        has: (key: string) => fs.exists(keyPath(key)),
+          withKeyPath("set", key, (path) =>
+            typeof value === "string" ? fs.writeFileString(path, value) : fs.writeFile(path, value)),
+        remove: (key: string) =>
+          withKeyPath("remove", key, fs.remove),
+        has: (key: string) =>
+          withKeyPath("has", key, fs.exists),
         clear: Effect.zipRight(
           fs.remove(directory, { recursive: true }),
           fs.makeDirectory(directory, { recursive: true })


### PR DESCRIPTION
## Summary

- port the file-backed key validation from #6772 to v3 using `PlatformError.BadArgument`
- document filename encoding, filesystem case sensitivity, and `clear` directory ownership
- cover every key operation with Node-backed filesystem preservation tests

This is a defensive hardening change for keys that already failed in normal use, not a security advisory fix.

## Testing

- `pnpm lint`
- `pnpm --filter @effect/platform check`
- `pnpm --filter @effect/platform-node-shared check`
- `pnpm --filter @effect/platform-node-shared test --run test/KeyValueStore.test.ts`

Closes EFF-219
