### PR TITLE
Fix Stream.mapAccumArrayEffect data-first usage

### DIFF
--- a/.changeset/fix-stream-map-accum-array-effect.md
+++ b/.changeset/fix-stream-map-accum-array-effect.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix data-first dispatch for `Stream.mapAccumArrayEffect`.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -7439,7 +7439,7 @@ export const mapAccumArrayEffect: {
       readonly onHalt?: ((state: S) => ReadonlyArray<B>) | undefined
     }
   ): Stream<B, E | E2, R | R2>
-} = dual((args) => isStream(args), <A, E, R, S, B, E2, R2>(
+} = dual((args) => isStream(args[0]), <A, E, R, S, B, E2, R2>(
   self: Stream<A, E, R>,
   initial: LazyArg<S>,
   f: (s: S, a: Arr.NonEmptyReadonlyArray<A>) => Effect.Effect<readonly [state: S, values: ReadonlyArray<B>], E2, R2>,

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -1255,6 +1255,17 @@ describe("Stream", () => {
 
         assert.deepStrictEqual(result, Array.scan([1, 2, 3, 4, 5], 0, (acc, curr) => acc + curr))
       }))
+
+    it.effect("mapAccumArrayEffect data-first", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.mapAccumArrayEffect(
+          Stream.make(1, 2, 3),
+          () => 0,
+          (sum, values) => Effect.succeed([sum + values.length, values] as const)
+        ).pipe(Stream.runCollect)
+
+        assert.deepStrictEqual(result, [1, 2, 3])
+      }))
   })
 
   describe("grouping", () => {


### PR DESCRIPTION
Fixes the data-first overload dispatch for `Stream.mapAccumArrayEffect`, which returned a curried function instead of a Stream.

Adds a focused regression test and patch changeset.

Validation:
- targeted Stream regression test
- `pnpm lint-fix`
- `git diff --check`

The worktree-local root typecheck could not resolve workspace packages through its temporary dependency symlink; the same integrated source previously passed the root `pnpm check`.