### PR TITLE
Prevent Metric attribute serialization key collisions

### DIFF
--- a/.changeset/fix-metric-attribute-key-collisions.md
+++ b/.changeset/fix-metric-attribute-key-collisions.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent distinct metric attribute sets from sharing registry state.

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3500,11 +3500,7 @@ function makeHooks<Input, State>(
 }
 
 function serializeAttributes(attributes: Metric.Attributes): string {
-  return serializeEntries(Array.isArray(attributes) ? attributes : Object.entries(attributes))
-}
-
-function serializeEntries(entries: ReadonlyArray<[string, string]>): string {
-  return JSON.stringify(entries)
+  return JSON.stringify(Array.isArray(attributes) ? attributes : Object.entries(attributes))
 }
 
 function mergeAttributes(

--- a/packages/effect/src/Metric.ts
+++ b/packages/effect/src/Metric.ts
@@ -3504,7 +3504,7 @@ function serializeAttributes(attributes: Metric.Attributes): string {
 }
 
 function serializeEntries(entries: ReadonlyArray<[string, string]>): string {
-  return entries.map(([key, value]) => `${key}=${value}`).join(",")
+  return JSON.stringify(entries)
 }
 
 function mergeAttributes(

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -6,6 +6,19 @@ import { TestClock } from "effect/testing"
 const attributes = { x: "a", y: "b" }
 
 describe("Metric", () => {
+  it.effect("keeps distinct attribute sets in separate series", () =>
+    Effect.gen(function*() {
+      const id = nextId()
+      const first = Metric.counter(id, { attributes: { a: "b,c=d" } })
+      const second = Metric.counter(id, { attributes: { a: "b", c: "d" } })
+
+      yield* Metric.update(first, 1)
+      yield* Metric.update(second, 10)
+
+      assert.strictEqual((yield* Metric.value(first)).count, 1)
+      assert.strictEqual((yield* Metric.value(second)).count, 10)
+    }))
+
   it.effect("should be referentially transparent", () =>
     Effect.gen(function*() {
       const id = nextId()


### PR DESCRIPTION
## Summary

Different valid metric attribute sets can serialize to the same registry key, causing logically separate series to share a hook and contaminate each other's values.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Distinct metric attribute sets can share registry state

**Module:** `Metric`  
**Audit ID:** `core-g-r-metric-attribute-series-key-collision`  
**Severity / confidence:** high / high

### What happens

Different valid metric attribute sets can serialize to the same registry key, causing logically separate series to share a hook and contaminate each other's values.

### Why it happens

makeKey concatenates unescaped key=value pairs with commas. The valid sets { a: "b,c=d" } and { a: "b", c: "d" } both serialize as a=b,c=d and occupy one registry entry.

### Expected behavior

Metric attributes identify dimensions: referentially equivalent definitions share a series, but each distinct attribute combination represents a separate series.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/Metric.ts:2823-2829`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Metric.ts#L2823-L2829)
- [`packages/effect/src/Metric.ts:3480-3508`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Metric.ts#L3480-L3508)

<details>
<summary>View problematic code at <code>packages/effect/src/Metric.ts:2823-2829</code></summary>

```ts
 * Returns a new metric that applies the specified attributes to all operations.
 *
 * **Details**
 *
 * Attributes are key-value pairs that provide additional context for metrics,
 * enabling filtering, grouping, and more detailed analysis. Each combination
 * of attribute values creates a separate metric series.
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Metric.ts#L2823-L2829)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/Metric.ts:3480-3508</code></summary>

```ts
function makeKey<Input, State>(
  metric: Metric<Input, State>,
  attributes: Metric.Attributes | undefined
) {
  let key = `${metric.type}:${metric.id}`
  if (Predicate.isNotUndefined(metric.description)) {
    key += `:${metric.description}`
  }
  if (Predicate.isNotUndefined(attributes)) {
    key += `:${serializeAttributes(attributes)}`
  }
  return key
}

function makeHooks<Input, State>(
  get: (context: Context.Context<never>) => State,
  update: (input: Input, context: Context.Context<never>) => void,
  modify?: (input: Input, context: Context.Context<never>) => void
): Metric.Hooks<Input, State> {
  return { get, update, modify: modify ?? update }
}

function serializeAttributes(attributes: Metric.Attributes): string {
  return serializeEntries(Array.isArray(attributes) ? attributes : Object.entries(attributes))
}

function serializeEntries(entries: ReadonlyArray<[string, string]>): string {
  return entries.map(([key, value]) => `${key}=${value}`).join(",")
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/Metric.ts#L3480-L3508)

</details>

### Reproduction

```sh
pnpm vitest run packages/effect/test/Metric.test.ts -t "keeps distinct attribute sets in separate series"
```

**Observed failure:** The intended failure was reproduced: the first counter was 11 instead of 1.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm vitest run packages/effect/test/Metric.test.ts -t "keeps distinct attribute sets in separate series"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-g-r-metric-attribute-series-key-collision`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-348
