### PR TITLE
Bound pending SSE decoder state

### DIFF
--- a/.changeset/eff-218-bound-sse-pending-state.md
+++ b/.changeset/eff-218-bound-sse-pending-state.md
@@ -1,0 +1,10 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+"@effect/openapi-generator": patch
+---
+
+Bound pending SSE decoder state with a configurable maximum event size.

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -52,7 +52,7 @@ export interface Service {
     schema: S
   ) => (request: HttpClientRequest.HttpClientRequest) => Stream.Stream<
     S["Type"],
-    HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError,
     S["DecodingServices"]
   >
 
@@ -259,7 +259,7 @@ export const make = Effect.fnUntraced(
       <S extends Sse.EventCodec>(schema: S) =>
       (request: HttpClientRequest.HttpClientRequest): Stream.Stream<
         S["Type"],
-        HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry,
+        HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError,
         S["DecodingServices"]
       > =>
         httpClientOk.execute(request).pipe(
@@ -312,6 +312,7 @@ export const make = Effect.fnUntraced(
         Stream.catchTags({
           // TODO: handle SSE retries
           Retry: (error) => Stream.die(error),
+          SseError: (error) => Stream.fail(Errors.mapSseError(error, "createMessageStream")),
           HttpClientError: (error) => Stream.fromEffect(Errors.mapHttpClientError(error, "createMessageStream")),
           SchemaError: (error) => Stream.fail(Errors.mapSchemaError(error, "createMessageStream"))
         })

--- a/packages/ai/anthropic/src/internal/errors.ts
+++ b/packages/ai/anthropic/src/internal/errors.ts
@@ -8,6 +8,7 @@ import * as Redactable from "effect/Redactable"
 import * as Schema from "effect/Schema"
 import * as AiError from "effect/unstable/ai/AiError"
 import type * as Response from "effect/unstable/ai/Response"
+import type * as Sse from "effect/unstable/encoding/Sse"
 import type * as HttpClientError from "effect/unstable/http/HttpClientError"
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
@@ -50,6 +51,17 @@ export const mapSchemaError = dual<
     module: "AnthropicClient",
     method,
     reason: AiError.InvalidOutputError.fromSchemaError(error)
+  }))
+
+/** @internal */
+export const mapSseError = dual<
+  (method: string) => (error: Sse.SseError) => AiError.AiError,
+  (error: Sse.SseError, method: string) => AiError.AiError
+>(2, (error, method) =>
+  AiError.make({
+    module: "AnthropicClient",
+    method,
+    reason: new AiError.InvalidOutputError({ description: error.message })
   }))
 
 /** @internal */

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -218,6 +218,7 @@ export const make = Effect.fnUntraced(
         Stream.takeUntil((event) => event === "[DONE]"),
         Stream.catchTags({
           Retry: (error) => Stream.die(error),
+          SseError: (error) => Stream.fail(Errors.mapSseError(error, "createResponseStream")),
           HttpClientError: (error) => Stream.fromEffect(Errors.mapHttpClientError(error, "createResponseStream"))
         })
       ) as any

--- a/packages/ai/openai-compat/src/internal/errors.ts
+++ b/packages/ai/openai-compat/src/internal/errors.ts
@@ -10,6 +10,7 @@ import * as SchemaTransformation from "effect/SchemaTransformation"
 import * as String from "effect/String"
 import * as AiError from "effect/unstable/ai/AiError"
 import type * as Response from "effect/unstable/ai/Response"
+import type * as Sse from "effect/unstable/encoding/Sse"
 import type * as HttpClientError from "effect/unstable/http/HttpClientError"
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
@@ -47,6 +48,17 @@ export const mapSchemaError = dual<
     module: "OpenAiClient",
     method,
     reason: AiError.InvalidOutputError.fromSchemaError(error)
+  }))
+
+/** @internal */
+export const mapSseError = dual<
+  (method: string) => (error: Sse.SseError) => AiError.AiError,
+  (error: Sse.SseError, method: string) => AiError.AiError
+>(2, (error, method) =>
+  AiError.make({
+    module: "OpenAiClient",
+    method,
+    reason: new AiError.InvalidOutputError({ description: error.message })
   }))
 
 /** @internal */

--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -30441,7 +30441,7 @@ export const make = (
     request: HttpClientRequest.HttpClientRequest
   ): Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     DecodingServices
   > =>
     HttpClient.filterStatusOk(httpClient).execute(request).pipe(
@@ -32832,7 +32832,7 @@ export interface OpenAiClient {
     options: { readonly payload: typeof CreateSpeechRequestJson.Encoded }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateSpeech200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateSpeech200Sse.DecodingServices
   >
   /**
@@ -32868,7 +32868,7 @@ export interface OpenAiClient {
     options: { readonly payload: typeof CreateTranscriptionRequestFormData.Encoded }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateTranscription200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateTranscription200Sse.DecodingServices
   >
   /**
@@ -33058,7 +33058,7 @@ export interface OpenAiClient {
     options: { readonly payload: typeof CreateChatCompletionRequestJson.Encoded }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateChatCompletion200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateChatCompletion200Sse.DecodingServices
   >
   /**
@@ -33659,7 +33659,7 @@ export interface OpenAiClient {
     options: { readonly payload: typeof CreateImageEditRequestFormData.Encoded }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateImageEdit200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateImageEdit200Sse.DecodingServices
   >
   /**
@@ -33678,7 +33678,7 @@ export interface OpenAiClient {
     options: { readonly payload: typeof CreateImageRequestJson.Encoded }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateImage200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateImage200Sse.DecodingServices
   >
   /**
@@ -34879,7 +34879,7 @@ export interface OpenAiClient {
     options: { readonly payload: typeof CreateResponseRequestJson.Encoded }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateResponse200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateResponse200Sse.DecodingServices
   >
   /**

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -276,6 +276,7 @@ export const make = Effect.fnUntraced(
         Stream.catchTags({
           // TODO: handle SSE retries
           Retry: (error) => Stream.die(error),
+          SseError: (error) => Stream.fail(Errors.mapSseError(error, "createResponseStream")),
           HttpClientError: (error) => Stream.fromEffect(Errors.mapHttpClientError(error, "createResponseStream")),
           SchemaError: (error) => Stream.fail(Errors.mapSchemaError(error, "createResponseStream"))
         })

--- a/packages/ai/openai/src/internal/errors.ts
+++ b/packages/ai/openai/src/internal/errors.ts
@@ -8,6 +8,7 @@ import * as Redactable from "effect/Redactable"
 import * as Schema from "effect/Schema"
 import * as AiError from "effect/unstable/ai/AiError"
 import type * as Response from "effect/unstable/ai/Response"
+import type * as Sse from "effect/unstable/encoding/Sse"
 import type * as HttpClientError from "effect/unstable/http/HttpClientError"
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
@@ -40,6 +41,17 @@ export const mapSchemaError = dual<
     module: "OpenAiClient",
     method,
     reason: AiError.InvalidOutputError.fromSchemaError(error)
+  }))
+
+/** @internal */
+export const mapSseError = dual<
+  (method: string) => (error: Sse.SseError) => AiError.AiError,
+  (error: Sse.SseError, method: string) => AiError.AiError
+>(2, (error, method) =>
+  AiError.make({
+    module: "OpenAiClient",
+    method,
+    reason: new AiError.InvalidOutputError({ description: error.message })
   }))
 
 /** @internal */

--- a/packages/ai/openrouter/src/Generated.ts
+++ b/packages/ai/openrouter/src/Generated.ts
@@ -32803,7 +32803,7 @@ export const make = (
     request: HttpClientRequest.HttpClientRequest
   ): Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     DecodingServices
   > =>
     HttpClient.filterStatusOk(httpClient).execute(request).pipe(
@@ -34824,7 +34824,7 @@ export interface OpenRouterClient {
       readonly id: string | undefined
       readonly data: typeof SendChatCompletionRequest200Sse.Type
     },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof SendChatCompletionRequest200Sse.DecodingServices
   >
   /**
@@ -35005,7 +35005,7 @@ export interface OpenRouterClient {
     }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateEmbeddings200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateEmbeddings200Sse.DecodingServices
   >
   /**
@@ -35450,7 +35450,7 @@ export interface OpenRouterClient {
     }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateImages200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateImages200Sse.DecodingServices
   >
   /**
@@ -35619,7 +35619,7 @@ export interface OpenRouterClient {
     }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateMessages200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateMessages200Sse.DecodingServices
   >
   /**
@@ -35987,7 +35987,7 @@ export interface OpenRouterClient {
     }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateRerank200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateRerank200Sse.DecodingServices
   >
   /**
@@ -36028,7 +36028,7 @@ export interface OpenRouterClient {
     }
   ) => Stream.Stream<
     { readonly event: string; readonly id: string | undefined; readonly data: typeof CreateResponses200Sse.Type },
-    HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+    HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
     typeof CreateResponses200Sse.DecodingServices
   >
   /**

--- a/packages/ai/openrouter/src/OpenRouterClient.ts
+++ b/packages/ai/openrouter/src/OpenRouterClient.ts
@@ -228,6 +228,7 @@ export const make = Effect.fnUntraced(
         Stream.catchTags({
           // TODO: handle SSE retries
           Retry: (error) => Stream.die(error),
+          SseError: (error) => Stream.fail(Errors.mapSseError(error, "createChatCompletionStream")),
           HttpClientError: (error) => Stream.fromEffect(Errors.mapHttpClientError(error, "createChatCompletionStream")),
           SchemaError: (error) => Stream.fail(Errors.mapSchemaError(error, "createChatCompletionStream"))
         })

--- a/packages/ai/openrouter/src/internal/errors.ts
+++ b/packages/ai/openrouter/src/internal/errors.ts
@@ -8,6 +8,7 @@ import * as Redactable from "effect/Redactable"
 import * as Schema from "effect/Schema"
 import * as AiError from "effect/unstable/ai/AiError"
 import type * as Response from "effect/unstable/ai/Response"
+import type * as Sse from "effect/unstable/encoding/Sse"
 import type * as HttpClientError from "effect/unstable/http/HttpClientError"
 import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
@@ -50,6 +51,17 @@ export const mapSchemaError = dual<
     module: "OpenRouterClient",
     method,
     reason: AiError.InvalidOutputError.fromSchemaError(error)
+  }))
+
+/** @internal */
+export const mapSseError = dual<
+  (method: string) => (error: Sse.SseError) => AiError.AiError,
+  (error: Sse.SseError, method: string) => AiError.AiError
+>(2, (error, method) =>
+  AiError.make({
+    module: "OpenRouterClient",
+    method,
+    reason: new AiError.InvalidOutputError({ description: error.message })
   }))
 
 /** @internal */

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -22,6 +22,50 @@ import * as Result from "../../Result.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaTransformation from "../../SchemaTransformation.ts"
 
+const SseErrorTypeId = "~effect/encoding/Sse/SseError"
+
+/**
+ * Error raised when decoding a Server-Sent Events stream fails.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class SseError extends Data.TaggedError("SseError")<{
+  readonly reason: "EventTooLarge"
+  readonly maxEventSize: number
+}> {
+  /**
+   * Marks this value as an SSE decoding error.
+   *
+   * @since 4.0.0
+   */
+  readonly [SseErrorTypeId] = SseErrorTypeId
+
+  /**
+   * Describes the pending event size limit that was exceeded.
+   *
+   * @since 4.0.0
+   */
+  override get message() {
+    return `Pending SSE event exceeded the maximum size of ${this.maxEventSize}`
+  }
+}
+
+/**
+ * Options for decoding Server-Sent Events streams.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export interface DecodeOptions {
+  /**
+   * Maximum number of string code units retained for a pending event. The default is 10 MiB.
+   */
+  readonly maxEventSize?: number | undefined
+}
+
+const defaultMaxEventSize = 10 * 1024 * 1024
+
 /**
  * Creates a channel that parses Server-Sent Events text chunks into `Event` values.
  *
@@ -33,9 +77,9 @@ import * as SchemaTransformation from "../../SchemaTransformation.ts"
  * @category decoding
  * @since 4.0.0
  */
-export const decode = <IE, Done>(): Channel.Channel<
+export const decode = <IE, Done>(options?: DecodeOptions): Channel.Channel<
   NonEmptyReadonlyArray<Event>,
-  IE | Retry,
+  IE | Retry | SseError,
   Done,
   NonEmptyReadonlyArray<string>,
   IE,
@@ -51,16 +95,19 @@ export const decode = <IE, Done>(): Channel.Channel<
         } else {
           buffer.push(event)
         }
-      })
+      }, options)
 
       const pump = Effect.flatMap(upstream, (arr) => {
         for (let i = 0; i < arr.length; i++) {
-          parser.feed(arr[i])
+          const error = parser.feed(arr[i])
+          if (error !== undefined) {
+            return Effect.fail(error)
+          }
         }
         return Effect.void
       })
 
-      return Effect.suspend(function loop(): Pull.Pull<NonEmptyReadonlyArray<Event>, IE | Retry, Done> {
+      return Effect.suspend(function loop(): Pull.Pull<NonEmptyReadonlyArray<Event>, IE | Retry | SseError, Done> {
         if (Arr.isArrayNonEmpty(buffer)) {
           const out = buffer
           buffer = []
@@ -108,10 +155,11 @@ export const decodeSchema = <
   IE,
   Done
 >(
-  schema: S
+  schema: S,
+  options?: DecodeOptions
 ): Channel.Channel<
   NonEmptyReadonlyArray<S["Type"]>,
-  IE | Retry | Schema.SchemaError,
+  IE | Retry | SseError | Schema.SchemaError,
   Done,
   NonEmptyReadonlyArray<string>,
   IE,
@@ -119,7 +167,7 @@ export const decodeSchema = <
   S["DecodingServices"]
 > =>
   Channel.pipeTo(
-    decode<IE, Done>(),
+    decode<IE, Done>(options),
     ChannelSchema.decode(EventEncoded.pipe(
       Schema.decodeTo(schema)
     ))()
@@ -137,14 +185,15 @@ export const decodeSchema = <
  * @since 4.0.0
  */
 export const decodeDataSchema = <Type, DecodingServices, IE, Done>(
-  schema: Schema.ConstraintDecoder<Type, DecodingServices>
+  schema: Schema.ConstraintDecoder<Type, DecodingServices>,
+  options?: DecodeOptions
 ): Channel.Channel<
   NonEmptyReadonlyArray<{
     readonly event: string
     readonly id: string | undefined
     readonly data: Type
   }>,
-  IE | Retry | Schema.SchemaError,
+  IE | Retry | SseError | Schema.SchemaError,
   Done,
   NonEmptyReadonlyArray<string>,
   IE,
@@ -156,7 +205,7 @@ export const decodeDataSchema = <Type, DecodingServices, IE, Done>(
     data: Schema.fromJsonString(schema)
   })
   return Channel.pipeTo(
-    decode<IE, Done>(),
+    decode<IE, Done>(options),
     Channel.map(
       ChannelSchema.decode(eventSchema)(),
       Arr.map((event) => ({ ...event, id: event.id }))
@@ -170,12 +219,15 @@ export const decodeDataSchema = <Type, DecodingServices, IE, Done>(
  * **Details**
  *
  * Call `feed` with text chunks to parse `Event` and `Retry` values through the
- * callback, and call `reset` to clear any buffered event state.
+ * callback, and call `reset` to clear any buffered event state. `feed` returns
+ * an `SseError` if the pending event exceeds `maxEventSize`.
  *
  * @category decoding
  * @since 4.0.0
  */
-export function makeParser(onParse: (event: AnyEvent) => void): Parser {
+export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeOptions): Parser {
+  const maxEventSize = options?.maxEventSize ?? defaultMaxEventSize
+
   // Processing state
   let isFirstChunk: boolean
   let buffer: string
@@ -202,7 +254,7 @@ export function makeParser(onParse: (event: AnyEvent) => void): Parser {
     data = ""
   }
 
-  function feed(chunk: string): void {
+  function feed(chunk: string): SseError | undefined {
     buffer = buffer ? buffer + chunk : chunk
 
     // Strip any UTF8 byte order mark (BOM) at the start of the stream.
@@ -271,6 +323,12 @@ export function makeParser(onParse: (event: AnyEvent) => void): Parser {
       // portion of the buffer only
       buffer = buffer.slice(position)
     }
+
+    if (buffer.length + data.length > maxEventSize) {
+      const error = new SseError({ reason: "EventTooLarge", maxEventSize })
+      reset()
+      return error
+    }
   }
 
   function parseEventStreamLine(
@@ -338,13 +396,15 @@ function hasBom(buffer: string) {
  *
  * **Details**
  *
- * `feed` accepts additional text chunks and `reset` clears buffered parser state.
+ * `feed` accepts additional text chunks and returns an `SseError` when the
+ * configured pending event size is exceeded. `reset` clears buffered parser
+ * state.
  *
  * @category decoding
  * @since 4.0.0
  */
 export interface Parser {
-  feed(chunk: string): void
+  feed(chunk: string): SseError | undefined
   reset(): void
 }
 

--- a/packages/effect/src/unstable/encoding/Sse.ts
+++ b/packages/effect/src/unstable/encoding/Sse.ts
@@ -25,14 +25,36 @@ import * as SchemaTransformation from "../../SchemaTransformation.ts"
 const SseErrorTypeId = "~effect/encoding/Sse/SseError"
 
 /**
+ * Error reason raised when pending Server-Sent Events state exceeds the
+ * configured maximum size.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class EventTooLarge extends Data.TaggedError("EventTooLarge")<{
+  readonly maxEventSize: number
+}> {
+  override get message() {
+    return `Pending SSE event exceeded the maximum size of ${this.maxEventSize}`
+  }
+}
+
+/**
+ * Union of Server-Sent Events decoding error reasons.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export type SseErrorReason = EventTooLarge
+
+/**
  * Error raised when decoding a Server-Sent Events stream fails.
  *
  * @category errors
  * @since 4.0.0
  */
 export class SseError extends Data.TaggedError("SseError")<{
-  readonly reason: "EventTooLarge"
-  readonly maxEventSize: number
+  readonly reason: SseErrorReason
 }> {
   /**
    * Marks this value as an SSE decoding error.
@@ -42,12 +64,12 @@ export class SseError extends Data.TaggedError("SseError")<{
   readonly [SseErrorTypeId] = SseErrorTypeId
 
   /**
-   * Describes the pending event size limit that was exceeded.
+   * Delegates the public message to the underlying SSE error reason.
    *
    * @since 4.0.0
    */
   override get message() {
-    return `Pending SSE event exceeded the maximum size of ${this.maxEventSize}`
+    return this.reason.message
   }
 }
 
@@ -325,7 +347,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
     }
 
     if (buffer.length + data.length > maxEventSize) {
-      const error = new SseError({ reason: "EventTooLarge", maxEventSize })
+      const error = new SseError({ reason: new EventTooLarge({ maxEventSize }) })
       reset()
       return error
     }

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -75,7 +75,7 @@ type SuccessType<S> = S extends HttpApiSchema.StreamSse<
   infer _Value
 > ? Stream.Stream<
     _Value,
-    _Error["Type"] | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry,
+    _Error["Type"] | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError,
     never
   >
   : S extends HttpApiSchema.StreamUint8Array ? Stream.Stream<Uint8Array, HttpClientError.HttpClientError, never>

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -59,4 +59,65 @@ describe("Sse", () => {
         }
       }])
     }))
+
+  it.effect("fails when an unterminated line exceeds maxEventSize", () =>
+    Effect.gen(function*() {
+      const error = yield* Stream.make("12345").pipe(
+        Stream.pipeThroughChannel(Sse.decode({ maxEventSize: 4 })),
+        Stream.runCollect,
+        Effect.flip
+      )
+
+      assert.instanceOf(error, Sse.SseError)
+      assert.strictEqual(error.reason, "EventTooLarge")
+      assert.strictEqual(error.maxEventSize, 4)
+    }))
+
+  it.effect("fails when pending data exceeds maxEventSize", () =>
+    Effect.gen(function*() {
+      const error = yield* Stream.make("data: a\n", "data: b\n").pipe(
+        Stream.pipeThroughChannel(Sse.decode({ maxEventSize: 3 })),
+        Stream.runCollect,
+        Effect.flip
+      )
+
+      assert.instanceOf(error, Sse.SseError)
+      assert.strictEqual(error.reason, "EventTooLarge")
+      assert.strictEqual(error.maxEventSize, 3)
+    }))
+
+  it.effect("parses pending state just under maxEventSize", () =>
+    Effect.gen(function*() {
+      const events = yield* Stream.make("data: a\ndata: b", "\n\n").pipe(
+        Stream.pipeThroughChannel(Sse.decode({ maxEventSize: 10 })),
+        Stream.runCollect
+      )
+
+      assert.deepStrictEqual([...events], [{
+        _tag: "Event",
+        event: "message",
+        id: undefined,
+        data: "a\nb"
+      }])
+    }))
+
+  it.effect("parses well-formed events split across chunks", () =>
+    Effect.gen(function*() {
+      const events = yield* Stream.make(
+        "id: 1\nevent: up",
+        "date\ndata: hel",
+        "lo\n",
+        "\n"
+      ).pipe(
+        Stream.pipeThroughChannel(Sse.decode()),
+        Stream.runCollect
+      )
+
+      assert.deepStrictEqual([...events], [{
+        _tag: "Event",
+        event: "update",
+        id: "1",
+        data: "hello"
+      }])
+    }))
 })

--- a/packages/effect/test/unstable/encoding/Sse.test.ts
+++ b/packages/effect/test/unstable/encoding/Sse.test.ts
@@ -69,8 +69,8 @@ describe("Sse", () => {
       )
 
       assert.instanceOf(error, Sse.SseError)
-      assert.strictEqual(error.reason, "EventTooLarge")
-      assert.strictEqual(error.maxEventSize, 4)
+      assert.instanceOf(error.reason, Sse.EventTooLarge)
+      assert.strictEqual(error.reason.maxEventSize, 4)
     }))
 
   it.effect("fails when pending data exceeds maxEventSize", () =>
@@ -82,8 +82,8 @@ describe("Sse", () => {
       )
 
       assert.instanceOf(error, Sse.SseError)
-      assert.strictEqual(error.reason, "EventTooLarge")
-      assert.strictEqual(error.maxEventSize, 3)
+      assert.instanceOf(error.reason, Sse.EventTooLarge)
+      assert.strictEqual(error.reason.maxEventSize, 3)
     }))
 
   it.effect("parses pending state just under maxEventSize", () =>

--- a/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
@@ -621,7 +621,7 @@ describe("HttpApiClient", () => {
       type StreamError = { readonly reason: string }
       type ClientStream = Stream.Stream<
         Event,
-        StreamError | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry
+        StreamError | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError
       >
 
       expect(f()).type.toBe<
@@ -663,7 +663,7 @@ describe("HttpApiClient", () => {
       type StreamError = { readonly reason: string }
       type ClientStream = Stream.Stream<
         Data,
-        StreamError | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry
+        StreamError | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError
       >
 
       expect(f()).type.toBe<
@@ -697,7 +697,7 @@ describe("HttpApiClient", () => {
       type Data = { readonly id: string }
       type ClientStream = Stream.Stream<
         Data,
-        HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry
+        HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError
       >
 
       expect(f()).type.toBe<
@@ -764,7 +764,7 @@ describe("HttpApiClient", () => {
 
       type ClientStream = Stream.Stream<
         Event,
-        StreamError | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry
+        StreamError | HttpClientError.HttpClientError | Schema.SchemaError | Sse.Retry | Sse.SseError
       >
 
       expect(f({ responseMode: "decoded-only" })).type.toBe<

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -186,7 +186,7 @@ ${clientErrorSource(name)}`
       ? `typeof ${operation.sseSchema}.Type`
       : `{ readonly event: string; readonly id: string | undefined; readonly data: typeof ${operation.sseSchema}.Type }`
     const returnType =
-      `Stream.Stream<${value}, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof ${operation.sseSchema}.DecodingServices>`
+      `Stream.Stream<${value}, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof ${operation.sseSchema}.DecodingServices>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
@@ -938,7 +938,7 @@ const sseRequestSource = (_importName: string) =>
       request: HttpClientRequest.HttpClientRequest
     ): Stream.Stream<
       { readonly event: string; readonly id: string | undefined; readonly data: Type },
-      HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+      HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
       DecodingServices
     > =>
       HttpClient.filterStatusOk(httpClient).execute(request).pipe(
@@ -953,7 +953,7 @@ const sseEventRequestSource = `const sseEventRequest = <S extends Sse.EventCodec
       request: HttpClientRequest.HttpClientRequest
     ): Stream.Stream<
       S["Type"],
-      HttpClientError.HttpClientError | SchemaError | Sse.Retry,
+      HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError,
       S["DecodingServices"]
     > =>
       HttpClient.filterStatusOk(httpClient).execute(request).pipe(

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -518,7 +518,7 @@ export const TestClientError = <Tag extends string, E>(
         },
         [
           `import * as Sse from "effect/unstable/encoding/Sse"`,
-          `readonly "streamEventsSse": () => Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: typeof StreamEvents200Sse.Type }, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof StreamEvents200Sse.DecodingServices>`,
+          `readonly "streamEventsSse": () => Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: typeof StreamEvents200Sse.Type }, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
           `"streamEventsSse": () => HttpClientRequest.get(\`/events\`).pipe(`,
           `sseRequest(StreamEvents200Sse)`,
           `schema: Schema.ConstraintDecoder<Type, DecodingServices>`
@@ -580,7 +580,7 @@ export const TestClientError = <Tag extends string, E>(
         [
           `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("message"), "data": Schema.String`,
           `"id": Schema.optionalKey(Schema.String), "event": Schema.Literal("effect/httpapi/stream/failure"), "data": Schema.String`,
-          `readonly "streamEventsSse": () => Stream.Stream<typeof StreamEvents200Sse.Type, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof StreamEvents200Sse.DecodingServices>`,
+          `readonly "streamEventsSse": () => Stream.Stream<typeof StreamEvents200Sse.Type, HttpClientError.HttpClientError | SchemaError | Sse.Retry | Sse.SseError, typeof StreamEvents200Sse.DecodingServices>`,
           `sseEventRequest(StreamEvents200Sse)`,
           `Stream.pipeThroughChannel(Sse.decodeSchema(schema))`
         ]


### PR DESCRIPTION
## Summary

- bound combined pending SSE line and event data state with a configurable 10 MiB default
- surface overflow as a typed `SseError` across low-level SSE stream contracts
- map provider stream overflows to `AiError.InvalidOutputError`

## Testing

- `pnpm lint-fix`
- `pnpm check`
- `pnpm --filter effect test --run test/unstable/encoding/Sse.test.ts`
- `pnpm --filter @effect/openapi-generator test --run test/OpenApiGenerator.test.ts`
- `pnpm test-types HttpApiClient.tst.ts`
- targeted Anthropic, OpenAI, OpenAI-compatible, and OpenRouter client tests

Closes EFF-218
