### PR TITLE
Add reproduction for Cause issue

### DIFF
--- a/.changeset/fix-cause-map-annotations.md
+++ b/.changeset/fix-cause-map-annotations.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve failure annotations when mapping errors with `Cause.map`.

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -239,7 +239,7 @@ export abstract class ReasonBase<Tag extends string> implements Cause.Cause.Reas
 }
 
 /** @internal */
-export const constEmptyAnnotations = new Map<string, unknown>()
+export const constEmptyAnnotations: ReadonlyMap<string, unknown> = new Map<string, unknown>()
 
 /** @internal */
 export class Fail<E> extends ReasonBase<"Fail"> implements Cause.Fail<E> {

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -268,7 +268,7 @@ export const causeMap: {
     const failures = self.reasons.map((failure) => {
       if (isFailReason(failure)) {
         hasFail = true
-        return new Fail(f(failure.error), new Map(failure.annotations))
+        return new Fail(f(failure.error), failure.annotations)
       }
       return failure
     })

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -268,7 +268,7 @@ export const causeMap: {
     const failures = self.reasons.map((failure) => {
       if (isFailReason(failure)) {
         hasFail = true
-        return new Fail(f(failure.error))
+        return new Fail(f(failure.error), new Map(failure.annotations))
       }
       return failure
     })

--- a/packages/effect/test/CauseMapAnnotations.test.ts
+++ b/packages/effect/test/CauseMapAnnotations.test.ts
@@ -1,0 +1,15 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Context } from "effect"
+
+describe("Cause.map", () => {
+  it("preserves annotations on mapped failures", () => {
+    class RequestId extends Context.Service<RequestId, string>()("RequestId") {}
+
+    const cause = Cause.fail("error").pipe(
+      Cause.annotate(Context.make(RequestId, "request-1")),
+      Cause.map((error) => error.toUpperCase())
+    )
+
+    assert.strictEqual(Context.get(Cause.annotations(cause), RequestId), "request-1")
+  })
+})

--- a/packages/effect/test/CauseMapAnnotations.test.ts
+++ b/packages/effect/test/CauseMapAnnotations.test.ts
@@ -10,6 +10,6 @@ describe("Cause.map", () => {
       Cause.map((error) => error.toUpperCase())
     )
 
-    assert.strictEqual(Context.get(Cause.annotations(cause), RequestId), "request-1")
+    assert.strictEqual(Context.getOrUndefined(Cause.annotations(cause), RequestId), "request-1")
   })
 })


### PR DESCRIPTION
## Summary

Fix `Cause.map` so transforming typed errors preserves annotations attached to `Fail` reasons.

## Root cause

`Cause.map` rebuilt each mapped `Fail` reason with only the transformed error, dropping the original reason's annotations. The mapped reason now receives a copy of those annotations while `Die` and `Interrupt` reasons continue to pass through unchanged.

## Validation

```text
pnpm test --run packages/effect/test/Cause.test.ts packages/effect/test/CauseMapAnnotations.test.ts
pnpm check
pnpm lint
```

Closes EFF-313
