### PR TITLE
Add reproduction for Trie issue

### DIFF
--- a/.changeset/fix-trie-longest-prefix.md
+++ b/.changeset/fix-trie-longest-prefix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Trie.longestPrefixOf` returning a valued sibling that does not match the input key.

--- a/packages/effect/src/internal/trie.ts
+++ b/packages/effect/src/internal/trie.ts
@@ -693,10 +693,6 @@ export const longestPrefixOf = dual<
     let cIndex = 0
     while (cIndex < key.length) {
       const c = key[cIndex]
-      if (n.value !== undefined) {
-        longestPrefixNode = Option.some([key.slice(0, cIndex + 1), n.value.value])
-      }
-
       if (c > n.key) {
         if (n.right === undefined) {
           break
@@ -710,6 +706,9 @@ export const longestPrefixOf = dual<
           n = n.left
         }
       } else {
+        if (n.value !== undefined) {
+          longestPrefixNode = Option.some([key.slice(0, cIndex + 1), n.value.value])
+        }
         if (n.mid === undefined) {
           break
         } else {

--- a/packages/effect/test/Trie.test.ts
+++ b/packages/effect/test/Trie.test.ts
@@ -368,6 +368,16 @@ describe("Trie", () => {
     assertSome(Trie.longestPrefixOf(trie, "shellsort"), ["shells", 0])
   })
 
+  it("longestPrefixOf ignores valued sibling nodes that do not match the input", () => {
+    const trie = Trie.make(["a", 1], ["b", 2])
+
+    strictEqual(
+      Option.isNone(Trie.longestPrefixOf(trie, "c")),
+      true,
+      "a non-matching sibling must not be reported as a prefix"
+    )
+  })
+
   it("map transforms values and can use keys", () => {
     const trie = Trie.empty<number>().pipe(
       Trie.insert("shells", 0),


### PR DESCRIPTION
## Summary

- fix `Trie.longestPrefixOf` so valued sibling nodes are not accepted as prefixes
- retain the regression test covering a non-matching sibling
- add a patch changeset for `effect`

## Root cause

The traversal recorded a node's value before checking whether the current input character matched that node. Values on left or right siblings could therefore be returned as prefixes.

## Validation

- `pnpm test --run packages/effect/test/Trie.test.ts`
- `pnpm lint`
- `pnpm check`

Closes EFF-316