### PR TITLE
Preserve colliding definitions when sanitizing JsonSchema keys

### DIFF
--- a/packages/effect/test/JsonSchema.test.ts
+++ b/packages/effect/test/JsonSchema.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { deepStrictEqual } from "@effect/vitest/utils"
 import * as JsonSchema from "effect/JsonSchema"
 
@@ -1209,6 +1209,21 @@ describe("JsonSchema", () => {
           "B_C": { type: "string" }
         }
       })
+    })
+
+    it("preserves definitions whose keys sanitize to the same component name", () => {
+      const input: JsonSchema.MultiDocument<"draft-2020-12"> = {
+        dialect: "draft-2020-12",
+        schemas: [{ anyOf: [{ $ref: "#/$defs/A$B" }, { $ref: "#/$defs/A B" }] }],
+        definitions: {
+          "A$B": { const: 1 },
+          "A B": { const: 2 }
+        }
+      }
+
+      const result = JsonSchema.toMultiDocumentOpenApi3_1(input)
+
+      assert.strictEqual(Object.keys(result.definitions).length, 2)
     })
   })
 


### PR DESCRIPTION
## Summary

Distinct canonical definitions whose names sanitize to the same OpenAPI component key are silently merged. One schema is discarded and references to both definitions alias the surviving component.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## OpenAPI component-key sanitization merges definitions

**Module:** `JsonSchema`  
**Audit ID:** `core-g-r-jsonschema-component-key-collision`  
**Severity / confidence:** high / high

### What happens

Distinct canonical definitions whose names sanitize to the same OpenAPI component key are silently merged. One schema is discarded and references to both definitions alias the surviving component.

### Why it happens

Invalid key characters are independently replaced with underscores, but the converter neither detects nor resolves collisions. A$B and A B both become A_B, and Rec.mapEntries emits only one property.

### Expected behavior

toMultiDocumentOpenApi3_1 converts every canonical definition into a valid OpenAPI component and rewrites references to the corresponding converted definitions.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/JsonSchema.ts:669-699`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/JsonSchema.ts#L669-L699)
- [`packages/effect/src/JsonSchema.ts:703-735`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/JsonSchema.ts#L703-L735)

<details>
<summary>View problematic code at <code>packages/effect/src/JsonSchema.ts:669-699</code></summary>

```ts
export function toMultiDocumentOpenApi3_1(multiDocument: MultiDocument<"draft-2020-12">): MultiDocument<"openapi-3.1"> {
  const keyMap = new Map<string, string>()
  for (const key of Object.keys(multiDocument.definitions)) {
    const sanitized = sanitizeOpenApiComponentsSchemasKey(key)
    if (sanitized !== key) {
      keyMap.set(key, sanitized)
    }
  }

  function rewrite(schema: JsonSchema): JsonSchema {
    return rewrite_refs(schema, ($ref) => {
      const tokens = $ref.split("/")
      if (tokens.length > 0) {
        const identifier = unescapeToken(tokens[tokens.length - 1])
        const sanitized = keyMap.get(identifier)
        if (sanitized !== undefined) {
          $ref = tokens.slice(0, -1).join("/") + "/" + sanitized
        }
      }
      return $ref.replace(RE_DEFS, "#/components/schemas")
    }) as JsonSchema
  }

  return {
    dialect: "openapi-3.1",
    schemas: Arr.map(multiDocument.schemas, rewrite),
    definitions: Rec.mapEntries(
      multiDocument.definitions,
      (definition, key) => [keyMap.get(key) ?? key, rewrite(definition)]
    )
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/JsonSchema.ts#L669-L699)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/JsonSchema.ts:703-735</code></summary>

```ts
export const VALID_OPEN_API_COMPONENTS_SCHEMAS_KEY_REGEXP = /^[a-zA-Z0-9.\-_]+$/

/**
 * Returns a sanitized key for an OpenAPI component schema.
 * Should match the `^[a-zA-Z0-9.\-_]+$` regular expression.
 *
 * @internal
 */
export function sanitizeOpenApiComponentsSchemasKey(s: string): string {
  if (s.length === 0) return "_"
  if (VALID_OPEN_API_COMPONENTS_SCHEMAS_KEY_REGEXP.test(s)) return s

  const out: Array<string> = []

  for (const ch of s) {
    const code = ch.codePointAt(0)
    if (
      code !== undefined &&
      ((code >= 48 && code <= 57) || // 0-9
        (code >= 65 && code <= 90) || // A-Z
        (code >= 97 && code <= 122) || // a-z
        code === 46 || // .
        code === 45 || // -
        code === 95) // _
    ) {
      out.push(ch)
    } else {
      out.push("_")
    }
  }

  return out.join("")
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/JsonSchema.ts#L703-L735)

</details>

### Reproduction

```sh
pnpm vitest run packages/effect/test/JsonSchema.test.ts -t "preserves definitions whose keys sanitize to the same component name"
```

**Observed failure:** The intended failure was reproduced: one definition was emitted instead of two.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm vitest run packages/effect/test/JsonSchema.test.ts -t "preserves definitions whose keys sanitize to the same component name"
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-g-r-jsonschema-component-key-collision`
- Initial patch: focused reproduction tests; implementation fix pending