### PR TITLE
Fix SQL cleanup test clock race

### DIFF
--- a/packages/sql/mysql2/test/Persistence.integration.test.ts
+++ b/packages/sql/mysql2/test/Persistence.integration.test.ts
@@ -55,7 +55,7 @@ it.layer(MysqlContainer.layerClient, { timeout: "30 seconds" })("Persistence SQL
         VALUES ('live', 'live', '{}', NULL), ('live', 'future', '{}', ${SqlCleanupTest.futureExpiresAt})
       `
 
-      yield* Layer.build(Persistence.layerBackingSql)
+      yield* Layer.build(Persistence.layerBackingSql).pipe(TestClock.withLive)
 
       let expired = yield* SqlCleanupTest.waitForCount(
         expiredCount,
@@ -65,7 +65,6 @@ it.layer(MysqlContainer.layerClient, { timeout: "30 seconds" })("Persistence SQL
 
       while (expired > 0) {
         const previous = expired
-        yield* TestClock.adjust(SqlCleanupTest.cleanupBatchDelay)
         expired = yield* SqlCleanupTest.waitForCount(expiredCount, (count) => count < previous)
       }
       assert.strictEqual(expired, 0)

--- a/packages/sql/pg/test/Persistence.integration.test.ts
+++ b/packages/sql/pg/test/Persistence.integration.test.ts
@@ -136,7 +136,7 @@ it.layer(PgContainer.layerClient, { timeout: "30 seconds" })("Persistence SQL cl
         VALUES ('live', 'live', '{}', NULL), ('live', 'future', '{}', ${SqlCleanupTest.futureExpiresAt})
       `
 
-      yield* Layer.build(Persistence.layerBackingSql)
+      yield* Layer.build(Persistence.layerBackingSql).pipe(TestClock.withLive)
 
       let expired = yield* SqlCleanupTest.waitForCount(
         expiredCount,
@@ -146,7 +146,6 @@ it.layer(PgContainer.layerClient, { timeout: "30 seconds" })("Persistence SQL cl
 
       while (expired > 0) {
         const previous = expired
-        yield* TestClock.adjust(SqlCleanupTest.cleanupBatchDelay)
         expired = yield* SqlCleanupTest.waitForCount(expiredCount, (count) => count < previous)
       }
       assert.strictEqual(expired, 0)

--- a/packages/sql/sqlite-node/test/Persistence.test.ts
+++ b/packages/sql/sqlite-node/test/Persistence.test.ts
@@ -139,7 +139,7 @@ it.layer(ClientLayer)("Persistence SQL cleanup", (it) => {
         VALUES ('live', 'live', '{}', NULL), ('live', 'future', '{}', ${SqlCleanupTest.futureExpiresAt})
       `
 
-      yield* Layer.build(Persistence.layerBackingSql)
+      yield* Layer.build(Persistence.layerBackingSql).pipe(TestClock.withLive)
 
       let expired = yield* SqlCleanupTest.waitForCount(
         expiredCount,
@@ -149,7 +149,6 @@ it.layer(ClientLayer)("Persistence SQL cleanup", (it) => {
 
       while (expired > 0) {
         const previous = expired
-        yield* TestClock.adjust(SqlCleanupTest.cleanupBatchDelay)
         expired = yield* SqlCleanupTest.waitForCount(expiredCount, (count) => count < previous)
       }
       assert.strictEqual(expired, 0)


### PR DESCRIPTION
## Summary

- run SQL persistence cleanup workers on the live clock in their integration tests
- remove the one-shot test-clock adjustment that could occur before the worker registered its batch delay
- apply the fix consistently to MySQL, PostgreSQL, and SQLite cleanup coverage

This is test-only; production cleanup behavior is unchanged.

## Validation

- `pnpm lint`
- Deno: MySQL and PostgreSQL cleanup tests
- Deno: complete MySQL and PostgreSQL persistence test files (26 tests)
- Node: MySQL, PostgreSQL, and SQLite cleanup tests
- Node: complete SQLite persistence test file (11 tests)

An exact local Deno shard run also exposed unrelated Vite/OXC N-API transform-cache failures in six suites while 159 files passed. CI history likewise shows broader Deno runner pressure affecting unrelated SQL tests; that is intentionally out of scope for this focused clock-race fix.

Closes EFF-263
