### PR TITLE
Fix SubscriptionRef getAndUpdateSome None result

### DIFF
--- a/.changeset/fix-subscription-ref-get-and-update-some.md
+++ b/.changeset/fix-subscription-ref-get-and-update-some.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `SubscriptionRef.getAndUpdateSome` to return the current value when no update is selected.

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -374,7 +374,7 @@ export const getAndUpdateSome: {
     const current = self.value
     const option = update(current)
     if (Option.isNone(option)) {
-      return Effect.succeed(current)
+      return current
     }
     setUnsafe(self, option.value)
     return current

--- a/packages/effect/test/SubscriptionRef.test.ts
+++ b/packages/effect/test/SubscriptionRef.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Effect, Exit, Fiber, Latch, Number, Pull, Random, Stream, SubscriptionRef } from "effect"
+import { Array, Effect, Exit, Fiber, Latch, Number, Option, Pull, Random, Stream, SubscriptionRef } from "effect"
 
 describe("SubscriptionRef", () => {
   it.effect("isSubscriptionRef", () =>
@@ -15,6 +15,14 @@ describe("SubscriptionRef", () => {
       const previous = yield* SubscriptionRef.getAndUpdateEffect(ref, (value) => Effect.succeed(value + 1))
       assert.strictEqual(previous, 1)
       assert.strictEqual(yield* SubscriptionRef.get(ref), 2)
+    }))
+
+  it.effect("getAndUpdateSome returns the current value when no update is selected", () =>
+    Effect.gen(function*() {
+      const ref = yield* SubscriptionRef.make(1)
+      const previous = yield* SubscriptionRef.getAndUpdateSome(ref, () => Option.none())
+
+      assert.strictEqual(previous, 1)
     }))
 
   it.effect("multiple subscribers can receive changes", () =>


### PR DESCRIPTION
## Summary

- adds a regression test for `SubscriptionRef.getAndUpdateSome`
- returns the current value directly when `Option.none` selects no update

## Covered audit issue

### 1. `core-s-z-testing-subscription-ref-nested-effect`: getAndUpdateSome returns a nested Effect on None

Module: `SubscriptionRef`

Expected contract: getAndUpdateSome returns the old A whether the update is Option.some or Option.none.

Observed result: success Exit object instead of 1

Reproduction command:

```text
pnpm test --run packages/effect/test/SubscriptionRef.test.ts -t "getAndUpdateSome returns the current value when no update is selected"
```

Closes EFF-293
