### PR TITLE
Replace existing HashRing nodes when primary keys match

### DIFF
--- a/.changeset/brave-rings-update.md
+++ b/.changeset/brave-rings-update.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Update existing `HashRing` nodes when adding a value with the same primary key.

--- a/packages/effect/src/HashRing.ts
+++ b/packages/effect/src/HashRing.ts
@@ -145,6 +145,7 @@ export const addMany: {
       const key = PrimaryKey.value(node)
       const entry = self.nodes.get(key)
       if (entry) {
+        entry[0] = node
         if (entry[1] === weight) continue
         toRemove ??= new Set()
         toRemove.add(key)

--- a/packages/effect/test/HashRing.test.ts
+++ b/packages/effect/test/HashRing.test.ts
@@ -1,0 +1,26 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as HashRing from "effect/HashRing"
+import * as PrimaryKey from "effect/PrimaryKey"
+
+describe("HashRing", () => {
+  it("updates the stored node when adding the same primary key", () => {
+    const first = {
+      name: "first",
+      [PrimaryKey.symbol]() {
+        return "node"
+      }
+    }
+    const updated = {
+      name: "updated",
+      [PrimaryKey.symbol]() {
+        return "node"
+      }
+    }
+    const ring = HashRing.make<typeof first>()
+
+    HashRing.add(ring, first)
+    HashRing.add(ring, updated)
+
+    assert.strictEqual(HashRing.get(ring, "request"), updated)
+  })
+})

--- a/packages/effect/test/HashRing.test.ts
+++ b/packages/effect/test/HashRing.test.ts
@@ -23,4 +23,25 @@ describe("HashRing", () => {
 
     assert.strictEqual(HashRing.get(ring, "request"), updated)
   })
+
+  it("updates the stored node when changing its weight", () => {
+    const first = {
+      name: "first",
+      [PrimaryKey.symbol]() {
+        return "node"
+      }
+    }
+    const updated = {
+      name: "updated",
+      [PrimaryKey.symbol]() {
+        return "node"
+      }
+    }
+    const ring = HashRing.make<typeof first>()
+
+    HashRing.add(ring, first)
+    HashRing.add(ring, updated, { weight: 2 })
+
+    assert.strictEqual(HashRing.get(ring, "request"), updated)
+  })
 })


### PR DESCRIPTION
## Summary

Adding a replacement node with an existing PrimaryKey updates at most its weight. Routing, iteration, JSON output, and shard assignment continue returning the old node value, including when the replacement has the same weight.

> [!IMPORTANT]
> This PR starts with focused failing reproduction tests. Add the implementation fix to this same branch; CI is expected to fail until that fix is included.

## Re-adding an existing primary key retains the stale node

**Module:** `HashRing`  
**Audit ID:** `core-g-r-hashring-existing-key-retains-stale-node`  
**Severity / confidence:** medium / high

### What happens

Adding a replacement node with an existing PrimaryKey updates at most its weight. Routing, iteration, JSON output, and shard assignment continue returning the old node value, including when the replacement has the same weight.

### Why it happens

For an existing key, addMany assigns only entry[1], the weight, and never replaces entry[0], the node. The same-weight branch returns before any update, while all value-returning operations continue reading entry[0].

### Expected behavior

add and addMany update an existing node keyed by PrimaryKey.value, and subsequent routing returns the currently registered node value.

### Relevant implementation

These links and excerpts are pinned to audit base `c9b56ab507f224426ee8388dc450da447ec4715f`.

- [`packages/effect/src/HashRing.ts:118-165`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L118-L165)
- [`packages/effect/src/HashRing.ts:297-304`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L297-L304)
- [`packages/effect/src/HashRing.ts:317-377`](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L317-L377)

<details>
<summary>View problematic code at <code>packages/effect/src/HashRing.ts:118-165</code></summary>

```ts
/**
 * Adds new nodes to the ring. If a node already exists in the ring, it
 * will be updated. For example, you can use this to update the node's weight.
 *
 * **When to use**
 *
 * Use to register or update several nodes in a `HashRing` at the same weight.
 *
 * @category combinators
 * @since 3.19.0
 */
export const addMany: {
  <A extends PrimaryKey.PrimaryKey>(nodes: Iterable<A>, options?: {
    readonly weight?: number | undefined
  }): (self: HashRing<A>) => HashRing<A>
  <A extends PrimaryKey.PrimaryKey>(self: HashRing<A>, nodes: Iterable<A>, options?: {
    readonly weight?: number | undefined
  }): HashRing<A>
} = dual(
  (args) => isHashRing(args[0]),
  <A extends PrimaryKey.PrimaryKey>(self: HashRing<A>, nodes: Iterable<A>, options?: {
    readonly weight?: number | undefined
  }): HashRing<A> => {
    const weight = Math.max(options?.weight ?? 1, 0.1)
    const keys: Array<string> = []
    let toRemove: Set<string> | undefined
    for (const node of nodes) {
      const key = PrimaryKey.value(node)
      const entry = self.nodes.get(key)
      if (entry) {
        if (entry[1] === weight) continue
        toRemove ??= new Set()
        toRemove.add(key)
        self.totalWeightCache -= entry[1]
        self.totalWeightCache += weight
        entry[1] = weight
      } else {
        self.nodes.set(key, [node, weight])
        self.totalWeightCache += weight
      }
      keys.push(key)
    }
    if (toRemove) {
      self.ring = self.ring.filter(([, n]) => !toRemove.has(n))
    }
    addNodesToRing(self, keys, Math.round(weight * self.baseWeight))
    return self
  }
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L118-L165)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/HashRing.ts:297-304</code></summary>

```ts
export const get = <A extends PrimaryKey.PrimaryKey>(self: HashRing<A>, input: string): A | undefined => {
  if (self.ring.length === 0) {
    return undefined
  }
  const index = getIndexForInput(self, Hash.string(input))[0]
  const node = self.ring[index][1]!
  return self.nodes.get(node)![0]
}
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L297-L304)

</details>
<details>
<summary>View problematic code at <code>packages/effect/src/HashRing.ts:317-366</code></summary>

```ts
export const getShards = <A extends PrimaryKey.PrimaryKey>(self: HashRing<A>, count: number): Array<A> | undefined => {
  if (self.ring.length === 0) {
    return undefined
  }

  const shards = new Array<A>(count)

  // for tracking how many shards have been allocated to each node
  const allocations = new Map<string, number>()
  // for tracking which shards still need to be allocated
  const remaining = new Set<number>()
  // for tracking which nodes have reached the max allocation
  const exclude = new Set<string>()

  // First pass - allocate the closest nodes, skipping nodes that have reached
  // max
  const distances = new Array<[shard: number, node: string, distance: number]>(count)
  for (let shard = 0; shard < count; shard++) {
    const hash = (shardHashes[shard] ??= Hash.string(`shard-${shard}`))
    const [index, distance] = getIndexForInput(self, hash)
    const node = self.ring[index][1]!
    distances[shard] = [shard, node, distance]
    remaining.add(shard)
  }
  distances.sort((a, b) => a[2] - b[2])
  for (let i = 0; i < count; i++) {
    const [shard, node] = distances[i]
    if (exclude.has(node)) continue
    const [value, weight] = self.nodes.get(node)!
    shards[shard] = value
    remaining.delete(shard)
    const nodeCount = (allocations.get(node) ?? 0) + 1
    allocations.set(node, nodeCount)
    const maxPerNode = Math.max(1, Math.floor(count * (weight / self.totalWeightCache)))
    if (nodeCount >= maxPerNode) {
      exclude.add(node)
    }
  }

  // Second pass - allocate any remaining shards, skipping nodes that have
  // reached max
  let allAtMax = exclude.size === self.nodes.size
  remaining.forEach((shard) => {
    const index = getIndexForInput(self, shardHashes[shard], allAtMax ? undefined : exclude)[0]
    const node = self.ring[index][1]
    const [value, weight] = self.nodes.get(node)!
    shards[shard] = value

    if (allAtMax) return
    const nodeCount = (allocations.get(node) ?? 0) + 1
```

[View exact lines on GitHub](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L317-L377)

_Excerpt truncated. [Open the complete packages/effect/src/HashRing.ts:317-377 range.](https://github.com/Effect-TS/effect/blob/c9b56ab507f224426ee8388dc450da447ec4715f/packages/effect/src/HashRing.ts#L317-L377)_

</details>

### Reproduction

```sh
pnpm vitest run packages/effect/test/HashRing.test.ts
```

**Observed failure:** The intended failure was reproduced: the first node was returned instead of its replacement.

## Implementation handoff

The initial reproduction tests on this branch are the regression specification for the implementation fix that should follow in this PR.

1. Start with the pinned implementation excerpts and the **Why it happens** analysis above.
2. Change the implementation so it satisfies the stated **Expected behavior**; do not weaken or remove the reproduction assertions.
3. Run the focused reproduction command(s) and confirm the observed failures become passing tests:

```sh
pnpm vitest run packages/effect/test/HashRing.test.ts
```

4. Run the affected package's existing tests, then the repository lint and type checks before requesting review.

## Audit provenance

- Audit base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Reproduction base: `c9b56ab507f224426ee8388dc450da447ec4715f`
- Findings: `core-g-r-hashring-existing-key-retains-stale-node`
- Initial patch: focused reproduction tests; implementation fix pending

Closes EFF-341
