### PR TITLE
Fix empty snake case conversions

### DIFF
--- a/.changeset/empty-snakes-return.md
+++ b/.changeset/empty-snakes-return.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `String.snakeToCamel` and `String.snakeToPascal` to return an empty string for empty input.

--- a/packages/effect/src/String.ts
+++ b/packages/effect/src/String.ts
@@ -1034,6 +1034,7 @@ export const stripMargin = (self: string): string => stripMarginWith(self, "|")
  * @since 2.0.0
  */
 export const snakeToCamel = (self: string): string => {
+  if (self.length === 0) return self
   let str = self[0]
   for (let i = 1; i < self.length; i++) {
     str += self[i] === "_" ? self[++i].toUpperCase() : self[i]
@@ -1057,6 +1058,7 @@ export const snakeToCamel = (self: string): string => {
  * @since 2.0.0
  */
 export const snakeToPascal = (self: string): string => {
+  if (self.length === 0) return self
   let str = self[0].toUpperCase()
   for (let i = 1; i < self.length; i++) {
     str += self[i] === "_" ? self[++i].toUpperCase() : self[i]

--- a/packages/effect/test/String.test.ts
+++ b/packages/effect/test/String.test.ts
@@ -587,12 +587,20 @@ describe("String", () => {
     it("handles single word", () => {
       strictEqual(S.snakeToCamel("hello"), "hello")
     })
+
+    it("handles an empty string", () => {
+      strictEqual(S.snakeToCamel(""), "")
+    })
   })
 
   describe("snakeToPascal", () => {
     it("converts snake_case to PascalCase", () => {
       strictEqual(S.snakeToPascal("hello_world"), "HelloWorld")
       strictEqual(S.snakeToPascal("foo_bar_baz"), "FooBarBaz")
+    })
+
+    it("handles an empty string", () => {
+      strictEqual(S.snakeToPascal(""), "")
     })
   })
 


### PR DESCRIPTION
## Summary

- add regression coverage for empty snake-case conversions
- make `String.snakeToCamel("")` and `String.snakeToPascal("")` return the empty string

## Verification

- `pnpm test --run packages/effect/test/String.test.ts`
- `pnpm lint`
- `pnpm check`

Closes EFF-300
