### PR TITLE
Refresh v3 to v4 migration guidance

### DIFF
--- a/migration/annotations/effect__ConfigProvider.yaml
+++ b/migration/annotations/effect__ConfigProvider.yaml
@@ -1,6 +1,6 @@
 "effect/ConfigProvider#ConfigProvider":
   replacement: "ConfigProvider.ConfigProvider"
-  note: "The model remains but now exposes load(path), returning a raw Node or undefined, and has one unified provider representation."
+  note: "The model remains but now exposes `load(path)`, returning `Effect<Option<Node>, SourceError>`, and `mapInput(f)` for provider-owned path transformation. `Option.none()` means the path is missing; `Option.some(node)` means it exists."
 "effect/ConfigProvider#ConfigProvider.Flat":
   replacement: "ConfigProvider.ConfigProvider"
   note: "Flat providers were removed; implement the unified path-based provider with ConfigProvider.make."
@@ -33,7 +33,7 @@
   note: "The constructor remains; pass env and preserveEmptyStrings options. Paths use underscore semantics, while sequence separators belong on Config schemas."
 "effect/ConfigProvider#fromFlat":
   replacement: "ConfigProvider.make"
-  note: "Flat providers were unified with ConfigProvider; implement load by returning Value, Record, or Array nodes for each path."
+  note: "Flat providers were unified with ConfigProvider; implement lookup by returning `Option.some(node)` for a found `Value`, `Record`, or `Array` node, or `Option.none()` when missing."
 "effect/ConfigProvider#fromJson":
   replacement: "ConfigProvider.fromUnknown"
   note: "Renamed to reflect support for any in-memory JavaScript value."
@@ -48,10 +48,10 @@
   note: "Transform string path segments explicitly with mapInput."
 "effect/ConfigProvider#make":
   replacement: "ConfigProvider.make"
-  note: "The constructor now takes a path lookup returning Effect<Node | undefined, SourceError>, rather than a full Config loader and flattened provider."
+  note: "The constructor now takes a path lookup returning `Effect<Option<Node>, SourceError>`, rather than a full Config loader and flattened provider. Use `Option.none()` for a missing path and `Option.some(node)` for a found node."
 "effect/ConfigProvider#makeFlat":
   replacement: "ConfigProvider.make"
-  note: "The flat-provider constructor was removed; return Value, Record, or Array nodes from the unified path lookup."
+  note: "The flat-provider constructor was removed; return `Option.some(node)` for a found `Value`, `Record`, or `Array` node, or `Option.none()` when missing."
 "effect/ConfigProvider#mapInputPath":
   replacement: "ConfigProvider.mapInput"
   note: "Renamed and generalized: the callback receives and returns the complete Path, including numeric array indexes."

--- a/migration/annotations/effect__experimental__RequestResolver.yaml
+++ b/migration/annotations/effect__experimental__RequestResolver.yaml
@@ -7,3 +7,6 @@
 "@effect/experimental/RequestResolver#PersistedRequest.Any":
   replacement: effect/Request#Any & effect/unstable/persistence/Persistable#Any
   note: Intersect the Request and Persistable helper types for an arbitrary persisted request.
+"@effect/experimental/RequestResolver#persisted":
+  replacement: effect/RequestResolver#persisted
+  note: Retained after moving to core RequestResolver; requests now implement Persistable and use Persistence.Persistence, timeToLive is optional, and staleWhileRevalidate is supported.

--- a/migration/annotations/effect__platform__FileSystem.yaml
+++ b/migration/annotations/effect__platform__FileSystem.yaml
@@ -4,6 +4,12 @@
 "@effect/platform/FileSystem#CopyOptions":
   replacement: "NonNullable<Parameters<FileSystem.FileSystem[\"copy\"]>[2]>"
   note: "Operation option interfaces are inline in the v4 FileSystem service."
+"@effect/platform/FileSystem#File.Descriptor":
+  replacement: "none"
+  note: "Native file descriptors are no longer part of the portable File interface; use the File methods and keep any platform handle private in custom implementations."
+"@effect/platform/FileSystem#FileDescriptor":
+  replacement: "none"
+  note: "The descriptor branding constructor was removed with the public fd field; use File operations instead of exposing a native descriptor."
 "@effect/platform/FileSystem#FileTypeId":
   replacement: "typeof FileSystem.FileTypeId"
   note: "The runtime marker remains exported, but the separate type alias was removed."
@@ -56,8 +62,8 @@
   replacement: "FileSystem.WatchEvent.Update"
   note: "The constructor was removed; construct a tagged object with _tag: \"Update\" and path."
 "@effect/platform/FileSystem#WatchOptions":
-  replacement: "none"
-  note: "FileSystem.watch now accepts only a path; the recursive watch option was removed."
+  replacement: "FileSystem.WatchOptions"
+  note: "Retained after moving the module to effect/FileSystem; pass `{ recursive: true }` as the optional second argument to FileSystem.watch."
 "@effect/platform/FileSystem#WriteFileOptions":
   replacement: "NonNullable<Parameters<FileSystem.FileSystem[\"writeFile\"]>[2]>"
   note: "Operation option interfaces are inline in the v4 FileSystem service."

--- a/migration/annotations/effect__rpc__Rpc.yaml
+++ b/migration/annotations/effect__rpc__Rpc.yaml
@@ -67,3 +67,6 @@
 "@effect/rpc/Rpc#WrapperTypeId":
   replacement: "none"
   note: "The wrapper marker is private in v4; use Rpc.isWrapper and the public Wrapper type."
+"@effect/rpc/Rpc#wrap":
+  replacement: "effect/unstable/rpc/Rpc#wrap"
+  note: "Retained after the module move; it still applies fork and uninterruptible handler options, while the return type is now uniformly Rpc.Wrapper."

--- a/migration/annotations/effect__sql__Model.yaml
+++ b/migration/annotations/effect__sql__Model.yaml
@@ -13,6 +13,9 @@
 "@effect/sql/Model#DateTimeFromDate":
   replacement: "effect/Schema#DateTimeUtcFromDate"
   note: "Moved to core Schema and retains Date to DateTime.Utc conversion."
+"@effect/sql/Model#extract":
+  replacement: "effect/unstable/schema/Model#extract"
+  note: "Retained after moving the model variant helpers into core Effect's unstable schema package."
 "@effect/sql/Model#fieldFromKey":
   replacement: "effect/Schema#encodeKeys"
   note: "The field helper was removed; apply encodeKeys to each concrete struct or model-variant schema that crosses the naming boundary."

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -4,7 +4,7 @@
 
 Base: `v3` (`3d390f232bdbc3f0d3d6a2ae3c775084f494b547`)
 
-Head: `main` (`0a532e503f165fdea485a5343fc2f420917e8376`)
+Head: `main` (`24e0e93dc307dc2c2ae86caacb7289e1dab3c103`)
 
 This file is generated from the API diff and `migration/annotations/*.yaml`.
 
@@ -5971,6 +5971,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `RequestResolver.dataLoader` -> `effect/RequestResolver#setDelay + effect/RequestResolver#batchN`: Pipe the resolver through setDelay(options.window) and batchN(options.maxBatchSize ?? Infinity); the transformation is now pure.
 
+- `RequestResolver.persisted` -> `effect/RequestResolver#persisted`: Retained after moving to core RequestResolver; requests now implement Persistable and use Persistence.Persistence, timeToLive is optional, and staleWhileRevalidate is supported.
+
 ### `@effect/experimental/Sse`
 
 - `Sse.RetryTypeId` -> `none`: The Retry identifier is private in v4; use effect/unstable/encoding/Sse#Retry and Retry.is instead of inspecting the brand.
@@ -6439,6 +6441,10 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `FileSystem.CopyOptions` -> `NonNullable<Parameters<FileSystem.FileSystem["copy"]>[2]>`: Operation option interfaces are inline in the v4 FileSystem service.
 
+- `FileSystem.File.Descriptor` -> `none`: Native file descriptors are no longer part of the portable File interface; use the File methods and keep any platform handle private in custom implementations.
+
+- `FileSystem.FileDescriptor` -> `none`: The descriptor branding constructor was removed with the public fd field; use File operations instead of exposing a native descriptor.
+
 - `FileSystem.FileTypeId` -> `typeof FileSystem.FileTypeId`: The runtime marker remains exported, but the separate type alias was removed.
 
 - `FileSystem.MakeDirectoryOptions` -> `NonNullable<Parameters<FileSystem.FileSystem["makeDirectory"]>[1]>`: Operation option interfaces are inline in the v4 FileSystem service.
@@ -6463,7 +6469,7 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `FileSystem.WatchEventUpdate` -> `FileSystem.WatchEvent.Update`: The constructor was removed; construct a tagged object with \_tag: "Update" and path.
 
-- `FileSystem.WatchOptions` -> `none`: FileSystem.watch now accepts only a path; the recursive watch option was removed.
+- `FileSystem.WatchOptions` -> `FileSystem.WatchOptions`: Retained after moving the module to effect/FileSystem; pass `{ recursive: true }` as the optional second argument to FileSystem.watch.
 
 - `FileSystem.WriteFileOptions` -> `NonNullable<Parameters<FileSystem.FileSystem["writeFile"]>[2]>`: Operation option interfaces are inline in the v4 FileSystem service.
 
@@ -7493,6 +7499,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 
 - `Rpc.make` -> `effect/unstable/rpc/Rpc#make`: Retained; schemas use v4 Schema.Top constraints and the defect option accepts Rpc.DefectSchema.
 
+- `Rpc.wrap` -> `effect/unstable/rpc/Rpc#wrap`: Retained after the module move; it still applies fork and uninterruptible handler options, while the return type is now uniformly Rpc.Wrapper.
+
 ### `@effect/rpc/RpcClient`
 
 - `RpcClient.Protocol` -> `effect/unstable/rpc/RpcClient#Protocol`: Retained as a Context.Service; custom transports now route multiple client ids through run and send.
@@ -7726,6 +7734,8 @@ effect/unstable/rpc/Utils (barrel: effect/unstable/rpc)
 - `Model.DateTimeFromDate` -> `effect/Schema#DateTimeUtcFromDate`: Moved to core Schema and retains Date to DateTime.Utc conversion.
 
 - `Model.Generated` -> `effect/unstable/schema/Model#GeneratedByDb`: Renamed and now read-only, with select and json variants only. Use Model.Field with select, update, and json to preserve writable v3 behavior.
+
+- `Model.extract` -> `effect/unstable/schema/Model#extract`: Retained after moving the model variant helpers into core Effect's unstable schema package.
 
 - `Model.fieldFromKey` -> `effect/Schema#encodeKeys`: The field helper was removed; apply encodeKeys to each concrete struct or model-variant schema that crosses the naming boundary.
 


### PR DESCRIPTION
## Summary

- refresh the generated v3-to-v4 reference through main `24e0e93dc307dc2c2ae86caacb7289e1dab3c103`
- document the removal of public file descriptors and the restoration of recursive `FileSystem.watch` options
- persist the current `ConfigProvider` `Option<Node>` contract in annotations and add guidance for APIs surfaced by the doctest documentation update

## Validation

- `pnpm api-diff --base-ref 3d390f232bdbc3f0d3d6a2ae3c775084f494b547 --head-ref 24e0e93dc307dc2c2ae86caacb7289e1dab3c103 --write-doc migration/v3-to-v4.md --check`
- `pnpm lint-fix`
- `git diff --check`

Closes EFF-233