### PR TITLE
Add reproduction for Sink issue

### DIFF
--- a/.changeset/calm-wolves-reduce.md
+++ b/.changeset/calm-wolves-reduce.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Sink.reduceWhileArray` applying its reducer more than once per input array.

--- a/packages/effect/src/Sink.ts
+++ b/packages/effect/src/Sink.ts
@@ -1336,11 +1336,9 @@ export const reduceWhileArray = <S, In>(
     }
     return upstream.pipe(
       Effect.flatMap((arr) => {
-        for (let i = 0; i < arr.length; i++) {
-          state = f(state, arr)
-          if (!contFn(state)) {
-            return Cause.done()
-          }
+        state = f(state, arr)
+        if (!contFn(state)) {
+          return Cause.done()
         }
         return Effect.void
       }),

--- a/packages/effect/test/Sink.test.ts
+++ b/packages/effect/test/Sink.test.ts
@@ -106,6 +106,18 @@ describe("Sink", () => {
         strictEqual(result, 45)
       }))
   })
+
+  describe("reduceWhileArray", () => {
+    it.effect("applies the reducer once per non-empty input array", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.fromArrays([1, 2, 3]).pipe(
+          Stream.run(Sink.reduceWhileArray(() => 0, constTrue, (count) => count + 1))
+        )
+
+        strictEqual(result, 1, "the reducer must run once for each input array")
+      }))
+  })
+
   describe("reduceWhileEffect", () => {
     it.effect("short circuits", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- add a regression test proving `Sink.reduceWhileArray` invokes its reducer once per non-empty input array
- fix `Sink.reduceWhileArray` to reduce each pulled array once instead of once per element
- add a patch changeset for `effect`

## Root cause

The synchronous implementation looped over every element in a pulled array while passing the full array to the reducer on each iteration. The effectful counterpart already applied its reducer once per pulled array.

## Validation

- `pnpm test --run packages/effect/test/Sink.test.ts -t "applies the reducer once per non-empty input array"`
- `pnpm test --run packages/effect/test/Sink.test.ts`
- `pnpm check`
- `pnpm lint`

Closes EFF-312