### PR TITLE
Add retry and response header options to HttpClient.withRateLimiter

### DIFF
--- a/.changeset/calm-pandas-retry.md
+++ b/.changeset/calm-pandas-retry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add bounded 429 retries and custom response header names to `HttpClient.withRateLimiter`.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -992,7 +992,8 @@ export declare namespace WithRateLimiter {
    *
    * **Details**
    *
-   * They define the backing limiter, initial limit window, keying strategy, algorithm, token cost, and whether response headers update future limits.
+   * They define the backing limiter, initial limit window, keying strategy,
+   * algorithm, token cost, retry count, and response header inspection.
    *
    * @category rate limiting
    * @since 4.0.0
@@ -1025,11 +1026,48 @@ export declare namespace WithRateLimiter {
      */
     readonly tokens?: number | ((request: HttpClientRequest.HttpClientRequest) => number) | undefined
     /**
-     * Disable automatic limits updates from response headers.
+     * The maximum number of automatic retries after an HTTP `429` response.
+     * Use a non-negative integer. Defaults to an unlimited number of retries.
+     * Set to `0` to disable automatic retries.
+     */
+    readonly times?: number | undefined
+    /**
+     * Overrides the response header names used for rate limit inspection.
+     * Header names are matched case-insensitively. An omitted field continues
+     * using the built-in names, while a configured field replaces them for
+     * that value. Header value formats are unchanged.
+     */
+    readonly responseHeaders?: {
+      /**
+       * Header containing the maximum number of requests in a window.
+       */
+      readonly limit?: string | undefined
+      /**
+       * Header containing the number of requests remaining in a window.
+       */
+      readonly remaining?: string | undefined
+      /**
+       * Header containing the rate limit reset time.
+       */
+      readonly reset?: string | undefined
+      /**
+       * Header containing the number of seconds until the rate limit resets.
+       */
+      readonly resetAfter?: string | undefined
+      /**
+       * Header containing the retry delay for an HTTP `429` response.
+       */
+      readonly retryAfter?: string | undefined
+    } | undefined
+    /**
+     * Disables automatic limit updates, `Retry-After` delays, and adaptive
+     * feedback from response headers. This does not disable automatic HTTP
+     * `429` retries. Set `times` to `0` to disable them.
      */
     readonly disableResponseInspection?: boolean | undefined
     /**
-     * Disable adaptive learning from `Retry-After` responses.
+     * Disables adaptive learning from `Retry-After` responses. Response
+     * inspection and direct `Retry-After` delays remain enabled.
      */
     readonly disableAdaptiveLearning?: boolean | undefined
   }
@@ -1043,6 +1081,12 @@ export declare namespace WithRateLimiter {
  * It can update limits by inspecting common rate limit response headers and
  * automatically retries HTTP `429` responses (or `HttpClientError` values
  * wrapping a `429` response) by forcing the retry back through the limiter.
+ *
+ * **Gotchas**
+ *
+ * Automatic HTTP `429` retries are unlimited unless `times` is specified.
+ * Disabling response inspection does not disable retries; set `times` to `0`
+ * to return or fail with the first `429`.
  *
  * @category rate limiting
  * @since 4.0.0
@@ -1075,6 +1119,7 @@ export const withRateLimiter: {
     ? tokensOption
     : constant(tokensOption ?? 1)
   const adaptiveLearningEnabled = !options.disableAdaptiveLearning
+  const headerNames = resolveRateLimiterHeaderNames(options.responseHeaders)
 
   const getState = (key: string): RateLimiterState => {
     const current = states.get(key)
@@ -1089,13 +1134,13 @@ export const withRateLimiter: {
     ? undefined
     : (clock: Clock, key: string, headers: Headers.Headers, tokens: number) => {
       const current = getState(key)
-      const next = parseRateLimiterState(current, clock, headers, tokens)
+      const next = parseRateLimiterState(current, clock, headers, tokens, headerNames)
       if (next.limit !== current.limit || !Duration.equals(next.window, current.window)) {
         states.set(key, next)
       }
     }
 
-  return transform(self, function loop(effect, request): Effect.Effect<
+  return transform(self, function loop(effect, request, retries = 0): Effect.Effect<
     HttpClientResponse.HttpClientResponse,
     E | RateLimiter.RateLimiterError,
     R
@@ -1105,11 +1150,11 @@ export const withRateLimiter: {
     const key = resolveKey(request)
     const tokens = Math.max(resolveTokens(request), 1)
     const current = getState(key)
+    const canRetry = options.times === undefined || retries < options.times
     function retry(retryAfter: Duration.Duration | undefined) {
-      if (options.disableResponseInspection) return loop(effect, request)
       return retryAfter
-        ? Effect.flatMap(Effect.sleep(retryAfter), () => loop(effect, request))
-        : loop(effect, request)
+        ? Effect.flatMap(Effect.sleep(retryAfter), () => loop(effect, request, retries + 1))
+        : loop(effect, request, retries + 1)
     }
     const inspectResponse = (
       response: HttpClientResponse.HttpClientResponse,
@@ -1119,11 +1164,11 @@ export const withRateLimiter: {
       if (options.disableResponseInspection || response.status !== 429) {
         return Effect.succeed<Duration.Duration | undefined>(undefined)
       }
-      const retryAfter = parseRetryAfter(clock, getHeader(response.headers, "retry-after"))
+      const retryAfter = parseRetryAfter(clock, getHeader(response.headers, ...headerNames.retryAfter))
       if (retryAfter === undefined) {
         return Effect.succeed<Duration.Duration | undefined>(undefined)
       }
-      const delay = parseRateLimitWindow(clock, response.headers) ?? retryAfter
+      const delay = parseRateLimitWindow(clock, response.headers, headerNames) ?? retryAfter
       if (adaptive === undefined) {
         return Effect.succeed<Duration.Duration | undefined>(delay)
       }
@@ -1157,7 +1202,7 @@ export const withRateLimiter: {
             const request = Effect.matchEffect(effect, {
               onSuccess(response) {
                 return Effect.flatMap(inspectResponse(response, adaptive), (retryAfter) => {
-                  if (response.status !== 429) return Effect.succeed(response)
+                  if (response.status !== 429 || !canRetry) return Effect.succeed(response)
                   return retry(retryAfter)
                 })
               },
@@ -1165,7 +1210,7 @@ export const withRateLimiter: {
                 if (isTooManyRequestsHttpClientError(error)) {
                   return Effect.flatMap(
                     inspectResponse(error.reason.response, adaptive),
-                    (retryAfter) => retry(retryAfter)
+                    (retryAfter) => canRetry ? retry(retryAfter) : Effect.fail(error)
                   )
                 }
                 return Effect.fail(error)
@@ -1199,6 +1244,34 @@ export const withRateLimiter: {
   })
 })
 
+interface RateLimiterHeaderNames {
+  readonly limit: ReadonlyArray<string>
+  readonly remaining: ReadonlyArray<string>
+  readonly reset: ReadonlyArray<string>
+  readonly resetAfter: ReadonlyArray<string>
+  readonly retryAfter: ReadonlyArray<string>
+}
+
+const resolveRateLimiterHeaderNames = (
+  responseHeaders: WithRateLimiter.Options["responseHeaders"]
+): RateLimiterHeaderNames => ({
+  limit: responseHeaders?.limit === undefined
+    ? ["ratelimit-limit", "x-ratelimit-limit"]
+    : [responseHeaders.limit.toLowerCase()],
+  remaining: responseHeaders?.remaining === undefined
+    ? ["ratelimit-remaining", "x-ratelimit-remaining"]
+    : [responseHeaders.remaining.toLowerCase()],
+  reset: responseHeaders?.reset === undefined
+    ? ["ratelimit-reset", "x-ratelimit-reset"]
+    : [responseHeaders.reset.toLowerCase()],
+  resetAfter: responseHeaders?.resetAfter === undefined
+    ? ["ratelimit-reset-after", "x-ratelimit-reset-after"]
+    : [responseHeaders.resetAfter.toLowerCase()],
+  retryAfter: responseHeaders?.retryAfter === undefined
+    ? ["retry-after"]
+    : [responseHeaders.retryAfter.toLowerCase()]
+})
+
 interface RateLimiterState {
   readonly limit: number
   readonly window: Duration.Duration
@@ -1209,10 +1282,11 @@ const parseRateLimiterState = (
   state: RateLimiterState,
   clock: Clock,
   headers: Headers.Headers,
-  tokens: number
+  tokens: number,
+  headerNames: RateLimiterHeaderNames
 ): RateLimiterState => {
-  const limit = parseRateLimitLimit(state, headers, tokens) ?? state.limit
-  const window = parseRateLimitWindow(clock, headers) ?? state.window
+  const limit = parseRateLimitLimit(state, headers, tokens, headerNames) ?? state.limit
+  const window = parseRateLimitWindow(clock, headers, headerNames) ?? state.window
   if (limit === state.limit && Duration.equals(window, state.window)) {
     return state
   }
@@ -1222,35 +1296,40 @@ const parseRateLimiterState = (
 const parseRateLimitLimit = (
   state: RateLimiterState,
   headers: Headers.Headers,
-  tokens: number
+  tokens: number,
+  headerNames: RateLimiterHeaderNames
 ): number | undefined => {
-  const raw = getHeader(headers, "ratelimit-limit", "x-ratelimit-limit")
+  const raw = getHeader(headers, ...headerNames.limit)
   const value = parseNumberHeader(raw)
   if (value !== undefined && value > 0) {
     return value
   }
-  const remaining = parseRateLimitRemaining(headers)
+  const remaining = parseRateLimitRemaining(headers, headerNames)
   if (remaining === undefined) {
     return undefined
   }
   return state.initial ? remaining + tokens : Math.max(remaining + tokens, state.limit)
 }
 
-const parseRateLimitRemaining = (headers: Headers.Headers): number | undefined => {
-  const raw = getHeader(headers, "ratelimit-remaining", "x-ratelimit-remaining")
+const parseRateLimitRemaining = (
+  headers: Headers.Headers,
+  headerNames: RateLimiterHeaderNames
+): number | undefined => {
+  const raw = getHeader(headers, ...headerNames.remaining)
   const value = parseNumberHeader(raw)
   return value !== undefined && value >= 0 ? value : undefined
 }
 
 const parseRateLimitWindow = (
   clock: Clock,
-  headers: Headers.Headers
+  headers: Headers.Headers,
+  headerNames: RateLimiterHeaderNames
 ): Duration.Duration | undefined => {
-  const resetAfter = parseResetAfter(getHeader(headers, "ratelimit-reset-after", "x-ratelimit-reset-after"))
+  const resetAfter = parseResetAfter(getHeader(headers, ...headerNames.resetAfter))
   if (resetAfter !== undefined) {
     return resetAfter
   }
-  return parseResetHeader(clock, getHeader(headers, "ratelimit-reset", "x-ratelimit-reset"))
+  return parseResetHeader(clock, getHeader(headers, ...headerNames.reset))
 }
 
 const parseRetryAfter = (

--- a/packages/effect/test/unstable/http/HttpClient.test.ts
+++ b/packages/effect/test/unstable/http/HttpClient.test.ts
@@ -384,6 +384,52 @@ describe("HttpClient", () => {
         strictEqual(yield* Ref.get(attempts), 2)
       }).pipe(Effect.provide(RateLimiterTestLayer)))
 
+    it.effect("updates limits from custom response headers", () =>
+      Effect.gen(function*() {
+        const attempts = yield* Ref.make(0)
+        const client = HttpClient.make((request) =>
+          Effect.map(
+            Ref.updateAndGet(attempts, (n) => n + 1),
+            (attempt) =>
+              HttpClientResponse.fromWeb(
+                request,
+                attempt === 1
+                  ? new Response(null, {
+                    status: 200,
+                    headers: {
+                      "x-vendor-limit": "1",
+                      "x-vendor-reset": "60"
+                    }
+                  })
+                  : new Response(null, { status: 200 })
+              )
+          )
+        ).pipe(
+          HttpClient.withRateLimiter({
+            limiter: yield* RateLimiter.RateLimiter,
+            key: "custom-limit",
+            limit: 10,
+            window: "1 minute",
+            responseHeaders: {
+              limit: "X-Vendor-Limit",
+              reset: "X-Vendor-Reset"
+            }
+          })
+        )
+
+        const fiber = yield* client.get("http://test/").pipe(
+          Effect.andThen(client.get("http://test/")),
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        yield* TestClock.adjust("5 seconds")
+        strictEqual(yield* Ref.get(attempts), 1)
+
+        yield* TestClock.adjust("1 minute")
+        yield* Fiber.join(fiber)
+        strictEqual(yield* Ref.get(attempts), 2)
+      }).pipe(Effect.provide(RateLimiterTestLayer)))
+
     it.effect("inspects remaining headers to infer updated limits", () =>
       Effect.gen(function*() {
         const attempts = yield* Ref.make(0)
@@ -423,6 +469,90 @@ describe("HttpClient", () => {
 
         yield* TestClock.adjust("10 seconds")
         yield* Fiber.join(fiber)
+        strictEqual(yield* Ref.get(attempts), 2)
+      }).pipe(Effect.provide(RateLimiterTestLayer)))
+
+    it.effect("inspects custom remaining and reset-after headers", () =>
+      Effect.gen(function*() {
+        const attempts = yield* Ref.make(0)
+        const limiter = yield* RateLimiter.RateLimiter
+        const client = HttpClient.make((request) =>
+          Effect.map(
+            Ref.updateAndGet(attempts, (n) => n + 1),
+            (attempt) =>
+              HttpClientResponse.fromWeb(
+                request,
+                attempt === 1
+                  ? new Response(null, {
+                    status: 200,
+                    headers: {
+                      "x-vendor-remaining": "0",
+                      "x-vendor-reset-after": "60"
+                    }
+                  })
+                  : new Response(null, { status: 200 })
+              )
+          )
+        ).pipe(
+          HttpClient.withRateLimiter({
+            limiter,
+            key: "custom-remaining",
+            limit: 10,
+            window: "1 minute",
+            responseHeaders: {
+              remaining: "X-Vendor-Remaining",
+              resetAfter: "X-Vendor-Reset-After"
+            }
+          })
+        )
+
+        const fiber = yield* client.get("http://test/").pipe(
+          Effect.andThen(client.get("http://test/")),
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        strictEqual(yield* Ref.get(attempts), 1)
+
+        yield* TestClock.adjust("10 seconds")
+        yield* Fiber.join(fiber)
+        strictEqual(yield* Ref.get(attempts), 2)
+      }).pipe(Effect.provide(RateLimiterTestLayer)))
+
+    it.effect("uses custom header overrides without falling back to built-in names", () =>
+      Effect.gen(function*() {
+        const attempts = yield* Ref.make(0)
+        const client = HttpClient.make((request) =>
+          Effect.map(
+            Ref.updateAndGet(attempts, (n) => n + 1),
+            (attempt) =>
+              HttpClientResponse.fromWeb(
+                request,
+                attempt === 1
+                  ? new Response(null, {
+                    status: 200,
+                    headers: {
+                      "x-ratelimit-limit": "1",
+                      "x-ratelimit-reset": "60"
+                    }
+                  })
+                  : new Response(null, { status: 200 })
+              )
+          )
+        ).pipe(
+          HttpClient.withRateLimiter({
+            limiter: yield* RateLimiter.RateLimiter,
+            key: "custom-override",
+            limit: 10,
+            window: "1 minute",
+            responseHeaders: {
+              limit: "X-Vendor-Limit"
+            }
+          })
+        )
+
+        yield* client.get("http://test/")
+        yield* client.get("http://test/")
+
         strictEqual(yield* Ref.get(attempts), 2)
       }).pipe(Effect.provide(RateLimiterTestLayer)))
 
@@ -542,6 +672,95 @@ describe("HttpClient", () => {
         strictEqual(yield* Ref.get(attempts), 2)
       }).pipe(Effect.provide(RateLimiterTestLayer)))
 
+    it.effect("bounds automatic 429 response retries", () =>
+      Effect.gen(function*() {
+        const { attempts, client } = yield* makeStatusClient(429)
+        const limitedClient = client.pipe(
+          HttpClient.withRateLimiter({
+            limiter: yield* RateLimiter.RateLimiter,
+            key: "bounded-response",
+            limit: 100,
+            window: "1 minute",
+            times: 2,
+            disableResponseInspection: true
+          })
+        )
+
+        const response = yield* limitedClient.get("http://test/")
+
+        strictEqual(response.status, 429)
+        strictEqual(yield* Ref.get(attempts), 3)
+      }).pipe(Effect.provide(RateLimiterTestLayer)))
+
+    it.effect("bounds automatic HttpClientError 429 retries", () =>
+      Effect.gen(function*() {
+        const { attempts, client } = yield* makeStatusClient(429)
+        const limitedClient = client.pipe(
+          HttpClient.filterStatusOk,
+          HttpClient.withRateLimiter({
+            limiter: yield* RateLimiter.RateLimiter,
+            key: "bounded-error",
+            limit: 100,
+            window: "1 minute",
+            times: 2,
+            disableResponseInspection: true
+          })
+        )
+
+        const error = yield* limitedClient.get("http://test/").pipe(Effect.flip)
+
+        strictEqual(error._tag, "HttpClientError")
+        strictEqual(error.reason._tag, "StatusCodeError")
+        if (error.reason._tag === "StatusCodeError") {
+          strictEqual(error.reason.response.status, 429)
+        }
+        strictEqual(yield* Ref.get(attempts), 3)
+      }).pipe(Effect.provide(RateLimiterTestLayer)))
+
+    it.effect("uses a custom Retry-After header", () =>
+      Effect.gen(function*() {
+        const attempts = yield* Ref.make(0)
+        const client = HttpClient.make((request) =>
+          Effect.map(
+            Ref.updateAndGet(attempts, (n) => n + 1),
+            (attempt) =>
+              HttpClientResponse.fromWeb(
+                request,
+                attempt === 1
+                  ? new Response(null, {
+                    status: 429,
+                    headers: { "x-vendor-retry-after": "10" }
+                  })
+                  : new Response(null, { status: 200 })
+              )
+          )
+        ).pipe(
+          HttpClient.withRateLimiter({
+            limiter: yield* RateLimiter.RateLimiter,
+            key: "custom-retry-after",
+            limit: 100,
+            window: "1 minute",
+            times: 1,
+            responseHeaders: {
+              retryAfter: "X-Vendor-Retry-After"
+            },
+            disableAdaptiveLearning: true
+          })
+        )
+
+        const fiber = yield* client.get("http://test/").pipe(Effect.forkChild({ startImmediately: true }))
+        strictEqual(yield* Ref.get(attempts), 1)
+
+        yield* TestClock.adjust("9 seconds")
+        strictEqual(yield* Ref.get(attempts), 1)
+
+        yield* TestClock.adjust("1 second")
+        const response = yield* Fiber.join(fiber)
+
+        strictEqual(response.status, 200)
+        strictEqual(yield* Ref.get(attempts), 2)
+      }).pipe(Effect.provide(RateLimiterTestLayer)))
+
     it.effect("applies adaptive cooldown to requests delayed by the configured limiter", () =>
       Effect.gen(function*() {
         const attempts = yield* Ref.make<Array<number>>([])
@@ -649,6 +868,56 @@ describe("HttpClient", () => {
         yield* Fiber.join(fiberB)
 
         strictEqual(yield* Ref.get(attemptsA), 2)
+        strictEqual(yield* Ref.get(attemptsB), 1)
+      }).pipe(Effect.provide(RateLimiter.layerStoreMemory)))
+
+    it.effect("applies Retry-After feedback when automatic retries are disabled", () =>
+      Effect.gen(function*() {
+        const attemptsB = yield* Ref.make(0)
+        const limiterA = yield* RateLimiter.make
+        const limiterB = yield* RateLimiter.make
+        const clientA = HttpClient.make((request) =>
+          Effect.succeed(
+            HttpClientResponse.fromWeb(
+              request,
+              new Response(null, {
+                status: 429,
+                headers: { "retry-after": "10" }
+              })
+            )
+          )
+        ).pipe(
+          HttpClient.withRateLimiter({
+            limiter: limiterA,
+            key: "terminal-feedback",
+            limit: 100,
+            window: "1 minute",
+            times: 0
+          })
+        )
+        const clientB = HttpClient.make((request) =>
+          Effect.as(
+            Ref.update(attemptsB, (n) => n + 1),
+            HttpClientResponse.fromWeb(request, new Response(null, { status: 200 }))
+          )
+        ).pipe(
+          HttpClient.withRateLimiter({
+            limiter: limiterB,
+            key: "terminal-feedback",
+            limit: 100,
+            window: "1 minute"
+          })
+        )
+
+        const response = yield* clientA.get("http://test/a")
+        strictEqual(response.status, 429)
+
+        const fiberB = yield* clientB.get("http://test/b").pipe(Effect.forkChild({ startImmediately: true }))
+        yield* TestClock.adjust("9 seconds")
+        strictEqual(yield* Ref.get(attemptsB), 0)
+
+        yield* TestClock.adjust("1 second")
+        yield* Fiber.join(fiberB)
         strictEqual(yield* Ref.get(attemptsB), 1)
       }).pipe(Effect.provide(RateLimiter.layerStoreMemory)))
 

--- a/packages/effect/typetest/unstable/http/HttpClient.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpClient.tst.ts
@@ -122,7 +122,12 @@ describe("HttpClient", () => {
         limiter,
         key: "test",
         limit: 1,
-        window: "1 minute"
+        window: "1 minute",
+        times: 2,
+        responseHeaders: {
+          limit: "x-vendor-limit",
+          retryAfter: "x-vendor-retry-after"
+        }
       } as const
 
       const dataLast = client.pipe(HttpClient.withRateLimiter(options))


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds two options to `HttpClient.withRateLimiter`:

- `times` limits the number of automatic retries after a `429` response. It counts retries after the initial request, and `times: 0` disables automatic retries. Omitting it preserves the existing unlimited behavior.
- `responseHeaders` allows individual rate-limit response header names to be overridden. Fields that are not configured continue using the existing built-in names.

When the retry limit is reached, the final `429` is returned or failed through its original channel. Response inspection still runs before that happens, allowing the limiter to learn from the final response.

Also updates the public API JSDoc and adds runtime and type-level coverage.

Validation:

- `pnpm lint-fix`
- `pnpm lint`
- `pnpm --filter effect test --run test/unstable/http/HttpClient.test.ts`
- `pnpm test-types packages/effect/typetest/unstable/http/HttpClient.tst.ts`
- `pnpm check`