### PR TITLE
Keep Stream.range advancing with a zero-sized chunk

### DIFF
--- a/.changeset/fix-stream-range-zero-chunk.md
+++ b/.changeset/fix-stream-range-zero-chunk.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure `Stream.range` emits the full range when the chunk size is zero.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1570,14 +1570,15 @@ export const range = (
   chunkSize = Channel.DefaultChunkSize
 ): Stream<number> =>
   min > max ? empty : fromPull(Effect.sync(() => {
+    const size = Math.max(1, chunkSize)
     let start = min
     let done = false
     return Effect.suspend(() => {
       if (done) return Cause.done()
       const remaining = max - start + 1
-      if (remaining > chunkSize) {
-        const chunk = Arr.range(start, start + chunkSize - 1)
-        start += chunkSize
+      if (remaining > size) {
+        const chunk = Arr.range(start, start + size - 1)
+        start += size
         return Effect.succeed(chunk)
       }
       const chunk = Arr.range(start, start + remaining - 1)

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -404,6 +404,16 @@ describe("Stream", () => {
         assert.deepStrictEqual(result, [1, 2, 3])
       }))
 
+    it.effect("range - zero chunk size does not change the emitted range", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.range(1, 3, 0).pipe(
+          Stream.take(4),
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, [1, 2, 3])
+      }))
+
     it.effect("service", () =>
       Effect.gen(function*() {
         const result = yield* Stream.service(Greeter).pipe(


### PR DESCRIPTION
## Summary

Stream.range with chunkSize zero emits the lower bound forever instead of the finite inclusive range.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Zero-sized range chunks never advance

**Module:** `Stream`  
**Audit ID:** `core-s-z-testing-stream-range-zero-chunk`  
**Severity / confidence:** high / high

### What happens

Stream.range with chunkSize zero emits the lower bound forever instead of the finite inclusive range.

### Why it happens

With chunkSize === 0, the remaining > chunkSize branch emits [start] and advances start by zero, so every pull repeats the lower bound.

### Expected behavior

range(min, max, chunkSize) emits the finite inclusive integer range when min <= max; chunkSize controls batching, not values, and no positive-only precondition is documented.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/Stream.ts:1567-1585`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Stream.ts#L1567-L1585)

<details>
<summary>View problematic code at <code>packages/effect/src/Stream.ts:1567-1585</code></summary>

```ts
export const range = (
  min: number,
  max: number,
  chunkSize = Channel.DefaultChunkSize
): Stream<number> =>
  min > max ? empty : fromPull(Effect.sync(() => {
    let start = min
    let done = false
    return Effect.suspend(() => {
      if (done) return Cause.done()
      const remaining = max - start + 1
      if (remaining > chunkSize) {
        const chunk = Arr.range(start, start + chunkSize - 1)
        start += chunkSize
        return Effect.succeed(chunk)
      }
      const chunk = Arr.range(start, start + remaining - 1)
      done = true
      return Effect.succeed(chunk)
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Stream.ts#L1567-L1585)

</details>

### Reproduction

```sh
pnpm test --run packages/effect/test/Stream.test.ts -t "range - zero chunk size does not change the emitted range"
```

**Observed failure:** [1, 1, 1, 1] instead of [1, 2, 3]

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm test --run packages/effect/test/Stream.test.ts -t "range - zero chunk size does not change the emitted range"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-s-z-testing-stream-range-zero-chunk`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-349
