### PR TITLE
fix(schema): share representation identity across rebuilt containers of one declaration

### DIFF
--- a/.changeset/httpapi-status-key-context.md
+++ b/.changeset/httpapi-status-key-context.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+unstable/httpapi HttpApiSchema: carry `httpApiStatus` in the key context so a named schema reused with `status()` keeps one representation identity — one OpenAPI component referenced by every status — instead of throwing `Duplicate identifier`

--- a/.changeset/representation-annotated-container-identity.md
+++ b/.changeset/representation-annotated-container-identity.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+SchemaRepresentation: compare container slots structurally when two ASTs carry the same annotations object, so a derivation of a context-only copy (e.g. the JSON codec of a schema containing `Unknown` reused with `HttpApiSchema.status`) no longer publishes duplicate components for one declared identifier

--- a/packages/effect/src/internal/schema/toRepresentation.ts
+++ b/packages/effect/src/internal/schema/toRepresentation.ts
@@ -60,6 +60,7 @@ function fromASTs(
   const anonymousReferences = new Map<SchemaAST.AST, string>()
   const referenceOwners = new Map<string, SchemaAST.AST>()
   const valueIds = new Map<unknown, number>()
+  const compositeIds = new Map<string, number>()
   const canonicalByKey = new Map<string, SchemaAST.AST>()
   let nextValueId = 0
   const buildingReferences = new Set<string>()
@@ -95,10 +96,39 @@ function fromASTs(
     return id
   }
 
+  // Identity of a container slot on an annotated node: arrays and property/index
+  // signature wrappers are pure structure with no identity of their own, so they
+  // compare by their contents. AST nodes (and any other value) keep reference identity.
+  function getSlotId(value: unknown): number {
+    let composite: string | undefined
+    if (globalThis.Array.isArray(value)) {
+      composite = `[${value.map(getSlotId).join(",")}]`
+    } else if (value instanceof SchemaAST.PropertySignature) {
+      composite = `ps:${getValueId(value.name)}:${getValueId(value.type)}`
+    } else if (value instanceof SchemaAST.IndexSignature) {
+      composite = `is:${getValueId(value.parameter)}:${getValueId(value.type)}`
+    } else {
+      return getValueId(value)
+    }
+    const existing = compositeIds.get(composite)
+    if (existing !== undefined) return existing
+    const id = nextValueId++
+    compositeIds.set(composite, id)
+    return id
+  }
+
   function getIdentityKey(ast: SchemaAST.AST): string {
     let identity = ast._tag
+    // Two ASTs holding the same annotations object are claims to one declared schema:
+    // rebuilds of it (e.g. a codec derivation of a context-only copy) allocate fresh
+    // container wrappers, and those must not read as a second schema. Anonymous nodes
+    // and nodes with different annotation objects keep pure reference identity, so
+    // referentially distinct declarations stay distinct.
+    const structural = ast.annotations !== undefined
     for (const [key, value] of Object.entries(ast)) {
-      if (key !== "_tag" && key !== "context") identity += `:${getValueId(value)}`
+      if (key !== "_tag" && key !== "context") {
+        identity += `:${structural ? getSlotId(value) : getValueId(value)}`
+      }
     }
     return identity
   }

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -150,9 +150,15 @@ export type StatusLiteral = keyof typeof statusCodeByLiteral
  *
  * **Details**
  *
- * This is equivalent to calling `.annotate({ httpApiStatus: code })` on the
+ * This is equivalent to calling `.annotateKey({ httpApiStatus: code })` on the
  * schema. You can pass either a numeric status code (for example, `201`) or a
  * common literal name (for example, `"Created"`).
+ *
+ * The status is carried in the AST's key context rather than its annotations:
+ * the status describes how one endpoint uses the schema, not what the schema
+ * is, and context is excluded from representation identity. A named schema
+ * reused with different statuses therefore stays one schema — and one OpenAPI
+ * component — instead of forking into duplicate identifiers.
  *
  * @category schemas
  * @since 4.0.0
@@ -165,7 +171,7 @@ export function status(code: StatusLiteral): {
 }
 export function status(code: number | StatusLiteral) {
   const statusCode = typeof code === "string" ? statusCodeByLiteral[code] : code
-  return <S extends Schema.Top>(self: S): S["Rebuild"] => self.annotate({ httpApiStatus: statusCode })
+  return <S extends Schema.Top>(self: S): S["Rebuild"] => self.annotateKey({ httpApiStatus: statusCode })
 }
 
 /**
@@ -667,7 +673,15 @@ export const isNoContent = (ast: SchemaAST.AST): boolean => {
 
 const resolveHttpApiEncoding = SchemaAST.resolveAt<Encoding>("~httpApiEncoding")
 
-const resolveHttpApiStatus = SchemaAST.resolveAt<number>("httpApiStatus")
+const resolveHttpApiStatusAnnotation = SchemaAST.resolveAt<number>("httpApiStatus")
+
+// `status` stores the code in the key context (see `status` for why); the
+// annotation fallback keeps declaration-site statuses like the `HttpApiError`
+// classes working.
+function resolveHttpApiStatus(ast: SchemaAST.AST): number | undefined {
+  const fromContext = ast.context?.annotations?.httpApiStatus
+  return typeof fromContext === "number" ? fromContext : resolveHttpApiStatusAnnotation(ast)
+}
 
 const defaultJsonEncoding: Encoding = {
   _tag: "Json",

--- a/packages/effect/test/schema/representation/toRepresentations.test.ts
+++ b/packages/effect/test/schema/representation/toRepresentations.test.ts
@@ -167,6 +167,26 @@ describe("SchemaRepresentation.toRepresentations", () => {
       )
     })
 
+    it("shares a named reference across context-only copies whose derivation rebuilds a container", () => {
+      const Widget = Schema.Struct({
+        id: Schema.String,
+        metadata: Schema.Unknown
+      }).annotate({ identifier: "Widget" })
+      const forked = Widget.annotateKey({ description: "context-only fork" })
+
+      const base = Schema.toCodecJson(Widget)
+      const fork = Schema.toCodecJson(forked)
+      assert.notStrictEqual(base.ast, fork.ast)
+
+      const document = SchemaRepresentation.toRepresentations([base.ast, fork.ast])
+
+      assert.deepStrictEqual(Object.keys(document.references), ["Widget"])
+      assert.deepStrictEqual(document.representations, [
+        { _tag: "Reference", $ref: "Widget" },
+        { _tag: "Reference", $ref: "Widget" }
+      ])
+    })
+
     it("suffixes referentially distinct ASTs with equal representations", () => {
       const first = Schema.String.annotate({ identifier: "Value" })
       const second = Schema.String.annotate({ identifier: "Value" })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -260,4 +260,33 @@ describe("OpenApi", () => {
 
     assert.throws(() => OpenApi.fromApi(Api), /Conflicting OpenAPI security scheme: __proto__/)
   })
+
+  it("emits one component for a named schema reused with HttpApiSchema.status", () => {
+    const Widget = Schema.Struct({ id: Schema.String }).annotate({ identifier: "Widget" })
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("widgets").add(
+        HttpApiEndpoint.get("get", "/widgets/:id", {
+          params: { id: Schema.String },
+          success: Widget
+        }),
+        HttpApiEndpoint.post("create", "/widgets", {
+          success: Widget.pipe(HttpApiSchema.status(201))
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+    const schemaNames = Object.keys(spec.components.schemas).filter((name) => name.startsWith("Widget"))
+
+    assert.deepStrictEqual(schemaNames, ["Widget"])
+    assert.deepStrictEqual(
+      spec.paths["/widgets/{id}"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema,
+      { $ref: "#/components/schemas/Widget" }
+    )
+    assert.deepStrictEqual(
+      spec.paths["/widgets"]?.post?.responses?.["201"]?.content?.["application/json"]?.schema,
+      { $ref: "#/components/schemas/Widget" }
+    )
+  })
 })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -289,4 +289,35 @@ describe("OpenApi", () => {
       { $ref: "#/components/schemas/Widget" }
     )
   })
+  it("emits one component for a named schema containing Unknown reused with HttpApiSchema.status", () => {
+    const Widget = Schema.Struct({
+      id: Schema.String,
+      metadata: Schema.Record(Schema.String, Schema.Unknown)
+    }).annotate({ identifier: "Widget" })
+
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("widgets").add(
+        HttpApiEndpoint.get("get", "/widgets/:id", {
+          params: { id: Schema.String },
+          success: Widget
+        }),
+        HttpApiEndpoint.post("create", "/widgets", {
+          success: Widget.pipe(HttpApiSchema.status(201))
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+    const schemaNames = Object.keys(spec.components.schemas).filter((name) => name.startsWith("Widget"))
+
+    assert.deepStrictEqual(schemaNames, ["Widget"])
+    assert.deepStrictEqual(
+      spec.paths["/widgets/{id}"]?.get?.responses?.["200"]?.content?.["application/json"]?.schema,
+      { $ref: "#/components/schemas/Widget" }
+    )
+    assert.deepStrictEqual(
+      spec.paths["/widgets"]?.post?.responses?.["201"]?.content?.["application/json"]?.schema,
+      { $ref: "#/components/schemas/Widget" }
+    )
+  })
 })


### PR DESCRIPTION
Stacked on #6837 — the branch includes its commit; only the last commit (`Share representation identity across rebuilt containers of one declaration`) is new here. The two are companion halves of one invariant: #6837 stops `HttpApiSchema.status` from forking the annotations slot; this stops derivation rebuilds from forking the container slots.

## Problem

`SchemaRepresentation` resolves component identity by reference: an AST's identity key is the
composition of the object identities of its slots, with `context` excluded. That works as long as
every reuse of a declared schema reaches the representation as reference-shared structure.

Memoized derivations break that assumption whenever the derivation is non-identity. `toCodecJson`
lowers `Unknown` to `Json` by rewriting the child node, which forces the parent rebuild to allocate
fresh `PropertySignature` wrappers and a fresh `propertySignatures` array — once per top-level
derivation input. A named schema and its context-only copy (`HttpApiSchema.status` after #6837) are
two derivation inputs, so their rebuilt containers can never be reference-equal, and the identity
key diverges at exactly that slot:

```ts
const Widget = Schema.Struct({
  id: Schema.String,
  metadata: Schema.Record(Schema.String, Schema.Unknown)
}).annotate({ identifier: "Widget" })

HttpApiEndpoint.get("get", "/widgets/:id", { params: { id: Schema.String }, success: Widget })
HttpApiEndpoint.post("create", "/widgets", { success: Widget.pipe(HttpApiSchema.status(201)) })

OpenApi.fromApi(Api).components.schemas
// { Widget: …, Widget_1: … } — two identical components for one declared name
// (on 4.0.0-beta.102 this is a `Duplicate identifier: "Widget"` throw instead)
```

Remove the `metadata` field and the pair unifies — the failure is keyed to whether any child's
derivation is non-identity, which makes it look nondeterministic from the API author's seat. Any
schema carrying `Schema.Unknown` (a JSON metadata column, a `Record(String, Unknown)`) hits it in
the default CRUD shape.

## Fix

Container wrappers — `propertySignatures` / `indexSignatures` arrays, `PropertySignature`,
`IndexSignature` — are pure structure: they carry no annotations, checks, or context of their own,
so they have no identity to defend. When two ASTs hold the **same annotations object** — the token
of one user declaration — their container slots now compare by contents (element-wise reference
identity) instead of by container reference.

The gate is what keeps existing semantics intact:

- Anonymous nodes keep pure reference identity — "does not extract structurally equivalent schemas
  with distinct ASTs" is unchanged.
- Two `.annotate({ identifier: "Value" })` calls create two annotations objects, so referentially
  distinct declarations still suffix (`Value` / `Value_1`).
- Two composites sharing a declaration but with genuinely different recursive dependencies still
  split: their containers differ at the child references themselves ("does not deduplicate fallback
  definitions with distinct recursive dependencies" is unchanged).

Scope: one function in `internal/schema/toRepresentation.ts`; no AST or derivation changes.

## Tests

- `toRepresentations.test.ts`: "shares a named reference across context-only copies whose
  derivation rebuilds a container" — pure representation-level regression, fails with
  `["Widget", "Widget_1"]` refs before the fix.
- `OpenApi.test.ts`: "emits one component for a named schema containing Unknown reused with
  HttpApiSchema.status" — end-to-end CRUD shape, both `200` and `201` referencing one `Widget`
  component. Depends on #6837 (without it the copies also differ at the annotations slot).

`packages/effect/test/schema` + `packages/effect/test/unstable/httpapi`: 2220 tests green;
`tsc -b packages/effect` and lint clean.
