### PR TITLE
fix(ai-openai-compat): decode tool call parameters

### DIFF
--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1437,7 +1437,9 @@ const transformToolCallParams = Effect.fnUntraced(function*<Tools extends Readon
     })
   }
 
-  const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
+  const codec = Tool.isProviderDefined(tool)
+    ? tool.parametersSchema
+    : (yield* tryCodecTransform(tool.parametersSchema, "makeResponse")).codec
 
   const transform = Schema.decodeEffect(codec)
 

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -18,7 +18,7 @@ import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as Rec from "effect/Record"
 import * as Redactable from "effect/Redactable"
-import type * as Schema from "effect/Schema"
+import * as Schema from "effect/Schema"
 import * as AST from "effect/SchemaAST"
 import * as Stream from "effect/Stream"
 import type { Span } from "effect/Tracer"
@@ -631,6 +631,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
         const [rawResponse, response] = yield* client.createResponse(request)
         annotateResponse(options.span, rawResponse)
         return yield* makeResponse({
+          options,
           rawResponse,
           response,
           toolNameMapper
@@ -645,6 +646,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
         annotateRequest(options.span, request)
         const [response, stream] = yield* client.createResponseStream(request)
         return yield* makeStreamResponse({
+          options,
           stream,
           response,
           toolNameMapper
@@ -1042,10 +1044,12 @@ type ActiveToolCall = {
 
 const makeResponse = Effect.fnUntraced(
   function*<Tools extends ReadonlyArray<Tool.Any>>({
+    options,
     rawResponse,
     response,
     toolNameMapper
   }: {
+    readonly options: LanguageModel.ProviderOptions
     readonly rawResponse: CreateResponse200
     readonly response: HttpClientResponse.HttpClientResponse
     readonly toolNameMapper: Tool.NameMapper<Tools>
@@ -1085,7 +1089,7 @@ const makeResponse = Effect.fnUntraced(
           const toolId = toolCall.id ?? `${rawResponse.id}_tool_${index}`
           const toolName = toolNameMapper.getCustomName(toolCall.function?.name ?? "unknown_tool")
           const toolParams = toolCall.function?.arguments ?? "{}"
-          const params = yield* Effect.try({
+          const encodedParams = yield* Effect.try({
             try: () => Tool.unsafeSecureJsonParse(toolParams),
             catch: (cause) =>
               AiError.make({
@@ -1098,6 +1102,7 @@ const makeResponse = Effect.fnUntraced(
                 })
               })
           })
+          const params = yield* transformToolCallParams(options.tools, toolName, encodedParams)
           hasToolCalls = true
           parts.push({
             type: "tool-call",
@@ -1130,10 +1135,12 @@ const makeResponse = Effect.fnUntraced(
 
 const makeStreamResponse = Effect.fnUntraced(
   function*<Tools extends ReadonlyArray<Tool.Any>>({
+    options,
     stream,
     response,
     toolNameMapper
   }: {
+    readonly options: LanguageModel.ProviderOptions
     readonly stream: Stream.Stream<ResponseStreamEvent, AiError.AiError>
     readonly response: HttpClientResponse.HttpClientResponse
     readonly toolNameMapper: Tool.NameMapper<Tools>
@@ -1175,7 +1182,7 @@ const makeStreamResponse = Effect.fnUntraced(
 
           for (const toolCall of Object.values(activeToolCalls)) {
             const toolParams = toolCall.arguments.length > 0 ? toolCall.arguments : "{}"
-            const params = yield* Effect.try({
+            const encodedParams = yield* Effect.try({
               try: () => Tool.unsafeSecureJsonParse(toolParams),
               catch: (cause) =>
                 AiError.make({
@@ -1188,6 +1195,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   })
                 })
             })
+            const params = yield* transformToolCallParams(options.tools, toolCall.name, encodedParams)
             parts.push({ type: "tool-params-end", id: toolCall.id })
             parts.push({
               type: "tool-call",
@@ -1404,6 +1412,49 @@ const unsupportedSchemaError = (error: unknown, method: string): AiError.AiError
       description: error instanceof Error ? error.message : String(error)
     })
   })
+
+const tryCodecTransform = <S extends Schema.Constraint>(schema: S, method: string) =>
+  Effect.try({
+    try: () => toCodecOpenAI(schema),
+    catch: (error) => unsupportedSchemaError(error, method)
+  })
+
+const transformToolCallParams = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Tool.Any>>(
+  tools: Tools,
+  toolName: string,
+  toolParams: unknown
+): Effect.fn.Return<unknown, AiError.AiError> {
+  const tool = tools.find((tool) => tool.name === toolName)
+
+  if (Predicate.isUndefined(tool)) {
+    return yield* AiError.make({
+      module: "OpenAiLanguageModel",
+      method: "makeResponse",
+      reason: new AiError.ToolNotFoundError({
+        toolName,
+        availableTools: tools.map((tool) => tool.name)
+      })
+    })
+  }
+
+  const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
+
+  const transform = Schema.decodeEffect(codec)
+
+  return yield* (
+    transform(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
+  ).pipe(Effect.mapError((error) =>
+    AiError.make({
+      module: "OpenAiLanguageModel",
+      method: "makeResponse",
+      reason: new AiError.ToolParameterValidationError({
+        toolName,
+        toolParams,
+        description: error.issue.toString()
+      })
+    })
+  ))
+})
 
 const tryJsonSchema = <S extends Schema.Constraint>(schema: S, method: string) =>
   Effect.try({

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -329,6 +329,58 @@ describe("OpenAiLanguageModel", () => {
         assert.strictEqual(functionTool.function.strict, true)
       }))
 
+    it.effect("decodes provider-compatible tool parameters", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "tool_calls",
+                    message: {
+                      role: "assistant",
+                      content: null,
+                      tool_calls: [{
+                        id: "call_record_1",
+                        type: "function",
+                        function: {
+                          name: "RecordTool",
+                          arguments: JSON.stringify({
+                            env: [{ "0": "PATH", "1": "/usr/bin" }]
+                          })
+                        }
+                      }]
+                    }
+                  }]
+                })
+              ))
+            )
+          ))
+        )
+
+        const result = yield* LanguageModel.generateText({
+          prompt: "use the record tool",
+          toolkit: RecordToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(RecordToolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const toolCall = result.content.find((part) => part.type === "tool-call")
+        assert.isDefined(toolCall)
+        if (toolCall?.type !== "tool-call") {
+          return
+        }
+
+        assert.deepStrictEqual(toolCall.params, { env: { PATH: "/usr/bin" } })
+      }))
+
     it.effect("groups parallel tool calls into one assistant message", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
@@ -1312,6 +1364,62 @@ describe("OpenAiLanguageModel", () => {
         assert.deepStrictEqual(toolCall.params, { input: "hello" })
       }))
 
+    it.effect("decodes provider-compatible streamed tool parameters", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                {
+                  id: "chatcmpl_record_1",
+                  object: "chat.completion.chunk",
+                  model: "gpt-4o-mini",
+                  created: 1,
+                  choices: [{
+                    index: 0,
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        id: "call_record_1",
+                        type: "function",
+                        function: {
+                          name: "RecordTool",
+                          arguments: JSON.stringify({
+                            env: [{ "0": "PATH", "1": "/usr/bin" }]
+                          })
+                        }
+                      }]
+                    },
+                    finish_reason: "tool_calls"
+                  }]
+                },
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "use the record tool",
+          toolkit: RecordToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(RecordToolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const toolCall = globalThis.Array.from(partsChunk).find((part) => part.type === "tool-call")
+        assert.isDefined(toolCall)
+        if (toolCall?.type !== "tool-call") {
+          return
+        }
+
+        assert.deepStrictEqual(toolCall.params, { env: { PATH: "/usr/bin" } })
+      }))
+
     it.effect("emits reasoning lifecycle parts for delta.reasoning", () =>
       Effect.gen(function*() {
         const chunk = (delta: Record<string, unknown>, finishReason: string | null = null) => ({
@@ -1502,6 +1610,19 @@ const TestToolkit = Toolkit.make(TestTool)
 
 const TestToolkitLayer = TestToolkit.toLayer({
   TestTool: ({ input }) => Effect.succeed({ output: input })
+})
+
+const RecordTool = Tool.make("RecordTool", {
+  parameters: Schema.Struct({
+    env: Schema.Record(Schema.String, Schema.String)
+  }),
+  success: Schema.String
+})
+
+const RecordToolkit = Toolkit.make(RecordTool)
+
+const RecordToolkitLayer = RecordToolkit.toLayer({
+  RecordTool: ({ env }) => Effect.succeed(JSON.stringify(env))
 })
 
 const CompatApplyPatchTool = Tool.providerDefined({

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -381,6 +381,61 @@ describe("OpenAiLanguageModel", () => {
         assert.deepStrictEqual(toolCall.params, { env: { PATH: "/usr/bin" } })
       }))
 
+    it.effect("decodes provider-defined tool parameters with their original schema", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "tool_calls",
+                    message: {
+                      role: "assistant",
+                      content: null,
+                      tool_calls: [{
+                        id: "call_provider_record_1",
+                        type: "function",
+                        function: {
+                          name: "provider_record",
+                          arguments: JSON.stringify({ env: { PATH: "/usr/bin" } })
+                        }
+                      }]
+                    }
+                  }]
+                })
+              ))
+            )
+          ))
+        )
+
+        const toolkit = Toolkit.make(CompatRecordTool({}))
+        const toolkitLayer = toolkit.toLayer({
+          CompatRecord: ({ env }) => Effect.succeed(JSON.stringify(env))
+        })
+        const result = yield* LanguageModel.generateText({
+          prompt: "use the provider record tool",
+          toolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(toolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const toolCall = result.content.find((part) => part.type === "tool-call")
+        assert.isDefined(toolCall)
+        if (toolCall?.type !== "tool-call") {
+          return
+        }
+
+        assert.strictEqual(toolCall.name, "CompatRecord")
+        assert.deepStrictEqual(toolCall.params, { env: { PATH: "/usr/bin" } })
+      }))
+
     it.effect("groups parallel tool calls into one assistant message", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
@@ -1623,6 +1678,17 @@ const RecordToolkit = Toolkit.make(RecordTool)
 
 const RecordToolkitLayer = RecordToolkit.toLayer({
   RecordTool: ({ env }) => Effect.succeed(JSON.stringify(env))
+})
+
+const CompatRecordTool = Tool.providerDefined({
+  id: "compat.provider_record",
+  customName: "CompatRecord",
+  providerName: "provider_record",
+  requiresHandler: true,
+  parameters: Schema.Struct({
+    env: Schema.Record(Schema.String, Schema.String)
+  }),
+  success: Schema.String
 })
 
 const CompatApplyPatchTool = Tool.providerDefined({


### PR DESCRIPTION
## Summary

- Decode OpenAI-compatible tool-call parameters with the same provider codec used to generate tool schemas.
- Apply decoding to both non-streaming and streaming responses.
- Add regression coverage for `Schema.Record` parameters.

Closes #6818

## Tests

- `pnpm vitest run packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts`
- `pnpm --filter @effect/ai-openai-compat check`
- `pnpm exec dprint check packages/ai/openai-compat/src/OpenAiLanguageModel.ts packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts`