### PR TITLE
Fix Array index handling

### DIFF
--- a/.changeset/fix-array-non-finite-indexes.md
+++ b/.changeset/fix-array-non-finite-indexes.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Array index operations handling `NaN` and fractional indexes.

--- a/packages/effect/src/Array.ts
+++ b/packages/effect/src/Array.ts
@@ -909,7 +909,7 @@ export const length = <A>(self: ReadonlyArray<A>): number => self.length
 
 /** @internal */
 export function isOutOfBounds<A>(i: number, as: ReadonlyArray<A>): boolean {
-  return i < 0 || i >= as.length
+  return !Number.isFinite(i) || i < 0 || i >= as.length
 }
 
 const clamp = <A>(i: number, as: ReadonlyArray<A>): number => Math.floor(Math.min(Math.max(0, i), as.length))
@@ -1875,10 +1875,11 @@ export const insertAt: {
   <A, B>(self: Iterable<A>, i: number, b: B): Option.Option<NonEmptyArray<A | B>>
 } = dual(3, <A, B>(self: Iterable<A>, i: number, b: B): Option.Option<NonEmptyArray<A | B>> => {
   const out: Array<A | B> = Array.from(self) // copy because `splice` mutates the array
-  if (i < 0 || i > out.length) {
+  const index = Math.floor(i)
+  if (index !== out.length && isOutOfBounds(index, out)) {
     return Option.none()
   }
-  out.splice(i, 0, b)
+  out.splice(index, 0, b)
   return Option.some(out as any)
 })
 
@@ -1966,12 +1967,13 @@ export const modify: {
   ): Option.Option<ReadonlyArray.With<S, ReadonlyArray.Infer<S> | B>>
 } = dual(3, <A, B>(self: Iterable<A>, i: number, f: (a: A) => B): Option.Option<Array<A | B>> => {
   const arr = Array.from(self)
-  if (isOutOfBounds(i, arr)) {
+  const index = Math.floor(i)
+  if (isOutOfBounds(index, arr)) {
     return Option.none()
   }
   const out: Array<A | B> = arr
-  const b = f(arr[i])
-  out[i] = b
+  const b = f(arr[index])
+  out[index] = b
   return Option.some(out)
 })
 
@@ -2004,10 +2006,11 @@ export const remove: {
   <A>(self: Iterable<A>, i: number): Array<A>
 } = dual(2, <A>(self: Iterable<A>, i: number): Array<A> => {
   const out = Array.from(self)
-  if (isOutOfBounds(i, out)) {
+  const index = Math.floor(i)
+  if (isOutOfBounds(index, out)) {
     return out
   }
-  out.splice(i, 1)
+  out.splice(index, 1)
   return out
 })
 

--- a/packages/effect/test/ArrayNaNIndex.test.ts
+++ b/packages/effect/test/ArrayNaNIndex.test.ts
@@ -1,0 +1,30 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Array as Arr, Option } from "effect"
+
+describe("Array NaN indexes", () => {
+  const input = [1, 2, 3]
+
+  it("rejects NaN in get", () => {
+    assert.deepStrictEqual(Arr.get(input, Number.NaN), Option.none())
+  })
+
+  it("rejects NaN in getUnsafe", () => {
+    assert.throws(() => Arr.getUnsafe(input, Number.NaN), /Index out of bounds/)
+  })
+
+  it("rejects NaN in insertAt", () => {
+    assert.deepStrictEqual(Arr.insertAt(input, Number.NaN, 4), Option.none())
+  })
+
+  it("rejects NaN in replace", () => {
+    assert.deepStrictEqual(Arr.replace(input, Number.NaN, 4), Option.none())
+  })
+
+  it("rejects NaN in modify", () => {
+    assert.deepStrictEqual(Arr.modify(input, Number.NaN, (n) => n * 2), Option.none())
+  })
+
+  it("treats removing NaN as an out-of-bounds no-op", () => {
+    assert.deepStrictEqual(Arr.remove(input, Number.NaN), input)
+  })
+})

--- a/packages/effect/test/ArrayNaNIndex.test.ts
+++ b/packages/effect/test/ArrayNaNIndex.test.ts
@@ -1,9 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Array as Arr, Option } from "effect"
 
-describe("Array NaN indexes", () => {
-  const input = [1, 2, 3]
+const input = [1, 2, 3]
 
+describe("Array NaN indexes", () => {
   it("rejects NaN in get", () => {
     assert.deepStrictEqual(Arr.get(input, Number.NaN), Option.none())
   })
@@ -26,5 +26,15 @@ describe("Array NaN indexes", () => {
 
   it("treats removing NaN as an out-of-bounds no-op", () => {
     assert.deepStrictEqual(Arr.remove(input, Number.NaN), input)
+  })
+})
+
+describe("Array fractional indexes", () => {
+  it("floors the index in replace", () => {
+    assert.deepStrictEqual(Arr.replace(input, 1.5, 4), Option.some([1, 4, 3]))
+  })
+
+  it("floors the index in modify", () => {
+    assert.deepStrictEqual(Arr.modify(input, 1.5, (n) => n * 2), Option.some([1, 4, 3]))
   })
 })


### PR DESCRIPTION
## Reproduction only

This PR adds reproduction tests only. No implementation fix is included. CI is expected to fail until the underlying issue is fixed.

## Covered audit issues

### 1. `core-a-f-array-nan-index-validation`: NaN bypasses shared index validation

Module: `Array`

Expected contract: get safely returns None for an invalid index, getUnsafe throws for one, insertAt, replace, and modify report invalid indexes with None, and remove treats an invalid index as an out-of-bounds no-op. The documented valid insertion range is the integer indexes from 0 through length.

Observed result: All 6 focused assertions failed for the reported values and coercions.

Reproduction command:

```text
pnpm test --run packages/effect/test/ArrayNaNIndex.test.ts
```