### PR TITLE
Fix PubSub replay value retention

### DIFF
--- a/.changeset/fix-pubsub-replay-retention.md
+++ b/.changeset/fix-pubsub-replay-retention.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent replay-enabled PubSubs from retaining values beyond each subscription's replay window.

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -2067,7 +2067,7 @@ class BoundedPubSubSingleSubscription<in out A> implements PubSub.BackingSubscri
 
 interface Node<out A> {
   value: A | AbsentValue
-  replayIndex?: number
+  replayIndex: number | undefined
   subscribers: number
   next: Node<A> | null
 }
@@ -2075,6 +2075,7 @@ interface Node<out A> {
 class UnboundedPubSub<in out A> implements PubSub.Atomic<A> {
   publisherHead: Node<A> = {
     value: AbsentValue,
+    replayIndex: undefined,
     subscribers: 0,
     next: null
   }
@@ -2111,11 +2112,9 @@ class UnboundedPubSub<in out A> implements PubSub.Atomic<A> {
     if (subscribers !== 0) {
       const node: Node<A> = {
         value,
+        replayIndex,
         subscribers,
         next: null
-      }
-      if (replayIndex !== undefined) {
-        node.replayIndex = replayIndex
       }
       this.publisherTail.next = node
       this.publisherTail = this.publisherTail.next

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -139,6 +139,7 @@ export declare namespace PubSub {
     take(): A | undefined
     takeN(n: number): Array<A>
     takeAll(): Array<A>
+    close(): void
     readonly remaining: number
   }
 
@@ -1115,9 +1116,7 @@ const unsubscribe = <A>(self: Subscription<A>): Effect.Effect<void> =>
           Effect.sync(() => {
             self.subscribers.delete(self.subscription)
             self.subscription.unsubscribe()
-            if (self.replayWindow instanceof ReplayWindowImpl) {
-              self.replayWindow.close()
-            }
+            self.replayWindow.close()
             self.strategy.onPubSubEmptySpaceUnsafe(self.pubsub, self.subscribers)
           })
         ),
@@ -1529,6 +1528,7 @@ const makeSubscriptionUnsafe = <A>(
 
 class BoundedPubSubArb<in out A> implements PubSub.Atomic<A> {
   array: Array<A>
+  replayIndices: Array<number>
   publisherIndex = 0
   subscribers: Array<number>
   subscriberCount = 0
@@ -1541,6 +1541,7 @@ class BoundedPubSubArb<in out A> implements PubSub.Atomic<A> {
     this.capacity = capacity
     this.replayBuffer = replayBuffer
     this.array = Array.from({ length: capacity })
+    this.replayIndices = replayBuffer ? Array.from({ length: capacity }) : []
     this.subscribers = Array.from({ length: capacity })
   }
 
@@ -1564,14 +1565,15 @@ class BoundedPubSubArb<in out A> implements PubSub.Atomic<A> {
     if (this.isFull()) {
       return false
     }
+    const replayIndex = this.replayBuffer?.offer(value)
     if (this.subscriberCount !== 0) {
       const index = this.publisherIndex % this.capacity
       this.array[index] = value
+      if (replayIndex !== undefined) {
+        this.replayIndices[index] = replayIndex
+      }
       this.subscribers[index] = this.subscriberCount
       this.publisherIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.offer(value)
     }
     return true
   }
@@ -1597,11 +1599,12 @@ class BoundedPubSubArb<in out A> implements PubSub.Atomic<A> {
       const a = chunk[iteratorIndex++]
       const index = this.publisherIndex % this.capacity
       this.array[index] = a
+      const replayIndex = this.replayBuffer?.offer(a)
+      if (replayIndex !== undefined) {
+        this.replayIndices[index] = replayIndex
+      }
       this.subscribers[index] = this.subscriberCount
       this.publisherIndex += 1
-      if (this.replayBuffer) {
-        this.replayBuffer.offer(a)
-      }
     }
     return chunk.slice(iteratorIndex)
   }
@@ -1613,7 +1616,7 @@ class BoundedPubSubArb<in out A> implements PubSub.Atomic<A> {
       this.array[index] = AbsentValue as unknown as A
       this.subscribers[index] = 0
       this.subscribersIndex += 1
-      this.replayBuffer?.slide(value)
+      this.replayBuffer?.slide(value, this.replayIndices[index])
     }
   }
 
@@ -1719,6 +1722,7 @@ class BoundedPubSubArbSubscription<in out A> implements PubSub.BackingSubscripti
 
 class BoundedPubSubPow2<in out A> implements PubSub.Atomic<A> {
   array: Array<A>
+  replayIndices: Array<number>
   mask: number
   publisherIndex = 0
   subscribers: Array<number>
@@ -1732,6 +1736,7 @@ class BoundedPubSubPow2<in out A> implements PubSub.Atomic<A> {
     this.capacity = capacity
     this.replayBuffer = replayBuffer
     this.array = Array.from({ length: capacity })
+    this.replayIndices = replayBuffer ? Array.from({ length: capacity }) : []
     this.mask = capacity - 1
     this.subscribers = Array.from({ length: capacity })
   }
@@ -1756,14 +1761,15 @@ class BoundedPubSubPow2<in out A> implements PubSub.Atomic<A> {
     if (this.isFull()) {
       return false
     }
+    const replayIndex = this.replayBuffer?.offer(value)
     if (this.subscriberCount !== 0) {
       const index = this.publisherIndex & this.mask
       this.array[index] = value
+      if (replayIndex !== undefined) {
+        this.replayIndices[index] = replayIndex
+      }
       this.subscribers[index] = this.subscriberCount
       this.publisherIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.offer(value)
     }
     return true
   }
@@ -1789,11 +1795,12 @@ class BoundedPubSubPow2<in out A> implements PubSub.Atomic<A> {
       const elem = chunk[iteratorIndex++]
       const index = this.publisherIndex & this.mask
       this.array[index] = elem
+      const replayIndex = this.replayBuffer?.offer(elem)
+      if (replayIndex !== undefined) {
+        this.replayIndices[index] = replayIndex
+      }
       this.subscribers[index] = this.subscriberCount
       this.publisherIndex += 1
-      if (this.replayBuffer) {
-        this.replayBuffer.offer(elem)
-      }
     }
     return chunk.slice(iteratorIndex)
   }
@@ -1805,7 +1812,7 @@ class BoundedPubSubPow2<in out A> implements PubSub.Atomic<A> {
       this.array[index] = AbsentValue as unknown as A
       this.subscribers[index] = 0
       this.subscribersIndex += 1
-      this.replayBuffer?.slide(value)
+      this.replayBuffer?.slide(value, this.replayIndices[index])
     }
   }
 
@@ -1913,6 +1920,7 @@ class BoundedPubSubSingle<in out A> implements PubSub.Atomic<A> {
   subscriberCount = 0
   subscribers = 0
   value: A = AbsentValue as unknown as A
+  replayIndex = 0
 
   readonly capacity = 1
   readonly replayBuffer: ReplayBuffer<A> | undefined
@@ -1945,13 +1953,14 @@ class BoundedPubSubSingle<in out A> implements PubSub.Atomic<A> {
     if (this.isFull()) {
       return false
     }
+    const replayIndex = this.replayBuffer?.offer(value)
     if (this.subscriberCount !== 0) {
       this.value = value
+      if (replayIndex !== undefined) {
+        this.replayIndex = replayIndex
+      }
       this.subscribers = this.subscriberCount
       this.publisherIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.offer(value)
     }
     return true
   }
@@ -1979,7 +1988,7 @@ class BoundedPubSubSingle<in out A> implements PubSub.Atomic<A> {
       const value = this.value
       this.subscribers = 0
       this.value = AbsentValue as unknown as A
-      this.replayBuffer?.slide(value)
+      this.replayBuffer?.slide(value, this.replayIndex)
     }
   }
 
@@ -2058,6 +2067,7 @@ class BoundedPubSubSingleSubscription<in out A> implements PubSub.BackingSubscri
 
 interface Node<out A> {
   value: A | AbsentValue
+  replayIndex?: number
   subscribers: number
   next: Node<A> | null
 }
@@ -2096,18 +2106,20 @@ class UnboundedPubSub<in out A> implements PubSub.Atomic<A> {
   }
 
   publish(value: A): boolean {
+    const replayIndex = this.replayBuffer?.offer(value)
     const subscribers = this.publisherTail.subscribers
     if (subscribers !== 0) {
-      this.publisherTail.next = {
+      const node: Node<A> = {
         value,
         subscribers,
         next: null
       }
+      if (replayIndex !== undefined) {
+        node.replayIndex = replayIndex
+      }
+      this.publisherTail.next = node
       this.publisherTail = this.publisherTail.next
       this.publisherIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.offer(value)
     }
     return true
   }
@@ -2125,11 +2137,12 @@ class UnboundedPubSub<in out A> implements PubSub.Atomic<A> {
 
   slide(): void {
     if (this.publisherHead !== this.publisherTail) {
-      const value = this.publisherHead.next!.value as A
+      const node = this.publisherHead.next!
+      const value = node.value as A
       this.publisherHead = this.publisherHead.next!
       this.publisherHead.value = AbsentValue
       this.subscribersIndex += 1
-      this.replayBuffer?.slide(value)
+      this.replayBuffer?.slide(value, node.replayIndex!)
     }
   }
 
@@ -2701,29 +2714,40 @@ const strategyCompleteSubscribersUnsafe = <A>(
 
 interface ReplayNode<A> {
   value: A | AbsentValue
+  index: number
   next: ReplayNode<A> | null
 }
 
 class ReplayBuffer<A> {
   readonly capacity: number
-  head: ReplayNode<A> = { value: AbsentValue, next: null }
+  head: ReplayNode<A> = { value: AbsentValue, index: 0, next: null }
   tail: ReplayNode<A> = this.head
-  readonly slideValues: Array<A> = []
+  readonly slideValues: Array<{
+    readonly value: A
+    readonly index: number
+  }> = []
   size = 0
   index = 0
+  publisherIndex = 0
 
   constructor(capacity: number) {
     this.capacity = capacity
   }
 
-  slide(value: A): void {
-    this.slideValues[this.index % this.capacity] = value
+  slide(value: A, publisherIndex: number): void {
+    this.slideValues[this.index % this.capacity] = {
+      value,
+      index: publisherIndex
+    }
     this.index++
   }
-  offer(a: A): void {
+  offer(a: A): number {
+    const index = this.publisherIndex++
     this.tail.value = a
+    this.tail.index = index
     this.tail.next = {
       value: AbsentValue,
+      index: 0,
       next: null
     }
     this.tail = this.tail.next
@@ -2732,6 +2756,7 @@ class ReplayBuffer<A> {
     } else {
       this.size += 1
     }
+    return index
   }
   offerAll(as: Iterable<A>): void {
     for (const a of as) {
@@ -2746,6 +2771,7 @@ class ReplayWindowImpl<A> implements PubSub.ReplayWindow<A> {
   index = 0
   remaining: number
   slideIndex: number
+  newestIndex = -1
 
   constructor(buffer: ReplayBuffer<A>) {
     this.buffer = buffer
@@ -2755,6 +2781,7 @@ class ReplayWindowImpl<A> implements PubSub.ReplayWindow<A> {
     let node = buffer.head
     for (let i = 0; i < this.remaining; i++) {
       this.values[i] = node.value as A
+      this.newestIndex = node.index
       node = node.next!
     }
   }
@@ -2767,19 +2794,14 @@ class ReplayWindowImpl<A> implements PubSub.ReplayWindow<A> {
     if (slides === 0 || this.remaining === 0) {
       return
     }
-    const count = Math.min(slides, this.remaining)
+    const count = Math.min(slides, this.buffer.capacity)
     const start = this.buffer.index - count
-    if (slides >= this.remaining) {
-      this.values.fill(AbsentValue as unknown as A)
-      this.index = 0
-      for (let i = 0; i < count; i++) {
-        this.values[i] = this.buffer.slideValues[(start + i) % this.buffer.capacity]
-      }
-    } else {
-      for (let i = 0; i < count; i++) {
+    for (let i = 0; i < count; i++) {
+      const entry = this.buffer.slideValues[(start + i) % this.buffer.capacity]
+      if (entry.index > this.newestIndex) {
         this.index = (this.index + 1) % this.values.length
-        this.values[(this.index + this.remaining - 1) % this.values.length] =
-          this.buffer.slideValues[(start + i) % this.buffer.capacity]
+        this.values[(this.index + this.remaining - 1) % this.values.length] = entry.value
+        this.newestIndex = entry.index
       }
     }
     this.slideIndex = this.buffer.index
@@ -2815,5 +2837,6 @@ const emptyReplayWindow: PubSub.ReplayWindow<never> = {
   remaining: 0,
   take: () => undefined,
   takeN: () => [],
-  takeAll: () => []
+  takeAll: () => [],
+  close: () => void 0
 }

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -1115,6 +1115,9 @@ const unsubscribe = <A>(self: Subscription<A>): Effect.Effect<void> =>
           Effect.sync(() => {
             self.subscribers.delete(self.subscription)
             self.subscription.unsubscribe()
+            if (self.replayWindow instanceof ReplayWindowImpl) {
+              self.replayWindow.close()
+            }
             self.strategy.onPubSubEmptySpaceUnsafe(self.pubsub, self.subscribers)
           })
         ),
@@ -1606,12 +1609,11 @@ class BoundedPubSubArb<in out A> implements PubSub.Atomic<A> {
   slide(): void {
     if (this.subscribersIndex !== this.publisherIndex) {
       const index = this.subscribersIndex % this.capacity
+      const value = this.array[index]
       this.array[index] = AbsentValue as unknown as A
       this.subscribers[index] = 0
       this.subscribersIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.slide()
+      this.replayBuffer?.slide(value)
     }
   }
 
@@ -1799,12 +1801,11 @@ class BoundedPubSubPow2<in out A> implements PubSub.Atomic<A> {
   slide(): void {
     if (this.subscribersIndex !== this.publisherIndex) {
       const index = this.subscribersIndex & this.mask
+      const value = this.array[index]
       this.array[index] = AbsentValue as unknown as A
       this.subscribers[index] = 0
       this.subscribersIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.slide()
+      this.replayBuffer?.slide(value)
     }
   }
 
@@ -1975,11 +1976,10 @@ class BoundedPubSubSingle<in out A> implements PubSub.Atomic<A> {
 
   slide(): void {
     if (this.isFull()) {
+      const value = this.value
       this.subscribers = 0
       this.value = AbsentValue as unknown as A
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.slide()
+      this.replayBuffer?.slide(value)
     }
   }
 
@@ -2125,12 +2125,11 @@ class UnboundedPubSub<in out A> implements PubSub.Atomic<A> {
 
   slide(): void {
     if (this.publisherHead !== this.publisherTail) {
+      const value = this.publisherHead.next!.value as A
       this.publisherHead = this.publisherHead.next!
       this.publisherHead.value = AbsentValue
       this.subscribersIndex += 1
-    }
-    if (this.replayBuffer) {
-      this.replayBuffer.slide()
+      this.replayBuffer?.slide(value)
     }
   }
 
@@ -2709,6 +2708,7 @@ class ReplayBuffer<A> {
   readonly capacity: number
   head: ReplayNode<A> = { value: AbsentValue, next: null }
   tail: ReplayNode<A> = this.head
+  readonly slideValues: Array<A> = []
   size = 0
   index = 0
 
@@ -2716,7 +2716,8 @@ class ReplayBuffer<A> {
     this.capacity = capacity
   }
 
-  slide() {
+  slide(value: A): void {
+    this.slideValues[this.index % this.capacity] = value
     this.index++
   }
   offer(a: A): void {
@@ -2740,48 +2741,69 @@ class ReplayBuffer<A> {
 }
 
 class ReplayWindowImpl<A> implements PubSub.ReplayWindow<A> {
-  head: ReplayNode<A>
-  index: number
-  remaining: number
   readonly buffer: ReplayBuffer<A>
+  readonly values: Array<A>
+  index = 0
+  remaining: number
+  slideIndex: number
 
   constructor(buffer: ReplayBuffer<A>) {
     this.buffer = buffer
-    this.index = buffer.index
     this.remaining = buffer.size
-    this.head = buffer.head
-  }
-  fastForward() {
-    while (this.index < this.buffer.index) {
-      this.head = this.head.next!
-      this.index++
+    this.slideIndex = buffer.index
+    this.values = new Array(this.remaining)
+    let node = buffer.head
+    for (let i = 0; i < this.remaining; i++) {
+      this.values[i] = node.value as A
+      node = node.next!
     }
+  }
+  close(): void {
+    this.values.length = 0
+    this.remaining = 0
+  }
+  sync(): void {
+    const slides = this.buffer.index - this.slideIndex
+    if (slides === 0 || this.remaining === 0) {
+      return
+    }
+    const count = Math.min(slides, this.remaining)
+    const start = this.buffer.index - count
+    if (slides >= this.remaining) {
+      this.values.fill(AbsentValue as unknown as A)
+      this.index = 0
+      for (let i = 0; i < count; i++) {
+        this.values[i] = this.buffer.slideValues[(start + i) % this.buffer.capacity]
+      }
+    } else {
+      for (let i = 0; i < count; i++) {
+        this.index = (this.index + 1) % this.values.length
+        this.values[(this.index + this.remaining - 1) % this.values.length] =
+          this.buffer.slideValues[(start + i) % this.buffer.capacity]
+      }
+    }
+    this.slideIndex = this.buffer.index
   }
   take(): A | undefined {
     if (this.remaining === 0) {
       return undefined
-    } else if (this.index < this.buffer.index) {
-      this.fastForward()
     }
+    this.sync()
+    const value = this.values[this.index]
+    this.values[this.index] = AbsentValue as unknown as A
+    this.index = (this.index + 1) % this.values.length
     this.remaining--
-    const value = this.head.value
-    this.head = this.head.next!
+    if (this.remaining === 0) {
+      this.close()
+    }
     return value as A
   }
   takeN(n: number): Array<A> {
-    if (this.remaining === 0) {
-      return []
-    } else if (this.index < this.buffer.index) {
-      this.fastForward()
-    }
     const len = Math.min(n, this.remaining)
     const items = new Array(len)
     for (let i = 0; i < len; i++) {
-      const value = this.head.value as A
-      this.head = this.head.next!
-      items[i] = value
+      items[i] = this.take()!
     }
-    this.remaining -= len
     return items
   }
   takeAll(): Array<A> {

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -2,6 +2,29 @@ import { assert, describe, it } from "@effect/vitest"
 import { Array, Effect, Exit, Fiber, Latch, PubSub, Stream } from "effect"
 import { pipe } from "effect/Function"
 
+const retains = (root: object, target: object): boolean => {
+  const objects = [root]
+  const seen = new Set<object>()
+  while (objects.length > 0) {
+    const current = objects.pop()!
+    if (current === target) {
+      return true
+    }
+    if (seen.has(current)) {
+      continue
+    }
+    seen.add(current)
+    for (const key of Reflect.ownKeys(current)) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key)
+      const value = descriptor && "value" in descriptor ? descriptor.value : undefined
+      if (typeof value === "object" && value !== null) {
+        objects.push(value)
+      }
+    }
+  }
+  return false
+}
+
 describe("PubSub", () => {
   it.effect("publishAll - capacity 2 (BoundedPubSubPow2)", () => {
     const messages = [1, 2]
@@ -399,6 +422,48 @@ describe("PubSub", () => {
     }))
 
   describe("replay", () => {
+    it("does not retain values published after the replay window is drained", () => {
+      const pubsub = PubSub.makeAtomicUnbounded<object>({ replay: 1 })
+      pubsub.publish({})
+      const replayWindow = pubsub.replayWindow()
+      replayWindow.take()
+
+      const slidOut = {}
+      pubsub.publish(slidOut)
+      pubsub.publish({})
+
+      assert.isFalse(retains(replayWindow, slidOut))
+    })
+
+    it("does not retain values published outside an undrained replay window", () => {
+      const pubsub = PubSub.makeAtomicUnbounded<object>({ replay: 1 })
+      const replayed = {}
+      pubsub.publish(replayed)
+      const replayWindow = pubsub.replayWindow()
+
+      const slidOut = {}
+      pubsub.publish(slidOut)
+      pubsub.publish({})
+
+      assert.isFalse(retains(replayWindow, slidOut))
+      assert.strictEqual(replayWindow.take(), replayed)
+    })
+
+    it("preserves replay order across multiple slides", () => {
+      const pubsub = PubSub.makeAtomicBounded<number>({ capacity: 4, replay: 3 })
+      pubsub.publishAll([1, 2, 3, 4, 5])
+      const subscription = pubsub.subscribe()
+      const replayWindow = pubsub.replayWindow()
+      pubsub.publishAll([6, 7, 8, 9])
+      for (const value of [10, 11, 12]) {
+        pubsub.slide()
+        pubsub.publish(value)
+      }
+
+      assert.deepStrictEqual(replayWindow.takeAll(), [6, 7, 8])
+      assert.deepStrictEqual(subscription.pollUpTo(Number.POSITIVE_INFINITY), [9, 10, 11, 12])
+    })
+
     it.effect("unbounded", () =>
       Effect.gen(function*() {
         const messages = [1, 2, 3, 4, 5]

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -2,29 +2,6 @@ import { assert, describe, it } from "@effect/vitest"
 import { Array, Effect, Exit, Fiber, Latch, PubSub, Stream } from "effect"
 import { pipe } from "effect/Function"
 
-const retains = (root: object, target: object): boolean => {
-  const objects = [root]
-  const seen = new Set<object>()
-  while (objects.length > 0) {
-    const current = objects.pop()!
-    if (current === target) {
-      return true
-    }
-    if (seen.has(current)) {
-      continue
-    }
-    seen.add(current)
-    for (const key of Reflect.ownKeys(current)) {
-      const descriptor = Object.getOwnPropertyDescriptor(current, key)
-      const value = descriptor && "value" in descriptor ? descriptor.value : undefined
-      if (typeof value === "object" && value !== null) {
-        objects.push(value)
-      }
-    }
-  }
-  return false
-}
-
 describe("PubSub", () => {
   it.effect("publishAll - capacity 2 (BoundedPubSubPow2)", () => {
     const messages = [1, 2]
@@ -539,6 +516,20 @@ describe("PubSub", () => {
         const sub3 = yield* PubSub.subscribe(pubsub)
         assert.deepStrictEqual(yield* PubSub.takeAll(sub3), [14, 15, 16])
       }))
+
+    it.effect("sliding preserves publish order with a lagging subscriber", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          const pubsub = yield* PubSub.sliding<number>({ capacity: 4, replay: 3 })
+          yield* PubSub.subscribe(pubsub)
+          yield* PubSub.publishAll(pubsub, [1, 2])
+          const subscription = yield* PubSub.subscribe(pubsub)
+          yield* PubSub.publishAll(pubsub, [3, 4, 5])
+
+          const values = yield* PubSub.takeAll(subscription)
+          assert.isTrue(values.every((value, index) => index === 0 || values[index - 1] <= value))
+        })
+      ))
   })
 
   it.effect("shutdown interrupts suspended subscribers", () =>
@@ -615,3 +606,26 @@ describe("PubSub", () => {
       })
     ))
 })
+
+const retains = (root: object, target: object): boolean => {
+  const objects = [root]
+  const seen = new Set<object>()
+  while (objects.length > 0) {
+    const current = objects.pop()!
+    if (current === target) {
+      return true
+    }
+    if (seen.has(current)) {
+      continue
+    }
+    seen.add(current)
+    for (const key of Reflect.ownKeys(current)) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key)
+      const value = descriptor && "value" in descriptor ? descriptor.value : undefined
+      if (typeof value === "object" && value !== null) {
+        objects.push(value)
+      }
+    }
+  }
+  return false
+}


### PR DESCRIPTION
## Summary

- store each subscription's replay values in a bounded snapshot instead of retaining a cursor into the append-only replay list
- preserve sliding PubSub ordering with a bounded ring of values removed from active subscriptions
- release replay snapshots when drained or unsubscribed
- add deterministic object-graph regressions for drained and never-draining replay windows

## Root cause

`ReplayWindowImpl` retained a node from `ReplayBuffer`'s linked list. Future publications extended that same list, so a live subscription could keep every later value reachable even after its replay window was drained. A never-draining subscription retained the same unbounded suffix from its original replay node.

The replay window cannot simply derive every take from the current buffer head: existing replay semantics require a subscription to retain its original replay snapshot, while sliding PubSubs replace only values that are explicitly slid out. This change keeps those semantics while bounding all replay-owned references.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/PubSub.test.ts packages/effect/test/SubscriptionRef.test.ts` (38 tests)
- `pnpm check`

Closes EFF-262
Closes EFF-264
Closes #6804
