### PR TITLE
Route provider-executed tool results into the assistant message in Prompt.fromResponseParts

### DIFF
--- a/.changeset/provider-executed-tool-results.md
+++ b/.changeset/provider-executed-tool-results.md
@@ -2,6 +2,4 @@
 "effect": patch
 ---
 
-Route provider-executed tool results into the assistant message in `Prompt.fromResponseParts`.
-
-Previously a provider-executed tool result (e.g. OpenAI `web_search`) was placed in a `tool` message like a framework-executed result, so round-tripping the conversation sent it back to OpenAI as a `function_call_output` whose corresponding `web_search_call` had been dropped, failing the request with HTTP 400 `No tool call found for function call output with call_id ws_...`. `Prompt.ToolResultPart` now carries `providerExecuted` (decoding default `false`), and `fromResponseParts` keeps provider-executed results in the assistant message, where the provider packages already expect them. Ports #5944 to the v4 line.
+Route provider-executed tool results into the assistant message in `Prompt.fromResponseParts`

--- a/.changeset/provider-executed-tool-results.md
+++ b/.changeset/provider-executed-tool-results.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Route provider-executed tool results into the assistant message in `Prompt.fromResponseParts`.
+
+Previously a provider-executed tool result (e.g. OpenAI `web_search`) was placed in a `tool` message like a framework-executed result, so round-tripping the conversation sent it back to OpenAI as a `function_call_output` whose corresponding `web_search_call` had been dropped, failing the request with HTTP 400 `No tool call found for function call output with call_id ws_...`. `Prompt.ToolResultPart` now carries `providerExecuted` (decoding default `false`), and `fromResponseParts` keeps provider-executed results in the assistant message, where the provider packages already expect them. Ports #5944 to the v4 line.

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -1,7 +1,14 @@
 import { AnthropicClient, AnthropicLanguageModel, AnthropicTool } from "@effect/ai-anthropic"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted, Schema, Stream } from "effect"
-import { AnthropicStructuredOutput, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
+import {
+  AnthropicStructuredOutput,
+  LanguageModel,
+  Prompt,
+  Response as AiResponse,
+  Tool,
+  Toolkit
+} from "effect/unstable/ai"
 import { HttpClient, type HttpClientError, type HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 describe("AnthropicLanguageModel", () => {
@@ -275,6 +282,103 @@ describe("AnthropicLanguageModel", () => {
 
         assert.strictEqual(dynamicTool.description, "A dynamic tool")
         assert.deepStrictEqual(dynamicTool.input_schema, inputSchema)
+      }))
+
+    it.effect("serializes provider-executed web_search parts from the assistant message", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_2",
+                type: "message",
+                role: "assistant",
+                model: "claude-sonnet-4-20250514",
+                content: [{ type: "text", text: "You're welcome" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        const searchResults = [{
+          type: "web_search_result",
+          url: "https://example.com/gold",
+          title: "Gold price",
+          encrypted_content: "encrypted",
+          page_age: null
+        }]
+
+        const history = Prompt.fromResponseParts([
+          AiResponse.makePart("tool-call", {
+            id: "srvtoolu_1",
+            name: "AnthropicWebSearch",
+            params: { query: "gold price today" },
+            providerExecuted: true
+          }),
+          AiResponse.makePart("tool-result", {
+            id: "srvtoolu_1",
+            name: "AnthropicWebSearch",
+            isFailure: false,
+            result: searchResults,
+            encodedResult: searchResults,
+            preliminary: false,
+            providerExecuted: true
+          }),
+          AiResponse.makePart("text", { text: "Gold is around $4,000." })
+        ])
+
+        const prompt = Prompt.concat(
+          Prompt.concat(Prompt.make("what is the gold price?"), history),
+          Prompt.make("thanks")
+        )
+
+        yield* LanguageModel.generateText({
+          prompt,
+          toolkit: Toolkit.make(AnthropicTool.WebSearch_20250305({})),
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const body = yield* getRequestBody(capturedRequest)
+        const assistantMessage = body.messages.find((message: any) => message.role === "assistant")
+        assert.isDefined(assistantMessage)
+
+        const serverToolUse = assistantMessage.content.find((block: any) => block.type === "server_tool_use")
+        assert.isDefined(serverToolUse)
+        assert.strictEqual(serverToolUse.id, "srvtoolu_1")
+        assert.strictEqual(serverToolUse.name, "web_search")
+
+        const searchResult = assistantMessage.content.find((block: any) => block.type === "web_search_tool_result")
+        assert.isDefined(searchResult)
+        assert.strictEqual(searchResult.tool_use_id, "srvtoolu_1")
+
+        const clientToolResults = body.messages.flatMap((message: any) =>
+          Array.isArray(message.content)
+            ? message.content.filter((block: any) => block.type === "tool_result")
+            : []
+        )
+        assert.strictEqual(clientToolResults.length, 0)
       }))
   })
 

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -370,13 +370,15 @@ describe("OpenAiLanguageModel", () => {
                   id: "call_1",
                   name: "TestTool",
                   isFailure: false,
-                  result: { output: "first" }
+                  result: { output: "first" },
+                  providerExecuted: false
                 }),
                 Prompt.toolResultPart({
                   id: "call_2",
                   name: "TestTool",
                   isFailure: false,
-                  result: { output: "second" }
+                  result: { output: "second" },
+                  providerExecuted: false
                 })
               ]
             }
@@ -922,7 +924,8 @@ describe("OpenAiLanguageModel", () => {
                 id: toolCall.id,
                 name: toolCall.name,
                 isFailure: false,
-                result: "done"
+                result: "done",
+                providerExecuted: false
               })]
             }
           ]),

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -342,7 +342,8 @@ describe("OpenAiLanguageModel", () => {
                       id: "call_abc",
                       name: "TestTool",
                       isFailure: false,
-                      result: { output: "result" }
+                      result: { output: "result" },
+                      providerExecuted: false
                     })
                   ]
                 }
@@ -384,7 +385,8 @@ describe("OpenAiLanguageModel", () => {
                       id: "call_abc",
                       name: "TestTool",
                       isFailure: false,
-                      result: { output: "result" }
+                      result: { output: "result" },
+                      providerExecuted: false
                     })
                   ]
                 }

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -2055,7 +2055,8 @@ const executeApprovedToolCalls = <Tools extends Record<string, Tool.Any>>(
       id: approval.toolCallId,
       name: toolCall.name,
       isFailure: terminalResult.isFailure,
-      result: terminalResult.encodedResult
+      result: terminalResult.encodedResult,
+      providerExecuted: false
     })
   })
 
@@ -2075,7 +2076,8 @@ const createDenialResults = (
           id: denial.toolCallId,
           name: denial.toolCall.name,
           isFailure: true,
-          result: { type: "execution-denied", reason: denial.reason }
+          result: { type: "execution-denied", reason: denial.reason },
+          providerExecuted: false
         })
       )
     }

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -632,7 +632,8 @@ export const toolCallPart = (params: PartConstructorParams<ToolCallPart>): ToolC
  *     temperature: 22,
  *     condition: "sunny",
  *     humidity: 65
- *   }
+ *   },
+ *   providerExecuted: false
  * })
  * const result = [toolResultPart.name, toolResultPart.isFailure] // => ["get_weather", false]
  * ```
@@ -657,6 +658,10 @@ export interface ToolResultPart extends BasePart<"tool-result", ToolResultPartOp
    * The result returned by the tool execution.
    */
   readonly result: unknown
+  /**
+   * Whether the tool was executed by the provider (true) or framework (false).
+   */
+  readonly providerExecuted: boolean
 }
 
 /**
@@ -682,6 +687,10 @@ export interface ToolResultPartEncoded extends BasePartEncoded<"tool-result", To
    * The result returned by the tool execution.
    */
   readonly result: unknown
+  /**
+   * Whether the tool was executed by the provider (true) or framework (false).
+   */
+  readonly providerExecuted?: boolean | undefined
 }
 
 /**
@@ -705,6 +714,7 @@ export const ToolResultPart: Schema.Struct<{
   readonly name: Schema.String
   readonly isFailure: Schema.Boolean
   readonly result: Schema.Unknown
+  readonly providerExecuted: Schema.withDecodingDefault<Schema.Boolean>
   readonly "~effect/ai/Prompt/Part": Schema.withDecodingDefaultKey<Schema.Literal<"~effect/ai/Prompt/Part">>
   readonly options: Schema.withDecodingDefault<
     Schema.$Record<
@@ -718,7 +728,8 @@ export const ToolResultPart: Schema.Struct<{
   id: Schema.String,
   name: Schema.String,
   isFailure: Schema.Boolean,
-  result: Schema.Unknown
+  result: Schema.Unknown,
+  providerExecuted: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false)))
 }).annotate({ identifier: "ToolResultPart" })
 
 /**
@@ -1421,7 +1432,8 @@ export const userMessage = (params: MessageConstructorParams<UserMessage>): User
  *         result: {
  *           temperature: 72,
  *           condition: "sunny"
- *         }
+ *         },
+ *         providerExecuted: true
  *       }),
  *       Prompt.makePart("text", {
  *         text: "The weather in San Francisco is currently 72°F and sunny."
@@ -1628,7 +1640,8 @@ export const assistantMessage = (params: MessageConstructorParams<AssistantMessa
  *           { title: "TypeScript Handbook", url: "https://..." },
  *           { title: "Effective TypeScript", url: "https://..." }
  *         ]
- *       }
+ *       },
+ *       providerExecuted: false
  *     })
  *   ]
  * })
@@ -2099,11 +2112,13 @@ export const fromResponseParts = (parts: ReadonlyArray<Response.AnyPart>): Promp
       // Tool Result Parts (skip preliminary results)
       case "tool-result": {
         if (part.preliminary !== true) {
-          toolParts.push(makePart("tool-result", {
+          const target = part.providerExecuted === true ? assistantParts : toolParts
+          target.push(makePart("tool-result", {
             id: part.id,
             name: part.name,
             isFailure: part.isFailure,
-            result: part.encodedResult
+            result: part.encodedResult,
+            providerExecuted: part.providerExecuted ?? false
           }))
         }
         break

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -780,7 +780,8 @@ describe("LanguageModel", () => {
                 id: toolCallId,
                 name: "ApprovalTool",
                 result: { result: "approved-result" },
-                isFailure: false
+                isFailure: false,
+                providerExecuted: false
               })
             ]
           }),
@@ -988,7 +989,8 @@ describe("LanguageModel", () => {
                 id: toolCallId,
                 name: "ApprovalTool",
                 result: { result: "approved-result" },
-                isFailure: false
+                isFailure: false,
+                providerExecuted: false
               })
             ]
           }),
@@ -1082,7 +1084,8 @@ describe("LanguageModel", () => {
                 id: toolCallId,
                 name: "ApprovalTool",
                 result: { result: "approved-result" },
-                isFailure: false
+                isFailure: false,
+                providerExecuted: false
               })
             ]
           }),
@@ -1744,7 +1747,8 @@ describe("LanguageModel", () => {
                 id: toolCallId,
                 name: "ApprovalTool",
                 result: { result: "approved-result" },
-                isFailure: false
+                isFailure: false,
+                providerExecuted: false
               })
             ]
           }),
@@ -1823,7 +1827,8 @@ describe("LanguageModel", () => {
                 id: toolCallId,
                 name: "ApprovalTool",
                 result: { result: "approved-result" },
-                isFailure: false
+                isFailure: false,
+                providerExecuted: false
               })
             ]
           }),

--- a/packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts
@@ -393,7 +393,8 @@ describe("LanguageModel tracker lifecycle integration", () => {
               id: toolCallId,
               name: "ApprovalTool",
               result: { result: "approved-result" },
-              isFailure: false
+              isFailure: false,
+              providerExecuted: false
             })
           ]
         })

--- a/packages/effect/test/unstable/ai/Prompt.test.ts
+++ b/packages/effect/test/unstable/ai/Prompt.test.ts
@@ -117,6 +117,59 @@ describe("Prompt", () => {
       assert.strictEqual(typeof toolContent[0] === "object" && toolContent[0].type, "tool-result")
     })
 
+    it("places provider-executed tool results in the assistant message", () => {
+      const parts = [
+        Response.makePart("tool-call", {
+          id: "ws-1",
+          name: "web_search",
+          params: {},
+          providerExecuted: true
+        }),
+        Response.makePart("tool-result", {
+          id: "ws-1",
+          name: "web_search",
+          isFailure: false,
+          result: { sources: 3 },
+          encodedResult: { sources: 3 },
+          preliminary: false,
+          providerExecuted: true
+        }),
+        Response.makePart("tool-call", {
+          id: "call-1",
+          name: "get_weather",
+          params: { city: "London" },
+          providerExecuted: false
+        }),
+        Response.makePart("tool-result", {
+          id: "call-1",
+          name: "get_weather",
+          isFailure: false,
+          result: { temp: 20 },
+          encodedResult: { temp: 20 },
+          preliminary: false,
+          providerExecuted: false
+        })
+      ]
+      const prompt = Prompt.fromResponseParts(parts)
+
+      // Provider-executed pair stays in the assistant message; only the
+      // framework-executed result forms a tool message
+      assert.strictEqual(prompt.content.length, 2)
+      assert.strictEqual(prompt.content[0].role, "assistant")
+      assert.strictEqual(prompt.content[1].role, "tool")
+
+      const assistantContent = prompt.content[0].content
+      assert.strictEqual(assistantContent.length, 3)
+      assert.strictEqual(typeof assistantContent[1] === "object" && assistantContent[1].type, "tool-result")
+      assert.deepStrictEqual((assistantContent[1] as any).id, "ws-1")
+      assert.strictEqual((assistantContent[1] as any).providerExecuted, true)
+
+      const toolContent = prompt.content[1].content
+      assert.strictEqual(toolContent.length, 1)
+      assert.deepStrictEqual((toolContent[0] as any).id, "call-1")
+      assert.strictEqual((toolContent[0] as any).providerExecuted, false)
+    })
+
     it("should handle out-of-order tool results (result before call in stream)", () => {
       // This simulates concurrent tool execution where results may arrive
       // in different order than their corresponding calls

--- a/packages/effect/test/unstable/ai/ResponseIdTracker.test.ts
+++ b/packages/effect/test/unstable/ai/ResponseIdTracker.test.ts
@@ -27,7 +27,8 @@ const toolResultMessage = (id: string) =>
         id,
         name: "test_tool",
         result: { ok: true },
-        isFailure: false
+        isFailure: false,
+        providerExecuted: false
       })
     ]
   })


### PR DESCRIPTION
## Summary

Ports #5944 to the v4 line. `Prompt.fromResponseParts` places provider-executed tool results (e.g. OpenAI `web_search`) in a `tool` message like framework results, so round-tripping a conversation sends them back to OpenAI as `function_call_output` items whose corresponding `web_search_call` was dropped from the request (`prepareMessages` skips provider-executed tool calls). OpenAI rejects the request:

```
HTTP 400 from POST /v1/responses
No tool call found for function call output with call_id ws_<...>.
```

The first turn with a provider web search succeeds; every follow-up turn that round-trips the history fails, deterministically. This is exactly #5939, which #5944 fixed on the v3 line (`@effect/ai`) -- neither of that PR's two changes exists in the v4 rewrite.

## Changes

- `Prompt.ToolResultPart` / `ToolResultPartEncoded` / schema gain `providerExecuted` (decoding default `false`), mirroring `ToolCallPart`.
- `fromResponseParts` routes tool results with `providerExecuted: true` into `assistantParts`, keeping the provider call/result pair together in the assistant message. Framework results still form `tool` messages.
- The consumer half already exists in v4: `@effect/ai-openai`'s `prepareMessages` assistant branch has a tool-result case ("Assistant tool-result parts are always provider executed") that skips provider results or emits `item_reference` under `store: true` -- it was dead code until now, since `fromResponseParts` never delivered results to it.
- Mechanical: the now-required field added at the two framework construction sites in `LanguageModel.ts` (`providerExecuted: false`), the JSDoc examples, and existing test fixtures.
- Tests: `fromResponseParts` keeps a provider-executed call/result pair in the assistant message while a framework result still lands in the tool message; and on the Anthropic side, a history built via `fromResponseParts` containing a provider-executed `web_search` pair serializes to `server_tool_use` + `web_search_tool_result` blocks in the assistant turn with no client `tool_result` block (the assistant-branch serializer case this change activates).
- Changeset: `"effect": patch`.

## Validation

- `pnpm test packages/effect/test/unstable/ai packages/ai/openai/test/OpenAiLanguageModel.test.ts packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts packages/ai/anthropic` -- 642/642 across 24 files, run at the branch tip.
- `pnpm check` -- clean.
- `pnpm lint-fix` applied.

## Notes

The `store: true` / `item_reference` path still cannot engage for web search because the streamed and non-streamed `web_search_call` parts carry no `metadata.openai.itemId` (unlike e.g. reasoning and apply_patch parts) and `fromResponseParts` drops response-part metadata for all part types. With this PR the pair is coherently omitted from the request, which unbreaks the round-trip; carrying item ids through for `item_reference` replay would be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)