### PR TITLE
Add OpenAI prompt cache breakpoints

### DIFF
--- a/.changeset/add-openai-prompt-cache-breakpoints.md
+++ b/.changeset/add-openai-prompt-cache-breakpoints.md
@@ -1,0 +1,6 @@
+---
+"@effect/ai-openai": patch
+"effect": patch
+---
+
+Support explicit OpenAI prompt-cache breakpoints on Responses API input content and correct message constructor provider option types.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -125,6 +125,45 @@ export class Config extends Context.Service<
 
 declare module "effect/unstable/ai/Prompt" {
   /**
+   * OpenAI-specific options for system messages.
+   *
+   * **Details**
+   *
+   * A prompt-cache breakpoint is placed on the system message's input text block.
+   *
+   * @category request
+   * @since 4.0.0
+   */
+  export interface SystemMessageOptions extends ProviderOptions {
+    readonly openai?: {
+      /**
+       * Marks the end of reusable prompt content eligible for caching.
+       */
+      readonly promptCacheBreakpoint?: typeof OpenAiSchema.PromptCacheBreakpoint.Encoded | null
+    } | null
+  }
+
+  /**
+   * OpenAI-specific options for user messages.
+   *
+   * **Details**
+   *
+   * A message-level prompt-cache breakpoint is used as a fallback for the last
+   * content part when that part has no breakpoint of its own.
+   *
+   * @category request
+   * @since 4.0.0
+   */
+  export interface UserMessageOptions extends ProviderOptions {
+    readonly openai?: {
+      /**
+       * Marks the end of reusable prompt content eligible for caching.
+       */
+      readonly promptCacheBreakpoint?: typeof OpenAiSchema.PromptCacheBreakpoint.Encoded | null
+    } | null
+  }
+
+  /**
    * OpenAI-specific options for file prompt parts.
    *
    * @category request
@@ -139,6 +178,10 @@ declare module "effect/unstable/ai/Prompt" {
        * The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
        */
       readonly imageDetail?: ImageDetail | null
+      /**
+       * Marks the end of reusable prompt content eligible for caching.
+       */
+      readonly promptCacheBreakpoint?: typeof OpenAiSchema.PromptCacheBreakpoint.Encoded | null
     } | null
   }
 
@@ -241,6 +284,10 @@ declare module "effect/unstable/ai/Prompt" {
        * A list of annotations that apply to the output text.
        */
       readonly annotations?: ReadonlyArray<typeof OpenAiSchema.Annotation.Encoded> | null
+      /**
+       * Marks the end of reusable prompt content eligible for caching.
+       */
+      readonly promptCacheBreakpoint?: typeof OpenAiSchema.PromptCacheBreakpoint.Encoded | null
     } | null
   }
 }
@@ -814,9 +861,15 @@ const prepareMessages = Effect.fnUntraced(
     for (const message of prompt.content) {
       switch (message.role) {
         case "system": {
+          const prompt_cache_breakpoint = getPromptCacheBreakpoint(message)
+
           messages.push({
             role: getSystemMessageMode(config.model as string),
-            content: [{ type: "input_text", text: message.content }]
+            content: [{
+              type: "input_text",
+              text: message.content,
+              ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+            }]
           })
           break
         }
@@ -826,10 +879,17 @@ const prepareMessages = Effect.fnUntraced(
 
           for (let index = 0; index < message.content.length; index++) {
             const part = message.content[index]
+            const prompt_cache_breakpoint = getPromptCacheBreakpoint(part) ?? (
+              index === message.content.length - 1 ? getPromptCacheBreakpoint(message) : null
+            )
 
             switch (part.type) {
               case "text": {
-                content.push({ type: "input_text", text: part.text })
+                content.push({
+                  type: "input_text",
+                  text: part.text,
+                  ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                })
                 break
               }
 
@@ -839,32 +899,60 @@ const prepareMessages = Effect.fnUntraced(
                   const mediaType = part.mediaType === "image/*" ? "image/jpeg" : part.mediaType
 
                   if (typeof part.data === "string" && isFileId(part.data, config)) {
-                    content.push({ type: "input_image", file_id: part.data, detail })
+                    content.push({
+                      type: "input_image",
+                      file_id: part.data,
+                      detail,
+                      ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                    })
                   }
 
                   if (part.data instanceof URL) {
-                    content.push({ type: "input_image", image_url: part.data.toString(), detail })
+                    content.push({
+                      type: "input_image",
+                      image_url: part.data.toString(),
+                      detail,
+                      ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                    })
                   }
 
                   if (part.data instanceof Uint8Array) {
                     const base64 = Encoding.encodeBase64(part.data)
                     const imageUrl = `data:${mediaType};base64,${base64}`
-                    content.push({ type: "input_image", image_url: imageUrl, detail })
+                    content.push({
+                      type: "input_image",
+                      image_url: imageUrl,
+                      detail,
+                      ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                    })
                   }
                 } else if (part.mediaType === "application/pdf") {
                   if (typeof part.data === "string" && isFileId(part.data, config)) {
-                    content.push({ type: "input_file", file_id: part.data })
+                    content.push({
+                      type: "input_file",
+                      file_id: part.data,
+                      ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                    })
                   }
 
                   if (part.data instanceof URL) {
-                    content.push({ type: "input_file", file_url: part.data.toString() })
+                    content.push({
+                      type: "input_file",
+                      file_url: part.data.toString(),
+                      ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                    })
                   }
 
                   if (part.data instanceof Uint8Array) {
                     const base64 = Encoding.encodeBase64(part.data)
                     const fileName = part.fileName ?? `part-${index}.pdf`
                     const fileData = `data:application/pdf;base64,${base64}`
-                    content.push({ type: "input_file", filename: fileName, file_data: fileData })
+                    content.push({
+                      type: "input_file",
+                      filename: fileName,
+                      file_data: fileData,
+                      ...(Predicate.isNotNull(prompt_cache_breakpoint) ? { prompt_cache_breakpoint } : undefined)
+                    })
                   }
                 } else {
                   return yield* AiError.make({
@@ -2876,6 +2964,10 @@ const getEncryptedContent = (
 ): string | null => part.options.openai?.encryptedContent ?? null
 
 const getImageDetail = (part: Prompt.FilePart): ImageDetail => part.options.openai?.imageDetail ?? "auto"
+
+const getPromptCacheBreakpoint = (
+  input: Prompt.SystemMessage | Prompt.UserMessage | Prompt.TextPart | Prompt.FilePart
+): typeof OpenAiSchema.PromptCacheBreakpoint.Encoded | null => input.options.openai?.promptCacheBreakpoint ?? null
 
 const makeItemIdMetadata = (itemId: string | undefined) => Predicate.isNotUndefined(itemId) ? { itemId } : {}
 

--- a/packages/ai/openai/src/OpenAiSchema.ts
+++ b/packages/ai/openai/src/OpenAiSchema.ts
@@ -19,6 +19,29 @@ const MessageRole = Schema.Literals(["system", "developer", "user", "assistant"]
 const ImageDetail = Schema.Literals(["low", "high", "auto"])
 
 /**
+ * Schema for an explicit prompt-cache breakpoint on an OpenAI input content block.
+ *
+ * **Details**
+ *
+ * The breakpoint includes the marked block and all preceding prompt content in
+ * the candidate cached prefix. OpenAI currently accepts only `"explicit"`.
+ *
+ * @category schemas
+ * @since 4.0.0
+ */
+export const PromptCacheBreakpoint = Schema.Struct({
+  mode: Schema.Literal("explicit")
+})
+
+/**
+ * Explicit prompt-cache breakpoint attached to an OpenAI input content block.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type PromptCacheBreakpoint = typeof PromptCacheBreakpoint.Type
+
+/**
  * Schema for optional `include` values supported by the local handwritten
  * Responses client schema.
  *
@@ -75,14 +98,16 @@ export type MessageStatus = typeof MessageStatus.Type
 
 const InputTextContent = Schema.Struct({
   type: Schema.Literal("input_text"),
-  text: Schema.String
+  text: Schema.String,
+  prompt_cache_breakpoint: Schema.optionalKey(PromptCacheBreakpoint)
 })
 
 const InputImageContent = Schema.Struct({
   type: Schema.Literal("input_image"),
   image_url: Schema.optionalKey(Schema.NullOr(Schema.String)),
   file_id: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  detail: Schema.optionalKey(Schema.NullOr(ImageDetail))
+  detail: Schema.optionalKey(Schema.NullOr(ImageDetail)),
+  prompt_cache_breakpoint: Schema.optionalKey(PromptCacheBreakpoint)
 })
 
 const InputFileContent = Schema.Struct({
@@ -90,7 +115,8 @@ const InputFileContent = Schema.Struct({
   file_id: Schema.optionalKey(Schema.NullOr(Schema.String)),
   filename: Schema.optionalKey(Schema.String),
   file_url: Schema.optionalKey(Schema.String),
-  file_data: Schema.optionalKey(Schema.String)
+  file_data: Schema.optionalKey(Schema.String),
+  prompt_cache_breakpoint: Schema.optionalKey(PromptCacheBreakpoint)
 })
 
 /**
@@ -99,6 +125,7 @@ const InputFileContent = Schema.Struct({
  * **Details**
  *
  * Accepted block variants are `input_text`, `input_image`, and `input_file`.
+ * Each variant can carry an explicit prompt-cache breakpoint.
  *
  * @see {@link InputItem} for request input item shapes that can contain these content blocks
  *

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -31,6 +31,162 @@ describe("OpenAiLanguageModel", () => {
 
   describe("generateText", () => {
     describe("message preparation", () => {
+      describe("prompt cache breakpoints", () => {
+        const breakpoint = { mode: "explicit" } as const
+
+        it.effect("places a breakpoint on system input_text", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([
+                Prompt.systemMessage({
+                  content: "Stable instructions",
+                  options: { openai: { promptCacheBreakpoint: breakpoint } }
+                }),
+                { role: "user", content: "Hello" }
+              ])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-5.6")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+            const systemMessage = body.input.find((message: any) => message.role === "developer")
+
+            deepStrictEqual(systemMessage.content, [{
+              type: "input_text",
+              text: "Stable instructions",
+              prompt_cache_breakpoint: breakpoint
+            }])
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.6" } }))))
+
+        it.effect("places a breakpoint on a user input_text part", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([{
+                role: "user",
+                content: [Prompt.textPart({
+                  text: "Stable context",
+                  options: { openai: { promptCacheBreakpoint: breakpoint } }
+                })]
+              }])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-5.6")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            deepStrictEqual(body.input[0].content, [{
+              type: "input_text",
+              text: "Stable context",
+              prompt_cache_breakpoint: breakpoint
+            }])
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.6" } }))))
+
+        it.effect("places a breakpoint on an input_image part", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([{
+                role: "user",
+                content: [Prompt.filePart({
+                  mediaType: "image/png",
+                  data: new URL("https://example.com/stable.png"),
+                  options: { openai: { promptCacheBreakpoint: breakpoint } }
+                })]
+              }])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-5.6")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            deepStrictEqual(body.input[0].content, [{
+              type: "input_image",
+              image_url: "https://example.com/stable.png",
+              detail: "auto",
+              prompt_cache_breakpoint: breakpoint
+            }])
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.6" } }))))
+
+        it.effect("uses a user message breakpoint on the last input_file part", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([{
+                role: "user",
+                content: [
+                  Prompt.textPart({ text: "Read this file" }),
+                  Prompt.filePart({
+                    mediaType: "application/pdf",
+                    data: new URL("https://example.com/stable.pdf")
+                  })
+                ],
+                options: { openai: { promptCacheBreakpoint: breakpoint } }
+              }])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-5.6")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            deepStrictEqual(body.input[0].content, [
+              { type: "input_text", text: "Read this file" },
+              {
+                type: "input_file",
+                file_url: "https://example.com/stable.pdf",
+                prompt_cache_breakpoint: breakpoint
+              }
+            ])
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.6" } }))))
+
+        it.effect("prefers a part breakpoint over the user message fallback", () =>
+          Effect.gen(function*() {
+            const messageOptions = {
+              openai: {
+                get promptCacheBreakpoint(): never {
+                  throw new Error("message fallback should not be read")
+                }
+              }
+            }
+
+            yield* LanguageModel.generateText({
+              prompt: Prompt.fromMessages([Prompt.userMessage({
+                content: [Prompt.textPart({
+                  text: "Stable context",
+                  options: { openai: { promptCacheBreakpoint: breakpoint } }
+                })],
+                options: messageOptions
+              })])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-5.6")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            deepStrictEqual(body.input[0].content[0].prompt_cache_breakpoint, breakpoint)
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.6" } }))))
+
+        it.effect("omits breakpoints when no OpenAI provider option is set", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([{
+                role: "system",
+                content: "Instructions"
+              }, {
+                role: "user",
+                content: [
+                  Prompt.textPart({ text: "Question" }),
+                  Prompt.filePart({
+                    mediaType: "image/png",
+                    data: new URL("https://example.com/image.png")
+                  })
+                ]
+              }])
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-5.6")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            for (const message of body.input) {
+              if (Array.isArray(message.content)) {
+                assert.isTrue(message.content.every((part: any) => !("prompt_cache_breakpoint" in part)))
+              }
+            }
+          }).pipe(Effect.provide(makeTestLayer({ body: { model: "gpt-5.6" } }))))
+      })
+
       describe("system messages", () => {
         it.effect("uses system role for standard models", () =>
           Effect.gen(function*() {

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -1088,7 +1088,7 @@ export type MessageConstructorParams<M extends Message> = Omit<M, typeof Message
   /**
    * Optional provider-specific options for this message.
    */
-  readonly options?: Part["options"] | undefined
+  readonly options?: M["options"] | undefined
 }
 
 /**


### PR DESCRIPTION
## RFC status

**Implementation complete, locally validated, and independently reviewed with no findings.** This is a ready-for-review PR. RFC feedback is specifically requested on the provider-option/public API shape before merge.

Closes #6831.

## Summary

Adds content-level `prompt_cache_breakpoint` support to the handwritten OpenAI Responses API path:

```ts
options: {
  openai: {
    promptCacheBreakpoint: { mode: "explicit" }
  }
}
```

The marker is represented in `OpenAiSchema` and emitted only on the OpenAI-documented Responses content blocks: `input_text`, `input_image`, and `input_file`.

This PR intentionally does not add or duplicate request-level `safety_identifier`, `prompt_cache_key`, `prompt_cache_retention`, or `prompt_cache_options` work from #6830. Explicit breakpoints work with OpenAI's default implicit request policy.

## API design and precedent

Anthropic and OpenRouter already expose cache controls through provider options at both message and part level. Their converters prefer a part-level marker and use a message-level marker as a fallback on translated content. OpenRouter also places a system-message marker on the text block produced from the system string.

This implementation follows that established Effect shape:

- `SystemMessageOptions.openai.promptCacheBreakpoint` is placed on the system/developer `input_text` block.
- `TextPartOptions` and `FilePartOptions` support exact block placement. A file part maps to `input_image` or `input_file` according to its media type.
- `UserMessageOptions` is an ergonomic fallback placed on the last content part.
- Part-level placement takes precedence over message-level fallback. The marker currently has a single legal value, `{ mode: "explicit" }`; the precedence test verifies that the message fallback is not read when the last part defines its own marker.
- Assistant and tool content are deliberately excluded because OpenAI documents the Responses placements only on `input_text`, `input_image`, and `input_file`.

Adding genuinely message-specific OpenAI options exposed a pre-existing `MessageConstructorParams` typo: it selected `Part["options"]` rather than `M["options"]`. The one-line correction aligns the helper with `makeMessage`'s existing role-specific signature and avoids falsely adding ignored breakpoint fields to reasoning/tool parts.

Official contract:

- [Prompt cache breakpoints](https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-breakpoints)
- [GPT-5.6 caching behavior](https://developers.openai.com/api/docs/guides/prompt-caching#caching-behavior-changes-when-migrating-to-gpt-56)

## Tradeoffs

- Message fallback is convenient and consistent with existing provider integrations, but exact placement remains clearest at part level.
- Exporting `OpenAiSchema.PromptCacheBreakpoint` gives provider augmentations and handwritten transport schemas one source of truth, at the cost of one small public schema/type addition.
- The provider does not gate the option by model name. Older models may reject it, matching normal provider-specific option behavior and avoiding a stale local capability table.
- Request policy remains untouched: without #6830-style request options, OpenAI keeps its documented default implicit breakpoint in addition to explicit markers.

## Focused maintainer questions

1. Is `promptCacheBreakpoint` under `options.openai` the preferred public name and nesting?
2. Should user-message fallback remain, or should OpenAI require exact part-level placement except for system messages?
3. Is the narrow `MessageConstructorParams<M>["options"]` correction acceptable here, or would maintainers prefer it split into a prerequisite PR?

## Validation

- `pnpm test --run packages/ai/openai/test/OpenAiLanguageModel.test.ts packages/ai/openai/test/OpenAiSchema.test.ts` — 64 tests passed
- `pnpm check` — passed
- `pnpm lint` — passed
- `pnpm docgen` in `packages/ai/openai` — passed
- Independent review agent — clean after re-review

Positive coverage includes system/input text, user text, image, file, message fallback, part precedence, and absence behavior.
