### PR TITLE
Add HttpApiSchema.WithHeaders for typed response headers

### DIFF
--- a/.changeset/httpapi-response-header-schemas.md
+++ b/.changeset/httpapi-response-header-schemas.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
 Add `HttpApiSchema.WithHeaders` for typed HTTP response headers.

--- a/.changeset/httpapi-response-header-schemas.md
+++ b/.changeset/httpapi-response-header-schemas.md
@@ -1,0 +1,30 @@
+---
+"effect": minor
+---
+
+Add `HttpApiSchema.WithHeaders` for typed HTTP response headers.
+
+Response schemas can now declare headers alongside a body:
+
+```ts
+import { Schema } from "effect"
+import { HttpApiEndpoint, HttpApiSchema } from "effect/unstable/httpapi"
+
+const create = HttpApiEndpoint.post("create", "/things", {
+  success: HttpApiSchema.WithHeaders({
+    headers: { location: Schema.String },
+    body: HttpApiSchema.Created
+  })
+})
+```
+
+Handlers return `{ headers, body }` and generated clients decode the declared
+headers into the same shape. Header strictness follows the schema: a required
+header that is missing from a response is a decode failure, while
+`Schema.optional` yields `undefined`. `WithHeaders` works for successes, errors,
+and streaming responses, and the declared headers are emitted in the generated
+OpenAPI document as `responses[status].headers`.
+
+A `WithHeaders` response may not share a status and content-type with any other
+response of the same endpoint, since the client discriminates response
+alternatives on exactly those two signals.

--- a/.changeset/httpapi-response-header-schemas.md
+++ b/.changeset/httpapi-response-header-schemas.md
@@ -18,13 +18,6 @@ const create = HttpApiEndpoint.post("create", "/things", {
 })
 ```
 
-Handlers return `{ headers, body }` and generated clients decode the declared
-headers into the same shape. Header strictness follows the schema: a required
-header that is missing from a response is a decode failure, while
-`Schema.optional` yields `undefined`. `WithHeaders` works for successes, errors,
-and streaming responses, and the declared headers are emitted in the generated
-OpenAPI document as `responses[status].headers`.
+Handlers return `{ headers, body }` and generated clients decode the declared headers into the same shape. Header strictness follows the schema: a required header that is missing from a response is a decode failure, while `Schema.optional` yields `undefined`. `WithHeaders` works for successes, errors, and streaming responses, and the declared headers are emitted in the generated OpenAPI document as `responses[status].headers`.
 
-A `WithHeaders` response may not share a status and content-type with any other
-response of the same endpoint, since the client discriminates response
-alternatives on exactly those two signals.
+A `WithHeaders` response may not share a status and content-type with any other response of the same endpoint, since the client discriminates response alternatives on exactly those two signals.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -927,7 +927,7 @@ function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undef
 
   const streamSchema = streamSuccess.stream
   const hasBuffered = hasBufferedSuccess(endpoint)
-  const status = HttpApiSchema.getStatusStream(streamSchema)
+  const status = streamSuccess.status
   const contentType = streamSchema.contentType
   const encodeHeaders = streamSuccess.headers === undefined
     ? undefined
@@ -989,6 +989,7 @@ function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undef
 
 interface StreamSuccess {
   readonly stream: HttpApiSchema.StreamSchema
+  readonly status: number
   readonly headers: Schema.Top | undefined
 }
 
@@ -998,6 +999,10 @@ function getStreamSuccessSchema(endpoint: HttpApiEndpoint.Top): StreamSuccess | 
     if (HttpApiSchema.isStreamSchema(body)) {
       return {
         stream: body,
+        // read the status off the outer schema: for a `WithHeaders` wrapper an
+        // annotation applied to the wrapper wins over the body's lifted one, and
+        // for a bare stream the two schemas are the same object
+        status: HttpApiSchema.getStatusSuccess(schema.ast),
         headers: HttpApiSchema.isWithHeaders(schema) ? schema.headers : undefined
       }
     }
@@ -1098,14 +1103,20 @@ function toResponseSchema(getStatus: (ast: SchemaAST.AST) => number) {
   const cache = new WeakMap<SchemaAST.AST, Schema.Top>()
 
   return (schema: Schema.Constraint): Schema.ConstraintEncoder<HttpServerResponse, unknown> => {
-    const cached = cache.get(schema.ast)
+    // `WithHeaders` transformations close over the instance's `headers` / `body`
+    // sub-schemas, which the opaque declaration AST does not describe, so the
+    // AST is not a sound cache key for them.
+    const cacheable = !HttpApiSchema.isWithHeaders(schema)
+    const cached = cacheable ? cache.get(schema.ast) : undefined
     if (cached !== undefined) {
       return cached as any
     }
     const responseSchema = $HttpServerResponse.pipe(
       Schema.decodeTo(schema, getResponseTransformation(getStatus, schema))
     )
-    cache.set(schema.ast, responseSchema)
+    if (cacheable) {
+      cache.set(schema.ast, responseSchema)
+    }
     return responseSchema
   }
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -920,63 +920,98 @@ type StreamEncoder = (response: unknown, context: Context.Context<never>) =>
   | undefined
 
 function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undefined {
-  const streamSchema = getStreamSuccessSchema(endpoint)
-  if (streamSchema === undefined) {
+  const streamSuccess = getStreamSuccessSchema(endpoint)
+  if (streamSuccess === undefined) {
     return undefined
   }
 
+  const streamSchema = streamSuccess.stream
   const hasBuffered = hasBufferedSuccess(endpoint)
   const status = HttpApiSchema.getStatusStream(streamSchema)
   const contentType = streamSchema.contentType
+  const encodeHeaders = streamSuccess.headers === undefined
+    ? undefined
+    : Schema.encodeUnknownEffect(streamSuccess.headers)
+
+  // With a headers wrapper the handler returns `{ headers, body: Stream }`;
+  // without one it returns the stream directly.
+  const takeStream = (response: unknown): Stream.Stream<unknown, unknown, unknown> | undefined => {
+    const value = encodeHeaders === undefined ? response : (response as any)?.body
+    return Stream.isStream(value) ? value as Stream.Stream<unknown, unknown, unknown> : undefined
+  }
+
+  const withHeaders = (
+    response: unknown,
+    make: (headers: Record<string, string> | undefined) => HttpServerResponse
+  ) =>
+    encodeHeaders === undefined
+      ? Effect.succeed(make(undefined))
+      : Effect.map(
+        encodeHeaders((response as any)?.headers),
+        (headers) => make(headers as Record<string, string>)
+      )
+
+  const mismatch = () =>
+    hasBuffered ? undefined : new Schema.SchemaError(
+      new SchemaIssue.InvalidValue({ message: "Expected a streaming response" })
+    )
 
   if (HttpApiSchema.isStreamUint8Array(streamSchema)) {
     return (response, context) => {
-      if (!Stream.isStream(response)) {
-        return hasBuffered ? undefined : new Schema.SchemaError(
-          new SchemaIssue.InvalidValue({ message: "Expected a streaming response" })
-        )
-      }
-
-      return Effect.succeed(Response.stream(
-        Stream.provideContext(
-          response as Stream.Stream<Uint8Array, unknown, unknown>,
-          context as Context.Context<unknown>
-        ),
-        { status, contentType }
-      ))
+      const stream = takeStream(response)
+      if (stream === undefined) return mismatch()
+      return withHeaders(response, (headers) =>
+        Response.stream(
+          Stream.provideContext(
+            stream as Stream.Stream<Uint8Array, unknown, unknown>,
+            context as Context.Context<unknown>
+          ),
+          { status, contentType, headers }
+        ))
     }
   }
 
   const sseEncoder = makeSseEncoder(streamSchema)
 
   return (response, context) => {
-    if (!Stream.isStream(response)) {
-      return hasBuffered ? undefined : new Schema.SchemaError(
-        new SchemaIssue.InvalidValue({ message: "Expected a streaming response" })
-      )
-    }
-
-    return Effect.succeed(Response.stream(
-      Stream.provideContext(
-        encodeSseStream(response, sseEncoder),
-        context as Context.Context<unknown>
-      ),
-      { status, contentType }
-    ))
+    const stream = takeStream(response)
+    if (stream === undefined) return mismatch()
+    return withHeaders(response, (headers) =>
+      Response.stream(
+        Stream.provideContext(
+          encodeSseStream(stream, sseEncoder),
+          context as Context.Context<unknown>
+        ),
+        { status, contentType, headers }
+      ))
   }
 }
 
-function getStreamSuccessSchema(endpoint: HttpApiEndpoint.Top) {
+interface StreamSuccess {
+  readonly stream: HttpApiSchema.StreamSchema
+  readonly headers: Schema.Top | undefined
+}
+
+function getStreamSuccessSchema(endpoint: HttpApiEndpoint.Top): StreamSuccess | undefined {
   for (const schema of endpoint.success) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      return schema
+    const body = HttpApiSchema.unwrapResponseSchema(schema)
+    if (HttpApiSchema.isStreamSchema(body)) {
+      return {
+        stream: body,
+        headers: HttpApiSchema.isWithHeaders(schema) ? schema.headers : undefined
+      }
     }
   }
 }
 
 function hasBufferedSuccess(endpoint: HttpApiEndpoint.Top): boolean {
   for (const schema of endpoint.success) {
-    if (Schema.isSchema(schema) && !HttpApiSchema.isStreamSchema(schema)) return true
+    if (
+      Schema.isSchema(schema) &&
+      !HttpApiSchema.isStreamSchema(HttpApiSchema.unwrapResponseSchema(schema))
+    ) {
+      return true
+    }
   }
   return endpoint.success.size === 0
 }
@@ -1099,17 +1134,16 @@ function getWithHeadersTransformation(
   getStatus: (ast: SchemaAST.AST) => number,
   schema: HttpApiSchema.WithHeaders<Schema.Top, Schema.Top>
 ): SchemaTransformation.Transformation<unknown, Response.HttpServerResponse> {
-  const decode = (res: unknown) =>
-    Effect.fail(new SchemaIssue.Forbidden(Option.some(res), { message: "Encode only schema" }))
+  const decode = (_res: unknown) => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" }))
 
   // Streaming bodies never reach this transformation: `makeStreamEncoder` handles
   // them before success encoding runs.
   if (HttpApiSchema.isStreamSchema(schema.body)) {
     return SchemaTransformation.transformOrFail({
       decode,
-      encode: (value: unknown): Effect.Effect<Response.HttpServerResponse, SchemaIssue.Issue> =>
+      encode: (_value: unknown): Effect.Effect<Response.HttpServerResponse, SchemaIssue.Issue> =>
         Effect.fail(
-          new SchemaIssue.Forbidden(Option.some(value), {
+          new SchemaIssue.Forbidden({
             message: "Expected a streaming response"
           })
         )

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -26,6 +26,7 @@ import * as Result from "../../Result.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
 import * as SchemaIssue from "../../SchemaIssue.ts"
+import * as SchemaParser from "../../SchemaParser.ts"
 import * as SchemaTransformation from "../../SchemaTransformation.ts"
 import * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
@@ -1078,6 +1079,9 @@ function getResponseTransformation(
   getStatus: (ast: SchemaAST.AST) => number,
   schema: Schema.Constraint
 ): SchemaTransformation.Transformation<unknown, Response.HttpServerResponse> {
+  if (HttpApiSchema.isWithHeaders(schema)) {
+    return getWithHeadersTransformation(getStatus, schema)
+  }
   const ast = schema.ast
   const encode = getResponseEncode(
     getStatus(ast),
@@ -1088,6 +1092,50 @@ function getResponseTransformation(
   return SchemaTransformation.transformOrFail({
     decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
     encode
+  })
+}
+
+function getWithHeadersTransformation(
+  getStatus: (ast: SchemaAST.AST) => number,
+  schema: HttpApiSchema.WithHeaders<Schema.Top, Schema.Top>
+): SchemaTransformation.Transformation<unknown, Response.HttpServerResponse> {
+  const decode = (res: unknown) =>
+    Effect.fail(new SchemaIssue.Forbidden(Option.some(res), { message: "Encode only schema" }))
+
+  // Streaming bodies never reach this transformation: `makeStreamEncoder` handles
+  // them before success encoding runs.
+  if (HttpApiSchema.isStreamSchema(schema.body)) {
+    return SchemaTransformation.transformOrFail({
+      decode,
+      encode: (value: unknown): Effect.Effect<Response.HttpServerResponse, SchemaIssue.Issue> =>
+        Effect.fail(
+          new SchemaIssue.Forbidden(Option.some(value), {
+            message: "Expected a streaming response"
+          })
+        )
+    })
+  }
+
+  const encodeResponse = getResponseEncode(
+    getStatus(schema.ast),
+    HttpApiSchema.getResponseEncoding(schema.ast),
+    HttpApiSchema.isNoContentSchema(schema)
+  )
+  const encodeBody = SchemaParser.encodeUnknownEffect(schema.body) as any
+  const encodeHeaders = SchemaParser.encodeUnknownEffect(schema.headers) as any
+
+  return SchemaTransformation.transformOrFail({
+    decode,
+    encode: (value: any) =>
+      Effect.flatMap(
+        encodeBody(value?.body),
+        (encodedBody) =>
+          Effect.flatMap(encodeResponse(encodedBody), (response) =>
+            Effect.map(
+              encodeHeaders(value?.headers),
+              (headers) => Response.setHeaders(response, headers as Record<string, string>)
+            ))
+      )
   })
 }
 

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -721,8 +721,11 @@ const compilePath = (path: string) => {
   }
 }
 
-function schemasToResponse(schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>]) {
-  const codec = toCodecArrayBuffer(schemas)
+function schemasToResponse(
+  schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>],
+  encoding?: HttpApiSchema.ResponseEncoding
+) {
+  const codec = toCodecArrayBuffer(schemas, encoding)
   const decode = Schema.decodeEffect(codec)
   return (response: HttpClientResponse.HttpClientResponse) => Effect.flatMap(response.arrayBuffer, decode)
 }
@@ -736,7 +739,9 @@ function withHeadersToResponse(
   const body = schema.body
   const decodeBody = HttpApiSchema.isStreamSchema(body)
     ? streamToResponse(body)
-    : schemasToResponse([body as Schema.Constraint])
+    // the wrapper's AST is authoritative for encoding: it carries the body's
+    // lifted annotation unless one was applied to the wrapper itself
+    : schemasToResponse([body as Schema.Constraint], HttpApiSchema.getResponseEncoding(schema.ast))
   return (response) =>
     Effect.flatMap(
       decodeHeaders(response.headers),
@@ -744,6 +749,9 @@ function withHeadersToResponse(
     )
 }
 
+// Relies on the exclusivity invariant enforced by `HttpApiEndpoint`: a
+// `WithHeaders` member may not share a `(status, content-type)` pair with any
+// other member, so a bucket is either entirely wrapped or entirely plain.
 function schemasToResponseDecoder(
   schemas: Arr.NonEmptyReadonlyArray<Schema.Top>
 ): ResponseDecoder {
@@ -960,11 +968,14 @@ const UnknownFromArrayBuffer = StringFromArrayBuffer.pipe(Schema.decodeTo(
   ])
 ))
 
-function toCodecArrayBuffer(schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>]): Schema.Top {
+function toCodecArrayBuffer(
+  schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>],
+  encodingOverride?: HttpApiSchema.ResponseEncoding
+): Schema.Top {
   return Schema.Union(schemas.map(onSchema))
 
   function onSchema(schema: Schema.Constraint) {
-    const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
+    const encoding = encodingOverride ?? HttpApiSchema.getResponseEncoding(schema.ast)
     switch (encoding._tag) {
       case "Json": {
         // handle json codecs that transform void schemas to null

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -335,7 +335,7 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
         for (const [status, schemas] of errors.entries()) {
           const grouped = groupSchemasByContentType(schemas)
           for (const [contentType, schemas] of grouped.entries()) {
-            addResponseAlternative(errorAlternatives, status, contentType, schemasToResponse(schemas))
+            addResponseAlternative(errorAlternatives, status, contentType, schemasToResponseDecoder(schemas))
           }
         }
         for (const [status, alternatives] of errorAlternatives.entries()) {
@@ -362,7 +362,7 @@ export const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Con
         for (const [status, schemas] of successes.entries()) {
           const grouped = groupSchemasByContentType(schemas)
           for (const [contentType, schemas] of grouped.entries()) {
-            addResponseAlternative(successAlternatives, status, contentType, schemasToResponse(schemas))
+            addResponseAlternative(successAlternatives, status, contentType, schemasToResponseDecoder(schemas))
           }
         }
         for (const streamSuccess of getStreamSuccessSchemas(endpoint)) {
@@ -729,6 +729,30 @@ function schemasToResponse(schemas: readonly [Schema.Constraint, ...Array<Schema
 
 type ResponseDecoder = (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<unknown, unknown, unknown>
 
+function withHeadersToResponse(
+  schema: HttpApiSchema.WithHeaders<Schema.Top, Schema.Top>
+): ResponseDecoder {
+  const decodeHeaders = Schema.decodeUnknownEffect(schema.headers)
+  const body = schema.body
+  const decodeBody = HttpApiSchema.isStreamSchema(body)
+    ? streamToResponse(body)
+    : schemasToResponse([body as Schema.Constraint])
+  return (response) =>
+    Effect.flatMap(
+      decodeHeaders(response.headers),
+      (headers) => Effect.map(decodeBody(response), (body) => ({ headers, body }))
+    )
+}
+
+function schemasToResponseDecoder(
+  schemas: Arr.NonEmptyReadonlyArray<Schema.Top>
+): ResponseDecoder {
+  const first = schemas[0]
+  return schemas.length === 1 && HttpApiSchema.isWithHeaders(first)
+    ? withHeadersToResponse(first)
+    : schemasToResponse(schemas as readonly [Schema.Constraint, ...Array<Schema.Constraint>])
+}
+
 interface ResponseAlternative {
   readonly contentType: string
   readonly decode: ResponseDecoder
@@ -768,9 +792,9 @@ function groupSchemasByContentType(
 ): Map<string, Arr.NonEmptyReadonlyArray<Schema.Top>> {
   const grouped = new Map<string, [Schema.Top, ...Array<Schema.Top>]>()
   for (const schema of schemas) {
-    const contentType = HttpApiSchema.isNoContent(schema.ast)
+    const contentType = HttpApiSchema.isNoContentSchema(schema)
       ? ""
-      : MediaType.normalize(HttpApiSchema.getResponseEncoding(schema.ast).contentType)
+      : MediaType.normalize(HttpApiSchema.getResponseContentType(schema))
     const existing = grouped.get(contentType)
     if (existing === undefined) {
       grouped.set(contentType, [schema])

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -721,11 +721,27 @@ const compilePath = (path: string) => {
   }
 }
 
+// An `encoding` override is only sound when `schemas` is a single member: it
+// forces every union branch onto that one content type, which would silently
+// flatten a genuinely mixed-encoding union. The overloads below make that
+// invariant a type error at the call site instead of a convention.
+function schemasToResponse(
+  schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>]
+): (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<unknown, unknown, unknown>
+function schemasToResponse(
+  schemas: readonly [Schema.Constraint],
+  encoding: HttpApiSchema.ResponseEncoding
+): (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<unknown, unknown, unknown>
 function schemasToResponse(
   schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>],
   encoding?: HttpApiSchema.ResponseEncoding
 ) {
-  const codec = toCodecArrayBuffer(schemas, encoding)
+  // The overloads above already reject an `encoding` override paired with a
+  // multi-member array at every call site, so the cast here only restates
+  // what the caller already proved.
+  const codec = encoding === undefined
+    ? toCodecArrayBuffer(schemas)
+    : toCodecArrayBuffer(schemas as readonly [Schema.Constraint], encoding)
   const decode = Schema.decodeEffect(codec)
   return (response: HttpClientResponse.HttpClientResponse) => Effect.flatMap(response.arrayBuffer, decode)
 }
@@ -968,6 +984,15 @@ const UnknownFromArrayBuffer = StringFromArrayBuffer.pipe(Schema.decodeTo(
   ])
 ))
 
+// See the comment on `schemasToResponse`: `encodingOverride` is only sound
+// for a single-member array, so the overloads below reject it otherwise.
+function toCodecArrayBuffer(
+  schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>]
+): Schema.Top
+function toCodecArrayBuffer(
+  schemas: readonly [Schema.Constraint],
+  encodingOverride: HttpApiSchema.ResponseEncoding
+): Schema.Top
 function toCodecArrayBuffer(
   schemas: readonly [Schema.Constraint, ...Array<Schema.Constraint>],
   encodingOverride?: HttpApiSchema.ResponseEncoding

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1298,15 +1298,24 @@ function hasReservedEventLiteral(ast: AST.AST, seen: Set<AST.AST>): boolean {
 }
 
 function transformResponse(schema: Schema.Top): Schema.Top {
+  // The wrapper's AST is authoritative for encoding: it carries the body's
+  // lifted annotation unless one was applied to the wrapper itself, which wins.
+  const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
   if (HttpApiSchema.isWithHeaders(schema)) {
     const body = schema.body
     return HttpApiSchema.replaceWithHeaders(
       schema,
       Schema.toCodecStringTree(schema.headers),
-      HttpApiSchema.isStreamSchema(body) ? body : transformResponse(body)
+      HttpApiSchema.isStreamSchema(body) ? body : transformResponseBody(body, encoding)
     )
   }
-  const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
+  return transformResponseBody(schema, encoding)
+}
+
+function transformResponseBody(
+  schema: Schema.Top,
+  encoding: HttpApiSchema.ResponseEncoding
+): Schema.Top {
   switch (encoding._tag) {
     case "Json":
       return Schema.toCodecJson(schema)

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1191,7 +1191,7 @@ function validateSuccessResponse(schemas: ReadonlyArray<Schema.Top>, method: Htt
       entry.stream = body
     } else {
       const noContent = HttpApiSchema.isNoContent(body.ast)
-      const encoding = HttpApiSchema.getResponseEncoding(body.ast)
+      const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
       if (entry.stream !== undefined) {
         if (noContent) {
           throw new Error(`Cannot combine no-content and streaming success responses for status: ${status}`)

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -1153,78 +1153,102 @@ function getErrorResponse(
   if (error === undefined) return new Set()
   const schemas = Arr.ensure(error)
   for (const schema of schemas) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
+    if (HttpApiSchema.isStreamSchema(HttpApiSchema.unwrapResponseSchema(schema))) {
       throw new Error("Streaming schemas are not supported in error responses")
     }
   }
+  validateResponseExclusivity(schemas, HttpApiSchema.getStatusError)
   return new Set(disableCodecs ? schemas : schemas.map(transformResponse))
 }
 
-function validateSuccessResponse(schemas: ReadonlyArray<Schema.Constraint>, method: HttpMethod) {
-  const statuses = new Map<number, {
-    readonly stream?: HttpApiSchema.StreamSchema | undefined
-    bufferedContentTypes: Set<string>
-    noContent: boolean
-  }>()
+interface StatusEntry {
+  stream: HttpApiSchema.StreamSchema | undefined
+  bufferedContentTypes: Set<string>
+  noContent: boolean
+}
+
+function validateSuccessResponse(schemas: ReadonlyArray<Schema.Top>, method: HttpMethod) {
+  const statuses = new Map<number, StatusEntry>()
 
   for (const schema of schemas) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      validateStreamSuccess(schema, method)
-      const status = HttpApiSchema.getStatusStream(schema)
-      const entry = getStatusEntry(statuses, status)
+    const body = HttpApiSchema.unwrapResponseSchema(schema)
+    const status = HttpApiSchema.getStatusSuccess(schema.ast)
+    const entry = getStatusEntry(statuses, status)
+
+    if (HttpApiSchema.isStreamSchema(body)) {
+      validateStreamSuccess(body, method)
       if (entry.stream !== undefined) {
         throw new Error(`Multiple streaming success responses for status: ${status}`)
       }
       if (entry.noContent) {
         throw new Error(`Cannot combine no-content and streaming success responses for status: ${status}`)
       }
-      if (entry.bufferedContentTypes.has(MediaType.normalize(schema.contentType))) {
+      if (entry.bufferedContentTypes.has(MediaType.normalize(body.contentType))) {
         throw new Error(
-          `Cannot combine buffered and streaming success responses for status ${status} and content-type: ${schema.contentType}`
+          `Cannot combine buffered and streaming success responses for status ${status} and content-type: ${body.contentType}`
         )
       }
-      statuses.set(status, { ...entry, stream: schema })
+      entry.stream = body
     } else {
-      const status = HttpApiSchema.getStatusSuccess(schema.ast)
-      const entry = getStatusEntry(statuses, status)
-      const noContent = HttpApiSchema.isNoContent(schema.ast)
+      const noContent = HttpApiSchema.isNoContent(body.ast)
+      const encoding = HttpApiSchema.getResponseEncoding(body.ast)
       if (entry.stream !== undefined) {
         if (noContent) {
           throw new Error(`Cannot combine no-content and streaming success responses for status: ${status}`)
         }
-        const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
-        if (
-          MediaType.normalize(encoding.contentType) === MediaType.normalize(entry.stream.contentType)
-        ) {
+        if (MediaType.normalize(encoding.contentType) === MediaType.normalize(entry.stream.contentType)) {
           throw new Error(
             `Cannot combine buffered and streaming success responses for status ${status} and content-type: ${encoding.contentType}`
           )
         }
       }
       if (!noContent) {
-        entry.bufferedContentTypes.add(
-          MediaType.normalize(HttpApiSchema.getResponseEncoding(schema.ast).contentType)
-        )
+        entry.bufferedContentTypes.add(MediaType.normalize(encoding.contentType))
       }
       entry.noContent = entry.noContent || noContent
     }
   }
+
+  validateResponseExclusivity(schemas, HttpApiSchema.getStatusSuccess)
 }
 
-function getStatusEntry(
-  statuses: Map<number, {
-    readonly stream?: HttpApiSchema.StreamSchema | undefined
-    bufferedContentTypes: Set<string>
-    noContent: boolean
-  }>,
-  status: number
-) {
+function getStatusEntry(statuses: Map<number, StatusEntry>, status: number): StatusEntry {
   let entry = statuses.get(status)
   if (entry === undefined) {
-    entry = { bufferedContentTypes: new Set(), noContent: false }
+    entry = { stream: undefined, bufferedContentTypes: new Set(), noContent: false }
     statuses.set(status, entry)
   }
   return entry
+}
+
+/**
+ * A `WithHeaders` response may not share a `(status, content-type)` pair with
+ * any other response: the client discriminates alternatives on exactly those
+ * two signals, so a shared bucket would make the decoded shape depend on which
+ * headers the server happened to send.
+ */
+function validateResponseExclusivity(
+  schemas: ReadonlyArray<Schema.Top>,
+  getStatus: (ast: AST.AST) => number
+) {
+  const occupied = new Map<string, boolean>()
+  for (const schema of schemas) {
+    const status = getStatus(schema.ast)
+    const contentType = HttpApiSchema.isNoContentSchema(schema)
+      ? ""
+      : MediaType.normalize(HttpApiSchema.getResponseContentType(schema))
+    const key = `${status} ${contentType}`
+    const wrapped = HttpApiSchema.isWithHeaders(schema)
+    const existing = occupied.get(key)
+    if (existing !== undefined && (wrapped || existing)) {
+      throw new Error(
+        `Cannot combine a WithHeaders response with another response for status ${status} and content-type: ${
+          contentType || "<no content>"
+        }`
+      )
+    }
+    occupied.set(key, Boolean(existing) || wrapped)
+  }
 }
 
 function validateStreamSuccess(schema: HttpApiSchema.StreamSchema, method: HttpMethod) {
@@ -1274,6 +1298,14 @@ function hasReservedEventLiteral(ast: AST.AST, seen: Set<AST.AST>): boolean {
 }
 
 function transformResponse(schema: Schema.Top): Schema.Top {
+  if (HttpApiSchema.isWithHeaders(schema)) {
+    const body = schema.body
+    return HttpApiSchema.replaceWithHeaders(
+      schema,
+      Schema.toCodecStringTree(schema.headers),
+      HttpApiSchema.isStreamSchema(body) ? body : transformResponse(body)
+    )
+  }
   const encoding = HttpApiSchema.getResponseEncoding(schema.ast)
   switch (encoding._tag) {
     case "Json":

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -458,6 +458,139 @@ export const isStreamSse = (u: unknown): u is StreamSse<Sse.EventCodec, Schema.T
 export const isStreamUint8Array = (u: unknown): u is StreamUint8Array =>
   isStreamSchema(u) && u._tag === "StreamUint8Array"
 
+/**
+ * Runtime brand key used to mark response schemas that carry a headers schema.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const WithHeadersTypeId = "~effect/httpapi/HttpApiSchema/WithHeaders"
+
+/**
+ * Schema for a response that carries typed headers alongside a body.
+ *
+ * **Details**
+ *
+ * This declaration stores the headers and body schemas for later endpoint,
+ * server, client, and OpenAPI integrations. Its runtime value is
+ * `{ headers, body }`: handlers return that shape, and generated clients
+ * produce it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface WithHeaders<Headers extends Schema.Top, Body extends Schema.Top> extends
+  Schema.Bottom<
+    { readonly headers: Headers["Type"]; readonly body: Body["Type"] },
+    { readonly headers: Headers["Encoded"]; readonly body: Body["Encoded"] },
+    Headers["DecodingServices"] | Body["DecodingServices"],
+    Headers["EncodingServices"] | Body["EncodingServices"],
+    SchemaAST.Declaration,
+    WithHeaders<Headers, Body>
+  >
+{
+  readonly "Rebuild": WithHeaders<Headers, Body>
+  readonly [WithHeadersTypeId]: typeof WithHeadersTypeId
+  readonly headers: Headers
+  readonly body: Body
+}
+
+const withHeadersSchema = Schema.declare(
+  (u: unknown): u is { readonly headers: unknown; readonly body: unknown } =>
+    Predicate.hasProperty(u, "headers") && Predicate.hasProperty(u, "body")
+)
+
+/**
+ * Creates a response schema that carries typed headers alongside a body.
+ *
+ * **Details**
+ *
+ * Header names should be declared in lowercase: Effect normalizes header names
+ * to lowercase on both the client and the server. A header declared with a
+ * required schema fails decoding when absent from the response; use
+ * `Schema.optional` for headers that may be missing.
+ *
+ * The body's status and encoding annotations are lifted onto the wrapper, so
+ * `HttpApiSchema.Created`, `asText()`, and friends compose as expected. An
+ * annotation applied to the wrapper itself takes precedence.
+ *
+ * **Example**
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ * import { HttpApiSchema } from "effect/unstable/httpapi"
+ *
+ * const CreatedWithLocation = HttpApiSchema.WithHeaders({
+ *   headers: { location: Schema.String },
+ *   body: HttpApiSchema.Created
+ * })
+ * ```
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const WithHeaders = <
+  H extends Schema.Struct.Fields | Schema.Top,
+  B extends Schema.Top
+>(options: {
+  readonly headers: H
+  readonly body: B
+}): WithHeaders<H extends Schema.Struct.Fields ? Schema.Struct<H> : H, B> => {
+  const headers = Schema.isSchema(options.headers)
+    ? options.headers as Schema.Top
+    : Schema.Struct(options.headers as Schema.Struct.Fields)
+  const body = options.body
+  if (isWithHeaders(body)) {
+    throw new Error("WithHeaders cannot wrap another WithHeaders")
+  }
+  const annotations: Schema.Annotations.Augment = {}
+  const status = resolveHttpApiStatus(body.ast)
+  if (status !== undefined) {
+    ;(annotations as any).httpApiStatus = status
+  }
+  const encoding = resolveHttpApiEncoding(body.ast)
+  if (encoding !== undefined) {
+    ;(annotations as any)["~httpApiEncoding"] = encoding
+  }
+  const declaration = status === undefined && encoding === undefined
+    ? withHeadersSchema
+    : withHeadersSchema.annotate(annotations)
+  return makeWithHeaders(declaration.ast, headers, body) as any
+}
+
+function makeWithHeaders(
+  ast: SchemaAST.Declaration,
+  headers: Schema.Top,
+  body: Schema.Top
+): WithHeaders<Schema.Top, Schema.Top> {
+  return Schema.make<WithHeaders<Schema.Top, Schema.Top>>(ast, {
+    [WithHeadersTypeId]: WithHeadersTypeId,
+    headers,
+    body
+  })
+}
+
+/**
+ * Returns `true` when a value is a {@link WithHeaders} schema.
+ *
+ * @category guards
+ * @since 4.0.0
+ */
+export const isWithHeaders = (u: unknown): u is WithHeaders<Schema.Top, Schema.Top> =>
+  Schema.isSchema(u) && Predicate.hasProperty(u, WithHeadersTypeId)
+
+/**
+ * Rebuilds a {@link WithHeaders} schema with new sub-schemas, preserving the
+ * wrapper's own AST and therefore any annotations applied to it.
+ *
+ * @internal
+ */
+export const replaceWithHeaders = (
+  self: WithHeaders<Schema.Top, Schema.Top>,
+  headers: Schema.Top,
+  body: Schema.Top
+): WithHeaders<Schema.Top, Schema.Top> => makeWithHeaders(self.ast, headers, body)
+
 function defaultStreamContentType(mode: StreamMode): string {
   switch (mode) {
     case "sse":
@@ -663,6 +796,36 @@ export const isNoContent = (ast: SchemaAST.AST): boolean => {
   const target = ast.encoding?.[0].to
   if (target === undefined) return false
   return SchemaAST.isVoid(target)
+}
+
+/**
+ * Returns the response body schema, unwrapping {@link WithHeaders}.
+ *
+ * @internal
+ */
+export function unwrapResponseSchema(schema: Schema.Top): Schema.Top {
+  return isWithHeaders(schema) ? schema.body : schema
+}
+
+/**
+ * `isNoContent` for a schema rather than a bare AST, unwrapping
+ * {@link WithHeaders} first.
+ *
+ * @internal
+ */
+export function isNoContentSchema(schema: Schema.Top): boolean {
+  return isNoContent(unwrapResponseSchema(schema).ast)
+}
+
+/**
+ * Returns the response content type for buffered, streaming, and
+ * {@link WithHeaders} response schemas alike.
+ *
+ * @internal
+ */
+export function getResponseContentType(schema: Schema.Top): string {
+  const body = unwrapResponseSchema(schema)
+  return isStreamSchema(body) ? body.contentType : getResponseEncoding(body.ast).contentType
 }
 
 const resolveHttpApiEncoding = SchemaAST.resolveAt<Encoding>("~httpApiEncoding")

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -534,6 +534,59 @@ const withHeadersSchema = Schema.declare(
  * createUser.identifier // => "createUser"
  * ```
  *
+ * **Example** (Producing and consuming the headers)
+ *
+ * ```ts import.meta.vitest
+ * import { Effect, FileSystem, Layer, Path, Schema } from "effect"
+ * import { Etag, HttpPlatform } from "effect/unstable/http"
+ * import {
+ *   HttpApi,
+ *   HttpApiBuilder,
+ *   HttpApiEndpoint,
+ *   HttpApiGroup,
+ *   HttpApiSchema,
+ *   HttpApiTest
+ * } from "effect/unstable/httpapi"
+ *
+ * const Api = HttpApi.make("Api").add(
+ *   HttpApiGroup.make("users").add(
+ *     HttpApiEndpoint.post("createUser", "/users", {
+ *       payload: Schema.Struct({ name: Schema.String }),
+ *       success: HttpApiSchema.WithHeaders({
+ *         headers: { location: Schema.String },
+ *         body: HttpApiSchema.Created
+ *       })
+ *     })
+ *   )
+ * )
+ *
+ * // The handler returns the same `{ headers, body }` shape the schema declares.
+ * const UsersLive = HttpApiBuilder.group(Api, "users", (handlers) =>
+ *   handlers.handle("createUser", () =>
+ *     Effect.succeed({
+ *       headers: { location: "/users/1" },
+ *       body: HttpApiSchema.Created.make()
+ *     })))
+ *
+ * const TestServices = Layer.mergeAll(
+ *   Path.layer,
+ *   Etag.layerWeak,
+ *   HttpPlatform.layer
+ * ).pipe(Layer.provideMerge(FileSystem.layerNoop({})))
+ *
+ * const program = Effect.gen(function*() {
+ *   const client = yield* HttpApiTest.groups(Api, ["users"]).pipe(
+ *     Effect.provide(UsersLive)
+ *   )
+ *   // The client decodes the headers back into the declared type.
+ *   const response = yield* client.users.createUser({ payload: { name: "Ada" } })
+ *   return response.headers.location
+ * }).pipe(Effect.scoped, Effect.provide(TestServices))
+ *
+ * const location = await Effect.runPromise(program)
+ * location // => "/users/1"
+ * ```
+ *
  * @category constructors
  * @since 4.0.0
  */

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -543,18 +543,22 @@ export const WithHeaders = <
   if (isWithHeaders(body)) {
     throw new Error("WithHeaders cannot wrap another WithHeaders")
   }
-  const annotations: Schema.Annotations.Augment = {}
+  const annotations: {
+    httpApiStatus?: number
+    "~httpApiEncoding"?: Encoding
+  } = {}
   const status = resolveHttpApiStatus(body.ast)
   if (status !== undefined) {
-    ;(annotations as any).httpApiStatus = status
+    annotations.httpApiStatus = status
   }
   const encoding = resolveHttpApiEncoding(body.ast)
   if (encoding !== undefined) {
-    ;(annotations as any)["~httpApiEncoding"] = encoding
+    annotations["~httpApiEncoding"] = encoding
   }
-  const declaration = status === undefined && encoding === undefined
-    ? withHeadersSchema
-    : withHeadersSchema.annotate(annotations)
+  // Annotating always allocates a fresh AST. Consumers key per-instance caches
+  // (and the whole encode/decode pipeline) on the wrapper's AST, so two wrappers
+  // must never share one — even when neither carries a lifted annotation.
+  const declaration = withHeadersSchema.annotate(annotations as Schema.Annotations.Augment)
   return makeWithHeaders(declaration.ast, headers, body) as any
 }
 
@@ -825,7 +829,9 @@ export function isNoContentSchema(schema: Schema.Top): boolean {
  */
 export function getResponseContentType(schema: Schema.Top): string {
   const body = unwrapResponseSchema(schema)
-  return isStreamSchema(body) ? body.contentType : getResponseEncoding(body.ast).contentType
+  // The wrapper's AST is authoritative: it carries the body's lifted encoding
+  // annotation unless one was applied to the wrapper itself, which wins.
+  return isStreamSchema(body) ? body.contentType : getResponseEncoding(schema.ast).contentType
 }
 
 const resolveHttpApiEncoding = SchemaAST.resolveAt<Encoding>("~httpApiEncoding")

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -618,7 +618,7 @@ export const WithHeaders = <
   }
   // Annotating always allocates a fresh AST. Consumers key per-instance caches
   // (and the whole encode/decode pipeline) on the wrapper's AST, so two wrappers
-  // must never share one — even when neither carries a lifted annotation.
+  // must never share one, even when neither carries a lifted annotation.
   const declaration = withHeadersSchema.annotate(annotations as Schema.Annotations.Augment)
   return makeWithHeaders(declaration.ast, headers, body) as any
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -458,13 +458,7 @@ export const isStreamSse = (u: unknown): u is StreamSse<Sse.EventCodec, Schema.T
 export const isStreamUint8Array = (u: unknown): u is StreamUint8Array =>
   isStreamSchema(u) && u._tag === "StreamUint8Array"
 
-/**
- * Runtime brand key used to mark response schemas that carry a headers schema.
- *
- * @category type IDs
- * @since 4.0.0
- */
-export const WithHeadersTypeId = "~effect/httpapi/HttpApiSchema/WithHeaders"
+const WithHeadersTypeId = "~effect/httpapi/HttpApiSchema/WithHeaders"
 
 /**
  * Schema for a response that carries typed headers alongside a body.
@@ -514,16 +508,30 @@ const withHeadersSchema = Schema.declare(
  * `HttpApiSchema.Created`, `asText()`, and friends compose as expected. An
  * annotation applied to the wrapper itself takes precedence.
  *
- * **Example**
+ * Only object-shaped headers schemas appear in the generated OpenAPI document:
+ * OpenAPI models `Response.headers` as a fixed map from header name to schema,
+ * so a schema with dynamic keys such as `Schema.Record` has no representation
+ * there. Such a schema still encodes and decodes normally on the server and the
+ * client; it simply contributes no `responses[status].headers` entries. This
+ * matches how request `params`, `query`, and `headers` are handled.
  *
- * ```ts
+ * **Example** (Declaring a Location response header)
+ *
+ * ```ts import.meta.vitest
  * import { Schema } from "effect"
- * import { HttpApiSchema } from "effect/unstable/httpapi"
+ * import { HttpApiEndpoint, HttpApiSchema } from "effect/unstable/httpapi"
  *
- * const CreatedWithLocation = HttpApiSchema.WithHeaders({
- *   headers: { location: Schema.String },
- *   body: HttpApiSchema.Created
+ * const createUser = HttpApiEndpoint.post("createUser", "/users", {
+ *   payload: Schema.Struct({ name: Schema.String }),
+ *   success: HttpApiSchema.WithHeaders({
+ *     headers: { location: Schema.String },
+ *     body: HttpApiSchema.Created
+ *   })
  * })
+ *
+ * // The handler for this endpoint returns `{ headers, body }`, and the
+ * // generated client decodes the same shape back.
+ * createUser.identifier // => "createUser"
  * ```
  *
  * @category constructors
@@ -583,12 +591,8 @@ function makeWithHeaders(
 export const isWithHeaders = (u: unknown): u is WithHeaders<Schema.Top, Schema.Top> =>
   Schema.isSchema(u) && Predicate.hasProperty(u, WithHeadersTypeId)
 
-/**
- * Rebuilds a {@link WithHeaders} schema with new sub-schemas, preserving the
- * wrapper's own AST and therefore any annotations applied to it.
- *
- * @internal
- */
+/** @internal */
+// Reuses `self.ast` so that annotations applied to the wrapper survive the rebuild.
 export const replaceWithHeaders = (
   self: WithHeaders<Schema.Top, Schema.Top>,
   headers: Schema.Top,
@@ -802,31 +806,17 @@ export const isNoContent = (ast: SchemaAST.AST): boolean => {
   return SchemaAST.isVoid(target)
 }
 
-/**
- * Returns the response body schema, unwrapping {@link WithHeaders}.
- *
- * @internal
- */
+/** @internal */
 export function unwrapResponseSchema(schema: Schema.Top): Schema.Top {
   return isWithHeaders(schema) ? schema.body : schema
 }
 
-/**
- * `isNoContent` for a schema rather than a bare AST, unwrapping
- * {@link WithHeaders} first.
- *
- * @internal
- */
+/** @internal */
 export function isNoContentSchema(schema: Schema.Top): boolean {
   return isNoContent(unwrapResponseSchema(schema).ast)
 }
 
-/**
- * Returns the response content type for buffered, streaming, and
- * {@link WithHeaders} response schemas alike.
- *
- * @internal
- */
+/** @internal */
 export function getResponseContentType(schema: Schema.Top): string {
   const body = unwrapResponseSchema(schema)
   // The wrapper's AST is authoritative: it carries the body's lifted encoding

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -369,7 +369,7 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
       const method = endpoint.method.toLowerCase() as OpenAPISpecMethodName
 
       function processResponseBodies(bodies: ResponseBodies, defaultDescription: () => string) {
-        for (const [status, { content, descriptions, streamContent }] of bodies) {
+        for (const [status, { content, descriptions, headers, members, streamContent }] of bodies) {
           const description = descriptions.size > 0 ? Array.from(descriptions).join(" | ") : defaultDescription()
           InternalRecord.assignProperty(op.responses, status, {
             description
@@ -451,6 +451,18 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
                   }
                 })
               }
+            })
+          }
+          for (const [name, header] of headers) {
+            op.responses[status].headers ??= {}
+            InternalRecord.assignProperty(op.responses[status].headers, name, {
+              required: header.required && header.count === members,
+              schema: {}
+            })
+            pathOps.push({
+              _tag: "parameter",
+              ast: header.ast,
+              path: ["paths", path, method, "responses", String(status), "headers", name, "schema"]
             })
           }
         }
@@ -668,12 +680,30 @@ function fromApiWith<Id extends string, Groups extends HttpApiGroup.Constraint>(
   return spec
 }
 
+type ResponseHeaders = Map<string, { ast: SchemaAST.AST; required: boolean; count: number }>
+
+// `Schema.optional` encodes optionality as an `undefined` member unioned onto the
+// property type (with the optionality itself tracked separately via
+// `SchemaAST.isOptional`). Strip that member so the generated JSON Schema for an
+// optional header is a plain `{ type: "string" }` rather than `{ anyOf: [..., { type: "null" }] }`.
+function dropUndefinedMember(ast: SchemaAST.AST): SchemaAST.AST {
+  if (SchemaAST.isUnion(ast)) {
+    const types = ast.types.filter((type) => !SchemaAST.isUndefined(type))
+    if (types.length !== ast.types.length) {
+      return types.length === 1 ? types[0] : new SchemaAST.Union(types, ast.mode, ast.annotations, ast.checks)
+    }
+  }
+  return ast
+}
+
 type ResponseBodies = Map<
   number, // status
   {
     descriptions: Set<string>
     content: Content | undefined // undefined means no content
     streamContent: StreamContent | undefined
+    headers: ResponseHeaders
+    members: number
   }
 >
 
@@ -688,7 +718,7 @@ function extractSuccessResponseBodies(endpoint: HttpApiEndpoint.Top): ResponseBo
 }
 
 function extractResponseBodies(
-  schemas: Array<Schema.Constraint>,
+  schemas: Array<Schema.Top>,
   getStatus: (ast: SchemaAST.AST) => number,
   getDescription: (ast: SchemaAST.AST) => string | undefined
 ): ResponseBodies {
@@ -696,23 +726,52 @@ function extractResponseBodies(
     descriptions: Set<string>
     content: Content | undefined
     streamContent: StreamContent | undefined
+    headers: ResponseHeaders
+    members: number
   }>()
 
   schemas.forEach(process)
 
   return map
 
-  function process(schema: Schema.Constraint) {
-    if (HttpApiSchema.isStreamSchema(schema)) {
-      addStreamContent(schema)
-      return
-    }
-    const ast = schema.ast
-    const status = getStatus(ast)
-    if (HttpApiSchema.isNoContent(ast)) {
-      addNoContent(status, getDescription(schema.ast) ?? "<No Content>")
+  function process(schema: Schema.Top) {
+    const body = HttpApiSchema.unwrapResponseSchema(schema)
+    const status = getStatus(schema.ast)
+    if (HttpApiSchema.isStreamSchema(body)) {
+      addStreamContent(body)
     } else {
-      addContent(schema, status, HttpApiSchema.getResponseEncoding(ast))
+      const ast = body.ast
+      if (HttpApiSchema.isNoContent(ast)) {
+        addNoContent(status, getDescription(ast) ?? "<No Content>")
+      } else {
+        addContent(body, status, HttpApiSchema.getResponseEncoding(ast))
+      }
+    }
+    const entry = map.get(status)!
+    entry.members += 1
+    if (HttpApiSchema.isWithHeaders(schema)) {
+      addResponseHeaders(entry.headers, schema.headers)
+    }
+  }
+
+  function addResponseHeaders(headers: ResponseHeaders, schema: Schema.Top) {
+    const ast = SchemaAST.getLastEncoding(schema.ast)
+    if (!SchemaAST.isObjects(ast)) return
+    for (const ps of ast.propertySignatures) {
+      const name = String(ps.name)
+      const required = !SchemaAST.isOptional(ps.type)
+      const type = dropUndefinedMember(ps.type)
+      const existing = headers.get(name)
+      if (existing === undefined) {
+        headers.set(name, {
+          ast: type,
+          required,
+          count: 1
+        })
+      } else {
+        existing.count += 1
+        existing.required = existing.required && required
+      }
     }
   }
 
@@ -722,7 +781,9 @@ function extractResponseBodies(
       map.set(status, {
         descriptions: new Set([description]),
         content: undefined,
-        streamContent: undefined
+        streamContent: undefined,
+        headers: new Map(),
+        members: 0
       })
     } else {
       if (description !== undefined) {
@@ -739,7 +800,9 @@ function extractResponseBodies(
       map.set(status, {
         descriptions: new Set(description !== undefined ? [description] : []),
         content: new Map([[_tag, new Map([[contentType, new Set([schema])]])]]),
-        streamContent: undefined
+        streamContent: undefined,
+        headers: new Map(),
+        members: 0
       })
     } else {
       // concat descriptions
@@ -772,7 +835,9 @@ function extractResponseBodies(
       map.set(status, {
         descriptions: new Set(),
         content: undefined,
-        streamContent: new Map([[stream.contentType, stream]])
+        streamContent: new Map([[stream.contentType, stream]]),
+        headers: new Map(),
+        members: 0
       })
     } else if (statusMap.streamContent === undefined) {
       statusMap.streamContent = new Map([[stream.contentType, stream]])
@@ -1042,6 +1107,18 @@ export type OpenApiSpecContent = {
 export interface OpenApiSpecResponse {
   description: string
   content?: OpenApiSpecContent
+  headers?: Record<string, OpenApiSpecResponseHeader>
+}
+
+/**
+ * Generated OpenAPI response header object.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface OpenApiSpecResponseHeader {
+  required?: boolean
+  schema: JsonSchema.JsonSchema
 }
 
 /**

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -736,18 +736,21 @@ function extractResponseBodies(
 
   function process(schema: Schema.Top) {
     const body = HttpApiSchema.unwrapResponseSchema(schema)
+    // The wrapper's AST is authoritative for both status and encoding: it
+    // carries the body's lifted annotations unless the wrapper declares its own.
     const status = getStatus(schema.ast)
     if (HttpApiSchema.isStreamSchema(body)) {
-      addStreamContent(body)
+      addStreamContent(body, status)
     } else {
       const ast = body.ast
       if (HttpApiSchema.isNoContent(ast)) {
         addNoContent(status, getDescription(ast) ?? "<No Content>")
       } else {
-        addContent(body, status, HttpApiSchema.getResponseEncoding(ast))
+        addContent(body, status, HttpApiSchema.getResponseEncoding(schema.ast))
       }
     }
-    const entry = map.get(status)!
+    const entry = map.get(status)
+    if (entry === undefined) return
     entry.members += 1
     if (HttpApiSchema.isWithHeaders(schema)) {
       addResponseHeaders(entry.headers, schema.headers)
@@ -828,8 +831,7 @@ function extractResponseBodies(
     }
   }
 
-  function addStreamContent(stream: HttpApiSchema.StreamSchema) {
-    const status = HttpApiSchema.getStatusStream(stream)
+  function addStreamContent(stream: HttpApiSchema.StreamSchema, status: number) {
     const statusMap = map.get(status)
     if (statusMap === undefined) {
       map.set(status, {

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -739,14 +739,16 @@ function extractResponseBodies(
     // The wrapper's AST is authoritative for both status and encoding: it
     // carries the body's lifted annotations unless the wrapper declares its own.
     const status = getStatus(schema.ast)
+    // A description on the wrapper wins over one on the body, so that
+    // `WithHeaders` behaves like every other annotation-bearing wrapper.
+    const description = getDescription(schema.ast) ?? getDescription(body.ast)
     if (HttpApiSchema.isStreamSchema(body)) {
       addStreamContent(body, status)
     } else {
-      const ast = body.ast
-      if (HttpApiSchema.isNoContent(ast)) {
-        addNoContent(status, getDescription(ast) ?? "<No Content>")
+      if (HttpApiSchema.isNoContent(body.ast)) {
+        addNoContent(status, description ?? "<No Content>")
       } else {
-        addContent(body, status, HttpApiSchema.getResponseEncoding(schema.ast))
+        addContent(body, status, HttpApiSchema.getResponseEncoding(schema.ast), description)
       }
     }
     const entry = map.get(status)
@@ -795,8 +797,12 @@ function extractResponseBodies(
     }
   }
 
-  function addContent(schema: Schema.Constraint, status: number, encoding: HttpApiSchema.Encoding) {
-    const description = getDescription(schema.ast)
+  function addContent(
+    schema: Schema.Constraint,
+    status: number,
+    encoding: HttpApiSchema.Encoding,
+    description: string | undefined
+  ) {
     const statusMap = map.get(status)
     const { _tag, contentType } = encoding
     if (statusMap === undefined) {

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1,6 +1,6 @@
 import { assert, it, vi } from "@effect/vitest"
 import { Cause, Effect, FileSystem, Layer, Path, Redacted, Schema, Stream } from "effect"
-import { Etag, HttpPlatform } from "effect/unstable/http"
+import { Etag, type HttpClientResponse, HttpPlatform } from "effect/unstable/http"
 import {
   HttpApi,
   HttpApiBuilder,
@@ -768,8 +768,8 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
           HttpApiEndpoint.get("get", "/get", {
             success: HttpApiSchema.WithHeaders({
               headers: { "x-a": Schema.String },
-              body: Schema.String
-            }).pipe(HttpApiSchema.asText())
+              body: Schema.String.pipe(HttpApiSchema.asText())
+            }).pipe(HttpApiSchema.asJson({ contentType: "application/vnd.custom+json" }))
           })
         )
       )
@@ -782,7 +782,7 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
       const [value, response] = yield* client.test.get({ responseMode: "decoded-and-response" })
 
-      assert.strictEqual(response.headers["content-type"], "text/plain")
+      assert.strictEqual(response.headers["content-type"], "application/vnd.custom+json")
       assert.deepStrictEqual(value, { headers: { "x-a": "a" }, body: "hello" })
     }))
 
@@ -810,7 +810,7 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
             HttpApiEndpoint.get("get", "/get", { success: success as any })
           )
         )
-      const respond = (Api: any) =>
+      const respond = (Api: any): Effect.Effect<HttpClientResponse.HttpClientResponse, any, any> =>
         HttpApiTest.groups(Api, ["test"]).pipe(
           Effect.provide(HttpApiBuilder.group(
             Api,

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -785,4 +785,49 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       assert.strictEqual(response.headers["content-type"], "text/plain")
       assert.deepStrictEqual(value, { headers: { "x-a": "a" }, body: "hello" })
     }))
+
+  // The `WithHeaders` declaration predicate matches any `{ headers, body }`
+  // value, so a plain struct of that shape is indistinguishable from a wrapper
+  // in the server's encode union and the first declared member wins. The
+  // exclusivity rule only forbids sharing a (status, content-type) pair, so
+  // these two members coexist legally. Clients are unaffected: their decode map
+  // is keyed by status, and the two members have different statuses.
+  it.effect("dispatches an ambiguous { headers, body } value to the first declared member", () =>
+    Effect.gen(function*() {
+      const WrappedFirst = HttpApiSchema.status(201)(
+        HttpApiSchema.WithHeaders({
+          headers: { location: Schema.String },
+          body: Schema.String
+        })
+      )
+      const PlainStruct = Schema.Struct({
+        headers: Schema.Struct({ location: Schema.String }),
+        body: Schema.String
+      })
+      const makeApi = (success: ReadonlyArray<Schema.Top>) =>
+        HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("get", "/get", { success: success as any })
+          )
+        )
+      const respond = (Api: any) =>
+        HttpApiTest.groups(Api, ["test"]).pipe(
+          Effect.provide(HttpApiBuilder.group(
+            Api,
+            "test",
+            (handlers: any) => handlers.handle("get", () => Effect.succeed({ headers: { location: "/x" }, body: "hi" }))
+          )),
+          Effect.flatMap((client: any) => client.test.get({ responseMode: "response-only" }))
+        )
+
+      const wrapped = yield* respond(makeApi([WrappedFirst, PlainStruct]))
+      assert.strictEqual(wrapped.status, 201)
+      assert.strictEqual(wrapped.headers.location, "/x")
+      assert.strictEqual(yield* wrapped.text, JSON.stringify("hi"))
+
+      const plain = yield* respond(makeApi([PlainStruct, WrappedFirst]))
+      assert.strictEqual(plain.status, 200)
+      assert.isUndefined(plain.headers.location)
+      assert.strictEqual(yield* plain.text, JSON.stringify({ headers: { location: "/x" }, body: "hi" }))
+    }))
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -528,3 +528,105 @@ it.layer(TestServices)("HttpApiBuilder streaming success responses", (it) => {
       assert.deepStrictEqual(error, new HandlerFailure({ message: "handler failed" }))
     }))
 })
+
+it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
+  it.effect("sets declared headers on an empty 201 response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.post("create", "/create", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { location: Schema.String },
+              body: HttpApiSchema.Created
+            })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("create", () =>
+            Effect.succeed({
+              headers: { location: "/things/1" },
+              body: undefined
+            }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
+      // on the decoded `value` once the client understands `WithHeaders` responses.
+      const response = yield* client.test.create({ responseMode: "response-only" })
+
+      assert.strictEqual(response.status, 201)
+      assert.strictEqual(response.headers["location"], "/things/1")
+    }))
+
+  it.effect("sets declared headers on a json response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("get", "/get", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-total-count": Schema.FiniteFromString },
+              body: Schema.Struct({ name: Schema.String })
+            })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("get", () =>
+            Effect.succeed({
+              headers: { "x-total-count": 3 },
+              body: { name: "Ada" }
+            }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
+      // on the decoded `value` once the client understands `WithHeaders` responses.
+      const response = yield* client.test.get({ responseMode: "response-only" })
+      const body = yield* response.json
+
+      assert.strictEqual(response.headers["x-total-count"], "3")
+      assert.strictEqual(response.headers["content-type"], "application/json")
+      assert.deepStrictEqual(body, { name: "Ada" })
+    }))
+
+  it.effect("sets declared headers on an error response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("get", "/get", {
+            error: HttpApiSchema.WithHeaders({
+              headers: { "retry-after": Schema.String },
+              body: Schema.Struct({ reason: Schema.String })
+            })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("get", () =>
+            Effect.fail({
+              headers: { "retry-after": "120" },
+              body: { reason: "busy" }
+            }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      // TODO(Task 5): switch back to `yield* Effect.flip(client.test.get())` and assert on the
+      // decoded error once the client understands `WithHeaders` responses.
+      const response = yield* client.test.get({ responseMode: "response-only" })
+      const body = yield* response.json
+
+      assert.strictEqual(response.status, 500)
+      assert.strictEqual(response.headers["retry-after"], "120")
+      assert.deepStrictEqual(body, { reason: "busy" })
+    }))
+})

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -554,12 +554,11 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
-      // on the decoded `value` once the client understands `WithHeaders` responses.
-      const response = yield* client.test.create({ responseMode: "response-only" })
+      const [value, response] = yield* client.test.create({ responseMode: "decoded-and-response" })
 
       assert.strictEqual(response.status, 201)
       assert.strictEqual(response.headers["location"], "/things/1")
+      assert.deepStrictEqual(value, { headers: { location: "/things/1" }, body: undefined })
     }))
 
   it.effect("sets declared headers on a json response", () =>
@@ -586,14 +585,11 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
-      // on the decoded `value` once the client understands `WithHeaders` responses.
-      const response = yield* client.test.get({ responseMode: "response-only" })
-      const body = yield* response.json
+      const [value, response] = yield* client.test.get({ responseMode: "decoded-and-response" })
 
       assert.strictEqual(response.headers["x-total-count"], "3")
       assert.strictEqual(response.headers["content-type"], "application/json")
-      assert.deepStrictEqual(body, { name: "Ada" })
+      assert.deepStrictEqual(value, { headers: { "x-total-count": 3 }, body: { name: "Ada" } })
     }))
 
   it.effect("sets declared headers on an error response", () =>
@@ -620,14 +616,12 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      // TODO(Task 5): switch back to `yield* Effect.flip(client.test.get())` and assert on the
-      // decoded error once the client understands `WithHeaders` responses.
-      const response = yield* client.test.get({ responseMode: "response-only" })
-      const body = yield* response.json
+      const error = yield* Effect.flip(client.test.get({}))
 
-      assert.strictEqual(response.status, 500)
-      assert.strictEqual(response.headers["retry-after"], "120")
-      assert.deepStrictEqual(body, { reason: "busy" })
+      assert.deepStrictEqual(error, {
+        headers: { "retry-after": "120" },
+        body: { reason: "busy" }
+      })
     }))
 
   it.effect("sets declared headers on a Uint8Array stream response", () =>
@@ -654,12 +648,12 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
-      // on the decoded `value` once the client understands `WithHeaders` responses.
-      const response = yield* client.test.download({ responseMode: "response-only" })
+      const [value, response] = yield* client.test.download({ responseMode: "decoded-and-response" })
 
       assert.strictEqual(response.headers["x-trace-id"], "abc")
       assert.strictEqual(response.headers["content-type"], "application/custom-bytes")
+      assert.deepStrictEqual(value.headers, { "x-trace-id": "abc" })
+      assert.deepStrictEqual(yield* Stream.runCollect(value.body), [new Uint8Array([1, 2, 3])])
     }))
 
   it.effect("sets declared headers on an SSE stream response", () =>
@@ -688,11 +682,11 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       )
 
       const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
-      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
-      // on the decoded `value` once the client understands `WithHeaders` responses.
-      const response = yield* client.test.events({ responseMode: "response-only" })
+      const [value, response] = yield* client.test.events({ responseMode: "decoded-and-response" })
 
       assert.strictEqual(response.headers["x-trace-id"], "abc")
       assert.strictEqual(response.headers["content-type"], "text/event-stream")
+      assert.deepStrictEqual(value.headers, { "x-trace-id": "abc" })
+      assert.deepStrictEqual(yield* Stream.runCollect(value.body), [{ event: "tick", data: "one" }])
     }))
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -689,4 +689,100 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       assert.deepStrictEqual(value.headers, { "x-trace-id": "abc" })
       assert.deepStrictEqual(yield* Stream.runCollect(value.body), [{ event: "tick", data: "one" }])
     }))
+
+  it.effect("keeps two WithHeaders endpoints independent", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test")
+          .add(HttpApiEndpoint.get("first", "/first", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-first": Schema.String },
+              body: Schema.Struct({ a: Schema.String })
+            })
+          }))
+          .add(HttpApiEndpoint.get("second", "/second", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-second": Schema.String },
+              body: Schema.Struct({ b: Schema.Number })
+            })
+          }))
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers
+            .handle("first", () => Effect.succeed({ headers: { "x-first": "1" }, body: { a: "one" } }))
+            .handle("second", () => Effect.succeed({ headers: { "x-second": "2" }, body: { b: 2 } }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+
+      assert.deepStrictEqual(yield* client.test.first({}), {
+        headers: { "x-first": "1" },
+        body: { a: "one" }
+      })
+      assert.deepStrictEqual(yield* client.test.second({}), {
+        headers: { "x-second": "2" },
+        body: { b: 2 }
+      })
+    }))
+
+  it.effect("honours a status annotation applied to a stream wrapper", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("download", "/download", {
+            success: HttpApiSchema.status(206)(
+              HttpApiSchema.WithHeaders({
+                headers: { "content-range": Schema.String },
+                body: HttpApiSchema.StreamUint8Array()
+              })
+            )
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("download", () =>
+            Effect.succeed({
+              headers: { "content-range": "bytes 0-2/9" },
+              body: Stream.make(new Uint8Array([1, 2, 3]))
+            }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const [value, response] = yield* client.test.download({ responseMode: "decoded-and-response" })
+
+      assert.strictEqual(response.status, 206)
+      assert.deepStrictEqual(value.headers, { "content-range": "bytes 0-2/9" })
+      assert.deepStrictEqual(yield* Stream.runCollect(value.body), [new Uint8Array([1, 2, 3])])
+    }))
+
+  it.effect("honours an encoding annotation applied to the wrapper", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("get", "/get", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-a": Schema.String },
+              body: Schema.String
+            }).pipe(HttpApiSchema.asText())
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) => handlers.handle("get", () => Effect.succeed({ headers: { "x-a": "a" }, body: "hello" }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      const [value, response] = yield* client.test.get({ responseMode: "decoded-and-response" })
+
+      assert.strictEqual(response.headers["content-type"], "text/plain")
+      assert.deepStrictEqual(value, { headers: { "x-a": "a" }, body: "hello" })
+    }))
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -629,4 +629,70 @@ it.layer(TestServices)("HttpApiBuilder response headers", (it) => {
       assert.strictEqual(response.headers["retry-after"], "120")
       assert.deepStrictEqual(body, { reason: "busy" })
     }))
+
+  it.effect("sets declared headers on a Uint8Array stream response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("download", "/download", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-trace-id": Schema.String },
+              body: HttpApiSchema.StreamUint8Array({ contentType: "application/custom-bytes" })
+            })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("download", () =>
+            Effect.succeed({
+              headers: { "x-trace-id": "abc" },
+              body: Stream.make(new Uint8Array([1, 2, 3]))
+            }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
+      // on the decoded `value` once the client understands `WithHeaders` responses.
+      const response = yield* client.test.download({ responseMode: "response-only" })
+
+      assert.strictEqual(response.headers["x-trace-id"], "abc")
+      assert.strictEqual(response.headers["content-type"], "application/custom-bytes")
+    }))
+
+  it.effect("sets declared headers on an SSE stream response", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api").add(
+        HttpApiGroup.make("test").add(
+          HttpApiEndpoint.get("events", "/events", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-trace-id": Schema.String },
+              body: HttpApiSchema.StreamSse({
+                events: Schema.Struct({ event: Schema.Literal("tick"), data: Schema.String })
+              })
+            })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "test",
+        (handlers) =>
+          handlers.handle("events", () =>
+            Effect.succeed({
+              headers: { "x-trace-id": "abc" },
+              body: Stream.make({ event: "tick" as const, data: "one" })
+            }))
+      )
+
+      const client = yield* HttpApiTest.groups(Api, ["test"]).pipe(Effect.provide(GroupLive))
+      // TODO(Task 5): switch back to `{ responseMode: "decoded-and-response" }` and assert
+      // on the decoded `value` once the client understands `WithHeaders` responses.
+      const response = yield* client.test.events({ responseMode: "response-only" })
+
+      assert.strictEqual(response.headers["x-trace-id"], "abc")
+      assert.strictEqual(response.headers["content-type"], "text/event-stream")
+    }))
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -541,6 +541,140 @@ describe("HttpApiClient", () => {
       strictEqual(urls[0], "https://api.example.com/files")
       strictEqual(urls[1], "https://api.example.com/files/a%2Fb")
     }))
+
+  describe("response headers", () => {
+    const CreatedApi = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.post("create", "/create", {
+          success: HttpApiSchema.WithHeaders({
+            headers: { location: Schema.String },
+            body: HttpApiSchema.Created
+          })
+        })
+      )
+    )
+
+    it.effect("decodes declared headers alongside an empty body", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpApiClient.makeWith(CreatedApi, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() => new Response(null, { status: 201, headers: { location: "/things/1" } }))
+        })
+
+        const result = yield* client.test.create({})
+
+        assert.deepStrictEqual(result, { headers: { location: "/things/1" }, body: undefined })
+      }))
+
+    it.effect("fails when a required header is missing", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpApiClient.makeWith(CreatedApi, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() => new Response(null, { status: 201 }))
+        })
+
+        const error = yield* Effect.flip(client.test.create({}))
+
+        assert.isTrue(Schema.isSchemaError(error))
+      }))
+
+    it.effect("yields undefined for an absent optional header", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.post("create", "/create", {
+              success: HttpApiSchema.WithHeaders({
+                headers: { location: Schema.optional(Schema.String) },
+                body: HttpApiSchema.Created
+              })
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() => new Response(null, { status: 201 }))
+        })
+
+        const result = yield* client.test.create({})
+
+        assert.deepStrictEqual(result, { headers: {}, body: undefined })
+      }))
+
+    it.effect("does not decode headers in response-only mode", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpApiClient.makeWith(CreatedApi, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() => new Response(null, { status: 201 }))
+        })
+
+        const response = yield* client.test.create({ responseMode: "response-only" })
+
+        strictEqual(response.status, 201)
+      }))
+
+    it.effect("decodes headers on an error response", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("get", "/get", {
+              error: HttpApiSchema.WithHeaders({
+                headers: { "retry-after": Schema.String },
+                body: Schema.Struct({ reason: Schema.String })
+              })
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() =>
+            new Response(JSON.stringify({ reason: "busy" }), {
+              status: 500,
+              headers: { "content-type": "application/json", "retry-after": "120" }
+            })
+          )
+        })
+
+        const error = yield* Effect.flip(client.test.get({}))
+
+        assert.deepStrictEqual(error, {
+          headers: { "retry-after": "120" },
+          body: { reason: "busy" }
+        })
+      }))
+
+    it.effect("decodes headers alongside a stream body", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.get("events", "/events", {
+              success: HttpApiSchema.WithHeaders({
+                headers: { "x-trace-id": Schema.String },
+                body: HttpApiSchema.StreamSse({
+                  events: Schema.Struct({ event: Schema.Literal("tick"), data: Schema.String })
+                })
+              })
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() =>
+            new Response(textStream(["event: tick\ndata: one\n\n"]), {
+              status: 200,
+              headers: { "content-type": "text/event-stream", "x-trace-id": "abc" }
+            })
+          )
+        })
+
+        const result = yield* client.test.events({})
+
+        assert.deepStrictEqual(result.headers, { "x-trace-id": "abc" })
+        assert.deepStrictEqual(
+          yield* Stream.runCollect(result.body),
+          [{ event: "tick", data: "one" }]
+        )
+      }))
+  })
 })
 
 const textEncoder = new TextEncoder()

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -674,6 +674,31 @@ describe("HttpApiClient", () => {
           [{ event: "tick", data: "one" }]
         )
       }))
+
+    // A headers schema with dynamic keys has no OpenAPI representation (see
+    // OpenApi.test.ts), but it must still decode normally at runtime.
+    it.effect("decodes a headers schema that is not object-shaped", () =>
+      Effect.gen(function*() {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("test").add(
+            HttpApiEndpoint.post("create", "/create", {
+              success: HttpApiSchema.WithHeaders({
+                headers: Schema.Record(Schema.String, Schema.String),
+                body: HttpApiSchema.Created
+              })
+            })
+          )
+        )
+        const client = yield* HttpApiClient.makeWith(Api, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() => new Response(null, { status: 201, headers: { location: "/things/1" } }))
+        })
+
+        const result = yield* client.test.create({})
+
+        strictEqual(result.headers.location, "/things/1")
+        strictEqual(result.body, undefined)
+      }))
   })
 })
 

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -207,3 +207,137 @@ describe("HttpApiEndpoint streaming success schemas", () => {
     )
   })
 })
+
+describe("WithHeaders responses", () => {
+  it("stores a wrapper whose sub-schemas are codecs", () => {
+    const endpoint = HttpApiEndpoint.post("create", "/create", {
+      success: HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: HttpApiSchema.Created
+      })
+    })
+
+    const [success] = Array.from(endpoint.success)
+    assert.isTrue(HttpApiSchema.isWithHeaders(success))
+    assert.strictEqual(HttpApiSchema.getStatusSuccess(success.ast), 201)
+  })
+
+  it("leaves sub-schemas untouched when codecs are disabled", () => {
+    const headers = Schema.Struct({ location: Schema.String })
+    const body = HttpApiSchema.Created
+    const endpoint = HttpApiEndpoint.post("create", "/create", {
+      success: HttpApiSchema.WithHeaders({ headers, body }),
+      disableCodecs: true
+    })
+
+    const [success] = Array.from(endpoint.success) as [
+      HttpApiSchema.WithHeaders<Schema.Top, Schema.Top>
+    ]
+    assert.strictEqual(success.headers, headers)
+    assert.strictEqual(success.body, body)
+  })
+
+  it("rejects sharing a status and content-type with a plain success", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/get", {
+          success: [
+            Schema.Struct({ a: Schema.String }),
+            HttpApiSchema.WithHeaders({
+              headers: { "x-trace-id": Schema.String },
+              body: Schema.Struct({ b: Schema.String })
+            })
+          ]
+        }),
+      "Cannot combine a WithHeaders response with another response for status 200 and content-type: application/json"
+    )
+  })
+
+  it("rejects sharing a status and content-type with another WithHeaders", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/get", {
+          success: [
+            HttpApiSchema.WithHeaders({
+              headers: { "x-a": Schema.String },
+              body: Schema.Struct({ a: Schema.String })
+            }),
+            HttpApiSchema.WithHeaders({
+              headers: { "x-b": Schema.String },
+              body: Schema.Struct({ b: Schema.String })
+            })
+          ]
+        }),
+      "Cannot combine a WithHeaders response with another response for status 200 and content-type: application/json"
+    )
+  })
+
+  it("allows a WithHeaders response at a distinct status", () => {
+    const endpoint = HttpApiEndpoint.get("get", "/get", {
+      success: [
+        Schema.Struct({ a: Schema.String }),
+        HttpApiSchema.WithHeaders({
+          headers: { location: Schema.String },
+          body: HttpApiSchema.Created
+        })
+      ]
+    })
+
+    assert.strictEqual(endpoint.success.size, 2)
+  })
+
+  it("allows a WithHeaders response at a distinct content-type", () => {
+    const endpoint = HttpApiEndpoint.get("get", "/get", {
+      success: [
+        Schema.Struct({ a: Schema.String }),
+        HttpApiSchema.WithHeaders({
+          headers: { "x-trace-id": Schema.String },
+          body: Schema.String.pipe(HttpApiSchema.asText())
+        })
+      ]
+    })
+
+    assert.strictEqual(endpoint.success.size, 2)
+  })
+
+  it("applies exclusivity to errors", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/get", {
+          error: [
+            Schema.Struct({ reason: Schema.String }),
+            HttpApiSchema.WithHeaders({
+              headers: { "retry-after": Schema.String },
+              body: Schema.Struct({ cause: Schema.String })
+            })
+          ]
+        }),
+      "Cannot combine a WithHeaders response with another response for status 500 and content-type: application/json"
+    )
+  })
+
+  it("rejects a streaming body in an error response", () => {
+    assert.throws(
+      () =>
+        HttpApiEndpoint.get("get", "/get", {
+          error: HttpApiSchema.WithHeaders({
+            headers: { "x-trace-id": Schema.String },
+            body: HttpApiSchema.StreamUint8Array()
+          })
+        }),
+      "Streaming schemas are not supported in error responses"
+    )
+  })
+
+  it("accepts a streaming body in a success response", () => {
+    const endpoint = HttpApiEndpoint.get("download", "/download", {
+      success: HttpApiSchema.WithHeaders({
+        headers: { "x-trace-id": Schema.String },
+        body: HttpApiSchema.StreamUint8Array({ contentType: "application/custom-bytes" })
+      })
+    })
+
+    const [success] = Array.from(endpoint.success)
+    assert.isTrue(HttpApiSchema.isStreamSchema(HttpApiSchema.unwrapResponseSchema(success)))
+  })
+})

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -340,4 +340,18 @@ describe("WithHeaders responses", () => {
     const [success] = Array.from(endpoint.success)
     assert.isTrue(HttpApiSchema.isStreamSchema(HttpApiSchema.unwrapResponseSchema(success)))
   })
+
+  it("streaming success mixed with a WithHeaders buffered success is allowed when the wrapper's content-type differs from the body's", () => {
+    const endpoint = HttpApiEndpoint.get("download", "/download", {
+      success: [
+        HttpApiSchema.StreamUint8Array({ contentType: "application/json" }),
+        HttpApiSchema.WithHeaders({
+          headers: { "x-a": Schema.String },
+          body: Schema.String
+        }).pipe(HttpApiSchema.asText())
+      ]
+    })
+
+    assert.strictEqual(endpoint.success.size, 2)
+  })
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiEndpoint.test.ts
@@ -348,7 +348,7 @@ describe("WithHeaders responses", () => {
         HttpApiSchema.WithHeaders({
           headers: { "x-a": Schema.String },
           body: Schema.String
-        }).pipe(HttpApiSchema.asText())
+        }).pipe(HttpApiSchema.asJson({ contentType: "application/vnd.custom+json" }))
       ]
     })
 

--- a/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
@@ -133,6 +133,21 @@ describe("HttpApiSchema", () => {
       assert.strictEqual(schema.body, body)
     })
 
+    it("gives each wrapper its own AST", () => {
+      const a = HttpApiSchema.WithHeaders({
+        headers: { "x-a": Schema.String },
+        body: Schema.Struct({ a: Schema.String })
+      })
+      const b = HttpApiSchema.WithHeaders({
+        headers: { "x-b": Schema.String },
+        body: Schema.Struct({ b: Schema.String })
+      })
+
+      // consumers key per-instance caches on the wrapper AST, so two
+      // annotation-less wrappers must never share one
+      assert.notStrictEqual(a.ast, b.ast)
+    })
+
     it("accepts a field record for headers", () => {
       const schema = HttpApiSchema.WithHeaders({
         headers: { location: Schema.String },

--- a/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSchema.test.ts
@@ -119,4 +119,118 @@ describe("HttpApiSchema", () => {
     assert.isFalse(HttpApiSchema.isStreamSchema(Schema.String))
     assert.isFalse(HttpApiSchema.isStreamSchema(Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array())))
   })
+
+  describe("WithHeaders", () => {
+    it("stores the headers and body sub-schemas", () => {
+      const headers = Schema.Struct({ location: Schema.String })
+      const body = Schema.String
+      const schema = HttpApiSchema.WithHeaders({ headers, body })
+
+      assert.isTrue(Schema.isSchema(schema))
+      assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+      assert.isFalse(HttpApiSchema.isStreamSchema(schema))
+      assert.strictEqual(schema.headers, headers)
+      assert.strictEqual(schema.body, body)
+    })
+
+    it("accepts a field record for headers", () => {
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: Schema.String
+      })
+
+      assert.isTrue(Schema.isSchema(schema.headers))
+      assert.deepStrictEqual(
+        Object.keys((schema.headers as Schema.Struct<any>).fields),
+        ["location"]
+      )
+    })
+
+    it("lifts the body status annotation onto the wrapper", () => {
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: HttpApiSchema.Created
+      })
+
+      assert.strictEqual(HttpApiSchema.getStatusSuccess(schema.ast), 201)
+    })
+
+    it("lifts the body encoding annotation onto the wrapper", () => {
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: Schema.String.pipe(HttpApiSchema.asText({ contentType: "text/custom" }))
+      })
+
+      assert.strictEqual(
+        HttpApiSchema.getResponseEncoding(schema.ast).contentType,
+        "text/custom"
+      )
+    })
+
+    it("lets an explicit status on the wrapper win", () => {
+      const schema = HttpApiSchema.status(202)(
+        HttpApiSchema.WithHeaders({
+          headers: { location: Schema.String },
+          body: HttpApiSchema.Created
+        })
+      )
+
+      assert.strictEqual(HttpApiSchema.getStatusSuccess(schema.ast), 202)
+      assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+      assert.strictEqual(schema.body, HttpApiSchema.Created)
+    })
+
+    it("defaults to 200 and json when the body carries no annotations", () => {
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: Schema.Struct({ id: Schema.String })
+      })
+
+      assert.strictEqual(HttpApiSchema.getStatusSuccess(schema.ast), 200)
+      assert.strictEqual(HttpApiSchema.getStatusError(schema.ast), 500)
+      assert.strictEqual(
+        HttpApiSchema.getResponseEncoding(schema.ast).contentType,
+        "application/json"
+      )
+    })
+
+    it("wraps a stream body", () => {
+      const stream = HttpApiSchema.StreamUint8Array({ contentType: "application/custom-bytes" })
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { "x-trace-id": Schema.String },
+        body: stream
+      })
+
+      assert.isTrue(HttpApiSchema.isWithHeaders(schema))
+      assert.isFalse(HttpApiSchema.isStreamSchema(schema))
+      assert.strictEqual(HttpApiSchema.unwrapResponseSchema(schema), stream)
+      assert.strictEqual(
+        HttpApiSchema.getResponseContentType(schema),
+        "application/custom-bytes"
+      )
+    })
+
+    it("rejects nested WithHeaders", () => {
+      assert.throws(
+        () =>
+          HttpApiSchema.WithHeaders({
+            headers: { a: Schema.String },
+            body: HttpApiSchema.WithHeaders({ headers: { b: Schema.String }, body: Schema.String })
+          }),
+        "WithHeaders cannot wrap another WithHeaders"
+      )
+    })
+
+    it("classifies a no-content body through the wrapper", () => {
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: HttpApiSchema.Created
+      })
+
+      assert.isFalse(HttpApiSchema.isNoContent(schema.ast))
+      assert.isTrue(HttpApiSchema.isNoContentSchema(schema))
+      assert.isTrue(HttpApiSchema.isNoContentSchema(HttpApiSchema.Created))
+      assert.isFalse(HttpApiSchema.isNoContentSchema(Schema.String))
+    })
+  })
 })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -332,4 +332,68 @@ describe("OpenApi", () => {
     })
     assert.deepStrictEqual(Object.keys(response.content!), ["application/octet-stream"])
   })
+
+  // OpenAPI models `Response.headers` as a fixed name -> schema map, so a headers
+  // schema with dynamic keys has no representation. It still encodes and decodes
+  // at runtime (see HttpApiClient.test.ts), it just contributes no entries here.
+  // This mirrors `processParameters`, which bails the same way for request
+  // `params` / `query` / `headers` that are not object-shaped.
+  it("omits response headers for a headers schema that is not object-shaped", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.post("create", "/create", {
+          success: HttpApiSchema.WithHeaders({
+            headers: Schema.Record(Schema.String, Schema.String),
+            body: HttpApiSchema.Created
+          })
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+    const response = spec.paths["/create"]!.post!.responses[201]!
+
+    assert.isUndefined(response.headers)
+  })
+
+  it("prefers a description on the wrapper over one on the body", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.post("create", "/create", {
+          success: HttpApiSchema.WithHeaders({
+            headers: { location: Schema.String },
+            body: HttpApiSchema.Created.annotate({ description: "body description" })
+          }).annotate({ description: "wrapper description" })
+        }),
+        HttpApiEndpoint.get("get", "/get", {
+          success: HttpApiSchema.WithHeaders({
+            headers: { "x-trace-id": Schema.String },
+            body: Schema.Struct({ name: Schema.String }).annotate({ description: "body description" })
+          }).annotate({ description: "wrapper description" })
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.strictEqual(spec.paths["/create"]!.post!.responses[201]!.description, "wrapper description")
+    assert.strictEqual(spec.paths["/get"]!.get!.responses[200]!.description, "wrapper description")
+  })
+
+  it("falls back to the body description when the wrapper has none", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.post("create", "/create", {
+          success: HttpApiSchema.WithHeaders({
+            headers: { location: Schema.String },
+            body: HttpApiSchema.Created.annotate({ description: "body description" })
+          })
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+
+    assert.strictEqual(spec.paths["/create"]!.post!.responses[201]!.description, "body description")
+  })
 })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -260,4 +260,51 @@ describe("OpenApi", () => {
 
     assert.throws(() => OpenApi.fromApi(Api), /Conflicting OpenAPI security scheme: __proto__/)
   })
+
+  it("emits response headers declared with WithHeaders", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.post("create", "/create", {
+          success: HttpApiSchema.WithHeaders({
+            headers: {
+              location: Schema.String,
+              "x-request-id": Schema.optional(Schema.String)
+            },
+            body: HttpApiSchema.Created
+          })
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+    const response = spec.paths["/create"]!.post!.responses[201]!
+
+    assert.deepStrictEqual(response.headers, {
+      location: { required: true, schema: { type: "string" } },
+      "x-request-id": { required: false, schema: { type: "string" } }
+    })
+  })
+
+  it("marks a response header optional when only some content-types declare it", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("get", "/get", {
+          success: [
+            Schema.String.pipe(HttpApiSchema.asText()),
+            HttpApiSchema.WithHeaders({
+              headers: { "x-trace-id": Schema.String },
+              body: Schema.Struct({ name: Schema.String })
+            })
+          ]
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+    const response = spec.paths["/get"]!.get!.responses[200]!
+
+    assert.deepStrictEqual(response.headers, {
+      "x-trace-id": { required: false, schema: { type: "string" } }
+    })
+  })
 })

--- a/packages/effect/test/unstable/httpapi/OpenApi.test.ts
+++ b/packages/effect/test/unstable/httpapi/OpenApi.test.ts
@@ -307,4 +307,29 @@ describe("OpenApi", () => {
       "x-trace-id": { required: false, schema: { type: "string" } }
     })
   })
+
+  it("uses the wrapper status for a status-annotated stream wrapper", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("test").add(
+        HttpApiEndpoint.get("download", "/download", {
+          success: HttpApiSchema.status(206)(
+            HttpApiSchema.WithHeaders({
+              headers: { "content-range": Schema.String },
+              body: HttpApiSchema.StreamUint8Array()
+            })
+          )
+        })
+      )
+    )
+
+    const spec = OpenApi.fromApi(Api)
+    const responses = spec.paths["/download"]!.get!.responses
+
+    assert.isUndefined(responses[200])
+    const response = responses[206]!
+    assert.deepStrictEqual(response.headers, {
+      "content-range": { required: true, schema: { type: "string" } }
+    })
+    assert.deepStrictEqual(Object.keys(response.content!), ["application/octet-stream"])
+  })
 })

--- a/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, hole, Layer, Schema } from "effect"
 import type { FileSystem } from "effect/FileSystem"
 import type { Path } from "effect/Path"
 import type { Generator } from "effect/unstable/http/Etag"
@@ -84,6 +84,25 @@ describe("HttpApiBuilder", () => {
         )
 
         expect(handlers).type.toBe<Layer.Layer<HttpApiGroup.Service<"api", "users">>>()
+      })
+
+      it("requires a headers/body handler result for WithHeaders successes", () => {
+        const Api = HttpApi.make("Api").add(
+          HttpApiGroup.make("group").add(
+            HttpApiEndpoint.post("create", "/create", {
+              success: HttpApiSchema.WithHeaders({
+                headers: { location: Schema.String },
+                body: HttpApiSchema.Created
+              })
+            })
+          )
+        )
+        HttpApiBuilder.group(Api, "group", (handlers) =>
+          handlers.handle("create", () =>
+            Effect.succeed(hole<{
+              readonly headers: { readonly location: string }
+              readonly body: void
+            }>())))
       })
 
       it("propagates handler service requirements", () => {

--- a/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiBuilder.tst.ts
@@ -103,6 +103,24 @@ describe("HttpApiBuilder", () => {
               readonly headers: { readonly location: string }
               readonly body: void
             }>())))
+
+        HttpApiBuilder.group(Api, "group", (handlers) => {
+          expect(handlers.handle).type.not.toBeCallableWith(
+            "create",
+            () => Effect.succeed(hole<{ readonly body: void }>())
+          )
+
+          expect(handlers.handle).type.not.toBeCallableWith(
+            "create",
+            () => Effect.succeed(hole<{ readonly headers: { readonly location: string } }>())
+          )
+
+          return handlers.handle("create", () =>
+            Effect.succeed(hole<{
+              readonly headers: { readonly location: string }
+              readonly body: void
+            }>()))
+        })
       })
 
       it("propagates handler service requirements", () => {

--- a/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiClient.tst.ts
@@ -780,6 +780,57 @@ describe("HttpApiClient", () => {
     })
   })
 
+  describe("WithHeaders", () => {
+    const Api = HttpApi.make("Api").add(
+      HttpApiGroup.make("group").add(
+        HttpApiEndpoint.post("create", "/create", {
+          success: HttpApiSchema.WithHeaders({
+            headers: { location: Schema.String },
+            body: HttpApiSchema.Created
+          }),
+          error: HttpApiSchema.WithHeaders({
+            headers: { "retry-after": Schema.String },
+            body: Schema.Struct({ reason: Schema.String })
+          })
+        })
+      )
+    )
+    const client = Effect.runSync(
+      HttpApiClient.make(Api).pipe(Effect.provide(FetchHttpClient.layer))
+    )
+
+    it("returns headers and body by default", () => {
+      expect(client.group.create({})).type.toBe<
+        Effect.Effect<
+          { readonly headers: { readonly location: string }; readonly body: void },
+          | { readonly headers: { readonly "retry-after": string }; readonly body: { readonly reason: string } }
+          | HttpClientError.HttpClientError
+          | Schema.SchemaError
+        >
+      >()
+    })
+
+    it("pairs the decoded value with the response", () => {
+      expect(client.group.create({ responseMode: "decoded-and-response" })).type.toBe<
+        Effect.Effect<
+          [
+            { readonly headers: { readonly location: string }; readonly body: void },
+            HttpClientResponse.HttpClientResponse
+          ],
+          | { readonly headers: { readonly "retry-after": string }; readonly body: { readonly reason: string } }
+          | HttpClientError.HttpClientError
+          | Schema.SchemaError
+        >
+      >()
+    })
+
+    it("returns only the response in response-only mode", () => {
+      expect(client.group.create({ responseMode: "response-only" })).type.toBe<
+        Effect.Effect<HttpClientResponse.HttpClientResponse, HttpClientError.HttpClientError>
+      >()
+    })
+  })
+
   describe("error", () => {
     it("defaults to client and schema errors", () => {
       const Api = HttpApi.make("Api")

--- a/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiSchema.tst.ts
@@ -117,6 +117,19 @@ describe("HttpApiSchema", () => {
     })
   })
 
+  describe("WithHeaders", () => {
+    it("exposes a headers/body type", () => {
+      const schema = HttpApiSchema.WithHeaders({
+        headers: { location: Schema.String },
+        body: Schema.Struct({ id: Schema.String })
+      })
+      expect<typeof schema["Type"]>().type.toBe<{
+        readonly headers: { readonly location: string }
+        readonly body: { readonly id: string }
+      }>()
+    })
+  })
+
   describe("StreamUint8Array", () => {
     it("constructs the stream schema", () => {
       const stream = HttpApiSchema.StreamUint8Array()

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -992,6 +992,80 @@ describe("HttpApi", () => {
     })
   })
 
+  // `HttpApiTest` runs in memory, so these cover the parts of `WithHeaders` that
+  // only a real server exercises: the empty-body path, where headers are the
+  // only thing written, and the streaming path, where they must be flushed
+  // before the first chunk.
+  describe("response headers", () => {
+    it.effect("empty body, json body, and stream", () => {
+      const Api = HttpApi.make("api").add(
+        HttpApiGroup.make("group").add(
+          HttpApiEndpoint.post("create", "/things", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { location: Schema.String },
+              body: HttpApiSchema.Created
+            })
+          }),
+          HttpApiEndpoint.get("json", "/json", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-total": Schema.String },
+              body: Schema.Struct({ a: Schema.String })
+            })
+          }),
+          HttpApiEndpoint.get("stream", "/stream", {
+            success: HttpApiSchema.WithHeaders({
+              headers: { "x-trace": Schema.String },
+              body: HttpApiSchema.StreamUint8Array()
+            })
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "group",
+        (handlers) =>
+          handlers
+            .handle("create", () =>
+              Effect.succeed({
+                headers: { location: "/things/1" },
+                body: HttpApiSchema.Created.make()
+              }))
+            .handle("json", () => Effect.succeed({ headers: { "x-total": "7" }, body: { a: "hi" } }))
+            .handle("stream", () =>
+              Effect.succeed({
+                headers: { "x-trace": "t1" },
+                body: Stream.make(new Uint8Array([1, 2, 3]))
+              }))
+      )
+
+      const ApiLive = HttpRouter.serve(
+        HttpApiBuilder.layer(Api).pipe(Layer.provide(GroupLive)),
+        { disableListenLog: true, disableLogger: true }
+      ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
+
+      return Effect.gen(function*() {
+        // server side
+        const created = yield* HttpClient.post("/things")
+        yield* assertServerText(created, 201, "")
+        assert.strictEqual(created.headers["location"], "/things/1")
+
+        const json = yield* HttpClient.get("/json")
+        yield* assertServerJson(json, 200, { a: "hi" })
+        assert.strictEqual(json.headers["x-total"], "7")
+
+        const stream = yield* HttpClient.get("/stream")
+        assert.strictEqual(stream.status, 200)
+        assert.strictEqual(stream.headers["x-trace"], "t1")
+
+        // client side
+        const client = yield* HttpApiClient.make(Api)
+        assert.strictEqual((yield* client.group.create()).headers.location, "/things/1")
+        yield* assertClientJson(client.group.json(), { headers: { "x-total": "7" }, body: { a: "hi" } })
+        assert.strictEqual((yield* client.group.stream()).headers["x-trace"], "t1")
+      }).pipe(Effect.provide(ApiLive))
+    })
+  })
+
   describe("error option", () => {
     it.effect("no content", () => {
       const Api = HttpApi.make("api")


### PR DESCRIPTION
## Type

- [x] Feature

## Description

- add `HttpApiSchema.WithHeaders`, a marker schema pairing a headers schema with a body schema, usable for successes and errors
- intercept it in `HttpApiEndpoint`, `HttpApiBuilder`, `HttpApiClient`, and `OpenApi`, the same way those modules already intercept the stream markers
- handlers return `{ headers, body }`, generated clients decode the same shape, and the OpenAPI document gains `responses[status].headers`
- reject a `WithHeaders` member that shares a `(status, content-type)` pair with another member of the same endpoint, since the client discriminates on exactly those two signals
- no platform package needed a source change, because `WithHeaders` resolves inside `unstable/httpapi` into an ordinary `HttpServerResponse`

## Motivation

`HttpApi` can declare a schema for _request_ headers, but the success and error sides can describe only a status code and a body. There is no typed way to declare, produce, or consume a _response_ header.

The motivating case is a `POST` that creates an entity and returns `201 Created` with an empty body and a `Location` header, a bog-standard REST pattern. Today `HttpApiClient` gives no typed access to that `Location`.

Existing escape hatches all work but are untyped: reading `HttpClientResponse` via `responseMode`, returning an `HttpServerResponse` from a handler (which requires a cast and teaches neither the client types nor the OpenAPI document anything), or setting blanket headers from `HttpApiMiddleware`.

This follows the API shape @tim-smart called for in [the Discord thread](https://discord.com/channels/795981131316985866/1348774989029183621) on 15 Oct 2025:

> I think a `WithHeaders` special schema in `HttpApiSchema`, that accepts schemas as options `{ headers, body }`. Then the other modules can intercept it.
>
> Then the return type for the handlers would be `{ headers, body }` and it would somehow get mapped to a `HttpServerResponse` correctly.
>
> And the reverse on the client etc.

#5633 was closed as stale in Jul 2026 asking for a fresh proposal against the current API shape. The API has moved since that thread: `effect-smol` merged, HttpApi lives in `packages/effect/src/unstable/httpapi/`, the builder-style `addSuccess`/`addError` are gone, and the client's `withResponse: true` is now `responseMode`. This is written against the current shape.

## API

```ts
const create = HttpApiEndpoint.post("create", "/things", {
  success: HttpApiSchema.WithHeaders({
    headers: { location: Schema.String },
    body: HttpApiSchema.Created
  })
})
```

Handlers return `{ headers, body }`; generated clients decode the same shape.

**Strictness follows the schema**, matching request headers: `Schema.String` is required and a missing header is a decode failure surfaced as `Schema.SchemaError`, the same failure type the client already produces for response _body_ decode failures. `Schema.optional(...)` yields `undefined`. No implicit leniency, so the declared type never lies.

**Status and content-type are not re-derived.** The constructor lifts `httpApiStatus` and `~httpApiEncoding` off `body.ast` onto the wrapper's AST, so `HttpApiSchema.Created`, `asText()`, and `HttpApiSchema.status(...)` compose unchanged. The wrapper's AST is authoritative everywhere; an annotation applied to the wrapper itself wins over the body's.

`responseMode` interaction:

| mode                     | returns                                           |
| ------------------------ | ------------------------------------------------- |
| `decoded-only` (default) | `{ headers, body }`                               |
| `decoded-and-response`   | `[{ headers, body }, HttpClientResponse]`         |
| `response-only`          | `HttpClientResponse`, with **no** header decoding |

`response-only` short-circuits before any schema work, as it does today, so a declared-but-missing header cannot fail a `response-only` call.

## Implementation

`WithHeaders` is a **marker schema** carrying `.headers` and `.body` sub-schemas, which the other httpapi modules intercept. That is structurally identical to how `HttpApiSchema.StreamSse` / `StreamUint8Array` are built and detected today via `isStreamSchema`. The interception mechanism already exists, is already threaded through all five modules, and is already tested.

- **`HttpApiSchema.ts`**: the schema, `isWithHeaders`, and internal unwrap helpers.
- **`HttpApiEndpoint.ts`**: `transformResponse` applies codecs (headers via `Schema.toCodecStringTree`, matching how request headers are built), so `disableCodecs: true` stays honest. `validateSuccessResponse` and `getErrorResponse` unwrap before classifying.
- **`HttpApiBuilder.ts`**: the buffered path encodes the body through the untouched `getResponseEncode`, then applies a single trailing `Response.setHeaders`, so all four encodings gain headers uniformly including the empty-body path. The streaming path passes encoded headers to `Response.stream`.
- **`HttpApiClient.ts`**: decodes `response.headers` through the headers codec alongside the body.
- **`OpenApi.ts`**: emits `responses[status].headers`. The OpenAPI `Response.headers` object was previously never emitted, so this is purely additive.

Errors use the same wrapper and the same machinery: `makeErrorSchema` already routes through `toResponseSchema`. The accepted consequence is that the value a handler fails with becomes `{ headers, body: MyError }`, and the client's error channel matches. That is noisier at the `fail`/`catch` site than for successes, but a second, divergent mechanism for errors would be worse and would not handle empty-body error responses cleanly.

## Deliberate decisions worth a reviewer's attention

**Exclusivity rule.** A `WithHeaders` member may not share a `(status, content-type)` pair with any other member of the same endpoint; violations throw at endpoint construction. The client's decode map is keyed by status, and within a status `groupSchemasByContentType` unions each content-type bucket into one codec over the response bytes, so status and content-type are the only runtime signals. If a plain schema and a `WithHeaders` schema shared a bucket, the caller's return shape would vary at runtime depending on which headers the server happened to send. This is a client-side ambiguity only; the server discriminates on the input value's shape.

Its main cost falls on errors, which share a status more often: two `500` JSON errors where only one carries `Retry-After` are rejected and need distinct statuses. A looser rule, permitting a shared bucket when every member is `WithHeaders` with a structurally equal headers schema, was considered and deferred, since loosening later is backwards-compatible while tightening is not.

**Nesting throws in the schema constructor**, not at endpoint construction. That is stricter and earlier than strictly necessary, and it gives a better error site.

**The declaration predicate is shape-based**, matching any `{ headers, body }` value. A plain `Schema.Struct({ headers, body })` declared alongside a `WithHeaders` member at a different status is therefore indistinguishable in the server's encode union, and the first declared member wins. This is pinned by a test (`HttpApiBuilder.test.ts`, "dispatches an ambiguous `{ headers, body }` value to the first declared member") rather than prevented, and it is not new in kind: `streamSchema = Schema.declare(Stream.isStream)` is looser still and backs both stream markers. The difference is that endpoint validation already guarantees at most one stream candidate per status, whereas these two members coexist legally. Happy to close it with an extra construction-time check if you would prefer that.

**Only object-shaped headers schemas reach the OpenAPI document.** OpenAPI models `Response.headers` as a fixed name to schema map, so a schema with dynamic keys (`Schema.Record`) has no representation there. It still encodes and decodes normally; it simply contributes no entries. This mirrors `processParameters`, which bails identically for non-object-shaped request `params`/`query`/`headers` on `main`. Documented in the `WithHeaders` JSDoc and pinned on both sides.

**Two bits of machinery that are not obvious from the diff:**

- `dropUndefinedMember` (`OpenApi.ts`) strips the `undefined` union member that `Schema.optional` injects, so an optional header renders as `{ type: "string" }` rather than an `anyOf`. The same defect is latent in `processParameters` for request parameters; that is pre-existing and left for a follow-up rather than mixed into this changeset.
- The encoding-override overloads on `schemasToResponse` / `toCodecArrayBuffer` (`HttpApiClient.ts`) exist so the wrapper's AST stays authoritative for content-type. The overload is type-level, so a multi-member array cannot be passed together with an override.

## Testing

Runtime (`packages/effect/test/unstable/httpapi/`): the motivating `Location`-on-`201`-with-empty-body round trip, headers on a JSON body, a missing required header failing as `Schema.SchemaError`, an absent optional header yielding `undefined`, error responses with headers, SSE and `Uint8Array` streams with headers, `response-only` not decoding headers, both construction-time validation errors, wrapper-annotation precedence for status/encoding/description, two `WithHeaders` endpoints staying independent, and the OpenAPI `responses[status].headers` output.

Integration (`packages/platform-node/test/HttpApi.test.ts`): `HttpApiTest` runs in memory, so one case was added to the platform-node suite, which serves over a real socket via `NodeHttpServer.layerTest`. It covers the empty-body path, where the headers are the only thing written, and the streaming path, where they must be flushed before the first chunk. It asserts both the raw wire headers and the generated client's decoded shape.

No platform package needed a source change: `WithHeaders` resolves entirely inside `unstable/httpapi` into an ordinary `HttpServerResponse`, and both `NodeHttpServer` and `BunHttpServer` already apply `response.headers` uniformly across every body variant.

Type-level (`packages/effect/typetest/unstable/httpapi/`): handler return type, client return type across all three `responseMode` values, and the error channel for a `WithHeaders` error. The handler-return test carries negative `.not.toBeCallableWith` assertions so it cannot pass vacuously.

## Validation

Every job in `.github/workflows/check.yml` was run locally:

- `pnpm lint`: pass
- `pnpm check` and `pnpm test-types`: pass, 1992 tests and 4986 assertions
- `pnpm build`: pass, with `stripInternal: true` as CI sets it
- `deno check .`: pass, same `stripInternal` patch
- `pnpm test`: 8717 passed across 340 files. Two unrelated flakes, both passing on their own and neither touching httpapi: `@effect/platform-browser` `RpcWorker.test.ts > Stream` asserts on a 2-second sleep, and `@effect/platform-node` `NodeHttpClient.test.ts > jsonplaceholder schemaBodyJson` makes a live network request.
- `pnpm doctest`: pass, 3376 tests
- `pnpm docgen`: pass, 3319 examples typechecked
- `pnpm ai-docgen`: pass, `LLMS.md` unchanged
- `pnpm circular`: pass
- `pnpm bundle-compare 0a0f2f0fb`: 0.00 KB / 0.00% on every fixture. Note there is no httpapi bundle fixture, so this confirms no regression elsewhere rather than measuring this feature's own cost.

Narrower runs worth naming: the httpapi suite is 139/139, and `@effect/platform-node` `HttpApi.test.ts` is 45/45.

A changeset is included (`patch`, matching the repo's pre-release convention).

## Related

- Closes #5633