### PR TITLE
Fix KeyValueStore file backend docs

### DIFF
--- a/packages/platform/src/KeyValueStore.ts
+++ b/packages/platform/src/KeyValueStore.ts
@@ -139,6 +139,12 @@ export const prefix: {
 } = internal.prefix
 
 /**
+ * @since 1.0.0
+ * @category layers
+ */
+export const layerMemory: Layer.Layer<KeyValueStore> = internal.layerMemory
+
+/**
  * Provides a file-backed key-value store in the specified directory.
  *
  * Keys are percent-encoded as single file names. Empty keys, `.` and `..` are
@@ -148,12 +154,6 @@ export const prefix: {
  * `clear` removes the directory recursively, so it must not be shared with
  * unrelated data.
  *
- * @since 1.0.0
- * @category layers
- */
-export const layerMemory: Layer.Layer<KeyValueStore> = internal.layerMemory
-
-/**
  * @since 1.0.0
  * @category layers
  */


### PR DESCRIPTION
## Summary

- restore generic layer documentation for layerMemory
- attach the file key and directory ownership contract to layerFileSystem

## Verification

- pnpm lint-fix
- pnpm test run packages/platform-node-shared/test/KeyValueStore.test.ts
- pnpm check
- pnpm build
- pnpm docgen

Closes EFF-223