### PR TITLE
Add reproduction for TxQueue issue

### DIFF
--- a/.changeset/fix-txqueue-offer-all-iterables.md
+++ b/.changeset/fix-txqueue-offer-all-iterables.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `TxQueue.offerAll` to preserve one-shot iterables across transaction retries and repeated runs.

--- a/packages/effect/src/TxQueue.ts
+++ b/packages/effect/src/TxQueue.ts
@@ -608,23 +608,22 @@ export const offerAll: {
   <A, E>(self: TxEnqueue<A, E>, values: Iterable<A>): Effect.Effect<Array<A>>
 } = dual(
   2,
-  <A, E>(self: TxEnqueue<A, E>, values: Iterable<A>): Effect.Effect<Array<A>> =>
-    Effect.suspend(() => {
-      const valuesArray = Array.from(values)
+  <A, E>(self: TxEnqueue<A, E>, values: Iterable<A>): Effect.Effect<Array<A>> => {
+    const valuesArray = Array.from(values)
 
-      return Effect.gen(function*() {
-        const rejected: Array<A> = []
+    return Effect.gen(function*() {
+      const rejected: Array<A> = []
 
-        for (const value of valuesArray) {
-          const accepted = yield* offer(self, value)
-          if (!accepted) {
-            rejected.push(value)
-          }
+      for (const value of valuesArray) {
+        const accepted = yield* offer(self, value)
+        if (!accepted) {
+          rejected.push(value)
         }
+      }
 
-        return rejected
-      }).pipe(Effect.tx)
-    })
+      return rejected
+    }).pipe(Effect.tx)
+  }
 )
 
 /**

--- a/packages/effect/src/TxQueue.ts
+++ b/packages/effect/src/TxQueue.ts
@@ -609,18 +609,22 @@ export const offerAll: {
 } = dual(
   2,
   <A, E>(self: TxEnqueue<A, E>, values: Iterable<A>): Effect.Effect<Array<A>> =>
-    Effect.gen(function*() {
-      const rejected: Array<A> = []
+    Effect.suspend(() => {
+      const valuesArray = Array.from(values)
 
-      for (const value of values) {
-        const accepted = yield* offer(self, value)
-        if (!accepted) {
-          rejected.push(value)
+      return Effect.gen(function*() {
+        const rejected: Array<A> = []
+
+        for (const value of valuesArray) {
+          const accepted = yield* offer(self, value)
+          if (!accepted) {
+            rejected.push(value)
+          }
         }
-      }
 
-      return rejected
-    }).pipe(Effect.tx)
+        return rejected
+      }).pipe(Effect.tx)
+    })
 )
 
 /**

--- a/packages/effect/test/TxQueue.test.ts
+++ b/packages/effect/test/TxQueue.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Fiber, Latch, Option, Result, TxQueue } from "effect"
+import { Cause, Effect, Fiber, Option, Result, TxQueue } from "effect"
 
 describe("TxQueue", () => {
   describe("interfaces", () => {
@@ -230,21 +230,22 @@ describe("TxQueue", () => {
         assert.strictEqual(size, 5)
       })))
 
-    it.effect("offerAll preserves a one-shot iterable across retries", () =>
+    it.effect("offerAll preserves a one-shot iterable across retries and runs", () =>
       Effect.gen(function*() {
         const queue = yield* TxQueue.bounded<number>(1)
         yield* TxQueue.offer(queue, 1)
 
-        const iterationStarted = Latch.makeUnsafe()
         const values = (function*() {
-          iterationStarted.openUnsafe()
           yield 2
         })()
-        const fiber = yield* Effect.forkChild(TxQueue.offerAll(queue, values))
-        yield* iterationStarted.await
+        const offer = TxQueue.offerAll(queue, values)
+        const fiber = yield* Effect.forkChild(offer, { startImmediately: true })
 
         assert.strictEqual(yield* TxQueue.take(queue), 1)
         assert.deepStrictEqual(yield* Fiber.join(fiber), [])
+        assert.deepStrictEqual(yield* TxQueue.poll(queue), Option.some(2))
+
+        assert.deepStrictEqual(yield* offer, [])
         assert.deepStrictEqual(yield* TxQueue.poll(queue), Option.some(2))
       }))
 

--- a/packages/effect/test/TxQueue.test.ts
+++ b/packages/effect/test/TxQueue.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Fiber, Option, Result, TxQueue } from "effect"
+import { Cause, Effect, Fiber, Latch, Option, Result, TxQueue } from "effect"
 
 describe("TxQueue", () => {
   describe("interfaces", () => {
@@ -235,15 +235,13 @@ describe("TxQueue", () => {
         const queue = yield* TxQueue.bounded<number>(1)
         yield* TxQueue.offer(queue, 1)
 
-        let iterations = 0
+        const iterationStarted = Latch.makeUnsafe()
         const values = (function*() {
-          iterations++
+          iterationStarted.openUnsafe()
           yield 2
         })()
         const fiber = yield* Effect.forkChild(TxQueue.offerAll(queue, values))
-        while (iterations === 0) {
-          yield* Effect.yieldNow
-        }
+        yield* iterationStarted.await
 
         assert.strictEqual(yield* TxQueue.take(queue), 1)
         assert.deepStrictEqual(yield* Fiber.join(fiber), [])

--- a/packages/effect/test/TxQueue.test.ts
+++ b/packages/effect/test/TxQueue.test.ts
@@ -230,6 +230,26 @@ describe("TxQueue", () => {
         assert.strictEqual(size, 5)
       })))
 
+    it.effect("offerAll preserves a one-shot iterable across retries", () =>
+      Effect.gen(function*() {
+        const queue = yield* TxQueue.bounded<number>(1)
+        yield* TxQueue.offer(queue, 1)
+
+        let iterations = 0
+        const values = (function*() {
+          iterations++
+          yield 2
+        })()
+        const fiber = yield* Effect.forkChild(TxQueue.offerAll(queue, values))
+        while (iterations === 0) {
+          yield* Effect.yieldNow
+        }
+
+        assert.strictEqual(yield* TxQueue.take(queue), 1)
+        assert.deepStrictEqual(yield* Fiber.join(fiber), [])
+        assert.deepStrictEqual(yield* TxQueue.poll(queue), Option.some(2))
+      }))
+
     it.effect("takeAll works correctly with new signature", () =>
       Effect.tx(Effect.gen(function*() {
         const queue = yield* TxQueue.bounded<number>(10)


### PR DESCRIPTION
## Summary

- fix `TxQueue.offerAll` to materialize input iterables outside the effect
- preserve one-shot iterable values across transaction retries and repeated runs
- add regression coverage for bounded backpressure and effect reuse

## Testing

```text
pnpm test --run packages/effect/test/TxQueue.test.ts -t "offerAll preserves a one-shot iterable across retries"
```

Closes EFF-295