### PR TITLE
Stabilize child process and libSQL tests

### DIFF
--- a/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
+++ b/packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts
@@ -624,7 +624,10 @@ export const suite = (
             const exitCode = yield* handle.exitCode
 
             assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
-            assert.strictEqual(output, ["out1", "err1", "out2"].join("\n"))
+            const lines = output.split("\n")
+            assert.strictEqual(lines.length, 3)
+            assert.deepStrictEqual(lines.filter((line) => line.startsWith("out")), ["out1", "out2"])
+            assert.deepStrictEqual(lines.filter((line) => line.startsWith("err")), ["err1"])
           }).pipe(Effect.scoped))
 
         it.effect("should default to stdout when no options provided", () =>

--- a/packages/sql/libsql/test/Resolver.integration.test.ts
+++ b/packages/sql/libsql/test/Resolver.integration.test.ts
@@ -1,6 +1,6 @@
 import { LibsqlClient } from "@effect/sql-libsql"
 import { assert, describe, layer } from "@effect/vitest"
-import { Cause, Effect, Iterable } from "effect"
+import { Cause, Effect } from "effect"
 import * as Schema from "effect/Schema"
 import { SqlError, SqlResolver } from "effect/unstable/sql"
 import { LibsqlContainer } from "./util.ts"
@@ -8,9 +8,14 @@ import { LibsqlContainer } from "./util.ts"
 const seededClient = Effect.gen(function*() {
   const sql = yield* LibsqlClient.LibsqlClient
   yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
-  for (const id of Iterable.range(1, 100)) {
-    yield* sql`INSERT INTO test ${sql.insert({ id, name: `name${id}` })}`
-  }
+  yield* sql`INSERT INTO test ${
+    sql.insert([
+      { id: 1, name: "name1" },
+      { id: 2, name: "name2" },
+      { id: 3, name: "name3" },
+      { id: 100, name: "name100" }
+    ])
+  }`
   yield* Effect.addFinalizer(() => sql`DROP TABLE test;`.pipe(Effect.orDie))
   return sql
 })


### PR DESCRIPTION
## Summary

- verify combined child-process output without assuming an ordering between stdout and stderr
- seed the libSQL resolver fixture with one batch containing only the rows exercised by the tests

## Root cause

The child-process test assumed that writes to separate stdout and stderr pipes would retain a total cross-stream order. Linux may deliver the two streams in a different order even when the subprocess sleeps between writes.

The libSQL resolver fixture made 100 sequential HTTP inserts before every test. Under load, that setup could exceed the five-second test timeout; interruption then left the shared `test` table behind, causing the remaining cases to fail with `table test already exists`.

The other failures in the investigated runs are already addressed on main by #6815 (D1 fixture batching) and #6894 (Deno MySQL integration serialization).

## Validation

- `nix develop -c pnpm vitest run packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts --project @effect/platform-node-shared` (66 passed)
- `nix develop -c pnpm check --pretty false`
- `nix develop -c pnpm dprint check packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts packages/sql/libsql/test/Resolver.integration.test.ts`
- `nix develop -c pnpm oxlint packages/effect/test/unstable/process/ChildProcessSpawnerTest.ts packages/sql/libsql/test/Resolver.integration.test.ts -f unix`

The libSQL integration suite could not run locally because no container runtime is available; CI provides the required container environment.

Closes EFF-323
