### PR TITLE
Fix stream execution plan retry limits

### DIFF
--- a/.changeset/fix-stream-execution-plan-retries.md
+++ b/.changeset/fix-stream-execution-plan-retries.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.withExecutionPlan` retry limits resetting after partial stream emissions.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -5888,6 +5888,27 @@ export const retry: {
   ): Stream<A, E | E2, R2 | R> => fromChannel(Channel.retry(self.channel, policy))
 )
 
+const retryWithoutReset = <A, E, R, X, E2, R2>(
+  self: Stream<A, E, R>,
+  schedule: Schedule.Schedule<X, E, E2, R2>
+): Stream<A, E | E2, R | R2> =>
+  unwrap(Effect.map(Schedule.toStepWithMetadata(schedule), (step) => {
+    let meta = Schedule.CurrentMetadata.defaultValue()
+    const loop = (): Stream<A, E | E2, R | R2> =>
+      catch_(
+        provideServiceEffect(self, Schedule.CurrentMetadata, Effect.sync(() => meta)),
+        (error) =>
+          unwrap(Pull.catchDone(
+            Effect.map(step(error), (meta_) => {
+              meta = meta_
+              return unwrap(Effect.as(Effect.yieldNow, loop()))
+            }),
+            () => Effect.succeed(fail(error))
+          ))
+      )
+    return loop()
+  }))
+
 /**
  * Applies an `ExecutionPlan` to a stream, retrying with step-provided resources
  * until it succeeds or the plan is exhausted.
@@ -5993,10 +6014,10 @@ export const withExecutionPlan: {
           attempted = true
           return fail(error)
         })
-        nextStream = retry(nextStream, internalExecutionPlan.scheduleFromStep(step, false) as any)
+        nextStream = retryWithoutReset(nextStream, internalExecutionPlan.scheduleFromStep(step, false) as any)
       } else {
         const schedule = internalExecutionPlan.scheduleFromStep(step, true)
-        nextStream = schedule ? retry(nextStream, schedule as any) : nextStream
+        nextStream = schedule ? retryWithoutReset(nextStream, schedule as any) : nextStream
       }
 
       return catch_(

--- a/packages/effect/test/ExecutionPlan.test.ts
+++ b/packages/effect/test/ExecutionPlan.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertTrue, deepStrictEqual } from "@effect/vitest/utils"
-import { Array, Context, Effect, ExecutionPlan, Exit, Layer, Stream } from "effect"
+import { Array, Context, Effect, ExecutionPlan, Exit, Layer, Option, Stream } from "effect"
 
 describe("ExecutionPlan", () => {
   class Service extends Context.Service<Service>()("Service", {
@@ -46,6 +46,51 @@ describe("ExecutionPlan", () => {
   })
 
   describe("Stream.withExecutionPlan", () => {
+    it.effect("limits attempts after partial stream failures", () =>
+      Effect.gen(function*() {
+        let runs = 0
+        const stream = Stream.fromEffect(Effect.sync(() => {
+          runs++
+          return 1
+        })).pipe(Stream.concat(Stream.fail("boom")))
+        const plan = ExecutionPlan.make({
+          provide: Context.empty(),
+          attempts: 3
+        })
+        const items = Array.empty<number>()
+
+        const result = yield* stream.pipe(
+          Stream.withExecutionPlan(plan),
+          Stream.runForEach((item) =>
+            Effect.sync(() => {
+              items.push(item)
+            })
+          ),
+          Effect.exit
+        )
+
+        deepStrictEqual(items, [1, 1, 1])
+        deepStrictEqual(runs, 3)
+        deepStrictEqual(result, Exit.fail("boom"))
+      }))
+
+    it.live("allows timeouts to interrupt retries after partial stream failures", () =>
+      Effect.gen(function*() {
+        const stream = Stream.make(1).pipe(Stream.concat(Stream.fail("boom")))
+        const plan = ExecutionPlan.make({
+          provide: Context.empty(),
+          attempts: Number.MAX_SAFE_INTEGER
+        })
+
+        const result = yield* stream.pipe(
+          Stream.withExecutionPlan(plan),
+          Stream.runDrain,
+          Effect.timeoutOption(10)
+        )
+
+        assertTrue(Option.isNone(result))
+      }))
+
     it.effect("falls back through failing layers and records stream attempt metadata", () =>
       Effect.gen(function*() {
         const stream = Stream.unwrap(Effect.map(Service, (_) => _.stream))

--- a/packages/effect/test/ExecutionPlan.test.ts
+++ b/packages/effect/test/ExecutionPlan.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertTrue, deepStrictEqual } from "@effect/vitest/utils"
-import { Array, Context, Effect, ExecutionPlan, Exit, Layer, Option, Stream } from "effect"
+import { Array, Context, Effect, ExecutionPlan, Exit, Fiber, Latch, Layer, Scheduler, Stream } from "effect"
 
 describe("ExecutionPlan", () => {
   class Service extends Context.Service<Service>()("Service", {
@@ -74,21 +74,34 @@ describe("ExecutionPlan", () => {
         deepStrictEqual(result, Exit.fail("boom"))
       }))
 
-    it.live("allows timeouts to interrupt retries after partial stream failures", () =>
+    it.effect("allows interruption between retries after partial stream failures", () =>
       Effect.gen(function*() {
-        const stream = Stream.make(1).pipe(Stream.concat(Stream.fail("boom")))
+        let runs = 0
+        const retried = yield* Latch.make()
+        const stream = Stream.fromEffect(Effect.gen(function*() {
+          runs++
+          if (runs > 1) {
+            yield* retried.open
+          }
+          return 1
+        })).pipe(Stream.concat(Stream.fail("boom")))
         const plan = ExecutionPlan.make({
           provide: Context.empty(),
           attempts: Number.MAX_SAFE_INTEGER
         })
-
-        const result = yield* stream.pipe(
+        const fiber = yield* stream.pipe(
           Stream.withExecutionPlan(plan),
           Stream.runDrain,
-          Effect.timeoutOption(10)
+          Effect.provideService(Scheduler.PreventSchedulerYield, true),
+          Effect.forkChild
         )
 
-        assertTrue(Option.isNone(result))
+        yield* retried.await
+        yield* Fiber.interrupt(fiber)
+        const exit = yield* Fiber.await(fiber)
+
+        assertTrue(runs > 1)
+        assertTrue(Exit.hasInterrupts(exit))
       }))
 
     it.effect("falls back through failing layers and records stream attempt metadata", () =>


### PR DESCRIPTION
## Summary

- preserve execution-plan retry schedule state across partial stream emissions
- enforce `attempts` as an absolute cap for `Stream.withExecutionPlan`
- yield between retries so unbounded plans remain interruptible
- add regression coverage for partial-emission attempt limits and direct fiber interruption
- add a patch changeset for `effect`

## Root cause

`Stream.withExecutionPlan` delegated each step to `Stream.retry`, whose channel-level semantics reset schedule state after the first emitted element. A stream that emitted before failing therefore restarted its attempt budget on every run.

## Validation

- `pnpm vitest run packages/effect/test/ExecutionPlan.test.ts`
- `pnpm --dir packages/effect check`
- targeted `dprint` and `oxlint` checks
- `pnpm exec changeset status --since origin/main`

Closes EFF-291