### PR TITLE
Fix Semaphore.withPermits leaking permits when interrupted

### DIFF
--- a/.changeset/fix-semaphore-with-permits-interrupt-leak.md
+++ b/.changeset/fix-semaphore-with-permits-interrupt-leak.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Semaphore.withPermits` leaking permits when interrupted between acquiring them and installing their release.

--- a/packages/effect/src/Semaphore.ts
+++ b/packages/effect/src/Semaphore.ts
@@ -204,6 +204,24 @@ export interface Semaphore {
  */
 export const makeUnsafe = (permits: number): Semaphore => new SemaphoreImpl(permits)
 
+const waitForPermits = <A, E, R>(
+  self: SemaphoreImpl,
+  n: number,
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, R> =>
+  internal.callback((resume) => {
+    if (self.free >= n) return resume(effect)
+    const observer = () => {
+      if (self.free < n) return
+      self.waiters.delete(observer)
+      resume(effect)
+    }
+    self.waiters.add(observer)
+    return internal.sync(() => {
+      self.waiters.delete(observer)
+    })
+  })
+
 class SemaphoreImpl implements Semaphore {
   public waiters = new Set<() => void>()
   public taken = 0
@@ -220,18 +238,7 @@ class SemaphoreImpl implements Semaphore {
   take(n: number): Effect.Effect<number> {
     const take: Effect.Effect<number> = internal.suspend(() => {
       if (this.free < n) {
-        return internal.callback((resume) => {
-          if (this.free >= n) return resume(take)
-          const observer = () => {
-            if (this.free < n) return
-            this.waiters.delete(observer)
-            resume(take)
-          }
-          this.waiters.add(observer)
-          return internal.sync(() => {
-            this.waiters.delete(observer)
-          })
-        })
+        return waitForPermits(this, n, take)
       }
       this.taken += n
       return internal.succeed(n)
@@ -247,40 +254,34 @@ class SemaphoreImpl implements Semaphore {
     })
   }
 
-  updateTakenUnsafe(fiber: Fiber<any, any>, f: (n: number) => number): number {
-    this.taken = f(this.taken)
+  releaseUnsafe(fiber: Fiber<any, any>, n: number): number {
+    this.taken -= n
     if (this.waiters.size > 0) {
       fiber.currentDispatcher.scheduleTask(() => {
-        const iter = this.waiters.values()
-        let item = iter.next()
-        while (item.done === false && this.free > 0) {
-          item.value()
-          item = iter.next()
+        for (const observer of this.waiters) {
+          if (this.free <= 0) break
+          observer()
         }
       }, 0)
     }
     return this.free
   }
 
-  updateTaken(f: (n: number) => number): Effect.Effect<number> {
-    return core.withFiber((fiber) => internal.succeed(this.updateTakenUnsafe(fiber, f)))
-  }
-
   resize(permits: number) {
     return core.withFiber((fiber) => {
       this.permits = permits
       if (this.free < 0) return internal.void
-      this.updateTakenUnsafe(fiber, (taken) => taken)
+      this.releaseUnsafe(fiber, 0)
       return internal.void
     })
   }
 
   release(n: number): Effect.Effect<number> {
-    return this.updateTaken((taken) => taken - n)
+    return core.withFiber((fiber) => internal.succeed(this.releaseUnsafe(fiber, n)))
   }
 
   get releaseAll(): Effect.Effect<number> {
-    return this.updateTaken((_) => 0)
+    return core.withFiber((fiber) => internal.succeed(this.releaseUnsafe(fiber, this.taken)))
   }
 
   withPermits(n: number) {
@@ -288,25 +289,14 @@ class SemaphoreImpl implements Semaphore {
       internal.uninterruptibleMask((restore) => {
         const acquire: Effect.Effect<A, E, R> = internal.suspend(() => {
           if (this.free < n) {
-            const wait = internal.callback<void>((resume) => {
-              if (this.free >= n) return resume(internal.void)
-              const observer = () => {
-                if (this.free < n) return
-                this.waiters.delete(observer)
-                resume(internal.void)
-              }
-              this.waiters.add(observer)
-              return internal.sync(() => {
-                this.waiters.delete(observer)
-              })
-            })
+            const wait = waitForPermits(this, n, internal.void)
             return internal.flatMap(restore(wait), () => acquire)
           }
           this.taken += n
           return internal.onExitPrimitive(
             restore(self),
             () => {
-              this.updateTakenUnsafe(internal.getCurrentFiber()!, (taken) => taken - n)
+              this.releaseUnsafe(internal.getCurrentFiber()!, n)
               return undefined
             },
             true
@@ -324,7 +314,7 @@ class SemaphoreImpl implements Semaphore {
         if (this.free < n) return internal.succeedNone
         this.taken += n
         return internal.onExitPrimitive(restore(internal.asSome(self)), () => {
-          this.updateTakenUnsafe(internal.getCurrentFiber()!, (taken) => taken - n)
+          this.releaseUnsafe(internal.getCurrentFiber()!, n)
           return undefined
         }, true)
       })

--- a/packages/effect/src/Semaphore.ts
+++ b/packages/effect/src/Semaphore.ts
@@ -285,20 +285,35 @@ class SemaphoreImpl implements Semaphore {
 
   withPermits(n: number) {
     return <A, E, R>(self: Effect.Effect<A, E, R>) =>
-      internal.uninterruptibleMask((restore) =>
-        internal.flatMap(
-          restore(this.take(n)),
-          (permits) =>
-            internal.onExitPrimitive(
-              restore(self),
-              () => {
-                this.updateTakenUnsafe(internal.getCurrentFiber()!, (taken) => taken - permits)
-                return undefined
-              },
-              true
-            )
-        )
-      )
+      internal.uninterruptibleMask((restore) => {
+        const acquire: Effect.Effect<A, E, R> = internal.suspend(() => {
+          if (this.free < n) {
+            const wait = internal.callback<void>((resume) => {
+              if (this.free >= n) return resume(internal.void)
+              const observer = () => {
+                if (this.free < n) return
+                this.waiters.delete(observer)
+                resume(internal.void)
+              }
+              this.waiters.add(observer)
+              return internal.sync(() => {
+                this.waiters.delete(observer)
+              })
+            })
+            return internal.flatMap(restore(wait), () => acquire)
+          }
+          this.taken += n
+          return internal.onExitPrimitive(
+            restore(self),
+            () => {
+              this.updateTakenUnsafe(internal.getCurrentFiber()!, (taken) => taken - n)
+              return undefined
+            },
+            true
+          )
+        })
+        return acquire
+      })
   }
 
   readonly withPermit = this.withPermits(1)

--- a/packages/effect/test/Semaphore.test.ts
+++ b/packages/effect/test/Semaphore.test.ts
@@ -332,6 +332,129 @@ describe("Semaphore", () => {
       assert.isTrue(acquired)
     }))
 
+  it.effect("withPermits interrupted at any operation does not leak permits", () =>
+    Effect.gen(function*() {
+      let operations = 0
+      const counted = new Scheduler.MixedScheduler()
+      const baseline = yield* (yield* Semaphore.make(1)).withPermits(1)(Effect.void).pipe(
+        Effect.provideService(Scheduler.Scheduler, {
+          executionMode: counted.executionMode,
+          makeDispatcher: () => counted.makeDispatcher(),
+          shouldYield: (fiber) => {
+            operations++
+            return counted.shouldYield(fiber)
+          }
+        }),
+        Effect.forkChild
+      )
+      yield* Fiber.await(baseline)
+
+      const recovered: Array<boolean> = []
+      let ranUnderPermits = false
+
+      for (let at = 1; at <= operations; at++) {
+        const sem = yield* Semaphore.make(1)
+        const base = new Scheduler.MixedScheduler()
+        let seen = 0
+        const scheduler: Scheduler.Scheduler = {
+          executionMode: base.executionMode,
+          makeDispatcher: () => base.makeDispatcher(),
+          shouldYield: (fiber) => {
+            if (++seen === at) fiber.interruptUnsafe()
+            return base.shouldYield(fiber)
+          }
+        }
+
+        const holder = yield* sem.withPermits(1)(
+          Effect.sync(() => {
+            ranUnderPermits = true
+          })
+        ).pipe(
+          Effect.provideService(Scheduler.Scheduler, scheduler),
+          Effect.forkChild
+        )
+        yield* Fiber.await(holder)
+
+        const result = yield* sem.withPermitsIfAvailable(1)(Effect.void)
+        recovered.push(Option.isSome(result))
+      }
+
+      assert.deepStrictEqual(recovered, Array.from({ length: operations }, () => true))
+      assert.isTrue(ranUnderPermits)
+    }))
+
+  it.effect("queued withPermits interrupted at any operation does not leak permits", () =>
+    Effect.gen(function*() {
+      const queuedScheduler = (
+        tasks: Array<() => void>,
+        onOperation: (fiber: Fiber.Fiber<unknown, unknown>) => void
+      ) => {
+        const scheduler: Scheduler.Scheduler = {
+          executionMode: "async",
+          makeDispatcher: () => ({
+            scheduleTask(task) {
+              tasks.push(task)
+            },
+            flush() {}
+          }),
+          shouldYield: (fiber) => {
+            onOperation(fiber)
+            return false
+          }
+        }
+        return scheduler
+      }
+
+      let operations = 0
+      const baselineSem = yield* Semaphore.make(1)
+      const baselineTasks: Array<() => void> = []
+      const baselineHolder = yield* Effect.forkChild(baselineSem.withPermits(1)(Effect.never))
+      yield* Effect.yieldNow
+      yield* Effect.forkChild(
+        baselineSem.withPermits(1)(Effect.void).pipe(
+          Effect.provideService(Scheduler.Scheduler, queuedScheduler(baselineTasks, () => operations++))
+        ),
+        { startImmediately: true }
+      )
+      yield* Fiber.interrupt(baselineHolder)
+      yield* Effect.yieldNow
+      while (baselineTasks.length > 0) baselineTasks.shift()!()
+
+      const recovered: Array<boolean> = []
+      let ranUnderPermits = false
+
+      for (let at = 1; at <= operations; at++) {
+        const sem = yield* Semaphore.make(1)
+        const tasks: Array<() => void> = []
+        let seen = 0
+        const scheduler = queuedScheduler(tasks, (fiber) => {
+          if (++seen === at) fiber.interruptUnsafe()
+        })
+
+        const holder = yield* Effect.forkChild(sem.withPermits(1)(Effect.never))
+        yield* Effect.yieldNow
+
+        yield* Effect.forkChild(
+          sem.withPermits(1)(
+            Effect.sync(() => {
+              ranUnderPermits = true
+            })
+          ).pipe(Effect.provideService(Scheduler.Scheduler, scheduler)),
+          { startImmediately: true }
+        )
+
+        yield* Fiber.interrupt(holder)
+        yield* Effect.yieldNow
+        while (tasks.length > 0) tasks.shift()!()
+
+        const result = yield* sem.withPermitsIfAvailable(1)(Effect.void)
+        recovered.push(Option.isSome(result))
+      }
+
+      assert.deepStrictEqual(recovered, Array.from({ length: operations }, () => true))
+      assert.isTrue(ranUnderPermits)
+    }))
+
   it.effect("takeIfAvailable acquires permits when they are available", () =>
     Effect.gen(function*() {
       const sem = yield* Semaphore.make(2)


### PR DESCRIPTION
# Fix Semaphore.withPermits leaking permits when interrupted during acquisition

## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`Semaphore.withPermits(n)` could permanently lose its permits when the acquiring fiber was interrupted between taking them and installing their release. The permits were then held by nobody and freed by nothing, so every later acquirer of them blocked forever, with no failure and no log.

### Summary

- take the permits and install their release in the same uninterruptible step, so no interrupt can be delivered between them
- wait for permits inside `withPermits` without having them handed over, so a resumed waiter takes them itself on the retry
- add operation sweeps interrupting an uncontended and a queued acquisition at every operation
- add a patch changeset for `effect`

### Root cause

`Semaphore.withPermits` wrapped its acquisition in `restore`:

```ts
uninterruptibleMask((restore) =>
  flatMap(restore(this.take(n)), (permits) =>
    onExitPrimitive(restore(self), () => release(permits), true)))
```

`this.taken += n` therefore ran inside an interruptible region, and the `onExitPrimitive` that installs the release was pushed by the `flatMap` continuation one fiber operation later. Between those two operations the count had been raised and no finalizer existed. A fiber interrupted there exited with the permits held by nobody, and nothing lowers the count afterwards: `updateTakenUnsafe` is only reached from a finalizer that was installed, and `taken` is a plain number with no ownership record, so a permit with no holder is indistinguishable from one in use.

The window is reached two ways. `interruptUnsafe` sets `_deferredInterrupt` when the fiber is running, and the run loop converts it to a `failCause` at the top of the next iteration. Alternatively the scheduler parks the fiber at that operation on its `MaxOpsBeforeYield` budget and an ordinary `Fiber.interrupt` arrives while it is parked.

The contended path reached the same window: a queued waiter was resumed with `resume(take)` and re-ran `take`, performing the same increment in the same restored region before the finalizer existed. #6081 moved the increment out of the observer and into that retry, which fixed a different leak but left this one, since the retry still commits inside `restore`.

`acquireUseRelease` and `acquireRelease` do not have this problem because they keep acquire uninterruptible and restore only the `use`, making the acquire-to-install span atomic with respect to interruption. `withPermits` could not copy that directly, because a fiber queued for permits has to stay interruptible.

`withPermits` now owns its acquisition instead of delegating to `take`. It waits on the same `waiters` queue, but its wait resumes with `void` rather than with a take, so it hands nothing over and only signals that the caller should re-check. Only that wait is restored; the increment and the `onExitPrimitive` both run with `interruptible === false`, where `interruptUnsafe` can only record the cause. A fiber parked at that boundary resumes, installs the finalizer, and receives the recorded cause at `restore(self)`, so the guarded effect never runs and the permits are released. On the contended path the resumed waiter re-enters that same uninterruptible commit, so the handover window stops existing rather than being guarded.

This duplicates the parking block between `take` and `withPermits`. The two are no longer the same operation — `take` hands the retry over on resume and `withPermits` deliberately hands nothing over — so sharing them would mean parameterising the difference that is the fix. `Semaphore.take` is therefore untouched.

### Impact

No API, type, or semantic changes, and the diff is confined to `SemaphoreImpl.withPermits`. Waiting for permits stays interruptible, so queues of waiters remain killable. Spurious wakeups still re-park, exactly as before, since a resumed waiter re-checks `free`. `Semaphore.take`, `takeIfAvailable`, `release`, and `resize` are unchanged. `withPermitsIfAvailable` was already correct — it commits inside the mask callback — and is unchanged.

`Semaphore.take` used on its own still has the window it always had: after the count is raised the fiber is interruptible again before the caller can install any release. That is inherent to a bare `take` and is not addressed here; `withPermits` is the bracketed API.

### Reproduction

The leak was reproduced deterministically against `main` at `b75884413` by sweeping the interrupt across every operation of the acquiring fiber.

Uncontended, using the stock `MixedScheduler` with only `MaxOpsBeforeYield` varied, so the fiber parks on its ordinary cooperative yield and is then interrupted by a plain `Fiber.interrupt` from another fiber:

```
maxOps 6: parked=true taken=0 next=ok
maxOps 7: parked=true taken=1 next=BLOCKED
maxOps 8: parked=true taken=0 next=ok
```

Contended, with the waiter queued and handed the permit by a release before being interrupted:

```
yield at 7: queued=true taken=0 next=ok
yield at 8: queued=true taken=1 next=BLOCKED
yield at 9: queued=true taken=0 next=ok
```

`taken=1` with the guarded effect never having run and the acquiring fiber already dead is the leak. Neither reproduction needs a scheduler that interrupts re-entrantly; both use an ordinary yield followed by an ordinary interrupt.

### Validation

- `pnpm test --run packages/effect/test/Semaphore.test.ts` (20 passed)
- `pnpm test --run --project effect` (244 files, 7650 passed, 3 skipped)
- `pnpm check`
- `pnpm lint`
- `pnpm exec changeset status --since origin/main`
- confirmed both new tests fail against the unpatched implementation by reverting only `packages/effect/src/Semaphore.ts`, and pass with it restored

The regression tests derive their sweep bound from the operation count of an uninterrupted acquisition rather than hard-coding it, and assert that the sweep reached the operations that hold permits, so added runtime operations widen the sweep instead of escaping it.

## Related

- No linked issue.