### PR TITLE
Avoid redundant HttpRouter context clone

### DIFF
--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -217,14 +217,14 @@ export const make = Effect.gen(function*() {
         if (span && span._tag === "Span") {
           span.attribute("http.route", route.path)
         }
-        return Effect.provideContext(
+        return Effect.updateContext(
           (route.uninterruptible ?
             route.handler :
             Effect.interruptible(route.handler)) as Effect.Effect<
               HttpServerResponse.HttpServerResponse,
               unknown
             >,
-          Context.makeUnsafe(contextMap)
+          () => Context.makeUnsafe(contextMap)
         )
       })
       if (middleware.size === 0) return handler


### PR DESCRIPTION
## Summary

- replace `provideContext` with `updateContext` in the HTTP router hot path
- reuse the complete context map instead of cloning and merging it again

## Testing

- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm test --run packages/effect/test/unstable/http/HttpEffect.test.ts`
- `nix develop -c pnpm test --run packages/platform-node/test/NodeHttpServer.test.ts`
- `nix develop -c pnpm check`

Closes EFF-272
