### PR TITLE
Stabilize SuspendOnFailure workflow test

### DIFF
--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -381,6 +381,9 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       }).pipe(Effect.forkChild({ startImmediately: true }))
 
       yield* TestClock.adjust(2000)
+      while (!flags.has("suspended")) {
+        yield* Effect.yieldNow
+      }
 
       assert.isTrue(flags.get("suspended"))
       assert.include(flags.get("cause"), "boom")


### PR DESCRIPTION
## Summary

- wait for the `SuspendOnFailure` workflow finalizer to publish its state before asserting it
- preserve the existing virtual-time advancement while removing the assumption that it also synchronizes independently scheduled RPC fibers

## Root cause

The test forks `SuspendOnFailureWorkflow.execute` and then reads a shared `Map` after `TestClock.adjust(2000)`. Advancing the test clock wakes time-based work, but it does not establish a happens-before relationship with the workflow/activity RPC fiber or its finalizer. Under CI scheduler load, the assertion could therefore run before the finalizer populated the map.

## Validation

- `pnpm lint-fix`
- `pnpm test --run packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`
- `pnpm check`
- 64 concurrent stress repetitions of the single `SuspendOnFailure` test

Closes EFF-319