### PR TITLE
Cap RPC streaming decoder buffers

### DIFF
--- a/.changeset/cap-rpc-streaming-buffers.md
+++ b/.changeset/cap-rpc-streaming-buffers.md
@@ -1,0 +1,5 @@
+---
+"@effect/rpc": patch
+---
+
+Cap NDJSON and MessagePack streaming decoder buffers with configurable limits.

--- a/.changeset/configure-cluster-rpc-buffer-limits.md
+++ b/.changeset/configure-cluster-rpc-buffer-limits.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+---
+
+Allow configuring cluster RPC serialization buffer limits.

--- a/packages/platform-bun/src/BunClusterHttp.ts
+++ b/packages/platform-bun/src/BunClusterHttp.ts
@@ -55,6 +55,7 @@ export const layer = <
 >(options: {
   readonly transport: "http" | "websocket"
   readonly serialization?: "msgpack" | "ndjson" | undefined
+  readonly serializationMaxBufferSize?: number | "unbounded" | undefined
   readonly clientOnly?: ClientOnly | undefined
   readonly storage?: Storage | undefined
   readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Type"]> | undefined
@@ -117,7 +118,9 @@ export const layer = <
     ),
     Layer.provide(ShardingConfig.layerFromEnv(options?.shardingConfig)),
     Layer.provide(
-      options?.serialization === "ndjson" ? RpcSerialization.layerNdjson : RpcSerialization.layerMsgPack
+      options?.serialization === "ndjson"
+        ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options.serializationMaxBufferSize })
+        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options.serializationMaxBufferSize })
     )
   ) as any
 }

--- a/packages/platform-bun/src/BunClusterSocket.ts
+++ b/packages/platform-bun/src/BunClusterSocket.ts
@@ -40,6 +40,7 @@ export const layer = <
 >(
   options?: {
     readonly serialization?: "msgpack" | "ndjson" | undefined
+    readonly serializationMaxBufferSize?: number | "unbounded" | undefined
     readonly clientOnly?: ClientOnly | undefined
     readonly storage?: Storage | undefined
     readonly shardingConfig?: Partial<ShardingConfig.ShardingConfig["Type"]> | undefined
@@ -95,7 +96,9 @@ export const layer = <
     ),
     Layer.provide(ShardingConfig.layerFromEnv(options?.shardingConfig)),
     Layer.provide(
-      options?.serialization === "ndjson" ? RpcSerialization.layerNdjson : RpcSerialization.layerMsgPack
+      options?.serialization === "ndjson"
+        ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
     )
   ) as any
 }

--- a/packages/platform-node/src/NodeClusterHttp.ts
+++ b/packages/platform-node/src/NodeClusterHttp.ts
@@ -46,6 +46,7 @@ export const layer = <
 >(options: {
   readonly transport: "http" | "websocket"
   readonly serialization?: "msgpack" | "ndjson" | undefined
+  readonly serializationMaxBufferSize?: number | "unbounded" | undefined
   readonly clientOnly?: ClientOnly | undefined
   readonly storage?: Storage | undefined
   readonly runnerHealth?: Health | undefined
@@ -112,7 +113,9 @@ export const layer = <
     ),
     Layer.provide(ShardingConfig.layerFromEnv(options?.shardingConfig)),
     Layer.provide(
-      options?.serialization === "ndjson" ? RpcSerialization.layerNdjson : RpcSerialization.layerMsgPack
+      options?.serialization === "ndjson"
+        ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options.serializationMaxBufferSize })
+        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options.serializationMaxBufferSize })
     )
   ) as any
 }

--- a/packages/platform-node/src/NodeClusterSocket.ts
+++ b/packages/platform-node/src/NodeClusterSocket.ts
@@ -47,6 +47,7 @@ export const layer = <
 >(
   options?: {
     readonly serialization?: "msgpack" | "ndjson" | undefined
+    readonly serializationMaxBufferSize?: number | "unbounded" | undefined
     readonly clientOnly?: ClientOnly | undefined
     readonly storage?: Storage | undefined
     readonly runnerHealth?: Health | undefined
@@ -106,7 +107,9 @@ export const layer = <
     ),
     Layer.provide(ShardingConfig.layerFromEnv(options?.shardingConfig)),
     Layer.provide(
-      options?.serialization === "ndjson" ? RpcSerialization.layerNdjson : RpcSerialization.layerMsgPack
+      options?.serialization === "ndjson"
+        ? RpcSerialization.layerNdjsonWith({ maxBufferSize: options?.serializationMaxBufferSize })
+        : RpcSerialization.layerMsgPackWith({ maxBufferSize: options?.serializationMaxBufferSize })
     )
   ) as any
 }

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -35,14 +35,10 @@ export interface StreamOptions {
   readonly maxBufferSize?: number | "unbounded" | undefined
 }
 
-const ensureBufferSize = (bufferSize: number, maxBufferSize: number | "unbounded") => {
-  if (maxBufferSize === "unbounded" || bufferSize <= maxBufferSize) return
-  throw new RpcSerializationError({
-    reason: "BufferSizeExceeded",
-    maxBufferSize,
-    bufferSize
-  })
-}
+const isBufferSizeExceeded = (
+  bufferSize: number,
+  maxBufferSize: number | "unbounded"
+): maxBufferSize is number => maxBufferSize !== "unbounded" && bufferSize > maxBufferSize
 
 /**
  * @since 1.0.0
@@ -98,11 +94,14 @@ export const makeNdjson = (options?: StreamOptions): RpcSerialization["Type"] =>
           let nlIndex = buffer.indexOf("\n", position)
           const items: Array<unknown> = []
           while (nlIndex !== -1) {
-            try {
-              ensureBufferSize(nlIndex - position, maxBufferSize)
-            } catch (error) {
+            const bufferSize = nlIndex - position
+            if (isBufferSizeExceeded(bufferSize, maxBufferSize)) {
               buffer = ""
-              throw error
+              throw new RpcSerializationError({
+                reason: "BufferSizeExceeded",
+                maxBufferSize,
+                bufferSize
+              })
             }
             const item = JSON.parse(buffer.slice(position, nlIndex))
             items.push(item)
@@ -110,11 +109,14 @@ export const makeNdjson = (options?: StreamOptions): RpcSerialization["Type"] =>
             nlIndex = buffer.indexOf("\n", position)
           }
           buffer = buffer.slice(position)
-          try {
-            ensureBufferSize(buffer.length, maxBufferSize)
-          } catch (error) {
+          const bufferSize = buffer.length
+          if (isBufferSizeExceeded(bufferSize, maxBufferSize)) {
             buffer = ""
-            throw error
+            throw new RpcSerializationError({
+              reason: "BufferSizeExceeded",
+              maxBufferSize,
+              bufferSize
+            })
           }
           return items
         },
@@ -485,7 +487,14 @@ export const makeMsgPack = (
             const error = error_ as any
             if (error.incomplete) {
               const nextIncomplete = buf.subarray(error.lastPosition)
-              ensureBufferSize(nextIncomplete.length, maxBufferSize)
+              const bufferSize = nextIncomplete.length
+              if (isBufferSizeExceeded(bufferSize, maxBufferSize)) {
+                throw new RpcSerializationError({
+                  reason: "BufferSizeExceeded",
+                  maxBufferSize,
+                  bufferSize
+                })
+              }
               incomplete = nextIncomplete
               return error.values ?? []
             }

--- a/packages/rpc/src/RpcSerialization.ts
+++ b/packages/rpc/src/RpcSerialization.ts
@@ -2,10 +2,47 @@
  * @since 1.0.0
  */
 import * as Context from "effect/Context"
+import * as Data from "effect/Data"
 import * as Layer from "effect/Layer"
 import { hasProperty } from "effect/Predicate"
 import * as Msgpackr from "msgpackr"
 import type * as RpcMessage from "./RpcMessage.js"
+
+const defaultMaxBufferSize = 16 * 1024 * 1024
+
+/**
+ * @since 1.0.0
+ * @category errors
+ */
+export class RpcSerializationError extends Data.TaggedError("RpcSerializationError")<{
+  readonly reason: "BufferSizeExceeded"
+  readonly maxBufferSize: number
+  readonly bufferSize: number
+}> {
+  /**
+   * @since 1.0.0
+   */
+  get message() {
+    return `RPC serialization buffer exceeded the maximum size of ${this.maxBufferSize}`
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @category serialization
+ */
+export interface StreamOptions {
+  readonly maxBufferSize?: number | "unbounded" | undefined
+}
+
+const ensureBufferSize = (bufferSize: number, maxBufferSize: number | "unbounded") => {
+  if (maxBufferSize === "unbounded" || bufferSize <= maxBufferSize) return
+  throw new RpcSerializationError({
+    reason: "BufferSizeExceeded",
+    maxBufferSize,
+    bufferSize
+  })
+}
 
 /**
  * @since 1.0.0
@@ -46,41 +83,62 @@ export const json: RpcSerialization["Type"] = RpcSerialization.of({
  * @since 1.0.0
  * @category serialization
  */
-export const ndjson: RpcSerialization["Type"] = RpcSerialization.of({
-  contentType: "application/ndjson",
-  includesFraming: true,
-  unsafeMake: () => {
-    const decoder = new TextDecoder()
-    let buffer = ""
-    return ({
-      decode: (bytes) => {
-        buffer += typeof bytes === "string" ? bytes : decoder.decode(bytes)
-        let position = 0
-        let nlIndex = buffer.indexOf("\n", position)
-        const items: Array<unknown> = []
-        while (nlIndex !== -1) {
-          const item = JSON.parse(buffer.slice(position, nlIndex))
-          items.push(item)
-          position = nlIndex + 1
-          nlIndex = buffer.indexOf("\n", position)
-        }
-        buffer = buffer.slice(position)
-        return items
-      },
-      encode: (response) => {
-        if (Array.isArray(response)) {
-          if (response.length === 0) return undefined
-          let data = ""
-          for (let i = 0; i < response.length; i++) {
-            data += JSON.stringify(response[i]) + "\n"
+export const makeNdjson = (options?: StreamOptions): RpcSerialization["Type"] => {
+  const maxBufferSize = options?.maxBufferSize ?? defaultMaxBufferSize
+  return RpcSerialization.of({
+    contentType: "application/ndjson",
+    includesFraming: true,
+    unsafeMake: () => {
+      const decoder = new TextDecoder()
+      let buffer = ""
+      return ({
+        decode: (bytes) => {
+          buffer += typeof bytes === "string" ? bytes : decoder.decode(bytes)
+          let position = 0
+          let nlIndex = buffer.indexOf("\n", position)
+          const items: Array<unknown> = []
+          while (nlIndex !== -1) {
+            try {
+              ensureBufferSize(nlIndex - position, maxBufferSize)
+            } catch (error) {
+              buffer = ""
+              throw error
+            }
+            const item = JSON.parse(buffer.slice(position, nlIndex))
+            items.push(item)
+            position = nlIndex + 1
+            nlIndex = buffer.indexOf("\n", position)
           }
-          return data
+          buffer = buffer.slice(position)
+          try {
+            ensureBufferSize(buffer.length, maxBufferSize)
+          } catch (error) {
+            buffer = ""
+            throw error
+          }
+          return items
+        },
+        encode: (response) => {
+          if (Array.isArray(response)) {
+            if (response.length === 0) return undefined
+            let data = ""
+            for (let i = 0; i < response.length; i++) {
+              data += JSON.stringify(response[i]) + "\n"
+            }
+            return data
+          }
+          return JSON.stringify(response) + "\n"
         }
-        return JSON.stringify(response) + "\n"
-      }
-    })
-  }
-})
+      })
+    }
+  })
+}
+
+/**
+ * @since 1.0.0
+ * @category serialization
+ */
+export const ndjson: RpcSerialization["Type"] = makeNdjson()
 
 /**
  * @since 1.0.0
@@ -119,12 +177,13 @@ export const jsonRpc = (options?: {
  */
 export const ndJsonRpc = (options?: {
   readonly contentType?: string | undefined
+  readonly maxBufferSize?: number | "unbounded" | undefined
 }): RpcSerialization["Type"] =>
   RpcSerialization.of({
     contentType: options?.contentType ?? "application/json-rpc",
     includesFraming: true,
     unsafeMake: () => {
-      const parser = ndjson.unsafeMake()
+      const parser = makeNdjson(options).unsafeMake()
       const batches = new Map<string, {
         readonly size: number
         readonly responses: Map<string, RpcMessage.FromServerEncoded>
@@ -397,13 +456,16 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse
  * @since 1.0.0
  * @category serialization
  */
-export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerialization["Type"] =>
-  RpcSerialization.of({
+export const makeMsgPack = (
+  options?: Msgpackr.Options & StreamOptions | undefined
+): RpcSerialization["Type"] => {
+  const { maxBufferSize = defaultMaxBufferSize, ...msgpackOptions } = options ?? {}
+  return RpcSerialization.of({
     contentType: "application/msgpack",
     includesFraming: true,
     unsafeMake() {
-      const unpackr = new Msgpackr.Unpackr(options)
-      const packr = new Msgpackr.Packr(options)
+      const unpackr = new Msgpackr.Unpackr(msgpackOptions)
+      const packr = new Msgpackr.Packr(msgpackOptions)
       const encoder = new TextEncoder()
       let incomplete: Uint8Array | undefined = undefined
       return {
@@ -422,7 +484,9 @@ export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerializ
           } catch (error_) {
             const error = error_ as any
             if (error.incomplete) {
-              incomplete = buf.subarray(error.lastPosition)
+              const nextIncomplete = buf.subarray(error.lastPosition)
+              ensureBufferSize(nextIncomplete.length, maxBufferSize)
+              incomplete = nextIncomplete
               return error.values ?? []
             }
             throw error_
@@ -432,6 +496,7 @@ export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerializ
       }
     }
   })
+}
 
 /**
  * @since 1.0.0
@@ -462,6 +527,13 @@ export const layerJson: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSeriali
 export const layerNdjson: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSerialization, ndjson)
 
 /**
+ * @since 1.0.0
+ * @category serialization
+ */
+export const layerNdjsonWith = (options?: StreamOptions): Layer.Layer<RpcSerialization> =>
+  Layer.succeed(RpcSerialization, makeNdjson(options))
+
+/**
  * A rpc serialization layer that uses JSON-RPC for serialization.
  *
  * @since 1.0.0
@@ -480,6 +552,7 @@ export const layerJsonRpc = (options?: {
  */
 export const layerNdJsonRpc = (options?: {
   readonly contentType?: string | undefined
+  readonly maxBufferSize?: number | "unbounded" | undefined
 }): Layer.Layer<RpcSerialization> => Layer.succeed(RpcSerialization, ndJsonRpc(options))
 
 /**
@@ -492,3 +565,11 @@ export const layerNdJsonRpc = (options?: {
  * @category serialization
  */
 export const layerMsgPack: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSerialization, msgPack)
+
+/**
+ * @since 1.0.0
+ * @category serialization
+ */
+export const layerMsgPackWith = (
+  options?: Msgpackr.Options & StreamOptions | undefined
+): Layer.Layer<RpcSerialization> => Layer.succeed(RpcSerialization, makeMsgPack(options))

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -29,6 +29,7 @@ import * as Layer from "effect/Layer"
 import * as Mailbox from "effect/Mailbox"
 import * as Option from "effect/Option"
 import { type ParseError, TreeFormatter } from "effect/ParseResult"
+import * as Predicate from "effect/Predicate"
 import * as Runtime from "effect/Runtime"
 import * as RuntimeFlags from "effect/RuntimeFlags"
 import * as Schedule from "effect/Schedule"
@@ -1484,8 +1485,8 @@ const makeSocketProtocol = Effect.gen(function*() {
           step: constVoid
         })
       } catch (cause) {
-        if (cause instanceof RpcSerialization.RpcSerializationError) {
-          return writeRaw(new Socket.CloseEvent(1009, cause.message))
+        if (Predicate.isTagged(cause, "RpcSerializationError")) {
+          return writeRaw(new Socket.CloseEvent(1009, (cause as RpcSerialization.RpcSerializationError).message))
         }
         return writeRaw(parser.encode(ResponseDefectEncoded(cause))!)
       }

--- a/packages/rpc/src/RpcServer.ts
+++ b/packages/rpc/src/RpcServer.ts
@@ -8,7 +8,7 @@ import * as HttpRouter from "@effect/platform/HttpRouter"
 import type * as HttpServerError from "@effect/platform/HttpServerError"
 import * as HttpServerRequest from "@effect/platform/HttpServerRequest"
 import * as HttpServerResponse from "@effect/platform/HttpServerResponse"
-import type * as Socket from "@effect/platform/Socket"
+import * as Socket from "@effect/platform/Socket"
 import * as SocketServer from "@effect/platform/SocketServer"
 import * as Transferable from "@effect/platform/Transferable"
 import type { WorkerError } from "@effect/platform/WorkerError"
@@ -1484,6 +1484,9 @@ const makeSocketProtocol = Effect.gen(function*() {
           step: constVoid
         })
       } catch (cause) {
+        if (cause instanceof RpcSerialization.RpcSerializationError) {
+          return writeRaw(new Socket.CloseEvent(1009, cause.message))
+        }
         return writeRaw(parser.encode(ResponseDefectEncoded(cause))!)
       }
     }).pipe(

--- a/packages/rpc/test/RpcSerialization.test.ts
+++ b/packages/rpc/test/RpcSerialization.test.ts
@@ -1,5 +1,7 @@
-import { RpcSerialization } from "@effect/rpc"
+import { Socket, SocketServer } from "@effect/platform"
+import { RpcSerialization, RpcServer } from "@effect/rpc"
 import { afterEach, assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Layer } from "effect"
 
 const prototypeDescriptors = new Map<PropertyKey, PropertyDescriptor | undefined>()
 
@@ -56,7 +58,39 @@ const assertBatchRoundTrip = (parser: RpcSerialization.Parser, frame: string) =>
   }])
 }
 
+const captureSerializationError = (decode: () => unknown) => {
+  try {
+    decode()
+  } catch (error) {
+    assert(error instanceof RpcSerialization.RpcSerializationError)
+    return error
+  }
+  return assert.fail("Expected an RpcSerializationError")
+}
+
 describe("RpcSerialization", () => {
+  describe("ndjson", () => {
+    it("limits the buffered frame size", () => {
+      const parser = RpcSerialization.makeNdjson({ maxBufferSize: 4 }).unsafeMake()
+      assert.deepStrictEqual(parser.decode("1234"), [])
+      const error = captureSerializationError(() => parser.decode("5"))
+      assert.strictEqual(error.reason, "BufferSizeExceeded")
+      assert.strictEqual(error.bufferSize, 5)
+    })
+
+    it("allows the buffer limit to be disabled", () => {
+      const parser = RpcSerialization.makeNdjson({ maxBufferSize: "unbounded" }).unsafeMake()
+      assert.deepStrictEqual(parser.decode("123456789"), [])
+    })
+  })
+
+  describe("ndJsonRpc", () => {
+    it("passes the buffer limit to ndjson", () => {
+      const parser = RpcSerialization.ndJsonRpc({ maxBufferSize: 4 }).unsafeMake()
+      captureSerializationError(() => parser.decode("12345"))
+    })
+  })
+
   describe("jsonRpc", () => {
     it("dispatches batched requests and clears completed batch state", () => {
       assertBatchRoundTrip(
@@ -104,6 +138,15 @@ describe("RpcSerialization", () => {
   })
 
   describe("makeMsgPack", () => {
+    it("limits incomplete frame buffering", () => {
+      const parser = RpcSerialization.makeMsgPack({ maxBufferSize: 6 }).unsafeMake()
+      assert.deepStrictEqual(parser.decode(Uint8Array.of(0xdb, 0, 0, 0, 10)), [])
+      assert.deepStrictEqual(parser.decode(Uint8Array.of(1)), [])
+      const error = captureSerializationError(() => parser.decode(Uint8Array.of(2)))
+      assert.strictEqual(error.reason, "BufferSizeExceeded")
+      assert.strictEqual(error.bufferSize, 7)
+    })
+
     it("useRecords false encode and decode correctly", () => {
       const parser = RpcSerialization.makeMsgPack({ useRecords: false }).unsafeMake()
       const payload = { _tag: "Request", id: 1, method: "echo" }
@@ -131,6 +174,48 @@ describe("RpcSerialization", () => {
       assert.deepStrictEqual(decoded[0], payload)
     })
   })
+
+  it.effect("closes a socket when the buffer limit is exceeded", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const closed = yield* Deferred.make<Socket.CloseEvent>()
+      const socket = Socket.Socket.of({
+        [Socket.TypeId]: Socket.TypeId,
+        run: () => Effect.void,
+        runRaw: (handler) =>
+          Effect.suspend(() => {
+            const result = handler("12345")
+            return Effect.isEffect(result) ? result : Effect.void
+          }),
+        writer: Effect.succeed((chunk) =>
+          Socket.isCloseEvent(chunk)
+            ? Deferred.succeed(closed, chunk).pipe(Effect.asVoid)
+            : Effect.die("Expected the socket to close")
+        )
+      })
+      const server = SocketServer.SocketServer.of({
+        address: {
+          _tag: "TcpAddress",
+          hostname: "localhost",
+          port: 0
+        },
+        run: (handler) =>
+          Effect.andThen(handler(socket), Effect.never).pipe(
+            Effect.catchAllCause((cause) => Effect.die(cause))
+          )
+      })
+      const layer = RpcServer.layerProtocolSocketServer.pipe(
+        Layer.provide(Layer.succeed(SocketServer.SocketServer, server)),
+        Layer.provide(
+          Layer.succeed(
+            RpcSerialization.RpcSerialization,
+            RpcSerialization.makeNdjson({ maxBufferSize: 4 })
+          )
+        )
+      )
+      yield* Layer.build(layer)
+      const event = yield* Deferred.await(closed)
+      assert.strictEqual(event.code, 1009)
+    })))
 
   describe("jsonRpc", () => {
     const response = JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" })


### PR DESCRIPTION
## Summary

- cap retained NDJSON and MessagePack decoder buffers with a 16 MiB default
- expose configurable limits and an explicit `"unbounded"` opt-out, including layer constructors
- propagate the NDJSON cap through NDJSON-RPC framing
- close socket transports with code 1009 when the typed buffer overflow error is raised
- add regression coverage and a patch changeset for `@effect/rpc`

## Why

Incomplete MessagePack frames and newline-free NDJSON streams could retain and repeatedly grow per-connection parser state without a bound. The configurable cap limits that retained state while allowing applications with legitimate large frames to raise or disable the limit.

## Validation

- `pnpm test run packages/rpc/test/RpcSerialization.test.ts`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`

Closes EFF-259