### PR TITLE
Expose OpenAI prompt cache request options

### DIFF
--- a/.changeset/openai-response-cache-config.md
+++ b/.changeset/openai-response-cache-config.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Expose Responses API safety identifier and request-level prompt cache options through `OpenAiLanguageModel.Config`.

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -639,7 +639,8 @@ export type TextResponseFormatConfiguration = typeof TextResponseFormatConfigura
  * Validates the Responses API request payload, including input content, model
  * selection, instructions, reasoning options, text output format, tools,
  * `tool_choice`, streaming, storage, response continuation, sampling options,
- * and optional response fields requested through `include`.
+ * safety identification, prompt caching, and optional response fields requested
+ * through `include`.
  *
  * **Gotchas**
  *
@@ -658,6 +659,13 @@ export const CreateResponse = Schema.Struct({
   temperature: Schema.optional(Schema.Finite),
   top_p: Schema.optional(Schema.Finite),
   user: Schema.optional(Schema.String),
+  safety_identifier: Schema.optional(Schema.String.check(Schema.isMaxLength(64))),
+  prompt_cache_key: Schema.optional(Schema.String),
+  prompt_cache_retention: Schema.optional(Schema.Literals(["in_memory", "24h"])),
+  prompt_cache_options: Schema.optional(Schema.Struct({
+    mode: Schema.optional(Schema.Literals(["implicit", "explicit"])),
+    ttl: Schema.optional(Schema.Literal("30m"))
+  })),
   service_tier: Schema.optional(Schema.String),
   previous_response_id: Schema.optional(Schema.String),
   model: Schema.optional(Schema.String),

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -30,6 +30,24 @@ describe("OpenAiLanguageModel", () => {
   })
 
   describe("generateText", () => {
+    it.effect("forwards safety and legacy prompt-cache config", () =>
+      Effect.gen(function*() {
+        yield* LanguageModel.generateText({ prompt: "test" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-5.5", {
+            safety_identifier: "user-hash-123",
+            prompt_cache_key: "reviewer:v1",
+            prompt_cache_retention: "24h"
+          }))
+        )
+
+        const requests = yield* MockHttpClient.requests
+        const body = yield* getRequestBody(requests[0])
+
+        strictEqual(body.safety_identifier, "user-hash-123")
+        strictEqual(body.prompt_cache_key, "reviewer:v1")
+        strictEqual(body.prompt_cache_retention, "24h")
+      }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.5" as any } }))))
+
     describe("message preparation", () => {
       describe("system messages", () => {
         it.effect("uses system role for standard models", () =>
@@ -913,6 +931,36 @@ describe("OpenAiLanguageModel", () => {
   })
 
   describe("streamText", () => {
+    it.effect("forwards safety and GPT-5.6 prompt-cache config", () =>
+      Effect.gen(function*() {
+        const streamEvents = [{
+          type: "response.completed",
+          sequence_number: 1,
+          response: makeDefaultResponse({ model: "gpt-5.6" as any })
+        }] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
+
+        const requests = yield* Effect.gen(function*() {
+          yield* LanguageModel.streamText({ prompt: "test" }).pipe(Stream.runCollect)
+          return yield* MockHttpClient.requests
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-5.6", {
+            safety_identifier: "user-hash-456",
+            prompt_cache_key: "reviewer:v2",
+            prompt_cache_options: {
+              mode: "implicit",
+              ttl: "30m"
+            }
+          })),
+          Effect.provide(makeStreamHttpTestLayer(streamEvents))
+        )
+        const body = yield* getRequestBody(requests[0])
+
+        strictEqual(body.safety_identifier, "user-hash-456")
+        strictEqual(body.prompt_cache_key, "reviewer:v2")
+        deepStrictEqual(body.prompt_cache_options, { mode: "implicit", ttl: "30m" })
+        strictEqual(body.stream, true)
+      }))
+
     it.effect("extracts usage information", () =>
       Effect.gen(function*() {
         const streamEvents = [
@@ -1363,7 +1411,8 @@ describe("OpenAiLanguageModel", () => {
 
 class MockOpenAiResponse extends Context.Service<MockOpenAiResponse, {
   readonly status: number
-  readonly body: Generated.Response
+  readonly body?: Generated.Response | undefined
+  readonly events?: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type> | undefined
   readonly headers?: Record<string, string> | undefined
 }>()("MockOpenAiResponse") {}
 
@@ -1380,7 +1429,7 @@ const encodeResponse = Schema.encodeUnknownEffect(OpenAiSchema.Response)
 const makeHttpClient = Effect.gen(function*() {
   const capturedRequests = yield* Ref.make<ReadonlyArray<HttpClientRequest.HttpClientRequest>>([])
   const response = yield* MockOpenAiResponse
-  const body = yield* Effect.orDie(encodeResponse(response.body))
+  const body = response.body === undefined ? undefined : yield* Effect.orDie(encodeResponse(response.body))
 
   const httpClient = HttpClient.makeWith(
     Effect.fnUntraced(function*(requestEffect) {
@@ -1388,10 +1437,18 @@ const makeHttpClient = Effect.gen(function*() {
       yield* Ref.update(capturedRequests, Array.append(request))
       return HttpClientResponse.fromWeb(
         request,
-        new Response(JSON.stringify(body), {
-          headers: response.headers ?? {},
-          status: response.status
-        })
+        new Response(
+          response.events === undefined
+            ? JSON.stringify(body)
+            : response.events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+          {
+            headers: {
+              "content-type": response.events === undefined ? "application/json" : "text/event-stream",
+              ...response.headers
+            },
+            status: response.status
+          }
+        )
       )
     }),
     Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
@@ -1423,6 +1480,15 @@ const makeStreamTestLayer = (events: ReadonlyArray<typeof Generated.ResponseStre
     })
   )
 }
+
+const makeStreamHttpTestLayer = (events: ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>) =>
+  OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+    Layer.provideMerge(HttpClientLayer),
+    Layer.provide(Layer.succeed(MockOpenAiResponse, {
+      events,
+      status: 200
+    }))
+  )
 
 const makeDefaultResponse = (
   overrides: Partial<Generated.Response> = {}

--- a/packages/ai/openai/test/OpenAiSchema.test.ts
+++ b/packages/ai/openai/test/OpenAiSchema.test.ts
@@ -14,6 +14,25 @@ const makeResponse = (overrides: Record<string, unknown> = {}) => ({
 })
 
 describe("OpenAiSchema", () => {
+  it("validates Responses safety and prompt-cache request options", () => {
+    const decoded = Schema.decodeUnknownSync(OpenAiSchema.CreateResponse)({
+      safety_identifier: "user-hash-123",
+      prompt_cache_key: "reviewer:v1",
+      prompt_cache_retention: "24h",
+      prompt_cache_options: {
+        mode: "explicit",
+        ttl: "30m"
+      }
+    })
+
+    assert.strictEqual(decoded.safety_identifier, "user-hash-123")
+    assert.throws(() =>
+      Schema.decodeUnknownSync(OpenAiSchema.CreateResponse)({
+        safety_identifier: "x".repeat(65)
+      })
+    )
+  })
+
   it("decodes a representative response payload", () => {
     const decoded = Schema.decodeUnknownSync(OpenAiSchema.Response)({
       ...makeResponse(),


### PR DESCRIPTION
## RFC status

**Implementation complete and tested.** This PR is ready for review. It is framed as an RFC because feedback is requested on the public `OpenAiSchema.CreateResponse` / `OpenAiLanguageModel.Config` shape, not because implementation work remains.

## Summary

Expose the following OpenAI Responses API request-level options through `OpenAiLanguageModel.Config`:

- `safety_identifier`
- `prompt_cache_key`
- legacy `prompt_cache_retention` (`in_memory` or `24h`)
- GPT-5.6+ `prompt_cache_options` (`mode` and `ttl`)

The request builder already forwards schema-derived config, so the implementation is deliberately limited to the handwritten request schema, request/schema tests, and a patch changeset. Content-level `prompt_cache_breakpoint` is not included; that remains #6831.

## Design decisions

- Keep request configuration in the handwritten `OpenAiSchema.CreateResponse`, which is the source for the high-level model config and client request type.
- Model `prompt_cache_options.mode` as optional `implicit | explicit` and `ttl` as optional `30m`, matching current GPT-5.6 Responses request semantics and defaults.
- Retain the legacy pre-GPT-5.6 field separately as `prompt_cache_retention: in_memory | 24h`.
- Enforce the documented 64-character maximum for `safety_identifier`.
- Do not add model-name gating. The model type accepts custom strings, so compatibility remains an OpenAI API concern rather than a brittle client-side model registry.
- Leave `@effect/ai-openai-compat` unchanged: it uses a separate Chat Completions-compatible request surface and is not the Responses high-level config reported in this issue.

## Generated vs handwritten schema

The checked-in generated OpenAI request schema already contains `safety_identifier`, `prompt_cache_key`, and `prompt_cache_retention`, but it does not contain the newer `prompt_cache_options`. Current official OpenAI Responses documentation and the official Node SDK do document `prompt_cache_options` for GPT-5.6+.

This PR does not hand-edit `Generated.ts` or add a speculative codegen patch. The generated client is not the source of `OpenAiLanguageModel.Config`; keeping this change in the handwritten Responses schema provides the requested high-level support without creating a broad generated diff. Generated parity can follow when the configured Stainless schema includes the field, or via a maintainer-preferred codegen patch.

## Focused RFC questions

1. Should `prompt_cache_options` remain an inline nested schema, consistent with nearby request options, or be exported as a named public schema?
2. Should these high-level optional config fields also accept explicit `null` to mirror raw OpenAI SDK types, or remain optional non-null values consistent with the existing handwritten config style?
3. Is leaving `Generated.ts` unchanged preferable until the configured upstream schema catches up, or would maintainers prefer a targeted codegen patch now?

## Verification

- `pnpm lint-fix`
- `pnpm test --run packages/ai/openai/test/OpenAiLanguageModel.test.ts packages/ai/openai/test/OpenAiSchema.test.ts` — 61 tests passed
- `pnpm check`
- Independent review loop completed; the final pass reported no actionable findings.

Positive tests verify that all supported fields survive high-level model config and reach real HTTP request bodies:

- non-streamed GPT-5.5 request: safety identifier, cache key, and legacy retention
- streamed GPT-5.6 request: safety identifier, cache key, cache options, and `stream: true`

Schema coverage also verifies the supported option shapes and rejects safety identifiers longer than 64 characters.

## Tradeoffs

- The strict enums intentionally track current documented values; future OpenAI values will require a schema update.
- No client-side model compatibility check is added, avoiding false rejection of custom or newly released model identifiers.
- Generated and handwritten request schemas remain temporarily asymmetric for `prompt_cache_options`; that limitation is explicit rather than hidden by guessing at generated output.

Closes #6830
