### PR TITLE
ci: post pullfrog commit-status checks on PR runs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -30,3 +30,4 @@ jobs:
         uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
+          status_checks: enabled


### PR DESCRIPTION
Enables Pullfrog's opt-in commit-status check-runs on PR runs.

Each PR run now posts two checks anchored to the head SHA:

- `pullfrog` — run completion, review-verdict-agnostic. Success when the run finishes, failure on error/timeout.
- `pullfrog-approval` — posted only when the run produced an approval verdict.

Both become requireable in branch protection. No workflow `permissions:` change is needed: `checks: write` comes from the Pullfrog app installation token, not `GITHUB_TOKEN`.

Checks are terminal-only by design — no `in_progress` check is created, so a cancelled run cannot strand a required check. While a run is in flight the check is simply absent.

Requiring these in branch protection is a separate repo-settings step, not done here. Worth noting before doing so: runs are dispatched by the Pullfrog app, so a PR that never triggers a run would get no check and would block on a required `pullfrog`.
