### PR TITLE
Add reproduction for internal/protobuf issue

### DIFF
--- a/.changeset/tidy-cats-smile.md
+++ b/.changeset/tidy-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix protobuf serialization of negative signed integers to use ten-byte two's-complement varints.

--- a/packages/effect/src/unstable/observability/internal/protobuf.ts
+++ b/packages/effect/src/unstable/observability/internal/protobuf.ts
@@ -29,6 +29,9 @@ const encodeTag = (fieldNumber: number, wireType: WireType): number => (fieldNum
 export const encodeVarint = (value: number | bigint): Uint8Array => {
   const bytes: Array<number> = []
   let n = typeof value === "bigint" ? value : BigInt(value)
+  if (n < BigInt(0)) {
+    n = BigInt.asUintN(64, n)
+  }
   while (n > BigInt(127)) {
     bytes.push(Number(n & BigInt(127)) | 0x80)
     n >>= BigInt(7)

--- a/packages/effect/test/unstable/observability/OtlpSerialization.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpSerialization.test.ts
@@ -1,0 +1,10 @@
+import { assert, describe, it } from "@effect/vitest"
+import { encodeAnyValue } from "effect/unstable/observability/internal/otlpProtobuf"
+
+describe("OtlpSerialization", () => {
+  it("encodes a negative protobuf int64 as a ten-byte varint", () => {
+    const encoded = encodeAnyValue({ intValue: -1 })
+    assert.strictEqual(encoded.length, 11)
+    assert.deepStrictEqual(Array.from(encoded), [0x18, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01])
+  })
+})

--- a/packages/effect/test/unstable/observability/OtlpSerializationNegativeInt64.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpSerializationNegativeInt64.test.ts
@@ -1,8 +1,0 @@
-import { assert, it } from "@effect/vitest"
-import { encodeAnyValue } from "effect/unstable/observability/internal/otlpProtobuf"
-
-it("encodes a negative protobuf int64 as a ten-byte varint", () => {
-  const encoded = encodeAnyValue({ intValue: -1 })
-  assert.strictEqual(encoded.length, 11)
-  assert.deepStrictEqual(Array.from(encoded), [0x18, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01])
-})

--- a/packages/effect/test/unstable/observability/OtlpSerializationNegativeInt64.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpSerializationNegativeInt64.test.ts
@@ -1,5 +1,5 @@
 import { assert, it } from "@effect/vitest"
-import { encodeAnyValue } from "../../../src/unstable/observability/internal/otlpProtobuf.ts"
+import { encodeAnyValue } from "effect/unstable/observability/internal/otlpProtobuf"
 
 it("encodes a negative protobuf int64 as a ten-byte varint", () => {
   const encoded = encodeAnyValue({ intValue: -1 })

--- a/packages/effect/test/unstable/observability/OtlpSerializationNegativeInt64.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpSerializationNegativeInt64.test.ts
@@ -1,0 +1,8 @@
+import { assert, it } from "@effect/vitest"
+import { encodeAnyValue } from "../../../src/unstable/observability/internal/otlpProtobuf.ts"
+
+it("encodes a negative protobuf int64 as a ten-byte varint", () => {
+  const encoded = encodeAnyValue({ intValue: -1 })
+  assert.strictEqual(encoded.length, 11)
+  assert.deepStrictEqual(Array.from(encoded), [0x18, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01])
+})


### PR DESCRIPTION
## Summary

- Add a regression test for negative protobuf `int64` values.
- Encode negative signed integers as ten-byte, 64-bit two's-complement varints.
- Use the package import for the internal OTLP encoder so repository typechecking succeeds.

## Covered audit issue

### `unstable-distributed-otlp-protobuf-negative-int64-varint`

Module: `internal/protobuf`

Negative protobuf `int32` and `int64` values must use ten-byte two's-complement varints.

Reproduction command:

```text
pnpm test --run packages/effect/test/unstable/observability/OtlpSerialization.test.ts
```

Closes EFF-311
