### PR TITLE
Bind event log RPCs to authenticated identities

### DIFF
--- a/.changeset/secure-eventlog-identities.md
+++ b/.changeset/secure-eventlog-identities.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Bind event-log read and write requests to the identities authenticated on their RPC connection.

--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -80,7 +80,8 @@ export const layerRpcHandlers = (options: {
     signingPublicKey: Uint8Array<ArrayBuffer>
   ) => Effect.Effect<Uint8Array<ArrayBuffer>>
   readonly onWrite: (
-    data: Uint8Array<ArrayBuffer>
+    data: Uint8Array<ArrayBuffer>,
+    authenticatedPublicKeys: ReadonlySet<string>
   ) => Effect.Effect<void, EventLogProtocolError>
   readonly changes: (options: {
     readonly publicKey: string
@@ -161,24 +162,38 @@ export const layerRpcHandlers = (options: {
           })
         }
 
+        const authenticatedIdentities = Context.get(client.annotations, AuthenticatedIdentities)
+        authenticatedIdentities.add(request.publicKey)
         void client
           .annotate(EventLog.Identity, {
             publicKey: request.publicKey,
             privateKey: constEmptyPrivateKey
           })
+          .annotate(AuthenticatedIdentities, authenticatedIdentities)
           .annotate(ChunkedMessageState, new Map())
       }),
-      "EventLog.WriteSingle": Effect.fnUntraced(function*(request) {
-        yield* options.onWrite(request.data)
+      "EventLog.WriteSingle": Effect.fnUntraced(function*(request, { client }) {
+        yield* options.onWrite(request.data, Context.get(client.annotations, AuthenticatedIdentities))
       }),
       "EventLog.WriteChunked": Effect.fnUntraced(function*(request, { client }) {
         const state = Context.get(client.annotations, ChunkedMessageState)
         const data = ChunkedMessage.join(state, request)
         if (!data) return
-        yield* options.onWrite(data)
+        yield* options.onWrite(data, Context.get(client.annotations, AuthenticatedIdentities))
       }),
-      "EventLog.Changes": (request) =>
-        options.changes({
+      "EventLog.Changes": (request, { client }) => {
+        const authenticatedIdentities = Context.get(client.annotations, AuthenticatedIdentities)
+        if (!authenticatedIdentities.has(request.publicKey)) {
+          return Stream.fail(
+            new EventLogProtocolError({
+              requestTag: "Changes",
+              publicKey: request.publicKey,
+              code: "Forbidden",
+              message: "Identity is not authenticated"
+            })
+          )
+        }
+        return options.changes({
           publicKey: request.publicKey,
           storeId: request.storeId,
           startSequence: request.startSequence
@@ -200,6 +215,7 @@ export const layerRpcHandlers = (options: {
             )
           )
         )
+      }
     })
   })).pipe(
     Layer.merge(layerAuthMiddleware)
@@ -226,6 +242,17 @@ export class ChunkedMessageState extends Context.Reference<
 >("effect/eventlog/EventLogServer/ChunkedMessageState", {
   defaultValue: () => new Map()
 }) {}
+
+/**
+ * Annotation containing the public keys authenticated on an RPC connection.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export class AuthenticatedIdentities extends Context.Reference<Set<string>>(
+  "effect/eventlog/EventLogServer/AuthenticatedIdentities",
+  { defaultValue: () => new Set() }
+) {}
 
 class SessionAuthCacheKey extends Data.Class<{
   readonly publicKey: string

--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -175,17 +175,23 @@ export const layerRpcHandlers = (options: {
           .annotate(ChunkedMessageState, new Map())
       }),
       "EventLog.WriteSingle": Effect.fnUntraced(function*(request, { client }) {
-        yield* options.onWrite(request.data, Context.get(client.annotations, AuthenticatedIdentities))
+        yield* options.onWrite(
+          request.data,
+          Context.getOrUndefined(client.annotations, AuthenticatedIdentities) ?? new Set()
+        )
       }),
       "EventLog.WriteChunked": Effect.fnUntraced(function*(request, { client }) {
         const state = Context.get(client.annotations, ChunkedMessageState)
         const data = ChunkedMessage.join(state, request)
         if (!data) return
-        yield* options.onWrite(data, Context.get(client.annotations, AuthenticatedIdentities))
+        yield* options.onWrite(
+          data,
+          Context.getOrUndefined(client.annotations, AuthenticatedIdentities) ?? new Set()
+        )
       }),
       "EventLog.Changes": (request, { client }) => {
-        const authenticatedIdentities = Context.get(client.annotations, AuthenticatedIdentities)
-        if (!authenticatedIdentities.has(request.publicKey)) {
+        const authenticatedIdentities = Context.getOrUndefined(client.annotations, AuthenticatedIdentities)
+        if (!authenticatedIdentities?.has(request.publicKey)) {
           return Stream.fail(
             new EventLogProtocolError({
               requestTag: "Changes",
@@ -251,9 +257,8 @@ export class ChunkedMessageState extends Context.Reference<
  * @category services
  * @since 4.0.0
  */
-export class AuthenticatedIdentities extends Context.Reference<Set<string>>(
-  "effect/eventlog/EventLogServer/AuthenticatedIdentities",
-  { defaultValue: () => new Set() }
+export class AuthenticatedIdentities extends Context.Service<AuthenticatedIdentities, Set<string>>()(
+  "effect/eventlog/EventLogServer/AuthenticatedIdentities"
 ) {}
 
 class SessionAuthCacheKey extends Data.Class<{

--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -162,7 +162,9 @@ export const layerRpcHandlers = (options: {
           })
         }
 
-        const authenticatedIdentities = Context.get(client.annotations, AuthenticatedIdentities)
+        const authenticatedIdentities = new Set(
+          Context.getOrUndefined(client.annotations, AuthenticatedIdentities)
+        )
         authenticatedIdentities.add(request.publicKey)
         void client
           .annotate(EventLog.Identity, {

--- a/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerEncrypted.ts
@@ -47,7 +47,7 @@ export const layerRpcHandlers = Layer.unwrap(Effect.gen(function*() {
     remoteId,
     getOrCreateSessionAuthBinding: (publicKey, signingPublicKey) =>
       storage.getOrCreateSessionAuthBinding(publicKey, signingPublicKey),
-    onWrite: Effect.fnUntraced(function*(data) {
+    onWrite: Effect.fnUntraced(function*(data, authenticatedPublicKeys) {
       const request = yield* WriteEntries.decode(data).pipe(
         Effect.mapError((_) =>
           new EventLogProtocolError({
@@ -58,6 +58,14 @@ export const layerRpcHandlers = Layer.unwrap(Effect.gen(function*() {
           })
         )
       )
+      if (!authenticatedPublicKeys.has(request.publicKey)) {
+        return yield* new EventLogProtocolError({
+          requestTag: "WriteEntries",
+          publicKey: request.publicKey,
+          code: "Forbidden",
+          message: "Identity is not authenticated"
+        })
+      }
       if (request.encryptedEntries.length === 0) return
       const entries = request.encryptedEntries.map(({ encryptedEntry, entryId }) =>
         new PersistedEntry({

--- a/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServerUnencrypted.ts
@@ -146,7 +146,7 @@ export const layerRpcHandlers: Layer.Layer<
     remoteId,
     getOrCreateSessionAuthBinding: (publicKey, signingPublicKey) =>
       storage.getOrCreateSessionAuthBinding(publicKey, signingPublicKey),
-    onWrite: Effect.fnUntraced(function*(data) {
+    onWrite: Effect.fnUntraced(function*(data, authenticatedPublicKeys) {
       const request = yield* WriteEntriesUnencrypted.decode(data).pipe(
         Effect.mapError((_) =>
           new EventLogProtocolError({
@@ -157,6 +157,14 @@ export const layerRpcHandlers: Layer.Layer<
           })
         )
       )
+      if (!authenticatedPublicKeys.has(request.publicKey)) {
+        return yield* new EventLogProtocolError({
+          requestTag: "WriteEntries",
+          publicKey: request.publicKey,
+          code: "Forbidden",
+          message: "Identity is not authenticated"
+        })
+      }
       if (!Arr.isReadonlyArrayNonEmpty(request.entries)) return
 
       const resolvedStoreId = yield* mapping.resolve({

--- a/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
@@ -41,6 +41,23 @@ const persistEntries = (
     )
   })
 
+const encodeWrite = Effect.fnUntraced(function*(
+  encryption: EventLogEncryption.EventLogEncryption["Service"],
+  identity: EventLog.Identity["Service"],
+  entry: EventJournal.Entry
+) {
+  const encrypted = yield* encryption.encrypt(identity, [entry])
+  return yield* new EventLogMessage.WriteEntries({
+    publicKey: identity.publicKey,
+    storeId: storeIdA,
+    iv: encrypted.iv,
+    encryptedEntries: [{
+      entryId: entry.id,
+      encryptedEntry: encrypted.encryptedEntries[0]
+    }]
+  }).encoded
+})
+
 const makePersistedEntry = (index: number, entryId = EventJournal.makeEntryIdUnsafe()) =>
   new EventLogServer.PersistedEntry({
     entryId,
@@ -71,7 +88,137 @@ const makeAuthenticateRequest = Effect.fnUntraced(function*(options: {
   })
 })
 
+const makeAuthenticatedRpcClient = Effect.fnUntraced(function*(
+  storage: EventLogServer.Storage["Service"],
+  identities: ReadonlyArray<EventLog.Identity["Service"]>
+) {
+  const rpcClient = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+    Effect.provide(
+      EventLogServer.layerRpcHandlers.pipe(
+        Layer.provide(Layer.succeed(EventLogServer.Storage, storage))
+      )
+    )
+  )
+  for (const identity of identities) {
+    const hello = yield* rpcClient["EventLog.Hello"]()
+    yield* rpcClient["EventLog.Authenticate"](
+      yield* makeAuthenticateRequest({
+        identity,
+        challenge: hello.challenge,
+        remoteId: hello.remoteId
+      })
+    )
+  }
+  return rpcClient
+})
+
 describe("SqlEventLogServer", () => {
+  it.effect("forbids reading another identity's changes", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const storage = yield* SqlEventLogServer.makeStorage().pipe(
+        Effect.provideService(SqlClient.SqlClient, sql)
+      )
+      const encryption = yield* EventLogEncryption.EventLogEncryption
+      const identityA = yield* encryption.generateIdentity
+      const identityB = yield* encryption.generateIdentity
+      const rpcClient = yield* makeAuthenticatedRpcClient(storage, [identityA])
+
+      yield* storage.write(identityB.publicKey, storeIdA, [makePersistedEntry(1)])
+      const error = yield* rpcClient["EventLog.Changes"]({
+        publicKey: identityB.publicKey,
+        storeId: storeIdA,
+        startSequence: 0
+      }).pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.flip
+      )
+
+      assert.instanceOf(error, EventLogMessage.EventLogProtocolError)
+      assert.strictEqual(error.code, "Forbidden")
+    }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
+  it.effect("forbids writing entries for another identity", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const storage = yield* SqlEventLogServer.makeStorage().pipe(
+        Effect.provideService(SqlClient.SqlClient, sql)
+      )
+      const encryption = yield* EventLogEncryption.EventLogEncryption
+      const identityA = yield* encryption.generateIdentity
+      const identityB = yield* encryption.generateIdentity
+      const rpcClient = yield* makeAuthenticatedRpcClient(storage, [identityA])
+      const entry = makeEntry(1)
+      const data = yield* encodeWrite(encryption, identityB, entry)
+
+      const error = yield* rpcClient["EventLog.WriteSingle"]({ data }).pipe(Effect.flip)
+
+      assert.instanceOf(error, EventLogMessage.EventLogProtocolError)
+      assert.strictEqual(error.code, "Forbidden")
+      const written = yield* storage.write(identityB.publicKey, storeIdA, [makePersistedEntry(2)])
+      assert.deepStrictEqual(written.map((entry) => entry.sequence), [1])
+    }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
+  it.effect("forbids writing chunked entries for another identity", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const storage = yield* SqlEventLogServer.makeStorage().pipe(
+        Effect.provideService(SqlClient.SqlClient, sql)
+      )
+      const encryption = yield* EventLogEncryption.EventLogEncryption
+      const identityA = yield* encryption.generateIdentity
+      const identityB = yield* encryption.generateIdentity
+      const rpcClient = yield* makeAuthenticatedRpcClient(storage, [identityA])
+      const entry = makeEntry(1)
+      const data = yield* encodeWrite(encryption, identityB, entry)
+      const midpoint = Math.ceil(data.byteLength / 2)
+      const parts = [
+        new EventLogMessage.ChunkedMessage({ id: 1, part: [0, 2], data: data.subarray(0, midpoint) }),
+        new EventLogMessage.ChunkedMessage({ id: 1, part: [1, 2], data: data.subarray(midpoint) })
+      ] as const
+
+      yield* rpcClient["EventLog.WriteChunked"](parts[0])
+      const error = yield* rpcClient["EventLog.WriteChunked"](parts[1]).pipe(Effect.flip)
+
+      assert.instanceOf(error, EventLogMessage.EventLogProtocolError)
+      assert.strictEqual(error.code, "Forbidden")
+      const written = yield* storage.write(identityB.publicKey, storeIdA, [makePersistedEntry(2)])
+      assert.deepStrictEqual(written.map((entry) => entry.sequence), [1])
+    }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
+  it.effect("supports multiple authenticated identities on one connection", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const storage = yield* SqlEventLogServer.makeStorage().pipe(
+        Effect.provideService(SqlClient.SqlClient, sql)
+      )
+      const encryption = yield* EventLogEncryption.EventLogEncryption
+      const identityA = yield* encryption.generateIdentity
+      const identityB = yield* encryption.generateIdentity
+      const rpcClient = yield* makeAuthenticatedRpcClient(storage, [identityA, identityB])
+      const entryA = makeEntry(1)
+      const entryB = makeEntry(2)
+      const dataA = yield* encodeWrite(encryption, identityA, entryA)
+      const dataB = yield* encodeWrite(encryption, identityB, entryB)
+
+      yield* rpcClient["EventLog.WriteSingle"]({ data: dataA })
+      yield* rpcClient["EventLog.WriteSingle"]({ data: dataB })
+      const changesA = yield* rpcClient["EventLog.Changes"]({
+        publicKey: identityA.publicKey,
+        storeId: storeIdA,
+        startSequence: 0
+      }).pipe(Stream.take(1), Stream.runCollect)
+      const changesB = yield* rpcClient["EventLog.Changes"]({
+        publicKey: identityB.publicKey,
+        storeId: storeIdA,
+        startSequence: 0
+      }).pipe(Stream.take(1), Stream.runCollect)
+
+      assert.strictEqual(changesA.length, 1)
+      assert.strictEqual(changesB.length, 1)
+    }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
   it.effect("persists remote id across storage instances", () =>
     Effect.gen(function*() {
       const sql = yield* SqliteClient.make({ filename: ":memory:" })

--- a/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts
@@ -112,6 +112,14 @@ const makeAuthenticatedRpcClient = Effect.fnUntraced(function*(
   return rpcClient
 })
 
+const assertForbidden = Effect.fnUntraced(function*<A>(
+  effect: Effect.Effect<A, EventLogMessage.EventLogProtocolError>
+) {
+  const error = yield* Effect.flip(effect)
+  assert.instanceOf(error, EventLogMessage.EventLogProtocolError)
+  assert.strictEqual(error.code, "Forbidden")
+})
+
 describe("SqlEventLogServer", () => {
   it.effect("forbids reading another identity's changes", () =>
     Effect.gen(function*() {
@@ -185,6 +193,62 @@ describe("SqlEventLogServer", () => {
       assert.strictEqual(error.code, "Forbidden")
       const written = yield* storage.write(identityB.publicKey, storeIdA, [makePersistedEntry(2)])
       assert.deepStrictEqual(written.map((entry) => entry.sequence), [1])
+    }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
+  it.effect("isolates authenticated identities between connections", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const storage = yield* SqlEventLogServer.makeStorage().pipe(
+        Effect.provideService(SqlClient.SqlClient, sql)
+      )
+      const encryption = yield* EventLogEncryption.EventLogEncryption
+      const identityA = yield* encryption.generateIdentity
+      const identityB = yield* encryption.generateIdentity
+      const handlers = yield* Layer.build(
+        EventLogServer.layerRpcHandlers.pipe(
+          Layer.provide(Layer.succeed(EventLogServer.Storage, storage))
+        )
+      )
+      const rpcClientA = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+        Effect.provide(handlers)
+      )
+      const rpcClientB = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+        Effect.provide(handlers)
+      )
+      const helloA = yield* rpcClientA["EventLog.Hello"]()
+      yield* rpcClientA["EventLog.Authenticate"](
+        yield* makeAuthenticateRequest({
+          identity: identityA,
+          challenge: helloA.challenge,
+          remoteId: helloA.remoteId
+        })
+      )
+      const helloB = yield* rpcClientB["EventLog.Hello"]()
+      yield* rpcClientB["EventLog.Authenticate"](
+        yield* makeAuthenticateRequest({
+          identity: identityB,
+          challenge: helloB.challenge,
+          remoteId: helloB.remoteId
+        })
+      )
+      const data = yield* encodeWrite(encryption, identityB, makeEntry(1))
+      const midpoint = Math.ceil(data.byteLength / 2)
+      const parts = [
+        new EventLogMessage.ChunkedMessage({ id: 1, part: [0, 2], data: data.subarray(0, midpoint) }),
+        new EventLogMessage.ChunkedMessage({ id: 1, part: [1, 2], data: data.subarray(midpoint) })
+      ] as const
+
+      yield* storage.write(identityB.publicKey, storeIdA, [makePersistedEntry(1)])
+      yield* assertForbidden(
+        rpcClientA["EventLog.Changes"]({
+          publicKey: identityB.publicKey,
+          storeId: storeIdA,
+          startSequence: 0
+        }).pipe(Stream.take(1), Stream.runCollect)
+      )
+      yield* assertForbidden(rpcClientA["EventLog.WriteSingle"]({ data }))
+      yield* rpcClientA["EventLog.WriteChunked"](parts[0])
+      yield* assertForbidden(rpcClientA["EventLog.WriteChunked"](parts[1]))
     }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
 
   it.effect("supports multiple authenticated identities on one connection", () =>

--- a/packages/sql/sqlite-node/test/SqlEventLogServerUnencrypted.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServerUnencrypted.test.ts
@@ -2,7 +2,7 @@ import { SqliteClient } from "@effect/sql-sqlite-node"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Redacted } from "effect"
 import * as SqlEventLogServerUnencryptedStorageTest from "effect-test/unstable/eventlog/SqlEventLogServerUnencryptedStorageTest"
-import type * as EventJournal from "effect/unstable/eventlog/EventJournal"
+import * as EventJournal from "effect/unstable/eventlog/EventJournal"
 import * as EventLog from "effect/unstable/eventlog/EventLog"
 import * as EventLogEncryption from "effect/unstable/eventlog/EventLogEncryption"
 import * as EventLogMessage from "effect/unstable/eventlog/EventLogMessage"
@@ -22,6 +22,15 @@ SqlEventLogServerUnencryptedStorageTest.suite(
 )
 
 const getIdentityRootSecretMaterial = makeGetIdentityRootSecretMaterial(globalThis.crypto)
+const storeId = EventLogMessage.StoreId.make("store-a")
+
+const makeEntry = (value: number) =>
+  new EventJournal.Entry({
+    id: EventJournal.makeEntryIdUnsafe(),
+    event: "UserCreated",
+    primaryKey: `user-${value}`,
+    payload: new Uint8Array([value])
+  }, { disableChecks: true })
 
 const makeAuthenticateRequest = Effect.fnUntraced(function*(options: {
   readonly identity: EventLog.Identity["Service"]
@@ -45,6 +54,54 @@ const makeAuthenticateRequest = Effect.fnUntraced(function*(options: {
 })
 
 describe("SqlEventLogServerUnencrypted (sql-sqlite-node)", () => {
+  it.effect("forbids writing entries for another identity", () =>
+    Effect.gen(function*() {
+      const sql = yield* SqliteClient.make({ filename: ":memory:" })
+      const storage = yield* SqlEventLogServerUnencrypted.makeStorage().pipe(
+        Effect.provideService(SqlClient.SqlClient, sql),
+        Effect.orDie
+      )
+      const rpcClient = yield* RpcTest.makeClient(EventLogMessage.EventLogRemoteRpcs).pipe(
+        Effect.provide(
+          EventLogServerUnencrypted.layerRpcHandlers.pipe(
+            Layer.provideMerge(EventLog.layerRegistry),
+            Layer.provide(Layer.succeed(EventLogServerUnencrypted.Storage, storage)),
+            Layer.provide(Layer.succeed(EventLogServerUnencrypted.StoreMapping, {
+              resolve: ({ storeId }) => Effect.succeed(storeId),
+              hasStore: () => Effect.succeed(true)
+            })),
+            Layer.provide(Layer.succeed(EventLogServerUnencrypted.EventLogServerAuthorization, {
+              authorizeWrite: () => Effect.void,
+              authorizeRead: () => Effect.void,
+              authorizeIdentity: () => Effect.void
+            }))
+          )
+        )
+      )
+      const identityA = yield* EventLog.makeIdentity
+      const identityB = yield* EventLog.makeIdentity
+      const hello = yield* rpcClient["EventLog.Hello"]()
+      yield* rpcClient["EventLog.Authenticate"](
+        yield* makeAuthenticateRequest({
+          identity: identityA,
+          challenge: hello.challenge,
+          remoteId: hello.remoteId
+        })
+      )
+      const data = yield* new EventLogMessage.WriteEntriesUnencrypted({
+        publicKey: identityB.publicKey,
+        storeId,
+        entries: [makeEntry(1)]
+      }).encoded
+
+      const error = yield* rpcClient["EventLog.WriteSingle"]({ data }).pipe(Effect.flip)
+
+      assert.instanceOf(error, EventLogMessage.EventLogProtocolError)
+      assert.strictEqual(error.code, "Forbidden")
+      const written = yield* storage.write(storeId, [makeEntry(2)])
+      assert.deepStrictEqual(written.map((entry) => entry.remoteSequence), [1])
+    }).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
   it.effect("rejects session-auth rebinding for an existing publicKey", () =>
     Effect.gen(function*() {
       const sql = yield* SqliteClient.make({ filename: ":memory:" })


### PR DESCRIPTION
## Summary

- track every identity authenticated on an event-log RPC connection
- isolate authenticated identity sets per connection with copy-on-write updates
- reject read and decoded write claims that are not in that connection's authenticated identity set
- preserve legitimate multi-identity multiplexing on a shared connection
- cover forged changes, single writes, chunked writes, plaintext writes, cross-connection isolation, and the multi-identity positive control

## Root cause

The authentication middleware only required some authenticated identity on the connection. Tenant selection still trusted the `publicKey` carried in request payloads, allowing a client authenticated as A to read or write B's scope.

The first implementation also mutated the cached default `AuthenticatedIdentities` set, which made authenticated keys process-wide. Authentication now performs a raw optional lookup and copies the connection's existing set before adding a key.

## Impact

Encrypted and unencrypted event-log servers now return `Forbidden` before storage, mapping, authorization, or handler execution when the claimed identity was not authenticated on the same connection. Identities authenticated on other connections are not accepted. Wire schemas remain unchanged.

## Validation

- `pnpm test --run packages/sql/sqlite-node/test/SqlEventLogServerEncrypted.test.ts packages/sql/sqlite-node/test/SqlEventLogServerUnencrypted.test.ts` (17 passed)
- `pnpm lint-fix`
- `pnpm check`

Closes EFF-325