### PR TITLE
Add reproduction for Channel issue

### DIFF
--- a/packages/effect/test/Channel.test.ts
+++ b/packages/effect/test/Channel.test.ts
@@ -8,6 +8,7 @@ import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import * as Filter from "effect/Filter"
 import * as Latch from "effect/Latch"
+import * as Option from "effect/Option"
 import * as Queue from "effect/Queue"
 import * as Result from "effect/Result"
 
@@ -117,6 +118,12 @@ describe("Channel", () => {
         const resultChunked = yield* Channel.runCollect(Channel.fromIterableArray(numbers, 4))
         assert.deepStrictEqual(result, [[1, 2, 3, 4, 5]])
         assert.deepStrictEqual(resultChunked, [[1, 2, 3, 4], [5]])
+      }))
+
+    it.effect("fromIterableArray does not emit an empty chunk for a zero chunk size", () =>
+      Effect.gen(function*() {
+        const result = yield* Channel.runHead(Channel.fromIterableArray([1, 2, 3], 0))
+        assert.deepStrictEqual(result, Option.some([1]))
       }))
 
     it.effect("fromReadableStream", () =>


### PR DESCRIPTION
## Reproduction only

This PR adds reproduction tests only. No implementation fix is included. CI is expected to fail until the underlying issue is fixed.

## Covered audit issues

### 1. `core-a-f-channel-zero-chunk-size`: Zero chunk size emits empty arrays without progress

Module: `Channel`

Expected contract: fromIteratorArray and fromIterableArray emit non-empty arrays containing the iterator's elements, with no positive-only chunkSize precondition stated.

Observed result: The first pull returned Option.some([]) instead of Option.some([1]).

Reproduction command:

```text
pnpm test --run packages/effect/test/Channel.test.ts -t "fromIterableArray does not emit an empty chunk for a zero chunk size"
```