### PR TITLE
Bound pending SSE decoder state on v3

### DIFF
--- a/.changeset/eff-224-bound-sse-pending-state.md
+++ b/.changeset/eff-224-bound-sse-pending-state.md
@@ -1,0 +1,5 @@
+---
+"@effect/experimental": patch
+---
+
+Bound pending SSE decoder state with a configurable maximum event size.

--- a/packages/experimental/src/Sse.ts
+++ b/packages/experimental/src/Sse.ts
@@ -1,6 +1,7 @@
 /**
  * @since 1.0.0
  */
+import * as Cause from "effect/Cause"
 import * as Channel from "effect/Channel"
 import * as Chunk from "effect/Chunk"
 import * as Data from "effect/Data"
@@ -10,13 +11,62 @@ import * as Mailbox from "effect/Mailbox"
 import { hasProperty } from "effect/Predicate"
 import type * as AsyncInput from "effect/SingleProducerAsyncInput"
 
+const SseErrorTypeId = "@effect/experimental/Sse/SseError"
+
+/**
+ * @since 1.0.0
+ * @category errors
+ */
+export class EventTooLarge extends Data.TaggedError("EventTooLarge")<{
+  readonly maxEventSize: number
+}> {
+  override get message() {
+    return `Pending SSE event exceeded the maximum size of ${this.maxEventSize}`
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category errors
+ */
+export type SseErrorReason = EventTooLarge
+
+/**
+ * @since 1.0.0
+ * @category errors
+ */
+export class SseError extends Data.TaggedError("SseError")<{
+  readonly reason: SseErrorReason
+}> {
+  readonly [SseErrorTypeId] = SseErrorTypeId
+
+  override get message() {
+    return this.reason.message
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
+export interface DecodeOptions {
+  /**
+   * Maximum number of string code units retained for a pending event. The default is 10 MiB.
+   */
+  readonly maxEventSize?: number | undefined
+}
+
+const defaultMaxEventSize = 10 * 1024 * 1024
+
 /**
  * @since 1.0.0
  * @category constructors
  */
-export const makeChannel = <IE, Done>(options?: {
-  readonly bufferSize?: number
-}): Channel.Channel<
+export const makeChannel = <IE, Done>(
+  options?: DecodeOptions & {
+    readonly bufferSize?: number
+  }
+): Channel.Channel<
   Chunk.Chunk<Event>,
   Chunk.Chunk<string>,
   IE,
@@ -35,7 +85,7 @@ export const makeChannel = <IE, Done>(options?: {
           case "Event":
             return events.push(event)
         }
-      })
+      }, options)
       const input: AsyncInput.AsyncInputProducer<
         IE,
         Chunk.Chunk<string>,
@@ -45,10 +95,17 @@ export const makeChannel = <IE, Done>(options?: {
           return Effect.void
         },
         emit(chunks) {
-          Chunk.forEach(chunks, parser.feed)
+          let error: SseError | undefined
+          Chunk.forEach(chunks, (chunk) => {
+            if (error === undefined) {
+              error = parser.feed(chunk)
+            }
+          })
           const toEmit = events
           events = []
-          return retry
+          return error
+            ? Effect.zipRight(mailbox.offerAll(toEmit), mailbox.failCause(Cause.die(error)))
+            : retry
             ? Effect.zipRight(mailbox.offerAll(toEmit), mailbox.fail(retry))
             : mailbox.offerAll(toEmit)
         },
@@ -86,11 +143,14 @@ export const makeChannel = <IE, Done>(options?: {
  * Create a SSE parser.
  *
  * Adapted from https://github.com/rexxars/eventsource-parser under MIT license.
+ * `feed` returns an `SseError` if the pending event exceeds `maxEventSize`.
  *
  * @since 1.0.0
  * @category constructors
  */
-export function makeParser(onParse: (event: AnyEvent) => void): Parser {
+export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeOptions): Parser {
+  const maxEventSize = options?.maxEventSize ?? defaultMaxEventSize
+
   // Processing state
   let isFirstChunk: boolean
   let buffer: string
@@ -117,7 +177,7 @@ export function makeParser(onParse: (event: AnyEvent) => void): Parser {
     data = ""
   }
 
-  function feed(chunk: string): void {
+  function feed(chunk: string): SseError | undefined {
     buffer = buffer ? buffer + chunk : chunk
 
     // Strip any UTF8 byte order mark (BOM) at the start of the stream.
@@ -186,6 +246,12 @@ export function makeParser(onParse: (event: AnyEvent) => void): Parser {
       // portion of the buffer only
       buffer = buffer.slice(position)
     }
+
+    if (buffer.length + data.length > maxEventSize) {
+      const error = new SseError({ reason: new EventTooLarge({ maxEventSize }) })
+      reset()
+      return error
+    }
   }
 
   function parseEventStreamLine(
@@ -253,7 +319,7 @@ function hasBom(buffer: string) {
  * @category models
  */
 export interface Parser {
-  feed(chunk: string): void
+  feed(chunk: string): SseError | undefined
   reset(): void
 }
 

--- a/packages/experimental/src/Sse.ts
+++ b/packages/experimental/src/Sse.ts
@@ -36,12 +36,12 @@ export type SseErrorReason = EventTooLarge
  * @category errors
  */
 export class SseError extends Data.TaggedError("SseError")<{
-  readonly reason: SseErrorReason
+  readonly cause: SseErrorReason
 }> {
   readonly [SseErrorTypeId] = SseErrorTypeId
 
   override get message() {
-    return this.reason.message
+    return this.cause.message
   }
 }
 
@@ -248,7 +248,7 @@ export function makeParser(onParse: (event: AnyEvent) => void, options?: DecodeO
     }
 
     if (buffer.length + data.length > maxEventSize) {
-      const error = new SseError({ reason: new EventTooLarge({ maxEventSize }) })
+      const error = new SseError({ cause: new EventTooLarge({ maxEventSize }) })
       reset()
       return error
     }

--- a/packages/experimental/test/Sse.test.ts
+++ b/packages/experimental/test/Sse.test.ts
@@ -1,0 +1,70 @@
+import * as Sse from "@effect/experimental/Sse"
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Effect, Exit, Stream } from "effect"
+
+describe("Sse", () => {
+  it.effect("fails when an unterminated line exceeds maxEventSize", () =>
+    Effect.gen(function*() {
+      const exit = yield* Stream.make("12345").pipe(
+        Stream.pipeThroughChannel(Sse.makeChannel({ maxEventSize: 4 })),
+        Stream.runCollect,
+        Effect.exit
+      )
+
+      assert(Exit.isFailure(exit))
+      const [error] = Cause.defects(exit.cause)
+      assert.instanceOf(error, Sse.SseError)
+      assert.instanceOf(error.reason, Sse.EventTooLarge)
+      assert.strictEqual(error.reason.maxEventSize, 4)
+    }))
+
+  it.effect("fails when pending data exceeds maxEventSize", () =>
+    Effect.gen(function*() {
+      const exit = yield* Stream.make("data: a\n", "data: b\n").pipe(
+        Stream.pipeThroughChannel(Sse.makeChannel({ maxEventSize: 3 })),
+        Stream.runCollect,
+        Effect.exit
+      )
+
+      assert(Exit.isFailure(exit))
+      const [error] = Cause.defects(exit.cause)
+      assert.instanceOf(error, Sse.SseError)
+      assert.instanceOf(error.reason, Sse.EventTooLarge)
+      assert.strictEqual(error.reason.maxEventSize, 3)
+    }))
+
+  it.effect("parses pending state just under maxEventSize", () =>
+    Effect.gen(function*() {
+      const events = yield* Stream.make("data: a\ndata: b", "\n\n").pipe(
+        Stream.pipeThroughChannel(Sse.makeChannel({ maxEventSize: 10 })),
+        Stream.runCollect
+      )
+
+      assert.deepStrictEqual([...events], [{
+        _tag: "Event",
+        event: "message",
+        id: undefined,
+        data: "a\nb"
+      }])
+    }))
+
+  it.effect("parses well-formed events split across chunks", () =>
+    Effect.gen(function*() {
+      const events = yield* Stream.make(
+        "id: 1\nevent: up",
+        "date\ndata: hel",
+        "lo\n",
+        "\n"
+      ).pipe(
+        Stream.pipeThroughChannel(Sse.makeChannel()),
+        Stream.runCollect
+      )
+
+      assert.deepStrictEqual([...events], [{
+        _tag: "Event",
+        event: "update",
+        id: "1",
+        data: "hello"
+      }])
+    }))
+})

--- a/packages/experimental/test/Sse.test.ts
+++ b/packages/experimental/test/Sse.test.ts
@@ -14,8 +14,8 @@ describe("Sse", () => {
       assert(Exit.isFailure(exit))
       const [error] = Cause.defects(exit.cause)
       assert.instanceOf(error, Sse.SseError)
-      assert.instanceOf(error.reason, Sse.EventTooLarge)
-      assert.strictEqual(error.reason.maxEventSize, 4)
+      assert.instanceOf(error.cause, Sse.EventTooLarge)
+      assert.strictEqual(error.cause.maxEventSize, 4)
     }))
 
   it.effect("fails when pending data exceeds maxEventSize", () =>
@@ -29,8 +29,8 @@ describe("Sse", () => {
       assert(Exit.isFailure(exit))
       const [error] = Cause.defects(exit.cause)
       assert.instanceOf(error, Sse.SseError)
-      assert.instanceOf(error.reason, Sse.EventTooLarge)
-      assert.strictEqual(error.reason.maxEventSize, 3)
+      assert.instanceOf(error.cause, Sse.EventTooLarge)
+      assert.strictEqual(error.cause.maxEventSize, 3)
     }))
 
   it.effect("parses pending state just under maxEventSize", () =>


### PR DESCRIPTION
## Summary

- bound combined pending SSE line and event data state with a configurable 10 MiB default
- return a typed `SseError` from the parser and terminate channel decoding on overflow
- cover both overflow paths and normal boundary/multi-chunk parsing

## Testing

- `pnpm lint-fix`
- `pnpm test run packages/experimental/test/Sse.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-224
