### PR TITLE
Use layered storage for Context

### DIFF
--- a/.changeset/layered-context-storage.md
+++ b/.changeset/layered-context-storage.md
@@ -5,4 +5,4 @@
 "@effect/platform-node": patch
 ---
 
-Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Services and references can opt into cached O(1) reads with `enableCaching`.
+Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Services and references can opt into fiber-level caching with `enableCaching`.

--- a/.changeset/layered-context-storage.md
+++ b/.changeset/layered-context-storage.md
@@ -1,0 +1,8 @@
+---
+"effect": patch
+"@effect/platform-bun": patch
+"@effect/platform-deno": patch
+"@effect/platform-node": patch
+---
+
+Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers.

--- a/.changeset/layered-context-storage.md
+++ b/.changeset/layered-context-storage.md
@@ -5,4 +5,4 @@
 "@effect/platform-node": patch
 ---
 
-Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers.
+Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Services and references can opt into dense slab storage with `allocateSlot`.

--- a/.changeset/layered-context-storage.md
+++ b/.changeset/layered-context-storage.md
@@ -5,4 +5,4 @@
 "@effect/platform-node": patch
 ---
 
-Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. References are stored in the slab automatically; services can opt in with `allocateSlot`.
+Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Services and references can opt into cached O(1) reads with `enableCaching`.

--- a/.changeset/layered-context-storage.md
+++ b/.changeset/layered-context-storage.md
@@ -5,4 +5,4 @@
 "@effect/platform-node": patch
 ---
 
-Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Services and references can opt into dense slab storage with `allocateSlot`.
+Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. References are stored in the slab automatically; services can opt in with `allocateSlot`.

--- a/.changeset/layered-context-storage.md
+++ b/.changeset/layered-context-storage.md
@@ -1,8 +1,9 @@
 ---
 "effect": patch
+"@effect/docgen": patch
 "@effect/platform-bun": patch
 "@effect/platform-deno": patch
 "@effect/platform-node": patch
 ---
 
-Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Services and references can opt into fiber-level caching with `enableCaching`.
+Use layered storage for Context, making `Context.add` O(1) and eliminating per-request service map clones in the HTTP servers. Docgen now omits `@internal` option properties from generated signatures.

--- a/.changeset/remove-context-mutate.md
+++ b/.changeset/remove-context-mutate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove `Context.mutate` and `Context.getReferenceUnsafe`. Context updates now use overlays, and `Context.get` resolves reference defaults.

--- a/migration/v3-to-v4.md
+++ b/migration/v3-to-v4.md
@@ -10547,9 +10547,9 @@ FastCheck.uuid({ version: 4 })
 
 - `FiberRefs.forkAs` -> `none`: Context is inherited automatically when a v4 child fiber is forked; custom per-reference fork patches were removed.
 
-- `FiberRefs.get` -> `Context.getOption`: Read an explicitly stored service from Context; Context.Reference defaults can be read with Context.getReferenceUnsafe.
+- `FiberRefs.get` -> `Context.getOption`: Read an explicitly stored service from Context; Context.Reference defaults can be read with Context.get.
 
-- `FiberRefs.getOrDefault` -> `Context.getReferenceUnsafe`: Reads an override or the Context.Reference default value.
+- `FiberRefs.getOrDefault` -> `Context.get`: Reads an override or the Context.Reference default value.
 
 - `FiberRefs.joinAs` -> `none`: Child-to-parent FiberRef joining was removed; pass results explicitly or merge ordinary Context values where appropriate.
 
@@ -12782,7 +12782,7 @@ Schema.toFormatter(schema)
 
 - `Runtime.setFiberRef` -> `Context.add`: FiberRefs became Context.Reference values; add the Reference override to the Context.
 
-- `Runtime.updateFiberRefs` -> `Context.mutate`: There is no aggregate FiberRefs update; mutate targeted Context.Reference overrides explicitly.
+- `Runtime.updateFiberRefs` -> `Context.add`: There is no aggregate FiberRefs update; add targeted Context.Reference overrides explicitly.
 
 - `Runtime.updateRuntimeFlags` -> `none`: Runtime flags and aggregate patches were removed; configure each semantic behavior independently.
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -471,6 +471,10 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
   mutable: boolean
 }
 
+interface ContextImpl<in Services> extends Context<Services> {
+  readonly _mapUnsafe: ReadonlyMap<string, any>
+}
+
 /**
  * Creates a `Context` from an existing service map.
  *
@@ -503,16 +507,19 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
  * @since 4.0.0
  */
 export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>): Context<Services> => {
-  const self = Object.create(Proto)
-  self.mapUnsafe = mapUnsafe
+  const self: ContextImpl<Services> = Object.create(Proto)
+  self._mapUnsafe = mapUnsafe
   self.mutable = false
   return self
 }
 
-const Proto: Omit<Context<never>, "mapUnsafe" | "mutable"> = {
+const Proto: Omit<ContextImpl<never>, "_mapUnsafe" | "mutable"> = {
   ...PipeInspectableProto,
   [TypeId]: {
     _Services: (_: never) => _
+  },
+  get mapUnsafe() {
+    return this._mapUnsafe
   },
   toJSON(this: Context<never>) {
     return {

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -68,14 +68,7 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
   readonly Identifier: Identifier
   readonly key: string
   readonly stack?: string | undefined
-}
-
-const CacheKeyId = Symbol.for("effect/Context/CacheKey")
-const cacheKeys = new Set<string>()
-
-const addCacheKey = (key: Key<any, any>): void => {
-  ;(key as any)[CacheKeyId] = true
-  cacheKeys.add(key.key)
+  readonly enableCaching: boolean
 }
 
 /**
@@ -267,6 +260,7 @@ export const Service: {
       return err.stack
     }
   })
+  self.enableCaching = false
   if (arguments.length > 0) {
     self.key = arguments[0]
     if (arguments[1]?.defaultValue) {
@@ -274,7 +268,8 @@ export const Service: {
       self.defaultValue = arguments[1].defaultValue
     }
     if (arguments[1]?.enableCaching) {
-      addCacheKey(self)
+      self.enableCaching = true
+      cacheKeys.add(self.key)
     }
     return self
   }
@@ -287,7 +282,8 @@ export const Service: {
       ;(self as any).make = options.make
     }
     if (options?.enableCaching) {
-      addCacheKey(self)
+      self.enableCaching = true
+      cacheKeys.add(self.key)
     }
     return self
   }
@@ -324,6 +320,8 @@ const ServiceProto: any = {
     return withFiber((fiber) => exitSucceed(f(get(fiber.context, this))))
   }
 }
+
+const cacheKeys = new Set<string>()
 
 const ReferenceTypeId = "~effect/Context/Reference" as const
 
@@ -495,7 +493,6 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
     readonly _Services: Types.Contravariant<Services>
   }
   readonly mapUnsafe: ReadonlyMap<string, any>
-  mutable: boolean
 }
 
 interface ContextImpl<in Services> extends Context<Services> {
@@ -525,68 +522,45 @@ const makeImpl = <Services>(
   self.base = base
   self.overlay = overlay
   self.depth = depth
-  self.mutable = false
   self._flat = undefined
   return self
 }
 
-const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
-  if (overlay === undefined) return
-  applyOverlays(map, overlay.parent)
-  map.set(overlay.key, overlay.value)
-}
-
-// Some cycle-locked modules build Context objects that only carry `mapUnsafe`
-// (Redactable's no-fiber fallback, cause stack annotations in internal/core),
-// so every read path tolerates that shape by checking for a missing `base`
 const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
-  if (self._flat !== undefined) return self._flat
-  if (self.base === undefined) return self.mapUnsafe
-  if (self.overlay === undefined) return self._flat = self.base
+  if (self._flat) return self._flat
+  if (!self.overlay) return self._flat = self.base
   const map = new Map(self.base)
   applyOverlays(map, self.overlay)
   return self._flat = map
 }
 
-// Applies a mutation to the flat view of the context: in place for mutable
-// scratch contexts, on a copy otherwise
+const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
+  if (!overlay) return
+  applyOverlays(map, overlay.parent)
+  map.set(overlay.key, overlay.value)
+}
+
 const withFlat = <B>(self: ContextImpl<any>, f: (map: Map<string, any>) => void): Context<B> => {
-  if (self.mutable) {
-    f(self.base as Map<string, any>)
-    return self as any
-  }
   const map = new Map(flatten(self))
   f(map)
   return makeUnsafe(map)
 }
 
+const notFound = Symbol.for("effect/Context/notFound")
+
 const lookup = (self: ContextImpl<any>, key: string): unknown => {
-  if (self.base === undefined) {
-    return self.mapUnsafe.get(key)
-  }
-  for (let overlay = self.overlay; overlay !== undefined; overlay = overlay.parent) {
+  for (let overlay = self.overlay; overlay; overlay = overlay.parent) {
     if (overlay.key === key) return overlay.value
   }
-  return self.base.get(key)
+  return self.base.has(key) ? self.base.get(key) : notFound
 }
 
-// Cached values are also present in overlay/base, so the cache is safe to skip
-const lookupKey = (self: Context<any>, key: Key<any, any>): unknown => {
+const lookupKey = <I, S>(self: Context<any>, key: Key<I, S>): S | typeof notFound => {
   const impl = self as ContextImpl<any>
-  if ((key as any)[CacheKeyId] === true && impl.cache !== undefined) {
-    const value = impl.cache.get(key.key)
-    if (value !== undefined) return value
+  if (key.enableCaching) {
+    return impl.cache.has(key.key) ? impl.cache.get(key.key) as S : notFound
   }
-  return lookup(impl, key.key)
-}
-
-const hasKey = (self: Context<any>, key: string): boolean => {
-  const impl = self as ContextImpl<any>
-  if (impl.base === undefined) return impl.mapUnsafe.has(key)
-  for (let overlay = impl.overlay; overlay !== undefined; overlay = overlay.parent) {
-    if (overlay.key === key) return true
-  }
-  return impl.base.has(key)
+  return lookup(impl, key.key) as any
 }
 
 /**
@@ -630,7 +604,7 @@ export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>
 
 const Proto: Omit<
   ContextImpl<never>,
-  "cache" | "base" | "overlay" | "depth" | "mutable" | "_flat"
+  "cache" | "base" | "overlay" | "depth" | "_flat"
 > = {
   ...PipeInspectableProto,
   [TypeId]: {
@@ -666,18 +640,10 @@ const Proto: Omit<
 }
 
 /** @internal */
-export const unsafeHasSameCache = <Services, Services2>(
+export const hasSameCache = <Services, Services2>(
   self: Context<Services>,
   that: Context<Services2>
 ): boolean => (self as ContextImpl<Services>).cache === (that as ContextImpl<Services2>).cache
-
-/** @internal */
-export const unsafeGetByKey = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
-  const impl = self as ContextImpl<Services>
-  const value = impl.cache?.get(key)
-  if (value !== undefined) return value as A
-  return lookup(impl, key) as A | undefined
-}
 
 /**
  * Checks whether the provided argument is a `Context`.
@@ -746,7 +712,7 @@ export const isKey = (u: unknown): u is Key<any, any> => hasProperty(u, ServiceT
  * @category guards
  * @since 3.11.0
  */
-export const isReference = (u: unknown): u is Reference<any> => hasProperty(u, ReferenceTypeId)
+export const isReference = <I, S>(u: Key<I, S>): u is Reference<S> => !!(u as Reference<S>)[ReferenceTypeId]
 
 /**
  * Returns an empty `Context`.
@@ -839,12 +805,12 @@ export const add: {
   service: Types.NoInfer<S>
 ): Context<Services | I> => {
   const impl = self as ContextImpl<Services>
-  if (impl.mutable || impl.base === undefined || impl.depth >= MaxDepth) {
+  if (impl.depth >= MaxDepth) {
     return withFlat(impl, (map) => map.set(key.key, service))
   }
 
   let cache = impl.cache
-  if (cacheKeys.has(key.key)) {
+  if (key.enableCaching) {
     cache = new Map(impl.cache)
     ;(cache as Map<string, unknown>).set(key.key, service)
   }
@@ -963,7 +929,7 @@ export const getOrElse: {
   <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B
 } = dual(3, <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B => {
   const value = lookupKey(self, key)
-  if (value !== undefined || hasKey(self, key.key)) return value as any
+  if (value !== notFound) return value as any
   return isReference(key) ? getDefaultValue(key) : orElse()
 })
 
@@ -991,10 +957,15 @@ export const getOrUndefined: {
   <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined
 } = dual(
   2,
-  <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined => {
-    return lookupKey(self, key) as S | undefined
-  }
+  <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined => getOrUndefinedUnsafe(self, key.key)
 )
+
+/** @internal */
+export const getOrUndefinedUnsafe = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
+  const impl = self as ContextImpl<Services>
+  const value = impl.cache.has(key) ? impl.cache.get(key) : lookup(impl, key)
+  return value === notFound ? undefined : value as A
+}
 
 /**
  * Gets the service for a key, throwing if an absent non-reference key cannot be
@@ -1038,8 +1009,8 @@ export const getUnsafe: {
   2,
   <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): S => {
     const value = lookupKey(self, service)
-    if (value === undefined && !hasKey(self, service.key)) {
-      if (ReferenceTypeId in service) return getDefaultValue(service as any)
+    if (value === notFound) {
+      if (isReference(service)) return getDefaultValue(service as any)
       throw serviceNotFoundError(service)
     }
     return value as any
@@ -1080,54 +1051,6 @@ export const get: {
   <Services, I extends Services, S>(service: Key<I, S>): (self: Context<Services>) => S
   <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): S
 } = getUnsafe
-
-/**
- * Gets the value for a `Context.Reference`, returning its cached default when
- * the context does not contain an override.
- *
- * **When to use**
- *
- * Use when you need a `Context.Reference` value resolved from either a stored
- * override or the reference's default value.
- *
- * **Details**
- *
- * Stored overrides take precedence. If no override is present, the reference's
- * default value is computed lazily and cached on the reference itself.
- *
- * **Gotchas**
- *
- * Mutable default values can be shared across contexts unless an override is
- * provided, because the default is cached on the `Context.Reference`.
- *
- * **Example** (Getting reference defaults unsafely)
- *
- * ```ts import.meta.vitest
- * import { Context } from "effect"
- *
- * const messages: Array<string> = []
- * const LoggerRef = Context.Reference("Logger", {
- *   defaultValue: () => ({ log: (msg: string) => messages.push(msg) })
- * })
- *
- * const context = Context.empty()
- * const logger = Context.getReferenceUnsafe(context, LoggerRef)
- *
- * logger.log("message")
- * messages // => ["message"]
- * ```
- *
- * @see {@link getUnsafe} for unsafe access with any service key
- * @see {@link get} for type-checked reference-aware access
- * @see {@link getOption} for optional access to non-reference keys
- *
- * @category unsafe
- * @since 4.0.0
- */
-export const getReferenceUnsafe = <Services, S>(self: Context<Services>, service: Reference<S>): S => {
-  const value = lookupKey(self, service)
-  return value === undefined && !hasKey(self, service.key) ? getDefaultValue(service as any) : value as S
-}
 
 const defaultValueCacheKey = "~effect/Context/defaultValue" as const
 
@@ -1197,7 +1120,7 @@ export const getOption: {
   <Services, S, I>(self: Context<Services>, service: Key<I, S>): Option.Option<S>
 } = dual(2, <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): Option.Option<S> => {
   const value = lookupKey(self, service)
-  if (value !== undefined || hasKey(self, service.key)) return Option.some(value as any)
+  if (value !== notFound) return Option.some(value as any)
   return isReference(service) ? Option.some(getDefaultValue(service as any)) : Option.none()
 })
 
@@ -1379,46 +1302,6 @@ export const omit = <S extends ReadonlyArray<Key<any, any>>>(
       map.delete(keys[i].key)
     }
   })
-
-/**
- * Performs a series of mutations on a `Context`. Prevents unnecessary copying
- * of the underlying map when multiple mutations are needed.
- *
- * **When to use**
- *
- * Use to apply several `Context` transformations in one callback while copying
- * the underlying service map only once.
- *
- * @see {@link add} for adding or replacing a service
- * @see {@link addOrOmit} for adding or removing a service from an `Option`
- * @see {@link merge} for combining two contexts
- * @see {@link pick} for keeping selected services
- * @see {@link omit} for removing selected services
- *
- * @category mutations
- * @since 4.0.0
- */
-export const mutate: {
-  <Services, B>(
-    f: (context: Context<Services>) => Context<B>
-  ): <Services>(self: Context<Services>) => Context<B>
-  <Services, B>(self: Context<Services>, f: (context: Context<Services>) => Context<B>): Context<B>
-} = dual(
-  2,
-  <Services, B>(self: Context<Services>, f: (context: Context<Services>) => Context<B>): Context<B> => {
-    // The scratch context gets an empty cache, so every operation on it reads
-    // and writes `base` alone; the cache is rebuilt once when sealing
-    const map = new Map(flatten(self as ContextImpl<Services>))
-    const scratch = makeImpl<Services>(new Map(), map, undefined, 0)
-    scratch.mutable = true
-    try {
-      const result = f(scratch)
-      return result === (scratch as unknown) ? makeUnsafe(map) : result
-    } finally {
-      scratch.mutable = false
-    }
-  }
-)
 
 /**
  * Creates a context key with a default value.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -497,6 +497,7 @@ interface ContextImpl<in Services> extends Context<Services> {
   overlay: Overlay | undefined
   depth: number
   _flat: ReadonlyMap<string, any> | undefined
+  baseFallThroughs: number
 }
 
 interface Overlay {
@@ -506,6 +507,7 @@ interface Overlay {
 }
 
 const MaxDepth = 8
+const FlattenAfterBaseFallThroughs = 8
 
 const makeImpl = <Services>(
   cacheRoot: ContextImpl<any> | undefined,
@@ -519,6 +521,7 @@ const makeImpl = <Services>(
   self.overlay = overlay
   self.depth = depth
   self._flat = undefined
+  self.baseFallThroughs = 0
   return self
 }
 
@@ -526,6 +529,14 @@ const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): voi
   if (!overlay) return
   applyOverlays(map, overlay.parent)
   map.set(overlay.key, overlay.value)
+}
+
+const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
+  if (self._flat) return self._flat
+  if (!self.overlay) return self._flat = self.base
+  const map = new Map(self.base)
+  applyOverlays(map, self.overlay)
+  return self._flat = map
 }
 
 const withFlat = <B>(self: Context<any>, f: (map: Map<string, any>) => void): Context<B> => {
@@ -542,7 +553,14 @@ const lookup = (self: Context<any>, key: string): unknown => {
   for (let overlay = impl.overlay; overlay; overlay = overlay.parent) {
     if (overlay.key === key) return overlay.value
   }
-  return impl.base.has(key) ? impl.base.get(key) : notFound
+  if (!impl.base.has(key)) return notFound
+  const value = impl.base.get(key)
+  if (impl.overlay && ++impl.baseFallThroughs >= FlattenAfterBaseFallThroughs) {
+    impl.base = flatten(impl)
+    impl.overlay = undefined
+    impl.depth = 0
+  }
+  return value
 }
 
 /**
@@ -581,19 +599,14 @@ export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>
 
 const Proto: Omit<
   ContextImpl<never>,
-  "cacheRoot" | "base" | "overlay" | "depth" | "_flat"
+  "cacheRoot" | "base" | "overlay" | "depth" | "_flat" | "baseFallThroughs"
 > = {
   ...PipeInspectableProto,
   [TypeId]: {
     _Services: (_: never) => _
   },
   get mapUnsafe() {
-    const self = this as any as ContextImpl<any>
-    if (self._flat) return self._flat
-    if (!self.overlay) return self._flat = self.base
-    const map = new Map(self.base)
-    applyOverlays(map, self.overlay)
-    return self._flat = map
+    return flatten(this as any as ContextImpl<any>)
   },
   toJSON(this: Context<never>) {
     return {

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -182,6 +182,11 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
+ * Pass `slot: true` to allocate a dense slab slot for the key, making reads
+ * O(1). Reserve this for services that are added and read on hot paths;
+ * every slotted key grows the array that slotted `Context.add`s copy.
+ * `Reference` keys always get a slot.
+ *
  * **Gotchas**
  *
  * The string key is the runtime identity of the service. Reusing the same key
@@ -218,7 +223,12 @@ export declare namespace ServiceClass {
  * @since 4.0.0
  */
 export const Service: {
-  <Identifier, Shape = Identifier>(key: string): Service<Identifier, Shape>
+  <Identifier, Shape = Identifier>(
+    key: string,
+    options?: {
+      readonly slot?: boolean | undefined
+    } | undefined
+  ): Service<Identifier, Shape>
   <Self, Shape>(): <
     const Identifier extends string,
     E,
@@ -227,7 +237,8 @@ export const Service: {
   >(
     id: Identifier,
     options?: {
-      readonly make: ((...args: Args) => Effect<Shape, E, R>) | Effect<Shape, E, R> | undefined
+      readonly make?: ((...args: Args) => Effect<Shape, E, R>) | Effect<Shape, E, R> | undefined
+      readonly slot?: boolean | undefined
     } | undefined
   ) =>
     & ServiceClass<Self, Identifier, Shape>
@@ -240,6 +251,7 @@ export const Service: {
     id: Identifier,
     options: {
       readonly make: Make
+      readonly slot?: boolean | undefined
     }
   ) =>
     & ServiceClass<
@@ -269,16 +281,22 @@ export const Service: {
     if (arguments[1]?.defaultValue) {
       self[ReferenceTypeId] = ReferenceTypeId
       self.defaultValue = arguments[1].defaultValue
+    }
+    if (arguments[1]?.defaultValue || arguments[1]?.slot) {
       allocateSlot(self)
     }
     return self
   }
   return function(key: string, options?: {
     readonly make?: any
+    readonly slot?: boolean
   }) {
     self.key = key
     if (options?.make) {
       ;(self as any).make = options.make
+    }
+    if (options?.slot) {
+      allocateSlot(self)
     }
     return self
   }

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -259,30 +259,25 @@ export const Service: {
       return err.stack
     }
   })
-  if (arguments.length > 0) {
-    self.key = arguments[0]
-    if (arguments[1]?.defaultValue) {
-      self[ReferenceTypeId] = ReferenceTypeId
-      self.defaultValue = arguments[1].defaultValue
-    }
-    if (arguments[1]?.enableCaching) {
-      cacheKeys.add(self.key)
-    }
-    return self
-  }
-  return function(key: string, options?: {
+  const init = (key: string, options?: {
+    readonly defaultValue?: any
     readonly make?: any
     readonly enableCaching?: boolean
-  }) {
+  }) => {
     self.key = key
+    if (options?.defaultValue) {
+      self[ReferenceTypeId] = ReferenceTypeId
+      self.defaultValue = options.defaultValue
+    }
     if (options?.make) {
       ;(self as any).make = options.make
     }
     if (options?.enableCaching) {
-      cacheKeys.add(self.key)
+      cacheKeys.add(key)
     }
     return self
   }
+  return arguments.length > 0 ? init(arguments[0], arguments[1]) : init
 } as any
 
 const ServiceProto: any = {
@@ -615,17 +610,12 @@ const Proto: Omit<
     }
   },
   [Equal.symbol]<A>(this: Context<A>, that: unknown): boolean {
-    if (
-      !isContext(that)
-      || this.mapUnsafe.size !== that.mapUnsafe.size
-    ) return false
-    for (const k of this.mapUnsafe.keys()) {
-      if (
-        !that.mapUnsafe.has(k) ||
-        !Equal.equals(this.mapUnsafe.get(k), that.mapUnsafe.get(k))
-      ) {
-        return false
-      }
+    if (!isContext(that)) return false
+    const self = this.mapUnsafe
+    const other = that.mapUnsafe
+    if (self.size !== other.size) return false
+    for (const [key, value] of self) {
+      if (!other.has(key) || !Equal.equals(value, other.get(key))) return false
     }
     return true
   },

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -547,12 +547,15 @@ const lookup = (self: Context<any>, key: string): unknown => {
     if (overlay.key === key) return overlay.value
   }
   const value = impl.base.get(key)
+  // Misses must not advance the counter: reference-default lookups miss the
+  // base on every fiber cache refresh, which would flatten every short-lived
+  // request context and reintroduce the O(services) per-request cost
+  if (value === undefined && !impl.base.has(key)) return notFound
   if (impl.overlay && ++impl.baseHits >= FlattenAfterBaseHits) {
     impl.base = flatten(impl)
     impl.overlay = undefined
     impl.depth = 0
   }
-  if (value === undefined && !impl.base.has(key)) return notFound
   return value
 }
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -70,12 +70,12 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
   readonly stack?: string | undefined
 }
 
-const SlabKeyId = Symbol.for("effect/Context/SlabKey")
-const slabKeys = new Set<string>()
+const CacheKeyId = Symbol.for("effect/Context/CacheKey")
+const cacheKeys = new Set<string>()
 
-const addSlabKey = (key: Key<any, any>): void => {
-  ;(key as any)[SlabKeyId] = true
-  slabKeys.add(key.key)
+const addCacheKey = (key: Key<any, any>): void => {
+  ;(key as any)[CacheKeyId] = true
+  cacheKeys.add(key.key)
 }
 
 /**
@@ -173,10 +173,10 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
- * Pass `allocateSlot: true` to store the key in the slab, making reads O(1).
- * Reserve this for services that are added and read on hot paths; every slab
- * key grows the small Map that a slotted `Context.add` copies. `Reference`
- * keys are stored in the slab automatically.
+ * Pass `enableCaching: true` to store the key in the context's cache, making
+ * reads O(1). Reserve this for keys that are added and read on hot paths;
+ * every cached key grows the small Map that a caching `Context.add` copies.
+ * The same option is available on `Reference`.
  *
  * **Gotchas**
  *
@@ -217,7 +217,7 @@ export const Service: {
   <Identifier, Shape = Identifier>(
     key: string,
     options?: {
-      readonly allocateSlot?: boolean | undefined
+      readonly enableCaching?: boolean | undefined
     } | undefined
   ): Service<Identifier, Shape>
   <Self, Shape>(): <
@@ -229,7 +229,7 @@ export const Service: {
     id: Identifier,
     options?: {
       readonly make?: ((...args: Args) => Effect<Shape, E, R>) | Effect<Shape, E, R> | undefined
-      readonly allocateSlot?: boolean | undefined
+      readonly enableCaching?: boolean | undefined
     } | undefined
   ) =>
     & ServiceClass<Self, Identifier, Shape>
@@ -242,7 +242,7 @@ export const Service: {
     id: Identifier,
     options: {
       readonly make: Make
-      readonly allocateSlot?: boolean | undefined
+      readonly enableCaching?: boolean | undefined
     }
   ) =>
     & ServiceClass<
@@ -273,21 +273,21 @@ export const Service: {
       self[ReferenceTypeId] = ReferenceTypeId
       self.defaultValue = arguments[1].defaultValue
     }
-    if (arguments[1]?.defaultValue || arguments[1]?.allocateSlot) {
-      addSlabKey(self)
+    if (arguments[1]?.enableCaching) {
+      addCacheKey(self)
     }
     return self
   }
   return function(key: string, options?: {
     readonly make?: any
-    readonly allocateSlot?: boolean
+    readonly enableCaching?: boolean
   }) {
     self.key = key
     if (options?.make) {
       ;(self as any).make = options.make
     }
-    if (options?.allocateSlot) {
-      addSlabKey(self)
+    if (options?.enableCaching) {
+      addCacheKey(self)
     }
     return self
   }
@@ -499,7 +499,7 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
 }
 
 interface ContextImpl<in Services> extends Context<Services> {
-  slab: ReadonlyMap<string, unknown>
+  cache: ReadonlyMap<string, unknown>
   base: ReadonlyMap<string, any>
   overlay: Overlay | undefined
   depth: number
@@ -515,13 +515,13 @@ interface Overlay {
 const MaxDepth = 8
 
 const makeImpl = <Services>(
-  slab: ReadonlyMap<string, unknown>,
+  cache: ReadonlyMap<string, unknown>,
   base: ReadonlyMap<string, any>,
   overlay: Overlay | undefined,
   depth: number
 ): ContextImpl<Services> => {
   const self: ContextImpl<Services> = Object.create(Proto)
-  self.slab = slab
+  self.cache = cache
   self.base = base
   self.overlay = overlay
   self.depth = depth
@@ -531,11 +531,11 @@ const makeImpl = <Services>(
 }
 
 const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
-  const slab = new Map<string, unknown>()
+  const cache = new Map<string, unknown>()
   map.forEach((value, key) => {
-    if (slabKeys.has(key)) slab.set(key, value)
+    if (cacheKeys.has(key)) cache.set(key, value)
   })
-  return makeImpl(slab, map, undefined, 0)
+  return makeImpl(cache, map, undefined, 0)
 }
 
 const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
@@ -578,11 +578,11 @@ const lookup = (self: ContextImpl<any>, key: string): unknown => {
   return self.base.get(key)
 }
 
-// The slab is a cache: every slotted value is also present in overlay/base
+// Cached values are also present in overlay/base, so the cache is safe to skip
 const lookupKey = (self: Context<any>, key: Key<any, any>): unknown => {
   const impl = self as ContextImpl<any>
-  if ((key as any)[SlabKeyId] === true && impl.slab !== undefined) {
-    const value = impl.slab.get(key.key)
+  if ((key as any)[CacheKeyId] === true && impl.cache !== undefined) {
+    const value = impl.cache.get(key.key)
     if (value !== undefined) return value
   }
   return lookup(impl, key.key)
@@ -634,7 +634,7 @@ export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>
 
 const Proto: Omit<
   ContextImpl<never>,
-  "slab" | "base" | "overlay" | "depth" | "mutable" | "_flat"
+  "cache" | "base" | "overlay" | "depth" | "mutable" | "_flat"
 > = {
   ...PipeInspectableProto,
   [TypeId]: {
@@ -670,15 +670,15 @@ const Proto: Omit<
 }
 
 /** @internal */
-export const unsafeHasSameSlab = <Services, Services2>(
+export const unsafeHasSameCache = <Services, Services2>(
   self: Context<Services>,
   that: Context<Services2>
-): boolean => (self as ContextImpl<Services>).slab === (that as ContextImpl<Services2>).slab
+): boolean => (self as ContextImpl<Services>).cache === (that as ContextImpl<Services2>).cache
 
 /** @internal */
 export const unsafeGetByKey = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
   const impl = self as ContextImpl<Services>
-  const value = impl.slab?.get(key)
+  const value = impl.cache?.get(key)
   if (value !== undefined) return value as A
   return lookup(impl, key) as A | undefined
 }
@@ -847,14 +847,14 @@ export const add: {
     return withFlat(impl, (map) => map.set(key.key, service))
   }
 
-  let slab = impl.slab
-  if (slabKeys.has(key.key)) {
-    slab = new Map(impl.slab)
-    ;(slab as Map<string, unknown>).set(key.key, service)
+  let cache = impl.cache
+  if (cacheKeys.has(key.key)) {
+    cache = new Map(impl.cache)
+    ;(cache as Map<string, unknown>).set(key.key, service)
   }
 
   return makeImpl(
-    slab,
+    cache,
     impl.base,
     { key: key.key, value: service, parent: impl.overlay },
     impl.depth + 1
@@ -1410,8 +1410,8 @@ export const mutate: {
 } = dual(
   2,
   <Services, B>(self: Context<Services>, f: (context: Context<Services>) => Context<B>): Context<B> => {
-    // The scratch context gets an empty slab, so every operation on it reads
-    // and writes `base` alone; the slab is rebuilt once when sealing
+    // The scratch context gets an empty cache, so every operation on it reads
+    // and writes `base` alone; the cache is rebuilt once when sealing
     const map = new Map(flatten(self as ContextImpl<Services>))
     const scratch = makeImpl<Services>(new Map(), map, undefined, 0)
     scratch.mutable = true
@@ -1474,5 +1474,6 @@ export const Reference: <Service>(
   key: string,
   options: {
     readonly defaultValue: () => Service
+    readonly enableCaching?: boolean | undefined
   }
 ) => Reference<Service> = Service as any

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -165,7 +165,7 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
- * Pass `enableCaching: true` for keys whose values fibers cache locally, such
+ * Pass `enableFiberCaching: true` for keys whose values fibers cache locally, such
  * as runtime references read on every context change. Adding a caching key
  * invalidates those fiber caches, while adds of regular keys keep them intact.
  * The same option is available on `Reference`.
@@ -209,7 +209,7 @@ export const Service: {
   <Identifier, Shape = Identifier>(
     key: string,
     options?: {
-      readonly enableCaching?: boolean | undefined
+      readonly enableFiberCaching?: boolean | undefined
     } | undefined
   ): Service<Identifier, Shape>
   <Self, Shape>(): <
@@ -221,7 +221,7 @@ export const Service: {
     id: Identifier,
     options?: {
       readonly make?: ((...args: Args) => Effect<Shape, E, R>) | Effect<Shape, E, R> | undefined
-      readonly enableCaching?: boolean | undefined
+      readonly enableFiberCaching?: boolean | undefined
     } | undefined
   ) =>
     & ServiceClass<Self, Identifier, Shape>
@@ -234,7 +234,7 @@ export const Service: {
     id: Identifier,
     options: {
       readonly make: Make
-      readonly enableCaching?: boolean | undefined
+      readonly enableFiberCaching?: boolean | undefined
     }
   ) =>
     & ServiceClass<
@@ -262,7 +262,7 @@ export const Service: {
   const init = (key: string, options?: {
     readonly defaultValue?: any
     readonly make?: any
-    readonly enableCaching?: boolean
+    readonly enableFiberCaching?: boolean
   }) => {
     self.key = key
     if (options?.defaultValue) {
@@ -272,7 +272,7 @@ export const Service: {
     if (options?.make) {
       ;(self as any).make = options.make
     }
-    if (options?.enableCaching) {
+    if (options?.enableFiberCaching) {
       cacheKeys.add(key)
     }
     return self
@@ -489,10 +489,10 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
 interface ContextImpl<in Services> extends Context<Services> {
   cacheRoot: ContextImpl<any> | undefined
   base: ReadonlyMap<string, any>
+  baseHits: number
   overlay: Overlay | undefined
   depth: number
   _flat: ReadonlyMap<string, any> | undefined
-  baseFallThroughs: number
 }
 
 interface Overlay {
@@ -502,7 +502,7 @@ interface Overlay {
 }
 
 const MaxDepth = 8
-const FlattenAfterBaseFallThroughs = 8
+const FlattenAfterBaseHits = 8
 
 const makeImpl = <Services>(
   cacheRoot: ContextImpl<any> | undefined,
@@ -516,7 +516,7 @@ const makeImpl = <Services>(
   self.overlay = overlay
   self.depth = depth
   self._flat = undefined
-  self.baseFallThroughs = 0
+  self.baseHits = 0
   return self
 }
 
@@ -549,12 +549,12 @@ const lookup = (self: Context<any>, key: string): unknown => {
     if (overlay.key === key) return overlay.value
   }
   const value = impl.base.get(key)
-  if (value === undefined && !impl.base.has(key)) return notFound
-  if (impl.overlay && ++impl.baseFallThroughs >= FlattenAfterBaseFallThroughs) {
+  if (impl.overlay && ++impl.baseHits >= FlattenAfterBaseHits) {
     impl.base = flatten(impl)
     impl.overlay = undefined
     impl.depth = 0
   }
+  if (value === undefined && !impl.base.has(key)) return notFound
   return value
 }
 
@@ -594,7 +594,7 @@ export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>
 
 const Proto: Omit<
   ContextImpl<never>,
-  "cacheRoot" | "base" | "overlay" | "depth" | "_flat" | "baseFallThroughs"
+  "cacheRoot" | "base" | "overlay" | "depth" | "_flat" | "baseHits"
 > = {
   ...PipeInspectableProto,
   [TypeId]: {
@@ -1334,6 +1334,6 @@ export const Reference: <Service>(
   key: string,
   options: {
     readonly defaultValue: () => Service
-    readonly enableCaching?: boolean | undefined
+    readonly enableFiberCaching?: boolean | undefined
   }
 ) => Reference<Service> = Service as any

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -68,7 +68,6 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
   readonly Identifier: Identifier
   readonly key: string
   readonly stack?: string | undefined
-  readonly enableCaching: boolean
 }
 
 /**
@@ -166,9 +165,9 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
- * Pass `enableCaching: true` to store the key in the context's cache, making
- * reads O(1). Reserve this for keys that are added and read on hot paths;
- * every cached key grows the small Map that a caching `Context.add` copies.
+ * Pass `enableCaching: true` for keys whose values fibers cache locally, such
+ * as runtime references read on every context change. Adding a caching key
+ * invalidates those fiber caches, while adds of regular keys keep them intact.
  * The same option is available on `Reference`.
  *
  * **Gotchas**
@@ -260,7 +259,6 @@ export const Service: {
       return err.stack
     }
   })
-  self.enableCaching = false
   if (arguments.length > 0) {
     self.key = arguments[0]
     if (arguments[1]?.defaultValue) {
@@ -268,7 +266,6 @@ export const Service: {
       self.defaultValue = arguments[1].defaultValue
     }
     if (arguments[1]?.enableCaching) {
-      self.enableCaching = true
       cacheKeys.add(self.key)
     }
     return self
@@ -282,7 +279,6 @@ export const Service: {
       ;(self as any).make = options.make
     }
     if (options?.enableCaching) {
-      self.enableCaching = true
       cacheKeys.add(self.key)
     }
     return self
@@ -496,7 +492,7 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
 }
 
 interface ContextImpl<in Services> extends Context<Services> {
-  cache: ReadonlyMap<string, unknown>
+  cacheRoot: ContextImpl<any> | undefined
   base: ReadonlyMap<string, any>
   overlay: Overlay | undefined
   depth: number
@@ -512,26 +508,18 @@ interface Overlay {
 const MaxDepth = 8
 
 const makeImpl = <Services>(
-  cache: ReadonlyMap<string, unknown>,
+  cacheRoot: ContextImpl<any> | undefined,
   base: ReadonlyMap<string, any>,
   overlay: Overlay | undefined,
   depth: number
 ): ContextImpl<Services> => {
   const self: ContextImpl<Services> = Object.create(Proto)
-  self.cache = cache
+  self.cacheRoot = cacheRoot ?? self
   self.base = base
   self.overlay = overlay
   self.depth = depth
   self._flat = undefined
   return self
-}
-
-const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
-  if (self._flat) return self._flat
-  if (!self.overlay) return self._flat = self.base
-  const map = new Map(self.base)
-  applyOverlays(map, self.overlay)
-  return self._flat = map
 }
 
 const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
@@ -540,27 +528,20 @@ const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): voi
   map.set(overlay.key, overlay.value)
 }
 
-const withFlat = <B>(self: ContextImpl<any>, f: (map: Map<string, any>) => void): Context<B> => {
-  const map = new Map(flatten(self))
+const withFlat = <B>(self: Context<any>, f: (map: Map<string, any>) => void): Context<B> => {
+  const map = new Map(self.mapUnsafe)
   f(map)
   return makeUnsafe(map)
 }
 
 const notFound = Symbol.for("effect/Context/notFound")
 
-const lookup = (self: ContextImpl<any>, key: string): unknown => {
-  for (let overlay = self.overlay; overlay; overlay = overlay.parent) {
+const lookup = (self: Context<any>, key: string): unknown => {
+  const impl = self as ContextImpl<any>
+  for (let overlay = impl.overlay; overlay; overlay = overlay.parent) {
     if (overlay.key === key) return overlay.value
   }
-  return self.base.has(key) ? self.base.get(key) : notFound
-}
-
-const lookupKey = <I, S>(self: Context<any>, key: Key<I, S>): S | typeof notFound => {
-  const impl = self as ContextImpl<any>
-  if (key.enableCaching) {
-    return impl.cache.has(key.key) ? impl.cache.get(key.key) as S : notFound
-  }
-  return lookup(impl, key.key) as any
+  return impl.base.has(key) ? impl.base.get(key) : notFound
 }
 
 /**
@@ -594,24 +575,24 @@ const lookupKey = <I, S>(self: Context<any>, key: Key<I, S>): S | typeof notFoun
  * @category constructors
  * @since 4.0.0
  */
-export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>): Context<Services> => {
-  const cache = new Map<string, unknown>()
-  mapUnsafe.forEach((value, key) => {
-    if (cacheKeys.has(key)) cache.set(key, value)
-  })
-  return makeImpl(cache, mapUnsafe, undefined, 0)
-}
+export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>): Context<Services> =>
+  makeImpl(undefined, mapUnsafe, undefined, 0)
 
 const Proto: Omit<
   ContextImpl<never>,
-  "cache" | "base" | "overlay" | "depth" | "_flat"
+  "cacheRoot" | "base" | "overlay" | "depth" | "_flat"
 > = {
   ...PipeInspectableProto,
   [TypeId]: {
     _Services: (_: never) => _
   },
   get mapUnsafe() {
-    return flatten(this as ContextImpl<any>)
+    const self = this as any as ContextImpl<any>
+    if (self._flat) return self._flat
+    if (!self.overlay) return self._flat = self.base
+    const map = new Map(self.base)
+    applyOverlays(map, self.overlay)
+    return self._flat = map
   },
   toJSON(this: Context<never>) {
     return {
@@ -643,7 +624,7 @@ const Proto: Omit<
 export const hasSameCache = <Services, Services2>(
   self: Context<Services>,
   that: Context<Services2>
-): boolean => (self as ContextImpl<Services>).cache === (that as ContextImpl<Services2>).cache
+): boolean => (self as ContextImpl<Services>).cacheRoot === (that as ContextImpl<Services2>).cacheRoot
 
 /**
  * Checks whether the provided argument is a `Context`.
@@ -809,14 +790,8 @@ export const add: {
     return withFlat(impl, (map) => map.set(key.key, service))
   }
 
-  let cache = impl.cache
-  if (key.enableCaching) {
-    cache = new Map(impl.cache)
-    ;(cache as Map<string, unknown>).set(key.key, service)
-  }
-
   return makeImpl(
-    cache,
+    cacheKeys.has(key.key) ? undefined : impl.cacheRoot,
     impl.base,
     { key: key.key, value: service, parent: impl.overlay },
     impl.depth + 1
@@ -928,7 +903,7 @@ export const getOrElse: {
   <S, I, B>(key: Key<I, S>, orElse: LazyArg<B>): <Services>(self: Context<Services>) => S | B
   <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B
 } = dual(3, <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B => {
-  const value = lookupKey(self, key)
+  const value = lookup(self, key.key)
   if (value !== notFound) return value as any
   return isReference(key) ? getDefaultValue(key) : orElse()
 })
@@ -962,8 +937,7 @@ export const getOrUndefined: {
 
 /** @internal */
 export const getOrUndefinedUnsafe = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
-  const impl = self as ContextImpl<Services>
-  const value = impl.cache.has(key) ? impl.cache.get(key) : lookup(impl, key)
+  const value = lookup(self, key)
   return value === notFound ? undefined : value as A
 }
 
@@ -1008,7 +982,7 @@ export const getUnsafe: {
 } = dual(
   2,
   <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): S => {
-    const value = lookupKey(self, service)
+    const value = lookup(self, service.key)
     if (value === notFound) {
       if (isReference(service)) return getDefaultValue(service as any)
       throw serviceNotFoundError(service)
@@ -1119,7 +1093,7 @@ export const getOption: {
   <S, I>(service: Key<I, S>): <Services>(self: Context<Services>) => Option.Option<S>
   <Services, S, I>(self: Context<Services>, service: Key<I, S>): Option.Option<S>
 } = dual(2, <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): Option.Option<S> => {
-  const value = lookupKey(self, service)
+  const value = lookup(self, service.key)
   if (value !== notFound) return Option.some(value as any)
   return isReference(service) ? Option.some(getDefaultValue(service as any)) : Option.none()
 })
@@ -1162,11 +1136,9 @@ export const merge: {
   <R1>(that: Context<R1>): <Services>(self: Context<Services>) => Context<R1 | Services>
   <Services, R1>(self: Context<Services>, that: Context<R1>): Context<Services | R1>
 } = dual(2, <Services, R1>(self: Context<Services>, that: Context<R1>): Context<Services | R1> => {
-  const selfImpl = self as ContextImpl<Services>
-  const thatFlat = flatten(that as ContextImpl<R1>)
-  if (flatten(selfImpl).size === 0) return that as any
-  if (thatFlat.size === 0) return self as any
-  return withFlat(selfImpl, (map) => thatFlat.forEach((value, key) => map.set(key, value)))
+  if (self.mapUnsafe.size === 0) return that as any
+  if (that.mapUnsafe.size === 0) return self as any
+  return withFlat(self, (map) => that.mapUnsafe.forEach((value, key) => map.set(key, value)))
 })
 
 /**
@@ -1213,7 +1185,7 @@ export const mergeAll = <T extends Array<unknown>>(
 ): Context<T[number]> => {
   const map = new Map()
   for (let i = 0; i < ctxs.length; i++) {
-    flatten(ctxs[i] as ContextImpl<any>).forEach((value, key) => {
+    ctxs[i].mapUnsafe.forEach((value, key) => {
       map.set(key, value)
     })
   }
@@ -1256,7 +1228,7 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
 ) =>
 <Services>(self: Context<Services>): Context<Services & Service.Identifier<S[number]>> => {
   const keep = new Set(services.map((key) => key.key))
-  return withFlat(self as ContextImpl<Services>, (map) =>
+  return withFlat(self, (map) =>
     map.forEach((_, key) => {
       if (!keep.has(key)) map.delete(key)
     }))
@@ -1297,7 +1269,7 @@ export const omit = <S extends ReadonlyArray<Key<any, any>>>(
   ...keys: S
 ) =>
 <Services>(self: Context<Services>): Context<Exclude<Services, Service.Identifier<S[number]>>> =>
-  withFlat(self as ContextImpl<Services>, (map) => {
+  withFlat(self, (map) => {
     for (let i = 0; i < keys.length; i++) {
       map.delete(keys[i].key)
     }

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -553,8 +553,8 @@ const lookup = (self: Context<any>, key: string): unknown => {
   for (let overlay = impl.overlay; overlay; overlay = overlay.parent) {
     if (overlay.key === key) return overlay.value
   }
-  if (!impl.base.has(key)) return notFound
   const value = impl.base.get(key)
+  if (value === undefined && !impl.base.has(key)) return notFound
   if (impl.overlay && ++impl.baseFallThroughs >= FlattenAfterBaseFallThroughs) {
     impl.base = flatten(impl)
     impl.overlay = undefined

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -530,14 +530,6 @@ const makeImpl = <Services>(
   return self
 }
 
-const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
-  const cache = new Map<string, unknown>()
-  map.forEach((value, key) => {
-    if (cacheKeys.has(key)) cache.set(key, value)
-  })
-  return makeImpl(cache, map, undefined, 0)
-}
-
 const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
   if (overlay === undefined) return
   applyOverlays(map, overlay.parent)
@@ -565,7 +557,7 @@ const withFlat = <B>(self: ContextImpl<any>, f: (map: Map<string, any>) => void)
   }
   const map = new Map(flatten(self))
   f(map)
-  return fromMap(map)
+  return makeUnsafe(map)
 }
 
 const lookup = (self: ContextImpl<any>, key: string): unknown => {
@@ -607,9 +599,9 @@ const hasKey = (self: Context<any>, key: string): boolean => {
  *
  * **Gotchas**
  *
- * The provided map is copied so later mutations are not observed by the
- * created `Context`. Prefer `empty`, `make`, `add`, or `merge` for normal
- * Context construction.
+ * The provided map is retained without copying and must not be mutated after
+ * construction. Prefer `empty`, `make`, `add`, or `merge` for normal Context
+ * construction.
  *
  * **Example** (Creating a context from a map)
  *
@@ -629,7 +621,11 @@ const hasKey = (self: Context<any>, key: string): boolean => {
  * @since 4.0.0
  */
 export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>): Context<Services> => {
-  return fromMap(new Map(mapUnsafe))
+  const cache = new Map<string, unknown>()
+  mapUnsafe.forEach((value, key) => {
+    if (cacheKeys.has(key)) cache.set(key, value)
+  })
+  return makeImpl(cache, mapUnsafe, undefined, 0)
 }
 
 const Proto: Omit<
@@ -1298,7 +1294,7 @@ export const mergeAll = <T extends Array<unknown>>(
       map.set(key, value)
     })
   }
-  return fromMap(map)
+  return makeUnsafe(map)
 }
 
 /**
@@ -1417,7 +1413,7 @@ export const mutate: {
     scratch.mutable = true
     try {
       const result = f(scratch)
-      return result === (scratch as unknown) ? fromMap(map) : result
+      return result === (scratch as unknown) ? makeUnsafe(map) : result
     } finally {
       scratch.mutable = false
     }

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -643,6 +643,18 @@ export const unsafeMakeSlot = (key: Key<any, any>): void => {
   allocateSlot(key)
 }
 
+/** @internal */
+export const unsafeHasSameSlab = <Services, Services2>(
+  self: Context<Services>,
+  that: Context<Services2>
+): boolean => (self as ContextImpl<Services>).slab === (that as ContextImpl<Services2>).slab
+
+/** @internal */
+export const unsafeGetByKey = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
+  const value = lookup(self as ContextImpl<Services>, key, slotByKey.get(key))
+  return value === Unset ? undefined : value as A
+}
+
 /**
  * Checks whether the provided argument is a `Context`.
  *
@@ -1227,6 +1239,22 @@ export const merge: {
   const thatImpl = that as ContextImpl<R1>
   if (selfImpl.size === 0) return that as any
   if (thatImpl.size === 0) return self as any
+  if (selfImpl.mutable) {
+    const base = selfImpl.base as Map<string, any>
+    const slab = selfImpl.slab as Array<unknown>
+    flatten(thatImpl).forEach((value, key) => {
+      const grew = !base.has(key)
+      base.set(key, value)
+      const slot = slotByKey.get(key)
+      if (slot !== undefined) {
+        while (slab.length <= slot) slab.push(Unset)
+        slab[slot] = value
+      }
+      selfImpl.size += grew ? 1 : 0
+    })
+    selfImpl._flat = undefined
+    return self as any
+  }
   const map = new Map(flatten(selfImpl))
   flatten(thatImpl).forEach((value, key) => map.set(key, value))
   return fromMap(map)
@@ -1319,8 +1347,22 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
 ) =>
 <Services>(self: Context<Services>): Context<Services & Service.Identifier<S[number]>> => {
   const keep = new Set(services.map((key) => key.key))
+  const impl = self as ContextImpl<Services>
+  if (impl.mutable) {
+    const base = impl.base as Map<string, any>
+    const slab = impl.slab as Array<unknown>
+    base.forEach((_, key) => {
+      if (keep.has(key)) return
+      base.delete(key)
+      const slot = slotByKey.get(key)
+      if (slot !== undefined && slot < slab.length) slab[slot] = Unset
+    })
+    impl.size = base.size
+    impl._flat = undefined
+    return self as any
+  }
   const map = new Map<string, any>()
-  flatten(self as ContextImpl<Services>).forEach((value, key) => {
+  flatten(impl).forEach((value, key) => {
     if (keep.has(key)) map.set(key, value)
   })
   return fromMap(map)
@@ -1362,8 +1404,21 @@ export const omit = <S extends ReadonlyArray<Key<any, any>>>(
 ) =>
 <Services>(self: Context<Services>): Context<Exclude<Services, Service.Identifier<S[number]>>> => {
   const drop = new Set(keys.map((key) => key.key))
+  const impl = self as ContextImpl<Services>
+  if (impl.mutable) {
+    const base = impl.base as Map<string, any>
+    const slab = impl.slab as Array<unknown>
+    drop.forEach((key) => {
+      if (!base.delete(key)) return
+      const slot = slotByKey.get(key)
+      if (slot !== undefined && slot < slab.length) slab[slot] = Unset
+    })
+    impl.size = base.size
+    impl._flat = undefined
+    return self as any
+  }
   const map = new Map<string, any>()
-  flatten(self as ContextImpl<Services>).forEach((value, key) => {
+  flatten(impl).forEach((value, key) => {
     if (!drop.has(key)) map.set(key, value)
   })
   return fromMap(map)

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -580,24 +580,28 @@ const withFlat = <B>(self: ContextImpl<any>, f: (map: Map<string, any>) => void)
   return fromMap(map)
 }
 
-const lookup = (self: ContextImpl<any>, key: string, slot?: number): unknown => {
+const lookup = (self: ContextImpl<any>, key: string): unknown => {
   if (self.base === undefined) {
     return self.mapUnsafe.has(key) ? self.mapUnsafe.get(key) : Unset
-  }
-  if (slot !== undefined && slot < self.slab.length) {
-    const value = self.slab[slot]
-    if (value !== Unset) return value
   }
   for (let overlay = self.overlay; overlay !== undefined; overlay = overlay.parent) {
     if (overlay.key === key) return overlay.value
   }
-  return self.base.has(key) ? self.base.get(key) : Unset
+  const value = self.base.get(key)
+  return value === undefined && !self.base.has(key) ? Unset : value
 }
 
 // The slab is a cache: every slotted value is also present in overlay/base, so
 // reads can use the key's own slot without consulting the registry
-const lookupKey = (self: Context<any>, key: Key<any, any>): unknown =>
-  lookup(self as ContextImpl<any>, key.key, (key as any)[SlotId])
+const lookupKey = (self: Context<any>, key: Key<any, any>): unknown => {
+  const impl = self as ContextImpl<any>
+  const slot = (key as any)[SlotId]
+  if (slot !== undefined && slot < impl.slab.length) {
+    const value = impl.slab[slot]
+    if (value !== Unset) return value
+  }
+  return lookup(impl, key.key)
+}
 
 /**
  * Creates a `Context` from an existing service map.
@@ -679,7 +683,14 @@ export const unsafeHasSameSlab = <Services, Services2>(
 
 /** @internal */
 export const unsafeGetByKey = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
-  const value = lookup(self as ContextImpl<Services>, key, slotByKey.get(key))
+  const impl = self as ContextImpl<Services>
+  const slot = slotByKey.get(key)
+  let value: unknown
+  if (slot !== undefined && slot < impl.slab.length && impl.slab[slot] !== Unset) {
+    value = impl.slab[slot]
+  } else {
+    value = lookup(impl, key)
+  }
   return value === Unset ? undefined : value as A
 }
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -534,7 +534,8 @@ const withFlat = <B>(self: Context<any>, f: (map: Map<string, any>) => void): Co
   return makeUnsafe(map)
 }
 
-const notFound = Symbol.for("effect/Context/notFound")
+// A private symbol so user code cannot forge a value that reads as absent
+const notFound = Symbol()
 
 const lookup = (self: Context<any>, key: string): unknown => {
   const impl = self as ContextImpl<any>
@@ -786,12 +787,17 @@ export const add: {
   service: Types.NoInfer<S>
 ): Context<Services | I> => {
   const impl = self as ContextImpl<Services>
+  const cacheRoot = cacheKeys.has(key.key) ? undefined : impl.cacheRoot
   if (impl.depth >= MaxDepth) {
-    return withFlat(impl, (map) => map.set(key.key, service))
+    // Rebase the overlay chain into a flat map, keeping the cacheRoot so a
+    // rebase on an ordinary key does not invalidate fiber caches
+    const map = new Map(impl.mapUnsafe)
+    map.set(key.key, service)
+    return makeImpl(cacheRoot, map, undefined, 0)
   }
 
   return makeImpl(
-    cacheKeys.has(key.key) ? undefined : impl.cacheRoot,
+    cacheRoot,
     impl.base,
     { key: key.key, value: service, parent: impl.overlay },
     impl.depth + 1

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -165,11 +165,6 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
- * Pass `enableFiberCaching: true` for keys whose values fibers cache locally, such
- * as runtime references read on every context change. Adding a caching key
- * invalidates those fiber caches, while adds of regular keys keep them intact.
- * The same option is available on `Reference`.
- *
  * **Gotchas**
  *
  * The string key is the runtime identity of the service. Reusing the same key
@@ -209,7 +204,8 @@ export const Service: {
   <Identifier, Shape = Identifier>(
     key: string,
     options?: {
-      readonly enableFiberCaching?: boolean | undefined
+      /** @internal */
+      readonly fiberCached?: boolean | undefined
     } | undefined
   ): Service<Identifier, Shape>
   <Self, Shape>(): <
@@ -221,7 +217,8 @@ export const Service: {
     id: Identifier,
     options?: {
       readonly make?: ((...args: Args) => Effect<Shape, E, R>) | Effect<Shape, E, R> | undefined
-      readonly enableFiberCaching?: boolean | undefined
+      /** @internal */
+      readonly fiberCached?: boolean | undefined
     } | undefined
   ) =>
     & ServiceClass<Self, Identifier, Shape>
@@ -234,7 +231,8 @@ export const Service: {
     id: Identifier,
     options: {
       readonly make: Make
-      readonly enableFiberCaching?: boolean | undefined
+      /** @internal */
+      readonly fiberCached?: boolean | undefined
     }
   ) =>
     & ServiceClass<
@@ -262,7 +260,7 @@ export const Service: {
   const init = (key: string, options?: {
     readonly defaultValue?: any
     readonly make?: any
-    readonly enableFiberCaching?: boolean
+    readonly fiberCached?: boolean
   }) => {
     self.key = key
     if (options?.defaultValue) {
@@ -272,7 +270,7 @@ export const Service: {
     if (options?.make) {
       ;(self as any).make = options.make
     }
-    if (options?.enableFiberCaching) {
+    if (options?.fiberCached) {
       cacheKeys.add(key)
     }
     return self
@@ -1334,6 +1332,7 @@ export const Reference: <Service>(
   key: string,
   options: {
     readonly defaultValue: () => Service
-    readonly enableFiberCaching?: boolean | undefined
+    /** @internal */
+    readonly fiberCached?: boolean | undefined
   }
 ) => Reference<Service> = Service as any

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -639,11 +639,6 @@ const Proto: Omit<
 }
 
 /** @internal */
-export const unsafeMakeSlot = (key: Key<any, any>): void => {
-  allocateSlot(key)
-}
-
-/** @internal */
 export const unsafeHasSameSlab = <Services, Services2>(
   self: Context<Services>,
   that: Context<Services2>
@@ -815,32 +810,27 @@ export const add: {
   service: Types.NoInfer<S>
 ): Context<Services | I> => {
   const impl = self as ContextImpl<Services>
-  const slot = slotOf(key)
-  const grew = !has(impl, key)
 
   if (impl.mutable) {
-    const mutable = impl as any
-    if (slot !== undefined) {
-      while (mutable.slab.length <= slot) mutable.slab.push(Unset)
-      mutable.slab[slot] = service
-    }
-    ;(mutable.base as Map<string, any>).set(key.key, service)
-    mutable.size += grew ? 1 : 0
-    mutable._flat = undefined
+    ;(impl.base as Map<string, any>).set(key.key, service)
+    impl.size = impl.base.size
     return self as any
-  }
-
-  let slab = impl.slab
-  if (slot !== undefined) {
-    slab = impl.slab.slice()
-    while (slab.length <= slot) (slab as Array<unknown>).push(Unset)
-    ;(slab as Array<unknown>)[slot] = service
   }
 
   if (impl.depth >= MaxDepth) {
     const map = new Map(flatten(impl))
     map.set(key.key, service)
     return fromMap(map)
+  }
+
+  const grew = !has(impl, key)
+  let slab = impl.slab
+  const slot = slotOf(key)
+  if (slot !== undefined) {
+    const copy = impl.slab.slice()
+    while (copy.length <= slot) copy.push(Unset)
+    copy[slot] = service
+    slab = copy
   }
 
   return makeImpl(
@@ -1241,18 +1231,8 @@ export const merge: {
   if (thatImpl.size === 0) return self as any
   if (selfImpl.mutable) {
     const base = selfImpl.base as Map<string, any>
-    const slab = selfImpl.slab as Array<unknown>
-    flatten(thatImpl).forEach((value, key) => {
-      const grew = !base.has(key)
-      base.set(key, value)
-      const slot = slotByKey.get(key)
-      if (slot !== undefined) {
-        while (slab.length <= slot) slab.push(Unset)
-        slab[slot] = value
-      }
-      selfImpl.size += grew ? 1 : 0
-    })
-    selfImpl._flat = undefined
+    flatten(thatImpl).forEach((value, key) => base.set(key, value))
+    selfImpl.size = base.size
     return self as any
   }
   const map = new Map(flatten(selfImpl))
@@ -1350,15 +1330,10 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
   const impl = self as ContextImpl<Services>
   if (impl.mutable) {
     const base = impl.base as Map<string, any>
-    const slab = impl.slab as Array<unknown>
     base.forEach((_, key) => {
-      if (keep.has(key)) return
-      base.delete(key)
-      const slot = slotByKey.get(key)
-      if (slot !== undefined && slot < slab.length) slab[slot] = Unset
+      if (!keep.has(key)) base.delete(key)
     })
     impl.size = base.size
-    impl._flat = undefined
     return self as any
   }
   const map = new Map<string, any>()
@@ -1407,14 +1382,8 @@ export const omit = <S extends ReadonlyArray<Key<any, any>>>(
   const impl = self as ContextImpl<Services>
   if (impl.mutable) {
     const base = impl.base as Map<string, any>
-    const slab = impl.slab as Array<unknown>
-    drop.forEach((key) => {
-      if (!base.delete(key)) return
-      const slot = slotByKey.get(key)
-      if (slot !== undefined && slot < slab.length) slab[slot] = Unset
-    })
+    drop.forEach((key) => base.delete(key))
     impl.size = base.size
-    impl._flat = undefined
     return self as any
   }
   const map = new Map<string, any>()
@@ -1450,15 +1419,19 @@ export const mutate: {
 } = dual(
   2,
   <Services, B>(self: Context<Services>, f: (context: Context<Services>) => Context<B>): Context<B> => {
-    const next = fromMap<Services>(new Map(flatten(self as ContextImpl<Services>)))
-    next.mutable = true
+    // The scratch context gets an empty slab, so every operation on it reads
+    // and writes `base` alone; the slab is rebuilt once when sealing
+    const map = new Map(flatten(self as ContextImpl<Services>))
+    const scratch = makeImpl<Services>([], map, undefined, 0, map.size, map)
+    scratch.mutable = true
     let result: Context<B> | undefined
     try {
-      return result = f(next)
+      result = f(scratch)
     } finally {
-      next.mutable = false
+      scratch.mutable = false
       if (result !== undefined) result.mutable = false
     }
+    return result === (scratch as unknown) ? fromMap(map) : result
   }
 )
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -518,8 +518,7 @@ const makeImpl = <Services>(
   slab: ReadonlyMap<string, unknown>,
   base: ReadonlyMap<string, any>,
   overlay: Overlay | undefined,
-  depth: number,
-  flat?: ReadonlyMap<string, any>
+  depth: number
 ): ContextImpl<Services> => {
   const self: ContextImpl<Services> = Object.create(Proto)
   self.slab = slab
@@ -527,7 +526,7 @@ const makeImpl = <Services>(
   self.overlay = overlay
   self.depth = depth
   self.mutable = false
-  self._flat = flat
+  self._flat = undefined
   return self
 }
 
@@ -536,7 +535,7 @@ const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
   map.forEach((value, key) => {
     if (slabKeys.has(key)) slab.set(key, value)
   })
-  return makeImpl(slab, map, undefined, 0, map)
+  return makeImpl(slab, map, undefined, 0)
 }
 
 const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
@@ -635,7 +634,7 @@ export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>
 
 const Proto: Omit<
   ContextImpl<never>,
-  "slab" | "base" | "overlay" | "depth" | "size" | "mutable" | "_flat"
+  "slab" | "base" | "overlay" | "depth" | "mutable" | "_flat"
 > = {
   ...PipeInspectableProto,
   [TypeId]: {
@@ -1414,7 +1413,7 @@ export const mutate: {
     // The scratch context gets an empty slab, so every operation on it reads
     // and writes `base` alone; the slab is rebuilt once when sealing
     const map = new Map(flatten(self as ContextImpl<Services>))
-    const scratch = makeImpl<Services>(new Map(), map, undefined, 0, map)
+    const scratch = makeImpl<Services>(new Map(), map, undefined, 0)
     scratch.mutable = true
     try {
       const result = f(scratch)
@@ -1475,6 +1474,5 @@ export const Reference: <Service>(
   key: string,
   options: {
     readonly defaultValue: () => Service
-    readonly allocateSlot?: boolean | undefined
   }
 ) => Reference<Service> = Service as any

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -73,18 +73,15 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
 const SlotId = Symbol.for("effect/Context/Slot")
 const Unset = Symbol()
 const slotByKey = new Map<string, number>()
-let nextSlot = 0
 
-const allocateSlot = (key: Key<any, any>): number => {
-  let slot = slotByKey.get(key.key)
-  if (slot === undefined) {
-    slot = nextSlot++
-    slotByKey.set(key.key, slot)
-  }
-  ;(key as any)[SlotId] = slot
-  return slot
+const allocateSlot = (key: Key<any, any>): void => {
+  if (!slotByKey.has(key.key)) slotByKey.set(key.key, slotByKey.size)
+  ;(key as any)[SlotId] = slotByKey.get(key.key)
 }
 
+// Writes must consult the registry as well: a slotted key string can be written
+// through a second key object that never allocated the slot itself, and the
+// slab copy has to happen regardless of which object performs the add
 const slotOf = (key: Key<any, any>): number | undefined => (key as any)[SlotId] ?? slotByKey.get(key.key)
 
 /**
@@ -512,7 +509,6 @@ interface ContextImpl<in Services> extends Context<Services> {
   base: ReadonlyMap<string, any>
   overlay: Overlay | undefined
   depth: number
-  size: number
   _flat: ReadonlyMap<string, any> | undefined
 }
 
@@ -529,7 +525,6 @@ const makeImpl = <Services>(
   base: ReadonlyMap<string, any>,
   overlay: Overlay | undefined,
   depth: number,
-  size: number,
   flat?: ReadonlyMap<string, any>
 ): ContextImpl<Services> => {
   const self: ContextImpl<Services> = Object.create(Proto)
@@ -537,21 +532,28 @@ const makeImpl = <Services>(
   self.base = base
   self.overlay = overlay
   self.depth = depth
-  self.size = size
   self.mutable = false
   self._flat = flat
   return self
 }
 
+const slabSet = (slab: Array<unknown>, slot: number, value: unknown): void => {
+  while (slab.length <= slot) slab.push(Unset)
+  slab[slot] = value
+}
+
 const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
   const slab: Array<unknown> = []
-  map.forEach((value, key) => {
-    const slot = slotByKey.get(key)
-    if (slot === undefined) return
-    while (slab.length <= slot) slab.push(Unset)
-    slab[slot] = value
+  slotByKey.forEach((slot, key) => {
+    if (map.has(key)) slabSet(slab, slot, map.get(key))
   })
-  return makeImpl(slab, map, undefined, 0, map.size, map)
+  return makeImpl(slab, map, undefined, 0, map)
+}
+
+const applyOverlays = (map: Map<string, any>, overlay: Overlay | undefined): void => {
+  if (overlay === undefined) return
+  applyOverlays(map, overlay.parent)
+  map.set(overlay.key, overlay.value)
 }
 
 // Some cycle-locked modules build Context objects that only carry `mapUnsafe`
@@ -561,26 +563,29 @@ const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
   if (self._flat !== undefined) return self._flat
   if (self.base === undefined) return self.mapUnsafe
   if (self.overlay === undefined) return self._flat = self.base
-
   const map = new Map(self.base)
-  const stack: Array<Overlay> = []
-  for (let overlay: Overlay | undefined = self.overlay; overlay !== undefined; overlay = overlay.parent) {
-    stack.push(overlay)
-  }
-  for (let i = stack.length - 1; i >= 0; i--) {
-    map.set(stack[i].key, stack[i].value)
-  }
+  applyOverlays(map, self.overlay)
   return self._flat = map
 }
 
-const slabAt = (self: ContextImpl<any>, slot: number): unknown => slot < self.slab.length ? self.slab[slot] : Unset
+// Applies a mutation to the flat view of the context: in place for mutable
+// scratch contexts, on a copy otherwise
+const withFlat = <B>(self: ContextImpl<any>, f: (map: Map<string, any>) => void): Context<B> => {
+  if (self.mutable) {
+    f(self.base as Map<string, any>)
+    return self as any
+  }
+  const map = new Map(flatten(self))
+  f(map)
+  return fromMap(map)
+}
 
 const lookup = (self: ContextImpl<any>, key: string, slot?: number): unknown => {
   if (self.base === undefined) {
     return self.mapUnsafe.has(key) ? self.mapUnsafe.get(key) : Unset
   }
-  if (slot !== undefined) {
-    const value = slabAt(self, slot)
+  if (slot !== undefined && slot < self.slab.length) {
+    const value = self.slab[slot]
     if (value !== Unset) return value
   }
   for (let overlay = self.overlay; overlay !== undefined; overlay = overlay.parent) {
@@ -589,7 +594,10 @@ const lookup = (self: ContextImpl<any>, key: string, slot?: number): unknown => 
   return self.base.has(key) ? self.base.get(key) : Unset
 }
 
-const has = (self: ContextImpl<any>, key: Key<any, any>): boolean => lookup(self, key.key, slotOf(key)) !== Unset
+// The slab is a cache: every slotted value is also present in overlay/base, so
+// reads can use the key's own slot without consulting the registry
+const lookupKey = (self: Context<any>, key: Key<any, any>): unknown =>
+  lookup(self as ContextImpl<any>, key.key, (key as any)[SlotId])
 
 /**
  * Creates a `Context` from an existing service map.
@@ -659,7 +667,7 @@ const Proto: Omit<
     return true
   },
   [Hash.symbol]<A>(this: Context<A>): number {
-    return Hash.number((this as ContextImpl<A>).size)
+    return Hash.number(this.mapUnsafe.size)
   }
 }
 
@@ -834,37 +842,23 @@ export const add: {
   key: Key<I, S>,
   service: Types.NoInfer<S>
 ): Context<Services | I> => {
-  let impl = self as ContextImpl<Services>
-  if (impl.base === undefined) impl = fromMap(new Map(impl.mapUnsafe))
-
-  if (impl.mutable) {
-    ;(impl.base as Map<string, any>).set(key.key, service)
-    impl.size = impl.base.size
-    return self as any
+  const impl = self as ContextImpl<Services>
+  if (impl.mutable || impl.base === undefined || impl.depth >= MaxDepth) {
+    return withFlat(impl, (map) => map.set(key.key, service))
   }
 
-  if (impl.depth >= MaxDepth) {
-    const map = new Map(flatten(impl))
-    map.set(key.key, service)
-    return fromMap(map)
-  }
-
-  const grew = !has(impl, key)
   let slab = impl.slab
   const slot = slotOf(key)
   if (slot !== undefined) {
-    const copy = impl.slab.slice()
-    while (copy.length <= slot) copy.push(Unset)
-    copy[slot] = service
-    slab = copy
+    slab = impl.slab.slice()
+    slabSet(slab as Array<unknown>, slot, service)
   }
 
   return makeImpl(
     slab,
     impl.base,
     { key: key.key, value: service, parent: impl.overlay },
-    impl.depth + 1,
-    impl.size + (grew ? 1 : 0)
+    impl.depth + 1
   )
 })
 
@@ -973,7 +967,7 @@ export const getOrElse: {
   <S, I, B>(key: Key<I, S>, orElse: LazyArg<B>): <Services>(self: Context<Services>) => S | B
   <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B
 } = dual(3, <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B => {
-  const value = lookup(self as ContextImpl<Services>, key.key, slotOf(key))
+  const value = lookupKey(self, key)
   if (value !== Unset) return value as any
   return isReference(key) ? getDefaultValue(key) : orElse()
 })
@@ -1003,7 +997,7 @@ export const getOrUndefined: {
 } = dual(
   2,
   <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined => {
-    const value = lookup(self as ContextImpl<Services>, key.key, slotOf(key))
+    const value = lookupKey(self, key)
     return value === Unset ? undefined : value as S
   }
 )
@@ -1049,7 +1043,7 @@ export const getUnsafe: {
 } = dual(
   2,
   <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): S => {
-    const value = lookup(self as ContextImpl<Services>, service.key, slotOf(service))
+    const value = lookupKey(self, service)
     if (value === Unset) {
       if (ReferenceTypeId in service) return getDefaultValue(service as any)
       throw serviceNotFoundError(service)
@@ -1137,7 +1131,7 @@ export const get: {
  * @since 4.0.0
  */
 export const getReferenceUnsafe = <Services, S>(self: Context<Services>, service: Reference<S>): S => {
-  const value = lookup(self as ContextImpl<Services>, service.key, slotOf(service))
+  const value = lookupKey(self, service)
   return value === Unset ? getDefaultValue(service as any) : value as S
 }
 
@@ -1208,7 +1202,7 @@ export const getOption: {
   <S, I>(service: Key<I, S>): <Services>(self: Context<Services>) => Option.Option<S>
   <Services, S, I>(self: Context<Services>, service: Key<I, S>): Option.Option<S>
 } = dual(2, <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): Option.Option<S> => {
-  const value = lookup(self as ContextImpl<Services>, service.key, slotOf(service))
+  const value = lookupKey(self, service)
   if (value !== Unset) return Option.some(value as any)
   return isReference(service) ? Option.some(getDefaultValue(service as any)) : Option.none()
 })
@@ -1252,18 +1246,10 @@ export const merge: {
   <Services, R1>(self: Context<Services>, that: Context<R1>): Context<Services | R1>
 } = dual(2, <Services, R1>(self: Context<Services>, that: Context<R1>): Context<Services | R1> => {
   const selfImpl = self as ContextImpl<Services>
-  const thatImpl = that as ContextImpl<R1>
-  if (selfImpl.size === 0) return that as any
-  if (thatImpl.size === 0) return self as any
-  if (selfImpl.mutable) {
-    const base = selfImpl.base as Map<string, any>
-    flatten(thatImpl).forEach((value, key) => base.set(key, value))
-    selfImpl.size = base.size
-    return self as any
-  }
-  const map = new Map(flatten(selfImpl))
-  flatten(thatImpl).forEach((value, key) => map.set(key, value))
-  return fromMap(map)
+  const thatFlat = flatten(that as ContextImpl<R1>)
+  if (flatten(selfImpl).size === 0) return that as any
+  if (thatFlat.size === 0) return self as any
+  return withFlat(selfImpl, (map) => thatFlat.forEach((value, key) => map.set(key, value)))
 })
 
 /**
@@ -1353,20 +1339,10 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
 ) =>
 <Services>(self: Context<Services>): Context<Services & Service.Identifier<S[number]>> => {
   const keep = new Set(services.map((key) => key.key))
-  const impl = self as ContextImpl<Services>
-  if (impl.mutable) {
-    const base = impl.base as Map<string, any>
-    base.forEach((_, key) => {
-      if (!keep.has(key)) base.delete(key)
-    })
-    impl.size = base.size
-    return self as any
-  }
-  const map = new Map<string, any>()
-  flatten(impl).forEach((value, key) => {
-    if (keep.has(key)) map.set(key, value)
-  })
-  return fromMap(map)
+  return withFlat(self as ContextImpl<Services>, (map) =>
+    map.forEach((_, key) => {
+      if (!keep.has(key)) map.delete(key)
+    }))
 }
 
 /**
@@ -1403,21 +1379,12 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
 export const omit = <S extends ReadonlyArray<Key<any, any>>>(
   ...keys: S
 ) =>
-<Services>(self: Context<Services>): Context<Exclude<Services, Service.Identifier<S[number]>>> => {
-  const drop = new Set(keys.map((key) => key.key))
-  const impl = self as ContextImpl<Services>
-  if (impl.mutable) {
-    const base = impl.base as Map<string, any>
-    drop.forEach((key) => base.delete(key))
-    impl.size = base.size
-    return self as any
-  }
-  const map = new Map<string, any>()
-  flatten(impl).forEach((value, key) => {
-    if (!drop.has(key)) map.set(key, value)
+<Services>(self: Context<Services>): Context<Exclude<Services, Service.Identifier<S[number]>>> =>
+  withFlat(self as ContextImpl<Services>, (map) => {
+    for (let i = 0; i < keys.length; i++) {
+      map.delete(keys[i].key)
+    }
   })
-  return fromMap(map)
-}
 
 /**
  * Performs a series of mutations on a `Context`. Prevents unnecessary copying
@@ -1448,16 +1415,14 @@ export const mutate: {
     // The scratch context gets an empty slab, so every operation on it reads
     // and writes `base` alone; the slab is rebuilt once when sealing
     const map = new Map(flatten(self as ContextImpl<Services>))
-    const scratch = makeImpl<Services>([], map, undefined, 0, map.size, map)
+    const scratch = makeImpl<Services>([], map, undefined, 0, map)
     scratch.mutable = true
-    let result: Context<B> | undefined
     try {
-      result = f(scratch)
+      const result = f(scratch)
+      return result === (scratch as unknown) ? fromMap(map) : result
     } finally {
       scratch.mutable = false
-      if (result !== undefined) result.mutable = false
     }
-    return result === (scratch as unknown) ? fromMap(map) : result
   }
 )
 

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -70,6 +70,23 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
   readonly stack?: string | undefined
 }
 
+const SlotId = Symbol.for("effect/Context/Slot")
+const Unset = Symbol()
+const slotByKey = new Map<string, number>()
+let nextSlot = 0
+
+const allocateSlot = (key: Key<any, any>): number => {
+  let slot = slotByKey.get(key.key)
+  if (slot === undefined) {
+    slot = nextSlot++
+    slotByKey.set(key.key, slot)
+  }
+  ;(key as any)[SlotId] = slot
+  return slot
+}
+
+const slotOf = (key: Key<any, any>): number | undefined => (key as any)[SlotId] ?? slotByKey.get(key.key)
+
 /**
  * Context key with helper methods for working with a service.
  *
@@ -252,6 +269,7 @@ export const Service: {
     if (arguments[1]?.defaultValue) {
       self[ReferenceTypeId] = ReferenceTypeId
       self.defaultValue = arguments[1].defaultValue
+      allocateSlot(self)
     }
     return self
   }
@@ -472,8 +490,81 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
 }
 
 interface ContextImpl<in Services> extends Context<Services> {
-  readonly _mapUnsafe: ReadonlyMap<string, any>
+  slab: ReadonlyArray<unknown>
+  base: ReadonlyMap<string, any>
+  overlay: Overlay | undefined
+  depth: number
+  size: number
+  _flat: ReadonlyMap<string, any> | undefined
 }
+
+interface Overlay {
+  readonly key: string
+  readonly value: unknown
+  readonly parent: Overlay | undefined
+}
+
+const MaxDepth = 8
+
+const makeImpl = <Services>(
+  slab: ReadonlyArray<unknown>,
+  base: ReadonlyMap<string, any>,
+  overlay: Overlay | undefined,
+  depth: number,
+  size: number,
+  flat?: ReadonlyMap<string, any>
+): ContextImpl<Services> => {
+  const self: ContextImpl<Services> = Object.create(Proto)
+  self.slab = slab
+  self.base = base
+  self.overlay = overlay
+  self.depth = depth
+  self.size = size
+  self.mutable = false
+  self._flat = flat
+  return self
+}
+
+const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
+  const slab: Array<unknown> = []
+  map.forEach((value, key) => {
+    const slot = slotByKey.get(key)
+    if (slot === undefined) return
+    while (slab.length <= slot) slab.push(Unset)
+    slab[slot] = value
+  })
+  return makeImpl(slab, map, undefined, 0, map.size, map)
+}
+
+const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
+  if (self._flat !== undefined) return self._flat
+  if (self.overlay === undefined) return self._flat = self.base
+
+  const map = new Map(self.base)
+  const stack: Array<Overlay> = []
+  for (let overlay: Overlay | undefined = self.overlay; overlay !== undefined; overlay = overlay.parent) {
+    stack.push(overlay)
+  }
+  for (let i = stack.length - 1; i >= 0; i--) {
+    map.set(stack[i].key, stack[i].value)
+  }
+  return self._flat = map
+}
+
+const slabAt = (self: ContextImpl<any>, slot: number): unknown => slot < self.slab.length ? self.slab[slot] : Unset
+
+const lookup = (self: ContextImpl<any>, key: string, slot?: number): unknown => {
+  if (slot !== undefined) {
+    const value = slabAt(self, slot)
+    if (value !== Unset) return value
+  }
+  for (let overlay = self.overlay; overlay !== undefined; overlay = overlay.parent) {
+    if (overlay.key === key) return overlay.value
+  }
+  return self.base.has(key) ? self.base.get(key) : Unset
+}
+
+const has = (self: ContextImpl<any>, key: Key<any, any>): boolean => lookup(self, key.key, slotOf(key)) !== Unset
 
 /**
  * Creates a `Context` from an existing service map.
@@ -485,7 +576,7 @@ interface ContextImpl<in Services> extends Context<Services> {
  *
  * **Gotchas**
  *
- * This is unsafe because later mutation of the provided map can affect the
+ * The provided map is copied so later mutations are not observed by the
  * created `Context`. Prefer `empty`, `make`, `add`, or `merge` for normal
  * Context construction.
  *
@@ -507,19 +598,19 @@ interface ContextImpl<in Services> extends Context<Services> {
  * @since 4.0.0
  */
 export const makeUnsafe = <Services = never>(mapUnsafe: ReadonlyMap<string, any>): Context<Services> => {
-  const self: ContextImpl<Services> = Object.create(Proto)
-  self._mapUnsafe = mapUnsafe
-  self.mutable = false
-  return self
+  return fromMap(new Map(mapUnsafe))
 }
 
-const Proto: Omit<ContextImpl<never>, "_mapUnsafe" | "mutable"> = {
+const Proto: Omit<
+  ContextImpl<never>,
+  "slab" | "base" | "overlay" | "depth" | "size" | "mutable" | "_flat"
+> = {
   ...PipeInspectableProto,
   [TypeId]: {
     _Services: (_: never) => _
   },
   get mapUnsafe() {
-    return this._mapUnsafe
+    return flatten(this as ContextImpl<any>)
   },
   toJSON(this: Context<never>) {
     return {
@@ -543,8 +634,13 @@ const Proto: Omit<ContextImpl<never>, "_mapUnsafe" | "mutable"> = {
     return true
   },
   [Hash.symbol]<A>(this: Context<A>): number {
-    return Hash.number(this.mapUnsafe.size)
+    return Hash.number((this as ContextImpl<A>).size)
   }
+}
+
+/** @internal */
+export const unsafeMakeSlot = (key: Key<any, any>): void => {
+  allocateSlot(key)
 }
 
 /**
@@ -705,10 +801,44 @@ export const add: {
   self: Context<Services>,
   key: Key<I, S>,
   service: Types.NoInfer<S>
-): Context<Services | I> =>
-  withMapUnsafe(self, (map) => {
+): Context<Services | I> => {
+  const impl = self as ContextImpl<Services>
+  const slot = slotOf(key)
+  const grew = !has(impl, key)
+
+  if (impl.mutable) {
+    const mutable = impl as any
+    if (slot !== undefined) {
+      while (mutable.slab.length <= slot) mutable.slab.push(Unset)
+      mutable.slab[slot] = service
+    }
+    ;(mutable.base as Map<string, any>).set(key.key, service)
+    mutable.size += grew ? 1 : 0
+    mutable._flat = undefined
+    return self as any
+  }
+
+  let slab = impl.slab
+  if (slot !== undefined) {
+    slab = impl.slab.slice()
+    while (slab.length <= slot) (slab as Array<unknown>).push(Unset)
+    ;(slab as Array<unknown>)[slot] = service
+  }
+
+  if (impl.depth >= MaxDepth) {
+    const map = new Map(flatten(impl))
     map.set(key.key, service)
-  }))
+    return fromMap(map)
+  }
+
+  return makeImpl(
+    slab,
+    impl.base,
+    { key: key.key, value: service, parent: impl.overlay },
+    impl.depth + 1,
+    impl.size + (grew ? 1 : 0)
+  )
+})
 
 /**
  * Adds or removes a service depending on an `Option`.
@@ -760,13 +890,9 @@ export const addOrOmit: {
   key: Key<I, S>,
   service: Option.Option<Types.NoInfer<S>>
 ): Context<Services | I> =>
-  withMapUnsafe(self, (map) => {
-    if (service._tag === "None") {
-      map.delete(key.key)
-    } else {
-      map.set(key.key, service.value)
-    }
-  }))
+  service._tag === "None"
+    ? omit(key)(self) as any
+    : add(self, key, service.value))
 
 /**
  * Gets the service for a key, or evaluates the fallback when a non-reference
@@ -819,9 +945,8 @@ export const getOrElse: {
   <S, I, B>(key: Key<I, S>, orElse: LazyArg<B>): <Services>(self: Context<Services>) => S | B
   <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B
 } = dual(3, <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B => {
-  if (self.mapUnsafe.has(key.key)) {
-    return self.mapUnsafe.get(key.key)! as any
-  }
+  const value = lookup(self as ContextImpl<Services>, key.key, slotOf(key))
+  if (value !== Unset) return value as any
   return isReference(key) ? getDefaultValue(key) : orElse()
 })
 
@@ -849,7 +974,10 @@ export const getOrUndefined: {
   <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined
 } = dual(
   2,
-  <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined => self.mapUnsafe.get(key.key)
+  <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined => {
+    const value = lookup(self as ContextImpl<Services>, key.key, slotOf(key))
+    return value === Unset ? undefined : value as S
+  }
 )
 
 /**
@@ -893,11 +1021,12 @@ export const getUnsafe: {
 } = dual(
   2,
   <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): S => {
-    if (!self.mapUnsafe.has(service.key)) {
+    const value = lookup(self as ContextImpl<Services>, service.key, slotOf(service))
+    if (value === Unset) {
       if (ReferenceTypeId in service) return getDefaultValue(service as any)
       throw serviceNotFoundError(service)
     }
-    return self.mapUnsafe.get(service.key)! as any
+    return value as any
   }
 )
 
@@ -980,10 +1109,8 @@ export const get: {
  * @since 4.0.0
  */
 export const getReferenceUnsafe = <Services, S>(self: Context<Services>, service: Reference<S>): S => {
-  if (!self.mapUnsafe.has(service.key)) {
-    return getDefaultValue(service as any)
-  }
-  return self.mapUnsafe.get(service.key)! as any
+  const value = lookup(self as ContextImpl<Services>, service.key, slotOf(service))
+  return value === Unset ? getDefaultValue(service as any) : value as S
 }
 
 const defaultValueCacheKey = "~effect/Context/defaultValue" as const
@@ -1053,9 +1180,8 @@ export const getOption: {
   <S, I>(service: Key<I, S>): <Services>(self: Context<Services>) => Option.Option<S>
   <Services, S, I>(self: Context<Services>, service: Key<I, S>): Option.Option<S>
 } = dual(2, <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): Option.Option<S> => {
-  if (self.mapUnsafe.has(service.key)) {
-    return Option.some(self.mapUnsafe.get(service.key)! as any)
-  }
+  const value = lookup(self as ContextImpl<Services>, service.key, slotOf(service))
+  if (value !== Unset) return Option.some(value as any)
   return isReference(service) ? Option.some(getDefaultValue(service as any)) : Option.none()
 })
 
@@ -1097,11 +1223,13 @@ export const merge: {
   <R1>(that: Context<R1>): <Services>(self: Context<Services>) => Context<R1 | Services>
   <Services, R1>(self: Context<Services>, that: Context<R1>): Context<Services | R1>
 } = dual(2, <Services, R1>(self: Context<Services>, that: Context<R1>): Context<Services | R1> => {
-  if (self.mapUnsafe.size === 0) return that as any
-  if (that.mapUnsafe.size === 0) return self as any
-  return withMapUnsafe(self, (map) => {
-    that.mapUnsafe.forEach((value, key) => map.set(key, value))
-  })
+  const selfImpl = self as ContextImpl<Services>
+  const thatImpl = that as ContextImpl<R1>
+  if (selfImpl.size === 0) return that as any
+  if (thatImpl.size === 0) return self as any
+  const map = new Map(flatten(selfImpl))
+  flatten(thatImpl).forEach((value, key) => map.set(key, value))
+  return fromMap(map)
 })
 
 /**
@@ -1148,11 +1276,11 @@ export const mergeAll = <T extends Array<unknown>>(
 ): Context<T[number]> => {
   const map = new Map()
   for (let i = 0; i < ctxs.length; i++) {
-    ctxs[i].mapUnsafe.forEach((value, key) => {
+    flatten(ctxs[i] as ContextImpl<any>).forEach((value, key) => {
       map.set(key, value)
     })
   }
-  return makeUnsafe(map)
+  return fromMap(map)
 }
 
 /**
@@ -1189,14 +1317,14 @@ export const mergeAll = <T extends Array<unknown>>(
 export const pick = <S extends ReadonlyArray<Key<any, any>>>(
   ...services: S
 ) =>
-<Services>(self: Context<Services>): Context<Services & Service.Identifier<S[number]>> =>
-  withMapUnsafe(self, (map) => {
-    const keySet = new Set(services.map((key) => key.key))
-    map.forEach((_, key) => {
-      if (keySet.has(key)) return
-      map.delete(key)
-    })
+<Services>(self: Context<Services>): Context<Services & Service.Identifier<S[number]>> => {
+  const keep = new Set(services.map((key) => key.key))
+  const map = new Map<string, any>()
+  flatten(self as ContextImpl<Services>).forEach((value, key) => {
+    if (keep.has(key)) map.set(key, value)
   })
+  return fromMap(map)
+}
 
 /**
  * Returns a new `Context` with the specified service keys removed.
@@ -1232,12 +1360,14 @@ export const pick = <S extends ReadonlyArray<Key<any, any>>>(
 export const omit = <S extends ReadonlyArray<Key<any, any>>>(
   ...keys: S
 ) =>
-<Services>(self: Context<Services>): Context<Exclude<Services, Service.Identifier<S[number]>>> =>
-  withMapUnsafe(self, (map) => {
-    for (let i = 0; i < keys.length; i++) {
-      map.delete(keys[i].key)
-    }
+<Services>(self: Context<Services>): Context<Exclude<Services, Service.Identifier<S[number]>>> => {
+  const drop = new Set(keys.map((key) => key.key))
+  const map = new Map<string, any>()
+  flatten(self as ContextImpl<Services>).forEach((value, key) => {
+    if (!drop.has(key)) map.set(key, value)
   })
+  return fromMap(map)
+}
 
 /**
  * Performs a series of mutations on a `Context`. Prevents unnecessary copying
@@ -1265,23 +1395,17 @@ export const mutate: {
 } = dual(
   2,
   <Services, B>(self: Context<Services>, f: (context: Context<Services>) => Context<B>): Context<B> => {
-    const next = makeUnsafe<Services>(new Map(self.mapUnsafe))
+    const next = fromMap<Services>(new Map(flatten(self as ContextImpl<Services>)))
     next.mutable = true
-    const result = f(next)
-    result.mutable = false
-    return result
+    let result: Context<B> | undefined
+    try {
+      return result = f(next)
+    } finally {
+      next.mutable = false
+      if (result !== undefined) result.mutable = false
+    }
   }
 )
-
-const withMapUnsafe = <Services, B>(self: Context<Services>, f: (map: Map<string, any>) => void): Context<B> => {
-  if (self.mutable) {
-    f(self.mapUnsafe as any)
-    return self as any
-  }
-  const map = new Map(self.mapUnsafe)
-  f(map)
-  return makeUnsafe(map)
-}
 
 /**
  * Creates a context key with a default value.

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -182,10 +182,10 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
- * Pass `slot: true` to allocate a dense slab slot for the key, making reads
+ * Pass `allocateSlot: true` to allocate a dense slab slot for the key, making reads
  * O(1). Reserve this for services that are added and read on hot paths;
  * every slotted key grows the array that slotted `Context.add`s copy.
- * `Reference` keys always get a slot.
+ * The option is also available on `Reference` keys.
  *
  * **Gotchas**
  *
@@ -226,7 +226,7 @@ export const Service: {
   <Identifier, Shape = Identifier>(
     key: string,
     options?: {
-      readonly slot?: boolean | undefined
+      readonly allocateSlot?: boolean | undefined
     } | undefined
   ): Service<Identifier, Shape>
   <Self, Shape>(): <
@@ -238,7 +238,7 @@ export const Service: {
     id: Identifier,
     options?: {
       readonly make?: ((...args: Args) => Effect<Shape, E, R>) | Effect<Shape, E, R> | undefined
-      readonly slot?: boolean | undefined
+      readonly allocateSlot?: boolean | undefined
     } | undefined
   ) =>
     & ServiceClass<Self, Identifier, Shape>
@@ -251,7 +251,7 @@ export const Service: {
     id: Identifier,
     options: {
       readonly make: Make
-      readonly slot?: boolean | undefined
+      readonly allocateSlot?: boolean | undefined
     }
   ) =>
     & ServiceClass<
@@ -282,20 +282,20 @@ export const Service: {
       self[ReferenceTypeId] = ReferenceTypeId
       self.defaultValue = arguments[1].defaultValue
     }
-    if (arguments[1]?.defaultValue || arguments[1]?.slot) {
+    if (arguments[1]?.allocateSlot) {
       allocateSlot(self)
     }
     return self
   }
   return function(key: string, options?: {
     readonly make?: any
-    readonly slot?: boolean
+    readonly allocateSlot?: boolean
   }) {
     self.key = key
     if (options?.make) {
       ;(self as any).make = options.make
     }
-    if (options?.slot) {
+    if (options?.allocateSlot) {
       allocateSlot(self)
     }
     return self
@@ -1509,5 +1509,8 @@ export const mutate: {
  */
 export const Reference: <Service>(
   key: string,
-  options: { readonly defaultValue: () => Service }
+  options: {
+    readonly defaultValue: () => Service
+    readonly allocateSlot?: boolean | undefined
+  }
 ) => Reference<Service> = Service as any

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -70,19 +70,13 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
   readonly stack?: string | undefined
 }
 
-const SlotId = Symbol.for("effect/Context/Slot")
-const Unset = Symbol()
-const slotByKey = new Map<string, number>()
+const SlabKeyId = Symbol.for("effect/Context/SlabKey")
+const slabKeys = new Set<string>()
 
-const allocateSlot = (key: Key<any, any>): void => {
-  if (!slotByKey.has(key.key)) slotByKey.set(key.key, slotByKey.size)
-  ;(key as any)[SlotId] = slotByKey.get(key.key)
+const addSlabKey = (key: Key<any, any>): void => {
+  ;(key as any)[SlabKeyId] = true
+  slabKeys.add(key.key)
 }
-
-// Writes must consult the registry as well: a slotted key string can be written
-// through a second key object that never allocated the slot itself, and the
-// slab copy has to happen regardless of which object performs the add
-const slotOf = (key: Key<any, any>): number | undefined => (key as any)[SlotId] ?? slotByKey.get(key.key)
 
 /**
  * Context key with helper methods for working with a service.
@@ -179,10 +173,10 @@ export declare namespace ServiceClass {
  * declarations. The returned key can be yielded as an Effect and passed to
  * `Context.make`, `Context.add`, and the Context getter functions.
  *
- * Pass `allocateSlot: true` to allocate a dense slab slot for the key, making reads
- * O(1). Reserve this for services that are added and read on hot paths;
- * every slotted key grows the array that slotted `Context.add`s copy.
- * The option is also available on `Reference` keys.
+ * Pass `allocateSlot: true` to store the key in the slab, making reads O(1).
+ * Reserve this for services that are added and read on hot paths; every slab
+ * key grows the small Map that a slotted `Context.add` copies. `Reference`
+ * keys are stored in the slab automatically.
  *
  * **Gotchas**
  *
@@ -279,8 +273,8 @@ export const Service: {
       self[ReferenceTypeId] = ReferenceTypeId
       self.defaultValue = arguments[1].defaultValue
     }
-    if (arguments[1]?.allocateSlot) {
-      allocateSlot(self)
+    if (arguments[1]?.defaultValue || arguments[1]?.allocateSlot) {
+      addSlabKey(self)
     }
     return self
   }
@@ -293,7 +287,7 @@ export const Service: {
       ;(self as any).make = options.make
     }
     if (options?.allocateSlot) {
-      allocateSlot(self)
+      addSlabKey(self)
     }
     return self
   }
@@ -505,7 +499,7 @@ export interface Context<in Services> extends Equal.Equal, Pipeable, Inspectable
 }
 
 interface ContextImpl<in Services> extends Context<Services> {
-  slab: ReadonlyArray<unknown>
+  slab: ReadonlyMap<string, unknown>
   base: ReadonlyMap<string, any>
   overlay: Overlay | undefined
   depth: number
@@ -521,7 +515,7 @@ interface Overlay {
 const MaxDepth = 8
 
 const makeImpl = <Services>(
-  slab: ReadonlyArray<unknown>,
+  slab: ReadonlyMap<string, unknown>,
   base: ReadonlyMap<string, any>,
   overlay: Overlay | undefined,
   depth: number,
@@ -537,15 +531,10 @@ const makeImpl = <Services>(
   return self
 }
 
-const slabSet = (slab: Array<unknown>, slot: number, value: unknown): void => {
-  while (slab.length <= slot) slab.push(Unset)
-  slab[slot] = value
-}
-
 const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
-  const slab: Array<unknown> = []
-  slotByKey.forEach((slot, key) => {
-    if (map.has(key)) slabSet(slab, slot, map.get(key))
+  const slab = new Map<string, unknown>()
+  map.forEach((value, key) => {
+    if (slabKeys.has(key)) slab.set(key, value)
   })
   return makeImpl(slab, map, undefined, 0, map)
 }
@@ -582,25 +571,31 @@ const withFlat = <B>(self: ContextImpl<any>, f: (map: Map<string, any>) => void)
 
 const lookup = (self: ContextImpl<any>, key: string): unknown => {
   if (self.base === undefined) {
-    return self.mapUnsafe.has(key) ? self.mapUnsafe.get(key) : Unset
+    return self.mapUnsafe.get(key)
   }
   for (let overlay = self.overlay; overlay !== undefined; overlay = overlay.parent) {
     if (overlay.key === key) return overlay.value
   }
-  const value = self.base.get(key)
-  return value === undefined && !self.base.has(key) ? Unset : value
+  return self.base.get(key)
 }
 
-// The slab is a cache: every slotted value is also present in overlay/base, so
-// reads can use the key's own slot without consulting the registry
+// The slab is a cache: every slotted value is also present in overlay/base
 const lookupKey = (self: Context<any>, key: Key<any, any>): unknown => {
   const impl = self as ContextImpl<any>
-  const slot = (key as any)[SlotId]
-  if (slot !== undefined && slot < impl.slab.length) {
-    const value = impl.slab[slot]
-    if (value !== Unset) return value
+  if ((key as any)[SlabKeyId] === true && impl.slab !== undefined) {
+    const value = impl.slab.get(key.key)
+    if (value !== undefined) return value
   }
   return lookup(impl, key.key)
+}
+
+const hasKey = (self: Context<any>, key: string): boolean => {
+  const impl = self as ContextImpl<any>
+  if (impl.base === undefined) return impl.mapUnsafe.has(key)
+  for (let overlay = impl.overlay; overlay !== undefined; overlay = overlay.parent) {
+    if (overlay.key === key) return true
+  }
+  return impl.base.has(key)
 }
 
 /**
@@ -684,14 +679,9 @@ export const unsafeHasSameSlab = <Services, Services2>(
 /** @internal */
 export const unsafeGetByKey = <A, Services = never>(self: Context<Services>, key: string): A | undefined => {
   const impl = self as ContextImpl<Services>
-  const slot = slotByKey.get(key)
-  let value: unknown
-  if (slot !== undefined && slot < impl.slab.length && impl.slab[slot] !== Unset) {
-    value = impl.slab[slot]
-  } else {
-    value = lookup(impl, key)
-  }
-  return value === Unset ? undefined : value as A
+  const value = impl.slab?.get(key)
+  if (value !== undefined) return value as A
+  return lookup(impl, key) as A | undefined
 }
 
 /**
@@ -859,10 +849,9 @@ export const add: {
   }
 
   let slab = impl.slab
-  const slot = slotOf(key)
-  if (slot !== undefined) {
-    slab = impl.slab.slice()
-    slabSet(slab as Array<unknown>, slot, service)
+  if (slabKeys.has(key.key)) {
+    slab = new Map(impl.slab)
+    ;(slab as Map<string, unknown>).set(key.key, service)
   }
 
   return makeImpl(
@@ -979,7 +968,7 @@ export const getOrElse: {
   <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B
 } = dual(3, <Services, S, I, B>(self: Context<Services>, key: Key<I, S>, orElse: LazyArg<B>): S | B => {
   const value = lookupKey(self, key)
-  if (value !== Unset) return value as any
+  if (value !== undefined || hasKey(self, key.key)) return value as any
   return isReference(key) ? getDefaultValue(key) : orElse()
 })
 
@@ -1008,8 +997,7 @@ export const getOrUndefined: {
 } = dual(
   2,
   <Services, S, I>(self: Context<Services>, key: Key<I, S>): S | undefined => {
-    const value = lookupKey(self, key)
-    return value === Unset ? undefined : value as S
+    return lookupKey(self, key) as S | undefined
   }
 )
 
@@ -1055,7 +1043,7 @@ export const getUnsafe: {
   2,
   <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): S => {
     const value = lookupKey(self, service)
-    if (value === Unset) {
+    if (value === undefined && !hasKey(self, service.key)) {
       if (ReferenceTypeId in service) return getDefaultValue(service as any)
       throw serviceNotFoundError(service)
     }
@@ -1143,7 +1131,7 @@ export const get: {
  */
 export const getReferenceUnsafe = <Services, S>(self: Context<Services>, service: Reference<S>): S => {
   const value = lookupKey(self, service)
-  return value === Unset ? getDefaultValue(service as any) : value as S
+  return value === undefined && !hasKey(self, service.key) ? getDefaultValue(service as any) : value as S
 }
 
 const defaultValueCacheKey = "~effect/Context/defaultValue" as const
@@ -1214,7 +1202,7 @@ export const getOption: {
   <Services, S, I>(self: Context<Services>, service: Key<I, S>): Option.Option<S>
 } = dual(2, <Services, I extends Services, S>(self: Context<Services>, service: Key<I, S>): Option.Option<S> => {
   const value = lookupKey(self, service)
-  if (value !== Unset) return Option.some(value as any)
+  if (value !== undefined || hasKey(self, service.key)) return Option.some(value as any)
   return isReference(service) ? Option.some(getDefaultValue(service as any)) : Option.none()
 })
 
@@ -1426,7 +1414,7 @@ export const mutate: {
     // The scratch context gets an empty slab, so every operation on it reads
     // and writes `base` alone; the slab is rebuilt once when sealing
     const map = new Map(flatten(self as ContextImpl<Services>))
-    const scratch = makeImpl<Services>([], map, undefined, 0, map)
+    const scratch = makeImpl<Services>(new Map(), map, undefined, 0, map)
     scratch.mutable = true
     try {
       const result = f(scratch)

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -554,8 +554,12 @@ const fromMap = <Services>(map: Map<string, any>): ContextImpl<Services> => {
   return makeImpl(slab, map, undefined, 0, map.size, map)
 }
 
+// Some cycle-locked modules build Context objects that only carry `mapUnsafe`
+// (Redactable's no-fiber fallback, cause stack annotations in internal/core),
+// so every read path tolerates that shape by checking for a missing `base`
 const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
   if (self._flat !== undefined) return self._flat
+  if (self.base === undefined) return self.mapUnsafe
   if (self.overlay === undefined) return self._flat = self.base
 
   const map = new Map(self.base)
@@ -572,6 +576,9 @@ const flatten = (self: ContextImpl<any>): ReadonlyMap<string, any> => {
 const slabAt = (self: ContextImpl<any>, slot: number): unknown => slot < self.slab.length ? self.slab[slot] : Unset
 
 const lookup = (self: ContextImpl<any>, key: string, slot?: number): unknown => {
+  if (self.base === undefined) {
+    return self.mapUnsafe.has(key) ? self.mapUnsafe.get(key) : Unset
+  }
   if (slot !== undefined) {
     const value = slabAt(self, slot)
     if (value !== Unset) return value
@@ -827,7 +834,8 @@ export const add: {
   key: Key<I, S>,
   service: Types.NoInfer<S>
 ): Context<Services | I> => {
-  const impl = self as ContextImpl<Services>
+  let impl = self as ContextImpl<Services>
+  if (impl.base === undefined) impl = fromMap(new Map(impl.mapUnsafe))
 
   if (impl.mutable) {
     ;(impl.base as Map<string, any>).set(key.key, service)

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3311,7 +3311,7 @@ export interface FiberRuntimeMetricsService {
  */
 export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService | undefined>(
   InternalMetric.FiberRuntimeMetricsKey,
-  { defaultValue: constUndefined }
+  { allocateSlot: true, defaultValue: constUndefined }
 )
 
 /**

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3311,7 +3311,7 @@ export interface FiberRuntimeMetricsService {
  */
 export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService | undefined>(
   InternalMetric.FiberRuntimeMetricsKey,
-  { defaultValue: constUndefined }
+  { enableCaching: true, defaultValue: constUndefined }
 )
 
 /**

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3311,7 +3311,7 @@ export interface FiberRuntimeMetricsService {
  */
 export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService | undefined>(
   InternalMetric.FiberRuntimeMetricsKey,
-  { enableCaching: true, defaultValue: constUndefined }
+  { enableFiberCaching: true, defaultValue: constUndefined }
 )
 
 /**

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3311,7 +3311,7 @@ export interface FiberRuntimeMetricsService {
  */
 export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService | undefined>(
   InternalMetric.FiberRuntimeMetricsKey,
-  { allocateSlot: true, defaultValue: constUndefined }
+  { defaultValue: constUndefined }
 )
 
 /**

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3311,7 +3311,7 @@ export interface FiberRuntimeMetricsService {
  */
 export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService | undefined>(
   InternalMetric.FiberRuntimeMetricsKey,
-  { enableFiberCaching: true, defaultValue: constUndefined }
+  { fiberCached: true, defaultValue: constUndefined }
 )
 
 /**

--- a/packages/effect/src/Redactable.ts
+++ b/packages/effect/src/Redactable.ts
@@ -166,11 +166,8 @@ export const currentFiberTypeId = "~effect/Fiber/currentFiber"
 const emptyMap = new Map()
 const emptyContext: Context.Context<never> = {
   "~effect/Context": {} as any,
-  cache: emptyMap,
   base: emptyMap,
-  overlay: undefined,
   depth: 0,
-  _flat: undefined,
   mapUnsafe: emptyMap,
   pipe() {
     return pipeArguments(this, arguments)

--- a/packages/effect/src/Redactable.ts
+++ b/packages/effect/src/Redactable.ts
@@ -163,9 +163,15 @@ export function getRedacted(redactable: Redactable): unknown {
 /** @internal */
 export const currentFiberTypeId = "~effect/Fiber/currentFiber"
 
+const emptyMap = new Map()
 const emptyContext: Context.Context<never> = {
   "~effect/Context": {} as any,
-  mapUnsafe: new Map(),
+  cache: emptyMap,
+  base: emptyMap,
+  overlay: undefined,
+  depth: 0,
+  _flat: undefined,
+  mapUnsafe: emptyMap,
   pipe() {
     return pipeArguments(this, arguments)
   }

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -76,7 +76,7 @@ export interface SchedulerDispatcher {
  * @since 2.0.0
  */
 export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Scheduler>("effect/Scheduler", {
-  enableFiberCaching: true,
+  fiberCached: true,
   defaultValue: () => new MixedScheduler()
 })
 
@@ -267,7 +267,7 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  * @since 4.0.0
  */
 export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
-  enableFiberCaching: true,
+  fiberCached: true,
   defaultValue: () => 2048
 })
 
@@ -293,6 +293,6 @@ export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/Max
  * @since 4.0.0
  */
 export const PreventSchedulerYield = Context.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {
-  enableFiberCaching: true,
+  fiberCached: true,
   defaultValue: () => false
 })

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -76,6 +76,7 @@ export interface SchedulerDispatcher {
  * @since 2.0.0
  */
 export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Scheduler>("effect/Scheduler", {
+  allocateSlot: true,
   defaultValue: () => new MixedScheduler()
 })
 
@@ -266,6 +267,7 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  * @since 4.0.0
  */
 export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
+  allocateSlot: true,
   defaultValue: () => 2048
 })
 
@@ -291,5 +293,6 @@ export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/Max
  * @since 4.0.0
  */
 export const PreventSchedulerYield = Context.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {
+  allocateSlot: true,
   defaultValue: () => false
 })

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -76,7 +76,6 @@ export interface SchedulerDispatcher {
  * @since 2.0.0
  */
 export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Scheduler>("effect/Scheduler", {
-  allocateSlot: true,
   defaultValue: () => new MixedScheduler()
 })
 
@@ -267,7 +266,6 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  * @since 4.0.0
  */
 export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
-  allocateSlot: true,
   defaultValue: () => 2048
 })
 
@@ -293,6 +291,5 @@ export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/Max
  * @since 4.0.0
  */
 export const PreventSchedulerYield = Context.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {
-  allocateSlot: true,
   defaultValue: () => false
 })

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -76,7 +76,7 @@ export interface SchedulerDispatcher {
  * @since 2.0.0
  */
 export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Scheduler>("effect/Scheduler", {
-  enableCaching: true,
+  enableFiberCaching: true,
   defaultValue: () => new MixedScheduler()
 })
 
@@ -267,7 +267,7 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  * @since 4.0.0
  */
 export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
-  enableCaching: true,
+  enableFiberCaching: true,
   defaultValue: () => 2048
 })
 
@@ -293,6 +293,6 @@ export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/Max
  * @since 4.0.0
  */
 export const PreventSchedulerYield = Context.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {
-  enableCaching: true,
+  enableFiberCaching: true,
   defaultValue: () => false
 })

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -76,6 +76,7 @@ export interface SchedulerDispatcher {
  * @since 2.0.0
  */
 export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Scheduler>("effect/Scheduler", {
+  enableCaching: true,
   defaultValue: () => new MixedScheduler()
 })
 
@@ -266,6 +267,7 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  * @since 4.0.0
  */
 export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
+  enableCaching: true,
   defaultValue: () => 2048
 })
 
@@ -291,5 +293,6 @@ export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/Max
  * @since 4.0.0
  */
 export const PreventSchedulerYield = Context.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {
+  enableCaching: true,
   defaultValue: () => false
 })

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -167,7 +167,7 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @category services
  * @since 2.0.0
  */
-export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { enableCaching: true }) {}
+export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { enableFiberCaching: true }) {}
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span
@@ -629,7 +629,7 @@ export const TracerKey = "effect/Tracer"
  * @since 2.0.0
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {
-  enableCaching: true,
+  enableFiberCaching: true,
   defaultValue: () =>
     make({
       span: (options) => new NativeSpan(options)

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -629,7 +629,6 @@ export const TracerKey = "effect/Tracer"
  * @since 2.0.0
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {
-  allocateSlot: true,
   defaultValue: () =>
     make({
       span: (options) => new NativeSpan(options)

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -168,6 +168,7 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @since 2.0.0
  */
 export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey) {}
+Context.unsafeMakeSlot(ParentSpan)
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -167,7 +167,7 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @category services
  * @since 2.0.0
  */
-export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { slot: true }) {}
+export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { allocateSlot: true }) {}
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span
@@ -629,6 +629,7 @@ export const TracerKey = "effect/Tracer"
  * @since 2.0.0
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {
+  allocateSlot: true,
   defaultValue: () =>
     make({
       span: (options) => new NativeSpan(options)

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -167,7 +167,7 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @category services
  * @since 2.0.0
  */
-export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey) {}
+export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { slot: true }) {}
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -167,7 +167,7 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @category services
  * @since 2.0.0
  */
-export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { allocateSlot: true }) {}
+export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { enableCaching: true }) {}
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span
@@ -629,6 +629,7 @@ export const TracerKey = "effect/Tracer"
  * @since 2.0.0
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {
+  enableCaching: true,
   defaultValue: () =>
     make({
       span: (options) => new NativeSpan(options)

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -167,7 +167,7 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @category services
  * @since 2.0.0
  */
-export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { enableFiberCaching: true }) {}
+export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey, { fiberCached: true }) {}
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span
@@ -629,7 +629,7 @@ export const TracerKey = "effect/Tracer"
  * @since 2.0.0
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {
-  enableFiberCaching: true,
+  fiberCached: true,
   defaultValue: () =>
     make({
       span: (options) => new NativeSpan(options)

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -168,7 +168,6 @@ export const ParentSpanKey = "effect/Tracer/ParentSpan"
  * @since 2.0.0
  */
 export class ParentSpan extends Context.Service<ParentSpan, AnySpan>()(ParentSpanKey) {}
-Context.unsafeMakeSlot(ParentSpan)
 
 /**
  * Represents a span created outside Effect's tracer, carrying trace and span

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -708,9 +708,9 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   setContext(context: Context.Context<never>): void {
     const previous = this.context
     this.context = context
-    // Every key cached below opts in to a slab slot, so a shared slab means
-    // none of them changed
-    if (previous !== undefined && Context.unsafeHasSameSlab(previous, context)) return
+    // Every key cached below opts in to Context caching, so a shared cache
+    // means none of them changed
+    if (previous !== undefined && Context.unsafeHasSameCache(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -710,20 +710,21 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.context = context
     // Every key cached below opts in to Context caching, so contexts related
     // only by non-caching adds cannot have changed any of them
-    if (previous !== undefined && Context.hasSameCache(previous, context)) return
+    if (previous && Context.hasSameCache(previous, context)) return
+    const map = context.mapUnsafe
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
-    this.currentSpan = Context.getOrUndefined(context, Tracer.ParentSpan)
+    this.currentSpan = map.get(Tracer.ParentSpanKey)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = this.getRef(CurrentStackFrame)
     this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
     this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
-    this.runtimeMetrics = Context.getOrUndefinedUnsafe(context, InternalMetric.FiberRuntimeMetricsKey)
-    const currentTracer = Context.getOrUndefined(context, Tracer.Tracer)
+    this.runtimeMetrics = map.get(InternalMetric.FiberRuntimeMetricsKey)
+    const currentTracer = map.get(Tracer.TracerKey)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
   }
   get currentSpanLocal(): Tracer.Span | undefined {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -555,7 +555,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   }
 
   getRef<X>(ref: Context.Reference<X>): X {
-    return Context.getReferenceUnsafe(this.context, ref)
+    return Context.get(this.context, ref)
   }
   addObserver(cb: (exit: Exit.Exit<A, E>) => void): () => void {
     if (this._exit) {
@@ -710,20 +710,20 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.context = context
     // Every key cached below opts in to Context caching, so a shared cache
     // means none of them changed
-    if (previous !== undefined && Context.unsafeHasSameCache(previous, context)) return
+    if (previous !== undefined && Context.hasSameCache(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
-    this.currentSpan = Context.unsafeGetByKey(context, Tracer.ParentSpanKey)
+    this.currentSpan = Context.getOrUndefined(context, Tracer.ParentSpan)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = this.getRef(CurrentStackFrame)
     this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
     this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
-    this.runtimeMetrics = Context.unsafeGetByKey(context, InternalMetric.FiberRuntimeMetricsKey)
-    const currentTracer = Context.unsafeGetByKey<Tracer.Tracer>(context, Tracer.TracerKey)
+    this.runtimeMetrics = Context.getOrUndefinedUnsafe(context, InternalMetric.FiberRuntimeMetricsKey)
+    const currentTracer = Context.getOrUndefined(context, Tracer.Tracer)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
   }
   get currentSpanLocal(): Tracer.Span | undefined {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -708,8 +708,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   setContext(context: Context.Context<never>): void {
     const previous = this.context
     this.context = context
-    // Every key cached below opts in to Context caching, so a shared cache
-    // means none of them changed
+    // Every key cached below opts in to Context caching, so contexts related
+    // only by non-caching adds cannot have changed any of them
     if (previous !== undefined && Context.hasSameCache(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -706,20 +706,22 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     return pipeArguments(this, arguments)
   }
   setContext(context: Context.Context<never>): void {
+    const previous = this.context
     this.context = context
+    if (previous !== undefined && Context.unsafeHasSameSlab(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
-    this.currentSpan = context.mapUnsafe.get(Tracer.ParentSpanKey)
+    this.currentSpan = Context.unsafeGetByKey(context, Tracer.ParentSpanKey)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
-    this.currentStackFrame = context.mapUnsafe.get(CurrentStackFrame.key)
+    this.currentStackFrame = this.getRef(CurrentStackFrame)
     this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
     this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
-    this.runtimeMetrics = context.mapUnsafe.get(InternalMetric.FiberRuntimeMetricsKey)
-    const currentTracer = context.mapUnsafe.get(Tracer.TracerKey)
+    this.runtimeMetrics = Context.unsafeGetByKey(context, InternalMetric.FiberRuntimeMetricsKey)
+    const currentTracer = Context.unsafeGetByKey<Tracer.Tracer>(context, Tracer.TracerKey)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
   }
   get currentSpanLocal(): Tracer.Span | undefined {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -708,9 +708,8 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   setContext(context: Context.Context<never>): void {
     const previous = this.context
     this.context = context
-    // Every key cached below must have a slab slot (References always do;
-    // ParentSpan opts in via `slot: true`), so a shared slab means none of
-    // them changed
+    // Every key cached below opts in to a slab slot, so a shared slab means
+    // none of them changed
     if (previous !== undefined && Context.unsafeHasSameSlab(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -708,15 +708,16 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   setContext(context: Context.Context<never>): void {
     const previous = this.context
     this.context = context
-    // ParentSpan is not a Reference so it has no slab slot; refresh it even
-    // when the slab is unchanged
-    this.currentSpan = Context.unsafeGetByKey(context, Tracer.ParentSpanKey)
+    // Every key cached below must have a slab slot (References always do;
+    // ParentSpan opts in via `slot: true`), so a shared slab means none of
+    // them changed
     if (previous !== undefined && Context.unsafeHasSameSlab(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
+    this.currentSpan = Context.unsafeGetByKey(context, Tracer.ParentSpanKey)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = this.getRef(CurrentStackFrame)

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -716,14 +716,16 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
-    this.currentSpan = Context.getOrUndefined(context, Tracer.ParentSpan)
+    // The string-keyed lookups keep the Tracer key values (and the native
+    // tracer behind Tracer.Tracer's default) out of every bundle
+    this.currentSpan = Context.getOrUndefinedUnsafe(context, Tracer.ParentSpanKey)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = this.getRef(CurrentStackFrame)
     this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
     this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
     this.runtimeMetrics = Context.getOrUndefinedUnsafe(context, InternalMetric.FiberRuntimeMetricsKey)
-    const currentTracer = Context.getOrUndefined(context, Tracer.Tracer)
+    const currentTracer = Context.getOrUndefinedUnsafe<Tracer.Tracer>(context, Tracer.TracerKey)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
   }
   get currentSpanLocal(): Tracer.Span | undefined {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -708,13 +708,15 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   setContext(context: Context.Context<never>): void {
     const previous = this.context
     this.context = context
+    // ParentSpan is not a Reference so it has no slab slot; refresh it even
+    // when the slab is unchanged
+    this.currentSpan = Context.unsafeGetByKey(context, Tracer.ParentSpanKey)
     if (previous !== undefined && Context.unsafeHasSameSlab(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
-    this.currentSpan = Context.unsafeGetByKey(context, Tracer.ParentSpanKey)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = this.getRef(CurrentStackFrame)

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -710,21 +710,20 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.context = context
     // Every key cached below opts in to Context caching, so contexts related
     // only by non-caching adds cannot have changed any of them
-    if (previous && Context.hasSameCache(previous, context)) return
-    const map = context.mapUnsafe
+    if (previous !== undefined && Context.hasSameCache(previous, context)) return
     const scheduler = this.getRef(Scheduler.Scheduler)
     if (scheduler !== this.currentScheduler) {
       this.currentScheduler = scheduler
       this._dispatcher = undefined
     }
-    this.currentSpan = map.get(Tracer.ParentSpanKey)
+    this.currentSpan = Context.getOrUndefined(context, Tracer.ParentSpan)
     this.currentLogLevel = this.getRef(CurrentLogLevel)
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = this.getRef(CurrentStackFrame)
     this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
     this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
-    this.runtimeMetrics = map.get(InternalMetric.FiberRuntimeMetricsKey)
-    const currentTracer = map.get(Tracer.TracerKey)
+    this.runtimeMetrics = Context.getOrUndefinedUnsafe(context, InternalMetric.FiberRuntimeMetricsKey)
+    const currentTracer = Context.getOrUndefined(context, Tracer.Tracer)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined
   }
   get currentSpanLocal(): Tracer.Span | undefined {

--- a/packages/effect/src/internal/references.ts
+++ b/packages/effect/src/internal/references.ts
@@ -14,7 +14,7 @@ export const CurrentErrorReporters = Context.Reference<ReadonlySet<ErrorReporter
 
 /** @internal */
 export const CurrentStackFrame = Context.Reference<StackFrame | undefined>("effect/References/CurrentStackFrame", {
-  enableCaching: true,
+  enableFiberCaching: true,
   defaultValue: constUndefined
 })
 
@@ -48,13 +48,13 @@ export const CurrentLogAnnotations = Context.Reference<ReadonlyRecord<string, un
 /** @internal */
 export const CurrentLogLevel: Context.Reference<Severity> = Context.Reference<Severity>(
   "effect/References/CurrentLogLevel",
-  { enableCaching: true, defaultValue: () => "Info" }
+  { enableFiberCaching: true, defaultValue: () => "Info" }
 )
 
 /** @internal */
 export const MinimumLogLevel = Context.Reference<
   LogLevel
->("effect/References/MinimumLogLevel", { enableCaching: true, defaultValue: () => "Info" })
+>("effect/References/MinimumLogLevel", { enableFiberCaching: true, defaultValue: () => "Info" })
 
 /** @internal */
 export const UnhandledLogLevel: Context.Reference<Severity | undefined> = Context.Reference(

--- a/packages/effect/src/internal/references.ts
+++ b/packages/effect/src/internal/references.ts
@@ -14,7 +14,7 @@ export const CurrentErrorReporters = Context.Reference<ReadonlySet<ErrorReporter
 
 /** @internal */
 export const CurrentStackFrame = Context.Reference<StackFrame | undefined>("effect/References/CurrentStackFrame", {
-  enableFiberCaching: true,
+  fiberCached: true,
   defaultValue: constUndefined
 })
 
@@ -48,13 +48,13 @@ export const CurrentLogAnnotations = Context.Reference<ReadonlyRecord<string, un
 /** @internal */
 export const CurrentLogLevel: Context.Reference<Severity> = Context.Reference<Severity>(
   "effect/References/CurrentLogLevel",
-  { enableFiberCaching: true, defaultValue: () => "Info" }
+  { fiberCached: true, defaultValue: () => "Info" }
 )
 
 /** @internal */
 export const MinimumLogLevel = Context.Reference<
   LogLevel
->("effect/References/MinimumLogLevel", { enableFiberCaching: true, defaultValue: () => "Info" })
+>("effect/References/MinimumLogLevel", { fiberCached: true, defaultValue: () => "Info" })
 
 /** @internal */
 export const UnhandledLogLevel: Context.Reference<Severity | undefined> = Context.Reference(

--- a/packages/effect/src/internal/references.ts
+++ b/packages/effect/src/internal/references.ts
@@ -14,7 +14,6 @@ export const CurrentErrorReporters = Context.Reference<ReadonlySet<ErrorReporter
 
 /** @internal */
 export const CurrentStackFrame = Context.Reference<StackFrame | undefined>("effect/References/CurrentStackFrame", {
-  allocateSlot: true,
   defaultValue: constUndefined
 })
 
@@ -48,13 +47,13 @@ export const CurrentLogAnnotations = Context.Reference<ReadonlyRecord<string, un
 /** @internal */
 export const CurrentLogLevel: Context.Reference<Severity> = Context.Reference<Severity>(
   "effect/References/CurrentLogLevel",
-  { allocateSlot: true, defaultValue: () => "Info" }
+  { defaultValue: () => "Info" }
 )
 
 /** @internal */
 export const MinimumLogLevel = Context.Reference<
   LogLevel
->("effect/References/MinimumLogLevel", { allocateSlot: true, defaultValue: () => "Info" })
+>("effect/References/MinimumLogLevel", { defaultValue: () => "Info" })
 
 /** @internal */
 export const UnhandledLogLevel: Context.Reference<Severity | undefined> = Context.Reference(

--- a/packages/effect/src/internal/references.ts
+++ b/packages/effect/src/internal/references.ts
@@ -14,6 +14,7 @@ export const CurrentErrorReporters = Context.Reference<ReadonlySet<ErrorReporter
 
 /** @internal */
 export const CurrentStackFrame = Context.Reference<StackFrame | undefined>("effect/References/CurrentStackFrame", {
+  enableCaching: true,
   defaultValue: constUndefined
 })
 
@@ -47,13 +48,13 @@ export const CurrentLogAnnotations = Context.Reference<ReadonlyRecord<string, un
 /** @internal */
 export const CurrentLogLevel: Context.Reference<Severity> = Context.Reference<Severity>(
   "effect/References/CurrentLogLevel",
-  { defaultValue: () => "Info" }
+  { enableCaching: true, defaultValue: () => "Info" }
 )
 
 /** @internal */
 export const MinimumLogLevel = Context.Reference<
   LogLevel
->("effect/References/MinimumLogLevel", { defaultValue: () => "Info" })
+>("effect/References/MinimumLogLevel", { enableCaching: true, defaultValue: () => "Info" })
 
 /** @internal */
 export const UnhandledLogLevel: Context.Reference<Severity | undefined> = Context.Reference(

--- a/packages/effect/src/internal/references.ts
+++ b/packages/effect/src/internal/references.ts
@@ -14,6 +14,7 @@ export const CurrentErrorReporters = Context.Reference<ReadonlySet<ErrorReporter
 
 /** @internal */
 export const CurrentStackFrame = Context.Reference<StackFrame | undefined>("effect/References/CurrentStackFrame", {
+  allocateSlot: true,
   defaultValue: constUndefined
 })
 
@@ -47,13 +48,13 @@ export const CurrentLogAnnotations = Context.Reference<ReadonlyRecord<string, un
 /** @internal */
 export const CurrentLogLevel: Context.Reference<Severity> = Context.Reference<Severity>(
   "effect/References/CurrentLogLevel",
-  { defaultValue: () => "Info" }
+  { allocateSlot: true, defaultValue: () => "Info" }
 )
 
 /** @internal */
 export const MinimumLogLevel = Context.Reference<
   LogLevel
->("effect/References/MinimumLogLevel", { defaultValue: () => "Info" })
+>("effect/References/MinimumLogLevel", { allocateSlot: true, defaultValue: () => "Info" })
 
 /** @internal */
 export const UnhandledLogLevel: Context.Reference<Severity | undefined> = Context.Reference(

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -645,12 +645,11 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       shardId: makeShardId(entityId)
     })
     const scope = yield* Effect.scope
-    const handlerContext = Context.mutate(entityEntry.context, (context) =>
-      context.pipe(
-        Context.add(CurrentRunnerAddress, runnerAddress),
-        Context.add(CurrentAddress, address),
-        Context.add(Scope, scope)
-      ))
+    const handlerContext = entityEntry.context.pipe(
+      Context.add(CurrentRunnerAddress, runnerAddress),
+      Context.add(CurrentAddress, address),
+      Context.add(Scope, scope)
+    )
     const handlers = yield* entityEntry.build.pipe(
       Effect.setContext(handlerContext as Context.Context<any>)
     )

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -1436,12 +1436,11 @@ const make = Effect.gen(function*() {
         runnerAddress,
         sharding
       }).pipe(
-        Effect.provideContext(Context.mutate(services, (services) =>
-          services.pipe(
-            Context.add(EntityReaper, reaper),
-            Context.add(Scope.Scope, scope),
-            Context.add(Snowflake.Generator, snowflakeGen)
-          )))
+        Effect.provideContext(services.pipe(
+          Context.add(EntityReaper, reaper),
+          Context.add(Scope.Scope, scope),
+          Context.add(Snowflake.Generator, snowflakeGen)
+        ))
       ) as Effect.Effect<EntityManager.EntityManager>
       const state: EntityManagerState = {
         entity,

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -163,14 +163,13 @@ export const make = Effect.fnUntraced(function*<
       Effect.fnUntraced(function*(scope) {
         let isShuttingDown = false
 
-        const handlerContext = Context.mutate(context, (context) =>
-          context.pipe(
-            Context.add(CurrentAddress, address),
-            Context.add(CurrentRunnerAddress, options.runnerAddress),
-            Context.add(KeepAliveLatch, keepAliveLatch),
-            Context.add(Scope.Scope, scope),
-            Context.add(CurrentLogAnnotations, {})
-          ))
+        const handlerContext = context.pipe(
+          Context.add(CurrentAddress, address),
+          Context.add(CurrentRunnerAddress, options.runnerAddress),
+          Context.add(KeepAliveLatch, keepAliveLatch),
+          Context.add(Scope.Scope, scope),
+          Context.add(CurrentLogAnnotations, {})
+        )
 
         // Initiate the behavior for the entity
         const handlers = yield* (entity.protocol.toHandlers(buildHandlers as any).pipe(

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -190,8 +190,8 @@ export const make = Effect.gen(function*() {
       }),
     asHttpEffect() {
       let handler = Effect.withFiber<HttpServerResponse.HttpServerResponse, unknown>((fiber) => {
-        const contextMap = new Map(fiber.context.mapUnsafe)
-        const request = contextMap.get(HttpServerRequest.HttpServerRequest.key) as HttpServerRequest.HttpServerRequest
+        let context = fiber.context
+        const request = Context.getUnsafe(context, HttpServerRequest.HttpServerRequest)
         let result = router.find(request.method, request.url)
         if (result === undefined && request.method === "HEAD") {
           result = router.find("GET", request.url)
@@ -205,15 +205,19 @@ export const make = Effect.gen(function*() {
         }
         const route = result.handler
         if (Option.isSome(route.prefix)) {
-          contextMap.set(HttpServerRequest.HttpServerRequest.key, sliceRequestUrl(request, route.prefix.value))
+          context = Context.add(
+            context,
+            HttpServerRequest.HttpServerRequest,
+            sliceRequestUrl(request, route.prefix.value)
+          )
         }
-        contextMap.set(HttpServerRequest.ParsedSearchParams.key, result.searchParams)
-        contextMap.set(RouteContext.key, {
+        context = Context.add(context, HttpServerRequest.ParsedSearchParams, result.searchParams)
+        context = Context.add(context, RouteContext, {
           route,
           params: result.params
         })
 
-        const span = contextMap.get(Tracer.ParentSpan.key) as Tracer.Span | undefined
+        const span = Context.getOrUndefined(context, Tracer.ParentSpan) as Tracer.Span | undefined
         if (span && span._tag === "Span") {
           span.attribute("http.route", route.path)
         }
@@ -224,7 +228,7 @@ export const make = Effect.gen(function*() {
               HttpServerResponse.HttpServerResponse,
               unknown
             >,
-          () => Context.makeUnsafe(contextMap)
+          () => context
         )
       })
       if (middleware.size === 0) return handler

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -217,7 +217,7 @@ export const make = Effect.gen(function*() {
           params: result.params
         })
 
-        const span = Context.getOrUndefined(context, Tracer.ParentSpan) as Tracer.Span | undefined
+        const span = Context.getOrUndefined(context, Tracer.ParentSpan)
         if (span && span._tag === "Span") {
           span.attribute("http.route", route.path)
         }

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -254,11 +254,10 @@ export const makeWithTransaction = <I, S>(options: {
                 Effect.flatMap(() =>
                   Effect.provideContext(
                     restore(effect),
-                    Context.mutate(services, (services) =>
-                      services.pipe(
-                        Context.add(options.transactionService, [conn, id]),
-                        Context.add(Tracer.ParentSpan, span)
-                      ))
+                    services.pipe(
+                      Context.add(options.transactionService, [conn, id]),
+                      Context.add(Tracer.ParentSpan, span)
+                    )
                   )
                 ),
                 Effect.exit,

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,6 +1,7 @@
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
 import * as Context from "effect/Context"
 import * as Equal from "effect/Equal"
+import * as Option from "effect/Option"
 import { describe, it } from "vitest"
 
 describe("Context", () => {
@@ -120,6 +121,18 @@ describe("Context", () => {
       })
     )
     assertFalse(thrownInput!.mutable)
+  })
+
+  it("applies merge and removal operations in a mutation", () => {
+    const source = Context.make(A, 1).pipe(Context.add(B, 2))
+    const result = Context.mutate(source, (mutable) => {
+      Context.addOrOmit(mutable, B, Option.none())
+      return Context.merge(mutable, Context.make(C, 3))
+    })
+
+    deepStrictEqual([...source.mapUnsafe], [[A.key, 1], [B.key, 2]])
+    deepStrictEqual([...result.mapUnsafe], [[A.key, 1], [C.key, 3]])
+    assertFalse(result.mutable)
   })
 
   it("resolves reference defaults lazily and caches them", () => {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -124,6 +124,32 @@ describe("Context", () => {
     assertTrue(Context.hasSameCache(Context.empty(), context))
   })
 
+  it("flattens after repeated base fall-throughs", () => {
+    const context = Context.make(A, 1).pipe(Context.add(B, 2))
+    const impl = context as any
+
+    for (let i = 0; i < 8; i++) {
+      strictEqual(Context.getUnsafe(context, B), 2)
+      assertTrue(Context.getOption(context, C)._tag === "None")
+    }
+    strictEqual(impl.baseFallThroughs, 0)
+    strictEqual(impl._flat, undefined)
+
+    for (let i = 0; i < 7; i++) {
+      strictEqual(Context.getUnsafe(context, A), 1)
+    }
+    strictEqual(impl._flat, undefined)
+
+    strictEqual(Context.getUnsafe(context, A), 1)
+    assertTrue(impl._flat instanceof Map)
+    strictEqual(impl.overlay, undefined)
+    strictEqual(impl.depth, 0)
+
+    const added = Context.add(context, C, 3) as any
+    strictEqual(added._flat, undefined)
+    strictEqual(added.baseFallThroughs, 0)
+  })
+
   it("supports the ReadonlyMap surface through mapUnsafe", () => {
     const context = Context.make(A, 1).pipe(Context.add(B, 2))
     const visited: Array<[string, number]> = []

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -35,6 +35,35 @@ describe("Context", () => {
     ])
   })
 
+  it("supports slot-allocated services", () => {
+    const Slotted = Context.Service<number>("ContextTest/Slotted", { slot: true })
+    class SlottedClass extends Context.Service<SlottedClass, number>()("ContextTest/SlottedClass", { slot: true }) {}
+
+    const source = Context.make(A, 1)
+    const context = source.pipe(
+      Context.add(Slotted, 2),
+      Context.add(SlottedClass, 3)
+    )
+
+    strictEqual(Context.get(context, Slotted), 2)
+    strictEqual(Context.get(context, SlottedClass), 3)
+    assertTrue(Context.getOption(source, Slotted)._tag === "None")
+
+    const replaced = Context.add(context, Slotted, 4)
+    strictEqual(Context.get(replaced, Slotted), 4)
+    strictEqual(Context.get(context, Slotted), 2)
+
+    deepStrictEqual([...replaced.mapUnsafe], [
+      [A.key, 1],
+      [Slotted.key, 4],
+      [SlottedClass.key, 3]
+    ])
+    deepStrictEqual([...Context.omit(Slotted)(replaced).mapUnsafe], [
+      [A.key, 1],
+      [SlottedClass.key, 3]
+    ])
+  })
+
   it("distinguishes an undefined service from an absent service", () => {
     const Undefined = Context.Service<undefined>("ContextTest/Undefined")
     const Missing = Context.Service<undefined>("ContextTest/Missing")

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -41,15 +41,10 @@ describe("Context", () => {
       allocateSlot: true
     }) {}
     const Ref = Context.Reference<number>("ContextTest/Ref", { defaultValue: () => 0 })
-    const SlottedRef = Context.Reference<number>("ContextTest/SlottedRef", {
-      allocateSlot: true,
-      defaultValue: () => 0
-    })
 
     const source = Context.make(A, 1)
     assertTrue(Context.unsafeHasSameSlab(source, Context.add(source, B, 1)))
     assertFalse(Context.unsafeHasSameSlab(source, Context.add(source, Ref, 1)))
-    assertFalse(Context.unsafeHasSameSlab(source, Context.add(source, SlottedRef, 1)))
     const context = source.pipe(
       Context.add(Slotted, 2),
       Context.add(SlottedClass, 3)

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -35,37 +35,42 @@ describe("Context", () => {
     ])
   })
 
-  it("copies the slab only for references and opted-in services", () => {
-    const Slotted = Context.Service<number>("ContextTest/Slotted", { allocateSlot: true })
-    class SlottedClass extends Context.Service<SlottedClass, number>()("ContextTest/SlottedClass", {
-      allocateSlot: true
+  it("copies the cache only for opted-in keys", () => {
+    const Cached = Context.Service<number>("ContextTest/Cached", { enableCaching: true })
+    class CachedClass extends Context.Service<CachedClass, number>()("ContextTest/CachedClass", {
+      enableCaching: true
     }) {}
     const Ref = Context.Reference<number>("ContextTest/Ref", { defaultValue: () => 0 })
+    const CachedRef = Context.Reference<number>("ContextTest/CachedRef", {
+      enableCaching: true,
+      defaultValue: () => 0
+    })
 
     const source = Context.make(A, 1)
-    assertTrue(Context.unsafeHasSameSlab(source, Context.add(source, B, 1)))
-    assertFalse(Context.unsafeHasSameSlab(source, Context.add(source, Ref, 1)))
+    assertTrue(Context.unsafeHasSameCache(source, Context.add(source, B, 1)))
+    assertTrue(Context.unsafeHasSameCache(source, Context.add(source, Ref, 1)))
+    assertFalse(Context.unsafeHasSameCache(source, Context.add(source, CachedRef, 1)))
     const context = source.pipe(
-      Context.add(Slotted, 2),
-      Context.add(SlottedClass, 3)
+      Context.add(Cached, 2),
+      Context.add(CachedClass, 3)
     )
 
-    strictEqual(Context.get(context, Slotted), 2)
-    strictEqual(Context.get(context, SlottedClass), 3)
-    assertTrue(Context.getOption(source, Slotted)._tag === "None")
+    strictEqual(Context.get(context, Cached), 2)
+    strictEqual(Context.get(context, CachedClass), 3)
+    assertTrue(Context.getOption(source, Cached)._tag === "None")
 
-    const replaced = Context.add(context, Slotted, 4)
-    strictEqual(Context.get(replaced, Slotted), 4)
-    strictEqual(Context.get(context, Slotted), 2)
+    const replaced = Context.add(context, Cached, 4)
+    strictEqual(Context.get(replaced, Cached), 4)
+    strictEqual(Context.get(context, Cached), 2)
 
     deepStrictEqual([...replaced.mapUnsafe], [
       [A.key, 1],
-      [Slotted.key, 4],
-      [SlottedClass.key, 3]
+      [Cached.key, 4],
+      [CachedClass.key, 3]
     ])
-    deepStrictEqual([...Context.omit(Slotted)(replaced).mapUnsafe], [
+    deepStrictEqual([...Context.omit(Cached)(replaced).mapUnsafe], [
       [A.key, 1],
-      [SlottedClass.key, 3]
+      [CachedClass.key, 3]
     ])
   })
 

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -37,13 +37,13 @@ describe("Context", () => {
   })
 
   it("invalidates the fiber cache only for opted-in keys", () => {
-    const Cached = Context.Service<number>("ContextTest/Cached", { enableFiberCaching: true })
+    const Cached = Context.Service<number>("ContextTest/Cached", { fiberCached: true })
     class CachedClass extends Context.Service<CachedClass, number>()("ContextTest/CachedClass", {
-      enableFiberCaching: true
+      fiberCached: true
     }) {}
     const Ref = Context.Reference<number>("ContextTest/Ref", { defaultValue: () => 0 })
     const CachedRef = Context.Reference<number>("ContextTest/CachedRef", {
-      enableFiberCaching: true,
+      fiberCached: true,
       defaultValue: () => 0
     })
 
@@ -76,7 +76,7 @@ describe("Context", () => {
   })
 
   it("supports the Redactable fallback context", () => {
-    const Cached = Context.Service<number>("ContextTest/RedactableCached", { enableFiberCaching: true })
+    const Cached = Context.Service<number>("ContextTest/RedactableCached", { fiberCached: true })
     const context = Redactable.getRedacted({
       [Redactable.symbolRedactable](context: Context.Context<never>) {
         return context
@@ -92,11 +92,11 @@ describe("Context", () => {
   })
 
   it("distinguishes an undefined service from an absent service", () => {
-    const Undefined = Context.Service<undefined>("ContextTest/Undefined", { enableFiberCaching: true })
+    const Undefined = Context.Service<undefined>("ContextTest/Undefined", { fiberCached: true })
     const Missing = Context.Service<undefined>("ContextTest/Missing")
     const Ref = Context.Reference<string | undefined>("ContextTest/UndefinedRef", {
       defaultValue: () => "default",
-      enableFiberCaching: true
+      fiberCached: true
     })
     const context = Context.make(Undefined, undefined).pipe(Context.add(Ref, undefined))
 

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,0 +1,150 @@
+import { assertFalse, assertTrue, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
+import * as Context from "effect/Context"
+import * as Equal from "effect/Equal"
+import { describe, it } from "vitest"
+
+describe("Context", () => {
+  const A = Context.Service<number>("ContextTest/A")
+  const B = Context.Service<number>("ContextTest/B")
+  const C = Context.Service<number>("ContextTest/C")
+
+  it("keeps the source immutable across additions", () => {
+    const source = Context.make(A, 1)
+    const result = Context.add(source, B, 2)
+
+    deepStrictEqual([...source.mapUnsafe], [[A.key, 1]])
+    deepStrictEqual([...result.mapUnsafe], [[A.key, 1], [B.key, 2]])
+  })
+
+  it("preserves Map insertion order for replacements and appends", () => {
+    const Ref = Context.Reference<number>("ContextTest/OrderRef", { defaultValue: () => 0 })
+    const context = Context.empty().pipe(
+      Context.add(A, 1),
+      Context.add(Ref, 2),
+      Context.add(B, 3),
+      Context.add(A, 4),
+      Context.add(C, 5)
+    )
+
+    deepStrictEqual([...context.mapUnsafe], [
+      [A.key, 4],
+      [Ref.key, 2],
+      [B.key, 3],
+      [C.key, 5]
+    ])
+  })
+
+  it("distinguishes an undefined service from an absent service", () => {
+    const Undefined = Context.Service<undefined>("ContextTest/Undefined")
+    const Missing = Context.Service<undefined>("ContextTest/Missing")
+    const context = Context.make(Undefined, undefined)
+
+    assertTrue(Context.getOption(context, Undefined)._tag === "Some")
+    assertTrue(Context.getOption(context, Missing)._tag === "None")
+    strictEqual(Context.getUnsafe(context, Undefined), undefined)
+  })
+
+  it("bounds deep overlay chains without changing values or order", () => {
+    const keys = Array.from({ length: 20 }, (_, i) => Context.Service<number>(`ContextTest/Deep${i}`))
+    let context = Context.empty()
+    for (let i = 0; i < keys.length; i++) {
+      context = Context.add(context, keys[i], i)
+    }
+
+    strictEqual(context.mapUnsafe.size, 20)
+    deepStrictEqual([...context.mapUnsafe.keys()], keys.map((key) => key.key))
+    for (let i = 0; i < keys.length; i++) {
+      strictEqual(Context.getUnsafe(context, keys[i]), i)
+    }
+  })
+
+  it("supports the ReadonlyMap surface through mapUnsafe", () => {
+    const context = Context.make(A, 1).pipe(Context.add(B, 2))
+    const visited: Array<[string, number]> = []
+    context.mapUnsafe.forEach((value, key) => visited.push([key, value]))
+
+    strictEqual(context.mapUnsafe.size, 2)
+    assertTrue(context.mapUnsafe.has(A.key))
+    strictEqual(context.mapUnsafe.get(B.key), 2)
+    deepStrictEqual([...context.mapUnsafe.keys()], [A.key, B.key])
+    deepStrictEqual([...context.mapUnsafe.values()], [1, 2])
+    deepStrictEqual([...context.mapUnsafe.entries()], [[A.key, 1], [B.key, 2]])
+    deepStrictEqual(visited, [[A.key, 1], [B.key, 2]])
+  })
+
+  it("supports equality and JSON materialization", () => {
+    const left = Context.make(A, 1).pipe(Context.add(B, 2))
+    const right = Context.makeUnsafe(new Map([[A.key, 1], [B.key, 2]]))
+
+    assertTrue(Equal.equals(left, right))
+    assertFalse(Equal.equals(left, Context.make(A, 2)))
+    deepStrictEqual(left.toJSON(), {
+      _id: "Context",
+      services: [{ key: A.key, value: 1 }, { key: B.key, value: 2 }]
+    })
+  })
+
+  it("merges with right bias and preserves empty operand identity", () => {
+    const left = Context.make(A, 1).pipe(Context.add(B, 2))
+    const right = Context.make(A, 3).pipe(Context.add(C, 4))
+    const merged = Context.merge(left, right)
+
+    strictEqual(Context.merge(Context.empty(), left), left)
+    strictEqual(Context.merge(left, Context.empty()), left)
+    deepStrictEqual([...merged.mapUnsafe], [[A.key, 3], [B.key, 2], [C.key, 4]])
+  })
+
+  it("pick and omit retain source ordering", () => {
+    const source = Context.make(A, 1).pipe(Context.add(B, 2), Context.add(C, 3))
+
+    deepStrictEqual([...Context.pick(C, A)(source).mapUnsafe], [[A.key, 1], [C.key, 3]])
+    deepStrictEqual([...Context.omit(B)(source).mapUnsafe], [[A.key, 1], [C.key, 3]])
+  })
+
+  it("reseals mutable contexts after return and throw", () => {
+    let returnedInput: Context.Context<any> | undefined
+    const result = Context.mutate(Context.make(A, 1), (mutable) => {
+      returnedInput = mutable
+      return Context.add(mutable, B, 2)
+    })
+
+    assertFalse(result.mutable)
+    assertFalse(returnedInput!.mutable)
+
+    let thrownInput: Context.Context<any> | undefined
+    throws(() =>
+      Context.mutate(Context.make(A, 1), (mutable) => {
+        thrownInput = mutable
+        Context.add(mutable, B, 2)
+        throw new Error("boom")
+      })
+    )
+    assertFalse(thrownInput!.mutable)
+  })
+
+  it("resolves reference defaults lazily and caches them", () => {
+    let calls = 0
+    const Ref = Context.Reference<object>("ContextTest/LazyRef", {
+      defaultValue: () => {
+        calls++
+        return {}
+      }
+    })
+    const context = Context.empty()
+
+    strictEqual(calls, 0)
+    const first = Context.getReferenceUnsafe(context, Ref)
+    strictEqual(calls, 1)
+    strictEqual(Context.getReferenceUnsafe(context, Ref), first)
+    strictEqual(calls, 1)
+  })
+
+  it("does not observe later mutation of makeUnsafe input", () => {
+    const map = new Map([[A.key, 1]])
+    const context = Context.makeUnsafe(map)
+    map.set(A.key, 2)
+    map.set(B.key, 3)
+
+    deepStrictEqual([...context.mapUnsafe], [[A.key, 1]])
+  })
+})

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -120,6 +120,8 @@ describe("Context", () => {
     for (let i = 0; i < keys.length; i++) {
       strictEqual(Context.getUnsafe(context, keys[i]), i)
     }
+    // Rebasing on ordinary keys must not invalidate fiber caches
+    assertTrue(Context.hasSameCache(Context.empty(), context))
   })
 
   it("supports the ReadonlyMap surface through mapUnsafe", () => {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,9 +1,9 @@
+import { assert, describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Context from "effect/Context"
 import * as Equal from "effect/Equal"
 import * as Option from "effect/Option"
 import * as Redactable from "effect/Redactable"
-import { describe, it } from "vitest"
 
 describe("Context", () => {
   const A = Context.Service<number>("ContextTest/A")
@@ -141,6 +141,51 @@ describe("Context", () => {
     const added = Context.add(context, C, 3) as any
     strictEqual(added._flat, undefined)
     strictEqual(added.baseHits, 0)
+  })
+
+  it("keeps request-style default misses independent of context size", () => {
+    const Request = Context.Service<number>("ContextTest/Scaling/Request")
+    const defaults = Array.from(
+      { length: 8 },
+      (_, i) => Context.Reference<number>(`ContextTest/Scaling/Default${i}`, { defaultValue: () => i })
+    )
+    const makeBase = (size: number) =>
+      Context.makeUnsafe(new Map(Array.from({ length: size }, (_, i) => [`ContextTest/Scaling/Base${i}`, i])))
+    const small = makeBase(16)
+    const large = makeBase(200)
+    const iterations = 50_000
+
+    const measure = (base: Context.Context<never>, count: number) => {
+      let checksum = 0
+      const start = performance.now()
+      for (let i = 0; i < count; i++) {
+        const child = Context.add(base, Request, i)
+        for (let j = 0; j < defaults.length; j++) {
+          checksum += Context.get(child, defaults[j])
+        }
+      }
+      const elapsed = performance.now() - start
+      strictEqual(checksum, count * 28)
+      return elapsed
+    }
+    const median = (samples: Array<number>) => samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]
+
+    measure(small, 5_000)
+    measure(large, 5_000)
+    const smallSamples: Array<number> = []
+    const largeSamples: Array<number> = []
+    for (let i = 0; i < 5; i++) {
+      if (i % 2 === 0) {
+        smallSamples.push(measure(small, iterations))
+        largeSamples.push(measure(large, iterations))
+      } else {
+        largeSamples.push(measure(large, iterations))
+        smallSamples.push(measure(small, iterations))
+      }
+    }
+
+    const ratio = median(largeSamples) / median(smallSamples)
+    assert.isBelow(ratio, 2, `200-service request cost was ${ratio.toFixed(2)}x the 16-service cost`)
   })
 
   it("supports the ReadonlyMap surface through mapUnsafe", () => {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -35,11 +35,20 @@ describe("Context", () => {
     ])
   })
 
-  it("supports slot-allocated services", () => {
-    const Slotted = Context.Service<number>("ContextTest/Slotted", { slot: true })
-    class SlottedClass extends Context.Service<SlottedClass, number>()("ContextTest/SlottedClass", { slot: true }) {}
+  it("allocates slab slots only when requested", () => {
+    const Slotted = Context.Service<number>("ContextTest/Slotted", { allocateSlot: true })
+    class SlottedClass extends Context.Service<SlottedClass, number>()("ContextTest/SlottedClass", {
+      allocateSlot: true
+    }) {}
+    const Ref = Context.Reference<number>("ContextTest/Ref", { defaultValue: () => 0 })
+    const SlottedRef = Context.Reference<number>("ContextTest/SlottedRef", {
+      allocateSlot: true,
+      defaultValue: () => 0
+    })
 
     const source = Context.make(A, 1)
+    assertTrue(Context.unsafeHasSameSlab(source, Context.add(source, Ref, 1)))
+    assertFalse(Context.unsafeHasSameSlab(source, Context.add(source, SlottedRef, 1)))
     const context = source.pipe(
       Context.add(Slotted, 2),
       Context.add(SlottedClass, 3)

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -36,7 +36,7 @@ describe("Context", () => {
     ])
   })
 
-  it("copies the cache only for opted-in keys", () => {
+  it("invalidates the fiber cache only for opted-in keys", () => {
     const Cached = Context.Service<number>("ContextTest/Cached", { enableCaching: true })
     class CachedClass extends Context.Service<CachedClass, number>()("ContextTest/CachedClass", {
       enableCaching: true

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -128,13 +128,6 @@ describe("Context", () => {
     const context = Context.make(A, 1).pipe(Context.add(B, 2))
     const impl = context as any
 
-    for (let i = 0; i < 8; i++) {
-      strictEqual(Context.getUnsafe(context, B), 2)
-      assertTrue(Context.getOption(context, C)._tag === "None")
-    }
-    strictEqual(impl.baseFallThroughs, 0)
-    strictEqual(impl._flat, undefined)
-
     for (let i = 0; i < 7; i++) {
       strictEqual(Context.getUnsafe(context, A), 1)
     }
@@ -147,7 +140,7 @@ describe("Context", () => {
 
     const added = Context.add(context, C, 3) as any
     strictEqual(added._flat, undefined)
-    strictEqual(added.baseFallThroughs, 0)
+    strictEqual(added.baseHits, 0)
   })
 
   it("supports the ReadonlyMap surface through mapUnsafe", () => {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -64,6 +64,22 @@ describe("Context", () => {
     ])
   })
 
+  it("reads legacy contexts that only carry mapUnsafe", () => {
+    // Redactable and cause annotations build these in cycle-locked modules
+    const legacy = { mapUnsafe: new Map([[A.key, 1]]) } as any
+    const Ref = Context.Reference<number>("ContextTest/LegacyRef", { defaultValue: () => 7 })
+
+    strictEqual(Context.getOrUndefined(legacy, A), 1)
+    strictEqual(Context.getOrUndefined(legacy, B), undefined)
+    strictEqual(Context.getReferenceUnsafe(legacy, Ref), 7)
+
+    const added = Context.add(legacy, B, 2) as Context.Context<any>
+    strictEqual(Context.getOrUndefined(added, A), 1)
+    strictEqual(Context.getOrUndefined(added, B), 2)
+
+    deepStrictEqual([...Context.merge(Context.make(C, 3), legacy).mapUnsafe], [[C.key, 3], [A.key, 1]])
+  })
+
   it("distinguishes an undefined service from an absent service", () => {
     const Undefined = Context.Service<undefined>("ContextTest/Undefined")
     const Missing = Context.Service<undefined>("ContextTest/Missing")

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -207,12 +207,10 @@ describe("Context", () => {
     strictEqual(calls, 1)
   })
 
-  it("does not observe later mutation of makeUnsafe input", () => {
+  it("retains the makeUnsafe input map", () => {
     const map = new Map([[A.key, 1]])
     const context = Context.makeUnsafe(map)
-    map.set(A.key, 2)
-    map.set(B.key, 3)
 
-    deepStrictEqual([...context.mapUnsafe], [[A.key, 1]])
+    strictEqual(context.mapUnsafe, map)
   })
 })

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -35,7 +35,7 @@ describe("Context", () => {
     ])
   })
 
-  it("allocates slab slots only when requested", () => {
+  it("copies the slab only for references and opted-in services", () => {
     const Slotted = Context.Service<number>("ContextTest/Slotted", { allocateSlot: true })
     class SlottedClass extends Context.Service<SlottedClass, number>()("ContextTest/SlottedClass", {
       allocateSlot: true
@@ -47,7 +47,8 @@ describe("Context", () => {
     })
 
     const source = Context.make(A, 1)
-    assertTrue(Context.unsafeHasSameSlab(source, Context.add(source, Ref, 1)))
+    assertTrue(Context.unsafeHasSameSlab(source, Context.add(source, B, 1)))
+    assertFalse(Context.unsafeHasSameSlab(source, Context.add(source, Ref, 1)))
     assertFalse(Context.unsafeHasSameSlab(source, Context.add(source, SlottedRef, 1)))
     const context = source.pipe(
       Context.add(Slotted, 2),

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,7 +1,8 @@
-import { assertFalse, assertTrue, deepStrictEqual, strictEqual, throws } from "@effect/vitest/utils"
+import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Context from "effect/Context"
 import * as Equal from "effect/Equal"
 import * as Option from "effect/Option"
+import * as Redactable from "effect/Redactable"
 import { describe, it } from "vitest"
 
 describe("Context", () => {
@@ -47,9 +48,9 @@ describe("Context", () => {
     })
 
     const source = Context.make(A, 1)
-    assertTrue(Context.unsafeHasSameCache(source, Context.add(source, B, 1)))
-    assertTrue(Context.unsafeHasSameCache(source, Context.add(source, Ref, 1)))
-    assertFalse(Context.unsafeHasSameCache(source, Context.add(source, CachedRef, 1)))
+    assertTrue(Context.hasSameCache(source, Context.add(source, B, 1)))
+    assertTrue(Context.hasSameCache(source, Context.add(source, Ref, 1)))
+    assertFalse(Context.hasSameCache(source, Context.add(source, CachedRef, 1)))
     const context = source.pipe(
       Context.add(Cached, 2),
       Context.add(CachedClass, 3)
@@ -74,30 +75,37 @@ describe("Context", () => {
     ])
   })
 
-  it("reads legacy contexts that only carry mapUnsafe", () => {
-    // Redactable and cause annotations build these in cycle-locked modules
-    const legacy = { mapUnsafe: new Map([[A.key, 1]]) } as any
-    const Ref = Context.Reference<number>("ContextTest/LegacyRef", { defaultValue: () => 7 })
+  it("supports the Redactable fallback context", () => {
+    const Cached = Context.Service<number>("ContextTest/RedactableCached", { enableCaching: true })
+    const context = Redactable.getRedacted({
+      [Redactable.symbolRedactable](context: Context.Context<never>) {
+        return context
+      }
+    }) as Context.Context<never>
 
-    strictEqual(Context.getOrUndefined(legacy, A), 1)
-    strictEqual(Context.getOrUndefined(legacy, B), undefined)
-    strictEqual(Context.getReferenceUnsafe(legacy, Ref), 7)
+    strictEqual(context.mapUnsafe.size, 0)
+    assertTrue(Context.getOption(context, Cached)._tag === "None")
 
-    const added = Context.add(legacy, B, 2) as Context.Context<any>
-    strictEqual(Context.getOrUndefined(added, A), 1)
-    strictEqual(Context.getOrUndefined(added, B), 2)
-
-    deepStrictEqual([...Context.merge(Context.make(C, 3), legacy).mapUnsafe], [[C.key, 3], [A.key, 1]])
+    const added = Context.add(context, Cached, 1)
+    strictEqual(Context.get(added, Cached), 1)
+    strictEqual(context.mapUnsafe.size, 0)
   })
 
   it("distinguishes an undefined service from an absent service", () => {
-    const Undefined = Context.Service<undefined>("ContextTest/Undefined")
+    const Undefined = Context.Service<undefined>("ContextTest/Undefined", { enableCaching: true })
     const Missing = Context.Service<undefined>("ContextTest/Missing")
-    const context = Context.make(Undefined, undefined)
+    const Ref = Context.Reference<string | undefined>("ContextTest/UndefinedRef", {
+      defaultValue: () => "default",
+      enableCaching: true
+    })
+    const context = Context.make(Undefined, undefined).pipe(Context.add(Ref, undefined))
 
     assertTrue(Context.getOption(context, Undefined)._tag === "Some")
     assertTrue(Context.getOption(context, Missing)._tag === "None")
     strictEqual(Context.getUnsafe(context, Undefined), undefined)
+    strictEqual(Context.getOrElse(context, Undefined, () => 1), undefined)
+    deepStrictEqual(Context.getOption(context, Ref), Option.some(undefined))
+    strictEqual(Context.get(context, Ref), undefined)
   })
 
   it("bounds deep overlay chains without changing values or order", () => {
@@ -157,39 +165,6 @@ describe("Context", () => {
     deepStrictEqual([...Context.omit(B)(source).mapUnsafe], [[A.key, 1], [C.key, 3]])
   })
 
-  it("reseals mutable contexts after return and throw", () => {
-    let returnedInput: Context.Context<any> | undefined
-    const result = Context.mutate(Context.make(A, 1), (mutable) => {
-      returnedInput = mutable
-      return Context.add(mutable, B, 2)
-    })
-
-    assertFalse(result.mutable)
-    assertFalse(returnedInput!.mutable)
-
-    let thrownInput: Context.Context<any> | undefined
-    throws(() =>
-      Context.mutate(Context.make(A, 1), (mutable) => {
-        thrownInput = mutable
-        Context.add(mutable, B, 2)
-        throw new Error("boom")
-      })
-    )
-    assertFalse(thrownInput!.mutable)
-  })
-
-  it("applies merge and removal operations in a mutation", () => {
-    const source = Context.make(A, 1).pipe(Context.add(B, 2))
-    const result = Context.mutate(source, (mutable) => {
-      Context.addOrOmit(mutable, B, Option.none())
-      return Context.merge(mutable, Context.make(C, 3))
-    })
-
-    deepStrictEqual([...source.mapUnsafe], [[A.key, 1], [B.key, 2]])
-    deepStrictEqual([...result.mapUnsafe], [[A.key, 1], [C.key, 3]])
-    assertFalse(result.mutable)
-  })
-
   it("resolves reference defaults lazily and caches them", () => {
     let calls = 0
     const Ref = Context.Reference<object>("ContextTest/LazyRef", {
@@ -201,9 +176,9 @@ describe("Context", () => {
     const context = Context.empty()
 
     strictEqual(calls, 0)
-    const first = Context.getReferenceUnsafe(context, Ref)
+    const first = Context.get(context, Ref)
     strictEqual(calls, 1)
-    strictEqual(Context.getReferenceUnsafe(context, Ref), first)
+    strictEqual(Context.get(context, Ref), first)
     strictEqual(calls, 1)
   })
 

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -1,9 +1,9 @@
-import { assert, describe, it } from "@effect/vitest"
 import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import * as Context from "effect/Context"
 import * as Equal from "effect/Equal"
 import * as Option from "effect/Option"
 import * as Redactable from "effect/Redactable"
+import { describe, it } from "vitest"
 
 describe("Context", () => {
   const A = Context.Service<number>("ContextTest/A")
@@ -141,51 +141,6 @@ describe("Context", () => {
     const added = Context.add(context, C, 3) as any
     strictEqual(added._flat, undefined)
     strictEqual(added.baseHits, 0)
-  })
-
-  it("keeps request-style default misses independent of context size", () => {
-    const Request = Context.Service<number>("ContextTest/Scaling/Request")
-    const defaults = Array.from(
-      { length: 8 },
-      (_, i) => Context.Reference<number>(`ContextTest/Scaling/Default${i}`, { defaultValue: () => i })
-    )
-    const makeBase = (size: number) =>
-      Context.makeUnsafe(new Map(Array.from({ length: size }, (_, i) => [`ContextTest/Scaling/Base${i}`, i])))
-    const small = makeBase(16)
-    const large = makeBase(200)
-    const iterations = 50_000
-
-    const measure = (base: Context.Context<never>, count: number) => {
-      let checksum = 0
-      const start = performance.now()
-      for (let i = 0; i < count; i++) {
-        const child = Context.add(base, Request, i)
-        for (let j = 0; j < defaults.length; j++) {
-          checksum += Context.get(child, defaults[j])
-        }
-      }
-      const elapsed = performance.now() - start
-      strictEqual(checksum, count * 28)
-      return elapsed
-    }
-    const median = (samples: Array<number>) => samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]
-
-    measure(small, 5_000)
-    measure(large, 5_000)
-    const smallSamples: Array<number> = []
-    const largeSamples: Array<number> = []
-    for (let i = 0; i < 5; i++) {
-      if (i % 2 === 0) {
-        smallSamples.push(measure(small, iterations))
-        largeSamples.push(measure(large, iterations))
-      } else {
-        largeSamples.push(measure(large, iterations))
-        smallSamples.push(measure(small, iterations))
-      }
-    }
-
-    const ratio = median(largeSamples) / median(smallSamples)
-    assert.isBelow(ratio, 2, `200-service request cost was ${ratio.toFixed(2)}x the 16-service cost`)
   })
 
   it("supports the ReadonlyMap surface through mapUnsafe", () => {

--- a/packages/effect/test/Context.test.ts
+++ b/packages/effect/test/Context.test.ts
@@ -37,13 +37,13 @@ describe("Context", () => {
   })
 
   it("invalidates the fiber cache only for opted-in keys", () => {
-    const Cached = Context.Service<number>("ContextTest/Cached", { enableCaching: true })
+    const Cached = Context.Service<number>("ContextTest/Cached", { enableFiberCaching: true })
     class CachedClass extends Context.Service<CachedClass, number>()("ContextTest/CachedClass", {
-      enableCaching: true
+      enableFiberCaching: true
     }) {}
     const Ref = Context.Reference<number>("ContextTest/Ref", { defaultValue: () => 0 })
     const CachedRef = Context.Reference<number>("ContextTest/CachedRef", {
-      enableCaching: true,
+      enableFiberCaching: true,
       defaultValue: () => 0
     })
 
@@ -76,7 +76,7 @@ describe("Context", () => {
   })
 
   it("supports the Redactable fallback context", () => {
-    const Cached = Context.Service<number>("ContextTest/RedactableCached", { enableCaching: true })
+    const Cached = Context.Service<number>("ContextTest/RedactableCached", { enableFiberCaching: true })
     const context = Redactable.getRedacted({
       [Redactable.symbolRedactable](context: Context.Context<never>) {
         return context
@@ -92,11 +92,11 @@ describe("Context", () => {
   })
 
   it("distinguishes an undefined service from an absent service", () => {
-    const Undefined = Context.Service<undefined>("ContextTest/Undefined", { enableCaching: true })
+    const Undefined = Context.Service<undefined>("ContextTest/Undefined", { enableFiberCaching: true })
     const Missing = Context.Service<undefined>("ContextTest/Missing")
     const Ref = Context.Reference<string | undefined>("ContextTest/UndefinedRef", {
       defaultValue: () => "default",
-      enableCaching: true
+      enableFiberCaching: true
     })
     const context = Context.make(Undefined, undefined).pipe(Context.add(Ref, undefined))
 

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -1,6 +1,6 @@
-import { describe, test } from "@effect/vitest"
+import { describe, it, test } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Context, Effect, Stream } from "effect"
+import { Context, Effect, References, Scope, Stream } from "effect"
 import * as Layer from "effect/Layer"
 import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import {
@@ -11,6 +11,30 @@ import {
 const TestValue = Context.Reference<number>("test/TestValue", { defaultValue: () => 0 })
 
 describe("HttpEffect", () => {
+  it.effect("restores the request Scope context identity", () => {
+    const request = HttpServerRequest.fromWeb(new Request("http://localhost:3000/"))
+    return Effect.gen(function*() {
+      const before = yield* Effect.withFiber((fiber) => Effect.succeed(fiber.context))
+      let during: Context.Context<never> | undefined
+
+      yield* HttpEffect.toHandled(
+        Effect.withFiber((fiber) => {
+          during = fiber.context
+          strictEqual(Context.getOrUndefined(fiber.context, Scope.Scope) !== undefined, true)
+          return Effect.succeed(HttpServerResponse.empty())
+        }),
+        () => Effect.void
+      )
+
+      const after = yield* Effect.withFiber((fiber) => Effect.succeed(fiber.context))
+      strictEqual(during === before, false)
+      strictEqual(after, before)
+    }).pipe(
+      Effect.provideService(HttpServerRequest.HttpServerRequest, request),
+      Effect.provideService(References.TracerEnabled, false)
+    )
+  })
+
   describe("toWebHandler", () => {
     test("json", async () => {
       const handler = HttpEffect.toWebHandler(HttpServerResponse.json({ foo: "bar" }))

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import * as Cause from "effect/Cause"
+import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Logger from "effect/Logger"
@@ -59,6 +60,26 @@ describe("HttpMiddleware", () => {
   })
 
   describe("tracer", () => {
+    it.effect("restores the ParentSpan context identity", () => {
+      const request = HttpServerRequest.fromWeb(new Request("http://localhost:3000/"))
+      return Effect.gen(function*() {
+        const before = yield* Effect.withFiber((fiber) => Effect.succeed(fiber.context))
+        let during: typeof before | undefined
+
+        yield* HttpMiddleware.tracer(
+          Effect.withFiber((fiber) => {
+            during = fiber.context
+            assert.strictEqual(Context.getOrUndefined(fiber.context, Tracer.ParentSpan) !== undefined, true)
+            return Effect.succeed(HttpServerResponse.empty())
+          })
+        )
+
+        const after = yield* Effect.withFiber((fiber) => Effect.succeed(fiber.context))
+        assert.notStrictEqual(during, before)
+        assert.strictEqual(after, before)
+      }).pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request))
+    })
+
     it.effect("records attributes for sampled spans", () =>
       Effect.gen(function*() {
         let serverSpan: Tracer.NativeSpan | undefined

--- a/packages/opentelemetry/src/OtelTracer.ts
+++ b/packages/opentelemetry/src/OtelTracer.ts
@@ -130,24 +130,20 @@ export const makeExternalSpan = (options: {
   readonly traceFlags?: number | undefined
   readonly traceState?: string | Otel.TraceState | undefined
 }): Tracer.ExternalSpan => {
-  const annotations = Context.mutate(Context.empty(), (annotations) => {
-    let next = annotations
-    if (options.traceFlags !== undefined) {
-      next = Context.add(next, OtelTraceFlags, options.traceFlags)
-    }
+  let annotations = Context.empty()
+  if (options.traceFlags !== undefined) {
+    annotations = Context.add(annotations, OtelTraceFlags, options.traceFlags)
+  }
 
-    if (typeof options.traceState === "string") {
-      try {
-        next = Context.add(next, OtelTraceState, Otel.createTraceState(options.traceState))
-      } catch {
-        //
-      }
-    } else if (options.traceState) {
-      next = Context.add(next, OtelTraceState, options.traceState)
+  if (typeof options.traceState === "string") {
+    try {
+      annotations = Context.add(annotations, OtelTraceState, Otel.createTraceState(options.traceState))
+    } catch {
+      //
     }
-
-    return next
-  })
+  } else if (options.traceState) {
+    annotations = Context.add(annotations, OtelTraceState, options.traceState)
+  }
 
   return {
     _tag: "ExternalSpan",

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -158,12 +158,12 @@ export const make = Effect.fnUntraced(
 
         function handler(request: Request, server: BunServer<WebSocketContext>) {
           return new Promise<Response>((resolve, _reject) => {
-            const map = new Map(services.mapUnsafe)
-            map.set(
-              ServerRequest.HttpServerRequest.key,
+            const context = Context.add(
+              services,
+              ServerRequest.HttpServerRequest,
               new BunServerRequest(request, resolve, removeHost(request.url), server)
             )
-            const fiber = Fiber.runIn(Effect.runForkWith(Context.makeUnsafe<any>(map))(httpEffect), scope)
+            const fiber = Fiber.runIn(Effect.runForkWith(context)(httpEffect), scope)
             request.signal.addEventListener("abort", () => {
               fiber.interruptUnsafe(parent.id, Error.ClientAbort.annotation)
             }, { once: true })

--- a/packages/platform-deno/src/DenoHttpServer.ts
+++ b/packages/platform-deno/src/DenoHttpServer.ts
@@ -125,12 +125,12 @@ export const make = Effect.fnUntraced(function*(
         info: Deno.ServeHandlerInfo<Deno.NetAddr | Deno.UnixAddr>
       ): Promise<Response> {
         return new Promise<Response>((resolve) => {
-          const map = new Map(services.mapUnsafe)
-          map.set(
-            ServerRequest.HttpServerRequest.key,
+          const context = Context.add(
+            services,
+            ServerRequest.HttpServerRequest,
             new DenoServerRequest(request, info.remoteAddr, resolve, removeHost(request.url), websocket)
           )
-          const fiber = Fiber.runIn(Effect.runForkWith(Context.makeUnsafe<any>(map))(httpEffect), scope)
+          const fiber = Fiber.runIn(Effect.runForkWith(context)(httpEffect), scope)
           request.signal.addEventListener("abort", () => {
             fiber.interruptUnsafe(parent.id, Error.ClientAbort.annotation)
           }, { once: true })

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -206,9 +206,8 @@ export const makeHandler = <
       nodeRequest: Http.IncomingMessage,
       nodeResponse: Http.ServerResponse
     ) {
-      const map = new Map(services.mapUnsafe)
-      map.set(HttpServerRequest.key, new ServerRequestImpl(nodeRequest, nodeResponse))
-      const fiber = Fiber.runIn(Effect.runForkWith(Context.makeUnsafe<any>(map))(handled), options.scope)
+      const context = Context.add(services, HttpServerRequest, new ServerRequestImpl(nodeRequest, nodeResponse))
+      const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handled), options.scope)
       nodeResponse.on("close", () => {
         if (!nodeResponse.writableEnded) {
           fiber.interruptUnsafe(parent.id, ClientAbort.annotation)
@@ -273,9 +272,12 @@ export const makeUpgradeHandler = <
             (ws) => Effect.sync(() => ws.close())
           )
       ))
-      const map = new Map(services.mapUnsafe)
-      map.set(HttpServerRequest.key, new ServerRequestImpl(nodeRequest, nodeResponse, upgradeEffect))
-      const fiber = Fiber.runIn(Effect.runForkWith(Context.makeUnsafe<any>(map))(handledApp), options.scope)
+      const context = Context.add(
+        services,
+        HttpServerRequest,
+        new ServerRequestImpl(nodeRequest, nodeResponse, upgradeEffect)
+      )
+      const fiber = Fiber.runIn(Effect.runForkWith(context as Context.Context<any>)(handledApp), options.scope)
       socket.on("close", () => {
         if (!socket.writableEnded) {
           fiber.interruptUnsafe(parent.id, ClientAbort.annotation)

--- a/packages/tools/docgen/src/Parser.ts
+++ b/packages/tools/docgen/src/Parser.ts
@@ -156,8 +156,8 @@ export const parseInterfaces = Effect.flatMap(
   (source) => parseInterfaceDeclarations(source.sourceFile.getInterfaces())
 )
 
-const parseType = (node: ast.Node) => {
-  const text = node.getType().getText(
+const getTypeText = (node: ast.Node) =>
+  node.getType().getText(
     node,
     ast.ts.TypeFormatFlags.NoTruncation
       | ast.ts.TypeFormatFlags.WriteArrayAsGenericType
@@ -166,6 +166,20 @@ const parseType = (node: ast.Node) => {
       | ast.ts.TypeFormatFlags.AllowUniqueESSymbolType
       | ast.ts.TypeFormatFlags.WriteArrowStyleSignature
   )
+
+const parseType = (node: ast.Node) => {
+  let text = getTypeText(node)
+  for (const property of node.getDescendantsOfKind(ast.ts.SyntaxKind.PropertySignature)) {
+    if (!shouldIgnore(parseDoc(getJSDocText(property.getJsDocs())))) continue
+    const readonly = property.getFirstModifierByKind(ast.ts.SyntaxKind.ReadonlyKeyword) ? "readonly " : ""
+    const optional = property.hasQuestionToken() ? "?" : ""
+    const type = property.getTypeNode()?.getText() ?? getTypeText(property)
+    const signature = `${readonly}${property.getName()}${optional}: ${type}`
+    text = text
+      .replaceAll(`; ${signature}`, "")
+      .replaceAll(`${signature}; `, "")
+      .replaceAll(signature, "")
+  }
   return text
 }
 

--- a/packages/tools/docgen/test/Parser.test.ts
+++ b/packages/tools/docgen/test/Parser.test.ts
@@ -212,6 +212,32 @@ Since v1.0.0`
   })
 
   describe("parseFunctions", () => {
+    it.effect("omits internal properties from signatures", () =>
+      Effect.gen(function*() {
+        yield* expectMarkdown(
+          Parser.parseFunctions,
+          `/**
+           * @since 1.0.0
+           */
+          export const myfunc: (options: {
+            readonly visible?: string
+            /** @internal */
+            readonly internal?: boolean
+          }) => void = () => {}`,
+          `## myfunc
+
+**Signature**
+
+\`\`\`ts
+declare const myfunc: (options: { readonly visible?: string; }) => void
+\`\`\`
+
+[Source](https://github.com/effect-ts/docgen/blob/main/src/test.ts#L4)
+
+Since v1.0.0`
+        )
+      }))
+
     it.effect(`should remove all metadata from typedcript code blocks when the theme is ${Configuration.DEFAULT_THEME}`, () =>
       Effect.gen(function*() {
         yield* expectMarkdown(

--- a/packages/vitest/src/utils.ts
+++ b/packages/vitest/src/utils.ts
@@ -59,7 +59,11 @@ export function notDeepStrictEqual<A>(actual: A, expected: A, message?: string, 
  * @since 4.0.0
  */
 export function strictEqual<A>(actual: A, expected: A, message?: string, ..._: Array<never>) {
-  assert.strictEqual(actual, expected, message as string)
+  if (message !== undefined) {
+    assert.strictEqual(actual, expected, message)
+  } else {
+    assert.strictEqual(actual, expected)
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- store ordinary services in bounded copy-on-write overlays so `Context.add` is O(1) on the request path
- adaptively flatten read-heavy layered contexts after eight base hits
- memoize cold-path `mapUnsafe` materialization while preserving map ordering, equality, merging, and filtering behavior
- skip fiber derived-state recomputation when a context change preserves the same cache root
- replace per-request context map clones in the Node, Bun, Deno, and HTTP router paths with immutable `Context.add` operations
- preserve scoped `Scope` and `ParentSpan` restoration semantics with focused coverage

`Context.makeUnsafe` retains its trusted input map without copying; callers must not mutate it after construction.

## HTTP throughput benchmark

Current `main` (`5441c8e65`) versus the benchmarked PR implementation (`4c7152d63`) on Node 26.4.0/arm64. `GET /` used the default tracer, 50 keep-alive connections, 8 pipelined requests, a 3-second warmup, and a 10-second measured interval. Each result is the median of three sequential runs on separate worktrees of the same machine. The request contexts were verified through the harness as 16, 46, and 200 entries respectively.

| Request context | `main` | PR | Change |
|---|---:|---:|---:|
| natural (16 services) | 88,581 rps | 100,055 rps | +13.0% |
| +30 inert services (46 services) | 65,233 rps | 101,934 rps | +56.3% |
| +184 inert services (200 services) | 30,196 rps | 109,621 rps | +263.0% |

The PR retains 101.9% of natural throughput at 46 services and 109.6% at 200 services, preserving the flat scaling curve. The adaptive counter was also inspected directly for all three request-context sizes: it remained zero and no request context flattened, confirming that the heuristic is not reached on this short-lived path. Absolute throughput varied between benchmark windows, but there was no service-count-dependent regression. All measured runs completed without errors or timeouts.

## Context read benchmark

Each value is the mean of two process medians. Each process took ten 10-million-read samples per case after a 1-million-read warmup, with case order reversed in the second process. “Depth” is the number of `Context.add` operations. The before/after columns isolate the adaptive-flattening change (`6a4e47686` to `75081721e`); `4c7152d63` reduces successful defined base reads to one map probe and does not touch the overlay-hit path.

| Read case | Before heuristic | After heuristic | Change |
|---|---:|---:|---:|
| flat base hit | 183.7M ops/s | 179.1M ops/s | -2.5% |
| depth-1 base hit | 153.5M ops/s | 163.3M ops/s | +6.4% |
| depth-1 overlay hit | 198.6M ops/s | 199.5M ops/s | +0.4% |
| depth-8 base hit | 73.3M ops/s | 142.8M ops/s | +94.9% |
| depth-8 oldest-overlay hit | 86.1M ops/s | 83.4M ops/s | -3.2% |
| cached hit | 137.7M ops/s | 137.8M ops/s | +0.1% |

After the eighth base hit, the context memoizes and structurally adopts its flat map, so subsequent reads use the original direct-map path without adding an `_flat` check to every overlay lookup. The depth-8 base hit recovers from 73.3M to 142.8M ops/s, above the earlier `main` result of 132.7M. Flat, overlay, and cached cases remain within process variance. Overlay hits do not advance the counter, and adding to the context creates a fresh layered context with a reset counter.

## Validation

- full Effect suite on the benchmarked implementation: 7,546 passed, 3 skipped
- focused Context and docgen parser suites
- Effect documentation generation and example type-checking
- `pnpm check`
- `pnpm lint-fix`

Closes EFF-274
Closes EFF-277
Closes EFF-278
