### PR TITLE
Fix flaky arbitrary candidate property assertion

### DIFF
--- a/packages/effect/test/schema/toArbitrary.test.ts
+++ b/packages/effect/test/schema/toArbitrary.test.ts
@@ -283,7 +283,7 @@ describe("Arbitrary generation", () => {
       const result = Schema.toArbitrary(schema, { report: true })
 
       deepStrictEqual(result.report.warnings, [])
-      FastCheck.assert(FastCheck.property(result.value, (s) => s === "a"), { numRuns: 20 })
+      FastCheck.assert(FastCheck.property(result.value, (s) => s.startsWith("a") && s.endsWith("a")), { numRuns: 20 })
     })
 
     it("should not report warnings for constructive built-in filters", () => {


### PR DESCRIPTION
## Summary

- assert the filter group's schema invariant instead of requiring every generated value to equal its candidate
- preserve coverage that grouped arbitrary metadata suppresses child-filter warnings

## Root cause

`candidate` adds a weighted source alongside the base arbitrary; it does not replace the base generator. The existing property incorrectly required every value to be the candidate `"a"`, so valid base-generated values such as `"aa"` caused a seed-dependent failure.

## Validation

- reproduced with fast-check 4.9.0 using seed `-967948883` and path `15:1:1:1:1`
- replayed the failing seed/path successfully after the fix
- `nix develop -c pnpm lint-fix`
- `nix develop -c pnpm --filter effect test --run test/schema/toArbitrary.test.ts`
- `nix develop -c pnpm check`

Closes EFF-330
