### PR TITLE
Stabilize Deno MySQL integration tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -159,7 +159,23 @@ export default defineConfig({
       ...project("@effect/sql-d1", "packages/sql/d1", !isDeno),
       ...project("@effect/sql-libsql", "packages/sql/libsql"),
       ...project("@effect/sql-mssql", "packages/sql/mssql"),
-      ...project("@effect/sql-mysql2", "packages/sql/mysql2"),
+      // MySQL starts a fresh container per integration test, so avoid competing
+      // with the other container-backed projects on Deno CI runners.
+      ...project(
+        "@effect/sql-mysql2",
+        "packages/sql/mysql2",
+        true,
+        isDeno && integrationTestsEnabled
+          ? {
+            test: {
+              fileParallelism: false,
+              sequence: {
+                groupOrder: 1
+              }
+            }
+          }
+          : {}
+      ),
       ...project("@effect/sql-pg", "packages/sql/pg"),
       ...project("@effect/sql-pglite", "packages/sql/pglite"),
       ...project("@effect/sql-sqlite-bun", "packages/sql/sqlite-bun"),


### PR DESCRIPTION
## Summary

- serialize `@effect/sql-mysql2` test files during Deno integration runs
- schedule the MySQL project after the other container-backed projects
- keep the existing test and hook timeouts unchanged

## Root cause

Each MySQL integration test starts a fresh `mysql:lts` container. On the failed Deno runner, concurrent container-backed projects inflated normally 10–12 second MySQL setup work to 20–41 seconds. The MySQL suites with 30-second limits then timed out, and interrupted container scopes surfaced `MysqlClient: Failed to connect` / `ECONNREFUSED` during cleanup.

Isolating and serializing this project removes the container startup contention instead of hiding it behind larger timeouts.

## Validation

- `pnpm lint-fix`
- `pnpm lint`
- `pnpm check`
- `deno task test --run --project @effect/sql-mysql2 packages/sql/mysql2/test/SqlErrorClassification.test.ts`
- resolved the Deno integration config directly and confirmed `fileParallelism: false` with `sequence.groupOrder: 1`

A full local Deno integration run was unavailable because the local Deno 2.8.3/Vite OXC stack failed during collection and Testcontainers could not discover the local Docker runtime; CI uses Deno 2.9.4 and provides the integration environment.

Closes EFF-322