### PR TITLE
Backport cluster and workflow reliability fixes to v3

### DIFF
--- a/.changeset/bound-activity-interrupt-retries.md
+++ b/.changeset/bound-activity-interrupt-retries.md
@@ -1,0 +1,5 @@
+---
+"@effect/workflow": patch
+---
+
+Bound the default activity interrupt retry policy while retaining exponential backoff.

--- a/.changeset/fix-cluster-entity-context-bleed.md
+++ b/.changeset/fix-cluster-entity-context-bleed.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Use the entity registration context when building and running handlers.

--- a/.changeset/fix-cluster-runner-storage-iterables.md
+++ b/.changeset/fix-cluster-runner-storage-iterables.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Backport the upstream in-memory RunnerStorage fix for acquiring shards from one-shot iterables.

--- a/.changeset/fix-durable-race-replay.md
+++ b/.changeset/fix-durable-race-replay.md
@@ -1,0 +1,5 @@
+---
+"@effect/workflow": patch
+---
+
+Fix replay of persisted `DurableDeferred.raceAll` results.

--- a/.changeset/fix-workflow-entity-client-collision.md
+++ b/.changeset/fix-workflow-entity-client-collision.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Fix partial workflow clients colliding with full workflow clients.

--- a/.changeset/hash-cluster-dedupe-keys.md
+++ b/.changeset/hash-cluster-dedupe-keys.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Backport upstream SQL message deduplication handling by hashing composed keys longer than 255 characters while preserving short and legacy SQLite keys.

--- a/.changeset/isolate-cluster-runner-defects.md
+++ b/.changeset/isolate-cluster-runner-defects.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Backport upstream runner defect isolation so reply serialization and peer defects remain scoped to their request.

--- a/.changeset/propagate-workflow-trace-context.md
+++ b/.changeset/propagate-workflow-trace-context.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Propagate active trace context through persisted cluster workflow requests.

--- a/.changeset/quiet-locks-refresh.md
+++ b/.changeset/quiet-locks-refresh.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Prevent SQL runner lock operations from hanging and safely recover shard ownership after lock storage failures.

--- a/.changeset/retry-cluster-handler-construction-defects.md
+++ b/.changeset/retry-cluster-handler-construction-defects.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Retry defects raised while building entity handlers.

--- a/.changeset/tidy-lock-tables.md
+++ b/.changeset/tidy-lock-tables.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Avoid creating PostgreSQL and MySQL lock tables when advisory locks are enabled.

--- a/packages/cluster/src/ClusterWorkflowEngine.ts
+++ b/packages/cluster/src/ClusterWorkflowEngine.ts
@@ -122,6 +122,7 @@ export const make = Effect.gen(function*() {
       if (!entity) {
         return yield* Effect.dieMessage(`Workflow ${workflowName} not registered`)
       }
+      yield* RcMap.invalidate(clientsPartial, workflowName)
       return yield* entity.client
     }),
     idleTimeToLive: "5 minutes"

--- a/packages/cluster/src/ClusterWorkflowEngine.ts
+++ b/packages/cluster/src/ClusterWorkflowEngine.ts
@@ -157,12 +157,18 @@ export const make = Effect.gen(function*() {
     const payload = options.rpc.payloadSchema.make
       ? options.rpc.payloadSchema.make(options.payload)
       : options.payload
+    const span = yield* Effect.option(Effect.currentSpan)
     const envelope = Envelope.makeRequest<any>({
       requestId: yield* sharding.getSnowflake,
       address: options.address,
       tag: options.rpc._tag as any,
       payload,
-      headers: Headers.empty
+      headers: Headers.empty,
+      ...(Option.isSome(span) && {
+        traceId: span.value.traceId,
+        spanId: span.value.spanId,
+        sampled: span.value.sampled
+      })
     })
     yield* sharding.sendOutgoing(
       new Message.OutgoingRequest({

--- a/packages/cluster/src/Entity.ts
+++ b/packages/cluster/src/Entity.ts
@@ -516,11 +516,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
   const entityMap = new Map<string, {
     readonly context: Context.Context<Rpc.Context<Rpcs> | Rpc.Middleware<Rpcs> | LR>
     readonly concurrency: number | "unbounded"
-    readonly build: Effect.Effect<
-      Context.Context<Rpc.ToHandler<Rpcs>>,
-      never,
-      Scope | CurrentAddress
-    >
+    readonly build: Effect.Effect<Context.Context<Rpc.ToHandler<Rpcs>>>
   }>()
   const sharding = shardingTag.of({
     ...({} as Sharding["Type"]),
@@ -529,12 +525,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
         entityMap.set(entity.type, {
           context: context as any,
           concurrency: options?.concurrency ?? 1,
-          build: entity.protocol.toHandlersContext(handlers).pipe(
-            Effect.provide(context.pipe(
-              Context.add(CurrentRunnerAddress, runnerAddress),
-              Context.omit(Scope)
-            ))
-          ) as any
+          build: entity.protocol.toHandlersContext(handlers) as any
         })
       })
   })
@@ -550,8 +541,14 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       entityId: entityId as EntityId,
       shardId: makeShardId(entityId)
     })
+    const scope = yield* Effect.scope
+    const handlerContext = entityEntry.context.pipe(
+      Context.add(CurrentRunnerAddress, runnerAddress),
+      Context.add(CurrentAddress, address),
+      Context.add(Scope, scope)
+    )
     const handlers = yield* entityEntry.build.pipe(
-      Effect.provideService(CurrentAddress, address)
+      Effect.mapInputContext<never, never>(() => handlerContext as Context.Context<never>)
     )
 
     // eslint-disable-next-line prefer-const
@@ -561,7 +558,9 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       onFromServer(response) {
         return client.write(response)
       }
-    }).pipe(Effect.provide(handlers))
+    }).pipe(
+      Effect.mapInputContext<never, any>(() => Context.merge(handlerContext, handlers) as Context.Context<any>)
+    )
 
     client = yield* RpcClient.makeNoSerialization(entity.protocol, {
       supportsAck: true,

--- a/packages/cluster/src/HttpRunner.ts
+++ b/packages/cluster/src/HttpRunner.ts
@@ -119,7 +119,8 @@ export const toHttpEffect: Effect.Effect<
   const handlers = yield* Layer.build(RunnerServer.layerHandlers)
   return yield* RpcServer.toHttpApp(Runners.Rpcs, {
     spanPrefix: "RunnerServer",
-    disableTracing: true
+    disableTracing: true,
+    disableFatalDefects: true
   }).pipe(Effect.provide(handlers))
 })
 
@@ -135,7 +136,8 @@ export const toHttpEffectWebsocket: Effect.Effect<
   const handlers = yield* Layer.build(RunnerServer.layerHandlers)
   return yield* RpcServer.toHttpAppWebsocket(Runners.Rpcs, {
     spanPrefix: "RunnerServer",
-    disableTracing: true
+    disableTracing: true,
+    disableFatalDefects: true
   }).pipe(Effect.provide(handlers))
 })
 

--- a/packages/cluster/src/RunnerServer.ts
+++ b/packages/cluster/src/RunnerServer.ts
@@ -1,9 +1,10 @@
 /**
  * @since 1.0.0
  */
+import type * as Rpc from "@effect/rpc/Rpc"
 import * as RpcServer from "@effect/rpc/RpcServer"
 import * as Effect from "effect/Effect"
-import type * as Exit from "effect/Exit"
+import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { constant } from "effect/Function"
 import * as Layer from "effect/Layer"
@@ -21,6 +22,25 @@ import * as Sharding from "./Sharding.js"
 import { ShardingConfig } from "./ShardingConfig.js"
 
 const constVoid = constant(Effect.void)
+
+const serializeDefectReply = <R extends Rpc.Any>(
+  reply: Reply.ReplyWithContext<R>,
+  defect: unknown
+): Effect.Effect<Reply.ReplyEncoded<any>> =>
+  Effect.orDie(Reply.serialize(Reply.ReplyWithContext.fromDefect({
+    id: reply.reply.id,
+    requestId: reply.reply.requestId,
+    defect
+  })))
+
+const serializeReply = <R extends Rpc.Any>(
+  reply: Reply.ReplyWithContext<R>
+): Effect.Effect<Reply.ReplyEncoded<any>> =>
+  Effect.catchTag(
+    Reply.serialize(reply),
+    "MalformedMessage",
+    (error) => serializeDefectReply(reply, error)
+  )
 
 /**
  * @since 1.0.0
@@ -56,7 +76,7 @@ export const layerHandlers = Runners.Rpcs.toLayer(Effect.gen(function*() {
         envelope: request,
         lastSentReply: Option.none(),
         respond(reply) {
-          resume(Effect.orDie(Reply.serialize(reply)))
+          resume(serializeReply(reply))
           return Effect.void
         }
       })
@@ -111,17 +131,27 @@ export const layerHandlers = Runners.Rpcs.toLayer(Effect.gen(function*() {
             envelope: request,
             lastSentReply: Option.none(),
             respond(reply) {
-              return Effect.flatMap(Reply.serialize(reply), (reply) => {
-                mailbox.unsafeOffer(reply)
-                return Effect.void
-              })
+              return Reply.serialize(reply).pipe(
+                Effect.flatMap((reply) => {
+                  mailbox.unsafeOffer(reply)
+                  return Effect.void
+                }),
+                Effect.catchTag("MalformedMessage", (error) =>
+                  Effect.flatMap(serializeDefectReply(reply, error), (reply) => {
+                    mailbox.unsafeOffer(reply)
+                    mailbox.unsafeDone(Exit.void)
+                    return Effect.void
+                  }))
+              )
             }
           })
           return Effect.as(
             persisted ?
               Effect.zipRight(
                 storage.registerReplyHandler(message).pipe(
-                  Effect.onError((cause) => mailbox.failCause(cause)),
+                  Effect.onError((cause) =>
+                    mailbox.failCause(cause)
+                  ),
                   Effect.forkScoped,
                   Effect.interruptible
                 ),
@@ -153,7 +183,8 @@ export const layer: Layer.Layer<
   RpcServer.Protocol | Sharding.Sharding | MessageStorage.MessageStorage
 > = RpcServer.layer(Runners.Rpcs, {
   spanPrefix: "RunnerServer",
-  disableTracing: true
+  disableTracing: true,
+  disableFatalDefects: true
 }).pipe(Layer.provide(layerHandlers))
 
 /**

--- a/packages/cluster/src/RunnerStorage.ts
+++ b/packages/cluster/src/RunnerStorage.ts
@@ -197,7 +197,7 @@ export const makeMemory = Effect.gen(function*() {
     setRunnerHealth: () => Effect.void,
     acquire: (_address, shardIds) => {
       acquired = Array.from(shardIds)
-      return Effect.succeed(Array.from(shardIds))
+      return Effect.succeed(acquired)
     },
     refresh: () => Effect.sync(() => acquired),
     release: () => Effect.void,

--- a/packages/cluster/src/Runners.ts
+++ b/packages/cluster/src/Runners.ts
@@ -516,11 +516,20 @@ export const makeRpc: Effect.Effect<
               persisted: isPersisted
             })
           ),
-          Effect.catchTag("RpcClientError", Effect.die),
           Effect.scoped,
-          Effect.catchAllDefect(() => Effect.fail(new RunnerUnavailable({ address })))
+          Effect.catchTag("RpcClientError", () => Effect.fail(new RunnerUnavailable({ address })))
         )
       }
+      const respondDefect = (defect: unknown) =>
+        isPersisted
+          ? Effect.fail(new RunnerUnavailable({ address }))
+          : message.respond(
+            new Reply.WithExit({
+              id: snowflakeGen.unsafeNext(),
+              requestId: message.envelope.requestId,
+              exit: Exit.die(defect)
+            })
+          )
       const isStream = RpcSchema.isStreamSchema(rpc.successSchema)
       if (!isStream) {
         return Effect.matchEffect(Message.serializeRequest(message), {
@@ -532,7 +541,6 @@ export const makeRpc: Effect.Effect<
                   persisted: isPersisted
                 })
               ),
-              Effect.catchTag("RpcClientError", Effect.die),
               Effect.flatMap((reply) =>
                 Schema.decode(Reply.Reply(message.rpc))(reply).pipe(
                   Effect.locally(FiberRef.currentContext, message.context),
@@ -541,7 +549,8 @@ export const makeRpc: Effect.Effect<
               ),
               Effect.flatMap(message.respond),
               Effect.scoped,
-              Effect.catchAllDefect(() => Effect.fail(new RunnerUnavailable({ address })))
+              Effect.catchTag("RpcClientError", () => Effect.fail(new RunnerUnavailable({ address }))),
+              Effect.catchAllDefect(respondDefect)
             ),
           onFailure: (error) =>
             message.respond(
@@ -568,10 +577,10 @@ export const makeRpc: Effect.Effect<
                 Effect.flatMap((reply) => Effect.orDie(decode(reply))),
                 Effect.flatMap(message.respond),
                 Effect.forever,
-                Effect.catchTag("RpcClientError", Effect.die),
                 Effect.locally(FiberRef.currentContext, message.context),
                 Effect.catchIf(Cause.isNoSuchElementException, () => Effect.void),
-                Effect.catchAllDefect(() => Effect.fail(new RunnerUnavailable({ address })))
+                Effect.catchTag("RpcClientError", () => Effect.fail(new RunnerUnavailable({ address }))),
+                Effect.catchAllDefect(respondDefect)
               )
             }),
             Effect.scoped

--- a/packages/cluster/src/Sharding.ts
+++ b/packages/cluster/src/Sharding.ts
@@ -46,6 +46,7 @@ import { joinAllDiscard } from "./internal/fiber.js"
 import { hashString } from "./internal/hash.js"
 import { internalInterruptors } from "./internal/interruptors.js"
 import { ResourceMap } from "./internal/resourceMap.js"
+import { effectiveInterval } from "./internal/shardLock.js"
 import * as Message from "./Message.js"
 import * as MessageStorage from "./MessageStorage.js"
 import * as Reply from "./Reply.js"
@@ -199,6 +200,7 @@ interface EntityManagerState {
 
 const make = Effect.gen(function*() {
   const config = yield* ShardingConfig
+  const shardLockInterval = effectiveInterval(config)
   const shardGroups = shardGroupConfig(config)
   const clock = yield* Effect.clock
 
@@ -220,6 +222,8 @@ const make = Effect.gen(function*() {
 
   const shardAssignments = MutableHashMap.empty<ShardId, RunnerAddress>()
   const selfShards = MutableHashSet.empty<ShardId>()
+  const shardLocksHealthyLatch = Effect.unsafeMakeLatch(true)
+  let shardLocksHealthy = true
 
   // the active shards are the ones that we have acquired the lock for
   const acquiredShards = MutableHashSet.empty<ShardId>()
@@ -256,6 +260,7 @@ const make = Effect.gen(function*() {
   // allow them to move to another runner.
 
   const releasingShards = MutableHashSet.empty<ShardId>()
+  const forceReleasingShards = MutableHashSet.empty<ShardId>()
   if (Option.isSome(config.runnerAddress)) {
     const selfAddress = config.runnerAddress.value
     yield* Scope.addFinalizerExit(shardingScope, () => {
@@ -264,38 +269,81 @@ const make = Effect.gen(function*() {
     })
 
     const releaseShardsMap = yield* FiberMap.make<ShardId>()
-    const releaseShard = Effect.fnUntraced(
-      function*(shardId: ShardId) {
-        const fibers = Arr.empty<Fiber.RuntimeFiber<void>>()
+    let forcedShardReleaseRunning = false
+    const runShardRelease = Effect.fnUntraced(function*<E>(
+      shardIds: ReadonlyArray<ShardId>,
+      force: boolean,
+      release: Effect.Effect<void, E>
+    ) {
+      const fibers = Arr.empty<Fiber.RuntimeFiber<void>>()
+      for (const shardId of shardIds) {
         for (const state of entityManagers.values()) {
           if (state.status === "closed") continue
-          fibers.push(yield* Effect.fork(state.manager.interruptShard(shardId)))
+          fibers.push(yield* Effect.fork(state.manager.interruptShard(shardId, { force })))
         }
-        yield* joinAllDiscard(fibers)
-        yield* runnerStorage.release(selfAddress, shardId)
+      }
+      yield* joinAllDiscard(fibers)
+      yield* shardLocksHealthyLatch.await
+      yield* release
+      for (const shardId of shardIds) {
         MutableHashSet.remove(releasingShards, shardId)
+        MutableHashSet.remove(forceReleasingShards, shardId)
         yield* storage.unregisterShardReplyHandlers(shardId)
-      },
-      Effect.sandbox,
-      (effect, shardId) =>
+      }
+    })
+    const retryShardRelease =
+      (annotations: { readonly fiber: string; readonly shardId?: ShardId }) =>
+      <A, E, R>(effect: Effect.Effect<A, E, R>) =>
         effect.pipe(
+          Effect.sandbox,
           Effect.tapError((cause) =>
-            Effect.logDebug(`Could not release shard, retrying`, cause).pipe(
+            Effect.logDebug(`Could not release shards, retrying`, cause).pipe(
               Effect.annotateLogs({
                 package: "@effect/cluster",
                 module: "Sharding",
-                fiber: "releaseShard",
                 runner: selfAddress,
-                shardId
-              })
+                ...annotations
+              }),
+              Effect.andThen(Effect.sleep(50))
             )
           ),
-          Effect.eventually,
+          Effect.eventually
+        )
+    const releaseShard = Effect.fnUntraced(
+      function*(shardId: ShardId) {
+        yield* runShardRelease(
+          [shardId],
+          MutableHashSet.has(forceReleasingShards, shardId),
+          runnerStorage.release(selfAddress, shardId)
+        )
+      },
+      (effect, shardId) =>
+        effect.pipe(
+          retryShardRelease({ fiber: "releaseShard", shardId }),
           FiberMap.run(releaseShardsMap, shardId, { onlyIfMissing: true })
         )
     )
+    const forcedShardReleasePending = () => forcedShardReleaseRunning || MutableHashSet.size(forceReleasingShards) > 0
+    const releaseForcedShards = Effect.suspend(() => {
+      if (forcedShardReleaseRunning || MutableHashSet.size(forceReleasingShards) === 0) {
+        return Effect.void
+      }
+      forcedShardReleaseRunning = true
+      const shardIds = [...forceReleasingShards]
+      return runShardRelease(shardIds, true, runnerStorage.releaseAll(selfAddress)).pipe(
+        retryShardRelease({ fiber: "releaseForcedShards" }),
+        Effect.ensuring(Effect.sync(() => {
+          forcedShardReleaseRunning = false
+          activeShardsLatch.unsafeOpen()
+        })),
+        Effect.forkIn(shardingScope),
+        Effect.asVoid
+      )
+    })
     const releaseShards = Effect.gen(function*() {
+      yield* releaseForcedShards
       for (const shardId of releasingShards) {
+        if (MutableHashSet.has(forceReleasingShards, shardId)) continue
         if (FiberMap.unsafeHas(releaseShardsMap, shardId)) continue
         yield* releaseShard(shardId)
       }
@@ -315,9 +363,13 @@ const make = Effect.gen(function*() {
           MutableHashSet.add(releasingShards, shardId)
         }
 
-        if (MutableHashSet.size(releasingShards) > 0) {
+        if (MutableHashSet.size(releasingShards) > 0 || MutableHashSet.size(forceReleasingShards) > 0) {
           yield* Effect.forkIn(syncSingletons, shardingScope)
           yield* releaseShards
+        }
+
+        if (!shardLocksHealthy || forcedShardReleasePending()) {
+          continue
         }
 
         // if a shard has been assigned to this runner, we acquire it
@@ -332,7 +384,7 @@ const make = Effect.gen(function*() {
         }
 
         const oacquired = yield* runnerStorage.acquire(selfAddress, unacquiredShards).pipe(
-          Effect.timeoutOption(config.shardLockRefreshInterval)
+          Effect.timeoutOption(shardLockInterval)
         )
         if (Option.isNone(oacquired)) {
           activeShardsLatch.unsafeOpen()
@@ -342,10 +394,17 @@ const make = Effect.gen(function*() {
         const acquired = oacquired.value
         yield* storage.resetShards(acquired).pipe(
           Effect.ignore,
-          Effect.timeoutOption(config.shardLockRefreshInterval)
+          Effect.timeoutOption(shardLockInterval)
         )
+        const forcedReleasePending = forcedShardReleasePending()
         for (const shardId of acquired) {
-          if (MutableHashSet.has(releasingShards, shardId) || !MutableHashSet.has(selfShards, shardId)) {
+          if (
+            !shardLocksHealthy ||
+            forcedReleasePending ||
+            MutableHashSet.has(releasingShards, shardId) ||
+            !MutableHashSet.has(selfShards, shardId)
+          ) {
+            MutableHashSet.add(releasingShards, shardId)
             continue
           }
           MutableHashSet.add(acquiredShards, shardId)
@@ -373,8 +432,52 @@ const make = Effect.gen(function*() {
       Effect.interruptible
     )
 
-    // refresh the shard locks every `shardLockRefreshInterval`
-    yield* Effect.suspend(() =>
+    const markShardLocksUnhealthy = (cause: Cause.Cause<unknown>) =>
+      Effect.suspend(() => {
+        if (!shardLocksHealthy) return Effect.void
+        shardLocksHealthy = false
+        shardLocksHealthyLatch.unsafeClose()
+
+        const affectedShards = MutableHashSet.fromIterable([...acquiredShards, ...releasingShards])
+        MutableHashSet.clear(selfShards)
+        MutableHashSet.clear(acquiredShards)
+        for (const shardId of affectedShards) {
+          MutableHashSet.add(releasingShards, shardId)
+          MutableHashSet.add(forceReleasingShards, shardId)
+        }
+        ClusterMetrics.shards.unsafeUpdate(BigInt(0), [])
+        activeShardsLatch.unsafeOpen()
+
+        return Effect.gen(function*() {
+          yield* Effect.logError("Shard lock storage is unhealthy", cause)
+          yield* Effect.forkIn(syncSingletons, shardingScope)
+
+          for (const shardId of affectedShards) {
+            for (const state of entityManagers.values()) {
+              if (state.status === "closed") continue
+              yield* Effect.forkIn(state.manager.interruptShard(shardId, { force: true }), shardingScope)
+            }
+          }
+          activeShardsLatch.unsafeOpen()
+        })
+      })
+
+    const markShardLocksHealthy = Effect.suspend(() => {
+      if (shardLocksHealthy) return Effect.void
+      shardLocksHealthy = true
+      shardLocksHealthyLatch.unsafeOpen()
+
+      MutableHashSet.clear(selfShards)
+      MutableHashMap.forEach(shardAssignments, (runner, shardId) => {
+        if (isLocalRunner(runner)) {
+          MutableHashSet.add(selfShards, shardId)
+        }
+      })
+      activeShardsLatch.unsafeOpen()
+      return Effect.logInfo("Shard lock storage has recovered")
+    })
+
+    const refreshShardLocks = Effect.suspend(() =>
       runnerStorage.refresh(selfAddress, [
         ...acquiredShards,
         ...releasingShards
@@ -402,12 +505,18 @@ const make = Effect.gen(function*() {
         times: 5,
         schedule: Schedule.spaced(50)
       }),
-      Effect.catchAllCause((cause) =>
-        Effect.logError("Could not refresh shard locks", cause).pipe(
-          Effect.andThen(clearSelfShards)
-        )
-      ),
-      Effect.repeat(Schedule.fixed(config.shardLockRefreshInterval)),
+      Effect.timeout(shardLockInterval),
+      Effect.catchAllCause(markShardLocksUnhealthy)
+    )
+
+    const probeShardLocks = runnerStorage.refresh(selfAddress, []).pipe(
+      Effect.timeout(shardLockInterval),
+      Effect.andThen(markShardLocksHealthy),
+      Effect.catchAllCause(() => Effect.void)
+    )
+
+    yield* Effect.suspend(() => shardLocksHealthy ? refreshShardLocks : probeShardLocks).pipe(
+      Effect.repeat(Schedule.fixed(shardLockInterval)),
       Effect.forever,
       Effect.forkIn(shardingScope),
       Effect.interruptible
@@ -421,11 +530,6 @@ const make = Effect.gen(function*() {
       Effect.interruptible
     )
   }
-
-  const clearSelfShards = Effect.sync(() => {
-    MutableHashSet.clear(selfShards)
-    activeShardsLatch.unsafeOpen()
-  })
 
   // --- Storage inbox ---
   //
@@ -959,7 +1063,7 @@ const make = Effect.gen(function*() {
             if (newAssignments) {
               const runner = newAssignments[i]
               MutableHashMap.set(shardAssignments, shard, runner)
-              if (isLocalRunner(runner)) {
+              if (shardLocksHealthy && isLocalRunner(runner)) {
                 MutableHashSet.add(selfShards, shard)
               }
             } else {

--- a/packages/cluster/src/Sharding.ts
+++ b/packages/cluster/src/Sharding.ts
@@ -1017,144 +1017,147 @@ const make = Effect.gen(function*() {
       MailboxFull | AlreadyProcessingMessage
     >,
     never
-  > = yield* ResourceMap.make(Effect.fnUntraced(function*(entity: Entity<string, any>) {
-    const client = yield* RpcClient.makeNoSerialization(entity.protocol, {
-      spanPrefix: `${entity.type}.client`,
-      disableTracing: !Context.get(entity.protocol.annotations, ClusterSchema.ClientTracingEnabled),
-      supportsAck: true,
-      generateRequestId: () => RequestId(snowflakeGen.unsafeNext()),
-      flatten: true,
-      onFromClient(options): Effect.Effect<
-        void,
-        MailboxFull | AlreadyProcessingMessage | PersistenceError
-      > {
-        const address = Context.unsafeGet(options.context, ClientAddressTag)
-        switch (options.message._tag) {
-          case "Request": {
-            const fiber = Option.getOrThrow(Fiber.getCurrentFiber())
-            const id = Snowflake.Snowflake(options.message.id)
-            const rpc = entity.protocol.requests.get(options.message.tag)!
-            let respond: (reply: Reply.Reply<any>) => Effect.Effect<void>
-            if (!options.discard) {
-              const entry: ClientRequestEntry = {
-                rpc: rpc as any,
-                services: fiber.currentContext
+  > = yield* ResourceMap.make(
+    Effect.fnUntraced(function*(entity: Entity<string, any>) {
+      const client = yield* RpcClient.makeNoSerialization(entity.protocol, {
+        spanPrefix: `${entity.type}.client`,
+        disableTracing: !Context.get(entity.protocol.annotations, ClusterSchema.ClientTracingEnabled),
+        supportsAck: true,
+        generateRequestId: () => RequestId(snowflakeGen.unsafeNext()),
+        flatten: true,
+        onFromClient(options): Effect.Effect<
+          void,
+          MailboxFull | AlreadyProcessingMessage | PersistenceError
+        > {
+          const address = Context.unsafeGet(options.context, ClientAddressTag)
+          switch (options.message._tag) {
+            case "Request": {
+              const fiber = Option.getOrThrow(Fiber.getCurrentFiber())
+              const id = Snowflake.Snowflake(options.message.id)
+              const rpc = entity.protocol.requests.get(options.message.tag)!
+              let respond: (reply: Reply.Reply<any>) => Effect.Effect<void>
+              if (!options.discard) {
+                const entry: ClientRequestEntry = {
+                  rpc: rpc as any,
+                  services: fiber.currentContext
+                }
+                clientRequests.set(id, entry)
+                respond = makeClientRespond(entry, client.write)
+              } else {
+                respond = clientRespondDiscard
               }
-              clientRequests.set(id, entry)
-              respond = makeClientRespond(entry, client.write)
-            } else {
-              respond = clientRespondDiscard
-            }
-            return sendOutgoing(
-              new Message.OutgoingRequest({
-                envelope: Envelope.makeRequest({
-                  requestId: id,
-                  address,
-                  tag: options.message.tag,
-                  payload: options.message.payload,
-                  headers: options.message.headers,
-                  traceId: options.message.traceId,
-                  spanId: options.message.spanId,
-                  sampled: options.message.sampled
+              return sendOutgoing(
+                new Message.OutgoingRequest({
+                  envelope: Envelope.makeRequest({
+                    requestId: id,
+                    address,
+                    tag: options.message.tag,
+                    payload: options.message.payload,
+                    headers: options.message.headers,
+                    traceId: options.message.traceId,
+                    spanId: options.message.spanId,
+                    sampled: options.message.sampled
+                  }),
+                  lastReceivedReply: Option.none(),
+                  rpc,
+                  context: fiber.currentContext as Context.Context<any>,
+                  respond
                 }),
-                lastReceivedReply: Option.none(),
-                rpc,
-                context: fiber.currentContext as Context.Context<any>,
-                respond
-              }),
-              options.discard
-            )
-          }
-          case "Ack": {
-            const requestId = Snowflake.Snowflake(options.message.requestId)
-            const entry = clientRequests.get(requestId)
-            if (!entry) return Effect.void
-            return sendOutgoing(
-              new Message.OutgoingEnvelope({
-                envelope: new Envelope.AckChunk({
-                  id: snowflakeGen.unsafeNext(),
-                  address,
-                  requestId,
-                  replyId: entry.lastChunkId!
-                }),
-                rpc: entry.rpc
-              }),
-              false
-            )
-          }
-          case "Interrupt": {
-            const requestId = Snowflake.Snowflake(options.message.requestId)
-            const entry = clientRequests.get(requestId)!
-            if (!entry) return Effect.void
-            clientRequests.delete(requestId)
-            if (Uninterruptible.forClient(entry.rpc.annotations)) {
-              return Effect.void
+                options.discard
+              )
             }
-            // for durable messages, we ignore interrupts on shutdown or as a
-            // result of a shard being resassigned
-            const isTransientInterrupt = MutableRef.get(isShutdown) ||
-              options.message.interruptors.some((id) => internalInterruptors.has(id))
-            if (isTransientInterrupt && Context.get(entry.rpc.annotations, Persisted)) {
-              return Effect.void
-            }
-            return Effect.ignore(sendOutgoing(
-              new Message.OutgoingEnvelope({
-                envelope: new Envelope.Interrupt({
-                  id: snowflakeGen.unsafeNext(),
-                  address,
-                  requestId
+            case "Ack": {
+              const requestId = Snowflake.Snowflake(options.message.requestId)
+              const entry = clientRequests.get(requestId)
+              if (!entry) return Effect.void
+              return sendOutgoing(
+                new Message.OutgoingEnvelope({
+                  envelope: new Envelope.AckChunk({
+                    id: snowflakeGen.unsafeNext(),
+                    address,
+                    requestId,
+                    replyId: entry.lastChunkId!
+                  }),
+                  rpc: entry.rpc
                 }),
-                rpc: entry.rpc
-              }),
-              false,
-              3
-            ))
+                false
+              )
+            }
+            case "Interrupt": {
+              const requestId = Snowflake.Snowflake(options.message.requestId)
+              const entry = clientRequests.get(requestId)!
+              if (!entry) return Effect.void
+              clientRequests.delete(requestId)
+              if (Uninterruptible.forClient(entry.rpc.annotations)) {
+                return Effect.void
+              }
+              // for durable messages, we ignore interrupts on shutdown or as a
+              // result of a shard being resassigned
+              const isTransientInterrupt = MutableRef.get(isShutdown) ||
+                options.message.interruptors.some((id) => internalInterruptors.has(id))
+              if (isTransientInterrupt && Context.get(entry.rpc.annotations, Persisted)) {
+                return Effect.void
+              }
+              return Effect.ignore(sendOutgoing(
+                new Message.OutgoingEnvelope({
+                  envelope: new Envelope.Interrupt({
+                    id: snowflakeGen.unsafeNext(),
+                    address,
+                    requestId
+                  }),
+                  rpc: entry.rpc
+                }),
+                false,
+                3
+              ))
+            }
           }
+          return Effect.void
         }
-        return Effect.void
-      }
-    })
-
-    yield* Scope.addFinalizer(
-      yield* Effect.scope,
-      Effect.fiberIdWith((fiberId) => {
-        internalInterruptors.add(fiberId)
-        return Effect.void
       })
-    )
 
-    return (entityId: string) => {
-      const id = makeEntityId(entityId)
-      const address = ClientAddressTag.context(makeEntityAddress({
-        shardId: getShardId(id, entity.getShardGroup(entityId as EntityId)),
-        entityId: id,
-        entityType: entity.type
-      }))
-      const clientFn = function(tag: string, payload: any, options?: {
-        readonly context?: Context.Context<never>
-      }) {
-        const context = options?.context ? Context.merge(options.context, address) : address
-        return client.client(tag, payload, {
-          ...options,
-          context
+      yield* Scope.addFinalizer(
+        yield* Effect.scope,
+        Effect.fiberIdWith((fiberId) => {
+          internalInterruptors.add(fiberId)
+          return Effect.void
+        })
+      )
+
+      return (entityId: string) => {
+        const id = makeEntityId(entityId)
+        const address = ClientAddressTag.context(makeEntityAddress({
+          shardId: getShardId(id, entity.getShardGroup(entityId as EntityId)),
+          entityId: id,
+          entityType: entity.type
+        }))
+        const clientFn = function(tag: string, payload: any, options?: {
+          readonly context?: Context.Context<never>
+        }) {
+          const context = options?.context ? Context.merge(options.context, address) : address
+          return client.client(tag, payload, {
+            ...options,
+            context
+          })
+        }
+        const proxyClient: any = {}
+        return new Proxy(proxyClient, {
+          has(_, p) {
+            return entity.protocol.requests.has(p as string)
+          },
+          get(target, p) {
+            if (p in target) {
+              return target[p]
+            } else if (!entity.protocol.requests.has(p as string)) {
+              return undefined
+            }
+            return target[p] = (payload: any, options?: {}) => clientFn(p as string, payload, options)
+          }
         })
       }
-      const proxyClient: any = {}
-      return new Proxy(proxyClient, {
-        has(_, p) {
-          return entity.protocol.requests.has(p as string)
-        },
-        get(target, p) {
-          if (p in target) {
-            return target[p]
-          } else if (!entity.protocol.requests.has(p as string)) {
-            return undefined
-          }
-          return target[p] = (payload: any, options?: {}) => clientFn(p as string, payload, options)
-        }
-      })
-    }
-  }))
+    }),
+    { referential: true }
+  )
 
   const makeClient = <Type extends string, Rpcs extends Rpc.Any>(entity: Entity<Type, Rpcs>): Effect.Effect<
     (

--- a/packages/cluster/src/ShardingConfig.ts
+++ b/packages/cluster/src/ShardingConfig.ts
@@ -62,7 +62,11 @@ export class ShardingConfig extends Context.Tag("@effect/cluster/ShardingConfig"
    */
   readonly shardsPerGroup: number
   /**
-   * Shard lock refresh interval.
+   * The maximum interval between shard lock refreshes.
+   *
+   * The runner may shorten this interval to one third of
+   * `shardLockExpiration` to preserve enough time to stop entities safely if
+   * lock storage becomes unavailable.
    */
   readonly shardLockRefreshInterval: DurationInput
   /**

--- a/packages/cluster/src/SqlMessageStorage.ts
+++ b/packages/cluster/src/SqlMessageStorage.ts
@@ -7,6 +7,7 @@ import type { Row } from "@effect/sql/SqlConnection"
 import type { SqlError } from "@effect/sql/SqlError"
 import * as Arr from "effect/Array"
 import * as Effect from "effect/Effect"
+import * as Encoding from "effect/Encoding"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as Schedule from "effect/Schedule"
@@ -48,6 +49,22 @@ export const make = Effect.fnUntraced(function*(options?: {
 
   const repliesTable = table("replies")
   const repliesTableSql = sql(repliesTable)
+
+  const encoder = new TextEncoder()
+  const messageIdForPrimaryKey = (primaryKey: string): Effect.Effect<string> =>
+    primaryKey.length <= 255
+      ? Effect.succeed(primaryKey)
+      : Effect.promise(() => globalThis.crypto.subtle.digest("SHA-256", encoder.encode(primaryKey))).pipe(
+        Effect.map((digest) => Encoding.encodeHex(new Uint8Array(digest)))
+      )
+
+  const messageIdEnforcesWidth = sql.onDialectOrElse({
+    mssql: () => true,
+    mysql: () => true,
+    pg: () => true,
+    orElse: () => false
+  })
+  const mayHaveLegacyRow = (primaryKey: string): boolean => !messageIdEnforcesWidth && primaryKey.length > 255
 
   const envelopeToRow = (
     envelope: Envelope.Envelope.Encoded,
@@ -199,6 +216,14 @@ export const make = Effect.fnUntraced(function*(options?: {
   const sqlFalse = sql.literal(supportsBooleans ? "FALSE" : "0")
   const sqlTrue = sql.literal(supportsBooleans ? "TRUE" : "1")
 
+  const selectByMessageId = (message_id: string): Effect.Effect<ReadonlyArray<Row>, SqlError> =>
+    sql`
+      SELECT m.id, r.id as reply_id, r.kind as reply_kind, r.payload as reply_payload, r.sequence as reply_sequence
+      FROM ${messagesTableSql} m
+      LEFT JOIN ${repliesTableSql} r ON r.id = m.last_reply_id
+      WHERE m.message_id = ${message_id}
+    `
+
   const insertEnvelope: (
     row: MessageRow,
     message_id: string
@@ -211,12 +236,7 @@ export const make = Effect.fnUntraced(function*(options?: {
       `.pipe(Effect.flatMap((rows) => {
         // inserted a new row
         if (rows.length > 0) return Effect.succeed([])
-        return sql`
-          SELECT m.id, r.id as reply_id, r.kind as reply_kind, r.payload as reply_payload, r.sequence as reply_sequence
-          FROM ${messagesTableSql} m
-          LEFT JOIN ${repliesTableSql} r ON r.id = m.last_reply_id
-          WHERE m.message_id = ${message_id}
-        `
+        return selectByMessageId(message_id)
       })),
     mysql: () => (row, message_id) =>
       Effect.flatMap(
@@ -225,12 +245,7 @@ export const make = Effect.fnUntraced(function*(options?: {
           if (row.affectedRows > 0) {
             return Effect.succeed([])
           }
-          return sql`
-            SELECT m.id, r.id as reply_id, r.kind as reply_kind, r.payload as reply_payload, r.sequence as reply_sequence
-            FROM ${messagesTableSql} m
-            LEFT JOIN ${repliesTableSql} r ON r.id = m.last_reply_id
-            WHERE m.message_id = ${message_id}
-          `
+          return selectByMessageId(message_id)
         }
       ),
     mssql: () => (row, message_id) =>
@@ -272,12 +287,7 @@ export const make = Effect.fnUntraced(function*(options?: {
           END as reply_sequence;
       `,
     orElse: () => (row, message_id) =>
-      sql`
-        SELECT m.id, r.id as reply_id, r.kind as reply_kind, r.payload as reply_payload, r.sequence as reply_sequence
-        FROM ${messagesTableSql} m
-        LEFT JOIN ${repliesTableSql} r ON r.id = m.last_reply_id
-        WHERE m.message_id = ${message_id}
-      `.pipe(
+      selectByMessageId(message_id).pipe(
         Effect.tap(sql`INSERT OR IGNORE INTO ${messagesTableSql} ${sql.insert(row)}`),
         sql.withTransaction,
         Effect.retry({ times: 3 })
@@ -367,10 +377,21 @@ export const make = Effect.fnUntraced(function*(options?: {
   return yield* MessageStorage.makeEncoded({
     saveEnvelope: ({ deliverAt, envelope, primaryKey }) =>
       Effect.suspend(() => {
-        const row = envelopeToRow(envelope, primaryKey, deliverAt)
-        let insert = primaryKey
-          ? insertEnvelope(row, primaryKey)
-          : Effect.as(sql`INSERT INTO ${messagesTableSql} ${sql.insert(row)}`.unprepared, [])
+        let insert = primaryKey !== null
+          ? Effect.flatMap(messageIdForPrimaryKey(primaryKey), (messageId) => {
+            const row = envelopeToRow(envelope, messageId, deliverAt)
+            if (!mayHaveLegacyRow(primaryKey)) {
+              return insertEnvelope(row, messageId)
+            }
+            return Effect.flatMap(
+              selectByMessageId(primaryKey),
+              (rows) => rows.length > 0 ? Effect.succeed(rows) : insertEnvelope(row, messageId)
+            )
+          })
+          : Effect.as(
+            sql`INSERT INTO ${messagesTableSql} ${sql.insert(envelopeToRow(envelope, null, deliverAt))}`.unprepared,
+            []
+          )
         if (envelope._tag === "AckChunk") {
           insert = sql`UPDATE ${repliesTableSql} SET acked = ${sqlTrue} WHERE id = ${envelope.replyId}`.pipe(
             Effect.andThen(
@@ -443,7 +464,15 @@ export const make = Effect.fnUntraced(function*(options?: {
     ),
 
     requestIdForPrimaryKey: (primaryKey) =>
-      sql<{ id: string | bigint }>`SELECT id FROM ${messagesTableSql} WHERE message_id = ${primaryKey}`.pipe(
+      messageIdForPrimaryKey(primaryKey).pipe(
+        Effect.flatMap((messageId) =>
+          sql<{ id: string | bigint }>`SELECT id FROM ${messagesTableSql} WHERE message_id = ${messageId}`
+        ),
+        Effect.flatMap((rows) =>
+          rows.length === 0 && mayHaveLegacyRow(primaryKey)
+            ? sql<{ id: string | bigint }>`SELECT id FROM ${messagesTableSql} WHERE message_id = ${primaryKey}`
+            : Effect.succeed(rows)
+        ),
         Effect.map((rows) =>
           Option.fromNullable(rows[0]?.id).pipe(
             Option.map(Snowflake.Snowflake)

--- a/packages/cluster/src/SqlRunnerStorage.ts
+++ b/packages/cluster/src/SqlRunnerStorage.ts
@@ -7,10 +7,13 @@ import type * as Statement from "@effect/sql/Statement"
 import * as Arr from "effect/Array"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
 import * as Scope from "effect/Scope"
 import { PersistenceError } from "./ClusterError.js"
 import { ResourceRef } from "./internal/resourceRef.js"
+import { effectiveInterval } from "./internal/shardLock.js"
 import * as RunnerStorage from "./RunnerStorage.js"
 import * as ShardId from "./ShardId.js"
 import * as ShardingConfig from "./ShardingConfig.js"
@@ -28,18 +31,31 @@ export const make = Effect.fnUntraced(function*(options: {
   const shardGroups = ShardingConfig.shardGroupConfig(config)
   const availableShardGroups = Array.from(shardGroups.available)
   const disableAdvisoryLocks = config.shardLockDisableAdvisory
+  const lockOperationInterval = effectiveInterval(config)
   const sql = (yield* SqlClient.SqlClient).withoutTransforms()
+  const layerScope = yield* Effect.scope
   const prefix = options?.prefix ?? "cluster"
   const table = (name: string) => `${prefix}_${name}`
 
+  // Keep all PostgreSQL and MySQL shard-lock operations on a rebuildable
+  // reserved connection, including when advisory locks are disabled.
   const acquireLockConn = sql.onDialectOrElse({
     pg: () =>
       Effect.fnUntraced(function*(scope: Scope.Scope) {
         const conn = yield* Effect.orDie(sql.reserve).pipe(
           Scope.extend(scope)
         )
-        const pid = (yield* conn.executeValues("SELECT pg_backend_pid()", []))[0][0] as number
-        yield* Scope.addFinalizerExit(scope, () => Effect.orDie(conn.executeRaw("SELECT pg_advisory_unlock_all()", [])))
+        const pid = disableAdvisoryLocks
+          ? 0
+          : (yield* conn.executeValues("SELECT pg_backend_pid()", []))[0][0] as number
+        if (!disableAdvisoryLocks) {
+          yield* Scope.addFinalizerExit(scope, () =>
+            conn.executeRaw("SELECT pg_advisory_unlock_all()", []).pipe(
+              Effect.timeout(lockOperationInterval),
+              Effect.interruptible,
+              Effect.catchAllCause(() => Effect.void)
+            ))
+        }
         return [conn, pid] as const
       }, Effect.orDie),
     mysql: () =>
@@ -47,6 +63,7 @@ export const make = Effect.fnUntraced(function*(options: {
         const conn = yield* Effect.orDie(sql.reserve).pipe(
           Scope.extend(scope)
         )
+        if (disableAdvisoryLocks) return [conn, 0] as const
         // we need to get the connection id using IS_USED_LOCK to properly
         // support vitess
         let pid: number | undefined = undefined
@@ -59,12 +76,64 @@ export const make = Effect.fnUntraced(function*(options: {
           if (taken[0] === null) continue
           pid = taken[1]
         }
-        yield* Scope.addFinalizerExit(scope, () => Effect.orDie(conn.executeRaw("SELECT RELEASE_ALL_LOCKS()", [])))
+        yield* Scope.addFinalizerExit(scope, () =>
+          conn.executeRaw("SELECT RELEASE_ALL_LOCKS()", []).pipe(
+            Effect.timeout(lockOperationInterval),
+            Effect.interruptible,
+            Effect.catchAllCause(() => Effect.void)
+          ))
         return [conn, pid] as const
       }, Effect.orDie),
     orElse: () => undefined
   })
-  const lockConn = acquireLockConn && (yield* ResourceRef.from(yield* Effect.scope, acquireLockConn))
+  const lockConn = acquireLockConn && (yield* ResourceRef.from(layerScope, acquireLockConn))
+
+  // Timeout the join rather than the operation so stalled interruption and
+  // cleanup can finish detached in the layer scope.
+  const withDeadline = Effect.fnUntraced(function*<A, E, R>(operation: Effect.Effect<A, E, R>) {
+    const fiber = yield* Effect.forkIn(operation, layerScope)
+    return yield* Fiber.join(fiber).pipe(
+      Effect.timeout(lockOperationInterval),
+      Effect.ensuring(Effect.suspend(() =>
+        fiber.unsafePoll() !== null ? Effect.void : Fiber.interrupt(fiber).pipe(
+          Effect.forkIn(layerScope),
+          Effect.asVoid
+        )
+      ))
+    )
+  })
+
+  let lockConnRebuilding = false
+  let lockConnGeneration = 0
+  const rebuildLockConn = (generation: number) => {
+    if (
+      !lockConn ||
+      lockConnRebuilding ||
+      generation !== lockConnGeneration ||
+      lockConn.state.current._tag === "Closed"
+    ) return Effect.void
+    lockConnRebuilding = true
+    return withDeadline(lockConn.unsafeRebuild()).pipe(
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          if (Exit.isSuccess(exit) && lockConn.state.current._tag === "Acquired") {
+            lockConnGeneration++
+          }
+        })
+      ),
+      Effect.ensuring(Effect.sync(() => {
+        lockConnRebuilding = false
+      })),
+      Effect.forkIn(layerScope),
+      Effect.asVoid
+    )
+  }
+  const onErrorRebuildLockConn = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    Effect.suspend(() => {
+      const generation = lockConnGeneration
+      return Effect.onError(effect, () => rebuildLockConn(generation))
+    })
 
   const runnersTable = table("runners")
   const runnersTableSql = sql(runnersTable)
@@ -142,21 +211,25 @@ export const make = Effect.fnUntraced(function*(options: {
         )
       `,
     mysql: () =>
-      sql`
-        CREATE TABLE IF NOT EXISTS ${locksTableSql} (
-          shard_id VARCHAR(50) PRIMARY KEY,
-          address VARCHAR(255) NOT NULL,
-          acquired_at DATETIME NOT NULL
-        )
-      `,
+      disableAdvisoryLocks
+        ? sql`
+          CREATE TABLE IF NOT EXISTS ${locksTableSql} (
+            shard_id VARCHAR(50) PRIMARY KEY,
+            address VARCHAR(255) NOT NULL,
+            acquired_at DATETIME NOT NULL
+          )
+        `
+        : Effect.void,
     pg: () =>
-      sql`
-        CREATE TABLE IF NOT EXISTS ${locksTableSql} (
-          shard_id VARCHAR(50) PRIMARY KEY,
-          address VARCHAR(255) NOT NULL,
-          acquired_at TIMESTAMP NOT NULL
-        )
-      `,
+      disableAdvisoryLocks
+        ? sql`
+          CREATE TABLE IF NOT EXISTS ${locksTableSql} (
+            shard_id VARCHAR(50) PRIMARY KEY,
+            address VARCHAR(255) NOT NULL,
+            acquired_at TIMESTAMP NOT NULL
+          )
+        `
+        : Effect.void,
     orElse: () =>
       // sqlite
       sql`
@@ -246,7 +319,7 @@ export const make = Effect.fnUntraced(function*(options: {
     const [query, params] = effect.compile()
     return lockConn.await.pipe(
       Effect.flatMap(([conn]) => conn.executeRaw(query, params)),
-      Effect.onError(() => lockConn.unsafeRebuild())
+      onErrorRebuildLockConn
     )
   }
   const execWithLockConnUnprepared = <A>(
@@ -256,7 +329,7 @@ export const make = Effect.fnUntraced(function*(options: {
     const [query, params] = effect.compile()
     return lockConn.await.pipe(
       Effect.flatMap(([conn]) => conn.executeUnprepared(query, params, undefined)),
-      Effect.onError(() => lockConn.unsafeRebuild())
+      onErrorRebuildLockConn
     )
   }
   const execWithLockConnValues = <A>(
@@ -266,7 +339,7 @@ export const make = Effect.fnUntraced(function*(options: {
     const [query, params] = effect.compile()
     return lockConn.await.pipe(
       Effect.flatMap(([conn]) => conn.executeValues(query, params)),
-      Effect.onError(() => lockConn.unsafeRebuild())
+      onErrorRebuildLockConn
     )
   }
 
@@ -284,6 +357,7 @@ export const make = Effect.fnUntraced(function*(options: {
             WHERE ${locksTableSql}.address = ${address}
               OR ${locksTableSql}.acquired_at < ${lockExpiresAt}
 `.pipe(
+            execWithLockConn,
             Effect.andThen(acquiredLocks(address, shardIds))
           )
         }
@@ -312,7 +386,7 @@ export const make = Effect.fnUntraced(function*(options: {
           }
         }
         return acquiredShardIds
-      }, Effect.onError(() => lockConn!.unsafeRebuild()))
+      }, onErrorRebuildLockConn)
     },
 
     mysql: () => {
@@ -326,7 +400,8 @@ export const make = Effect.fnUntraced(function*(options: {
             ON DUPLICATE KEY UPDATE
             address = IF(address = VALUES(address) OR acquired_at < ${lockExpiresAt}, VALUES(address), address),
             acquired_at = IF(address = VALUES(address) OR acquired_at < ${lockExpiresAt}, VALUES(acquired_at), acquired_at)
-`.unprepared.pipe(
+`.pipe(
+            execWithLockConnUnprepared,
             Effect.andThen(acquiredLocks(address, shardIds))
           )
         }
@@ -355,7 +430,7 @@ export const make = Effect.fnUntraced(function*(options: {
           }
         }
         return acquiredShardIds
-      }, Effect.onError(() => lockConn!.unsafeRebuild()))
+      }, onErrorRebuildLockConn)
     },
 
     mssql: () => (address: string, shardIds: ReadonlyArray<string>) => {
@@ -447,7 +522,8 @@ export const make = Effect.fnUntraced(function*(options: {
       WHERE address = ${address}
       AND acquired_at >= ${lockExpiresAt}
       AND shard_id IN ${stringLiteralArr(shardIds)}
-    `.values.pipe(
+    `.pipe(
+      execWithLockConnValues,
       Effect.map((rows) => rows.map((row) => row[0] as string))
     )
 
@@ -503,6 +579,73 @@ export const make = Effect.fnUntraced(function*(options: {
       `.pipe(execWithLockConnValues, Effect.map((rows) => rows.map((row) => row[0] as string)))
   })
 
+  const withLockOperationDeadline = <A, E, R>(operation: Effect.Effect<A, E, R>) =>
+    onErrorRebuildLockConn(withDeadline(operation))
+
+  const releaseShard = sql.onDialectOrElse({
+    pg: () => {
+      if (disableAdvisoryLocks) {
+        return (address: string, shardId: string) =>
+          sql`DELETE FROM ${locksTableSql} WHERE address = ${address} AND shard_id = ${shardId}`.pipe(
+            execWithLockConn
+          )
+      }
+      return Effect.fnUntraced(
+        function*(_address, shardId) {
+          const lockNum = lockNumbers.get(shardId)!
+          for (let i = 0; i < 5; i++) {
+            const [conn] = yield* lockConn!.await
+            yield* conn.executeRaw(`SELECT pg_advisory_unlock(${lockNum})`, [])
+            const takenLocks = yield* conn.executeValues(
+              `SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND pid = pg_backend_pid() AND objid = ${lockNum}`,
+              []
+            )
+            if (takenLocks.length === 0) return
+          }
+          const [conn] = yield* lockConn!.await
+          yield* conn.executeRaw(`SELECT pg_advisory_unlock_all()`, [])
+        },
+        onErrorRebuildLockConn,
+        Effect.asVoid
+      )
+    },
+    mysql: () => {
+      if (disableAdvisoryLocks) {
+        return (address: string, shardId: string) =>
+          sql`DELETE FROM ${locksTableSql} WHERE address = ${address} AND shard_id = ${shardId}`.pipe(
+            execWithLockConn
+          )
+      }
+      return Effect.fnUntraced(
+        function*(_address, shardId) {
+          const lockName = lockNames.get(shardId)!
+          while (true) {
+            const [conn, pid] = yield* lockConn!.await
+            yield* conn.executeRaw(`SELECT RELEASE_LOCK('${lockName}')`, [])
+            const takenLocks = yield* conn.executeValues(`SELECT IS_USED_LOCK('${lockName}')`, [])
+            if (takenLocks.length === 0 || takenLocks[0][0] !== pid) return
+          }
+        },
+        onErrorRebuildLockConn,
+        Effect.asVoid
+      )
+    },
+    orElse: () => (address: string, shardId: string) =>
+      sql`DELETE FROM ${locksTableSql} WHERE address = ${address} AND shard_id = ${shardId}`
+  })
+
+  const releaseAllShards = sql.onDialectOrElse({
+    pg: () => (address: string) =>
+      disableAdvisoryLocks
+        ? sql`DELETE FROM ${locksTableSql} WHERE address = ${address}`.pipe(execWithLockConn)
+        : sql`SELECT pg_advisory_unlock_all()`.pipe(execWithLockConn, Effect.asVoid),
+    mysql: () => (address: string) =>
+      disableAdvisoryLocks
+        ? sql`DELETE FROM ${locksTableSql} WHERE address = ${address}`.pipe(execWithLockConn)
+        : sql`SELECT RELEASE_ALL_LOCKS()`.pipe(execWithLockConn, Effect.asVoid),
+    orElse: () => (address: string) => sql`DELETE FROM ${locksTableSql} WHERE address = ${address}`
+  })
+
   return RunnerStorage.makeEncoded({
     getRunners: sql`SELECT runner, healthy FROM ${runnersTableSql} WHERE last_heartbeat > ${lockExpiresAt}`.values.pipe(
       PersistenceError.refail,
@@ -533,114 +676,36 @@ export const make = Effect.fnUntraced(function*(options: {
         ),
 
     acquire: (address, shardIds) =>
-      acquireLock(address, shardIds).pipe(
+      withLockOperationDeadline(acquireLock(address, shardIds)).pipe(
         PersistenceError.refail,
         withTracerDisabled
       ),
 
     refresh: (address, shardIds) =>
-      sql`UPDATE ${runnersTableSql} SET last_heartbeat = ${sqlNow} WHERE address = ${address}`.pipe(
-        execWithLockConn,
-        shardIds.length > 0 ?
-          Effect.andThen(refreshShards(address, shardIds)) :
-          Effect.as([]),
+      withLockOperationDeadline(
+        sql`UPDATE ${runnersTableSql} SET last_heartbeat = ${sqlNow} WHERE address = ${address}`.pipe(
+          execWithLockConn,
+          shardIds.length > 0
+            ? Effect.andThen(refreshShards(address, shardIds))
+            : Effect.as([])
+        )
+      ).pipe(
         PersistenceError.refail
       ),
 
-    release: sql.onDialectOrElse({
-      pg: () => {
-        if (disableAdvisoryLocks) {
-          return (address: string, shardId: string) =>
-            sql`DELETE FROM ${locksTableSql} WHERE address = ${address} AND shard_id = ${shardId}`.pipe(
-              PersistenceError.refail
-            )
-        }
-        return Effect.fnUntraced(
-          function*(_address, shardId) {
-            const lockNum = lockNumbers.get(shardId)!
-            for (let i = 0; i < 5; i++) {
-              const [conn] = yield* lockConn!.await
-              yield* conn.executeRaw(`SELECT pg_advisory_unlock(${lockNum})`, [])
-              const takenLocks = yield* conn.executeValues(
-                `SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND pid = pg_backend_pid() AND objid = ${lockNum}`,
-                []
-              )
-              if (takenLocks.length === 0) return
-            }
-            const [conn] = yield* lockConn!.await
-            yield* conn.executeRaw(`SELECT pg_advisory_unlock_all()`, [])
-          },
-          Effect.onError(() => lockConn!.unsafeRebuild()),
-          Effect.asVoid,
-          PersistenceError.refail
-        )
-      },
-      mysql: () => {
-        if (disableAdvisoryLocks) {
-          return (address: string, shardId: string) =>
-            sql`DELETE FROM ${locksTableSql} WHERE address = ${address} AND shard_id = ${shardId}`.pipe(
-              PersistenceError.refail
-            )
-        }
-        return Effect.fnUntraced(
-          function*(_address, shardId) {
-            const lockName = lockNames.get(shardId)!
-            while (true) {
-              const [conn, pid] = yield* lockConn!.await
-              yield* conn.executeRaw(`SELECT RELEASE_LOCK('${lockName}')`, [])
-              const takenLocks = yield* conn.executeValues(
-                `SELECT IS_USED_LOCK('${lockName}')`,
-                []
-              )
-              if (takenLocks.length === 0 || takenLocks[0][0] !== pid) return
-            }
-          },
-          Effect.onError(() => lockConn!.unsafeRebuild()),
-          Effect.asVoid,
-          PersistenceError.refail
-        )
-      },
-      orElse: () => (address, shardId) =>
-        sql`DELETE FROM ${locksTableSql} WHERE address = ${address} AND shard_id = ${shardId}`.pipe(
-          PersistenceError.refail
-        )
-    }),
+    release: (address, shardId) =>
+      withLockOperationDeadline(releaseShard(address, shardId)).pipe(
+        Effect.asVoid,
+        PersistenceError.refail,
+        withTracerDisabled
+      ),
 
-    releaseAll: sql.onDialectOrElse({
-      pg: () => (address) => {
-        if (disableAdvisoryLocks) {
-          return sql`DELETE FROM ${locksTableSql} WHERE address = ${address}`.pipe(
-            PersistenceError.refail,
-            withTracerDisabled
-          )
-        }
-        return sql`SELECT pg_advisory_unlock_all()`.pipe(
-          execWithLockConn,
-          Effect.asVoid,
-          PersistenceError.refail,
-          withTracerDisabled
-        )
-      },
-      mysql: () => (address) => {
-        if (disableAdvisoryLocks) {
-          return sql`DELETE FROM ${locksTableSql} WHERE address = ${address}`.pipe(
-            PersistenceError.refail,
-            withTracerDisabled
-          )
-        }
-        return sql`SELECT RELEASE_ALL_LOCKS()`.pipe(
-          execWithLockConn,
-          Effect.asVoid,
-          PersistenceError.refail,
-          withTracerDisabled
-        )
-      },
-      orElse: () => (address) =>
-        sql`DELETE FROM ${locksTableSql} WHERE address = ${address}`.pipe(
-          PersistenceError.refail,
-          withTracerDisabled
-        )
-    })
+    releaseAll: (address) =>
+      withLockOperationDeadline(releaseAllShards(address)).pipe(
+        Effect.asVoid,
+        PersistenceError.refail,
+        withTracerDisabled
+      )
   })
 }, withTracerDisabled)
 

--- a/packages/cluster/src/internal/entityManager.ts
+++ b/packages/cluster/src/internal/entityManager.ts
@@ -108,9 +108,10 @@ export const make = Effect.fnUntraced(function*<
   const mailboxCapacity = options.mailboxCapacity ?? config.entityMailboxCapacity
   const clock = yield* Effect.clock
   const context = yield* Effect.context<Rpc.Context<Rpcs> | Rpc.Middleware<Rpcs> | RX>()
-  const retryDriver = yield* Schedule.driver(
-    options.defectRetryPolicy ? Schedule.andThen(options.defectRetryPolicy, defaultRetryPolicy) : defaultRetryPolicy
-  )
+  const defectRetryPolicy = options.defectRetryPolicy
+    ? Schedule.andThen(options.defectRetryPolicy, defaultRetryPolicy)
+    : defaultRetryPolicy
+  const retryDriver = yield* Schedule.driver(defectRetryPolicy)
   const entityRpcs = new Map(entity.protocol.requests)
 
   // add internal rpcs
@@ -154,15 +155,24 @@ export const make = Effect.fnUntraced(function*<
       Effect.fnUntraced(function*(scope) {
         let isShuttingDown = false
 
+        const handlerContext = context.pipe(
+          Context.add(CurrentAddress, address),
+          Context.add(CurrentRunnerAddress, options.runnerAddress),
+          Context.add(KeepAliveLatch, keepAliveLatch),
+          Context.add(Scope.Scope, scope)
+        )
+
         // Initiate the behavior for the entity
-        const handlers = yield* (entity.protocol.toHandlersContext(buildHandlers).pipe(
-          Effect.provide(context.pipe(
-            Context.add(CurrentAddress, address),
-            Context.add(CurrentRunnerAddress, options.runnerAddress),
-            Context.add(KeepAliveLatch, keepAliveLatch),
-            Context.add(Scope.Scope, scope)
-          )),
-          Effect.locally(FiberRef.currentLogAnnotations, HashMap.empty())
+        const handlers = yield* ((entity.protocol.toHandlersContext(buildHandlers) as Effect.Effect<
+          Context.Context<Rpc.ToHandler<Rpcs>>,
+          never,
+          any
+        >).pipe(
+          Effect.mapInputContext<never, any>(() => handlerContext as Context.Context<any>),
+          Effect.locally(FiberRef.currentLogAnnotations, HashMap.empty()),
+          Effect.sandbox,
+          Effect.tapError((cause) => Effect.logError("Defect building entity handlers", cause)),
+          Effect.retry(defectRetryPolicy)
         ) as Effect.Effect<Context.Context<Rpc.ToHandler<Rpcs>>>)
 
         const server = yield* RpcServer.makeNoSerialization(entity.protocol, {
@@ -276,7 +286,7 @@ export const make = Effect.fnUntraced(function*<
           }
         }).pipe(
           Scope.extend(scope),
-          Effect.provide(handlers)
+          Effect.mapInputContext<never, any>(() => Context.merge(handlerContext, handlers) as Context.Context<any>)
         )
 
         yield* Scope.addFinalizer(

--- a/packages/cluster/src/internal/entityManager.ts
+++ b/packages/cluster/src/internal/entityManager.ts
@@ -57,7 +57,9 @@ export interface EntityManager {
   }) => boolean
   readonly clearProcessed: () => void
 
-  readonly interruptShard: (shardId: ShardId) => Effect.Effect<void>
+  readonly interruptShard: (shardId: ShardId, options?: {
+    readonly force?: boolean
+  }) => Effect.Effect<void>
 
   readonly activeEntityCount: Effect.Effect<number>
 }
@@ -118,7 +120,10 @@ export const make = Effect.fnUntraced(function*<
   entityRpcs.set(KeepAliveRpc._tag, KeepAliveRpc as any)
 
   const activeServers = new Map<EntityId, EntityState>()
-  const serverCloseLatches = new Map<EntityAddress, Effect.Latch>()
+  const serverCloseLatches = new Map<EntityAddress, {
+    readonly closed: Effect.Latch
+    readonly force: Effect.Latch
+  }>()
   const processedRequestIds = new Set<Snowflake.Snowflake>()
 
   const entities: ResourceMap<
@@ -133,12 +138,16 @@ export const make = Effect.fnUntraced(function*<
     const scope = yield* Effect.scope
     const endLatch = Effect.unsafeMakeLatch()
     const keepAliveLatch = Effect.unsafeMakeLatch(false)
+    const closeLatches = {
+      closed: Effect.unsafeMakeLatch(),
+      force: Effect.unsafeMakeLatch()
+    }
 
     // on shutdown, reset the storage for the entity
     yield* Scope.addFinalizerExit(
       scope,
       () => {
-        serverCloseLatches.get(address)?.unsafeOpen()
+        serverCloseLatches.get(address)?.closed.unsafeOpen()
         serverCloseLatches.delete(address)
         return Effect.void
       }
@@ -366,14 +375,18 @@ export const make = Effect.fnUntraced(function*<
       scope,
       Effect.withFiberRuntime((fiber) => {
         activeServers.delete(address.entityId)
-        serverCloseLatches.set(address, Effect.unsafeMakeLatch(false))
         internalInterruptors.add(fiber.id())
-        return state.write(0, { _tag: "Eof" }).pipe(
-          Effect.andThen(Effect.interruptible(endLatch.await)),
-          Effect.timeoutOption(config.entityTerminationTimeout)
+        return Effect.raceFirst(
+          state.write(0, { _tag: "Eof" }).pipe(
+            Effect.andThen(endLatch.await),
+            Effect.timeoutOption(config.entityTerminationTimeout),
+            Effect.interruptible
+          ),
+          Effect.interruptible(closeLatches.force.await)
         )
       })
     )
+    serverCloseLatches.set(address, closeLatches)
     activeServers.set(address.entityId, state)
 
     return state
@@ -516,17 +529,24 @@ export const make = Effect.fnUntraced(function*<
   )
 
   return identity<EntityManager>({
-    interruptShard: (shardId: ShardId) =>
+    interruptShard: (shardId: ShardId, options) =>
       Effect.suspend(function loop(): Effect.Effect<void> {
         const fibers = Arr.empty<Fiber.RuntimeFiber<void>>()
+        if (options?.force === true) {
+          serverCloseLatches.forEach((latches, address) => {
+            if (shardId[Equal.symbol](address.shardId)) {
+              latches.force.unsafeOpen()
+            }
+          })
+        }
         activeServers.forEach((state) => {
           if (shardId[Equal.symbol](state.address.shardId)) {
             fibers.push(runFork(entities.removeIgnore(state.address)))
           }
         })
-        serverCloseLatches.forEach((latch, address) => {
+        serverCloseLatches.forEach((latches, address) => {
           if (shardId[Equal.symbol](address.shardId)) {
-            fibers.push(runFork(latch.await))
+            fibers.push(runFork(latches.closed.await))
           }
         })
         if (fibers.length === 0) return Effect.void

--- a/packages/cluster/src/internal/resourceMap.ts
+++ b/packages/cluster/src/internal/resourceMap.ts
@@ -4,35 +4,32 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as MutableHashMap from "effect/MutableHashMap"
 import * as MutableRef from "effect/MutableRef"
-import * as Option from "effect/Option"
 import * as Scope from "effect/Scope"
 
 export class ResourceMap<K, A, E> {
   constructor(
     readonly lookup: (key: K, scope: Scope.Scope) => Effect.Effect<A, E>,
-    readonly entries: MutableHashMap.MutableHashMap<K, {
-      readonly scope: Scope.CloseableScope
-      readonly deferred: Deferred.Deferred<A, E>
-    }>,
+    readonly entries: BackingMap<K, A, E>,
     readonly isClosed: MutableRef.MutableRef<boolean>
   ) {}
 
-  static make = Effect.fnUntraced(function*<K, A, E, R>(lookup: (key: K) => Effect.Effect<A, E, R>) {
+  static make = Effect.fnUntraced(function*<K, A, E, R>(lookup: (key: K) => Effect.Effect<A, E, R>, options?: {
+    readonly referential?: boolean | undefined
+  }) {
     const scope = yield* Effect.scope
     const context = yield* Effect.context<R>()
     const isClosed = MutableRef.make(false)
 
-    const entries = MutableHashMap.empty<K, {
-      scope: Scope.CloseableScope
-      deferred: Deferred.Deferred<A, E>
-    }>()
+    const entries: BackingMap<K, A, E> = options?.referential
+      ? { _tag: "Referential", map: new Map() }
+      : { _tag: "Equal", map: MutableHashMap.empty() }
 
     yield* Scope.addFinalizerExit(
       scope,
       (exit) => {
         MutableRef.set(isClosed, true)
-        return Effect.forEach(entries, ([key, { scope }]) => {
-          MutableHashMap.remove(entries, key)
+        return Effect.forEach(entries.map, ([key, { scope }]) => {
+          backingDelete(entries, key)
           return Effect.exit(Scope.close(scope, exit))
         }, { concurrency: "unbounded", discard: true })
       }
@@ -50,18 +47,18 @@ export class ResourceMap<K, A, E> {
       if (MutableRef.get(this.isClosed)) {
         return Effect.interrupt
       }
-      const existing = MutableHashMap.get(this.entries, key)
-      if (Option.isSome(existing)) {
-        return Deferred.await(existing.value.deferred)
+      const existing = backingGet(this.entries, key)
+      if (existing) {
+        return Deferred.await(existing.deferred)
       }
       const scope = Effect.runSync(Scope.make())
       const deferred = Deferred.unsafeMake<A, E>(fiber.id())
-      MutableHashMap.set(this.entries, key, { scope, deferred })
+      backingSet(this.entries, key, { scope, deferred })
       return Effect.onExit(this.lookup(key, scope), (exit) => {
         if (exit._tag === "Success") {
           return Deferred.done(deferred, exit)
         }
-        MutableHashMap.remove(this.entries, key)
+        backingDelete(this.entries, key)
         return Deferred.done(deferred, exit)
       })
     })
@@ -69,12 +66,12 @@ export class ResourceMap<K, A, E> {
 
   remove(key: K): Effect.Effect<void> {
     return Effect.suspend(() => {
-      const entry = MutableHashMap.get(this.entries, key)
-      if (Option.isNone(entry)) {
+      const entry = backingGet(this.entries, key)
+      if (!entry) {
         return Effect.void
       }
-      MutableHashMap.remove(this.entries, key)
-      return Scope.close(entry.value.scope, Exit.void)
+      backingDelete(this.entries, key)
+      return Scope.close(entry.scope, Exit.void)
     })
   }
 
@@ -85,5 +82,42 @@ export class ResourceMap<K, A, E> {
         method: "removeIgnore",
         key
       }))
+  }
+}
+
+type BackingMap<K, A, E> = {
+  readonly _tag: "Equal"
+  readonly map: MutableHashMap.MutableHashMap<K, Entry<A, E>>
+} | {
+  readonly _tag: "Referential"
+  readonly map: Map<K, Entry<A, E>>
+}
+
+type Entry<A, E> = {
+  readonly scope: Scope.CloseableScope
+  readonly deferred: Deferred.Deferred<A, E>
+}
+
+const backingGet = <K, A, E>(map: BackingMap<K, A, E>, key: K): Entry<A, E> | undefined => {
+  if (map._tag === "Referential") {
+    return map.map.get(key)
+  }
+  const entry = MutableHashMap.get(map.map, key)
+  return entry._tag === "Some" ? entry.value : undefined
+}
+
+const backingSet = <K, A, E>(map: BackingMap<K, A, E>, key: K, entry: Entry<A, E>): void => {
+  if (map._tag === "Referential") {
+    map.map.set(key, entry)
+  } else {
+    MutableHashMap.set(map.map, key, entry)
+  }
+}
+
+const backingDelete = <K, A, E>(map: BackingMap<K, A, E>, key: K): void => {
+  if (map._tag === "Referential") {
+    map.map.delete(key)
+  } else {
+    MutableHashMap.remove(map.map, key)
   }
 }

--- a/packages/cluster/src/internal/shardLock.ts
+++ b/packages/cluster/src/internal/shardLock.ts
@@ -1,0 +1,9 @@
+import * as Duration from "effect/Duration"
+import type { ShardingConfig } from "../ShardingConfig.js"
+
+/** @internal */
+export const effectiveInterval = (config: ShardingConfig["Type"]): Duration.Duration =>
+  Duration.min(
+    config.shardLockRefreshInterval,
+    Duration.unsafeDivide(config.shardLockExpiration, 3)
+  )

--- a/packages/cluster/test/ClusterWorkflowEngine.test.ts
+++ b/packages/cluster/test/ClusterWorkflowEngine.test.ts
@@ -326,6 +326,41 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       assert.strictEqual(envelope.sampled, span.sampled)
     }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
 
+  it.effect("routes activities to the workflow shard group after a partial client is cached", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const engine = yield* WorkflowEngine
+      const payload = { id: "partial-client-before-execute" }
+      const executionId = yield* ShardedDeferredWorkflow.executionId(payload)
+      const token = DurableDeferred.tokenFromExecutionId(ShardedDeferred, {
+        workflow: ShardedDeferredWorkflow,
+        executionId
+      })
+
+      const pendingDone = yield* DurableDeferred.done(ShardedDeferred, {
+        token,
+        exit: Exit.void
+      }).pipe(Effect.fork)
+
+      yield* engine.register(ShardedDeferredWorkflow, () =>
+        Activity.make({
+          name: "ShardedActivity",
+          execute: Effect.void
+        }))
+      yield* Fiber.join(pendingDone)
+
+      const journalLength = driver.journal.length
+      yield* ShardedDeferredWorkflow.execute(payload).pipe(Effect.fork)
+      yield* TestClock.adjust(1)
+      const envelope = driver.journal.slice(journalLength).find((envelope) =>
+        envelope._tag === "Request" &&
+        envelope.address.entityType === "Workflow/ShardedDeferredWorkflow" &&
+        envelope.tag === "activity"
+      )
+      assert.exists(envelope)
+      assert.strictEqual(envelope.address.shardId.group, "workflow")
+    }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
+
   it.effect("SuspendOnFailure", () =>
     Effect.gen(function*() {
       const flags = yield* Flags

--- a/packages/cluster/test/ClusterWorkflowEngine.test.ts
+++ b/packages/cluster/test/ClusterWorkflowEngine.test.ts
@@ -181,6 +181,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
   it.effect("Activity.raceAll durable", () =>
     Effect.gen(function*() {
+      const flags = yield* Flags
       const sharding = yield* Sharding.Sharding
       yield* TestClock.adjust(1)
 
@@ -190,6 +191,15 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       yield* TestClock.adjust(1)
       yield* TestClock.adjust(1000)
+      yield* sharding.pollStorage
+      yield* TestClock.adjust(5000)
+
+      const token = flags.get("durable-race-token")
+      assert(typeof token === "string")
+      yield* DurableDeferred.done(DurableRaceGate, {
+        token: DurableDeferred.Token.make(token),
+        exit: Exit.void
+      })
       yield* sharding.pollStorage
       yield* TestClock.adjust(5000)
 
@@ -284,6 +294,38 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       assert.strictEqual(envelope.address.shardId.group, "workflow")
     }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
 
+  it.effect("propagates trace context to persisted workflow requests", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const engine = yield* WorkflowEngine
+      yield* engine.register(ShardedDeferredWorkflow, () => Effect.void)
+
+      const executionId = yield* ShardedDeferredWorkflow.executionId({ id: "trace-context" })
+      const token = DurableDeferred.tokenFromExecutionId(ShardedDeferred, {
+        workflow: ShardedDeferredWorkflow,
+        executionId
+      })
+      const journalLength = driver.journal.length
+      const span = yield* Effect.gen(function*() {
+        const span = yield* Effect.currentSpan
+        yield* DurableDeferred.done(ShardedDeferred, {
+          token,
+          exit: Exit.void
+        })
+        return span
+      }).pipe(Effect.withSpan("complete durable deferred"))
+
+      const envelope = driver.journal.slice(journalLength).find((envelope) =>
+        envelope._tag === "Request" &&
+        envelope.address.entityType === "Workflow/ShardedDeferredWorkflow" &&
+        envelope.tag === "deferred"
+      )
+      assert(envelope?._tag === "Request")
+      assert.strictEqual(envelope.traceId, span.traceId)
+      assert.strictEqual(envelope.spanId, span.spanId)
+      assert.strictEqual(envelope.sampled, span.sampled)
+    }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
+
   it.effect("SuspendOnFailure", () =>
     Effect.gen(function*() {
       const flags = yield* Flags
@@ -310,6 +352,20 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       yield* Fiber.join(fiber)
 
       assert.isTrue(flags.get("catch"))
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("can serialize workflow defects", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+
+      const exit = yield* ErrorDefectWorkflow.execute({
+        id: "raw-error-defect"
+      }).pipe(Effect.exit)
+
+      assert(Exit.isFailure(exit))
+      const [defect] = Cause.defects(exit.cause)
+      assert(defect instanceof Error)
+      assert.strictEqual(defect.message, "Batch request error: Request timed out")
     }).pipe(Effect.provide(TestWorkflowLayer)))
 
   it.effect("forwards parent pointer when spawning a child with discard:true", () =>
@@ -507,6 +563,8 @@ const DurableRaceWorkflow = Workflow.make({
   idempotencyKey: ({ id }) => id
 })
 
+const DurableRaceGate = DurableDeferred.make("DurableRaceGate")
+
 const DurableRaceWorkflowLayer = DurableRaceWorkflow.toLayer(Effect.fnUntraced(function*() {
   const flags = yield* Flags
 
@@ -516,7 +574,7 @@ const DurableRaceWorkflowLayer = DurableRaceWorkflow.toLayer(Effect.fnUntraced(f
     })
   )
 
-  return yield* Activity.raceAll("race", [
+  const result = yield* Activity.raceAll("race", [
     Activity.make({
       name: "Activity1",
       success: Schema.String,
@@ -554,6 +612,9 @@ const DurableRaceWorkflowLayer = DurableRaceWorkflow.toLayer(Effect.fnUntraced(f
       )
     })
   ])
+  flags.set("durable-race-token", yield* DurableDeferred.token(DurableRaceGate))
+  yield* DurableDeferred.await(DurableRaceGate)
+  return result
 }))
 
 const ParentWorkflow = Workflow.make({
@@ -707,6 +768,32 @@ const CatchWorkflowLayer = CatchWorkflow.toLayer(Effect.fnUntraced(function*() {
   )
 }))
 
+const ErrorDefectWorkflow = Workflow.make({
+  name: "ErrorDefectWorkflow",
+  payload: {
+    id: Schema.String
+  },
+  idempotencyKey(payload) {
+    return payload.id
+  }
+})
+
+const ErrorDefectWorkflowLayer = ErrorDefectWorkflow.toLayer(Effect.fnUntraced(function*() {
+  yield* Activity.make({
+    name: "raw-error-defect",
+    execute: Effect.die(makeBatchRequestError())
+  })
+}))
+
+const makeBatchRequestError = () => {
+  const error = new Error("Batch request error: Request timed out")
+  Object.defineProperty(error, "nonJson", {
+    enumerable: true,
+    value: 1n
+  })
+  return error
+}
+
 const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(RaceWorkflowLayer),
   Layer.merge(DurableRaceWorkflowLayer),
@@ -717,6 +804,7 @@ const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(DiscardChildWorkflowLayer),
   Layer.merge(SuspendOnFailureWorkflowLayer),
   Layer.merge(CatchWorkflowLayer),
+  Layer.merge(ErrorDefectWorkflowLayer),
   Layer.provideMerge(Flags.Default),
   Layer.provideMerge(TestWorkflowEngine)
 )

--- a/packages/cluster/test/ClusterWorkflowEngine.test.ts
+++ b/packages/cluster/test/ClusterWorkflowEngine.test.ts
@@ -341,6 +341,7 @@ describe.concurrent("ClusterWorkflowEngine", () => {
         token,
         exit: Exit.void
       }).pipe(Effect.fork)
+      yield* Effect.yieldNow()
 
       yield* engine.register(ShardedDeferredWorkflow, () =>
         Activity.make({

--- a/packages/cluster/test/Entity.test.ts
+++ b/packages/cluster/test/Entity.test.ts
@@ -1,7 +1,7 @@
 import { Entity, ShardingConfig } from "@effect/cluster"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
-import { TestEntity, TestEntityLayer, User } from "./TestEntity.js"
+import { CallerId, ContextBleedEntity, ContextBleedLayer, TestEntity, TestEntityLayer, User } from "./TestEntity.js"
 
 describe.concurrent("Entity", () => {
   describe("makeTestClient", () => {
@@ -11,6 +11,15 @@ describe.concurrent("Entity", () => {
         const client = yield* makeClient("123")
         const user = yield* client.GetUser({ id: 1 })
         assert.deepEqual(user, new User({ id: 1, name: "User 1" }))
+      }).pipe(Effect.provide(TestShardingConfig)))
+
+    it.scoped("does not freeze the acquiring fiber's context into the entity server", () =>
+      Effect.gen(function*() {
+        const makeClient = yield* Entity.makeTestClient(ContextBleedEntity, ContextBleedLayer)
+        const client = yield* makeClient("1").pipe(Effect.provideService(CallerId, "A"))
+
+        const observed = yield* client.ReadCaller()
+        assert.strictEqual(observed, "none")
       }).pipe(Effect.provide(TestShardingConfig)))
   })
 })

--- a/packages/cluster/test/MessageStorage.test.ts
+++ b/packages/cluster/test/MessageStorage.test.ts
@@ -184,6 +184,18 @@ export class PrimaryKeyTest extends Schema.TaggedRequest<PrimaryKeyTest>()("Prim
   }
 }
 
+export class LongKeyTest extends Schema.TaggedRequest<LongKeyTest>()("LongKeyTest", {
+  success: Schema.Void,
+  failure: Schema.Never,
+  payload: { id: Schema.String }
+}) {
+  [PrimaryKey.symbol]() {
+    return this.id
+  }
+}
+
+export const LongKeyRpc = Rpc.fromTaggedRequest(LongKeyTest)
+
 export class StreamTest extends Schema.TaggedRequest<StreamTest>()("StreamTest", {
   success: RpcSchema.Stream({
     success: Schema.Void,

--- a/packages/cluster/test/RunnerStorage.test.ts
+++ b/packages/cluster/test/RunnerStorage.test.ts
@@ -1,0 +1,21 @@
+import { RunnerAddress, RunnerStorage, ShardId } from "@effect/cluster"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("RunnerStorage", () => {
+  it.effect("memory acquire accepts a one-shot iterable", () =>
+    Effect.gen(function*() {
+      const storage = yield* RunnerStorage.makeMemory
+      const address = RunnerAddress.make("localhost", 1234)
+      const shards = [ShardId.make("default", 1), ShardId.make("default", 2)]
+      const acquired = yield* storage.acquire(
+        address,
+        (function*() {
+          yield* shards
+        })()
+      )
+
+      assert.deepStrictEqual(acquired, shards)
+      assert.deepStrictEqual(yield* storage.refresh(address, []), shards)
+    }))
+})

--- a/packages/cluster/test/Runners.test.ts
+++ b/packages/cluster/test/Runners.test.ts
@@ -1,0 +1,239 @@
+import {
+  ClusterError,
+  ClusterSchema,
+  Entity,
+  EntityAddress,
+  EntityId,
+  EntityType,
+  Envelope,
+  Message,
+  MessageStorage,
+  type Reply,
+  RunnerAddress,
+  RunnerHealth,
+  Runners,
+  RunnerServer,
+  RunnerStorage,
+  ShardId,
+  Sharding,
+  ShardingConfig,
+  Snowflake
+} from "@effect/cluster"
+import { Headers } from "@effect/platform"
+import { Rpc, RpcClient, RpcTest } from "@effect/rpc"
+import { RpcClientError } from "@effect/rpc/RpcClientError"
+import type { FromClientEncoded, FromServerEncoded } from "@effect/rpc/RpcMessage"
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Context, Effect, Exit, Layer, Option, Schema, Stream, TestClock } from "effect"
+
+const BadReplyEntity = Entity.make("BadReplyEntity", [
+  Rpc.make("BadReply", {
+    success: Schema.Int,
+    payload: { id: Schema.Number }
+  }),
+  Rpc.make("BadStream", {
+    success: Schema.Int,
+    payload: { id: Schema.Number },
+    stream: true
+  })
+]).annotateRpcs(ClusterSchema.Persisted, false)
+
+const BadReplyEntityLayer = BadReplyEntity.toLayer({
+  BadReply: () => Effect.succeed(1.5),
+  BadStream: () => Stream.make(2.5)
+})
+
+const TestShardingConfig = ShardingConfig.layer({
+  entityMailboxCapacity: 10,
+  entityTerminationTimeout: 0,
+  entityMessagePollInterval: 5000,
+  sendRetryInterval: 100
+})
+
+const RunnerServerHandlers = RunnerServer.layerHandlers.pipe(
+  Layer.provideMerge(BadReplyEntityLayer),
+  Layer.provideMerge(Sharding.layer),
+  Layer.provideMerge(Snowflake.layerGenerator),
+  Layer.provide(RunnerStorage.layerMemory),
+  Layer.provide(RunnerHealth.layerNoop),
+  Layer.provide(Runners.layerNoop),
+  Layer.provideMerge(MessageStorage.layerMemory),
+  Layer.provide(TestShardingConfig)
+)
+
+describe.concurrent("RunnerServer", () => {
+  const makeRequest = (options: { readonly entityId: string; readonly tag: string }) =>
+    Effect.gen(function*() {
+      const sharding = yield* Sharding.Sharding
+      const snowflakeGen = yield* Snowflake.Generator
+      const entityId = EntityId.make(options.entityId)
+      return {
+        _tag: "Request" as const,
+        requestId: snowflakeGen.unsafeNext(),
+        address: EntityAddress.make({
+          shardId: sharding.getShardId(entityId, BadReplyEntity.getShardGroup(entityId)),
+          entityType: EntityType.EntityType.make("BadReplyEntity"),
+          entityId
+        }),
+        tag: options.tag,
+        payload: { id: 1 },
+        headers: Headers.empty
+      }
+    })
+
+  it.scoped("a reply that fails to serialize fails only its own request", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const client = yield* RpcTest.makeClient(Runners.Rpcs)
+      const request = yield* makeRequest({ entityId: "bad-1", tag: "BadReply" })
+
+      const exit = yield* Effect.exit(client.Effect({ request, persisted: false }))
+      if (!Exit.isSuccess(exit)) {
+        return assert.fail("Effect rpc must not defect on a reply serialization failure")
+      }
+      const reply = exit.value
+      if (reply._tag !== "WithExit" || reply.exit._tag !== "Failure") {
+        return assert.fail("expected a WithExit reply with a failure exit")
+      }
+      assert.strictEqual(reply.requestId, String(request.requestId))
+      assert.include(JSON.stringify(reply.exit), "MalformedMessage")
+    }).pipe(Effect.provide(RunnerServerHandlers)))
+
+  it.scoped("a stream reply that fails to serialize ends the stream with the defect", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const client = yield* RpcTest.makeClient(Runners.Rpcs)
+      const request = yield* makeRequest({ entityId: "bad-2", tag: "BadStream" })
+      const mailbox = yield* client.Stream({ request, persisted: false }, { asMailbox: true })
+      const replies: Array<Reply.ReplyEncoded<any>> = []
+
+      yield* mailbox.take.pipe(
+        Effect.tap((reply) => Effect.sync(() => replies.push(reply))),
+        Effect.forever,
+        Effect.catchIf(Cause.isNoSuchElementException, () => Effect.void)
+      )
+
+      assert.strictEqual(replies.length, 1)
+      const reply = replies[0]
+      if (reply._tag !== "WithExit" || reply.exit._tag !== "Failure") {
+        return assert.fail("expected a terminal WithExit reply with a failure exit")
+      }
+      assert.strictEqual(reply.requestId, String(request.requestId))
+      assert.include(JSON.stringify(reply.exit), "MalformedMessage")
+    }).pipe(Effect.provide(RunnerServerHandlers)))
+})
+
+describe.concurrent("Runners.makeRpc", () => {
+  const runnerAddress = RunnerAddress.make("localhost", 42_000)
+  const TestRpc = Rpc.make("TestRpc", {
+    success: Schema.Number,
+    payload: { id: Schema.Number }
+  }).annotate(ClusterSchema.Persisted, false)
+  const TestRpcPersisted = Rpc.make("TestRpcPersisted", {
+    success: Schema.Number,
+    payload: { id: Schema.Number }
+  }).annotate(ClusterSchema.Persisted, true)
+  type SendRpc = typeof TestRpc | typeof TestRpcPersisted
+
+  const makeOutgoingRequest = (
+    rpc: SendRpc,
+    requestId: Snowflake.Snowflake,
+    respond: (reply: Reply.Reply<SendRpc>) => Effect.Effect<void>
+  ): Message.OutgoingRequest<SendRpc> =>
+    new Message.OutgoingRequest({
+      envelope: Envelope.makeRequest<SendRpc>({
+        requestId,
+        address: EntityAddress.make({
+          shardId: ShardId.make("default", 1),
+          entityType: EntityType.EntityType.make("TestRpcEntity"),
+          entityId: EntityId.make("1")
+        }),
+        tag: rpc._tag,
+        payload: { id: 1 },
+        headers: Headers.empty
+      }),
+      rpc,
+      context: Context.empty(),
+      lastReceivedReply: Option.none(),
+      respond
+    })
+
+  const layerFakeProtocol = (
+    onRequest: (
+      request: FromClientEncoded,
+      write: (data: FromServerEncoded) => Effect.Effect<void>
+    ) => Effect.Effect<void, RpcClientError>
+  ) =>
+    Layer.succeed(Runners.RpcClientProtocol, () =>
+      Effect.sync(() => {
+        let write!: (data: FromServerEncoded) => Effect.Effect<void>
+        return RpcClient.Protocol.of({
+          run(f) {
+            write = f
+            return Effect.never
+          },
+          send(request) {
+            return onRequest(request, write)
+          },
+          supportsAck: true,
+          supportsTransferables: false
+        })
+      }))
+
+  const layerRunners = (protocol: Layer.Layer<Runners.RpcClientProtocol>) =>
+    Runners.layerRpc.pipe(
+      Layer.provideMerge(Snowflake.layerGenerator),
+      Layer.provide(protocol),
+      Layer.provideMerge(MessageStorage.layerNoop),
+      Layer.provide(TestShardingConfig)
+    )
+
+  const respondWithDefect = (
+    request: FromClientEncoded,
+    write: (data: FromServerEncoded) => Effect.Effect<void>
+  ) => request._tag === "Request" ? write({ _tag: "Defect", defect: "boom" }) : Effect.void
+
+  it.effect("a server-delivered defect resolves a volatile request", () =>
+    Effect.gen(function*() {
+      const runners = yield* Runners.Runners
+      const snowflakeGen = yield* Snowflake.Generator
+      const replies: Array<Reply.Reply<SendRpc>> = []
+      const message = makeOutgoingRequest(TestRpc, snowflakeGen.unsafeNext(), (reply) =>
+        Effect.sync(() =>
+          replies.push(reply)
+        ))
+
+      const exit = yield* Effect.exit(runners.send({ address: runnerAddress, message }))
+      assert.isTrue(Exit.isSuccess(exit))
+      assert.strictEqual(replies.length, 1)
+      const reply = replies[0]
+      if (reply._tag !== "WithExit" || !Exit.isFailure(reply.exit)) {
+        return assert.fail("expected a WithExit reply with a failure exit")
+      }
+      assert.include(String(Cause.squash(reply.exit.cause)), "boom")
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(respondWithDefect)))))
+
+  it.effect("transport failures still map to RunnerUnavailable", () =>
+    Effect.gen(function*() {
+      const runners = yield* Runners.Runners
+      const snowflakeGen = yield* Snowflake.Generator
+      const message = makeOutgoingRequest(TestRpc, snowflakeGen.unsafeNext(), () => Effect.void)
+      const exit = yield* Effect.exit(runners.send({ address: runnerAddress, message }))
+
+      if (!Exit.isFailure(exit)) return assert.fail("send must fail for a transport failure")
+      assert.instanceOf(Cause.squash(exit.cause), ClusterError.RunnerUnavailable)
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(() =>
+      Effect.fail(new RpcClientError({ reason: "Protocol", message: "boom" }))
+    )))))
+
+  it.effect("a delivered defect for a persisted request maps to RunnerUnavailable", () =>
+    Effect.gen(function*() {
+      const runners = yield* Runners.Runners
+      const snowflakeGen = yield* Snowflake.Generator
+      const message = makeOutgoingRequest(TestRpcPersisted, snowflakeGen.unsafeNext(), () => Effect.void)
+      const exit = yield* Effect.exit(runners.send({ address: runnerAddress, message }))
+
+      if (!Exit.isFailure(exit)) return assert.fail("send must fail for a persisted request defect")
+      assert.instanceOf(Cause.squash(exit.cause), ClusterError.RunnerUnavailable)
+    }).pipe(Effect.provide(layerRunners(layerFakeProtocol(respondWithDefect)))))
+})

--- a/packages/cluster/test/Sharding.test.ts
+++ b/packages/cluster/test/Sharding.test.ts
@@ -1,4 +1,6 @@
 import {
+  EntityId,
+  MachineId,
   MessageStorage,
   RunnerAddress,
   Runners,
@@ -7,6 +9,7 @@ import {
   ShardingConfig,
   Snowflake
 } from "@effect/cluster"
+import type { Runner, ShardId } from "@effect/cluster"
 import { assert, describe, expect, it } from "@effect/vitest"
 import {
   Array,
@@ -23,6 +26,7 @@ import {
   Stream,
   TestClock
 } from "effect"
+import type { Clock } from "effect"
 import * as RunnerHealth from "../src/RunnerHealth.js"
 import {
   CallerId,
@@ -570,6 +574,128 @@ describe.concurrent("Sharding", () => {
       assert.deepStrictEqual(state.envelopes.unsafeSize(), Option.some(4))
     }).pipe(Effect.provide(TestSharding)))
 })
+
+describe("Sharding shard lock failover", () => {
+  it.effect("interrupts entities and reacquires shards after lock storage recovers", () =>
+    Effect.gen(function*() {
+      const storageState = makeFailoverStorageState()
+      const runnerStorage = Layer.effect(
+        RunnerStorage.RunnerStorage,
+        Effect.map(Effect.clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const config = ShardingConfig.layer({
+        runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+        shardsPerGroup: 1,
+        shardLockExpiration: 300,
+        shardLockRefreshInterval: 1000,
+        entityTerminationTimeout: 30_000,
+        entityMessagePollInterval: 10,
+        refreshAssignmentsInterval: 10,
+        sendRetryInterval: 10
+      })
+      const layer = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(runnerStorage),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provideMerge(TestEntityState.Default),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provide(config)
+      )
+
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const entityState = yield* TestEntityState
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        const shardId = sharding.getShardId(EntityId.make("1"), "default")
+
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+        while (!storageState.refreshCalls.some((call) => call.shards.length > 0)) {
+          yield* TestClock.adjust(100)
+        }
+
+        const entityFiber = yield* client.NeverVolatile().pipe(Effect.fork)
+        yield* TestClock.adjust(1)
+        assert.deepStrictEqual(entityState.envelopes.unsafeSize(), Option.some(1))
+
+        const acquireCount = storageState.acquireCalls.length
+        storageState.blackholed = true
+        yield* TestClock.adjust(201)
+
+        assert.isFalse(sharding.hasShardId(shardId))
+        const entityExit = entityFiber.unsafePoll()
+        assert(entityExit && Exit.isFailure(entityExit) && Cause.isInterrupted(entityExit.cause))
+
+        yield* TestClock.adjust(1000)
+        assert.strictEqual(storageState.acquireCalls.length, acquireCount)
+        assert(storageState.refreshCalls.some((call) => call.shards.length === 0))
+
+        storageState.blackholed = false
+        yield* TestClock.adjust(101)
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+
+        assert.isAbove(storageState.acquireCalls.length, acquireCount)
+        assert.strictEqual(storageState.releaseAllCalls, 1)
+        assert.deepStrictEqual(yield* client.GetUserVolatile({ id: 2 }), new User({ id: 2, name: "User 2" }))
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    }))
+})
+
+interface FailoverStorageState {
+  blackholed: boolean
+  runner: Runner.Runner | undefined
+  readonly acquireCalls: Array<ReadonlyArray<ShardId.ShardId>>
+  readonly refreshCalls: Array<{
+    readonly at: number
+    readonly shards: ReadonlyArray<ShardId.ShardId>
+  }>
+  releaseAllCalls: number
+}
+
+const makeFailoverStorageState = (): FailoverStorageState => ({
+  blackholed: false,
+  runner: undefined,
+  acquireCalls: [],
+  refreshCalls: [],
+  releaseAllCalls: 0
+})
+
+const makeFailoverStorage = (state: FailoverStorageState, clock: Clock.Clock) =>
+  RunnerStorage.RunnerStorage.of({
+    getRunners: Effect.sync(() => state.runner ? [[state.runner, true] as const] : []),
+    register: (runner) =>
+      Effect.sync(() => {
+        state.runner = runner
+        return MachineId.make(1)
+      }),
+    unregister: () => Effect.void,
+    setRunnerHealth: () => Effect.void,
+    acquire: (_address, shardIds) =>
+      Effect.sync(() => {
+        const shards = globalThis.Array.from(shardIds)
+        state.acquireCalls.push(shards)
+        return shards
+      }),
+    refresh: (_address, shardIds) =>
+      Effect.suspend(() => {
+        const shards = globalThis.Array.from(shardIds)
+        state.refreshCalls.push({
+          at: clock.unsafeCurrentTimeMillis(),
+          shards
+        })
+        return state.blackholed ? Effect.never : Effect.succeed(shards)
+      }),
+    release: () => Effect.void,
+    releaseAll: () =>
+      Effect.sync(() => {
+        state.releaseAllCalls++
+      })
+  })
 
 const TestShardingConfig = ShardingConfig.layer({
   entityMailboxCapacity: 10,

--- a/packages/cluster/test/Sharding.test.ts
+++ b/packages/cluster/test/Sharding.test.ts
@@ -1,15 +1,17 @@
+import type { Runner, ShardId } from "@effect/cluster"
 import {
   EntityId,
   MachineId,
   MessageStorage,
+  Runner as RunnerModule,
   RunnerAddress,
   Runners,
   RunnerStorage,
+  ShardId as ShardIdModule,
   Sharding,
   ShardingConfig,
   Snowflake
 } from "@effect/cluster"
-import type { Runner, ShardId } from "@effect/cluster"
 import { assert, describe, expect, it } from "@effect/vitest"
 import {
   Array,
@@ -640,34 +642,258 @@ describe("Sharding shard lock failover", () => {
         }
 
         assert.isAbove(storageState.acquireCalls.length, acquireCount)
-        assert.strictEqual(storageState.releaseAllCalls, 1)
+        assert.strictEqual(storageState.releaseAllCalls.length, 1)
         assert.deepStrictEqual(yield* client.GetUserVolatile({ id: 2 }), new User({ id: 2, name: "User 2" }))
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    }))
+
+  it.effect("keeps the graceful timeout for normal shard reassignment", () =>
+    Effect.gen(function*() {
+      const storageState = makeFailoverStorageState()
+      const runnerStorage = Layer.effect(
+        RunnerStorage.RunnerStorage,
+        Effect.map(Effect.clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const config = ShardingConfig.layer({
+        runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+        shardsPerGroup: 1,
+        shardLockExpiration: 3000,
+        shardLockRefreshInterval: 100,
+        entityTerminationTimeout: 1000,
+        entityMessagePollInterval: 10,
+        refreshAssignmentsInterval: 10,
+        sendRetryInterval: 10
+      })
+      const layer = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(runnerStorage),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provideMerge(TestEntityState.Default),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provide(config)
+      )
+
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        const shardId = sharding.getShardId(EntityId.make("1"), "default")
+
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+        const entityFiber = yield* client.NeverVolatile().pipe(Effect.fork)
+        yield* TestClock.adjust(1)
+
+        storageState.assignSelf = false
+        for (let i = 0; i < 100 && sharding.hasShardId(shardId); i++) {
+          yield* TestClock.adjust(10)
+        }
+        assert.isFalse(sharding.hasShardId(shardId))
+        for (let i = 0; i < 200 && (yield* sharding.activeEntityCount) > 0; i++) {
+          yield* TestClock.adjust(10)
+        }
+        assert.strictEqual(yield* sharding.activeEntityCount, 0)
+
+        assert.isNull(entityFiber.unsafePoll())
+        assert.strictEqual(storageState.releaseCalls.length, 0)
+        yield* TestClock.adjust(900)
+        assert.isNull(entityFiber.unsafePoll())
+        assert.strictEqual(storageState.releaseCalls.length, 0)
+
+        for (let i = 0; i < 20 && entityFiber.unsafePoll() === null; i++) {
+          yield* TestClock.adjust(10)
+        }
+        const entityExit = entityFiber.unsafePoll()
+        assert(entityExit && Exit.isFailure(entityExit) && Cause.isInterrupted(entityExit.cause))
+        assert.strictEqual(storageState.releaseCalls.length, 1)
+      }).pipe(
+        Effect.ensuring(TestClock.adjust(2000)),
+        Effect.provide(layer),
+        Effect.scoped
+      )
+    }), 10_000)
+
+  it.effect("does not wait for entity construction before a forced shard release", () =>
+    Effect.gen(function*() {
+      const storageState = makeFailoverStorageState()
+      const runnerStorage = Layer.effect(
+        RunnerStorage.RunnerStorage,
+        Effect.map(Effect.clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const config = ShardingConfig.layer({
+        runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+        shardsPerGroup: 1,
+        shardLockExpiration: 300,
+        shardLockRefreshInterval: 1000,
+        entityTerminationTimeout: 0,
+        entityMessagePollInterval: 10,
+        refreshAssignmentsInterval: 10,
+        sendRetryInterval: 10
+      })
+      const layer = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(runnerStorage),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provideMerge(TestEntityState.Default),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provide(config)
+      )
+
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const entityState = yield* TestEntityState
+        const makeClient = yield* TestEntity.client
+        const client = makeClient("1")
+        const shardId = sharding.getShardId(EntityId.make("1"), "default")
+
+        while (!sharding.hasShardId(shardId)) {
+          yield* TestClock.adjust(10)
+        }
+        while (!storageState.refreshCalls.some((call) => call.shards.length > 0)) {
+          yield* TestClock.adjust(100)
+        }
+
+        yield* Effect.gen(function*() {
+          entityState.buildLatch.unsafeClose()
+          const entityFiber = yield* client.GetUserVolatile({ id: 1 }).pipe(Effect.fork)
+          while (entityState.layerBuilds.current === 0) {
+            yield* TestClock.adjust(1)
+          }
+
+          storageState.blackholed = true
+          yield* TestClock.adjust(201)
+          assert.isFalse(sharding.hasShardId(shardId))
+
+          storageState.blackholed = false
+          yield* TestClock.adjust(1000)
+
+          assert.strictEqual(storageState.releaseAllCalls.length, 1)
+          entityState.buildLatch.unsafeOpen()
+          yield* TestClock.adjust(1)
+          yield* Fiber.interrupt(entityFiber)
+        }).pipe(Effect.ensuring(entityState.buildLatch.open))
+      }).pipe(Effect.provide(layer), Effect.scoped)
+    }))
+
+  it.effect("does not acquire shards while a forced release is pending", () =>
+    Effect.gen(function*() {
+      const shardsPerGroup = 4
+      const storageState = makeFailoverStorageState({
+        otherRunnerHealthy: true,
+        releaseAllDuration: 500
+      })
+      const runnerStorage = Layer.effect(
+        RunnerStorage.RunnerStorage,
+        Effect.map(Effect.clock, (clock) => makeFailoverStorage(storageState, clock))
+      )
+      const config = ShardingConfig.layer({
+        runnerAddress: Option.some(RunnerAddress.make("localhost", 1234)),
+        shardsPerGroup,
+        shardLockExpiration: 300,
+        shardLockRefreshInterval: 1000,
+        entityTerminationTimeout: 0,
+        entityMessagePollInterval: 10,
+        refreshAssignmentsInterval: 10,
+        sendRetryInterval: 10
+      })
+      const layer = TestEntityNoState.pipe(
+        Layer.provideMerge(Sharding.layer),
+        Layer.provide(runnerStorage),
+        Layer.provide(RunnerHealth.layerNoop),
+        Layer.provideMerge(TestEntityState.Default),
+        Layer.provide(Runners.layerNoop),
+        Layer.provide([MessageStorage.layerMemory, Snowflake.layerGenerator]),
+        Layer.provide(config)
+      )
+
+      yield* Effect.gen(function*() {
+        const sharding = yield* Sharding.Sharding
+        const allShards = Array.makeBy(shardsPerGroup, (i) => ShardIdModule.make("default", i + 1))
+        const ownedCount = () => allShards.filter((shardId) => sharding.hasShardId(shardId)).length
+
+        while (ownedCount() === 0) {
+          yield* TestClock.adjust(10)
+        }
+        assert.isBelow(ownedCount(), shardsPerGroup)
+        while (!storageState.refreshCalls.some((call) => call.shards.length > 0)) {
+          yield* TestClock.adjust(100)
+        }
+
+        const acquiresBeforeOutage = storageState.acquireCalls.length
+        storageState.blackholed = true
+        yield* TestClock.adjust(201)
+        assert.strictEqual(ownedCount(), 0)
+
+        storageState.otherRunnerHealthy = false
+        yield* TestClock.adjust(100)
+        assert.strictEqual(storageState.releaseAllCalls.length, 0)
+
+        storageState.blackholed = false
+        while (storageState.releaseAllCalls.length === 0) {
+          yield* TestClock.adjust(10)
+        }
+        while (!storageState.releaseAllCalls[0].completed) {
+          yield* TestClock.adjust(10)
+        }
+        storageState.releaseAllDuration = 0
+
+        while (ownedCount() < shardsPerGroup) {
+          yield* TestClock.adjust(10)
+        }
+
+        assert.strictEqual(storageState.releaseAllCalls.length, 1)
+        assert(
+          storageState.acquireCalls
+            .slice(acquiresBeforeOutage)
+            .every((call) => call.completedReleaseAlls > 0)
+        )
       }).pipe(Effect.provide(layer), Effect.scoped)
     }))
 })
 
 interface FailoverStorageState {
   blackholed: boolean
+  assignSelf: boolean
+  otherRunnerHealthy: boolean
+  releaseAllDuration: number
   runner: Runner.Runner | undefined
-  readonly acquireCalls: Array<ReadonlyArray<ShardId.ShardId>>
+  readonly acquireCalls: Array<{
+    readonly shards: ReadonlyArray<ShardId.ShardId>
+    readonly completedReleaseAlls: number
+  }>
   readonly refreshCalls: Array<{
     readonly at: number
     readonly shards: ReadonlyArray<ShardId.ShardId>
   }>
-  releaseAllCalls: number
+  readonly releaseCalls: Array<ShardId.ShardId>
+  readonly releaseAllCalls: Array<{ completed: boolean }>
 }
 
-const makeFailoverStorageState = (): FailoverStorageState => ({
+const makeFailoverStorageState = (
+  overrides?: Partial<FailoverStorageState>
+): FailoverStorageState => ({
   blackholed: false,
+  assignSelf: true,
+  otherRunnerHealthy: false,
+  releaseAllDuration: 0,
   runner: undefined,
   acquireCalls: [],
   refreshCalls: [],
-  releaseAllCalls: 0
+  releaseCalls: [],
+  releaseAllCalls: [],
+  ...overrides
 })
 
 const makeFailoverStorage = (state: FailoverStorageState, clock: Clock.Clock) =>
   RunnerStorage.RunnerStorage.of({
-    getRunners: Effect.sync(() => state.runner ? [[state.runner, true] as const] : []),
+    getRunners: Effect.sync(() => {
+      if (!state.runner) return []
+      if (!state.assignSelf) return [[state.runner, false], [otherRunner, true]]
+      return state.otherRunnerHealthy ? [[state.runner, true], [otherRunner, true]] : [[state.runner, true]]
+    }),
     register: (runner) =>
       Effect.sync(() => {
         state.runner = runner
@@ -678,7 +904,10 @@ const makeFailoverStorage = (state: FailoverStorageState, clock: Clock.Clock) =>
     acquire: (_address, shardIds) =>
       Effect.sync(() => {
         const shards = globalThis.Array.from(shardIds)
-        state.acquireCalls.push(shards)
+        state.acquireCalls.push({
+          shards,
+          completedReleaseAlls: state.releaseAllCalls.filter((call) => call.completed).length
+        })
         return shards
       }),
     refresh: (_address, shardIds) =>
@@ -690,12 +919,28 @@ const makeFailoverStorage = (state: FailoverStorageState, clock: Clock.Clock) =>
         })
         return state.blackholed ? Effect.never : Effect.succeed(shards)
       }),
-    release: () => Effect.void,
-    releaseAll: () =>
+    release: (_address, shardId) =>
       Effect.sync(() => {
-        state.releaseAllCalls++
+        state.releaseCalls.push(shardId)
+      }),
+    releaseAll: () =>
+      Effect.suspend(() => {
+        const call = { completed: false }
+        state.releaseAllCalls.push(call)
+        return Effect.andThen(
+          Effect.sleep(state.releaseAllDuration),
+          Effect.sync(() => {
+            call.completed = true
+          })
+        )
       })
   })
+
+const otherRunner = RunnerModule.make({
+  address: RunnerAddress.make("localhost", 5678),
+  groups: ["default"],
+  weight: 1
+})
 
 const TestShardingConfig = ShardingConfig.layer({
   entityMailboxCapacity: 10,

--- a/packages/cluster/test/Sharding.test.ts
+++ b/packages/cluster/test/Sharding.test.ts
@@ -24,7 +24,15 @@ import {
   TestClock
 } from "effect"
 import * as RunnerHealth from "../src/RunnerHealth.js"
-import { TestEntity, TestEntityNoState, TestEntityState, User } from "./TestEntity.js"
+import {
+  CallerId,
+  ContextBleedEntity,
+  ContextBleedLayer,
+  TestEntity,
+  TestEntityNoState,
+  TestEntityState,
+  User
+} from "./TestEntity.js"
 
 describe.concurrent("Sharding", () => {
   it.scoped("delivers a message", () =>
@@ -35,6 +43,22 @@ describe.concurrent("Sharding", () => {
       const user = yield* client.GetUserVolatile({ id: 1 })
       expect(user).toEqual(new User({ id: 1, name: "User 1" }))
     }).pipe(Effect.provide(TestSharding)))
+
+  it.scoped("does not freeze the first caller's context into the entity server", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const makeClient = yield* ContextBleedEntity.client
+      const client = makeClient("1")
+
+      const first = yield* client.ReadCaller().pipe(Effect.provideService(CallerId, "A"))
+      assert.strictEqual(first, "A")
+
+      const second = yield* client.ReadCaller()
+      assert.strictEqual(second, "none")
+
+      const durable = yield* client.ReadCallerPersisted()
+      assert.strictEqual(durable, "none")
+    }).pipe(Effect.provide(ContextBleedSharding)))
 
   it.scoped("delivers a message via storage", () =>
     Effect.gen(function*() {
@@ -512,6 +536,20 @@ describe.concurrent("Sharding", () => {
       expect(state.layerBuilds.current).toEqual(2)
     }).pipe(Effect.provide(TestSharding)))
 
+  it.scoped("retries defects when building handlers", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const state = yield* TestEntityState
+      const makeClient = yield* TestEntity.client
+      const client = makeClient("handler-build-defect")
+
+      MutableRef.set(state.handlerBuildDefectTrigger, true)
+      const result = yield* client.GetUserVolatile({ id: 123 })
+
+      assert.deepStrictEqual(result, new User({ id: 123, name: "User 123" }))
+      assert.strictEqual(state.layerBuilds.current, 2)
+    }).pipe(Effect.provide(TestSharding)))
+
   it.effect("replays in-flight requests when restarting after a defect", () =>
     Effect.gen(function*() {
       yield* TestClock.adjust(1)
@@ -561,3 +599,5 @@ const TestSharding = TestShardingWithoutStorage.pipe(
   Layer.provideMerge(MessageStorage.layerMemory),
   Layer.provide(TestShardingConfig)
 )
+
+const ContextBleedSharding = ContextBleedLayer.pipe(Layer.provideMerge(TestSharding))

--- a/packages/cluster/test/SqlMessageStorage.test.ts
+++ b/packages/cluster/test/SqlMessageStorage.test.ts
@@ -1,14 +1,16 @@
-import { Message, MessageStorage, ShardingConfig, Snowflake, SqlMessageStorage } from "@effect/cluster"
+import { Envelope, Message, MessageStorage, ShardingConfig, Snowflake, SqlMessageStorage } from "@effect/cluster"
 import { FileSystem } from "@effect/platform"
 import { NodeFileSystem } from "@effect/platform-node"
 import { Rpc } from "@effect/rpc"
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { SqlClient } from "@effect/sql/SqlClient"
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Effect, Fiber, Layer, TestClock } from "effect"
+import { Effect, Fiber, Layer, Option, TestClock } from "effect"
 import { MysqlContainer } from "./fixtures/utils-mysql.js"
 import { PgContainer } from "./fixtures/utils-pg.js"
 import {
+  LongKeyRpc,
+  LongKeyTest,
   makeAckChunk,
   makeChunkReply,
   makeReply,
@@ -138,6 +140,103 @@ describe("SqlMessageStorage", () => {
           )
           expect(result._tag).toEqual("Duplicate")
         }))
+
+      it.effect("hashes primary keys longer than the message_id column", () =>
+        Effect.gen(function*() {
+          yield* truncate
+
+          const storage = yield* MessageStorage.MessageStorage
+          const longId = "long-key-".repeat(50)
+          const request = yield* makeRequest({
+            rpc: LongKeyRpc,
+            payload: new LongKeyTest({ id: longId })
+          })
+          const result = yield* storage.saveRequest(request)
+          expect(result._tag).toEqual("Success")
+
+          const duplicate = yield* storage.saveRequest(
+            yield* makeRequest({ rpc: LongKeyRpc, payload: new LongKeyTest({ id: longId }) })
+          )
+          expect(duplicate._tag).toEqual("Duplicate")
+
+          const requestId = yield* storage.requestIdForPrimaryKey({
+            address: request.envelope.address,
+            tag: request.envelope.tag,
+            id: longId
+          })
+          expect(requestId).toEqual(Option.some(request.envelope.requestId))
+
+          const sql = yield* SqlClient
+          const rows = yield* sql<{ message_id: string }>`SELECT message_id FROM cluster_messages`
+          expect(rows).toHaveLength(1)
+          expect(rows[0].message_id).toMatch(/^[0-9a-f]{64}$/)
+        }))
+
+      it.effect("keeps primary keys within the column width as plaintext", () =>
+        Effect.gen(function*() {
+          yield* truncate
+
+          const sql = yield* SqlClient
+          const storage = yield* MessageStorage.MessageStorage
+          const request = yield* makeRequest({
+            rpc: Rpc.fromTaggedRequest(PrimaryKeyTest),
+            payload: new PrimaryKeyTest({ id: 456 })
+          })
+          yield* storage.saveRequest(request)
+
+          const plaintext = Envelope.primaryKey(request.envelope)!
+          const rows = yield* sql<{ message_id: string }>`SELECT message_id FROM cluster_messages`
+          expect(rows).toHaveLength(1)
+          expect(rows[0].message_id).toEqual(plaintext)
+
+          const result = yield* storage.saveRequest(
+            yield* makeRequest({
+              rpc: Rpc.fromTaggedRequest(PrimaryKeyTest),
+              payload: new PrimaryKeyTest({ id: 456 })
+            })
+          )
+          assert(result._tag === "Duplicate")
+          expect(result.originalId).toEqual(request.envelope.requestId)
+
+          const requestId = yield* storage.requestIdForPrimaryKey({
+            address: request.envelope.address,
+            tag: request.envelope.tag,
+            id: "456"
+          })
+          expect(requestId).toEqual(Option.some(request.envelope.requestId))
+        }))
+
+      if (label === "sqlite") {
+        it.effect("detects duplicates for legacy long-key plaintext rows", () =>
+          Effect.gen(function*() {
+            yield* truncate
+
+            const sql = yield* SqlClient
+            const storage = yield* MessageStorage.MessageStorage
+            const longId = "legacy-long-key-".repeat(30)
+            const request = yield* makeRequest({ rpc: LongKeyRpc, payload: new LongKeyTest({ id: longId }) })
+            yield* storage.saveRequest(request)
+
+            const plaintext = Envelope.primaryKey(request.envelope)!
+            expect(plaintext.length).toBeGreaterThan(255)
+            yield* sql`UPDATE cluster_messages SET message_id = ${plaintext} WHERE id = ${
+              String(request.envelope.requestId)
+            }`
+
+            const result = yield* storage.saveRequest(
+              yield* makeRequest({ rpc: LongKeyRpc, payload: new LongKeyTest({ id: longId }) })
+            )
+            assert(result._tag === "Duplicate")
+            expect(result.originalId).toEqual(request.envelope.requestId)
+
+            const requestId = yield* storage.requestIdForPrimaryKey({
+              address: request.envelope.address,
+              tag: request.envelope.tag,
+              id: longId
+            })
+            expect(requestId).toEqual(Option.some(request.envelope.requestId))
+          }))
+      }
 
       it.effect("unprocessedMessages", () =>
         Effect.gen(function*() {

--- a/packages/cluster/test/SqlRunnerStorage.test.ts
+++ b/packages/cluster/test/SqlRunnerStorage.test.ts
@@ -2,8 +2,10 @@ import { Runner, RunnerAddress, RunnerStorage, ShardId, SqlRunnerStorage } from 
 import { FileSystem } from "@effect/platform"
 import { NodeFileSystem } from "@effect/platform-node"
 import { SqliteClient } from "@effect/sql-sqlite-node"
-import { describe, expect, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import * as SqlClient from "@effect/sql/SqlClient"
+import type * as SqlConnection from "@effect/sql/SqlConnection"
+import { assert, describe, expect, it } from "@effect/vitest"
+import { Duration, Effect, Exit, Layer, Schedule, TestServices } from "effect"
 import * as ShardingConfig from "../src/ShardingConfig.js"
 import { MysqlContainer } from "./fixtures/utils-mysql.js"
 import { PgContainer } from "./fixtures/utils-pg.js"
@@ -11,6 +13,75 @@ import { PgContainer } from "./fixtures/utils-pg.js"
 const StorageLive = SqlRunnerStorage.layer
 
 describe("SqlRunnerStorage", () => {
+  it.effect("bounds lock operations and rebuilds an unresponsive reserved connection", () => {
+    const partition = makePartitionState()
+    const layer = StorageLive.pipe(
+      Layer.provideMerge(blackholeReservedConnection(partition)),
+      Layer.provide(ShardingConfig.layer({
+        shardLockExpiration: 1000,
+        shardLockRefreshInterval: 100
+      }))
+    )
+
+    return Effect.gen(function*() {
+      const storage = yield* RunnerStorage.RunnerStorage
+      const runner = Runner.make({
+        address: runnerAddress1,
+        groups: ["default"],
+        weight: 1
+      })
+      const shards = [ShardId.make("default", 1)]
+
+      yield* storage.register(runner, true)
+      yield* storage.acquire(runnerAddress1, shards)
+      partition.current = true
+
+      const [elapsed, exit] = yield* storage.refresh(runnerAddress1, shards).pipe(
+        Effect.exit,
+        Effect.timed,
+        TestServices.provideLive
+      )
+      assert(Exit.isFailure(exit))
+      assert.isAtLeast(Duration.toMillis(elapsed), 90)
+      assert.isBelow(Duration.toMillis(elapsed), 1000)
+
+      partition.current = false
+      expect(
+        yield* storage.refresh(runnerAddress1, shards).pipe(
+          Effect.retry({ times: 10, schedule: Schedule.spaced(20) }),
+          TestServices.provideLive
+        )
+      ).toEqual(shards)
+      assert.isAtLeast(partition.interruptedQueries, 1)
+      assert.isAtLeast(partition.reservedConnections, 2)
+    }).pipe(Effect.provide(layer))
+  }, 60_000)
+  ;([
+    ["pg", Layer.orDie(PgContainer.ClientLive)],
+    ["mysql", Layer.orDie(MysqlContainer.ClientLive)]
+  ] as const).forEach(([label, client]) => {
+    const prefix = `advisory_table_gate_${label}`
+    const layer = SqlRunnerStorage.layerWith({ prefix }).pipe(
+      Layer.provideMerge(client),
+      Layer.provide(ShardingConfig.layer())
+    )
+
+    it.layer(layer, { timeout: 60_000 })(`${label} advisory locks`, (it) => {
+      it.effect("does not create the locks table", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          const rows = yield* sql.onDialectOrElse({
+            pg: () => sql`SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE tablename = ${prefix + "_locks"}`.values,
+            mysql: () =>
+              sql`SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${
+                prefix + "_locks"
+              }`.values,
+            orElse: () => Effect.succeed([])
+          })
+          expect(Number(rows[0][0])).toEqual(0)
+        }))
+    })
+  })
   ;([
     ["pg", Layer.orDie(PgContainer.ClientLive)],
     ["mysql", Layer.orDie(MysqlContainer.ClientLive)],
@@ -86,6 +157,70 @@ describe("SqlRunnerStorage", () => {
 })
 
 const runnerAddress1 = RunnerAddress.make("localhost", 1234)
+
+interface PartitionState {
+  current: boolean
+  activeQueries: number
+  interruptedQueries: number
+  reservedConnections: number
+}
+
+const makePartitionState = (): PartitionState => ({
+  current: false,
+  activeQueries: 0,
+  interruptedQueries: 0,
+  reservedConnections: 0
+})
+
+const blackholeReservedConnection = (partition: PartitionState) =>
+  Layer.effect(
+    SqlClient.SqlClient,
+    Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      const wrapConnection = (connection: SqlConnection.Connection): SqlConnection.Connection => {
+        const execute = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+          Effect.suspend(() => {
+            partition.activeQueries++
+            return Effect.suspend(function waitForConnection(): Effect.Effect<A, E, R> {
+              return partition.current
+                ? Effect.andThen(Effect.sleep(5), waitForConnection)
+                : effect
+            }).pipe(
+              Effect.onExit((exit) =>
+                Effect.sync(() => {
+                  partition.activeQueries--
+                  if (Exit.isFailure(exit) && Exit.isInterrupted(exit)) {
+                    partition.interruptedQueries++
+                  }
+                })
+              )
+            )
+          })
+        return {
+          ...connection,
+          execute: (...args) => execute(connection.execute(...args)),
+          executeRaw: (...args) => execute(connection.executeRaw(...args)),
+          executeValues: (...args) => execute(connection.executeValues(...args)),
+          executeUnprepared: (...args) => execute(connection.executeUnprepared(...args))
+        }
+      }
+      const client: SqlClient.SqlClient = new Proxy(sql, {
+        get(target, property, receiver) {
+          if (property === "reserve") {
+            return Effect.map(target.reserve, (connection) => {
+              partition.reservedConnections++
+              return wrapConnection(connection)
+            })
+          }
+          if (property === "withoutTransforms") {
+            return () => client
+          }
+          return Reflect.get(target, property, receiver)
+        }
+      })
+      return client
+    })
+  ).pipe(Layer.provide(PgContainer.ClientLive))
 
 const SqliteLayer = Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem

--- a/packages/cluster/test/TestEntity.ts
+++ b/packages/cluster/test/TestEntity.ts
@@ -2,7 +2,7 @@ import type { Envelope } from "@effect/cluster"
 import { ClusterSchema, Entity } from "@effect/cluster"
 import type { RpcGroup } from "@effect/rpc"
 import { Rpc, RpcSchema } from "@effect/rpc"
-import { Effect, Layer, Mailbox, MutableRef, Option, PrimaryKey, Schedule, Schema, Stream } from "effect"
+import { Context, Effect, Layer, Mailbox, MutableRef, Option, PrimaryKey, Schedule, Schema, Stream } from "effect"
 
 export class User extends Schema.Class<User>("User")({
   id: Schema.Number,
@@ -59,6 +59,7 @@ export class TestEntityState extends Effect.Service<TestEntityState>()("TestEnti
         : never
     >()
     const defectTrigger = MutableRef.make(false)
+    const handlerBuildDefectTrigger = MutableRef.make(false)
     const layerBuilds = MutableRef.make(0)
 
     return {
@@ -67,6 +68,7 @@ export class TestEntityState extends Effect.Service<TestEntityState>()("TestEnti
       envelopes,
       interrupts,
       defectTrigger,
+      handlerBuildDefectTrigger,
       layerBuilds
     } as const
   })
@@ -77,6 +79,10 @@ export const TestEntityNoState = TestEntity.toLayer(
     const state = yield* TestEntityState
 
     MutableRef.update(state.layerBuilds, (count) => count + 1)
+    if (state.handlerBuildDefectTrigger.current) {
+      MutableRef.set(state.handlerBuildDefectTrigger, false)
+      yield* Effect.die("Handler build defect")
+    }
 
     const never = (envelope: any) =>
       Effect.suspend(() => {
@@ -129,3 +135,17 @@ export const TestEntityNoState = TestEntity.toLayer(
 )
 
 export const TestEntityLayer = TestEntityNoState.pipe(Layer.provideMerge(TestEntityState.Default))
+
+export class CallerId extends Context.Tag("effect/test/cluster/CallerId")<CallerId, string>() {}
+
+export const ContextBleedEntity = Entity.make("ContextBleedEntity", [
+  Rpc.make("ReadCaller", { success: Schema.String }).annotate(ClusterSchema.Persisted, false),
+  Rpc.make("ReadCallerPersisted", { success: Schema.String }).annotate(ClusterSchema.Persisted, true)
+])
+
+const readCaller = () => Effect.map(Effect.serviceOption(CallerId), Option.getOrElse(() => "none"))
+
+export const ContextBleedLayer = ContextBleedEntity.toLayer({
+  ReadCaller: readCaller,
+  ReadCallerPersisted: readCaller
+})

--- a/packages/cluster/test/TestEntity.ts
+++ b/packages/cluster/test/TestEntity.ts
@@ -61,6 +61,7 @@ export class TestEntityState extends Effect.Service<TestEntityState>()("TestEnti
     const defectTrigger = MutableRef.make(false)
     const handlerBuildDefectTrigger = MutableRef.make(false)
     const layerBuilds = MutableRef.make(0)
+    const buildLatch = Effect.unsafeMakeLatch(true)
 
     return {
       messages,
@@ -69,7 +70,8 @@ export class TestEntityState extends Effect.Service<TestEntityState>()("TestEnti
       interrupts,
       defectTrigger,
       handlerBuildDefectTrigger,
-      layerBuilds
+      layerBuilds,
+      buildLatch
     } as const
   })
 }) {}
@@ -79,6 +81,7 @@ export const TestEntityNoState = TestEntity.toLayer(
     const state = yield* TestEntityState
 
     MutableRef.update(state.layerBuilds, (count) => count + 1)
+    yield* state.buildLatch.await
     if (state.handlerBuildDefectTrigger.current) {
       MutableRef.set(state.handlerBuildDefectTrigger, false)
       yield* Effect.die("Handler build defect")

--- a/packages/workflow/src/Activity.ts
+++ b/packages/workflow/src/Activity.ts
@@ -127,7 +127,7 @@ export const make = <
 
 const interruptRetryPolicy = Schedule.exponential(100, 1.5).pipe(
   Schedule.union(Schedule.spaced("10 seconds")),
-  Schedule.union(Schedule.recurs(10)),
+  Schedule.intersect(Schedule.recurs(10)),
   Schedule.whileInput((cause: Cause.Cause<unknown>) => Cause.isInterrupted(cause))
 )
 

--- a/packages/workflow/src/DurableDeferred.ts
+++ b/packages/workflow/src/DurableDeferred.ts
@@ -222,7 +222,7 @@ export const raceAll = <
     const engine = yield* EngineTag
     const exit = yield* Workflow.wrapActivityResult(engine.deferredResult(deferred), Predicate.isUndefined)
     if (exit) {
-      return yield* (Effect.flatten(exit) as Effect.Effect<any, any, any>)
+      return yield* exit
     }
     return yield* into(Effect.raceAll(options.effects), deferred)
   })

--- a/packages/workflow/test/Activity.test.ts
+++ b/packages/workflow/test/Activity.test.ts
@@ -1,0 +1,30 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Activity } from "@effect/workflow"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import * as TestClock from "effect/TestClock"
+
+describe("Activity", () => {
+  it.effect("bounds retries after interruption", () =>
+    Effect.gen(function*() {
+      let attempts = 0
+      const activity = Activity.make({
+        name: "interrupting",
+        execute: Effect.suspend(() => {
+          attempts++
+          return Effect.interrupt
+        })
+      })
+
+      const execute = activity.execute as Effect.Effect<void>
+      const fiber = yield* execute.pipe(Effect.exit, Effect.fork)
+      yield* TestClock.adjust("1 day")
+      const exit = yield* Fiber.join(fiber)
+
+      assert(Exit.isFailure(exit))
+      assert.strictEqual(attempts, 11)
+      assert.include(String(Cause.squash(exit.cause)), "retry attempts exhausted")
+    }))
+})


### PR DESCRIPTION
## Summary

Backports the applicable v4 cluster and workflow reliability fixes to v3:

- #6516 bounds SQL shard-lock operations, rebuilds unresponsive reserved connections, and safely releases and reacquires shards after lock storage failures
- #6618 hashes SQL message deduplication keys longer than 255 characters while preserving short keys and SQLite legacy rows
- #6579 scopes reply serialization failures and peer-delivered defects to their request
- #2546 separates partial and full workflow entity clients
- #2545 isolates entity handlers from the fiber context that wakes them
- #1975 retries defects raised while building entity handlers
- #2559 bounds activity interrupt retries at 10 retries
- #2612 fixes replay of persisted durable race results
- #6783 propagates active trace context through persisted workflow requests
- #6498 avoids creating PostgreSQL and MySQL lock tables when advisory locks are enabled
- #6438 fixes one-shot iterables in in-memory `RunnerStorage.acquire`

## Skipped

- #2424: the requested regression was written and run first against unchanged v3 production code. It already passed because v3's `Schema.ExitFromSelf` and `Schema.Defect` hydrate both encoded defects and existing `Error` values. The regression remains, but no speculative production change or changeset was added.

## Verification

- `@effect/workflow` tests: 7 passed
- `@effect/cluster` non-container tests: 59 passed
- SQLite `SqlMessageStorage` tests: 11 passed
- SQLite `SqlRunnerStorage` tests: 4 passed
- `@effect/cluster` and `@effect/workflow` typechecks passed
- lint, build, docgen, changeset validation, and diff checks passed
- PostgreSQL, MySQL, and Vitess suites could not start locally because no container runtime is available

Closes EFF-234
