### PR TITLE
Namespace Postgres advisory locks by table prefix

### DIFF
--- a/.changeset/wise-pandas-lock.md
+++ b/.changeset/wise-pandas-lock.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Namespace PostgreSQL advisory shard locks by the `SqlRunnerStorage` table prefix.
+
+This changes the advisory-lock protocol. PostgreSQL clusters using advisory locks require a full cluster stop before upgrading; a rolling deploy is unsafe because old and new runners use different lock keys and can both acquire the same shard.

--- a/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
@@ -28,6 +28,17 @@ import * as ShardingConfig from "./ShardingConfig.ts"
 
 const withTracerDisabled = Effect.withTracerEnabled(false)
 
+// This exact FNV-1a hash, including its tag and UTF-8 encoding, is a persistent
+// advisory-lock wire format and must never change.
+const postgresLockNamespace = (prefix: string): number => {
+  const bytes = new TextEncoder().encode(`effect-cluster:${prefix}`)
+  let hash = 0x811c9dc5
+  for (let i = 0; i < bytes.length; i++) {
+    hash = Math.imul(hash ^ bytes[i], 0x01000193)
+  }
+  return hash | 0
+}
+
 /**
  * Creates a SQL-backed `RunnerStorage` implementation for registered runners and
  * shard locks, using the configured table prefix and advisory locks where
@@ -68,6 +79,9 @@ export const make = Effect.fnUntraced(function*(options: {
   const layerScope = yield* Effect.scope
   const prefix = options?.prefix ?? "cluster"
   const table = (name: string) => `${prefix}_${name}`
+  const pgLockNamespace = postgresLockNamespace(prefix)
+  // PostgreSQL exposes the signed int4 lock key through pg_locks as an unsigned oid.
+  const pgLockNamespaceOid = pgLockNamespace >>> 0
 
   // Keep all PostgreSQL and MySQL shard-lock operations on a rebuildable
   // reserved connection, including when advisory locks are disabled.
@@ -408,12 +422,14 @@ export const make = Effect.fnUntraced(function*(options: {
         const acquiredShardIds: Array<string> = []
         const toAcquire = new Map(shardIds.map((shardId) => [lockNumbers.get(shardId)!, shardId]))
         const takenLocks = yield* conn.executeValues(
-          `SELECT objid FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND pid = ${pid} ORDER BY objid`,
+          `SELECT objid FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND classid = ${pgLockNamespaceOid} AND objsubid = 2 AND pid = ${pid} ORDER BY objid`,
           []
         )
         for (let i = 0; i < takenLocks.length; i++) {
           const lockNum = takenLocks[i][0] as number
-          acquiredShardIds.push(lockNumbersReverse.get(lockNum)!)
+          const shardId = lockNumbersReverse.get(lockNum)
+          if (shardId === undefined) continue
+          acquiredShardIds.push(shardId)
           toAcquire.delete(lockNum)
         }
         if (toAcquire.size === 0) {
@@ -546,7 +562,7 @@ export const make = Effect.fnUntraced(function*(options: {
   const pgLocks = (shardIdsMap: Map<number, string>) =>
     Array.from(
       shardIdsMap.entries(),
-      ([lockNum, shardId]) => `pg_try_advisory_lock(${lockNum}) AS "${shardId}"`
+      ([lockNum, shardId]) => `pg_try_advisory_lock(${pgLockNamespace}, ${lockNum}) AS "${shardId}"`
     ).join(", ")
 
   const mysqlLocks = (shardIds: ReadonlyArray<string>) =>
@@ -634,9 +650,9 @@ export const make = Effect.fnUntraced(function*(options: {
           const lockNum = lockNumbers.get(shardId)!
           for (let i = 0; i < 5; i++) {
             const [conn] = yield* lockConn!.await
-            yield* conn.executeRaw(`SELECT pg_advisory_unlock(${lockNum})`, [])
+            yield* conn.executeRaw(`SELECT pg_advisory_unlock(${pgLockNamespace}, ${lockNum})`, [])
             const takenLocks = yield* conn.executeValues(
-              `SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND pid = pg_backend_pid() AND objid = ${lockNum}`,
+              `SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND granted = true AND classid = ${pgLockNamespaceOid} AND objid = ${lockNum} AND objsubid = 2 AND pid = pg_backend_pid()`,
               []
             )
             if (takenLocks.length === 0) return

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -211,6 +211,34 @@ describe("SqlRunnerStorage", () => {
       Effect.provide(layer)
     )
   }, 60_000)
+
+  it.effect("isolates advisory shard locks by prefix", () =>
+    Effect.gen(function*() {
+      const storageA = yield* SqlRunnerStorage.make({ prefix: "cluster" })
+      const storageB = yield* SqlRunnerStorage.make({ prefix: "other" })
+      const shard = ShardId.make("default", 1)
+
+      expect(yield* storageA.acquire(runnerAddress1, [shard])).toEqual([shard])
+      expect(yield* storageB.acquire(runnerAddress2, [shard])).toEqual([shard])
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(PgContainer.layerClient),
+      Effect.provide(ShardingConfig.layer())
+    ), 60_000)
+
+  it.effect("excludes other storages using the same prefix", () =>
+    Effect.gen(function*() {
+      const storageA = yield* SqlRunnerStorage.make({ prefix: "cluster" })
+      const storageB = yield* SqlRunnerStorage.make({ prefix: "cluster" })
+      const shard = ShardId.make("default", 1)
+
+      expect(yield* storageA.acquire(runnerAddress1, [shard])).toEqual([shard])
+      expect(yield* storageB.acquire(runnerAddress2, [shard])).toEqual([])
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(PgContainer.layerClient),
+      Effect.provide(ShardingConfig.layer())
+    ), 60_000)
   ;([
     ["pg", Layer.orDie(PgContainer.layerClient)],
     ["mysql", Layer.orDie(MysqlContainer.layerClient)],
@@ -286,6 +314,7 @@ describe("SqlRunnerStorage", () => {
 })
 
 const runnerAddress1 = RunnerAddress.make("localhost", 1234)
+const runnerAddress2 = RunnerAddress.make("localhost", 5678)
 
 interface PartitionState {
   current: boolean


### PR DESCRIPTION
## Summary

- derive a stable FNV-1a namespace from the `SqlRunnerStorage` table prefix
- use PostgreSQL's two-key advisory lock APIs and filter `pg_locks` by namespace and `objsubid`
- ignore advisory-lock rows that do not map to a configured shard
- cover different-prefix isolation and same-prefix mutual exclusion with PostgreSQL integration tests

## Deployment impact

This changes the PostgreSQL advisory-lock protocol. Deployments using advisory locks require a full cluster stop before upgrading. A rolling deploy is unsafe because old and new runners use different lock keys and can both acquire the same shard.

## Validation

- confirmed `pg` decodes `pg_locks.classid` and `objid` OIDs as JavaScript numbers, and validated signed int4 namespace / unsigned OID matching against live PostgreSQL
- confirmed the two-prefix integration test fails on `main` before the fix
- `pnpm check`
- targeted oxlint and dprint checks
- PostgreSQL prefix, acquire/release, and reserved-connection recovery integration tests

Closes EFF-247