### PR TITLE
Decode OpenAI-compatible tool parameters

### DIFF
--- a/.changeset/openai-compat-decode-tool-params.md
+++ b/.changeset/openai-compat-decode-tool-params.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Decode streaming and non-streaming tool call parameters with the provider-facing OpenAI schema codec.

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -18,7 +18,7 @@ import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import * as Rec from "effect/Record"
 import * as Redactable from "effect/Redactable"
-import type * as Schema from "effect/Schema"
+import * as Schema from "effect/Schema"
 import * as AST from "effect/SchemaAST"
 import * as Stream from "effect/Stream"
 import type { Span } from "effect/Tracer"
@@ -631,6 +631,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
         const [rawResponse, response] = yield* client.createResponse(request)
         annotateResponse(options.span, rawResponse)
         return yield* makeResponse({
+          options,
           rawResponse,
           response,
           toolNameMapper
@@ -645,6 +646,7 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
         annotateRequest(options.span, request)
         const [response, stream] = yield* client.createResponseStream(request)
         return yield* makeStreamResponse({
+          options,
           stream,
           response,
           toolNameMapper
@@ -1042,10 +1044,12 @@ type ActiveToolCall = {
 
 const makeResponse = Effect.fnUntraced(
   function*<Tools extends ReadonlyArray<Tool.Any>>({
+    options,
     rawResponse,
     response,
     toolNameMapper
   }: {
+    readonly options: LanguageModel.ProviderOptions
     readonly rawResponse: CreateResponse200
     readonly response: HttpClientResponse.HttpClientResponse
     readonly toolNameMapper: Tool.NameMapper<Tools>
@@ -1084,9 +1088,9 @@ const makeResponse = Effect.fnUntraced(
         for (const [index, toolCall] of message.tool_calls.entries()) {
           const toolId = toolCall.id ?? `${rawResponse.id}_tool_${index}`
           const toolName = toolNameMapper.getCustomName(toolCall.function?.name ?? "unknown_tool")
-          const toolParams = toolCall.function?.arguments ?? "{}"
-          const params = yield* Effect.try({
-            try: () => Tool.unsafeSecureJsonParse(toolParams),
+          const toolParamsJson = toolCall.function?.arguments ?? "{}"
+          const toolParams = yield* Effect.try({
+            try: () => Tool.unsafeSecureJsonParse(toolParamsJson),
             catch: (cause) =>
               AiError.make({
                 module: "OpenAiLanguageModel",
@@ -1098,6 +1102,7 @@ const makeResponse = Effect.fnUntraced(
                 })
               })
           })
+          const params = yield* transformToolCallParams(options.tools, toolName, toolParams)
           hasToolCalls = true
           parts.push({
             type: "tool-call",
@@ -1130,10 +1135,12 @@ const makeResponse = Effect.fnUntraced(
 
 const makeStreamResponse = Effect.fnUntraced(
   function*<Tools extends ReadonlyArray<Tool.Any>>({
+    options,
     stream,
     response,
     toolNameMapper
   }: {
+    readonly options: LanguageModel.ProviderOptions
     readonly stream: Stream.Stream<ResponseStreamEvent, AiError.AiError>
     readonly response: HttpClientResponse.HttpClientResponse
     readonly toolNameMapper: Tool.NameMapper<Tools>
@@ -1175,7 +1182,7 @@ const makeStreamResponse = Effect.fnUntraced(
 
           for (const toolCall of Object.values(activeToolCalls)) {
             const toolParams = toolCall.arguments.length > 0 ? toolCall.arguments : "{}"
-            const params = yield* Effect.try({
+            const parsedParams = yield* Effect.try({
               try: () => Tool.unsafeSecureJsonParse(toolParams),
               catch: (cause) =>
                 AiError.make({
@@ -1188,6 +1195,7 @@ const makeStreamResponse = Effect.fnUntraced(
                   })
                 })
             })
+            const params = yield* transformToolCallParams(options.tools, toolCall.name, parsedParams)
             parts.push({ type: "tool-params-end", id: toolCall.id })
             parts.push({
               type: "tool-call",
@@ -1405,6 +1413,12 @@ const unsupportedSchemaError = (error: unknown, method: string): AiError.AiError
     })
   })
 
+const tryCodecTransform = <S extends Schema.Constraint>(schema: S, method: string) =>
+  Effect.try({
+    try: () => toCodecOpenAI(schema),
+    catch: (error) => unsupportedSchemaError(error, method)
+  })
+
 const tryJsonSchema = <S extends Schema.Constraint>(schema: S, method: string) =>
   Effect.try({
     try: () => Tool.getJsonSchemaFromSchema(schema, { transformer: toCodecOpenAI }),
@@ -1416,6 +1430,42 @@ const tryToolJsonSchema = <T extends Tool.Any>(tool: T, method: string) =>
     try: () => Tool.getJsonSchema(tool, { transformer: toCodecOpenAI }),
     catch: (error) => unsupportedSchemaError(error, method)
   })
+
+const transformToolCallParams = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Tool.Any>>(
+  tools: Tools,
+  toolName: string,
+  toolParams: unknown
+): Effect.fn.Return<unknown, AiError.AiError> {
+  const tool = tools.find((tool) => tool.name === toolName)
+
+  if (Predicate.isUndefined(tool)) {
+    return yield* AiError.make({
+      module: "OpenAiLanguageModel",
+      method: "makeResponse",
+      reason: new AiError.ToolNotFoundError({
+        toolName,
+        availableTools: tools.map((tool) => tool.name)
+      })
+    })
+  }
+
+  const { codec } = yield* tryCodecTransform(tool.parametersSchema, "makeResponse")
+  const transform = Schema.decodeEffect(codec)
+
+  return yield* (
+    transform(toolParams) as Effect.Effect<unknown, Schema.SchemaError>
+  ).pipe(Effect.mapError((error) =>
+    AiError.make({
+      module: "OpenAiLanguageModel",
+      method: "makeResponse",
+      reason: new AiError.ToolParameterValidationError({
+        toolName,
+        toolParams,
+        description: error.issue.toString()
+      })
+    })
+  ))
+})
 
 const prepareTools = Effect.fnUntraced(function*<Tools extends ReadonlyArray<Tool.Any>>({
   config,

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -329,6 +329,55 @@ describe("OpenAiLanguageModel", () => {
         assert.strictEqual(functionTool.function.strict, true)
       }))
 
+    it.effect("decodes tool call params with the OpenAI codec", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "tool_calls",
+                    message: {
+                      role: "assistant",
+                      content: null,
+                      tool_calls: [{
+                        id: "call_record_1",
+                        type: "function",
+                        function: {
+                          name: "RecordTool",
+                          arguments: JSON.stringify({ env: [{ 0: "PATH", 1: "/usr/bin" }] })
+                        }
+                      }]
+                    }
+                  }]
+                })
+              ))
+            )
+          ))
+        )
+
+        const result = yield* LanguageModel.generateText({
+          prompt: "read the environment",
+          toolkit: RecordToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(RecordToolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const toolCall = result.content.find((part) => part.type === "tool-call")
+        assert.isDefined(toolCall)
+        if (toolCall?.type !== "tool-call") {
+          return
+        }
+        assert.deepStrictEqual(toolCall.params, { env: { PATH: "/usr/bin" } })
+      }))
+
     it.effect("groups parallel tool calls into one assistant message", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
@@ -848,6 +897,59 @@ describe("OpenAiLanguageModel", () => {
         if (finish?.type === "finish") {
           assert.strictEqual(finish.reason, "stop")
         }
+      }))
+
+    it.effect("decodes streamed tool call params with the OpenAI codec", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                {
+                  id: "chatcmpl_record_1",
+                  object: "chat.completion.chunk",
+                  model: "gpt-4o-mini",
+                  created: 1,
+                  choices: [{
+                    index: 0,
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        id: "call_record_1",
+                        type: "function",
+                        function: {
+                          name: "RecordTool",
+                          arguments: JSON.stringify({ env: [{ 0: "PATH", 1: "/usr/bin" }] })
+                        }
+                      }]
+                    },
+                    finish_reason: "tool_calls"
+                  }]
+                },
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "read the environment",
+          toolkit: RecordToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(RecordToolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const toolCall = globalThis.Array.from(partsChunk).find((part) => part.type === "tool-call")
+        assert.isDefined(toolCall)
+        if (toolCall?.type !== "tool-call") {
+          return
+        }
+        assert.deepStrictEqual(toolCall.params, { env: { PATH: "/usr/bin" } })
       }))
 
     it.effect("maps local shell stream tool calls to local_shell call outputs", () =>
@@ -1502,6 +1604,19 @@ const TestToolkit = Toolkit.make(TestTool)
 
 const TestToolkitLayer = TestToolkit.toLayer({
   TestTool: ({ input }) => Effect.succeed({ output: input })
+})
+
+const RecordTool = Tool.make("RecordTool", {
+  parameters: Schema.Struct({
+    env: Schema.Record(Schema.String, Schema.String)
+  }),
+  success: Schema.String
+})
+
+const RecordToolkit = Toolkit.make(RecordTool)
+
+const RecordToolkitLayer = RecordToolkit.toLayer({
+  RecordTool: () => Effect.succeed("done")
 })
 
 const CompatApplyPatchTool = Tool.providerDefined({


### PR DESCRIPTION
## Summary

- decode non-streaming tool call parameters with the same `toCodecOpenAI` codec used to generate provider-facing schemas
- apply the same decoding to streamed tool calls after their argument fragments are assembled
- cover both paths with record-schema regressions

## Why

OpenAI-compatible providers return tool arguments in the representation described by the transformed JSON Schema. The adapter previously stopped after JSON parsing, so transformed values such as records remained arrays of key/value pairs and failed downstream tool validation. Tool handlers now receive values in their original Effect Schema representation.

## Validation

- `nix develop -c pnpm test packages/ai/openai-compat/test --run` (42 tests)
- `nix develop -c pnpm --filter @effect/ai-openai-compat check`
- `nix develop -c pnpm exec oxlint -f unix packages/ai/openai-compat/src/OpenAiLanguageModel.ts packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts`
- `nix develop -c pnpm exec dprint check packages/ai/openai-compat/src/OpenAiLanguageModel.ts packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts`

Closes EFF-286
Closes #6818