### PR TITLE
Standardize JSDoc categories

### DIFF
--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -36,7 +36,7 @@ import * as Errors from "./internal/errors.ts"
  * Represents the Anthropic client service with methods for the Messages API, including regular and streaming message
  * creation.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Service {

--- a/packages/ai/anthropic/src/AnthropicConfig.ts
+++ b/packages/ai/anthropic/src/AnthropicConfig.ts
@@ -52,7 +52,7 @@ export declare namespace AnthropicConfig {
    *
    * Use `transformClient` to wrap or replace the `HttpClient` used by generated Anthropic API requests.
    *
-   * @category models
+   * @category services
    * @since 4.0.0
    */
   export interface Service {

--- a/packages/ai/anthropic/src/AnthropicError.ts
+++ b/packages/ai/anthropic/src/AnthropicError.ts
@@ -77,7 +77,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Includes request identifiers, Anthropic error types, and parsed request or token limit headers when the provider rejects a request due to rate limits.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface RateLimitErrorMetadata {
@@ -91,7 +91,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Captures the Anthropic error type and request identifier for failures where the account or workspace has exhausted its available quota.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface QuotaExhaustedErrorMetadata {
@@ -105,7 +105,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Preserves Anthropic error details for missing, invalid, or unauthorized API credentials while keeping the error in the shared AI error model.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface AuthenticationErrorMetadata {
@@ -119,7 +119,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Records Anthropic error details returned when a request or response is rejected by Anthropic safety or content policy enforcement.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface ContentPolicyErrorMetadata {
@@ -133,7 +133,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Provides the Anthropic error type and request identifier for malformed or unsupported requests rejected before model execution.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InvalidRequestErrorMetadata {
@@ -147,7 +147,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Preserves Anthropic request correlation data for provider-side failures that should be reported or investigated with Anthropic support.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InternalProviderErrorMetadata {
@@ -161,7 +161,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Describes Anthropic-specific context for responses that could not be decoded or interpreted as valid AI output.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InvalidOutputErrorMetadata {
@@ -175,7 +175,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Captures Anthropic error details for structured-output failures, including request correlation data useful when diagnosing schema-related responses.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface StructuredOutputErrorMetadata {
@@ -189,7 +189,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Provides Anthropic error details for schemas that cannot be represented by or submitted to the Anthropic API.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface UnsupportedSchemaErrorMetadata {
@@ -203,7 +203,7 @@ declare module "effect/unstable/ai/AiError" {
    *
    * Retains the Anthropic error type and request identifier when a provider response cannot be classified as a more specific AI error.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface UnknownErrorMetadata {

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -65,7 +65,7 @@ export type Model = (typeof Generated.Model)["members"][1]["Encoded"]
  * requests. Scoped configuration overrides defaults supplied to `model`,
  * `make`, or `layer`.
  *
- * @category configuration
+ * @category services
  * @since 4.0.0
  */
 export class Config extends Context.Service<

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -111,7 +111,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when translating system messages into Anthropic
    * request content.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface SystemMessageOptions extends ProviderOptions {
@@ -131,7 +131,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when translating user messages into Anthropic
    * request content.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface UserMessageOptions extends ProviderOptions {
@@ -151,7 +151,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when replaying assistant messages in Anthropic
    * conversation history.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface AssistantMessageOptions extends ProviderOptions {
@@ -171,7 +171,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when converting tool results into Anthropic user
    * content blocks.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolMessageOptions extends ProviderOptions {
@@ -190,7 +190,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Use when you use these options to control how text blocks are sent to Anthropic.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface TextPartOptions extends ProviderOptions {
@@ -210,7 +210,7 @@ declare module "effect/unstable/ai/Prompt" {
    * Preserves Claude thinking metadata when reasoning content is sent back to
    * Anthropic in later turns.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartOptions extends ProviderOptions {
@@ -245,7 +245,7 @@ declare module "effect/unstable/ai/Prompt" {
    * Controls document metadata, citations, and prompt caching for files sent to
    * Anthropic.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface FilePartOptions extends ProviderOptions {
@@ -283,7 +283,7 @@ declare module "effect/unstable/ai/Prompt" {
    * Carries Anthropic tool caller metadata, MCP metadata, and cache control for
    * tool use blocks.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartOptions extends ProviderOptions {
@@ -315,7 +315,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Controls Anthropic prompt caching for tool result content.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolResultPartOptions extends ProviderOptions {
@@ -334,7 +334,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Controls prompt caching for human approval requests in conversations.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolApprovalRequestPartOptions extends ProviderOptions {
@@ -353,7 +353,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Controls prompt caching for human approval responses in conversations.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolApprovalResponsePartOptions extends ProviderOptions {
@@ -375,7 +375,7 @@ declare module "effect/unstable/ai/Response" {
    * Includes Claude thinking metadata needed to continue reasoning-aware
    * conversations.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningStartPartMetadata extends ProviderMetadata {
@@ -405,7 +405,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Includes the signature for streamed Claude thinking content when available.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningDeltaPartMetadata extends ProviderMetadata {
@@ -428,7 +428,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Preserves Claude thinking or redacted thinking information for later turns.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartMetadata extends ProviderMetadata {
@@ -459,7 +459,7 @@ declare module "effect/unstable/ai/Response" {
    * Identifies Anthropic caller details and MCP tool metadata emitted by the
    * provider.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartMetadata extends ProviderMetadata {
@@ -488,7 +488,7 @@ declare module "effect/unstable/ai/Response" {
    * Identifies MCP tool metadata associated with provider-executed tool
    * results.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ToolResultPartMetadata extends ProviderMetadata {
@@ -512,7 +512,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Records the cited document span by character position or page number.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface DocumentSourcePartMetadata extends ProviderMetadata {
@@ -556,7 +556,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Records cited URL text or web-search source freshness information.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface UrlSourcePartMetadata extends ProviderMetadata {
@@ -586,7 +586,7 @@ declare module "effect/unstable/ai/Response" {
    * Includes container state, context management information, stop details, and
    * token usage reported by Anthropic.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface FinishPartMetadata extends ProviderMetadata {
@@ -605,7 +605,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Includes the provider request identifier when Anthropic returns one.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ErrorPartMetadata extends ProviderMetadata {

--- a/packages/ai/anthropic/src/AnthropicTelemetry.ts
+++ b/packages/ai/anthropic/src/AnthropicTelemetry.ts
@@ -113,7 +113,7 @@ const addAnthropicResponseAttributes = Telemetry.addSpanAttributes("gen_ai.anthr
  *
  * This method mutates the `Span` in place.
  *
- * @category annotations
+ * @category tracing
  * @since 4.0.0
  */
 export const addGenAIAnnotations: {

--- a/packages/ai/anthropic/src/AnthropicTool.ts
+++ b/packages/ai/anthropic/src/AnthropicTool.ts
@@ -65,7 +65,7 @@ export type AnthropicTool =
  *
  * @see {@link Bash_20250124} for the newer 2025-01-24 version of the bash tool
  *
- * @category Bash
+ * @category tools
  * @since 4.0.0
  */
 export const Bash_20241022 = Tool.providerDefined({
@@ -95,7 +95,7 @@ export const Bash_20241022 = Tool.providerDefined({
  *
  * @see {@link Bash_20241022} for the older 2024-10-22 version of the bash tool
  *
- * @category Bash
+ * @category tools
  * @since 4.0.0
  */
 export const Bash_20250124 = Tool.providerDefined({
@@ -128,7 +128,7 @@ export const Bash_20250124 = Tool.providerDefined({
  *
  * @see {@link CodeExecution_20250522} for the parent tool definition
  *
- * @category Code Execution
+ * @category schemas
  * @since 4.0.0
  */
 export const CodeExecutionProgrammaticToolCall = Schema.Struct({
@@ -141,7 +141,7 @@ export const CodeExecutionProgrammaticToolCall = Schema.Struct({
 /**
  * Input payload for a programmatic code execution tool call, including the source code to execute.
  *
- * @category Code Execution
+ * @category models
  * @since 4.0.0
  */
 export type CodeExecutionProgrammaticToolCall = typeof CodeExecutionProgrammaticToolCall.Type
@@ -161,7 +161,7 @@ export type CodeExecutionProgrammaticToolCall = typeof CodeExecutionProgrammatic
  *
  * @see {@link CodeExecution_20250522} for the provider-defined tool that consumes this input variant
  *
- * @category Code Execution
+ * @category schemas
  * @since 4.0.0
  */
 export const CodeExecutionBashCommand = Schema.Struct({
@@ -191,7 +191,7 @@ export const CodeExecutionBashCommand = Schema.Struct({
  * @see {@link CodeExecutionTextEditorStrReplace} for replacing text through text editor code execution
  * @see {@link CodeExecution_20250522} for the provider-defined tool that consumes this payload
  *
- * @category Code Execution
+ * @category models
  * @since 4.0.0
  */
 export type CodeExecutionBashCommand = typeof CodeExecutionBashCommand.Type
@@ -212,7 +212,7 @@ export type CodeExecutionBashCommand = typeof CodeExecutionBashCommand.Type
  * @see {@link CodeExecutionTextEditorCreate} for the command that creates a file
  * @see {@link CodeExecutionTextEditorStrReplace} for the command that replaces text in a file
  *
- * @category Code Execution
+ * @category schemas
  * @since 4.0.0
  */
 export const CodeExecutionTextEditorView = Schema.Struct({
@@ -245,7 +245,7 @@ export const CodeExecutionTextEditorView = Schema.Struct({
  * @see {@link CodeExecution_20250522} for the provider-defined code execution tool that includes this payload
  * @see {@link TextEditorViewCommand} for the standalone text editor view payload
  *
- * @category Code Execution
+ * @category models
  * @since 4.0.0
  */
 export type CodeExecutionTextEditorView = typeof CodeExecutionTextEditorView.Type
@@ -268,7 +268,7 @@ export type CodeExecutionTextEditorView = typeof CodeExecutionTextEditorView.Typ
  * @see {@link CodeExecutionTextEditorView} for the matching view request
  * @see {@link CodeExecutionTextEditorStrReplace} for the matching replace request
  *
- * @category Code Execution
+ * @category schemas
  * @since 4.0.0
  */
 export const CodeExecutionTextEditorCreate = Schema.Struct({
@@ -286,7 +286,7 @@ export const CodeExecutionTextEditorCreate = Schema.Struct({
 /**
  * Input payload for creating a file through the text editor code execution tool, optionally including initial file text.
  *
- * @category Code Execution
+ * @category models
  * @since 4.0.0
  */
 export type CodeExecutionTextEditorCreate = typeof CodeExecutionTextEditorCreate.Type
@@ -307,7 +307,7 @@ export type CodeExecutionTextEditorCreate = typeof CodeExecutionTextEditorCreate
  * @see {@link CodeExecutionTextEditorView} for reading file contents before choosing the replacement text
  * @see {@link CodeExecution_20250522} for the provider-defined tool that consumes this payload
  *
- * @category Code Execution
+ * @category schemas
  * @since 4.0.0
  */
 export const CodeExecutionTextEditorStrReplace = Schema.Struct({
@@ -329,7 +329,7 @@ export const CodeExecutionTextEditorStrReplace = Schema.Struct({
 /**
  * Input payload for replacing text in a file through the text editor code execution tool.
  *
- * @category Code Execution
+ * @category models
  * @since 4.0.0
  */
 export type CodeExecutionTextEditorStrReplace = typeof CodeExecutionTextEditorStrReplace.Type
@@ -356,7 +356,7 @@ const CodeExecution_20250522_Parameters = Schema.Union([
  *
  * @see {@link CodeExecution_20250825} for the provider-defined tool that consumes this schema
  *
- * @category Code Execution
+ * @category schemas
  * @since 4.0.0
  */
 export const CodeExecution_20250825_Parameters = Schema.Struct({
@@ -380,7 +380,7 @@ export const CodeExecution_20250825_Parameters = Schema.Struct({
  *
  * @see {@link CodeExecution_20250825} for the provider-defined tool that consumes this payload
  *
- * @category Code Execution
+ * @category models
  * @since 4.0.0
  */
 export type CodeExecution_20250825_Parameters = typeof CodeExecution_20250825_Parameters.Type
@@ -405,7 +405,7 @@ export type CodeExecution_20250825_Parameters = typeof CodeExecution_20250825_Pa
  *
  * @see {@link CodeExecutionProgrammaticToolCall} for the programmatic tool call schema
  *
- * @category Code Execution
+ * @category tools
  * @since 4.0.0
  */
 export const CodeExecution_20250522 = Tool.providerDefined({
@@ -433,7 +433,7 @@ export const CodeExecution_20250522 = Tool.providerDefined({
  * @see {@link CodeExecution_20250522} for the older 2025-05-22 code execution tool
  * @see {@link CodeExecution_20250825_Parameters} for the input schema consumed by this tool
  *
- * @category Code Execution
+ * @category tools
  * @since 4.0.0
  */
 export const CodeExecution_20250825 = Tool.providerDefined({
@@ -480,14 +480,14 @@ export const CodeExecution_20250825 = Tool.providerDefined({
  *
  * This schema validates tuple shape only and does not check display bounds.
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const Coordinate = Schema.Tuple([Schema.Int, Schema.Int])
 /**
  * An `[x, y]` screen coordinate in pixels.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type Coordinate = typeof Coordinate.Type
@@ -509,14 +509,14 @@ export type Coordinate = typeof Coordinate.Type
  * This schema validates four numbers only and does not check coordinate ordering
  * or display bounds.
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const Region = Schema.Tuple([Schema.Int, Schema.Int, Schema.Int, Schema.Int])
 /**
  * An `[x1, y1, x2, y2]` screen region in pixels, from top-left to bottom-right.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type Region = typeof Region.Type
@@ -526,14 +526,14 @@ export type Region = typeof Region.Type
  *
  * @see {@link ComputerUseScrollAction} for the action payload that consumes this schema
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ScrollDirection = Schema.Literals(["up", "down", "left", "right"])
 /**
  * Direction used by computer-use scroll actions: `"up"`, `"down"`, `"left"`, or `"right"`.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ScrollDirection = typeof ScrollDirection.Type
@@ -545,7 +545,7 @@ export type ScrollDirection = typeof ScrollDirection.Type
  *
  * Allowed values are `"alt"`, `"ctrl"`, `"meta"`, and `"shift"`.
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ModifierKey = Schema.Literals(["alt", "ctrl", "meta", "shift"])
@@ -556,7 +556,7 @@ export const ModifierKey = Schema.Literals(["alt", "ctrl", "meta", "shift"])
  *
  * Allowed values are `"alt"`, `"ctrl"`, `"meta"`, and `"shift"`.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ModifierKey = typeof ModifierKey.Type
@@ -605,7 +605,7 @@ const ComputerUse_20251124_Args = Schema.Struct({
  * @see {@link TypeAction} for entering ordinary text strings
  * @see {@link ComputerUseHoldKeyAction} for holding a key for a duration
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseKeyAction = Schema.Struct({
@@ -634,7 +634,7 @@ export const ComputerUseKeyAction = Schema.Struct({
  * `text` is typed as `string`; the paired schema does not validate
  * provider-specific key names or key combinations.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseKeyAction = typeof ComputerUseKeyAction.Type
@@ -662,7 +662,7 @@ export type ComputerUseKeyAction = typeof ComputerUseKeyAction.Type
  * @see {@link ComputerUseDoubleClickAction} for performing a double click
  * @see {@link ComputerUseMouseMoveAction} for moving the mouse without clicking
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseLeftClickAction = Schema.Struct({
@@ -676,7 +676,7 @@ export const ComputerUseLeftClickAction = Schema.Struct({
 /**
  * Computer-use action payload for performing a left click, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseLeftClickAction = typeof ComputerUseLeftClickAction.Type
@@ -701,7 +701,7 @@ export type ComputerUseLeftClickAction = typeof ComputerUseLeftClickAction.Type
  * does not validate that the point falls within the configured display
  * dimensions.
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseMouseMoveAction = Schema.Struct({
@@ -714,7 +714,7 @@ export const ComputerUseMouseMoveAction = Schema.Struct({
 /**
  * Computer-use action payload for moving the mouse cursor to a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseMouseMoveAction = typeof ComputerUseMouseMoveAction.Type
@@ -734,7 +734,7 @@ export type ComputerUseMouseMoveAction = typeof ComputerUseMouseMoveAction.Type
  *
  * @see {@link ComputerUseZoomAction} for requesting a zoomed-in screenshot of a specific screen region with the 2025-11-24 computer-use tool
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseScreenshotAction = Schema.Struct({
@@ -743,7 +743,7 @@ export const ComputerUseScreenshotAction = Schema.Struct({
 /**
  * Computer-use action payload for capturing the current display.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseScreenshotAction = typeof ComputerUseScreenshotAction.Type
@@ -763,7 +763,7 @@ export type ComputerUseScreenshotAction = typeof ComputerUseScreenshotAction.Typ
  *
  * @see {@link ComputerUseKeyAction} for key presses and keyboard shortcuts
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const TypeAction = Schema.Struct({
@@ -781,7 +781,7 @@ export const TypeAction = Schema.Struct({
  * The payload uses `action: "type"` and a `text` string containing the text to
  * enter.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type TypeAction = typeof TypeAction.Type
@@ -820,7 +820,7 @@ const ComputerUse_20241022_Actions = Schema.Union([
  *
  * @see {@link ComputerUseLeftClickAction} for performing a single left click
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseDoubleClickAction = Schema.Struct({
@@ -834,7 +834,7 @@ export const ComputerUseDoubleClickAction = Schema.Struct({
 /**
  * Computer-use action payload for performing a double click, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseDoubleClickAction = typeof ComputerUseDoubleClickAction.Type
@@ -861,7 +861,7 @@ export type ComputerUseDoubleClickAction = typeof ComputerUseDoubleClickAction.T
  * @see {@link ComputerUseKeyAction} for pressing a key or key combination without holding it
  * @see {@link ComputerUseWaitAction} for pausing between actions without holding a key
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseHoldKeyAction = Schema.Struct({
@@ -889,7 +889,7 @@ export const ComputerUseHoldKeyAction = Schema.Struct({
  *
  * @see {@link ComputerUseKeyAction} for a single key press or key combination without a hold duration
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseHoldKeyAction = typeof ComputerUseHoldKeyAction.Type
@@ -916,7 +916,7 @@ export type ComputerUseHoldKeyAction = typeof ComputerUseHoldKeyAction.Type
  * @see {@link ComputerUseLeftMouseDownAction} for starting a manual drag sequence
  * @see {@link ComputerUseLeftMouseUpAction} for ending a manual drag sequence
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseLeftClickDragAction = Schema.Struct({
@@ -933,7 +933,7 @@ export const ComputerUseLeftClickDragAction = Schema.Struct({
 /**
  * Computer-use action payload for dragging from a start coordinate to an end coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseLeftClickDragAction = typeof ComputerUseLeftClickDragAction.Type
@@ -946,7 +946,7 @@ export type ComputerUseLeftClickDragAction = typeof ComputerUseLeftClickDragActi
  * Use when constructing a manual click or drag sequence that should press and
  * hold the left mouse button before a later release.
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseLeftMouseDownAction = Schema.Struct({
@@ -960,7 +960,7 @@ export const ComputerUseLeftMouseDownAction = Schema.Struct({
 /**
  * Computer-use action payload for pressing and holding the left mouse button, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseLeftMouseDownAction = typeof ComputerUseLeftMouseDownAction.Type
@@ -973,7 +973,7 @@ export type ComputerUseLeftMouseDownAction = typeof ComputerUseLeftMouseDownActi
  * Use when constructing a manual click or drag sequence that should release the
  * left mouse button after it was previously held down.
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseLeftMouseUpAction = Schema.Struct({
@@ -987,7 +987,7 @@ export const ComputerUseLeftMouseUpAction = Schema.Struct({
 /**
  * Computer-use action payload for releasing the left mouse button, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseLeftMouseUpAction = typeof ComputerUseLeftMouseUpAction.Type
@@ -1014,7 +1014,7 @@ export type ComputerUseLeftMouseUpAction = typeof ComputerUseLeftMouseUpAction.T
  * @see {@link ComputerUseLeftClickAction} for primary-button clicks
  * @see {@link ComputerUseRightClickAction} for secondary-button clicks
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseMiddleClickAction = Schema.Struct({
@@ -1028,7 +1028,7 @@ export const ComputerUseMiddleClickAction = Schema.Struct({
 /**
  * Computer-use action payload for performing a middle click, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseMiddleClickAction = typeof ComputerUseMiddleClickAction.Type
@@ -1051,7 +1051,7 @@ export type ComputerUseMiddleClickAction = typeof ComputerUseMiddleClickAction.T
  * @see {@link ComputerUseLeftClickAction} for the corresponding left-click action
  * @see {@link ComputerUseMiddleClickAction} for the corresponding middle-click action
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseRightClickAction = Schema.Struct({
@@ -1065,7 +1065,7 @@ export const ComputerUseRightClickAction = Schema.Struct({
 /**
  * Computer-use action payload for performing a right click, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseRightClickAction = typeof ComputerUseRightClickAction.Type
@@ -1090,7 +1090,7 @@ export type ComputerUseRightClickAction = typeof ComputerUseRightClickAction.Typ
  * @see {@link ComputerUse_20250124} for the tool version that accepts this action
  * @see {@link ScrollDirection} for the accepted direction literals
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseScrollAction = Schema.Struct({
@@ -1112,7 +1112,7 @@ export const ComputerUseScrollAction = Schema.Struct({
 /**
  * Computer-use action payload for scrolling by a specified amount in a specified direction, optionally from a coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseScrollAction = typeof ComputerUseScrollAction.Type
@@ -1139,7 +1139,7 @@ export type ComputerUseScrollAction = typeof ComputerUseScrollAction.Type
  * @see {@link ComputerUseDoubleClickAction} for the two-click variant
  * @see {@link ComputerUseLeftClickAction} for a single left click
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseTripleClickAction = Schema.Struct({
@@ -1153,7 +1153,7 @@ export const ComputerUseTripleClickAction = Schema.Struct({
 /**
  * Computer-use action payload for performing a triple click, optionally at a specific coordinate.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseTripleClickAction = typeof ComputerUseTripleClickAction.Type
@@ -1179,7 +1179,7 @@ export type ComputerUseTripleClickAction = typeof ComputerUseTripleClickAction.T
  * @see {@link ComputerUseHoldKeyAction} for another duration-based computer-use action
  * @see {@link ComputerUse_20250124} for the tool version that accepts this action
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseWaitAction = Schema.Struct({
@@ -1192,7 +1192,7 @@ export const ComputerUseWaitAction = Schema.Struct({
 /**
  * Computer-use action payload for pausing for a specified duration.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseWaitAction = typeof ComputerUseWaitAction.Type
@@ -1235,7 +1235,7 @@ const ComputerUse_20250124_Actions = Schema.Union([
  * @see {@link ComputerUse_20251124} for the tool version that accepts this action
  * @see {@link ComputerUseScreenshotAction} for capturing the full screen instead
  *
- * @category computer use
+ * @category schemas
  * @since 4.0.0
  */
 export const ComputerUseZoomAction = Schema.Struct({
@@ -1255,7 +1255,7 @@ export const ComputerUseZoomAction = Schema.Struct({
  * `region` is only a four-number tuple and does not validate corner ordering or
  * display bounds.
  *
- * @category computer use
+ * @category models
  * @since 4.0.0
  */
 export type ComputerUseZoomAction = typeof ComputerUseZoomAction.Type
@@ -1277,7 +1277,7 @@ const ComputerUse_20251124_Actions = Schema.Union([
  * Requires the "computer-use-2024-10-22" beta header.
  * Basic actions only: screenshot, left_click, type, key, mouse_move.
  *
- * @category computer use
+ * @category tools
  * @since 4.0.0
  */
 export const ComputerUse_20241022 = Tool.providerDefined({
@@ -1308,7 +1308,7 @@ export const ComputerUse_20241022 = Tool.providerDefined({
  * @see {@link ComputerUse_20241022} for the older basic action set
  * @see {@link ComputerUse_20251124} for the newer zoom-capable version
  *
- * @category computer use
+ * @category tools
  * @since 4.0.0
  */
 export const ComputerUse_20250124 = Tool.providerDefined({
@@ -1342,7 +1342,7 @@ export const ComputerUse_20250124 = Tool.providerDefined({
  * @see {@link ComputerUse_20250124} for the previous action set without zoom
  * @see {@link ComputerUseZoomAction} for the zoom action payload
  *
- * @category computer use
+ * @category tools
  * @since 4.0.0
  */
 export const ComputerUse_20251124 = Tool.providerDefined({
@@ -1380,7 +1380,7 @@ export const ComputerUse_20251124 = Tool.providerDefined({
  * @see {@link MemoryViewCommand} for memory view payloads that use this range
  * @see {@link TextEditorViewCommand} for text editor view payloads that use this range
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const ViewRange = Schema.Tuple([Schema.Int, Schema.Int])
@@ -1391,7 +1391,7 @@ export const ViewRange = Schema.Tuple([Schema.Int, Schema.Int])
  *
  * Use when typing `view_range` for memory or text editor view commands.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type ViewRange = typeof ViewRange.Type
@@ -1408,7 +1408,7 @@ export type ViewRange = typeof ViewRange.Type
  * The payload contains `command: "create"`, a `path` string, and the
  * `file_text` content to write to the file.
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const MemoryCreateCommand = Schema.Struct({
@@ -1425,7 +1425,7 @@ export const MemoryCreateCommand = Schema.Struct({
 /**
  * Memory tool command payload for creating a new file at a path.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryCreateCommand = typeof MemoryCreateCommand.Type
@@ -1433,7 +1433,7 @@ export type MemoryCreateCommand = typeof MemoryCreateCommand.Type
 /**
  * Schema for a memory command that deletes a file or directory.
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const MemoryDeleteCommand = Schema.Struct({
@@ -1446,7 +1446,7 @@ export const MemoryDeleteCommand = Schema.Struct({
 /**
  * Memory tool command payload for deleting a file or directory at a path.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryDeleteCommand = typeof MemoryDeleteCommand.Type
@@ -1466,7 +1466,7 @@ export type MemoryDeleteCommand = typeof MemoryDeleteCommand.Type
  * @see {@link Memory_20250818} for the provider-defined tool that consumes this command
  * @see {@link MemoryStrReplaceCommand} for replacing existing text instead
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const MemoryInsertCommand = Schema.Struct({
@@ -1487,7 +1487,7 @@ export const MemoryInsertCommand = Schema.Struct({
 /**
  * Memory tool command payload for inserting text at a specific line in a file.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryInsertCommand = typeof MemoryInsertCommand.Type
@@ -1500,7 +1500,7 @@ export type MemoryInsertCommand = typeof MemoryInsertCommand.Type
  * The payload uses `command: "rename"` and requires `old_path` as the current
  * path plus `new_path` as the new destination path.
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const MemoryRenameCommand = Schema.Struct({
@@ -1517,7 +1517,7 @@ export const MemoryRenameCommand = Schema.Struct({
 /**
  * Memory tool command payload for renaming or moving a file or directory.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryRenameCommand = typeof MemoryRenameCommand.Type
@@ -1537,7 +1537,7 @@ export type MemoryRenameCommand = typeof MemoryRenameCommand.Type
  *
  * @see {@link Memory_20250818} for the provider-defined tool that consumes this command
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const MemoryStrReplaceCommand = Schema.Struct({
@@ -1558,7 +1558,7 @@ export const MemoryStrReplaceCommand = Schema.Struct({
 /**
  * Memory tool command payload for replacing text in a file.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryStrReplaceCommand = typeof MemoryStrReplaceCommand.Type
@@ -1571,7 +1571,7 @@ export type MemoryStrReplaceCommand = typeof MemoryStrReplaceCommand.Type
  * When used on a file, returns file contents optionally limited by `view_range`.
  * When used on a directory, lists contents.
  *
- * @category memory
+ * @category schemas
  * @since 4.0.0
  */
 export const MemoryViewCommand = Schema.Struct({
@@ -1588,7 +1588,7 @@ export const MemoryViewCommand = Schema.Struct({
 /**
  * Memory tool command payload for viewing a file or directory, optionally with a file line range.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryViewCommand = typeof MemoryViewCommand.Type
@@ -1614,7 +1614,7 @@ const Memory_20250818_Commands = Schema.Union([
  * Provides commands for creating, viewing, editing, renaming, and deleting
  * files within the model's memory space.
  *
- * @category memory
+ * @category tools
  * @since 4.0.0
  */
 export const Memory_20250818 = Tool.providerDefined({
@@ -1651,7 +1651,7 @@ export const Memory_20250818 = Tool.providerDefined({
  *
  * @see {@link CodeExecutionTextEditorView} for the code-execution variant without `view_range`
  *
- * @category text editor
+ * @category schemas
  * @since 4.0.0
  */
 export const TextEditorViewCommand = Schema.Struct({
@@ -1674,7 +1674,7 @@ export const TextEditorViewCommand = Schema.Struct({
  * `view_range` is a 1-indexed `[start, end]` tuple where `-1` means through
  * the end of the file.
  *
- * @category text editor
+ * @category models
  * @since 4.0.0
  */
 export type TextEditorViewCommand = typeof TextEditorViewCommand.Type
@@ -1696,7 +1696,7 @@ export type TextEditorViewCommand = typeof TextEditorViewCommand.Type
  *
  * Fails if the file already exists. Parent directories must exist.
  *
- * @category text editor
+ * @category schemas
  * @since 4.0.0
  */
 export const TextEditorCreateCommand = Schema.Struct({
@@ -1722,7 +1722,7 @@ export const TextEditorCreateCommand = Schema.Struct({
  *
  * The command fails if the file already exists or if parent directories are missing.
  *
- * @category text editor
+ * @category models
  * @since 4.0.0
  */
 export type TextEditorCreateCommand = typeof TextEditorCreateCommand.Type
@@ -1748,7 +1748,7 @@ export type TextEditorCreateCommand = typeof TextEditorCreateCommand.Type
  * @see {@link TextEditorViewCommand} for reading contents before choosing `old_str`
  * @see {@link CodeExecutionTextEditorStrReplace} for the code-execution variant
  *
- * @category text editor
+ * @category schemas
  * @since 4.0.0
  */
 export const TextEditorStrReplaceCommand = Schema.Struct({
@@ -1779,7 +1779,7 @@ export const TextEditorStrReplaceCommand = Schema.Struct({
  * The `old_str` must match exactly, including whitespace and indentation, and
  * must be unique in the file.
  *
- * @category text editor
+ * @category models
  * @since 4.0.0
  */
 export type TextEditorStrReplaceCommand = typeof TextEditorStrReplaceCommand.Type
@@ -1792,7 +1792,7 @@ export type TextEditorStrReplaceCommand = typeof TextEditorStrReplaceCommand.Typ
  * Inserts the new text after the specified line number. Use `0` to insert at
  * the beginning of the file; other values are 1-indexed.
  *
- * @category text editor
+ * @category schemas
  * @since 4.0.0
  */
 export const TextEditorInsertCommand = Schema.Struct({
@@ -1813,7 +1813,7 @@ export const TextEditorInsertCommand = Schema.Struct({
 /**
  * Text editor command payload for inserting text after a specific line number in a file.
  *
- * @category text editor
+ * @category models
  * @since 4.0.0
  */
 export type TextEditorInsertCommand = typeof TextEditorInsertCommand.Type
@@ -1832,7 +1832,7 @@ export type TextEditorInsertCommand = typeof TextEditorInsertCommand.Type
  * `text_editor_20250124`, but not in `text_editor_20250429` or
  * `text_editor_20250728`.
  *
- * @category text editor
+ * @category schemas
  * @since 4.0.0
  */
 export const TextEditorUndoEditCommand = Schema.Struct({
@@ -1850,7 +1850,7 @@ export const TextEditorUndoEditCommand = Schema.Struct({
  * Available for `text_editor_20241022` and `text_editor_20250124`, but not for
  * `text_editor_20250429` or `text_editor_20250728`.
  *
- * @category text editor
+ * @category models
  * @since 4.0.0
  */
 export type TextEditorUndoEditCommand = typeof TextEditorUndoEditCommand.Type
@@ -1902,7 +1902,7 @@ const TextEditor_StrReplaceBasedEdit_Args = Schema.Struct({
  * @see {@link TextEditor_20250124} for the newer `str_replace_editor` version
  * @see {@link TextEditor_20250728} for the Claude 4 `str_replace_based_edit_tool` line
  *
- * @category text editor
+ * @category tools
  * @since 4.0.0
  */
 export const TextEditor_20241022 = Tool.providerDefined({
@@ -1930,7 +1930,7 @@ export const TextEditor_20241022 = Tool.providerDefined({
  * @see {@link TextEditor_20241022} for the older `str_replace_editor` version
  * @see {@link TextEditor_20250429} for the Claude 4 `str_replace_based_edit_tool` line
  *
- * @category text editor
+ * @category tools
  * @since 4.0.0
  */
 export const TextEditor_20250124 = Tool.providerDefined({
@@ -1961,7 +1961,7 @@ export const TextEditor_20250124 = Tool.providerDefined({
  * @see {@link TextEditor_20250124} for the previous `str_replace_editor` version
  * @see {@link TextEditor_20250728} for the later Claude 4 text editor version
  *
- * @category text editor
+ * @category tools
  * @since 4.0.0
  */
 export const TextEditor_20250429 = Tool.providerDefined({
@@ -1986,7 +1986,7 @@ export const TextEditor_20250429 = Tool.providerDefined({
  *
  * This version does not support the `undo_edit` command.
  *
- * @category text editor
+ * @category tools
  * @since 4.0.0
  */
 export const TextEditor_20250728 = Tool.providerDefined({
@@ -2023,7 +2023,7 @@ export const TextEditor_20250728 = Tool.providerDefined({
  *
  * @see {@link WebSearch_20250305_Args} for the argument schema that consumes this location
  *
- * @category Web Search
+ * @category schemas
  * @since 4.0.0
  */
 export const WebSearchUserLocation = Schema.Struct({
@@ -2073,7 +2073,7 @@ export const WebSearchUserLocation = Schema.Struct({
  * @see {@link WebSearch_20250305} for the provider-defined tool that consumes these arguments
  * @see {@link WebSearchUserLocation} for localizing search results
  *
- * @category Web Search
+ * @category schemas
  * @since 4.0.0
  */
 export const WebSearch_20250305_Args = Schema.Struct({
@@ -2105,7 +2105,7 @@ export const WebSearch_20250305_Args = Schema.Struct({
  *
  * `allowedDomains` and `blockedDomains` are mutually exclusive.
  *
- * @category Web Search
+ * @category models
  * @since 4.0.0
  */
 export type WebSearch_20250305_Args = typeof WebSearch_20250305_Args.Type
@@ -2124,7 +2124,7 @@ export type WebSearch_20250305_Args = typeof WebSearch_20250305_Args.Type
  *
  * @see {@link WebSearch_20250305} for the provider-defined tool that consumes this payload
  *
- * @category Web Search
+ * @category schemas
  * @since 4.0.0
  */
 export const WebSearchParameters = Schema.Struct({
@@ -2142,7 +2142,7 @@ export const WebSearchParameters = Schema.Struct({
  *
  * @see {@link WebSearch_20250305} for the provider-defined tool that consumes this payload
  *
- * @category Web Search
+ * @category models
  * @since 4.0.0
  */
 export type WebSearchParameters = typeof WebSearchParameters.Type
@@ -2166,7 +2166,7 @@ export type WebSearchParameters = typeof WebSearchParameters.Type
  *
  * @see {@link WebFetch_20250910} for retrieving known URLs after discovery
  *
- * @category Web Search
+ * @category tools
  * @since 4.0.0
  */
 export const WebSearch_20250305 = Tool.providerDefined({
@@ -2201,7 +2201,7 @@ export const WebSearch_20250305 = Tool.providerDefined({
  *
  * @see {@link WebFetch_20250910_Args} for the argument schema that consumes this configuration
  *
- * @category Web Fetch
+ * @category schemas
  * @since 4.0.0
  */
 export const WebFetchCitationsConfig = Schema.Struct({
@@ -2225,7 +2225,7 @@ export const WebFetchCitationsConfig = Schema.Struct({
  *
  * @see {@link WebFetch_20250910_Args} for the argument schema that consumes this configuration
  *
- * @category Web Fetch
+ * @category models
  * @since 4.0.0
  */
 export type WebFetchCitationsConfig = typeof WebFetchCitationsConfig.Type
@@ -2256,7 +2256,7 @@ export type WebFetchCitationsConfig = typeof WebFetchCitationsConfig.Type
  * @see {@link WebFetch_20250910} for the provider-defined tool that consumes these arguments
  * @see {@link WebFetchCitationsConfig} for configuring citations
  *
- * @category Web Fetch
+ * @category schemas
  * @since 4.0.0
  */
 export const WebFetch_20250910_Args = Schema.Struct({
@@ -2299,7 +2299,7 @@ export const WebFetch_20250910_Args = Schema.Struct({
  * `maxContentTokens` is approximate and does not apply to binary content such
  * as PDFs.
  *
- * @category Web Fetch
+ * @category models
  * @since 4.0.0
  */
 export type WebFetch_20250910_Args = typeof WebFetch_20250910_Args.Type
@@ -2327,7 +2327,7 @@ export type WebFetch_20250910_Args = typeof WebFetch_20250910_Args.Type
  *
  * @see {@link WebFetch_20250910} for the provider-defined tool that consumes this payload
  *
- * @category Web Fetch
+ * @category schemas
  * @since 4.0.0
  */
 export const WebFetchParameters = Schema.Struct({
@@ -2354,7 +2354,7 @@ export const WebFetchParameters = Schema.Struct({
  * The URL must be user-provided or from prior search/fetch results. Maximum URL
  * length is 250 characters.
  *
- * @category Web Fetch
+ * @category models
  * @since 4.0.0
  */
 export type WebFetchParameters = typeof WebFetchParameters.Type
@@ -2379,7 +2379,7 @@ export type WebFetchParameters = typeof WebFetchParameters.Type
  *
  * @see {@link WebSearch_20250305} for discovering URLs before fetching specific content
  *
- * @category Web Fetch
+ * @category tools
  * @since 4.0.0
  */
 export const WebFetch_20250910 = Tool.providerDefined({
@@ -2408,7 +2408,7 @@ export const WebFetch_20250910 = Tool.providerDefined({
  * Claude constructs regex patterns using Python's `re.search()` syntax.
  * Maximum query length: 200 characters.
  *
- * @category tool search
+ * @category schemas
  * @since 4.0.0
  */
 export const ToolSearchRegexParameters = Schema.Struct({
@@ -2425,7 +2425,7 @@ export const ToolSearchRegexParameters = Schema.Struct({
  * Claude constructs regex patterns using Python's `re.search()` syntax.
  * Maximum query length: 200 characters.
  *
- * @category tool search
+ * @category models
  * @since 4.0.0
  */
 export type ToolSearchRegexParameters = typeof ToolSearchRegexParameters.Type
@@ -2445,7 +2445,7 @@ export type ToolSearchRegexParameters = typeof ToolSearchRegexParameters.Type
  *
  * @see {@link ToolSearchBM25_20251119} for the provider-defined tool that consumes these parameters
  *
- * @category tool search
+ * @category schemas
  * @since 4.0.0
  */
 export const ToolSearchBM25Parameters = Schema.Struct({
@@ -2457,7 +2457,7 @@ export const ToolSearchBM25Parameters = Schema.Struct({
 /**
  * Type of the parameters Claude supplies when invoking BM25 natural-language Anthropic tool search.
  *
- * @category tool search
+ * @category models
  * @since 4.0.0
  */
 export type ToolSearchBM25Parameters = typeof ToolSearchBM25Parameters.Type
@@ -2476,7 +2476,7 @@ export type ToolSearchBM25Parameters = typeof ToolSearchBM25Parameters.Type
  * argument names, and argument descriptions.
  * Requires the "advanced-tool-use-2025-11-20" beta header.
  *
- * @category tool search
+ * @category tools
  * @since 4.0.0
  */
 export const ToolSearchRegex_20251119 = Tool.providerDefined({
@@ -2505,7 +2505,7 @@ export const ToolSearchRegex_20251119 = Tool.providerDefined({
  *
  * @see {@link ToolSearchRegex_20251119} for the regex-pattern alternative
  *
- * @category tool search
+ * @category tools
  * @since 4.0.0
  */
 export const ToolSearchBM25_20251119 = Tool.providerDefined({

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -34,7 +34,7 @@ import { OpenAiConfig } from "./OpenAiConfig.ts"
  * completions, streaming chat completions, and embeddings. Transport and
  * schema decoding failures are mapped to `AiError`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Service {
@@ -352,7 +352,7 @@ type JsonObject = { readonly [x: string]: Schema.Json }
 /**
  * Optional response fields that can be requested with the `include` parameter.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type IncludeEnum =
@@ -391,7 +391,7 @@ type InputFileContent = {
 /**
  * Content blocks accepted in input messages.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type InputContent = InputTextContent | InputImageContent | InputFileContent
@@ -399,7 +399,7 @@ export type InputContent = InputTextContent | InputImageContent | InputFileConte
 /**
  * Text content block used for model-provided reasoning summaries.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type SummaryTextContent = {
@@ -461,7 +461,7 @@ type FilePathAnnotation = {
 /**
  * Citation and file-path annotations attached to output text content.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type Annotation =
@@ -500,7 +500,7 @@ type OutputMessage = {
  * Reasoning output item containing encrypted reasoning content, summaries, and
  * optional reasoning text.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ReasoningItem = {
@@ -557,7 +557,7 @@ type ItemReference = {
  * Supports input messages, output messages, tool calls, tool outputs, reasoning
  * items, custom tool interactions, and item references.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type InputItem =
@@ -598,7 +598,7 @@ type CustomToolParam = {
 /**
  * Tool definitions that can be supplied to a Responses-style request.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type Tool =
@@ -649,7 +649,7 @@ export type TextResponseFormatConfiguration =
  * Request options for creating a Responses-style response with an
  * OpenAI-compatible provider.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type CreateResponse = {
@@ -689,7 +689,7 @@ export type CreateResponse = {
 /**
  * Token accounting reported on Responses-style response objects.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ResponseUsage = {
@@ -710,7 +710,7 @@ type OutputItem =
  * Responses-style response object returned by compatible providers or embedded
  * in response stream lifecycle events.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type Response = {
@@ -867,7 +867,7 @@ export type ResponseStreamEvent =
  * string. The `index` field identifies the input item that produced this
  * embedding.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type Embedding = {
@@ -879,7 +879,7 @@ export type Embedding = {
 /**
  * Request payload for the embeddings endpoint.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type CreateEmbeddingRequest = {
@@ -893,7 +893,7 @@ export type CreateEmbeddingRequest = {
 /**
  * Successful response payload returned by the embeddings endpoint.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type CreateEmbeddingResponse = {
@@ -909,21 +909,21 @@ export type CreateEmbeddingResponse = {
 /**
  * JSON request body accepted by the embeddings endpoint.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type CreateEmbeddingRequestJson = CreateEmbeddingRequest
 /**
  * Decoded successful embeddings response body.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type CreateEmbedding200 = CreateEmbeddingResponse
 /**
  * Structured content parts accepted in chat completion messages.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionContentPart =
@@ -941,7 +941,7 @@ export type ChatCompletionContentPart =
 /**
  * Tool call data attached to an assistant chat completion message.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionRequestToolCall = {
@@ -955,7 +955,7 @@ export type ChatCompletionRequestToolCall = {
 /**
  * Message shapes accepted by the chat completions endpoint.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionRequestMessage =
@@ -972,7 +972,7 @@ export type ChatCompletionRequestMessage =
 /**
  * Function tool definition accepted by the chat completions endpoint.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionTool = {
@@ -1022,7 +1022,7 @@ export type ChatCompletionResponseFormat =
 /**
  * Request payload for the OpenAI-compatible chat completions endpoint.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionRequest = {
@@ -1048,14 +1048,14 @@ export type ChatCompletionRequest = {
 /**
  * JSON request body used by this client when creating a chat completion response.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type CreateResponseRequestJson = ChatCompletionRequest
 /**
  * Decoded successful chat completion response body returned by `createResponse`.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type CreateResponse200 = ChatCompletionResponse
@@ -1162,35 +1162,35 @@ const ChatCompletionChunk = Schema.Struct({
 /**
  * Decoded tool-call object from a chat completion response or streaming chunk.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionToolCall = typeof ChatCompletionToolCall.Type
 /**
  * Decoded message object from a non-streaming chat completion choice.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionMessage = typeof ChatCompletionMessage.Type
 /**
  * Decoded choice object returned by chat completion responses and chunks.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionChoice = typeof ChatCompletionChoice.Type
 /**
  * Decoded token usage summary returned by chat completions.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionUsage = typeof ChatCompletionUsage.Type
 /**
  * Decoded successful response from the chat completions endpoint.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ChatCompletionResponse = typeof ChatCompletionResponse.Type

--- a/packages/ai/openai-compat/src/OpenAiConfig.ts
+++ b/packages/ai/openai-compat/src/OpenAiConfig.ts
@@ -50,7 +50,7 @@ export declare namespace OpenAiConfig {
    * Configuration consumed by OpenAI-compatible clients when they build or
    * resolve the underlying HTTP client.
    *
-   * @category models
+   * @category services
    * @since 4.0.0
    */
   export interface Service {

--- a/packages/ai/openai-compat/src/OpenAiEmbeddingModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiEmbeddingModel.ts
@@ -46,7 +46,7 @@ type ModelConfig = Omit<ConfigOptions, "model"> & { readonly [x: string]: unknow
  *
  * @see {@link withConfigOverride} for scoping embedding request overrides
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class Config extends Context.Service<

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -127,7 +127,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-compatible options for file prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface FilePartOptions extends ProviderOptions {
@@ -145,7 +145,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-compatible options for reasoning prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartOptions extends ProviderOptions {
@@ -169,7 +169,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-compatible options for assistant tool-call prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartOptions extends ProviderOptions {
@@ -191,7 +191,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-compatible options for tool-result prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolResultPartOptions extends ProviderOptions {
@@ -213,7 +213,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-compatible options for text prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface TextPartOptions extends ProviderOptions {
@@ -241,7 +241,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata attached to a complete text response part.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface TextPartMetadata extends ProviderMetadata {
@@ -273,7 +273,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata emitted when a streamed text part starts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface TextStartPartMetadata extends ProviderMetadata {
@@ -291,7 +291,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata emitted when a streamed text part ends.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface TextEndPartMetadata extends ProviderMetadata {
@@ -313,7 +313,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata attached to a complete reasoning response part.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartMetadata extends ProviderMetadata {
@@ -335,7 +335,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata emitted when a streamed reasoning part starts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningStartPartMetadata extends ProviderMetadata {
@@ -357,7 +357,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata emitted for a streamed reasoning delta.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningDeltaPartMetadata extends ProviderMetadata {
@@ -375,7 +375,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata emitted when a streamed reasoning part ends.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningEndPartMetadata extends ProviderMetadata {
@@ -397,7 +397,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata attached to tool-call response parts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartMetadata extends ProviderMetadata {
@@ -415,7 +415,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata attached to document source citations.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface DocumentSourcePartMetadata extends ProviderMetadata {
@@ -471,7 +471,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata attached to URL source citations.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface UrlSourcePartMetadata extends ProviderMetadata {
@@ -497,7 +497,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI-compatible metadata attached to finish response parts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface FinishPartMetadata extends ProviderMetadata {

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -111,7 +111,7 @@ type ModelConfig = Omit<ConfigOptions, "model"> & { readonly [x: string]: unknow
  *
  * @see {@link withConfigOverride} for scoping language model request overrides
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class Config extends Context.Service<

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -460,7 +460,7 @@ export type ResponseStreamEvent = typeof OpenAiSchema.ResponseStreamEvent.Type
  * @see {@link withWebSocketMode} for enabling WebSocket mode for one effect
  * @see {@link layerWebSocketMode} for providing WebSocket mode through a layer
  *
- * @category Websocket mode
+ * @category WebSocket mode
  * @since 4.0.0
  */
 export class OpenAiSocket extends Context.Service<OpenAiSocket, {
@@ -696,7 +696,7 @@ const decodeEvent = Schema.decodeUnknownSync(Schema.fromJsonString(AllEvents))
  * @see {@link layerWebSocketMode} for providing WebSocket mode through a layer
  * @see {@link OpenAiSocket} for direct access to the WebSocket-backed streaming service
  *
- * @category Websocket mode
+ * @category WebSocket mode
  * @since 4.0.0
  */
 export const withWebSocketMode = <A, E, R>(
@@ -733,7 +733,7 @@ export const withWebSocketMode = <A, E, R>(
  *
  * @see {@link withWebSocketMode} for enabling WebSocket mode around a single effect
  *
- * @category Websocket mode
+ * @category WebSocket mode
  * @since 4.0.0
  */
 export const layerWebSocketMode: Layer.Layer<

--- a/packages/ai/openai/src/OpenAiClient.ts
+++ b/packages/ai/openai/src/OpenAiClient.ts
@@ -47,7 +47,7 @@ import * as OpenAiSchema from "./OpenAiSchema.ts"
  *
  * Provides the configured HTTP client plus helpers for Responses API calls, streaming Responses events, and embeddings. Transport and schema decoding failures are mapped to `AiError`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Service {
@@ -433,7 +433,7 @@ export const layerConfig = (options?: {
 /**
  * Response stream event emitted by the OpenAI Responses API.
  *
- * @category Events
+ * @category models
  * @since 4.0.0
  */
 export type ResponseStreamEvent = typeof OpenAiSchema.ResponseStreamEvent.Type
@@ -460,7 +460,7 @@ export type ResponseStreamEvent = typeof OpenAiSchema.ResponseStreamEvent.Type
  * @see {@link withWebSocketMode} for enabling WebSocket mode for one effect
  * @see {@link layerWebSocketMode} for providing WebSocket mode through a layer
  *
- * @category WebSocket mode
+ * @category services
  * @since 4.0.0
  */
 export class OpenAiSocket extends Context.Service<OpenAiSocket, {
@@ -696,7 +696,7 @@ const decodeEvent = Schema.decodeUnknownSync(Schema.fromJsonString(AllEvents))
  * @see {@link layerWebSocketMode} for providing WebSocket mode through a layer
  * @see {@link OpenAiSocket} for direct access to the WebSocket-backed streaming service
  *
- * @category WebSocket mode
+ * @category providing services
  * @since 4.0.0
  */
 export const withWebSocketMode = <A, E, R>(
@@ -733,7 +733,7 @@ export const withWebSocketMode = <A, E, R>(
  *
  * @see {@link withWebSocketMode} for enabling WebSocket mode around a single effect
  *
- * @category WebSocket mode
+ * @category layers
  * @since 4.0.0
  */
 export const layerWebSocketMode: Layer.Layer<

--- a/packages/ai/openai/src/OpenAiConfig.ts
+++ b/packages/ai/openai/src/OpenAiConfig.ts
@@ -49,7 +49,7 @@ export declare namespace OpenAiConfig {
    * Configuration values read by OpenAI provider operations when executing
    * requests.
    *
-   * @category models
+   * @category services
    * @since 4.0.0
    */
   export interface Service {

--- a/packages/ai/openai/src/OpenAiError.ts
+++ b/packages/ai/openai/src/OpenAiError.ts
@@ -68,7 +68,7 @@ declare module "effect/unstable/ai/AiError" {
    * from responses where the provider rejected the request because a limit was
    * reached.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface RateLimitErrorMetadata {
@@ -86,7 +86,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for failures caused by exhausted account,
    * billing, or usage quota.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface QuotaExhaustedErrorMetadata {
@@ -104,7 +104,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for failed API key, authorization, or
    * permission checks.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface AuthenticationErrorMetadata {
@@ -122,7 +122,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when OpenAI rejects input or output because
    * it violates a content policy.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface ContentPolicyErrorMetadata {
@@ -140,7 +140,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for malformed requests, unsupported
    * parameters, or other request validation failures reported by OpenAI.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InvalidRequestErrorMetadata {
@@ -158,7 +158,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for OpenAI-side failures such as transient
    * server errors.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InternalProviderErrorMetadata {
@@ -176,7 +176,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when an OpenAI response cannot be parsed or
    * validated as the expected output.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InvalidOutputErrorMetadata {
@@ -194,7 +194,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when OpenAI returns content that does not
    * satisfy the requested structured output schema.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface StructuredOutputErrorMetadata {
@@ -212,7 +212,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when an unsupported schema failure is
    * associated with an OpenAI response.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface UnsupportedSchemaErrorMetadata {
@@ -230,7 +230,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for OpenAI failures that do not map cleanly
    * to a more specific AI error category.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface UnknownErrorMetadata {

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -127,7 +127,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-specific options for file prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface FilePartOptions extends ProviderOptions {
@@ -145,7 +145,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-specific options for reasoning prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartOptions extends ProviderOptions {
@@ -169,7 +169,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-specific options for assistant tool-call prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartOptions extends ProviderOptions {
@@ -195,7 +195,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-specific options for tool-result prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolResultPartOptions extends ProviderOptions {
@@ -221,7 +221,7 @@ declare module "effect/unstable/ai/Prompt" {
   /**
    * OpenAI-specific options for text prompt parts.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface TextPartOptions extends ProviderOptions {
@@ -249,7 +249,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata attached to a complete text response part.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface TextPartMetadata extends ProviderMetadata {
@@ -281,7 +281,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata emitted when a streamed text part starts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface TextStartPartMetadata extends ProviderMetadata {
@@ -299,7 +299,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata emitted when a streamed text part ends.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface TextEndPartMetadata extends ProviderMetadata {
@@ -321,7 +321,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata attached to a complete reasoning response part.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartMetadata extends ProviderMetadata {
@@ -343,7 +343,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata emitted when a streamed reasoning part starts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningStartPartMetadata extends ProviderMetadata {
@@ -365,7 +365,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata emitted for a streamed reasoning delta.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningDeltaPartMetadata extends ProviderMetadata {
@@ -383,7 +383,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata emitted when a streamed reasoning part ends.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningEndPartMetadata extends ProviderMetadata {
@@ -405,7 +405,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata attached to tool-call response parts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartMetadata extends ProviderMetadata {
@@ -423,7 +423,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata attached to document source citations.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface DocumentSourcePartMetadata extends ProviderMetadata {
@@ -479,7 +479,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata attached to URL source citations.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface UrlSourcePartMetadata extends ProviderMetadata {
@@ -505,7 +505,7 @@ declare module "effect/unstable/ai/Response" {
   /**
    * OpenAI metadata attached to finish response parts.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface FinishPartMetadata extends ProviderMetadata {

--- a/packages/ai/openrouter/src/OpenRouterClient.ts
+++ b/packages/ai/openrouter/src/OpenRouterClient.ts
@@ -37,7 +37,7 @@ import { OpenRouterConfig } from "./OpenRouterConfig.ts"
  * Provides methods for interacting with OpenRouter's Chat Completions API,
  * including both synchronous and streaming message creation.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Service {

--- a/packages/ai/openrouter/src/OpenRouterConfig.ts
+++ b/packages/ai/openrouter/src/OpenRouterConfig.ts
@@ -50,7 +50,7 @@ export declare namespace OpenRouterConfig {
    * Configuration values read by OpenRouter provider operations when resolving
    * the generated HTTP client.
    *
-   * @category models
+   * @category services
    * @since 4.0.0
    */
   export interface Service {

--- a/packages/ai/openrouter/src/OpenRouterError.ts
+++ b/packages/ai/openrouter/src/OpenRouterError.ts
@@ -51,7 +51,7 @@ declare module "effect/unstable/ai/AiError" {
    * information from responses where the provider rejected the request because
    * a limit was reached.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface RateLimitErrorMetadata {
@@ -69,7 +69,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for failures caused by exhausted account,
    * billing, or usage quota.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface QuotaExhaustedErrorMetadata {
@@ -87,7 +87,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for failed API key, authorization, or
    * permission checks.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface AuthenticationErrorMetadata {
@@ -105,7 +105,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when OpenRouter rejects input or output
    * because it violates a content policy.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface ContentPolicyErrorMetadata {
@@ -123,7 +123,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for malformed requests, unsupported
    * parameters, or other request validation failures reported by OpenRouter.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InvalidRequestErrorMetadata {
@@ -141,7 +141,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for OpenRouter-side failures such as
    * transient server errors or overload responses.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InternalProviderErrorMetadata {
@@ -159,7 +159,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when an OpenRouter response cannot be
    * parsed or validated as the expected output.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface InvalidOutputErrorMetadata {
@@ -177,7 +177,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when OpenRouter returns content that does
    * not satisfy the requested structured output schema.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface StructuredOutputErrorMetadata {
@@ -195,7 +195,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details when an unsupported schema failure is
    * associated with an OpenRouter response.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface UnsupportedSchemaErrorMetadata {
@@ -213,7 +213,7 @@ declare module "effect/unstable/ai/AiError" {
    * Preserves provider error details for OpenRouter failures that do not map
    * cleanly to a more specific AI error category.
    *
-   * @category configuration
+   * @category models
    * @since 4.0.0
    */
   export interface UnknownErrorMetadata {

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -112,7 +112,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when translating system instructions into
    * OpenRouter chat messages.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface SystemMessageOptions extends ProviderOptions {
@@ -135,7 +135,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when translating user content into OpenRouter chat
    * messages.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface UserMessageOptions extends ProviderOptions {
@@ -158,7 +158,7 @@ declare module "effect/unstable/ai/Prompt" {
    * Preserves reasoning metadata when assistant messages are replayed in later
    * OpenRouter requests.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface AssistantMessageOptions extends ProviderOptions {
@@ -185,7 +185,7 @@ declare module "effect/unstable/ai/Prompt" {
    * These options are used when converting tool results into OpenRouter chat
    * messages.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolMessageOptions extends ProviderOptions {
@@ -207,7 +207,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Use when you use these options to control how text content is sent to OpenRouter.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface TextPartOptions extends ProviderOptions {
@@ -230,7 +230,7 @@ declare module "effect/unstable/ai/Prompt" {
    * Preserves provider reasoning blocks so reasoning-aware conversations can
    * continue across OpenRouter requests.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartOptions extends ProviderOptions {
@@ -256,7 +256,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Controls file naming and prompt caching for files sent to OpenRouter.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface FilePartOptions extends ProviderOptions {
@@ -284,7 +284,7 @@ declare module "effect/unstable/ai/Prompt" {
    * Preserves reasoning details associated with tool calls when a conversation
    * is sent back to OpenRouter.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartOptions extends ProviderOptions {
@@ -306,7 +306,7 @@ declare module "effect/unstable/ai/Prompt" {
    *
    * Controls prompt caching for tool results sent to OpenRouter.
    *
-   * @category request
+   * @category models
    * @since 4.0.0
    */
   export interface ToolResultPartOptions extends ProviderOptions {
@@ -330,7 +330,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Preserves provider reasoning details that can be sent back in later turns.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningPartMetadata extends ProviderMetadata {
@@ -352,7 +352,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Carries the first reasoning detail chunk when OpenRouter exposes one.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningStartPartMetadata extends ProviderMetadata {
@@ -374,7 +374,7 @@ declare module "effect/unstable/ai/Response" {
    *
    * Carries provider reasoning detail chunks as they arrive from OpenRouter.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ReasoningDeltaPartMetadata extends ProviderMetadata {
@@ -397,7 +397,7 @@ declare module "effect/unstable/ai/Response" {
    * Associates tool calls with provider reasoning details when the model emits
    * reasoning and tool calls together.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface ToolCallPartMetadata extends ProviderMetadata {
@@ -420,7 +420,7 @@ declare module "effect/unstable/ai/Response" {
    * Includes citation text and offsets returned by providers that support URL
    * annotations.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface UrlSourcePartMetadata extends ProviderMetadata {
@@ -451,7 +451,7 @@ declare module "effect/unstable/ai/Response" {
    * Exposes provider response details that are not represented by the common
    * Effect AI finish part fields.
    *
-   * @category response
+   * @category models
    * @since 4.0.0
    */
   export interface FinishPartMetadata extends ProviderMetadata {

--- a/packages/atom/vue/src/index.ts
+++ b/packages/atom/vue/src/index.ts
@@ -12,25 +12,25 @@ import { computed, type ComputedRef, inject, type InjectionKey, type Ref, shallo
 
 /**
  * @since 4.0.0
- * @category modules
+ * @category re-exports
  */
 export * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
 
 /**
  * @since 4.0.0
- * @category modules
+ * @category re-exports
  */
 export * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 
 /**
  * @since 4.0.0
- * @category modules
+ * @category re-exports
  */
 export * as Atom from "effect/unstable/reactivity/Atom"
 
 /**
  * @since 4.0.0
- * @category modules
+ * @category re-exports
  */
 export * as AtomRef from "effect/unstable/reactivity/AtomRef"
 
@@ -42,25 +42,25 @@ export * as AtomHttpApi from "effect/unstable/reactivity/AtomHttpApi"
 
 /**
  * @since 4.0.0
- * @category modules
+ * @category re-exports
  */
 export * as AtomRpc from "effect/unstable/reactivity/AtomRpc"
 
 /**
  * @since 4.0.0
- * @category registry
+ * @category symbols
  */
 export const registryKey = Symbol.for("@effect/atom-vue/registryKey") as InjectionKey<AtomRegistry.AtomRegistry>
 
 /**
  * @since 4.0.0
- * @category registry
+ * @category constants
  */
 export const defaultRegistry: AtomRegistry.AtomRegistry = AtomRegistry.make()
 
 /**
  * @since 4.0.0
- * @category registry
+ * @category accessors
  */
 export const injectRegistry = (): AtomRegistry.AtomRegistry => {
   return inject(registryKey, defaultRegistry)

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -2528,7 +2528,7 @@ export const rotate: {
  *
  * @see {@link contains} for the `Equal.equivalence()` variant
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const containsWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
@@ -2563,7 +2563,7 @@ export const containsWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
  *
  * @see {@link containsWith} — use custom equality
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const contains: {
@@ -3424,7 +3424,7 @@ export declare namespace ReadonlyArray {
    * // StringArrayType is string
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type Infer<S extends Iterable<any>> = S extends ReadonlyArray<infer A> ? A
@@ -3443,7 +3443,7 @@ export declare namespace ReadonlyArray {
    * // Result is NonEmptyArray<string>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type With<S extends Iterable<any>, A> = S extends NonEmptyReadonlyArray<any> ? NonEmptyArray<A>
@@ -3465,7 +3465,7 @@ export declare namespace ReadonlyArray {
    * // Result is NonEmptyArray<number>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type OrNonEmpty<
@@ -3492,7 +3492,7 @@ export declare namespace ReadonlyArray {
    * // Result is NonEmptyArray<boolean>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type AndNonEmpty<
@@ -3516,7 +3516,7 @@ export declare namespace ReadonlyArray {
    * // Flattened is Array<number>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type Flatten<T extends ReadonlyArray<ReadonlyArray<any>>> = T extends
@@ -4188,7 +4188,7 @@ export const liftResult = <A extends Array<unknown>, E, B>(
  *
  * @see {@link some} — test if any element matches
  *
- * @category elements
+ * @category guards
  * @since 2.0.0
  */
 export const every: {
@@ -4220,7 +4220,7 @@ export const every: {
  * @see {@link every} — test if all elements match
  * @see {@link contains} — test for a specific value
  *
- * @category elements
+ * @category guards
  * @since 2.0.0
  */
 export const some: {

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -52,7 +52,7 @@ export const Array = globalThis.Array
 /**
  * Type lambda for `ReadonlyArray`, used for higher-kinded type operations.
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface ReadonlyArrayTypeLambda extends TypeLambda {
@@ -1636,7 +1636,7 @@ export const dropWhileFilter: {
  * @see {@link findLastIndex} — search from the end
  * @see {@link findFirst} — get the element itself
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findFirstIndex: {
@@ -1672,7 +1672,7 @@ export const findFirstIndex: {
  * @see {@link findFirstIndex} — search from the start
  * @see {@link findLast} — get the element itself
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findLastIndex: {
@@ -1715,7 +1715,7 @@ export const findLastIndex: {
  * @see {@link findFirstIndex} — get the index instead
  * @see {@link findFirstWithIndex} — get both element and index
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findFirst: {
@@ -1752,7 +1752,7 @@ export const findFirst: {
  * @see {@link findFirst} — get only the element
  * @see {@link findFirstIndex} — get only the index
  *
- * @category elements
+ * @category searching
  * @since 3.17.0
  */
 export const findFirstWithIndex: {
@@ -1810,7 +1810,7 @@ export const findFirstWithIndex: {
  * @see {@link findFirst} — search from the start
  * @see {@link findLastIndex} — get the index instead
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findLast: {
@@ -1867,7 +1867,7 @@ export const findLast: {
  * @see {@link replace} — replace an existing element
  * @see {@link modify} — transform an element at an index
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const insertAt: {
@@ -1905,7 +1905,7 @@ export const insertAt: {
  * @see {@link modify} — transform an element with a function
  * @see {@link insertAt} — insert without removing
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const replace: {
@@ -1951,7 +1951,7 @@ export const replace: {
  * @see {@link modifyHeadNonEmpty} — modify the first element
  * @see {@link modifyLastNonEmpty} — modify the last element
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const modify: {
@@ -1996,7 +1996,7 @@ export const modify: {
  * @see {@link insertAt} — insert an element
  * @see {@link filter} — remove elements by predicate
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const remove: {
@@ -2031,7 +2031,7 @@ export const remove: {
  * Array.reverse([1, 2, 3, 4]) // => [4, 3, 2, 1]
  * ```
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const reverse = <S extends Iterable<any>>(
@@ -2101,7 +2101,7 @@ export const sort: {
  * @see {@link sort} for sorting with an `Order` that compares the elements directly
  * @see {@link sortBy} for sorting with multiple `Order`s applied in sequence
  *
- * @category elements
+ * @category sorting
  * @since 2.0.0
  */
 export const sortWith: {
@@ -2307,7 +2307,7 @@ export const unzip: <S extends Iterable<readonly [any, any]>>(
  *
  * @see {@link join} — intersperse and join into a string
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const intersperse: {
@@ -2351,7 +2351,7 @@ export const intersperse: {
  * @see {@link setHeadNonEmpty} — replace with a fixed value
  * @see {@link modifyLastNonEmpty} — modify the last element
  *
- * @category elements
+ * @category transforming
  * @since 4.0.0
  */
 export const modifyHeadNonEmpty: {
@@ -2384,7 +2384,7 @@ export const modifyHeadNonEmpty: {
  * @see {@link modifyHeadNonEmpty} — transform the head with a function
  * @see {@link setLastNonEmpty} — replace the last element
  *
- * @category elements
+ * @category transforming
  * @since 4.0.0
  */
 export const setHeadNonEmpty: {
@@ -2415,7 +2415,7 @@ export const setHeadNonEmpty: {
  * @see {@link setLastNonEmpty} — replace with a fixed value
  * @see {@link modifyHeadNonEmpty} — modify the first element
  *
- * @category elements
+ * @category transforming
  * @since 4.0.0
  */
 export const modifyLastNonEmpty: {
@@ -2446,7 +2446,7 @@ export const modifyLastNonEmpty: {
  * @see {@link modifyLastNonEmpty} — transform the last element with a function
  * @see {@link setHeadNonEmpty} — replace the first element
  *
- * @category elements
+ * @category transforming
  * @since 4.0.0
  */
 export const setLastNonEmpty: {
@@ -2483,7 +2483,7 @@ export const setLastNonEmpty: {
  * @see {@link take} for taking a fixed number of elements from the start
  * @see {@link drop} for dropping a fixed number of elements from the start
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const rotate: {
@@ -2596,7 +2596,7 @@ export const contains: {
  * @see {@link chunksOf} — split into fixed-size chunks
  * @see {@link splitAt} — split at an index
  *
- * @category elements
+ * @category splitting
  * @since 2.0.0
  */
 export const chop: {
@@ -2796,7 +2796,7 @@ export const splitWhere: {
  *
  * @see {@link fromIterable} — returns the same reference for arrays
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const copy: {
@@ -2827,7 +2827,7 @@ export const copy: {
  * @see {@link take} — truncate without padding
  * @see {@link replicate} — create an array of a single repeated value
  *
- * @category elements
+ * @category transforming
  * @since 3.8.4
  */
 export const pad: {
@@ -3134,7 +3134,7 @@ const hashBucketsHas = (buckets: HashBuckets, value: unknown): boolean => {
  * @see {@link intersectionWith} for keeping elements present in both arrays
  * @see {@link differenceWith} for keeping elements present only in the first array
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const unionWith: {
@@ -3182,7 +3182,7 @@ export const unionWith: {
  * @see {@link intersection} — elements in both arrays
  * @see {@link difference} — elements only in the first array
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const union: {
@@ -3231,7 +3231,7 @@ export const union: {
  * @see {@link unionWith} for keeping values from either array with custom equality
  * @see {@link differenceWith} for keeping values only from the first array with custom equality
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const intersectionWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
@@ -3269,7 +3269,7 @@ export const intersectionWith = <A>(isEquivalent: (self: A, that: A) => boolean)
  * @see {@link union} — elements in either array
  * @see {@link difference} — elements only in the first array
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const intersection: {
@@ -3306,7 +3306,7 @@ export const intersection: {
  * @see {@link unionWith} for keeping values from either array with custom equality
  * @see {@link intersectionWith} for keeping values present in both arrays with custom equality
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const differenceWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
@@ -3344,7 +3344,7 @@ export const differenceWith = <A>(isEquivalent: (self: A, that: A) => boolean): 
  * @see {@link union} — elements in either array
  * @see {@link intersection} — elements in both arrays
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const difference: {
@@ -4283,7 +4283,7 @@ export const extend: {
  * @see {@link max} — find the maximum
  * @see {@link sort} — sort the entire array
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const min: {
@@ -4306,7 +4306,7 @@ export const min: {
  * @see {@link min} — find the minimum
  * @see {@link sort} — sort the entire array
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const max: {
@@ -4415,7 +4415,7 @@ export const makeEquivalence: <A>(
  *
  * @see {@link map} for transforming each element into a new array
  *
- * @category elements
+ * @category traversing
  * @since 2.0.0
  */
 export const forEach: {
@@ -4443,7 +4443,7 @@ export const forEach: {
  * @see {@link dedupe} — uses default equality
  * @see {@link dedupeAdjacentWith} — only dedupes consecutive elements
  *
- * @category elements
+ * @category deduplication
  * @since 2.0.0
  */
 export const dedupeWith: {
@@ -4490,7 +4490,7 @@ export const dedupeWith: {
  * @see {@link dedupeWith} — use custom equality
  * @see {@link dedupeAdjacent} — only dedupes consecutive elements
  *
- * @category elements
+ * @category deduplication
  * @since 2.0.0
  */
 export const dedupe = <S extends Iterable<any>>(
@@ -4534,7 +4534,7 @@ export const dedupe = <S extends Iterable<any>>(
  * @see {@link dedupeAdjacent} — uses default equality
  * @see {@link dedupeWith} — dedupes all duplicates, not just adjacent
  *
- * @category elements
+ * @category deduplication
  * @since 2.0.0
  */
 export const dedupeAdjacentWith: {
@@ -4571,7 +4571,7 @@ export const dedupeAdjacentWith: {
  * @see {@link dedupeAdjacentWith} — use custom equality
  * @see {@link dedupe} — remove all duplicates
  *
- * @category elements
+ * @category deduplication
  * @since 2.0.0
  */
 export const dedupeAdjacent: <A>(self: Iterable<A>) => Array<A> = dedupeAdjacentWith(Equal.asEquivalence())
@@ -4676,7 +4676,7 @@ export const mapAccum: {
  *
  * @see {@link cartesian} for returning tuples instead of applying a combiner
  *
- * @category elements
+ * @category combining
  * @since 2.0.0
  */
 export const cartesianWith: {
@@ -4710,7 +4710,7 @@ export const cartesianWith: {
  *
  * @see {@link cartesianWith} — apply a combiner to each pair
  *
- * @category elements
+ * @category combining
  * @since 2.0.0
  */
 export const cartesian: {
@@ -4757,7 +4757,7 @@ export const cartesian: {
  * @see {@link bindTo} — start a pipeline by naming the first array
  * @see {@link let_ let} — introduce a plain computed value
  *
- * @category do notation
+ * @category constructors
  * @since 3.2.0
  */
 export const Do: ReadonlyArray<{}> = of({})
@@ -4792,7 +4792,7 @@ export const Do: ReadonlyArray<{}> = of({})
  * @see {@link bindTo} — name the first array in a pipeline
  * @see {@link let_ let} — add a plain computed value
  *
- * @category do notation
+ * @category sequencing
  * @since 3.2.0
  */
 export const bind: {
@@ -4833,7 +4833,7 @@ export const bind: {
  * @see {@link Do} — start with an empty scope
  * @see {@link bind} — add another array variable to the scope
  *
- * @category do notation
+ * @category mapping
  * @since 3.2.0
  */
 export const bindTo: {
@@ -4883,7 +4883,7 @@ export {
    * @see {@link Do} — start a do-notation pipeline
    * @see {@link bind} — introduce an array variable (produces cartesian product)
    *
-   * @category do notation
+   * @category mapping
    * @since 3.2.0
    */
   let_ as let

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -239,7 +239,7 @@ export declare namespace Cause {
    * type E = Cause.Cause.Error<Cause.Cause<string>>
    * ```
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type Error<T> = T extends Cause<infer E> ? E : never
@@ -285,7 +285,7 @@ export declare namespace Reason {
    * type E = Cause.Reason.Error<Cause.Reason<string>>
    * ```
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type Error<T> = T extends Reason<infer E> ? E : never
@@ -1809,7 +1809,7 @@ export const annotations: <E>(self: Cause<E>) => Context.Context<never> = effect
  * @see {@link annotations} for reading merged annotations from a cause
  * @see {@link InterruptorStackTrace} for the interrupt-specific stack-frame annotation
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class StackTrace extends Context.Service<StackTrace, StackFrame>()("effect/Cause/StackTrace") {}
@@ -1831,7 +1831,7 @@ export class StackTrace extends Context.Service<StackTrace, StackFrame>()("effec
  * @see {@link reasonAnnotations} for reading annotations from a single reason
  * @see {@link annotate} for attaching annotations to a cause
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class InterruptorStackTrace

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -987,7 +987,7 @@ export const findInterrupt: <E>(self: Cause<E>) => Result.Result<Interrupt, Caus
  *
  * @see {@link filterInterruptors} — `Result`-based variant
  *
- * @category accessors
+ * @category getters
  * @since 2.0.0
  */
 export const interruptors: <E>(self: Cause<E>) => ReadonlySet<number> = effect.causeInterruptors
@@ -1062,7 +1062,7 @@ export const filterInterruptors: <E>(self: Cause<E>) => Result.Result<Set<number
  * @see {@link pretty} — renders the cause as a single string
  * @see {@link squash} — lossy collapse to a single thrown value
  *
- * @category rendering
+ * @category formatting
  * @since 3.2.0
  */
 export const prettyErrors: <E>(self: Cause<E>, options?: {
@@ -1109,7 +1109,7 @@ export const prettyErrors: <E>(self: Cause<E>, options?: {
  *
  * @see {@link prettyErrors} — get the individual `Error` instances
  *
- * @category rendering
+ * @category formatting
  * @since 2.0.0
  */
 export const pretty: <E>(cause: Cause<E>) => string = effect.causePretty

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6486,7 +6486,7 @@ export const mergeEffect: {
  * result // => ["hello", "world"]
  * ```
  *
- * @category String manipulation
+ * @category string manipulation
  * @since 2.0.0
  */
 export const splitLines = <Err, Done>(): Channel<
@@ -6600,7 +6600,7 @@ export const splitLines = <Err, Done>(): Channel<
  * span `Uint8Array` boundaries. The optional `encoding` and `options` are
  * passed to `TextDecoder`.
  *
- * @category String manipulation
+ * @category string manipulation
  * @since 4.0.0
  */
 export const decodeText = <Err, Done>(encoding?: string, options?: TextDecoderOptions): Channel<
@@ -6626,7 +6626,7 @@ export const decodeText = <Err, Done>(encoding?: string, options?: TextDecoderOp
  *
  * Each string inside an emitted array is encoded independently.
  *
- * @category String manipulation
+ * @category string manipulation
  * @since 4.0.0
  */
 export const encodeText = <Err, Done>(): Channel<
@@ -6900,7 +6900,7 @@ export const embedInput: {
  *
  * @see {@link bufferArray} for buffering elements from array outputs
  *
- * @category Buffering
+ * @category buffering
  * @since 2.0.0
  */
 export const buffer: {
@@ -6966,7 +6966,7 @@ export const buffer: {
  *
  * @see {@link buffer} for buffering output elements without flattening arrays
  *
- * @category Buffering
+ * @category buffering
  * @since 4.0.0
  */
 export const bufferArray: {
@@ -7329,7 +7329,7 @@ const runWith = <
 /**
  * Creates a channel from the specified services.
  *
- * @category services
+ * @category accessors
  * @since 2.0.0
  */
 export const contextWith = <Env, OutElem, OutErr, OutDone, InElem, InErr, InDone, Env2>(
@@ -7343,7 +7343,7 @@ export const contextWith = <Env, OutElem, OutErr, OutDone, InElem, InErr, InDone
  * Provides a `Context` to the channel, removing the corresponding service
  * requirements from the returned channel.
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const provideContext: {
@@ -7371,7 +7371,7 @@ export const provideContext: {
  * Provides a concrete service for a context key, removing that service
  * requirement from the returned channel.
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const provideService: {
@@ -7411,7 +7411,7 @@ export const provideService: {
  * If the service effect fails, the returned channel fails. The provided service
  * removes the corresponding service requirement from the returned channel.
  *
- * @category services
+ * @category providing services
  * @since 4.0.0
  */
 export const provideServiceEffect: {
@@ -7448,7 +7448,7 @@ export const provideServiceEffect: {
  * builds the layer in the channel scope. Use `options.local` to build a fresh
  * layer instance for this provision.
  *
- * @category services
+ * @category providing services
  * @since 4.0.0
  */
 export const provide: {
@@ -7496,7 +7496,7 @@ export const provide: {
  * provide to the channel. The returned channel requires the services needed to
  * build that context.
  *
- * @category services
+ * @category providing services
  * @since 4.0.0
  */
 export const updateContext: {
@@ -7528,7 +7528,7 @@ export const updateContext: {
  * The existing service is read from the context. The updated service is
  * provided to the channel under the same key.
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const updateService: {

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6486,7 +6486,7 @@ export const mergeEffect: {
  * result // => ["hello", "world"]
  * ```
  *
- * @category string manipulation
+ * @category splitting
  * @since 2.0.0
  */
 export const splitLines = <Err, Done>(): Channel<
@@ -6600,7 +6600,7 @@ export const splitLines = <Err, Done>(): Channel<
  * span `Uint8Array` boundaries. The optional `encoding` and `options` are
  * passed to `TextDecoder`.
  *
- * @category string manipulation
+ * @category decoding
  * @since 4.0.0
  */
 export const decodeText = <Err, Done>(encoding?: string, options?: TextDecoderOptions): Channel<
@@ -6626,7 +6626,7 @@ export const decodeText = <Err, Done>(encoding?: string, options?: TextDecoderOp
  *
  * Each string inside an emitted array is encoded independently.
  *
- * @category string manipulation
+ * @category encoding
  * @since 4.0.0
  */
 export const encodeText = <Err, Done>(): Channel<
@@ -7608,7 +7608,7 @@ const withSpanImpl = <OutElem, OutErr, OutDone, InElem, InErr, InDone, R>(
 /**
  * The starting channel for Do notation, emitting an empty object.
  *
- * @category do notation
+ * @category constructors
  * @since 4.0.0
  */
 export const Do: Channel<{}> = succeed({})
@@ -7662,7 +7662,7 @@ export {
   /**
    * Adds a computed field to each object emitted by a channel.
    *
-   * @category do notation
+   * @category mapping
    * @since 4.0.0
    */
   let_ as let
@@ -7678,7 +7678,7 @@ export {
  * channel's output becomes the value of the new field. `options.concurrency`
  * and `options.bufferSize` control how derived channels are flattened.
  *
- * @category do notation
+ * @category sequencing
  * @since 4.0.0
  */
 export const bind: {
@@ -7784,7 +7784,7 @@ export const bind: {
  * @see {@link bind} for adding a field produced by another channel
  * @see {@link let_ let} for adding a computed field
  *
- * @category do notation
+ * @category mapping
  * @since 4.0.0
  */
 export const bindTo: {
@@ -7845,7 +7845,7 @@ export const bindTo: {
  * Effect.runSync(countEffect) // => 5
  * ```
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runCount = <OutElem, OutErr, OutDone, Env>(
@@ -7874,7 +7874,7 @@ export const runCount = <OutElem, OutErr, OutDone, Env>(
  * Effect.runSync(drainEffect) // => "completed"
  * ```
  *
- * @category execution
+ * @category running
  * @since 2.0.0
  */
 export const runDrain = <OutElem, OutErr, OutDone, Env>(
@@ -7907,7 +7907,7 @@ export const runDrain = <OutElem, OutErr, OutDone, Env>(
  * processed // => [1, 2, 3]
  * ```
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runForEach: {
@@ -7938,7 +7938,7 @@ export const runForEach: {
  * Returning `true` continues consuming the channel. Returning `false` stops
  * consumption early. The returned effect completes with `void`.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runForEachWhile: {
@@ -7986,7 +7986,7 @@ export const runForEachWhile: {
  * Effect.runSync(collectEffect) // => [1, 2, 3, 4, 5]
  * ```
  *
- * @category execution
+ * @category running
  * @since 2.0.0
  */
 export const runCollect = <OutElem, OutErr, OutDone, Env>(
@@ -8000,7 +8000,7 @@ export const runCollect = <OutElem, OutErr, OutDone, Env>(
 /**
  * Runs a channel and outputs the done value.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runDone = <OutElem, OutErr, OutDone, Env>(
@@ -8016,7 +8016,7 @@ export const runDone = <OutElem, OutErr, OutDone, Env>(
  * Returns `Option.some` with the first output element, or `Option.none` if the
  * channel completes without emitting output.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runHead = <OutElem, OutErr, OutDone, Env>(
@@ -8043,7 +8043,7 @@ export const runHead = <OutElem, OutErr, OutDone, Env>(
  * Returns `Option.some` with the last emitted element, or `Option.none` if the
  * channel completes without emitting output.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runLast = <OutElem, OutErr, OutDone, Env>(
@@ -8087,7 +8087,7 @@ export const runLast = <OutElem, OutErr, OutDone, Env>(
  * Effect.runSync(sumEffect) // => 15
  * ```
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runFold: {
@@ -8137,7 +8137,7 @@ export const runFold: {
  * the effectful accumulator function. The returned effect succeeds with the
  * final accumulator value.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const runFoldEffect: {

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -90,7 +90,7 @@ export interface NonEmptyChunk<out A> extends Chunk<A>, NonEmptyIterable<A> {}
  * // Equivalent to: Chunk<number>
  * ```
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface ChunkTypeLambda extends TypeLambda {
@@ -494,7 +494,7 @@ const reverseChunk = <A>(self: Chunk<A>): Chunk<A> => {
  * Chunk.toArray(Chunk.reverse(chunk)) // => [3, 2, 1]
  * ```
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const reverse: <S extends Chunk<any>>(self: S) => Chunk.With<S, Chunk.Infer<S>> = reverseChunk as any
@@ -518,7 +518,7 @@ export const reverse: <S extends Chunk<any>>(self: S) => Chunk.With<S, Chunk.Inf
  * chunk.pipe(Chunk.get(2)) // => Option.some("c")
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const get: {
@@ -722,7 +722,7 @@ export const prepend: {
  * Chunk.toArray(Chunk.take(chunk, 3)) // => [1, 2, 3]
  * ```
  *
- * @category elements
+ * @category filtering
  * @since 2.0.0
  */
 export const take: {
@@ -778,7 +778,7 @@ export const take: {
  * Chunk.toArray(Chunk.drop(chunk, 2)) // => [3, 4, 5]
  * ```
  *
- * @category elements
+ * @category filtering
  * @since 2.0.0
  */
 export const drop: {
@@ -833,7 +833,7 @@ export const drop: {
  * Chunk.toArray(Chunk.dropRight(chunk, 2)) // => [1, 2, 3]
  * ```
  *
- * @category elements
+ * @category filtering
  * @since 2.0.0
  */
 export const dropRight: {
@@ -853,7 +853,7 @@ export const dropRight: {
  * Chunk.toArray(Chunk.dropWhile(chunk, (n) => n < 3)) // => [3, 4, 5]
  * ```
  *
- * @category elements
+ * @category filtering
  * @since 2.0.0
  */
 export const dropWhile: {
@@ -1254,7 +1254,7 @@ export const flatten: <S extends Chunk<Chunk<any>>>(self: S) => Chunk.Flatten<S>
  *
  * @see {@link split} for splitting into a target number of chunks instead of a fixed chunk size
  *
- * @category elements
+ * @category splitting
  * @since 2.0.0
  */
 export const chunksOf: {
@@ -1303,7 +1303,7 @@ export const chunksOf: {
  * Chunk.toArray(Chunk.intersection(chunk3, chunk4)) // => []
  * ```
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const intersection: {
@@ -1361,7 +1361,7 @@ export const isNonEmpty = <A>(self: Chunk<A>): self is NonEmptyChunk<A> => self.
  * Chunk.head(Chunk.make(1, 2, 3)) // => Option.some(1)
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const head: <A>(self: Chunk<A>) => Option<A> = get(0)
@@ -1416,7 +1416,7 @@ export const headUnsafe = <A>(self: Chunk<A>): A => getUnsafe(self, 0)
  * // Chunk.headNonEmpty(Chunk.empty()) // TypeScript error
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const headNonEmpty: <A>(self: NonEmptyChunk<A>) => A = headUnsafe
@@ -1433,7 +1433,7 @@ export const headNonEmpty: <A>(self: NonEmptyChunk<A>) => A = headUnsafe
  * Chunk.last(Chunk.make(1, 2, 3)) // => Option.some(3)
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const last = <A>(self: Chunk<A>): Option<A> => get(self, self.length - 1)
@@ -1488,7 +1488,7 @@ export const lastUnsafe = <A>(self: Chunk<A>): A => getUnsafe(self, self.length 
  * // Chunk.lastNonEmpty(Chunk.empty()) // TypeScript error
  * ```
  *
- * @category elements
+ * @category getters
  * @since 3.4.0
  */
 export const lastNonEmpty: <A>(self: NonEmptyChunk<A>) => A = lastUnsafe
@@ -1805,7 +1805,7 @@ export const separate = <A, B>(self: Chunk<Result<B, A>>): [Chunk<A>, Chunk<B>] 
  * Chunk.size(Chunk.make(1, 2, 3)) // => 3
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const size = <A>(self: Chunk<A>): number => self.length
@@ -2047,7 +2047,7 @@ export const splitWhere: {
  * Chunk.tail(Chunk.empty<number>()) // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const tail = <A>(self: Chunk<A>): O.Option<Chunk<A>> => self.length > 0 ? O.some(drop(self, 1)) : O.none()
@@ -2070,7 +2070,7 @@ export const tail = <A>(self: Chunk<A>): O.Option<Chunk<A>> => self.length > 0 ?
  * // Chunk.tailNonEmpty(Chunk.empty()) // TypeScript error
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const tailNonEmpty = <A>(self: NonEmptyChunk<A>): Chunk<A> => drop(self, 1)
@@ -2093,7 +2093,7 @@ export const tailNonEmpty = <A>(self: NonEmptyChunk<A>): Chunk<A> => drop(self, 
  * Chunk.toArray(Chunk.takeRight(chunk, 0)) // => []
  * ```
  *
- * @category elements
+ * @category filtering
  * @since 2.0.0
  */
 export const takeRight: {
@@ -2120,7 +2120,7 @@ export const takeRight: {
  * Chunk.toArray(Chunk.takeWhile(small, (n) => n < 10)) // => [1, 2, 3]
  * ```
  *
- * @category elements
+ * @category filtering
  * @since 2.0.0
  */
 export const takeWhile: {
@@ -2158,7 +2158,7 @@ export const takeWhile: {
  * Chunk.toArray(Chunk.union(withDupes1, withDupes2)) // => [1, 2, 3]
  * ```
  *
- * @category elements
+ * @category set operations
  * @since 2.0.0
  */
 export const union: {
@@ -2190,7 +2190,7 @@ export const union: {
  * Chunk.toArray(Chunk.dedupe(unique)) // => [1, 2, 3]
  * ```
  *
- * @category elements
+ * @category deduplication
  * @since 2.0.0
  */
 export const dedupe = <A>(self: Chunk<A>): Chunk<A> => fromArrayUnsafe(RA.dedupe(toReadonlyArray(self)))
@@ -2244,7 +2244,7 @@ export const dedupeAdjacent = <A>(self: Chunk<A>): Chunk<A> => fromArrayUnsafe(R
  * Chunk.toArray(emptyStrs) // => []
  * ```
  *
- * @category elements
+ * @category splitting
  * @since 2.0.0
  */
 export const unzip = <A, B>(self: Chunk<readonly [A, B]>): [Chunk<A>, Chunk<B>] => {
@@ -2329,7 +2329,7 @@ export const zip: {
  * Chunk.toArray(Chunk.remove(chunk, 10)) // => ["a", "b", "c", "d"]
  * ```
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const remove: {
@@ -2359,7 +2359,7 @@ export const remove: {
  * chunk.pipe(Chunk.modify(-1, (n) => n * 10)) // => Option.none()
  * ```
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const modify: {
@@ -2390,7 +2390,7 @@ export const modify: {
  * chunk.pipe(Chunk.replace(-1, "Z")) // => Option.none()
  * ```
  *
- * @category elements
+ * @category transforming
  * @since 2.0.0
  */
 export const replace: {
@@ -2537,7 +2537,7 @@ export const containsWith: <A>(
  * firstString // => Option.some("hello")
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findFirst: {
@@ -2565,7 +2565,7 @@ export const findFirst: {
  * Chunk.findFirstIndex(chunk, (n) => n % 2 === 0) // => Option.some(1)
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findFirstIndex: {
@@ -2594,7 +2594,7 @@ export const findFirstIndex: {
  * Chunk.findLast(chunk, (n) => n % 2 === 0) // => Option.some(4)
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findLast: {
@@ -2622,7 +2622,7 @@ export const findLast: {
  * Chunk.findLastIndex(chunk, (n) => n % 2 === 0) // => Option.some(3)
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findLastIndex: {

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -273,7 +273,7 @@ const makeChunk = <A>(backing: Backing<A>): Chunk<A> => {
  * Chunk.isChunk("string") // => false
  * ```
  *
- * @category constructors
+ * @category guards
  * @since 2.0.0
  */
 export const isChunk: {
@@ -1327,7 +1327,7 @@ export const intersection: {
  * Chunk.isEmpty(Chunk.make(1, 2, 3)) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty = <A>(self: Chunk<A>): boolean => self.length === 0
@@ -1344,7 +1344,7 @@ export const isEmpty = <A>(self: Chunk<A>): boolean => self.length === 0
  * Chunk.isNonEmpty(Chunk.make(1, 2, 3)) // => true
  * ```
  *
- * @category elements
+ * @category guards
  * @since 2.0.0
  */
 export const isNonEmpty = <A>(self: Chunk<A>): self is NonEmptyChunk<A> => self.length > 0
@@ -1528,7 +1528,7 @@ export declare namespace Chunk {
    * type StringType = Chunk.Chunk.Infer<typeof stringChunk> // string
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type Infer<S extends Chunk<any>> = S extends Chunk<infer A> ? A : never
@@ -1548,7 +1548,7 @@ export declare namespace Chunk {
    * type WithString2 = Chunk.Chunk.With<typeof nonEmptyChunk, string> // Chunk.NonEmptyChunk<string>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type With<S extends Chunk<any>, A> = S extends NonEmptyChunk<any> ? NonEmptyChunk<A> : Chunk<A>
@@ -1581,7 +1581,7 @@ export declare namespace Chunk {
    * > // Chunk.NonEmptyChunk<string>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type OrNonEmpty<S extends Chunk<any>, T extends Chunk<any>, A> = S extends NonEmptyChunk<any> ?
@@ -1617,7 +1617,7 @@ export declare namespace Chunk {
    * > // Chunk.NonEmptyChunk<string>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type AndNonEmpty<S extends Chunk<any>, T extends Chunk<any>, A> = S extends NonEmptyChunk<any> ?
@@ -1640,7 +1640,7 @@ export declare namespace Chunk {
    * type Flattened2 = Chunk.Chunk.Flatten<typeof nestedNonEmpty> // Chunk.NonEmptyChunk<string>
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 2.0.0
    */
   export type Flatten<T extends Chunk<Chunk<any>>> = T extends NonEmptyChunk<NonEmptyChunk<infer A>> ? NonEmptyChunk<A>
@@ -2469,7 +2469,7 @@ export const range = (start: number, end: number): NonEmptyChunk<number> =>
  * Chunk.contains(Chunk.empty<number>(), 1) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const contains: {
@@ -2503,7 +2503,7 @@ export const contains: {
  * containsCaseInsensitive(words, "grape") // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const containsWith: <A>(
@@ -2655,7 +2655,7 @@ export const findLastIndex: {
  * }
  * ```
  *
- * @category elements
+ * @category guards
  * @since 2.0.0
  */
 export const every: {
@@ -2689,7 +2689,7 @@ export const every: {
  * Chunk.some(words, (word) => word.includes("ban")) // => true
  * ```
  *
- * @category elements
+ * @category guards
  * @since 2.0.0
  */
 export const some: {

--- a/packages/effect/src/Clock.ts
+++ b/packages/effect/src/Clock.ts
@@ -183,7 +183,7 @@ export interface Clock {
  * @see {@link currentTimeMillis} for reading the current time in milliseconds
  * @see {@link currentTimeNanos} for reading the current time in nanoseconds
  *
- * @category references
+ * @category services
  * @since 2.0.0
  */
 export const Clock: Context.Reference<Clock> = effect.ClockRef

--- a/packages/effect/src/Clock.ts
+++ b/packages/effect/src/Clock.ts
@@ -45,7 +45,7 @@ import * as effect from "./internal/effect.ts"
  * await Effect.runPromise(Effect.provideService(clockOperations, Clock.Clock, testClock)) // => [1_000, 1_000_000_000n]
  * ```
  *
- * @category models
+ * @category services
  * @since 2.0.0
  */
 export interface Clock {
@@ -219,7 +219,7 @@ export const Clock: Context.Reference<Clock> = effect.ClockRef
  * @see {@link Clock} for the service reference
  * @see {@link currentTimeMillis} for convenience accessor that returns milliseconds
  * @see {@link currentTimeNanos} for convenience accessor that returns nanoseconds
- * @category constructors
+ * @category accessors
  * @since 2.0.0
  */
 export const clockWith: <A, E, R>(f: (clock: Clock) => Effect<A, E, R>) => Effect<A, E, R> = effect.clockWith
@@ -259,7 +259,7 @@ export const clockWith: <A, E, R>(f: (clock: Clock) => Effect<A, E, R>) => Effec
  * @see {@link monotonicTimeNanos} for measuring elapsed time
  * @see {@link clockWith} for accessing the full Clock service
  *
- * @category constructors
+ * @category accessors
  * @since 2.0.0
  */
 export const currentTimeMillis: Effect<number> = effect.currentTimeMillis
@@ -299,7 +299,7 @@ export const currentTimeMillis: Effect<number> = effect.currentTimeMillis
  *
  * @see {@link monotonicTimeNanos} for measuring elapsed time
  *
- * @category constructors
+ * @category accessors
  * @since 2.0.0
  */
 export const currentTimeNanos: Effect<bigint> = effect.currentTimeNanos
@@ -320,7 +320,7 @@ export const currentTimeNanos: Effect<bigint> = effect.currentTimeNanos
  *
  * @see {@link currentTimeNanos} for Unix wall-clock timestamps
  *
- * @category constructors
+ * @category accessors
  * @since 4.0.0
  */
 export const monotonicTimeNanos: Effect<bigint> = effect.monotonicTimeNanos

--- a/packages/effect/src/Config.ts
+++ b/packages/effect/src/Config.ts
@@ -580,7 +580,7 @@ export type Success<T> = [T] extends [Config<infer A>] ? A : never
  *
  * @see {@link unwrap} – construct a `Config` from a `Wrap<T>`
  *
- * @category Wrap
+ * @category utility types
  * @since 2.0.0
  */
 export type Wrap<A> = [NonNullable<A>] extends [infer T] ? [IsPlainObject<T>] extends [true] ?
@@ -625,7 +625,7 @@ type IsPlainObject<A> = [A] extends [Record<string, any>]
  *
  * @see {@link Wrap} – the utility type accepted by this function
  *
- * @category Wrap
+ * @category converting
  * @since 2.0.0
  */
 export const unwrap = <T>(wrapped: Wrap<T>): Config<T> => {

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -201,7 +201,7 @@ export function makeArray(length: number, value?: string): Node {
  * @see {@link ConfigProvider} – the interface whose `load` may fail with this
  *   error
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class SourceError extends Data.TaggedError("SourceError")<{
@@ -263,7 +263,7 @@ export type Path = ReadonlyArray<string | number>
  * @see {@link make} – construct a provider from a lookup function
  * @see {@link orElse} – compose providers with fallback
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface ConfigProvider extends Pipeable {
@@ -773,7 +773,7 @@ export const layerAdd = <E = never, R = never>(
  * @see {@link fromEnv} – for environment variables
  * @see {@link make} – for custom backing stores
  *
- * @category ConfigProviders
+ * @category constructors
  * @since 4.0.0
  */
 export function fromUnknown(root: unknown, options?: {
@@ -882,7 +882,7 @@ function emptyStringAsMissing(value: string | undefined, preserveEmptyStrings: b
  * @see {@link fromUnknown} – for JSON objects
  * @see {@link constantCase} – bridge camelCase keys to SCREAMING_SNAKE_CASE
  *
- * @category ConfigProviders
+ * @category constructors
  * @since 2.0.0
  */
 export function fromEnv(options?: {
@@ -1005,7 +1005,7 @@ function trieNodeAt(root: EnvTrieNode, path: Path): EnvTrieNode | undefined {
  * @see {@link fromDotEnv} – loads a `.env` file from disk
  * @see {@link fromEnv} – for raw environment variable access
  *
- * @category ConfigProviders
+ * @category constructors
  * @since 4.0.0
  */
 export function fromDotEnvContents(lines: string, options?: {
@@ -1157,7 +1157,7 @@ function searchLast(str: string, rgx: RegExp): number {
  * @see {@link fromDotEnvContents} – parse a `.env` string directly
  * @see {@link fromEnv} – read from the runtime environment
  *
- * @category ConfigProviders
+ * @category constructors
  * @since 4.0.0
  */
 export const fromDotEnv: (options?: {
@@ -1228,7 +1228,7 @@ export const fromDotEnv: (options?: {
  * @see {@link fromEnv} – for environment variables
  * @see {@link fromDotEnv} – for `.env` files
  *
- * @category ConfigProviders
+ * @category constructors
  * @since 4.0.0
  */
 export const fromDir: (options?: {

--- a/packages/effect/src/Console.ts
+++ b/packages/effect/src/Console.ts
@@ -77,7 +77,7 @@ export interface Console {
  *
  * @see {@link consoleWith} for using the current console service inside an effect
  *
- * @category references
+ * @category services
  * @since 2.0.0
  */
 export const Console: Context.Reference<Console> = effect.ConsoleRef

--- a/packages/effect/src/Console.ts
+++ b/packages/effect/src/Console.ts
@@ -19,7 +19,7 @@ import type { Scope } from "./Scope.ts"
 /**
  * Represents a console interface for logging, debugging, timing, and grouping output.
  *
- * @category models
+ * @category services
  * @since 2.0.0
  */
 export interface Console {

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -681,7 +681,7 @@ export const make = <I, S>(
  *
  * @see {@link addOrOmit} for adding or removing a service from an `Option`
  *
- * @category adders
+ * @category combining
  * @since 2.0.0
  */
 export const add: {
@@ -735,7 +735,7 @@ export const add: {
  *
  * @see {@link add} for always storing a service value
  *
- * @category adders
+ * @category combining
  * @since 4.0.0
  */
 export const addOrOmit: {

--- a/packages/effect/src/Context.ts
+++ b/packages/effect/src/Context.ts
@@ -94,7 +94,7 @@ export interface Key<out Identifier, out Shape> extends Effect<Shape, never, Ide
  * Context.get(context, Database).query("SELECT 1") // => "Result: SELECT 1"
  * ```
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Service<in out Identifier, in out Shape> extends Key<Identifier, Shape> {
@@ -119,7 +119,7 @@ export interface Service<in out Identifier, in out Shape> extends Key<Identifier
  *
  * @see {@link Service} for creating function-style keys or class-style service keys
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface ServiceClass<in out Self, in out Identifier extends string, in out Shape>
@@ -140,7 +140,7 @@ export declare namespace ServiceClass {
    * Runtime and type-level metadata carried by a class-style service key,
    * including its service type identifier, string key, and service shape.
    *
-   * @category models
+   * @category services
    * @since 4.0.0
    */
   export interface Shape<Identifier extends string, Service> {
@@ -197,7 +197,7 @@ export declare namespace ServiceClass {
  *
  * @see {@link Reference} for service keys with default values
  *
- * @category constructors
+ * @category services
  * @since 4.0.0
  */
 export const Service: {
@@ -328,7 +328,7 @@ const ReferenceTypeId = "~effect/Context/Reference" as const
  * messages // => ["default logger"]
  * ```
  *
- * @category models
+ * @category services
  * @since 3.11.0
  */
 export interface Reference<in out Shape> extends Service<never, Shape> {
@@ -379,7 +379,7 @@ export declare namespace Service {
    * services.map((service) => service.key) // => ["Logger", "Database"]
    * ```
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type Any = Key<never, any> | Key<any, any>
@@ -403,7 +403,7 @@ export declare namespace Service {
    * Database.key // => "Database"
    * ```
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type Shape<T> = T extends Key<infer _I, infer S> ? S : never
@@ -427,7 +427,7 @@ export declare namespace Service {
    * Database.key // => "Database"
    * ```
    *
-   * @category models
+   * @category utility types
    * @since 2.0.0
    */
   export type Identifier<T> = T extends Key<infer I, infer _S> ? I : never
@@ -1319,7 +1319,7 @@ const withMapUnsafe = <Services, B>(self: Context<Services>, f: (map: Map<string
  *
  * @see {@link Service} for required services without default values
  *
- * @category references
+ * @category services
  * @since 3.11.0
  */
 export const Reference: <Service>(

--- a/packages/effect/src/Crypto.ts
+++ b/packages/effect/src/Crypto.ts
@@ -69,7 +69,7 @@ export type DigestAlgorithm = "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512"
  * await Effect.runPromise(Effect.provide(program, TestCrypto)) // => [16, 36, 16]
  * ```
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Crypto {

--- a/packages/effect/src/Data.ts
+++ b/packages/effect/src/Data.ts
@@ -384,7 +384,7 @@ export declare namespace TaggedEnum {
    *
    * @see {@link taggedEnum} — creates constructors and matchers
    *
-   * @category types
+   * @category utility types
    * @since 3.1.0
    */
   export type Constructor<A extends { readonly _tag: string }> = Types.Simplify<

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -1813,7 +1813,7 @@ export const setPartsUtc: {
  * await Effect.runPromise(Effect.provide(program, layer)) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category services
  * @since 3.11.0
  */
 export class CurrentTimeZone extends Context.Service<CurrentTimeZone, TimeZone>()(

--- a/packages/effect/src/DateTime.ts
+++ b/packages/effect/src/DateTime.ts
@@ -895,7 +895,7 @@ export const nowUnsafe: LazyArg<Utc> = Internal.nowUnsafe
  * utc // => DateTime.makeUnsafe("2024-01-01T00:00:00Z")
  * ```
  *
- * @category time zones
+ * @category converting
  * @since 3.13.0
  */
 export const toUtc: (self: DateTime) => Utc = Internal.toUtc
@@ -914,7 +914,7 @@ export const toUtc: (self: DateTime) => Utc = Internal.toUtc
  * DateTime.isZoned(zoned) // => true
  * ```
  *
- * @category time zones
+ * @category transforming
  * @since 3.6.0
  */
 export const setZone: {
@@ -946,7 +946,7 @@ export const setZone: {
  * DateTime.zoneToString(zoned.zone) // => "+03:00"
  * ```
  *
- * @category time zones
+ * @category transforming
  * @since 3.6.0
  */
 export const setZoneOffset: {
@@ -984,7 +984,7 @@ export const setZoneOffset: {
  * // DateTime.zoneMakeNamedUnsafe("Invalid/Zone")
  * ```
  *
- * @category time zones
+ * @category constructors
  * @since 4.0.0
  */
 export const zoneMakeNamedUnsafe: (zoneId: string) => TimeZone.Named = Internal.zoneMakeNamedUnsafe
@@ -1011,7 +1011,7 @@ export const zoneMakeNamedUnsafe: (zoneId: string) => TimeZone.Named = Internal.
  * DateTime.formatIsoZoned(dt) // => "2024-01-01T15:00:00.000+03:00"
  * ```
  *
- * @category time zones
+ * @category constructors
  * @since 3.6.0
  */
 export const zoneMakeOffset: (offset: number) => TimeZone.Offset = Internal.zoneMakeOffset
@@ -1032,7 +1032,7 @@ export const zoneMakeOffset: (offset: number) => TimeZone.Offset = Internal.zone
  * DateTime.zoneMakeNamed("Invalid/Zone") // => Option.none()
  * ```
  *
- * @category time zones
+ * @category constructors
  * @since 3.6.0
  */
 export const zoneMakeNamed: (zoneId: string) => Option.Option<TimeZone.Named> = Internal.zoneMakeNamed
@@ -1059,7 +1059,7 @@ export const zoneMakeNamed: (zoneId: string) => Option.Option<TimeZone.Named> = 
  * DateTime.zoneToString((await Effect.runPromise(program)).zone) // => "Europe/London"
  * ```
  *
- * @category time zones
+ * @category constructors
  * @since 3.6.0
  */
 export const zoneMakeNamedEffect: (zoneId: string) => Effect.Effect<TimeZone.Named, IllegalArgumentError> =
@@ -1081,7 +1081,7 @@ export const zoneMakeNamedEffect: (zoneId: string) => Effect.Effect<TimeZone.Nam
  * DateTime.isTimeZoneNamed(DateTime.zoneMakeLocal()) // => true
  * ```
  *
- * @category time zones
+ * @category constructors
  * @since 3.6.0
  */
 export const zoneMakeLocal: () => TimeZone.Named = Internal.zoneMakeLocal
@@ -1103,7 +1103,7 @@ export const zoneMakeLocal: () => TimeZone.Named = Internal.zoneMakeLocal
  * DateTime.zoneFromString("invalid") // => Option.none()
  * ```
  *
- * @category time zones
+ * @category decoding
  * @since 3.6.0
  */
 export const zoneFromString: (zone: string) => Option.Option<TimeZone> = Internal.zoneFromString
@@ -1120,7 +1120,7 @@ export const zoneFromString: (zone: string) => Option.Option<TimeZone> = Interna
  * DateTime.zoneToString(DateTime.zoneMakeNamedUnsafe("Europe/London")) // => "Europe/London"
  * ```
  *
- * @category time zones
+ * @category encoding
  * @since 3.6.0
  */
 export const zoneToString: (self: TimeZone) => string = Internal.zoneToString
@@ -1140,7 +1140,7 @@ export const zoneToString: (self: TimeZone) => string = Internal.zoneToString
  * result // => Option.some("2024-01-01T00:00:00.000+00:00[Europe/London]")
  * ```
  *
- * @category time zones
+ * @category transforming
  * @since 3.6.0
  */
 export const setZoneNamed: {
@@ -1169,7 +1169,7 @@ export const setZoneNamed: {
  * DateTime.zoneToString(zoned.zone) // => "Europe/London"
  * ```
  *
- * @category time zones
+ * @category transforming
  * @since 4.0.0
  */
 export const setZoneNamedUnsafe: {
@@ -1646,7 +1646,7 @@ export const removeTime: (self: DateTime) => Utc = Internal.removeTime
  * const selectedParts = [parts.year, parts.month, parts.day, parts.hour] // => [2024, 1, 1, 12]
  * ```
  *
- * @category parts
+ * @category getters
  * @since 3.6.0
  */
 export const toParts: (self: DateTime) => DateTime.PartsWithWeekday = Internal.toParts
@@ -1671,7 +1671,7 @@ export const toParts: (self: DateTime) => DateTime.PartsWithWeekday = Internal.t
  * const selectedParts = [parts.year, parts.month, parts.day, parts.hour] // => [2024, 1, 1, 12]
  * ```
  *
- * @category parts
+ * @category getters
  * @since 3.6.0
  */
 export const toPartsUtc: (self: DateTime) => DateTime.PartsWithWeekday = Internal.toPartsUtc
@@ -1692,7 +1692,7 @@ export const toPartsUtc: (self: DateTime) => DateTime.PartsWithWeekday = Interna
  * DateTime.getPartUtc(dateTime, "year") // => 2024
  * ```
  *
- * @category parts
+ * @category getters
  * @since 3.6.0
  */
 export const getPartUtc: {
@@ -1718,7 +1718,7 @@ export const getPartUtc: {
  * DateTime.getPart(dateTime, "year") // => 2024
  * ```
  *
- * @category parts
+ * @category getters
  * @since 3.6.0
  */
 export const getPart: {
@@ -1748,7 +1748,7 @@ export const getPart: {
  * updated // => DateTime.makeZonedUnsafe("2025-06-15T12:00:00Z", { timeZone: "UTC" })
  * ```
  *
- * @category parts
+ * @category transforming
  * @since 3.6.0
  */
 export const setParts: {
@@ -1777,7 +1777,7 @@ export const setParts: {
  * updated // => DateTime.makeUnsafe("2025-01-01T18:00:00Z")
  * ```
  *
- * @category parts
+ * @category transforming
  * @since 3.6.0
  */
 export const setPartsUtc: {
@@ -1835,7 +1835,7 @@ export class CurrentTimeZone extends Context.Service<CurrentTimeZone, TimeZone>(
  * }).pipe(DateTime.withCurrentZoneNamed("Europe/London"))) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category accessors
  * @since 3.6.0
  */
 export const setZoneCurrent = (self: DateTime): Effect.Effect<Zoned, never, CurrentTimeZone> =>
@@ -1857,7 +1857,7 @@ export const setZoneCurrent = (self: DateTime): Effect.Effect<Zoned, never, Curr
  * }).pipe(DateTime.withCurrentZone(zone))) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category providing services
  * @since 3.6.0
  */
 export const withCurrentZone: {
@@ -1879,7 +1879,7 @@ export const withCurrentZone: {
  * }).pipe(DateTime.withCurrentZoneLocal)) // => true
  * ```
  *
- * @category current time zone
+ * @category providing services
  * @since 3.6.0
  */
 export const withCurrentZoneLocal = <A, E, R>(
@@ -1902,7 +1902,7 @@ export const withCurrentZoneLocal = <A, E, R>(
  * await Effect.runPromise(program) // => "+03:00"
  * ```
  *
- * @category current time zone
+ * @category providing services
  * @since 3.6.0
  */
 export const withCurrentZoneOffset: {
@@ -1935,7 +1935,7 @@ export const withCurrentZoneOffset: {
  * }).pipe(DateTime.withCurrentZoneNamed("Europe/London"))) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category providing services
  * @since 3.6.0
  */
 export const withCurrentZoneNamed: {
@@ -1968,7 +1968,7 @@ export const withCurrentZoneNamed: {
  * }).pipe(DateTime.withCurrentZoneNamed("Europe/London"))) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category accessors
  * @since 3.6.0
  */
 export const nowInCurrentZone: Effect.Effect<Zoned, never, CurrentTimeZone> = Effect.flatMap(now, setZoneCurrent)
@@ -2741,7 +2741,7 @@ export const formatIsoZoned: (self: Zoned) => string = Internal.formatIsoZoned
  * await Effect.runPromise(Effect.provide(program, layer)) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category layers
  * @since 3.6.0
  */
 export const layerCurrentZone: (resource: NoInfer<TimeZone>) => Layer.Layer<CurrentTimeZone> = Layer.succeed(
@@ -2771,7 +2771,7 @@ export const layerCurrentZone: (resource: NoInfer<TimeZone>) => Layer.Layer<Curr
  * await Effect.runPromise(Effect.provide(program, layer)) // => "+03:00"
  * ```
  *
- * @category current time zone
+ * @category layers
  * @since 3.6.0
  */
 export const layerCurrentZoneOffset = (offset: number): Layer.Layer<CurrentTimeZone> =>
@@ -2800,7 +2800,7 @@ export const layerCurrentZoneOffset = (offset: number): Layer.Layer<CurrentTimeZ
  * await Effect.runPromise(Effect.provide(program, layer)) // => "Europe/London"
  * ```
  *
- * @category current time zone
+ * @category layers
  * @since 3.6.0
  */
 export const layerCurrentZoneNamed: (zoneId: string) => Layer.Layer<
@@ -2830,7 +2830,7 @@ export const layerCurrentZoneNamed: (zoneId: string) => Layer.Layer<
  * await Effect.runPromise(Effect.provide(program, DateTime.layerCurrentZoneLocal)) // => true
  * ```
  *
- * @category current time zone
+ * @category layers
  * @since 3.6.0
  */
 export const layerCurrentZoneLocal: Layer.Layer<CurrentTimeZone> = Layer.sync(CurrentTimeZone)(zoneMakeLocal)

--- a/packages/effect/src/Deferred.ts
+++ b/packages/effect/src/Deferred.ts
@@ -690,7 +690,7 @@ export const interruptWith: {
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isDone = <A, E>(self: Deferred<A, E>): Effect<boolean> => internalEffect.sync(() => isDoneUnsafe(self))
@@ -706,7 +706,7 @@ export const isDone = <A, E>(self: Deferred<A, E>): Effect<boolean> => internalE
  * @see {@link isDone} for checking completion inside `Effect`
  * @see {@link poll} for reading the completed effect when available
  *
- * @category getters
+ * @category predicates
  * @since 4.0.0
  */
 export const isDoneUnsafe = <A, E>(self: Deferred<A, E>): boolean => self.effect !== undefined
@@ -894,7 +894,7 @@ export const doneUnsafe = <A, E>(self: Deferred<A, E>, effect: Effect<A, E>): bo
  * await Effect.runPromise(program) // => [true, 42]
  * ```
  *
- * @category Synchronization Utilities
+ * @category completion
  * @since 4.0.0
  */
 export const into: {

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -423,7 +423,7 @@ export const isDuration = (u: unknown): u is Duration => hasProperty(u, TypeId)
  * Duration.isFinite(Duration.infinity) // => false
  * ```
  *
- * @category guards
+ * @category predicates
  * @since 2.0.0
  */
 export const isFinite = (self: Duration): boolean =>
@@ -441,7 +441,7 @@ export const isFinite = (self: Duration): boolean =>
  * Duration.isZero(Duration.seconds(1)) // => false
  * ```
  *
- * @category guards
+ * @category predicates
  * @since 3.5.0
  */
 export const isZero = (self: Duration): boolean => {
@@ -469,7 +469,7 @@ export const isZero = (self: Duration): boolean => {
  * Duration.isNegative(Duration.negativeInfinity) // => true
  * ```
  *
- * @category guards
+ * @category predicates
  * @since 4.0.0
  */
 export const isNegative = (self: Duration): boolean => {
@@ -498,7 +498,7 @@ export const isNegative = (self: Duration): boolean => {
  * Duration.isPositive(Duration.infinity) // => true
  * ```
  *
- * @category guards
+ * @category predicates
  * @since 4.0.0
  */
 export const isPositive = (self: Duration): boolean => {

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -168,7 +168,7 @@ export interface Variance<A, E, R> {
  * @see {@link Error} for extracting the failure type from the same `Effect`
  * @see {@link Services} for extracting the required services from the same `Effect`
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Success<T> = T extends Effect<infer _A, infer _E, infer _R> ? _A
@@ -189,7 +189,7 @@ export type Success<T> = T extends Effect<infer _A, infer _E, infer _R> ? _A
  * @see {@link Success} for extracting the success value type instead
  * @see {@link Services} for extracting the required services type instead
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Error<T> = T extends Effect<infer _A, infer _E, infer _R> ? _E
@@ -206,7 +206,7 @@ export type Error<T> = T extends Effect<infer _A, infer _E, infer _R> ? _E
  * @see {@link Success} for extracting the success value type instead
  * @see {@link Error} for extracting the failure type instead
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Services<T> = T extends Effect<infer _A, infer _E, infer _R> ? _R
@@ -5600,7 +5600,7 @@ export const matchEffect: {
  * output // => [true]
  * ```
  *
- * @category condition checking
+ * @category predicates
  * @since 2.0.0
  */
 export const isFailure: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, never, R> = internal.isFailure
@@ -5630,7 +5630,7 @@ export const isFailure: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, neve
  * output // => ["ok: true", "failed: false"]
  * ```
  *
- * @category condition checking
+ * @category predicates
  * @since 2.0.0
  */
 export const isSuccess: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, never, R> = internal.isSuccess
@@ -14409,7 +14409,7 @@ export const trackDuration: {
  * Effect.runSync(runnable) // => "Transaction complete"
  * ```
  *
- * @category transactions
+ * @category services
  * @since 4.0.0
  */
 export class Transaction extends Context.Service<

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -138,7 +138,7 @@ export interface EffectUnify<A extends { [Unify.typeSymbol]?: any }> {
 /**
  * Type lambda used to represent `Effect` in higher-kinded APIs.
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface EffectTypeLambda extends TypeLambda {
@@ -488,7 +488,7 @@ export declare namespace All {
  * ```
  *
  * @see {@link forEach} for iterating over elements and applying an effect.
- * @category collecting
+ * @category combining
  * @since 2.0.0
  */
 export const all: <
@@ -529,7 +529,7 @@ export const all: <
  * await Effect.runPromise(program) // => [['0 is even', '2 is even'], [1, 3]]
  * ```
  *
- * @category collecting
+ * @category filtering
  * @since 2.0.0
  */
 export const partition: {
@@ -578,7 +578,7 @@ export const partition: {
  * output // => ["Adding 1 at index 0", "Adding 2 at index 1", "Adding 3 at index 2", 6]
  * ```
  *
- * @category collecting
+ * @category folding
  * @since 2.0.0
  */
 export const reduce: {
@@ -617,7 +617,7 @@ export const reduce: {
  * await Effect.runPromiseExit(program) // => Exit.fail(["0 is even", "2 is even"])
  * ```
  *
- * @category error accumulation
+ * @category validation
  * @since 2.0.0
  */
 export const validate: {
@@ -671,7 +671,7 @@ export const validate: {
  * await Effect.runPromise(program) // => Option.some(3)
  * ```
  *
- * @category collecting
+ * @category searching
  * @since 2.0.0
  */
 export const findFirst: {
@@ -699,7 +699,7 @@ export const findFirst: {
  *
  * @see {@link findFirst} for the simpler effectful predicate-based variant
  *
- * @category collecting
+ * @category searching
  * @since 4.0.0
  */
 export const findFirstFilter: {
@@ -773,7 +773,7 @@ export const findFirstFilter: {
  * ```
  *
  * @see {@link all} for combining multiple effects into one.
- * @category collecting
+ * @category sequencing
  * @since 2.0.0
  */
 export const forEach: {
@@ -809,7 +809,7 @@ export const forEach: {
  * output // => ["Current count: 1", "Current count: 2", "Current count: 3", "Current count: 4", "Current count: 5"]
  * ```
  *
- * @category collecting
+ * @category repetition
  * @since 2.0.0
  */
 export const whileLoop: <A, E, R>(options: {
@@ -1242,7 +1242,7 @@ export const never: Effect<never> = internal.never
  * Effect.runSync(program) // => { x: 2, y: 3, sum: 5 }
  * ```
  *
- * @category do notation
+ * @category constructors
  * @since 2.0.0
  */
 export const Do: Effect<{}> = internal.Do
@@ -1259,7 +1259,7 @@ export const Do: Effect<{}> = internal.Do
  * @see {@link Do} for starting from an empty accumulated record
  * @see {@link bind} for adding fields produced by effects
  *
- * @category do notation
+ * @category mapping
  * @since 2.0.0
  */
 export const bindTo: {
@@ -1301,7 +1301,7 @@ export {
    * @see {@link Do} for starting from an empty accumulated record
    * @see {@link gen} for sequencing without accumulating a record
    *
-   * @category do notation
+   * @category mapping
    * @since 2.0.0
    */
   let_ as let
@@ -1331,7 +1331,7 @@ export {
  * @see {@link bindTo} for naming the success value of an existing effect
  * @see {@link gen} for generator-based sequencing without accumulating a record
  *
- * @category do notation
+ * @category sequencing
  * @since 2.0.0
  */
 export const bind: {
@@ -2209,7 +2209,7 @@ export const tap: {
  * @see {@link option} for a version that uses `Option` instead.
  * @see {@link exit} for a version that encapsulates both recoverable errors and defects in an `Exit`.
  *
- * @category outcome encapsulation
+ * @category error handling
  * @since 4.0.0
  */
 export const result: <A, E, R>(self: Effect<A, E, R>) => Effect<Result.Result<A, E>, never, R> = internal.result
@@ -2252,7 +2252,7 @@ export const result: <A, E, R>(self: Effect<A, E, R>) => Effect<Result.Result<A,
  * @see {@link result} for a version that uses `Result` instead.
  * @see {@link exit} for a version that encapsulates both recoverable errors and defects in an `Exit`.
  *
- * @category outcome encapsulation
+ * @category error handling
  * @since 2.0.0
  */
 export const option: <A, E, R>(self: Effect<A, E, R>) => Effect<Option<A>, never, R> = internal.option
@@ -2294,7 +2294,7 @@ export const option: <A, E, R>(self: Effect<A, E, R>) => Effect<Option<A>, never
  * @see {@link option} for a version that uses `Option` instead.
  * @see {@link result} for a version that uses `Result` instead.
  *
- * @category outcome encapsulation
+ * @category error handling
  * @since 2.0.0
  */
 export const exit: <A, E, R>(
@@ -3622,7 +3622,7 @@ export const mapBoth: {
  * Effect.runSyncExit(program) // => Exit.die(new DivideByZeroError())
  * ```
  *
- * @category converting failures to defects
+ * @category error handling
  * @since 2.0.0
  */
 export const orDie: <A, E, R>(self: Effect<A, E, R>) => Effect<A, never, R> = internal.orDie
@@ -4283,7 +4283,7 @@ export const ignoreCause: <
  * Effect.runSync(program) // => "good"
  * ```
  *
- * @category fallback
+ * @category error handling
  * @since 3.16.0
  */
 export const withExecutionPlan: {
@@ -4354,7 +4354,7 @@ export const withErrorReporting: <
  * Effect.runSyncExit(program) // => Exit.succeed(18)
  * ```
  *
- * @category fallback
+ * @category error handling
  * @since 2.0.0
  */
 export const orElseSucceed: {
@@ -4407,7 +4407,7 @@ export const orElseSucceed: {
  * Effect.runSync(program) // => "secondary result"
  * ```
  *
- * @category fallback
+ * @category error handling
  * @since 2.0.0
  */
 export const firstSuccessOf: <Eff extends Effect<any, any, any>>(
@@ -5177,7 +5177,7 @@ export const filterMapOrFail: {
  * output // => ["Condition is true!", Option.some(undefined)]
  * ```
  *
- * @category conditional operators
+ * @category filtering
  * @since 2.0.0
  */
 export const when: {
@@ -5687,7 +5687,7 @@ export const isSuccess: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, neve
  * @see {@link contextWith} for deriving an effect from the complete context
  * @see {@link service} for reading one service from the context
  *
- * @category environment
+ * @category accessors
  * @since 2.0.0
  */
 export const context: <R = never>() => Effect<Context.Context<R>, never, R> = internal.context
@@ -5746,7 +5746,7 @@ export const context: <R = never>() => Effect<Context.Context<R>, never, R> = in
  * @see {@link context} for reading the complete context as a value
  * @see {@link service} for reading one service from the context
  *
- * @category environment
+ * @category accessors
  * @since 2.0.0
  */
 export const contextWith: <R, A, E, R2>(
@@ -5783,7 +5783,7 @@ export const contextWith: <R, A, E, R2>(
  * await Effect.runPromise(provided) // => "Result for: SELECT * FROM users"
  * ```
  *
- * @category environment
+ * @category providing services
  * @since 2.0.0
  */
 export const provide: {
@@ -5874,7 +5874,7 @@ export const provide: {
  * output // => ["Querying database", "result"]
  * ```
  *
- * @category environment
+ * @category providing services
  * @since 4.0.0
  */
 export const provideContext: {
@@ -5925,7 +5925,7 @@ export const provideContext: {
  * @see {@link provideContext} for partially satisfying an effect's context requirements.
  * @see {@link updateContext} for deriving the required context from the current one.
  *
- * @category environment
+ * @category providing services
  * @since 4.0.0
  */
 export const setContext: {
@@ -5958,7 +5958,7 @@ export const setContext: {
  * Effect.runSync(runnable) // => "Result for: SELECT * FROM users"
  * ```
  *
- * @category context
+ * @category accessors
  * @since 4.0.0
  */
 export const service: <I, S>(service: Context.Key<I, S>) => Effect<S, never, I> = internal.service
@@ -6004,7 +6004,7 @@ export const service: <I, S>(service: Context.Key<I, S>) => Effect<S, never, I> 
  * output // => ["Service not available"]
  * ```
  *
- * @category context
+ * @category accessors
  * @since 2.0.0
  */
 export const serviceOption: <I, S>(key: Context.Key<I, S>) => Effect<Option<S>> = internal.serviceOption
@@ -6048,7 +6048,7 @@ export const serviceOption: <I, S>(key: Context.Key<I, S>) => Effect<Option<S>> 
  * Effect.runSync(result) // => "Hello World!"
  * ```
  *
- * @category context
+ * @category providing services
  * @since 4.0.0
  */
 export const updateContext: {
@@ -6093,7 +6093,7 @@ export const updateContext: {
  * output // => ["Updated count: 1", 1]
  * ```
  *
- * @category context
+ * @category providing services
  * @since 2.0.0
  */
 export const updateService: {
@@ -6164,7 +6164,7 @@ export const updateService: {
  *
  * @see {@link updateService} for updating a service only within a wrapped effect
  *
- * @category context
+ * @category providing services
  * @since 4.0.0
  */
 export const updateServiceScoped: <I, A>(
@@ -6219,7 +6219,7 @@ export const updateServiceScoped: <I, A>(
  * @see {@link provide} for providing multiple layers to an effect.
  * @see {@link provideServiceEffect} for acquiring the service implementation effectfully.
  * @see {@link provideContext} for providing a complete context.
- * @category context
+ * @category providing services
  * @since 2.0.0
  */
 export const provideService: {
@@ -6292,7 +6292,7 @@ export const provideService: {
  * output // => ["Establishing database connection...", "Database connected!", "Result for: SELECT * FROM users"]
  * ```
  *
- * @category context
+ * @category providing services
  * @since 2.0.0
  */
 export const provideServiceEffect: {
@@ -7615,7 +7615,7 @@ export const repeatOrElse: {
  * @see {@link all} for running the returned effects and collecting results
  * @see {@link replicateEffect} for repeating an effect and collecting results in one step with concurrency and discard options
  *
- * @category collecting
+ * @category repetition
  * @since 2.0.0
  */
 export const replicate: {
@@ -7650,7 +7650,7 @@ export const replicate: {
  * output // => [[1, 1, 1]]
  * ```
  *
- * @category collecting
+ * @category repetition
  * @since 2.0.0
  */
 export const replicateEffect: {
@@ -8351,7 +8351,7 @@ export const withParentSpan: {
  *
  * @see {@link requestUnsafe} for the low-level entry point when you already have a `Context` and need to enqueue outside an `Effect`
  *
- * @category requests & batching
+ * @category running
  * @since 2.0.0
  */
 export const request: {
@@ -8378,7 +8378,7 @@ export const request: {
  *
  * @see {@link request} for the `Effect`-returning API used for normal request execution
  *
- * @category requests & batching
+ * @category unsafe
  * @since 4.0.0
  */
 export const requestUnsafe: <A extends Request.Any>(
@@ -8433,7 +8433,7 @@ export const requestUnsafe: <A extends Request.Any>(
  * await Effect.runPromise(program) // => "result"
  * ```
  *
- * @category supervision & fibers
+ * @category forking
  * @since 4.0.0
  */
 export const forkChild: <
@@ -8476,7 +8476,7 @@ export const forkChild: <
  * await Effect.runPromise(program) // => "done"
  * ```
  *
- * @category supervision & fibers
+ * @category forking
  * @since 2.0.0
  */
 export const forkIn: {
@@ -8519,7 +8519,7 @@ export const forkIn: {
  * await Effect.runPromise(program) // => "scope completed"
  * ```
  *
- * @category supervision & fibers
+ * @category forking
  * @since 2.0.0
  */
 export const forkScoped: <
@@ -8559,7 +8559,7 @@ export const forkScoped: <
  * await Effect.runPromise(program) // => "daemon result"
  * ```
  *
- * @category supervision & fibers
+ * @category forking
  * @since 4.0.0
  */
 export const forkDetach: <
@@ -8598,7 +8598,7 @@ export const forkDetach: <
  * @see {@link forkIn} for forking into an explicit scope
  * @see {@link forkScoped} for forking fibers tied to the current scope
  *
- * @category supervision & fibers
+ * @category sequencing
  * @since 2.0.0
  */
 export const awaitAllChildren: <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, R> = internal.awaitAllChildren
@@ -8621,7 +8621,7 @@ export const awaitAllChildren: <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, 
  * output // => ["number"]
  * ```
  *
- * @category supervision & fibers
+ * @category accessors
  * @since 4.0.0
  */
 export const fiber: Effect<Fiber<unknown, unknown>> = internal.fiber
@@ -8638,7 +8638,7 @@ export const fiber: Effect<Fiber<unknown, unknown>> = internal.fiber
  * Effect.runSync(program) // => "number"
  * ```
  *
- * @category supervision & fibers
+ * @category accessors
  * @since 2.0.0
  */
 export const fiberId: Effect<number> = internal.fiberId
@@ -13389,7 +13389,7 @@ export declare namespace fn {
  * Effect.runSync(program) // => "hello"
  * ```
  *
- * @category functions
+ * @category constructors
  * @since 3.12.0
  */
 export const fnUntraced: fn.Untraced = internal.fnUntraced
@@ -13513,7 +13513,7 @@ export const fnUntraced: fn.Untraced = internal.fnUntraced
  * Effect.runSync(program) // => "hello"
  * ```
  *
- * @category functions
+ * @category constructors
  * @since 3.11.0
  */
 export const fn: fn.Traced & {
@@ -13542,7 +13542,7 @@ export const fn: fn.Traced & {
  * Effect.runSync(program) // => "Clock is available"
  * ```
  *
- * @category clock
+ * @category accessors
  * @since 2.0.0
  */
 export const clockWith: <A, E, R>(
@@ -14037,7 +14037,7 @@ export const withLogSpan = dual<
  * Effect.runSync(Metric.value(exitTracker)).occurrences.get("success") // => 1
  * ```
  *
- * @category tracking
+ * @category metrics
  * @since 4.0.0
  */
 export const track: {
@@ -14112,7 +14112,7 @@ export const track: {
  * Effect.runSync(Metric.value(requestSizeGauge)).value // => 12
  * ```
  *
- * @category tracking
+ * @category metrics
  * @since 4.0.0
  */
 export const trackSuccesses: {
@@ -14189,7 +14189,7 @@ export const trackSuccesses: {
  * Effect.runSync(Metric.value(errorTypeFrequency)).occurrences.get("ConnectionFailedError") // => 1
  * ```
  *
- * @category tracking
+ * @category metrics
  * @since 4.0.0
  */
 export const trackErrors: {
@@ -14267,7 +14267,7 @@ export const trackErrors: {
  * Effect.runSync(Metric.value(defectTypeFrequency)).occurrences.get("Error") // => 1
  * ```
  *
- * @category tracking
+ * @category metrics
  * @since 4.0.0
  */
 export const trackDefects: {
@@ -14337,7 +14337,7 @@ export const trackDefects: {
  * Effect.runSync(Metric.value(durationGauge)).value // => 1
  * ```
  *
- * @category tracking
+ * @category metrics
  * @since 4.0.0
  */
 export const trackDuration: {
@@ -14621,7 +14621,7 @@ export declare namespace Effectify {
   /**
    * Converts a callback-based function type into an `Effect`-returning function type.
    *
-   * @category effectify
+   * @category utility types
    * @since 4.0.0
    */
   export type Effectify<T, E> = T extends {
@@ -14769,7 +14769,7 @@ export declare namespace Effectify {
   /**
    * Extracts the callback error type from a callback-based function type.
    *
-   * @category effectify
+   * @category utility types
    * @since 4.0.0
    */
   export type EffectifyError<T> = T extends {
@@ -14899,7 +14899,7 @@ export declare namespace Effectify {
  * error.message // => "Failed to process hello: unavailable"
  * ```
  *
- * @category effectify
+ * @category converting
  * @since 4.0.0
  */
 export const effectify: {
@@ -15057,7 +15057,7 @@ export const satisfiesServicesType = <R>() => <A, E, R2 extends R>(effect: Effec
  * await Effect.runPromise(Effect.all([mapped, mappedPending])) // => [10, 10]
  * ```
  *
- * @category eager
+ * @category mapping
  * @since 4.0.0
  */
 export const mapEager: {
@@ -15104,7 +15104,7 @@ export const mapEager: {
  * output // => [['mapped: original error', 'mapped: error']]
  * ```
  *
- * @category eager
+ * @category error handling
  * @since 4.0.0
  */
 export const mapErrorEager: {
@@ -15150,7 +15150,7 @@ export const mapErrorEager: {
  * output // => [10, "Failed: error"]
  * ```
  *
- * @category eager
+ * @category mapping
  * @since 4.0.0
  */
 export const mapBothEager: {
@@ -15196,7 +15196,7 @@ export const mapBothEager: {
  * await Effect.runPromise(Effect.all([flatMapped, flatMappedPending])) // => [10, 10]
  * ```
  *
- * @category eager
+ * @category sequencing
  * @since 4.0.0
  */
 export const flatMapEager: {
@@ -15253,7 +15253,7 @@ export const flatMapEager: {
  * output // => [['recovered from: original error', 42, 'recovered from: error']]
  * ```
  *
- * @category eager
+ * @category error handling
  * @since 4.0.0
  */
 export const catchEager: {
@@ -15289,7 +15289,7 @@ export const catchEager: {
  * Effect.runSync(effect) // => "computed eagerly"
  * ```
  *
- * @category eager
+ * @category constructors
  * @since 4.0.0
  */
 export const fnUntracedEager: fn.Untraced = internal.fnUntracedEager

--- a/packages/effect/src/Encoding.ts
+++ b/packages/effect/src/Encoding.ts
@@ -64,7 +64,7 @@ export type EncodingErrorTypeId = typeof EncodingErrorTypeId
  * message.
  *
  * @see {@link isEncodingError} for checking whether a value is an EncodingError
- * @category constructors
+ * @category errors
  * @since 4.0.0
  */
 export class EncodingError extends Data.TaggedError("EncodingError")<{

--- a/packages/effect/src/Equivalence.ts
+++ b/packages/effect/src/Equivalence.ts
@@ -54,7 +54,7 @@ import * as Reducer from "./Reducer.ts"
  *
  * @see {@link make}
  * @see {@link strictEqual}
- * @category type class
+ * @category models
  * @since 2.0.0
  */
 export type Equivalence<in A> = (self: A, that: A) => boolean
@@ -89,7 +89,7 @@ export type Equivalence<in A> = (self: A, that: A) => boolean
  *
  * @see {@link Equivalence}
  * @see {@link TypeLambda}
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface EquivalenceTypeLambda extends TypeLambda {

--- a/packages/effect/src/ErrorReporter.ts
+++ b/packages/effect/src/ErrorReporter.ts
@@ -70,7 +70,7 @@ export const TypeId: TypeId = "~effect/ErrorReporter"
  * @see {@link report} for manually reporting a `Cause`
  * @see {@link Effect.withErrorReporting} for reporting failures from an effect
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface ErrorReporter {
@@ -284,7 +284,7 @@ export const layer = <
  * output // => "fallback value"
  * ```
  *
- * @category reporting
+ * @category logging
  * @since 4.0.0
  */
 export const report = <E>(cause: Cause.Cause<E>): Effect.Effect<void> =>

--- a/packages/effect/src/ErrorReporter.ts
+++ b/packages/effect/src/ErrorReporter.ts
@@ -170,7 +170,7 @@ export const make = (
  * Use when you need to read or replace the current set of error reporters
  * directly.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const CurrentErrorReporters: Context.Reference<ReadonlySet<ErrorReporter>> = references.CurrentErrorReporters
@@ -284,7 +284,7 @@ export const layer = <
  * output // => "fallback value"
  * ```
  *
- * @category Reporting
+ * @category reporting
  * @since 4.0.0
  */
 export const report = <E>(cause: Cause.Cause<E>): Effect.Effect<void> =>
@@ -395,7 +395,7 @@ export const ignore: ignore = "~effect/ErrorReporter/ignore"
  *
  * @see {@link ignore} for the annotation key this predicate reads
  *
- * @category annotations
+ * @category predicates
  * @since 4.0.0
  */
 export const isIgnored = (u: unknown): boolean =>

--- a/packages/effect/src/ExecutionPlan.ts
+++ b/packages/effect/src/ExecutionPlan.ts
@@ -363,7 +363,7 @@ export interface Metadata {
  * Use to read the active plan step and attempt while code is running under an
  * execution plan.
  *
- * @category metadata
+ * @category services
  * @since 4.0.0
  */
 export const CurrentMetadata = Context.Reference<Metadata>("effect/ExecutionPlan/CurrentMetadata", {

--- a/packages/effect/src/Exit.ts
+++ b/packages/effect/src/Exit.ts
@@ -964,7 +964,7 @@ export const asVoidAll: <I extends Iterable<Exit<any, any>>>(
  * @see {@link getCause} to extract the Cause of a failure
  * @see {@link filterValue} for filter-pipeline usage
  *
- * @category accessors
+ * @category getters
  * @since 4.0.0
  */
 export const getSuccess: <A, E>(self: Exit<A, E>) => Option<A> = effect.exitGetSuccess
@@ -993,7 +993,7 @@ export const getSuccess: <A, E>(self: Exit<A, E>) => Option<A> = effect.exitGetS
  * @see {@link getSuccess} to extract the success value
  * @see {@link filterCause} for filter-pipeline usage
  *
- * @category accessors
+ * @category getters
  * @since 4.0.0
  */
 export const getCause: <A, E>(self: Exit<A, E>) => Option<Cause.Cause<E>> = effect.exitGetCause
@@ -1029,7 +1029,7 @@ export const getCause: <A, E>(self: Exit<A, E>) => Option<Cause.Cause<E>> = effe
  * @see {@link findError} for filter-pipeline usage
  * @see {@link getCause} to get the full Cause as an Option
  *
- * @category accessors
+ * @category getters
  * @since 4.0.0
  */
 export const findErrorOption: <A, E>(self: Exit<A, E>) => Option<E> = effect.exitFindErrorOption

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -562,7 +562,7 @@ export const isFiber = (
  * actual // => true
  * ```
  *
- * @category accessors
+ * @category getters
  * @since 4.0.0
  */
 export const getCurrent: () => Fiber<any, any> | undefined = effect.getCurrentFiber

--- a/packages/effect/src/FiberHandle.ts
+++ b/packages/effect/src/FiberHandle.ts
@@ -84,7 +84,7 @@ export interface FiberHandle<out A = unknown, out E = unknown> extends Pipeable,
  * actual // => [true, false]
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 2.0.0
  */
 export const isFiberHandle = (u: unknown): u is FiberHandle => Predicate.hasProperty(u, TypeId)

--- a/packages/effect/src/FiberMap.ts
+++ b/packages/effect/src/FiberMap.ts
@@ -92,7 +92,7 @@ export interface FiberMap<in out K, out A = unknown, out E = unknown>
  * actual // => [true, false, false]
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 2.0.0
  */
 export const isFiberMap = (u: unknown): u is FiberMap<unknown> => Predicate.hasProperty(u, TypeId)

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -84,7 +84,7 @@ export interface FiberSet<out A = unknown, out E = unknown>
  * actual // => [true, false]
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 2.0.0
  */
 export const isFiberSet = (u: unknown): u is FiberSet<unknown, unknown> => Predicate.hasProperty(u, TypeId)

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -72,7 +72,7 @@ const TypeId = "~effect/platform/FileSystem"
  * result.content // => "{\"env\": \"development\"}"
  * ```
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface FileSystem {
@@ -1034,7 +1034,7 @@ export const isFile = (u: unknown): u is File => hasProperty(u, FileTypeId)
  * Effect.runSync(program) // => { size: 5n, bytesRead: 5n, buffer: [1, 2, 3, 4, 5] }
  * ```
  *
- * @category file
+ * @category models
  * @since 4.0.0
  */
 export interface File {
@@ -1064,7 +1064,7 @@ export declare namespace File {
    * Represents the different types of entries that can exist in a file system,
    * from regular files to special device files and symbolic links.
    *
-   * @category file
+   * @category models
    * @since 4.0.0
    */
   export type Type =
@@ -1120,7 +1120,7 @@ export declare namespace File {
    * info.type === "File" // => true
    * ```
    *
-   * @category file
+   * @category models
    * @since 4.0.0
    */
   export interface Info {

--- a/packages/effect/src/FileSystem.ts
+++ b/packages/effect/src/FileSystem.ts
@@ -988,7 +988,7 @@ export const FileTypeId = "~effect/platform/FileSystem/File"
  * @see {@link File} for the file-handle interface narrowed by this guard
  * @see {@link FileTypeId} for the runtime marker checked by this guard
  *
- * @category file
+ * @category guards
  * @since 4.0.0
  */
 export const isFile = (u: unknown): u is File => hasProperty(u, FileTypeId)
@@ -1287,7 +1287,7 @@ export declare namespace WatchEvent {
  * Effect.runSync(withCustomBackend) // => true
  * ```
  *
- * @category file watcher
+ * @category services
  * @since 4.0.0
  */
 export class WatchBackend extends Context.Service<WatchBackend, {

--- a/packages/effect/src/Function.ts
+++ b/packages/effect/src/Function.ts
@@ -29,7 +29,7 @@ import { pipeArguments } from "./Pipeable.ts"
  * // Equivalent to: (a: string) => number
  * ```
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface FunctionTypeLambda extends TypeLambda {

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -2709,7 +2709,7 @@ export const neighbors: {
  * @see {@link predecessors} for incoming neighbors in a directed graph
  * @see {@link neighbors} for generic neighbor lookup across graph kinds
  *
- * @category queries
+ * @category getters
  * @since 4.0.0
  */
 export const successors: {
@@ -2745,7 +2745,7 @@ export const successors: {
  * @see {@link successors} for outgoing neighbors in a directed graph
  * @see {@link neighbors} for generic neighbor lookup across graph kinds
  *
- * @category queries
+ * @category getters
  * @since 4.0.0
  */
 export const predecessors: {
@@ -2803,7 +2803,7 @@ export const predecessors: {
  * @deprecated Use {@link successors} for outgoing neighbors or {@link predecessors} for incoming neighbors.
  * @see {@link successors} for outgoing neighbors in a directed graph
  * @see {@link predecessors} for incoming neighbors in a directed graph
- * @category queries
+ * @category getters
  * @since 3.18.0
  */
 export const neighborsDirected: {

--- a/packages/effect/src/HashMap.ts
+++ b/packages/effect/src/HashMap.ts
@@ -221,7 +221,7 @@ export declare namespace HashMap {
  * HashMap.isHashMap(null) // => false
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 2.0.0
  */
 export const isHashMap: {
@@ -298,7 +298,7 @@ export const fromIterable: <K, V>(entries: Iterable<readonly [K, V]>) => HashMap
  * HashMap.isEmpty(nonEmptyMap) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty: <K, V>(self: HashMap<K, V>) => boolean = internal.isEmpty
@@ -422,7 +422,7 @@ export const getUnsafe: {
  * HashMap.has("b")(map) // => true
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -457,7 +457,7 @@ export const has: {
  * HashMap.hasHash(userMap, "Admin", lowercaseHash) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const hasHash: {
@@ -478,7 +478,7 @@ export const hasHash: {
  * HashMap.hasBy(hm, (value) => value === "b") // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 3.16.0
  */
 export const hasBy: {
@@ -1163,7 +1163,7 @@ export const findFirst: {
  * HashMap.some(map, (value) => value > 5) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 3.13.0
  */
 export const some: {
@@ -1185,7 +1185,7 @@ export const some: {
  * HashMap.every(map, (value) => value > 1) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 3.14.0
  */
 export const every: {

--- a/packages/effect/src/HashMap.ts
+++ b/packages/effect/src/HashMap.ts
@@ -321,7 +321,7 @@ export const isEmpty: <K, V>(self: HashMap<K, V>) => boolean = internal.isEmpty
  * HashMap.get("b")(map) // => Option.some(2)
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const get: {
@@ -354,7 +354,7 @@ export const get: {
  * HashMap.getHash(userMap, "user999", Hash.string("user999")) // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const getHash: {
@@ -1141,7 +1141,7 @@ export const filterMap: {
  * HashMap.findFirst(map, (value, key) => key === "b" && value > 1) // => Option.some(["b", 2])
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findFirst: {

--- a/packages/effect/src/HashSet.ts
+++ b/packages/effect/src/HashSet.ts
@@ -254,7 +254,7 @@ export const add: {
  * HashSet.has(people, new Person("Alice")) // => true
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -328,7 +328,7 @@ export const size: <V>(self: HashSet<V>) => number = internal.size
  * HashSet.isEmpty(HashSet.make("a")) // => false
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 4.0.0
  */
 export const isEmpty: <V>(self: HashSet<V>) => boolean = internal.isEmpty
@@ -417,7 +417,7 @@ export const difference: {
  * HashSet.isSubset(small, small) // => true
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const isSubset: {
@@ -504,7 +504,7 @@ export const filter: {
  * HashSet.some(HashSet.empty<number>(), (n) => n > 0) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const some: {
@@ -531,7 +531,7 @@ export const some: {
  * HashSet.every(HashSet.empty<number>(), (n) => n > 0) // => true
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const every: {

--- a/packages/effect/src/Inspectable.ts
+++ b/packages/effect/src/Inspectable.ts
@@ -283,7 +283,7 @@ export const BaseProto: Inspectable = {
  * user[Inspectable.NodeInspectSymbol]() // => { _tag: "User", id: 1, name: "Alice", email: "alice@example.com" }
  * ```
  *
- * @category classes
+ * @category models
  * @since 2.0.0
  */
 export abstract class Class {

--- a/packages/effect/src/Iterable.ts
+++ b/packages/effect/src/Iterable.ts
@@ -1033,7 +1033,7 @@ export const intersperse: {
  * hasAlmostTwo // => true
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const containsWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
@@ -1082,7 +1082,7 @@ export const containsWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
  * containsThree([4, 5, 6]) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const contains: {
@@ -1971,7 +1971,7 @@ export const flatMapNullishOr: {
  * hasString // => true
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const some: {

--- a/packages/effect/src/Iterable.ts
+++ b/packages/effect/src/Iterable.ts
@@ -727,7 +727,7 @@ export const drop: {
  * findSquareRoot // => Option.some(1)
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findFirst: {
@@ -787,7 +787,7 @@ export const findFirst: {
  * lastString // => Option.some("world")
  * ```
  *
- * @category elements
+ * @category searching
  * @since 2.0.0
  */
 export const findLast: {
@@ -2085,7 +2085,7 @@ export const unfold = <B, A>(b: B, f: (b: B) => Option<readonly [A, B]>): Iterab
  * processed // => [[1, 2], [3, 4], [5, 6]]
  * ```
  *
- * @category elements
+ * @category traversing
  * @since 2.0.0
  */
 export const forEach: {
@@ -2315,7 +2315,7 @@ export const dedupeAdjacent: <A>(self: Iterable<A>) => Iterable<A> = dedupeAdjac
  * Array.from(testCases) // => ["admin_can_read", "admin_can_write", "admin_can_delete", "user_can_read", "user_can_write", "user_can_delete"]
  * ```
  *
- * @category elements
+ * @category combining
  * @since 2.0.0
  */
 export const cartesianWith: {
@@ -2389,7 +2389,7 @@ export const cartesianWith: {
  * Array.from(withEmpty) // => []
  * ```
  *
- * @category elements
+ * @category combining
  * @since 2.0.0
  */
 export const cartesian: {

--- a/packages/effect/src/Latch.ts
+++ b/packages/effect/src/Latch.ts
@@ -376,7 +376,7 @@ export const whenOpen: {
  *
  * Use to check the state of the latch without suspending or changing its state.
  *
- * @category getters
+ * @category predicates
  * @since 4.0.0
  */
 export const isOpen = (self: Latch): boolean => self.isOpen()

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -270,7 +270,7 @@ const memoMapReuse = <RIn, E, ROut>(
  * Layer.isLayer(notALayer) // => false
  * ```
  *
- * @category getters
+ * @category guards
  * @since 2.0.0
  */
 export const isLayer = (u: unknown): u is Layer<unknown, unknown, unknown> => hasProperty(u, TypeId)
@@ -576,7 +576,7 @@ export const forkMemoMap = (parent: MemoMap): Effect<MemoMap> => internalEffect.
  *
  * @see {@link MemoMap} the memoization map type wrapped by this service
  *
- * @category models
+ * @category services
  * @since 3.13.0
  */
 export class CurrentMemoMap extends Context.Service<CurrentMemoMap, MemoMap>()("effect/Layer/CurrentMemoMap") {

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -484,7 +484,7 @@ class MemoMapImpl implements MemoMap {
  * Effect.runSync(database.query("SELECT 1")) // => "result"
  * ```
  *
- * @category memo map
+ * @category constructors
  * @since 4.0.0
  */
 export const makeMemoMapUnsafe = (): MemoMap => new MemoMapImpl()
@@ -503,7 +503,7 @@ export const makeMemoMapUnsafe = (): MemoMap => new MemoMapImpl()
  * @see {@link forkMemoMap} for allocating the child memo map inside `Effect`
  * @see {@link makeMemoMapUnsafe} for creating a root memo map without a parent
  *
- * @category memo map
+ * @category constructors
  * @since 4.0.0
  */
 export const forkMemoMapUnsafe = (parent: MemoMap): MemoMap => new MemoMapImpl(parent)
@@ -537,7 +537,7 @@ export const forkMemoMapUnsafe = (parent: MemoMap): MemoMap => new MemoMapImpl(p
  * Effect.runSync(database.query("SELECT 1")) // => "result"
  * ```
  *
- * @category memo map
+ * @category constructors
  * @since 2.0.0
  */
 export const makeMemoMap: Effect<MemoMap> = internalEffect.sync(makeMemoMapUnsafe)
@@ -556,7 +556,7 @@ export const makeMemoMap: Effect<MemoMap> = internalEffect.sync(makeMemoMapUnsaf
  * @see {@link forkMemoMapUnsafe} for the synchronous constructor variant
  * @see {@link buildWithMemoMap} for building layers with an explicit memo map
  *
- * @category memo map
+ * @category constructors
  * @since 4.0.0
  */
 export const forkMemoMap = (parent: MemoMap): Effect<MemoMap> => internalEffect.sync(() => forkMemoMapUnsafe(parent))
@@ -637,7 +637,7 @@ export class CurrentMemoMap extends Context.Service<CurrentMemoMap, MemoMap>()("
  * logs // => ["ready"]
  * ```
  *
- * @category memo map
+ * @category destructors
  * @since 2.0.0
  */
 export const buildWithMemoMap: {

--- a/packages/effect/src/LayerMap.ts
+++ b/packages/effect/src/LayerMap.ts
@@ -437,7 +437,7 @@ export declare namespace Service {
   /**
    * Extracts the key type accepted by a `LayerMap.Service` definition.
    *
-   * @category services
+   * @category utility types
    * @since 3.14.0
    */
   export type Key<Options> = Options extends { readonly lookup: (key: infer K) => any } ? K
@@ -447,7 +447,7 @@ export declare namespace Service {
   /**
    * Extracts the layer type produced by a `LayerMap.Service` definition.
    *
-   * @category services
+   * @category utility types
    * @since 3.14.0
    */
   export type Layers<Options> = Options extends { readonly lookup: (key: infer _K) => infer Layers } ? Layers
@@ -458,7 +458,7 @@ export declare namespace Service {
    * Extracts the services provided by the layers in a `LayerMap.Service`
    * definition.
    *
-   * @category services
+   * @category utility types
    * @since 3.14.0
    */
   export type Success<Options> = Layers<Options> extends Layer.Layer<infer _A, infer _E, infer _R> ? _A : never
@@ -466,7 +466,7 @@ export declare namespace Service {
   /**
    * Extracts the error type of the layers in a `LayerMap.Service` definition.
    *
-   * @category services
+   * @category utility types
    * @since 3.14.0
    */
   export type Error<Options> = Layers<Options> extends Layer.Layer<infer _A, infer _E, infer _R> ? _E : never
@@ -475,7 +475,7 @@ export declare namespace Service {
    * Extracts the service requirements of the layers in a `LayerMap.Service`
    * definition.
    *
-   * @category services
+   * @category utility types
    * @since 4.0.0
    */
   export type Services<Options> = Layers<Options> extends Layer.Layer<infer _A, infer _E, infer _R> ? _R : never

--- a/packages/effect/src/LogLevel.ts
+++ b/packages/effect/src/LogLevel.ts
@@ -108,7 +108,7 @@ export type Severity = "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace"
  * @see {@link Severity} for the concrete message severity type that excludes `All` and `None`
  * @see {@link Order} for comparing these levels by severity order
  *
- * @category models
+ * @category constants
  * @since 4.0.0
  */
 export const values: ReadonlyArray<LogLevel> = ["All", "Fatal", "Error", "Warn", "Info", "Debug", "Trace", "None"]
@@ -377,7 +377,7 @@ export const isLessThanOrEqualTo: {
  * await Effect.runPromise(warnOnly) // => { debugEnabled: false, errorEnabled: true }
  * ```
  *
- * @category filtering
+ * @category predicates
  * @since 4.0.0
  */
 export const isEnabled = (self: LogLevel): Effect.Effect<boolean> =>

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -156,7 +156,7 @@ export const isLogger = (u: unknown): u is Logger<unknown, unknown> => Predicate
  * messages // => [["Hello from custom logger"]]
  * ```
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const CurrentLoggers: Context.Reference<ReadonlySet<Logger<unknown, any>>> = effect.CurrentLoggers
@@ -179,7 +179,7 @@ export const CurrentLoggers: Context.Reference<ReadonlySet<Logger<unknown, any>>
  * @see {@link consolePretty} for the TTY-mode pretty console logger affected by this reference
  * @see {@link withConsoleError} for routing a specific formatter logger to `console.error`
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const LogToStderr: Context.Reference<boolean> = effect.LogToStderr

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -908,7 +908,7 @@ export const tracerLogger: Logger<unknown, void> = effect.tracerLogger
  * messages // => [["Application started"]]
  * ```
  *
- * @category context
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <
@@ -998,7 +998,7 @@ export const layer = <
  * writes // => ["Application started"]
  * ```
  *
- * @category file
+ * @category logging
  * @since 4.0.0
  */
 export const toFile = dual<

--- a/packages/effect/src/ManagedRuntime.ts
+++ b/packages/effect/src/ManagedRuntime.ts
@@ -279,7 +279,7 @@ export interface ManagedRuntime<in R, out ER> {
  * @see {@link Layer.MemoMap} for shared layer memoization
  * @see {@link Layer.build} for lower-level scoped layer construction
  *
- * @category runtime class
+ * @category constructors
  * @since 2.0.0
  */
 export const make = <R, ER>(

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -514,7 +514,7 @@ export const withReturnType: <Ret>() => <I, F, R, A, Pr, _>(
  * @see {@link not} for handling inputs that do not match a pattern
  * @see {@link orElse} for providing a fallback when no pattern case matches
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const when: <
@@ -574,7 +574,7 @@ export const when: <
  * handleError({ _tag: "ValidationError", field: "email" }) // => "Invalid field: email"
  * ```
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const whenOr: <
@@ -630,7 +630,7 @@ export const whenOr: <
  * checkUser({ age: 20, role: "user" }) // => "Access denied"
  * ```
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const whenAnd: <
@@ -688,7 +688,7 @@ export const whenAnd: <
  * @see {@link discriminators} for defining several discriminator handlers at once
  * @see {@link discriminatorStartsWith} for matching string discriminator values by prefix
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const discriminator: <D extends string>(
@@ -739,7 +739,7 @@ export const discriminator: <D extends string>(
  *
  * @see {@link discriminator} for matching exact discriminator values
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const discriminatorStartsWith: <D extends string>(
@@ -802,7 +802,7 @@ export const discriminatorStartsWith: <D extends string>(
  * @see {@link discriminator} for adding one discriminator case to a matcher pipeline
  * @see {@link discriminatorsExhaustive} for handling every discriminator value and finalizing the matcher
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const discriminators: <D extends string>(
@@ -865,7 +865,7 @@ export const discriminators: <D extends string>(
  *
  * @see {@link discriminators} for defining discriminator handlers without finalizing the matcher
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const discriminatorsExhaustive: <D extends string>(
@@ -922,7 +922,7 @@ export const discriminatorsExhaustive: <D extends string>(
  * match({ _tag: "error", error: new Error("Oops!") }) // => "Error: Oops!"
  * ```
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const tag: <
@@ -970,7 +970,7 @@ export const tag: <
  * match({ _tag: "A.A" }) // => 1
  * ```
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const tagStartsWith: <
@@ -1025,7 +1025,7 @@ export const tagStartsWith: <
  * match({ _tag: "A", a: "ok" }) // => "ok"
  * ```
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const tags: <
@@ -1080,7 +1080,7 @@ export const tags: <
  * match({ _tag: "B", b: 42 }) // => 42
  * ```
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const tagsExhaustive: <
@@ -1129,7 +1129,7 @@ export const tagsExhaustive: <
  *
  * @see {@link when} for adding a positive pattern case
  *
- * @category Defining patterns
+ * @category defining patterns
  * @since 4.0.0
  */
 export const not: <
@@ -1389,7 +1389,7 @@ export const any: SafeRefinement<unknown, any> = internal.any
  *
  * @see {@link any} for matching every value without excluding nullish inputs
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const defined: <A>(u: A) => u is A & {} = internal.defined
@@ -2051,7 +2051,7 @@ export declare namespace Types {
    * // Result: { type: "user"; name: string }
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type WhenMatch<R, P> =
@@ -2093,7 +2093,7 @@ export declare namespace Types {
    * // Result: "b" | "c"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type NotMatch<R, P> = Exclude<R, ExtractMatch<R, PForNotMatch<P>>>
@@ -2123,7 +2123,7 @@ export declare namespace Types {
    * // Result: { name: string }
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type PForMatch<P> = [ResolvePred<P>] extends [infer X] ? X
@@ -2151,7 +2151,7 @@ export declare namespace Types {
    * // Used internally to filter out admin objects
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type PForExclude<P> = [SafeRefinementR<ToSafeRefinement<P>>] extends [infer X] ? X
@@ -2228,7 +2228,7 @@ export declare namespace Types {
    * result // => "Admin: Alice"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type PatternBase<A> = A extends ReadonlyArray<infer _T> ? ReadonlyArray<any> | PatternPrimitive<A>
@@ -2246,7 +2246,7 @@ export declare namespace Types {
    * literal values, and safe refinements. These are the atomic patterns that
    * can be composed into more complex matching logic.
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type PatternPrimitive<A> = PredicateA<A> | A | SafeRefinement<any>
@@ -2274,7 +2274,7 @@ export declare namespace Types {
    * match(42) // => "not string: 42"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export interface Without<out X> {
@@ -2305,7 +2305,7 @@ export declare namespace Types {
    * match("ok") // => "string: ok"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export interface Only<out X> {
@@ -2337,7 +2337,7 @@ export declare namespace Types {
    * match(true) // => "not string"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type AddWithout<A, X> = [A] extends [Without<infer WX>] ? Without<X | WX>
@@ -2367,7 +2367,7 @@ export declare namespace Types {
    * match({ type: "admin", name: "Alice" }) // => "Alice"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type AddOnly<A, X> = [A] extends [Without<infer WX>] ? [X] extends [WX] ? never
@@ -2404,7 +2404,7 @@ export declare namespace Types {
    * // Result: number | boolean
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type ApplyFilters<I, A> = A extends Only<infer X> ? X
@@ -2441,7 +2441,7 @@ export declare namespace Types {
    * // Result: "user" | "admin"
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type Tags<D extends string, P> = P extends Record<D, infer X> ? X : never
@@ -2473,7 +2473,7 @@ export declare namespace Types {
    * // for advanced pattern matching scenarios
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type ArrayToIntersection<A extends ReadonlyArray<any>> = T.UnionToIntersection<
@@ -2511,7 +2511,7 @@ export declare namespace Types {
    * //                      ^^^ s is correctly typed as string
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type ExtractMatch<I, P> = [ExtractAndNarrow<I, P>] extends [infer EI] ? EI

--- a/packages/effect/src/Match.ts
+++ b/packages/effect/src/Match.ts
@@ -1183,7 +1183,7 @@ export const not: <
  *
  * @see {@link string} for matching any string
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const nonEmptyString: SafeRefinement<string, never> = internal.nonEmptyString
@@ -1224,7 +1224,7 @@ export const nonEmptyString: SafeRefinement<string, never> = internal.nonEmptySt
  * handleStatus("pending") // => "Unknown status: pending"
  * ```
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const is: <
@@ -1256,7 +1256,7 @@ export const is: <
  * processValue(true) // => "Boolean: yes"
  * ```
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const string: Predicate.Refinement<unknown, string> = Predicate.isString
@@ -1297,7 +1297,7 @@ export const string: Predicate.Refinement<unknown, string> = Predicate.isString
  *
  * @see {@link bigint} for matching primitive bigint values
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const number: Predicate.Refinement<unknown, number> = Predicate.isNumber
@@ -1346,7 +1346,7 @@ export const number: Predicate.Refinement<unknown, number> = Predicate.isNumber
  * @see {@link defined} for matching only non-nullish values
  * @see {@link orElse} for providing a fallback after earlier cases
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const any: SafeRefinement<unknown, any> = internal.any
@@ -1430,7 +1430,7 @@ export const defined: <A>(u: A) => u is A & {} = internal.defined
  *
  * @see {@link is} for matching specific literal boolean values
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const boolean: Predicate.Refinement<unknown, boolean> = Predicate.isBoolean
@@ -1452,7 +1452,7 @@ export {
    * @see {@link defined} for matching non-nullish values
    * @see {@link is} for matching literal values
    *
-   * @category predicates
+   * @category guards
    * @since 4.0.0
    */
   _undefined as undefined
@@ -1475,7 +1475,7 @@ export {
    * @see {@link defined} for matching non-nullish values
    * @see {@link is} for matching literal values
    *
-   * @category predicates
+   * @category guards
    * @since 4.0.0
    */
   _null as null
@@ -1517,7 +1517,7 @@ export {
  *
  * @see {@link number} for matching primitive number values
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const bigint: Predicate.Refinement<unknown, bigint> = Predicate.isBigInt
@@ -1555,7 +1555,7 @@ export const bigint: Predicate.Refinement<unknown, bigint> = Predicate.isBigInt
  * handleSymbol("string") // => "Not a symbol"
  * ```
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const symbol: Predicate.Refinement<unknown, symbol> = Predicate.isSymbol
@@ -1597,7 +1597,7 @@ export const symbol: Predicate.Refinement<unknown, symbol> = Predicate.isSymbol
  *
  * @see {@link instanceOf} for matching instances of any constructor
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const date: Predicate.Refinement<unknown, Date> = Predicate.isDate
@@ -1642,7 +1642,7 @@ export const date: Predicate.Refinement<unknown, Date> = Predicate.isDate
  *
  * @see {@link instanceOf} for matching a specific constructor
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const record: Predicate.Refinement<unknown, { [x: PropertyKey]: unknown }> = Predicate.isObject
@@ -1701,7 +1701,7 @@ export const record: Predicate.Refinement<unknown, { [x: PropertyKey]: unknown }
  * @see {@link instanceOfUnsafe} for constructor matching without the same type-safety guarantee
  * @see {@link record} for matching broad non-null, non-array objects
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const instanceOf: <A extends abstract new(...args: any) => any>(
@@ -1746,7 +1746,7 @@ export const instanceOf: <A extends abstract new(...args: any) => any>(
  *
  * @see {@link instanceOf} for type-safe constructor matching
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const instanceOfUnsafe: <A extends abstract new(...args: any) => any>(

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -183,7 +183,7 @@ export interface Metric<in Input, out State> extends Pipeable {
  * const counts = [result.requests.count, result.bytes.count] // => [6, 1024n]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 2.0.0
  */
 export interface Counter<in Input extends number | bigint> extends Metric<Input, CounterState<Input>> {}
@@ -243,7 +243,7 @@ export interface Counter<in Input extends number | bigint> extends Metric<Input,
  * const counts = [result.requests.total, result.errors.total, result.bytes.total] // => [3, 3, 1024000n]
  * ```
  *
- * @category Counter
+ * @category models
  * @since 4.0.0
  */
 export interface CounterState<in Input extends number | bigint> {
@@ -317,7 +317,7 @@ export interface CounterState<in Input extends number | bigint> {
  * const values = [result.statusAnalysis.mostFrequent, result.actionAnalysis.mostFrequent] // => ["200", "login"]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 2.0.0
  */
 export interface Frequency extends Metric<string, FrequencyState> {}
@@ -401,7 +401,7 @@ export interface Frequency extends Metric<string, FrequencyState> {}
  * mostCommon.map(({ key, count }) => [key, count]) // => [["200", 3], ["click", 3]]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 4.0.0
  */
 export interface FrequencyState {
@@ -462,7 +462,7 @@ export interface FrequencyState {
  * const values = [result.memory.currentValue, result.disk.currentValue] // => [704, 5000000000n]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 2.0.0
  */
 export interface Gauge<in Input extends number | bigint> extends Metric<Input, GaugeState<Input>> {}
@@ -530,7 +530,7 @@ export interface Gauge<in Input extends number | bigint> extends Metric<Input, G
  * values // => [23.1, 5000000000n, 15]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 4.0.0
  */
 export interface GaugeState<in Input extends number | bigint> {
@@ -618,7 +618,7 @@ export interface GaugeState<in Input extends number | bigint> {
  * values // => [4, 445, 118]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 2.0.0
  */
 export interface Histogram<Input> extends Metric<Input, HistogramState> {}
@@ -705,7 +705,7 @@ export interface Histogram<Input> extends Metric<Input, HistogramState> {}
  * values // => [5, 50, 750, 1295]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 4.0.0
  */
 export interface HistogramState {
@@ -810,7 +810,7 @@ export interface HistogramState {
  * counts // => [5, 1461, 3]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 2.0.0
  */
 export interface Summary<Input> extends Metric<Input, SummaryState> {}
@@ -892,7 +892,7 @@ export interface Summary<Input> extends Metric<Input, SummaryState> {}
  * values // => [7, 45, 890, 1879]
  * ```
  *
- * @category metrics
+ * @category models
  * @since 4.0.0
  */
 export interface SummaryState {
@@ -974,7 +974,7 @@ export declare namespace Metric {
    * const actual = types // => ["Counter", "Gauge", "Frequency", "Histogram", "Summary"]
    * ```
    *
-   * @category types
+   * @category models
    * @since 4.0.0
    */
   export type Type = "Counter" | "Frequency" | "Gauge" | "Histogram" | "Summary"
@@ -1049,7 +1049,7 @@ export declare namespace Metric {
    * sameAttributes // => [{ service: "api", environment: "production", version: "1.2.3" }, { service: "api", environment: "production", version: "1.2.3" }]
    * ```
    *
-   * @category types
+   * @category models
    * @since 4.0.0
    */
   export type Attributes = AttributeSet | ReadonlyArray<[string, string]>
@@ -1126,7 +1126,7 @@ export declare namespace Metric {
    * const validation = [result.attributes.isValid, result.attributes.totalKeys] // => [true, 9]
    * ```
    *
-   * @category types
+   * @category models
    * @since 4.0.0
    */
   export type AttributeSet = Readonly<Record<string, string>>
@@ -1286,7 +1286,7 @@ export declare namespace Metric {
    * const state = result // => { currentCount: 6, isIncremental: false }
    * ```
    *
-   * @category interfaces
+   * @category models
    * @since 4.0.0
    */
   export interface Hooks<in Input, out State> {
@@ -1351,7 +1351,7 @@ export declare namespace Metric {
    * const types = [result.counter.type, result.gauge.type, result.frequency.type] // => ["Counter", "Gauge", "Frequency"]
    * ```
    *
-   * @category interfaces
+   * @category models
    * @since 4.0.0
    */
   export interface Metadata<in Input, out State> {
@@ -1423,7 +1423,7 @@ export declare namespace Metric {
    * const counts = [result.counter?.count, result.histogram?.observations] // => [25, 2]
    * ```
    *
-   * @category interfaces
+   * @category models
    * @since 4.0.0
    */
   export interface SnapshotProto<T extends Type, State> {
@@ -1499,7 +1499,7 @@ export declare namespace Metric {
    * const types = result.metricTypes // => ["Counter", "Gauge", "Frequency", "Histogram", "Summary"]
    * ```
    *
-   * @category types
+   * @category models
    * @since 4.0.0
    */
   export type Snapshot =
@@ -2746,7 +2746,7 @@ export const update: {
  * const values = [value.count, value.sum] // => [1, 250]
  * ```
  *
- * @category mapping
+ * @category annotations
  * @since 2.0.0
  */
 export const mapInput: {
@@ -2808,7 +2808,7 @@ export const mapInput: {
  * const count = value.count // => 3
  * ```
  *
- * @category input
+ * @category mapping
  * @since 2.0.0
  */
 export const withConstantInput: {
@@ -2873,7 +2873,7 @@ export const withConstantInput: {
  * await Effect.runPromise(Effect.provideService(result, Metric.MetricRegistry, new Map())) // => [2, 1]
  * ```
  *
- * @category attributes
+ * @category mapping
  * @since 4.0.0
  */
 export const withAttributes: {
@@ -2995,7 +2995,7 @@ export const snapshot: Effect<ReadonlyArray<Metric.Snapshot>> = InternalEffect.m
  * included // => [true, true, true]
  * ```
  *
- * @category debugging
+ * @category formatting
  * @since 4.0.0
  */
 export const dump: Effect<string> = InternalEffect.flatMap(InternalEffect.context(), (context) => {
@@ -3152,7 +3152,7 @@ const attributesToString = (attributes: Metric.AttributeSet): string => {
  * Metric.boundariesFromIterable([-5, 0, 10, 10, 25, 50]) // => [10, 25, 50, Infinity]
  * ```
  *
- * @category boundaries
+ * @category constructors
  * @since 4.0.0
  */
 export const boundariesFromIterable = (iterable: Iterable<number>): ReadonlyArray<number> =>
@@ -3177,7 +3177,7 @@ export const boundariesFromIterable = (iterable: Iterable<number>): ReadonlyArra
  * Metric.linearBoundaries({ start: 10, width: 20, count: 5 }) // => [10, 30, 50, 70, Infinity]
  * ```
  *
- * @category boundaries
+ * @category constructors
  * @since 4.0.0
  */
 export const linearBoundaries = (options: {
@@ -3203,7 +3203,7 @@ export const linearBoundaries = (options: {
  * Metric.exponentialBoundaries({ start: 1, factor: 2, count: 5 }) // => [1, 2, 4, 8, Infinity]
  * ```
  *
- * @category boundaries
+ * @category constructors
  * @since 4.0.0
  */
 export const exponentialBoundaries = (options: {
@@ -3242,7 +3242,7 @@ const fiberFailures = counter("child_fiber_failures", {
  * Metric.FiberRuntimeMetricsKey // => "effect/observability/Metric/FiberRuntimeMetricsKey"
  * ```
  *
- * @category metrics
+ * @category constants
  * @since 4.0.0
  */
 export const FiberRuntimeMetricsKey: "effect/observability/Metric/FiberRuntimeMetricsKey" =
@@ -3271,7 +3271,7 @@ export const FiberRuntimeMetricsKey: "effect/observability/Metric/FiberRuntimeMe
  * events // => ["start", "success"]
  * ```
  *
- * @category metrics
+ * @category services
  * @since 4.0.0
  */
 export interface FiberRuntimeMetricsService {
@@ -3332,7 +3332,7 @@ export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService 
  * ] // => ["function", "function"]
  * ```
  *
- * @category metrics
+ * @category services
  * @since 4.0.0
  */
 export const FiberRuntimeMetricsImpl: FiberRuntimeMetricsService = {
@@ -3372,7 +3372,7 @@ export const FiberRuntimeMetricsImpl: FiberRuntimeMetricsService = {
  * await Effect.runPromise(Effect.provide(program, Metric.enableRuntimeMetricsLayer)) // => true
  * ```
  *
- * @category metrics
+ * @category layers
  * @since 4.0.0
  */
 export const enableRuntimeMetricsLayer = Layer.succeed(FiberRuntimeMetrics)(FiberRuntimeMetricsImpl)
@@ -3411,7 +3411,7 @@ export const enableRuntimeMetricsLayer = Layer.succeed(FiberRuntimeMetrics)(Fibe
  * const values = [result.counterValue.count, result.metricsEnabled] // => [1, false]
  * ```
  *
- * @category metrics
+ * @category layers
  * @since 4.0.0
  */
 export const disableRuntimeMetricsLayer = Layer.succeed(FiberRuntimeMetrics)(undefined)
@@ -3438,7 +3438,7 @@ export const disableRuntimeMetricsLayer = Layer.succeed(FiberRuntimeMetrics)(und
  * await Effect.runPromise(Metric.enableRuntimeMetrics(program)) // => true
  * ```
  *
- * @category metrics
+ * @category providing services
  * @since 4.0.0
  */
 export const enableRuntimeMetrics: <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, R> = InternalEffect.provideService(
@@ -3467,7 +3467,7 @@ export const enableRuntimeMetrics: <A, E, R>(self: Effect<A, E, R>) => Effect<A,
  * await Effect.runPromise(Metric.disableRuntimeMetrics(program)) // => true
  * ```
  *
- * @category metrics
+ * @category providing services
  * @since 4.0.0
  */
 export const disableRuntimeMetrics: <A, E, R>(self: Effect<A, E, R>) => Effect<A, E, R> = InternalEffect.provideService(

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -1178,7 +1178,7 @@ export declare namespace Metric {
    * metricIds // => ["requests:Counter", "bytes:Counter", "status_codes:Frequency", "cpu_usage:Gauge", "response_time:Histogram"]
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type Input<A> = A extends Metric<infer _Input, infer _State> ? _Input
@@ -1241,7 +1241,7 @@ export declare namespace Metric {
    * values // => [10, 85.5, 1]
    * ```
    *
-   * @category types
+   * @category utility types
    * @since 4.0.0
    */
   export type State<A> = A extends Metric<infer _Input, infer _State> ? _State
@@ -1555,7 +1555,7 @@ export declare namespace Metric {
  * const key = result // => { keyValue: "effect/Metric/CurrentMetricAttributes", keyType: "string", isConstant: true }
  * ```
  *
- * @category references
+ * @category constants
  * @since 4.0.0
  */
 export const CurrentMetricAttributesKey = "effect/Metric/CurrentMetricAttributes" as const
@@ -1602,7 +1602,7 @@ export const CurrentMetricAttributesKey = "effect/Metric/CurrentMetricAttributes
  * const actual = attributes // => { service: "api", version: "1.0" }
  * ```
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const CurrentMetricAttributes = Context.Reference<Metric.AttributeSet>(CurrentMetricAttributesKey, {
@@ -1634,7 +1634,7 @@ const MetricRegistryKey = "~effect/observability/Metric/MetricRegistryKey"
  * @see {@link snapshot} for reading all registered metrics from the current `Effect` context
  * @see {@link snapshotUnsafe} for reading all registered metrics from an explicit `Context`
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MetricRegistry = Context.Reference<Map<string, Metric.Metadata<any, any>>>(
@@ -2808,7 +2808,7 @@ export const mapInput: {
  * const count = value.count // => 3
  * ```
  *
- * @category Input
+ * @category input
  * @since 2.0.0
  */
 export const withConstantInput: {
@@ -2873,7 +2873,7 @@ export const withConstantInput: {
  * await Effect.runPromise(Effect.provideService(result, Metric.MetricRegistry, new Map())) // => [2, 1]
  * ```
  *
- * @category Attributes
+ * @category attributes
  * @since 4.0.0
  */
 export const withAttributes: {
@@ -2936,7 +2936,7 @@ export const withAttributes: {
  * const ids = snapshots.map((snapshot) => snapshot.id).sort() // => ["http_requests", "response_time_ms"]
  * ```
  *
- * @category Snapshotting
+ * @category snapshotting
  * @since 2.0.0
  */
 export const snapshot: Effect<ReadonlyArray<Metric.Snapshot>> = InternalEffect.map(
@@ -2995,7 +2995,7 @@ export const snapshot: Effect<ReadonlyArray<Metric.Snapshot>> = InternalEffect.m
  * included // => [true, true, true]
  * ```
  *
- * @category Debugging
+ * @category debugging
  * @since 4.0.0
  */
 export const dump: Effect<string> = InternalEffect.flatMap(InternalEffect.context(), (context) => {
@@ -3063,7 +3063,7 @@ export const dump: Effect<string> = InternalEffect.flatMap(InternalEffect.contex
  * await Effect.runPromise(Effect.provideService(program, Metric.MetricRegistry, new Map())) // => ["http_requests"]
  * ```
  *
- * @category Snapshotting
+ * @category snapshotting
  * @since 4.0.0
  */
 export const snapshotUnsafe = (context: Context.Context<never>): ReadonlyArray<Metric.Snapshot> => {
@@ -3310,7 +3310,7 @@ export interface FiberRuntimeMetricsService {
  * const isDefault = result // => true
  * ```
  *
- * @category runtime metrics
+ * @category services
  * @since 4.0.0
  */
 export const FiberRuntimeMetrics = Context.Reference<FiberRuntimeMetricsService | undefined>(

--- a/packages/effect/src/MutableHashMap.ts
+++ b/packages/effect/src/MutableHashMap.ts
@@ -83,7 +83,7 @@ export interface MutableHashMap<out K, out V> extends Iterable<[K, V]>, Pipeable
  *
  * @see {@link MutableHashMap} for the mutable hash map interface
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isMutableHashMap = <K, V>(value: unknown): value is MutableHashMap<K, V> => hasProperty(value, TypeId)

--- a/packages/effect/src/MutableHashMap.ts
+++ b/packages/effect/src/MutableHashMap.ts
@@ -254,7 +254,7 @@ export const fromIterable = <K, V>(entries: Iterable<readonly [K, V]>): MutableH
  * @see {@link has} for checking only whether a key is present
  * @see {@link set} for inserting or replacing a value by key
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const get: {
@@ -308,7 +308,7 @@ const isSimpleKey = (u: unknown): boolean => typeof u !== "object" && typeof u !
  * @see {@link values} for iterating over stored values
  * @see {@link has} for checking one key without iterating
  *
- * @category elements
+ * @category getters
  * @since 3.8.0
  */
 export const keys = <K, V>(self: MutableHashMap<K, V>): Iterable<K> => self.backing.keys()
@@ -342,7 +342,7 @@ export const keys = <K, V>(self: MutableHashMap<K, V>): Iterable<K> => self.back
  *
  * @see {@link keys} for iterating over stored keys
  *
- * @category elements
+ * @category getters
  * @since 3.8.0
  */
 export const values = <K, V>(self: MutableHashMap<K, V>): Iterable<V> => self.backing.values()
@@ -386,7 +386,7 @@ const getFromBucket = <K, V>(
  *
  * @see {@link get} for reading the value as an `Option`
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -778,7 +778,7 @@ export const clear = <K, V>(self: MutableHashMap<K, V>) => {
  *
  * @see {@link isEmpty} for checking whether the map has no entries
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const size = <K, V>(self: MutableHashMap<K, V>): number => self.backing.size

--- a/packages/effect/src/MutableHashSet.ts
+++ b/packages/effect/src/MutableHashSet.ts
@@ -84,7 +84,7 @@ export interface MutableHashSet<out V> extends Iterable<V>, Pipeable, Inspectabl
  *
  * @see {@link MutableHashSet} for the mutable hash set interface
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isMutableHashSet = <V>(value: unknown): value is MutableHashSet<V> => hasProperty(value, TypeId)

--- a/packages/effect/src/MutableHashSet.ts
+++ b/packages/effect/src/MutableHashSet.ts
@@ -296,7 +296,7 @@ export const add: {
  * @see {@link add} for adding a value to the set
  * @see {@link remove} for removing a value from the set
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -377,7 +377,7 @@ export const remove: {
  * MutableHashSet.size(set) // => 0
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const size = <V>(self: MutableHashSet<V>): number => MutableHashMap.size(self.keyMap)

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -411,7 +411,7 @@ export const clear = <A>(self: MutableList<A>): void => {
  * list.length // => 7
  * ```
  *
- * @category elements
+ * @category mutations
  * @since 4.0.0
  */
 export const takeN = <A>(self: MutableList<A>, n: number): Array<A> => {
@@ -461,7 +461,7 @@ export const takeN = <A>(self: MutableList<A>, n: number): Array<A> => {
  * @see {@link takeN} for removing up to `n` values and returning them as an array
  * @see {@link clear} for removing every value from the list
  *
- * @category elements
+ * @category mutations
  * @since 4.0.0
  */
 export const takeNVoid = <A>(self: MutableList<A>, n: number): void => {
@@ -504,7 +504,7 @@ export const takeNVoid = <A>(self: MutableList<A>, n: number): void => {
  * list.length // => 0
  * ```
  *
- * @category elements
+ * @category mutations
  * @since 4.0.0
  */
 export const takeAll = <A>(self: MutableList<A>): Array<A> => takeN(self, self.length)
@@ -527,7 +527,7 @@ export const takeAll = <A>(self: MutableList<A>): Array<A> => takeN(self, self.l
  * list.length // => 2
  * ```
  *
- * @category elements
+ * @category mutations
  * @since 4.0.0
  */
 export const take = <A>(self: MutableList<A>): Empty | A => {
@@ -557,7 +557,7 @@ export const take = <A>(self: MutableList<A>): Empty | A => {
  *
  * @see {@link takeN} for removing up to `n` values and returning them as an array
  *
- * @category elements
+ * @category converting
  * @since 4.0.0
  */
 export const toArrayN = <A>(self: MutableList<A>, n: number): Array<A> => {
@@ -586,7 +586,7 @@ export const toArrayN = <A>(self: MutableList<A>, n: number): Array<A> => {
  *
  * @see {@link takeAll} for converting all elements to an array and clearing the list
  *
- * @category elements
+ * @category converting
  * @since 4.0.0
  */
 export const toArray = <A>(self: MutableList<A>): Array<A> => toArrayN(self, self.length)

--- a/packages/effect/src/MutableRef.ts
+++ b/packages/effect/src/MutableRef.ts
@@ -166,7 +166,7 @@ export const make = <T>(value: T): MutableRef<T> => {
  * MutableRef.get(ref) // => "final"
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const compareAndSet: {
@@ -218,7 +218,7 @@ export const compareAndSet: {
  * MutableRef.get(countdown) // => 0
  * ```
  *
- * @category numeric
+ * @category mutations
  * @since 2.0.0
  */
 export const decrement = (self: MutableRef<number>): MutableRef<number> => update(self, (n) => n - 1)
@@ -261,7 +261,7 @@ export const decrement = (self: MutableRef<number>): MutableRef<number> => updat
  * MutableRef.get(attempts) // => -1
  * ```
  *
- * @category numeric
+ * @category mutations
  * @since 2.0.0
  */
 export const decrementAndGet = (self: MutableRef<number>): number => updateAndGet(self, (n) => n - 1)
@@ -299,7 +299,7 @@ export const decrementAndGet = (self: MutableRef<number>): number => updateAndGe
  * value1 === value2 // => true
  * ```
  *
- * @category general
+ * @category getters
  * @since 2.0.0
  */
 export const get = <T>(self: MutableRef<T>): T => self.current
@@ -344,7 +344,7 @@ export const get = <T>(self: MutableRef<T>): T => self.current
  * nextIndex // => 2
  * ```
  *
- * @category numeric
+ * @category mutations
  * @since 2.0.0
  */
 export const getAndDecrement = (self: MutableRef<number>): number => getAndUpdate(self, (n) => n - 1)
@@ -396,7 +396,7 @@ export const getAndDecrement = (self: MutableRef<number>): number => getAndUpdat
  * MutableRef.get(iterations) // => 5
  * ```
  *
- * @category numeric
+ * @category mutations
  * @since 2.0.0
  */
 export const getAndIncrement = (self: MutableRef<number>): number => getAndUpdate(self, (n) => n + 1)
@@ -445,7 +445,7 @@ export const getAndIncrement = (self: MutableRef<number>): number => getAndUpdat
  * MutableRef.get(buffer) // => []
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const getAndSet: {
@@ -510,7 +510,7 @@ export const getAndSet: {
  * MutableRef.get(list) // => [1, 2, 3, 4]
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const getAndUpdate: {
@@ -561,7 +561,7 @@ export const getAndUpdate: {
  * MutableRef.get(counter) // => 9
  * ```
  *
- * @category numeric
+ * @category mutations
  * @since 2.0.0
  */
 export const increment = (self: MutableRef<number>): MutableRef<number> => update(self, (n) => n + 1)
@@ -607,7 +607,7 @@ export const increment = (self: MutableRef<number>): MutableRef<number> => updat
  * MutableRef.get(attempts) // => 1
  * ```
  *
- * @category numeric
+ * @category mutations
  * @since 2.0.0
  */
 export const incrementAndGet = (self: MutableRef<number>): number => updateAndGet(self, (n) => n + 1)
@@ -659,7 +659,7 @@ export const incrementAndGet = (self: MutableRef<number>): number => updateAndGe
  * MutableRef.get(state) // => "success"
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const set: {
@@ -716,7 +716,7 @@ export const set: {
  * MutableRef.get(ref1) // => 3
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const setAndGet: {
@@ -782,7 +782,7 @@ export const setAndGet: {
  * MutableRef.get(list) // => [1, 2, 3, 4]
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const update: {
@@ -847,7 +847,7 @@ export const update: {
  * MutableRef.get(list) // => [2, 4, 6]
  * ```
  *
- * @category general
+ * @category mutations
  * @since 2.0.0
  */
 export const updateAndGet: {
@@ -907,7 +907,7 @@ export const updateAndGet: {
  * MutableRef.get(flag) // => true
  * ```
  *
- * @category boolean
+ * @category mutations
  * @since 2.0.0
  */
 export const toggle = (self: MutableRef<boolean>): MutableRef<boolean> => update(self, (_) => !_)

--- a/packages/effect/src/Optic.ts
+++ b/packages/effect/src/Optic.ts
@@ -59,7 +59,7 @@ import type { IsUnion } from "./Types.ts"
  * @see {@link Lens} — when you only need a one-directional focus into a whole
  * @see {@link Prism} — when the focus may not be present
  *
- * @category Iso
+ * @category models
  * @since 4.0.0
  */
 export interface Iso<in out S, in out A> extends Lens<S, A>, Prism<S, A> {}
@@ -134,7 +134,7 @@ export function makeIso<S, A>(get: (s: S) => A, set: (a: A) => S): Iso<S, A> {
  * @see {@link Iso} — when conversion is lossless in both directions
  * @see {@link Optional} — when reading can also fail
  *
- * @category Lens
+ * @category models
  * @since 4.0.0
  */
 export interface Lens<in out S, in out A> extends Optional<S, A> {
@@ -218,7 +218,7 @@ export function makeLens<S, A>(get: (s: S) => A, replace: (a: A, s: S) => S): Le
  * @see {@link fromChecks} — build a Prism from schema checks
  * @see {@link Lens} — when reading always succeeds
  *
- * @category Prism
+ * @category models
  * @since 4.0.0
  */
 export interface Prism<in out S, in out A> extends Optional<S, A> {
@@ -434,7 +434,7 @@ type ForbidUnion<A, Message extends string> = IsUnion<A> extends true ? [Message
  * @see {@link Lens} — when reading always succeeds
  * @see {@link Prism} — when writing always succeeds
  *
- * @category Optional
+ * @category models
  * @since 4.0.0
  */
 export interface Optional<in out S, in out A> {
@@ -945,7 +945,7 @@ export function makeOptional<S, A>(
  * @see {@link getAll} — extract focused elements
  * @see {@link Optional} — the base type
  *
- * @category Traversal
+ * @category models
  * @since 4.0.0
  */
 export interface Traversal<in out S, in out A> extends Optional<S, ReadonlyArray<A>> {}
@@ -1291,7 +1291,7 @@ function composeKind(a: Kind, b: Kind): Kind {
  *
  * @see {@link Traversal} — the optic type this operates on
  *
- * @category Traversal
+ * @category getters
  * @since 4.0.0
  */
 export function getAll<S, A>(traversal: Traversal<S, A>): (s: S) => Array<A> {
@@ -1335,7 +1335,7 @@ const identityIso = make([])
  *
  * @see {@link Iso} — the type this function returns
  *
- * @category Iso
+ * @category constructors
  * @since 4.0.0
  */
 export function id<S>(): Iso<S, S> {
@@ -1373,7 +1373,7 @@ export function id<S>(): Iso<S, S> {
  * @see {@link Iso} — the type this function returns
  * @see {@link id} — identity iso
  *
- * @category Iso
+ * @category constructors
  * @since 4.0.0
  */
 export function entries<A>(): Iso<Record<string, A>, ReadonlyArray<readonly [string, A]>> {
@@ -1410,7 +1410,7 @@ export function entries<A>(): Iso<Record<string, A>, ReadonlyArray<readonly [str
  * @see {@link none} — focuses on `None` instead
  * @see {@link Prism} — the type this function returns
  *
- * @category Prism
+ * @category constructors
  * @since 4.0.0
  */
 export function some<A>(): Prism<Option.Option<A>, A> {
@@ -1453,7 +1453,7 @@ export function some<A>(): Prism<Option.Option<A>, A> {
  * @see {@link some} — focuses on `Some` instead
  * @see {@link Prism} — the type this function returns
  *
- * @category Prism
+ * @category constructors
  * @since 4.0.0
  */
 export function none<A>(): Prism<Option.Option<A>, undefined> {
@@ -1496,7 +1496,7 @@ export function none<A>(): Prism<Option.Option<A>, undefined> {
  * @see {@link failure} — focuses on the failure side
  * @see {@link Prism} — the type this function returns
  *
- * @category Prism
+ * @category constructors
  * @since 4.0.0
  */
 export function success<A, E>(): Prism<Result.Result<A, E>, A> {
@@ -1539,7 +1539,7 @@ export function success<A, E>(): Prism<Result.Result<A, E>, A> {
  * @see {@link success} — focuses on the success side
  * @see {@link Prism} — the type this function returns
  *
- * @category Prism
+ * @category constructors
  * @since 4.0.0
  */
 export function failure<A, E>(): Prism<Result.Result<A, E>, E> {

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -187,7 +187,7 @@ export declare namespace Option {
    * const witness: MyType = "value"
    * ```
    *
-   * @category Type-level Utils
+   * @category utility types
    * @since 2.0.0
    */
   export type Value<T extends Option<any>> = [T] extends [Option<infer _A>] ? _A : never

--- a/packages/effect/src/Option.ts
+++ b/packages/effect/src/Option.ts
@@ -218,7 +218,7 @@ export interface OptionUnifyIgnore {}
  * Use when defining higher-kinded abstractions that must accept optional-value
  * types as one of their type-lambda inputs.
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface OptionTypeLambda extends TypeLambda {
@@ -1715,7 +1715,7 @@ export const zipWith: {
  * pipe(items, Option.reduceCompact(0, (b, a) => b + a)) // => 3
  * ```
  *
- * @category reducing
+ * @category folding
  * @since 2.0.0
  */
 export const reduceCompact: {
@@ -2072,7 +2072,7 @@ export const liftPredicate: { // Note: I intentionally avoid using the NoInfer p
  *
  * @see {@link contains} for a version using default equality
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const containsWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
@@ -2107,7 +2107,7 @@ export const containsWith = <A>(isEquivalent: (self: A, that: A) => boolean): {
  * @see {@link containsWith} for custom equality
  * @see {@link exists} to test with a predicate
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const contains: {
@@ -2144,7 +2144,7 @@ export const contains: {
  * @see {@link filter} to keep or discard based on a predicate
  * @see {@link contains} to test for a specific value
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const exists: {
@@ -2188,7 +2188,7 @@ export const exists: {
  * @see {@link bind} to add `Option` values
  * @see {@link let_ let} to add plain values
  *
- * @category do notation
+ * @category mapping
  * @since 2.0.0
  */
 export const bindTo: {
@@ -2234,7 +2234,7 @@ export {
    * @see {@link bind} to add `Option` values
    * @see {@link bindTo} to start by naming an existing `Option`
    *
-   * @category do notation
+   * @category mapping
    * @since 2.0.0
    */
   let_ as let
@@ -2266,7 +2266,7 @@ export {
  * @see {@link let_ let} to add plain values
  * @see {@link bindTo} to start by naming an existing `Option`
  *
- * @category do notation
+ * @category sequencing
  * @since 2.0.0
  */
 export const bind: {
@@ -2308,7 +2308,7 @@ export const bind: {
  * @see {@link let_ let} to add plain values
  * @see {@link bindTo} to start by naming an existing `Option`
  *
- * @category do notation
+ * @category constructors
  * @since 2.0.0
  */
 export const Do: Option<{}> = some({})
@@ -2390,7 +2390,7 @@ export const gen: Gen.Gen<OptionTypeLambda> = (...args) => {
  *
  * @see {@link makeReducerFailFast} for fail-fast semantics
  *
- * @category Reducer
+ * @category constructors
  * @since 4.0.0
  */
 export function makeReducer<A>(combiner: Combiner.Combiner<A>): Reducer.Reducer<Option<A>> {
@@ -2428,7 +2428,7 @@ export function makeReducer<A>(combiner: Combiner.Combiner<A>): Reducer.Reducer<
  *
  * @see {@link makeReducerFailFast} to get a full `Reducer`
  *
- * @category Combiner
+ * @category constructors
  * @since 4.0.0
  */
 export function makeCombinerFailFast<A>(combiner: Combiner.Combiner<A>): Combiner.Combiner<Option<A>> {
@@ -2466,7 +2466,7 @@ export function makeCombinerFailFast<A>(combiner: Combiner.Combiner<A>): Combine
  * @see {@link makeCombinerFailFast} for just the combiner
  * @see {@link makeReducer} for non-fail-fast semantics
  *
- * @category Reducer
+ * @category constructors
  * @since 4.0.0
  */
 export function makeReducerFailFast<A>(reducer: Reducer.Reducer<A>): Reducer.Reducer<Option<A>> {

--- a/packages/effect/src/Order.ts
+++ b/packages/effect/src/Order.ts
@@ -47,7 +47,7 @@ import * as Reducer from "./Reducer.ts"
  *
  * @see {@link make} to create an order from a comparison function
  * @see {@link Ordering} for the result type of comparisons
- * @category type class
+ * @category models
  * @since 2.0.0
  */
 export interface Order<in A> {
@@ -66,7 +66,7 @@ export interface Order<in A> {
  * This is type-level only, has no runtime representation, and is used
  * internally by the Effect type system.
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface OrderTypeLambda extends TypeLambda {

--- a/packages/effect/src/Path.ts
+++ b/packages/effect/src/Path.ts
@@ -78,7 +78,7 @@ export const TypeId = "~effect/platform/Path"
  * result.resolved // => "/base/relative/path"
  * ```
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Path {

--- a/packages/effect/src/PlatformError.ts
+++ b/packages/effect/src/PlatformError.ts
@@ -30,7 +30,7 @@ const TypeId = "~effect/platform/PlatformError"
  * @see {@link SystemError} for failures reported by the host platform or operating system
  * @see {@link PlatformError} for the wrapper used by most platform APIs
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class BadArgument extends Data.TaggedError("BadArgument")<{
@@ -69,7 +69,7 @@ export class BadArgument extends Data.TaggedError("BadArgument")<{
  * @see {@link SystemError} for the error data that carries this tag on its `_tag` field
  * @see {@link systemError} for creating a `PlatformError` from a system failure with one of these tags
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export type SystemErrorTag =
@@ -103,7 +103,7 @@ export type SystemErrorTag =
  * @see {@link BadArgument} for platform API failures caused by rejected caller input before an operation runs
  * @see {@link SystemErrorTag} for the normalized tag values stored in `_tag`
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class SystemError extends Data.Error<{
@@ -151,7 +151,7 @@ export class SystemError extends Data.Error<{
  * @see {@link badArgument} for creating this wrapper from rejected caller input
  * @see {@link systemError} for creating this wrapper from a host or operating-system failure
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class PlatformError extends Data.TaggedError("PlatformError")<{

--- a/packages/effect/src/Pool.ts
+++ b/packages/effect/src/Pool.ts
@@ -184,7 +184,7 @@ export interface Strategy<A, E> {
  *
  * This predicate narrows the input to `Pool<unknown, unknown>`.
  *
- * @category refinements
+ * @category guards
  * @since 2.0.0
  */
 export const isPool = (u: unknown): u is Pool<unknown, unknown> => hasProperty(u, TypeId)

--- a/packages/effect/src/Predicate.ts
+++ b/packages/effect/src/Predicate.ts
@@ -73,7 +73,7 @@ export interface Predicate<in A> {
  * ```
  *
  * @see {@link Predicate}
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface PredicateTypeLambda extends TypeLambda {
@@ -452,7 +452,7 @@ export const isTupleOfAtLeast: {
  *
  * @see {@link isNullish}
  * @see {@link isNotNullish}
- * @category guards
+ * @category predicates
  * @since 2.0.0
  */
 export function isTruthy(input: unknown): boolean {
@@ -1830,7 +1830,7 @@ export const nand: {
  *
  * @see {@link some}
  * @see {@link and}
- * @category elements
+ * @category combining
  * @since 2.0.0
  */
 export function every<A>(collection: Iterable<Predicate<A>>): Predicate<A> {
@@ -1868,7 +1868,7 @@ export function every<A>(collection: Iterable<Predicate<A>>): Predicate<A> {
  *
  * @see {@link every}
  * @see {@link or}
- * @category elements
+ * @category combining
  * @since 2.0.0
  */
 export function some<A>(collection: Iterable<Predicate<A>>): Predicate<A> {

--- a/packages/effect/src/PrimaryKey.ts
+++ b/packages/effect/src/PrimaryKey.ts
@@ -117,7 +117,7 @@ export const isPrimaryKey = (u: unknown): u is PrimaryKey => hasProperty(u, symb
  * PrimaryKey.value(simpleKey) // => "simple-key-123"
  * ```
  *
- * @category accessors
+ * @category getters
  * @since 2.0.0
  */
 export const value = (self: PrimaryKey): string => self[symbol]()

--- a/packages/effect/src/PrimaryKey.ts
+++ b/packages/effect/src/PrimaryKey.ts
@@ -81,7 +81,7 @@ export interface PrimaryKey {
  * @see {@link PrimaryKey} for the protocol being checked
  * @see {@link value} for extracting the string value after narrowing
  *
- * @category models
+ * @category guards
  * @since 4.0.0
  */
 export const isPrimaryKey = (u: unknown): u is PrimaryKey => hasProperty(u, symbol)

--- a/packages/effect/src/Pull.ts
+++ b/packages/effect/src/Pull.ts
@@ -53,7 +53,7 @@ export interface Pull<out A, out E = never, out Done = void, out R = never>
  * @see {@link Leftover} for extracting the completion leftover type
  * @see {@link Services} for extracting the required services type instead
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Success<P> = P extends Effect<infer _A, infer _E, infer _R> ? _A : never
@@ -71,7 +71,7 @@ export type Success<P> = P extends Effect<infer _A, infer _E, infer _R> ? _A : n
  * @see {@link Services} for extracting the required services type instead
  * @see {@link ExcludeDone} for excluding `Cause.Done` from an error union
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<P> = P extends Effect<infer _A, infer _E, infer _R> ? _E extends Cause.Done<infer _L> ? never : _E
@@ -90,7 +90,7 @@ export type Error<P> = P extends Effect<infer _A, infer _E, infer _R> ? _E exten
  * @see {@link Error} for extracting the ordinary failure type, excluding `Cause.Done`
  * @see {@link Services} for extracting the required services type instead
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Leftover<P> = P extends Effect<infer _A, infer _E, infer _R> ? _E extends Cause.Done<infer _L> ? _L : never
@@ -108,7 +108,7 @@ export type Leftover<P> = P extends Effect<infer _A, infer _E, infer _R> ? _E ex
  * @see {@link Error} for extracting the ordinary failure type
  * @see {@link Leftover} for extracting the completion leftover type
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Services<P> = P extends Effect<infer _A, infer _E, infer _R> ? _R : never
@@ -124,7 +124,7 @@ export type Services<P> = P extends Effect<infer _A, infer _E, infer _R> ? _R : 
  * @see {@link Error} for extracting ordinary failures from a `Pull`
  * @see {@link Leftover} for extracting the completion leftover type
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeDone<E> = Exclude<E, Cause.Done<any>>
@@ -180,7 +180,7 @@ export const catchDone: {
  * @see {@link filterDone} for extracting the `Cause.Done` value from a `Cause`
  * @see {@link filterNoDone} for selecting causes with no done failures
  *
- * @category Done
+ * @category predicates
  * @since 4.0.0
  */
 export const isDoneCause = <E>(cause: Cause.Cause<E>): boolean => cause.reasons.some(isDoneFailure)
@@ -197,7 +197,7 @@ export const isDoneCause = <E>(cause: Cause.Cause<E>): boolean => cause.reasons.
  * @see {@link isDoneCause} for checking an entire `Cause` for any done reason
  * @see {@link filterDone} for extracting the `Cause.Done` value from a `Cause`
  *
- * @category Done
+ * @category guards
  * @since 4.0.0
  */
 export const isDoneFailure = <E>(

--- a/packages/effect/src/Pull.ts
+++ b/packages/effect/src/Pull.ts
@@ -151,7 +151,7 @@ export type ExcludeDone<E> = Exclude<E, Cause.Done<any>>
  * @see {@link matchEffect} for handling success, ordinary failure, and done outcomes explicitly
  * @see {@link filterDoneLeftover} for extracting a done leftover from an existing `Cause`
  *
- * @category Done
+ * @category error handling
  * @since 4.0.0
  */
 export const catchDone: {
@@ -217,7 +217,7 @@ export const isDoneFailure = <E>(
  * Returns a successful `Result` with the `Cause.Done` value when one is
  * present, otherwise returns a failed `Result` containing the non-done cause.
  *
- * @category Done
+ * @category filtering
  * @since 4.0.0
  */
 export const filterDone: <E>(
@@ -245,7 +245,7 @@ export const filterDone: <E>(
  * @see {@link filterDoneLeftover} for extracting only the done leftover value
  * @see {@link filterNoDone} for the inverse filter that succeeds only when no done failure is present
  *
- * @category Done
+ * @category filtering
  * @since 4.0.0
  */
 export const filterDoneVoid: <E extends Cause.Done>(
@@ -271,7 +271,7 @@ export const filterDoneVoid: <E extends Cause.Done>(
  * @see {@link filterDone} for the inverse typed done filter
  * @see {@link filterDoneVoid} for done detection when the payload is not needed
  *
- * @category Done
+ * @category filtering
  * @since 4.0.0
  */
 export const filterNoDone: <E>(
@@ -291,7 +291,7 @@ export const filterNoDone: <E>(
  * Use to extract only the leftover value carried by a `Cause.Done` completion
  * signal.
  *
- * @category Done
+ * @category filtering
  * @since 4.0.0
  */
 export const filterDoneLeftover: <E>(
@@ -319,7 +319,7 @@ export const filterDoneLeftover: <E>(
  * @see {@link filterDone} for extracting the done signal without converting the cause to an `Exit`
  * @see {@link matchEffect} for handling `Pull` success, failure, and done outcomes directly
  *
- * @category Done
+ * @category converting
  * @since 4.0.0
  */
 export const doneExitFromCause = <E>(cause: Cause.Cause<E>): Exit.Exit<Cause.Done.Extract<E>, ExcludeDone<E>> => {

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -639,7 +639,7 @@ export const unbounded = <A, E = never>(): Effect<Queue<A, E>> => make()
  * await Effect.runPromise(program) // => { offered: [true, true], size: 2 }
  * ```
  *
- * @category Offering
+ * @category offering
  * @since 2.0.0
  */
 export const offer = <A, E>(self: Enqueue<A, E>, message: Types.NoInfer<A>): Effect<boolean> =>
@@ -702,7 +702,7 @@ export const offer = <A, E>(self: Enqueue<A, E>, message: Types.NoInfer<A>): Eff
  * await Effect.runPromise(program) // => { offered: [true, true], size: 2 }
  * ```
  *
- * @category Offering
+ * @category offering
  * @since 4.0.0
  */
 export const offerUnsafe = <A, E>(self: Enqueue<A, E>, message: Types.NoInfer<A>): boolean => {
@@ -756,7 +756,7 @@ export const offerUnsafe = <A, E>(self: Enqueue<A, E>, message: Types.NoInfer<A>
  * await Effect.runPromise(program) // => [4, 5]
  * ```
  *
- * @category Offering
+ * @category offering
  * @since 2.0.0
  */
 export const offerAll = <A, E>(self: Enqueue<A, E>, messages: Iterable<A>): Effect<Array<A>> =>
@@ -806,7 +806,7 @@ export const offerAll = <A, E>(self: Enqueue<A, E>, messages: Iterable<A>): Effe
  * await Effect.runPromise(program) // => { remaining: [4, 5], size: 3 }
  * ```
  *
- * @category Offering
+ * @category offering
  * @since 4.0.0
  */
 export const offerAllUnsafe = <A, E>(self: Enqueue<A, E>, messages: Iterable<A>): Array<A> => {
@@ -1681,7 +1681,7 @@ export const size = <A, E>(self: Dequeue<A, E>): Effect<number> => internalEffec
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category sizes
+ * @category predicates
  * @since 2.0.0
  */
 export const isFull = <A, E>(self: Dequeue<A, E>): Effect<boolean> => internalEffect.sync(() => isFullUnsafe(self))
@@ -1764,7 +1764,7 @@ export const sizeUnsafe = <A, E>(self: Dequeue<A, E>): number => self.state._tag
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category sizes
+ * @category predicates
  * @since 4.0.0
  */
 export const isFullUnsafe = <A, E>(self: Dequeue<A, E>): boolean => sizeUnsafe(self) === self.capacity

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -46,7 +46,7 @@ import * as Predicate from "./Predicate.ts"
  * await Effect.runPromise(program.pipe(Random.withSeed("example"))) // => [0.1633802591287037, 3434461687501127, 1]
  * ```
  *
- * @category Random Number Generators
+ * @category services
  * @since 2.0.0
  */
 export const Random: Context.Reference<{
@@ -73,7 +73,7 @@ const randomWith = <A>(f: (random: typeof Random["Service"]) => A): Effect.Effec
  * await Effect.runPromise(Random.next.pipe(Random.withSeed("example"))) // => 0.1633802591287037
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 2.0.0
  */
 export const next: Effect.Effect<number> = randomWith((r) => r.nextDoubleUnsafe())
@@ -93,7 +93,7 @@ export const next: Effect.Effect<number> = randomWith((r) => r.nextDoubleUnsafe(
  * await Effect.runPromise(Random.nextBoolean.pipe(Random.withSeed("example"))) // => false
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 2.0.0
  */
 export const nextBoolean: Effect.Effect<boolean> = randomWith((r) => r.nextDoubleUnsafe() > 0.5)
@@ -115,7 +115,7 @@ export const nextBoolean: Effect.Effect<boolean> = randomWith((r) => r.nextDoubl
  * await Effect.runPromise(Random.nextInt.pipe(Random.withSeed("example"))) // => -6064002158214091
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 2.0.0
  */
 export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe())
@@ -135,7 +135,7 @@ export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe(
  * await Effect.runPromise(Random.nextBetween(0, 1).pipe(Random.withSeed("example"))) // => 0.1633802591287037
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 4.0.0
  */
 export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
@@ -171,7 +171,7 @@ export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
  * await Effect.runPromise(program.pipe(Random.withSeed("example"))) // => [1, 4, 0]
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 2.0.0
  */
 export const nextIntBetween = (min: number, max: number, options?: {
@@ -200,7 +200,7 @@ export const nextIntBetween = (min: number, max: number, options?: {
  * await Effect.runPromise(Random.shuffle([1, 2, 3, 4, 5]).pipe(Random.withSeed("example"))) // => [4, 2, 5, 3, 1]
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 2.0.0
  */
 export const shuffle = <A>(elements: Iterable<A>): Effect.Effect<Array<A>> =>
@@ -236,7 +236,7 @@ export const shuffle = <A>(elements: Iterable<A>): Effect.Effect<Array<A>> =>
  * await Effect.runPromise(Random.choice(["red", "green", "blue"] as const).pipe(Random.withSeed("example"))) // => "red"
  * ```
  *
- * @category Random Number Generators
+ * @category random number generators
  * @since 3.6.0
  */
 export const choice: <Self extends Iterable<unknown>>(
@@ -284,7 +284,7 @@ export const choice: <Self extends Iterable<unknown>>(
  * ])) // => [[0.018368576514773527, 0.4010840628128671], [0.018368576514773527, 0.4010840628128671]]
  * ```
  *
- * @category Seeding
+ * @category seeding
  * @since 4.0.0
  */
 export const withSeed: {

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -73,7 +73,7 @@ const randomWith = <A>(f: (random: typeof Random["Service"]) => A): Effect.Effec
  * await Effect.runPromise(Random.next.pipe(Random.withSeed("example"))) // => 0.1633802591287037
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 2.0.0
  */
 export const next: Effect.Effect<number> = randomWith((r) => r.nextDoubleUnsafe())
@@ -93,7 +93,7 @@ export const next: Effect.Effect<number> = randomWith((r) => r.nextDoubleUnsafe(
  * await Effect.runPromise(Random.nextBoolean.pipe(Random.withSeed("example"))) // => false
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 2.0.0
  */
 export const nextBoolean: Effect.Effect<boolean> = randomWith((r) => r.nextDoubleUnsafe() > 0.5)
@@ -115,7 +115,7 @@ export const nextBoolean: Effect.Effect<boolean> = randomWith((r) => r.nextDoubl
  * await Effect.runPromise(Random.nextInt.pipe(Random.withSeed("example"))) // => -6064002158214091
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 2.0.0
  */
 export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe())
@@ -135,7 +135,7 @@ export const nextInt: Effect.Effect<number> = randomWith((r) => r.nextIntUnsafe(
  * await Effect.runPromise(Random.nextBetween(0, 1).pipe(Random.withSeed("example"))) // => 0.1633802591287037
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 4.0.0
  */
 export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
@@ -171,7 +171,7 @@ export const nextBetween = (min: number, max: number): Effect.Effect<number> =>
  * await Effect.runPromise(program.pipe(Random.withSeed("example"))) // => [1, 4, 0]
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 2.0.0
  */
 export const nextIntBetween = (min: number, max: number, options?: {
@@ -200,7 +200,7 @@ export const nextIntBetween = (min: number, max: number, options?: {
  * await Effect.runPromise(Random.shuffle([1, 2, 3, 4, 5]).pipe(Random.withSeed("example"))) // => [4, 2, 5, 3, 1]
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 2.0.0
  */
 export const shuffle = <A>(elements: Iterable<A>): Effect.Effect<Array<A>> =>
@@ -236,7 +236,7 @@ export const shuffle = <A>(elements: Iterable<A>): Effect.Effect<Array<A>> =>
  * await Effect.runPromise(Random.choice(["red", "green", "blue"] as const).pipe(Random.withSeed("example"))) // => "red"
  * ```
  *
- * @category random number generators
+ * @category generators
  * @since 3.6.0
  */
 export const choice: <Self extends Iterable<unknown>>(
@@ -284,7 +284,7 @@ export const choice: <Self extends Iterable<unknown>>(
  * ])) // => [[0.018368576514773527, 0.4010840628128671], [0.018368576514773527, 0.4010840628128671]]
  * ```
  *
- * @category seeding
+ * @category providing services
  * @since 4.0.0
  */
 export const withSeed: {

--- a/packages/effect/src/RcMap.ts
+++ b/packages/effect/src/RcMap.ts
@@ -233,7 +233,7 @@ const makeUnsafe = <K, A, E>(options: {
  * @see {@link get} for acquiring or retaining a resource by key
  * @see {@link invalidate} for removing a resource from the map
  *
- * @category models
+ * @category constructors
  * @since 3.5.0
  */
 export const make: {

--- a/packages/effect/src/Record.ts
+++ b/packages/effect/src/Record.ts
@@ -1175,7 +1175,7 @@ export const reduce: {
  * Record.every({ a: 1, b: -1 }, (n) => n > 0) // => false
  * ```
  *
- * @category predicates
+ * @category guards
  * @since 2.0.0
  */
 export const every: {

--- a/packages/effect/src/Record.ts
+++ b/packages/effect/src/Record.ts
@@ -152,7 +152,7 @@ export declare namespace ReadonlyRecord {
  * defaults // => { port: 3000, retries: 3 }
  * ```
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface ReadonlyRecordTypeLambda<K extends string = string> extends TypeLambda {
@@ -396,7 +396,7 @@ export const size = <K extends string, A>(self: ReadonlyRecord<K, A>): number =>
  * Record.has(Record.empty<string>(), "c") // => false
  * ```
  *
- * @category guards
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -1498,7 +1498,7 @@ export function makeReducerIntersection<K extends string, A>(
  * ) // => Option.some(["c", 3])
  * ```
  *
- * @category elements
+ * @category searching
  * @since 3.14.0
  */
 export const findFirst: {

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -153,7 +153,7 @@ export declare namespace Redacted {
  * Redacted.isRedacted(plainString) // => false
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 3.3.0
  */
 export const isRedacted = (u: unknown): u is Redacted<unknown> => hasProperty(u, TypeId)

--- a/packages/effect/src/Ref.ts
+++ b/packages/effect/src/Ref.ts
@@ -230,7 +230,7 @@ export const get = <A>(self: Ref<A>) => Effect.sync(() => self.ref.current)
  * @see {@link getAndSet} for setting while returning the previous value
  * @see {@link setAndGet} for setting while returning the new value
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const set = dual<
@@ -455,7 +455,7 @@ export const setAndGet = dual<
  * @see {@link updateAndGet} for returning the new stored value
  * @see {@link modifySome} for optionally updating while returning a separate result
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const modify = dual<
@@ -515,7 +515,7 @@ export const modify = dual<
  * @see {@link modify} for always storing a new value
  * @see {@link updateSome} for optional updates without a separate return value
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const modifySome: {
@@ -567,7 +567,7 @@ export const modifySome: {
  * @see {@link updateAndGet} for returning the new value
  * @see {@link getAndUpdate} for returning the previous value
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const update = dual<
@@ -652,7 +652,7 @@ export const updateAndGet = dual<
  * @see {@link update} for always applying an update
  * @see {@link updateSomeAndGet} for returning the resulting current value
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const updateSome = dual<

--- a/packages/effect/src/RegExp.ts
+++ b/packages/effect/src/RegExp.ts
@@ -72,7 +72,7 @@ export const isRegExp: (input: unknown) => input is RegExp = predicate.isRegExp
  * RegExp.escape("a*b") // => "a\\*b"
  * ```
  *
- * @category RegExp
+ * @category transforming
  * @since 2.0.0
  */
 export const escape = (string: string): string => string.replace(/[/\\^$*+?.()|[\]{}]/g, "\\$&")

--- a/packages/effect/src/Request.ts
+++ b/packages/effect/src/Request.ts
@@ -65,7 +65,7 @@ export interface Request<out A, out E = never, out R = never> extends Variance<A
  * @see {@link Services} for extracting a request's service requirements
  * @see {@link Result} for the exit type produced by completing a request
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Any = Request<any, any, any>
@@ -562,7 +562,7 @@ export const succeed: {
  * an `uninterruptible` flag used by batching and caching internals, and the
  * `completeUnsafe` callback used by resolvers to supply the final `Exit`.
  *
- * @category entry
+ * @category models
  * @since 2.0.0
  */
 export interface Entry<out R> {
@@ -588,7 +588,7 @@ export interface Entry<out R> {
  * most application code receives entries from a `RequestResolver` instead of
  * constructing them directly.
  *
- * @category entry
+ * @category constructors
  * @since 2.0.0
  */
 export const makeEntry = <R>(options: {

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -582,7 +582,7 @@ export const fromEffectTagged = <A extends Request.Any & { readonly _tag: string
  * Array.of(delayRan, RequestResolver.isRequestResolver(resolverWithCustomDelay)) // => [true, true]
  * ```
  *
- * @category delay
+ * @category delays & timeouts
  * @since 4.0.0
  */
 export const setDelayEffect: {
@@ -625,7 +625,7 @@ export const setDelayEffect: {
  * await Effect.runPromise(program) // => "data"
  * ```
  *
- * @category delay
+ * @category delays & timeouts
  * @since 4.0.0
  */
 export const setDelay: {
@@ -1208,7 +1208,7 @@ export const withCache: {
  * @see {@link withCache} for in-memory resolver caching that does not require persistable request values or a persistence store
  * @see {@link asCache} for exposing resolver results through a `Cache` instead of returning another resolver
  *
- * @category Persistence
+ * @category caching
  * @since 4.0.0
  */
 export const persisted: {

--- a/packages/effect/src/Result.ts
+++ b/packages/effect/src/Result.ts
@@ -240,14 +240,14 @@ export declare namespace Result {
   /**
    * Extracts the failure type `E` from `Result<A, E>`.
    *
-   * @category Type Level
+   * @category utility types
    * @since 4.0.0
    */
   export type Failure<T extends Result<any, any>> = [T] extends [Result<infer _A, infer _E>] ? _E : never
   /**
    * Extracts the success type `A` from `Result<A, E>`.
    *
-   * @category Type Level
+   * @category utility types
    * @since 4.0.0
    */
   export type Success<T extends Result<any, any>> = [T] extends [Result<infer _A, infer _E>] ? _A : never
@@ -1701,7 +1701,7 @@ export {
  *
  * @see {@link transposeMapOption} to map and transpose in one step
  *
- * @category Transposing
+ * @category transposing
  * @since 3.14.0
  */
 export const transposeOption = <A = never, E = never>(
@@ -1742,7 +1742,7 @@ export const transposeOption = <A = never, E = never>(
  *
  * @see {@link transposeOption} when the Option already contains a Result
  *
- * @category Transposing
+ * @category transposing
  * @since 3.15.0
  */
 export const transposeMapOption = dual<

--- a/packages/effect/src/Result.ts
+++ b/packages/effect/src/Result.ts
@@ -206,7 +206,7 @@ export interface ResultUnifyIgnore {}
  * (e.g., `map`, `flatMap` abstractions). You typically do not need to
  * reference this directly.
  *
- * @category type lambdas
+ * @category utility types
  * @since 4.0.0
  */
 export interface ResultTypeLambda extends TypeLambda {
@@ -1538,7 +1538,7 @@ export const gen: Gen.Gen<ResultTypeLambda> = (...args) => {
  * @see {@link gen} for an alternative generator-based syntax
  * @see {@link bindTo} for starting a do-notation chain from an existing Result
  *
- * @category do notation
+ * @category constructors
  * @since 2.0.0
  */
 export const Do: Result<{}> = succeed({})
@@ -1575,7 +1575,7 @@ export const Do: Result<{}> = succeed({})
  * @see {@link let_ let} for pure computed fields
  * @see {@link bindTo} to wrap an initial Result into a named field
  *
- * @category do notation
+ * @category sequencing
  * @since 2.0.0
  */
 export const bind: {
@@ -1618,7 +1618,7 @@ export const bind: {
  * @see {@link Do} to start from an empty object
  * @see {@link bind} to add more fields
  *
- * @category do notation
+ * @category mapping
  * @since 2.0.0
  */
 export const bindTo: {
@@ -1669,7 +1669,7 @@ export {
    * @see {@link Do} to start the do-notation chain
    * @see {@link bind} for Result-producing fields
    *
-   * @category do notation
+   * @category mapping
    * @since 2.0.0
    */
   let_ as let

--- a/packages/effect/src/Runtime.ts
+++ b/packages/effect/src/Runtime.ts
@@ -305,7 +305,7 @@ export const errorExitCode: errorExitCode = "~effect/Runtime/errorExitCode"
  *
  * @see {@link errorExitCode} for the marker read by this function
  *
- * @category accessors
+ * @category getters
  * @since 4.0.0
  */
 export const getErrorExitCode = (u: unknown): number => {
@@ -393,7 +393,7 @@ export const errorReported: errorReported = "~effect/Runtime/errorReported"
  *
  * @see {@link errorReported} for the marker read by this function
  *
- * @category accessors
+ * @category getters
  * @since 4.0.0
  */
 export const getErrorReported = (u: unknown): boolean => {

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -90,7 +90,7 @@ export interface Metadata<Output = unknown, Input = unknown> extends InputMetada
  * input and output values, zero duration, and zeroed timing fields before any
  * schedule step has produced metadata.
  *
- * @category metadata
+ * @category services
  * @since 4.0.0
  */
 export const CurrentMetadata = Context.Reference<Metadata>("effect/Schedule/CurrentMetadata", {
@@ -154,7 +154,7 @@ export declare namespace Schedule {
 /**
  * Extracts the output type from a `Schedule`.
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Output<S> = S extends Schedule<infer Output, any, any, any> ? Output : never
@@ -162,7 +162,7 @@ export type Output<S> = S extends Schedule<infer Output, any, any, any> ? Output
 /**
  * Extracts the input type from a `Schedule`.
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Input<S> = S extends Schedule<any, infer Input, any, any> ? Input : never
@@ -170,7 +170,7 @@ export type Input<S> = S extends Schedule<any, infer Input, any, any> ? Input : 
 /**
  * Extracts the error type from a `Schedule`.
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<S> = S extends Schedule<any, any, infer Error, any> ? Error : never
@@ -178,7 +178,7 @@ export type Error<S> = S extends Schedule<any, any, infer Error, any> ? Error : 
 /**
  * Extracts the service requirements from a `Schedule`.
  *
- * @category type extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Env<S> = S extends Schedule<any, any, any, infer Env> ? Env : never

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -72,7 +72,7 @@ export interface SchedulerDispatcher {
  * The default value creates a `MixedScheduler`. Provide this service to
  * customize execution mode, task dispatching, or yield behavior.
  *
- * @category references
+ * @category services
  * @since 2.0.0
  */
 export const Scheduler: Context.Reference<Scheduler> = Context.Reference<Scheduler>("effect/Scheduler", {
@@ -262,7 +262,7 @@ class MixedSchedulerDispatcher implements SchedulerDispatcher {
  *
  * @see {@link PreventSchedulerYield} for bypassing scheduler yield checks entirely rather than tuning the operation budget
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
@@ -287,7 +287,7 @@ export const MaxOpsBeforeYield = Context.Reference<number>("effect/Scheduler/Max
  * @see {@link MaxOpsBeforeYield} for tuning yield frequency without disabling yield checks
  * @see {@link Scheduler} for providing custom scheduler yield behavior
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const PreventSchedulerYield = Context.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -26,7 +26,7 @@ import type * as Fiber from "./Fiber.ts"
  * priorities, and decides when fibers should yield control after consuming
  * their operation budget.
  *
- * @category models
+ * @category services
  * @since 2.0.0
  */
 export interface Scheduler {
@@ -145,7 +145,7 @@ class PriorityBuckets {
  * operation counts to decide when fibers should yield, and is the default
  * scheduler implementation.
  *
- * @category schedulers
+ * @category models
  * @since 2.0.0
  */
 export class MixedScheduler implements Scheduler {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -7800,7 +7800,7 @@ export function makeIsBetween<T>(deriveOptions: {
  * Creates a divisibility check for any numeric type from a remainder function
  * and a zero value.
  *
- * @category Numeric checks
+ * @category numeric checks
  * @since 4.0.0
  */
 export function makeIsMultipleOf<T>(options: {
@@ -14796,7 +14796,7 @@ export function toEquivalence<T>(schema: Schema<T>): Equivalence.Equivalence<T> 
  *
  * Use {@link toType} before this function to represent the type side instead.
  *
- * @category Representation
+ * @category representation
  * @since 4.0.0
  */
 export function toRepresentation(schema: Constraint): SchemaRepresentation.Document {
@@ -14912,7 +14912,7 @@ export function toJsonSchemaDocument(
 /**
  * Type-level representation returned by {@link toCodecJson}.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export interface toCodecJson<S extends Constraint> extends
@@ -14949,7 +14949,7 @@ export interface toCodecJson<S extends Constraint> extends
  * `toCodecJson` callback can return `undefined` when the declaration is already
  * in canonical JSON form.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export function toCodecJson<S extends Constraint>(schema: S): toCodecJson<S> {
@@ -15071,7 +15071,7 @@ function toCodecJsonBase(ast: SchemaAST.AST, recur: (ast: SchemaAST.AST) => Sche
  * Derives an isomorphism codec from a schema. The encoded form is the
  * schema's `Iso` type — the intermediate representation used for round-tripping.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export function toCodecIso<S extends Constraint>(schema: S): Codec<S["Type"], S["Iso"]> {
@@ -15108,7 +15108,7 @@ function toCodecIsoBase(ast: SchemaAST.AST, recur: (ast: SchemaAST.AST) => Schem
  * A {@link Tree} of `string | undefined` nodes. Leaf values are either a
  * string representation or `undefined` for opaque/declaration types.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export type StringTree = Tree<string | undefined>
@@ -15116,7 +15116,7 @@ export type StringTree = Tree<string | undefined>
 /**
  * Type-level representation returned by {@link toCodecStringTree}.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export interface toCodecStringTree<S extends Constraint> extends
@@ -15151,7 +15151,7 @@ export interface toCodecStringTree<S extends Constraint> extends
  * `toCodec` encoding. A callback can return `undefined` when the declaration is
  * already in canonical StringTree form.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export function toCodecStringTree<S extends Constraint>(schema: S): toCodecStringTree<S> {
@@ -15161,7 +15161,7 @@ export function toCodecStringTree<S extends Constraint>(schema: S): toCodecStrin
 /**
  * Type-level representation returned by {@link toCodecArrayFromSingle}.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export interface toCodecArrayFromSingle<S extends Constraint> extends
@@ -15200,7 +15200,7 @@ export interface toCodecArrayFromSingle<S extends Constraint> extends
  * decoding convenience rather than a canonical StringTree representation. It
  * does not parse comma-separated strings.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export function toCodecArrayFromSingle<S extends Constraint>(schema: S): toCodecArrayFromSingle<S> {
@@ -15229,7 +15229,7 @@ type XmlEncoderOptions = {
  * an `Effect` that succeeds with the XML string or fails with `SchemaError` if
  * codec encoding fails.
  *
- * @category Canonical Codecs
+ * @category canonical codecs
  * @since 4.0.0
  */
 export function toEncoderXml<T, RE>(
@@ -16007,7 +16007,7 @@ export const MutableJsonReviver = makeFixedDeclarationReviver(
  * annotations are taken from the last check; otherwise they are taken from
  * the base schema instance.
  *
- * @category Schema Resolvers
+ * @category schema resolvers
  * @since 4.0.0
  */
 export function resolveAnnotations<S extends Constraint>(
@@ -16021,7 +16021,7 @@ export function resolveAnnotations<S extends Constraint>(
  * annotations are those attached via `annotateKey` and live on the AST's
  * `context` rather than on the schema node itself.
  *
- * @category Schema Resolvers
+ * @category schema resolvers
  * @since 4.0.0
  */
 export function resolveAnnotationsKey<S extends Constraint>(schema: S): Annotations.Key<S["Type"]> | undefined {

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -1255,7 +1255,7 @@ function makeStandardResult<A>(exit: Exit_.Exit<StandardSchemaV1.Result<A>>): St
  * invalidResult.issues?.map((issue) => issue.path) // => [["name"], ["age"]]
  * ```
  *
- * @category Standard Schema
+ * @category converting
  * @since 4.0.0
  */
 export function toStandardSchemaV1<S extends ConstraintDecoder<unknown>>(
@@ -1334,7 +1334,7 @@ function toBaseStandardJSONSchemaV1(self: Constraint, target: StandardJSONSchema
  *
  * https://github.com/standard-schema/standard-schema/pull/134
  *
- * @category Standard Schema
+ * @category converting
  * @since 4.0.0
  */
 export function toStandardJSONSchemaV1<S extends Constraint>(
@@ -3130,7 +3130,7 @@ export interface Boolean extends Bottom<boolean, boolean, never, never, SchemaAS
  *
  * @see {@link BooleanFromBit} for a schema that decodes bit literals `0` or `1` into a boolean
  *
- * @category boolean
+ * @category schemas
  * @since 4.0.0
  */
 export const Boolean: Boolean = make(SchemaAST.boolean)
@@ -6638,7 +6638,7 @@ const TRIMMED_PATTERN = "^\\S[\\s\\S]*\\S$|^\\S$|^$"
  * When generating test data with fast-check, this applies a `patterns`
  * constraint to ensure generated strings match the trimmed pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isTrimmed(annotations?: Annotations.Filter) {
@@ -6672,7 +6672,7 @@ export function isTrimmed(annotations?: Annotations.Filter) {
  *
  * @see {@link isTrimmed} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isTrimmedReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -6695,7 +6695,7 @@ export const isTrimmedReviver: SchemaRepresentation.FilterReviver<null> = Intern
  * When generating test data with fast-check, this applies a `patterns`
  * constraint to ensure generated strings match the specified RegExp pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isPattern(
@@ -6732,7 +6732,7 @@ const IsPatternPayload = Struct({
  *
  * @see {@link isPattern} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isPatternReviver: SchemaRepresentation.FilterReviver<{
@@ -6759,7 +6759,7 @@ export const isPatternReviver: SchemaRepresentation.FilterReviver<{
  * When generating test data with fast-check, this applies a `patterns`
  * constraint to ensure generated strings match the number string pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isStringFinite(annotations?: Annotations.Filter): SchemaAST.Filter<string> {
@@ -6778,7 +6778,7 @@ export function isStringFinite(annotations?: Annotations.Filter): SchemaAST.Filt
  *
  * @see {@link isStringFinite} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isStringFiniteReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -6801,7 +6801,7 @@ export const isStringFiniteReviver: SchemaRepresentation.FilterReviver<null> = I
  * This check corresponds to a `pattern` constraint with the same signed
  * base-10 integer pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isStringBigInt(annotations?: Annotations.Filter): SchemaAST.Filter<string> {
@@ -6820,7 +6820,7 @@ export function isStringBigInt(annotations?: Annotations.Filter): SchemaAST.Filt
  *
  * @see {@link isStringBigInt} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isStringBigIntReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -6838,7 +6838,7 @@ export const isStringBigIntReviver: SchemaRepresentation.FilterReviver<null> = I
  * The check uses the pattern `^Symbol\((.*)\)$`. It is not a general test for
  * whether a string can be passed to JavaScript's `Symbol()` function.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isStringSymbol(annotations?: Annotations.Filter): SchemaAST.Filter<string> {
@@ -6857,7 +6857,7 @@ export function isStringSymbol(annotations?: Annotations.Filter): SchemaAST.Filt
  *
  * @see {@link isStringSymbol} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isStringSymbolReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -6907,7 +6907,7 @@ const getUUIDRegExp = (version?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8): globalThis.RegE
  * constraint to ensure generated strings match the UUID pattern.
  *
  * @see {@link isGUID} for shape-only GUID validation.
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isUUID(version?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, annotations?: Annotations.Filter) {
@@ -6936,7 +6936,7 @@ export function isUUID(version?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, annotations?: An
  *
  * @see {@link isUUID} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isUUIDReviver: SchemaRepresentation.FilterReviver<{
@@ -6970,7 +6970,7 @@ const GUID_REGEXP = /^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{
  * constraint to ensure generated strings match the GUID pattern.
  *
  * @see {@link isUUID} for strict UUID validation.
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isGUID(annotations?: Annotations.Filter) {
@@ -6998,7 +6998,7 @@ export function isGUID(annotations?: Annotations.Filter) {
  *
  * @see {@link isGUID} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGUIDReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7023,7 +7023,7 @@ export const isGUIDReviver: SchemaRepresentation.FilterReviver<null> = InternalS
  * When generating test data with fast-check, this applies a `patterns`
  * constraint to ensure generated strings match the ULID pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isULID(annotations?: Annotations.Filter) {
@@ -7051,7 +7051,7 @@ export function isULID(annotations?: Annotations.Filter) {
  *
  * @see {@link isULID} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isULIDReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7075,7 +7075,7 @@ export const isULIDReviver: SchemaRepresentation.FilterReviver<null> = InternalS
  * When generating test data with fast-check, this applies a `patterns`
  * constraint to ensure generated strings match the Base64 pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isBase64(annotations?: Annotations.Filter) {
@@ -7104,7 +7104,7 @@ export function isBase64(annotations?: Annotations.Filter) {
  *
  * @see {@link isBase64} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBase64Reviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7129,7 +7129,7 @@ export const isBase64Reviver: SchemaRepresentation.FilterReviver<null> = Interna
  * When generating test data with fast-check, this applies a `patterns`
  * constraint to ensure generated strings match the Base64URL pattern.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isBase64Url(annotations?: Annotations.Filter) {
@@ -7158,7 +7158,7 @@ export function isBase64Url(annotations?: Annotations.Filter) {
  *
  * @see {@link isBase64Url} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBase64UrlReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7175,7 +7175,7 @@ export const isBase64UrlReviver: SchemaRepresentation.FilterReviver<null> = Inte
  * RegExp metacharacters in the prefix are escaped in JSON Schema and arbitrary
  * metadata so that the generated patterns retain literal `startsWith` semantics.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isStartsWith(startsWith: string, annotations?: Annotations.Filter) {
@@ -7210,7 +7210,7 @@ export function isStartsWith(startsWith: string, annotations?: Annotations.Filte
  *
  * @see {@link isStartsWith} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isStartsWithReviver: SchemaRepresentation.FilterReviver<{
@@ -7229,7 +7229,7 @@ export const isStartsWithReviver: SchemaRepresentation.FilterReviver<{
  * RegExp metacharacters in the suffix are escaped in JSON Schema and arbitrary
  * metadata so that the generated patterns retain literal `endsWith` semantics.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isEndsWith(endsWith: string, annotations?: Annotations.Filter) {
@@ -7264,7 +7264,7 @@ export function isEndsWith(endsWith: string, annotations?: Annotations.Filter) {
  *
  * @see {@link isEndsWith} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isEndsWithReviver: SchemaRepresentation.FilterReviver<{
@@ -7284,7 +7284,7 @@ export const isEndsWithReviver: SchemaRepresentation.FilterReviver<{
  * arbitrary metadata so that the generated patterns retain literal `includes`
  * semantics.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isIncludes(includes: string, annotations?: Annotations.Filter) {
@@ -7319,7 +7319,7 @@ export function isIncludes(includes: string, annotations?: Annotations.Filter) {
  *
  * @see {@link isIncludes} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isIncludesReviver: SchemaRepresentation.FilterReviver<{
@@ -7341,7 +7341,7 @@ const UPPERCASED_PATTERN = "^[^a-z]*$"
  * such as digits, punctuation, and whitespace. It rejects strings that would
  * change when uppercased.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isUppercased(annotations?: Annotations.Filter) {
@@ -7375,7 +7375,7 @@ export function isUppercased(annotations?: Annotations.Filter) {
  *
  * @see {@link isUppercased} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isUppercasedReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7395,7 +7395,7 @@ const LOWERCASED_PATTERN = "^[^A-Z]*$"
  * such as digits, punctuation, and whitespace. It rejects strings that would
  * change when lowercased.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isLowercased(annotations?: Annotations.Filter) {
@@ -7429,7 +7429,7 @@ export function isLowercased(annotations?: Annotations.Filter) {
  *
  * @see {@link isLowercased} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLowercasedReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7449,7 +7449,7 @@ const CAPITALIZED_PATTERN = "^[^a-z]?.*$"
  * Empty strings pass. Strings whose first character has no lowercase form, such
  * as a digit, punctuation mark, or whitespace, also pass.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isCapitalized(annotations?: Annotations.Filter) {
@@ -7483,7 +7483,7 @@ export function isCapitalized(annotations?: Annotations.Filter) {
  *
  * @see {@link isCapitalized} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isCapitalizedReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7503,7 +7503,7 @@ const UNCAPITALIZED_PATTERN = "^[^A-Z]?.*$"
  * Empty strings pass. Strings whose first character has no uppercase form, such
  * as a digit, punctuation mark, or whitespace, also pass.
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export function isUncapitalized(annotations?: Annotations.Filter) {
@@ -7537,7 +7537,7 @@ export function isUncapitalized(annotations?: Annotations.Filter) {
  *
  * @see {@link isUncapitalized} for creating the corresponding check
  *
- * @category String checks
+ * @category validation
  * @since 4.0.0
  */
 export const isUncapitalizedReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7549,7 +7549,7 @@ export const isUncapitalizedReviver: SchemaRepresentation.FilterReviver<null> = 
 /**
  * Type-level representation of {@link Finite}.
  *
- * @category Number
+ * @category models
  * @since 3.10.0
  */
 export interface Finite extends Number {
@@ -7559,7 +7559,7 @@ export interface Finite extends Number {
 /**
  * Schema for finite numbers, rejecting `NaN`, `Infinity`, and `-Infinity`.
  *
- * @category Number
+ * @category schemas
  * @since 3.10.0
  */
 export const Finite: Finite = make(SchemaAST.finite)
@@ -7579,7 +7579,7 @@ export const Finite: Finite = make(SchemaAST.finite)
  * When generating test data with fast-check, this applies `noNaN: true` and
  * `noInfinity: true` constraints to ensure generated numbers are finite.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isFinite: (annotations?: Annotations.Filter) => SchemaAST.Filter<number> = SchemaAST.isFinite
@@ -7593,7 +7593,7 @@ export const isFinite: (annotations?: Annotations.Filter) => SchemaAST.Filter<nu
  *
  * @see {@link isFinite} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isFiniteReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -7606,7 +7606,7 @@ export const isFiniteReviver: SchemaRepresentation.FilterReviver<null> = Interna
  * Creates a greater-than (`>`) check for any ordered type from an
  * `Order.Order` instance.
  *
- * @category Order checks
+ * @category validation
  * @since 4.0.0
  */
 export function makeIsGreaterThan<T>(options: {
@@ -7641,7 +7641,7 @@ export function makeIsGreaterThan<T>(options: {
  * Creates a greater-than-or-equal-to (`>=`) check for any ordered type from an
  * `Order.Order` instance.
  *
- * @category Order checks
+ * @category validation
  * @since 4.0.0
  */
 export function makeIsGreaterThanOrEqualTo<T>(options: {
@@ -7675,7 +7675,7 @@ export function makeIsGreaterThanOrEqualTo<T>(options: {
  * Creates a less-than (`<`) check for any ordered type from an `Order.Order`
  * instance.
  *
- * @category Order checks
+ * @category validation
  * @since 4.0.0
  */
 export function makeIsLessThan<T>(options: {
@@ -7710,7 +7710,7 @@ export function makeIsLessThan<T>(options: {
  * Creates a less-than-or-equal-to (`<=`) check for any ordered type from an
  * `Order.Order` instance.
  *
- * @category Order checks
+ * @category validation
  * @since 4.0.0
  */
 export function makeIsLessThanOrEqualTo<T>(options: {
@@ -7744,7 +7744,7 @@ export function makeIsLessThanOrEqualTo<T>(options: {
  * Creates an inclusive or exclusive range check for any ordered type from an
  * `Order.Order` instance.
  *
- * @category Order checks
+ * @category validation
  * @since 4.0.0
  */
 export function makeIsBetween<T>(deriveOptions: {
@@ -7800,7 +7800,7 @@ export function makeIsBetween<T>(deriveOptions: {
  * Creates a divisibility check for any numeric type from a remainder function
  * and a zero value.
  *
- * @category numeric checks
+ * @category validation
  * @since 4.0.0
  */
 export function makeIsMultipleOf<T>(options: {
@@ -7844,7 +7844,7 @@ function encodeNumberPayload(number: number): number {
  * `exclusiveMinimum` constraint to ensure generated numbers are greater than
  * the specified value.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThan = makeIsGreaterThan({
@@ -7868,7 +7868,7 @@ export const isGreaterThan = makeIsGreaterThan({
  *
  * @see {@link isGreaterThan} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanReviver: SchemaRepresentation.FilterReviver<{
@@ -7894,7 +7894,7 @@ export const isGreaterThanReviver: SchemaRepresentation.FilterReviver<{
  * When generating test data with fast-check, this applies a `minimum` constraint
  * to ensure generated numbers are greater than or equal to the specified value.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualTo = makeIsGreaterThanOrEqualTo({
@@ -7918,7 +7918,7 @@ export const isGreaterThanOrEqualTo = makeIsGreaterThanOrEqualTo({
  *
  * @see {@link isGreaterThanOrEqualTo} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualToReviver: SchemaRepresentation.FilterReviver<{
@@ -7944,7 +7944,7 @@ export const isGreaterThanOrEqualToReviver: SchemaRepresentation.FilterReviver<{
  * `exclusiveMaximum` constraint to ensure generated numbers are less than the
  * specified value.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThan = makeIsLessThan({
@@ -7968,7 +7968,7 @@ export const isLessThan = makeIsLessThan({
  *
  * @see {@link isLessThan} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanReviver: SchemaRepresentation.FilterReviver<{
@@ -7994,7 +7994,7 @@ export const isLessThanReviver: SchemaRepresentation.FilterReviver<{
  * When generating test data with fast-check, this applies a `maximum` constraint
  * to ensure generated numbers are less than or equal to the specified value.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualTo = makeIsLessThanOrEqualTo({
@@ -8018,7 +8018,7 @@ export const isLessThanOrEqualTo = makeIsLessThanOrEqualTo({
  *
  * @see {@link isLessThanOrEqualTo} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualToReviver: SchemaRepresentation.FilterReviver<{
@@ -8047,7 +8047,7 @@ export const isLessThanOrEqualToReviver: SchemaRepresentation.FilterReviver<{
  * `exclusiveMaximum` flags to ensure generated numbers fall within the
  * specified range.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetween = makeIsBetween({
@@ -8088,7 +8088,7 @@ export const isBetween = makeIsBetween({
  *
  * @see {@link isBetween} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetweenReviver: SchemaRepresentation.FilterReviver<{
@@ -8121,7 +8121,7 @@ export const isBetweenReviver: SchemaRepresentation.FilterReviver<{
  * When generating test data with fast-check, this applies constraints to ensure
  * generated numbers are multiples of the specified divisor.
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMultipleOf = makeIsMultipleOf({
@@ -8147,7 +8147,7 @@ export const isMultipleOf = makeIsMultipleOf({
  *
  * @see {@link isMultipleOf} for creating the corresponding check
  *
- * @category Number checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMultipleOfReviver: SchemaRepresentation.FilterReviver<{
@@ -8173,7 +8173,7 @@ export const isMultipleOfReviver: SchemaRepresentation.FilterReviver<{
  * When generating test data with fast-check, this applies an `integer: true`
  * constraint to ensure generated numbers are integers.
  *
- * @category Integer checks
+ * @category validation
  * @since 4.0.0
  */
 export function isInt(annotations?: Annotations.Filter) {
@@ -8206,7 +8206,7 @@ export function isInt(annotations?: Annotations.Filter) {
  *
  * @see {@link isInt} for creating the corresponding check
  *
- * @category Integer checks
+ * @category validation
  * @since 4.0.0
  */
 export const isIntReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -8218,7 +8218,7 @@ export const isIntReviver: SchemaRepresentation.FilterReviver<null> = InternalSc
 /**
  * Type-level representation of {@link Int}.
  *
- * @category Number
+ * @category models
  * @since 3.10.0
  */
 export interface Int extends Number {
@@ -8228,7 +8228,7 @@ export interface Int extends Number {
 /**
  * Schema for integers, rejecting `NaN`, `Infinity`, and `-Infinity`.
  *
- * @category Number
+ * @category schemas
  * @since 3.10.0
  */
 export const Int: Int = Number.check(isInt())
@@ -8236,7 +8236,7 @@ export const Int: Int = Number.check(isInt())
 /**
  * Type-level representation of {@link Natural}.
  *
- * @category Number
+ * @category models
  * @since 4.0.0
  */
 export interface Natural extends Int {
@@ -8252,7 +8252,7 @@ export interface Natural extends Int {
  *
  * @see {@link Int} for safe integers that may be negative
  *
- * @category Number
+ * @category schemas
  * @since 4.0.0
  */
 export const Natural: Natural = Int.check(isGreaterThanOrEqualTo(0))
@@ -8273,7 +8273,7 @@ export const Natural: Natural = Int.check(isGreaterThanOrEqualTo(0))
  * When generating test data with fast-check, this applies integer and range
  * constraints to ensure generated numbers are 32-bit signed integers.
  *
- * @category Integer checks
+ * @category validation
  * @since 4.0.0
  */
 export function isInt32(annotations?: Annotations.Filter) {
@@ -8305,7 +8305,7 @@ export function isInt32(annotations?: Annotations.Filter) {
  * When generating test data with fast-check, this applies integer and range
  * constraints to ensure generated numbers are 32-bit unsigned integers.
  *
- * @category Integer checks
+ * @category validation
  * @since 4.0.0
  */
 export function isUint32(annotations?: Annotations.Filter) {
@@ -8343,7 +8343,7 @@ function formatDateRuntime(date: globalThis.Date): string {
  * one millisecond after the specified value to ensure generated Date objects are
  * greater than it.
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanDate = makeIsGreaterThan({
@@ -8378,7 +8378,7 @@ export const isGreaterThanDate = makeIsGreaterThan({
  * to ensure generated Date objects are greater than or equal to the specified
  * date.
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualToDate = makeIsGreaterThanOrEqualTo({
@@ -8407,7 +8407,7 @@ export const isGreaterThanOrEqualToDate = makeIsGreaterThanOrEqualTo({
  * one millisecond before the specified value to ensure generated Date objects
  * are less than it.
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanDate = makeIsLessThan({
@@ -8442,7 +8442,7 @@ export const isLessThanDate = makeIsLessThan({
  * to ensure generated Date objects are less than or equal to the specified
  * date.
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualToDate = makeIsLessThanOrEqualTo({
@@ -8477,7 +8477,7 @@ export const isLessThanOrEqualToDate = makeIsLessThanOrEqualTo({
  * constraints to ensure generated Date objects fall within the specified range,
  * shifting exclusive bounds by one millisecond.
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetweenDate = makeIsBetween({
@@ -8517,7 +8517,7 @@ export const isBetweenDate = makeIsBetween({
  * `exclusiveMinimum + 1n` to ensure generated BigInts are greater than the
  * specified value.
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanBigInt = makeIsGreaterThan({
@@ -8547,7 +8547,7 @@ export const isGreaterThanBigInt = makeIsGreaterThan({
  * to ensure generated BigInt values are greater than or equal to the specified
  * value.
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualToBigInt = makeIsGreaterThanOrEqualTo({
@@ -8576,7 +8576,7 @@ export const isGreaterThanOrEqualToBigInt = makeIsGreaterThanOrEqualTo({
  * `exclusiveMaximum - 1n` to ensure generated BigInts are less than the
  * specified value.
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanBigInt = makeIsLessThan({
@@ -8606,7 +8606,7 @@ export const isLessThanBigInt = makeIsLessThan({
  * to ensure generated BigInt values are less than or equal to the specified
  * value.
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualToBigInt = makeIsLessThanOrEqualTo({
@@ -8636,7 +8636,7 @@ export const isLessThanOrEqualToBigInt = makeIsLessThanOrEqualTo({
  * constraints to ensure generated BigInt values fall within the specified
  * range.
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetweenBigInt = makeIsBetween({
@@ -8668,7 +8668,7 @@ export const isBetweenBigInt = makeIsBetween({
 /**
  * Validates that a BigDecimal is greater than the specified value (exclusive).
  *
- * @category BigDecimal checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanBigDecimal = makeIsGreaterThan({
@@ -8680,7 +8680,7 @@ export const isGreaterThanBigDecimal = makeIsGreaterThan({
  * Validates that a BigDecimal is greater than or equal to the specified value
  * (inclusive).
  *
- * @category BigDecimal checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualToBigDecimal = makeIsGreaterThanOrEqualTo({
@@ -8691,7 +8691,7 @@ export const isGreaterThanOrEqualToBigDecimal = makeIsGreaterThanOrEqualTo({
 /**
  * Validates that a BigDecimal is less than the specified value (exclusive).
  *
- * @category BigDecimal checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanBigDecimal = makeIsLessThan({
@@ -8703,7 +8703,7 @@ export const isLessThanBigDecimal = makeIsLessThan({
  * Validates that a BigDecimal is less than or equal to the specified value
  * (inclusive).
  *
- * @category BigDecimal checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualToBigDecimal = makeIsLessThanOrEqualTo({
@@ -8719,7 +8719,7 @@ export const isLessThanOrEqualToBigDecimal = makeIsLessThanOrEqualTo({
  * The minimum and maximum boundaries are inclusive by default. Pass
  * `exclusiveMinimum` or `exclusiveMaximum` to exclude either boundary.
  *
- * @category BigDecimal checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetweenBigDecimal = makeIsBetween({
@@ -8755,7 +8755,7 @@ export const isBetweenBigDecimal = makeIsBetween({
  * Schema.is(NonEmptyArraySchema)([1]) // => true
  * ```
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export function isMinLength(minLength: number, annotations?: Annotations.Filter) {
@@ -8790,7 +8790,7 @@ export function isMinLength(minLength: number, annotations?: Annotations.Filter)
  *
  * @see {@link isMinLength} for creating the corresponding check
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMinLengthReviver: SchemaRepresentation.FilterReviver<{
@@ -8817,7 +8817,7 @@ export const isMinLengthReviver: SchemaRepresentation.FilterReviver<{
  * When generating test data with fast-check, this applies a `minLength: 1`
  * constraint to ensure generated strings or arrays are non-empty.
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export function isNonEmpty(annotations?: Annotations.Filter) {
@@ -8841,7 +8841,7 @@ export function isNonEmpty(annotations?: Annotations.Filter) {
  * constraint to ensure generated strings or arrays have at most the required
  * length.
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export function isMaxLength(maxLength: number, annotations?: Annotations.Filter) {
@@ -8876,7 +8876,7 @@ export function isMaxLength(maxLength: number, annotations?: Annotations.Filter)
  *
  * @see {@link isMaxLength} for creating the corresponding check
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMaxLengthReviver: SchemaRepresentation.FilterReviver<{
@@ -8904,7 +8904,7 @@ export const isMaxLengthReviver: SchemaRepresentation.FilterReviver<{
  * `maxLength` constraints to ensure generated strings or arrays have a length
  * within the specified range.
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export function isLengthBetween(minimum: number, maximum: number, annotations?: Annotations.Filter) {
@@ -8947,7 +8947,7 @@ export function isLengthBetween(minimum: number, maximum: number, annotations?: 
  *
  * @see {@link isLengthBetween} for creating the corresponding check
  *
- * @category Length checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLengthBetweenReviver: SchemaRepresentation.FilterReviver<{
@@ -8976,7 +8976,7 @@ export const isLengthBetweenReviver: SchemaRepresentation.FilterReviver<{
  * `minLength` constraint. Generators for values with a final `.size`, such as
  * sets and maps, interpret it as final cardinality.
  *
- * @category Size checks
+ * @category validation
  * @since 4.0.0
  */
 export function isMinSize(minSize: number, annotations?: Annotations.Filter) {
@@ -9011,7 +9011,7 @@ export function isMinSize(minSize: number, annotations?: Annotations.Filter) {
  *
  * @see {@link isMinSize} for creating the corresponding check
  *
- * @category Size checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMinSizeReviver: SchemaRepresentation.FilterReviver<{
@@ -9039,7 +9039,7 @@ export const isMinSizeReviver: SchemaRepresentation.FilterReviver<{
  * `maxLength` constraint. Generators for values with a final `.size`, such as
  * sets and maps, interpret it as final cardinality.
  *
- * @category Size checks
+ * @category validation
  * @since 4.0.0
  */
 export function isMaxSize(maxSize: number, annotations?: Annotations.Filter) {
@@ -9074,7 +9074,7 @@ export function isMaxSize(maxSize: number, annotations?: Annotations.Filter) {
  *
  * @see {@link isMaxSize} for creating the corresponding check
  *
- * @category Size checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMaxSizeReviver: SchemaRepresentation.FilterReviver<{
@@ -9102,7 +9102,7 @@ export const isMaxSizeReviver: SchemaRepresentation.FilterReviver<{
  * `minLength` and `maxLength` constraints. Generators for values with a final
  * `.size`, such as sets and maps, interpret them as final cardinality.
  *
- * @category Size checks
+ * @category validation
  * @since 4.0.0
  */
 export function isSizeBetween(minimum: number, maximum: number, annotations?: Annotations.Filter) {
@@ -9142,7 +9142,7 @@ export function isSizeBetween(minimum: number, maximum: number, annotations?: An
  *
  * @see {@link isSizeBetween} for creating the corresponding check
  *
- * @category Size checks
+ * @category validation
  * @since 4.0.0
  */
 export const isSizeBetweenReviver: SchemaRepresentation.FilterReviver<{
@@ -9171,7 +9171,7 @@ export const isSizeBetweenReviver: SchemaRepresentation.FilterReviver<{
  * `minLength` constraint. Object generators interpret it as the final number
  * of own properties.
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export function isMinProperties(minProperties: number, annotations?: Annotations.Filter) {
@@ -9206,7 +9206,7 @@ export function isMinProperties(minProperties: number, annotations?: Annotations
  *
  * @see {@link isMinProperties} for creating the corresponding check
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMinPropertiesReviver: SchemaRepresentation.FilterReviver<{
@@ -9233,7 +9233,7 @@ export const isMinPropertiesReviver: SchemaRepresentation.FilterReviver<{
  * `maxLength` constraint. Object generators interpret it as the final number
  * of own properties.
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export function isMaxProperties(maxProperties: number, annotations?: Annotations.Filter) {
@@ -9268,7 +9268,7 @@ export function isMaxProperties(maxProperties: number, annotations?: Annotations
  *
  * @see {@link isMaxProperties} for creating the corresponding check
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export const isMaxPropertiesReviver: SchemaRepresentation.FilterReviver<{
@@ -9296,7 +9296,7 @@ export const isMaxPropertiesReviver: SchemaRepresentation.FilterReviver<{
  * `minLength` and `maxLength` constraints. Object generators interpret them as
  * the final number of own properties.
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export function isPropertiesLengthBetween(minimum: number, maximum: number, annotations?: Annotations.Filter) {
@@ -9336,7 +9336,7 @@ export function isPropertiesLengthBetween(minimum: number, maximum: number, anno
  *
  * @see {@link isPropertiesLengthBetween} for creating the corresponding check
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export const isPropertiesLengthBetweenReviver: SchemaRepresentation.FilterReviver<{
@@ -9361,7 +9361,7 @@ export const isPropertiesLengthBetweenReviver: SchemaRepresentation.FilterRevive
  * For string property names, this corresponds to the `propertyNames` constraint
  * in JSON Schema.
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export function isPropertyNames(keySchema: Constraint, annotations?: Annotations.Filter) {
@@ -9407,7 +9407,7 @@ export function isPropertyNames(keySchema: Constraint, annotations?: Annotations
  *
  * @see {@link isPropertyNames} for creating the corresponding check
  *
- * @category Object checks
+ * @category validation
  * @since 4.0.0
  */
 export const isPropertyNamesReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -9429,7 +9429,7 @@ export const isPropertyNamesReviver: SchemaRepresentation.FilterReviver<null> = 
  * `unique: true` constraint. Array generators translate it to `fast-check`
  * `uniqueArray` using Effect equality.
  *
- * @category Array checks
+ * @category validation
  * @since 4.0.0
  */
 export function isUnique<T>(annotations?: Annotations.Filter) {
@@ -9462,7 +9462,7 @@ export function isUnique<T>(annotations?: Annotations.Filter) {
  *
  * @see {@link isUnique} for creating the corresponding check
  *
- * @category Array checks
+ * @category validation
  * @since 4.0.0
  */
 export const isUniqueReviver: SchemaRepresentation.FilterReviver<null> = InternalSchema.makeFilterReviver(
@@ -9478,7 +9478,7 @@ export const isUniqueReviver: SchemaRepresentation.FilterReviver<null> = Interna
 /**
  * Type-level representation of {@link NonEmptyString}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface NonEmptyString extends String {
@@ -9489,7 +9489,7 @@ export interface NonEmptyString extends String {
  * Schema for non-empty strings. Validates that a string has at least one
  * character.
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const NonEmptyString: NonEmptyString = String.check(isNonEmpty())
@@ -9497,7 +9497,7 @@ export const NonEmptyString: NonEmptyString = String.check(isNonEmpty())
 /**
  * Type-level representation of {@link Char}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface Char extends String {
@@ -9520,7 +9520,7 @@ export interface Char extends String {
  * @see {@link NonEmptyString} for strings with length greater than zero
  * @see {@link isLengthBetween} for the underlying length check
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const Char: Char = String.check(isLengthBetween(1, 1))
@@ -9528,7 +9528,7 @@ export const Char: Char = String.check(isLengthBetween(1, 1))
 /**
  * Type-level representation returned by {@link Option}.
  *
- * @category Option
+ * @category models
  * @since 3.10.0
  */
 export interface Option<A extends Constraint> extends
@@ -9551,7 +9551,7 @@ export interface Option<A extends Constraint> extends
  * `None` is represented as `{ _tag: "None" }`, while `Some` is represented as
  * `{ _tag: "Some", value }` using the wrapped schema's `Iso` type.
  *
- * @category Option
+ * @category utility types
  * @since 4.0.0
  */
 export type OptionIso<A extends Constraint> =
@@ -9561,7 +9561,7 @@ export type OptionIso<A extends Constraint> =
 /**
  * Schema for `Option<A>` values.
  *
- * @category Option
+ * @category schemas
  * @since 3.10.0
  */
 export function Option<A extends Constraint>(value: A): Option<A> {
@@ -9637,7 +9637,7 @@ export function Option<A extends Constraint>(value: A): Option<A> {
  *
  * @see {@link Option} for creating the corresponding schema
  *
- * @category Option
+ * @category schemas
  * @since 4.0.0
  */
 export const OptionReviver = InternalSchema.makeDeclarationReviver(
@@ -9652,7 +9652,7 @@ export const OptionReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link OptionFromNullOr}.
  *
- * @category Option
+ * @category models
  * @since 3.10.0
  */
 export interface OptionFromNullOr<S extends Constraint> extends decodeTo<Option<toType<S>>, NullOr<S>> {
@@ -9667,7 +9667,7 @@ export interface OptionFromNullOr<S extends Constraint> extends decodeTo<Option<
  * Decoding maps `null` to `None` and all other values to `Some`. Encoding maps
  * `None` to `null` and maps `Some` to its value.
  *
- * @category Option
+ * @category schemas
  * @since 3.10.0
  */
 export function OptionFromNullOr<S extends Constraint>(schema: S): OptionFromNullOr<S> {
@@ -9680,7 +9680,7 @@ export function OptionFromNullOr<S extends Constraint>(schema: S): OptionFromNul
 /**
  * Type-level representation returned by {@link OptionFromUndefinedOr}.
  *
- * @category Option
+ * @category models
  * @since 3.10.0
  */
 export interface OptionFromUndefinedOr<S extends Constraint> extends decodeTo<Option<toType<S>>, UndefinedOr<S>> {
@@ -9696,7 +9696,7 @@ export interface OptionFromUndefinedOr<S extends Constraint> extends decodeTo<Op
  * Decoding maps `undefined` to `None` and all other values to `Some`. Encoding
  * maps `None` to `undefined` and maps `Some` to its value.
  *
- * @category Option
+ * @category schemas
  * @since 3.10.0
  */
 export function OptionFromUndefinedOr<S extends Constraint>(schema: S): OptionFromUndefinedOr<S> {
@@ -9709,7 +9709,7 @@ export function OptionFromUndefinedOr<S extends Constraint>(schema: S): OptionFr
 /**
  * Type-level representation returned by {@link OptionFromNullishOr}.
  *
- * @category Option
+ * @category models
  * @since 3.10.0
  */
 export interface OptionFromNullishOr<S extends Constraint> extends decodeTo<Option<toType<S>>, NullishOr<S>> {
@@ -9726,7 +9726,7 @@ export interface OptionFromNullishOr<S extends Constraint> extends decodeTo<Opti
  * `options.onNoneEncoding`, which defaults to `undefined`, and maps `Some` to
  * its value.
  *
- * @category Option
+ * @category schemas
  * @since 3.10.0
  */
 export function OptionFromNullishOr<S extends Constraint>(
@@ -9744,7 +9744,7 @@ export function OptionFromNullishOr<S extends Constraint>(
 /**
  * Type-level representation returned by {@link OptionFromOptionalKey}.
  *
- * @category Option
+ * @category models
  * @since 4.0.0
  */
 export interface OptionFromOptionalKey<S extends Constraint> extends decodeTo<Option<toType<S>>, optionalKey<S>> {
@@ -9759,7 +9759,7 @@ export interface OptionFromOptionalKey<S extends Constraint> extends decodeTo<Op
  * Decoding maps a missing key to `None` and a present value to `Some`.
  * Encoding maps `None` to a missing key and maps `Some` to its value.
  *
- * @category Option
+ * @category schemas
  * @since 4.0.0
  */
 export function OptionFromOptionalKey<S extends Constraint>(schema: S): OptionFromOptionalKey<S> {
@@ -9772,7 +9772,7 @@ export function OptionFromOptionalKey<S extends Constraint>(schema: S): OptionFr
 /**
  * Type-level representation returned by {@link OptionFromOptional}.
  *
- * @category Option
+ * @category models
  * @since 4.0.0
  */
 export interface OptionFromOptional<S extends Constraint> extends decodeTo<Option<toType<S>>, optional<S>> {
@@ -9789,7 +9789,7 @@ export interface OptionFromOptional<S extends Constraint> extends decodeTo<Optio
  * maps all other values to `Some`. Encoding maps `None` to a missing key and
  * maps `Some` to its value.
  *
- * @category Option
+ * @category schemas
  * @since 4.0.0
  */
 export function OptionFromOptional<S extends Constraint>(schema: S): OptionFromOptional<S> {
@@ -9802,7 +9802,7 @@ export function OptionFromOptional<S extends Constraint>(schema: S): OptionFromO
 /**
  * Type-level representation returned by {@link OptionFromOptionalNullOr}.
  *
- * @category Option
+ * @category models
  * @since 4.0.0
  */
 export interface OptionFromOptionalNullOr<S extends Constraint>
@@ -9822,7 +9822,7 @@ export interface OptionFromOptionalNullOr<S extends Constraint>
  * according to `options.onNoneEncoding`: `"omit"` encodes a missing key,
  * `null` encodes `null`, and `undefined` encodes `undefined`.
  *
- * @category Option
+ * @category schemas
  * @since 4.0.0
  */
 export function OptionFromOptionalNullOr<S extends Constraint>(
@@ -9849,7 +9849,7 @@ export function OptionFromOptionalNullOr<S extends Constraint>(
 /**
  * Type-level representation returned by {@link Result}.
  *
- * @category schemas
+ * @category models
  * @since 4.0.0
  */
 export interface Result<A extends Constraint, E extends Constraint> extends
@@ -9873,7 +9873,7 @@ export interface Result<A extends Constraint, E extends Constraint> extends
  * Successful results are represented as `{ _tag: "Success", success }`, while
  * failed results are represented as `{ _tag: "Failure", failure }`.
  *
- * @category schemas
+ * @category utility types
  * @since 4.0.0
  */
 export type ResultIso<A extends Constraint, E extends Constraint> =
@@ -9988,7 +9988,7 @@ export const ResultReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link Redacted}.
  *
- * @category Redacted
+ * @category models
  * @since 3.10.0
  */
 export interface Redacted<S extends Constraint> extends
@@ -10054,7 +10054,7 @@ const RedactedRepresentationPayload: Decoder<RedactedRepresentationPayload> = Un
  *   sensitive and should not be exposed in JSON.
  *
  * @see {@link RedactedFromValue} for decoding raw values and wrapping them in `Redacted`.
- * @category Redacted
+ * @category schemas
  * @since 3.10.0
  */
 export function Redacted<S extends Constraint>(value: S, options?: {
@@ -10146,7 +10146,7 @@ export function Redacted<S extends Constraint>(value: S, options?: {
  *
  * @see {@link Redacted} for creating the corresponding schema
  *
- * @category Redacted
+ * @category schemas
  * @since 4.0.0
  */
 export const RedactedReviver = InternalSchema.makeDeclarationReviver(
@@ -10161,7 +10161,7 @@ export const RedactedReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link RedactedFromValue}.
  *
- * @category Redacted
+ * @category models
  * @since 4.0.0
  */
 export interface RedactedFromValue<S extends Constraint>
@@ -10174,7 +10174,7 @@ export interface RedactedFromValue<S extends Constraint>
  * Middleware that wraps decoded errors in `Redacted`, preventing sensitive
  * schema details from leaking in error messages.
  *
- * @category Redacted
+ * @category transforming
  * @since 4.0.0
  */
 export function redact<S extends Constraint>(schema: S): middlewareDecoding<S, S["DecodingServices"]> {
@@ -10187,7 +10187,7 @@ export function redact<S extends Constraint>(schema: S): middlewareDecoding<S, S
  * the raw value and wraps it.
  *
  * @see {@link Redacted} for schemas whose input is already a `Redacted` value.
- * @category Redacted
+ * @category schemas
  * @since 4.0.0
  */
 export function RedactedFromValue<S extends Constraint>(value: S, options?: {
@@ -10216,7 +10216,7 @@ export function RedactedFromValue<S extends Constraint>(value: S, options?: {
 /**
  * Type-level representation returned by {@link CauseReason}.
  *
- * @category CauseReason
+ * @category models
  * @since 4.0.0
  */
 export interface CauseReason<E extends Constraint, D extends Constraint> extends
@@ -10240,7 +10240,7 @@ export interface CauseReason<E extends Constraint, D extends Constraint> extends
  * Failures are represented with a `Fail` tag and encoded error, defects with a
  * `Die` tag and encoded defect, and interrupts with an optional `fiberId`.
  *
- * @category CauseReason
+ * @category utility types
  * @since 4.0.0
  */
 export type CauseReasonIso<E extends Constraint, D extends Constraint> = {
@@ -10271,7 +10271,7 @@ export type CauseReasonIso<E extends Constraint, D extends Constraint> = {
  * @see {@link Cause} for constructing schemas for full Cause values
  * @see {@link CauseReasonIso} for the ISO shape of each cause reason
  *
- * @category CauseReason
+ * @category schemas
  * @since 4.0.0
  */
 export function CauseReason<E extends Constraint, D extends Constraint>(error: E, defect: D): CauseReason<E, D> {
@@ -10353,7 +10353,7 @@ export function CauseReason<E extends Constraint, D extends Constraint>(error: E
  *
  * @see {@link CauseReason} for creating the corresponding schema
  *
- * @category CauseReason
+ * @category schemas
  * @since 4.0.0
  */
 export const CauseReasonReviver = InternalSchema.makeDeclarationReviver(
@@ -10411,7 +10411,7 @@ function causeReasonToFormatter<E>(error: Formatter<E>, defect: Formatter<unknow
 /**
  * Type-level representation returned by {@link Cause}.
  *
- * @category Cause
+ * @category models
  * @since 3.10.0
  */
 export interface Cause<E extends Constraint, D extends Constraint> extends
@@ -10439,7 +10439,7 @@ export interface Cause<E extends Constraint, D extends Constraint> extends
  * @see {@link Cause} for constructing schemas for full Cause values
  * @see {@link CauseReasonIso} for the ISO shape of each array element
  *
- * @category Cause
+ * @category utility types
  * @since 4.0.0
  */
 export type CauseIso<E extends Constraint, D extends Constraint> = ReadonlyArray<CauseReasonIso<E, D>>
@@ -10462,7 +10462,7 @@ export type CauseIso<E extends Constraint, D extends Constraint> = ReadonlyArray
  * @see {@link CauseReason} for the schema used by each individual cause reason
  * @see {@link CauseIso} for the ordered array representation used by the schema ISO
  *
- * @category Cause
+ * @category schemas
  * @since 3.10.0
  */
 export function Cause<E extends Constraint, D extends Constraint>(error: E, defect: D): Cause<E, D> {
@@ -10517,7 +10517,7 @@ export function Cause<E extends Constraint, D extends Constraint>(error: E, defe
  *
  * @see {@link Cause} for creating the corresponding schema
  *
- * @category Cause
+ * @category schemas
  * @since 4.0.0
  */
 export const CauseReviver = InternalSchema.makeDeclarationReviver(
@@ -10554,7 +10554,7 @@ function causeToFormatter<E>(error: Formatter<E>, defect: Formatter<unknown>) {
 /**
  * Type-level representation of {@link Error}.
  *
- * @category Error
+ * @category models
  * @since 4.0.0
  */
 export interface Error extends instanceOf<globalThis.Error> {
@@ -10639,7 +10639,7 @@ const errorSchemaCache: Array<Error | undefined> = []
  * traces are omitted by default for security. Pass `{ includeStack: true }` to
  * include stack traces, or `{ excludeCause: true }` to omit causes.
  *
- * @category constructors
+ * @category schemas
  * @since 4.0.0
  */
 export function Error(options?: ErrorOptions): Error {
@@ -10675,7 +10675,7 @@ export function Error(options?: ErrorOptions): Error {
  *
  * @see {@link Error} for creating the corresponding schema
  *
- * @category Error
+ * @category schemas
  * @since 4.0.0
  */
 export const ErrorReviver = InternalSchema.makeDeclarationReviver(
@@ -10690,7 +10690,7 @@ export const ErrorReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation of {@link Defect}.
  *
- * @category Defect
+ * @category models
  * @since 3.10.0
  */
 export interface Defect extends decodeTo<Unknown, typeof Json> {
@@ -10737,7 +10737,7 @@ const defectSchemaCache: Array<Defect | undefined> = []
  *   string representation.
  *
  * @see {@link Error} for a schema that only accepts JavaScript `Error` values.
- * @category constructors
+ * @category schemas
  * @since 4.0.0
  */
 export function Defect(options?: ErrorOptions): Defect {
@@ -10754,7 +10754,7 @@ export function Defect(options?: ErrorOptions): Defect {
 /**
  * Type-level representation returned by {@link Exit}.
  *
- * @category Exit
+ * @category models
  * @since 3.10.0
  */
 export interface Exit<A extends Constraint, E extends Constraint, D extends Constraint> extends
@@ -10779,7 +10779,7 @@ export interface Exit<A extends Constraint, E extends Constraint, D extends Cons
  * Successful exits are represented as `{ _tag: "Success", value }`, while failed
  * exits are represented as `{ _tag: "Failure", cause }`.
  *
- * @category Exit
+ * @category utility types
  * @since 4.0.0
  */
 export type ExitIso<A extends Constraint, E extends Constraint, D extends Constraint> = {
@@ -10799,7 +10799,7 @@ export type ExitIso<A extends Constraint, E extends Constraint, D extends Constr
  * Use when serializing or validating an effect outcome where success, typed
  * failure, and defects each need their own schema.
  *
- * @category Exit
+ * @category schemas
  * @since 3.10.0
  */
 export function Exit<A extends Constraint, E extends Constraint, D extends Constraint>(
@@ -10919,7 +10919,7 @@ export function Exit<A extends Constraint, E extends Constraint, D extends Const
  *
  * @see {@link Exit} for creating the corresponding schema
  *
- * @category Exit
+ * @category schemas
  * @since 4.0.0
  */
 export const ExitReviver = InternalSchema.makeDeclarationReviver(
@@ -10934,7 +10934,7 @@ export const ExitReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link ReadonlyMap}.
  *
- * @category ReadonlyMap
+ * @category models
  * @since 4.0.0
  */
 export interface $ReadonlyMap<Key extends Constraint, Value extends Constraint> extends
@@ -10954,7 +10954,7 @@ export interface $ReadonlyMap<Key extends Constraint, Value extends Constraint> 
  * Iso representation used for `ReadonlyMap` schemas: an array of readonly
  * `[key, value]` tuples using each entry schema's `Iso` type.
  *
- * @category ReadonlyMap
+ * @category utility types
  * @since 4.0.0
  */
 export type ReadonlyMapIso<Key extends Constraint, Value extends Constraint> = ReadonlyArray<
@@ -11055,7 +11055,7 @@ function entriesArbitrary<K, V, Out>(
  * Schema for readonly maps whose keys and values conform to the provided
  * schemas.
  *
- * @category ReadonlyMap
+ * @category schemas
  * @since 3.10.0
  */
 export function ReadonlyMap<Key extends Constraint, Value extends Constraint>(
@@ -11126,7 +11126,7 @@ export function ReadonlyMap<Key extends Constraint, Value extends Constraint>(
  *
  * @see {@link ReadonlyMap} for creating the corresponding schema
  *
- * @category ReadonlyMap
+ * @category schemas
  * @since 4.0.0
  */
 export const ReadonlyMapReviver = InternalSchema.makeDeclarationReviver(
@@ -11141,7 +11141,7 @@ export const ReadonlyMapReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link HashMap}.
  *
- * @category HashMap
+ * @category models
  * @since 3.10.0
  */
 export interface HashMap<Key extends Constraint, Value extends Constraint> extends
@@ -11161,7 +11161,7 @@ export interface HashMap<Key extends Constraint, Value extends Constraint> exten
  * Iso representation used for `HashMap` schemas: an array of readonly
  * `[key, value]` tuples using each entry schema's `Iso` type.
  *
- * @category HashMap
+ * @category utility types
  * @since 4.0.0
  */
 export type HashMapIso<Key extends Constraint, Value extends Constraint> = ReadonlyArray<
@@ -11171,7 +11171,7 @@ export type HashMapIso<Key extends Constraint, Value extends Constraint> = Reado
 /**
  * Schema for hash maps whose keys and values conform to the provided schemas.
  *
- * @category HashMap
+ * @category schemas
  * @since 3.10.0
  */
 export function HashMap<Key extends Constraint, Value extends Constraint>(key: Key, value: Value): HashMap<Key, Value> {
@@ -11240,7 +11240,7 @@ export function HashMap<Key extends Constraint, Value extends Constraint>(key: K
  *
  * @see {@link HashMap} for creating the corresponding schema
  *
- * @category HashMap
+ * @category schemas
  * @since 4.0.0
  */
 export const HashMapReviver = InternalSchema.makeDeclarationReviver(
@@ -11255,7 +11255,7 @@ export const HashMapReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link ReadonlySet}.
  *
- * @category ReadonlySet
+ * @category models
  * @since 4.0.0
  */
 export interface $ReadonlySet<Value extends Constraint> extends
@@ -11274,7 +11274,7 @@ export interface $ReadonlySet<Value extends Constraint> extends
  * Iso representation used for `ReadonlySet` schemas: an array of element values
  * using the element schema's `Iso` type.
  *
- * @category ReadonlySet
+ * @category utility types
  * @since 4.0.0
  */
 export type ReadonlySetIso<Value extends Constraint> = ReadonlyArray<Value["Iso"]>
@@ -11282,7 +11282,7 @@ export type ReadonlySetIso<Value extends Constraint> = ReadonlyArray<Value["Iso"
 /**
  * Schema for readonly sets whose values conform to the provided element schema.
  *
- * @category ReadonlySet
+ * @category schemas
  * @since 3.10.0
  */
 export function ReadonlySet<Value extends Constraint>(value: Value): $ReadonlySet<Value> {
@@ -11351,7 +11351,7 @@ export function ReadonlySet<Value extends Constraint>(value: Value): $ReadonlySe
  *
  * @see {@link ReadonlySet} for creating the corresponding schema
  *
- * @category ReadonlySet
+ * @category schemas
  * @since 4.0.0
  */
 export const ReadonlySetReviver = InternalSchema.makeDeclarationReviver(
@@ -11366,7 +11366,7 @@ export const ReadonlySetReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link HashSet}.
  *
- * @category HashSet
+ * @category models
  * @since 3.10.0
  */
 export interface HashSet<Value extends Constraint> extends
@@ -11385,7 +11385,7 @@ export interface HashSet<Value extends Constraint> extends
  * Iso representation used for `HashSet` schemas: an array of element values
  * using the element schema's `Iso` type.
  *
- * @category HashSet
+ * @category utility types
  * @since 4.0.0
  */
 export type HashSetIso<Value extends Constraint> = ReadonlyArray<Value["Iso"]>
@@ -11393,7 +11393,7 @@ export type HashSetIso<Value extends Constraint> = ReadonlyArray<Value["Iso"]>
 /**
  * Schema for hash sets whose values conform to the provided element schema.
  *
- * @category HashSet
+ * @category schemas
  * @since 3.10.0
  */
 export function HashSet<Value extends Constraint>(value: Value): HashSet<Value> {
@@ -11462,7 +11462,7 @@ export function HashSet<Value extends Constraint>(value: Value): HashSet<Value> 
  *
  * @see {@link HashSet} for creating the corresponding schema
  *
- * @category HashSet
+ * @category schemas
  * @since 4.0.0
  */
 export const HashSetReviver = InternalSchema.makeDeclarationReviver(
@@ -11477,7 +11477,7 @@ export const HashSetReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation returned by {@link Chunk}.
  *
- * @category Chunk
+ * @category models
  * @since 3.10.0
  */
 export interface Chunk<Value extends Constraint> extends
@@ -11503,7 +11503,7 @@ export interface Chunk<Value extends Constraint> extends
  *
  * @see {@link Chunk} for the schema interface and constructor that use this ISO representation
  *
- * @category Chunk
+ * @category utility types
  * @since 4.0.0
  */
 export type ChunkIso<Value extends Constraint> = ReadonlyArray<Value["Iso"]>
@@ -11511,7 +11511,7 @@ export type ChunkIso<Value extends Constraint> = ReadonlyArray<Value["Iso"]>
 /**
  * Schema for chunks whose values conform to the provided element schema.
  *
- * @category Chunk
+ * @category schemas
  * @since 3.10.0
  */
 export function Chunk<Value extends Constraint>(value: Value): Chunk<Value> {
@@ -11580,7 +11580,7 @@ export function Chunk<Value extends Constraint>(value: Value): Chunk<Value> {
  *
  * @see {@link Chunk} for creating the corresponding schema
  *
- * @category Chunk
+ * @category schemas
  * @since 4.0.0
  */
 export const ChunkReviver = InternalSchema.makeDeclarationReviver(
@@ -11595,7 +11595,7 @@ export const ChunkReviver = InternalSchema.makeDeclarationReviver(
 /**
  * Type-level representation of {@link RegExp}.
  *
- * @category RegExp
+ * @category models
  * @since 4.0.0
  */
 export interface RegExp extends instanceOf<globalThis.RegExp> {
@@ -11609,7 +11609,7 @@ export interface RegExp extends instanceOf<globalThis.RegExp> {
  *
  * The default JSON serializer encodes a `RegExp` as `{ source, flags }`.
  *
- * @category RegExp
+ * @category schemas
  * @since 4.0.0
  */
 export const RegExp: RegExp = instanceOf(
@@ -11678,7 +11678,7 @@ export const RegExp: RegExp = instanceOf(
  *
  * @see {@link RegExp} for the corresponding schema
  *
- * @category RegExp
+ * @category schemas
  * @since 4.0.0
  */
 export const RegExpReviver = makeFixedDeclarationReviver(
@@ -11689,7 +11689,7 @@ export const RegExpReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link URL}.
  *
- * @category URL
+ * @category models
  * @since 4.0.0
  */
 export interface URL extends instanceOf<globalThis.URL> {
@@ -11707,7 +11707,7 @@ const URLString = String.annotate({ expected: "a string that will be decoded as 
  *
  * - encodes `URL` as a `string`
  *
- * @category URL
+ * @category schemas
  * @since 4.0.0
  */
 export const URL: URL = instanceOf(
@@ -11741,7 +11741,7 @@ export const URL: URL = instanceOf(
  *
  * @see {@link URL} for the corresponding schema
  *
- * @category URL
+ * @category schemas
  * @since 4.0.0
  */
 export const URLReviver = makeFixedDeclarationReviver(
@@ -11752,7 +11752,7 @@ export const URLReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link URLFromString}.
  *
- * @category URL
+ * @category models
  * @since 4.0.0
  */
 export interface URLFromString extends decodeTo<URL, String> {
@@ -11770,7 +11770,7 @@ export interface URLFromString extends decodeTo<URL, String> {
  * Encoding:
  * - A `URL` is encoded as a `string`
  *
- * @category URL
+ * @category schemas
  * @since 4.0.0
  */
 export const URLFromString: URLFromString = URLString.pipe(decodeTo(URL, SchemaTransformation.urlFromString))
@@ -11778,7 +11778,7 @@ export const URLFromString: URLFromString = URLString.pipe(decodeTo(URL, SchemaT
 /**
  * Type-level representation of {@link Date}.
  *
- * @category Date
+ * @category models
  * @since 4.0.0
  */
 export interface Date extends declare<globalThis.Date> {
@@ -11835,7 +11835,7 @@ const DateString = String.annotate({ expected: "a string that will be decoded as
  * @see {@link DateFromString} for decoding strings into Date instances
  * @see {@link DateFromMillis} for decoding epoch milliseconds into Date instances
  *
- * @category Date
+ * @category schemas
  * @since 4.0.0
  */
 export const Date: Date = declare(
@@ -11872,7 +11872,7 @@ export const Date: Date = declare(
  *
  * @see {@link Date} for the corresponding schema
  *
- * @category Date
+ * @category schemas
  * @since 4.0.0
  */
 export const DateReviver = makeFixedDeclarationReviver(
@@ -11883,7 +11883,7 @@ export const DateReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link DateFromString}.
  *
- * @category Date
+ * @category models
  * @since 3.10.0
  */
 export interface DateFromString extends decodeTo<Date, String> {
@@ -11912,7 +11912,7 @@ export interface DateFromString extends decodeTo<Date, String> {
  * @see {@link DateTimeUtcFromString} for decoding date-time strings into UTC values
  * @see {@link Date} for accepting Date instances directly
  *
- * @category Date
+ * @category schemas
  * @since 3.10.0
  */
 export const DateFromString: DateFromString = DateString.pipe(decodeTo(Date, SchemaTransformation.dateFromString))
@@ -11920,7 +11920,7 @@ export const DateFromString: DateFromString = DateString.pipe(decodeTo(Date, Sch
 /**
  * Type-level representation of {@link DateFromMillis}.
  *
- * @category Date
+ * @category models
  * @since 4.0.0
  */
 export interface DateFromMillis extends decodeTo<Date, Int> {
@@ -11952,7 +11952,7 @@ export interface DateFromMillis extends decodeTo<Date, Int> {
  * @see {@link DateFromString} for decoding string-encoded dates
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
  *
- * @category Date
+ * @category schemas
  * @since 4.0.0
  */
 export const DateFromMillis: DateFromMillis = Int.pipe(
@@ -11962,7 +11962,7 @@ export const DateFromMillis: DateFromMillis = Int.pipe(
 /**
  * Type-level representation of {@link Duration}.
  *
- * @category Duration
+ * @category models
  * @since 3.10.0
  */
 export interface Duration extends declare<Duration_.Duration> {
@@ -11985,7 +11985,7 @@ export interface Duration extends declare<Duration_.Duration> {
  * Schema.decodeUnknownSync(Schema.Duration)(Duration.seconds(5)) // => Duration.seconds(5)
  * ```
  *
- * @category Duration
+ * @category schemas
  *
  * @since 3.10.0
  */
@@ -12058,7 +12058,7 @@ export const Duration: Duration = declare(
  *
  * @see {@link Duration} for the corresponding schema
  *
- * @category Duration
+ * @category schemas
  * @since 4.0.0
  */
 export const DurationReviver = makeFixedDeclarationReviver(
@@ -12071,7 +12071,7 @@ const DurationString = String.annotate({ expected: "a string that will be decode
 /**
  * Type-level representation of {@link DurationFromString}.
  *
- * @category Duration
+ * @category models
  * @since 4.0.0
  */
 export interface DurationFromString extends decodeTo<Duration, String> {
@@ -12090,7 +12090,7 @@ export interface DurationFromString extends decodeTo<Duration, String> {
  * Encoding:
  * - A `Duration` is encoded as a parseable `string`.
  *
- * @category Duration
+ * @category schemas
  * @since 4.0.0
  */
 export const DurationFromString: DurationFromString = DurationString.pipe(
@@ -12100,7 +12100,7 @@ export const DurationFromString: DurationFromString = DurationString.pipe(
 /**
  * Type-level representation of {@link DurationFromNanos}.
  *
- * @category Duration
+ * @category models
  * @since 3.10.0
  */
 export interface DurationFromNanos extends decodeTo<Duration, BigInt> {
@@ -12121,7 +12121,7 @@ export interface DurationFromNanos extends decodeTo<Duration, BigInt> {
  * fails when the duration cannot be represented as nanoseconds, such as
  * `Duration.infinity` or `Duration.negativeInfinity`.
  *
- * @category Duration
+ * @category schemas
  * @since 3.10.0
  */
 export const DurationFromNanos: DurationFromNanos = BigInt.pipe(
@@ -12131,7 +12131,7 @@ export const DurationFromNanos: DurationFromNanos = BigInt.pipe(
 /**
  * Type-level representation of {@link DurationFromMillis}.
  *
- * @category Duration
+ * @category models
  * @since 3.10.0
  */
 export interface DurationFromMillis extends decodeTo<Duration, Number> {
@@ -12154,7 +12154,7 @@ export interface DurationFromMillis extends decodeTo<Duration, Number> {
  *
  * `NaN` is decoded as `Duration.zero`, matching `Duration.millis`.
  *
- * @category Duration
+ * @category schemas
  * @since 3.10.0
  */
 export const DurationFromMillis: DurationFromMillis = Number.pipe(
@@ -12164,7 +12164,7 @@ export const DurationFromMillis: DurationFromMillis = Number.pipe(
 /**
  * Type-level representation of {@link BigDecimal}.
  *
- * @category BigDecimal
+ * @category models
  * @since 3.10.0
  */
 export interface BigDecimal extends declare<BigDecimal_.BigDecimal> {
@@ -12264,7 +12264,7 @@ function bigDecimalScaleConstraints(
  *
  * @see {@link BigDecimalFromString} for parsing string input into a BigDecimal
  *
- * @category BigDecimal
+ * @category schemas
  * @since 3.10.0
  */
 export const BigDecimal: BigDecimal = declare(
@@ -12316,7 +12316,7 @@ export const BigDecimal: BigDecimal = declare(
  *
  * @see {@link BigDecimal} for the corresponding schema
  *
- * @category BigDecimal
+ * @category schemas
  * @since 4.0.0
  */
 export const BigDecimalReviver = makeFixedDeclarationReviver(
@@ -12327,7 +12327,7 @@ export const BigDecimalReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link BigDecimalFromString}.
  *
- * @category BigDecimal
+ * @category models
  * @since 4.0.0
  */
 export interface BigDecimalFromString extends decodeTo<BigDecimal, String> {
@@ -12358,7 +12358,7 @@ export interface BigDecimalFromString extends decodeTo<BigDecimal, String> {
  * @see {@link BigIntFromString} for parsing base-10 integer strings into bigint values
  * @see {@link NumberFromString} for parsing JavaScript number strings
  *
- * @category BigDecimal
+ * @category schemas
  * @since 4.0.0
  */
 export const BigDecimalFromString: BigDecimalFromString = BigDecimalString.pipe(
@@ -12406,7 +12406,7 @@ export interface fromJsonString<S extends Constraint> extends decodeTo<S, String
  * Schema.encodeSync(schemaFromJsonString)({ a: 1 }) // => "{\n  \"a\": 1\n}"
  * ```
  *
- * @category constructors
+ * @category schemas
  * @since 4.0.0
  */
 export function fromJsonString<S extends Constraint>(
@@ -12426,7 +12426,7 @@ export const UnknownFromJsonString: fromJsonString<Unknown> = fromJsonString(Unk
 /**
  * Type-level representation of {@link File}.
  *
- * @category file
+ * @category models
  * @since 4.0.0
  */
 export interface File extends instanceOf<globalThis.File> {
@@ -12441,7 +12441,7 @@ export interface File extends instanceOf<globalThis.File> {
  * The default JSON serializer encodes a `File` as `{ data, type, name, lastModified }`
  * where `data` is base64-encoded.
  *
- * @category file
+ * @category schemas
  * @since 4.0.0
  */
 export const File: File = instanceOf(globalThis.File, {
@@ -12507,7 +12507,7 @@ export const File: File = instanceOf(globalThis.File, {
  *
  * @see {@link File} for the corresponding schema
  *
- * @category file
+ * @category schemas
  * @since 4.0.0
  */
 export const FileReviver = makeFixedDeclarationReviver(
@@ -12518,7 +12518,7 @@ export const FileReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link FormData}.
  *
- * @category FormData
+ * @category models
  * @since 4.0.0
  */
 export interface FormData extends instanceOf<globalThis.FormData> {
@@ -12533,7 +12533,7 @@ export interface FormData extends instanceOf<globalThis.FormData> {
  * The default JSON serializer encodes a `FormData` as an array of `[key, entry]`
  * pairs where each entry is tagged as `"String"` or `"File"`.
  *
- * @category FormData
+ * @category schemas
  * @since 4.0.0
  */
 export const FormData: FormData = instanceOf(globalThis.FormData, {
@@ -12589,7 +12589,7 @@ export const FormData: FormData = instanceOf(globalThis.FormData, {
  *
  * @see {@link FormData} for the corresponding schema
  *
- * @category FormData
+ * @category schemas
  * @since 4.0.0
  */
 export const FormDataReviver = makeFixedDeclarationReviver(
@@ -12600,7 +12600,7 @@ export const FormDataReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation returned by {@link fromFormData}.
  *
- * @category FormData
+ * @category models
  * @since 4.0.0
  */
 export interface fromFormData<S extends Constraint> extends decodeTo<S, FormData> {
@@ -12696,7 +12696,7 @@ export function fromFormData<S extends Constraint>(schema: S): fromFormData<S> {
 /**
  * Type-level representation of {@link URLSearchParams}.
  *
- * @category search params
+ * @category models
  * @since 4.0.0
  */
 export interface URLSearchParams extends instanceOf<globalThis.URLSearchParams> {
@@ -12710,7 +12710,7 @@ export interface URLSearchParams extends instanceOf<globalThis.URLSearchParams> 
  *
  * The default JSON serializer encodes a `URLSearchParams` as a query string.
  *
- * @category search params
+ * @category schemas
  * @since 4.0.0
  */
 export const URLSearchParams: URLSearchParams = instanceOf(globalThis.URLSearchParams, {
@@ -12742,7 +12742,7 @@ export const URLSearchParams: URLSearchParams = instanceOf(globalThis.URLSearchP
  *
  * @see {@link URLSearchParams} for the corresponding schema
  *
- * @category search params
+ * @category schemas
  * @since 4.0.0
  */
 export const URLSearchParamsReviver = makeFixedDeclarationReviver(
@@ -12753,7 +12753,7 @@ export const URLSearchParamsReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation returned by {@link fromURLSearchParams}.
  *
- * @category search params
+ * @category models
  * @since 4.0.0
  */
 export interface fromURLSearchParams<S extends Constraint> extends decodeTo<S, URLSearchParams> {
@@ -12844,7 +12844,7 @@ export function fromURLSearchParams<S extends Constraint>(schema: S): fromURLSea
 /**
  * Type-level representation of {@link NumberFromString}.
  *
- * @category Number
+ * @category models
  * @since 3.10.0
  */
 export interface NumberFromString extends decodeTo<Number, String> {
@@ -12865,7 +12865,7 @@ export interface NumberFromString extends decodeTo<Number, String> {
  * Encoding:
  * A number is encoded as a `string`.
  *
- * @category Number
+ * @category schemas
  * @since 3.10.0
  */
 export const NumberFromString: NumberFromString = String.annotate({
@@ -12875,7 +12875,7 @@ export const NumberFromString: NumberFromString = String.annotate({
 /**
  * Type-level representation of {@link FiniteFromString}.
  *
- * @category Number
+ * @category models
  * @since 4.0.0
  */
 export interface FiniteFromString extends decodeTo<Finite, String> {
@@ -12894,7 +12894,7 @@ export interface FiniteFromString extends decodeTo<Finite, String> {
  * Encoding:
  * - A finite number is encoded as a `string`.
  *
- * @category Number
+ * @category schemas
  * @since 4.0.0
  */
 export const FiniteFromString: FiniteFromString = String.annotate({
@@ -12904,7 +12904,7 @@ export const FiniteFromString: FiniteFromString = String.annotate({
 /**
  * Type-level representation of {@link BigIntFromString}.
  *
- * @category BigInt
+ * @category models
  * @since 4.0.0
  */
 export interface BigIntFromString extends decodeTo<BigInt, String> {
@@ -12936,7 +12936,7 @@ export interface BigIntFromString extends decodeTo<BigInt, String> {
  * @see {@link NumberFromString} for parsing JavaScript number strings, including non-finite values
  * @see {@link BigDecimalFromString} for parsing decimal number strings
  *
- * @category BigInt
+ * @category schemas
  * @since 4.0.0
  */
 export const BigIntFromString: BigIntFromString = make<String>(SchemaAST.bigIntString).pipe(
@@ -12946,7 +12946,7 @@ export const BigIntFromString: BigIntFromString = make<String>(SchemaAST.bigIntS
 /**
  * Type-level representation of {@link Trimmed}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface Trimmed extends String {
@@ -12956,7 +12956,7 @@ export interface Trimmed extends String {
 /**
  * Schema for strings that contains no leading or trailing whitespaces.
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const Trimmed: Trimmed = String.check(isTrimmed())
@@ -12964,7 +12964,7 @@ export const Trimmed: Trimmed = String.check(isTrimmed())
 /**
  * Type-level representation of {@link Trim}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface Trim extends decodeTo<Trimmed, String> {
@@ -12982,7 +12982,7 @@ export interface Trim extends decodeTo<Trimmed, String> {
  * Encoding:
  * - The trimmed string is encoded as is.
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const Trim: Trim = String.annotate({
@@ -12992,7 +12992,7 @@ export const Trim: Trim = String.annotate({
 /**
  * Type-level representation of {@link StringFromBase64}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface StringFromBase64 extends decodeTo<String, String> {
@@ -13010,7 +13010,7 @@ export interface StringFromBase64 extends decodeTo<String, String> {
  * Encoding:
  * - A `string` is encoded as a base64-encoded string.
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const StringFromBase64: StringFromBase64 = String.annotate({
@@ -13022,7 +13022,7 @@ export const StringFromBase64: StringFromBase64 = String.annotate({
 /**
  * Type-level representation of {@link StringFromBase64Url}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface StringFromBase64Url extends decodeTo<String, String> {
@@ -13040,7 +13040,7 @@ export interface StringFromBase64Url extends decodeTo<String, String> {
  * Encoding:
  * - A `string` is encoded as a base64 (URL) encoded string.
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const StringFromBase64Url: StringFromBase64Url = String.annotate({
@@ -13052,7 +13052,7 @@ export const StringFromBase64Url: StringFromBase64Url = String.annotate({
 /**
  * Type-level representation of {@link StringFromHex}.
  *
- * @category string
+ * @category models
  * @since 3.10.0
  */
 export interface StringFromHex extends decodeTo<String, String> {
@@ -13070,7 +13070,7 @@ export interface StringFromHex extends decodeTo<String, String> {
  * Encoding:
  * - A `string` is encoded as a hex string.
  *
- * @category string
+ * @category schemas
  * @since 3.10.0
  */
 export const StringFromHex: StringFromHex = String.annotate({
@@ -13082,7 +13082,7 @@ export const StringFromHex: StringFromHex = String.annotate({
 /**
  * Type-level representation of {@link StringFromUriComponent}.
  *
- * @category string
+ * @category models
  * @since 3.12.0
  */
 export interface StringFromUriComponent extends decodeTo<String, String> {
@@ -13118,7 +13118,7 @@ export interface StringFromUriComponent extends decodeTo<String, String> {
  * Schema.encodeSync(UrlSchema)({ maxItemPerPage: 10, page: 1 }) // => "%7B%22maxItemPerPage%22%3A10%2C%22page%22%3A1%7D"
  * ```
  *
- * @category string
+ * @category schemas
  * @since 3.12.0
  */
 export const StringFromUriComponent: StringFromUriComponent = String.annotate({
@@ -13131,7 +13131,7 @@ export const StringFromUriComponent: StringFromUriComponent = String.annotate({
  * Schema for property keys accepted by Effect schemas: finite `number`,
  * `symbol`, or `string`.
  *
- * @category PropertyKey
+ * @category schemas
  * @since 4.0.0
  */
 export const PropertyKey = Union([Finite, Symbol, String])
@@ -13144,7 +13144,7 @@ export const PropertyKey = Union([Finite, Symbol, String])
  * The result contains an `issues` array where each issue has a message and an
  * optional path made of property keys or keyed path segments.
  *
- * @category Standard Schema
+ * @category schemas
  * @since 4.0.0
  */
 export const StandardSchemaV1FailureResult = Struct({
@@ -13157,7 +13157,7 @@ export const StandardSchemaV1FailureResult = Struct({
 /**
  * Type-level representation of {@link BooleanFromBit}.
  *
- * @category boolean
+ * @category models
  * @since 4.0.0
  */
 export interface BooleanFromBit extends decodeTo<Boolean, Literals<readonly [0, 1]>> {
@@ -13180,7 +13180,7 @@ export interface BooleanFromBit extends decodeTo<Boolean, Literals<readonly [0, 
  * @see {@link Boolean} for validating values that are already booleans
  * @see {@link Literals} for keeping bit literals instead of decoding them
  *
- * @category boolean
+ * @category schemas
  * @since 4.0.0
  */
 export const BooleanFromBit: BooleanFromBit = Literals([0, 1]).pipe(
@@ -13196,7 +13196,7 @@ export const BooleanFromBit: BooleanFromBit = Literals([0, 1]).pipe(
 /**
  * Type-level representation of {@link Uint8Array}.
  *
- * @category Uint8Array
+ * @category models
  * @since 4.0.0
  */
 export interface Uint8Array extends instanceOf<globalThis.Uint8Array<ArrayBufferLike>> {
@@ -13218,7 +13218,7 @@ const Base64String = String.annotate({
  *
  * The default JSON serializer encodes Uint8Array as a Base64 encoded string.
  *
- * @category Uint8Array
+ * @category schemas
  * @since 4.0.0
  */
 export const Uint8Array: Uint8Array = instanceOf(globalThis.Uint8Array<ArrayBufferLike>, {
@@ -13248,7 +13248,7 @@ export const Uint8Array: Uint8Array = instanceOf(globalThis.Uint8Array<ArrayBuff
  *
  * @see {@link Uint8Array} for the corresponding schema
  *
- * @category Uint8Array
+ * @category schemas
  * @since 4.0.0
  */
 export const Uint8ArrayReviver = makeFixedDeclarationReviver(
@@ -13259,7 +13259,7 @@ export const Uint8ArrayReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link Uint8ArrayFromBase64}.
  *
- * @category Uint8Array
+ * @category models
  * @since 3.10.0
  */
 export interface Uint8ArrayFromBase64 extends decodeTo<Uint8Array, String> {
@@ -13278,7 +13278,7 @@ export interface Uint8ArrayFromBase64 extends decodeTo<Uint8Array, String> {
  * Encoding:
  * - A `Uint8Array` is encoded as a base64-encoded string.
  *
- * @category Uint8Array
+ * @category schemas
  * @since 3.10.0
  */
 export const Uint8ArrayFromBase64: Uint8ArrayFromBase64 = Base64String.pipe(
@@ -13288,7 +13288,7 @@ export const Uint8ArrayFromBase64: Uint8ArrayFromBase64 = Base64String.pipe(
 /**
  * Type-level representation of {@link Uint8ArrayFromBase64Url}.
  *
- * @category Uint8Array
+ * @category models
  * @since 3.10.0
  */
 export interface Uint8ArrayFromBase64Url extends decodeTo<Uint8Array, String> {
@@ -13307,7 +13307,7 @@ export interface Uint8ArrayFromBase64Url extends decodeTo<Uint8Array, String> {
  * Encoding:
  * - A `Uint8Array` is encoded as a base64 (URL) encoded string.
  *
- * @category Uint8Array
+ * @category schemas
  * @since 3.10.0
  */
 export const Uint8ArrayFromBase64Url: Uint8ArrayFromBase64Url = String.annotate({
@@ -13322,7 +13322,7 @@ export const Uint8ArrayFromBase64Url: Uint8ArrayFromBase64Url = String.annotate(
 /**
  * Type-level representation of {@link Uint8ArrayFromHex}.
  *
- * @category Uint8Array
+ * @category models
  * @since 3.10.0
  */
 export interface Uint8ArrayFromHex extends decodeTo<Uint8Array, String> {
@@ -13341,7 +13341,7 @@ export interface Uint8ArrayFromHex extends decodeTo<Uint8Array, String> {
  * Encoding:
  * - A `Uint8Array` is encoded as a hex encoded string.
  *
- * @category Uint8Array
+ * @category schemas
  * @since 3.10.0
  */
 export const Uint8ArrayFromHex: Uint8ArrayFromHex = String.annotate({
@@ -13356,7 +13356,7 @@ export const Uint8ArrayFromHex: Uint8ArrayFromHex = String.annotate({
 /**
  * Type-level representation of {@link DateTimeUtc}.
  *
- * @category DateTime
+ * @category models
  * @since 3.10.0
  */
 export interface DateTimeUtc extends declare<DateTime.Utc> {
@@ -13381,7 +13381,7 @@ export interface DateTimeUtc extends declare<DateTime.Utc> {
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
  * @see {@link DateTimeZoned} for preserving zoned DateTime values
  *
- * @category DateTime
+ * @category schemas
  * @since 3.10.0
  */
 export const DateTimeUtc: DateTimeUtc = declare(
@@ -13423,7 +13423,7 @@ export const DateTimeUtc: DateTimeUtc = declare(
  *
  * @see {@link DateTimeUtc} for the corresponding schema
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeUtcReviver = makeFixedDeclarationReviver(
@@ -13434,7 +13434,7 @@ export const DateTimeUtcReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link DateTimeUtcFromDate}.
  *
- * @category DateTime
+ * @category models
  * @since 3.12.0
  */
 export interface DateTimeUtcFromDate extends decodeTo<DateTimeUtc, Date> {
@@ -13462,7 +13462,7 @@ export interface DateTimeUtcFromDate extends decodeTo<DateTimeUtc, Date> {
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
  * @see {@link Date} for validating Date instances without converting them
  *
- * @category DateTime
+ * @category schemas
  * @since 3.12.0
  */
 export const DateTimeUtcFromDate: DateTimeUtcFromDate = Date.pipe(
@@ -13475,7 +13475,7 @@ export const DateTimeUtcFromDate: DateTimeUtcFromDate = Date.pipe(
 /**
  * Type-level representation of {@link DateTimeUtcFromString}.
  *
- * @category DateTime
+ * @category models
  * @since 4.0.0
  */
 export interface DateTimeUtcFromString extends decodeTo<DateTimeUtc, String> {
@@ -13500,7 +13500,7 @@ export interface DateTimeUtcFromString extends decodeTo<DateTimeUtc, String> {
  * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
  * @see {@link DateFromString} for decoding strings into JavaScript Date instances
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeUtcFromString: DateTimeUtcFromString = String.annotate({
@@ -13515,7 +13515,7 @@ export const DateTimeUtcFromString: DateTimeUtcFromString = String.annotate({
 /**
  * Type-level representation of {@link DateTimeUtcFromMillis}.
  *
- * @category DateTime
+ * @category models
  * @since 4.0.0
  */
 export interface DateTimeUtcFromMillis extends decodeTo<instanceOf<DateTime.Utc>, Int> {
@@ -13537,7 +13537,7 @@ export interface DateTimeUtcFromMillis extends decodeTo<instanceOf<DateTime.Utc>
  * @see {@link DateTimeUtcFromString} for decoding date-time strings into UTC values
  * @see {@link DateFromMillis} for decoding epoch milliseconds into JavaScript Date instances
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeUtcFromMillis: DateTimeUtcFromMillis = Int.pipe(
@@ -13550,7 +13550,7 @@ export const DateTimeUtcFromMillis: DateTimeUtcFromMillis = Int.pipe(
 /**
  * Type-level representation of {@link TimeZoneOffset}.
  *
- * @category DateTime
+ * @category models
  * @since 3.10.0
  */
 export interface TimeZoneOffset extends declare<DateTime.TimeZone.Offset> {
@@ -13566,7 +13566,7 @@ export interface TimeZoneOffset extends declare<DateTime.TimeZone.Offset> {
  *
  * - encodes `DateTime.TimeZone.Offset` as a number (offset in milliseconds)
  *
- * @category DateTime
+ * @category schemas
  * @since 3.10.0
  */
 export const TimeZoneOffset: TimeZoneOffset = declare(
@@ -13603,7 +13603,7 @@ export const TimeZoneOffset: TimeZoneOffset = declare(
  *
  * @see {@link TimeZoneOffset} for the corresponding schema
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const TimeZoneOffsetReviver = makeFixedDeclarationReviver(
@@ -13614,7 +13614,7 @@ export const TimeZoneOffsetReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link TimeZoneNamed}.
  *
- * @category DateTime
+ * @category models
  * @since 3.10.0
  */
 export interface TimeZoneNamed extends declare<DateTime.TimeZone.Named> {
@@ -13632,7 +13632,7 @@ const TimeZoneNamedString = String.annotate({ expected: "an IANA time zone ident
  *
  * - encodes `DateTime.TimeZone.Named` as a string (IANA time zone identifier)
  *
- * @category DateTime
+ * @category schemas
  * @since 3.10.0
  */
 export const TimeZoneNamed: TimeZoneNamed = declare(
@@ -13673,7 +13673,7 @@ export const TimeZoneNamed: TimeZoneNamed = declare(
  *
  * @see {@link TimeZoneNamed} for the corresponding schema
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const TimeZoneNamedReviver = makeFixedDeclarationReviver(
@@ -13684,7 +13684,7 @@ export const TimeZoneNamedReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link TimeZoneNamedFromString}.
  *
- * @category DateTime
+ * @category models
  * @since 4.0.0
  */
 export interface TimeZoneNamedFromString extends decodeTo<TimeZoneNamed, String> {
@@ -13702,7 +13702,7 @@ export interface TimeZoneNamedFromString extends decodeTo<TimeZoneNamed, String>
  * Encoding:
  * - A `DateTime.TimeZone.Named` is encoded as a `string`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const TimeZoneNamedFromString: TimeZoneNamedFromString = TimeZoneNamedString.pipe(
@@ -13712,7 +13712,7 @@ export const TimeZoneNamedFromString: TimeZoneNamedFromString = TimeZoneNamedStr
 /**
  * Type-level representation of {@link TimeZone}.
  *
- * @category DateTime
+ * @category models
  * @since 3.10.0
  */
 export interface TimeZone extends declare<DateTime.TimeZone> {
@@ -13733,7 +13733,7 @@ const TimeZoneString = String.annotate({
  * - encodes `DateTime.TimeZone` as a string (IANA identifier or offset like
  *   `+03:00`)
  *
- * @category DateTime
+ * @category schemas
  * @since 3.10.0
  */
 export const TimeZone: TimeZone = declare(
@@ -13777,7 +13777,7 @@ export const TimeZone: TimeZone = declare(
  *
  * @see {@link TimeZone} for the corresponding schema
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const TimeZoneReviver = makeFixedDeclarationReviver(
@@ -13788,7 +13788,7 @@ export const TimeZoneReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link TimeZoneFromString}.
  *
- * @category DateTime
+ * @category models
  * @since 4.0.0
  */
 export interface TimeZoneFromString extends decodeTo<TimeZone, String> {
@@ -13806,7 +13806,7 @@ export interface TimeZoneFromString extends decodeTo<TimeZone, String> {
  * Encoding:
  * - A `DateTime.TimeZone` is encoded as a `string`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const TimeZoneFromString: TimeZoneFromString = TimeZoneString.pipe(
@@ -13816,7 +13816,7 @@ export const TimeZoneFromString: TimeZoneFromString = TimeZoneString.pipe(
 /**
  * Type-level representation of {@link DateTimeZoned}.
  *
- * @category DateTime
+ * @category models
  * @since 3.10.0
  */
 export interface DateTimeZoned extends declare<DateTime.Zoned> {
@@ -13839,7 +13839,7 @@ const DateTimeZonedString = String.annotate({
  * - encodes named zones by appending the IANA identifier in brackets, such as
  *   `YYYY-MM-DDTHH:mm:ss.sss+HH:MM[Time/Zone]`
  *
- * @category DateTime
+ * @category schemas
  * @since 3.10.0
  */
 export const DateTimeZoned: DateTimeZoned = declare(
@@ -13887,7 +13887,7 @@ export const DateTimeZoned: DateTimeZoned = declare(
  *
  * @see {@link DateTimeZoned} for the corresponding schema
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeZonedReviver = makeFixedDeclarationReviver(
@@ -13898,7 +13898,7 @@ export const DateTimeZonedReviver = makeFixedDeclarationReviver(
 /**
  * Type-level representation of {@link DateTimeZonedFromString}.
  *
- * @category DateTime
+ * @category models
  * @since 4.0.0
  */
 export interface DateTimeZonedFromString extends decodeTo<DateTimeZoned, String> {
@@ -13916,7 +13916,7 @@ export interface DateTimeZonedFromString extends decodeTo<DateTimeZoned, String>
  * Encoding:
  * - A `DateTime.Zoned` is encoded as a `string`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeZonedFromString: DateTimeZonedFromString = DateTimeZonedString.pipe(
@@ -14495,7 +14495,7 @@ export const TaggedErrorClass: {
  * Use this type when you need to defer instantiation of the arbitrary, for
  * example to support recursive schemas.
  *
- * @category Arbitrary
+ * @category utility types
  * @since 4.0.0
  */
 export type LazyArbitrary<T> = (fc: typeof FastCheck) => FastCheck.Arbitrary<T>
@@ -14511,7 +14511,7 @@ export type LazyArbitrary<T> = (fc: typeof FastCheck) => FastCheck.Arbitrary<T>
  * nodes, impossible constraints, invalid candidates, and recursive schemas
  * without a finite terminal path fail immediately.
  *
- * @category Arbitrary
+ * @category generators
  * @since 4.0.0
  */
 export function toArbitraryLazy<S extends Constraint>(schema: S): LazyArbitrary<S["Type"]> {
@@ -14544,7 +14544,7 @@ export function toArbitraryLazy<S extends Constraint>(schema: S): LazyArbitrary<
  * FastCheck.sample(PersonArb, 1)
  * ```
  *
- * @category Arbitrary
+ * @category generators
  * @since 4.0.0
  */
 export function toArbitrary<S extends Constraint>(schema: S): FastCheck.Arbitrary<S["Type"]>
@@ -14581,7 +14581,7 @@ export function toArbitrary<S extends Constraint>(
  * The annotation is applied through this helper because adding it directly to
  * `Annotations.Bottom` would make schemas invariant.
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export function overrideToFormatter<S extends Top>(toFormatter: () => Formatter<S["Type"]>) {
@@ -14600,7 +14600,7 @@ export function overrideToFormatter<S extends Top>(toFormatter: () => Formatter<
  * The optional `onBefore` hook lets you intercept specific AST nodes before
  * the default formatting logic runs.
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export function toFormatter<S extends Constraint>(schema: S, options?: {
@@ -14796,7 +14796,7 @@ export function toEquivalence<T>(schema: Schema<T>): Equivalence.Equivalence<T> 
  *
  * Use {@link toType} before this function to represent the type side instead.
  *
- * @category representation
+ * @category converting
  * @since 4.0.0
  */
 export function toRepresentation(schema: Constraint): SchemaRepresentation.Document {
@@ -14912,7 +14912,7 @@ export function toJsonSchemaDocument(
 /**
  * Type-level representation returned by {@link toCodecJson}.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export interface toCodecJson<S extends Constraint> extends
@@ -14949,7 +14949,7 @@ export interface toCodecJson<S extends Constraint> extends
  * `toCodecJson` callback can return `undefined` when the declaration is already
  * in canonical JSON form.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export function toCodecJson<S extends Constraint>(schema: S): toCodecJson<S> {
@@ -15071,7 +15071,7 @@ function toCodecJsonBase(ast: SchemaAST.AST, recur: (ast: SchemaAST.AST) => Sche
  * Derives an isomorphism codec from a schema. The encoded form is the
  * schema's `Iso` type — the intermediate representation used for round-tripping.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export function toCodecIso<S extends Constraint>(schema: S): Codec<S["Type"], S["Iso"]> {
@@ -15108,7 +15108,7 @@ function toCodecIsoBase(ast: SchemaAST.AST, recur: (ast: SchemaAST.AST) => Schem
  * A {@link Tree} of `string | undefined` nodes. Leaf values are either a
  * string representation or `undefined` for opaque/declaration types.
  *
- * @category canonical codecs
+ * @category models
  * @since 4.0.0
  */
 export type StringTree = Tree<string | undefined>
@@ -15116,7 +15116,7 @@ export type StringTree = Tree<string | undefined>
 /**
  * Type-level representation returned by {@link toCodecStringTree}.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export interface toCodecStringTree<S extends Constraint> extends
@@ -15151,7 +15151,7 @@ export interface toCodecStringTree<S extends Constraint> extends
  * `toCodec` encoding. A callback can return `undefined` when the declaration is
  * already in canonical StringTree form.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export function toCodecStringTree<S extends Constraint>(schema: S): toCodecStringTree<S> {
@@ -15161,7 +15161,7 @@ export function toCodecStringTree<S extends Constraint>(schema: S): toCodecStrin
 /**
  * Type-level representation returned by {@link toCodecArrayFromSingle}.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export interface toCodecArrayFromSingle<S extends Constraint> extends
@@ -15200,7 +15200,7 @@ export interface toCodecArrayFromSingle<S extends Constraint> extends
  * decoding convenience rather than a canonical StringTree representation. It
  * does not parse comma-separated strings.
  *
- * @category canonical codecs
+ * @category converting
  * @since 4.0.0
  */
 export function toCodecArrayFromSingle<S extends Constraint>(schema: S): toCodecArrayFromSingle<S> {
@@ -15229,7 +15229,7 @@ type XmlEncoderOptions = {
  * an `Effect` that succeeds with the XML string or fails with `SchemaError` if
  * codec encoding fails.
  *
- * @category canonical codecs
+ * @category encoding
  * @since 4.0.0
  */
 export function toEncoderXml<T, RE>(
@@ -15489,7 +15489,7 @@ function onSerializerArrayFromSingle(ast: SchemaAST.AST): SchemaAST.AST {
  *
  * @see {@link isGreaterThanDate} for creating the corresponding check
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanDateReviver: SchemaRepresentation.FilterReviver<{
@@ -15509,7 +15509,7 @@ export const isGreaterThanDateReviver: SchemaRepresentation.FilterReviver<{
  *
  * @see {@link isGreaterThanOrEqualToDate} for creating the corresponding check
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualToDateReviver: SchemaRepresentation.FilterReviver<{
@@ -15529,7 +15529,7 @@ export const isGreaterThanOrEqualToDateReviver: SchemaRepresentation.FilterReviv
  *
  * @see {@link isLessThanDate} for creating the corresponding check
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanDateReviver: SchemaRepresentation.FilterReviver<{
@@ -15549,7 +15549,7 @@ export const isLessThanDateReviver: SchemaRepresentation.FilterReviver<{
  *
  * @see {@link isLessThanOrEqualToDate} for creating the corresponding check
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualToDateReviver: SchemaRepresentation.FilterReviver<{
@@ -15569,7 +15569,7 @@ export const isLessThanOrEqualToDateReviver: SchemaRepresentation.FilterReviver<
  *
  * @see {@link isBetweenDate} for creating the corresponding check
  *
- * @category Date checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetweenDateReviver: SchemaRepresentation.FilterReviver<{
@@ -15597,7 +15597,7 @@ export const isBetweenDateReviver: SchemaRepresentation.FilterReviver<{
  *
  * @see {@link isGreaterThanBigInt} for creating the corresponding check
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanBigIntReviver: SchemaRepresentation.FilterReviver<{
@@ -15617,7 +15617,7 @@ export const isGreaterThanBigIntReviver: SchemaRepresentation.FilterReviver<{
  *
  * @see {@link isGreaterThanOrEqualToBigInt} for creating the corresponding check
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isGreaterThanOrEqualToBigIntReviver: SchemaRepresentation.FilterReviver<{
@@ -15637,7 +15637,7 @@ export const isGreaterThanOrEqualToBigIntReviver: SchemaRepresentation.FilterRev
  *
  * @see {@link isLessThanBigInt} for creating the corresponding check
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanBigIntReviver: SchemaRepresentation.FilterReviver<{
@@ -15657,7 +15657,7 @@ export const isLessThanBigIntReviver: SchemaRepresentation.FilterReviver<{
  *
  * @see {@link isLessThanOrEqualToBigInt} for creating the corresponding check
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isLessThanOrEqualToBigIntReviver: SchemaRepresentation.FilterReviver<{
@@ -15677,7 +15677,7 @@ export const isLessThanOrEqualToBigIntReviver: SchemaRepresentation.FilterRevive
  *
  * @see {@link isBetweenBigInt} for creating the corresponding check
  *
- * @category BigInt checks
+ * @category validation
  * @since 4.0.0
  */
 export const isBetweenBigIntReviver: SchemaRepresentation.FilterReviver<{
@@ -15704,7 +15704,7 @@ export const isBetweenBigIntReviver: SchemaRepresentation.FilterReviver<{
  * Derives an `Iso` optic from a schema that isomorphically converts between
  * the schema's `Type` and its `Iso` (intermediate / serialized form).
  *
- * @category Optic
+ * @category converting
  * @since 4.0.0
  */
 export function toIso<S extends Constraint>(schema: S): Optic_.Iso<S["Type"], S["Iso"]> {
@@ -15715,7 +15715,7 @@ export function toIso<S extends Constraint>(schema: S): Optic_.Iso<S["Type"], S[
 /**
  * Returns an identity `Iso` over the schema's source (`Type`) side.
  *
- * @category Optic
+ * @category constructors
  * @since 4.0.0
  */
 export function toIsoSource<S extends Constraint>(_: S): Optic_.Iso<S["Type"], S["Type"]> {
@@ -15725,7 +15725,7 @@ export function toIsoSource<S extends Constraint>(_: S): Optic_.Iso<S["Type"], S
 /**
  * Returns an identity `Iso` over the schema's focus (`Iso`) side.
  *
- * @category Optic
+ * @category constructors
  * @since 4.0.0
  */
 export function toIsoFocus<S extends Constraint>(_: S): Optic_.Iso<S["Iso"], S["Iso"]> {
@@ -15735,7 +15735,7 @@ export function toIsoFocus<S extends Constraint>(_: S): Optic_.Iso<S["Iso"], S["
 /**
  * Type-level representation returned by {@link overrideToCodecIso}.
  *
- * @category Optic
+ * @category transforming
  * @since 4.0.0
  */
 export interface overrideToCodecIso<S extends Constraint, Iso> extends
@@ -15774,7 +15774,7 @@ export interface overrideToCodecIso<S extends Constraint, Iso> extends
  * provided `decode` and `encode` getters to transform between the schema type
  * and the target codec.
  *
- * @category Optic
+ * @category transforming
  * @since 4.0.0
  */
 export function overrideToCodecIso<S extends Constraint, Iso>(
@@ -15826,7 +15826,7 @@ export function toDifferJsonPatch<T>(schema: ConstraintCodec<T, unknown>): Diffe
  * Recursive tree type whose leaves are `Node` values and whose branches are
  * readonly arrays or string-keyed records of child trees.
  *
- * @category Tree
+ * @category models
  * @since 4.0.0
  */
 export type Tree<Node> = Node | TreeRecord<Node> | ReadonlyArray<Tree<Node>>
@@ -15835,7 +15835,7 @@ export type Tree<Node> = Node | TreeRecord<Node> | ReadonlyArray<Tree<Node>>
  * A record node in a {@link Tree}: an object mapping string keys to child
  * `Tree` nodes.
  *
- * @category Tree
+ * @category models
  * @since 4.0.0
  */
 export interface TreeRecord<A> {
@@ -15847,7 +15847,7 @@ export interface TreeRecord<A> {
  * The resulting schema accepts a single node value, an array of trees, or an
  * object whose values are trees.
  *
- * @category Tree
+ * @category schemas
  * @since 4.0.0
  */
 export function Tree<S extends Constraint>(node: S) {
@@ -16007,7 +16007,7 @@ export const MutableJsonReviver = makeFixedDeclarationReviver(
  * annotations are taken from the last check; otherwise they are taken from
  * the base schema instance.
  *
- * @category schema resolvers
+ * @category getters
  * @since 4.0.0
  */
 export function resolveAnnotations<S extends Constraint>(
@@ -16021,7 +16021,7 @@ export function resolveAnnotations<S extends Constraint>(
  * annotations are those attached via `annotateKey` and live on the AST's
  * `context` rather than on the schema node itself.
  *
- * @category schema resolvers
+ * @category getters
  * @since 4.0.0
  */
 export function resolveAnnotationsKey<S extends Constraint>(schema: S): Annotations.Key<S["Type"]> | undefined {

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -683,7 +683,7 @@ export function withDefault<T, R = never>(
  *
  * @see {@link transform} for custom string conversions
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export function String<E>(): Getter<string, E> {
@@ -714,7 +714,7 @@ export function String<E>(): Getter<string, E> {
  *
  * @see {@link transformOrFail} for validated number parsing
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export function Number<E>(): Getter<number, E> {
@@ -742,7 +742,7 @@ export function Number<E>(): Getter<number, E> {
  * await Effect.runPromise(toBool.run(Option.some("true"), {})) // => Option.some(true)
  * ```
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export function Boolean<E>(): Getter<boolean, E> {
@@ -771,7 +771,7 @@ export function Boolean<E>(): Getter<boolean, E> {
  * await Effect.runPromise(toBigInt.run(Option.some("42"), {})) // => Option.some(42n)
  * ```
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export function BigInt<E extends string | number | bigint | boolean>(): Getter<bigint, E> {
@@ -803,7 +803,7 @@ export function BigInt<E extends string | number | bigint | boolean>(): Getter<b
  *
  * @see {@link dateTimeUtcFromInput} for validated DateTime parsing
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export function Date<E extends string | number | Date>(): Getter<Date, E> {

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -337,7 +337,7 @@ export function passthroughSubtype<T>(): Getter<T, T> {
  * @see {@link withDefault} for a simpler default value for undefined inputs
  * @see {@link onSome} to handle only present values
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function onNone<T, E extends T = T, R = never>(
@@ -373,7 +373,7 @@ export function onNone<T, E extends T = T, R = never>(
  * @see {@link onNone} to provide a fallback instead of failing
  * @see {@link withDefault} to substitute a default for undefined values
  *
- * @category constructors
+ * @category validation
  * @since 4.0.0
  */
 export function required<T, E extends T = T>(annotations?: Schema.Annotations.Key<T>): Getter<T, E> {
@@ -410,7 +410,7 @@ export function required<T, E extends T = T>(annotations?: Schema.Annotations.Ke
  * @see {@link transform} for a simpler pure transformation of present values
  * @see {@link transformOrFail} for fallible transformation of present values
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function onSome<T, E, R = never>(
@@ -453,7 +453,7 @@ export function onSome<T, E, R = never>(
  * @see {@link transform} when you need to change the value, not just validate
  * @see {@link fail} for unconditional failure
  *
- * @category constructors
+ * @category validation
  * @since 4.0.0
  */
 export function checkEffect<T, R = never>(
@@ -507,7 +507,7 @@ export function checkEffect<T, R = never>(
  * @see {@link transformOptional} when you need to handle `None` inputs
  * @see {@link passthrough} when no transformation is needed
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function transform<T, E>(f: (e: E) => T): Getter<T, E> {
@@ -547,7 +547,7 @@ export function transform<T, E>(f: (e: E) => T): Getter<T, E> {
  * @see {@link transform} when transformation cannot fail
  * @see {@link onSome} when you need full `Option` control over the output
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function transformOrFail<T, E, R = never>(
@@ -583,7 +583,7 @@ export function transformOrFail<T, E, R = never>(
  * @see {@link transform} when you only need to transform present values
  * @see {@link omit} when you always want `None`
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function transformOptional<T, E>(f: (oe: Option.Option<E>) => Option.Option<T>): Getter<T, E> {
@@ -615,7 +615,7 @@ export function transformOptional<T, E>(f: (oe: Option.Option<E>) => Option.Opti
  * @see {@link transformOptional} when you want conditional omission
  * @see {@link forbidden} when you want to fail instead of silently omit
  *
- * @category constructors
+ * @category filtering
  * @since 4.0.0
  */
 export function omit<T>(): Getter<never, T> {
@@ -648,7 +648,7 @@ export function omit<T>(): Getter<never, T> {
  * @see {@link onNone} to handle only absent keys (not `undefined` values)
  * @see {@link required} when absent input should fail instead of using a default
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function withDefault<T, R = never>(
@@ -683,7 +683,7 @@ export function withDefault<T, R = never>(
  *
  * @see {@link transform} for custom string conversions
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export function String<E>(): Getter<string, E> {
@@ -714,7 +714,7 @@ export function String<E>(): Getter<string, E> {
  *
  * @see {@link transformOrFail} for validated number parsing
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export function Number<E>(): Getter<number, E> {
@@ -742,7 +742,7 @@ export function Number<E>(): Getter<number, E> {
  * await Effect.runPromise(toBool.run(Option.some("true"), {})) // => Option.some(true)
  * ```
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export function Boolean<E>(): Getter<boolean, E> {
@@ -771,7 +771,7 @@ export function Boolean<E>(): Getter<boolean, E> {
  * await Effect.runPromise(toBigInt.run(Option.some("42"), {})) // => Option.some(42n)
  * ```
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export function BigInt<E extends string | number | bigint | boolean>(): Getter<bigint, E> {
@@ -803,7 +803,7 @@ export function BigInt<E extends string | number | bigint | boolean>(): Getter<b
  *
  * @see {@link dateTimeUtcFromInput} for validated DateTime parsing
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export function Date<E extends string | number | Date>(): Getter<Date, E> {
@@ -826,7 +826,7 @@ export function Date<E extends string | number | Date>(): Getter<Date, E> {
  * await Effect.runPromise(trimmed.run(Option.some("  hello  "), {})) // => Option.some("hello")
  * ```
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function trim<E extends string>(): Getter<string, E> {
@@ -849,7 +849,7 @@ export function trim<E extends string>(): Getter<string, E> {
  * await Effect.runPromise(cap.run(Option.some("hello"), {})) // => Option.some("Hello")
  * ```
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function capitalize<E extends string>(): Getter<string, E> {
@@ -872,7 +872,7 @@ export function capitalize<E extends string>(): Getter<string, E> {
  * await Effect.runPromise(uncap.run(Option.some("Hello"), {})) // => Option.some("hello")
  * ```
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function uncapitalize<E extends string>(): Getter<string, E> {
@@ -897,7 +897,7 @@ export function uncapitalize<E extends string>(): Getter<string, E> {
  *
  * @see {@link camelToSnake} for the inverse operation
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function snakeToCamel<E extends string>(): Getter<string, E> {
@@ -922,7 +922,7 @@ export function snakeToCamel<E extends string>(): Getter<string, E> {
  *
  * @see {@link snakeToCamel} for the inverse operation
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function camelToSnake<E extends string>(): Getter<string, E> {
@@ -947,7 +947,7 @@ export function camelToSnake<E extends string>(): Getter<string, E> {
  *
  * @see {@link toUpperCase} for the inverse operation
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function toLowerCase<E extends string>(): Getter<string, E> {
@@ -972,7 +972,7 @@ export function toLowerCase<E extends string>(): Getter<string, E> {
  *
  * @see {@link toLowerCase} for the inverse operation
  *
- * @category string
+ * @category transforming
  * @since 4.0.0
  */
 export function toUpperCase<E extends string>(): Getter<string, E> {
@@ -1009,7 +1009,7 @@ type ParseJsonOptions = {
  *
  * @see {@link stringifyJson} for the inverse operation
  *
- * @category JSON getters
+ * @category decoding
  * @since 4.0.0
  */
 export function parseJson<E extends string>(): Getter<Schema.MutableJson, E>
@@ -1026,7 +1026,7 @@ export function parseJson<E extends string>(options?: ParseJsonOptions | undefin
 /**
  * Replacer function or property allowlist accepted by `JSON.stringify`.
  *
- * @category JSON getters
+ * @category utility types
  * @since 4.0.0
  */
 export type JsonReplacer =
@@ -1066,7 +1066,7 @@ type StringifyJsonOptions = {
  *
  * @see {@link parseJson} for the inverse operation
  *
- * @category JSON getters
+ * @category encoding
  * @since 4.0.0
  */
 export function stringifyJson(options?: StringifyJsonOptions): Getter<string, unknown> {
@@ -1110,7 +1110,7 @@ export function stringifyJson(options?: StringifyJsonOptions): Getter<string, un
  * @see {@link joinKeyValue} for the inverse operation
  * @see {@link split} to split into an array of strings
  *
- * @category string
+ * @category splitting
  * @since 4.0.0
  */
 export function splitKeyValue<E extends string>(options?: {
@@ -1155,7 +1155,7 @@ export function splitKeyValue<E extends string>(options?: {
  *
  * @see {@link splitKeyValue} for the inverse operation
  *
- * @category string
+ * @category combining
  * @since 4.0.0
  */
 export function joinKeyValue<E extends Record<PropertyKey, string>>(options?: {
@@ -1193,7 +1193,7 @@ export function joinKeyValue<E extends Record<PropertyKey, string>>(options?: {
  *
  * @see {@link splitKeyValue} when values are key-value pairs
  *
- * @category string
+ * @category splitting
  * @since 4.0.0
  */
 export function split<E extends string>(options?: {
@@ -1223,7 +1223,7 @@ export function split<E extends string>(options?: {
  * @see {@link decodeBase64String} for the inverse operation to `string`
  * @see {@link encodeBase64Url} for the URL-safe variant
  *
- * @category Base64 getters
+ * @category encoding
  * @since 4.0.0
  */
 export function encodeBase64<E extends Uint8Array | string>(): Getter<string, E> {
@@ -1250,7 +1250,7 @@ export function encodeBase64<E extends Uint8Array | string>(): Getter<string, E>
  * @see {@link decodeBase64UrlString} for the inverse operation to `string`
  * @see {@link encodeBase64} for the standard Base64 variant
  *
- * @category Base64 getters
+ * @category encoding
  * @since 4.0.0
  */
 export function encodeBase64Url<E extends Uint8Array | string>(): Getter<string, E> {
@@ -1276,7 +1276,7 @@ export function encodeBase64Url<E extends Uint8Array | string>(): Getter<string,
  * @see {@link decodeHex} for the inverse operation to `Uint8Array`
  * @see {@link decodeHexString} for the inverse operation to `string`
  *
- * @category Hex getters
+ * @category encoding
  * @since 4.0.0
  */
 export function encodeHex<E extends Uint8Array | string>(): Getter<string, E> {
@@ -1303,7 +1303,7 @@ export function encodeHex<E extends Uint8Array | string>(): Getter<string, E> {
  * @see {@link decodeBase64String} to decode to `string` instead
  * @see {@link encodeBase64} for the inverse operation
  *
- * @category Base64 getters
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeBase64<E extends string>(): Getter<Uint8Array, E> {
@@ -1334,7 +1334,7 @@ export function decodeBase64<E extends string>(): Getter<Uint8Array, E> {
  * @see {@link decodeBase64} to decode to `Uint8Array` instead
  * @see {@link encodeBase64} for the inverse operation
  *
- * @category Base64 getters
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeBase64String<E extends string>(): Getter<string, E> {
@@ -1366,7 +1366,7 @@ export function decodeBase64String<E extends string>(): Getter<string, E> {
  * @see {@link decodeBase64UrlString} to decode to `string` instead
  * @see {@link encodeBase64Url} for the inverse operation
  *
- * @category Base64 getters
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeBase64Url<E extends string>(): Getter<Uint8Array, E> {
@@ -1397,7 +1397,7 @@ export function decodeBase64Url<E extends string>(): Getter<Uint8Array, E> {
  * @see {@link decodeBase64Url} to decode to `Uint8Array` instead
  * @see {@link encodeBase64Url} for the inverse operation
  *
- * @category Base64 getters
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeBase64UrlString<E extends string>(): Getter<string, E> {
@@ -1429,7 +1429,7 @@ export function decodeBase64UrlString<E extends string>(): Getter<string, E> {
  * @see {@link decodeHexString} to decode to `string` instead
  * @see {@link encodeHex} for the inverse operation
  *
- * @category Hex getters
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeHex<E extends string>(): Getter<Uint8Array, E> {
@@ -1460,7 +1460,7 @@ export function decodeHex<E extends string>(): Getter<Uint8Array, E> {
  * @see {@link decodeHex} to decode to `Uint8Array` instead
  * @see {@link encodeHex} for the inverse operation
  *
- * @category Hex getters
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeHexString<E extends string>(): Getter<string, E> {
@@ -1492,7 +1492,7 @@ export function decodeHexString<E extends string>(): Getter<string, E> {
  *
  * @see {@link decodeUriComponent} for the inverse operation
  *
- * @category URI
+ * @category encoding
  * @since 4.0.0
  */
 export function encodeUriComponent<E extends string>(): Getter<string, E> {
@@ -1517,7 +1517,7 @@ export function encodeUriComponent<E extends string>(): Getter<string, E> {
  *
  * @see {@link encodeUriComponent} for the inverse operation
  *
- * @category URI
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeUriComponent<E extends string>(): Getter<string, E> {
@@ -1563,7 +1563,7 @@ export function decodeUriComponent<E extends string>(): Getter<string, E> {
  *
  * @see {@link Date} for a simpler coercion to `Date` (no validation)
  *
- * @category DateTime
+ * @category converting
  * @since 4.0.0
  */
 export function dateTimeUtcFromInput<E extends DateTime.DateTime.Input>(): Getter<DateTime.Utc, E> {
@@ -1605,7 +1605,7 @@ export function dateTimeUtcFromInput<E extends DateTime.DateTime.Input>(): Gette
  * @see {@link makeTreeRecord} for the underlying bracket-path parser
  * @see {@link decodeURLSearchParams} for the URLSearchParams variant
  *
- * @category FormData
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeFormData(): Getter<Schema.TreeRecord<string | Blob>, FormData> {
@@ -1644,7 +1644,7 @@ const collectFormDataEntries = collectBracketPathEntries((value): value is strin
  * @see {@link collectBracketPathEntries} for the underlying flattener
  * @see {@link encodeURLSearchParams} for the URLSearchParams variant
  *
- * @category FormData
+ * @category encoding
  * @since 4.0.0
  */
 export function encodeFormData(): Getter<FormData, unknown> {
@@ -1688,7 +1688,7 @@ export function encodeFormData(): Getter<FormData, unknown> {
  * @see {@link makeTreeRecord} for the underlying bracket-path parser
  * @see {@link decodeFormData} for the FormData variant
  *
- * @category search params
+ * @category decoding
  * @since 4.0.0
  */
 export function decodeURLSearchParams(): Getter<Schema.TreeRecord<string>, URLSearchParams> {
@@ -1724,7 +1724,7 @@ const collectURLSearchParamsEntries = collectBracketPathEntries(Predicate.isStri
  * @see {@link collectBracketPathEntries} for the underlying flattener
  * @see {@link encodeFormData} for the FormData variant
  *
- * @category search params
+ * @category encoding
  * @since 4.0.0
  */
 export function encodeURLSearchParams(): Getter<URLSearchParams, unknown> {
@@ -1797,7 +1797,7 @@ function bracketPathToTokens(bracketPath: string): Array<string | number> {
  * @see {@link decodeFormData} for a higher-level FormData decoder
  * @see {@link decodeURLSearchParams} for a higher-level URLSearchParams decoder
  *
- * @category Tree
+ * @category constructors
  * @since 4.0.0
  */
 export function makeTreeRecord<A>(
@@ -1892,7 +1892,7 @@ export function makeTreeRecord<A>(
  * @see {@link encodeFormData} for a higher-level FormData encoder
  * @see {@link encodeURLSearchParams} for a higher-level URLSearchParams encoder
  *
- * @category Tree
+ * @category converting
  * @since 4.0.0
  */
 export function collectBracketPathEntries<A>(isLeaf: (value: unknown) => value is A) {

--- a/packages/effect/src/SchemaIssue.ts
+++ b/packages/effect/src/SchemaIssue.ts
@@ -836,7 +836,7 @@ export function make(input: unknown, ast: SchemaAST.AST, out: Schema.FilterOutpu
  * @see {@link makeFormatterDefault} — creates a `Formatter<string>`
  * @see {@link makeFormatterStandardSchemaV1} — creates a `Formatter<StandardSchemaV1.FailureResult>`
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export interface Formatter<out Format> extends FormatterI<Issue, Format> {}
@@ -852,7 +852,7 @@ export interface Formatter<out Format> extends FormatterI<Issue, Format> {}
  * @see {@link defaultLeafHook} — the built-in implementation
  * @see {@link Leaf} — the union of terminal issue types
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export type LeafHook = (issue: Leaf) => string
@@ -889,7 +889,7 @@ export type LeafHook = (issue: Leaf) => string
  * @see {@link LeafHook}
  * @see {@link makeFormatterStandardSchemaV1}
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export const defaultLeafHook: LeafHook = (issue): string => {
@@ -927,7 +927,7 @@ export const defaultLeafHook: LeafHook = (issue): string => {
  * @see {@link defaultCheckHook} — the built-in implementation
  * @see {@link Filter} — the issue type this hook formats
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export type CheckHook = (issue: Filter) => string | undefined
@@ -949,7 +949,7 @@ export type CheckHook = (issue: Filter) => string | undefined
  * @see {@link CheckHook}
  * @see {@link makeFormatterStandardSchemaV1}
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export const defaultCheckHook: CheckHook = (issue): string | undefined => {
@@ -986,7 +986,7 @@ export const defaultCheckHook: CheckHook = (issue): string | undefined => {
  * @see {@link LeafHook}
  * @see {@link CheckHook}
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export function makeFormatterStandardSchemaV1(options?: {
@@ -1093,7 +1093,7 @@ function formatCheck<T>(check: SchemaAST.Check<T>): string {
  * @see {@link makeFormatterStandardSchemaV1} — produces Standard Schema V1 format instead
  * @see {@link Formatter}
  *
- * @category Formatter
+ * @category formatting
  * @since 4.0.0
  */
 export function makeFormatterDefault(): Formatter<string> {

--- a/packages/effect/src/SchemaParser.ts
+++ b/packages/effect/src/SchemaParser.ts
@@ -222,7 +222,7 @@ export function _issue<T>(ast: SchemaAST.AST) {
  * synchronous boundary throw an `Error` whose cause is the underlying `Cause`,
  * instead of being converted to a schema validation error.
  *
- * @category asserting
+ * @category guards
  * @since 4.0.0
  */
 export function asserts<S extends Schema.Constraint, I>(schema: S, input: I): asserts input is I & S["Type"] {

--- a/packages/effect/src/SchemaParser.ts
+++ b/packages/effect/src/SchemaParser.ts
@@ -170,7 +170,7 @@ export function make<S extends Schema.Constraint>(schema: S) {
  * that contain defects, interruptions, or asynchronous work at this synchronous
  * boundary throw an `Error` whose cause is the underlying `Cause`.
  *
- * @category Asserting
+ * @category guards
  * @since 3.10.0
  */
 export function is<S extends Schema.Constraint>(schema: S): <I>(input: I) => input is I & S["Type"] {
@@ -222,7 +222,7 @@ export function _issue<T>(ast: SchemaAST.AST) {
  * synchronous boundary throw an `Error` whose cause is the underlying `Cause`,
  * instead of being converted to a schema validation error.
  *
- * @category Asserting
+ * @category asserting
  * @since 4.0.0
  */
 export function asserts<S extends Schema.Constraint, I>(schema: S, input: I): asserts input is I & S["Type"] {

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -280,7 +280,7 @@ export const make = <T, E, RD = never, RE = never>(options: {
  * @see {@link transformOptional} — for transformations that handle missing keys
  * @see {@link make} — for transformations from existing Getters
  *
- * @category constructors
+ * @category transforming
  * @since 3.10.0
  */
 export function transformOrFail<T, E, RD = never, RE = never>(options: {
@@ -329,7 +329,7 @@ export function transformOrFail<T, E, RD = never, RE = never>(options: {
  * @see {@link transformOptional} — for transformations that handle missing keys
  * @see {@link passthrough} — when no conversion is needed
  *
- * @category constructors
+ * @category transforming
  * @since 3.10.0
  */
 export function transform<T, E>(options: {
@@ -382,7 +382,7 @@ export function transform<T, E>(options: {
  * @see {@link optionFromOptionalKey} — built-in for the common optional-key-to-Option pattern
  * @see {@link optionFromOptional} — built-in for optional (undefined) to Option
  *
- * @category constructors
+ * @category transforming
  * @since 4.0.0
  */
 export function transformOptional<T, E>(options: {
@@ -425,7 +425,7 @@ export function transformOptional<T, E>(options: {
  * @see {@link toUpperCase}
  * @see {@link snakeToCamel}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function trim(): Transformation<string, string> {
@@ -464,7 +464,7 @@ export function trim(): Transformation<string, string> {
  * @see {@link trim}
  * @see {@link toLowerCase}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function snakeToCamel(): Transformation<string, string> {
@@ -502,7 +502,7 @@ export function snakeToCamel(): Transformation<string, string> {
  * @see {@link toUpperCase}
  * @see {@link trim}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function toLowerCase(): Transformation<string, string> {
@@ -540,7 +540,7 @@ export function toLowerCase(): Transformation<string, string> {
  * @see {@link toLowerCase}
  * @see {@link trim}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function toUpperCase(): Transformation<string, string> {
@@ -578,7 +578,7 @@ export function toUpperCase(): Transformation<string, string> {
  * @see {@link uncapitalize}
  * @see {@link toUpperCase}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function capitalize(): Transformation<string, string> {
@@ -616,7 +616,7 @@ export function capitalize(): Transformation<string, string> {
  * @see {@link capitalize}
  * @see {@link toLowerCase}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function uncapitalize(): Transformation<string, string> {
@@ -659,7 +659,7 @@ export function uncapitalize(): Transformation<string, string> {
  * @see {@link trim}
  * @see {@link snakeToCamel}
  *
- * @category string transformations
+ * @category transforming
  * @since 4.0.0
  */
 export function splitKeyValue(options?: {
@@ -815,7 +815,7 @@ export function passthroughSubtype<T>(): Transformation<T, T> {
  * @see {@link bigintFromString}
  * @see {@link transform}
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export const numberFromString = new Transformation(
@@ -852,7 +852,7 @@ export const numberFromString = new Transformation(
  * @see {@link numberFromString}
  * @see {@link transform}
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export const bigintFromString = new Transformation(
@@ -888,7 +888,7 @@ export const bigintFromString = new Transformation(
  * @see {@link dateFromMillis}
  * @see {@link dateTimeUtcFromString}
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export const dateFromString: Transformation<globalThis.Date, string> = new Transformation(
@@ -929,7 +929,7 @@ export const dateFromString: Transformation<globalThis.Date, string> = new Trans
  * @see {@link dateFromString}
  * @see {@link SchemaGetter.dateTimeUtcFromInput}
  *
- * @category coercions
+ * @category converting
  * @since 4.0.0
  */
 export const dateFromMillis: Transformation<globalThis.Date, number> = new Transformation(

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -425,7 +425,7 @@ export function transformOptional<T, E>(options: {
  * @see {@link toUpperCase}
  * @see {@link snakeToCamel}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function trim(): Transformation<string, string> {
@@ -464,7 +464,7 @@ export function trim(): Transformation<string, string> {
  * @see {@link trim}
  * @see {@link toLowerCase}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function snakeToCamel(): Transformation<string, string> {
@@ -502,7 +502,7 @@ export function snakeToCamel(): Transformation<string, string> {
  * @see {@link toUpperCase}
  * @see {@link trim}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function toLowerCase(): Transformation<string, string> {
@@ -540,7 +540,7 @@ export function toLowerCase(): Transformation<string, string> {
  * @see {@link toLowerCase}
  * @see {@link trim}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function toUpperCase(): Transformation<string, string> {
@@ -578,7 +578,7 @@ export function toUpperCase(): Transformation<string, string> {
  * @see {@link uncapitalize}
  * @see {@link toUpperCase}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function capitalize(): Transformation<string, string> {
@@ -616,7 +616,7 @@ export function capitalize(): Transformation<string, string> {
  * @see {@link capitalize}
  * @see {@link toLowerCase}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function uncapitalize(): Transformation<string, string> {
@@ -659,7 +659,7 @@ export function uncapitalize(): Transformation<string, string> {
  * @see {@link trim}
  * @see {@link snakeToCamel}
  *
- * @category String transformations
+ * @category string transformations
  * @since 4.0.0
  */
 export function splitKeyValue(options?: {
@@ -815,7 +815,7 @@ export function passthroughSubtype<T>(): Transformation<T, T> {
  * @see {@link bigintFromString}
  * @see {@link transform}
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export const numberFromString = new Transformation(
@@ -852,7 +852,7 @@ export const numberFromString = new Transformation(
  * @see {@link numberFromString}
  * @see {@link transform}
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export const bigintFromString = new Transformation(
@@ -888,7 +888,7 @@ export const bigintFromString = new Transformation(
  * @see {@link dateFromMillis}
  * @see {@link dateTimeUtcFromString}
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export const dateFromString: Transformation<globalThis.Date, string> = new Transformation(
@@ -929,7 +929,7 @@ export const dateFromString: Transformation<globalThis.Date, string> = new Trans
  * @see {@link dateFromString}
  * @see {@link SchemaGetter.dateTimeUtcFromInput}
  *
- * @category Coercions
+ * @category coercions
  * @since 4.0.0
  */
 export const dateFromMillis: Transformation<globalThis.Date, number> = new Transformation(

--- a/packages/effect/src/Scope.ts
+++ b/packages/effect/src/Scope.ts
@@ -39,7 +39,7 @@ const CloseableTypeId = effect.ScopeCloseableTypeId
  * Effect.runSync(program) // => [["sequential", "Empty"], "Closed"]
  * ```
  *
- * @category models
+ * @category services
  * @since 2.0.0
  */
 export interface Scope {

--- a/packages/effect/src/ScopedRef.ts
+++ b/packages/effect/src/ScopedRef.ts
@@ -165,7 +165,7 @@ export const make = <A>(evaluate: LazyArg<A>): Effect.Effect<ScopedRef<A>, never
  * changed to the new value, with old resources released, or until the attempt
  * to acquire a new value fails.
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const set: {

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -1147,7 +1147,7 @@ export const mapLeftover: {
  * If more elements are pulled than needed, the remaining elements from the same
  * array are returned as leftovers.
  *
- * @category collecting
+ * @category constructors
  * @since 2.0.0
  */
 export const take = <In>(n: number): Sink<Array<In>, In, In> =>
@@ -1244,7 +1244,7 @@ export const flatMap: {
  * A sink that reduces input elements from the provided `initial` state with
  * `f` while the specified `predicate` returns `true`.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduceWhile = <S, In>(
@@ -1280,7 +1280,7 @@ export const reduceWhile = <S, In>(
  * A sink that effectfully reduces input elements from the provided `initial`
  * state with `f` while the specified `predicate` returns `true`.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduceWhileEffect = <S, In, E, R>(
@@ -1321,7 +1321,7 @@ export const reduceWhileEffect = <S, In, E, R>(
  * A sink that reduces non-empty input arrays from the provided `initial` state
  * with `f` while the specified `predicate` returns `true`.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduceWhileArray = <S, In>(
@@ -1353,7 +1353,7 @@ export const reduceWhileArray = <S, In>(
  * A sink that effectfully reduces non-empty input arrays from the provided
  * `initial` state with `f` while the specified `predicate` returns `true`.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduceWhileArrayEffect = <S, In, E, R>(
@@ -1384,7 +1384,7 @@ export const reduceWhileArrayEffect = <S, In, E, R>(
  * A sink that reduces its inputs using the provided function `f` starting from
  * the provided `initial` state.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduce = <S, In>(initial: LazyArg<S>, f: (s: S, input: In) => S): Sink<S, In> =>
@@ -1399,7 +1399,7 @@ export const reduce = <S, In>(initial: LazyArg<S>, f: (s: S, input: In) => S): S
  * A sink that reduces its inputs using the provided function `f` starting from
  * the specified `initial` state.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduceArray = <S, In>(
@@ -1422,7 +1422,7 @@ export const reduceArray = <S, In>(
  * A sink that reduces its inputs using the provided effectful function `f`
  * starting from the specified `initial` state.
  *
- * @category reducing
+ * @category folding
  * @since 4.0.0
  */
 export const reduceEffect = <S, In, E, R>(
@@ -2146,7 +2146,7 @@ export {
  * The effect receives the sink's `Exit` for the result value. The original
  * sink result and leftovers are preserved unless the finalizer itself fails.
  *
- * @category finalization
+ * @category resource management
  * @since 4.0.0
  */
 export const onExit: {
@@ -2174,7 +2174,7 @@ export const onExit: {
  * The original sink result and leftovers are preserved unless the finalizer
  * itself fails.
  *
- * @category finalization
+ * @category resource management
  * @since 2.0.0
  */
 export const ensuring: {

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -1968,7 +1968,7 @@ export const timed: Sink<Duration.Duration, unknown> = map(withDuration(drain), 
  * Services contained in the provided context are removed from the sink's
  * service requirements.
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const provideContext: {
@@ -1997,7 +1997,7 @@ export const provideContext: {
  * The service identified by `key` is removed from the sink's service
  * requirements.
  *
- * @category services
+ * @category providing services
  * @since 4.0.0
  */
 export const provideService: {
@@ -2146,7 +2146,7 @@ export {
  * The effect receives the sink's `Exit` for the result value. The original
  * sink result and leftovers are preserved unless the finalizer itself fails.
  *
- * @category Finalization
+ * @category finalization
  * @since 4.0.0
  */
 export const onExit: {
@@ -2174,7 +2174,7 @@ export const onExit: {
  * The original sink result and leftovers are preserved unless the finalizer
  * itself fails.
  *
- * @category Finalization
+ * @category finalization
  * @since 2.0.0
  */
 export const ensuring: {

--- a/packages/effect/src/Stdio.ts
+++ b/packages/effect/src/Stdio.ts
@@ -57,7 +57,7 @@ export const TypeId: TypeId = "~effect/Stdio"
  * standard error, and a stream of standard input bytes. I/O operations can fail
  * with `PlatformError`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Stdio {

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -161,7 +161,7 @@ export interface StreamUnifyIgnore {
  * await Effect.runPromise(Stream.runCollect(stream)) // => [1, 2, 3]
  * ```
  *
- * @category type lambdas
+ * @category utility types
  * @since 2.0.0
  */
 export interface StreamTypeLambda extends TypeLambda {
@@ -364,7 +364,7 @@ export const fromEffect = <A, E, R>(effect: Effect.Effect<A, E, R>): Stream<A, E
  * ) // => ["Hello, World!"]
  * ```
  *
- * @category context
+ * @category accessors
  * @since 4.0.0
  */
 export const service = <I, S>(service: Context.Key<I, S>): Stream<S, never, I> => fromEffect(Effect.service(service))
@@ -406,7 +406,7 @@ export const service = <I, S>(service: Context.Key<I, S>): Stream<S, never, I> =
  * ) // => ["Hello, World!"]
  * ```
  *
- * @category context
+ * @category accessors
  * @since 4.0.0
  */
 export const serviceOption = <I, S>(service: Context.Key<I, S>): Stream<Option.Option<S>> =>
@@ -2551,7 +2551,7 @@ export const schedule: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category rate limiting
+ * @category delays & timeouts
  * @since 2.0.0
  */
 export const timeout: {
@@ -2587,7 +2587,7 @@ export const timeout: {
  *
  * @see {@link timeout} for ending the stream instead of switching to a fallback stream
  *
- * @category rate limiting
+ * @category delays & timeouts
  * @since 4.0.0
  */
 export const timeoutOrElse: {
@@ -4563,7 +4563,7 @@ export const peel: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category rate limiting
+ * @category buffering
  * @since 2.0.0
  */
 export const buffer: {
@@ -4615,7 +4615,7 @@ export const buffer: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category rate limiting
+ * @category buffering
  * @since 4.0.0
  */
 export const bufferArray: {
@@ -8793,7 +8793,7 @@ export const share: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category piping
+ * @category sequencing
  * @since 2.0.0
  */
 export const pipeThroughChannel: {
@@ -8840,7 +8840,7 @@ export const pipeThroughChannel: {
  * }))
  * ```
  *
- * @category piping
+ * @category sequencing
  * @since 2.0.0
  */
 export const pipeThroughChannelOrFail: {
@@ -8880,7 +8880,7 @@ export const pipeThroughChannelOrFail: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category piping
+ * @category sequencing
  * @since 2.0.0
  */
 export const pipeThrough: {
@@ -9123,7 +9123,7 @@ export const changesWithEffect: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category encoding
+ * @category decoding
  * @since 2.0.0
  */
 export const decodeText: <
@@ -9193,7 +9193,7 @@ export const encodeText = <E, R>(self: Stream<string, E, R>): Stream<Uint8Array,
  * }))
  * ```
  *
- * @category encoding
+ * @category splitting
  * @since 2.0.0
  */
 export const splitLines = <E, R>(self: Stream<string, E, R>): Stream<string, E, R> =>
@@ -9526,7 +9526,7 @@ export const haltWhen: {
  * exits // => ["success"]
  * ```
  *
- * @category finalization
+ * @category resource management
  * @since 4.0.0
  */
 export const onExit: {
@@ -9716,7 +9716,7 @@ export const onEnd: {
  * events // => ["cleanup"]
  * ```
  *
- * @category finalization
+ * @category resource management
  * @since 2.0.0
  */
 export const ensuring: {
@@ -10090,7 +10090,7 @@ export const withSpan: {
  * await Effect.runPromise(effect)
  * ```
  *
- * @category do notation
+ * @category constructors
  * @since 2.0.0
  */
 export const Do: Stream<{}> = succeed({})
@@ -10133,7 +10133,7 @@ export {
    * await Effect.runPromise(program)
    * ```
    *
-   * @category do notation
+   * @category mapping
    * @since 2.0.0
    */
   let_ as let
@@ -10157,7 +10157,7 @@ export {
  * await Effect.runPromise(result) // => [{ a: 1, b: 2 }, { a: 2, b: 3 }]
  * ```
  *
- * @category do notation
+ * @category sequencing
  * @since 2.0.0
  */
 export const bind: {
@@ -10210,7 +10210,7 @@ export const bind: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category do notation
+ * @category sequencing
  * @since 2.0.0
  */
 export const bindEffect: {
@@ -10258,7 +10258,7 @@ export const bindEffect: {
  * await Effect.runPromise(Stream.runCollect(stream)) // => [{ value: 1 }, { value: 2 }, { value: 3 }]
  * ```
  *
- * @category do notation
+ * @category mapping
  * @since 2.0.0
  */
 export const bindTo: {

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -7486,7 +7486,7 @@ export const mapAccumArrayEffect: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Accumulation
+ * @category accumulation
  * @since 2.0.0
  */
 export const scan: {
@@ -7538,7 +7538,7 @@ export const scan: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Accumulation
+ * @category accumulation
  * @since 2.0.0
  */
 export const scanEffect: {
@@ -8267,7 +8267,7 @@ export const groupAdjacentBy: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Aggregation
+ * @category aggregation
  * @since 2.0.0
  */
 export const transduce = dual<
@@ -8342,7 +8342,7 @@ export const transduce = dual<
  * }))
  * ```
  *
- * @category Aggregation
+ * @category aggregation
  * @since 2.0.0
  */
 export const aggregate: {
@@ -8383,7 +8383,7 @@ export const aggregate: {
  * }))
  * ```
  *
- * @category Aggregation
+ * @category aggregation
  * @since 2.0.0
  */
 export const aggregateWithin: {
@@ -8514,7 +8514,7 @@ export const aggregateWithin: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Broadcast
+ * @category broadcasting
  * @since 4.0.0
  */
 export const broadcastN: {
@@ -8631,7 +8631,7 @@ const makePubSub = <A>(
  * await Effect.runPromise(program)
  * ```
  *
- * @category Broadcast
+ * @category broadcasting
  * @since 2.0.0
  */
 export const broadcast: {
@@ -8712,7 +8712,7 @@ export const broadcast: {
  * result // => { values: [[1, 2, 3], [1, 2, 3]], acquisitions: 1 }
  * ```
  *
- * @category Broadcast
+ * @category broadcasting
  * @since 3.8.0
  */
 export const share: {
@@ -8793,7 +8793,7 @@ export const share: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Pipe
+ * @category piping
  * @since 2.0.0
  */
 export const pipeThroughChannel: {
@@ -8840,7 +8840,7 @@ export const pipeThroughChannel: {
  * }))
  * ```
  *
- * @category Pipe
+ * @category piping
  * @since 2.0.0
  */
 export const pipeThroughChannelOrFail: {
@@ -8880,7 +8880,7 @@ export const pipeThroughChannelOrFail: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Pipe
+ * @category piping
  * @since 2.0.0
  */
 export const pipeThrough: {
@@ -8914,7 +8914,7 @@ export const pipeThrough: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Accumulation
+ * @category accumulation
  * @since 4.0.0
  */
 export const collect = <A, E, R>(self: Stream<A, E, R>): Stream<Array<A>, E, R> => fromEffect(runCollect(self))
@@ -8940,7 +8940,7 @@ export const collect = <A, E, R>(self: Stream<A, E, R>): Stream<Array<A>, E, R> 
  * await Effect.runPromise(program)
  * ```
  *
- * @category Accumulation
+ * @category accumulation
  * @since 2.0.0
  */
 export const accumulate = <A, E, R>(self: Stream<A, E, R>): Stream<Arr.NonEmptyArray<A>, E, R> =>
@@ -8969,7 +8969,7 @@ export const accumulate = <A, E, R>(self: Stream<A, E, R>): Stream<Arr.NonEmptyA
  * await Effect.runPromise(program)
  * ```
  *
- * @category Deduplication
+ * @category deduplication
  * @since 2.0.0
  */
 export const changes = <A, E, R>(self: Stream<A, E, R>): Stream<A, E, R> => changesWith(self, Equal.equals)
@@ -8994,7 +8994,7 @@ export const changes = <A, E, R>(self: Stream<A, E, R>): Stream<A, E, R> => chan
  * )
  * ```
  *
- * @category Deduplication
+ * @category deduplication
  * @since 2.0.0
  */
 export const changesWith: {
@@ -9050,7 +9050,7 @@ export const changesWith: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category Deduplication
+ * @category deduplication
  * @since 2.0.0
  */
 export const changesWithEffect: {
@@ -9526,7 +9526,7 @@ export const haltWhen: {
  * exits // => ["success"]
  * ```
  *
- * @category Finalization
+ * @category finalization
  * @since 4.0.0
  */
 export const onExit: {
@@ -9716,7 +9716,7 @@ export const onEnd: {
  * events // => ["cleanup"]
  * ```
  *
- * @category Finalization
+ * @category finalization
  * @since 2.0.0
  */
 export const ensuring: {
@@ -9754,7 +9754,7 @@ export const ensuring: {
  * await Effect.runPromise(Stream.runCollect(withEnv)) // => ["Hello, Ada"]
  * ```
  *
- * @category services
+ * @category providing services
  * @since 4.0.0
  */
 export const provide: {
@@ -9812,7 +9812,7 @@ export const provide: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const provideContext: {
@@ -9857,7 +9857,7 @@ export const provideContext: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const provideService: {
@@ -9909,7 +9909,7 @@ export const provideService: {
  * events // => ["loading"]
  * ```
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const provideServiceEffect: {
@@ -9966,7 +9966,7 @@ export const provideServiceEffect: {
  * )
  * ```
  *
- * @category services
+ * @category providing services
  * @since 4.0.0
  */
 export const updateContext: {
@@ -10006,7 +10006,7 @@ export const updateContext: {
  * await Effect.runPromise(Effect.provideService(program, Counter, { count: 0 }))
  * ```
  *
- * @category services
+ * @category providing services
  * @since 2.0.0
  */
 export const updateService: {

--- a/packages/effect/src/String.ts
+++ b/packages/effect/src/String.ts
@@ -387,7 +387,7 @@ export const slice = (start?: number, end?: number) => (self: string): string =>
  * String.isEmpty("a") // => false
  * ```
  *
- * @category predicates
+ * @category guards
  * @since 2.0.0
  */
 export const isEmpty = (self: string): self is "" => self.length === 0

--- a/packages/effect/src/String.ts
+++ b/packages/effect/src/String.ts
@@ -404,7 +404,7 @@ export const isEmpty = (self: string): self is "" => self.length === 0
  * String.isNonEmpty("a") // => true
  * ```
  *
- * @category guards
+ * @category predicates
  * @since 2.0.0
  */
 export const isNonEmpty = (self: string): boolean => self.length > 0
@@ -516,7 +516,7 @@ export const endsWith = (searchString: string, position?: number) => (self: stri
  * String.charCodeAt("abc", 4) // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const charCodeAt: {
@@ -557,7 +557,7 @@ export const substring = (start: number, end?: number) => (self: string): string
  * pipe("abc", String.at(4)) // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const at: {
@@ -577,7 +577,7 @@ export const at: {
  * pipe("abc", String.charAt(4)) // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const charAt: {
@@ -600,7 +600,7 @@ export const charAt: {
  * pipe("abc", String.codePointAt(10)) // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const codePointAt: {
@@ -659,7 +659,7 @@ export const lastIndexOf = (searchString: string) => (self: string): Option.Opti
  * pipe("a", String.localeCompare("a")) // => 0
  * ```
  *
- * @category comparing
+ * @category comparisons
  * @since 2.0.0
  */
 export const localeCompare =

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -170,7 +170,7 @@ export const get: {
  *
  * @see {@link get} – access a single key's value
  * @see {@link pick} – select a subset of keys into a new struct
- * @category Key utilities
+ * @category key utilities
  * @since 3.6.0
  */
 export const keys = <S extends object>(self: S): Array<(keyof S) & string> =>
@@ -372,7 +372,7 @@ type KeyEvolved<S, E> = Simplify<
  * @see {@link renameKeys} – rename keys with a static mapping
  * @see {@link evolve} – transform values instead of keys
  * @see {@link evolveEntries} – transform both keys and values
- * @category Key utilities
+ * @category key utilities
  * @since 4.0.0
  */
 export const evolveKeys: {
@@ -466,7 +466,7 @@ export const evolveEntries: {
  *
  * @see {@link evolveKeys} – rename keys using functions
  * @see {@link evolveEntries} – rename keys and transform values
- * @category Key utilities
+ * @category key utilities
  * @since 4.0.0
  */
 export const renameKeys: {

--- a/packages/effect/src/Struct.ts
+++ b/packages/effect/src/Struct.ts
@@ -170,7 +170,7 @@ export const get: {
  *
  * @see {@link get} – access a single key's value
  * @see {@link pick} – select a subset of keys into a new struct
- * @category key utilities
+ * @category getters
  * @since 3.6.0
  */
 export const keys = <S extends object>(self: S): Array<(keyof S) & string> =>
@@ -372,7 +372,7 @@ type KeyEvolved<S, E> = Simplify<
  * @see {@link renameKeys} – rename keys with a static mapping
  * @see {@link evolve} – transform values instead of keys
  * @see {@link evolveEntries} – transform both keys and values
- * @category key utilities
+ * @category transforming
  * @since 4.0.0
  */
 export const evolveKeys: {
@@ -466,7 +466,7 @@ export const evolveEntries: {
  *
  * @see {@link evolveKeys} – rename keys using functions
  * @see {@link evolveEntries} – rename keys and transform values
- * @category key utilities
+ * @category transforming
  * @since 4.0.0
  */
 export const renameKeys: {
@@ -581,7 +581,7 @@ export const makeOrder = order.Struct
  * @see {@link Apply} – apply a Lambda to a concrete type
  * @see {@link lambda} – create a runtime lambda value
  * @see {@link map} – use a lambda to transform all struct values
- * @category Lambda
+ * @category utility types
  * @since 4.0.0
  */
 export interface Lambda {
@@ -619,7 +619,7 @@ export interface Lambda {
  * ```
  *
  * @see {@link Lambda} – the base interface
- * @category Lambda
+ * @category utility types
  * @since 4.0.0
  */
 export type Apply<L extends Lambda, V> = (L & { readonly "~lambda.in": V })["~lambda.out"]
@@ -657,7 +657,7 @@ export type Apply<L extends Lambda, V> = (L & { readonly "~lambda.in": V })["~la
  *
  * @see {@link Lambda} – the type-level interface
  * @see {@link map} – apply a lambda to all struct values
- * @category Lambda
+ * @category constructors
  * @since 4.0.0
  */
 export const lambda = <L extends (a: any) => any>(

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -154,7 +154,7 @@ export const make = <A>(value: A): Effect.Effect<SubscriptionRef<A>> =>
  * await Effect.runPromise(program) // => [0, 1, 2]
  * ```
  *
- * @category changes
+ * @category subscriptions
  * @since 4.0.0
  */
 export const changes = <A>(self: SubscriptionRef<A>): Stream.Stream<A> => Stream.fromPubSub(self.pubsub)
@@ -460,7 +460,7 @@ export const getAndUpdateSomeEffect: {
  * await Effect.runPromise(program) // => ["Old value was 10", 20]
  * ```
  *
- * @category modifications
+ * @category mutations
  * @since 2.0.0
  */
 export const modify: {
@@ -500,7 +500,7 @@ export const modify: {
  * await Effect.runPromise(program) // => ["Doubled from 10", 20]
  * ```
  *
- * @category modifications
+ * @category mutations
  * @since 2.0.0
  */
 export const modifyEffect: {
@@ -556,7 +556,7 @@ export const modifyEffect: {
  * await Effect.runPromise(program) // => ["Updated", 20]
  * ```
  *
- * @category modifications
+ * @category mutations
  * @since 2.0.0
  */
 export const modifySome: {
@@ -616,7 +616,7 @@ export const modifySome: {
  * await Effect.runPromise(program) // => ["Updated", 15]
  * ```
  *
- * @category modifications
+ * @category mutations
  * @since 2.0.0
  */
 export const modifySomeEffect: {
@@ -659,7 +659,7 @@ export const modifySomeEffect: {
  * await Effect.runPromise(program) // => 42
  * ```
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const set: {
@@ -688,7 +688,7 @@ export const set: {
  * await Effect.runPromise(program) // => 42
  * ```
  *
- * @category setters
+ * @category mutations
  * @since 2.0.0
  */
 export const setAndGet: {
@@ -720,7 +720,7 @@ export const setAndGet: {
  * await Effect.runPromise(program) // => 20
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const update: {
@@ -752,7 +752,7 @@ export const update: {
  * await Effect.runPromise(program) // => 15
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateEffect: {
@@ -784,7 +784,7 @@ export const updateEffect: {
  * await Effect.runPromise(program) // => 20
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateAndGet: {
@@ -819,7 +819,7 @@ export const updateAndGet: {
  * await Effect.runPromise(program) // => 15
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateAndGetEffect: {
@@ -860,7 +860,7 @@ export const updateAndGetEffect: {
  * await Effect.runPromise(program) // => 20
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateSome: {
@@ -909,7 +909,7 @@ export const updateSome: {
  * await Effect.runPromise(program) // => 13
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateSomeEffect: {
@@ -962,7 +962,7 @@ export const updateSomeEffect: {
  * await Effect.runPromise(program) // => 20
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateSomeAndGet: {
@@ -1011,7 +1011,7 @@ export const updateSomeAndGet: {
  * await Effect.runPromise(program) // => 13
  * ```
  *
- * @category updating
+ * @category mutations
  * @since 2.0.0
  */
 export const updateSomeAndGetEffect: {

--- a/packages/effect/src/Terminal.ts
+++ b/packages/effect/src/Terminal.ts
@@ -25,7 +25,7 @@ const TypeId = "~effect/platform/Terminal"
  * A `Terminal` represents a command-line interface which can read input from a
  * user and display messages to a user.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Terminal {
@@ -118,7 +118,7 @@ const QuitErrorTypeId = "effect/platform/Terminal/QuitError"
  *
  * @see {@link isQuitError} for checking unknown errors when handling terminal cancellation
  *
- * @category QuitError
+ * @category errors
  * @since 4.0.0
  */
 export class QuitError extends Schema.ErrorClass<QuitError>("QuitError")({

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -533,7 +533,7 @@ export const externalSpan = (
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category references
+ * @category services
  * @since 3.12.0
  */
 export const DisablePropagation = Context.Reference<boolean>(
@@ -556,7 +556,7 @@ export const DisablePropagation = Context.Reference<boolean>(
  *
  * @see {@link MinimumTraceLevel} for the threshold that decides whether spans at that level are sampled
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const CurrentTraceLevel: Context.Reference<LogLevel> = Context.Reference<LogLevel>(
@@ -585,7 +585,7 @@ export const CurrentTraceLevel: Context.Reference<LogLevel> = Context.Reference<
  *
  * @see {@link CurrentTraceLevel} for the default span level used when options do not specify one
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MinimumTraceLevel = Context.Reference<
@@ -600,7 +600,7 @@ export const MinimumTraceLevel = Context.Reference<
  * Use when you need the raw context key for active tracer lookup in lower-level
  * tracing code.
  *
- * @category references
+ * @category constants
  * @since 4.0.0
  */
 export const TracerKey = "effect/Tracer"
@@ -625,7 +625,7 @@ export const TracerKey = "effect/Tracer"
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category references
+ * @category services
  * @since 2.0.0
  */
 export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(TracerKey, {

--- a/packages/effect/src/Tracer.ts
+++ b/packages/effect/src/Tracer.ts
@@ -22,7 +22,7 @@ import * as Option from "./Option.ts"
  * `span` to allocate a span from the supplied name, parent, annotations,
  * links, start time, kind, root flag, and sampling decision.
  *
- * @category models
+ * @category services
  * @since 2.0.0
  */
 export interface Tracer {
@@ -648,7 +648,7 @@ export const Tracer: Context.Reference<Tracer> = Context.Reference<Tracer>(Trace
  *
  * @see {@link Span} for the interface implemented by native spans
  *
- * @category native tracer
+ * @category models
  * @since 4.0.0
  */
 export class NativeSpan implements Span {

--- a/packages/effect/src/Trie.ts
+++ b/packages/effect/src/Trie.ts
@@ -438,7 +438,7 @@ export const size: <V>(self: Trie<V>) => number = TR.size
  * Trie.get(trie, "mea") // => Option.none()
  * ```
  *
- * @category elements
+ * @category getters
  * @since 2.0.0
  */
 export const get: {

--- a/packages/effect/src/Trie.ts
+++ b/packages/effect/src/Trie.ts
@@ -471,7 +471,7 @@ export const get: {
  * Trie.has(trie, "mea") // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -494,7 +494,7 @@ export const has: {
  * Trie.isEmpty(trie1) // => false
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty: <V>(self: Trie<V>) => boolean = TR.isEmpty

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -320,7 +320,7 @@ export const evolve: {
  * ```
  *
  * @see {@link evolve} – transform element values instead of positions
- * @category index utilities
+ * @category transforming
  * @since 4.0.0
  */
 export const renameIndices: {

--- a/packages/effect/src/Tuple.ts
+++ b/packages/effect/src/Tuple.ts
@@ -320,7 +320,7 @@ export const evolve: {
  * ```
  *
  * @see {@link evolve} – transform element values instead of positions
- * @category Index utilities
+ * @category index utilities
  * @since 4.0.0
  */
 export const renameIndices: {

--- a/packages/effect/src/TxChunk.ts
+++ b/packages/effect/src/TxChunk.ts
@@ -504,7 +504,7 @@ export const size = <A>(self: TxChunk<A>): Effect.Effect<number> =>
  * await Effect.runPromise(program) // => [true, false]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const isEmpty = <A>(self: TxChunk<A>): Effect.Effect<boolean> =>
@@ -532,7 +532,7 @@ export const isEmpty = <A>(self: TxChunk<A>): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const isNonEmpty = <A>(self: TxChunk<A>): Effect.Effect<boolean> =>

--- a/packages/effect/src/TxHashMap.ts
+++ b/packages/effect/src/TxHashMap.ts
@@ -456,7 +456,7 @@ export const set: {
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -626,7 +626,7 @@ export const size = <K, V>(self: TxHashMap<K, V>): Effect.Effect<number> =>
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty = <K, V>(self: TxHashMap<K, V>): Effect.Effect<boolean> =>
@@ -656,7 +656,7 @@ export const isEmpty = <K, V>(self: TxHashMap<K, V>): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => false
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const isNonEmpty = <K, V>(self: TxHashMap<K, V>): Effect.Effect<boolean> =>
@@ -1305,7 +1305,7 @@ export const getHash: {
  * await Effect.runPromise(program) // => ["Role admin: true", "Role user: true", "Role moderator: false"]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const hasHash: {
@@ -1653,7 +1653,7 @@ export const filterMap: {
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const hasBy: {
@@ -1763,7 +1763,7 @@ export const findFirst: {
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const some: {
@@ -1819,7 +1819,7 @@ export const some: {
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const every: {

--- a/packages/effect/src/TxHashMap.ts
+++ b/packages/effect/src/TxHashMap.ts
@@ -2053,7 +2053,7 @@ export const compact = <K, A>(
  * await Effect.runPromise(program) // => { language: "en-US", theme: "dark", timezone: "UTC" }
  * ```
  *
- * @category combinators
+ * @category getters
  * @since 4.0.0
  */
 export const toEntries = <K, V>(
@@ -2094,7 +2094,7 @@ export const toEntries = <K, V>(
  * await Effect.runPromise(program) // => 1
  * ```
  *
- * @category combinators
+ * @category getters
  * @since 4.0.0
  */
 export const toValues = <K, V>(self: TxHashMap<K, V>): Effect.Effect<Array<V>> => values(self)

--- a/packages/effect/src/TxHashSet.ts
+++ b/packages/effect/src/TxHashSet.ts
@@ -427,7 +427,7 @@ export const remove: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 2.0.0
  */
 export const has: {
@@ -492,7 +492,7 @@ export const size = <V>(self: TxHashSet<V>): Effect.Effect<number> =>
  * await Effect.runPromise(program)
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty = <V>(self: TxHashSet<V>): Effect.Effect<boolean> =>
@@ -678,7 +678,7 @@ export const difference: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 4.0.0
  */
 export const isSubset: {
@@ -715,7 +715,7 @@ export const isSubset: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 4.0.0
  */
 export const some: {
@@ -751,7 +751,7 @@ export const some: {
  * await Effect.runPromise(program)
  * ```
  *
- * @category elements
+ * @category predicates
  * @since 4.0.0
  */
 export const every: {

--- a/packages/effect/src/TxPriorityQueue.ts
+++ b/packages/effect/src/TxPriorityQueue.ts
@@ -217,7 +217,7 @@ export const size = <A>(self: TxPriorityQueue<A>): Effect.Effect<number> => Effe
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty = <A>(self: TxPriorityQueue<A>): Effect.Effect<boolean> => Effect.map(size(self), (n) => n === 0)
@@ -238,7 +238,7 @@ export const isEmpty = <A>(self: TxPriorityQueue<A>): Effect.Effect<boolean> => 
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isNonEmpty = <A>(self: TxPriorityQueue<A>): Effect.Effect<boolean> => Effect.map(size(self), (n) => n > 0)

--- a/packages/effect/src/TxPubSub.ts
+++ b/packages/effect/src/TxPubSub.ts
@@ -317,7 +317,7 @@ export const size = <A>(self: TxPubSub<A>): Effect.Effect<number> =>
  * await Effect.runPromise(program) // => true
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty = <A>(self: TxPubSub<A>): Effect.Effect<boolean> => Effect.map(size(self), (s) => s === 0)
@@ -338,7 +338,7 @@ export const isEmpty = <A>(self: TxPubSub<A>): Effect.Effect<boolean> => Effect.
  * await Effect.runPromise(program) // => false
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isFull = <A>(self: TxPubSub<A>): Effect.Effect<boolean> =>
@@ -369,7 +369,7 @@ export const isFull = <A>(self: TxPubSub<A>): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category getters
+ * @category predicates
  * @since 2.0.0
  */
 export const isShutdown = <A>(self: TxPubSub<A>): Effect.Effect<boolean> => TxRef.get(self.shutdownRef)

--- a/packages/effect/src/TxQueue.ts
+++ b/packages/effect/src/TxQueue.ts
@@ -1073,7 +1073,7 @@ export const size = (self: TxQueueState): Effect.Effect<number> => TxChunk.size(
  * await Effect.runPromise(program) // => [true, false]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 2.0.0
  */
 export const isEmpty = (self: TxQueueState): Effect.Effect<boolean> => TxChunk.isEmpty(self.items)
@@ -1099,7 +1099,7 @@ export const isEmpty = (self: TxQueueState): Effect.Effect<boolean> => TxChunk.i
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 2.0.0
  */
 export const isFull = (self: TxQueueState): Effect.Effect<boolean> =>
@@ -1373,7 +1373,7 @@ export const shutdown = <A, E>(self: TxEnqueue<A, E>): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => [true, false]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const isOpen = (self: TxQueueState): Effect.Effect<boolean> =>
@@ -1401,7 +1401,7 @@ export const isOpen = (self: TxQueueState): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const isClosing = (self: TxQueueState): Effect.Effect<boolean> =>
@@ -1428,7 +1428,7 @@ export const isClosing = (self: TxQueueState): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 4.0.0
  */
 export const isDone = (self: TxQueueState): Effect.Effect<boolean> =>
@@ -1455,7 +1455,7 @@ export const isDone = (self: TxQueueState): Effect.Effect<boolean> =>
  * await Effect.runPromise(program) // => [false, true]
  * ```
  *
- * @category combinators
+ * @category predicates
  * @since 2.0.0
  */
 export const isShutdown = (self: TxQueueState): Effect.Effect<boolean> => isDone(self)

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -116,7 +116,7 @@ export type TupleOfAtLeast<N extends number, T> = [...TupleOf<N, T>, ...Array<T>
  * @see {@link ExtractTag}
  * @see {@link ExcludeTag}
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type Tags<E> = E extends { readonly _tag: string } ? E["_tag"] : never
@@ -152,7 +152,7 @@ export type Tags<E> = E extends { readonly _tag: string } ? E["_tag"] : never
  * @see {@link ExtractTag}
  * @see {@link Tags}
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type ExcludeTag<E, K extends string> = Exclude<E, { readonly _tag: K }>
@@ -187,7 +187,7 @@ export type ExcludeTag<E, K extends string> = Exclude<E, { readonly _tag: K }>
  * @see {@link ExcludeTag}
  * @see {@link Tags}
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type ExtractTag<E, K extends string> = E extends { readonly _tag: infer T } ? K extends T ? E : never : never
@@ -221,7 +221,7 @@ export type ExtractTag<E, K extends string> = E extends { readonly _tag: infer T
  *
  * @see {@link IsUnion}
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R
@@ -254,7 +254,7 @@ export type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) ext
  * @see {@link MergeLeft}
  * @see {@link MergeRight}
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type Simplify<A> = {
@@ -286,7 +286,7 @@ export type Simplify<A> = {
  *
  * @see {@link EqualsWith}
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
@@ -316,7 +316,7 @@ export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
  *
  * @see {@link Equals}
  *
- * @category models
+ * @category utility types
  * @since 3.15.0
  */
 export type EqualsWith<A, B, Y, N> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Y : N
@@ -343,7 +343,7 @@ export type EqualsWith<A, B, Y, N> = (<T>() => T extends A ? 1 : 2) extends (<T>
  * type No = Types.Has<{ a: number }, "b" | "c"> // false
  * ```
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Has<A, Key extends string> = (Key extends infer K ? K extends keyof A ? true : never : never) extends never
@@ -379,7 +379,7 @@ export type Has<A, Key extends string> = (Key extends infer K ? K extends keyof 
  * @see {@link MergeRight}
  * @see {@link Simplify}
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type MergeLeft<Source, Target> = MergeRight<Target, Source>
@@ -413,7 +413,7 @@ export type MergeLeft<Source, Target> = MergeRight<Target, Source>
  * @see {@link MergeLeft}
  * @see {@link Simplify}
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type MergeRight<Target, Source> = Simplify<
@@ -487,7 +487,7 @@ export type Concurrency = number | "unbounded"
  *
  * @see {@link DeepMutable}
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type Mutable<T> = {
@@ -524,7 +524,7 @@ export type Mutable<T> = {
  *
  * @see {@link Mutable}
  *
- * @category types
+ * @category utility types
  * @since 3.1.0
  */
 export type DeepMutable<T> = T extends ReadonlyMap<infer K, infer V> ? Map<DeepMutable<K>, DeepMutable<V>>
@@ -558,7 +558,7 @@ export type DeepMutable<T> = T extends ReadonlyMap<infer K, infer V> ? Map<DeepM
  * const result = withDefault<"a" | "b">("a", "b")
  * ```
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type NoInfer<A> = [A][A extends any ? 0 : never]
@@ -594,7 +594,7 @@ export type NoInfer<A> = [A][A extends any ? 0 : never]
  * @see {@link Covariant}
  * @see {@link Contravariant}
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Invariant<A> = (_: A) => A
@@ -629,7 +629,7 @@ export declare namespace Invariant {
    *
    * @see {@link Invariant}
    *
-   * @category models
+   * @category utility types
    * @since 3.9.0
    */
   export type Type<A> = A extends Invariant<infer U> ? U : never
@@ -666,7 +666,7 @@ export declare namespace Invariant {
  * @see {@link Contravariant}
  * @see {@link Invariant}
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Covariant<A> = (_: never) => A
@@ -701,7 +701,7 @@ export declare namespace Covariant {
    *
    * @see {@link Covariant}
    *
-   * @category models
+   * @category utility types
    * @since 3.9.0
    */
   export type Type<A> = A extends Covariant<infer U> ? U : never
@@ -741,7 +741,7 @@ export declare namespace Covariant {
  * @see {@link Covariant}
  * @see {@link Invariant}
  *
- * @category models
+ * @category utility types
  * @since 2.0.0
  */
 export type Contravariant<A> = (_: A) => void
@@ -776,7 +776,7 @@ export declare namespace Contravariant {
    *
    * @see {@link Contravariant}
    *
-   * @category models
+   * @category utility types
    * @since 3.9.0
    */
   export type Type<A> = A extends Contravariant<infer U> ? U : never
@@ -790,7 +790,7 @@ export declare namespace Contravariant {
  *
  * Use to erase an empty object type from an API result or parameter position.
  *
- * @category types
+ * @category utility types
  * @since 3.19.20
  */
 export type VoidIfEmpty<S> = keyof S extends never ? void : S
@@ -817,7 +817,7 @@ export type VoidIfEmpty<S> = keyof S extends never ? void : S
  * const witness: Result = "value"
  * ```
  *
- * @category types
+ * @category utility types
  * @since 2.0.0
  */
 export type NotFunction<T> = T extends Function ? never : T
@@ -847,7 +847,7 @@ export type NotFunction<T> = T extends Function ? never : T
  * const accepted: Types.NoExcessProperties<Expected, Expected> = { a: 1, b: "value" }
  * ```
  *
- * @category types
+ * @category utility types
  * @since 3.9.0
  */
 export type NoExcessProperties<T, U> = T & Readonly<Record<Exclude<keyof U, keyof T>, never>>
@@ -867,7 +867,7 @@ export type NoExcessProperties<T, U> = T & Readonly<Record<Exclude<keyof U, keyo
  *
  * @see {@link unhandled}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export interface unassigned {
@@ -889,7 +889,7 @@ export interface unassigned {
  *
  * @see {@link unassigned}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export interface unhandled {
@@ -921,7 +921,7 @@ export interface unhandled {
  *
  * @see {@link UnionToIntersection}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
@@ -957,7 +957,7 @@ export type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
  * @see {@link ExtractReason}
  * @see {@link ExcludeReason}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type ReasonOf<E> = E extends { readonly reason: infer R } ? R : never
@@ -993,7 +993,7 @@ export type ReasonOf<E> = E extends { readonly reason: infer R } ? R : never
  * @see {@link ReasonOf}
  * @see {@link ExtractReason}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type ReasonTags<E> = E extends { readonly reason: { readonly _tag: string } } ? E["reason"]["_tag"]
@@ -1031,7 +1031,7 @@ export type ReasonTags<E> = E extends { readonly reason: { readonly _tag: string
  * @see {@link ReasonOf}
  * @see {@link ReasonTags}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type ExtractReason<E, K extends string> = E extends { readonly reason: infer R }
@@ -1074,7 +1074,7 @@ export type ExtractReason<E, K extends string> = E extends { readonly reason: in
  * @see {@link ReasonOf}
  * @see {@link ReasonTags}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type NarrowReason<E, K extends string> = E extends { readonly reason: infer R }
@@ -1118,7 +1118,7 @@ export type NarrowReason<E, K extends string> = E extends { readonly reason: inf
  * @see {@link ReasonOf}
  * @see {@link ReasonTags}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type OmitReason<E, K extends string> = E extends { readonly reason: infer R }
@@ -1158,7 +1158,7 @@ export type OmitReason<E, K extends string> = E extends { readonly reason: infer
  * @see {@link ReasonOf}
  * @see {@link ReasonTags}
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeReason<E, K extends string> = E extends { readonly reason: infer R }
@@ -1172,7 +1172,7 @@ export type ExcludeReason<E, K extends string> = E extends { readonly reason: in
  *
  * Use to derive the keys whose properties must be present on an object type.
  *
- * @category types
+ * @category utility types
  * @since 4.0.0
  */
 export type RequiredKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? never : K }[keyof T]

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -10,7 +10,7 @@
  */
 
 /**
- * @category tuples
+ * @category utility types
  * @since 2.0.0
  */
 type TupleOf_<T, N extends number, R extends Array<unknown>> = `${N}` extends `-${number}` ? never
@@ -48,7 +48,7 @@ type TupleOf_<T, N extends number, R extends Array<unknown>> = `${N}` extends `-
  *
  * @see {@link TupleOfAtLeast}
  *
- * @category tuples
+ * @category utility types
  * @since 3.3.0
  */
 export type TupleOf<N extends number, T> = N extends N ? number extends N ? Array<T> : TupleOf_<T, N, []> : never
@@ -81,7 +81,7 @@ export type TupleOf<N extends number, T> = N extends N ? number extends N ? Arra
  *
  * @see {@link TupleOf}
  *
- * @category tuples
+ * @category utility types
  * @since 3.3.0
  */
 export type TupleOfAtLeast<N extends number, T> = [...TupleOf<N, T>, ...Array<T>]

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -1313,7 +1313,7 @@ export class InvalidUserInputError extends Schema.ErrorClass<InvalidUserInputErr
  * `isRetryable` getter. Provider-facing reasons may also include retry timing,
  * provider metadata, usage information, or HTTP context.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export type AiErrorReason =

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -73,7 +73,7 @@ const redactHeaders = (headers: Record<string, string>): Record<string, string> 
  * const result = [error.reason, error.isRetryable] // => ["TransportError", true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class NetworkError extends Schema.ErrorClass<NetworkError>(
@@ -366,7 +366,7 @@ export const HttpContext = Schema.Struct({
  * const result = [rateLimitError._tag, rateLimitError.isRetryable] // => ["RateLimitError", true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class RateLimitError extends Schema.ErrorClass<RateLimitError>(
@@ -417,7 +417,7 @@ export class RateLimitError extends Schema.ErrorClass<RateLimitError>(
  * const result = [quotaError._tag, quotaError.isRetryable] // => ["QuotaExhaustedError", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class QuotaExhaustedError extends Schema.ErrorClass<QuotaExhaustedError>(
@@ -470,7 +470,7 @@ export class QuotaExhaustedError extends Schema.ErrorClass<QuotaExhaustedError>(
  * const result = [authError.kind, authError.isRetryable] // => ["InvalidKey", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class AuthenticationError extends Schema.ErrorClass<AuthenticationError>(
@@ -528,7 +528,7 @@ export class AuthenticationError extends Schema.ErrorClass<AuthenticationError>(
  * const result = [policyError.description, policyError.isRetryable] // => ["Input contains prohibited content", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class ContentPolicyError extends Schema.ErrorClass<ContentPolicyError>(
@@ -581,7 +581,7 @@ export class ContentPolicyError extends Schema.ErrorClass<ContentPolicyError>(
  * const result = [invalidRequestError.parameter, invalidRequestError.isRetryable] // => ["temperature", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class InvalidRequestError extends Schema.ErrorClass<InvalidRequestError>(
@@ -638,7 +638,7 @@ export class InvalidRequestError extends Schema.ErrorClass<InvalidRequestError>(
  * const result = [providerError.description, providerError.isRetryable] // => ["Server encountered an unexpected error", true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class InternalProviderError extends Schema.ErrorClass<InternalProviderError>(
@@ -689,7 +689,7 @@ export class InternalProviderError extends Schema.ErrorClass<InternalProviderErr
  * const result = [parseError.description, parseError.isRetryable] // => ["Expected a string but received a number", true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
@@ -766,7 +766,7 @@ export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
  * const result = [error.description, error.responseText, error.isRetryable] // => ["Expected a valid JSON object", '{"foo":}', true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputError>(
@@ -845,7 +845,7 @@ export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputErr
  * const result = [error.description, error.isRetryable] // => ["Unions are not supported in Anthropic structured output", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class UnsupportedSchemaError extends Schema.ErrorClass<UnsupportedSchemaError>(
@@ -895,7 +895,7 @@ export class UnsupportedSchemaError extends Schema.ErrorClass<UnsupportedSchemaE
  * const result = [unknownError.description, unknownError.isRetryable] // => ["An unexpected error occurred", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class UnknownError extends Schema.ErrorClass<UnknownError>(
@@ -952,7 +952,7 @@ export class UnknownError extends Schema.ErrorClass<UnknownError>(
  * const result = [error.toolName, error.availableTools, error.isRetryable] // => ["unknownTool", ["GetWeather", "GetTime"], true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class ToolNotFoundError extends Schema.ErrorClass<ToolNotFoundError>(
@@ -1006,7 +1006,7 @@ export class ToolNotFoundError extends Schema.ErrorClass<ToolNotFoundError>(
  * const result = [error.toolName, error.description, error.isRetryable] // => ["GetWeather", "Expected string, got number", true]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class ToolParameterValidationError extends Schema.ErrorClass<ToolParameterValidationError>(
@@ -1060,7 +1060,7 @@ export class ToolParameterValidationError extends Schema.ErrorClass<ToolParamete
  * const result = [error.toolName, error.isRetryable] // => ["GetWeather", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class InvalidToolResultError extends Schema.ErrorClass<InvalidToolResultError>(
@@ -1113,7 +1113,7 @@ export class InvalidToolResultError extends Schema.ErrorClass<InvalidToolResultE
  * const result = [error.toolName, error.description, error.isRetryable] // => ["GetWeather", "Cannot encode bigint values as JSON", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class ToolResultEncodingError extends Schema.ErrorClass<ToolResultEncodingError>(
@@ -1166,7 +1166,7 @@ export class ToolResultEncodingError extends Schema.ErrorClass<ToolResultEncodin
  * const result = [error.toolName, error.description, error.isRetryable] // => ["OpenAiCodeInterpreter", "Invalid container ID format", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class ToolConfigurationError extends Schema.ErrorClass<ToolConfigurationError>(
@@ -1217,7 +1217,7 @@ export class ToolConfigurationError extends Schema.ErrorClass<ToolConfigurationE
  * const result = [error.pendingApprovals, error.isRetryable] // => [["GetWeather", "SendEmail"], false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class ToolkitRequiredError extends Schema.ErrorClass<ToolkitRequiredError>(
@@ -1270,7 +1270,7 @@ export class ToolkitRequiredError extends Schema.ErrorClass<ToolkitRequiredError
  * const result = [error._tag, error.isRetryable] // => ["InvalidUserInputError", false]
  * ```
  *
- * @category reason
+ * @category errors
  * @since 4.0.0
  */
 export class InvalidUserInputError extends Schema.ErrorClass<InvalidUserInputError>(

--- a/packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts
+++ b/packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts
@@ -48,7 +48,7 @@ import * as OpenAiStructuredOutput from "./OpenAiStructuredOutput.ts"
  * @see {@link LanguageModel.CodecTransformer} for the structured-output transformer contract
  * @see {@link OpenAiStructuredOutput.toCodecOpenAI} for the OpenAI-specific transformer
  *
- * @category Codec Transformation
+ * @category transforming
  * @since 4.0.0
  */
 export function toCodecAnthropic<T, E, RD, RE>(

--- a/packages/effect/src/unstable/ai/Chat.ts
+++ b/packages/effect/src/unstable/ai/Chat.ts
@@ -958,7 +958,7 @@ export const makePersisted = Effect.fnUntraced(function*(options: {
  *
  * @see {@link makePersisted} for the effect constructor when building the service directly instead of providing it as a layer
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layerPersisted = (options: {

--- a/packages/effect/src/unstable/ai/IdGenerator.ts
+++ b/packages/effect/src/unstable/ai/IdGenerator.ts
@@ -297,7 +297,7 @@ export const make = Effect.fnUntraced(function*({
  * const result = [toolCallId.startsWith("tool_call_"), toolCallId.length] // => [true, 22]
  * ```
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = (options: MakeOptions): Layer.Layer<IdGenerator, Cause.IllegalArgumentError> =>

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1728,7 +1728,7 @@ export const generateText: {
  * await Effect.runPromise(program) // => { title: "Tech Conference", date: "March 15th", location: "San Francisco" }
  * ```
  *
- * @category object generation
+ * @category generators
  * @since 4.0.0
  */
 export const generateObject = <

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -205,7 +205,7 @@ export interface Service {
  * express every constraint; the returned codec remains authoritative for
  * validating model output.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type CodecTransformer = <T, E, RD, RE>(schema: Schema.ConstraintCodec<T, E, RD, RE>) => {

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -663,7 +663,7 @@ export const McpError = Schema.Union([
  *
  * The receiver should respond promptly; otherwise the sender may disconnect.
  *
- * @category ping
+ * @category protocols
  * @since 4.0.0
  */
 export class Ping extends Rpc.make("ping", {
@@ -679,7 +679,7 @@ export class Ping extends Rpc.make("ping", {
 /**
  * Schema for the server's response to an initialize request from the client.
  *
- * @category initialization
+ * @category schemas
  * @since 4.0.0
  */
 export class InitializeResult extends Schema.Opaque<InitializeResult>()(Schema.Struct({
@@ -706,7 +706,7 @@ export class InitializeResult extends Schema.Opaque<InitializeResult>()(Schema.S
  * Sent from the client to the server when it first connects, asking it to begin
  * initialization.
  *
- * @category initialization
+ * @category protocols
  * @since 4.0.0
  */
 export class Initialize extends Rpc.make("initialize", {
@@ -735,7 +735,7 @@ export class Initialize extends Rpc.make("initialize", {
 /**
  * Sent from the client to the server after initialization has finished.
  *
- * @category initialization
+ * @category protocols
  * @since 4.0.0
  */
 export class InitializedNotification extends Rpc.make("notifications/initialized", {
@@ -755,7 +755,7 @@ export class InitializedNotification extends Rpc.make("notifications/initialized
  * The payload identifies the request to cancel and may include a
  * human-readable reason.
  *
- * @category cancellation
+ * @category protocols
  * @since 4.0.0
  */
 export class CancelledNotification extends Rpc.make("notifications/cancelled", {
@@ -783,7 +783,7 @@ export class CancelledNotification extends Rpc.make("notifications/cancelled", {
 /**
  * Sent from either peer to report progress for a long-running request.
  *
- * @category progress
+ * @category protocols
  * @since 4.0.0
  */
 export class ProgressNotification extends Rpc.make("notifications/progress", {
@@ -817,7 +817,7 @@ export class ProgressNotification extends Rpc.make("notifications/progress", {
 /**
  * Schema for a known resource that the server is capable of reading.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class Resource extends Schema.Class<Resource>(
@@ -869,7 +869,7 @@ export class Resource extends Schema.Class<Resource>(
 /**
  * Schema for a template description of resources available on the server.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class ResourceTemplate extends Schema.Class<ResourceTemplate>(
@@ -915,7 +915,7 @@ export class ResourceTemplate extends Schema.Class<ResourceTemplate>(
 /**
  * Schema for the contents of a specific resource or sub-resource.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class ResourceContents extends Schema.Opaque<ResourceContents>()(Schema.Struct({
@@ -936,7 +936,7 @@ export class ResourceContents extends Schema.Opaque<ResourceContents>()(Schema.S
 /**
  * Schema for text resource contents represented as a string.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class TextResourceContents extends Schema.Opaque<TextResourceContents>()(Schema.Struct({
@@ -951,7 +951,7 @@ export class TextResourceContents extends Schema.Opaque<TextResourceContents>()(
 /**
  * Schema for binary resource contents represented as a `Uint8Array`.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class BlobResourceContents extends Schema.Opaque<BlobResourceContents>()(Schema.Struct({
@@ -965,7 +965,7 @@ export class BlobResourceContents extends Schema.Opaque<BlobResourceContents>()(
 /**
  * Schema for the server's response to a resources/list request from the client.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class ListResourcesResult extends Schema.Class<ListResourcesResult>(
@@ -978,7 +978,7 @@ export class ListResourcesResult extends Schema.Class<ListResourcesResult>(
 /**
  * Sent from the client to request a list of resources the server has.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class ListResources extends Rpc.make("resources/list", {
@@ -991,7 +991,7 @@ export class ListResources extends Rpc.make("resources/list", {
  * Schema for the server's response to a resources/templates/list request from
  * the client.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class ListResourceTemplatesResult extends Schema.Class<ListResourceTemplatesResult>(
@@ -1004,7 +1004,7 @@ export class ListResourceTemplatesResult extends Schema.Class<ListResourceTempla
 /**
  * Sent from the client to request a list of resource templates the server has.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class ListResourceTemplates extends Rpc.make("resources/templates/list", {
@@ -1016,7 +1016,7 @@ export class ListResourceTemplates extends Rpc.make("resources/templates/list", 
 /**
  * Schema for the server's response to a resources/read request from the client.
  *
- * @category resources
+ * @category schemas
  * @since 4.0.0
  */
 export class ReadResourceResult extends Schema.Opaque<ReadResourceResult>()(Schema.Struct({
@@ -1027,7 +1027,7 @@ export class ReadResourceResult extends Schema.Opaque<ReadResourceResult>()(Sche
 /**
  * Sent from the client to the server, to read a specific resource URI.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class ReadResource extends Rpc.make("resources/read", {
@@ -1054,7 +1054,7 @@ export class ReadResource extends Rpc.make("resources/read", {
  *
  * Servers may send this notification without a previous client subscription.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class ResourceListChangedNotification extends Rpc.make("notifications/resources/list_changed", {
@@ -1065,7 +1065,7 @@ export class ResourceListChangedNotification extends Rpc.make("notifications/res
  * Sent from the client to request resources/updated notifications from the
  * server whenever a particular resource changes.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class Subscribe extends Rpc.make("resources/subscribe", {
@@ -1086,7 +1086,7 @@ export class Subscribe extends Rpc.make("resources/subscribe", {
  * notifications from the server. This should follow a previous
  * resources/subscribe request.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class Unsubscribe extends Rpc.make("resources/unsubscribe", {
@@ -1110,7 +1110,7 @@ export class Unsubscribe extends Rpc.make("resources/unsubscribe", {
  * The URI may identify a sub-resource of the resource that the client
  * originally subscribed to.
  *
- * @category resources
+ * @category protocols
  * @since 4.0.0
  */
 export class ResourceUpdatedNotification extends Rpc.make("notifications/resources/updated", {
@@ -1406,7 +1406,7 @@ export class PromptListChangedNotification extends Rpc.make("notifications/promp
  * Clients should never make tool use decisions based on ToolAnnotations
  * received from untrusted servers.
  *
- * @category tools
+ * @category schemas
  * @since 4.0.0
  */
 export class ToolAnnotations extends Schema.Opaque<ToolAnnotations>()(Schema.Struct({
@@ -1452,7 +1452,7 @@ export class ToolAnnotations extends Schema.Opaque<ToolAnnotations>()(Schema.Str
 /**
  * Schema for the definition of a tool the client can call.
  *
- * @category tools
+ * @category schemas
  * @since 4.0.0
  */
 export class Tool extends Schema.Class<Tool>(
@@ -1493,7 +1493,7 @@ export class Tool extends Schema.Class<Tool>(
 /**
  * Schema for the server's response to a tools/list request from the client.
  *
- * @category tools
+ * @category schemas
  * @since 4.0.0
  */
 export class ListToolsResult extends Schema.Class<ListToolsResult>(
@@ -1506,7 +1506,7 @@ export class ListToolsResult extends Schema.Class<ListToolsResult>(
 /**
  * Sent from the client to request a list of tools the server has.
  *
- * @category tools
+ * @category protocols
  * @since 4.0.0
  */
 export class ListTools extends Rpc.make("tools/list", {
@@ -1527,7 +1527,7 @@ export class ListTools extends Rpc.make("tools/list", {
  * indicating that the server does not support tool calls, or any other
  * exceptional conditions, should be reported as an MCP error response.
  *
- * @category tools
+ * @category schemas
  * @since 4.0.0
  */
 export class CallToolResult extends Schema.Class<CallToolResult>("@effect/ai/McpSchema/CallToolResult")({
@@ -1553,7 +1553,7 @@ export class CallToolResult extends Schema.Class<CallToolResult>("@effect/ai/Mcp
  * @see {@link ListTools} for discovering available tools before calling one
  * @see {@link CallToolResult} for the successful tool-call result shape
  *
- * @category tools
+ * @category protocols
  * @since 4.0.0
  */
 export class CallTool extends Rpc.make("tools/call", {
@@ -1580,7 +1580,7 @@ export class CallTool extends Rpc.make("tools/call", {
  *
  * Servers may send this notification without a previous client subscription.
  *
- * @category tools
+ * @category protocols
  * @since 4.0.0
  */
 export class ToolListChangedNotification extends Rpc.make("notifications/tools/list_changed", {
@@ -1686,7 +1686,7 @@ export class LoggingMessageNotification extends Rpc.make("notifications/message"
 /**
  * Describes a message issued to or received from an LLM API.
  *
- * @category sampling
+ * @category schemas
  * @since 4.0.0
  */
 export class SamplingMessage extends Schema.Opaque<SamplingMessage>()(Schema.Struct({
@@ -1702,7 +1702,7 @@ export class SamplingMessage extends Schema.Opaque<SamplingMessage>()(Schema.Str
  * Keys not declared here are currently left unspecified by the spec and are up
  * to the client to interpret.
  *
- * @category sampling
+ * @category schemas
  * @since 4.0.0
  */
 export class ModelHint extends Schema.Opaque<ModelHint>()(Schema.Struct({
@@ -1739,7 +1739,7 @@ export class ModelHint extends Schema.Opaque<ModelHint>()(Schema.Struct({
  * up to the client to decide how to interpret these preferences and how to
  * balance them against other considerations.
  *
- * @category sampling
+ * @category schemas
  * @since 4.0.0
  */
 export class ModelPreferences extends Schema.Class<ModelPreferences>(
@@ -1787,7 +1787,7 @@ export class ModelPreferences extends Schema.Class<ModelPreferences>(
  * The client should let the user inspect the sampled message before returning
  * it to the server.
  *
- * @category sampling
+ * @category schemas
  * @since 4.0.0
  */
 export class CreateMessageResult extends Schema.Class<CreateMessageResult>(
@@ -1817,7 +1817,7 @@ export class CreateMessageResult extends Schema.Class<CreateMessageResult>(
  * The client chooses the model and should ask the user to approve the sampling
  * request before it begins.
  *
- * @category sampling
+ * @category protocols
  * @since 4.0.0
  */
 export class CreateMessage extends Rpc.make("sampling/createMessage", {
@@ -1862,7 +1862,7 @@ export class CreateMessage extends Rpc.make("sampling/createMessage", {
 /**
  * Schema for a reference to a resource or resource template definition.
  *
- * @category autocomplete
+ * @category schemas
  * @since 4.0.0
  */
 export class ResourceReference extends Schema.Opaque<ResourceReference>()(Schema.Struct({
@@ -1876,7 +1876,7 @@ export class ResourceReference extends Schema.Opaque<ResourceReference>()(Schema
 /**
  * Schema for a prompt reference used in autocomplete requests.
  *
- * @category autocomplete
+ * @category schemas
  * @since 4.0.0
  */
 export class PromptReference extends Schema.Opaque<PromptReference>()(Schema.Struct({
@@ -1891,7 +1891,7 @@ export class PromptReference extends Schema.Opaque<PromptReference>()(Schema.Str
 /**
  * Schema for the server's response to a completion/complete request.
  *
- * @category autocomplete
+ * @category schemas
  * @since 4.0.0
  */
 export class CompleteResult extends Schema.Opaque<CompleteResult>()(Schema.Struct({
@@ -1929,7 +1929,7 @@ export class CompleteResult extends Schema.Opaque<CompleteResult>()(Schema.Struc
 /**
  * Sent from the client to the server to ask for completion options.
  *
- * @category autocomplete
+ * @category protocols
  * @since 4.0.0
  */
 export class Complete extends Rpc.make("completion/complete", {
@@ -1975,7 +1975,7 @@ export class Complete extends Rpc.make("completion/complete", {
 /**
  * Represents a root directory or file that the server can operate on.
  *
- * @category roots
+ * @category schemas
  * @since 4.0.0
  */
 export class Root extends Schema.Class<Root>(
@@ -2002,7 +2002,7 @@ export class Root extends Schema.Class<Root>(
  *
  * Use to return the directories or files that an MCP server may operate on.
  *
- * @category roots
+ * @category schemas
  * @since 4.0.0
  */
 export class ListRootsResult extends Schema.Class<ListRootsResult>(
@@ -2023,7 +2023,7 @@ export class ListRootsResult extends Schema.Class<ListRootsResult>(
  * system structure or access specific locations that the client has permission
  * to read from.
  *
- * @category roots
+ * @category protocols
  * @since 4.0.0
  */
 export class ListRoots extends Rpc.make("roots/list", {
@@ -2043,7 +2043,7 @@ export class ListRoots extends Rpc.make("roots/list", {
  *
  * Send this when the client adds, removes, or modifies a root.
  *
- * @category roots
+ * @category protocols
  * @since 4.0.0
  */
 export class RootsListChangedNotification extends Rpc.make("notifications/roots/list_changed", {
@@ -2057,7 +2057,7 @@ export class RootsListChangedNotification extends Rpc.make("notifications/roots/
 /**
  * Schema for an accepted client response to an elicitation request.
  *
- * @category elicitation
+ * @category schemas
  * @since 4.0.0
  */
 export class ElicitAcceptResult extends Schema.Class<ElicitAcceptResult>(
@@ -2081,7 +2081,7 @@ export class ElicitAcceptResult extends Schema.Class<ElicitAcceptResult>(
 /**
  * Schema for a declined or canceled client response to an elicitation request.
  *
- * @category elicitation
+ * @category schemas
  * @since 4.0.0
  */
 export class ElicitDeclineResult extends Schema.Class<ElicitDeclineResult>(
@@ -2100,7 +2100,7 @@ export class ElicitDeclineResult extends Schema.Class<ElicitDeclineResult>(
 /**
  * Schema for every client response to an elicitation request.
  *
- * @category elicitation
+ * @category schemas
  * @since 4.0.0
  */
 export const ElicitResult = Schema.Union([
@@ -2117,7 +2117,7 @@ export const ElicitResult = Schema.Union([
  * The client responds with accepted content, an explicit decline, or a
  * cancellation.
  *
- * @category elicitation
+ * @category protocols
  * @since 4.0.0
  */
 export class Elicit extends Rpc.make("elicitation/create", {
@@ -2146,7 +2146,7 @@ export class Elicit extends Rpc.make("elicitation/create", {
  * The error stores the original elicitation request and, when available, the
  * underlying cause.
  *
- * @category elicitation
+ * @category schemas
  * @since 4.0.0
  */
 export class ElicitationDeclined

--- a/packages/effect/src/unstable/ai/McpSchema.ts
+++ b/packages/effect/src/unstable/ai/McpSchema.ts
@@ -2169,7 +2169,7 @@ export class ElicitationDeclined
  * It exposes the current client id, the client's initialize payload, and a
  * scoped RPC client for server-initiated requests back to that client.
  *
- * @category client
+ * @category services
  * @since 4.0.0
  */
 export class McpServerClient extends Context.Service<McpServerClient, {
@@ -2469,7 +2469,7 @@ const ParamSchemaTypeId = "~effect/ai/McpSchema/ParamSchema"
  * Returns `true` when a schema was created with `param` and therefore carries
  * a resource URI template parameter name.
  *
- * @category parameters
+ * @category guards
  * @since 4.0.0
  */
 export function isParam(schema: Schema.Constraint): schema is Param<string, Schema.Top> {
@@ -2529,7 +2529,7 @@ export function param<const Name extends string, S extends Schema.Constraint>(
  * Annotation to conditionally enable or disable tools based on client
  * information.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class EnabledWhen

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -104,7 +104,7 @@ type CompletionContext = typeof Complete.payloadSchema.Type["context"]
  * Handlers use this service to register capabilities and resolve incoming MCP
  * requests.
  *
- * @category server
+ * @category services
  * @since 4.0.0
  */
 export class McpServer extends Context.Service<McpServer, {

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -452,7 +452,7 @@ const layerMcpProtocolState = (
  * tools, resources, and prompts, and forwards queued server notifications to
  * initialized clients.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: (options: {
@@ -1243,7 +1243,7 @@ const toolErrorResult = (message: string): CallToolResult =>
 /**
  * Registers a `Toolkit` with the `McpServer`.
  *
- * @category tools
+ * @category handlers
  * @since 4.0.0
  */
 export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
@@ -1331,7 +1331,7 @@ export const registerToolkit: <Tools extends Record<string, Tool.Any>>(
 /**
  * Registers an `AiToolkit` with the `McpServer`.
  *
- * @category tools
+ * @category layers
  * @since 4.0.0
  */
 export const toolkit = <Tools extends Record<string, Tool.Any>>(
@@ -1395,7 +1395,7 @@ export type ResourceCompletions<Schemas extends ReadonlyArray<Schema.Constraint>
  *
  * @see {@link resource} for the layer-based resource registration wrapper
  *
- * @category resources
+ * @category handlers
  * @since 4.0.0
  */
 export const registerResource: {
@@ -1574,7 +1574,7 @@ export const registerResource: {
  *
  * @see {@link registerResource} for the Effect-level resource registration API
  *
- * @category resources
+ * @category layers
  * @since 4.0.0
  */
 export const resource: {
@@ -1647,7 +1647,7 @@ export const resource: {
  *
  * @see {@link prompt} for the layer-based prompt registration wrapper
  *
- * @category prompts
+ * @category handlers
  * @since 4.0.0
  */
 export const registerPrompt = <
@@ -1772,7 +1772,7 @@ export const registerPrompt = <
  *
  * @see {@link registerPrompt} for the Effect-level prompt registration API
  *
- * @category prompts
+ * @category layers
  * @since 4.0.0
  */
 export const prompt = <
@@ -1810,7 +1810,7 @@ export const prompt = <
  * Accepted content is decoded with the supplied schema, declined requests fail
  * with `ElicitationDeclined`, and canceled requests interrupt the effect.
  *
- * @category elicitation
+ * @category accessors
  * @since 4.0.0
  */
 export const elicit: <S extends Schema.ConstraintEncoder<Record<string, unknown>, unknown>>(options: {
@@ -1847,7 +1847,7 @@ export const elicit: <S extends Schema.ConstraintEncoder<Record<string, unknown>
 /**
  * Accesses the current client's capabilities.
  *
- * @category capabilities
+ * @category accessors
  * @since 4.0.0
  */
 export const clientCapabilities: Effect.Effect<

--- a/packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts
+++ b/packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts
@@ -52,7 +52,7 @@ import * as InternalStructuredOutput from "./internal/structured-output.ts"
  * - Compatibility targets standard OpenAI models. Fine-tuned models support a
  *   smaller JSON Schema subset.
  *
- * @category Codec Transformation
+ * @category transforming
  * @since 4.0.0
  */
 export function toCodecOpenAI<T, E, RD, RE>(

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -1712,7 +1712,7 @@ const getJsonSchemaFromSchemaWith = <S extends Schema.Constraint>(
  * Context.getUnsafe(myTool.annotations, Tool.Title) // => "Tip Calculator"
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Title extends Context.Service<Title, string>()("effect/ai/Tool/Title") {}
@@ -1731,7 +1731,7 @@ export class Title extends Context.Service<Title, string>()("effect/ai/Tool/Titl
  * "ui" in Context.getUnsafe(myCalculatorUi.annotations, Tool.Meta) // => true
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Meta extends Context.Service<Meta, Record<string, unknown>>()("effect/ai/Tool/Meta") {}
@@ -1755,7 +1755,7 @@ export class Meta extends Context.Service<Meta, Record<string, unknown>>()("effe
  * Context.get(readOnlyTool.annotations, Tool.Readonly) // => true
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Readonly = Context.Reference<boolean>("effect/ai/Tool/Readonly", {
@@ -1781,7 +1781,7 @@ export const Readonly = Context.Reference<boolean>("effect/ai/Tool/Readonly", {
  * Context.get(safeTool.annotations, Tool.Destructive) // => false
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Destructive = Context.Reference<boolean>("effect/ai/Tool/Destructive", {
@@ -1808,7 +1808,7 @@ export const Destructive = Context.Reference<boolean>("effect/ai/Tool/Destructiv
  * Context.get(idempotentTool.annotations, Tool.Idempotent) // => true
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Idempotent = Context.Reference<boolean>("effect/ai/Tool/Idempotent", {
@@ -1835,7 +1835,7 @@ export const Idempotent = Context.Reference<boolean>("effect/ai/Tool/Idempotent"
  * Context.get(restrictedTool.annotations, Tool.OpenWorld) // => false
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const OpenWorld = Context.Reference<boolean>("effect/ai/Tool/OpenWorld", {
@@ -1865,7 +1865,7 @@ export const OpenWorld = Context.Reference<boolean>("effect/ai/Tool/OpenWorld", 
  * Tool.getStrictMode(flexibleTool) // => false
  * ```
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Strict = Context.Reference<boolean | undefined>("effect/ai/Tool/Strict", {

--- a/packages/effect/src/unstable/cli/CliError.ts
+++ b/packages/effect/src/unstable/cli/CliError.ts
@@ -68,7 +68,7 @@ export const isCliError = (u: unknown): u is CliError => Predicate.hasProperty(u
  * describe(new CliError.MissingOption({ option: "token" })) // => "Required flag missing: token"
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export type CliError =
@@ -112,7 +112,7 @@ export type CliError =
  * parseError._tag // => "UnrecognizedOption"
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class UnrecognizedOption extends Schema.TaggedErrorClass<UnrecognizedOption>(
@@ -165,7 +165,7 @@ export class UnrecognizedOption extends Schema.TaggedErrorClass<UnrecognizedOpti
  * duplicateError.childCommand // => "deploy"
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class DuplicateOption extends Schema.TaggedErrorClass<DuplicateOption>(
@@ -222,7 +222,7 @@ export class DuplicateOption extends Schema.TaggedErrorClass<DuplicateOption>(
  * validationError._tag // => "MissingOption"
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class MissingOption extends Schema.TaggedErrorClass<MissingOption>(
@@ -275,7 +275,7 @@ export class MissingOption extends Schema.TaggedErrorClass<MissingOption>(
  * parseError._tag // => "MissingArgument"
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class MissingArgument extends Schema.TaggedErrorClass<MissingArgument>(
@@ -316,7 +316,7 @@ export class MissingArgument extends Schema.TaggedErrorClass<MissingArgument>(
  * const details = [error._tag, error.arguments] // => ["UnexpectedArgument", ["extra.txt"]]
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class UnexpectedArgument extends Schema.TaggedErrorClass<UnexpectedArgument>(
@@ -373,7 +373,7 @@ export class UnexpectedArgument extends Schema.TaggedErrorClass<UnexpectedArgume
  * const details = [invalidArgError.kind, invalidArgError.option, invalidArgError.value] // => ["argument", "count", "abc"]
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
@@ -443,7 +443,7 @@ export class InvalidValue extends Schema.TaggedErrorClass<InvalidValue>(
  * parseError._tag // => "UnknownSubcomand"
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class UnknownSubcommand extends Schema.TaggedErrorClass<UnknownSubcommand>(
@@ -510,7 +510,7 @@ export class UnknownSubcommand extends Schema.TaggedErrorClass<UnknownSubcommand
  * await Effect.runPromise(handleError(userError)) // => 1
  * ```
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class UserError extends Schema.TaggedErrorClass<UserError>(
@@ -534,7 +534,7 @@ export class UserError extends Schema.TaggedErrorClass<UserError>(
  * This excludes `ShowHelp` itself, allowing parse and validation errors to be
  * stored in `ShowHelp.errors` without nesting another help-control value.
  *
- * @category models
+ * @category schemas
  * @since 4.0.0
  */
 export const NonShowHelpErrors: Schema.Union<
@@ -568,7 +568,7 @@ export const NonShowHelpErrors: Schema.Union<
  * runner should display help along with the underlying parse or validation
  * failures.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export type NonShowHelpErrors = typeof NonShowHelpErrors.Type
@@ -582,7 +582,7 @@ export type NonShowHelpErrors = typeof NonShowHelpErrors.Type
  * that should be shown with help text. When `errors` is non-empty, the runtime
  * exit code is `1`; otherwise it is `0`.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class ShowHelp extends Schema.TaggedErrorClass<ShowHelp>(

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -1612,7 +1612,7 @@ export const provideEffectDiscard: {
  * await Effect.runPromise(program) // => ["app"]
  * ```
  *
- * @category command execution
+ * @category running
  * @since 4.0.0
  */
 export const wizard = <Name extends string, Input, E, R, ContextInput>(
@@ -1728,7 +1728,7 @@ const showHelp = <Name extends string, Input, E, R, ContextInput>(
  *
  * @see {@link runWith} for running a command with an explicit argument array
  *
- * @category command execution
+ * @category running
  * @since 4.0.0
  */
 export const run: {
@@ -1810,7 +1810,7 @@ export const run: {
  * output // => ["Hello, Alice!", "Hello, Alice!"]
  * ```
  *
- * @category command execution
+ * @category running
  * @since 4.0.0
  */
 export const runWith = <const Name extends string, Input, E, R, ContextInput>(

--- a/packages/effect/src/unstable/cli/Flag.ts
+++ b/packages/effect/src/unstable/cli/Flag.ts
@@ -491,7 +491,7 @@ export const withAlias: {
  * const kinds = [portFlag.kind, configFlag.kind] // => ["flag", "flag"]
  * ```
  *
- * @category help documentation
+ * @category metadata
  * @since 4.0.0
  */
 export const withDescription: {

--- a/packages/effect/src/unstable/cli/GlobalFlag.ts
+++ b/packages/effect/src/unstable/cli/GlobalFlag.ts
@@ -58,7 +58,7 @@ export interface Action<A> {
 /**
  * Setting flag: configure command handler's environment (--log-level, --config).
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Setting<Id extends string, A> extends Context.Service<Setting.Identifier<Id>, A> {

--- a/packages/effect/src/unstable/cli/Param.ts
+++ b/packages/effect/src/unstable/cli/Param.ts
@@ -280,7 +280,7 @@ const Proto = {
  * Param.isParam(maybeParam) // => true
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isParam = (u: unknown): u is Param<any, ParamKind> => Predicate.hasProperty(u, TypeId)
@@ -300,7 +300,7 @@ export const isParam = (u: unknown): u is Param<any, ParamKind> => Predicate.has
  * Param.isSingle(optionalParam) // => false
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isSingle = <const Kind extends ParamKind, A>(

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -684,7 +684,7 @@ export declare namespace All {
  * await Effect.runPromise(Effect.provide(allWithRecord, services)) // => { username: "alice", password: "secret" }
  * ```
  *
- * @category collecting & elements
+ * @category combining
  * @since 4.0.0
  */
 export const all: <
@@ -1082,7 +1082,7 @@ export const password = (
  * The returned effect may fail with `Terminal.QuitError` if terminal input ends
  * or the prompt is quit.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const run: <Output>(

--- a/packages/effect/src/unstable/cluster/ClusterSchema.ts
+++ b/packages/effect/src/unstable/cluster/ClusterSchema.ts
@@ -20,7 +20,7 @@ import type { Request } from "./Envelope.ts"
  *
  * The default value is `false`.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Persisted = Context.Reference<boolean>("effect/cluster/ClusterSchema/Persisted", {
@@ -46,7 +46,7 @@ export const Persisted = Context.Reference<boolean>("effect/cluster/ClusterSchem
  * This annotation has transactional behavior only when the configured
  * `MessageStorage` implements it.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const WithTransaction = Context.Reference<boolean>(
@@ -64,7 +64,7 @@ export const WithTransaction = Context.Reference<boolean>(
  * handling only, `"server"` for server-side handling only, or `false` to allow
  * interruption.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Uninterruptible = Context.Reference<boolean | "client" | "server">(
@@ -83,7 +83,7 @@ export const Uninterruptible = Context.Reference<boolean | "client" | "server">(
  * @see {@link Uninterruptible} for the annotation values interpreted by this helper
  * @see {@link isUninterruptibleForClient} for the client-side counterpart
  *
- * @category annotations
+ * @category predicates
  * @since 4.0.0
  */
 export const isUninterruptibleForServer = (context: Context.Context<never>): boolean => {
@@ -108,7 +108,7 @@ export const isUninterruptibleForServer = (context: Context.Context<never>): boo
  * @see {@link Uninterruptible} for the annotation values interpreted by this helper
  * @see {@link isUninterruptibleForServer} for the server-side counterpart
  *
- * @category annotations
+ * @category predicates
  * @since 4.0.0
  */
 export const isUninterruptibleForClient = (context: Context.Context<never>): boolean => {
@@ -123,7 +123,7 @@ export const isUninterruptibleForClient = (context: Context.Context<never>): boo
  *
  * By default, every entity id is assigned to the `"default"` shard group.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const ShardGroup = Context.Reference<(entityId: EntityId) => string>(
@@ -139,7 +139,7 @@ export const ShardGroup = Context.Reference<(entityId: EntityId) => string>(
  *
  * The default value is `true`.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const ClientTracingEnabled = Context.Reference<boolean>("effect/cluster/ClusterSchema/ClientTracingEnabled", {
@@ -159,7 +159,7 @@ export const ClientTracingEnabled = Context.Reference<boolean>("effect/cluster/C
  * This only applies to requests handled by the entity, not to the generated
  * client.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Dynamic = Context.Reference<

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -216,7 +216,7 @@ export type Any = Entity<string, Rpc.Any>
  * Each handler receives the entity request envelope for that RPC and returns the
  * RPC result or a supported RPC wrapper.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlersFrom<Rpc extends Rpc.Any> = {
@@ -232,7 +232,7 @@ export type HandlersFrom<Rpc extends Rpc.Any> = {
  *
  * The check is based on the internal entity type identifier.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isEntity = (u: unknown): u is Any => Predicate.hasProperty(u, TypeId)
@@ -464,7 +464,7 @@ export const make = <const Type extends string, Rpcs extends ReadonlyArray<Rpc.A
  * Use to read the current entity identity and shard address from entity
  * handlers and keep-alive logic.
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class CurrentAddress extends Context.Service<
@@ -480,7 +480,7 @@ export class CurrentAddress extends Context.Service<
  * Use to read the runner address associated with the current entity handler
  * registration.
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class CurrentRunnerAddress extends Context.Service<
@@ -699,7 +699,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
  * When enabled it sends the internal keep-alive RPC for the current address; when
  * disabled it releases the keep-alive latch if one is present.
  *
- * @category Keep alive
+ * @category keep alive
  * @since 4.0.0
  */
 export const keepAlive: (
@@ -755,7 +755,7 @@ export const keepAlive: (
  * The RPC is marked as persisted and uninterruptible so the keep-alive signal
  * survives normal entity restarts.
  *
- * @category Keep alive
+ * @category keep alive
  * @since 4.0.0
  */
 export const KeepAliveRpc = Rpc.make("Cluster/Entity/keepAlive")
@@ -770,7 +770,7 @@ export const KeepAliveRpc = Rpc.make("Cluster/Entity/keepAlive")
  * `keepAlive` closes the latch when keep-alive is active and opens it again when
  * the resource no longer needs to keep the entity alive.
  *
- * @category Keep alive
+ * @category services
  * @since 4.0.0
  */
 export class KeepAliveLatch extends Context.Service<KeepAliveLatch, Latch.Latch>()(

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -496,7 +496,7 @@ export class CurrentRunnerAddress extends Context.Service<
  * Use when you use it to complete an entity request by succeeding, failing, failing with a
  * cause, or supplying an explicit `Exit`.
  *
- * @category Replier
+ * @category models
  * @since 4.0.0
  */
 export interface Replier<Rpcs extends Rpc.Any> {
@@ -535,7 +535,7 @@ export declare namespace Replier {
    * For streaming RPCs this may be either a stream of success chunks or a dequeue
    * of success chunks. For non-streaming RPCs it is the RPC success value.
    *
-   * @category Replier
+   * @category utility types
    * @since 4.0.0
    */
   export type Success<R extends Rpc.Any> = Rpc.Success<R> extends Stream.Stream<infer _A, infer _E, infer _R> ?
@@ -551,7 +551,7 @@ export declare namespace Replier {
  * It includes the underlying request envelope plus the last stream reply chunk
  * that was sent, allowing handlers to resume chunk sequencing after a restart.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export class Request<Rpc extends Rpc.Any> extends Data.Class<

--- a/packages/effect/src/unstable/cluster/EntityResource.ts
+++ b/packages/effect/src/unstable/cluster/EntityResource.ts
@@ -66,7 +66,7 @@ export interface EntityResource<out A, out E = never> {
  *
  * It is not closed during restarts, due to shard movement or node shutdowns.
  *
- * @category resource management
+ * @category services
  * @since 4.0.0
  */
 export class CloseScope extends Context.Service<

--- a/packages/effect/src/unstable/cluster/EntityResource.ts
+++ b/packages/effect/src/unstable/cluster/EntityResource.ts
@@ -156,7 +156,7 @@ export const make: <A, E, R>(options: {
  * The pod is created and waited on through `K8sHttpClient`, and is kept alive
  * until the resource is closed or its idle time to live expires.
  *
- * @category Kubernetes
+ * @category constructors
  * @since 4.0.0
  */
 export const makeK8sPod: (

--- a/packages/effect/src/unstable/cluster/Envelope.ts
+++ b/packages/effect/src/unstable/cluster/Envelope.ts
@@ -403,7 +403,7 @@ export const RequestTransform: SchemaTransformation.Transformation<
  * Returns the storage primary key for a request envelope whose payload has a
  * primary key, or `null` when the envelope is not a keyed request.
  *
- * @category primary key
+ * @category getters
  * @since 4.0.0
  */
 export const primaryKey = <R extends Rpc.Any>(envelope: Envelope<R>): string | null => {
@@ -421,7 +421,7 @@ export const primaryKey = <R extends Rpc.Any>(envelope: Envelope<R>): string | n
  * Builds a storage primary-key string from an entity address, RPC tag, and
  * payload primary-key ID.
  *
- * @category primary key
+ * @category constructors
  * @since 4.0.0
  */
 export const primaryKeyByAddress = (options: {

--- a/packages/effect/src/unstable/cluster/Envelope.ts
+++ b/packages/effect/src/unstable/cluster/Envelope.ts
@@ -320,7 +320,7 @@ export declare namespace Request {
  *
  * The check is based on the envelope type identifier.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isEnvelope = (u: unknown): u is Envelope<any> => Predicate.hasProperty(u, TypeId)

--- a/packages/effect/src/unstable/cluster/HttpRunner.ts
+++ b/packages/effect/src/unstable/cluster/HttpRunner.ts
@@ -139,7 +139,7 @@ export const layerClientProtocolWebsocketDefault: Layer.Layer<
  * The returned effect is produced from `RunnerServer.layerHandlers` and the
  * cluster runner RPC group.
  *
- * @category http app
+ * @category running
  * @since 4.0.0
  */
 export const toHttpEffect: Effect.Effect<
@@ -163,7 +163,7 @@ export const toHttpEffect: Effect.Effect<
  * The returned effect is produced from `RunnerServer.layerHandlers` and the
  * cluster runner RPC group.
  *
- * @category http app
+ * @category running
  * @since 4.0.0
  */
 export const toHttpEffectWebsocket: Effect.Effect<

--- a/packages/effect/src/unstable/cluster/Message.ts
+++ b/packages/effect/src/unstable/cluster/Message.ts
@@ -31,7 +31,7 @@ import type { Snowflake } from "./Snowflake.ts"
  * An incoming message is either a persisted request with an encoded payload or an
  * incoming control envelope.
  *
- * @category incoming
+ * @category models
  * @since 4.0.0
  */
 export type Incoming<R extends Rpc.Any> = IncomingRequest<R> | IncomingEnvelope
@@ -43,7 +43,7 @@ export type Incoming<R extends Rpc.Any> = IncomingRequest<R> | IncomingEnvelope
  *
  * It is either a request with a decoded payload or an incoming control envelope.
  *
- * @category incoming
+ * @category models
  * @since 4.0.0
  */
 export type IncomingLocal<R extends Rpc.Any> = IncomingRequestLocal<R> | IncomingEnvelope
@@ -56,7 +56,7 @@ export type IncomingLocal<R extends Rpc.Any> = IncomingRequestLocal<R> | Incomin
  * Request messages keep their decoded payload and response callback, while
  * control envelopes are wrapped as incoming envelopes.
  *
- * @category incoming
+ * @category converting
  * @since 4.0.0
  */
 export const incomingLocalFromOutgoing = <R extends Rpc.Any>(self: Outgoing<R>): IncomingLocal<R> => {
@@ -83,7 +83,7 @@ export const incomingLocalFromOutgoing = <R extends Rpc.Any>(self: Outgoing<R>):
  * It carries the last reply that was sent and a callback for persisting encoded
  * replies.
  *
- * @category incoming
+ * @category models
  * @since 4.0.0
  */
 export class IncomingRequest<R extends Rpc.Any> extends Data.TaggedClass("IncomingRequest")<{
@@ -100,7 +100,7 @@ export class IncomingRequest<R extends Rpc.Any> extends Data.TaggedClass("Incomi
  * It includes dynamic annotations, the last sent reply, and a callback for
  * replying with decoded replies.
  *
- * @category incoming
+ * @category models
  * @since 4.0.0
  */
 export class IncomingRequestLocal<R extends Rpc.Any> extends Data.TaggedClass("IncomingRequestLocal")<{
@@ -113,7 +113,7 @@ export class IncomingRequestLocal<R extends Rpc.Any> extends Data.TaggedClass("I
 /**
  * Represents an incoming control envelope carrying an `AckChunk` or `Interrupt`.
  *
- * @category incoming
+ * @category models
  * @since 4.0.0
  */
 export class IncomingEnvelope extends Data.TaggedClass("IncomingEnvelope")<{
@@ -128,7 +128,7 @@ export class IncomingEnvelope extends Data.TaggedClass("IncomingEnvelope")<{
  *
  * An outgoing message is either an entity request or a control envelope.
  *
- * @category outgoing
+ * @category models
  * @since 4.0.0
  */
 export type Outgoing<R extends Rpc.Any> = OutgoingRequest<R> | OutgoingEnvelope
@@ -141,7 +141,7 @@ export type Outgoing<R extends Rpc.Any> = OutgoingRequest<R> | OutgoingEnvelope
  * It carries the service context used for serialization, the last received reply,
  * the reply callback, dynamic annotations, and an optional encoded request cache.
  *
- * @category outgoing
+ * @category models
  * @since 4.0.0
  */
 export class OutgoingRequest<R extends Rpc.Any> extends Data.TaggedClass("OutgoingRequest")<{
@@ -168,7 +168,7 @@ export class OutgoingRequest<R extends Rpc.Any> extends Data.TaggedClass("Outgoi
  * Use to construct an interrupt envelope for an
  * in-flight request.
  *
- * @category outgoing
+ * @category models
  * @since 4.0.0
  */
 export class OutgoingEnvelope extends Data.TaggedClass("OutgoingEnvelope")<{

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -42,7 +42,7 @@ import * as Snowflake from "./Snowflake.ts"
  * messages; manages reply handlers; and provides transaction wrapping for storage
  * operations.
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class MessageStorage extends Context.Service<MessageStorage, {
@@ -284,7 +284,7 @@ export declare namespace SaveResult {
  * Implementations persist encoded messages, track primary keys and delayed
  * delivery, read unprocessed messages, and provide transaction wrapping.
  *
- * @category Encoded
+ * @category encoded
  * @since 4.0.0
  */
 export type Encoded = {
@@ -412,7 +412,7 @@ export type Encoded = {
  * The fields distinguish existing shards from newly assigned shards and carry the
  * driver-specific pagination cursor.
  *
- * @category Encoded
+ * @category encoded
  * @since 4.0.0
  */
 export type EncodedUnprocessedOptions<A> = {
@@ -429,7 +429,7 @@ export type EncodedUnprocessedOptions<A> = {
  * The fields distinguish existing requests from new requests and carry the
  * driver-specific pagination cursor.
  *
- * @category Encoded
+ * @category encoded
  * @since 4.0.0
  */
 export type EncodedRepliesOptions<A> = {
@@ -806,7 +806,7 @@ export type MemoryEntry = {
 /**
  * Provides a context reference used in tests to simulate a transaction.
  *
- * @category memory
+ * @category services
  * @since 4.0.0
  */
 export const MemoryTransaction = Context.Reference<boolean>("effect/cluster/MessageStorage/MemoryTransaction", {
@@ -822,7 +822,7 @@ export const MemoryTransaction = Context.Reference<boolean>("effect/cluster/Mess
  * maps used to track requests, primary keys, unprocessed envelopes, reply IDs,
  * and the journal.
  *
- * @category memory
+ * @category services
  * @since 4.0.0
  */
 export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluster/MessageStorage/MemoryDriver", {

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -180,7 +180,7 @@ export class MessageStorage extends Context.Service<MessageStorage, {
  * A duplicate result carries the original request ID and the last reply already
  * received for the duplicated request.
  *
- * @category SaveResult
+ * @category models
  * @since 4.0.0
  */
 export type SaveResult<R extends Rpc.Any> = SaveResult.Success | SaveResult.Duplicate<R>
@@ -188,7 +188,7 @@ export type SaveResult<R extends Rpc.Any> = SaveResult.Success | SaveResult.Dupl
 /**
  * Constructors and matchers for decoded save results.
  *
- * @category SaveResult
+ * @category constructors
  * @since 4.0.0
  */
 export const SaveResult = Data.taggedEnum<SaveResult.Constructor>()
@@ -197,7 +197,7 @@ export const SaveResult = Data.taggedEnum<SaveResult.Constructor>()
  * Constructors and matchers for encoded save results returned by storage
  * drivers.
  *
- * @category SaveResult
+ * @category constructors
  * @since 4.0.0
  */
 export const SaveResultEncoded = Data.taggedEnum<SaveResult.Encoded>()
@@ -216,7 +216,7 @@ export declare namespace SaveResult {
    * Duplicate results contain an encoded last received reply instead of a decoded
    * reply.
    *
-   * @category SaveResult
+   * @category models
    * @since 4.0.0
    */
   export type Encoded = SaveResult.Success | SaveResult.DuplicateEncoded
@@ -224,7 +224,7 @@ export declare namespace SaveResult {
   /**
    * Variant indicating that the message was saved as a new storage entry.
    *
-   * @category SaveResult
+   * @category models
    * @since 4.0.0
    */
   export interface Success {
@@ -239,7 +239,7 @@ export declare namespace SaveResult {
    * It carries the original request ID and the latest decoded reply, when one is
    * available.
    *
-   * @category SaveResult
+   * @category models
    * @since 4.0.0
    */
   export interface Duplicate<R extends Rpc.Any> {
@@ -256,7 +256,7 @@ export declare namespace SaveResult {
    * It carries the original request ID and the latest encoded reply, when one is
    * available.
    *
-   * @category SaveResult
+   * @category models
    * @since 4.0.0
    */
   export interface DuplicateEncoded {
@@ -268,7 +268,7 @@ export declare namespace SaveResult {
   /**
    * Generic tagged enum constructor type for `SaveResult`.
    *
-   * @category SaveResult
+   * @category utility types
    * @since 4.0.0
    */
   export interface Constructor extends Data.TaggedEnum.WithGenerics<1> {
@@ -284,7 +284,7 @@ export declare namespace SaveResult {
  * Implementations persist encoded messages, track primary keys and delayed
  * delivery, read unprocessed messages, and provide transaction wrapping.
  *
- * @category encoded
+ * @category services
  * @since 4.0.0
  */
 export type Encoded = {
@@ -412,7 +412,7 @@ export type Encoded = {
  * The fields distinguish existing shards from newly assigned shards and carry the
  * driver-specific pagination cursor.
  *
- * @category encoded
+ * @category models
  * @since 4.0.0
  */
 export type EncodedUnprocessedOptions<A> = {
@@ -429,7 +429,7 @@ export type EncodedUnprocessedOptions<A> = {
  * The fields distinguish existing requests from new requests and carry the
  * driver-specific pagination cursor.
  *
- * @category encoded
+ * @category models
  * @since 4.0.0
  */
 export type EncodedRepliesOptions<A> = {
@@ -793,7 +793,7 @@ export const noop: MessageStorage["Service"] = Effect.runSync(make({
  * It stores the encoded envelope, last acknowledged chunk, accumulated replies,
  * and optional delivery time.
  *
- * @category memory
+ * @category models
  * @since 4.0.0
  */
 export type MemoryEntry = {

--- a/packages/effect/src/unstable/cluster/RunnerHealth.ts
+++ b/packages/effect/src/unstable/cluster/RunnerHealth.ts
@@ -27,7 +27,7 @@ import * as Runners from "./Runners.ts"
  * still be processing messages. If a Runner is not responsive, then its
  * associated shards can and will be re-assigned to a different Runner.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class RunnerHealth extends Context.Service<

--- a/packages/effect/src/unstable/cluster/RunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/RunnerStorage.ts
@@ -84,7 +84,7 @@ export class RunnerStorage extends Context.Service<RunnerStorage, {
  * String-encoded runner storage interface used by adapters that persist runner
  * addresses, runners, machine ids, and shard ids outside the in-memory model.
  *
- * @category encoded
+ * @category services
  * @since 4.0.0
  */
 export interface Encoded {

--- a/packages/effect/src/unstable/cluster/RunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/RunnerStorage.ts
@@ -24,7 +24,7 @@ import * as ShardId from "./ShardId.ts"
  * Represents a generic interface to the persistent storage required by the
  * cluster.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class RunnerStorage extends Context.Service<RunnerStorage, {
@@ -84,7 +84,7 @@ export class RunnerStorage extends Context.Service<RunnerStorage, {
  * String-encoded runner storage interface used by adapters that persist runner
  * addresses, runners, machine ids, and shard ids outside the in-memory model.
  *
- * @category Encoded
+ * @category encoded
  * @since 4.0.0
  */
 export interface Encoded {

--- a/packages/effect/src/unstable/cluster/Runners.ts
+++ b/packages/effect/src/unstable/cluster/Runners.ts
@@ -41,7 +41,7 @@ import * as Snowflake from "./Snowflake.ts"
  * sending and notifying messages, coordinating persisted replies, and marking
  * runners unavailable.
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class Runners extends Context.Service<Runners, {
@@ -425,7 +425,7 @@ export const make: (options: Omit<Runners["Service"], "sendLocal" | "notifyLocal
  * `EntityNotAssignedToRunner` and ignores notifications, pings, and unavailable
  * runner reports.
  *
- * @category No-op
+ * @category no-op
  * @since 4.0.0
  */
 export const makeNoop: Effect.Effect<
@@ -466,7 +466,7 @@ const rpcErrors: Schema.Union<[
  * RPC group used for runner-to-runner communication, including ping, notify,
  * effect, stream, and envelope messages.
  *
- * @category Rpcs
+ * @category RPCs
  * @since 4.0.0
  */
 export class Rpcs extends RpcGroup.make(
@@ -507,7 +507,7 @@ export class Rpcs extends RpcGroup.make(
 /**
  * Client interface generated from the runner RPC group.
  *
- * @category Rpcs
+ * @category RPCs
  * @since 4.0.0
  */
 export interface RpcClient extends RpcClient_.FromGroup<typeof Rpcs, RpcClientError> {}
@@ -516,7 +516,7 @@ export interface RpcClient extends RpcClient_.FromGroup<typeof Rpcs, RpcClientEr
  * Builds a runner RPC client from the current `RpcClient.Protocol`, using the
  * `Runners` span prefix with tracing disabled.
  *
- * @category Rpcs
+ * @category RPCs
  * @since 4.0.0
  */
 export const makeRpcClient: Effect.Effect<
@@ -692,7 +692,7 @@ export const layerRpc: Layer.Layer<
  * Service that creates an RPC client protocol for communicating with a runner at a
  * given address.
  *
- * @category client
+ * @category services
  * @since 4.0.0
  */
 export class RpcClientProtocol extends Context.Service<

--- a/packages/effect/src/unstable/cluster/Runners.ts
+++ b/packages/effect/src/unstable/cluster/Runners.ts
@@ -425,7 +425,7 @@ export const make: (options: Omit<Runners["Service"], "sendLocal" | "notifyLocal
  * `EntityNotAssignedToRunner` and ignores notifications, pings, and unavailable
  * runner reports.
  *
- * @category no-op
+ * @category constructors
  * @since 4.0.0
  */
 export const makeNoop: Effect.Effect<
@@ -466,7 +466,7 @@ const rpcErrors: Schema.Union<[
  * RPC group used for runner-to-runner communication, including ping, notify,
  * effect, stream, and envelope messages.
  *
- * @category RPCs
+ * @category models
  * @since 4.0.0
  */
 export class Rpcs extends RpcGroup.make(
@@ -507,7 +507,7 @@ export class Rpcs extends RpcGroup.make(
 /**
  * Client interface generated from the runner RPC group.
  *
- * @category RPCs
+ * @category models
  * @since 4.0.0
  */
 export interface RpcClient extends RpcClient_.FromGroup<typeof Rpcs, RpcClientError> {}
@@ -516,7 +516,7 @@ export interface RpcClient extends RpcClient_.FromGroup<typeof Rpcs, RpcClientEr
  * Builds a runner RPC client from the current `RpcClient.Protocol`, using the
  * `Runners` span prefix with tracing disabled.
  *
- * @category RPCs
+ * @category constructors
  * @since 4.0.0
  */
 export const makeRpcClient: Effect.Effect<

--- a/packages/effect/src/unstable/cluster/ShardingConfig.ts
+++ b/packages/effect/src/unstable/cluster/ShardingConfig.ts
@@ -353,7 +353,7 @@ export const layerFromEnv = (options?: Partial<ShardingConfig["Service"]> | unde
  * Normalizes the provided `ShardingConfig` to calculate the `available` and
  * `assigned` shard groups.
  *
- * @category shard groups
+ * @category converting
  * @since 4.0.0
  */
 export const shardGroupConfig = (config: ShardingConfig["Service"]): {

--- a/packages/effect/src/unstable/cluster/ShardingConfig.ts
+++ b/packages/effect/src/unstable/cluster/ShardingConfig.ts
@@ -23,7 +23,7 @@ import { RunnerAddress } from "./RunnerAddress.ts"
 /**
  * Represents the configuration for the `Sharding` service on a given runner.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class ShardingConfig extends Context.Service<ShardingConfig, {
@@ -210,7 +210,7 @@ export const layer = (options?: Partial<ShardingConfig["Service"]>): Layer.Layer
 /**
  * Layer that provides the default `ShardingConfig` values.
  *
- * @category defaults
+ * @category layers
  * @since 4.0.0
  */
 export const layerDefaults: Layer.Layer<ShardingConfig> = layer()
@@ -353,7 +353,7 @@ export const layerFromEnv = (options?: Partial<ShardingConfig["Service"]> | unde
  * Normalizes the provided `ShardingConfig` to calculate the `available` and
  * `assigned` shard groups.
  *
- * @category Shard groups
+ * @category shard groups
  * @since 4.0.0
  */
 export const shardGroupConfig = (config: ShardingConfig["Service"]): {

--- a/packages/effect/src/unstable/cluster/SingletonAddress.ts
+++ b/packages/effect/src/unstable/cluster/SingletonAddress.ts
@@ -17,7 +17,7 @@ const TypeId = "~effect/cluster/SingletonAddress"
 /**
  * Represents the unique address of an singleton within the cluster.
  *
- * @category address
+ * @category schemas
  * @since 4.0.0
  */
 export class SingletonAddress extends Schema.Class<SingletonAddress>(TypeId)({

--- a/packages/effect/src/unstable/cluster/Snowflake.ts
+++ b/packages/effect/src/unstable/cluster/Snowflake.ts
@@ -170,7 +170,7 @@ export const make = (options: {
 /**
  * Extracts the Unix timestamp in milliseconds from a snowflake id.
  *
- * @category parts
+ * @category getters
  * @since 4.0.0
  */
 export const timestamp = (snowflake: Snowflake): number => Number(snowflake >> constBigInt22) + sinceUnixEpoch
@@ -178,7 +178,7 @@ export const timestamp = (snowflake: Snowflake): number => Number(snowflake >> c
 /**
  * Extracts the timestamp from a snowflake id as a `DateTime.Utc`.
  *
- * @category parts
+ * @category getters
  * @since 4.0.0
  */
 export const dateTime = (snowflake: Snowflake): DateTime.Utc => DateTime.makeUnsafe(timestamp(snowflake))
@@ -186,7 +186,7 @@ export const dateTime = (snowflake: Snowflake): DateTime.Utc => DateTime.makeUns
 /**
  * Extracts the machine id component from a snowflake id.
  *
- * @category parts
+ * @category getters
  * @since 4.0.0
  */
 export const machineId = (snowflake: Snowflake): MachineId =>
@@ -195,7 +195,7 @@ export const machineId = (snowflake: Snowflake): MachineId =>
 /**
  * Extracts the per-machine sequence component from a snowflake id.
  *
- * @category parts
+ * @category getters
  * @since 4.0.0
  */
 export const sequence = (snowflake: Snowflake): number => Number(snowflake % constBigInt4096)
@@ -203,7 +203,7 @@ export const sequence = (snowflake: Snowflake): number => Number(snowflake % con
 /**
  * Decomposes a snowflake id into its timestamp, machine id, and sequence parts.
  *
- * @category parts
+ * @category converting
  * @since 4.0.0
  */
 export const toParts = (snowflake: Snowflake): Snowflake.Parts => ({

--- a/packages/effect/src/unstable/cluster/Snowflake.ts
+++ b/packages/effect/src/unstable/cluster/Snowflake.ts
@@ -221,7 +221,7 @@ export const toParts = (snowflake: Snowflake): Snowflake.Parts => ({
  * backward, resets the sequence each millisecond, and advances the timestamp when
  * more than 4096 ids are requested in the same millisecond.
  *
- * @category Generator
+ * @category constructors
  * @since 4.0.0
  */
 export const makeGenerator: Effect.Effect<Snowflake.Generator> = Effect.gen(function*() {
@@ -265,7 +265,7 @@ export const makeGenerator: Effect.Effect<Snowflake.Generator> = Effect.gen(func
 /**
  * Context service for a stateful snowflake id generator.
  *
- * @category Generator
+ * @category services
  * @since 4.0.0
  */
 export class Generator extends Context.Service<
@@ -276,7 +276,7 @@ export class Generator extends Context.Service<
 /**
  * Layer that provides the default snowflake `Generator` service.
  *
- * @category Generator
+ * @category layers
  * @since 4.0.0
  */
 export const layerGenerator: Layer.Layer<Generator> = Layer.effect(Generator)(makeGenerator)

--- a/packages/effect/src/unstable/eventlog/Event.ts
+++ b/packages/effect/src/unstable/eventlog/Event.ts
@@ -114,7 +114,7 @@ export interface AnyWithProps extends Any {}
 /**
  * Derives the handler service marker for an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ToService<A> = A extends Event<
@@ -128,7 +128,7 @@ export type ToService<A> = A extends Event<
 /**
  * Extracts the tag string from an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Tag<A> = A extends Event<
@@ -142,7 +142,7 @@ export type Tag<A> = A extends Event<
 /**
  * Extracts the error schema from an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorSchema<A extends Any> = A extends Event<
@@ -156,7 +156,7 @@ export type ErrorSchema<A extends Any> = A extends Event<
 /**
  * Decoded error value type for an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<A extends Any> = Schema.Schema.Type<ErrorSchema<A>>
@@ -165,7 +165,7 @@ export type Error<A extends Any> = Schema.Schema.Type<ErrorSchema<A>>
  * Returns an event definition type whose error schema also includes the provided
  * error schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddError<A extends Any, Error extends Schema.Top> = A extends Event<
@@ -179,7 +179,7 @@ export type AddError<A extends Any, Error extends Schema.Top> = A extends Event<
 /**
  * Extracts the payload schema from an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadSchema<A extends Any> = A extends Event<
@@ -193,7 +193,7 @@ export type PayloadSchema<A extends Any> = A extends Event<
 /**
  * Extracts the payload schema for the event in a union with the specified tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadSchemaWithTag<A extends Any, Tag extends string> = A extends Event<
@@ -207,7 +207,7 @@ export type PayloadSchemaWithTag<A extends Any, Tag extends string> = A extends 
 /**
  * Decoded payload value type for an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Payload<A extends Any> = Schema.Schema.Type<PayloadSchema<A>>
@@ -220,7 +220,7 @@ export type Payload<A extends Any> = Schema.Schema.Type<PayloadSchema<A>>
  * The result contains `_tag` set to the event tag and `payload` set to the
  * decoded payload value.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type TaggedPayload<A extends Any> = A extends Event<
@@ -237,7 +237,7 @@ export type TaggedPayload<A extends Any> = A extends Event<
 /**
  * Extracts the success schema from an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessSchema<A extends Any> = A extends Event<
@@ -251,7 +251,7 @@ export type SuccessSchema<A extends Any> = A extends Event<
 /**
  * Decoded success value type for an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Success<A extends Any> = Schema.Schema.Type<SuccessSchema<A>>
@@ -264,7 +264,7 @@ export type Success<A extends Any> = Schema.Schema.Type<SuccessSchema<A>>
  * This includes payload encoding services plus success and error decoding
  * services.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesClient<A> = A extends Event<
@@ -286,7 +286,7 @@ export type ServicesClient<A> = A extends Event<
  * This includes payload decoding services plus success and error encoding
  * services.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesServer<A> = A extends Event<
@@ -304,7 +304,7 @@ export type ServicesServer<A> = A extends Event<
  * All schema services required to encode and decode the payload, success, and
  * error schemas for an event definition.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Services<A> = A extends Event<
@@ -324,7 +324,7 @@ export type Services<A> = A extends Event<
 /**
  * Extracts the event definition with the specified tag from an event union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type WithTag<Events extends Any, Tag extends string> = Extract<Events, { readonly tag: Tag }>
@@ -332,7 +332,7 @@ export type WithTag<Events extends Any, Tag extends string> = Extract<Events, { 
 /**
  * Removes event definitions with the specified tag from an event union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeTag<Events extends Any, Tag extends string> = Exclude<Events, { readonly tag: Tag }>
@@ -340,7 +340,7 @@ export type ExcludeTag<Events extends Any, Tag extends string> = Exclude<Events,
 /**
  * Decoded payload value type for the event in a union with the specified tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadWithTag<Events extends Any, Tag extends string> = Payload<WithTag<Events, Tag>>
@@ -348,7 +348,7 @@ export type PayloadWithTag<Events extends Any, Tag extends string> = Payload<Wit
 /**
  * Decoded success value type for the event in a union with the specified tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessWithTag<Events extends Any, Tag extends string> = Success<WithTag<Events, Tag>>
@@ -356,7 +356,7 @@ export type SuccessWithTag<Events extends Any, Tag extends string> = Success<Wit
 /**
  * Decoded error value type for the event in a union with the specified tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorWithTag<Events extends Any, Tag extends string> = Error<WithTag<Events, Tag>>
@@ -365,7 +365,7 @@ export type ErrorWithTag<Events extends Any, Tag extends string> = Error<WithTag
  * Client-side schema services required for the event in a union with the specified
  * tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesClientWithTag<Events extends Any, Tag extends string> = ServicesClient<WithTag<Events, Tag>>

--- a/packages/effect/src/unstable/eventlog/EventGroup.ts
+++ b/packages/effect/src/unstable/eventlog/EventGroup.ts
@@ -100,7 +100,7 @@ export type AnyWithProps = EventGroup<Event.Any>
 /**
  * Derives the handler service markers required for all events in an event group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ToService<A> = A extends EventGroup<infer _Events> ? Event.ToService<_Events>
@@ -109,7 +109,7 @@ export type ToService<A> = A extends EventGroup<infer _Events> ? Event.ToService
 /**
  * Extracts the union of event definitions contained in an event group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Events<Group> = Group extends EventGroup<infer _Events> ? _Events
@@ -118,7 +118,7 @@ export type Events<Group> = Group extends EventGroup<infer _Events> ? _Events
 /**
  * Client-side schema services required by all events in an event group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesClient<Group> = Event.ServicesClient<Events<Group>>
@@ -126,7 +126,7 @@ export type ServicesClient<Group> = Event.ServicesClient<Events<Group>>
 /**
  * Server-side schema services required by all events in an event group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesServer<Group> = Event.ServicesServer<Events<Group>>

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -34,7 +34,7 @@ import type { StoreId } from "./EventLogMessage.ts"
  * The service writes local entries, imports entries from remote journals, exposes
  * a stream of local changes, and provides per-store locking.
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export class EventJournal extends Context.Service<EventJournal, {
@@ -497,7 +497,7 @@ export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(fun
  * All journal data is stored in process memory and is not persisted across layer
  * lifetimes.
  *
- * @category memory
+ * @category layers
  * @since 4.0.0
  */
 export const layerMemory: Layer.Layer<EventJournal> = Layer.effect(EventJournal, makeMemory)
@@ -772,7 +772,7 @@ const decodeEntryIdbArray = Schema.decodeUnknownEffect(EntryIdbArray)
  * Provides `EventJournal` using the IndexedDB-backed implementation created by
  * `makeIndexedDb`.
  *
- * @category indexed db
+ * @category layers
  * @since 4.0.0
  */
 export const layerIndexedDb = (options?: {

--- a/packages/effect/src/unstable/eventlog/EventJournal.ts
+++ b/packages/effect/src/unstable/eventlog/EventJournal.ts
@@ -149,7 +149,7 @@ export const RemoteIdTypeId: RemoteIdTypeId = "effect/eventlog/EventJournal/Remo
 /**
  * Branded byte identifier for a remote event journal source.
  *
- * @category remote
+ * @category models
  * @since 4.0.0
  */
 export type RemoteId = Uint8Array & Brand<RemoteIdTypeId>
@@ -157,7 +157,7 @@ export type RemoteId = Uint8Array & Brand<RemoteIdTypeId>
 /**
  * Schema for branded remote event journal identifiers.
  *
- * @category remote
+ * @category schemas
  * @since 4.0.0
  */
 export const RemoteId = Schema.Uint8Array.pipe(Schema.brand(RemoteIdTypeId))
@@ -175,7 +175,7 @@ export const RemoteId = Schema.Uint8Array.pipe(Schema.brand(RemoteIdTypeId))
  * This is unsafe because the generated UUID bytes are cast to the brand without
  * schema validation.
  *
- * @category remote
+ * @category unsafe
  * @since 4.0.0
  */
 export const makeRemoteIdUnsafe = (): RemoteId => Uuid.v4({}, new globalThis.Uint8Array(16)) as RemoteId
@@ -199,7 +199,7 @@ export type EntryIdTypeId = "effect/eventlog/EventJournal/EntryId"
 /**
  * Branded byte identifier for an event journal entry.
  *
- * @category entry
+ * @category models
  * @since 4.0.0
  */
 export type EntryId = Uint8Array<ArrayBuffer> & Brand<EntryIdTypeId>
@@ -207,7 +207,7 @@ export type EntryId = Uint8Array<ArrayBuffer> & Brand<EntryIdTypeId>
 /**
  * Schema for branded event journal entry identifiers.
  *
- * @category entry
+ * @category schemas
  * @since 4.0.0
  */
 export const EntryId = (Schema.Uint8Array as Schema.instanceOf<Uint8Array<ArrayBuffer>>).pipe(
@@ -217,7 +217,7 @@ export const EntryId = (Schema.Uint8Array as Schema.instanceOf<Uint8Array<ArrayB
 /**
  * Provides an Ordering instance for entry identifiers based on their raw UUID bytes.
  *
- * @category entry
+ * @category ordering
  * @since 4.0.0
  */
 export const EntryIdOrder = Order.make<EntryId>((a, b) => {
@@ -243,7 +243,7 @@ export const EntryIdOrder = Order.make<EntryId>((a, b) => {
  * This is unsafe because the generated UUID bytes are cast to the brand without
  * schema validation.
  *
- * @category entry
+ * @category unsafe
  * @since 4.0.0
  */
 export const makeEntryIdUnsafe = (options: { msecs?: number } = {}): EntryId =>
@@ -252,7 +252,7 @@ export const makeEntryIdUnsafe = (options: { msecs?: number } = {}): EntryId =>
 /**
  * Extracts the millisecond timestamp encoded in a UUID v7 `EntryId`.
  *
- * @category entry
+ * @category getters
  * @since 4.0.0
  */
 export const entryIdMillis = (entryId: EntryId): number => {
@@ -269,7 +269,7 @@ export const entryIdMillis = (entryId: EntryId): number => {
  * An entry records its ID, event tag, primary key, and MessagePack-encoded
  * payload, with helpers for array MessagePack encoding and creation timestamps.
  *
- * @category entry
+ * @category schemas
  * @since 4.0.0
  */
 export class Entry extends Schema.Class<Entry>("effect/eventlog/EventJournal/Entry")({
@@ -341,7 +341,7 @@ export class Entry extends Schema.Class<Entry>("effect/eventlog/EventJournal/Ent
  *
  * It pairs the remote sequence number with the journal entry payload.
  *
- * @category entry
+ * @category schemas
  * @since 4.0.0
  */
 export class RemoteEntry extends Schema.Class<RemoteEntry>("effect/eventlog/EventJournal/RemoteEntry")({
@@ -357,7 +357,7 @@ export class RemoteEntry extends Schema.Class<RemoteEntry>("effect/eventlog/Even
  * Entries, remote tracking state, and locks live only in the current process and
  * are lost when the service is discarded.
  *
- * @category memory
+ * @category constructors
  * @since 4.0.0
  */
 export const makeMemory: Effect.Effect<EventJournal["Service"]> = Effect.gen(function*() {
@@ -511,7 +511,7 @@ export const layerMemory: Layer.Layer<EventJournal> = Layer.effect(EventJournal,
  * browser database, publishes local changes, and requires `Scope` so the database
  * connection can be closed when the scope ends.
  *
- * @category indexed db
+ * @category constructors
  * @since 4.0.0
  */
 export const makeIndexedDb = (options?: {

--- a/packages/effect/src/unstable/eventlog/EventLog.ts
+++ b/packages/effect/src/unstable/eventlog/EventLog.ts
@@ -1012,7 +1012,7 @@ export const layer = <Groups extends EventGroup.Any, E, R>(
  * The returned function delegates to the `EventLog` service and preserves each
  * event's success and error types.
  *
- * @category client
+ * @category constructors
  * @since 4.0.0
  */
 export const makeClient = <Groups extends EventGroup.Any>(

--- a/packages/effect/src/unstable/eventlog/EventLog.ts
+++ b/packages/effect/src/unstable/eventlog/EventLog.ts
@@ -205,7 +205,7 @@ export const SchemaTypeId: SchemaTypeId = "~effect/eventlog/EventLog/Schema"
 /**
  * Returns `true` when a value carries the `EventLogSchema` marker.
  *
- * @category schemas
+ * @category guards
  * @since 4.0.0
  */
 export const isEventLogSchema = (u: unknown): u is EventLogSchema<EventGroup.Any> =>
@@ -410,7 +410,7 @@ export declare namespace Handlers {
  *
  * Defaults to the branded store id `"default"`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class CurrentStoreId extends Context.Reference<StoreId>("effect/eventlog/EventLog/CurrentStoreId", {

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -160,7 +160,7 @@ export const makeEncryptionSubtle = (crypto: Crypto): Effect.Effect<EventLogEncr
 /**
  * Provides `EventLogEncryption` using `globalThis.crypto`.
  *
- * @category encryption
+ * @category layers
  * @since 4.0.0
  */
 export const layerSubtle: Layer.Layer<EventLogEncryption> = Layer.effect(

--- a/packages/effect/src/unstable/eventlog/EventLogMessage.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogMessage.ts
@@ -39,7 +39,7 @@ export const StoreIdTypeId: StoreIdTypeId = "effect/eventlog/EventLog/StoreId"
 /**
  * Branded string identifying a logical event-log store.
  *
- * @category StoreId
+ * @category models
  * @since 4.0.0
  */
 export type StoreId = string & Brand<StoreIdTypeId>
@@ -47,7 +47,7 @@ export type StoreId = string & Brand<StoreIdTypeId>
 /**
  * Schema for branded event-log store ids.
  *
- * @category StoreId
+ * @category schemas
  * @since 4.0.0
  */
 export const StoreId = Schema.String.pipe(Schema.brand(StoreIdTypeId))

--- a/packages/effect/src/unstable/eventlog/EventLogRemote.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogRemote.ts
@@ -119,7 +119,7 @@ const makeAuthenticate = Effect.fnUntraced(function*(options: {
  * Use to provide the RPC client used by remote event-log replicas to
  * authenticate, write entries, and subscribe to changes.
  *
- * @category RPC client
+ * @category services
  * @since 4.0.0
  */
 export class EventLogRemoteClient extends Context.Service<

--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -214,7 +214,7 @@ export const layerRpcHandlers = (options: {
  * Use to keep per-client chunk assembly state while handling chunked event-log
  * writes.
  *
- * @category chunked message state
+ * @category services
  * @since 4.0.0
  */
 export class ChunkedMessageState extends Context.Reference<

--- a/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
@@ -179,7 +179,7 @@ export class Storage extends Context.Service<Storage, {
  * Data, session authentication bindings, and streams are process-local and are
  * released with the surrounding scope.
  *
- * @category storage
+ * @category constructors
  * @since 4.0.0
  */
 export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.Scope> = Effect.gen(function*() {

--- a/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
@@ -116,7 +116,7 @@ export const layer: Layer.Layer<never, never, RpcServer.Protocol | Storage> = Rp
 /**
  * Schema for encrypted entries persisted by the encrypted event-log server.
  *
- * @category storage
+ * @category models
  * @since 4.0.0
  */
 export class PersistedEntry extends Schema.Class<PersistedEntry>(
@@ -150,7 +150,7 @@ export class PersistedEntry extends Schema.Class<PersistedEntry>(
  * persists encrypted entries, and streams encrypted changes for a public key and
  * store id.
  *
- * @category storage
+ * @category services
  * @since 4.0.0
  */
 export class Storage extends Context.Service<Storage, {
@@ -255,7 +255,7 @@ export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.S
 /**
  * Provides encrypted server `Storage` using the in-memory implementation.
  *
- * @category storage
+ * @category layers
  * @since 4.0.0
  */
 export const layerStorageMemory: Layer.Layer<Storage> = Layer.effect(Storage)(makeStorageMemory)

--- a/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
@@ -74,7 +74,7 @@ export class EventLogServerUnencrypted extends Context.Service<EventLogServerUne
  * Creates a typed server-side write function for events in the supplied
  * `EventLogSchema`.
  *
- * @category EventLogServerUnencrypted
+ * @category constructors
  * @since 4.0.0
  */
 export const makeWrite = <Groups extends EventGroup.Any>(
@@ -556,7 +556,7 @@ export const compactBacklog = Effect.fnUntraced(function*(options: {
  * in memory, publishes live changes, and serializes transactions with a
  * semaphore.
  *
- * @category storage
+ * @category constructors
  * @since 4.0.0
  */
 export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.Scope> = Effect.gen(function*() {

--- a/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
@@ -322,7 +322,7 @@ const toStoreNotFoundError = (options: {
  * Provides a `StoreMapping` that accepts only one configured store id and fails
  * all other store ids as not found.
  *
- * @category store
+ * @category layers
  * @since 4.0.0
  */
 export const layerStoreMappingStatic = (options: {
@@ -352,7 +352,7 @@ export const layerStoreMappingStatic = (options: {
  * allocates remote sequence numbers, persists entries, streams changes, and
  * exposes a transaction boundary.
  *
- * @category storage
+ * @category services
  * @since 4.0.0
  */
 export class Storage extends Context.Service<Storage, {
@@ -663,7 +663,7 @@ export const makeStorageMemory: Effect.Effect<Storage["Service"], never, Scope.S
 /**
  * Provides unencrypted server `Storage` using the in-memory implementation.
  *
- * @category storage
+ * @category layers
  * @since 4.0.0
  */
 export const layerStorageMemory: Layer.Layer<Storage> = Layer.effect(Storage)(makeStorageMemory)

--- a/packages/effect/src/unstable/eventlog/EventLogSessionAuth.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogSessionAuth.ts
@@ -479,7 +479,7 @@ export const verifySessionAuthPayload = (
 /**
  * Generates a random session authentication challenge using `globalThis.crypto`.
  *
- * @category challenge
+ * @category constructors
  * @since 4.0.0
  */
 export const makeSessionAuthChallenge: Effect.Effect<

--- a/packages/effect/src/unstable/http/Cookies.ts
+++ b/packages/effect/src/unstable/http/Cookies.ts
@@ -28,7 +28,7 @@ const TypeId = "~effect/http/Cookies"
 /**
  * Returns `true` when a value is a `Cookies` collection.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isCookies = (u: unknown): u is Cookies => Predicate.hasProperty(u, TypeId)
@@ -419,7 +419,7 @@ export const empty: Cookies = fromIterable([])
 /**
  * Returns `true` when the `Cookies` collection contains no cookies.
  *
- * @category refinements
+ * @category predicates
  * @since 4.0.0
  */
 export const isEmpty = (self: Cookies): boolean => Record.isEmptyRecord(self.cookies)

--- a/packages/effect/src/unstable/http/Etag.ts
+++ b/packages/effect/src/unstable/http/Etag.ts
@@ -71,7 +71,7 @@ export const toString = (self: Etag): string => {
 /**
  * Service for generating ETags from filesystem file information or Web `File`-like metadata.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class Generator extends Context.Service<Generator, {

--- a/packages/effect/src/unstable/http/Headers.ts
+++ b/packages/effect/src/unstable/http/Headers.ts
@@ -42,7 +42,7 @@ export type TypeId = typeof TypeId
 /**
  * Returns `true` if the provided value is a `Headers` value.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isHeaders = (u: unknown): u is Headers => Predicate.hasProperty(u, TypeId)
@@ -423,7 +423,7 @@ export const redact: {
  *
  * Defaults include `authorization`, `cookie`, `set-cookie`, and `x-api-key`.
  *
- * @category fiber refs
+ * @category services
  * @since 4.0.0
  */
 export const CurrentRedactedNames = Context.Reference<

--- a/packages/effect/src/unstable/http/HttpBody.ts
+++ b/packages/effect/src/unstable/http/HttpBody.ts
@@ -30,7 +30,7 @@ const TypeId = "~effect/http/HttpBody"
 /**
  * Returns `true` if the provided value is an `HttpBody`.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isHttpBody = (u: unknown): u is HttpBody => Predicate.hasProperty(u, TypeId)

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -258,7 +258,7 @@ export const options: (url: string | URL, options?: HttpClientRequest.Options.No
  *
  * The transformation receives both the response effect and the original request, allowing it to change success, error, and environment behavior.
  *
- * @category mapping & sequencing
+ * @category mapping
  * @since 4.0.0
  */
 export const transform: {
@@ -290,7 +290,7 @@ export const transform: {
 /**
  * Transforms a client by applying an effectful transformation to each response effect.
  *
- * @category mapping & sequencing
+ * @category mapping
  * @since 4.0.0
  */
 export const transformResponse: {
@@ -477,7 +477,7 @@ export const catchTags: {
 /**
  * Filters the result of a response, or runs an alternative effect if the predicate fails.
  *
- * @category filters
+ * @category filtering
  * @since 4.0.0
  */
 export const filterOrElse: {
@@ -522,7 +522,7 @@ export const filterOrElse: {
 /**
  * Filters successful responses, or fails with the error produced by `orFailWith` when the predicate does not match.
  *
- * @category filters
+ * @category filtering
  * @since 4.0.0
  */
 export const filterOrFail: {
@@ -549,7 +549,7 @@ export const filterOrFail: {
 /**
  * Filters responses by HTTP status code.
  *
- * @category filters
+ * @category filtering
  * @since 4.0.0
  */
 export const filterStatus: {
@@ -564,7 +564,7 @@ export const filterStatus: {
 /**
  * Filters responses that return a 2xx status code.
  *
- * @category filters
+ * @category filtering
  * @since 4.0.0
  */
 export const filterStatusOk: <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | Error.HttpClientError, R> =
@@ -728,7 +728,7 @@ export const make = (
 /**
  * Appends a transformation of the request object before sending it.
  *
- * @category mapping & sequencing
+ * @category mapping
  * @since 4.0.0
  */
 export const mapRequest: {
@@ -750,7 +750,7 @@ export const mapRequest: {
 /**
  * Appends an effectful transformation of the request object before sending it.
  *
- * @category mapping & sequencing
+ * @category mapping
  * @since 4.0.0
  */
 export const mapRequestEffect: {
@@ -773,7 +773,7 @@ export const mapRequestEffect: {
 /**
  * Prepends a transformation of the request object before sending it.
  *
- * @category mapping & sequencing
+ * @category mapping
  * @since 4.0.0
  */
 export const mapRequestInput: {
@@ -795,7 +795,7 @@ export const mapRequestInput: {
 /**
  * Prepends an effectful transformation of the request object before sending it.
  *
- * @category mapping & sequencing
+ * @category mapping
  * @since 4.0.0
  */
 export const mapRequestInputEffect: {
@@ -1326,7 +1326,7 @@ const getHeader = (headers: Headers.Headers, ...keys: Array<string>): string | u
 /**
  * Performs an additional effect after a successful request.
  *
- * @category mapping & sequencing
+ * @category sequencing
  * @since 4.0.0
  */
 export const tap: {
@@ -1348,7 +1348,7 @@ export const tap: {
 /**
  * Performs an additional effect after an unsuccessful request.
  *
- * @category mapping & sequencing
+ * @category sequencing
  * @since 4.0.0
  */
 export const tapError: {
@@ -1370,7 +1370,7 @@ export const tapError: {
 /**
  * Performs an additional effect on the request before sending it.
  *
- * @category mapping & sequencing
+ * @category sequencing
  * @since 4.0.0
  */
 export const tapRequest: {

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -1502,7 +1502,7 @@ export const followRedirects: {
 /**
  * Context reference for a predicate that disables client-side tracing for matching outgoing requests.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const TracerDisabledWhen = Context.Reference<
@@ -1514,7 +1514,7 @@ export const TracerDisabledWhen = Context.Reference<
 /**
  * Context reference for filtering request and response headers added to client spans.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const TracerHeaderFilter = Context.Reference<
@@ -1526,7 +1526,7 @@ export const TracerHeaderFilter = Context.Reference<
 /**
  * Context reference that controls whether outgoing client spans are propagated to request headers.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const TracerPropagationEnabled = Context.Reference<boolean>("effect/HttpClient/TracerPropagationEnabled", {
@@ -1536,7 +1536,7 @@ export const TracerPropagationEnabled = Context.Reference<boolean>("effect/HttpC
 /**
  * Context reference for generating the span name used for outgoing client request spans.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const SpanNameGenerator = Context.Reference<

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -201,7 +201,7 @@ export const matchStatus: {
 /**
  * Succeeds with the response when its status satisfies the predicate, otherwise fails with `HttpClientError`.
  *
- * @category filters
+ * @category filtering
  * @since 4.0.0
  */
 export const filterStatus: {
@@ -228,7 +228,7 @@ export const filterStatus: {
 /**
  * Succeeds with the response only when its status is in the 2xx range, otherwise fails with `HttpClientError`.
  *
- * @category filters
+ * @category filtering
  * @since 4.0.0
  */
 export const filterStatusOk = (self: HttpClientResponse): Effect.Effect<HttpClientResponse, Error.HttpClientError> =>

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -172,7 +172,7 @@ const scoped = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
 /**
  * Function run with the current request and response just before the response is sent, allowing the response to be replaced or failing with `HttpServerError`.
  *
- * @category pre-response handlers
+ * @category handlers
  * @since 4.0.0
  */
 export type PreResponseHandler = (
@@ -183,7 +183,7 @@ export type PreResponseHandler = (
 /**
  * Registers an additional pre-response handler for the current HTTP server request.
  *
- * @category fiber refs
+ * @category handlers
  * @since 4.0.0
  */
 export const appendPreResponseHandler = (handler: PreResponseHandler): Effect.Effect<void, never, HttpServerRequest> =>
@@ -195,7 +195,7 @@ export const appendPreResponseHandler = (handler: PreResponseHandler): Effect.Ef
 /**
  * Registers a pre-response handler for the supplied HTTP server request.
  *
- * @category fiber refs
+ * @category unsafe
  * @since 4.0.0
  */
 export const appendPreResponseHandlerUnsafe: (
@@ -206,7 +206,7 @@ export const appendPreResponseHandlerUnsafe: (
 /**
  * Runs an effect after registering a pre-response handler for the current HTTP server request.
  *
- * @category fiber refs
+ * @category handlers
  * @since 4.0.0
  */
 export const withPreResponseHandler: {

--- a/packages/effect/src/unstable/http/HttpEffect.ts
+++ b/packages/effect/src/unstable/http/HttpEffect.ts
@@ -172,7 +172,7 @@ const scoped = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
 /**
  * Function run with the current request and response just before the response is sent, allowing the response to be replaced or failing with `HttpServerError`.
  *
- * @category Pre-response handlers
+ * @category pre-response handlers
  * @since 4.0.0
  */
 export type PreResponseHandler = (

--- a/packages/effect/src/unstable/http/HttpIncomingMessage.ts
+++ b/packages/effect/src/unstable/http/HttpIncomingMessage.ts
@@ -108,7 +108,7 @@ export const schemaHeaders = <A, I extends Readonly<Record<string, string | unde
 /**
  * Context reference for the optional maximum size allowed when reading an incoming message body.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MaxBodySize = Context.Reference<FileSystem.Size | undefined>(

--- a/packages/effect/src/unstable/http/HttpIncomingMessage.ts
+++ b/packages/effect/src/unstable/http/HttpIncomingMessage.ts
@@ -108,7 +108,7 @@ export const schemaHeaders = <A, I extends Readonly<Record<string, string | unde
 /**
  * Context reference for the optional maximum size allowed when reading an incoming message body.
  *
- * @category services
+ * @category references
  * @since 4.0.0
  */
 export const MaxBodySize = Context.Reference<FileSystem.Size | undefined>(

--- a/packages/effect/src/unstable/http/HttpMethod.ts
+++ b/packages/effect/src/unstable/http/HttpMethod.ts
@@ -51,7 +51,7 @@ export declare namespace HttpMethod {
 /**
  * Returns `true` when a method can carry a request body and narrows it to `HttpMethod.WithBody`.
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const hasBody = (method: HttpMethod): method is HttpMethod.WithBody =>
@@ -115,7 +115,7 @@ export const allShort = [
  * HttpMethod.isHttpMethod(1) // => false
  * ```
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isHttpMethod = (u: unknown): u is HttpMethod => all.has(u as HttpMethod)

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -84,7 +84,7 @@ const stripSearchAndHash = (url: string): string => {
 /**
  * Runs an effect with HTTP response logging disabled for the current server request.
  *
- * @category Logger
+ * @category logging
  * @since 4.0.0
  */
 export const withLoggerDisabled = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | HttpServerRequest> =>
@@ -97,7 +97,7 @@ export const withLoggerDisabled = <A, E, R>(self: Effect.Effect<A, E, R>): Effec
 /**
  * Context reference for a predicate that disables server-side tracing for matching requests.
  *
- * @category Tracer
+ * @category services
  * @since 4.0.0
  */
 export const TracerDisabledWhen = Context.Reference<Predicate<HttpServerRequest>>(
@@ -108,7 +108,7 @@ export const TracerDisabledWhen = Context.Reference<Predicate<HttpServerRequest>
 /**
  * Creates a layer that disables server-side tracing for requests whose URL exactly matches one of the supplied URLs.
  *
- * @category Tracer
+ * @category layers
  * @since 4.0.0
  */
 export const layerTracerDisabledForUrls = (
@@ -118,7 +118,7 @@ export const layerTracerDisabledForUrls = (
 /**
  * Context reference for generating server span names from HTTP server requests.
  *
- * @category Tracer
+ * @category services
  * @since 4.0.0
  */
 export const SpanNameGenerator = Context.Reference<(request: HttpServerRequest) => string>(
@@ -129,7 +129,7 @@ export const SpanNameGenerator = Context.Reference<(request: HttpServerRequest) 
 /**
  * Middleware that logs sent HTTP responses with request method, request URL, and response status annotations.
  *
- * @category Logger
+ * @category logging
  * @since 4.0.0
  */
 export const logger: <E, R>(
@@ -170,7 +170,7 @@ export const logger: <E, R>(
 /**
  * Middleware that creates a server trace span for each request and records request and response HTTP attributes.
  *
- * @category Tracer
+ * @category tracing
  * @since 4.0.0
  */
 export const tracer: <E, R>(
@@ -245,7 +245,7 @@ export const tracer: <E, R>(
 /**
  * Middleware that trusts `X-Forwarded-Host` and `X-Forwarded-For`, updating the request host header and remote address.
  *
- * @category Proxying
+ * @category proxying
  * @since 4.0.0
  */
 export const xForwardedHeaders = make((httpApp) =>

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -265,7 +265,7 @@ export const xForwardedHeaders = make((httpApp) =>
 /**
  * Middleware that parses the current request URL's search parameters and provides them as `ParsedSearchParams`.
  *
- * @category search params
+ * @category parsing
  * @since 4.0.0
  */
 export const searchParamsParser = <E, R>(
@@ -285,7 +285,7 @@ export const searchParamsParser = <E, R>(
 /**
  * Middleware that handles CORS preflight requests and adds configured CORS headers to HTTP responses.
  *
- * @category CORS
+ * @category middleware
  * @since 4.0.0
  */
 export const cors = (options?: {

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -97,7 +97,7 @@ export interface HttpRouter {
  * Route and middleware layers require this service to register themselves with
  * the router.
  *
- * @category HttpRouter
+ * @category services
  * @since 4.0.0
  */
 export const HttpRouter: Context.Service<HttpRouter, HttpRouter> = Context.Service<HttpRouter>(
@@ -249,7 +249,7 @@ function sliceRequestUrl(request: HttpServerRequest.HttpServerRequest, prefix: s
  * The value is passed to the route matcher when an `HttpRouter` is created and
  * defaults to an empty configuration.
  *
- * @category configuration
+ * @category services
  * @since 4.0.0
  */
 export const RouterConfig = Context.Reference<Partial<FindMyWay.RouterConfig>>(
@@ -555,7 +555,7 @@ export const addAll = <Routes extends ReadonlyArray<Route<any, any>>, EX = never
 /**
  * Layer that provides a newly constructed `HttpRouter`.
  *
- * @category HttpRouter
+ * @category layers
  * @since 4.0.0
  */
 export const layer: Layer.Layer<HttpRouter> = Layer.effect(HttpRouter)(make)
@@ -601,7 +601,7 @@ const RouteTypeId = "~effect/http/HttpRouter/Route"
  * A route pairs an HTTP method and path pattern with a response handler, plus
  * metadata used for prefix handling and interruptibility.
  *
- * @category Route
+ * @category routes
  * @since 4.0.0
  */
 export interface Route<E = never, R = never> {
@@ -623,7 +623,7 @@ export declare namespace Route {
   /**
    * Extracts the error type produced by a `Route` handler.
    *
-   * @category Route
+   * @category routes
    * @since 4.0.0
    */
   export type Error<R extends Route<any, any>> = R extends Route<infer E, infer _R> ? E : never
@@ -631,7 +631,7 @@ export declare namespace Route {
   /**
    * Extracts the context requirements of a `Route` handler.
    *
-   * @category Route
+   * @category routes
    * @since 4.0.0
    */
   export type Context<T extends Route<any, any>> = T extends Route<infer _E, infer R> ? R : never
@@ -659,7 +659,7 @@ const makeRoute = <E, R>(options: {
  * function from the current request to a response effect. Set `uninterruptible` to
  * prevent the route handler from being made interruptible while it runs.
  *
- * @category Route
+ * @category routes
  * @since 4.0.0
  */
 export const route = <E = never, R = never>(
@@ -728,7 +728,7 @@ export const prefixPath: {
  * request, the matched prefix can be removed from the request URL seen by the
  * handler.
  *
- * @category Route
+ * @category routes
  * @since 4.0.0
  */
 export const prefixRoute: {
@@ -748,7 +748,7 @@ export const prefixRoute: {
  * Represents a request-level dependency, that needs to be provided by
  * middleware.
  *
- * @category Request types
+ * @category request types
  * @since 4.0.0
  */
 export interface Request<Kind extends string, T> {
@@ -767,7 +767,7 @@ export declare namespace Request {
   /**
    * Wraps a type in a request-level marker of the supplied kind.
    *
-   * @category Request types
+   * @category request types
    * @since 4.0.0
    */
   export type From<Kind extends string, R> = R extends infer T ? Request<Kind, T> : never
@@ -776,7 +776,7 @@ export declare namespace Request {
    * Extracts the payload types from request-level markers that have the supplied
    * kind.
    *
-   * @category Request types
+   * @category request types
    * @since 4.0.0
    */
   export type Only<Kind extends string, A> = A extends Request<Kind, infer T> ? T : never
@@ -785,7 +785,7 @@ export declare namespace Request {
    * Removes request-level markers from a union, leaving only ordinary requirement
    * or error types.
    *
-   * @category Request types
+   * @category request types
    * @since 4.0.0
    */
   export type Without<A> = A extends Request<infer _Kind, infer _> ? never : A
@@ -795,7 +795,7 @@ export declare namespace Request {
  * Services provided by the HTTP router, which are available in the
  * request context.
  *
- * @category Request types
+ * @category request types
  * @since 4.0.0
  */
 export type Provided =
@@ -807,7 +807,7 @@ export type Provided =
 /**
  * Services provided to global middleware.
  *
- * @category Request types
+ * @category request types
  * @since 4.0.0
  */
 export type GlobalProvided =

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -41,7 +41,7 @@ const TypeId = "~effect/http/HttpRouter"
  * and expose the registered routes as an Effect that handles the current server
  * request.
  *
- * @category HttpRouter
+ * @category services
  * @since 4.0.0
  */
 export interface HttpRouter {
@@ -112,7 +112,7 @@ export const HttpRouter: Context.Service<HttpRouter, HttpRouter> = Context.Servi
  * The returned router accepts route and middleware registrations and later routes
  * the current `HttpServerRequest` to the matching `HttpServerResponse`.
  *
- * @category HttpRouter
+ * @category constructors
  * @since 4.0.0
  */
 export const make = Effect.gen(function*() {
@@ -468,7 +468,7 @@ export const schemaPathParams = <A, I extends Readonly<Record<string, string | u
  * await Effect.runPromise(program) // => "ready"
  * ```
  *
- * @category HttpRouter
+ * @category layers
  * @since 4.0.0
  */
 export const use = <A, E, R>(
@@ -492,7 +492,7 @@ export const use = <A, E, R>(
  * Layer.isLayer(Route) // => true
  * ```
  *
- * @category HttpRouter
+ * @category layers
  * @since 4.0.0
  */
 export const add = <E = never, R = never>(
@@ -527,7 +527,7 @@ export const add = <E = never, R = never>(
  * Layer.isLayer(Routes) // => true
  * ```
  *
- * @category HttpRouter
+ * @category layers
  * @since 4.0.0
  */
 export const addAll = <Routes extends ReadonlyArray<Route<any, any>>, EX = never, RX = never>(
@@ -570,7 +570,7 @@ export const layer: Layer.Layer<HttpRouter> = Layer.effect(HttpRouter)(make)
  * `Scope`; route request markers are converted into the ordinary requirements of
  * the returned handler.
  *
- * @category HttpRouter
+ * @category converting
  * @since 4.0.0
  */
 export const toHttpEffect = <A, E, R>(
@@ -689,7 +689,7 @@ export const route = <E = never, R = never>(
  * Path pattern accepted by the router. Routes must use an absolute path
  * beginning with `/` or the wildcard `*`.
  *
- * @category PathInput
+ * @category models
  * @since 4.0.0
  */
 export type PathInput = `/${string}` | "*"
@@ -706,7 +706,7 @@ const removeTrailingSlash = (
  * Trailing slashes are removed from the prefix; `/` becomes the prefix itself and
  * `*` becomes a wildcard route under the prefix.
  *
- * @category PathInput
+ * @category transforming
  * @since 4.0.0
  */
 export const prefixPath: {
@@ -748,7 +748,7 @@ export const prefixRoute: {
  * Represents a request-level dependency, that needs to be provided by
  * middleware.
  *
- * @category request types
+ * @category utility types
  * @since 4.0.0
  */
 export interface Request<Kind extends string, T> {
@@ -767,7 +767,7 @@ export declare namespace Request {
   /**
    * Wraps a type in a request-level marker of the supplied kind.
    *
-   * @category request types
+   * @category utility types
    * @since 4.0.0
    */
   export type From<Kind extends string, R> = R extends infer T ? Request<Kind, T> : never
@@ -776,7 +776,7 @@ export declare namespace Request {
    * Extracts the payload types from request-level markers that have the supplied
    * kind.
    *
-   * @category request types
+   * @category utility types
    * @since 4.0.0
    */
   export type Only<Kind extends string, A> = A extends Request<Kind, infer T> ? T : never
@@ -785,7 +785,7 @@ export declare namespace Request {
    * Removes request-level markers from a union, leaving only ordinary requirement
    * or error types.
    *
-   * @category request types
+   * @category utility types
    * @since 4.0.0
    */
   export type Without<A> = A extends Request<infer _Kind, infer _> ? never : A
@@ -795,7 +795,7 @@ export declare namespace Request {
  * Services provided by the HTTP router, which are available in the
  * request context.
  *
- * @category request types
+ * @category utility types
  * @since 4.0.0
  */
 export type Provided =
@@ -807,7 +807,7 @@ export type Provided =
 /**
  * Services provided to global middleware.
  *
- * @category request types
+ * @category utility types
  * @since 4.0.0
  */
 export type GlobalProvided =
@@ -1145,7 +1145,7 @@ export declare namespace middleware {
 /**
  * Middleware that applies CORS headers to the HTTP response.
  *
- * @category middleware
+ * @category layers
  * @since 4.0.0
  */
 export const cors = (
@@ -1179,7 +1179,7 @@ export const cors = (
  * Layer.isLayer(Route) // => true
  * ```
  *
- * @category middleware
+ * @category layers
  * @since 4.0.0
  */
 export const disableLogger: Layer.Layer<never> = middleware(HttpMiddleware.withLoggerDisabled).layer
@@ -1187,7 +1187,7 @@ export const disableLogger: Layer.Layer<never> = middleware(HttpMiddleware.withL
 /**
  * Provides request-level dependencies to some routes.
  *
- * @category middleware
+ * @category layers
  * @since 4.0.0
  */
 export const provideRequest =
@@ -1212,7 +1212,7 @@ export const provideRequest =
 /**
  * Runs the provided application layer as an HTTP server.
  *
- * @category server
+ * @category layers
  * @since 4.0.0
  */
 export const serve = <A, E, R, HE, HR = Request.Only<"Requires", R> | Request.Only<"GlobalRequires", R>>(
@@ -1276,7 +1276,7 @@ export const serve = <A, E, R, HE, HR = Request.Only<"Requires", R> | Request.On
  * Web `Response` values and a `dispose` function for releasing the layer
  * resources.
  *
- * @category server
+ * @category converting
  * @since 4.0.0
  */
 export const toWebHandler = <

--- a/packages/effect/src/unstable/http/HttpServer.ts
+++ b/packages/effect/src/unstable/http/HttpServer.ts
@@ -32,7 +32,7 @@ import type { HttpServerResponse } from "./HttpServerResponse.ts"
  * The service can serve an HTTP response effect and exposes the address where the
  * server is listening.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class HttpServer extends Context.Service<HttpServer, {

--- a/packages/effect/src/unstable/http/HttpServer.ts
+++ b/packages/effect/src/unstable/http/HttpServer.ts
@@ -62,7 +62,7 @@ export class HttpServer extends Context.Service<HttpServer, {
  *
  * The address is either a TCP host and port or a Unix domain socket path.
  *
- * @category address
+ * @category models
  * @since 4.0.0
  */
 export type Address = UnixAddress | TcpAddress
@@ -70,7 +70,7 @@ export type Address = UnixAddress | TcpAddress
 /**
  * TCP address for an HTTP server, identified by hostname and port.
  *
- * @category address
+ * @category models
  * @since 4.0.0
  */
 export interface TcpAddress {
@@ -82,7 +82,7 @@ export interface TcpAddress {
 /**
  * Unix domain socket address for an HTTP server.
  *
- * @category address
+ * @category models
  * @since 4.0.0
  */
 export interface UnixAddress {
@@ -117,7 +117,7 @@ export const make = (
  * layer still requires the server, a scope, and any non-request dependencies of
  * the response effect or middleware.
  *
- * @category accessors
+ * @category layers
  * @since 4.0.0
  */
 export const serve: {
@@ -210,7 +210,7 @@ export const serveEffect: {
  * TCP addresses are formatted as `http://host:port`; Unix socket addresses are
  * formatted as `unix://path`.
  *
- * @category address
+ * @category converting
  * @since 4.0.0
  */
 export const formatAddress = (address: Address): string => {
@@ -226,7 +226,7 @@ export const formatAddress = (address: Address): string => {
  * Reads the current server address, formats it with `formatAddress`, and passes
  * the formatted address to the supplied effectful function.
  *
- * @category address
+ * @category accessors
  * @since 4.0.0
  */
 export const addressFormattedWith = <A, E, R>(
@@ -240,7 +240,7 @@ export const addressFormattedWith = <A, E, R>(
 /**
  * Logs the formatted address of the current HTTP server.
  *
- * @category address
+ * @category logging
  * @since 4.0.0
  */
 export const logAddress: Effect.Effect<void, never, HttpServer> = addressFormattedWith((_) =>
@@ -250,7 +250,7 @@ export const logAddress: Effect.Effect<void, never, HttpServer> = addressFormatt
 /**
  * Adds address logging to a layer that provides an `HttpServer`.
  *
- * @category address
+ * @category layers
  * @since 4.0.0
  */
 export const withLogAddress = <A, E, R>(

--- a/packages/effect/src/unstable/http/HttpServerError.ts
+++ b/packages/effect/src/unstable/http/HttpServerError.ts
@@ -178,7 +178,7 @@ export class InternalError extends Data.TaggedError("InternalError")<{
 /**
  * Returns `true` when the supplied value is an `HttpServerError`.
  *
- * @category predicates
+ * @category guards
  * @since 4.0.0
  */
 export const isHttpServerError = (u: unknown): u is HttpServerError => hasProperty(u, TypeId)
@@ -249,7 +249,7 @@ export class ServeError extends Data.TaggedError("ServeError")<{
  * `causeResponse` uses this annotation to map a pure client abort to a `499`
  * response instead of a server abort response.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class ClientAbort extends Context.Service<ClientAbort, true>()("effect/http/HttpServerError/ClientAbort") {

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -45,7 +45,7 @@ export {
    * Use to configure the maximum body size accepted while reading server
    * request bodies.
    *
-   * @category fiber refs
+   * @category references
    * @since 4.0.0
    */
   MaxBodySize
@@ -140,7 +140,7 @@ export class ParsedSearchParams extends Context.Service<
  *
  * Repeated parameters are represented as arrays in insertion order.
  *
- * @category search params
+ * @category parsing
  * @since 4.0.0
  */
 export const searchParamsFromURL = (url: URL): ReadonlyRecord<string, string | Array<string>> => {

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -105,7 +105,7 @@ export interface HttpServerRequest extends HttpIncomingMessage.HttpIncomingMessa
  * Use to access the request currently being handled by HTTP server routes and
  * middleware.
  *
- * @category context
+ * @category services
  * @since 4.0.0
  */
 export const HttpServerRequest: Context.Service<HttpServerRequest, HttpServerRequest> = Context.Service(
@@ -125,7 +125,7 @@ export const HttpServerRequest: Context.Service<HttpServerRequest, HttpServerReq
  * Each key maps to a string value, or to an array when the parameter appears more
  * than once.
  *
- * @category search params
+ * @category services
  * @since 4.0.0
  */
 export class ParsedSearchParams extends Context.Service<

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -438,7 +438,7 @@ export const makeConfig = (
  * non-empty batches of parsed `Part` values, failing with `MultipartError` for
  * parser and limit failures.
  *
- * @category parsers
+ * @category parsing
  * @since 4.0.0
  */
 export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channel<

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -438,7 +438,7 @@ export const makeConfig = (
  * non-empty batches of parsed `Part` values, failing with `MultipartError` for
  * parser and limit failures.
  *
- * @category Parsers
+ * @category parsers
  * @since 4.0.0
  */
 export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channel<
@@ -794,7 +794,7 @@ export declare namespace withLimits {
    * These settings control maximum part count, field size, file size, total body
    * size, and MIME types that should be treated as fields instead of files.
    *
-   * @category fiber refs
+   * @category options
    * @since 4.0.0
    */
   export type Options = {
@@ -813,7 +813,7 @@ export declare namespace withLimits {
  *
  * The default is `undefined`, meaning no explicit part-count limit.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MaxParts = Context.Reference<number | undefined>("effect/http/Multipart/MaxParts", {
@@ -827,7 +827,7 @@ export const MaxParts = Context.Reference<number | undefined>("effect/http/Multi
  *
  * The default limit is 10 MiB.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MaxFieldSize = Context.Reference<FileSystem.SizeInput>("effect/http/Multipart/MaxFieldSize", {
@@ -841,7 +841,7 @@ export const MaxFieldSize = Context.Reference<FileSystem.SizeInput>("effect/http
  *
  * The default is `undefined`, meaning no explicit per-file limit.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const MaxFileSize = Context.Reference<FileSystem.SizeInput | undefined>(
@@ -857,7 +857,7 @@ export const MaxFileSize = Context.Reference<FileSystem.SizeInput | undefined>(
  *
  * The default treats `application/json` parts as fields.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const FieldMimeTypes = Context.Reference<ReadonlyArray<string>>("effect/http/Multipart/FieldMimeTypes", {

--- a/packages/effect/src/unstable/http/Url.ts
+++ b/packages/effect/src/unstable/http/Url.ts
@@ -136,7 +136,7 @@ export const fromString: {
  * mutatedUrl.toString() // => "https://user:pass@example.com/"
  * ```
  *
- * @category modifiers
+ * @category transforming
  * @since 4.0.0
  */
 export const mutate: {
@@ -358,7 +358,7 @@ export const urlParams = (url: URL): UrlParams.UrlParams => UrlParams.fromInput(
  * changedUrl.toString() // => "https://example.com/?foo=bar&key=value"
  * ```
  *
- * @category modifiers
+ * @category transforming
  * @since 4.0.0
  */
 export const modifyUrlParams: {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -58,7 +58,7 @@ import * as OpenApi from "./OpenApi.ts"
 /**
  * Registers an `HttpApi` with a `HttpRouter`.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <Id extends string, Groups extends HttpApiGroup.Constraint>(

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -62,7 +62,7 @@ export type Client<Groups extends HttpApiGroup.Constraint, E = never, R = never>
  * Derives the typed client interface for an `HttpApi`, preserving any additional
  * client error and service requirements supplied by the caller.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ForApi<Api extends HttpApi.Constraint, E = never, R = never> = Api extends

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -869,7 +869,7 @@ function makeProto<
  * Constraint for path parameter schemas: each parameter must encode to
  * `string | undefined`, or the schema must encode to a record of those values.
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type ParamsConstraint =
@@ -880,7 +880,7 @@ export type ParamsConstraint =
  * Constraint for header schemas: each header must encode to `string | undefined`,
  * or the schema must encode to a record of those values.
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type HeadersConstraint =
@@ -891,7 +891,7 @@ export type HeadersConstraint =
  * Constraint for query schemas: each field must encode to `string`, an array of
  * strings, or `undefined`, or the schema must encode to a record of those values.
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type QueryConstraint =
@@ -906,7 +906,7 @@ export type QueryConstraint =
  * - for body methods, payload may be any `Schema.Top` (or content-type keyed
  *   schemas) and OpenAPI uses `requestBody` instead of `parameters`
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadConstraint<Method extends HttpMethod> = Method extends HttpMethod.NoBody ? Record<
@@ -920,7 +920,7 @@ export type PayloadConstraint<Method extends HttpMethod> = Method extends HttpMe
  * accept field records for query-style encoding, while body methods accept one or
  * more schemas.
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadConstraintCodecs<Method extends HttpMethod> = Method extends HttpMethod.NoBody ?
@@ -931,7 +931,7 @@ export type PayloadConstraintCodecs<Method extends HttpMethod> = Method extends 
  * Constraint for success response schemas, allowing either a single schema or a
  * readonly array of schemas.
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessConstraint = Schema.Top | ReadonlyArray<Schema.Top>
@@ -940,7 +940,7 @@ export type SuccessConstraint = Schema.Top | ReadonlyArray<Schema.Top>
  * Constraint for error response schemas, allowing either a single schema or a
  * readonly array of schemas.
  *
- * @category constraints
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorConstraint = Schema.Top | ReadonlyArray<Schema.Top>

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -334,7 +334,7 @@ export interface Top extends
 /**
  * Extracts the endpoint identifier literal from an `HttpApiEndpoint`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Identifier<Endpoint> = Endpoint extends Constraint ? Endpoint["identifier"] : never
@@ -342,7 +342,7 @@ export type Identifier<Endpoint> = Endpoint extends Constraint ? Endpoint["ident
 /**
  * Extracts the success schema associated with an endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Success<Endpoint> = Endpoint extends Constraint ? Endpoint["~Success"] : never
@@ -350,7 +350,7 @@ export type Success<Endpoint> = Endpoint extends Constraint ? Endpoint["~Success
 /**
  * Extracts the error schema associated with an endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<Endpoint> = Endpoint extends Constraint ? Endpoint["~Error"] : never
@@ -358,7 +358,7 @@ export type Error<Endpoint> = Endpoint extends Constraint ? Endpoint["~Error"] :
 /**
  * Extracts the schema used for an endpoint's path parameters.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Params<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~Params"]
@@ -367,7 +367,7 @@ export type Params<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~P
 /**
  * Extracts the schema used for an endpoint's query parameters.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Query<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~Query"]
@@ -376,7 +376,7 @@ export type Query<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~Qu
 /**
  * Extracts the schema used for an endpoint's request payload.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Payload<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~Payload"]
@@ -385,7 +385,7 @@ export type Payload<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~
 /**
  * Extracts the schema used for an endpoint's request headers.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Headers<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~Headers"]
@@ -394,7 +394,7 @@ export type Headers<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~
 /**
  * Extracts the middleware identifiers attached to an endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Middleware<Endpoint> = Endpoint extends { readonly "~Middleware": infer M } ? M
@@ -403,7 +403,7 @@ export type Middleware<Endpoint> = Endpoint extends { readonly "~Middleware": in
 /**
  * Computes the services provided by the middleware attached to an endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareProvides<Endpoint> = HttpApiMiddleware.Provides<Middleware<Endpoint>>
@@ -411,7 +411,7 @@ export type MiddlewareProvides<Endpoint> = HttpApiMiddleware.Provides<Middleware
 /**
  * Computes the client-side middleware services required by an endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareClient<Endpoint> = HttpApiMiddleware.MiddlewareClient<Middleware<Endpoint>>
@@ -420,7 +420,7 @@ export type MiddlewareClient<Endpoint> = HttpApiMiddleware.MiddlewareClient<Midd
  * Computes the error types that can be produced by the middleware attached to an
  * endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareError<Endpoint> = HttpApiMiddleware.Error<Middleware<Endpoint>>
@@ -429,7 +429,7 @@ export type MiddlewareError<Endpoint> = HttpApiMiddleware.Error<Middleware<Endpo
  * Computes the full error value union for an endpoint, including the endpoint
  * error schema's type and errors introduced by middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Errors<Endpoint> = Endpoint extends ConstraintRequest ?
@@ -440,7 +440,7 @@ export type Errors<Endpoint> = Endpoint extends ConstraintRequest ?
  * Computes the services required to encode an endpoint's error responses,
  * including services required by middleware error encoders.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesEncode<Endpoint> = Endpoint extends ConstraintRequest ?
@@ -453,7 +453,7 @@ export type ErrorServicesEncode<Endpoint> = Endpoint extends ConstraintRequest ?
  * available params, query, payload, headers, the raw request, endpoint, and group.
  * Multipart stream payloads are exposed as streams of parts.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Request<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~Request"]
@@ -464,7 +464,7 @@ export type Request<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~
  * params, query, and headers plus the raw request, endpoint, and group, while
  * leaving payload handling to the raw request.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type RequestRaw<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint["~RequestRaw"]
@@ -475,7 +475,7 @@ export type RequestRaw<Endpoint> = Endpoint extends ConstraintRequest ? Endpoint
  * the params, query, headers, payload, and response mode fields required by the
  * endpoint. Multipart payloads are supplied as `FormData`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ClientRequest<
@@ -511,7 +511,7 @@ export type ClientResponseMode = "decoded-only" | "decoded-and-response" | "resp
  * Computes the services required on the server to decode endpoint inputs and
  * encode endpoint success, error, and middleware error responses.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServerServices<Endpoint> = Endpoint extends ConstraintRequest ?
@@ -528,7 +528,7 @@ export type ServerServices<Endpoint> = Endpoint extends ConstraintRequest ?
  * Computes the services required on the client to encode endpoint requests and
  * decode endpoint success or error responses.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ClientServices<Endpoint> = Endpoint extends ConstraintRequest ?
@@ -543,7 +543,7 @@ export type ClientServices<Endpoint> = Endpoint extends ConstraintRequest ?
 /**
  * Extracts the additional services required by middleware applied to an endpoint.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareServices<Endpoint> = Endpoint extends { readonly "~MiddlewareServices": infer R } ? R
@@ -553,7 +553,7 @@ export type MiddlewareServices<Endpoint> = Endpoint extends { readonly "~Middlew
  * Computes the services required to decode an endpoint's error responses,
  * including services required by middleware error decoders.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesDecode<Endpoint> = Endpoint extends ConstraintRequest ?
@@ -565,7 +565,7 @@ export type ErrorServicesDecode<Endpoint> = Endpoint extends ConstraintRequest ?
  * The normal server handler for an endpoint, accepting the decoded request shape
  * and returning either the endpoint success value or a custom `HttpServerResponse`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Handler<Endpoint extends Constraint, E, R> = (
@@ -576,7 +576,7 @@ export type Handler<Endpoint extends Constraint, E, R> = (
  * The raw server handler for an endpoint, receiving a request shape without a
  * decoded payload so the handler can read the raw `HttpServerRequest` directly.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlerRaw<Endpoint extends Constraint, E, R> = (
@@ -586,7 +586,7 @@ export type HandlerRaw<Endpoint extends Constraint, E, R> = (
 /**
  * Selects the endpoint with the specified identifier from a union of endpoints.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type WithIdentifier<Endpoints, Identifier extends string> = Extract<
@@ -597,7 +597,7 @@ export type WithIdentifier<Endpoints, Identifier extends string> = Extract<
 /**
  * Removes endpoints with the specified identifier from a union of endpoints.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeIdentifier<Endpoints, Identifier extends string> = Exclude<
@@ -609,7 +609,7 @@ export type ExcludeIdentifier<Endpoints, Identifier extends string> = Exclude<
  * Derives the normal handler type for the endpoint with the specified identifier
  * in an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlerWithIdentifier<Endpoints extends Constraint, Identifier extends string, E, R> = Handler<
@@ -622,7 +622,7 @@ export type HandlerWithIdentifier<Endpoints extends Constraint, Identifier exten
  * Derives the raw handler type for the endpoint with the specified identifier in
  * an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlerRawWithIdentifier<Endpoints extends Constraint, Identifier extends string, E, R> = HandlerRaw<
@@ -635,7 +635,7 @@ export type HandlerRawWithIdentifier<Endpoints extends Constraint, Identifier ex
  * Extracts the decoded success value type for the endpoint with the specified
  * identifier in an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessWithIdentifier<Endpoints extends Constraint, Identifier extends string> = Success<
@@ -646,7 +646,7 @@ export type SuccessWithIdentifier<Endpoints extends Constraint, Identifier exten
  * Computes the full error value union for the endpoint with the specified
  * identifier in an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorsWithIdentifier<Endpoints extends Constraint, Identifier extends string> = Errors<
@@ -657,7 +657,7 @@ export type ErrorsWithIdentifier<Endpoints extends Constraint, Identifier extend
  * Computes the server-side service requirements for the endpoint with the
  * specified identifier in an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServerServicesWithIdentifier<Endpoints extends Constraint, Identifier extends string> = ServerServices<
@@ -668,7 +668,7 @@ export type ServerServicesWithIdentifier<Endpoints extends Constraint, Identifie
  * Extracts the middleware identifiers for the endpoint with the specified
  * identifier in an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareWithIdentifier<Endpoints extends Constraint, Identifier extends string> = Middleware<
@@ -679,7 +679,7 @@ export type MiddlewareWithIdentifier<Endpoints extends Constraint, Identifier ex
  * Extracts the middleware service requirements for the endpoint with the
  * specified identifier in an endpoint union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareServicesWithIdentifier<Endpoints extends Constraint, Identifier extends string> =
@@ -689,7 +689,7 @@ export type MiddlewareServicesWithIdentifier<Endpoints extends Constraint, Ident
  * Removes services provided by the HTTP router and the selected endpoint's
  * middleware from a service requirement union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeProvidedWithIdentifier<Endpoints extends Constraint, Identifier extends string, R> = ExcludeProvided<
@@ -701,7 +701,7 @@ export type ExcludeProvidedWithIdentifier<Endpoints extends Constraint, Identifi
  * Removes services provided by the HTTP router and endpoint middleware from a
  * service requirement union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeProvided<Endpoint extends Constraint, R> = Exclude<
@@ -714,7 +714,7 @@ export type ExcludeProvided<Endpoint extends Constraint, R> = Exclude<
  * Returns an endpoint type with the supplied path prefix prepended while
  * preserving the endpoint's schemas, method, errors, and middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddPrefix<Endpoint, Prefix extends HttpRouter.PathInput> = Endpoint extends HttpApiEndpoint<
@@ -748,7 +748,7 @@ export type AddPrefix<Endpoint, Prefix extends HttpRouter.PathInput> = Endpoint 
  * Returns an endpoint type with additional middleware applied and the endpoint's
  * middleware service requirements updated accordingly.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddMiddleware<Endpoint, M extends HttpApiMiddleware.AnyId> = Endpoint extends HttpApiEndpoint<

--- a/packages/effect/src/unstable/httpapi/HttpApiError.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiError.ts
@@ -56,7 +56,7 @@ export class BadRequest extends Schema.ErrorClass<BadRequest>("effect/HttpApiErr
  * No-content schema variant for `BadRequest`, decoding an empty 400 response into
  * a `BadRequest` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const BadRequestNoContent = BadRequest.pipe(HttpApiSchema.asNoContent({
@@ -86,7 +86,7 @@ export class Unauthorized extends Schema.ErrorClass<Unauthorized>("effect/HttpAp
  * No-content schema variant for `Unauthorized`, decoding an empty 401 response
  * into an `Unauthorized` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const UnauthorizedNoContent = Unauthorized.pipe(HttpApiSchema.asNoContent({
@@ -116,7 +116,7 @@ export class Forbidden extends Schema.ErrorClass<Forbidden>("effect/HttpApiError
  * No-content schema variant for `Forbidden`, decoding an empty 403 response into a
  * `Forbidden` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const ForbiddenNoContent = Forbidden.pipe(HttpApiSchema.asNoContent({
@@ -146,7 +146,7 @@ export class NotFound extends Schema.ErrorClass<NotFound>("effect/HttpApiError/N
  * No-content schema variant for `NotFound`, decoding an empty 404 response into a
  * `NotFound` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const NotFoundNoContent = NotFound.pipe(HttpApiSchema.asNoContent({
@@ -176,7 +176,7 @@ export class MethodNotAllowed extends Schema.ErrorClass<MethodNotAllowed>("effec
  * No-content schema variant for `MethodNotAllowed`, decoding an empty 405 response
  * into a `MethodNotAllowed` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const MethodNotAllowedNoContent = MethodNotAllowed.pipe(HttpApiSchema.asNoContent({
@@ -206,7 +206,7 @@ export class NotAcceptable extends Schema.ErrorClass<NotAcceptable>("effect/Http
  * No-content schema variant for `NotAcceptable`, decoding an empty 406 response
  * into a `NotAcceptable` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const NotAcceptableNoContent = NotAcceptable.pipe(HttpApiSchema.asNoContent({
@@ -236,7 +236,7 @@ export class RequestTimeout extends Schema.ErrorClass<RequestTimeout>("effect/Ht
  * No-content schema variant for `RequestTimeout`, decoding an empty 408 response
  * into a `RequestTimeout` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const RequestTimeoutNoContent = RequestTimeout.pipe(HttpApiSchema.asNoContent({
@@ -266,7 +266,7 @@ export class Conflict extends Schema.ErrorClass<Conflict>("effect/HttpApiError/C
  * No-content schema variant for `Conflict`, decoding an empty 409 response into a
  * `Conflict` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const ConflictNoContent = Conflict.pipe(HttpApiSchema.asNoContent({
@@ -296,7 +296,7 @@ export class Gone extends Schema.ErrorClass<Gone>("effect/HttpApiError/Gone")({
  * No-content schema variant for `Gone`, decoding an empty 410 response into a
  * `Gone` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const GoneNoContent = Gone.pipe(HttpApiSchema.asNoContent({
@@ -328,7 +328,7 @@ export class UnprocessableEntity
  * No-content schema variant for `UnprocessableEntity`, decoding an empty 422
  * response into an `UnprocessableEntity` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const UnprocessableEntityNoContent = UnprocessableEntity.pipe(HttpApiSchema.asNoContent({
@@ -359,7 +359,7 @@ export class InternalServerError
  * No-content schema variant for `InternalServerError`, decoding an empty 500
  * response into an `InternalServerError` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const InternalServerErrorNoContent = InternalServerError.pipe(HttpApiSchema.asNoContent({
@@ -388,7 +388,7 @@ export class NotImplemented extends Schema.ErrorClass<NotImplemented>("effect/Ht
  * No-content schema variant for `NotImplemented`, decoding an empty 501 response
  * into a `NotImplemented` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const NotImplementedNoContent = NotImplemented.pipe(HttpApiSchema.asNoContent({
@@ -419,7 +419,7 @@ export class ServiceUnavailable
  * No-content schema variant for `ServiceUnavailable`, decoding an empty 503
  * response into a `ServiceUnavailable` error value.
  *
- * @category NoContent errors
+ * @category schemas
  * @since 4.0.0
  */
 export const ServiceUnavailableNoContent = ServiceUnavailable.pipe(HttpApiSchema.asNoContent({

--- a/packages/effect/src/unstable/httpapi/HttpApiGroup.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiGroup.ts
@@ -136,7 +136,7 @@ export interface HttpApiGroup<
  * id and the group identifier so the relationship between an API and its
  * implemented groups is checked at compile time.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Service<ApiId extends string, Identifier extends string> {
@@ -154,7 +154,7 @@ export interface Service<ApiId extends string, Identifier extends string> {
  * When given an API id and a group or union of groups, this type maps each group
  * to the `Service` identity that must be provided by `HttpApiBuilder.group`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ToService<ApiId extends string, Group extends Constraint> = Group extends Constraint ?
@@ -187,7 +187,7 @@ export interface Top extends HttpApiGroup<string, HttpApiEndpoint.Top, boolean> 
 /**
  * Selects the group with the specified identifier from a union of groups.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type WithIdentifier<Group, Identifier extends string> = Extract<Group, { readonly identifier: Identifier }>
@@ -195,7 +195,7 @@ export type WithIdentifier<Group, Identifier extends string> = Extract<Group, { 
 /**
  * Extracts the identifier literal from an `HttpApiGroup`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Identifier<Group> = Group extends Constraint ? Group["identifier"] : never
@@ -203,7 +203,7 @@ export type Identifier<Group> = Group extends Constraint ? Group["identifier"] :
 /**
  * Extracts the endpoint union contained in an `HttpApiGroup`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Endpoints<Group> = Group extends HttpApiGroup<infer _Identifier, infer _Endpoints, infer _TopLevel> ?
@@ -214,7 +214,7 @@ export type Endpoints<Group> = Group extends HttpApiGroup<infer _Identifier, inf
  * Computes the services required to encode error responses for every endpoint in a
  * group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesEncode<Group> = HttpApiEndpoint.ErrorServicesEncode<Endpoints<Group>>
@@ -223,7 +223,7 @@ export type ErrorServicesEncode<Group> = HttpApiEndpoint.ErrorServicesEncode<End
  * Computes the services required to decode error responses for every endpoint in a
  * group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesDecode<Group> = HttpApiEndpoint.ErrorServicesDecode<Endpoints<Group>>
@@ -231,7 +231,7 @@ export type ErrorServicesDecode<Group> = HttpApiEndpoint.ErrorServicesDecode<End
 /**
  * Computes the middleware error union for every endpoint in a group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareError<Group> = HttpApiEndpoint.MiddlewareError<Endpoints<Group>>
@@ -240,7 +240,7 @@ export type MiddlewareError<Group> = HttpApiEndpoint.MiddlewareError<Endpoints<G
  * Computes the services provided by middleware attached to any endpoint in a
  * group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareProvides<Group> = HttpApiEndpoint.MiddlewareProvides<Endpoints<Group>>
@@ -248,7 +248,7 @@ export type MiddlewareProvides<Group> = HttpApiEndpoint.MiddlewareProvides<Endpo
 /**
  * Computes the client-side middleware services required by endpoints in a group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareClient<Group> = HttpApiEndpoint.MiddlewareClient<Endpoints<Group>>
@@ -256,7 +256,7 @@ export type MiddlewareClient<Group> = HttpApiEndpoint.MiddlewareClient<Endpoints
 /**
  * Extracts the runtime services required by middleware attached to the endpoints in an `HttpApiGroup`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareServices<Group> = HttpApiEndpoint.MiddlewareServices<Endpoints<Group>>
@@ -264,7 +264,7 @@ export type MiddlewareServices<Group> = HttpApiEndpoint.MiddlewareServices<Endpo
 /**
  * Extracts the endpoint union from the group with the specified identifier.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type EndpointsWithIdentifier<Group extends Constraint, Identifier extends string> = Endpoints<
@@ -274,7 +274,7 @@ export type EndpointsWithIdentifier<Group extends Constraint, Identifier extends
 /**
  * Computes the schema encoding and decoding services required by clients for all endpoints in a group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ClientServices<Group> = Group extends HttpApiGroup<infer _Identifier, infer _Endpoints, infer _TopLevel> ?
@@ -284,7 +284,7 @@ export type ClientServices<Group> = Group extends HttpApiGroup<infer _Identifier
 /**
  * Returns the type of a group after adding the supplied path prefix to each endpoint in the group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddPrefix<Group, Prefix extends PathInput> = Group extends
@@ -295,7 +295,7 @@ export type AddPrefix<Group, Prefix extends PathInput> = Group extends
 /**
  * Returns the type of a group after applying a middleware identifier to every endpoint in the group.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddMiddleware<Group, Id extends HttpApiMiddleware.AnyId> = Group extends

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -161,7 +161,7 @@ export interface AnyServiceSecurity extends AnyService {
 /**
  * Type-level identifier carried by middleware services to track provided services, required services, errors, client errors, and client requirements.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export interface AnyId {
@@ -177,7 +177,7 @@ export interface AnyId {
 /**
  * Extracts the services provided by a middleware identifier.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Provides<A> = A extends { readonly [TypeId]: { readonly provides: infer P } } ? P : never
@@ -185,7 +185,7 @@ export type Provides<A> = A extends { readonly [TypeId]: { readonly provides: in
 /**
  * Extracts the services required to run a middleware implementation.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Requires<A> = A extends { readonly [TypeId]: { readonly requires: infer R } } ? R : never
@@ -193,7 +193,7 @@ export type Requires<A> = A extends { readonly [TypeId]: { readonly requires: in
 /**
  * Applies a middleware's service changes to an existing requirement type by removing services it provides and adding services it requires.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ApplyServices<A extends AnyId, R> = Exclude<R, Provides<A>> | Requires<A>
@@ -201,7 +201,7 @@ export type ApplyServices<A extends AnyId, R> = Exclude<R, Provides<A>> | Requir
 /**
  * Extracts the schema or schema union used for errors declared by a middleware identifier.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorSchema<A> = A extends { readonly [TypeId]: { readonly error: infer E } } ? ErrorSchemaFromConstraint<E>
@@ -210,7 +210,7 @@ export type ErrorSchema<A> = A extends { readonly [TypeId]: { readonly error: in
 /**
  * Extracts the decoded error type declared by a middleware identifier.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<A> = ErrorSchema<A>["Type"]
@@ -218,7 +218,7 @@ export type Error<A> = ErrorSchema<A>["Type"]
 /**
  * Extracts the client-side error type for middleware that is required on generated clients.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ClientError<A> = A extends {
@@ -232,7 +232,7 @@ export type ClientError<A> = A extends {
 /**
  * Computes the client-side service marker required for middleware that must also run in generated clients.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareClient<A> = A extends {
@@ -245,7 +245,7 @@ export type MiddlewareClient<A> = A extends {
 /**
  * Extracts the schema services required to encode errors declared by a middleware identifier.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesEncode<A> = ErrorSchema<A>["EncodingServices"]
@@ -253,7 +253,7 @@ export type ErrorServicesEncode<A> = ErrorSchema<A>["EncodingServices"]
 /**
  * Extracts the schema services required to decode errors declared by a middleware identifier.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesDecode<A> = ErrorSchema<A>["DecodingServices"]
@@ -266,7 +266,7 @@ export type ErrorServicesDecode<A> = ErrorSchema<A>["DecodingServices"]
  * It combines a `Context.Service` class with the middleware metadata used by
  * endpoints, builders, and generated clients.
  *
- * @category schemas
+ * @category services
  * @since 4.0.0
  */
 export type ServiceClass<
@@ -314,7 +314,7 @@ export type ServiceClass<
  * required services, provided services, typed error schemas, security schemes,
  * client errors, or a matching client middleware requirement.
  *
- * @category schemas
+ * @category constructors
  * @since 4.0.0
  */
 export const Service = <
@@ -460,7 +460,7 @@ function getError(error: ErrorConstraint | undefined): ReadonlySet<Schema.Top> {
  * const result = [messages, body] // => [["Mapping Body schema error"], "CustomError"]
  * ```
  *
- * @category SchemaError transform
+ * @category layers
  * @since 4.0.0
  */
 export const layerSchemaErrorTransform = <Id, E extends ErrorConstraint, Requires>(
@@ -498,7 +498,7 @@ export const layerSchemaErrorTransform = <Id, E extends ErrorConstraint, Require
  * The layer captures the surrounding services and makes the middleware available
  * through the `ForClient` service marker used by HTTP API clients.
  *
- * @category client
+ * @category layers
  * @since 4.0.0
  */
 export const layerClient = <Id extends AnyId, S, R, EX = never, RX = never>(

--- a/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiMiddleware.ts
@@ -125,7 +125,7 @@ export interface HttpApiMiddlewareClient<_E, CE, R> {
 /**
  * Client-side service marker required when a middleware declares `requiredForClient`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export interface ForClient<Id> {
@@ -136,7 +136,7 @@ export interface ForClient<Id> {
 /**
  * Base service key shape for HTTP API middleware services, including provided services, declared error schemas, and client requirements.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface AnyService extends Context.Key<any, any> {
@@ -150,7 +150,7 @@ export interface AnyService extends Context.Key<any, any> {
 /**
  * Middleware service key shape for security middleware, including the security schemes handled by the service.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface AnyServiceSecurity extends AnyService {

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -140,7 +140,7 @@ const StreamSchemaTypeId = "~effect/httpapi/HttpApiSchema/Stream"
 /**
  * Common HTTP status code literals accepted by {@link status}.
  *
- * @category status
+ * @category models
  * @since 4.0.0
  */
 export type StatusLiteral = keyof typeof statusCodeByLiteral
@@ -154,7 +154,7 @@ export type StatusLiteral = keyof typeof statusCodeByLiteral
  * schema. You can pass either a numeric status code (for example, `201`) or a
  * common literal name (for example, `"Created"`).
  *
- * @category status
+ * @category schemas
  * @since 4.0.0
  */
 export function status(code: number): {
@@ -174,7 +174,7 @@ export function status(code: number | StatusLiteral) {
  *
  * @see {@link NoContent} for the predefined 204 no content schema.
  *
- * @category empty
+ * @category constructors
  * @since 4.0.0
  */
 export const Empty = (code: number): Schema.Void => Schema.Void.pipe(status(code))
@@ -190,7 +190,7 @@ export interface NoContent extends Schema.Void {}
 /**
  * Schema for empty HTTP responses with status code 204.
  *
- * @category empty
+ * @category schemas
  * @since 4.0.0
  */
 export const NoContent: NoContent = Empty(204)
@@ -206,7 +206,7 @@ export interface Created extends Schema.Void {}
 /**
  * Schema for empty HTTP responses with status code 201.
  *
- * @category empty
+ * @category schemas
  * @since 4.0.0
  */
 export const Created: Created = Empty(201)
@@ -222,7 +222,7 @@ export interface Accepted extends Schema.Void {}
 /**
  * Schema for empty HTTP responses with status code 202.
  *
- * @category empty
+ * @category schemas
  * @since 4.0.0
  */
 export const Accepted: Accepted = Empty(202)

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -174,7 +174,7 @@ export function status(code: number | StatusLiteral) {
  *
  * @see {@link NoContent} for the predefined 204 no content schema.
  *
- * @category Empty
+ * @category empty
  * @since 4.0.0
  */
 export const Empty = (code: number): Schema.Void => Schema.Void.pipe(status(code))
@@ -190,7 +190,7 @@ export interface NoContent extends Schema.Void {}
 /**
  * Schema for empty HTTP responses with status code 204.
  *
- * @category Empty
+ * @category empty
  * @since 4.0.0
  */
 export const NoContent: NoContent = Empty(204)
@@ -206,7 +206,7 @@ export interface Created extends Schema.Void {}
 /**
  * Schema for empty HTTP responses with status code 201.
  *
- * @category Empty
+ * @category empty
  * @since 4.0.0
  */
 export const Created: Created = Empty(201)
@@ -222,7 +222,7 @@ export interface Accepted extends Schema.Void {}
 /**
  * Schema for empty HTTP responses with status code 202.
  *
- * @category Empty
+ * @category empty
  * @since 4.0.0
  */
 export const Accepted: Accepted = Empty(202)

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -33,7 +33,7 @@ import type { HttpApiSecurity } from "./HttpApiSecurity.ts"
 /**
  * OpenAPI annotation for overriding generated identifiers, including operation ids.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Identifier extends Context.Service<Identifier, string>()("effect/httpapi/OpenApi/Identifier") {}
@@ -41,7 +41,7 @@ export class Identifier extends Context.Service<Identifier, string>()("effect/ht
 /**
  * OpenAPI annotation for setting the API title or group tag name.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Title extends Context.Service<Title, string>()("effect/httpapi/OpenApi/Title") {}
@@ -49,7 +49,7 @@ export class Title extends Context.Service<Title, string>()("effect/httpapi/Open
 /**
  * OpenAPI annotation for setting the generated API version.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Version extends Context.Service<Version, string>()("effect/httpapi/OpenApi/Version") {}
@@ -57,7 +57,7 @@ export class Version extends Context.Service<Version, string>()("effect/httpapi/
 /**
  * OpenAPI annotation for setting generated descriptions on APIs, groups, endpoints, or security schemes.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Description extends Context.Service<Description, string>()("effect/httpapi/OpenApi/Description") {}
@@ -65,7 +65,7 @@ export class Description extends Context.Service<Description, string>()("effect/
 /**
  * OpenAPI annotation for setting the generated API license metadata.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class License extends Context.Service<License, OpenAPISpecLicense>()("effect/httpapi/OpenApi/License") {}
@@ -73,7 +73,7 @@ export class License extends Context.Service<License, OpenAPISpecLicense>()("eff
 /**
  * OpenAPI annotation for adding external documentation metadata to groups or endpoints.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class ExternalDocs
@@ -83,7 +83,7 @@ export class ExternalDocs
 /**
  * OpenAPI annotation for setting the generated API server list.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Servers
@@ -93,7 +93,7 @@ export class Servers
 /**
  * OpenAPI annotation for setting the format metadata, such as a bearer token format on security schemes.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Format extends Context.Service<Format, string>()("effect/httpapi/OpenApi/Format") {}
@@ -101,7 +101,7 @@ export class Format extends Context.Service<Format, string>()("effect/httpapi/Op
 /**
  * OpenAPI annotation for setting generated summary text.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Summary extends Context.Service<Summary, string>()("effect/httpapi/OpenApi/Summary") {}
@@ -109,7 +109,7 @@ export class Summary extends Context.Service<Summary, string>()("effect/httpapi/
 /**
  * OpenAPI annotation for marking a generated endpoint operation as deprecated.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Deprecated extends Context.Service<Deprecated, boolean>()("effect/httpapi/OpenApi/Deprecated") {}
@@ -117,7 +117,7 @@ export class Deprecated extends Context.Service<Deprecated, boolean>()("effect/h
 /**
  * OpenAPI annotation for shallowly merging additional fields into a generated OpenAPI object.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Override extends Context.Service<Override, Record<string, unknown>>()("effect/httpapi/OpenApi/Override") {}
@@ -131,7 +131,7 @@ export class Override extends Context.Service<Override, Record<string, unknown>>
  * Use to hide internal, experimental, or otherwise undocumented HTTP API groups
  * and endpoints from generated OpenAPI output.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const Exclude = Context.Reference<boolean>("effect/httpapi/OpenApi/Exclude", {
@@ -146,7 +146,7 @@ export const Exclude = Context.Reference<boolean>("effect/httpapi/OpenApi/Exclud
  * The function is applied during generation to the annotated API, group tag, or
  * endpoint operation.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export class Transform extends Context.Service<

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -56,7 +56,7 @@ const policy = Schedule.forever.pipe(
  * exporter's temporary-disable window. Wrap it with `Effect.timeoutOption` to
  * bound its duration at the call site.
  *
- * @category flushing
+ * @category services
  * @since 4.0.0
  */
 export class Flusher extends Context.Service<Flusher, {
@@ -107,7 +107,7 @@ export class Flusher extends Context.Service<Flusher, {
  * was called (for example one started by the export interval); it only waits
  * for the exports it initiates.
  *
- * @category flushing
+ * @category layers
  * @since 4.0.0
  */
 export const layerFlusher: Layer.Layer<Flusher> = Layer.sync(Flusher, () => {

--- a/packages/effect/src/unstable/observability/OtlpResource.ts
+++ b/packages/effect/src/unstable/observability/OtlpResource.ts
@@ -142,7 +142,7 @@ export const fromConfig: (
  *
  * Throws if the resource does not contain a string `service.name` attribute.
  *
- * @category Attributes
+ * @category attributes
  * @since 4.0.0
  */
 export const serviceNameUnsafe = (resource: Resource): string => {
@@ -158,7 +158,7 @@ export const serviceNameUnsafe = (resource: Resource): string => {
 /**
  * Converts key/value entries into OTLP `KeyValue` attributes.
  *
- * @category Attributes
+ * @category attributes
  * @since 4.0.0
  */
 export const entriesToAttributes = (entries: Iterable<[string, unknown]>): Array<KeyValue> => {
@@ -180,7 +180,7 @@ export const entriesToAttributes = (entries: Iterable<[string, unknown]>): Array
  * Arrays are converted recursively, primitive values use their matching OTLP
  * fields, and unsupported values are formatted as strings.
  *
- * @category Attributes
+ * @category attributes
  * @since 4.0.0
  */
 export const unknownToAttributeValue = (value: unknown): AnyValue => {

--- a/packages/effect/src/unstable/observability/PrometheusMetrics.ts
+++ b/packages/effect/src/unstable/observability/PrometheusMetrics.ts
@@ -178,7 +178,7 @@ export const formatUnsafe = (
  * const result = [Layer.isLayer(PrometheusLayer), Layer.isLayer(CustomPrometheusLayer)] // => [true, true]
  * ```
  *
- * @category Http
+ * @category layers
  * @since 4.0.0
  */
 export const layerHttp = (

--- a/packages/effect/src/unstable/persistence/KeyValueStore.ts
+++ b/packages/effect/src/unstable/persistence/KeyValueStore.ts
@@ -701,7 +701,7 @@ const SchemaStoreTypeId = "~effect/persistence/KeyValueStore/SchemaStore" as con
 /**
  * Schema-aware view of a `KeyValueStore` that stores values as encoded JSON.
  *
- * @category SchemaStore
+ * @category models
  * @since 4.0.0
  */
 export interface SchemaStore<S extends Schema.Constraint> {
@@ -762,7 +762,7 @@ export interface SchemaStore<S extends Schema.Constraint> {
 /**
  * Adapts a `KeyValueStore` into a `SchemaStore` using the schema's JSON codec.
  *
- * @category SchemaStore
+ * @category converting
  * @since 4.0.0
  */
 export const toSchemaStore = <S extends Schema.Constraint>(self: KeyValueStore, schema: S): SchemaStore<S> => {

--- a/packages/effect/src/unstable/persistence/Persistable.ts
+++ b/packages/effect/src/unstable/persistence/Persistable.ts
@@ -56,7 +56,7 @@ export type Any = Persistable<Schema.Constraint, Schema.Constraint>
 /**
  * Extracts the success schema from a persistable request.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessSchema<A extends Any> = A["~effect/persistence/Persistable"]["success"]
@@ -64,7 +64,7 @@ export type SuccessSchema<A extends Any> = A["~effect/persistence/Persistable"][
 /**
  * Extracts the success value type from a persistable request.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Success<A extends Any> = A["~effect/persistence/Persistable"]["success"]["Type"]
@@ -72,7 +72,7 @@ export type Success<A extends Any> = A["~effect/persistence/Persistable"]["succe
 /**
  * Extracts the error schema from a persistable request.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorSchema<A extends Any> = A["~effect/persistence/Persistable"]["error"]
@@ -80,7 +80,7 @@ export type ErrorSchema<A extends Any> = A["~effect/persistence/Persistable"]["e
 /**
  * Extracts the error value type from a persistable request.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<A extends Any> = A["~effect/persistence/Persistable"]["error"]["Type"]
@@ -89,7 +89,7 @@ export type Error<A extends Any> = A["~effect/persistence/Persistable"]["error"]
  * Services required to decode a persisted success or error value for the
  * request.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type DecodingServices<A extends Any> =
@@ -99,7 +99,7 @@ export type DecodingServices<A extends Any> =
 /**
  * Services required to encode a success or error value for persistence.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type EncodingServices<A extends Any> =
@@ -110,7 +110,7 @@ export type EncodingServices<A extends Any> =
  * All schema services required to encode and decode a persistable request
  * result.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Services<A extends Any> =
@@ -123,7 +123,7 @@ export type Services<A extends Any> =
  * Computes the time to live for a persisted result from the result `Exit` and
  * request value.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type TimeToLiveFn<K extends Any> = (exit: Exit.Exit<Success<K>, Error<K>>, request: K) => Duration.Input

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -245,7 +245,7 @@ export class PersistedQueueError extends Schema.ErrorClass<PersistedQueueError>(
  * The store persists offered elements and returns taken elements in a scope so
  * the finalizer can complete or retry them based on the processing exit.
  *
- * @category store
+ * @category services
  * @since 4.0.0
  */
 export class PersistedQueueStore extends Context.Service<
@@ -283,7 +283,7 @@ export class PersistedQueueStore extends Context.Service<
  * The store is process-local and volatile; failed takes are requeued until the
  * configured maximum attempts is reached.
  *
- * @category store
+ * @category layers
  * @since 4.0.0
  */
 export const layerStoreMemory: Layer.Layer<
@@ -720,7 +720,7 @@ end
 /**
  * Provides a Redis-backed `PersistedQueueStore` using `makeStoreRedis`.
  *
- * @category store
+ * @category layers
  * @since 4.0.0
  */
 export const layerStoreRedis: (
@@ -1181,7 +1181,7 @@ class QueueKey extends Data.Class<{
 /**
  * Provides a SQL-backed `PersistedQueueStore` using `makeStoreSql`.
  *
- * @category store
+ * @category layers
  * @since 4.0.0
  */
 export const layerStoreSql: (

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -357,7 +357,7 @@ export const layerStoreMemory: Layer.Layer<
  * refreshes locks while items are being processed, and moves exhausted items
  * to a failed queue.
  *
- * @category store
+ * @category constructors
  * @since 4.0.0
  */
 export const makeStoreRedis = Effect.fnUntraced(function*(
@@ -745,7 +745,7 @@ export const layerStoreRedis: (
  * per-worker locks, refreshes active locks while scoped takes are running, and
  * retries or completes rows according to the processing exit.
  *
- * @category store
+ * @category constructors
  * @since 4.0.0
  */
 export const makeStoreSql: (

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -52,7 +52,7 @@ export class PersistenceError extends Schema.ErrorClass<PersistenceError>(ErrorT
  * Service for creating scoped stores of persisted `Persistable` request
  * results.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class Persistence extends Context.Service<Persistence, {
@@ -99,7 +99,7 @@ export interface PersistenceStore {
 /**
  * Service for creating raw backing stores for persistence store ids.
  *
- * @category BackingPersistence
+ * @category services
  * @since 4.0.0
  */
 export class BackingPersistence extends Context.Service<BackingPersistence, {

--- a/packages/effect/src/unstable/persistence/Persistence.ts
+++ b/packages/effect/src/unstable/persistence/Persistence.ts
@@ -110,7 +110,7 @@ export class BackingPersistence extends Context.Service<BackingPersistence, {
  * Raw persistence backing store for JSON-compatible objects with optional
  * TTLs.
  *
- * @category BackingPersistence
+ * @category services
  * @since 4.0.0
  */
 export interface BackingPersistenceStore {

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -885,7 +885,7 @@ export const layerStoreMemory: Layer.Layer<
  * Creates a Redis-backed `RateLimiterStore` using Lua scripts and the
  * configured key prefix.
  *
- * @category RateLimiterStore
+ * @category constructors
  * @since 4.0.0
  */
 export const makeStoreRedis = Effect.fnUntraced(function*(

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -497,7 +497,7 @@ export type AdaptivePhase = "inactive" | "cooldown" | "learning" | "learned"
 /**
  * Options for consuming tokens from the adaptive rate limiter store.
  *
- * @category models
+ * @category options
  * @since 4.0.0
  */
 export interface AdaptiveConsumeOptions {
@@ -548,7 +548,7 @@ export interface AdaptiveConsumeResult {
 /**
  * Options for reporting response feedback to the adaptive rate limiter store.
  *
- * @category models
+ * @category options
  * @since 4.0.0
  */
 export interface AdaptiveFeedbackOptions {
@@ -586,7 +586,7 @@ export interface AdaptiveFeedbackOptions {
  * Use to provide the shared counter storage and adaptive feedback state used by
  * persistent rate-limit checks.
  *
- * @category store
+ * @category services
  * @since 4.0.0
  */
 export class RateLimiterStore extends Context.Service<
@@ -666,7 +666,7 @@ interface AdaptiveState {
 /**
  * Provides a process-local in-memory `RateLimiterStore`.
  *
- * @category RateLimiterStore
+ * @category layers
  * @since 4.0.0
  */
 export const layerStoreMemory: Layer.Layer<

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -123,7 +123,7 @@ const ScriptTypeId: ScriptTypeId = "~effect/persistence/Redis/Script"
  * It defines the Lua source, parameter-to-argument mapping, Redis key count,
  * and result type used by `Redis.eval`.
  *
- * @category Scripting
+ * @category scripting
  * @since 4.0.0
  */
 export interface Script<
@@ -173,7 +173,7 @@ const ScriptProto = {
  * The result type defaults to `void` and can be refined with
  * `withReturnType`.
  *
- * @category Scripting
+ * @category scripting
  * @since 4.0.0
  */
 export const script = <Params extends ReadonlyArray<any>>(

--- a/packages/effect/src/unstable/process/ChildProcessSpawner.ts
+++ b/packages/effect/src/unstable/process/ChildProcessSpawner.ts
@@ -217,7 +217,7 @@ export const makeHandle = (params: Omit<ChildProcessHandle, typeof HandleTypeId>
  * Creates a `ChildProcessSpawner` service from a `spawn` function, deriving
  * helpers for exit codes and output collection from that implementation.
  *
- * @category models
+ * @category constructors
  * @since 4.0.0
  */
 export const make = (spawn: ChildProcessSpawner["Service"]["spawn"]): ChildProcessSpawner["Service"] => {

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -142,7 +142,7 @@ const ResultProto = {
 /**
  * Returns whether an `AsyncResult` is currently waiting for an asynchronous computation or refresh to finish.
  *
- * @category refinements
+ * @category predicates
  * @since 4.0.0
  */
 export const isWaiting = <A, E>(result: AsyncResult<A, E>): boolean => result.waiting
@@ -194,7 +194,7 @@ export const waitingFrom = <A, E>(previous: Option.Option<AsyncResult<A, E>>): A
 /**
  * Returns `true` when an `AsyncResult` is in the `Initial` state.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isInitial = <A, E>(result: AsyncResult<A, E>): result is Initial<A, E> => result._tag === "Initial"
@@ -202,7 +202,7 @@ export const isInitial = <A, E>(result: AsyncResult<A, E>): result is Initial<A,
 /**
  * Returns `true` when an `AsyncResult` is either `Success` or `Failure`.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isNotInitial = <A, E>(result: AsyncResult<A, E>): result is Success<A, E> | Failure<A, E> =>
@@ -236,7 +236,7 @@ export interface Success<A, E = never> extends AsyncResult.Proto<A, E> {
 /**
  * Returns `true` when an `AsyncResult` is a `Success`.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isSuccess = <A, E>(result: AsyncResult<A, E>): result is Success<A, E> => result._tag === "Success"
@@ -274,7 +274,7 @@ export interface Failure<A, E = never> extends AsyncResult.Proto<A, E> {
 /**
  * Returns `true` when an `AsyncResult` is a `Failure`.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isFailure = <A, E>(result: AsyncResult<A, E>): result is Failure<A, E> => result._tag === "Failure"
@@ -282,7 +282,7 @@ export const isFailure = <A, E>(result: AsyncResult<A, E>): result is Failure<A,
 /**
  * Returns `true` when an `AsyncResult` is a `Failure` whose cause contains only interruptions.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isInterrupted = <A, E>(result: AsyncResult<A, E>): result is Failure<A, E> =>
@@ -725,7 +725,7 @@ export const builder = <A extends AsyncResult<any, any>>(self: A): Builder<
 /**
  * Type marker used by `Builder` to track whether defect failures still need to be handled.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export interface Defect {
@@ -735,7 +735,7 @@ export interface Defect {
 /**
  * Type marker used by `Builder` to track whether interrupt failures still need to be handled.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export interface Interrupt {

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -355,7 +355,7 @@ const WritableProto = {
 /**
  * Returns `true` when an atom is writable.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isWritable = <R, W>(atom: Atom<R>): atom is Writable<R, W> => WritableTypeId in atom
@@ -1890,7 +1890,7 @@ const shouldRevalidateSWR = <A, E>(result: AsyncResult.AsyncResult<A, E>, staleT
  * transitions finish, the source atom is refreshed, and failures roll the value
  * back to the latest source value.
  *
- * @category Optimistic
+ * @category optimistic
  * @since 4.0.0
  */
 export const optimistic = <A>(self: Atom<A>): Writable<A, Atom<AsyncResult.AsyncResult<A, unknown>>> => {
@@ -1993,7 +1993,7 @@ export const optimistic = <A>(self: Atom<A>): Writable<A, Atom<AsyncResult.Async
  * input. The wrapped function result then completes the transition or updates the
  * optimistic value through the provided setter callback.
  *
- * @category Optimistic
+ * @category optimistic
  * @since 4.0.0
  */
 export const optimisticFn: {
@@ -2077,7 +2077,7 @@ export const batch: (f: () => void) => void = Registry.batch
  * It listens for `visibilitychange` events on `window` and removes the listener
  * when the atom is disposed.
  *
- * @category Focus
+ * @category focus
  * @since 4.0.0
  */
 export const windowFocusSignal: Atom<number> = readable((get) => {
@@ -2103,7 +2103,7 @@ export const windowFocusSignal: Atom<number> = readable((get) => {
  * The derived atom also subscribes to the source atom so normal source updates are
  * forwarded to its own value.
  *
- * @category Focus
+ * @category focus
  * @since 4.0.0
  */
 export const makeRefreshOnSignal = <_>(signal: Atom<_>) => <A extends Atom<any>>(self: A): WithoutSerializable<A> =>
@@ -2122,7 +2122,7 @@ export const makeRefreshOnSignal = <_>(signal: Atom<_>) => <A extends Atom<any>>
  * This helper is browser-only because `windowFocusSignal` depends on `window` and
  * `document.visibilityState`.
  *
- * @category Focus
+ * @category focus
  * @since 4.0.0
  */
 export const refreshOnWindowFocus: <A extends Atom<any>>(self: A) => WithoutSerializable<A> = makeRefreshOnSignal(
@@ -2450,7 +2450,7 @@ export type SerializableTypeId = "~effect-atom/atom/Atom/Serializable"
  * The key identifies the atom in dehydrated state, and the encode/decode
  * functions convert between the atom value and the schema encoded value.
  *
- * @category Serializable
+ * @category serializable
  * @since 4.0.0
  */
 export interface Serializable<S extends Schema.Constraint> {
@@ -2464,7 +2464,7 @@ export interface Serializable<S extends Schema.Constraint> {
 /**
  * Returns `true` when an atom carries `Serializable` metadata.
  *
- * @category Serializable
+ * @category guards
  * @since 4.0.0
  */
 export const isSerializable = (self: Atom<any>): self is Atom<any> & Serializable<any> => SerializableTypeId in self

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -1890,7 +1890,7 @@ const shouldRevalidateSWR = <A, E>(result: AsyncResult.AsyncResult<A, E>, staleT
  * transitions finish, the source atom is refreshed, and failures roll the value
  * back to the latest source value.
  *
- * @category optimistic
+ * @category constructors
  * @since 4.0.0
  */
 export const optimistic = <A>(self: Atom<A>): Writable<A, Atom<AsyncResult.AsyncResult<A, unknown>>> => {
@@ -1993,7 +1993,7 @@ export const optimistic = <A>(self: Atom<A>): Writable<A, Atom<AsyncResult.Async
  * input. The wrapped function result then completes the transition or updates the
  * optimistic value through the provided setter callback.
  *
- * @category optimistic
+ * @category combinators
  * @since 4.0.0
  */
 export const optimisticFn: {
@@ -2077,7 +2077,7 @@ export const batch: (f: () => void) => void = Registry.batch
  * It listens for `visibilitychange` events on `window` and removes the listener
  * when the atom is disposed.
  *
- * @category focus
+ * @category constants
  * @since 4.0.0
  */
 export const windowFocusSignal: Atom<number> = readable((get) => {
@@ -2103,7 +2103,7 @@ export const windowFocusSignal: Atom<number> = readable((get) => {
  * The derived atom also subscribes to the source atom so normal source updates are
  * forwarded to its own value.
  *
- * @category focus
+ * @category constructors
  * @since 4.0.0
  */
 export const makeRefreshOnSignal = <_>(signal: Atom<_>) => <A extends Atom<any>>(self: A): WithoutSerializable<A> =>
@@ -2122,7 +2122,7 @@ export const makeRefreshOnSignal = <_>(signal: Atom<_>) => <A extends Atom<any>>
  * This helper is browser-only because `windowFocusSignal` depends on `window` and
  * `document.visibilityState`.
  *
- * @category focus
+ * @category combinators
  * @since 4.0.0
  */
 export const refreshOnWindowFocus: <A extends Atom<any>>(self: A) => WithoutSerializable<A> = makeRefreshOnSignal(
@@ -2142,7 +2142,7 @@ export const refreshOnWindowFocus: <A extends Atom<any>>(self: A) => WithoutSeri
  * exposes the decoded value and writes the default value when the key is missing;
  * in async mode it exposes an `AsyncResult` of the decoded value.
  *
- * @category KeyValueStore
+ * @category constructors
  * @since 4.0.0
  */
 export const kvs = <S extends Schema.ConstraintCodec<any, any>, const Mode extends "sync" | "async" = never>(options: {
@@ -2207,7 +2207,7 @@ export const kvs = <S extends Schema.ConstraintCodec<any, any>, const Mode exten
  *
  * If you pass a schema, it has to be synchronous and have no context.
  *
- * @category search params
+ * @category constructors
  * @since 4.0.0
  */
 export const searchParam = <S extends Schema.ConstraintCodec<any, string> = never>(
@@ -2450,7 +2450,7 @@ export type SerializableTypeId = "~effect-atom/atom/Atom/Serializable"
  * The key identifies the atom in dehydrated state, and the encode/decode
  * functions convert between the atom value and the schema encoded value.
  *
- * @category serializable
+ * @category models
  * @since 4.0.0
  */
 export interface Serializable<S extends Schema.Constraint> {
@@ -2516,7 +2516,7 @@ export const ServerValueTypeId = "~effect-atom/atom/Atom/ServerValue" as const
 /**
  * Sets the value of an Atom when read on the server.
  *
- * @category ServerValue
+ * @category transforming
  * @since 4.0.0
  */
 export const withServerValue: {
@@ -2535,7 +2535,7 @@ export const withServerValue: {
  * Sets an `AsyncResult` atom's server-side value to
  * `AsyncResult.initial(true)`.
  *
- * @category ServerValue
+ * @category transforming
  * @since 4.0.0
  */
 export const withServerValueInitial = <A extends Atom<AsyncResult.AsyncResult<any, any>>>(self: A): A =>
@@ -2549,7 +2549,7 @@ export const withServerValueInitial = <A extends Atom<AsyncResult.AsyncResult<an
  *
  * Nested reads performed by the override are resolved against the same registry.
  *
- * @category ServerValue
+ * @category getters
  * @since 4.0.0
  */
 export const getServerValue: {

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -37,7 +37,7 @@ import * as Reactivity from "./Reactivity.ts"
  * It exposes the generated HTTP API client, an atom runtime, mutation helpers that
  * return `AtomResultFn`s, and query helpers that return atoms of endpoint results.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpApiGroup.Constraint>

--- a/packages/effect/src/unstable/reactivity/AtomRpc.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRpc.ts
@@ -37,7 +37,7 @@ import * as Reactivity from "./Reactivity.ts"
  * It exposes the RPC client, an atom runtime, mutation helpers that return `AtomResultFn`s, and query helpers that
  * return atoms or pull atoms for RPC results.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface AtomRpcClient<Self, Id extends string, Rpcs extends Rpc.Any> extends

--- a/packages/effect/src/unstable/reactivity/Hydration.ts
+++ b/packages/effect/src/unstable/reactivity/Hydration.ts
@@ -103,7 +103,7 @@ export const dehydrate = (
 /**
  * Returns dehydrated state entries as `DehydratedAtomValue` records.
  *
- * @category dehydration
+ * @category converting
  * @since 4.0.0
  */
 export const toValues = (state: ReadonlyArray<DehydratedAtom>): Array<DehydratedAtomValue> => state as any

--- a/packages/effect/src/unstable/rpc/Rpc.ts
+++ b/packages/effect/src/unstable/rpc/Rpc.ts
@@ -260,7 +260,7 @@ export interface AnyWithProps extends Pipeable {
 /**
  * Extracts the tag string from an `Rpc`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Tag<R> = R extends Rpc<
@@ -276,7 +276,7 @@ export type Tag<R> = R extends Rpc<
 /**
  * Extracts the success schema from an `Rpc`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessSchema<R> = R extends Rpc<
@@ -292,7 +292,7 @@ export type SuccessSchema<R> = R extends Rpc<
 /**
  * Extracts the decoded success value type from an `Rpc`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Success<R> = SuccessSchema<R>["Type"]
@@ -300,7 +300,7 @@ export type Success<R> = SuccessSchema<R>["Type"]
 /**
  * Extracts the encoded success value type from an `Rpc`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessEncoded<R> = R extends Rpc<
@@ -321,7 +321,7 @@ export type SuccessEncoded<R> = R extends Rpc<
  * For streaming RPCs, this is the stream element schema; otherwise it is the
  * RPC success schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessExitSchema<R> = SuccessSchema<R> extends RpcSchema.Stream<infer _A, infer _E> ? _A : SuccessSchema<R>
@@ -334,7 +334,7 @@ export type SuccessExitSchema<R> = SuccessSchema<R> extends RpcSchema.Stream<inf
  * For streaming RPCs, the immediate exit success is `void` because stream
  * elements are delivered separately.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessExit<R> = Success<R> extends infer T ? T extends Stream<infer _A, infer _E, infer _Env> ? void : T
@@ -344,7 +344,7 @@ export type SuccessExit<R> = Success<R> extends infer T ? T extends Stream<infer
  * Extracts the decoded stream element type from a streaming RPC, or `never` for
  * non-streaming RPCs.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SuccessChunk<R> = Success<R> extends Stream<infer _A, infer _E, infer _Env> ? _A : never
@@ -353,7 +353,7 @@ export type SuccessChunk<R> = Success<R> extends Stream<infer _A, infer _E, infe
  * Extracts the RPC error schema, including error schemas contributed by
  * middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorSchema<R> = R extends Rpc<
@@ -370,7 +370,7 @@ export type ErrorSchema<R> = R extends Rpc<
  * Extracts the decoded error value type from an `Rpc`, including middleware
  * errors.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<R> = Schema.Schema.Type<ErrorSchema<R>>
@@ -383,7 +383,7 @@ export type Error<R> = Schema.Schema.Type<ErrorSchema<R>>
  * For streaming RPCs, this includes both the stream error schema and the RPC
  * error schema; otherwise it is the RPC error schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorExitSchema<R> = SuccessSchema<R> extends RpcSchema.Stream<infer _A, infer _E> ? _E | ErrorSchema<R>
@@ -396,7 +396,7 @@ export type ErrorExitSchema<R> = SuccessSchema<R> extends RpcSchema.Stream<infer
  *
  * For streaming RPCs, this includes both stream errors and RPC errors.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorExit<R> = Success<R> extends Stream<infer _A, infer _E, infer _Env> ? _E | Error<R> : Error<R>
@@ -405,7 +405,7 @@ export type ErrorExit<R> = Success<R> extends Stream<infer _A, infer _E, infer _
  * The `Exit` type produced for an RPC, using the RPC's exit success and exit
  * error types.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Exit<R> = Exit_<SuccessExit<R>, ErrorExit<R>>
@@ -414,7 +414,7 @@ export type Exit<R> = Exit_<SuccessExit<R>, ErrorExit<R>>
  * Extracts the payload constructor input type accepted by the RPC payload
  * schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadConstructor<R> = R extends Rpc<
@@ -430,7 +430,7 @@ export type PayloadConstructor<R> = R extends Rpc<
 /**
  * Extracts the decoded payload type from an `Rpc`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Payload<R> = R extends Rpc<
@@ -447,7 +447,7 @@ export type Payload<R> = R extends Rpc<
  * Extracts all schema services required to encode or decode an RPC's payload,
  * success, error, and middleware error schemas.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Services<R> = R extends Rpc<
@@ -476,7 +476,7 @@ export type Services<R> = R extends Rpc<
  * This includes payload encoding services and success, error, and middleware
  * error decoding services.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesClient<R> = R extends Rpc<
@@ -501,7 +501,7 @@ export type ServicesClient<R> = R extends Rpc<
  * This includes payload decoding services and success, error, and middleware
  * error encoding services.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ServicesServer<R> = R extends Rpc<
@@ -521,7 +521,7 @@ export type ServicesServer<R> = R extends Rpc<
 /**
  * Extracts the service identifiers for middleware attached to an `Rpc`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Middleware<R> = R extends Rpc<
@@ -538,7 +538,7 @@ export type Middleware<R> = R extends Rpc<
  * Extracts client-side middleware service requirements for middleware marked as
  * required on the client.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type MiddlewareClient<R> = R extends Rpc<
@@ -556,7 +556,7 @@ export type MiddlewareClient<R> = R extends Rpc<
  * Returns an RPC type with an additional error schema unioned into its error
  * channel.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddError<R extends Any, Error extends Schema.Top> = R extends Rpc<
@@ -580,7 +580,7 @@ export type AddError<R extends Any, Error extends Schema.Top> = R extends Rpc<
  * Returns an RPC type with additional middleware and the corresponding
  * middleware service requirements applied.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AddMiddleware<R extends Any, Middleware extends RpcMiddleware.AnyService> = R extends Rpc<
@@ -603,7 +603,7 @@ export type AddMiddleware<R extends Any, Middleware extends RpcMiddleware.AnySer
 /**
  * Converts an RPC definition into the corresponding `Handler` type.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ToHandler<R extends Any> = R extends Rpc<
@@ -624,7 +624,7 @@ export type ToHandler<R extends Any> = R extends Rpc<
  * The function receives the decoded payload and request metadata, and returns
  * the RPC result shape, optionally wrapped with `Wrapper` options.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ToHandlerFn<Current extends Any, R = any> = (
@@ -641,7 +641,7 @@ export type ToHandlerFn<Current extends Any, R = any> = (
  * Returns `true` when the RPC with the specified tag has a streaming success
  * schema, or `never` otherwise.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type IsStream<R extends Any, Tag extends string> = R extends Rpc<
@@ -657,7 +657,7 @@ export type IsStream<R extends Any, Tag extends string> = R extends Rpc<
 /**
  * Extracts the RPC with the specified tag from an RPC union.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExtractTag<R extends Any, Tag extends string> = R extends Rpc<
@@ -674,7 +674,7 @@ export type ExtractTag<R extends Any, Tag extends string> = R extends Rpc<
  * Extracts the services provided by middleware on the RPC with the specified
  * tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExtractProvides<R extends Any, Tag extends string> = R extends Rpc<
@@ -690,7 +690,7 @@ export type ExtractProvides<R extends Any, Tag extends string> = R extends Rpc<
 /**
  * Extracts the service requirements of the RPC with the specified tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExtractRequires<R extends Any, Tag extends string> = R extends Rpc<
@@ -707,7 +707,7 @@ export type ExtractRequires<R extends Any, Tag extends string> = R extends Rpc<
  * Removes the services provided by middleware for the specified RPC tag from an
  * environment type.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ExcludeProvides<Env, R extends Any, Tag extends string> = Exclude<
@@ -724,7 +724,7 @@ export type ExcludeProvides<Env, R extends Any, Tag extends string> = Exclude<
  * RPCs return an effect that succeeds with the success value or a deferred
  * success value.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ResultFrom<R extends Any, Services> = R extends Rpc<
@@ -756,7 +756,7 @@ export type ResultFrom<R extends Any, Services> = R extends Rpc<
  * Returns an RPC type with the specified string prefix added to its tag while
  * preserving its payload, success, error, middleware, and requirements.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Prefixed<Rpcs extends Any, Prefix extends string> = Rpcs extends Rpc<
@@ -1180,7 +1180,7 @@ export type WrapperOr<A> = A | Wrapper<A>
 /**
  * Returns `true` when the value is an RPC `Wrapper`.
  *
- * @category wrapping
+ * @category guards
  * @since 4.0.0
  */
 export const isWrapper = (u: object): u is Wrapper<any> => WrapperTypeId in u

--- a/packages/effect/src/unstable/rpc/Rpc.ts
+++ b/packages/effect/src/unstable/rpc/Rpc.ts
@@ -47,7 +47,7 @@ export const isRpc = (u: unknown): u is Rpc<any, any, any> => Predicate.hasPrope
  * Defect schemas decode and encode without services and can be constructed from
  * `null`, `undefined`, or an object value.
  *
- * @category models
+ * @category schemas
  * @since 4.0.0
  */
 export interface DefectSchema extends Schema.Top {

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -55,7 +55,7 @@ import { withRunClient } from "./Utils.ts"
  * The object-shaped client generated from a union of RPC definitions, with one
  * method per RPC tag.
  *
- * @category client
+ * @category utility types
  * @since 4.0.0
  */
 export type RpcClient<Rpcs extends Rpc.Any, E = never> = Struct.Simplify<RpcClient.From<Rpcs, E>>
@@ -72,7 +72,7 @@ export declare namespace RpcClient {
    * method that accepts the RPC payload and returns either an `Effect` or
    * `Stream` based on the RPC success schema.
    *
-   * @category client
+   * @category utility types
    * @since 4.0.0
    */
   export type From<Rpcs extends Rpc.Any, E = never> = {
@@ -137,7 +137,7 @@ export declare namespace RpcClient {
    * Builds a flattened RPC client function that accepts an RPC tag and payload,
    * returning the corresponding `Effect` or `Stream` for that RPC.
    *
-   * @category client
+   * @category utility types
    * @since 4.0.0
    */
   export type Flat<Rpcs extends Rpc.Any, E = never> = <
@@ -212,7 +212,7 @@ let requestIdCounter = 0
  * client API together with a `write` function for delivering server messages
  * back to the client.
  *
- * @category client
+ * @category constructors
  * @since 4.0.0
  */
 export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extends boolean = false>(
@@ -622,7 +622,7 @@ let clientIdCounter = 0
  * Creates a schema-aware RPC client for a group using the current client
  * `Protocol`, encoding requests and decoding server responses.
  *
- * @category client
+ * @category constructors
  * @since 4.0.0
  */
 export const make: <Rpcs extends Rpc.Any, const Flatten extends boolean = false>(

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -200,7 +200,7 @@ export declare namespace RpcClient {
  * Derives the object-shaped RPC client type for all RPCs contained in an
  * `RpcGroup`.
  *
- * @category client
+ * @category utility types
  * @since 4.0.0
  */
 export type FromGroup<Group, E = never> = RpcClient<RpcGroup.Rpcs<Group>, E>
@@ -807,7 +807,7 @@ const rpcSchemas = (rpc: Rpc.AnyWithProps) => {
  * Use to set request headers that should be automatically merged into outgoing
  * RPC client messages.
  *
- * @category headers
+ * @category services
  * @since 4.0.0
  */
 export const CurrentHeaders = Context.Reference<Headers.Headers>("effect/rpc/RpcClient/CurrentHeaders", {
@@ -839,7 +839,7 @@ export const withHeaders: {
  * Use to provide the transport boundary for RPC clients over HTTP, WebSocket,
  * workers, sockets, or custom protocols.
  *
- * @category protocols
+ * @category services
  * @since 4.0.0
  */
 export class Protocol extends Context.Service<Protocol, {
@@ -980,7 +980,7 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
  * Provides a client `Protocol` backed by `HttpClient`, targeting the configured
  * URL and optionally transforming the client before use.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolHttp = (options: {
@@ -1171,7 +1171,7 @@ const makePinger = Effect.fnUntraced(function*<A, E, R>(writePing: Effect.Effect
  * Provides a client `Protocol` backed by the current `Socket` and
  * `RpcSerialization` services.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolSocket = (options?: {
@@ -1352,7 +1352,7 @@ export const makeProtocolWorker = (
  * Provides a client `Protocol` backed by a worker pool using the current worker
  * platform and spawner services.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolWorker: (
@@ -1382,7 +1382,7 @@ export const layerProtocolWorker: (
  * Use to run setup or cleanup effects when an RPC client transport opens or
  * closes.
  *
- * @category connection hooks
+ * @category services
  * @since 4.0.0
  */
 export class ConnectionHooks extends Context.Service<ConnectionHooks, {

--- a/packages/effect/src/unstable/rpc/RpcGroup.ts
+++ b/packages/effect/src/unstable/rpc/RpcGroup.ts
@@ -181,7 +181,7 @@ export interface Any {
  * Builds the object type of server handler functions required to implement each
  * RPC in a union.
  *
- * @category groups
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlersFrom<Rpc extends Rpc.Any> = {
@@ -192,7 +192,7 @@ export type HandlersFrom<Rpc extends Rpc.Any> = {
  * Extracts the server handler function type for a specific RPC tag from an RPC
  * union.
  *
- * @category groups
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlerFrom<Rpc extends Rpc.Any, Tag extends Rpc["_tag"]> = Extract<Rpc, { readonly _tag: Tag }> extends
@@ -202,7 +202,7 @@ export type HandlerFrom<Rpc extends Rpc.Any, Tag extends Rpc["_tag"]> = Extract<
  * Computes the services required by all handlers in a handler object for an RPC
  * union.
  *
- * @category groups
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlersServices<Rpcs extends Rpc.Any, Handlers> = keyof Handlers extends infer K ?
@@ -213,7 +213,7 @@ export type HandlersServices<Rpcs extends Rpc.Any, Handlers> = keyof Handlers ex
  * Computes the services required by a single RPC handler, excluding services
  * provided by middleware and `Scope` where the server supplies it.
  *
- * @category groups
+ * @category utility types
  * @since 4.0.0
  */
 export type HandlerServices<Rpcs extends Rpc.Any, K extends Rpcs["_tag"], Handler> = true extends
@@ -242,7 +242,7 @@ export type HandlerServices<Rpcs extends Rpc.Any, K extends Rpcs["_tag"], Handle
 /**
  * Extracts the union of RPC definitions from an `RpcGroup`.
  *
- * @category groups
+ * @category utility types
  * @since 4.0.0
  */
 export type Rpcs<Group> = Group extends RpcGroup<infer R> ? string extends R["_tag"] ? never : R : never

--- a/packages/effect/src/unstable/rpc/RpcGroup.ts
+++ b/packages/effect/src/unstable/rpc/RpcGroup.ts
@@ -29,7 +29,7 @@ const TypeId = "~effect/rpc/RpcGroup"
  * A collection of RPC definitions that can be composed, annotated, and
  * converted into server handlers or layers.
  *
- * @category groups
+ * @category models
  * @since 4.0.0
  */
 export interface RpcGroup<in out R extends Rpc.Any> extends Pipeable {
@@ -170,7 +170,7 @@ export interface RpcGroup<in out R extends Rpc.Any> extends Pipeable {
  * An erased `RpcGroup` type for APIs that only need to know that a value is an
  * RPC group.
  *
- * @category groups
+ * @category utility types
  * @since 4.0.0
  */
 export interface Any {
@@ -396,7 +396,7 @@ const makeProto = <Rpcs extends Rpc.Any>(options: {
 /**
  * Creates an `RpcGroup` from one or more RPC definitions.
  *
- * @category groups
+ * @category constructors
  * @since 4.0.0
  */
 export const make = <const Rpcs extends ReadonlyArray<Rpc.Any>>(

--- a/packages/effect/src/unstable/rpc/RpcMessage.ts
+++ b/packages/effect/src/unstable/rpc/RpcMessage.ts
@@ -20,7 +20,7 @@ import type { RpcClientError } from "./RpcClientError.ts"
 /**
  * Decoded messages that can be sent from an RPC client to a server.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type FromClient<A extends Rpc.Any> = Request<A> | Ack | Interrupt | Eof
@@ -28,7 +28,7 @@ export type FromClient<A extends Rpc.Any> = Request<A> | Ack | Interrupt | Eof
 /**
  * Transport-encoded messages that can be sent from an RPC client to a server.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type FromClientEncoded = RequestEncoded | AckEncoded | InterruptEncoded | Ping | Eof
@@ -37,7 +37,7 @@ export type FromClientEncoded = RequestEncoded | AckEncoded | InterruptEncoded |
  * A branded request identifier used to correlate RPC requests, responses,
  * chunks, acknowledgements, and interrupts.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export type RequestId = Branded<string | number, "~effect/rpc/RpcMessage/RequestId">
@@ -45,7 +45,7 @@ export type RequestId = Branded<string | number, "~effect/rpc/RpcMessage/Request
 /**
  * Converts a bigint or string request id into the branded `RequestId` type.
  *
- * @category request
+ * @category constructors
  * @since 4.0.0
  */
 export const RequestId = (id: string | number): RequestId => id as RequestId
@@ -54,7 +54,7 @@ export const RequestId = (id: string | number): RequestId => id as RequestId
  * The transport-encoded RPC request envelope, including the string request id,
  * RPC tag, encoded payload, headers, and optional trace context.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface RequestEncoded {
@@ -73,7 +73,7 @@ export interface RequestEncoded {
  * The decoded RPC request envelope for an RPC union, carrying a branded request
  * id, typed RPC tag, decoded payload, headers, and optional trace context.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface Request<A extends Rpc.Any> {
@@ -90,7 +90,7 @@ export interface Request<A extends Rpc.Any> {
 /**
  * A decoded acknowledgement for a streamed RPC response chunk.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface Ack {
@@ -102,7 +102,7 @@ export interface Ack {
  * A decoded request to interrupt an in-flight RPC, carrying the request id and
  * interrupting fiber ids.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface Interrupt {
@@ -114,7 +114,7 @@ export interface Interrupt {
 /**
  * The transport-encoded acknowledgement for a streamed RPC response chunk.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface AckEncoded {
@@ -125,7 +125,7 @@ export interface AckEncoded {
 /**
  * The transport-encoded request to interrupt an in-flight RPC.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface InterruptEncoded {
@@ -137,7 +137,7 @@ export interface InterruptEncoded {
  * A client-to-server message indicating that the client has finished sending
  * input for the current connection or request batch.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface Eof {
@@ -148,7 +148,7 @@ export interface Eof {
  * A client-to-server keepalive message used by protocols that monitor
  * connection liveness.
  *
- * @category request
+ * @category models
  * @since 4.0.0
  */
 export interface Ping {
@@ -158,7 +158,7 @@ export interface Ping {
 /**
  * Represents the reusable `Eof` message value.
  *
- * @category request
+ * @category constants
  * @since 4.0.0
  */
 export const constEof: Eof = { _tag: "Eof" }
@@ -166,7 +166,7 @@ export const constEof: Eof = { _tag: "Eof" }
 /**
  * Represents the reusable `Ping` message value.
  *
- * @category request
+ * @category constants
  * @since 4.0.0
  */
 export const constPing: Ping = { _tag: "Ping" }
@@ -174,7 +174,7 @@ export const constPing: Ping = { _tag: "Ping" }
 /**
  * Decoded messages that can be sent from an RPC server to a client.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type FromServer<A extends Rpc.Any> =
@@ -186,7 +186,7 @@ export type FromServer<A extends Rpc.Any> =
 /**
  * Transport-encoded messages that can be sent from an RPC server to a client.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type FromServerEncoded =
@@ -215,7 +215,7 @@ export type ResponseIdTypeId = typeof ResponseIdTypeId
 /**
  * A branded numeric identifier for server responses.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ResponseId = Branded<number, ResponseIdTypeId>
@@ -224,7 +224,7 @@ export type ResponseId = Branded<number, ResponseIdTypeId>
  * The transport-encoded response message containing a non-empty batch of stream
  * chunk values for a request.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ResponseChunkEncoded {
@@ -237,7 +237,7 @@ export interface ResponseChunkEncoded {
  * The decoded response message containing a non-empty batch of stream chunk
  * values for a specific client and request.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ResponseChunk<A extends Rpc.Any> {
@@ -251,7 +251,7 @@ export interface ResponseChunk<A extends Rpc.Any> {
  * The transport representation of an RPC `Exit`, encoding success values or a
  * failure cause made of failures, defects, and interrupts.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export type ExitEncoded<A, E> = {
@@ -277,7 +277,7 @@ export type ExitEncoded<A, E> = {
  * The transport-encoded terminal response for a request, carrying the encoded
  * `Exit`.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ResponseExitEncoded {
@@ -290,7 +290,7 @@ export interface ResponseExitEncoded {
  * A server-to-client protocol message reporting a client protocol error to all
  * affected in-flight requests.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ClientProtocolError {
@@ -302,7 +302,7 @@ export interface ClientProtocolError {
  * The decoded terminal response for a request, carrying the typed `Rpc.Exit`
  * for the RPC.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ResponseExit<A extends Rpc.Any> {
@@ -316,7 +316,7 @@ export interface ResponseExit<A extends Rpc.Any> {
  * The transport-encoded server defect message used for protocol-level defects
  * that affect the client connection.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ResponseDefectEncoded {
@@ -330,7 +330,7 @@ const encodeDefect = Schema.encodeSync(Schema.Defect())
  * Creates an encoded terminal response for a request whose exit is a defect
  * encoded with `Schema.Defect()`.
  *
- * @category response
+ * @category constructors
  * @since 4.0.0
  */
 export const ResponseExitDieEncoded = (options: {
@@ -352,7 +352,7 @@ export const ResponseExitDieEncoded = (options: {
  * Creates a transport-encoded defect response by encoding the input with
  * `Schema.Defect()`.
  *
- * @category response
+ * @category constructors
  * @since 4.0.0
  */
 export const ResponseDefectEncoded = (input: unknown): ResponseDefectEncoded => ({
@@ -363,7 +363,7 @@ export const ResponseDefectEncoded = (input: unknown): ResponseDefectEncoded => 
 /**
  * The decoded server defect message for a client connection.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ResponseDefect {
@@ -375,7 +375,7 @@ export interface ResponseDefect {
 /**
  * A server message indicating that the client connection has ended.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface ClientEnd {
@@ -386,7 +386,7 @@ export interface ClientEnd {
 /**
  * A server-to-client keepalive response to a `Ping` message.
  *
- * @category response
+ * @category models
  * @since 4.0.0
  */
 export interface Pong {
@@ -396,7 +396,7 @@ export interface Pong {
 /**
  * Represents the reusable `Pong` message value.
  *
- * @category response
+ * @category constants
  * @since 4.0.0
  */
 export const constPong: Pong = { _tag: "Pong" }

--- a/packages/effect/src/unstable/rpc/RpcMiddleware.ts
+++ b/packages/effect/src/unstable/rpc/RpcMiddleware.ts
@@ -119,7 +119,7 @@ export interface Any {
  * A type-level carrier for RPC middleware metadata, including provided
  * services, required services, error schema, and client error type.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export interface AnyId {
@@ -135,7 +135,7 @@ export interface AnyId {
  * The `Context.Service` class shape created for an RPC middleware, including
  * its error schema, service metadata, and client-side requirement marker.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface ServiceClass<
@@ -164,7 +164,7 @@ export interface ServiceClass<
 /**
  * Extracts the services provided by an RPC middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Provides<A> = A extends { readonly [TypeId]: { readonly provides: infer P } } ? P : never
@@ -172,7 +172,7 @@ export type Provides<A> = A extends { readonly [TypeId]: { readonly provides: in
 /**
  * Extracts the services required by an RPC middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Requires<A> = A extends { readonly [TypeId]: { readonly requires: infer R } } ? R : never
@@ -181,7 +181,7 @@ export type Requires<A> = A extends { readonly [TypeId]: { readonly requires: in
  * Applies a middleware's service transformation to an RPC environment by
  * removing services the middleware provides and adding services it requires.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ApplyServices<A, R> = Exclude<R, Provides<A>> | Requires<A>
@@ -189,7 +189,7 @@ export type ApplyServices<A, R> = Exclude<R, Provides<A>> | Requires<A>
 /**
  * Extracts the error schema associated with an RPC middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorSchema<A> = A extends { readonly [TypeId]: { readonly error: infer E } }
@@ -199,7 +199,7 @@ export type ErrorSchema<A> = A extends { readonly [TypeId]: { readonly error: in
 /**
  * Extracts the decoded error type produced by an RPC middleware.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Error<A> = ErrorSchema<A>["Type"]
@@ -207,7 +207,7 @@ export type Error<A> = ErrorSchema<A>["Type"]
 /**
  * Extracts the encoding services required by a middleware's error schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesEncode<A> = ErrorSchema<A>["EncodingServices"]
@@ -215,7 +215,7 @@ export type ErrorServicesEncode<A> = ErrorSchema<A>["EncodingServices"]
 /**
  * Extracts the decoding services required by a middleware's error schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type ErrorServicesDecode<A> = ErrorSchema<A>["DecodingServices"]
@@ -318,7 +318,7 @@ export const Service = <
  * capturing the layer's environment and merging it into each middleware
  * invocation.
  *
- * @category client
+ * @category layers
  * @since 4.0.0
  */
 export const layerClient = <Id extends AnyId, S, R, EX = never, RX = never>(

--- a/packages/effect/src/unstable/rpc/RpcSchema.ts
+++ b/packages/effect/src/unstable/rpc/RpcSchema.ts
@@ -23,7 +23,7 @@ const StreamSchemaTypeId = "~effect/rpc/RpcSchema/StreamSchema"
  * Returns `true` when a schema is an RPC stream schema created by
  * `RpcSchema.Stream`.
  *
- * @category streams
+ * @category guards
  * @since 4.0.0
  */
 export function isStreamSchema(schema: Schema.Constraint): schema is Stream<Schema.Top, Schema.Top> {
@@ -86,7 +86,7 @@ export function Stream<A extends Schema.Constraint, E extends Schema.Constraint>
  * Annotation that marks interruptions that originate from an RPC client
  * abort.
  *
- * @category Cause annotations
+ * @category services
  * @since 4.0.0
  */
 export class ClientAbort extends Context.Service<ClientAbort, true>()("effect/rpc/RpcSchema/ClientAbort") {

--- a/packages/effect/src/unstable/rpc/RpcSchema.ts
+++ b/packages/effect/src/unstable/rpc/RpcSchema.ts
@@ -47,7 +47,7 @@ export function getStreamSchemas(schema: Schema.Constraint): Option.Option<{
  * A schema marker for RPC streaming responses, storing the success element
  * schema and stream error schema used for encoding and decoding stream chunks.
  *
- * @category streams
+ * @category models
  * @since 4.0.0
  */
 export interface Stream<A extends Schema.Constraint, E extends Schema.Constraint> extends
@@ -75,7 +75,7 @@ const schema = Schema.declare(Stream_.isStream)
  * Creates an RPC stream schema from a stream element success schema and stream
  * error schema.
  *
- * @category streams
+ * @category constructors
  * @since 4.0.0
  */
 export function Stream<A extends Schema.Constraint, E extends Schema.Constraint>(success: A, error: E): Stream<A, E> {

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -27,7 +27,7 @@ import type * as RpcMessage from "./RpcMessage.ts"
  * Use to provide the serialization boundary shared by RPC clients and servers
  * for a chosen wire format.
  *
- * @category serialization
+ * @category services
  * @since 4.0.0
  */
 export class RpcSerialization extends Context.Service<RpcSerialization, {
@@ -571,7 +571,7 @@ export const msgPack: RpcSerialization["Service"] = makeMsgPack({ useRecords: tr
  *
  * @see {@link layerNdjson} for transports that need newline-delimited framing
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerJson: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSerialization)(json)
@@ -585,7 +585,7 @@ export const layerJson: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSeriali
  *
  * @see {@link layerJson} for transports that already provide message framing
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerNdjson: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSerialization)(ndjson)
@@ -593,7 +593,7 @@ export const layerNdjson: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSeria
 /**
  * RPC serialization layer that uses NDJSON with custom streaming options.
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerNdjsonWith = (options?: StreamOptions): Layer.Layer<RpcSerialization> =>
@@ -602,7 +602,7 @@ export const layerNdjsonWith = (options?: StreamOptions): Layer.Layer<RpcSeriali
 /**
  * RPC serialization layer that uses JSON-RPC for serialization.
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerJsonRpc = (options?: {
@@ -613,7 +613,7 @@ export const layerJsonRpc = (options?: {
  * RPC serialization layer that uses newline-delimited JSON-RPC for
  * serialization.
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerNdJsonRpc = (options?: {
@@ -629,7 +629,7 @@ export const layerNdJsonRpc = (options?: {
  * MessagePack has a more compact binary format compared to JSON and NDJSON. It
  * also has better support for binary data.
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerMsgPack: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSerialization)(msgPack)
@@ -637,7 +637,7 @@ export const layerMsgPack: Layer.Layer<RpcSerialization> = Layer.succeed(RpcSeri
 /**
  * RPC serialization layer that uses MessagePack with custom options.
  *
- * @category serialization
+ * @category layers
  * @since 4.0.0
  */
 export const layerMsgPackWith = (

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -762,7 +762,7 @@ export const make: <Rpcs extends Rpc.Any>(
  * Provides a scoped layer that starts an RPC server for a group using the
  * current server `Protocol`.
  *
- * @category server
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <Rpcs extends Rpc.Any>(
@@ -791,7 +791,7 @@ export const layer = <Rpcs extends Rpc.Any>(
  * Defaults to using websockets for communication, but can be configured to use
  * HTTP.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerHttp = <Rpcs extends Rpc.Any>(options: {
@@ -830,7 +830,7 @@ export const layerHttp = <Rpcs extends Rpc.Any>(options: {
  * Use to provide the transport boundary for RPC servers over HTTP, WebSocket,
  * workers, sockets, or custom protocols.
  *
- * @category protocols
+ * @category services
  * @since 4.0.0
  */
 export class Protocol extends Context.Service<
@@ -880,7 +880,7 @@ export const makeProtocolSocketServer = Effect.gen(function*() {
 /**
  * RPC protocol that uses `SocketServer` for communication.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolSocketServer: Layer.Layer<
@@ -947,7 +947,7 @@ export const makeProtocolWebsocket: (options: {
 /**
  * RPC protocol that uses WebSockets for communication.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolWebsocket = (options: {
@@ -1152,7 +1152,7 @@ export const makeProtocolHttp: (options: {
  * Provides a server `Protocol` that uses HTTP POST requests for RPC
  * communication.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolHttp = (options: {
@@ -1308,7 +1308,7 @@ export const makeProtocolStdio = Effect.gen(function*() {
  * Provides a server `Protocol` that reads RPC messages from `Stdio.stdin` and
  * writes encoded responses to `Stdio.stdout`.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolStdio: Layer.Layer<
@@ -1379,7 +1379,7 @@ export const makeProtocolWorkerRunner: Effect.Effect<
 /**
  * Provides a server `Protocol` backed by the current `WorkerRunnerPlatform`.
  *
- * @category protocols
+ * @category layers
  * @since 4.0.0
  */
 export const layerProtocolWorkerRunner: Layer.Layer<

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -63,7 +63,7 @@ import { withRun } from "./Utils.ts"
  * The decoded RPC server boundary, accepting client messages for a client id
  * and allowing that client to be disconnected.
  *
- * @category server
+ * @category models
  * @since 4.0.0
  */
 export interface RpcServer<A extends Rpc.Any> {
@@ -78,7 +78,7 @@ export interface RpcServer<A extends Rpc.Any> {
  * handlers for a group and sending decoded server responses through
  * `onFromServer`.
  *
- * @category server
+ * @category constructors
  * @since 4.0.0
  */
 export const makeNoSerialization: <Rpcs extends Rpc.Any>(
@@ -483,7 +483,7 @@ const applyMiddleware = <A, E, R>(
  * requests, invoking handlers, encoding responses, and managing in-flight
  * request lifetime.
  *
- * @category server
+ * @category running
  * @since 4.0.0
  */
 export const make: <Rpcs extends Rpc.Any>(
@@ -1165,7 +1165,7 @@ export const layerProtocolHttp = (options: {
  * Starts an RPC server for a group and returns the HTTP request/response effect
  * that serves the non-websocket HTTP RPC protocol.
  *
- * @category http app
+ * @category running
  * @since 4.0.0
  */
 export const toHttpEffect: <Rpcs extends Rpc.Any>(
@@ -1206,7 +1206,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
  * Starts an RPC server for a group and returns the HTTP effect that upgrades
  * requests to the websocket RPC protocol.
  *
- * @category http app
+ * @category running
  * @since 4.0.0
  */
 export const toHttpEffectWebsocket: <Rpcs extends Rpc.Any>(

--- a/packages/effect/src/unstable/rpc/RpcWorker.ts
+++ b/packages/effect/src/unstable/rpc/RpcWorker.ts
@@ -21,7 +21,7 @@ import type { Protocol } from "./RpcServer.ts"
  * Context service that supplies the initial RPC worker message as encoded data
  * paired with any transferables that should be posted with it.
  *
- * @category initial message
+ * @category services
  * @since 4.0.0
  */
 export class InitialMessage extends Context.Service<
@@ -86,7 +86,7 @@ export const makeInitialMessage = <S extends Schema.Constraint, E, R2>(
  * Provides the `InitialMessage` service from a schema and build effect,
  * capturing the layer context and dying if schema encoding fails.
  *
- * @category initial message
+ * @category layers
  * @since 4.0.0
  */
 export const layerInitialMessage = <S extends Schema.Constraint, R2>(

--- a/packages/effect/src/unstable/rpc/RpcWorker.ts
+++ b/packages/effect/src/unstable/rpc/RpcWorker.ts
@@ -44,7 +44,7 @@ export declare namespace InitialMessage {
    * Tagged wire representation of an RPC worker initial message after schema
    * encoding.
    *
-   * @category initial message
+   * @category models
    * @since 4.0.0
    */
   export interface Encoded {
@@ -61,7 +61,7 @@ const ProtocolTag = Context.Service<Protocol, Protocol["Service"]>(
  * Runs an effect, encodes its result with the schema's JSON codec, and returns
  * the encoded value together with collected transferables.
  *
- * @category initial message
+ * @category encoding
  * @since 4.0.0
  */
 export const makeInitialMessage = <S extends Schema.Constraint, E, R2>(
@@ -105,7 +105,7 @@ export const layerInitialMessage = <S extends Schema.Constraint, R2>(
  * Reads the protocol initial message and decodes it with the supplied schema,
  * failing if no initial message is available or decoding fails.
  *
- * @category initial message
+ * @category decoding
  * @since 4.0.0
  */
 export const initialMessage = <S extends Schema.Constraint>(

--- a/packages/effect/src/unstable/schema/Model.ts
+++ b/packages/effect/src/unstable/schema/Model.ts
@@ -118,21 +118,21 @@ export {
   /**
    * Extracts a generated variant schema from a model or variant struct.
    *
-   * @category extraction
+   * @category converting
    * @since 4.0.0
    */
   extract,
   /**
    * Creates a variant field from schemas keyed by variant name.
    *
-   * @category fields
+   * @category constructors
    * @since 4.0.0
    */
   Field,
   /**
    * Transforms schemas inside a variant field or plain schema by variant name.
    *
-   * @category fields
+   * @category transforming
    * @since 4.0.0
    */
   fieldEvolve,
@@ -140,14 +140,14 @@ export {
    * Creates a variant field that applies a schema to every variant except the
    * supplied keys.
    *
-   * @category fields
+   * @category constructors
    * @since 4.0.0
    */
   FieldExcept,
   /**
    * Creates a variant field that applies a schema only to the supplied variants.
    *
-   * @category fields
+   * @category constructors
    * @since 4.0.0
    */
   FieldOnly,
@@ -171,7 +171,7 @@ export {
 /**
  * Returns the variant field definitions stored on a model or variant struct.
  *
- * @category fields
+ * @category getters
  * @since 4.0.0
  */
 export const fields: <A extends VariantSchema.Struct<any>>(self: A) => A[typeof VariantSchema.TypeId] =
@@ -181,7 +181,7 @@ export const fields: <A extends VariantSchema.Struct<any>>(self: A) => A[typeof 
  * Marks a value as an explicit override for fields that otherwise use an
  * overrideable default.
  *
- * @category overrideable
+ * @category constructors
  * @since 4.0.0
  */
 export const Override: <A>(value: A) => A & Brand<"Override"> = VariantSchema.Override
@@ -198,7 +198,7 @@ export const Override: <A>(value: A) => A & Brand<"Override"> = VariantSchema.Ov
  * @see {@link Field} for generated columns that need a custom variant set, such
  * as primary keys used in update payloads.
  *
- * @category generated
+ * @category schemas
  * @since 4.0.0
  */
 export interface GeneratedByDb<S extends Schema.Top> extends
@@ -220,7 +220,7 @@ export interface GeneratedByDb<S extends Schema.Top> extends
  * @see {@link Field} for generated columns that need a custom variant set, such
  * as primary keys used in update payloads.
  *
- * @category generated
+ * @category schemas
  * @since 4.0.0
  */
 export const GeneratedByDb = <S extends Schema.Top>(
@@ -236,7 +236,7 @@ export const GeneratedByDb = <S extends Schema.Top>(
  * database variants and read JSON, but omitted from JSON create and update
  * variants.
  *
- * @category generated
+ * @category schemas
  * @since 4.0.0
  */
 export interface GeneratedByApp<S extends Schema.Top> extends
@@ -253,7 +253,7 @@ export interface GeneratedByApp<S extends Schema.Top> extends
  * variants and the read JSON variant, but omitted from JSON create and update
  * variants.
  *
- * @category generated
+ * @category schemas
  * @since 4.0.0
  */
 export const GeneratedByApp = <S extends Schema.Top>(schema: S): GeneratedByApp<S> =>
@@ -268,7 +268,7 @@ export const GeneratedByApp = <S extends Schema.Top>(schema: S): GeneratedByApp<
  * Variant field type for a sensitive value that is available to database variants
  * and omitted from all JSON variants.
  *
- * @category sensitive
+ * @category schemas
  * @since 4.0.0
  */
 export interface Sensitive<S extends Schema.Top> extends
@@ -283,7 +283,7 @@ export interface Sensitive<S extends Schema.Top> extends
  * A field that represents a sensitive value that should not be exposed in the
  * JSON variants.
  *
- * @category sensitive
+ * @category schemas
  * @since 4.0.0
  */
 export const Sensitive = <S extends Schema.Top>(schema: S): Sensitive<S> =>
@@ -297,7 +297,7 @@ export const Sensitive = <S extends Schema.Top>(schema: S): Sensitive<S> =>
  * Schema type for an optional object key whose encoded value may be missing or
  * null and whose decoded value is an `Option`.
  *
- * @category optional
+ * @category schemas
  * @since 4.0.0
  */
 export interface optionalOption<S extends Schema.Constraint>
@@ -308,7 +308,7 @@ export interface optionalOption<S extends Schema.Constraint>
  * Creates a schema for optional keys that decodes missing or null encoded values
  * through `Option` and encodes `Option` values back to optional nullable keys.
  *
- * @category optional
+ * @category schemas
  * @since 4.0.0
  */
 export const optionalOption = <S extends Schema.Constraint>(schema: S): optionalOption<S> =>
@@ -330,7 +330,7 @@ export const optionalOption = <S extends Schema.Constraint>(schema: S): optional
  * For the database variants, it will accept `null`able values.
  * For the JSON variants, it will also accept missing keys.
  *
- * @category optional
+ * @category schemas
  * @since 4.0.0
  */
 export interface FieldOption<S extends Schema.Top> extends
@@ -352,7 +352,7 @@ export interface FieldOption<S extends Schema.Top> extends
  * For the database variants, it will accept `null`able values.
  * For the JSON variants, it will also accept missing keys.
  *
- * @category optional
+ * @category schemas
  * @since 4.0.0
  */
 export const FieldOption: <Field extends VariantSchema.Field<any> | Schema.Top>(
@@ -378,7 +378,7 @@ export const FieldOption: <Field extends VariantSchema.Field<any> | Schema.Top>(
  * Variant field type for SQLite booleans stored as `0 | 1` in database variants
  * and exposed as `boolean` in JSON variants.
  *
- * @category booleans
+ * @category schemas
  * @since 4.0.0
  */
 export interface BooleanSqlite extends
@@ -396,7 +396,7 @@ export interface BooleanSqlite extends
  * Schema for sqlite booleans that are represented as `0 | 1` in database
  * variants and `boolean` in JSON variants.
  *
- * @category booleans
+ * @category schemas
  * @since 4.0.0
  */
 export const BooleanSqlite: BooleanSqlite = Field({
@@ -412,7 +412,7 @@ export const BooleanSqlite: BooleanSqlite = Field({
  * Schema type for a `DateTime.Utc` date-only value encoded as a `YYYY-MM-DD`
  * string.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface Date extends Schema.decodeTo<Schema.instanceOf<DateTime.Utc>, Schema.String> {}
@@ -421,7 +421,7 @@ export interface Date extends Schema.decodeTo<Schema.instanceOf<DateTime.Utc>, S
  * Schema for a `DateTime.Utc` that is serialized as a date string in the
  * format `YYYY-MM-DD`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const Date: Date = Schema.String.pipe(
@@ -435,7 +435,7 @@ export const Date: Date = Schema.String.pipe(
  * Schema for an overrideable UTC date-only field whose constructor default is
  * the current date with the time component removed.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateWithNow = VariantSchema.Overrideable(Date, {
@@ -446,7 +446,7 @@ export const DateWithNow = VariantSchema.Overrideable(Date, {
  * Schema for an overrideable UTC date-time field encoded as a string and
  * defaulted to the current `DateTime.Utc`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeWithNow = VariantSchema.Overrideable(Schema.DateTimeUtcFromString, {
@@ -457,7 +457,7 @@ export const DateTimeWithNow = VariantSchema.Overrideable(Schema.DateTimeUtcFrom
  * Schema for an overrideable UTC date-time field encoded as a JavaScript `Date`
  * and defaulted to the current `DateTime.Utc`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeFromDateWithNow = VariantSchema.Overrideable(Schema.DateTimeUtcFromDate, {
@@ -468,7 +468,7 @@ export const DateTimeFromDateWithNow = VariantSchema.Overrideable(Schema.DateTim
  * Schema for an overrideable UTC date-time field encoded as milliseconds and
  * defaulted to the current `DateTime.Utc`.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeFromNumberWithNow = VariantSchema.Overrideable(Schema.DateTimeUtcFromMillis, {
@@ -479,7 +479,7 @@ export const DateTimeFromNumberWithNow = VariantSchema.Overrideable(Schema.DateT
  * Variant field type for a UTC date-time stored as a string, defaulted to the
  * current time on insert, available for selection, and omitted from updates.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface DateTimeInsert extends
@@ -498,7 +498,7 @@ export interface DateTimeInsert extends
  *
  * It is omitted from updates and is available for selection.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeInsert: DateTimeInsert = Field({
@@ -511,7 +511,7 @@ export const DateTimeInsert: DateTimeInsert = Field({
  * Variant field type for a UTC date-time stored as a JavaScript `Date` in
  * database variants, encoded as a string for JSON, and defaulted on insert.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface DateTimeInsertFromDate extends
@@ -530,7 +530,7 @@ export interface DateTimeInsertFromDate extends
  *
  * It is omitted from updates and is available for selection.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeInsertFromDate: DateTimeInsertFromDate = Field({
@@ -543,7 +543,7 @@ export const DateTimeInsertFromDate: DateTimeInsertFromDate = Field({
  * Variant field type for a UTC date-time encoded as milliseconds and defaulted to
  * the current time on insert.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface DateTimeInsertFromNumber extends
@@ -562,7 +562,7 @@ export interface DateTimeInsertFromNumber extends
  *
  * It is omitted from updates and is available for selection.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeInsertFromNumber: DateTimeInsertFromNumber = Field({
@@ -575,7 +575,7 @@ export const DateTimeInsertFromNumber: DateTimeInsertFromNumber = Field({
  * Variant field type for a UTC date-time stored as a string and defaulted to the
  * current time on both inserts and updates.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface DateTimeUpdate extends
@@ -596,7 +596,7 @@ export interface DateTimeUpdate extends
  * It is set to the current `DateTime.Utc` on updates and inserts and is
  * available for selection.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeUpdate: DateTimeUpdate = Field({
@@ -611,7 +611,7 @@ export const DateTimeUpdate: DateTimeUpdate = Field({
  * database variants, encoded as a string for JSON, and defaulted on inserts and
  * updates.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface DateTimeUpdateFromDate extends
@@ -632,7 +632,7 @@ export interface DateTimeUpdateFromDate extends
  * It is set to the current `DateTime.Utc` on updates and inserts and is
  * available for selection.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeUpdateFromDate: DateTimeUpdateFromDate = Field({
@@ -646,7 +646,7 @@ export const DateTimeUpdateFromDate: DateTimeUpdateFromDate = Field({
  * Variant field type for a UTC date-time encoded as milliseconds and defaulted to
  * the current time on both inserts and updates.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export interface DateTimeUpdateFromNumber extends
@@ -667,7 +667,7 @@ export interface DateTimeUpdateFromNumber extends
  * It is set to the current `DateTime.Utc` on updates and inserts and is
  * available for selection.
  *
- * @category DateTime
+ * @category schemas
  * @since 4.0.0
  */
 export const DateTimeUpdateFromNumber: DateTimeUpdateFromNumber = Field({
@@ -681,7 +681,7 @@ export const DateTimeUpdateFromNumber: DateTimeUpdateFromNumber = Field({
  * Variant field type for a JSON value stored as text in database variants and
  * exposed through the supplied schema in JSON variants.
  *
- * @category models
+ * @category schemas
  * @since 4.0.0
  */
 export interface JsonFromString<S extends Schema.Top> extends
@@ -702,7 +702,7 @@ export interface JsonFromString<S extends Schema.Top> extends
  *
  * The "json" variants will use the object schema directly.
  *
- * @category constructors
+ * @category schemas
  * @since 4.0.0
  */
 export const JsonFromString = <S extends Schema.Top>(
@@ -723,7 +723,7 @@ export const JsonFromString = <S extends Schema.Top>(
  * Variant field type for a branded binary UUID v4 value whose insert variant
  * generates a UUID by default.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export interface UuidV4BytesInsert<B extends string> extends
@@ -738,7 +738,7 @@ export interface UuidV4BytesInsert<B extends string> extends
 /**
  * Schema for binary `Uint8Array` values backed by an `ArrayBuffer`.
  *
- * @category Uint8Array
+ * @category schemas
  * @since 4.0.0
  */
 export const Uint8Array: Schema.instanceOf<Uint8Array<ArrayBuffer>> = Schema.Uint8Array as Schema.instanceOf<
@@ -749,7 +749,7 @@ export const Uint8Array: Schema.instanceOf<Uint8Array<ArrayBuffer>> = Schema.Uin
  * Adds a constructor default that generates a binary UUID v4 for a branded
  * `Uint8Array` schema.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export const UuidV4BytesWithGenerate = <B extends string>(
@@ -760,7 +760,7 @@ export const UuidV4BytesWithGenerate = <B extends string>(
 /**
  * A field that represents a binary UUID v4 that is generated on inserts.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export const UuidV4BytesInsert = <const B extends string>(
@@ -777,7 +777,7 @@ export const UuidV4BytesInsert = <const B extends string>(
  * Variant field type for a branded string UUID v4 value whose insert variant
  * generates a UUID by default.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export interface UuidV4Insert<B extends string> extends
@@ -792,7 +792,7 @@ export interface UuidV4Insert<B extends string> extends
 /**
  * Adds a constructor default that generates a string UUID v4.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export const UuidV4WithGenerate = <B extends string>(
@@ -803,7 +803,7 @@ export const UuidV4WithGenerate = <B extends string>(
 /**
  * A field that represents a string UUID v4 that is generated on inserts.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export const UuidV4Insert = <const B extends string>(
@@ -820,7 +820,7 @@ export const UuidV4Insert = <const B extends string>(
  * Variant field type for a branded string UUID v7 value whose insert variant
  * generates a UUID by default.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export interface UuidV7Insert<B extends string> extends
@@ -835,7 +835,7 @@ export interface UuidV7Insert<B extends string> extends
 /**
  * Adds a constructor default that generates a string UUID v7.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export const UuidV7WithGenerate = <B extends string>(
@@ -850,7 +850,7 @@ export const UuidV7WithGenerate = <B extends string>(
 /**
  * A field that represents a string UUID v7 that is generated on inserts.
  *
- * @category uuid
+ * @category schemas
  * @since 4.0.0
  */
 export const UuidV7Insert = <const B extends string>(

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -167,7 +167,7 @@ export declare namespace Field {
  * Computes the `Schema.Struct` field map for a variant by selecting matching
  * field schemas and recursively extracting nested structs.
  *
- * @category extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type ExtractFields<V extends string, Fields extends Struct.Fields, IsDefault = false> = {
@@ -186,7 +186,7 @@ export type ExtractFields<V extends string, Fields extends Struct.Fields, IsDefa
  * Computes the schema type produced by extracting a single variant from a variant
  * schema struct.
  *
- * @category extractors
+ * @category utility types
  * @since 4.0.0
  */
 export type Extract<V extends string, A extends Struct<any>, IsDefault = false> = [A] extends [
@@ -506,7 +506,7 @@ export const make = <
 /**
  * Marks a value as an explicit override for an `Overrideable` schema default.
  *
- * @category overrideable
+ * @category constructors
  * @since 4.0.0
  */
 export const Override = <A>(value: A): A & Brand<"Override"> => value as any
@@ -515,7 +515,7 @@ export const Override = <A>(value: A): A & Brand<"Override"> => value as any
  * Schema type whose constructor can use an effectful default unless a value is
  * explicitly branded with `Override`.
  *
- * @category overrideable
+ * @category schemas
  * @since 4.0.0
  */
 export interface Overrideable<S extends Schema.Top & Schema.WithoutConstructorDefault> extends
@@ -543,7 +543,7 @@ export interface Overrideable<S extends Schema.Top & Schema.WithoutConstructorDe
  * Wraps a schema with an effectful constructor default while allowing explicit
  * values to be marked with `Override`.
  *
- * @category overrideable
+ * @category schemas
  * @since 4.0.0
  */
 export const Overrideable = <S extends Schema.Top & Schema.WithoutConstructorDefault>(

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -185,7 +185,7 @@ export class CloseEvent {
 /**
  * Returns `true` when a value is a `CloseEvent`.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isCloseEvent = (u: unknown): u is CloseEvent => Predicate.hasProperty(u, CloseEventTypeId)
@@ -209,7 +209,7 @@ export const SocketErrorTypeId: SocketErrorTypeId = "~effect/socket/Socket/Socke
 /**
  * Returns `true` when a value is a `SocketError`.
  *
- * @category refinements
+ * @category guards
  * @since 4.0.0
  */
 export const isSocketError = (u: unknown): u is SocketError => Predicate.hasProperty(u, SocketErrorTypeId)
@@ -796,7 +796,7 @@ export const layerWebSocket: (
 /**
  * Context reference for socket send queue capacity, defaulting to `16`.
  *
- * @category fiber refs
+ * @category services
  * @since 4.0.0
  */
 export const SendQueueCapacity = Context.Reference<number>("~effect/socket/Socket/SendQueueCapacity", {

--- a/packages/effect/src/unstable/sql/SqlClient.ts
+++ b/packages/effect/src/unstable/sql/SqlClient.ts
@@ -333,7 +333,7 @@ export const TransactionConnection = (
  * Context reference used by SQL integrations to opt in to safe integer
  * handling; defaults to `false`.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const SafeIntegers = Context.Reference<boolean>("effect/sql/SqlClient/SafeIntegers", {

--- a/packages/effect/src/unstable/sql/SqlModel.ts
+++ b/packages/effect/src/unstable/sql/SqlModel.ts
@@ -27,7 +27,7 @@ import * as SqlSchema from "./SqlSchema.ts"
  * supplied, reads ignore soft-deleted rows and delete updates that column
  * instead of removing the row.
  *
- * @category repository
+ * @category constructors
  * @since 4.0.0
  */
 export const makeRepository = <
@@ -224,7 +224,7 @@ select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(i
  * Creates batched request resolvers for a schema model's insert, insert-void,
  * find-by-id, and delete operations, honoring the optional soft-delete column.
  *
- * @category repository
+ * @category constructors
  * @since 4.0.0
  */
 export const makeResolvers = <

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -29,7 +29,7 @@ import { ResultLengthMismatch } from "./SqlError.ts"
  * Request type used by SQL request resolvers, carrying the input payload
  * together with the resolver's result, error, and environment types.
  *
- * @category requests
+ * @category models
  * @since 4.0.0
  */
 export interface SqlRequest<In, A, E, R> extends Request.Request<A, E | Schema.SchemaError, R> {
@@ -53,7 +53,7 @@ const SqlRequestProto = {
  * Runs a payload as a `SqlRequest` through a request resolver, either directly
  * with a payload and resolver or curried by resolver.
  *
- * @category requests
+ * @category running
  * @since 4.0.0
  */
 export const request: {
@@ -76,7 +76,7 @@ export const request: {
  * Constructs a `SqlRequest` from a payload. Equality and hashing are based on
  * the payload so equal requests can be batched and deduplicated.
  *
- * @category requests
+ * @category constructors
  * @since 4.0.0
  */
 export const SqlRequest = <In, A, E, R>(payload: In): SqlRequest<In, A, E, R> => {

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -738,7 +738,7 @@ const emptyFragment = fragment([literal("")])
  * Dialect-specific compiler that converts a SQL `Fragment` into SQL text and
  * bind parameters, with a no-transform variant.
  *
- * @category compiler
+ * @category models
  * @since 4.0.0
  */
 export interface Compiler {
@@ -754,7 +754,7 @@ export interface Compiler {
  * Callbacks used by `makeCompiler` to render dialect placeholders,
  * identifiers, insert helpers, update helpers, and custom SQL segments.
  *
- * @category compiler
+ * @category models
  * @since 4.0.0
  */
 export type CompilerOptions<C extends Custom<any, any, any, any> = any> = {
@@ -789,7 +789,7 @@ export type CompilerOptions<C extends Custom<any, any, any, any> = any> = {
 /**
  * Creates a dialect-specific SQL `Compiler` from rendering callbacks.
  *
- * @category compiler
+ * @category constructors
  * @since 4.0.0
  */
 export const makeCompiler = <C extends Custom<any, any, any, any> = any>(
@@ -1049,7 +1049,7 @@ const CompilerProto = {
  * Creates a SQLite compiler that uses `?` placeholders and quoted identifiers,
  * optionally transforming identifier names before escaping.
  *
- * @category compiler
+ * @category constructors
  * @since 4.0.0
  */
 export const makeCompilerSqlite = (transform?: ((_: string) => string) | undefined): Compiler =>
@@ -1092,7 +1092,7 @@ export function defaultEscape(c: string) {
  * Classifies a JavaScript value as a SQL primitive kind, treating `undefined`
  * as `null` and defaulting unrecognized objects to `string`.
  *
- * @category predicates
+ * @category converting
  * @since 4.0.0
  */
 export const primitiveKind = (value: unknown): PrimitiveKind => {

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -99,7 +99,7 @@ export type Transformer = (
  * Context reference for an optional current SQL statement transformer applied
  * before statement execution.
  *
- * @category transformer
+ * @category services
  * @since 4.0.0
  */
 export const CurrentTransformer = Context.Reference<Transformer | undefined>("effect/sql/CurrentTransformer", {

--- a/packages/effect/src/unstable/workers/Transferable.ts
+++ b/packages/effect/src/unstable/workers/Transferable.ts
@@ -20,7 +20,7 @@ import * as SchemaGetter from "../../SchemaGetter.ts"
  * Service for collecting `Transferable` objects while encoding worker messages
  * so they can be passed to `postMessage` transfer lists.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class Collector extends Context.Service<Collector, {

--- a/packages/effect/src/unstable/workers/Worker.ts
+++ b/packages/effect/src/unstable/workers/Worker.ts
@@ -23,7 +23,7 @@ import { WorkerError, WorkerSendError } from "./WorkerError.ts"
  * Service that spawns effect `Worker` instances for numeric worker ids using
  * the configured `Spawner`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class WorkerPlatform extends Context.Service<WorkerPlatform, {
@@ -60,7 +60,7 @@ export interface Worker<O = unknown, I = unknown> {
  * platform ready/data messages and running the optional `onSpawn` effect when
  * the worker reports readiness.
  *
- * @category models
+ * @category constructors
  * @since 4.0.0
  */
 export const makeUnsafe = (options: {

--- a/packages/effect/src/unstable/workers/WorkerError.ts
+++ b/packages/effect/src/unstable/workers/WorkerError.ts
@@ -31,7 +31,7 @@ export const isWorkerError = (u: unknown): u is WorkerError => hasProperty(u, Ty
 /**
  * Worker error reason for failures while spawning or setting up a worker.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class WorkerSpawnError extends Schema.ErrorClass<WorkerSpawnError>(
@@ -45,7 +45,7 @@ export class WorkerSpawnError extends Schema.ErrorClass<WorkerSpawnError>(
 /**
  * Worker error reason for failures while sending a message to a worker.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class WorkerSendError extends Schema.ErrorClass<WorkerSendError>(
@@ -60,7 +60,7 @@ export class WorkerSendError extends Schema.ErrorClass<WorkerSendError>(
  * Worker error reason for failures while receiving or handling a message from a
  * worker.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class WorkerReceiveError extends Schema.ErrorClass<WorkerReceiveError>(
@@ -74,7 +74,7 @@ export class WorkerReceiveError extends Schema.ErrorClass<WorkerReceiveError>(
 /**
  * Worker error reason for an unclassified worker failure.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class WorkerUnknownError extends Schema.ErrorClass<WorkerUnknownError>(
@@ -88,7 +88,7 @@ export class WorkerUnknownError extends Schema.ErrorClass<WorkerUnknownError>(
 /**
  * Union of the specific failure reasons that can be wrapped by a `WorkerError`.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export type WorkerErrorReason =
@@ -100,7 +100,7 @@ export type WorkerErrorReason =
 /**
  * Schema for decoding and encoding all supported worker error reason variants.
  *
- * @category models
+ * @category schemas
  * @since 4.0.0
  */
 export const WorkerErrorReason: Schema.Union<[
@@ -119,7 +119,7 @@ export const WorkerErrorReason: Schema.Union<[
  * Error raised by worker APIs, wrapping a specific `WorkerErrorReason` and
  * exposing its message and cause.
  *
- * @category models
+ * @category errors
  * @since 4.0.0
  */
 export class WorkerError extends Schema.ErrorClass<WorkerError>(TypeId)({

--- a/packages/effect/src/unstable/workers/WorkerRunner.ts
+++ b/packages/effect/src/unstable/workers/WorkerRunner.ts
@@ -49,7 +49,7 @@ export type PlatformMessage<I> = readonly [request: 0, I] | readonly [close: 1]
 /**
  * Context service that starts a platform-specific `WorkerRunner`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class WorkerRunnerPlatform extends Context.Service<WorkerRunnerPlatform, {

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -228,7 +228,7 @@ export const retry: {
  * Context reference containing the current activity retry attempt, defaulting
  * to `1`.
  *
- * @category Attempts
+ * @category services
  * @since 4.0.0
  */
 export const CurrentAttempt = Context.Reference<number>(
@@ -240,7 +240,7 @@ export const CurrentAttempt = Context.Reference<number>(
  * Computes a deterministic activity idempotency key from the current workflow
  * execution ID, the supplied name, and optionally the current attempt.
  *
- * @category Idempotency
+ * @category idempotency
  * @since 4.0.0
  */
 export const idempotencyKey: (

--- a/packages/effect/src/unstable/workflow/DurableClock.ts
+++ b/packages/effect/src/unstable/workflow/DurableClock.ts
@@ -64,7 +64,7 @@ const InstanceTag = Context.Service<
  * Waits inside a workflow, using an in-memory activity for durations at or
  * below the threshold and scheduling a durable clock for longer durations.
  *
- * @category sleeping
+ * @category delays & timeouts
  * @since 4.0.0
  */
 export const sleep: (

--- a/packages/effect/src/unstable/workflow/DurableDeferred.ts
+++ b/packages/effect/src/unstable/workflow/DurableDeferred.ts
@@ -309,7 +309,7 @@ export type TokenTypeId = typeof TokenTypeId
  * Branded string token identifying a durable deferred for a workflow
  * execution.
  *
- * @category token
+ * @category models
  * @since 4.0.0
  */
 export type Token = Brand.Branded<string, TokenTypeId>
@@ -317,7 +317,7 @@ export type Token = Brand.Branded<string, TokenTypeId>
 /**
  * Schema for branded durable deferred tokens.
  *
- * @category token
+ * @category schemas
  * @since 4.0.0
  */
 export const Token: Schema.brand<Schema.String, TokenTypeId> = Schema.String.pipe(Schema.brand(TokenTypeId))
@@ -326,7 +326,7 @@ export const Token: Schema.brand<Schema.String, TokenTypeId> = Schema.String.pip
  * Schema for a decoded durable deferred token containing the workflow
  * name, execution ID, and deferred name.
  *
- * @category token
+ * @category schemas
  * @since 4.0.0
  */
 export class TokenParsed extends Schema.Class<TokenParsed>(
@@ -401,7 +401,7 @@ export class TokenParsed extends Schema.Class<TokenParsed>(
  * Creates a token for a durable deferred using the current workflow instance's
  * workflow name and execution ID.
  *
- * @category token
+ * @category constructors
  * @since 4.0.0
  */
 export const token: <Success extends Schema.Constraint, Error extends Schema.Constraint>(
@@ -419,7 +419,7 @@ export const token: <Success extends Schema.Constraint, Error extends Schema.Con
  * Creates a durable deferred token from an explicit workflow, execution ID,
  * and deferred name.
  *
- * @category token
+ * @category constructors
  * @since 4.0.0
  */
 export const tokenFromExecutionId: {
@@ -453,7 +453,7 @@ export const tokenFromExecutionId: {
  * Creates a durable deferred token by deriving the workflow execution ID from
  * the supplied workflow payload.
  *
- * @category token
+ * @category constructors
  * @since 4.0.0
  */
 export const tokenFromPayload: {

--- a/packages/effect/src/unstable/workflow/DurableQueue.ts
+++ b/packages/effect/src/unstable/workflow/DurableQueue.ts
@@ -172,7 +172,7 @@ const getQueueSchema = <Payload extends Schema.Top>(
 /**
  * Adds an item to the queue and wait for a worker to process it.
  *
- * @category Processing
+ * @category processing
  * @since 4.0.0
  */
 export const process: <
@@ -249,7 +249,7 @@ const defaultRetrySchedule = Schedule.min([
 /**
  * Create a worker effect that processes items from the durable queue.
  *
- * @category Worker
+ * @category workers
  * @since 4.0.0
  */
 export const makeWorker: <
@@ -336,7 +336,7 @@ export const makeWorker: <
 /**
  * Create a layer that runs workers for the durable queue.
  *
- * @category Worker
+ * @category workers
  * @since 4.0.0
  */
 export const worker: <

--- a/packages/effect/src/unstable/workflow/DurableQueue.ts
+++ b/packages/effect/src/unstable/workflow/DurableQueue.ts
@@ -172,7 +172,7 @@ const getQueueSchema = <Payload extends Schema.Top>(
 /**
  * Adds an item to the queue and wait for a worker to process it.
  *
- * @category processing
+ * @category running
  * @since 4.0.0
  */
 export const process: <

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -200,7 +200,7 @@ export interface AnyStructSchema extends Schema.Top {
  * Type-level marker for services associated with a specific workflow
  * execution tag.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export interface Execution<Tag extends string> {
@@ -252,7 +252,7 @@ export interface AnyWithProps extends Any {
 /**
  * Extracts the payload schema from a `Workflow`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type PayloadSchema<W> = W extends Workflow<
@@ -267,7 +267,7 @@ export type PayloadSchema<W> = W extends Workflow<
  * Computes the schema services required by clients that execute or poll
  * workflows.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type RequirementsClient<Workflows extends Any> = Workflows extends Workflow<
@@ -285,7 +285,7 @@ export type RequirementsClient<Workflows extends Any> = Workflows extends Workfl
  * Computes the schema services required by handlers that decode workflow
  * payloads and encode workflow results.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type RequirementsHandler<Workflows extends Any> = Workflows extends Workflow<
@@ -465,7 +465,7 @@ const ResultTypeId = "~effect/workflow/Workflow/Result"
 /**
  * Returns `true` when a value is a workflow `Result`.
  *
- * @category results
+ * @category guards
  * @since 4.0.0
  */
 export const isResult = <A = unknown, E = unknown>(
@@ -825,7 +825,7 @@ export const addFinalizer: <R>(
  *
  * Compensation finalizers are only registered for top-level effects in the workflow and do not work for nested activities.
  *
- * @category Compensation
+ * @category compensation
  * @since 4.0.0
  */
 export const withCompensation: {
@@ -870,7 +870,7 @@ export const suspend = (instance: WorkflowInstance["Service"]): Effect.Effect<ne
  *
  * By default, this annotation is set to `true`, meaning defects are captured.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const CaptureDefects = Context.Reference<boolean>(
@@ -887,7 +887,7 @@ export const CaptureDefects = Context.Reference<boolean>(
  *
  * The suspended execution can later be resumed with the workflow's `resume` method, for example `MyWorkflow.resume(executionId)`.
  *
- * @category annotations
+ * @category services
  * @since 4.0.0
  */
 export const SuspendOnFailure = Context.Reference<boolean>(

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -476,7 +476,7 @@ export const isResult = <A = unknown, E = unknown>(
  * Result of a workflow execution, either a completed exit or a suspended
  * workflow state.
  *
- * @category results
+ * @category models
  * @since 4.0.0
  */
 export type Result<A, E> = Complete<A, E> | Suspended
@@ -484,7 +484,7 @@ export type Result<A, E> = Complete<A, E> | Suspended
 /**
  * Encoded representation of a workflow `Result`.
  *
- * @category results
+ * @category models
  * @since 4.0.0
  */
 export type ResultEncoded<A, E> =
@@ -495,7 +495,7 @@ export type ResultEncoded<A, E> =
  * Encoded representation of a completed workflow result containing an encoded
  * `Exit`.
  *
- * @category results
+ * @category models
  * @since 4.0.0
  */
 export interface CompleteEncoded<A, E> {
@@ -527,7 +527,7 @@ export interface CompleteSchema<
 /**
  * Represents a completed workflow execution with its success or failure `Exit`.
  *
- * @category results
+ * @category models
  * @since 4.0.0
  */
 export class Complete<A, E> extends Data.TaggedClass("Complete")<{
@@ -599,7 +599,7 @@ export class Complete<A, E> extends Data.TaggedClass("Complete")<{
  * Represents a suspended workflow execution, optionally carrying the cause that
  * triggered suspension.
  *
- * @category results
+ * @category schemas
  * @since 4.0.0
  */
 export class Suspended extends Schema.Class<Suspended>(
@@ -620,7 +620,7 @@ export class Suspended extends Schema.Class<Suspended>(
  * Creates a schema for workflow results using the supplied success and error
  * schemas.
  *
- * @category results
+ * @category schemas
  * @since 4.0.0
  */
 export const Result = <
@@ -636,7 +636,7 @@ const AnyOrVoid = Schema.Union([Schema.Any, Schema.Void])
 /**
  * Schema for encoded workflow results with generic success and error payloads.
  *
- * @category results
+ * @category schemas
  * @since 4.0.0
  */
 export const ResultEncoded: Schema.Codec<ResultEncoded<any, any>> = Schema.toEncoded(
@@ -653,7 +653,7 @@ export const ResultEncoded: Schema.Codec<ResultEncoded<any, any>> = Schema.toEnc
  * `Result`, handling suspension, defect capture, interruption, and workflow
  * scope finalization.
  *
- * @category results
+ * @category converting
  * @since 4.0.0
  */
 export const intoResult = <A, E, R>(
@@ -716,7 +716,7 @@ export const intoResult = <A, E, R>(
  * Wraps an activity-like effect so workflow suspension waits for currently
  * running activities to finish or suspend.
  *
- * @category results
+ * @category resource management
  * @since 4.0.0
  */
 export const wrapActivityResult = <A, E, R>(
@@ -853,7 +853,7 @@ export const withCompensation: {
  * Marks a workflow instance as suspended and interrupts the current fiber to
  * stop execution until it is resumed.
  *
- * @category results
+ * @category interruption
  * @since 4.0.0
  */
 export const suspend = (instance: WorkflowInstance["Service"]): Effect.Effect<never> =>

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -290,7 +290,7 @@ export class WorkflowInstance extends Context.Service<
  * Low-level workflow engine contract that works with encoded payloads and
  * results before `makeUnsafe` adds typed schema decoding and encoding.
  *
- * @category Encoded
+ * @category encoded
  * @since 4.0.0
  */
 export interface Encoded {

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -290,7 +290,7 @@ export class WorkflowInstance extends Context.Service<
  * Low-level workflow engine contract that works with encoded payloads and
  * results before `makeUnsafe` adds typed schema decoding and encoding.
  *
- * @category encoded
+ * @category services
  * @since 4.0.0
  */
 export interface Encoded {

--- a/packages/opentelemetry/src/OtelMetrics.ts
+++ b/packages/opentelemetry/src/OtelMetrics.ts
@@ -65,7 +65,7 @@ export const makeProducer = (temporality?: TemporalityPreference): Effect.Effect
 /**
  * Registers a metric producer with one or more metric readers.
  *
- * @category constructors
+ * @category resource management
  * @since 4.0.0
  */
 export const registerProducer = (

--- a/packages/opentelemetry/src/Resource.ts
+++ b/packages/opentelemetry/src/Resource.ts
@@ -75,7 +75,7 @@ export const layer = (config: {
  * @see {@link layer} for creating a `Resource` layer from explicit metadata
  * @see {@link layerFromEnv} for merging attributes with OpenTelemetry environment variables
  *
- * @category configuration
+ * @category converting
  * @since 4.0.0
  */
 export const configToAttributes = (options: {

--- a/packages/platform-browser/src/BrowserCrypto.ts
+++ b/packages/platform-browser/src/BrowserCrypto.ts
@@ -22,7 +22,7 @@ import * as PlatformError from "effect/PlatformError"
  * Use to override the browser `Crypto` object used by the platform crypto
  * layer.
  *
- * @category references
+ * @category services
  * @since 1.0.0
  */
 export const WebCrypto = Context.Reference<Crypto>("@effect/platform-browser/Crypto/WebCrypto", {

--- a/packages/platform-browser/src/BrowserHttpClient.ts
+++ b/packages/platform-browser/src/BrowserHttpClient.ts
@@ -39,14 +39,14 @@ export {
   /**
    * Context reference for the `fetch` implementation used by the fetch-based HTTP client.
    *
-   * @category fetch
+   * @category services
    * @since 4.0.0
    */
   Fetch,
   /**
    * Layer that provides an `HttpClient` implementation backed by the configured `Fetch` function.
    *
-   * @category fetch
+   * @category layers
    * @since 4.0.0
    */
   layer as layerFetch,
@@ -58,7 +58,7 @@ export {
    * Use to provide default credentials, cache, redirect, integrity, or other
    * fetch options for browser HTTP requests.
    *
-   * @category fetch
+   * @category services
    * @since 4.0.0
    */
   RequestInit
@@ -98,7 +98,7 @@ export const CurrentXHRResponseType: Context.Reference<XHRResponseType> = Contex
 /**
  * Runs an effect with `CurrentXHRResponseType` set to `"arraybuffer"` so the XHR HTTP client receives response bodies as `ArrayBuffer` values.
  *
- * @category references
+ * @category providing services
  * @since 4.0.0
  */
 export const withXHRArrayBuffer = <A, E, R>(

--- a/packages/platform-browser/src/BrowserHttpClient.ts
+++ b/packages/platform-browser/src/BrowserHttpClient.ts
@@ -87,7 +87,7 @@ export type XHRResponseType = "arraybuffer" | "text"
  * @see {@link XHRResponseType} for the allowed response body modes
  * @see {@link withXHRArrayBuffer} for scoping XHR response handling to `ArrayBuffer`
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const CurrentXHRResponseType: Context.Reference<XHRResponseType> = Context.Reference(

--- a/packages/platform-browser/src/BrowserRuntime.ts
+++ b/packages/platform-browser/src/BrowserRuntime.ts
@@ -29,7 +29,7 @@ import { makeRunMain, type Teardown } from "effect/Runtime"
  * The `beforeunload` interruption is best-effort. Browser teardown may prevent
  * asynchronous finalizers, network work, timers, or prompts from completing.
  *
- * @category Runtime
+ * @category running
  * @since 4.0.0
  */
 export const runMain: {

--- a/packages/platform-browser/src/BrowserStream.ts
+++ b/packages/platform-browser/src/BrowserStream.ts
@@ -19,7 +19,7 @@ import * as Stream from "effect/Stream"
  * buffer size by passing an object as the second argument with the `bufferSize`
  * field.
  *
- * @category streams
+ * @category constructors
  * @since 4.0.0
  */
 export const fromEventListenerWindow = <K extends keyof WindowEventMap>(
@@ -41,7 +41,7 @@ export const fromEventListenerWindow = <K extends keyof WindowEventMap>(
  * buffer size by passing an object as the second argument with the `bufferSize`
  * field.
  *
- * @category streams
+ * @category constructors
  * @since 4.0.0
  */
 export const fromEventListenerDocument = <K extends keyof DocumentEventMap>(

--- a/packages/platform-browser/src/Clipboard.ts
+++ b/packages/platform-browser/src/Clipboard.ts
@@ -38,7 +38,7 @@ const ErrorTypeId = "~@effect/platform-browser/Clipboard/ClipboardError"
  * MIME type support varies by browser. Failed browser operations are surfaced
  * as `ClipboardError`.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Clipboard {

--- a/packages/platform-browser/src/Geolocation.ts
+++ b/packages/platform-browser/src/Geolocation.ts
@@ -44,7 +44,7 @@ const ErrorTypeId = "~@effect/platform-browser/Geolocation/GeolocationError"
  * @see {@link GeolocationError} for represented browser geolocation failures
  * @see {@link layer} for the browser-backed service implementation
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Geolocation {

--- a/packages/platform-browser/src/IndexedDb.ts
+++ b/packages/platform-browser/src/IndexedDb.ts
@@ -93,7 +93,7 @@ export const make = (impl: Omit<IndexedDb, typeof TypeId>): IndexedDb => Indexed
 /**
  * Layer that provides `IndexedDb` from `window.indexedDB` and `window.IDBKeyRange`, failing with a config error when they are unavailable.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layerWindow: Layer.Layer<IndexedDb> = Layer.effect(

--- a/packages/platform-browser/src/IndexedDb.ts
+++ b/packages/platform-browser/src/IndexedDb.ts
@@ -19,7 +19,7 @@ const TypeId = "~@effect/platform-browser/IndexedDb"
 /**
  * Service interface that provides the browser `indexedDB` factory and `IDBKeyRange` constructor.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface IndexedDb {

--- a/packages/platform-browser/src/IndexedDbDatabase.ts
+++ b/packages/platform-browser/src/IndexedDbDatabase.ts
@@ -126,7 +126,7 @@ export class IndexedDbDatabaseError extends Data.TaggedError(
  * @see {@link IndexedDb.IndexedDb} for the lower-level browser IndexedDB primitives
  * @see {@link make} for creating a schema that provides this service as a layer
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class IndexedDbDatabase extends Context.Service<

--- a/packages/platform-browser/src/IndexedDbDatabase.ts
+++ b/packages/platform-browser/src/IndexedDbDatabase.ts
@@ -234,7 +234,7 @@ export interface Transaction<
 /**
  * Extracts the string-literal index names defined by an `IndexedDbTable`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type IndexFromTable<Table extends IndexedDbTable.AnyWithProps> = IsStringLiteral<
@@ -245,7 +245,7 @@ export type IndexFromTable<Table extends IndexedDbTable.AnyWithProps> = IsString
 /**
  * Extracts the valid index names for a table name within an IndexedDB version.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type IndexFromTableName<

--- a/packages/platform-browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform-browser/src/IndexedDbQueryBuilder.ts
@@ -719,7 +719,7 @@ export declare namespace IndexedDbQuery {
 /**
  * Service tag for the active `IDBTransaction` used to share a transaction across IndexedDB query effects.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export class IndexedDbTransaction extends Context.Service<IndexedDbTransaction, globalThis.IDBTransaction>()(

--- a/packages/platform-browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform-browser/src/IndexedDbQueryBuilder.ts
@@ -142,7 +142,7 @@ export interface IndexedDbQueryBuilder<
 /**
  * Valid key-path type for a table schema, using encoded fields whose values are IndexedDB-valid keys.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type KeyPath<TableSchema extends IndexedDbTable.AnySchemaStruct> =
@@ -152,7 +152,7 @@ export type KeyPath<TableSchema extends IndexedDbTable.AnySchemaStruct> =
 /**
  * Valid numeric key-path type for a table schema, used for auto-increment key paths.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type KeyPathNumber<TableSchema extends IndexedDbTable.AnySchemaStruct> =
@@ -168,7 +168,7 @@ export declare namespace IndexedDbQuery {
   /**
    * Decoded row type returned by select queries, adding a `key` field when the table does not define a key path.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type SelectType<
@@ -181,7 +181,7 @@ export declare namespace IndexedDbQuery {
   /**
    * Input type for insert and upsert operations, adjusted for auto-increment keys and out-of-line keys.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type ModifyType<
@@ -215,7 +215,7 @@ export declare namespace IndexedDbQuery {
   /**
    * Value type accepted by `equals` comparisons for a table key path or index.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type EqualsType<
@@ -229,7 +229,7 @@ export declare namespace IndexedDbQuery {
   /**
    * Value type accepted by range comparisons for a table key path or index, including partial tuples for compound indexes.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type ExtractIndexType<
@@ -248,7 +248,7 @@ export declare namespace IndexedDbQuery {
   /**
    * Mutation input type for insert and upsert operations, including any required key fields.
    *
-   * @category models
+   * @category utility types
    * @since 4.0.0
    */
   export type ModifyWithKey<Table extends IndexedDbTable.AnyWithProps> = ModifyType<Table>

--- a/packages/platform-browser/src/IndexedDbTable.ts
+++ b/packages/platform-browser/src/IndexedDbTable.ts
@@ -23,7 +23,7 @@ const TypeId = "~@effect/platform-browser/IndexedDbTable"
 /**
  * Typed IndexedDB table definition containing its name, schema, key path, indexes, auto-increment setting, and transaction durability.
  *
- * @category interface
+ * @category models
  * @since 4.0.0
  */
 export interface IndexedDbTable<

--- a/packages/platform-browser/src/IndexedDbTable.ts
+++ b/packages/platform-browser/src/IndexedDbTable.ts
@@ -94,14 +94,14 @@ export type AnyWithProps = IndexedDbTable<
 /**
  * Extracts the table name type from an `IndexedDbTable`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type TableName<Table extends Any> = Table["tableName"]
 /**
  * Extracts the key-path type from an `IndexedDbTable`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type KeyPath<Table extends Any> = Table["keyPath"]
@@ -109,7 +109,7 @@ export type KeyPath<Table extends Any> = Table["keyPath"]
 /**
  * Extracts the auto-increment flag type from an `IndexedDbTable`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type AutoIncrement<Table extends Any> = Table["autoIncrement"]
@@ -117,14 +117,14 @@ export type AutoIncrement<Table extends Any> = Table["autoIncrement"]
 /**
  * Extracts the schema type from an `IndexedDbTable`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type TableSchema<Table extends Any> = Table["tableSchema"]
 /**
  * Extracts the decoding or encoding service requirements needed by an `IndexedDbTable` schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Context<Table extends Any> =
@@ -134,7 +134,7 @@ export type Context<Table extends Any> =
 /**
  * Extracts the encoded row type from an `IndexedDbTable` schema.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Encoded<Table extends Any> = Table["tableSchema"]["Encoded"]
@@ -142,7 +142,7 @@ export type Encoded<Table extends Any> = Table["tableSchema"]["Encoded"]
 /**
  * Extracts the index definition map from an `IndexedDbTable`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Indexes<Table extends Any> = Table["indexes"]
@@ -150,7 +150,7 @@ export type Indexes<Table extends Any> = Table["indexes"]
 /**
  * Selects the table with the given name from a union of `IndexedDbTable` types.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type WithName<Table extends Any, TableName extends string> = Extract<

--- a/packages/platform-browser/src/IndexedDbVersion.ts
+++ b/packages/platform-browser/src/IndexedDbVersion.ts
@@ -59,7 +59,7 @@ export type AnyWithProps = IndexedDbVersion<IndexedDbTable.AnyWithProps>
 /**
  * Extracts the table union from an `IndexedDbVersion`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type Tables<Db extends Any> = Db extends IndexedDbVersion<infer _Tables> ? _Tables : never
@@ -67,7 +67,7 @@ export type Tables<Db extends Any> = Db extends IndexedDbVersion<infer _Tables> 
 /**
  * Selects a table by name from an `IndexedDbVersion`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type TableWithName<
@@ -78,7 +78,7 @@ export type TableWithName<
 /**
  * Extracts the schema for a named table within an `IndexedDbVersion`.
  *
- * @category models
+ * @category utility types
  * @since 4.0.0
  */
 export type SchemaWithName<

--- a/packages/platform-browser/src/IndexedDbVersion.ts
+++ b/packages/platform-browser/src/IndexedDbVersion.ts
@@ -27,7 +27,7 @@ const TypeId = "~@effect/platform-browser/IndexedDbVersion"
 /**
  * Typed IndexedDB version definition containing the tables available in that schema version.
  *
- * @category interface
+ * @category models
  * @since 4.0.0
  */
 export interface IndexedDbVersion<

--- a/packages/platform-browser/src/Permissions.ts
+++ b/packages/platform-browser/src/Permissions.ts
@@ -21,7 +21,7 @@ const ErrorTypeId = "~@effect/platform-browser/Permissions/PermissionsError"
  * Wrapper on the Permission API (`navigator.permissions`) with methods for
  * querying status of permissions.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Permissions {

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -296,7 +296,7 @@ export const layer = <R extends string>(
 /**
  * Layer that starts a Bun HTTP server on an ephemeral port for tests.
  *
- * @category layers
+ * @category testing
  * @since 4.0.0
  */
 export const layerTest: Layer.Layer<

--- a/packages/platform-deno/src/DenoHttpServer.ts
+++ b/packages/platform-deno/src/DenoHttpServer.ts
@@ -251,7 +251,7 @@ export const layer = (
 /**
  * Starts a Deno HTTP server on an ephemeral loopback port for tests.
  *
- * @category layers
+ * @category testing
  * @since 4.0.0
  */
 export const layerTest: Layer.Layer<

--- a/packages/platform-deno/src/DenoSocket.ts
+++ b/packages/platform-deno/src/DenoSocket.ts
@@ -25,7 +25,7 @@ import * as Socket from "effect/unstable/socket/Socket"
 /**
  * Options for opening a TCP or Unix connection.
  *
- * @category types
+ * @category options
  * @since 4.0.0
  */
 export type ConnectOptions = (Deno.ConnectOptions | Deno.UnixConnectOptions) & {
@@ -36,7 +36,7 @@ export type ConnectOptions = (Deno.ConnectOptions | Deno.UnixConnectOptions) & {
 /**
  * Options for opening a TCP or Unix connection.
  *
- * @category types
+ * @category options
  * @since 4.0.0
  */
 export type TcpOptions = ConnectOptions & {

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -51,14 +51,14 @@ export {
    * Use to access or override the fetch implementation used by the Node
    * fetch-based HTTP client.
    *
-   * @category fetch
+   * @category services
    * @since 4.0.0
    */
   Fetch,
   /**
    * Layer that provides the fetch-based HTTP client implementation.
    *
-   * @category fetch
+   * @category layers
    * @since 4.0.0
    */
   layer as layerFetch,
@@ -69,7 +69,7 @@ export {
    *
    * Use to provide default fetch request options for Node HTTP requests.
    *
-   * @category fetch
+   * @category services
    * @since 4.0.0
    */
   RequestInit
@@ -83,7 +83,7 @@ export {
  * Service tag for the Undici `Dispatcher` used by the Undici-backed HTTP
  * client.
  *
- * @category Dispatcher
+ * @category services
  * @since 4.0.0
  */
 export class Dispatcher extends Context.Service<Dispatcher, Undici.Dispatcher>()(
@@ -94,7 +94,7 @@ export class Dispatcher extends Context.Service<Dispatcher, Undici.Dispatcher>()
  * Acquires a new Undici `Agent` dispatcher and destroys it when the enclosing
  * scope is finalized.
  *
- * @category Dispatcher
+ * @category resource management
  * @since 4.0.0
  */
 export const makeDispatcher: Effect.Effect<Undici.Dispatcher, never, Scope.Scope> = Effect.acquireRelease(
@@ -107,7 +107,7 @@ export const makeDispatcher: Effect.Effect<Undici.Dispatcher, never, Scope.Scope
 /**
  * Provides the `Dispatcher` service using a scoped Undici `Agent`.
  *
- * @category Dispatcher
+ * @category layers
  * @since 4.0.0
  */
 export const layerDispatcher: Layer.Layer<Dispatcher> = Layer.effect(Dispatcher)(makeDispatcher)
@@ -116,7 +116,7 @@ export const layerDispatcher: Layer.Layer<Dispatcher> = Layer.effect(Dispatcher)
  * Provides the `Dispatcher` service from Undici's process-global dispatcher,
  * without creating or owning a new agent.
  *
- * @category Dispatcher
+ * @category layers
  * @since 4.0.0
  */
 // oxlint cannot resolve values re-exported through the local Undici facade.
@@ -127,7 +127,7 @@ export const dispatcherLayerGlobal: Layer.Layer<Dispatcher> = Layer.sync(Dispatc
  * Fiber reference containing default Undici request options applied to requests
  * sent by `makeUndici`.
  *
- * @category Undici
+ * @category services
  * @since 4.0.0
  */
 export const UndiciOptions = Context.Reference<Partial<Undici.Dispatcher.RequestOptions>>(
@@ -140,7 +140,7 @@ export const UndiciOptions = Context.Reference<Partial<Undici.Dispatcher.Request
  * `Dispatcher`, converts Effect HTTP bodies to Undici bodies, and maps
  * transport and decode failures to `HttpClientError`.
  *
- * @category Undici
+ * @category constructors
  * @since 4.0.0
  */
 export const makeUndici = Effect.gen(function*() {
@@ -357,7 +357,7 @@ class UndiciResponse extends Inspectable.Class implements HttpClientResponse, Pi
  * Provides an Undici-backed `HttpClient` using the current `Dispatcher`
  * service.
  *
- * @category Undici
+ * @category layers
  * @since 4.0.0
  */
 export const layerUndiciNoDispatcher: Layer.Layer<
@@ -370,7 +370,7 @@ export const layerUndiciNoDispatcher: Layer.Layer<
  * Provides an Undici-backed `HttpClient` together with a scoped default
  * Undici `Agent` dispatcher.
  *
- * @category Undici
+ * @category layers
  * @since 4.0.0
  */
 export const layerUndici: Layer.Layer<Client.HttpClient> = Layer.provide(layerUndiciNoDispatcher, layerDispatcher)
@@ -383,7 +383,7 @@ export const layerUndici: Layer.Layer<Client.HttpClient> = Layer.provide(layerUn
  * Service tag for the paired Node `http` and `https` agents used by the
  * node:http-backed HTTP client.
  *
- * @category HttpAgent
+ * @category services
  * @since 4.0.0
  */
 export class HttpAgent extends Context.Service<HttpAgent, {
@@ -395,7 +395,7 @@ export class HttpAgent extends Context.Service<HttpAgent, {
  * Acquires Node `http` and `https` agents with the supplied options and
  * destroys both agents when the enclosing scope is finalized.
  *
- * @category HttpAgent
+ * @category resource management
  * @since 4.0.0
  */
 export const makeAgent = (options?: Https.AgentOptions): Effect.Effect<HttpAgent["Service"], never, Scope.Scope> =>
@@ -415,7 +415,7 @@ export const makeAgent = (options?: Https.AgentOptions): Effect.Effect<HttpAgent
  * Provides the `HttpAgent` service using scoped Node `http` and `https`
  * agents configured with the supplied options.
  *
- * @category HttpAgent
+ * @category layers
  * @since 4.0.0
  */
 export const layerAgentOptions: (options?: Https.AgentOptions | undefined) => Layer.Layer<
@@ -426,7 +426,7 @@ export const layerAgentOptions: (options?: Https.AgentOptions | undefined) => La
  * Provides the `HttpAgent` service using default scoped Node `http` and
  * `https` agents.
  *
- * @category HttpAgent
+ * @category layers
  * @since 4.0.0
  */
 export const layerAgent: Layer.Layer<HttpAgent> = layerAgentOptions()
@@ -436,7 +436,7 @@ export const layerAgent: Layer.Layer<HttpAgent> = layerAgentOptions()
  * current `HttpAgent`, streaming request bodies, and wrapping Node responses
  * as `HttpClientResponse` values.
  *
- * @category node:http
+ * @category constructors
  * @since 4.0.0
  */
 export const makeNodeHttp = Effect.gen(function*() {
@@ -649,7 +649,7 @@ class NodeHttpResponse extends NodeHttpIncomingMessage<Error.HttpClientError> im
  * Provides a node:http-backed `HttpClient` using the current `HttpAgent`
  * service.
  *
- * @category node:http
+ * @category layers
  * @since 4.0.0
  */
 export const layerNodeHttpNoAgent: Layer.Layer<
@@ -662,7 +662,7 @@ export const layerNodeHttpNoAgent: Layer.Layer<
  * Provides a node:http-backed `HttpClient` together with default scoped Node
  * `http` and `https` agents.
  *
- * @category node:http
+ * @category layers
  * @since 4.0.0
  */
 export const layerNodeHttp: Layer.Layer<Client.HttpClient> = Layer.provide(layerNodeHttpNoAgent, layerAgent)

--- a/packages/platform-node/src/Undici.ts
+++ b/packages/platform-node/src/Undici.ts
@@ -17,13 +17,13 @@
 import Undici from "undici"
 
 /**
- * @category Undici
+ * @category re-exports
  * @since 4.0.0
  */
 export * from "undici"
 
 /**
- * @category Undici
+ * @category re-exports
  * @since 4.0.0
  */
 export default Undici

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -104,7 +104,7 @@ export type TypeId = "~@effect/sql-clickhouse/ClickhouseClient"
  * typed parameter fragments, command-mode execution, insert queries, and
  * per-effect query ID and ClickHouse settings.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface ClickhouseClient extends Client.SqlClient {
@@ -149,7 +149,7 @@ export const ClickhouseClient = Context.Service<ClickhouseClient>("@effect/sql-c
  * `@clickhouse/client` options with optional span attributes and query/result
  * name transforms.
  *
- * @category constructors
+ * @category models
  * @since 4.0.0
  */
 export interface ClickhouseClientConfig extends Clickhouse.ClickHouseClientConfigOptions {
@@ -504,7 +504,7 @@ const typeFromUnknown = (value: unknown): string => {
  * `{pN: Type}` placeholders and escaping identifiers with an optional query
  * name transform.
  *
- * @category compiler
+ * @category constructors
  * @since 4.0.0
  */
 export const makeCompiler = (transform?: (_: string) => string) =>
@@ -534,13 +534,13 @@ const escape = Statement.defaultEscape("\"")
  * Custom SQL fragment type used for ClickHouse typed parameters created by
  * `ClickhouseClient.param`.
  *
- * @category custom types
+ * @category models
  * @since 4.0.0
  */
 export type ClickhouseCustom = ClickhouseParam
 
 /**
- * @category custom types
+ * @category models
  * @since 4.0.0
  */
 interface ClickhouseParam extends Statement.Custom<"ClickhouseParam", string, unknown> {}

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -399,7 +399,7 @@ export const make = (
  * Fiber reference read by the low-level ClickHouse connection to choose query
  * or command execution for statements; defaults to `query`.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const ClientMethod = Context.Reference<"query" | "command" | "insert">(
@@ -413,7 +413,7 @@ export const ClientMethod = Context.Reference<"query" | "command" | "insert">(
  * Fiber reference for the ClickHouse `query_id` applied to queries and
  * inserts; a random UUID is generated when no query ID is set.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const QueryId = Context.Reference<string | undefined>(
@@ -425,7 +425,7 @@ export const QueryId = Context.Reference<string | undefined>(
  * Fiber reference containing ClickHouse settings to attach to queries,
  * commands, and inserts.
  *
- * @category references
+ * @category services
  * @since 4.0.0
  */
 export const ClickhouseSettings: Context.Reference<

--- a/packages/sql/clickhouse/src/ClickhouseMigrator.ts
+++ b/packages/sql/clickhouse/src/ClickhouseMigrator.ts
@@ -24,7 +24,7 @@ export * from "effect/unstable/sql/Migrator"
  * Runs SQL migrations for ClickHouse using the supplied migrator options and
  * returns the applied migration IDs and names.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -52,7 +52,7 @@ export type TypeId = "~@effect/sql-d1/D1Client"
 /**
  * Cloudflare D1 SQL client service, extending `SqlClient` with its D1 configuration and no `updateValues` support.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface D1Client extends Client.SqlClient {

--- a/packages/sql/libsql/src/LibsqlClient.ts
+++ b/packages/sql/libsql/src/LibsqlClient.ts
@@ -49,7 +49,7 @@ export type TypeId = "~@effect/sql-libsql/LibsqlClient"
 /**
  * libSQL-backed SQL client service, extending `SqlClient` with its runtime type marker and client configuration.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface LibsqlClient extends Client.SqlClient {

--- a/packages/sql/libsql/src/LibsqlMigrator.ts
+++ b/packages/sql/libsql/src/LibsqlMigrator.ts
@@ -24,7 +24,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations using the configured `SqlClient`, returning the migrations that were applied.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/libsql/src/LibsqlMigrator.ts
+++ b/packages/sql/libsql/src/LibsqlMigrator.ts
@@ -38,7 +38,7 @@ export const run: <R2 = never>(
 /**
  * Creates a layer that runs the configured SQL migrations during layer construction.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -160,7 +160,7 @@ export type TypeId = typeof TypeId
 /**
  * Microsoft SQL Server client service, extending `SqlClient` with typed parameter fragments and stored procedure calls.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface MssqlClient extends Client.SqlClient {
@@ -655,7 +655,7 @@ export const layer = (
 /**
  * Creates the SQL Server statement compiler, using `@1`-style placeholders, bracket-escaped identifiers, and SQL Server `OUTPUT INSERTED` returning clauses.
  *
- * @category compiler
+ * @category constructors
  * @since 4.0.0
  */
 export const makeCompiler = (transform?: (_: string) => string) =>
@@ -707,7 +707,7 @@ function numberToParamName(n: number) {
 /**
  * Default mapping from Effect SQL primitive value kinds to Tedious SQL Server parameter data types.
  *
- * @category configuration
+ * @category constants
  * @since 4.0.0
  */
 export const defaultParameterTypes: Record<Statement.PrimitiveKind, DataType> = {

--- a/packages/sql/mssql/src/MssqlMigrator.ts
+++ b/packages/sql/mssql/src/MssqlMigrator.ts
@@ -23,7 +23,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations using the configured `SqlClient`, returning the migrations that were applied.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R>(

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -153,7 +153,7 @@ export type TypeId = "~@effect/sql-mysql2/MysqlClient"
 /**
  * mysql2-backed SQL client service, extending `SqlClient` with its runtime type marker and client configuration.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface MysqlClient extends Client.SqlClient {
@@ -455,7 +455,7 @@ export const layer = (
 /**
  * Creates the MySQL statement compiler, using `?` placeholders and backtick-escaped identifiers.
  *
- * @category compiler
+ * @category constructors
  * @since 4.0.0
  */
 export const makeCompiler = (transform?: (_: string) => string) =>

--- a/packages/sql/mysql2/src/MysqlMigrator.ts
+++ b/packages/sql/mysql2/src/MysqlMigrator.ts
@@ -23,7 +23,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations using the configured `SqlClient`, returning the migrations that were applied.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -73,7 +73,7 @@ export type TypeId = "~@effect/sql-pg/PgClient"
 /**
  * PostgreSQL client service, extending `SqlClient` with JSON parameter fragments and LISTEN/NOTIFY helpers.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface PgClient extends Client.SqlClient {
@@ -99,7 +99,7 @@ export const PgClient = Context.Service<PgClient>("@effect/sql-pg/PgClient")
 /**
  * Configuration for a PostgreSQL client, including connection, TLS, custom stream, application name, type parser, JSON transform, and query/result name transform options.
  *
- * @category constructors
+ * @category models
  * @since 4.0.0
  */
 export interface PgClientConfig {
@@ -129,7 +129,7 @@ export interface PgClientConfig {
 /**
  * PostgreSQL pool configuration, extending `PgClientConfig` with idle timeout, pool size, and connection lifetime settings.
  *
- * @category constructors
+ * @category models
  * @since 4.0.0
  */
 export interface PgPoolConfig extends PgClientConfig {
@@ -865,18 +865,18 @@ const escape = Statement.defaultEscape("\"")
 /**
  * PostgreSQL-specific custom statement fragments supported by the compiler, currently JSON parameter fragments.
  *
- * @category custom types
+ * @category models
  * @since 4.0.0
  */
 export type PgCustom = PgJson
 
 /**
- * @category custom types
+ * @category models
  * @since 4.0.0
  */
 interface PgJson extends Custom<"PgJson", unknown> {}
 /**
- * @category custom types
+ * @category constructors
  * @since 4.0.0
  */
 const PgJson = Statement.custom<PgJson>("PgJson")

--- a/packages/sql/pg/src/PgMigrator.ts
+++ b/packages/sql/pg/src/PgMigrator.ts
@@ -29,7 +29,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs PostgreSQL SQL migrations using the configured clients. Schema dumps use `pg_dump` and require child process, filesystem, and path services.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -60,7 +60,7 @@ export type TypeId = "~@effect/sql-pglite/PgliteClient"
 /**
  * PGlite-backed PostgreSQL client service, extending `SqlClient` with access to the PGlite instance, JSON fragments, LISTEN/NOTIFY, data directory dumps, and array type refresh.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface PgliteClient extends Client.SqlClient {
@@ -436,13 +436,13 @@ const escapeLiteral = (value: string) => `'${value.replace(/'/g, "''")}'`
 /**
  * PGlite-specific custom statement fragments supported by the compiler, currently JSON parameter fragments.
  *
- * @category custom types
+ * @category models
  * @since 4.0.0
  */
 export type PgCustom = PgJson
 
 /**
- * @category custom types
+ * @category models
  * @since 4.0.0
  */
 interface PgJson extends Custom<"PgJson", unknown> {}

--- a/packages/sql/pglite/src/PgliteMigrator.ts
+++ b/packages/sql/pglite/src/PgliteMigrator.ts
@@ -22,7 +22,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations using the configured `SqlClient`, returning the migrations that were applied.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/pglite/src/PgliteMigrator.ts
+++ b/packages/sql/pglite/src/PgliteMigrator.ts
@@ -36,7 +36,7 @@ export const run: <R2 = never>(
 /**
  * Creates a layer that runs the configured SQL migrations during layer construction.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -48,7 +48,7 @@ export type TypeId = "~@effect/sql-sqlite-bun/SqliteClient"
 /**
  * Bun SQLite client service, extending `SqlClient` with database export and extension loading helpers. `updateValues` is not supported.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface SqliteClient extends Client.SqlClient {

--- a/packages/sql/sqlite-bun/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-bun/src/SqliteMigrator.ts
@@ -22,7 +22,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations using the configured `SqlClient`, returning the migrations that were applied.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/sqlite-bun/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-bun/src/SqliteMigrator.ts
@@ -78,7 +78,7 @@ export const run: <R2 = never>(
 /**
  * Creates a layer that runs the configured SQL migrations during layer construction.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -62,7 +62,7 @@ export type TypeId = "~@effect/sql-sqlite-do/SqliteClient"
 /**
  * Cloudflare Durable Object SQLite client service, extending `SqlClient` with its configuration. `updateValues` is not supported.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface SqliteClient extends Client.SqlClient {

--- a/packages/sql/sqlite-do/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-do/src/SqliteMigrator.ts
@@ -52,7 +52,7 @@ export const run: <R2 = never>(
 /**
  * Creates a layer that runs the configured SQL migrations during layer construction.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/sqlite-do/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-do/src/SqliteMigrator.ts
@@ -38,7 +38,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations using the configured `SqlClient`, returning the migrations that were applied.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -49,7 +49,7 @@ export type TypeId = "~@effect/sql-sqlite-node/SqliteClient"
 /**
  * Node SQLite client service, extending `SqlClient` with database export, backup, and extension loading helpers. `updateValues` is not supported.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface SqliteClient extends Client.SqlClient {

--- a/packages/sql/sqlite-node/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-node/src/SqliteMigrator.ts
@@ -78,7 +78,7 @@ export const run: <R2 = never>(
 /**
  * Creates a layer that runs the configured SQLite migrations during layer construction and provides no services.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/sqlite-node/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-node/src/SqliteMigrator.ts
@@ -22,7 +22,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations for a SQLite database using the shared `Migrator` implementation and the current `SqlClient`.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R2 = never>(

--- a/packages/sql/sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteClient.ts
@@ -93,7 +93,7 @@ export interface SqliteClientConfig {
  * Use to switch React Native SQLite query execution to the asynchronous driver
  * API for a scoped effect.
  *
- * @category fiber refs
+ * @category services
  * @since 4.0.0
  */
 export const AsyncQuery = Context.Reference<boolean>(

--- a/packages/sql/sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteClient.ts
@@ -51,7 +51,7 @@ export type TypeId = "~@effect/sql-sqlite-react-native/SqliteClient"
 /**
  * React Native SQLite client service interface, extending `SqlClient` with its configuration and marking `updateValues` as unsupported for SQLite.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface SqliteClient extends Client.SqlClient {
@@ -104,7 +104,7 @@ export const AsyncQuery = Context.Reference<boolean>(
 /**
  * Runs an effect with `AsyncQuery` enabled, causing React Native SQLite queries in that effect to use the asynchronous driver API.
  *
- * @category fiber refs
+ * @category providing services
  * @since 4.0.0
  */
 export const withAsyncQuery = <R, E, A>(effect: Effect.Effect<A, E, R>) =>

--- a/packages/sql/sqlite-react-native/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteMigrator.ts
@@ -47,7 +47,7 @@ export const run: <R>(
 /**
  * Creates a layer that runs the configured React Native SQLite migrations during layer construction and provides no services.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/sqlite-react-native/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteMigrator.ts
@@ -33,7 +33,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations for a React Native SQLite database using the shared `Migrator` implementation and the current `SqlClient`.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R>(

--- a/packages/sql/sqlite-wasm/src/OpfsWorker.ts
+++ b/packages/sql/sqlite-wasm/src/OpfsWorker.ts
@@ -36,7 +36,7 @@ export interface OpfsWorkerConfig {
 /**
  * Runs the SQLite OPFS worker loop, opening the configured database, posting a ready message, handling query/import/export/update-hook messages, and closing when a close message is received.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run = (

--- a/packages/sql/sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteClient.ts
@@ -467,7 +467,7 @@ const extractRows = (rows: [Array<string>, Array<any>]) => rows[1]
 /**
  * Fiber reference that stores transferables to include with worker-backed SQLite WASM query messages.
  *
- * @category transferables
+ * @category services
  * @since 4.0.0
  */
 export const Transferables = Context.Reference<ReadonlyArray<Transferable>>(

--- a/packages/sql/sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteClient.ts
@@ -60,7 +60,7 @@ export type TypeId = "~@effect/sql-sqlite-wasm/SqliteClient"
 /**
  * SQLite WASM client service interface, extending `SqlClient` with database `export` and `import` operations and marking `updateValues` as unsupported for SQLite.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface SqliteClient extends Client.SqlClient {

--- a/packages/sql/sqlite-wasm/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteMigrator.ts
@@ -47,7 +47,7 @@ export const run: <R>(
 /**
  * Creates a layer that runs the configured SQLite WASM migrations during layer construction and provides no services.
  *
- * @category constructors
+ * @category layers
  * @since 4.0.0
  */
 export const layer = <R>(

--- a/packages/sql/sqlite-wasm/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteMigrator.ts
@@ -33,7 +33,7 @@ export * from "effect/unstable/sql/Migrator"
 /**
  * Runs SQL migrations for a SQLite WASM database using the shared `Migrator` implementation and the current `SqlClient`.
  *
- * @category constructors
+ * @category running
  * @since 4.0.0
  */
 export const run: <R>(

--- a/packages/tools/ai-codegen/src/Discovery.ts
+++ b/packages/tools/ai-codegen/src/Discovery.ts
@@ -52,7 +52,7 @@ export interface DiscoveredProvider {
 /**
  * Service for discovering AI provider configurations.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface ProviderDiscovery {

--- a/packages/tools/ai-codegen/src/Generator.ts
+++ b/packages/tools/ai-codegen/src/Generator.ts
@@ -69,7 +69,7 @@ export class PatchError extends Data.TaggedError("PatchError")<{
 /**
  * Service for generating Effect code from OpenAPI specs.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface CodeGenerator {

--- a/packages/tools/ai-codegen/src/Glob.ts
+++ b/packages/tools/ai-codegen/src/Glob.ts
@@ -23,7 +23,7 @@ export class GlobError extends Data.TaggedError("GlobError")<{
 /**
  * Service for glob pattern matching.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Glob {

--- a/packages/tools/ai-codegen/src/PostProcess.ts
+++ b/packages/tools/ai-codegen/src/PostProcess.ts
@@ -66,7 +66,7 @@ export class PostProcessError extends Data.TaggedError("PostProcessError")<{
 /**
  * Service for post-processing generated code.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface PostProcessor {

--- a/packages/tools/ai-codegen/src/SpecFetcher.ts
+++ b/packages/tools/ai-codegen/src/SpecFetcher.ts
@@ -43,7 +43,7 @@ export class SpecFetchError extends Data.TaggedError("SpecFetchError")<{
 /**
  * Service for fetching OpenAPI specifications.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface SpecFetcher {

--- a/packages/tools/ai-codegen/src/main.ts
+++ b/packages/tools/ai-codegen/src/main.ts
@@ -229,7 +229,7 @@ const ServicesLayer = Layer.mergeAll(
 /**
  * Run the CLI.
  *
- * @category execution
+ * @category running
  * @since 4.0.0
  */
 export const run = Command.run(root, { version: "0.0.0" }).pipe(

--- a/packages/tools/docgen/src/CLI.ts
+++ b/packages/tools/docgen/src/CLI.ts
@@ -236,7 +236,7 @@ const command = docgenCommand.pipe(
 /**
  * Runs the docgen command-line program.
  *
- * @category CLI
+ * @category running
  * @since 0.6.0
  */
 export const cli = Command.runWith(command, {

--- a/packages/tools/docgen/src/Configuration.ts
+++ b/packages/tools/docgen/src/Configuration.ts
@@ -108,7 +108,7 @@ export const ConfigurationSchema = Schema.Struct({
 /**
  * Resolved configuration used by the docgen services.
  *
- * @category models
+ * @category services
  * @since 0.6.0
  */
 export interface ConfigurationShape {

--- a/packages/tools/docgen/src/Parser.ts
+++ b/packages/tools/docgen/src/Parser.ts
@@ -19,7 +19,7 @@ import * as Domain from "./Domain.ts"
 /**
  * Source file and path currently being parsed.
  *
- * @category models
+ * @category services
  * @since 0.6.0
  */
 export interface SourceShape {

--- a/packages/tools/docgen/src/Parser.ts
+++ b/packages/tools/docgen/src/Parser.ts
@@ -148,7 +148,7 @@ const parseInterfaceDeclarations = (interfaces: ReadonlyArray<ast.InterfaceDecla
 /**
  * Parses exported interfaces from the current source file.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseInterfaces = Effect.flatMap(
@@ -257,7 +257,7 @@ const getFunctionDeclarations = Effect.gen(function*() {
 /**
  * Parses exported function declarations and function-valued variables.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseFunctions = Effect.gen(function*() {
@@ -304,7 +304,7 @@ const parseTypeAliasDeclarations = (typeAliases: ReadonlyArray<ast.TypeAliasDecl
 /**
  * Parses exported type aliases from the current source file.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseTypeAliases = Effect.flatMap(
@@ -336,7 +336,7 @@ const parseConstantVariableDeclaration = (vd: ast.VariableDeclaration) =>
 /**
  * Parses exported non-function constants from the current source file.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseConstants = Effect.gen(function*() {
@@ -415,7 +415,7 @@ const parseNamedExports = (ed: ast.ExportDeclaration) => {
 /**
  * Parses explicit export declarations from the current source file.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseExports = pipe(
@@ -463,7 +463,7 @@ const parseModuleDeclarations = (namespaces: ReadonlyArray<ast.ModuleDeclaration
 /**
  * Parses exported namespaces from the current source file.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseNamespaces = Effect.gen(function*() {
@@ -612,7 +612,7 @@ const parseClass = (c: ast.ClassDeclaration) =>
 /**
  * Parses exported classes and their documented members from the current source file.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseClasses = Effect.gen(function*() {
@@ -640,7 +640,7 @@ export const parseModuleDocumentation = Effect.gen(function*() {
 /**
  * Parses the current source file into a module documentation model.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseModule = Effect.gen(function*() {
@@ -717,7 +717,7 @@ const createProject = (files: ReadonlyArray<Domain.File>) =>
 /**
  * Parses source files into module documentation models sorted by path.
  *
- * @category parsers
+ * @category parsing
  * @since 0.6.0
  */
 export const parseFiles = (files: ReadonlyArray<Domain.File>) =>

--- a/packages/tools/openapi-generator/src/OpenApiPatch.ts
+++ b/packages/tools/openapi-generator/src/OpenApiPatch.ts
@@ -497,7 +497,7 @@ export const parsePatchInput = Effect.fn("parsePatchInput")(function*(input: str
  * Effect.runSync(program) // => "New Title"
  * ```
  *
- * @category application
+ * @category transforming
  * @since 4.0.0
  */
 export const applyPatches = Effect.fn("applyPatches")(function*(

--- a/packages/tools/openapi-generator/src/OpenApiPatch.ts
+++ b/packages/tools/openapi-generator/src/OpenApiPatch.ts
@@ -300,7 +300,7 @@ export const JsonPatchDocument = Schema.Array(JsonPatchOperation)
 /**
  * Type for a JSON Patch document.
  *
- * @category types
+ * @category models
  * @since 4.0.0
  */
 export type JsonPatchDocument = typeof JsonPatchDocument.Type

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -26,7 +26,7 @@ import * as Utils from "./Utils.ts"
  * types, and the implementation body. The generator swaps implementations to
  * choose between schema-backed clients and type-only clients.
  *
- * @category code generation
+ * @category services
  * @since 4.0.0
  */
 export class OpenApiTransformer extends Context.Service<
@@ -477,7 +477,7 @@ export const make = (
  * Use when you use this layer when generated HttpClient code should perform runtime response
  * decoding with generated Effect Schema values.
  *
- * @category code generation
+ * @category layers
  * @since 4.0.0
  */
 export const layerTransformerSchema = Layer.sync(
@@ -888,7 +888,7 @@ export const make = (
  * generated client relies on TypeScript types instead of runtime Schema
  * decoding.
  *
- * @category code generation
+ * @category layers
  * @since 4.0.0
  */
 export const layerTransformerTs = Layer.sync(

--- a/packages/tools/openapi-generator/src/Utils.ts
+++ b/packages/tools/openapi-generator/src/Utils.ts
@@ -101,7 +101,7 @@ export const toComment = UndefinedOr.match({
  * This mutates `destination` directly, which avoids allocating an intermediate
  * array when generator code needs to merge collections.
  *
- * @category concatenating
+ * @category mutations
  * @since 4.0.0
  */
 export const spreadElementsInto = <A>(source: Array<A>, destination: Array<A>): void => {

--- a/packages/tools/utils/src/Codegen.ts
+++ b/packages/tools/utils/src/Codegen.ts
@@ -118,7 +118,7 @@ export interface BarrelFile {
 /**
  * Service interface for discovering annotated barrel files and regenerating their export contents.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface BarrelGenerator {

--- a/packages/tools/utils/src/Glob.ts
+++ b/packages/tools/utils/src/Glob.ts
@@ -28,7 +28,7 @@ export class GlobError extends Data.TaggedError("GlobError")<{
 /**
  * Service interface for matching filesystem paths with glob patterns.
  *
- * @category models
+ * @category services
  * @since 4.0.0
  */
 export interface Glob {


### PR DESCRIPTION
## Summary

- standardize JSDoc categories around shared declaration roles and operation families
- replace module names, provider features, implementation details, and narrow aliases with repository-generic categories
- distinguish models, schemas, utility types, services, layers, guards, predicates, accessors, getters, and service provisioning by declaration semantics
- reduce the source category vocabulary from 358 values to 142

## Validation

- `pnpm exec oxlint --fix`
- `dprint fmt` / `dprint check` using the repository Nix-compatible binary
- `pnpm exec oxlint -f unix`
- `pnpm jsdocs --check`
- `pnpm check`
- category-only diff audit: all 2,191 changed annotations are `@category` lines

Generated sources were not hand-edited; the remaining singular `service` category in `OpenAiClientGenerated.ts` requires a generator-level follow-up.