### PR TITLE
Keep Chunk.take and Chunk.drop valid for fractional counts

### DIFF
--- a/.changeset/fix-chunk-fractional-counts.md
+++ b/.changeset/fix-chunk-fractional-counts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure `Chunk.take` and `Chunk.drop` produce valid chunks for fractional counts.

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -728,11 +728,11 @@ export const prepend: {
 export const take: {
   (n: number): <A>(self: Chunk<A>) => Chunk<A>
   <A>(self: Chunk<A>, n: number): Chunk<A>
-} = dual(2, <A>(self: Chunk<A>, n: number): Chunk<A> => {
-  const _n = Math.floor(n)
-  if (_n <= 0) {
+} = dual(2, <A>(self: Chunk<A>, _n: number): Chunk<A> => {
+  const n = Math.floor(_n)
+  if (n <= 0) {
     return _empty
-  } else if (_n >= self.length) {
+  } else if (n >= self.length) {
     return self
   } else {
     switch (self.backing._tag) {
@@ -740,27 +740,27 @@ export const take: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self.backing.chunk,
-          length: _n,
+          length: n,
           offset: self.backing.offset
         })
       }
       case "IConcat": {
-        if (_n > self.left.length) {
+        if (n > self.left.length) {
           return makeChunk({
             _tag: "IConcat",
             left: self.left,
-            right: take(self.right, _n - self.left.length)
+            right: take(self.right, n - self.left.length)
           })
         }
 
-        return take(self.left, _n)
+        return take(self.left, n)
       }
       default: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self,
           offset: 0,
-          length: _n
+          length: n
         })
       }
     }
@@ -785,11 +785,11 @@ export const take: {
 export const drop: {
   (n: number): <A>(self: Chunk<A>) => Chunk<A>
   <A>(self: Chunk<A>, n: number): Chunk<A>
-} = dual(2, <A>(self: Chunk<A>, n: number): Chunk<A> => {
-  const _n = Math.floor(n)
-  if (_n <= 0) {
+} = dual(2, <A>(self: Chunk<A>, _n: number): Chunk<A> => {
+  const n = Math.floor(_n)
+  if (n <= 0) {
     return self
-  } else if (_n >= self.length) {
+  } else if (n >= self.length) {
     return _empty
   } else {
     switch (self.backing._tag) {
@@ -797,17 +797,17 @@ export const drop: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self.backing.chunk,
-          offset: self.backing.offset + _n,
-          length: self.backing.length - _n
+          offset: self.backing.offset + n,
+          length: self.backing.length - n
         })
       }
       case "IConcat": {
-        if (_n > self.left.length) {
-          return drop(self.right, _n - self.left.length)
+        if (n > self.left.length) {
+          return drop(self.right, n - self.left.length)
         }
         return makeChunk({
           _tag: "IConcat",
-          left: drop(self.left, _n),
+          left: drop(self.left, n),
           right: self.right
         })
       }
@@ -815,8 +815,8 @@ export const drop: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self,
-          offset: _n,
-          length: self.length - _n
+          offset: n,
+          length: self.length - n
         })
       }
     }

--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -729,9 +729,10 @@ export const take: {
   (n: number): <A>(self: Chunk<A>) => Chunk<A>
   <A>(self: Chunk<A>, n: number): Chunk<A>
 } = dual(2, <A>(self: Chunk<A>, n: number): Chunk<A> => {
-  if (n <= 0) {
+  const _n = Math.floor(n)
+  if (_n <= 0) {
     return _empty
-  } else if (n >= self.length) {
+  } else if (_n >= self.length) {
     return self
   } else {
     switch (self.backing._tag) {
@@ -739,27 +740,27 @@ export const take: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self.backing.chunk,
-          length: n,
+          length: _n,
           offset: self.backing.offset
         })
       }
       case "IConcat": {
-        if (n > self.left.length) {
+        if (_n > self.left.length) {
           return makeChunk({
             _tag: "IConcat",
             left: self.left,
-            right: take(self.right, n - self.left.length)
+            right: take(self.right, _n - self.left.length)
           })
         }
 
-        return take(self.left, n)
+        return take(self.left, _n)
       }
       default: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self,
           offset: 0,
-          length: n
+          length: _n
         })
       }
     }
@@ -785,9 +786,10 @@ export const drop: {
   (n: number): <A>(self: Chunk<A>) => Chunk<A>
   <A>(self: Chunk<A>, n: number): Chunk<A>
 } = dual(2, <A>(self: Chunk<A>, n: number): Chunk<A> => {
-  if (n <= 0) {
+  const _n = Math.floor(n)
+  if (_n <= 0) {
     return self
-  } else if (n >= self.length) {
+  } else if (_n >= self.length) {
     return _empty
   } else {
     switch (self.backing._tag) {
@@ -795,17 +797,17 @@ export const drop: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self.backing.chunk,
-          offset: self.backing.offset + n,
-          length: self.backing.length - n
+          offset: self.backing.offset + _n,
+          length: self.backing.length - _n
         })
       }
       case "IConcat": {
-        if (n > self.left.length) {
-          return drop(self.right, n - self.left.length)
+        if (_n > self.left.length) {
+          return drop(self.right, _n - self.left.length)
         }
         return makeChunk({
           _tag: "IConcat",
-          left: drop(self.left, n),
+          left: drop(self.left, _n),
           right: self.right
         })
       }
@@ -813,8 +815,8 @@ export const drop: {
         return makeChunk({
           _tag: "ISlice",
           chunk: self,
-          offset: n,
-          length: self.length - n
+          offset: _n,
+          length: self.length - _n
         })
       }
     }

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -388,6 +388,12 @@ describe("Chunk", () => {
   })
 
   describe("take", () => {
+    it("produces valid chunks for fractional counts", () => {
+      const chunk = Chunk.make(1, 2, 3)
+      deepStrictEqual(Chunk.toArray(Chunk.take(chunk, 1.5)), [1])
+      deepStrictEqual(Chunk.toArray(Chunk.drop(chunk, 1.5)), [2, 3])
+    })
+
     describe("Given a Chunk with more elements than the amount taken", () => {
       it("should return the subset", () => {
         assertEquals(pipe(Chunk.fromArrayUnsafe([1, 2, 3]), Chunk.take(2)), Chunk.fromArrayUnsafe([1, 2]))


### PR DESCRIPTION
## Summary

Fractional take and drop counts produce chunks with fractional public lengths that throw RangeError when materialized.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Fractional counts create malformed chunks

**Module:** `Chunk`  
**Audit ID:** `core-a-f-chunk-fractional-slice-dimensions`  
**Severity / confidence:** high / high

### What happens

Fractional take and drop counts produce chunks with fractional public lengths that throw RangeError when materialized.

### Why it happens

Fractional counts are stored directly as ISlice.length and ISlice.offset. Materialization passes the fractional length to new Array(self.length), which throws RangeError: Invalid array length.

### Expected behavior

take and drop return valid chunks containing a count-based prefix or suffix for their accepted number argument; no integer-only precondition is imposed.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/Chunk.ts:728-767`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Chunk.ts#L728-L767)
- [`packages/effect/src/Chunk.ts:784-822`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Chunk.ts#L784-L822)
- [`packages/effect/src/Chunk.ts:408-427`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Chunk.ts#L408-L427)

<details>
<summary>View problematic code at <code>packages/effect/src/Chunk.ts:728-767</code></summary>

```ts
export const take: {
  (n: number): <A>(self: Chunk<A>) => Chunk<A>
  <A>(self: Chunk<A>, n: number): Chunk<A>
} = dual(2, <A>(self: Chunk<A>, n: number): Chunk<A> => {
  if (n <= 0) {
    return _empty
  } else if (n >= self.length) {
    return self
  } else {
    switch (self.backing._tag) {
      case "ISlice": {
        return makeChunk({
          _tag: "ISlice",
          chunk: self.backing.chunk,
          length: n,
          offset: self.backing.offset
        })
      }
      case "IConcat": {
        if (n > self.left.length) {
          return makeChunk({
            _tag: "IConcat",
            left: self.left,
            right: take(self.right, n - self.left.length)
          })
        }

        return take(self.left, n)
      }
      default: {
        return makeChunk({
          _tag: "ISlice",
          chunk: self,
          offset: 0,
          length: n
        })
      }
    }
  }
})
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Chunk.ts#L728-L767)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/Chunk.ts:784-822</code></summary>

```ts
export const drop: {
  (n: number): <A>(self: Chunk<A>) => Chunk<A>
  <A>(self: Chunk<A>, n: number): Chunk<A>
} = dual(2, <A>(self: Chunk<A>, n: number): Chunk<A> => {
  if (n <= 0) {
    return self
  } else if (n >= self.length) {
    return _empty
  } else {
    switch (self.backing._tag) {
      case "ISlice": {
        return makeChunk({
          _tag: "ISlice",
          chunk: self.backing.chunk,
          offset: self.backing.offset + n,
          length: self.backing.length - n
        })
      }
      case "IConcat": {
        if (n > self.left.length) {
          return drop(self.right, n - self.left.length)
        }
        return makeChunk({
          _tag: "IConcat",
          left: drop(self.left, n),
          right: self.right
        })
      }
      default: {
        return makeChunk({
          _tag: "ISlice",
          chunk: self,
          offset: n,
          length: self.length - n
        })
      }
    }
  }
})
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Chunk.ts#L784-L822)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/Chunk.ts:408-427</code></summary>

```ts
const toReadonlyArray_ = <A>(self: Chunk<A>): ReadonlyArray<A> => {
  switch (self.backing._tag) {
    case "IEmpty": {
      return emptyArray
    }
    case "IArray": {
      return self.backing.array
    }
    default: {
      const arr = new Array<A>(self.length)
      copyToArray(self, arr, 0)
      self.backing = {
        _tag: "IArray",
        array: arr
      }
      self.left = _empty
      self.right = _empty
      self.depth = 0
      return arr
    }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Chunk.ts#L408-L427)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Chunk.test.ts -t "produces valid chunks for fractional counts"
```

**Observed failure:** Materializing Chunk.take(Chunk.make(1, 2, 3), 1.5) threw RangeError: Invalid array length.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/Chunk.test.ts -t "produces valid chunks for fractional counts"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-a-f-chunk-fractional-slice-dimensions`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-350
