### PR TITLE
Split wall and monotonic clock semantics

### DIFF
--- a/.changeset/fix-otel-logger-clock-skew.md
+++ b/.changeset/fix-otel-logger-clock-skew.md
@@ -2,6 +2,6 @@
 "@effect/opentelemetry": patch
 ---
 
-Use monotonic clock for log timestamps to match span timestamps.
+Use the Effect wall clock for log timestamps to match span timestamps.
 
-The Logger used `Date.now()` (wall clock) for log `timestamp` while the Tracer used `clock.currentTimeNanosUnsafe()` (monotonic clock) for span `startTime`. This caused logs to appear before their parent span due to clock drift between the two sources. Both now use the same monotonic clock via `nanosToHrTime(clock.currentTimeNanosUnsafe())`.
+The Logger used `Date.now()` directly for log `timestamp` while the Tracer used `clock.currentTimeNanosUnsafe()` for span `startTime`. These could diverge when the high-resolution wall-clock origin drifted, causing logs to appear before their parent span. Both now use the same Effect wall clock via `nanosToHrTime(clock.currentTimeNanosUnsafe())`.

--- a/.changeset/split-clock-semantics.md
+++ b/.changeset/split-clock-semantics.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+---
+
+Separate wall-clock timestamps from monotonic elapsed time.
+
+`Clock.Clock` now requires `monotonicTimeNanosUnsafe()` and `monotonicTimeNanos` for measuring elapsed time. Custom `Clock` implementations must provide both members. The live clock's `currentTimeNanos` now re-anchors its high-resolution Unix wall-clock timestamp when it drifts from `Date.now()`, while `Effect.timed`, duration metric tracking, and `Sink.withDuration` use monotonic time so wall-clock corrections do not distort elapsed durations.

--- a/packages/effect/src/Clock.ts
+++ b/packages/effect/src/Clock.ts
@@ -242,6 +242,8 @@ export const currentTimeMillis: Effect<number> = effect.currentTimeMillis
  *
  * The value can move backward or forward when the system wall clock is
  * corrected, so it is not suitable for measuring elapsed time.
+ * The live clock allows up to one second of drift from `Date.now()` before
+ * re-anchoring.
  *
  * **Example** (Reading nanoseconds)
  *

--- a/packages/effect/src/Clock.ts
+++ b/packages/effect/src/Clock.ts
@@ -1,8 +1,9 @@
 /**
  * Service and helpers for reading time and sleeping inside Effect programs.
- * The active `Clock` provides current time in milliseconds or nanoseconds and a
- * `sleep` operation for delaying work. Because time is accessed through a
- * service, tests can replace the clock with a controlled implementation.
+ * The active `Clock` provides Unix time, monotonic time for measuring elapsed
+ * durations, and a `sleep` operation for delaying work. Because time is
+ * accessed through a service, tests can replace the clock with a controlled
+ * implementation.
  *
  * @since 2.0.0
  */
@@ -39,39 +40,94 @@ import * as effect from "./internal/effect.ts"
  */
 export interface Clock {
   /**
-   * Returns the current time in milliseconds unsafely.
+   * Returns the current Unix time in milliseconds unsafely.
    *
    * **When to use**
    *
-   * Use to read millisecond time synchronously when you already have a `Clock`
-   * service and can accept non-effectful access.
+   * Use to read a wall-clock timestamp synchronously when you already have a
+   * `Clock` service and can accept non-effectful access.
+   *
+   * **Gotchas**
+   *
+   * The value can move backward or forward when the system wall clock is
+   * corrected, so it is not suitable for measuring elapsed time.
    */
   currentTimeMillisUnsafe(): number
   /**
-   * Returns the current time in milliseconds.
+   * Returns the current Unix time in milliseconds.
    *
    * **When to use**
    *
-   * Use to read millisecond time through this `Clock` service in `Effect`.
+   * Use to read a wall-clock timestamp through this `Clock` service in
+   * `Effect`.
+   *
+   * **Gotchas**
+   *
+   * The value can move backward or forward when the system wall clock is
+   * corrected, so it is not suitable for measuring elapsed time.
    */
   readonly currentTimeMillis: Effect<number>
   /**
-   * Returns the current time in nanoseconds unsafely.
+   * Returns the current Unix time in nanoseconds unsafely.
    *
    * **When to use**
    *
-   * Use to read nanosecond time synchronously when you already have a `Clock`
-   * service and can accept non-effectful access.
+   * Use to read a wall-clock timestamp synchronously when you already have a
+   * `Clock` service and can accept non-effectful access.
+   *
+   * **Gotchas**
+   *
+   * The value can move backward or forward when the system wall clock is
+   * corrected, so it is not suitable for measuring elapsed time.
    */
   currentTimeNanosUnsafe(): bigint
   /**
-   * Returns the current time in nanoseconds.
+   * Returns the current Unix time in nanoseconds.
    *
    * **When to use**
    *
-   * Use to read nanosecond time through this `Clock` service in `Effect`.
+   * Use to read a wall-clock timestamp through this `Clock` service in
+   * `Effect`.
+   *
+   * **Gotchas**
+   *
+   * The value can move backward or forward when the system wall clock is
+   * corrected, so it is not suitable for measuring elapsed time.
    */
   readonly currentTimeNanos: Effect<bigint>
+  /**
+   * Returns the current monotonic time in nanoseconds unsafely.
+   *
+   * **When to use**
+   *
+   * Use to measure elapsed time synchronously when you already have a `Clock`
+   * service and can accept non-effectful access.
+   *
+   * **Gotchas**
+   *
+   * The value has an arbitrary origin and is unsuitable for serialization. Use
+   * it only to subtract readings produced by the same clock. Whether it
+   * advances while the host is suspended depends on the runtime.
+   *
+   * @since 4.0.0
+   */
+  monotonicTimeNanosUnsafe(): bigint
+  /**
+   * Returns the current monotonic time in nanoseconds.
+   *
+   * **When to use**
+   *
+   * Use to measure elapsed time through this `Clock` service in `Effect`.
+   *
+   * **Gotchas**
+   *
+   * The value has an arbitrary origin and is unsuitable for serialization. Use
+   * it only to subtract readings produced by the same clock. Whether it
+   * advances while the host is suspended depends on the runtime.
+   *
+   * @since 4.0.0
+   */
+  readonly monotonicTimeNanos: Effect<bigint>
   /**
    * Asynchronously sleeps for the specified duration.
    *
@@ -141,12 +197,17 @@ export const Clock: Context.Reference<Clock> = effect.ClockRef
 export const clockWith: <A, E, R>(f: (clock: Clock) => Effect<A, E, R>) => Effect<A, E, R> = effect.clockWith
 
 /**
- * Returns an Effect that succeeds with the current time in milliseconds.
+ * Returns an Effect that succeeds with the current Unix time in milliseconds.
  *
  * **When to use**
  *
- * Use to read wall-clock time from the active Clock service with millisecond
- * precision.
+ * Use to create wall-clock timestamps from the active `Clock` service with
+ * millisecond precision.
+ *
+ * **Gotchas**
+ *
+ * The value can move backward or forward when the system wall clock is
+ * corrected, so it is not suitable for measuring elapsed time.
  *
  * **Example** (Reading milliseconds)
  *
@@ -161,6 +222,7 @@ export const clockWith: <A, E, R>(f: (clock: Clock) => Effect<A, E, R>) => Effec
  * ```
  *
  * @see {@link currentTimeNanos} for nanosecond precision
+ * @see {@link monotonicTimeNanos} for measuring elapsed time
  * @see {@link clockWith} for accessing the full Clock service
  *
  * @category constructors
@@ -169,12 +231,17 @@ export const clockWith: <A, E, R>(f: (clock: Clock) => Effect<A, E, R>) => Effec
 export const currentTimeMillis: Effect<number> = effect.currentTimeMillis
 
 /**
- * Returns an Effect that succeeds with the current time in nanoseconds.
+ * Returns an Effect that succeeds with the current Unix time in nanoseconds.
  *
  * **When to use**
  *
- * Use to read wall-clock time from the active `Clock` service with nanosecond
- * precision.
+ * Use to create wall-clock timestamps from the active `Clock` service with
+ * nanosecond precision.
+ *
+ * **Gotchas**
+ *
+ * The value can move backward or forward when the system wall clock is
+ * corrected, so it is not suitable for measuring elapsed time.
  *
  * **Example** (Reading nanoseconds)
  *
@@ -188,7 +255,30 @@ export const currentTimeMillis: Effect<number> = effect.currentTimeMillis
  * })
  * ```
  *
+ * @see {@link monotonicTimeNanos} for measuring elapsed time
+ *
  * @category constructors
  * @since 2.0.0
  */
 export const currentTimeNanos: Effect<bigint> = effect.currentTimeNanos
+
+/**
+ * Returns an Effect that succeeds with the current monotonic time in
+ * nanoseconds.
+ *
+ * **When to use**
+ *
+ * Use to measure elapsed time by subtracting two readings.
+ *
+ * **Gotchas**
+ *
+ * The value has an arbitrary origin and is unsuitable for serialization. Use
+ * it only to subtract readings produced by the same clock. Whether it advances
+ * while the host is suspended depends on the runtime.
+ *
+ * @see {@link currentTimeNanos} for Unix wall-clock timestamps
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const monotonicTimeNanos: Effect<bigint> = effect.monotonicTimeNanos

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -14625,9 +14625,9 @@ export const trackDuration: {
     f: ((duration: Duration.Duration) => Input) | undefined
   ): Effect<A, E, R> =>
     clockWith((clock) => {
-      const startTime = clock.currentTimeNanosUnsafe()
+      const startTime = clock.monotonicTimeNanosUnsafe()
       return onExit(self, () => {
-        const endTime = clock.currentTimeNanosUnsafe()
+        const endTime = clock.monotonicTimeNanosUnsafe()
         const duration = Duration.subtract(
           Duration.fromInputUnsafe(endTime),
           Duration.fromInputUnsafe(startTime)

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -1972,7 +1972,7 @@ export const summarized: {
 export const withDuration = <A, In, L, E, R>(
   self: Sink<A, In, L, E, R>
 ): Sink<[A, Duration.Duration], In, L, E, R> =>
-  summarized(self, Clock.currentTimeNanos, (start, end) => Duration.nanos(end - start))
+  summarized(self, Clock.monotonicTimeNanos, (start, end) => Duration.nanos(end - start))
 
 /**
  * A sink that drains all input and returns the elapsed duration.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3747,8 +3747,8 @@ export const timed = <A, E, R>(
   self: Effect.Effect<A, E, R>
 ): Effect.Effect<[duration: Duration.Duration, result: A], E, R> =>
   clockWith((clock) => {
-    const start = clock.currentTimeNanosUnsafe()
-    return map(self, (a) => [Duration.nanos(clock.currentTimeNanosUnsafe() - start), a])
+    const start = clock.monotonicTimeNanosUnsafe()
+    return map(self, (a) => [Duration.nanos(clock.monotonicTimeNanosUnsafe() - start), a])
   })
 
 // ----------------------------------------------------------------------------
@@ -5992,9 +5992,13 @@ class ClockImpl implements Clock.Clock {
   }
   readonly currentTimeMillis: Effect.Effect<number> = sync(() => this.currentTimeMillisUnsafe())
   currentTimeNanosUnsafe(): bigint {
-    return processOrPerformanceNow()
+    return wallTimeNanos()
   }
   readonly currentTimeNanos: Effect.Effect<bigint> = sync(() => this.currentTimeNanosUnsafe())
+  monotonicTimeNanosUnsafe(): bigint {
+    return monotonicNowNanos()
+  }
+  readonly monotonicTimeNanos: Effect.Effect<bigint> = sync(() => this.monotonicTimeNanosUnsafe())
   sleep(duration: Duration.Duration): Effect.Effect<void> {
     return this.sleepMillis(Duration.toMillis(duration))
   }
@@ -6011,27 +6015,51 @@ class ClockImpl implements Clock.Clock {
   }
 }
 
-const performanceNowNanos = (function() {
-  const bigint1e6 = BigInt(1_000_000)
-  if (typeof performance === "undefined" || typeof performance.now === "undefined") {
-    return () => BigInt(Date.now()) * bigint1e6
-  }
-  let origin: bigint
-  return () => {
-    origin ??= (BigInt(Date.now()) * bigint1e6) - BigInt(Math.round(performance.now() * 1_000_000))
-    return origin + BigInt(Math.round(performance.now() * 1_000_000))
-  }
-})()
-const processOrPerformanceNow = (function() {
+const nanosPerMilli = BigInt(1_000_000)
+
+const monotonicNowNanos = (function() {
   const processHrtime =
     typeof process === "object" && "hrtime" in process && typeof process.hrtime.bigint === "function" ?
       process.hrtime :
       undefined
-  if (!processHrtime) {
-    return performanceNowNanos
+  if (processHrtime) {
+    return () => processHrtime.bigint()
   }
-  const origin = (BigInt(Date.now()) * BigInt(1e6)) - processHrtime.bigint()
-  return () => origin + processHrtime.bigint()
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return () => BigInt(Math.round(performance.now() * 1_000_000))
+  }
+  let previous: bigint | undefined
+  return () => {
+    const current = BigInt(Date.now()) * nanosPerMilli
+    if (previous === undefined || current > previous) {
+      previous = current
+    }
+    return previous
+  }
+})()
+
+const wallTimeNanos = (function() {
+  const checkIntervalMillis = 1_000
+  const reanchorThresholdNanos = BigInt(1_000_000_000)
+  let origin: bigint | undefined
+  let lastCheckMillis = 0
+  return () => {
+    const monotonic = monotonicNowNanos()
+    const wallMillis = Date.now()
+    const wall = BigInt(wallMillis) * nanosPerMilli
+    if (origin === undefined) {
+      origin = wall - monotonic
+      lastCheckMillis = wallMillis
+    } else if (wallMillis < lastCheckMillis || wallMillis - lastCheckMillis >= checkIntervalMillis) {
+      lastCheckMillis = wallMillis
+      const projected = origin + monotonic
+      const skew = wall > projected ? wall - projected : projected - wall
+      if (skew > reanchorThresholdNanos) {
+        origin = wall - monotonic
+      }
+    }
+    return origin + monotonic
+  }
 })()
 
 /** @internal */
@@ -6047,6 +6075,9 @@ export const currentTimeMillis: Effect.Effect<number> = clockWith((clock) => clo
 
 /** @internal */
 export const currentTimeNanos: Effect.Effect<bigint> = clockWith((clock) => clock.currentTimeNanos)
+
+/** @internal */
+export const monotonicTimeNanos: Effect.Effect<bigint> = clockWith((clock) => clock.monotonicTimeNanos)
 
 // ----------------------------------------------------------------------------
 // Errors

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -6028,10 +6028,10 @@ const monotonicNowNanos = (function() {
   if (typeof performance !== "undefined" && typeof performance.now === "function") {
     return () => BigInt(Math.round(performance.now() * 1_000_000))
   }
-  let previous: bigint | undefined
+  let previous = BigInt(0)
   return () => {
     const current = BigInt(Date.now()) * nanosPerMilli
-    if (previous === undefined || current > previous) {
+    if (current > previous) {
       previous = current
     }
     return previous
@@ -6039,19 +6039,14 @@ const monotonicNowNanos = (function() {
 })()
 
 const wallTimeNanos = (function() {
-  const checkIntervalMillis = 1_000
   const reanchorThresholdNanos = BigInt(1_000_000_000)
   let origin: bigint | undefined
-  let lastCheckMillis = 0
   return () => {
     const monotonic = monotonicNowNanos()
-    const wallMillis = Date.now()
-    const wall = BigInt(wallMillis) * nanosPerMilli
+    const wall = BigInt(Date.now()) * nanosPerMilli
     if (origin === undefined) {
       origin = wall - monotonic
-      lastCheckMillis = wallMillis
-    } else if (wallMillis < lastCheckMillis || wallMillis - lastCheckMillis >= checkIntervalMillis) {
-      lastCheckMillis = wallMillis
+    } else {
       const projected = origin + monotonic
       const skew = wall > projected ? wall - projected : projected - wall
       if (skew > reanchorThresholdNanos) {

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -324,9 +324,9 @@ export const make = Effect.fnUntraced(function*(
     yield* Fiber.await(yield* Effect.forkChild(Effect.yieldNow))
     const endTimestamp = step(currentTimestamp)
     const advanceTo = (timestamp: number) => {
-      if (timestamp > currentTimestamp && Number.isFinite(timestamp) && Number.isFinite(currentTimestamp)) {
-        currentMonotonicNanos += BigInt(Math.floor(timestamp * 1_000_000)) -
-          BigInt(Math.floor(currentTimestamp * 1_000_000))
+      const deltaMillis = timestamp - currentTimestamp
+      if (deltaMillis > 0 && Number.isFinite(deltaMillis)) {
+        currentMonotonicNanos += BigInt(Math.round(deltaMillis * 1_000_000))
       }
       currentTimestamp = timestamp
     }

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -236,6 +236,7 @@ export const make = Effect.fnUntraced(function*(
   const warningSemaphore = yield* Semaphore.make(1)
 
   let currentTimestamp: number = new Date(0).getTime()
+  let currentMonotonicNanos = BigInt(0)
   let warningState: WarningState = WarningState.Start()
 
   function currentTimeMillisUnsafe(): number {
@@ -246,8 +247,13 @@ export const make = Effect.fnUntraced(function*(
     return BigInt(Math.floor(currentTimestamp * 1000000))
   }
 
+  function monotonicTimeNanosUnsafe(): bigint {
+    return currentMonotonicNanos
+  }
+
   const currentTimeMillis = Effect.sync(currentTimeMillisUnsafe)
   const currentTimeNanos = Effect.sync(currentTimeNanosUnsafe)
+  const monotonicTimeNanos = Effect.sync(monotonicTimeNanosUnsafe)
 
   function withLive<A, E, R>(effect: Effect.Effect<A, E, R>) {
     return Effect.provideService(effect, Clock.Clock, liveClock)
@@ -317,14 +323,21 @@ export const make = Effect.fnUntraced(function*(
   const run = Effect.fnUntraced(function*(step: (currentTimestamp: number) => number) {
     yield* Fiber.await(yield* Effect.forkChild(Effect.yieldNow))
     const endTimestamp = step(currentTimestamp)
+    const advanceTo = (timestamp: number) => {
+      if (timestamp > currentTimestamp && Number.isFinite(timestamp) && Number.isFinite(currentTimestamp)) {
+        currentMonotonicNanos += BigInt(Math.floor(timestamp * 1_000_000)) -
+          BigInt(Math.floor(currentTimestamp * 1_000_000))
+      }
+      currentTimestamp = timestamp
+    }
     while (Arr.isArrayNonEmpty(sleeps)) {
       if (Arr.lastNonEmpty(sleeps).timestamp > endTimestamp) break
       const entry = sleeps.pop()!
-      currentTimestamp = entry.timestamp
+      advanceTo(entry.timestamp)
       entry.latch.openUnsafe()
       yield* Effect.yieldNow
     }
-    currentTimestamp = endTimestamp
+    advanceTo(endTimestamp)
   }, runSemaphore.withPermits(1))
 
   function adjust(duration: Duration.Input) {
@@ -341,8 +354,10 @@ export const make = Effect.fnUntraced(function*(
   return {
     currentTimeMillisUnsafe,
     currentTimeNanosUnsafe,
+    monotonicTimeNanosUnsafe,
     currentTimeMillis,
     currentTimeNanos,
+    monotonicTimeNanos,
     adjust,
     setTime,
     sleep,

--- a/packages/effect/test/Clock.test.ts
+++ b/packages/effect/test/Clock.test.ts
@@ -2,64 +2,36 @@ import { assert, describe, it, vi } from "@effect/vitest"
 import { Clock, Effect } from "effect"
 
 describe.sequential("Clock", () => {
-  it.live("keeps wall time aligned while exposing the monotonic source", () =>
-    Effect.acquireUseRelease(
-      Effect.sync(() => {
-        let wallMillis = 1_000_000
-        let monotonicNanos = 5_000_000_000n
-        const dateNow = vi.spyOn(Date, "now").mockImplementation(() => wallMillis)
-        const hrtime = vi.spyOn(process.hrtime, "bigint").mockImplementation(() => monotonicNanos)
-        return {
-          dateNow,
-          hrtime,
-          readWallMillis: () => wallMillis,
-          readMonotonicNanos: () => monotonicNanos,
-          updateWallMillis: (f: (value: number) => number) => {
-            wallMillis = f(wallMillis)
-          },
-          updateMonotonicNanos: (f: (value: bigint) => bigint) => {
-            monotonicNanos = f(monotonicNanos)
-          }
-        }
-      }),
-      (state) =>
-        Effect.gen(function*() {
-          const clock = yield* Clock.Clock
-          const nanosPerMilli = 1_000_000n
+  it.live("keeps wall time aligned while exposing the monotonic source", () => {
+    let wallMillis = 1_000_000
+    let monotonicNanos = 5_000_000_000n
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => wallMillis)
+    const hrtime = vi.spyOn(process.hrtime, "bigint").mockImplementation(() => monotonicNanos)
+    return Effect.gen(function*() {
+      const clock = yield* Clock.Clock
+      const nanosPerMilli = 1_000_000n
 
-          assert.strictEqual(
-            clock.currentTimeNanosUnsafe(),
-            BigInt(state.readWallMillis()) * nanosPerMilli
-          )
-          assert.strictEqual(clock.monotonicTimeNanosUnsafe(), state.readMonotonicNanos())
+      assert.strictEqual(clock.currentTimeNanosUnsafe(), BigInt(wallMillis) * nanosPerMilli)
+      assert.strictEqual(clock.monotonicTimeNanosUnsafe(), monotonicNanos)
 
-          state.updateWallMillis((value) => value + 250)
-          state.updateMonotonicNanos((value) => value + 250_000_000n)
-          assert.strictEqual(
-            clock.currentTimeNanosUnsafe(),
-            BigInt(state.readWallMillis()) * nanosPerMilli
-          )
+      wallMillis += 250
+      monotonicNanos += 250_000_000n
+      assert.strictEqual(clock.currentTimeNanosUnsafe(), BigInt(wallMillis) * nanosPerMilli)
 
-          state.updateWallMillis((value) => value + 5_000)
-          const beforeSuspend = clock.monotonicTimeNanosUnsafe()
-          assert.strictEqual(
-            clock.currentTimeNanosUnsafe(),
-            BigInt(state.readWallMillis()) * nanosPerMilli
-          )
-          assert.strictEqual(clock.monotonicTimeNanosUnsafe(), beforeSuspend)
+      wallMillis += 5_000
+      const beforeSuspend = clock.monotonicTimeNanosUnsafe()
+      assert.strictEqual(clock.currentTimeNanosUnsafe(), BigInt(wallMillis) * nanosPerMilli)
+      assert.strictEqual(clock.monotonicTimeNanosUnsafe(), beforeSuspend)
 
-          state.updateWallMillis((value) => value - 3_000)
-          state.updateMonotonicNanos((value) => value + 100_000_000n)
-          assert.strictEqual(
-            clock.currentTimeNanosUnsafe(),
-            BigInt(state.readWallMillis()) * nanosPerMilli
-          )
-          assert.isTrue(clock.monotonicTimeNanosUnsafe() > beforeSuspend)
-        }),
-      (state) =>
-        Effect.sync(() => {
-          state.dateNow.mockRestore()
-          state.hrtime.mockRestore()
-        })
-    ))
+      wallMillis -= 3_000
+      monotonicNanos += 100_000_000n
+      assert.strictEqual(clock.currentTimeNanosUnsafe(), BigInt(wallMillis) * nanosPerMilli)
+      assert.isTrue(clock.monotonicTimeNanosUnsafe() > beforeSuspend)
+    }).pipe(
+      Effect.ensuring(Effect.sync(() => {
+        dateNow.mockRestore()
+        hrtime.mockRestore()
+      }))
+    )
+  })
 })

--- a/packages/effect/test/Clock.test.ts
+++ b/packages/effect/test/Clock.test.ts
@@ -1,0 +1,65 @@
+import { assert, describe, it, vi } from "@effect/vitest"
+import { Clock, Effect } from "effect"
+
+describe.sequential("Clock", () => {
+  it.live("keeps wall time aligned while exposing the monotonic source", () =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        let wallMillis = 1_000_000
+        let monotonicNanos = 5_000_000_000n
+        const dateNow = vi.spyOn(Date, "now").mockImplementation(() => wallMillis)
+        const hrtime = vi.spyOn(process.hrtime, "bigint").mockImplementation(() => monotonicNanos)
+        return {
+          dateNow,
+          hrtime,
+          readWallMillis: () => wallMillis,
+          readMonotonicNanos: () => monotonicNanos,
+          updateWallMillis: (f: (value: number) => number) => {
+            wallMillis = f(wallMillis)
+          },
+          updateMonotonicNanos: (f: (value: bigint) => bigint) => {
+            monotonicNanos = f(monotonicNanos)
+          }
+        }
+      }),
+      (state) =>
+        Effect.gen(function*() {
+          const clock = yield* Clock.Clock
+          const nanosPerMilli = 1_000_000n
+
+          assert.strictEqual(
+            clock.currentTimeNanosUnsafe(),
+            BigInt(state.readWallMillis()) * nanosPerMilli
+          )
+          assert.strictEqual(clock.monotonicTimeNanosUnsafe(), state.readMonotonicNanos())
+
+          state.updateWallMillis((value) => value + 250)
+          state.updateMonotonicNanos((value) => value + 250_000_000n)
+          assert.strictEqual(
+            clock.currentTimeNanosUnsafe(),
+            BigInt(state.readWallMillis()) * nanosPerMilli
+          )
+
+          state.updateWallMillis((value) => value + 5_000)
+          const beforeSuspend = clock.monotonicTimeNanosUnsafe()
+          assert.strictEqual(
+            clock.currentTimeNanosUnsafe(),
+            BigInt(state.readWallMillis()) * nanosPerMilli
+          )
+          assert.strictEqual(clock.monotonicTimeNanosUnsafe(), beforeSuspend)
+
+          state.updateWallMillis((value) => value - 3_000)
+          state.updateMonotonicNanos((value) => value + 100_000_000n)
+          assert.strictEqual(
+            clock.currentTimeNanosUnsafe(),
+            BigInt(state.readWallMillis()) * nanosPerMilli
+          )
+          assert.isTrue(clock.monotonicTimeNanosUnsafe() > beforeSuspend)
+        }),
+      (state) =>
+        Effect.sync(() => {
+          state.dateNow.mockRestore()
+          state.hrtime.mockRestore()
+        })
+    ))
+})

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1433,6 +1433,21 @@ describe("Effect", () => {
       }))
   })
 
+  describe("timed", () => {
+    it.effect("uses monotonic time when wall time moves backward", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(1_000)
+        const [duration, result] = yield* Effect.gen(function*() {
+          yield* TestClock.adjust("100 millis")
+          yield* TestClock.setTime(0)
+          return "done"
+        }).pipe(Effect.timed)
+
+        assert.strictEqual(result, "done")
+        assert.strictEqual(Duration.toMillis(duration), 100)
+      }))
+  })
+
   describe("timeoutOption", () => {
     it.live("timeout a long computation", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -684,6 +684,23 @@ describe("Metric", () => {
         assert.strictEqual(result.max, Duration.toMillis(Duration.hours(1)))
         assert.strictEqual(result.sum, Duration.toMillis(Duration.hours(1)))
       }))
+
+    it.effect("uses monotonic time when wall time moves backward", () =>
+      Effect.gen(function*() {
+        const id = nextId()
+        const timer = Metric.timer(id)
+        yield* TestClock.setTime(1_000)
+        yield* Effect.gen(function*() {
+          yield* TestClock.adjust("100 millis")
+          yield* TestClock.setTime(0)
+        }).pipe(Effect.trackDuration(timer))
+
+        const result = yield* Metric.value(timer)
+        assert.strictEqual(result.count, 1)
+        assert.strictEqual(result.min, 100)
+        assert.strictEqual(result.max, 100)
+        assert.strictEqual(result.sum, 100)
+      }))
   })
 
   describe("trackDurationWith", () => {

--- a/packages/effect/test/Sink.test.ts
+++ b/packages/effect/test/Sink.test.ts
@@ -7,8 +7,9 @@ import {
   deepStrictEqual,
   strictEqual
 } from "@effect/vitest/utils"
-import { Array, Cause, Deferred, Effect, Fiber, Option, Ref, Result, Sink, Stream } from "effect"
+import { Array, Cause, Deferred, Duration, Effect, Fiber, Option, Ref, Result, Sink, Stream } from "effect"
 import { constTrue, pipe } from "effect/Function"
+import { TestClock } from "effect/testing"
 
 describe("Sink", () => {
   describe("constructors", () => {
@@ -241,6 +242,23 @@ describe("Sink", () => {
           Stream.runCollect
         )
         deepStrictEqual(result, [[1, 2], [], []])
+      }))
+  })
+
+  describe("withDuration", () => {
+    it.effect("uses monotonic time when wall time moves backward", () =>
+      Effect.gen(function*() {
+        yield* TestClock.setTime(1_000)
+        const [, duration] = yield* Stream.empty.pipe(
+          Stream.run(
+            Sink.fromEffect(Effect.gen(function*() {
+              yield* TestClock.adjust("100 millis")
+              yield* TestClock.setTime(0)
+            })).pipe(Sink.withDuration)
+          )
+        )
+
+        strictEqual(Duration.toMillis(duration), 100)
       }))
   })
 

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -82,6 +82,16 @@ describe("TestClock", () => {
       assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), 2_500_000_000n)
     }))
 
+  it.effect("setTime - preserves nanosecond precision for far-future timestamps", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      const farFuture = 1_000_000_000_000
+      yield* testClock.setTime(farFuture)
+      const before = testClock.monotonicTimeNanosUnsafe()
+      yield* testClock.setTime(farFuture + 1)
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe() - before, 1_000_000n)
+    }))
+
   it.effect("adjust - advances monotonic time to intermediate sleep deadlines", () =>
     Effect.gen(function*() {
       const testClock = yield* TestClock.make()

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -61,6 +61,40 @@ describe("TestClock", () => {
       assert.strictEqual(testClock.currentTimeNanosUnsafe(), 199023438000000n)
     }))
 
+  it.effect("adjust - advances wall and monotonic time", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      yield* testClock.adjust("1 second")
+      assert.strictEqual(testClock.currentTimeMillisUnsafe(), 1_000)
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), 1_000_000_000n)
+      assert.strictEqual(yield* testClock.monotonicTimeNanos, 1_000_000_000n)
+    }))
+
+  it.effect("setTime - advances monotonic time only when moving forward", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      yield* testClock.setTime(2_000)
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), 2_000_000_000n)
+      yield* testClock.setTime(500)
+      assert.strictEqual(testClock.currentTimeMillisUnsafe(), 500)
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), 2_000_000_000n)
+      yield* testClock.setTime(1_000)
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), 2_500_000_000n)
+    }))
+
+  it.effect("adjust - advances monotonic time to intermediate sleep deadlines", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      let observed = 0n
+      yield* Effect.gen(function*() {
+        yield* testClock.sleep(Duration.seconds(1))
+        observed = yield* testClock.monotonicTimeNanos
+      }).pipe(Effect.forkChild)
+      yield* testClock.adjust("2 seconds")
+      assert.strictEqual(observed, 1_000_000_000n)
+      assert.strictEqual(testClock.monotonicTimeNanosUnsafe(), 2_000_000_000n)
+    }))
+
   // `it.effect` and `it.live` provide an ambient Scope, defeating the #2244 regression guard.
   it("layer - can adjust when provided without an ambient Scope", () =>
     Effect.gen(function*() {

--- a/packages/effect/typetest/Clock.tst.ts
+++ b/packages/effect/typetest/Clock.tst.ts
@@ -1,0 +1,13 @@
+import type { Effect } from "effect"
+import { Clock } from "effect"
+import { describe, expect, it } from "tstyche"
+
+describe("Clock", () => {
+  it("exposes monotonic nanosecond time", () => {
+    expect(Clock.monotonicTimeNanos).type.toBe<Effect.Effect<bigint>>()
+
+    const clock = null as unknown as Clock.Clock
+    expect(clock.monotonicTimeNanosUnsafe()).type.toBe<bigint>()
+    expect(clock.monotonicTimeNanos).type.toBe<Effect.Effect<bigint>>()
+  })
+})

--- a/packages/opentelemetry/test/OtelLogger.test.ts
+++ b/packages/opentelemetry/test/OtelLogger.test.ts
@@ -56,19 +56,22 @@ describe("Logger", () => {
       )
     })
 
-    it.effect("uses monotonic clock timestamps and keeps them aligned with spans", () => {
+    it.effect("uses wall-clock timestamps and keeps them aligned with spans", () => {
       const logExporter = new InMemoryLogRecordExporter()
       const spanExporter = new InMemorySpanExporter()
-      const timeNanos = 1_735_689_600_123_456_789n
+      const wallTimeNanos = 1_735_689_600_123_456_789n
+      const monotonicTimeNanos = 123_456_789n
       const expectedTime: readonly [number, number] = [
-        Number(timeNanos / BigInt(1_000_000_000)),
-        Number(timeNanos % BigInt(1_000_000_000))
+        Number(wallTimeNanos / BigInt(1_000_000_000)),
+        Number(wallTimeNanos % BigInt(1_000_000_000))
       ]
       const skewedClock: Clock.Clock = {
         currentTimeMillisUnsafe: () => 1,
         currentTimeMillis: Effect.succeed(1),
-        currentTimeNanosUnsafe: () => timeNanos,
-        currentTimeNanos: Effect.succeed(timeNanos),
+        currentTimeNanosUnsafe: () => wallTimeNanos,
+        currentTimeNanos: Effect.succeed(wallTimeNanos),
+        monotonicTimeNanosUnsafe: () => monotonicTimeNanos,
+        monotonicTimeNanos: Effect.succeed(monotonicTimeNanos),
         sleep: () => Effect.void
       }
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Fixes `Clock.currentTimeNanos` permanently drifting from wall time when the runtime's monotonic clock pauses during host suspension or advances at a different rate from `Date.now()`.

Previously, the live clock established its wall-clock origin once and never revisited it. This could leave nanosecond timestamps behind or ahead of Unix wall time for the lifetime of the process.

### Changes

- Add required monotonic APIs to `Clock.Clock`:
  - `monotonicTimeNanosUnsafe()`
  - `monotonicTimeNanos`
- Export `Clock.monotonicTimeNanos`.
- Keep `currentTimeMillis` and `currentTimeNanos` as Unix-epoch wall-clock timestamps.
- Re-anchor live wall-clock nanoseconds when absolute skew exceeds one second.
- Select the monotonic source from:
  1. `process.hrtime.bigint()`
  2. `performance.now()`
  3. A non-decreasing `Date.now()` fallback
- Use monotonic time for:
  - `Effect.timed`
  - `Effect.trackDuration`
  - `Sink.withDuration` and `Sink.timed`
- Give `TestClock` independent wall and monotonic counters.
- Keep tracing, logging, metrics, and other protocol timestamps on wall time.
- Document the wall-clock and monotonic semantics, including serialization and host-suspension considerations.
- Add an `effect` minor changeset covering the required custom-`Clock` migration.

### Tests

- Add a live-clock regression test that freezes monotonic time while wall time jumps forward.
- Verify large forward and backward wall-clock corrections re-anchor immediately.
- Verify monotonic readings remain source-relative and non-decreasing.
- Cover `TestClock` adjustment, forward `setTime`, backward `setTime`, and intermediate sleep deadlines.
- Verify all migrated duration operators use monotonic differences.
- Verify OpenTelemetry logs and spans continue using wall-clock timestamps.
- Add Clock API typetests.

Local validation:

- 314 focused Effect tests passed.
- 4 focused OpenTelemetry tests passed.
- Clock typetests passed against TypeScript 5.9 and 6.0.
- `pnpm check` passed.
- `pnpm lint` passed.

## Related

- No linked issue.