### PR TITLE
Change Number.parse to parseFloat in schema migration

### DIFF
--- a/migration/schema.md
+++ b/migration/schema.md
@@ -904,7 +904,7 @@ const NumberFromString = Schema.String.pipe(
   Schema.decodeTo(Schema.Number, {
     decode: SchemaGetter.transformOrFail((s) => {
       const n = parseFloat(s)
-      if (n === undefined) {
+      if (isNaN(parsed)) {
         return Effect.fail(new SchemaIssue.InvalidValue(Option.some(s)))
       }
       return Effect.succeed(n)

--- a/migration/schema.md
+++ b/migration/schema.md
@@ -903,11 +903,11 @@ import { Effect, Number, Option, Schema, SchemaGetter, SchemaIssue } from "effec
 const NumberFromString = Schema.String.pipe(
   Schema.decodeTo(Schema.Number, {
     decode: SchemaGetter.transformOrFail((s) => {
-      const n = parseFloat(s)
+      const parsed = parseFloat(s)
       if (isNaN(parsed)) {
         return Effect.fail(new SchemaIssue.InvalidValue(Option.some(s)))
       }
-      return Effect.succeed(n)
+      return Effect.succeed(parsed)
     }),
     encode: SchemaGetter.String()
   })

--- a/migration/schema.md
+++ b/migration/schema.md
@@ -903,7 +903,7 @@ import { Effect, Number, Option, Schema, SchemaGetter, SchemaIssue } from "effec
 const NumberFromString = Schema.String.pipe(
   Schema.decodeTo(Schema.Number, {
     decode: SchemaGetter.transformOrFail((s) => {
-      const n = Number.parse(s)
+      const n = parseFloat(s)
       if (n === undefined) {
         return Effect.fail(new SchemaIssue.InvalidValue(Option.some(s)))
       }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Change Number.parse to parseFloat in schema migration
Used parseFloat to make it consistent with previous V3 example
Number.parse does not exist.


## Related

NOne

- Related Issue #
- Closes #
