### PR TITLE
Stabilize SQL runner connection recovery test

### DIFF
--- a/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.integration.test.ts
@@ -60,17 +60,25 @@ describe("SqlRunnerStorage", () => {
       assert.isAtLeast(partitioned.interruptedQueries, 1)
       assert.isAtMost(partitioned.maxActiveQueries, 1)
 
+      // Rebuilding is asynchronous, so wait until the replacement connection
+      // is ready before checking that lock operations recover.
+      const usableConnections = partitioned.usableConnections
       partitioned.current = false
+      yield* waitUntil(() => partitioned.usableConnections > usableConnections)
       expect(yield* storage.refresh(runnerAddress1, shards).pipe(TestClock.withLive)).toEqual(shards)
 
       partitioned.current = true
       yield* expectDeadline(storage.acquire(runnerAddress1, [ShardId.make("default", 2)]))
+      const usableConnectionsAfterAcquire = partitioned.usableConnections
       partitioned.current = false
+      yield* waitUntil(() => partitioned.usableConnections > usableConnectionsAfterAcquire)
       yield* storage.refresh(runnerAddress1, shards).pipe(TestClock.withLive)
 
       partitioned.current = true
       yield* expectDeadline(storage.release(runnerAddress1, shards[0]))
+      const usableConnectionsAfterRelease = partitioned.usableConnections
       partitioned.current = false
+      yield* waitUntil(() => partitioned.usableConnections > usableConnectionsAfterRelease)
       yield* storage.refresh(runnerAddress1, shards).pipe(TestClock.withLive)
       yield* storage.release(runnerAddress1, shards[0]).pipe(TestClock.withLive)
 


### PR DESCRIPTION
## Summary

- wait for the simulated replacement SQL connection to become usable before asserting recovery
- retain one-shot recovery assertions after the asynchronous rebuild has completed
- avoid racing the intentionally detached connection rebuild on loaded CI runners

## Root cause

`SqlRunnerStorage` starts rebuilding a failed reserved connection asynchronously so the failing lock operation can return within its configured deadline. The test cleared its simulated network partition and immediately issued an unretried refresh, which could race that rebuild and receive another expected bounded `PersistenceError`.

## Validation

- `pnpm lint`
- `git diff --check`
- focused integration test attempted, but this host has no compatible container runtime for the PostgreSQL testcontainer

Closes EFF-289
