### PR TITLE
Fix Changesets GitHub query batching

### DIFF
--- a/patches/@changesets__get-github-info.patch
+++ b/patches/@changesets__get-github-info.patch
@@ -1,7 +1,22 @@
 diff --git a/dist/changesets-get-github-info.cjs.js b/dist/changesets-get-github-info.cjs.js
-index 4187b5c54532a1c1c179b60cb314026f67e48323..740a894a5f8ac240a5ce1d3f12d2d77cabc0c2aa 100644
+index 4187b5c54532a1c1c179b60cb314026f67e48323..2bd6660da392bca77dab2c8d72e2c3a50f22f5f1 100644
 --- a/dist/changesets-get-github-info.cjs.js
 +++ b/dist/changesets-get-github-info.cjs.js
+@@ -216,6 +216,13 @@ const GHDataLoader = new DataLoader__default["default"](async requests => {
+     return cleanedData[repo][data.kind][data.kind === "pull" ? data.pull : data.commit];
+   });
+-});
++}, {
++  maxBatchSize: 50,
++  cacheKeyFn: request => JSON.stringify([
++    request.repo,
++    request.kind,
++    request.kind === "pull" ? request.pull : request.commit
++  ])
++});
+ async function getInfo(request) {
+   if (!request.commit) {
+     throw new Error("Please pass a commit SHA to getInfo");
 @@ -237,16 +237,13 @@ async function getInfo(request) {
      b = new Date(b.mergedAt);
      return a > b ? 1 : a < b ? -1 : 0;
@@ -21,9 +36,24 @@ index 4187b5c54532a1c1c179b60cb314026f67e48323..740a894a5f8ac240a5ce1d3f12d2d77c
    };
  }
 diff --git a/dist/changesets-get-github-info.esm.js b/dist/changesets-get-github-info.esm.js
-index 071ec75bb2b5894f09c06d4ead395e56ddbfd1c8..9a6134e78ace53ff341ef21f0352f0bd734b6b2c 100644
+index 071ec75bb2b5894f09c06d4ead395e56ddbfd1c8..830770b9441e3aa86c1d411d7665a1957998f440 100644
 --- a/dist/changesets-get-github-info.esm.js
 +++ b/dist/changesets-get-github-info.esm.js
+@@ -207,6 +207,13 @@ const GHDataLoader = new DataLoader(async requests => {
+     return cleanedData[repo][data.kind][data.kind === "pull" ? data.pull : data.commit];
+   });
+-});
++}, {
++  maxBatchSize: 50,
++  cacheKeyFn: request => JSON.stringify([
++    request.repo,
++    request.kind,
++    request.kind === "pull" ? request.pull : request.commit
++  ])
++});
+ async function getInfo(request) {
+   if (!request.commit) {
+     throw new Error("Please pass a commit SHA to getInfo");
 @@ -228,16 +228,13 @@ async function getInfo(request) {
      b = new Date(b.mergedAt);
      return a > b ? 1 : a < b ? -1 : 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 29cf7a343aefd3c59ad238a4cb067f0a1a0adbeed07b6d57d6f31d6c80a5e25e
     path: patches/@changesets__assemble-release-plan.patch
   '@changesets/get-github-info':
-    hash: 314478eeae7ab2776d847d3b2b7ea1cd4231c65907e85597dacd0bea56355bc9
+    hash: b115194683c42c3551e1f0977acf715c8903aaf832147bd626d8f079a517a85b
     path: patches/@changesets__get-github-info.patch
 
 importers:
@@ -7556,7 +7556,7 @@ snapshots:
 
   '@changesets/changelog-github@0.7.0':
     dependencies:
-      '@changesets/get-github-info': 0.8.0(patch_hash=314478eeae7ab2776d847d3b2b7ea1cd4231c65907e85597dacd0bea56355bc9)
+      '@changesets/get-github-info': 0.8.0(patch_hash=b115194683c42c3551e1f0977acf715c8903aaf832147bd626d8f079a517a85b)
       '@changesets/types': 6.1.0
       dotenv: 8.6.0
     transitivePeerDependencies:
@@ -7615,7 +7615,7 @@ snapshots:
       picocolors: 1.1.1
       semver: 7.8.5
 
-  '@changesets/get-github-info@0.8.0(patch_hash=314478eeae7ab2776d847d3b2b7ea1cd4231c65907e85597dacd0bea56355bc9)':
+  '@changesets/get-github-info@0.8.0(patch_hash=b115194683c42c3551e1f0977acf715c8903aaf832147bd626d8f079a517a85b)':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0


### PR DESCRIPTION
## Summary

- deduplicate equivalent `@changesets/get-github-info` requests with a structural DataLoader cache key
- limit GraphQL batches to 50 lookups
- update the pnpm patch hash in the lockfile

## Context

The release workflow was sending roughly 1,466 commit lookups for 62 unique commits in one approximately 828 KB GraphQL request. DataLoader used request objects as cache keys, so equivalent requests were not deduplicated. GitHub then failed query validation with `Timeout on validation of query`.

The 50-item batch limit is fixed upstream by changesets/changesets#2121 and is published in the `1.0.0-next` line of `@changesets/get-github-info`, but not in the latest stable `0.8.0`. Upstream has also acknowledged that the structural `cacheKeyFn` fix is still missing: changesets/changesets#1925. This patch includes both protections.

## Future Upgrade

Moving the complete Changesets stack to the latest published `next` versions would require upgrading `@changesets/cli` to `3.0.0-next.10` and `@changesets/changelog-github` to `1.0.0-next.8`, which resolves `@changesets/get-github-info@1.0.0-next.4`. The new packages are ESM-only and require Node `^22.11 || ^24 || >=26`, which our release runner satisfies.

Both local pnpm patches would need to be rebased onto the new `dist/index.mjs` artifacts. The GitHub info patch must retain our commit-author/plain-mention behavior and should still add the missing structural cache key. The assemble-release-plan patch needs separate review because upstream changed peer-dependent bump behavior in `7.0.0-next`; applying our current `major` to `minor` patch mechanically would no longer preserve the same semantics.

## Validation

- `pnpm install --frozen-lockfile`
- local mock GraphQL verification: 102 loads for 51 unique commits produced two requests containing 50 and 1 lookups
- `git diff --check`
- `pnpm lint-fix` attempted; blocked by existing generated `build`/`dist` files outside `tsconfig.packages.json`
- `pnpm check` attempted; blocked by stale/missing project-reference outputs such as `platform-node-shared/dist/*.d.ts`
