### PR TITLE
Add reproduction for FiberSet issue

### DIFF
--- a/.changeset/fix-fiberset-runtime-interruption.md
+++ b/.changeset/fix-fiberset-runtime-interruption.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Propagate the `FiberSet.runtime` interruption option when registering managed fibers.

--- a/packages/effect/src/FiberSet.ts
+++ b/packages/effect/src/FiberSet.ts
@@ -576,7 +576,7 @@ export const runtime: <A, E>(
           return constInterruptedFiber()
         }
         const fiber = runFork(effect, options)
-        addUnsafe(self, fiber)
+        addUnsafe(self, fiber, options)
         return fiber
       }
     }

--- a/packages/effect/test/FiberSetRuntimePropagation.test.ts
+++ b/packages/effect/test/FiberSetRuntimePropagation.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from "@effect/vitest"
+import { assertTrue } from "@effect/vitest/utils"
+import { Deferred, Effect, Fiber, FiberSet } from "effect"
+
+describe("FiberSet.runtime interruption propagation", () => {
+  it.effect("records external interruption when enabled", () =>
+    Effect.scoped(Effect.gen(function*() {
+      const set = yield* FiberSet.make()
+      const run = yield* FiberSet.runtime(set)()
+      const fiber = run(Effect.never, { propagateInterruption: true })
+
+      yield* Fiber.interrupt(fiber)
+
+      assertTrue(yield* Deferred.isDone(set.deferred), "external interruption should be recorded")
+    })))
+})


### PR DESCRIPTION
## Summary

- Add a regression test for `FiberSet.runtime` interruption propagation.
- Forward runtime options when registering managed fibers so `propagateInterruption: true` records external interruption.
- Add a patch changeset for `effect`.

## Covered audit issues

### 1. `core-a-f-fiber-set-runtime-interruption`: Captured runtime drops interruption propagation

Module: `FiberSet`

Expected contract: The function returned by `FiberSet.runtime` accepts `propagateInterruption`; when true, an externally interrupted managed fiber completes the set's deferred failure, matching `run` and `addUnsafe`.

Before this fix, a direct Node 24 Effect probe returned false for `Deferred.isDone` after external interruption.

Verification command:

```text
pnpm test --run packages/effect/test/FiberSetRuntimePropagation.test.ts
```

Closes EFF-309
