### PR TITLE
Allow registry-scoped Atom memo maps

### DIFF
--- a/.changeset/quiet-maps-share.md
+++ b/.changeset/quiet-maps-share.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow Atom runtime memo maps to be resolved from the active `AtomRegistry`.

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -694,7 +694,7 @@ export interface AtomRuntime<R, ER = never> extends Atom<AsyncResult.AsyncResult
 }
 
 /**
- * Factory for `AtomRuntime` values that share a `Layer.MemoMap` and a set of global layers.
+ * Factory for `AtomRuntime` values that share a `Layer.MemoMap` or resolve one from the active registry.
  *
  * @category models
  * @since 4.0.0
@@ -705,7 +705,7 @@ export interface RuntimeFactory {
       | Layer.Layer<R, E, AtomRegistry | Reactivity.Reactivity>
       | ((get: AtomContext) => Layer.Layer<R, E, AtomRegistry | Reactivity.Reactivity>)
   ): AtomRuntime<R, E>
-  readonly memoMap: Layer.MemoMap
+  readonly memoMap: Layer.MemoMap | Atom<Layer.MemoMap>
   readonly addGlobalLayer: <A, E>(layer: Layer.Layer<A, E, AtomRegistry | Reactivity.Reactivity>) => void
 
   /**
@@ -718,15 +718,17 @@ export interface RuntimeFactory {
 }
 
 /**
- * Creates a `RuntimeFactory` backed by the supplied `Layer.MemoMap`.
+ * Creates a `RuntimeFactory` backed by a `Layer.MemoMap` or an atom that resolves one from the active registry.
  *
  * @category constructors
  * @since 4.0.0
  */
 export const context: (options: {
-  readonly memoMap: Layer.MemoMap
+  readonly memoMap: Layer.MemoMap | Atom<Layer.MemoMap>
 }) => RuntimeFactory = (options) => {
   let globalLayer: Layer.Layer<any, any, AtomRegistry> = Reactivity.layer
+  const resolveMemoMap = (get: AtomContext): Layer.MemoMap =>
+    isAtom(options.memoMap) ? get(options.memoMap) : options.memoMap
   function factory<E, R>(
     create:
       | Layer.Layer<R, E, AtomRegistry | Reactivity.Reactivity>
@@ -747,7 +749,7 @@ export const context: (options: {
 
     self.read = function read(get: AtomContext) {
       const layer = get(layerAtom)
-      const build = Effect.flatMap(Effect.scope, (scope) => Layer.buildWithMemoMap(layer, options.memoMap, scope))
+      const build = Effect.flatMap(Effect.scope, (scope) => Layer.buildWithMemoMap(layer, resolveMemoMap(get), scope))
       return effect(get, build, { uninterruptible: true })
     }
 
@@ -757,13 +759,15 @@ export const context: (options: {
   factory.addGlobalLayer = (layer: Layer.Layer<any, any, AtomRegistry | Reactivity.Reactivity>) => {
     globalLayer = Layer.provideMerge(globalLayer, Layer.provide(layer, Reactivity.layer))
   }
-  const reactivityAtom = removeTtl(make(
-    Effect.contextWith((services: Context.Context<Scope.Scope>) =>
-      Layer.buildWithMemoMap(Reactivity.layer, options.memoMap, Context.get(services, Scope.Scope))
-    ).pipe(
-      Effect.map(Context.get(Reactivity.Reactivity))
+  const reactivityAtom = removeTtl(
+    make((get) =>
+      Effect.contextWith((services: Context.Context<Scope.Scope>) =>
+        Layer.buildWithMemoMap(Reactivity.layer, resolveMemoMap(get), Context.get(services, Scope.Scope))
+      ).pipe(
+        Effect.map(Context.get(Reactivity.Reactivity))
+      )
     )
-  ))
+  )
   factory.withReactivity =
     (keys: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>>) =>
     <A extends Atom<any>>(atom: A): A =>

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -259,6 +259,111 @@ describe.sequential("Atom", () => {
     cancel()
   })
 
+  describe("runtime memo maps", () => {
+    it.effect("keeps concrete memo maps shared across registries", () => {
+      let builds = 0
+
+      class RuntimeIdentity extends Context.Service<RuntimeIdentity, number>()("test/RuntimeIdentity/concrete") {}
+
+      const runtime = Atom.context({ memoMap: Layer.makeMemoMapUnsafe() })(
+        Layer.sync(RuntimeIdentity, () => ++builds)
+      )
+      const value = runtime.atom(RuntimeIdentity)
+      const firstRegistry = AtomRegistry.make()
+      const secondRegistry = AtomRegistry.make()
+
+      return Effect.gen(function*() {
+        assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, value), 1)
+        assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, value), 1)
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            firstRegistry.dispose()
+            secondRegistry.dispose()
+          })
+        )
+      )
+    })
+
+    it.effect("isolates memo map atoms and finalizes each registry independently", () => {
+      let builds = 0
+      const finalized: Array<number> = []
+
+      class RuntimeIdentity extends Context.Service<RuntimeIdentity, number>()("test/RuntimeIdentity/registry") {}
+
+      const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+      const runtime = Atom.context({ memoMap })(
+        Layer.effect(
+          RuntimeIdentity,
+          Effect.acquireRelease(
+            Effect.sync(() => ++builds),
+            (identity) => Effect.sync(() => finalized.push(identity))
+          )
+        )
+      )
+      const firstValue = runtime.atom(RuntimeIdentity)
+      const secondValue = runtime.atom(RuntimeIdentity)
+      const firstRegistry = AtomRegistry.make()
+      const secondRegistry = AtomRegistry.make()
+      firstRegistry.mount(firstValue)
+      firstRegistry.mount(secondValue)
+      secondRegistry.mount(firstValue)
+      secondRegistry.mount(secondValue)
+
+      return Effect.gen(function*() {
+        assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, firstValue), 1)
+        assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, secondValue), 1)
+        assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, firstValue), 2)
+
+        firstRegistry.dispose()
+        yield* Effect.yieldNow
+        assert.deepStrictEqual(finalized, [1])
+        assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, secondValue), 2)
+
+        secondRegistry.dispose()
+        yield* Effect.yieldNow
+        assert.deepStrictEqual(finalized, [1, 2])
+      }).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            firstRegistry.dispose()
+            secondRegistry.dispose()
+          })
+        )
+      )
+    })
+
+    it("keeps reactive invalidation inside the active registry", async () => {
+      let reads = 0
+      const reactivityKeys = ["todos"]
+      const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+      const factory = Atom.context({ memoMap })
+      const runtime = factory(Layer.empty)
+      const query = Atom.make(() => ++reads).pipe(
+        factory.withReactivity(reactivityKeys),
+        Atom.keepAlive
+      )
+      const mutation = runtime.fn(Effect.fnUntraced(function*() {}), { reactivityKeys })
+      const firstRegistry = AtomRegistry.make()
+      const secondRegistry = AtomRegistry.make()
+
+      try {
+        assert.strictEqual(firstRegistry.get(query), 1)
+        assert.strictEqual(secondRegistry.get(query), 2)
+
+        firstRegistry.set(mutation, void 0)
+        await Effect.runPromise(Effect.yieldNow)
+
+        assert.strictEqual(firstRegistry.get(query), 3)
+        assert.strictEqual(secondRegistry.get(query), 2)
+        assert.strictEqual(reads, 3)
+      } finally {
+        firstRegistry.dispose()
+        secondRegistry.dispose()
+      }
+    })
+  })
+
   it("runtime direct tag", async () => {
     const counter = counterRuntime.atom(Counter)
     const r = AtomRegistry.make()

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -260,108 +260,118 @@ describe.sequential("Atom", () => {
   })
 
   describe("runtime memo maps", () => {
-    it.effect("keeps concrete memo maps shared across registries", () => {
-      let builds = 0
+    class RuntimeIdentity extends Context.Service<RuntimeIdentity, number>()("test/RuntimeIdentity") {}
 
-      class RuntimeIdentity extends Context.Service<RuntimeIdentity, number>()("test/RuntimeIdentity/concrete") {}
+    const acquireRegistry = Effect.acquireRelease(
+      Effect.sync(() => AtomRegistry.make()),
+      (registry) => Effect.sync(() => registry.dispose())
+    )
 
-      const runtime = Atom.context({ memoMap: Layer.makeMemoMapUnsafe() })(
-        Layer.sync(RuntimeIdentity, () => ++builds)
-      )
-      const value = runtime.atom(RuntimeIdentity)
-      const firstRegistry = AtomRegistry.make()
-      const secondRegistry = AtomRegistry.make()
+    it.effect("keeps concrete memo maps shared across registries", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          let builds = 0
+          const runtime = Atom.context({ memoMap: Layer.makeMemoMapUnsafe() })(
+            Layer.sync(RuntimeIdentity, () => ++builds)
+          )
+          const value = runtime.atom(RuntimeIdentity)
+          const firstRegistry = yield* acquireRegistry
+          const secondRegistry = yield* acquireRegistry
 
-      return Effect.gen(function*() {
-        assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, value), 1)
-        assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, value), 1)
-      }).pipe(
-        Effect.ensuring(
-          Effect.sync(() => {
-            firstRegistry.dispose()
-            secondRegistry.dispose()
-          })
-        )
-      )
-    })
+          assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, value), 1)
+          assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, value), 1)
+        })
+      ))
 
-    it.effect("isolates memo map atoms and finalizes each registry independently", () => {
-      let builds = 0
-      const finalized: Array<number> = []
+    it.effect("shares memo map atoms within a registry and isolates registries", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          let builds = 0
+          const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+          const runtime = Atom.context({ memoMap })(
+            Layer.sync(RuntimeIdentity, () => ++builds)
+          )
+          const firstValue = runtime.atom(RuntimeIdentity)
+          const secondValue = runtime.atom(RuntimeIdentity)
+          const firstRegistry = yield* acquireRegistry
+          const secondRegistry = yield* acquireRegistry
 
-      class RuntimeIdentity extends Context.Service<RuntimeIdentity, number>()("test/RuntimeIdentity/registry") {}
+          assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, firstValue), 1)
+          assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, secondValue), 1)
+          assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, firstValue), 2)
+          assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, secondValue), 2)
+        })
+      ))
 
-      const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
-      const runtime = Atom.context({ memoMap })(
-        Layer.effect(
-          RuntimeIdentity,
-          Effect.acquireRelease(
-            Effect.sync(() => ++builds),
-            (identity) => Effect.sync(() => finalized.push(identity))
+    it.effect("finalizes memo map atoms with their registry", () =>
+      Effect.gen(function*() {
+        let builds = 0
+        const finalized: Array<number> = []
+        const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+        const runtime = Atom.context({ memoMap })(
+          Layer.effect(
+            RuntimeIdentity,
+            Effect.acquireRelease(
+              Effect.sync(() => ++builds),
+              (identity) => Effect.sync(() => finalized.push(identity))
+            )
           )
         )
-      )
-      const firstValue = runtime.atom(RuntimeIdentity)
-      const secondValue = runtime.atom(RuntimeIdentity)
-      const firstRegistry = AtomRegistry.make()
-      const secondRegistry = AtomRegistry.make()
-      firstRegistry.mount(firstValue)
-      firstRegistry.mount(secondValue)
-      secondRegistry.mount(firstValue)
-      secondRegistry.mount(secondValue)
+        const value = runtime.atom(RuntimeIdentity)
 
-      return Effect.gen(function*() {
-        assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, firstValue), 1)
-        assert.strictEqual(yield* AtomRegistry.getResult(firstRegistry, secondValue), 1)
-        assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, firstValue), 2)
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            const survivingRegistry = yield* acquireRegistry
+            yield* AtomRegistry.mount(survivingRegistry, value)
+            assert.strictEqual(yield* AtomRegistry.getResult(survivingRegistry, value), 1)
 
-        firstRegistry.dispose()
-        yield* Effect.yieldNow
-        assert.deepStrictEqual(finalized, [1])
-        assert.strictEqual(yield* AtomRegistry.getResult(secondRegistry, secondValue), 2)
+            yield* Effect.scoped(
+              Effect.gen(function*() {
+                const shortLivedRegistry = yield* acquireRegistry
+                yield* AtomRegistry.mount(shortLivedRegistry, value)
+                assert.strictEqual(yield* AtomRegistry.getResult(shortLivedRegistry, value), 2)
+              })
+            )
 
-        secondRegistry.dispose()
-        yield* Effect.yieldNow
-        assert.deepStrictEqual(finalized, [1, 2])
-      }).pipe(
-        Effect.ensuring(
-          Effect.sync(() => {
-            firstRegistry.dispose()
-            secondRegistry.dispose()
+            yield* Effect.yieldNow
+            assert.deepStrictEqual(finalized, [2])
+            assert.strictEqual(yield* AtomRegistry.getResult(survivingRegistry, value), 1)
           })
         )
-      )
-    })
 
-    it("keeps reactive invalidation inside the active registry", async () => {
-      let reads = 0
-      const reactivityKeys = ["todos"]
-      const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
-      const factory = Atom.context({ memoMap })
-      const runtime = factory(Layer.empty)
-      const query = Atom.make(() => ++reads).pipe(
-        factory.withReactivity(reactivityKeys),
-        Atom.keepAlive
-      )
-      const mutation = runtime.fn(Effect.fnUntraced(function*() {}), { reactivityKeys })
-      const firstRegistry = AtomRegistry.make()
-      const secondRegistry = AtomRegistry.make()
+        yield* Effect.yieldNow
+        assert.deepStrictEqual(finalized, [2, 1])
+      }))
 
-      try {
-        assert.strictEqual(firstRegistry.get(query), 1)
-        assert.strictEqual(secondRegistry.get(query), 2)
+    it.effect("keeps reactive invalidation inside the active registry", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          let reads = 0
+          const reactivityKeys = ["todos"]
+          const memoMap = Atom.make(() => Layer.makeMemoMapUnsafe())
+          const factory = Atom.context({ memoMap })
+          const runtime = factory(Layer.empty)
+          const query = Atom.make(() => ++reads).pipe(
+            factory.withReactivity(reactivityKeys),
+            Atom.keepAlive
+          )
+          const mutation = runtime.fn(() => Effect.void, { reactivityKeys })
+          const firstRegistry = yield* acquireRegistry
+          const secondRegistry = yield* acquireRegistry
+          yield* AtomRegistry.mount(firstRegistry, query)
+          yield* AtomRegistry.mount(secondRegistry, query)
 
-        firstRegistry.set(mutation, void 0)
-        await Effect.runPromise(Effect.yieldNow)
+          assert.strictEqual(firstRegistry.get(query), 1)
+          assert.strictEqual(secondRegistry.get(query), 2)
 
-        assert.strictEqual(firstRegistry.get(query), 3)
-        assert.strictEqual(secondRegistry.get(query), 2)
-        assert.strictEqual(reads, 3)
-      } finally {
-        firstRegistry.dispose()
-        secondRegistry.dispose()
-      }
-    })
+          firstRegistry.set(mutation, void 0)
+          yield* Effect.yieldNow
+
+          assert.strictEqual(firstRegistry.get(query), 3)
+          assert.strictEqual(secondRegistry.get(query), 2)
+          assert.strictEqual(reads, 3)
+        })
+      ))
   })
 
   it("runtime direct tag", async () => {


### PR DESCRIPTION
## Summary

- allow `Atom.context` to accept a concrete `Layer.MemoMap` or an `Atom<Layer.MemoMap>`
- resolve atom-backed memo maps through the active `AtomRegistry`
- keep concrete memo maps factory-scoped, preserving the current behavior

Related to #6887.

## Why

One Atom runtime can be used by several registries, but its concrete memo map is shared by the whole factory. This means registries can hold different atom values while still sharing runtime layers and `Reactivity` through the same map.

We hit this with module-level `AtomRpc` atoms and request-scoped SSR registries. A mutation in one registry also refreshed a reactive query in another registry.

Recreating runtimes and atoms per request avoids the sharing, but gives up stable module-level atoms. `Layer.fresh` rebuilds more than the ownership boundary requires.

## Proposed API

```ts
const registryMemoMap = Atom.make(() => Layer.makeMemoMapUnsafe())

const runtime = Atom.context({
  memoMap: registryMemoMap
})
```

The memo-map atom is resolved through the active registry. A concrete map continues to work as before.

This PR is intentionally a draft. I am not sure an atom is the best public API; an explicit scope option or another composition may be better. The goal is to give #6887 a concrete implementation and proof for discussion.

## Proof

- concrete maps remain shared across registries
- atom-backed maps share layers inside one registry and isolate different registries
- each registry finalizes only its own scoped resources
- a reactive mutation refreshes queries only in its active registry

## Validation

- `pnpm lint-fix`
- `pnpm lint`
- `pnpm test --run packages/effect/test/reactivity/Atom.test.ts`
- `pnpm check`
- `pnpm exec changeset status --since upstream/main`
