### PR TITLE
Emit MCP tool output schemas

### DIFF
--- a/.changeset/mcp-tool-output-schema.md
+++ b/.changeset/mcp-tool-output-schema.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Include typed tool output schemas in MCP `tools/list` responses.

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -1472,6 +1472,10 @@ export class Tool extends Schema.Class<Tool>(
    */
   inputSchema: Schema.Any,
   /**
+   * An optional JSON Schema object defining the expected output of the tool.
+   */
+  outputSchema: optional(Schema.Any),
+  /**
    * Optional additional tool information.
    */
   annotations: optional(ToolAnnotations),

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -888,7 +888,7 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
       name: tool.name,
       description: Tool.getDescription(tool),
       inputSchema: Tool.getJsonSchema(tool),
-      ...(tool.successSchema === Schema.Void || tool.successSchema === Schema.Unknown ? {} : {
+      ...(SchemaAST.isVoid(tool.successSchema.ast) || SchemaAST.isUnknown(tool.successSchema.ast) ? {} : {
         outputSchema: Tool.getJsonSchemaFromSchema(tool.successSchema)
       }),
       annotations: {

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -884,13 +884,12 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
     const annotations = tool.annotations
     const toolMeta = Context.getOrUndefined(annotations, Tool.Meta)
     const isDeclaredFailure = Schema.is(tool.failureSchema)
+    const outputSchema = Tool.getJsonSchemaFromSchema(tool.successSchema)
     const mcpTool = new McpTool({
       name: tool.name,
       description: Tool.getDescription(tool),
       inputSchema: Tool.getJsonSchema(tool),
-      ...(SchemaAST.isVoid(tool.successSchema.ast) || SchemaAST.isUnknown(tool.successSchema.ast) ? {} : {
-        outputSchema: Tool.getJsonSchemaFromSchema(tool.successSchema)
-      }),
+      ...(outputSchema.type === "object" ? { outputSchema } : {}),
       annotations: {
         ...(Context.getOption(tool.annotations, Tool.Title).pipe(
           Option.map((title) => ({ title })),

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -888,6 +888,9 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
       name: tool.name,
       description: Tool.getDescription(tool),
       inputSchema: Tool.getJsonSchema(tool),
+      ...(tool.successSchema === Schema.Void || tool.successSchema === Schema.Unknown ? {} : {
+        outputSchema: Tool.getJsonSchemaFromSchema(tool.successSchema)
+      }),
       annotations: {
         ...(Context.getOption(tool.annotations, Tool.Title).pipe(
           Option.map((title) => ({ title })),

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -42,14 +42,17 @@ const DefectTool = Tool.make("DefectTool", {
   success: Schema.String
 })
 
-const TestToolkit = Toolkit.make(OptionalStringTool, PublicFailureTool, InternalAiErrorTool, DefectTool)
+const UntypedTool = Tool.make("UntypedTool")
+
+const TestToolkit = Toolkit.make(OptionalStringTool, PublicFailureTool, InternalAiErrorTool, DefectTool, UntypedTool)
 type TestToolkitHandlers = Toolkit.HandlersFrom<Toolkit.Tools<typeof TestToolkit>>
 
 const testToolkitHandlers = TestToolkit.of({
   OptionalStringTool: ({ signature }) => Effect.succeed(signature ?? "omitted"),
   PublicFailureTool: () => Effect.fail(new Error("Public failure")),
   InternalAiErrorTool: () => Effect.fail(new AiError.RateLimitError({})),
-  DefectTool: () => Effect.die("private defect details")
+  DefectTool: () => Effect.die("private defect details"),
+  UntypedTool: () => Effect.void
 })
 
 const INTERNAL_TOOL_ERROR_MESSAGE = "Tool execution failed due to an internal server error."
@@ -243,6 +246,19 @@ describe("McpServer", () => {
       strictEqual(response.status, 404)
     }))
   describe("registerToolkit", () => {
+    it.effect("lists output schemas only for tools with typed success schemas", () =>
+      Effect.gen(function*() {
+        const client = yield* makeToolkitTestClient()
+
+        const result = yield* client["tools/list"]({})
+        const typedTool = result.tools.find((tool) => tool.name === "OptionalStringTool")
+        const untypedTool = result.tools.find((tool) => tool.name === "UntypedTool")
+
+        assert.deepStrictEqual(typedTool?.outputSchema, { type: "string" })
+        assertTrue(untypedTool !== undefined)
+        assert.isFalse("outputSchema" in untypedTool)
+      }))
+
     it.effect("returns concise parameter-validation errors without invoking the handler", () =>
       Effect.gen(function*() {
         let handlerInvoked = false

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -44,7 +44,18 @@ const DefectTool = Tool.make("DefectTool", {
 
 const UntypedTool = Tool.make("UntypedTool")
 
-const TestToolkit = Toolkit.make(OptionalStringTool, PublicFailureTool, InternalAiErrorTool, DefectTool, UntypedTool)
+const AnnotatedVoidTool = Tool.make("AnnotatedVoidTool", {
+  success: Schema.Void.annotate({ description: "No output" })
+})
+
+const TestToolkit = Toolkit.make(
+  OptionalStringTool,
+  PublicFailureTool,
+  InternalAiErrorTool,
+  DefectTool,
+  UntypedTool,
+  AnnotatedVoidTool
+)
 type TestToolkitHandlers = Toolkit.HandlersFrom<Toolkit.Tools<typeof TestToolkit>>
 
 const testToolkitHandlers = TestToolkit.of({
@@ -52,7 +63,8 @@ const testToolkitHandlers = TestToolkit.of({
   PublicFailureTool: () => Effect.fail(new Error("Public failure")),
   InternalAiErrorTool: () => Effect.fail(new AiError.RateLimitError({})),
   DefectTool: () => Effect.die("private defect details"),
-  UntypedTool: () => Effect.void
+  UntypedTool: () => Effect.void,
+  AnnotatedVoidTool: () => Effect.void
 })
 
 const INTERNAL_TOOL_ERROR_MESSAGE = "Tool execution failed due to an internal server error."
@@ -253,10 +265,13 @@ describe("McpServer", () => {
         const result = yield* client["tools/list"]({})
         const typedTool = result.tools.find((tool) => tool.name === "OptionalStringTool")
         const untypedTool = result.tools.find((tool) => tool.name === "UntypedTool")
+        const annotatedVoidTool = result.tools.find((tool) => tool.name === "AnnotatedVoidTool")
 
         assert.deepStrictEqual(typedTool?.outputSchema, { type: "string" })
         assertTrue(untypedTool !== undefined)
         assert.isFalse("outputSchema" in untypedTool)
+        assertTrue(annotatedVoidTool !== undefined)
+        assert.isFalse("outputSchema" in annotatedVoidTool)
       }))
 
     it.effect("returns concise parameter-validation errors without invoking the handler", () =>

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -44,6 +44,10 @@ const DefectTool = Tool.make("DefectTool", {
 
 const UntypedTool = Tool.make("UntypedTool")
 
+const StructuredResultTool = Tool.make("StructuredResultTool", {
+  success: Schema.Struct({ answer: Schema.String })
+})
+
 const AnnotatedVoidTool = Tool.make("AnnotatedVoidTool", {
   success: Schema.Void.annotate({ description: "No output" })
 })
@@ -54,6 +58,7 @@ const TestToolkit = Toolkit.make(
   InternalAiErrorTool,
   DefectTool,
   UntypedTool,
+  StructuredResultTool,
   AnnotatedVoidTool
 )
 type TestToolkitHandlers = Toolkit.HandlersFrom<Toolkit.Tools<typeof TestToolkit>>
@@ -64,6 +69,7 @@ const testToolkitHandlers = TestToolkit.of({
   InternalAiErrorTool: () => Effect.fail(new AiError.RateLimitError({})),
   DefectTool: () => Effect.die("private defect details"),
   UntypedTool: () => Effect.void,
+  StructuredResultTool: () => Effect.succeed({ answer: "result" }),
   AnnotatedVoidTool: () => Effect.void
 })
 
@@ -258,16 +264,24 @@ describe("McpServer", () => {
       strictEqual(response.status, 404)
     }))
   describe("registerToolkit", () => {
-    it.effect("lists output schemas only for tools with typed success schemas", () =>
+    it.effect("lists output schemas only for structured tool results", () =>
       Effect.gen(function*() {
         const client = yield* makeToolkitTestClient()
 
         const result = yield* client["tools/list"]({})
-        const typedTool = result.tools.find((tool) => tool.name === "OptionalStringTool")
+        const structuredTool = result.tools.find((tool) => tool.name === "StructuredResultTool")
+        const scalarTool = result.tools.find((tool) => tool.name === "OptionalStringTool")
         const untypedTool = result.tools.find((tool) => tool.name === "UntypedTool")
         const annotatedVoidTool = result.tools.find((tool) => tool.name === "AnnotatedVoidTool")
 
-        assert.deepStrictEqual(typedTool?.outputSchema, { type: "string" })
+        assert.deepStrictEqual(structuredTool?.outputSchema, {
+          type: "object",
+          properties: { answer: { type: "string" } },
+          required: ["answer"],
+          additionalProperties: false
+        })
+        assertTrue(scalarTool !== undefined)
+        assert.isFalse("outputSchema" in scalarTool)
         assertTrue(untypedTool !== undefined)
         assert.isFalse("outputSchema" in untypedTool)
         assertTrue(annotatedVoidTool !== undefined)


### PR DESCRIPTION
## Summary

- add optional MCP tool output schemas to `tools/list`
- omit `outputSchema` for tools without typed success schemas
- cover typed and untyped tools in the MCP server tests

## Testing

- `pnpm --filter effect test --run test/unstable/ai/McpServer.test.ts`
- `pnpm lint-fix`
- `pnpm check`
- `git diff --check`

Closes EFF-226
Closes #6753
