### PR TITLE
Remove actual values from schema issues

### DIFF
--- a/.changeset/protect-schema-issue-actuals.md
+++ b/.changeset/protect-schema-issue-actuals.md
@@ -1,0 +1,36 @@
+---
+"effect": patch
+---
+
+Remove `actual` fields from every `SchemaIssue` variant, together with
+`SchemaIssue.getActual`, `SchemaIssue.redact`, and `Schema.redact`. Built-in
+formatters now use static messages that do not interpolate rejected input,
+while paths, AST metadata, union successes, and user-provided messages and
+annotations are preserved unchanged.
+
+Runtime performance was measured across the 16 Effect fixtures in the
+`schema-benchmarks` suite. These are the scenarios used for the cross-library
+comparison with Valibot and Zod. The paired HEAD-versus-`main` run classified 3
+fixtures as improvements, 0 as regressions, and 13 as inconclusive. Negative
+changes are faster. Absolute library values are medians from the same
+cross-library run; `—` means that the corresponding adapter does not expose
+that scenario.
+
+| Scenario                 | Effect (ns/op) | Valibot (ns/op) | Zod (ns/op) | HEAD vs main | Classification |
+| ------------------------ | -------------: | --------------: | ----------: | -----------: | -------------- |
+| `initialization-schema`  |      108191.30 |    **30549.81** |   212715.66 |       -0.92% | inconclusive   |
+| `initialization-decoder` |  **109796.34** |               — |           — |       +1.98% | inconclusive   |
+| `validation-valid`       |        5221.80 |     **5070.81** |           — |       +2.06% | inconclusive   |
+| `validation-invalid`     |        1279.77 |      **234.92** |           — |       +0.59% | inconclusive   |
+| `parsing-all-valid`      |    **5144.58** |         5192.19 |     7176.19 |       -3.79% | inconclusive   |
+| `parsing-all-invalid`    |    **7594.49** |        15236.82 |    37780.35 |       -5.94% | improvement    |
+| `parsing-first-valid`    |        5188.33 |     **5135.75** |           — |       -1.49% | inconclusive   |
+| `parsing-first-invalid`  |        1330.82 |      **243.64** |           — |       +1.01% | inconclusive   |
+| `standard-all-valid`     |        5722.01 |         5200.05 | **3801.26** |       -1.78% | inconclusive   |
+| `standard-all-invalid`   |   **12024.65** |        15528.50 |    30982.17 |       -7.78% | improvement    |
+| `standard-first-valid`   |    **5655.33** |               — |           — |       +3.84% | inconclusive   |
+| `standard-first-invalid` |    **2001.69** |               — |           — |       -4.56% | inconclusive   |
+| `codec-typed-encode`     |         342.59 |               — |   **39.29** |       -7.62% | inconclusive   |
+| `codec-typed-decode`     |         418.78 |               — |   **50.14** |      -10.89% | improvement    |
+| `codec-unknown-encode`   |     **328.38** |               — |           — |       -5.55% | inconclusive   |
+| `codec-unknown-decode`   |     **347.35** |               — |           — |       -5.25% | inconclusive   |

--- a/migration/schema.md
+++ b/migration/schema.md
@@ -898,14 +898,14 @@ const NumberFromString = Schema.transformOrFail(Schema.String, Schema.Number, {
 v4
 
 ```ts
-import { Effect, Number, Option, Schema, SchemaGetter, SchemaIssue } from "effect"
+import { Effect, Number, Schema, SchemaGetter, SchemaIssue } from "effect"
 
 const NumberFromString = Schema.String.pipe(
   Schema.decodeTo(Schema.Number, {
     decode: SchemaGetter.transformOrFail((s) => {
       const n = Number.parse(s)
       if (n === undefined) {
-        return Effect.fail(new SchemaIssue.InvalidValue(Option.some(s)))
+        return Effect.fail(new SchemaIssue.InvalidValue())
       }
       return Effect.succeed(n)
     }),

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -314,7 +314,7 @@ Success("a@b.com")
 
 console.log(String(Schema.decodeUnknownExit(email)("@b.com")))
 /*
-Failure(Cause([Fail(SchemaError(Expected a string matching template literal parts, got "@b.com"))]))
+Failure(Cause([Fail(SchemaError(Expected a string matching template literal parts))]))
 */
 ```
 
@@ -340,11 +340,11 @@ console.log(String(Schema.decodeUnknownExit(schema)("aa:1")))
 // Success(["aa",":",1])
 
 console.log(String(Schema.decodeUnknownExit(schema)("a:1")))
-// Failure(Cause([Fail(SchemaError(Expected a value with a length of at least 2, got "a"
+// Failure(Cause([Fail(SchemaError(Expected a value with a length of at least 2
 //   at [0]))]))
 
 console.log(String(Schema.decodeUnknownExit(schema)("aa:1.2")))
-// Failure(Cause([Fail(SchemaError(Expected an integer, got 1.2
+// Failure(Cause([Fail(SchemaError(Expected an integer
 //   at [2]))]))
 ```
 
@@ -1165,7 +1165,7 @@ console.log(
     })
   )
 )
-// Failure(Cause([Fail(SchemaError: Expected a === b, got {"a":"a","b":"b","c":"c"})]))
+// Failure(Cause([Fail(SchemaError: Expected a === b)]))
 ```
 
 #### Mapping individual fields
@@ -1642,7 +1642,7 @@ import { Schema } from "effect"
 const schema = Schema.UniqueArray(Schema.String)
 
 console.log(String(Schema.decodeUnknownExit(schema)(["a", "b", "a"])))
-// Failure(Cause([Fail(SchemaError: Expected an array with unique items, got ["a","b","a"])]))
+// Failure(Cause([Fail(SchemaError: Expected an array with unique items)]))
 ```
 
 ## Records
@@ -1706,7 +1706,7 @@ console.log(String(Schema.decodeUnknownExit(schema)({ 1.1: "ignored" })))
 // Success({})
 
 console.log(String(Schema.decodeUnknownExit(schema)({ 1: null })))
-// Failure(Cause([Fail(SchemaError(Expected string, got null
+// Failure(Cause([Fail(SchemaError(Expected string
 //  at ["1"]))]))
 ```
 
@@ -1816,7 +1816,7 @@ import { Schema } from "effect"
 const schema = Schema.Union([Schema.NonEmptyString, Schema.Number])
 
 console.log(String(Schema.decodeUnknownExit(schema)("")))
-// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 1, got "")]))
+// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 1)]))
 ```
 
 If none of the union members match the input, the union fails with a message at the top level.
@@ -1829,7 +1829,7 @@ import { Schema } from "effect"
 const schema = Schema.Union([Schema.NonEmptyString, Schema.Number])
 
 console.log(String(Schema.decodeUnknownExit(schema)(null)))
-// Failure(Cause([Fail(SchemaError: Expected string | number, got null)]))
+// Failure(Cause([Fail(SchemaError: Expected string | number)]))
 ```
 
 This behavior is especially helpful when working with literal values. Instead of producing a separate error for each literal (as in version 3), the schema reports a single, clear message.
@@ -1842,7 +1842,7 @@ import { Schema } from "effect"
 const schema = Schema.Literals(["a", "b"])
 
 console.log(String(Schema.decodeUnknownExit(schema)(null)))
-// Failure(Cause([Fail(SchemaError: Expected "a" | "b", got null)]))
+// Failure(Cause([Fail(SchemaError: Expected "a" | "b")]))
 ```
 
 ### Exclusive Unions
@@ -1859,7 +1859,7 @@ const schema = Schema.Union([Schema.Struct({ a: Schema.String }), Schema.Struct(
 })
 
 console.log(String(Schema.decodeUnknownExit(schema)({ a: "a", b: 1 })))
-// Failure(Cause([Fail(SchemaError: Expected exactly one member to match the input {"a":"a","b":1})]))
+// Failure(Cause([Fail(SchemaError: Expected exactly one member to match)]))
 ```
 
 ### Deriving Unions
@@ -2211,7 +2211,7 @@ console.log(String(Schema.decodeUnknownExit(URLSchema)(new URL("https://example.
 // Success(https://example.com/)
 
 console.log(String(Schema.decodeUnknownExit(URLSchema)(null)))
-// Failure(Cause([Fail(SchemaError(Expected <Declaration>, got null))]))
+// Failure(Cause([Fail(SchemaError(Expected <Declaration>))]))
 ```
 
 > **Tip**: For simple `instanceof` checks, prefer `Schema.instanceOf(URL)`, it wraps `Schema.declare` with an `instanceof` guard automatically.
@@ -2231,7 +2231,7 @@ const URLSchema = Schema.declare(
 )
 
 console.log(String(Schema.decodeUnknownExit(URLSchema)(null)))
-// Failure(Cause([Fail(SchemaError(Expected URL, got null))]))
+// Failure(Cause([Fail(SchemaError(Expected URL))]))
 //                                          ^^^
 //                          Now the error message shows "URL" instead of "<Declaration>"
 ```
@@ -2267,7 +2267,7 @@ You build a `Link` using `Schema.link<T>()`, which takes two arguments:
 **Example** (Making `URL` JSON-serializable)
 
 ```ts
-import { Effect, Option, Schema, SchemaIssue, SchemaTransformation } from "effect"
+import { Effect, Schema, SchemaIssue, SchemaTransformation } from "effect"
 
 const URLSchema = Schema.declare(
   (u): u is URL => u instanceof URL,
@@ -2284,7 +2284,7 @@ const URLSchema = Schema.declare(
           decode: (s) =>
             Effect.try({
               try: () => new URL(s),
-              catch: (e) => new SchemaIssue.InvalidValue(Option.some(s), { message: globalThis.String(e) })
+              catch: () => new SchemaIssue.InvalidValue({ message: "Invalid URL string" })
             }),
           // URL -> JSON string (always succeeds)
           encode: (url) => Effect.succeed(url.href)
@@ -2339,7 +2339,7 @@ The parsing function you return from `run` is responsible for:
 **Example** (A generic `Box<A>` container)
 
 ```ts
-import { Effect, Option, Schema, SchemaIssue, SchemaParser } from "effect"
+import { Effect, Schema, SchemaIssue, SchemaParser } from "effect"
 
 // 1. Define the type
 interface Box<A> {
@@ -2360,7 +2360,7 @@ const Box = <A extends Schema.Top>(item: A) =>
     (u, ast, options) => {
       // First, check the outer shape
       if (!isBox(u)) {
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(u)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       // Then, decode the inner value using the item codec
       return Effect.mapBothEager(
@@ -2381,7 +2381,7 @@ console.log(String(Schema.decodeUnknownExit(schema)({ value: "1" })))
 // Success({ value: 1 })
 
 console.log(String(Schema.decodeUnknownExit(schema)({ value: "a" })))
-// Failure(Cause([Fail(SchemaError(Expected a finite number, got NaN
+// Failure(Cause([Fail(SchemaError(Expected a finite number
 //   at ["value"]))]))
 ```
 
@@ -2404,7 +2404,7 @@ import { Schema } from "effect"
 const schema = Schema.String.check(Schema.makeFilter((s) => s.length >= 3))
 
 console.log(String(Schema.decodeUnknownExit(schema)("")))
-// Failure(Cause([Fail(SchemaError: Expected <filter>, got "")]))
+// Failure(Cause([Fail(SchemaError: Expected <filter>)]))
 ```
 
 You can attach annotations and provide a custom error message when defining a filter.
@@ -2449,10 +2449,10 @@ import { Schema } from "effect"
 const Username = Schema.NonEmptyString.annotate({ identifier: "Username" })
 
 console.log(String(Schema.decodeUnknownExit(Username)(null)))
-// Failure(Cause([Fail(SchemaError: Expected Username, got null)]))
+// Failure(Cause([Fail(SchemaError: Expected Username)]))
 
 console.log(String(Schema.decodeUnknownExit(Username)("")))
-// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 1, got "")]))
+// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 1)]))
 ```
 
 ### Filter return shapes
@@ -2563,7 +2563,7 @@ const schema = Schema.String.check(
 )
 
 console.log(String(Schema.decodeUnknownExit(schema)(" a")))
-// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3, got " a")]))
+// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3)]))
 ```
 
 **Example** (Using `isMinLength` with an object that has `length`)
@@ -2575,7 +2575,7 @@ import { Schema } from "effect"
 const schema = Schema.Struct({ length: Schema.Number }).check(Schema.isMinLength(3))
 
 console.log(String(Schema.decodeUnknownExit(schema)({ length: 2 })))
-// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3, got {"length":2}]))
+// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3)]))
 ```
 
 **Example** (Validating array length)
@@ -2587,7 +2587,7 @@ import { Schema } from "effect"
 const schema = Schema.Array(Schema.String).check(Schema.isMinLength(3))
 
 console.log(String(Schema.decodeUnknownExit(schema)(["a", "b"])))
-// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3, got ["a","b"]]))
+// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3)]))
 ```
 
 ## Multiple Issues Reporting
@@ -2609,8 +2609,8 @@ console.log(
   )
 )
 /*
-Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3, got " a"
-Expected a string with no leading or trailing whitespace, got " a")]))
+Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3
+Expected a string with no leading or trailing whitespace)]))
 */
 ```
 
@@ -2635,7 +2635,7 @@ console.log(
     })
   )
 )
-// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3, got " a")]))
+// Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 3)]))
 ```
 
 ## Filter Groups
@@ -2714,7 +2714,7 @@ const schema = Schema.Struct({
 
 console.log(String(Schema.decodeUnknownExit(schema)({ tags: ["a", ""] }, { errors: "all" })))
 /*
-Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 1, got ""
+Failure(Cause([Fail(SchemaError: Expected a value with a length of at least 1
   at ["tags"][1])]))
 */
 ```
@@ -2728,7 +2728,7 @@ Define an effectful filter with `Getter.checkEffect` as part of a transformation
 **Example** (Asynchronous validation of a numeric value)
 
 ```ts
-import { Effect, Option, Result, Schema, SchemaGetter, SchemaIssue } from "effect"
+import { Effect, Result, Schema, SchemaGetter, SchemaIssue } from "effect"
 
 // Simulated API call that fails when userId is 0
 const myapi = (userId: number) =>
@@ -2747,7 +2747,7 @@ const schema = Schema.Finite.pipe(
         const user = yield* Effect.result(myapi(n))
 
         // If the result is an error, return a SchemaIssue
-        return Result.isFailure(user) ? new SchemaIssue.InvalidValue(Option.some(n), { title: "not found" }) : undefined // No issue, value is valid
+        return Result.isFailure(user) ? new SchemaIssue.InvalidValue({ title: "not found" }) : undefined // No issue, value is valid
       })
     ),
     encode: SchemaGetter.passthrough()
@@ -3210,7 +3210,7 @@ This is useful when you need to validate input or enforce rules that may not alw
 **Example** (Converting a string URL into a `URL` object)
 
 ```ts
-import { Effect, Option, Schema, SchemaIssue, SchemaTransformation } from "effect"
+import { Effect, Schema, SchemaIssue, SchemaTransformation } from "effect"
 
 const URLFromString = Schema.String.pipe(
   Schema.decodeTo(
@@ -3219,7 +3219,7 @@ const URLFromString = Schema.String.pipe(
       decode: (s) =>
         Effect.try({
           try: () => new URL(s),
-          catch: () => new Issue.InvalidValue(Option.some(s), { message: `Invalid URL string: ${s}` })
+          catch: () => new SchemaIssue.InvalidValue({ message: "Invalid URL string" })
         }),
       encode: (url) => Effect.succeed(url.href)
     })
@@ -3679,7 +3679,7 @@ class Person extends Schema.Opaque<Person>()(
 ) {}
 
 console.log(String(Schema.decodeUnknownExit(Person)(null)))
-// Failure(Cause([Fail(SchemaError: Expected Person, got null)]))
+// Failure(Cause([Fail(SchemaError: Expected Person)]))
 ```
 
 When you call methods like `annotate` on an opaque struct, you get back the original struct, not a new class.
@@ -3925,7 +3925,7 @@ try {
   }
 }
 /*
-Expected a finite number, got NaN
+Expected a finite number
   at [1]
 */
 ```
@@ -4131,14 +4131,14 @@ try {
 } catch (error: any) {
   console.log(error.message)
 }
-// Expected a === b, got {"a":"a","b":"b"}
+// Expected a === b
 
 try {
   Schema.decodeUnknownSync(A)({ a: "a", b: "b" })
 } catch (error: any) {
   console.log(error.message)
 }
-// Expected a === b, got {"a":"a","b":"b"}
+// Expected a === b
 ```
 
 #### Branded Classes
@@ -5837,7 +5837,7 @@ Generic declarations receive one derivation per type parameter:
 For an opaque wrapper type, you usually map both sources in the same way:
 
 ```ts
-import { Effect, Option, Schema, SchemaIssue, SchemaParser } from "effect"
+import { Effect, Schema, SchemaIssue, SchemaParser } from "effect"
 
 class Box<A> {
   private constructor(private readonly value: A) {}
@@ -5858,7 +5858,7 @@ const BoxSchema = <A extends Schema.Top>(value: A) =>
     [value],
     ([valueCodec]) => (input, ast, options) => {
       if (!isBox(input)) {
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       return Effect.map(
         SchemaParser.decodeUnknownEffect(valueCodec)(Box.unbox(input), options),
@@ -6521,7 +6521,7 @@ Output:
 {
   issues: [
     { path: [ 'a' ], message: 'Missing key' },
-    { path: [ 'b' ], message: 'Expected a value with a length of at least 1, got ""' }
+    { path: [ 'b' ], message: 'Expected a value with a length of at least 1' }
   ]
 }
 */
@@ -6717,7 +6717,7 @@ if (r._tag === "Failure") {
 {
   issues: [
     {
-      message: 'Expected a value with a length of at least 1, got ""',
+      message: 'Expected a value with a length of at least 1',
       path: [ 'a' ]
     },
     { message: 'Missing key', path: [ 'c', 0 ] },

--- a/packages/effect/runtimeperf/compare.mts
+++ b/packages/effect/runtimeperf/compare.mts
@@ -1,8 +1,9 @@
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs"
 import os from "node:os"
-import { dirname, join, relative } from "node:path"
+import { join } from "node:path"
 import process from "node:process"
+import { materializeFixture } from "./materialize.mts"
 import { analyzePairs } from "./stats.mts"
 import {
   aggregateMeasurements,
@@ -22,8 +23,6 @@ import {
   repoRoot,
   reportPath,
   resolveDefaults,
-  runtimeperfDir,
-  sanitize,
   selectFixtures,
   sha256,
   workerPath,
@@ -88,14 +87,6 @@ const createWorktree = (runRoot, name, sha) => {
     removeWorktree(path)
     throw error
   }
-  return path
-}
-
-const materializeFixture = (targetRoot, fixture) => {
-  const name = sanitize(relative(runtimeperfDir, fixture.fixturePath))
-  const path = join(targetRoot, "packages", "effect", ".runtimeperf-compare", name)
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, readFileSync(fixture.fixturePath))
   return path
 }
 

--- a/packages/effect/runtimeperf/materialize.mts
+++ b/packages/effect/runtimeperf/materialize.mts
@@ -1,0 +1,14 @@
+import { cpSync, existsSync, mkdirSync } from "node:fs"
+import { basename, dirname, join, relative } from "node:path"
+import { runtimeperfDir, sanitize } from "./utils.mts"
+
+export const materializeFixture = (targetRoot, fixture) => {
+  const sourceDir = dirname(fixture.fixturePath)
+  const name = sanitize(relative(runtimeperfDir, sourceDir))
+  const targetDir = join(targetRoot, "packages", "effect", ".runtimeperf-compare", name)
+  mkdirSync(dirname(targetDir), { recursive: true })
+  if (!existsSync(targetDir)) {
+    cpSync(sourceDir, targetDir, { recursive: true })
+  }
+  return join(targetDir, basename(fixture.fixturePath))
+}

--- a/packages/effect/runtimeperf/test/materialize.test.mts
+++ b/packages/effect/runtimeperf/test/materialize.test.mts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { describe, it } from "node:test"
+import { materializeFixture } from "../materialize.mts"
+
+describe("runtimeperf fixture materialization", () => {
+  it("preserves relative fixture dependencies", () => {
+    const root = mkdtempSync(join(tmpdir(), "effect-runtimeperf-materialize-"))
+    try {
+      const fixturePath = join(root, "fixtures", "fixture.mts")
+      mkdirSync(dirname(fixturePath), { recursive: true })
+      writeFileSync(join(dirname(fixturePath), "data.mts"), "export const value = 1\n")
+      writeFileSync(fixturePath, 'import { value } from "./data.mts"\nexport { value }\n')
+
+      const materialized = materializeFixture(join(root, "target"), { fixturePath })
+
+      assert.equal(existsSync(join(dirname(materialized), "data.mts")), true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -449,7 +449,7 @@ export interface declareConstructor<T, E, TypeParameters extends ReadonlyArray<C
  * **Example** (Schema for a parametric `Box<A>` type)
  *
  * ```ts import.meta.vitest
- * import { Effect, Option, Schema, SchemaIssue as Issue, SchemaParser } from "effect"
+ * import { Effect, Schema, SchemaIssue as Issue, SchemaParser } from "effect"
  *
  * interface Box<A> {
  *   readonly value: A
@@ -464,7 +464,7 @@ export interface declareConstructor<T, E, TypeParameters extends ReadonlyArray<C
  *     ([itemCodec]) =>
  *       (u, ast, options) => {
  *         if (!isBox(u)) {
- *           return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(u)))
+ *           return Effect.fail(new SchemaIssue.InvalidType(ast))
  *         }
  *         return Effect.map(
  *           SchemaParser.decodeUnknownEffect(itemCodec)(u.value, options),
@@ -555,7 +555,7 @@ export function declare<T, Iso = T>(
     () => (input, ast) =>
       is(input) ?
         Effect.succeed(input) :
-        Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input))),
+        Effect.fail(new SchemaIssue.InvalidType(ast)),
     annotations
   )
 }
@@ -1160,22 +1160,22 @@ export {
    * **Details**
    *
    * The `issue` field contains a structured {@link SchemaIssue.Issue} tree describing
-   * every validation failure, including the path to the problematic value,
-   * expected types, and actual values received. `message` renders the issue tree
-   * as a human-readable string.
+   * every validation failure, including the path to the problematic value and
+   * the expected type or constraint. Built-in issues have no `actual` field,
+   * and built-in messages do not include the rejected value. Other Issue fields
+   * and custom annotations or messages are not sanitized. `message` renders the
+   * issue tree as a human-readable string.
    *
    * Use {@link isSchemaError} to narrow an unknown value to `SchemaError`.
    *
    * **Example** (Inspecting a SchemaError)
    *
    * ```ts import.meta.vitest
-   * import { Option, Result, Schema, SchemaIssue } from "effect"
+   * import { Result, Schema } from "effect"
    *
    * const result = Schema.decodeUnknownResult(Schema.Number)("not a number")
-   * const actual = Result.isFailure(result) && result.failure.issue instanceof SchemaIssue.InvalidType
-   *   ? result.failure.issue.actual
-   *   : Option.none()
-   * actual // => Option.some("not a number")
+   * const message = Result.isFailure(result) ? result.failure.message : ""
+   * message // => "Expected number"
    * ```
    *
    * @category errors
@@ -6551,8 +6551,8 @@ export const makeFilter: <T>(
  * **Details**
  *
  * - `string`: failure with that string as the message. Produces an
- *   {@link SchemaIssue.InvalidValue} wrapping the input, with the string used as
- *   the issue's `message` annotation.
+ *   {@link SchemaIssue.InvalidValue} with the string used as the issue's
+ *   `message` annotation.
  * - {@link SchemaIssue.Issue}: a fully-formed issue, returned as-is.
  * - `{ path, issue }`: failure attached to a nested path. `issue` is either
  *   a `string` (wrapped in an {@link SchemaIssue.InvalidValue}) or a full
@@ -6578,8 +6578,8 @@ export type FilterIssue = string | SchemaIssue.Issue | {
  * - `undefined`: success. The input satisfies the filter.
  * - `true`: success. Equivalent to `undefined`, useful when the predicate is
  *   a plain boolean expression.
- * - `false`: generic failure. Produces an {@link SchemaIssue.InvalidValue} wrapping
- *   the input, with no custom message.
+ * - `false`: generic failure. Produces an {@link SchemaIssue.InvalidValue}
+ *   with no custom message.
  * - {@link FilterIssue}: a single failure. See {@link FilterIssue} for the
  *   shapes (`string`, {@link SchemaIssue.Issue}, or `{ path, issue }`).
  * - `ReadonlyArray<FilterIssue>`: several failures reported together. An
@@ -9379,7 +9379,7 @@ export function isPropertyNames(keySchema: Constraint, annotations?: Annotations
         }
       }
       if (Arr.isArrayNonEmpty(issues)) {
-        return new SchemaIssue.Composite(ast, Option_.some(input), issues)
+        return new SchemaIssue.Composite(ast, issues)
       }
       return true
     },
@@ -9580,12 +9580,11 @@ export function Option<A extends Constraint>(value: A): Option<A> {
           SchemaParser.decodeUnknownEffect(value)(input.value, options),
           {
             onSuccess: Option_.some,
-            onFailure: (issue) =>
-              new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["value"], issue)])
+            onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["value"], issue)])
           }
         )
       }
-      return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+      return Effect.fail(new SchemaIssue.InvalidType(ast))
     },
     {
       representation: {
@@ -9898,20 +9897,18 @@ export function Result<A extends Constraint, E extends Constraint>(
     [success, failure],
     ([success, failure]) => (input, ast, options) => {
       if (!Result_.isResult(input)) {
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       switch (input._tag) {
         case "Success":
           return Effect.mapBothEager(SchemaParser.decodeEffect(success)(input.success, options), {
             onSuccess: Result_.succeed,
-            onFailure: (issue) =>
-              new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["success"], issue)])
+            onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["success"], issue)])
           })
         case "Failure":
           return Effect.mapBothEager(SchemaParser.decodeEffect(failure)(input.failure, options), {
             onSuccess: Result_.fail,
-            onFailure: (issue) =>
-              new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["failure"], issue)])
+            onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["failure"], issue)])
           })
       }
     },
@@ -10034,13 +10031,7 @@ const RedactedOptionsPayload = declare((input): input is RedactedRepresentationO
 const RedactedRepresentationPayload: Decoder<RedactedRepresentationPayload> = Union([Null, RedactedOptionsPayload])
 
 /**
- * Schema for values that hide sensitive information from error output and
- * inspection.
- *
- * **Details**
- *
- * If the wrapped schema fails, the issue will be redacted to prevent both
- * the actual value and the schema details from being exposed.
+ * Schema for `Redacted` values, which hide their contents from inspection.
  *
  * Options:
  *
@@ -10088,17 +10079,16 @@ export function Redacted<S extends Constraint>(value: S, options?: {
               SchemaParser.decodeUnknownEffect(value)(Redacted_.value(input), poptions),
               {
                 onSuccess: () => input,
-                onFailure: (/** ignore the actual issue because of security reasons */) => {
-                  const oinput = Option_.some(input)
-                  return new SchemaIssue.Composite(ast, oinput, [
-                    new SchemaIssue.Pointer(["value"], new SchemaIssue.InvalidValue(oinput))
+                onFailure: (/** ignore the issue because of security reasons */) => {
+                  return new SchemaIssue.Composite(ast, [
+                    new SchemaIssue.Pointer(["value"], new SchemaIssue.InvalidValue())
                   ])
                 }
               }
             )
         )
       }
-      return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+      return Effect.fail(new SchemaIssue.InvalidType(ast))
     },
     {
       representation: {
@@ -10115,7 +10105,7 @@ export function Redacted<S extends Constraint>(value: S, options?: {
       expected: "Redacted",
       toCodecJson: ([value]) =>
         link<Redacted_.Redacted<S["Encoded"]>>()(
-          redact(value),
+          value,
           {
             decode: SchemaGetter.transform((e) => Redacted_.make(e, { label })),
             encode: disallowJsonEncode ?
@@ -10164,21 +10154,8 @@ export const RedactedReviver = InternalSchema.makeDeclarationReviver(
  * @category models
  * @since 4.0.0
  */
-export interface RedactedFromValue<S extends Constraint>
-  extends decodeTo<Redacted<toType<S>>, middlewareDecoding<S, S["DecodingServices"]>>
-{
+export interface RedactedFromValue<S extends Constraint> extends decodeTo<Redacted<toType<S>>, S> {
   readonly "Rebuild": RedactedFromValue<S>
-}
-
-/**
- * Middleware that wraps decoded errors in `Redacted`, preventing sensitive
- * schema details from leaking in error messages.
- *
- * @category transforming
- * @since 4.0.0
- */
-export function redact<S extends Constraint>(schema: S): middlewareDecoding<S, S["DecodingServices"]> {
-  return middlewareDecoding<S, S["DecodingServices"]>(Effect.mapErrorEager(SchemaIssue.redact))(schema)
 }
 
 /**
@@ -10194,23 +10171,21 @@ export function RedactedFromValue<S extends Constraint>(value: S, options?: {
   readonly label?: string | undefined
   readonly disallowEncode?: boolean | undefined
 }): RedactedFromValue<S> {
-  return redact(value).pipe(
-    decodeTo(
-      Redacted(toType(value), {
-        label: options?.label,
-        disallowJsonEncode: options?.disallowEncode
-      }),
-      {
-        decode: SchemaGetter.transform((t) => Redacted_.make(t, { label: options?.label })),
-        encode: options?.disallowEncode ?
-          SchemaGetter.forbidden((oe) =>
-            "Cannot encode Redacted" +
-            (Option_.isSome(oe) && typeof oe.value.label === "string" ? ` with label: "${oe.value.label}"` : "")
-          ) :
-          SchemaGetter.transform(Redacted_.value)
-      }
-    )
-  )
+  return decodeTo<Redacted<toType<S>>, S>(
+    Redacted(toType(value), {
+      label: options?.label,
+      disallowJsonEncode: options?.disallowEncode
+    }),
+    {
+      decode: SchemaGetter.transform((t) => Redacted_.make(t, { label: options?.label })),
+      encode: options?.disallowEncode ?
+        SchemaGetter.forbidden((oe) =>
+          "Cannot encode Redacted" +
+          (Option_.isSome(oe) && typeof oe.value.label === "string" ? ` with label: "${oe.value.label}"` : "")
+        ) :
+        SchemaGetter.transform(Redacted_.value)
+    }
+  )(value)
 }
 
 /**
@@ -10279,7 +10254,7 @@ export function CauseReason<E extends Constraint, D extends Constraint>(error: E
     [error, defect],
     ([error, defect]) => (input, ast, options) => {
       if (!Cause_.isReason(input)) {
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       switch (input._tag) {
         case "Fail":
@@ -10287,8 +10262,7 @@ export function CauseReason<E extends Constraint, D extends Constraint>(error: E
             SchemaParser.decodeUnknownEffect(error)(input.error, options),
             {
               onSuccess: Cause_.makeFailReason,
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["error"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["error"], issue)])
             }
           )
         case "Die":
@@ -10296,8 +10270,7 @@ export function CauseReason<E extends Constraint, D extends Constraint>(error: E
             SchemaParser.decodeUnknownEffect(defect)(input.defect, options),
             {
               onSuccess: Cause_.makeDieReason,
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["defect"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["defect"], issue)])
             }
           )
         case "Interrupt":
@@ -10472,12 +10445,11 @@ export function Cause<E extends Constraint, D extends Constraint>(error: E, defe
       const failures = ArraySchema(CauseReason(error, defect))
       return (input, ast, options) => {
         if (!Cause_.isCause(input)) {
-          return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+          return Effect.fail(new SchemaIssue.InvalidType(ast))
         }
         return Effect.mapBothEager(SchemaParser.decodeUnknownEffect(failures)(input.reasons, options), {
           onSuccess: Cause_.fromReasons,
-          onFailure: (issue) =>
-            new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["failures"], issue)])
+          onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["failures"], issue)])
         })
       }
     },
@@ -10817,7 +10789,7 @@ export function Exit<A extends Constraint, E extends Constraint, D extends Const
       const cause = Cause(error, defect)
       return (input, ast, options) => {
         if (!Exit_.isExit(input)) {
-          return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+          return Effect.fail(new SchemaIssue.InvalidType(ast))
         }
         switch (input._tag) {
           case "Success":
@@ -10825,8 +10797,7 @@ export function Exit<A extends Constraint, E extends Constraint, D extends Const
               SchemaParser.decodeUnknownEffect(value)(input.value, options),
               {
                 onSuccess: Exit_.succeed,
-                onFailure: (issue) =>
-                  new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["value"], issue)])
+                onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["value"], issue)])
               }
             )
           case "Failure":
@@ -10834,8 +10805,7 @@ export function Exit<A extends Constraint, E extends Constraint, D extends Const
               SchemaParser.decodeUnknownEffect(cause)(input.cause, options),
               {
                 onSuccess: Exit_.failCause,
-                onFailure: (issue) =>
-                  new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["cause"], issue)])
+                onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["cause"], issue)])
               }
             )
         }
@@ -11076,12 +11046,11 @@ export function ReadonlyMap<Key extends Constraint, Value extends Constraint>(
             SchemaParser.decodeUnknownEffect(array)([...input], options),
             {
               onSuccess: (array: ReadonlyArray<readonly [Key["Type"], Value["Type"]]>) => new globalThis.Map(array),
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["entries"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["entries"], issue)])
             }
           )
         }
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
     },
     {
@@ -11189,12 +11158,11 @@ export function HashMap<Key extends Constraint, Value extends Constraint>(key: K
             SchemaParser.decodeUnknownEffect(entries)(HashMap_.toEntries(input), options),
             {
               onSuccess: HashMap_.fromIterable,
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["entries"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["entries"], issue)])
             }
           )
         }
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
     },
     {
@@ -11300,12 +11268,11 @@ export function ReadonlySet<Value extends Constraint>(value: Value): $ReadonlySe
             SchemaParser.decodeUnknownEffect(array)([...input], options),
             {
               onSuccess: (array: ReadonlyArray<Value["Type"]>) => new globalThis.Set(array),
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["values"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["values"], issue)])
             }
           )
         }
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
     },
     {
@@ -11411,12 +11378,11 @@ export function HashSet<Value extends Constraint>(value: Value): HashSet<Value> 
             SchemaParser.decodeUnknownEffect(values)(Arr.fromIterable(input), options),
             {
               onSuccess: HashSet_.fromIterable,
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["values"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["values"], issue)])
             }
           )
         }
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
     },
     {
@@ -11529,12 +11495,11 @@ export function Chunk<Value extends Constraint>(value: Value): Chunk<Value> {
             SchemaParser.decodeUnknownEffect(values)(Arr.fromIterable(input), options),
             {
               onSuccess: Chunk_.fromIterable,
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option_.some(input), [new SchemaIssue.Pointer(["values"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["values"], issue)])
             }
           )
         }
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
     },
     {
@@ -11634,7 +11599,7 @@ export const RegExp: RegExp = instanceOf(
           decode: (e) =>
             Effect.try({
               try: () => new globalThis.RegExp(e.source, e.flags),
-              catch: (e) => new SchemaIssue.InvalidValue(Option_.some(e), { message: globalThis.String(e) })
+              catch: () => new SchemaIssue.InvalidValue({ message: "Expected valid RegExp source and flags" })
             }),
           encode: (regExp) =>
             Effect.succeed({
@@ -12465,10 +12430,10 @@ export const File: File = instanceOf(globalThis.File, {
       SchemaTransformation.transformOrFail({
         decode: (e) =>
           Result_.match(Encoding.decodeBase64(e.data), {
-            onFailure: (error) =>
+            onFailure: () =>
               Effect.fail(
-                new SchemaIssue.InvalidValue(Option_.some(e.data), {
-                  message: error.message
+                new SchemaIssue.InvalidValue({
+                  message: "Expected a valid Base64 string"
                 })
               ),
             onSuccess: (bytes) => {
@@ -12489,9 +12454,9 @@ export const File: File = instanceOf(globalThis.File, {
                 lastModified: file.lastModified
               }
             },
-            catch: (e) =>
-              new SchemaIssue.InvalidValue(Option_.some(file), {
-                message: globalThis.String(e)
+            catch: () =>
+              new SchemaIssue.InvalidValue({
+                message: "Expected File to be readable"
               })
           })
       })
@@ -14172,7 +14137,7 @@ function getClassSchemaFactory<S extends Constraint>(
           return input instanceof self ||
               Predicate.hasProperty(input, getClassTypeId(identifier)) ?
             Effect.succeed(input) :
-            Effect.fail(new SchemaIssue.InvalidType(ast, Option_.some(input)))
+            Effect.fail(new SchemaIssue.InvalidType(ast))
         },
         {
           identifier,
@@ -16104,7 +16069,7 @@ export declare namespace Annotations {
      * `message` first, then `expected`, and finally falls back to `<filter>`.
      *
      * Use this to name a failed filter in the default message:
-     * `Expected <expected>, got <actual>`.
+     * `Expected <expected>`.
      */
     readonly expected?: string | undefined
     readonly title?: string | undefined
@@ -16163,7 +16128,7 @@ export declare namespace Annotations {
      * only changing the expected label. For a filter or refinement failure,
      * annotate the filter with `message` to replace the whole filter failure
      * message, or `expected` to keep the default
-     * `Expected <expected>, got <actual>` shape.
+     * `Expected <expected>` shape.
      */
     readonly message?: string | undefined
     /**
@@ -16178,7 +16143,7 @@ export declare namespace Annotations {
      * Identifiers are used by schema tooling, including JSON Schema
      * generation, to name references. The default formatter also uses
      * `identifier` as the expected label for type-level failures, such as
-     * `Expected UserId, got null`.
+     * `Expected UserId`.
      *
      * `identifier` does not name a failed filter or refinement. If the base
      * type matches and a filter fails, put `expected` or `message` on the

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -22,7 +22,6 @@ import * as InternalRecord from "./internal/record.ts"
 import * as InternalAnnotations from "./internal/schema/annotations.ts"
 import * as InternalSchemaCause from "./internal/schema/cause.ts"
 import * as InternalParser from "./internal/schema/parser.ts"
-import * as Option from "./Option.ts"
 import * as Pipeable from "./Pipeable.ts"
 import * as Predicate from "./Predicate.ts"
 import * as Result from "./Result.ts"
@@ -1152,7 +1151,7 @@ export class TemplateLiteral extends Base {
       }
       return Effect.mapBothEager(result, {
         onSuccess: () => input,
-        onFailure: (issue) => new SchemaIssue.Composite(this, InternalParser.toOption(input), [issue])
+        onFailure: (issue) => new SchemaIssue.Composite(this, [issue])
       })
     }
   }
@@ -1175,8 +1174,8 @@ export class TemplateLiteral extends Base {
           const segments = segmentTemplateLiteralParts(this, s, options)
           if (segments) return Effect.succeed(segments)
           return Effect.fail(
-            new SchemaIssue.InvalidValue(Option.some(s), {
-              message: `Expected a string matching template literal parts, got ${format(s)}`
+            new SchemaIssue.InvalidValue({
+              message: "Expected a string matching template literal parts"
             })
           )
         }),
@@ -1713,7 +1712,7 @@ export class Arrays extends Base {
 
       // If the input is not an array, return early with an error
       if (!Array.isArray(input)) {
-        return yield* Effect.fail(new SchemaIssue.InvalidType(ast, InternalParser.toOption(input)))
+        return yield* Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       if (!elements) {
         elements = ast.elements.map((ast) => ({ ast, parser: recur(ast) }))
@@ -1743,20 +1742,20 @@ export class Arrays extends Base {
       // ---------------------------------------------
       if (ast.rest.length === 0 && len > elementLen) {
         for (let i = elementLen; i <= len - 1; i++) {
-          const issue = new SchemaIssue.Pointer([i], new SchemaIssue.UnexpectedKey(ast, input[i]))
+          const issue = new SchemaIssue.Pointer([i], new SchemaIssue.UnexpectedKey(ast))
           if (options.errors === "all") {
             if (state.issues) state.issues.push(issue)
             else state.issues = [issue]
           } else {
             return yield* Effect.fail(
-              new SchemaIssue.Composite(ast, InternalParser.toOption(input), [issue])
+              new SchemaIssue.Composite(ast, [issue])
             )
           }
         }
       }
       if (state.issues) {
         return yield* Effect.fail(
-          new SchemaIssue.Composite(ast, InternalParser.toOption(input), state.issues)
+          new SchemaIssue.Composite(ast, state.issues)
         )
       }
       return state.output
@@ -1827,7 +1826,7 @@ const parseArray = iterateEager<{
         else s.issues = [issue]
       } else {
         return Exit.fail(
-          new SchemaIssue.Composite(s.ast, InternalParser.toOption(s.input), [issue])
+          new SchemaIssue.Composite(s.ast, [issue])
         )
       }
     }
@@ -1860,7 +1859,6 @@ const wrapPropertyKeyIssue = (
         (issue) =>
           new SchemaIssue.Composite(
             ast,
-            InternalParser.toOption(s.input),
             [new SchemaIssue.Pointer([key], issue)]
           )
       )
@@ -1872,7 +1870,7 @@ const wrapPropertyKeyIssue = (
     else s.issues = [pointer]
   } else {
     return Exit.fail(
-      new SchemaIssue.Composite(ast, InternalParser.toOption(s.input), [pointer])
+      new SchemaIssue.Composite(ast, [pointer])
     )
   }
 }
@@ -2173,7 +2171,7 @@ export class Objects extends Base {
 
       // If the input is not a record, return early with an error
       if (!(typeof input === "object" && input !== null && !Array.isArray(input))) {
-        return yield* Effect.fail(new SchemaIssue.InvalidType(ast, InternalParser.toOption(input)))
+        return yield* Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       if (!properties) {
         properties = ast.propertySignatures.map((ps) => ({
@@ -2215,7 +2213,7 @@ export class Objects extends Base {
           if (!expectedKeysSet.has(key)) {
             // key is unexpected
             if (onExcessPropertyError) {
-              const issue = new SchemaIssue.Pointer([key], new SchemaIssue.UnexpectedKey(ast, record[key]))
+              const issue = new SchemaIssue.Pointer([key], new SchemaIssue.UnexpectedKey(ast))
               if (errorsAllOption) {
                 if (state.issues) {
                   state.issues.push(issue)
@@ -2225,7 +2223,7 @@ export class Objects extends Base {
                 continue
               } else {
                 return yield* Effect.fail(
-                  new SchemaIssue.Composite(ast, InternalParser.toOption(input), [issue])
+                  new SchemaIssue.Composite(ast, [issue])
                 )
               }
             } else {
@@ -2277,7 +2275,7 @@ export class Objects extends Base {
 
       if (state.issues) {
         return yield* Effect.fail(
-          new SchemaIssue.Composite(ast, InternalParser.toOption(input), state.issues)
+          new SchemaIssue.Composite(ast, state.issues)
         )
       }
       if (options.propertyOrder === "original") {
@@ -2383,7 +2381,7 @@ const parseProperties = iterateEager<ObjectParserState, ParsedProperty>()({
         return
       } else {
         return Exit.fail(
-          new SchemaIssue.Composite(s.ast, InternalParser.toOption(s.input), [issue])
+          new SchemaIssue.Composite(s.ast, [issue])
         )
       }
     }
@@ -2759,8 +2757,8 @@ export class Union<A extends AST = AST> extends Base {
         const result = recur(candidates[0])(input, options)
         if ((result as Exit.Exit<unknown, SchemaIssue.Issue>)._tag === "Success") return result
         return effectIsExit(result)
-          ? failSingleUnionCandidate(ast, input, (result as Exit.Failure<unknown, SchemaIssue.Issue>).cause)
-          : Effect.catchCause(result, (cause) => failSingleUnionCandidate(ast, input, cause))
+          ? failSingleUnionCandidate(ast, (result as Exit.Failure<unknown, SchemaIssue.Issue>).cause)
+          : Effect.catchCause(result, (cause) => failSingleUnionCandidate(ast, cause))
       }
 
       const state = {
@@ -2775,12 +2773,12 @@ export class Union<A extends AST = AST> extends Base {
       const concurrency = resolveConcurrency(options?.concurrency)
       const eff = parseUnion(state, candidates, concurrency ? { ...concurrency, orderedStep: true } : undefined)
       if (!eff) {
-        return state.out ?? Effect.fail(new SchemaIssue.AnyOf(ast, input, state.issues ?? []))
+        return state.out ?? Effect.fail(new SchemaIssue.AnyOf(ast, state.issues ?? []))
       }
       return Effect.flatMapEager(eff, (_) => {
         return state.out === InternalParser.sameExit
           ? Effect.succeed(input)
-          : state.out ?? Effect.fail(new SchemaIssue.AnyOf(ast, input, state.issues ?? []))
+          : state.out ?? Effect.fail(new SchemaIssue.AnyOf(ast, state.issues ?? []))
       })
     }
   }
@@ -2847,12 +2845,11 @@ export class Union<A extends AST = AST> extends Base {
 
 function failSingleUnionCandidate(
   ast: Union,
-  input: unknown,
   cause: Cause.Cause<SchemaIssue.Issue>
 ) {
   const issue = InternalSchemaCause.getSchemaIssue(cause)
   return issue
-    ? Exit.fail(new SchemaIssue.AnyOf(ast, input, [issue]))
+    ? Exit.fail(new SchemaIssue.AnyOf(ast, [issue]))
     : Exit.failCause(cause)
 }
 
@@ -2880,7 +2877,7 @@ const parseUnion = iterateEager<{
     } else {
       if (s.out && s.successes) {
         s.successes.push(candidate)
-        return Exit.fail(new SchemaIssue.OneOf(s.ast, s.input, s.successes))
+        return Exit.fail(new SchemaIssue.OneOf(s.ast, s.successes))
       }
       s.out = exit
       if (s.successes) {
@@ -3106,7 +3103,7 @@ export function makeFilter<T>(
   aborted: boolean = false
 ): Filter<T> {
   return new Filter(
-    (input, ast, options) => SchemaIssue.make(input, ast, filter(input, ast, options)),
+    (input, ast, options) => SchemaIssue.normalizeFilterOutput(ast, filter(input, ast, options)),
     annotations,
     aborted
   )
@@ -3118,7 +3115,7 @@ export function makeFilterByGuard<T extends E, E>(
   annotations?: Schema.Annotations.Filter
 ): Filter<any> {
   return new Filter(
-    (input: E) => is(input) ? undefined : new SchemaIssue.InvalidValue(Option.some(input)),
+    (input: E) => is(input) ? undefined : new SchemaIssue.InvalidValue(),
     annotations,
     true // after a guard, we always want to abort
   )
@@ -3674,7 +3671,7 @@ function fromConst<const T>(
     return input === value
       ? succeed
       : Effect.fail(
-        new SchemaIssue.InvalidType(ast, InternalParser.toOption(input))
+        new SchemaIssue.InvalidType(ast)
       )
   }
 }
@@ -3688,7 +3685,7 @@ function fromRefinement<T>(
     return refinement(input)
       ? InternalParser.sameExit
       : Effect.fail(
-        new SchemaIssue.InvalidType(ast, InternalParser.toOption(input))
+        new SchemaIssue.InvalidType(ast)
       )
   }
 }
@@ -3883,7 +3880,7 @@ const symbolToString = new Link(
         return Effect.succeed(globalThis.String(sym))
       }
       return Effect.fail(
-        new SchemaIssue.Forbidden(Option.some(sym), { message: "cannot serialize to string, Symbol is not registered" })
+        new SchemaIssue.Forbidden({ message: "cannot serialize to string, Symbol is not registered" })
       )
     })
   )
@@ -3926,7 +3923,7 @@ export function collectIssues<T>(
     } else {
       const issue = check.run(value, ast, options)
       if (issue) {
-        const filter = new SchemaIssue.Filter(value, check, issue)
+        const filter = new SchemaIssue.Filter(check, issue)
         if (issues) issues.push(filter)
         else issues = [filter]
         if (options.errors !== "all" || check.aborted) {
@@ -3945,7 +3942,7 @@ export function runChecks<T>(
 ): Result.Result<T, SchemaIssue.Issue> {
   const issues = collectIssues(checks, s, undefined, unknown, { errors: "all" })
   if (issues) {
-    const issue = new SchemaIssue.Composite(unknown, Option.some(s), issues)
+    const issue = new SchemaIssue.Composite(unknown, issues)
     return Result.fail(issue)
   }
   return Result.succeed(s)
@@ -4128,7 +4125,7 @@ export const Json = new Declaration(
   () => (input, ast) =>
     isJson(input) ?
       InternalParser.sameExit :
-      Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+      Effect.fail(new SchemaIssue.InvalidType(ast)),
   {
     representation: {
       id: "effect/schema/Json",
@@ -4180,7 +4177,7 @@ const StringTree = new Declaration(
   () => (input, ast) =>
     isStringTree(input) ?
       InternalParser.sameExit :
-      Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+      Effect.fail(new SchemaIssue.InvalidType(ast)),
   { expected: "StringTree", toCodecStringTree: () => undefined }
 )
 

--- a/packages/effect/src/SchemaError.ts
+++ b/packages/effect/src/SchemaError.ts
@@ -14,9 +14,11 @@ const TypeId = "~effect/SchemaError/SchemaError"
  * **Details**
  *
  * The `issue` field contains a structured {@link Issue} tree describing
- * every validation failure, including the path to the problematic value,
- * expected types, and actual values received. `message` renders the issue tree
- * as a human-readable string.
+ * every validation failure, including the path to the problematic value and
+ * the expected type or constraint. Built-in issues have no `actual` field,
+ * and built-in messages do not include the rejected value. Other Issue fields
+ * and custom annotations or messages are not sanitized. `message` renders the
+ * issue tree as a human-readable string.
  *
  * Use {@link isSchemaError} to narrow an unknown value to `SchemaError`.
  *
@@ -29,7 +31,7 @@ const TypeId = "~effect/SchemaError/SchemaError"
  *   Schema.decodeUnknownSync(Schema.Number)("not a number")
  * } catch (err) {
  *   if (Schema.isSchemaError(err)) {
- *     err.message // => "Expected number, got \"not a number\""
+ *     err.message // => "Expected number"
  *   }
  * }
  * ```

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -141,7 +141,7 @@ export function succeed<const T, E>(t: T): Getter<T, E> {
  * import { Effect, Option, SchemaGetter, SchemaIssue } from "effect"
  *
  * const rejectAll = SchemaGetter.fail<string, string>(
- *   (oe) => new SchemaIssue.InvalidValue(oe, { message: "not allowed" })
+ *   () => new SchemaIssue.InvalidValue({ message: "not allowed" })
  * )
  * const issue = await Effect.runPromise(Effect.flip(rejectAll.run(Option.some("x"), {})))
  * issue._tag // => "InvalidValue"
@@ -189,7 +189,7 @@ export function fail<T, E>(f: (oe: Option.Option<E>) => SchemaIssue.Issue): Gett
  * @since 4.0.0
  */
 export function forbidden<T, E>(message: (oe: Option.Option<E>) => string): Getter<T, E> {
-  return fail<T, E>((oe) => new SchemaIssue.Forbidden(oe, { message: message(oe) }))
+  return fail<T, E>((oe) => new SchemaIssue.Forbidden({ message: message(oe) }))
 }
 
 const passthrough_ = new Getter<any, any>(Effect.succeed)
@@ -465,7 +465,7 @@ export function checkEffect<T, R = never>(
 ): Getter<T, T, R> {
   return onSome((t, options) => {
     return f(t, options).pipe(Effect.flatMapEager((out) => {
-      const issue = SchemaIssue.makeSingle(t, out)
+      const issue = SchemaIssue.makeSingle(out)
       return issue ?
         Effect.fail(issue) :
         Effect.succeed(Option.some(t))
@@ -537,7 +537,7 @@ export function transform<T, E>(f: (e: E) => T): Getter<T, E> {
  *   (s) => {
  *     const n = parseInt(s, 10)
  *     return isNaN(n)
- *       ? Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: "not an integer" }))
+ *       ? Effect.fail(new SchemaIssue.InvalidValue({ message: "not an integer" }))
  *       : Effect.succeed(n)
  *   }
  * )
@@ -996,7 +996,7 @@ type ParseJsonOptions = {
  * - Skips `None` inputs.
  * - Without `reviver`: returns `Schema.MutableJson` (typed JSON).
  * - With `reviver`: returns `unknown` (reviver may produce arbitrary values).
- * - On parse failure, fails with `SchemaIssue.InvalidValue` containing the error message.
+ * - On parse failure, fails with `SchemaIssue.InvalidValue` containing a static message.
  *
  * **Example** (Parsing JSON)
  *
@@ -1018,7 +1018,7 @@ export function parseJson<E extends string>(options?: ParseJsonOptions | undefin
   return onSome((input) =>
     Effect.try({
       try: () => Option.some(JSON.parse(input, options?.reviver)),
-      catch: (e) => new SchemaIssue.InvalidValue(Option.some(input), { message: globalThis.String(e) })
+      catch: () => new SchemaIssue.InvalidValue({ message: "Expected a valid JSON string" })
     })
   )
 }
@@ -1079,7 +1079,7 @@ export function stringifyJson(options?: StringifyJsonOptions): Getter<string, un
         }
         return Option.some(output)
       },
-      catch: (e) => new SchemaIssue.InvalidValue(Option.some(input), { message: globalThis.String(e) })
+      catch: () => new SchemaIssue.InvalidValue({ message: "Expected a JSON-serializable value" })
     })
   )
 }
@@ -1310,7 +1310,7 @@ export function decodeBase64<E extends string>(): Getter<Uint8Array, E> {
   return transformOrFail((input) =>
     Effect.mapErrorEager(
       Effect.fromResult(Encoding.decodeBase64(input)),
-      (e) => new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })
+      () => new SchemaIssue.InvalidValue({ message: "Expected a valid Base64 string" })
     )
   )
 }
@@ -1340,7 +1340,7 @@ export function decodeBase64<E extends string>(): Getter<Uint8Array, E> {
 export function decodeBase64String<E extends string>(): Getter<string, E> {
   return transformOrFail((input) =>
     Result.match(Encoding.decodeBase64String(input), {
-      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onFailure: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid Base64 string" })),
       onSuccess: Effect.succeed
     })
   )
@@ -1372,7 +1372,7 @@ export function decodeBase64String<E extends string>(): Getter<string, E> {
 export function decodeBase64Url<E extends string>(): Getter<Uint8Array, E> {
   return transformOrFail((input) =>
     Result.match(Encoding.decodeBase64Url(input), {
-      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onFailure: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid Base64Url string" })),
       onSuccess: Effect.succeed
     })
   )
@@ -1403,7 +1403,7 @@ export function decodeBase64Url<E extends string>(): Getter<Uint8Array, E> {
 export function decodeBase64UrlString<E extends string>(): Getter<string, E> {
   return transformOrFail((input) =>
     Result.match(Encoding.decodeBase64UrlString(input), {
-      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onFailure: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid Base64Url string" })),
       onSuccess: Effect.succeed
     })
   )
@@ -1435,7 +1435,10 @@ export function decodeBase64UrlString<E extends string>(): Getter<string, E> {
 export function decodeHex<E extends string>(): Getter<Uint8Array, E> {
   return transformOrFail((input) =>
     Result.match(Encoding.decodeHex(input), {
-      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onFailure: () =>
+        Effect.fail(
+          new SchemaIssue.InvalidValue({ message: "Expected a valid hexadecimal string" })
+        ),
       onSuccess: Effect.succeed
     })
   )
@@ -1466,7 +1469,10 @@ export function decodeHex<E extends string>(): Getter<Uint8Array, E> {
 export function decodeHexString<E extends string>(): Getter<string, E> {
   return transformOrFail((input) =>
     Result.match(Encoding.decodeHexString(input), {
-      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onFailure: () =>
+        Effect.fail(
+          new SchemaIssue.InvalidValue({ message: "Expected a valid hexadecimal string" })
+        ),
       onSuccess: Effect.succeed
     })
   )
@@ -1524,10 +1530,10 @@ export function decodeUriComponent<E extends string>(): Getter<string, E> {
   return transformOrFail((input) => {
     try {
       return Effect.succeed(globalThis.decodeURIComponent(input))
-    } catch (e) {
+    } catch {
       return Effect.fail(
-        new SchemaIssue.InvalidValue(Option.some(input), {
-          message: e instanceof URIError ? e.message : "Invalid URI component"
+        new SchemaIssue.InvalidValue({
+          message: "Expected a valid URI component"
         })
       )
     }
@@ -1569,8 +1575,7 @@ export function decodeUriComponent<E extends string>(): Getter<string, E> {
 export function dateTimeUtcFromInput<E extends DateTime.DateTime.Input>(): Getter<DateTime.Utc, E> {
   return transformOrFail((input) => {
     return Option.match(DateTime.make(input), {
-      onNone: () =>
-        Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: "Invalid DateTime input" })),
+      onNone: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Invalid DateTime input" })),
       onSome: (dt) => Effect.succeed(DateTime.toUtc(dt))
     })
   })

--- a/packages/effect/src/SchemaIssue.ts
+++ b/packages/effect/src/SchemaIssue.ts
@@ -5,18 +5,15 @@
  * An `Issue` records what failed and, for nested data, where the failure
  * happened. The Schema system uses these values for missing keys, unexpected
  * keys, invalid types, invalid values, failed filters, failed transformations,
- * and alternatives that did not match. This module also formats issues and
- * supports redaction for sensitive values.
+ * and alternatives that did not match. This module also formats issues.
  *
  * @since 4.0.0
  */
 import type { StandardSchemaV1 } from "@standard-schema/spec"
 import * as Arr from "./Array.ts"
-import { format, formatPath, type Formatter as FormatterI } from "./Formatter.ts"
+import { formatPath, type Formatter as FormatterI } from "./Formatter.ts"
 import * as InternalAnnotations from "./internal/schema/annotations.ts"
-import * as Option from "./Option.ts"
 import { hasProperty } from "./Predicate.ts"
-import * as Redacted from "./Redacted.ts"
 import type * as Schema from "./Schema.ts"
 import type * as SchemaAST from "./SchemaAST.ts"
 
@@ -96,11 +93,13 @@ export type Leaf =
  * {@link Filter}, {@link Encoding}, {@link Pointer}, {@link Composite},
  * {@link AnyOf}. All `Issue` instances have a `toString()` that delegates to
  * the default formatter, so `String(issue)` produces a human-readable message.
+ * Built-in issues have no `actual` field, and built-in messages do not include
+ * the rejected value. This is not a general sanitization boundary: paths,
+ * ASTs, union successes, and custom annotations or messages are preserved as
+ * supplied and remain the caller's responsibility.
  *
  * @see {@link Leaf} — the terminal subset
  * @see {@link isIssue} — type guard
- * @see {@link getActual} — extract the actual value from any issue
- *
  * @category models
  * @since 4.0.0
  */
@@ -130,29 +129,26 @@ class Base {
  *
  * **Details**
  *
- * - `actual` is the raw input value that was tested (plain `unknown`, not
- *   wrapped in `Option`).
  * - `filter` is the AST filter node that produced this issue.
  * - `issue` is the inner issue describing the failure reason.
  *
  * **Example** (Matching a Filter issue)
  *
  * ```ts import.meta.vitest
- * import { Option, SchemaAST, SchemaIssue } from "effect"
+ * import { SchemaAST, SchemaIssue } from "effect"
  *
  * function describe(issue: SchemaIssue.Issue): string {
  *   if (issue._tag === "Filter") {
- *     return `Filter failed on: ${String(issue.actual)}`
+ *     return `Filter failed: ${String(issue.issue)}`
  *   }
  *   return String(issue)
  * }
  *
  * const issue = new SchemaIssue.Filter(
- *   "invalid",
  *   SchemaAST.isPattern(/^valid$/),
- *   new SchemaIssue.InvalidValue(Option.some("invalid"))
+ *   new SchemaIssue.InvalidValue()
  * )
- * describe(issue) // => "Filter failed on: invalid"
+ * describe(issue) // => `Filter failed: Expected a valid value`
  * ```
  *
  * @see {@link Leaf} — terminal issue types that commonly appear as the inner `issue`
@@ -164,10 +160,6 @@ class Base {
 export class Filter extends Base {
   readonly _tag = "Filter"
   /**
-   * The input value that caused the issue.
-   */
-  readonly actual: unknown
-  /**
    * The filter that failed.
    */
   readonly filter: SchemaAST.Filter<unknown>
@@ -178,10 +170,6 @@ export class Filter extends Base {
 
   constructor(
     /**
-     * The input value that caused the issue.
-     */
-    actual: unknown,
-    /**
      * The filter that failed.
      */
     filter: SchemaAST.Filter<any>,
@@ -191,7 +179,6 @@ export class Filter extends Base {
     issue: Issue
   ) {
     super()
-    this.actual = actual
     this.filter = filter
     this.issue = issue
   }
@@ -208,8 +195,6 @@ export class Filter extends Base {
  * **Details**
  *
  * - `ast` is the AST node for the transformation that failed.
- * - `actual` is `Option.some(value)` when the input was present, or
- *   `Option.none()` when it was absent.
  * - `issue` is the inner issue describing the failure.
  *
  * @see {@link Filter} — failure from a refinement check (not a transformation)
@@ -225,10 +210,6 @@ export class Encoding extends Base {
    */
   readonly ast: SchemaAST.AST
   /**
-   * The input value that caused the issue.
-   */
-  readonly actual: Option.Option<unknown>
-  /**
    * The issue that occurred.
    */
   readonly issue: Issue
@@ -239,17 +220,12 @@ export class Encoding extends Base {
      */
     ast: SchemaAST.AST,
     /**
-     * The input value that caused the issue.
-     */
-    actual: Option.Option<unknown>,
-    /**
      * The issue that occurred.
      */
     issue: Issue
   ) {
     super()
     this.ast = ast
-    this.actual = actual
     this.issue = issue
   }
 }
@@ -266,11 +242,9 @@ export class Encoding extends Base {
  * **Details**
  *
  * - `path` is an array of property keys (strings, numbers, or symbols).
- * - Has no `actual` value — {@link getActual} returns `Option.none()`.
  * - Formatters concatenate nested `Pointer` paths into a single path like
  *   `["a"]["b"][0]`.
  *
- * @see {@link getActual} — returns `Option.none()` for `Pointer`
  * @see {@link Composite} — groups multiple issues under one schema node
  *
  * @category models
@@ -312,7 +286,6 @@ export class Pointer extends Base {
  *
  * **Details**
  *
- * - Has no `actual` value — {@link getActual} returns `Option.none()`.
  * - `annotations` may contain a custom `messageMissingKey` for formatting.
  *
  * @see {@link Pointer} — wraps this issue with the missing key's path
@@ -350,9 +323,9 @@ export class MissingKey extends Base {
  *
  * **Details**
  *
- * - `actual` is the raw value at the unexpected key (plain `unknown`).
  * - `ast` is the schema that was being validated against.
  * - `annotations` on `ast` may contain a custom `messageUnexpectedKey`.
+ * - The default formatter renders this as `"Expected no excess property"`.
  *
  * @see {@link MissingKey} — the opposite case (required key absent)
  * @see {@link Pointer} — wraps this issue with the unexpected key's path
@@ -366,24 +339,14 @@ export class UnexpectedKey extends Base {
    * The schema that caused the issue.
    */
   readonly ast: SchemaAST.AST
-  /**
-   * The input value that caused the issue.
-   */
-  readonly actual: unknown
-
   constructor(
     /**
      * The schema that caused the issue.
      */
-    ast: SchemaAST.AST,
-    /**
-     * The input value that caused the issue.
-     */
-    actual: unknown
+    ast: SchemaAST.AST
   ) {
     super()
     this.ast = ast
-    this.actual = actual
   }
 }
 
@@ -398,8 +361,6 @@ export class UnexpectedKey extends Base {
  * **Details**
  *
  * - `issues` is a non-empty readonly array (at least one child).
- * - `actual` is `Option.some(value)` when the input was present, or
- *   `Option.none()` when absent.
  * - Formatters flatten `Composite` by recursing into each child.
  *
  * @see {@link AnyOf} — used for union no-match errors (similar but different semantics)
@@ -415,10 +376,6 @@ export class Composite extends Base {
    */
   readonly ast: SchemaAST.AST
   /**
-   * The input value that caused the issue.
-   */
-  readonly actual: Option.Option<unknown>
-  /**
    * The issues that occurred.
    */
   readonly issues: readonly [Issue, ...Array<Issue>]
@@ -429,24 +386,19 @@ export class Composite extends Base {
      */
     ast: SchemaAST.AST,
     /**
-     * The input value that caused the issue.
-     */
-    actual: Option.Option<unknown>,
-    /**
      * The issues that occurred.
      */
     issues: readonly [Issue, ...Array<Issue>]
   ) {
     super()
     this.ast = ast
-    this.actual = actual
     this.issues = issues
   }
 }
 
 /**
  * Represents a schema issue produced when the runtime type of the input does not match the type
- * expected by the schema (e.g. got `null` when `string` was expected).
+ * expected by the schema.
  *
  * **When to use**
  *
@@ -456,17 +408,15 @@ export class Composite extends Base {
  * **Details**
  *
  * - `ast` is the schema node that expected a different type.
- * - `actual` is `Option.some(value)` when the input was present, or
- *   `Option.none()` when no value was provided.
- * - The default formatter renders this as `"Expected <type>, got <actual>"`.
+ * - The default formatter renders this as `"Expected <type>"`.
  *
- * **Example** (Inspecting the actual value)
+ * **Example** (Formatting a type mismatch)
  *
  * ```ts import.meta.vitest
- * import { Option, Schema, SchemaIssue } from "effect"
+ * import { Schema, SchemaIssue } from "effect"
  *
- * const issue = new SchemaIssue.InvalidType(Schema.String.ast, Option.some(42))
- * issue.actual // => Option.some(42)
+ * const issue = new SchemaIssue.InvalidType(Schema.String.ast)
+ * String(issue) // => "Expected string"
  * ```
  *
  * @see {@link InvalidValue} — the input has the right type but fails a value constraint
@@ -480,24 +430,14 @@ export class InvalidType extends Base {
    * The schema that caused the issue.
    */
   readonly ast: SchemaAST.AST
-  /**
-   * The input value that caused the issue.
-   */
-  readonly actual: Option.Option<unknown>
-
   constructor(
     /**
      * The schema that caused the issue.
      */
-    ast: SchemaAST.AST,
-    /**
-     * The input value that caused the issue.
-     */
-    actual: Option.Option<unknown>
+    ast: SchemaAST.AST
   ) {
     super()
     this.ast = ast
-    this.actual = actual
   }
 }
 
@@ -512,21 +452,16 @@ export class InvalidType extends Base {
  *
  * **Details**
  *
- * - `actual` is `Option.some(value)` when the failing value is known, or
- *   `Option.none()` when absent.
  * - `annotations` optionally carries a `message` string for formatting.
- * - The default formatter renders this as `"Invalid data <actual>"` unless a
+ * - The default formatter renders this as `"Expected a valid value"` unless a
  *   custom `message` annotation is provided.
  *
  * **Example** (Returning InvalidValue from a custom filter)
  *
  * ```ts import.meta.vitest
- * import { Option, SchemaIssue } from "effect"
+ * import { SchemaIssue } from "effect"
  *
- * const issue = new SchemaIssue.InvalidValue(
- *   Option.some(""),
- *   { message: "must not be empty" }
- * )
+ * const issue = new SchemaIssue.InvalidValue({ message: "must not be empty" })
  * String(issue) // => "must not be empty"
  * ```
  *
@@ -539,26 +474,14 @@ export class InvalidType extends Base {
 export class InvalidValue extends Base {
   readonly _tag = "InvalidValue"
   /**
-   * The value that caused the issue.
-   */
-  readonly actual: Option.Option<unknown>
-  /**
    * The metadata for the issue.
    */
   readonly annotations: Schema.Annotations.Issue | undefined
 
   constructor(
-    /**
-     * The value that caused the issue.
-     */
-    actual: Option.Option<unknown>,
-    /**
-     * The metadata for the issue.
-     */
     annotations?: Schema.Annotations.Issue | undefined
   ) {
     super()
-    this.actual = actual
     this.annotations = annotations
   }
 }
@@ -574,18 +497,15 @@ export class InvalidValue extends Base {
  *
  * **Details**
  *
- * - `actual` is `Option.some(value)` when the input is known, or
- *   `Option.none()` when absent.
  * - `annotations` optionally carries a `message` string.
  * - The default formatter renders this as `"Forbidden operation"`.
  *
  * **Example** (Creating a Forbidden issue)
  *
  * ```ts import.meta.vitest
- * import { Option, SchemaIssue } from "effect"
+ * import { SchemaIssue } from "effect"
  *
  * const issue = new SchemaIssue.Forbidden(
- *   Option.none(),
  *   { message: "async operation not allowed in sync context" }
  * )
  * String(issue) // => "async operation not allowed in sync context"
@@ -599,26 +519,17 @@ export class InvalidValue extends Base {
 export class Forbidden extends Base {
   readonly _tag = "Forbidden"
   /**
-   * The input value that caused the issue.
-   */
-  readonly actual: Option.Option<unknown>
-  /**
    * The metadata for the issue.
    */
   readonly annotations: Schema.Annotations.Issue | undefined
 
   constructor(
     /**
-     * The input value that caused the issue.
-     */
-    actual: Option.Option<unknown>,
-    /**
      * The metadata for the issue.
      */
     annotations: Schema.Annotations.Issue | undefined
   ) {
     super()
-    this.actual = actual
     this.annotations = annotations
   }
 }
@@ -634,9 +545,12 @@ export class Forbidden extends Base {
  * **Details**
  *
  * - `ast` is the `Union` AST node.
- * - `actual` is the raw input value (plain `unknown`).
- * - `issues` contains per-member failures. When empty, the formatter falls
- *   back to the union's `expected` annotation.
+ * - `issues` contains the per-member failures.
+ *
+ * **Gotchas**
+ *
+ * `issues` is empty when no union member was applicable. In that case, the
+ * default formatter reports the expected type for the union.
  *
  * @see {@link OneOf} — the opposite: *too many* members matched
  * @see {@link Composite} — groups multiple issues under a non-union schema
@@ -651,10 +565,6 @@ export class AnyOf extends Base {
    */
   readonly ast: SchemaAST.Union
   /**
-   * The input value that caused the issue.
-   */
-  readonly actual: unknown
-  /**
    * The issues that occurred.
    */
   readonly issues: ReadonlyArray<Issue>
@@ -665,17 +575,12 @@ export class AnyOf extends Base {
      */
     ast: SchemaAST.Union,
     /**
-     * The input value that caused the issue.
-     */
-    actual: unknown,
-    /**
      * The issues that occurred.
      */
     issues: ReadonlyArray<Issue>
   ) {
     super()
     this.ast = ast
-    this.actual = actual
     this.issues = issues
   }
 }
@@ -692,10 +597,9 @@ export class AnyOf extends Base {
  * **Details**
  *
  * - `ast` is the `Union` AST node.
- * - `actual` is the raw input value (plain `unknown`).
  * - `successes` lists the AST nodes of each member that accepted the input.
  * - The default formatter renders this as
- *   `"Expected exactly one member to match the input <actual>"`.
+ *   `"Expected exactly one member to match"`.
  *
  * @see {@link AnyOf} — the opposite: *no* members matched
  *
@@ -709,10 +613,6 @@ export class OneOf extends Base {
    */
   readonly ast: SchemaAST.Union
   /**
-   * The input value that caused the issue.
-   */
-  readonly actual: unknown
-  /**
    * The schemas that were successful.
    */
   readonly successes: ReadonlyArray<SchemaAST.AST>
@@ -723,109 +623,54 @@ export class OneOf extends Base {
      */
     ast: SchemaAST.Union,
     /**
-     * The input value that caused the issue.
-     */
-    actual: unknown,
-    /**
      * The schemas that were successful.
      */
     successes: ReadonlyArray<SchemaAST.AST>
   ) {
     super()
     this.ast = ast
-    this.actual = actual
     this.successes = successes
   }
 }
 
-/**
- * Extracts the actual input value from any {@link Issue} variant.
- *
- * **When to use**
- *
- * Use when you need to retrieve an `Issue`'s offending input value for logging
- * or custom error rendering.
- *
- * **Details**
- *
- * - Returns `Option.none()` for `Pointer` and `MissingKey` (they carry no
- *   value).
- * - Returns the existing `Option` for variants that already store `actual` as
- *   `Option<unknown>` (`InvalidType`, `InvalidValue`, `Forbidden`, `Encoding`,
- *   `Composite`).
- * - Wraps `actual` with `Option.some` for variants that store it as plain
- *   `unknown` (`AnyOf`, `UnexpectedKey`, `OneOf`, `Filter`).
- *
- * **Example** (Extracting the actual value)
- *
- * ```ts import.meta.vitest
- * import { Option, SchemaIssue } from "effect"
- *
- * const issue = new SchemaIssue.MissingKey(undefined)
- * SchemaIssue.getActual(issue) // => Option.none()
- * ```
- *
- * @see {@link Issue}
- * @see {@link isIssue}
- *
- * @category getters
- * @since 4.0.0
- */
-export function getActual(issue: Issue): Option.Option<unknown> {
-  switch (issue._tag) {
-    case "Pointer":
-    case "MissingKey":
-      return Option.none()
-    case "InvalidType":
-    case "InvalidValue":
-    case "Forbidden":
-    case "Encoding":
-    case "Composite":
-      return issue.actual
-    case "AnyOf":
-    case "UnexpectedKey":
-    case "OneOf":
-    case "Filter":
-      return Option.some(issue.actual)
-  }
-}
-
-function makeFilterIssue(input: unknown, entry: Schema.FilterIssue): Issue {
+function makeFilterIssue(entry: Schema.FilterIssue): Issue {
   if (isIssue(entry)) {
     return entry
   }
   if (typeof entry === "string") {
-    return new InvalidValue(Option.some(input), { message: entry })
+    return new InvalidValue({ message: entry })
   }
   const inner = typeof entry.issue === "string"
-    ? new InvalidValue(Option.some(input), { message: entry.issue })
+    ? new InvalidValue({ message: entry.issue })
     : entry.issue
   return new Pointer(entry.path, inner)
 }
 
 /** @internal */
-export function makeSingle(input: unknown, out: undefined | boolean | Schema.FilterIssue): Issue | undefined {
+export function makeSingle(out: undefined | boolean | Schema.FilterIssue): Issue | undefined {
   if (out === undefined) {
     return undefined
   }
   if (typeof out === "boolean") {
-    return out ? undefined : new InvalidValue(Option.some(input))
+    return out ? undefined : new InvalidValue()
   }
-  return makeFilterIssue(input, out)
+  return makeFilterIssue(out)
 }
 
 /** @internal */
-export function make(input: unknown, ast: SchemaAST.AST, out: Schema.FilterOutput): Issue | undefined {
+export function normalizeFilterOutput(
+  ast: SchemaAST.AST,
+  out: Schema.FilterOutput
+): Issue | undefined {
   if (Array.isArray(out)) {
-    if (Arr.isReadonlyArrayNonEmpty(out)) {
-      if (out.length === 1) {
-        return makeFilterIssue(input, out[0])
-      }
-      return new Composite(ast, Option.some(input), Arr.map(out, (entry) => makeFilterIssue(input, entry)))
+    if (!Arr.isReadonlyArrayNonEmpty(out)) {
+      return undefined
     }
-    return undefined
+    return out.length === 1
+      ? makeFilterIssue(out[0])
+      : new Composite(ast, Arr.map(out, makeFilterIssue))
   }
-  return makeSingle(input, out as undefined | boolean | Schema.FilterIssue)
+  return makeSingle(out as undefined | boolean | Schema.FilterIssue)
 }
 
 /**
@@ -868,12 +713,12 @@ export type LeafHook = (issue: Leaf) => string
  *
  * - Checks for a `message` annotation first; returns it if present.
  * - Otherwise generates a default message per `_tag`:
- *   - `InvalidType` → `"Expected <type>, got <actual>"`
- *   - `InvalidValue` → `"Invalid data <actual>"`
+ *   - `InvalidType` → `"Expected <type>"`
+ *   - `InvalidValue` → `"Expected a valid value"`
  *   - `MissingKey` → `"Missing key"`
- *   - `UnexpectedKey` → `"Unexpected key with value <actual>"`
+ *   - `UnexpectedKey` → `"Expected no excess property"`
  *   - `Forbidden` → `"Forbidden operation"`
- *   - `OneOf` → `"Expected exactly one member to match the input <actual>"`
+ *   - `OneOf` → `"Expected exactly one member to match"`
  *
  * **Example** (Formatting Standard Schema issues with defaultLeafHook)
  *
@@ -897,17 +742,17 @@ export const defaultLeafHook: LeafHook = (issue): string => {
   if (message !== undefined) return message
   switch (issue._tag) {
     case "InvalidType":
-      return getExpectedMessage(InternalAnnotations.getExpected(issue.ast), formatOption(issue.actual))
+      return getExpectedMessage(InternalAnnotations.getExpected(issue.ast))
     case "InvalidValue":
-      return `Invalid data ${formatOption(issue.actual)}`
+      return "Expected a valid value"
     case "MissingKey":
       return "Missing key"
     case "UnexpectedKey":
-      return `Unexpected key with value ${format(issue.actual)}`
+      return "Expected no excess property"
     case "Forbidden":
       return "Forbidden operation"
     case "OneOf":
-      return `Expected exactly one member to match the input ${format(issue.actual)}`
+      return "Expected exactly one member to match"
   }
 }
 
@@ -923,6 +768,7 @@ export const defaultLeafHook: LeafHook = (issue): string => {
  *
  * - Returns `string` to override the message, or `undefined` to fall back to
  *   the default formatting.
+ * - Built-in issues have no `actual` field.
  *
  * @see {@link defaultCheckHook} — the built-in implementation
  * @see {@link Filter} — the issue type this hook formats
@@ -944,7 +790,7 @@ export type CheckHook = (issue: Filter) => string | undefined
  * - Looks for a `message` annotation on the inner issue first, then on the
  *   filter itself.
  * - Returns `undefined` when no annotation is found, causing the formatter to
- *   fall back to `"Expected <filter>, got <actual>"`.
+ *   fall back to `"Expected <filter>"`.
  *
  * @see {@link CheckHook}
  * @see {@link makeFormatterStandardSchemaV1}
@@ -1004,8 +850,8 @@ type DefaultIssue = {
   readonly path: ReadonlyArray<PropertyKey>
 }
 
-function getExpectedMessage(expected: string, actual: string): string {
-  return `Expected ${expected}, got ${actual}`
+function getExpectedMessage(expected: string): string {
+  return `Expected ${expected}`
 }
 
 function toDefaultIssues(
@@ -1024,7 +870,7 @@ function toDefaultIssues(
         case "InvalidValue":
           return [{
             path,
-            message: getExpectedMessage(formatCheck(issue.filter), format(issue.actual))
+            message: getExpectedMessage(formatCheck(issue.filter))
           }]
         default:
           return toDefaultIssues(issue.issue, path, leafHook, checkHook)
@@ -1037,12 +883,11 @@ function toDefaultIssues(
     case "Composite":
       return issue.issues.flatMap((issue) => toDefaultIssues(issue, path, leafHook, checkHook))
     case "AnyOf": {
-      const message = findMessage(issue)
       if (issue.issues.length === 0) {
-        if (message !== undefined) return [{ path, message }]
-
-        const expected = getExpectedMessage(InternalAnnotations.getExpected(issue.ast), format(issue.actual))
-        return [{ path, message: expected }]
+        return [{
+          path,
+          message: findMessage(issue) ?? getExpectedMessage(InternalAnnotations.getExpected(issue.ast))
+        }]
       }
       return issue.issues.flatMap((issue) => toDefaultIssues(issue, path, leafHook, checkHook))
     }
@@ -1142,34 +987,4 @@ function getMessageAnnotation(
 ): string | undefined {
   const message = annotations?.[type]
   if (typeof message === "string") return message
-}
-
-function formatOption(actual: Option.Option<unknown>): string {
-  if (Option.isNone(actual)) return "no value provided"
-  return format(actual.value)
-}
-
-/** @internal */
-export function redact(issue: Issue): Issue {
-  switch (issue._tag) {
-    case "MissingKey":
-      return issue
-    case "Forbidden":
-      return new Forbidden(Option.map(issue.actual, Redacted.make), issue.annotations)
-    case "Filter":
-      return new Filter(Redacted.make(issue.actual), issue.filter, redact(issue.issue))
-    case "Pointer":
-      return new Pointer(issue.path, redact(issue.issue))
-
-    case "Encoding":
-    case "InvalidType":
-    case "InvalidValue":
-    case "Composite":
-      return new InvalidValue(Option.map(issue.actual, Redacted.make))
-
-    case "AnyOf":
-    case "OneOf":
-    case "UnexpectedKey":
-      return new InvalidValue(Option.some(Redacted.make(issue.actual)))
-  }
 }

--- a/packages/effect/src/SchemaParser.ts
+++ b/packages/effect/src/SchemaParser.ts
@@ -916,7 +916,7 @@ const mergeParseOptions = (
 
 const getValue = (value: unknown): Effect.Effect<any, SchemaIssue.Issue> => {
   if (value === InternalParser.missing) {
-    return Effect.fail(new SchemaIssue.InvalidValue(Option.none()))
+    return Effect.fail(new SchemaIssue.InvalidValue())
   }
   return Effect.succeed(value)
 }
@@ -1055,7 +1055,7 @@ function makeParser(ast: SchemaAST.AST): Parser {
             const issues = SchemaAST.collectIssues(encodingChecks, input, undefined, ast, options)
             if (issues) {
               result = Effect.fail(
-                new SchemaIssue.Composite(ast, InternalParser.toOption(input), issues)
+                new SchemaIssue.Composite(ast, issues)
               )
             }
           }
@@ -1066,7 +1066,7 @@ function makeParser(ast: SchemaAST.AST): Parser {
             const issues = SchemaAST.collectIssues(encodingChecks, input, undefined, ast, options)
             if (issues) {
               return Effect.fail(
-                new SchemaIssue.Composite(ast, InternalParser.toOption(input), issues)
+                new SchemaIssue.Composite(ast, issues)
               )
             }
           }
@@ -1085,7 +1085,7 @@ function makeParser(ast: SchemaAST.AST): Parser {
           const issues = SchemaAST.collectIssues(checks, value, undefined, ast, options)
           if (issues) {
             result = Effect.fail(
-              new SchemaIssue.Composite(ast, InternalParser.toOption(value), issues)
+              new SchemaIssue.Composite(ast, issues)
             )
           }
         }
@@ -1095,7 +1095,7 @@ function makeParser(ast: SchemaAST.AST): Parser {
             const issues = SchemaAST.collectIssues(checks, value, undefined, ast, options)
             if (issues) {
               return Effect.fail(
-                new SchemaIssue.Composite(ast, InternalParser.toOption(value), issues)
+                new SchemaIssue.Composite(ast, issues)
               )
             }
           }
@@ -1169,10 +1169,7 @@ function makeParser(ast: SchemaAST.AST): Parser {
     }
     result = Effect.catchCause(
       result,
-      (cause) =>
-        Effect.failCauseSync(() =>
-          Cause.map(cause, (issue) => new SchemaIssue.Encoding(ast, InternalParser.toOption(input), issue))
-        )
+      (cause) => Effect.failCauseSync(() => Cause.map(cause, (issue) => new SchemaIssue.Encoding(ast, issue)))
     )
     return Effect.flatMapEager(result, (value) => {
       const local = parseLocal(value, options)

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -59,7 +59,7 @@ import * as SchemaIssue from "./SchemaIssue.ts"
  *   (effect) => Effect.catch(effect, () => Effect.succeed(Option.some("fallback"))),
  *   (effect) => effect
  * )
- * const issue = new SchemaIssue.InvalidValue(Option.none(), { message: "Missing value" })
+ * const issue = new SchemaIssue.InvalidValue({ message: "Missing value" })
  * await Effect.runPromise(fallback.decode(Effect.fail(issue), {})) // => Option.some("fallback")
  * ```
  *
@@ -266,7 +266,7 @@ export const make = <T, E, RD = never, RE = never>(options: {
  *       decode: (s) => {
  *         const d = new Date(s)
  *         return isNaN(d.getTime())
- *           ? Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: "Invalid date" }))
+ *           ? Effect.fail(new SchemaIssue.InvalidValue({ message: "Invalid date" }))
  *           : Effect.succeed(d)
  *       },
  *       encode: (d) => Effect.succeed(d.toISOString())
@@ -976,8 +976,7 @@ export const durationFromString: Transformation<Duration.Duration, string> = tra
 >({
   decode: (s) =>
     Option.match(Duration.fromInput(s as Duration.Input), {
-      onNone: () =>
-        Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid Duration string: ${s}` })),
+      onNone: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid Duration string" })),
       onSome: Effect.succeed
     }),
   encode: (duration) => Effect.succeed(globalThis.String(duration))
@@ -1020,7 +1019,7 @@ export const durationFromNanos: Transformation<Duration.Duration, bigint> = tran
     Option.match(Duration.toNanos(a), {
       onNone: () =>
         Effect.fail(
-          new SchemaIssue.InvalidValue(Option.some(a), { message: `Unable to encode ${a} into a bigint` })
+          new SchemaIssue.InvalidValue({ message: "Expected a Duration representable as a bigint" })
         ),
       onSome: (nanos) => Effect.succeed(nanos)
     })
@@ -1399,7 +1398,7 @@ export const urlFromString: Transformation<URL, string> = transformOrFail<URL, s
   decode: (s) =>
     URL.canParse(s)
       ? Effect.succeed(new URL(s))
-      : Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid URL string: ${s}` })),
+      : Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid URL string" })),
   encode: (url) => Effect.succeed(url.href)
 })
 
@@ -1428,7 +1427,7 @@ export const bigDecimalFromString: Transformation<BigDecimal.BigDecimal, string>
   decode: (s) => {
     const result = BigDecimal.fromString(s)
     return Option.isNone(result)
-      ? Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid BigDecimal string: ${s}` }))
+      ? Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid BigDecimal string" }))
       : Effect.succeed(result.value)
   },
   encode: (bd) => Effect.succeed(BigDecimal.format(bd))
@@ -1787,8 +1786,7 @@ export const timeZoneNamedFromString: Transformation<DateTime.TimeZone.Named, st
 >({
   decode: (s) => {
     return Option.match(DateTime.zoneMakeNamed(s), {
-      onNone: () =>
-        Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid IANA time zone: ${s}` })),
+      onNone: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid IANA time zone" })),
       onSome: Effect.succeed
     })
   },
@@ -1822,7 +1820,7 @@ export const timeZoneFromString: Transformation<DateTime.TimeZone, string> = tra
 >({
   decode: (s) => {
     return Option.match(DateTime.zoneFromString(s), {
-      onNone: () => Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid time zone: ${s}` })),
+      onNone: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid time zone" })),
       onSome: Effect.succeed
     })
   },
@@ -1856,8 +1854,7 @@ export const dateTimeUtcFromString: Transformation<DateTime.Utc, string> = trans
 >({
   decode: (s) => {
     return Option.match(DateTime.make(s), {
-      onNone: () =>
-        Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid UTC DateTime string: ${s}` })),
+      onNone: () => Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a valid UTC DateTime string" })),
       onSome: (result) => Effect.succeed(DateTime.toUtc(result))
     })
   },
@@ -1891,7 +1888,9 @@ export const dateTimeZonedFromString: Transformation<DateTime.Zoned, string> = t
   decode: (s) => {
     return Option.match(DateTime.makeZonedFromString(s), {
       onNone: () =>
-        Effect.fail(new SchemaIssue.InvalidValue(Option.some(s), { message: `Invalid Zoned DateTime string: ${s}` })),
+        Effect.fail(
+          new SchemaIssue.InvalidValue({ message: "Expected a valid Zoned DateTime string" })
+        ),
       onSome: Effect.succeed
     })
   },

--- a/packages/effect/src/testing/TestSchema.ts
+++ b/packages/effect/src/testing/TestSchema.ts
@@ -207,7 +207,7 @@ export class Asserts<S extends Schema.Constraint> {
    * const asserts = new TestSchema.Asserts(Schema.NumberFromString)
    * const decoding = asserts.decoding()
    * await decoding.succeed("42", 42) // => undefined
-   * await decoding.fail(null, "Expected string, got null") // => undefined
+   * await decoding.fail(null, "Expected string") // => undefined
    * ```
    *
    * @see {@link Decoding}
@@ -389,7 +389,7 @@ export class Decoding<S extends Schema.Constraint> {
    * import { TestSchema } from "effect/testing"
    *
    * const decoding = new TestSchema.Asserts(Schema.String).decoding()
-   * await decoding.fail(42, "Expected string, got 42") // => undefined
+   * await decoding.fail(42, "Expected string") // => undefined
    * ```
    *
    * @see {@link succeed} for asserting successful decoding
@@ -529,7 +529,7 @@ export class Encoding<S extends Schema.Constraint> {
    * import { TestSchema } from "effect/testing"
    *
    * const encoding = new TestSchema.Asserts(Schema.NumberFromString).encoding()
-   * await encoding.fail("not-a-number", "Expected number, got \"not-a-number\"") // => undefined
+   * await encoding.fail("not-a-number", "Expected number") // => undefined
    * ```
    *
    * @see {@link succeed} for asserting successful encoding

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -729,7 +729,7 @@ export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
    *   Schema.decodeUnknownEffect(Schema.Number)("not a number").pipe(Effect.flip)
    * )
    * const parseError = AiError.InvalidOutputError.fromSchemaError(schemaError)
-   * parseError.description // => 'Expected number, got "not a number"'
+   * parseError.description // => "Expected number"
    * ```
    *
    * @since 4.0.0

--- a/packages/effect/src/unstable/ai/Prompt.ts
+++ b/packages/effect/src/unstable/ai/Prompt.ts
@@ -12,7 +12,6 @@
 import * as Arr from "../../Array.ts"
 import * as Effect from "../../Effect.ts"
 import { dual } from "../../Function.ts"
-import * as Option from "../../Option.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
@@ -1833,8 +1832,7 @@ export const Prompt: Schema.Codec<Prompt, PromptEncoded> = Schema.Struct({
           SchemaParser.decodeEffect(Schema.Array(Message))(input.content),
           {
             onSuccess: makePrompt,
-            onFailure: () =>
-              new SchemaIssue.InvalidValue(Option.some(input.content), { message: "Invalid Prompt messages" })
+            onFailure: () => new SchemaIssue.InvalidValue({ message: "Invalid Prompt messages" })
           }
         ),
       encode: (prompt) =>
@@ -1842,8 +1840,7 @@ export const Prompt: Schema.Codec<Prompt, PromptEncoded> = Schema.Struct({
           SchemaParser.encodeEffect(Schema.Array(Message))(prompt.content),
           {
             onSuccess: (messages) => ({ content: messages }),
-            onFailure: () =>
-              new SchemaIssue.InvalidValue(Option.some(prompt.content), { message: "Invalid Prompt messages" })
+            onFailure: () => new SchemaIssue.InvalidValue({ message: "Invalid Prompt messages" })
           }
         )
     })

--- a/packages/effect/src/unstable/cluster/Reply.ts
+++ b/packages/effect/src/unstable/cluster/Reply.ts
@@ -242,11 +242,10 @@ export class Chunk<R extends Rpc.Any> extends Data.TaggedClass("Chunk")<{
       [success],
       ([success]) => (input, ast, options) => {
         if (!isReply(input) || input._tag !== "Chunk") {
-          return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+          return Effect.fail(new SchemaIssue.InvalidType(ast))
         }
         return Effect.mapBothEager(SchemaParser.decodeEffect(Schema.NonEmptyArray(success))(input.values, options), {
-          onFailure: (issue) =>
-            new SchemaIssue.Composite(ast, Option.some(input), [new SchemaIssue.Pointer(["values"], issue)]),
+          onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["values"], issue)]),
           onSuccess: (values) => new Chunk({ ...input, values } as any)
         })
       },
@@ -352,11 +351,10 @@ export class WithExit<R extends Rpc.Any> extends Data.TaggedClass("WithExit")<{
       [exitSchema],
       ([exit]) => (input, ast, options) => {
         if (!isReply(input) || input._tag !== "WithExit") {
-          return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+          return Effect.fail(new SchemaIssue.InvalidType(ast))
         }
         return Effect.mapBothEager(SchemaParser.decodeEffect(exit)(input.exit, options), {
-          onFailure: (issue) =>
-            new SchemaIssue.Composite(ast, Option.some(input), [new SchemaIssue.Pointer(["exit"], issue)]),
+          onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["exit"], issue)]),
           onSuccess: (exit) => new WithExit({ ...input, exit: exit as any })
         })
       },

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -545,7 +545,7 @@ export const make = Effect.fnUntraced(function*<
     )
   }
 
-  const decodeMessage = makeMessageDecode(entity, entityRpcs)
+  const decodeMessage = makeMessageDecode(entityRpcs)
 
   const runFork = Effect.runForkWith(context)
 
@@ -649,10 +649,7 @@ const defaultRetryPolicy = Schedule.min([
   Schedule.spaced("10 seconds")
 ])
 
-const makeMessageDecode = <Type extends string, Rpcs extends Rpc.Any>(
-  entity: Entity<Type, Rpcs>,
-  entityRpcs: Map<string, Rpcs>
-) => {
+const makeMessageDecode = <Rpcs extends Rpc.Any>(entityRpcs: Map<string, Rpcs>) => {
   const decodeRequest = Effect.fnUntracedEager(function*(
     message: Message.IncomingRequest<Rpcs>,
     rpc: Rpc.AnyWithProps
@@ -690,8 +687,8 @@ const makeMessageDecode = <Type extends string, Rpcs extends Rpc.Any>(
     if (!rpc) {
       return Effect.fail(
         new Schema.SchemaError(
-          new SchemaIssue.InvalidValue(Option.some(message), {
-            message: `Unknown tag ${message.envelope.tag} for entity type ${entity.type}`
+          new SchemaIssue.InvalidValue({
+            message: "Expected a known entity RPC tag"
           })
         )
       )

--- a/packages/effect/src/unstable/encoding/Msgpack.ts
+++ b/packages/effect/src/unstable/encoding/Msgpack.ts
@@ -17,8 +17,6 @@ import * as ChannelSchema from "../../ChannelSchema.ts"
 import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
 import { dual } from "../../Function.ts"
-import * as Option from "../../Option.ts"
-import * as Predicate from "../../Predicate.ts"
 import type * as Pull from "../../Pull.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaIssue from "../../SchemaIssue.ts"
@@ -347,10 +345,10 @@ export const transformation: SchemaTransformation.Transformation<
   decode(e, _options) {
     try {
       return Effect.succeed(Msgpackr.decode(e))
-    } catch (cause) {
+    } catch {
       return Effect.fail(
-        new SchemaIssue.InvalidValue(Option.some(e), {
-          message: Predicate.hasProperty(cause, "message") ? String(cause.message) : String(cause)
+        new SchemaIssue.InvalidValue({
+          message: "Expected valid MessagePack bytes"
         })
       )
     }
@@ -358,10 +356,10 @@ export const transformation: SchemaTransformation.Transformation<
   encode(t, _options) {
     try {
       return Effect.succeed(Msgpackr.encode(t) as Uint8Array<ArrayBuffer>)
-    } catch (cause) {
+    } catch {
       return Effect.fail(
-        new SchemaIssue.InvalidValue(Option.some(t), {
-          message: Predicate.hasProperty(cause, "message") ? String(cause.message) : String(cause)
+        new SchemaIssue.InvalidValue({
+          message: "Expected a MessagePack-serializable value"
         })
       )
     }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -18,7 +18,6 @@ import type { FileSystem } from "../../FileSystem.ts"
 import { identity } from "../../Function.ts"
 import { stringOrRedacted } from "../../internal/redacted.ts"
 import * as Layer from "../../Layer.ts"
-import * as Option from "../../Option.ts"
 import type { Path } from "../../Path.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import { hasProperty } from "../../Predicate.ts"
@@ -724,10 +723,10 @@ function decodePayload(
         }
         try {
           return decode(JSON.parse(text))
-        } catch (cause) {
+        } catch {
           return Effect.fail(
             new Schema.SchemaError(
-              new SchemaIssue.InvalidValue(Option.some(text), { message: `Invalid JSON: ${cause}` })
+              new SchemaIssue.InvalidValue({ message: "Expected a valid JSON body" })
             )
           )
         }
@@ -933,7 +932,7 @@ function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undef
     return (response, context) => {
       if (!Stream.isStream(response)) {
         return hasBuffered ? undefined : new Schema.SchemaError(
-          new SchemaIssue.InvalidValue(Option.some(response), { message: "Expected a streaming response" })
+          new SchemaIssue.InvalidValue({ message: "Expected a streaming response" })
         )
       }
 
@@ -952,7 +951,7 @@ function makeStreamEncoder(endpoint: HttpApiEndpoint.Top): StreamEncoder | undef
   return (response, context) => {
     if (!Stream.isStream(response)) {
       return hasBuffered ? undefined : new Schema.SchemaError(
-        new SchemaIssue.InvalidValue(Option.some(response), { message: "Expected a streaming response" })
+        new SchemaIssue.InvalidValue({ message: "Expected a streaming response" })
       )
     }
 
@@ -1087,7 +1086,7 @@ function getResponseTransformation(
   )
 
   return SchemaTransformation.transformOrFail({
-    decode: (res) => Effect.fail(new SchemaIssue.Forbidden(Option.some(res), { message: "Encode only schema" })),
+    decode: () => Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" })),
     encode
   })
 }
@@ -1106,8 +1105,10 @@ function getResponseEncode<E>(
         try {
           const s = JSON.stringify(e)
           return Effect.succeed(Response.text(s, { status, contentType: encoding.contentType }))
-        } catch (error) {
-          return Effect.fail(new SchemaIssue.InvalidValue(Option.some(e), { message: globalThis.String(error) }))
+        } catch {
+          return Effect.fail(
+            new SchemaIssue.InvalidValue({ message: "Expected a JSON-serializable response body" })
+          )
         }
       })
     }

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -16,7 +16,6 @@ import type * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import { identity } from "../../Function.ts"
 import * as InternalRecord from "../../internal/record.ts"
-import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
@@ -1003,39 +1002,41 @@ function getEncodePayloadSchemaFromBody(
   const out = $HttpBody.pipe(Schema.decodeTo(
     schema,
     SchemaTransformation.transformOrFail<unknown, HttpBody.HttpBody>({
-      decode(httpBody) {
-        return Effect.fail(new SchemaIssue.Forbidden(Option.some(httpBody), { message: "Encode only schema" }))
+      decode() {
+        return Effect.fail(new SchemaIssue.Forbidden({ message: "Encode only schema" }))
       },
       encode(t) {
         switch (encoding._tag) {
           case "Multipart":
-            return Effect.fail(new SchemaIssue.Forbidden(Option.some(t), { message: "Payload must be a FormData" }))
+            return Effect.fail(new SchemaIssue.Forbidden({ message: "Payload must be a FormData" }))
           case "Json": {
             try {
               const body = JSON.stringify(t)
               return Effect.succeed(HttpBody.text(body, encoding.contentType))
-            } catch (error) {
-              return Effect.fail(new SchemaIssue.InvalidValue(Option.some(t), { message: globalThis.String(error) }))
+            } catch {
+              return Effect.fail(
+                new SchemaIssue.InvalidValue({ message: "Expected a JSON-serializable request body" })
+              )
             }
           }
           case "Text": {
             if (typeof t !== "string") {
               return Effect.fail(
-                new SchemaIssue.InvalidValue(Option.some(t), { message: "Expected a string" })
+                new SchemaIssue.InvalidValue({ message: "Expected a string" })
               )
             }
             return Effect.succeed(HttpBody.text(t, encoding.contentType))
           }
           case "FormUrlEncoded": {
             if (!Predicate.isObject(t)) {
-              return Effect.fail(new SchemaIssue.InvalidValue(Option.some(t), { message: "Expected a record" }))
+              return Effect.fail(new SchemaIssue.InvalidValue({ message: "Expected a record" }))
             }
             return Effect.succeed(HttpBody.urlParams(UrlParams.fromInput(t as any), encoding.contentType))
           }
           case "Uint8Array": {
             if (!(t instanceof Uint8Array)) {
               return Effect.fail(
-                new SchemaIssue.InvalidValue(Option.some(t), { message: "Expected a Uint8Array" })
+                new SchemaIssue.InvalidValue({ message: "Expected a Uint8Array" })
               )
             }
             return Effect.succeed(HttpBody.uint8Array(t, encoding.contentType))

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -961,7 +961,7 @@ export const Schema = <
     [success_, Schema_.Cause(error, Schema_.Defect())],
     ([value, cause]) => (input, ast, options) => {
       if (!isAsyncResult(input)) {
-        return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+        return Effect.fail(new SchemaIssue.InvalidType(ast))
       }
       switch (input._tag) {
         case "Initial":
@@ -971,8 +971,7 @@ export const Schema = <
             SchemaParser.decodeUnknownEffect(value)(input.value, options),
             {
               onSuccess: (value) => success(value, input),
-              onFailure: (issue) =>
-                new SchemaIssue.Composite(ast, Option.some(input), [new SchemaIssue.Pointer(["value"], issue)])
+              onFailure: (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["value"], issue)])
             }
           )
         case "Failure": {
@@ -983,7 +982,7 @@ export const Schema = <
                 {
                   onSuccess: (value) => Option.some(success<A["Type"], E["Type"]>(value, ps)),
                   onFailure: (issue) =>
-                    new SchemaIssue.Composite(ast, Option.some(input), [
+                    new SchemaIssue.Composite(ast, [
                       new SchemaIssue.Pointer(["previousSuccess", "value"], issue)
                     ])
                 }
@@ -993,7 +992,7 @@ export const Schema = <
           )
           const causeEffect = Effect.mapErrorEager(
             SchemaParser.decodeUnknownEffect(cause)(input.cause, options),
-            (issue) => new SchemaIssue.Composite(ast, Option.some(input), [new SchemaIssue.Pointer(["cause"], issue)])
+            (issue) => new SchemaIssue.Composite(ast, [new SchemaIssue.Pointer(["cause"], issue)])
           )
           return Effect.flatMapEager(
             prevSuccessEffect,

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -20,7 +20,7 @@ import * as Fiber from "../../Fiber.ts"
 import * as Filter from "../../Filter.ts"
 import { constFalse, constTrue, dual, identity } from "../../Function.ts"
 import * as Layer from "../../Layer.ts"
-import * as Option from "../../Option.ts"
+import type * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import type * as Schedule from "../../Schedule.ts"
 import * as Schema from "../../Schema.ts"
@@ -557,14 +557,14 @@ export class Complete<A, E> extends Data.TaggedClass("Complete")<{
       [Schema.Exit(options.success, options.error, Schema.Defect())],
       ([exit]) => (input, ast, options) => {
         if (!(isResult(input) && input._tag === "Complete")) {
-          return Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input)))
+          return Effect.fail(new SchemaIssue.InvalidType(ast))
         }
         return Effect.mapBothEager(
           SchemaParser.decodeEffect(exit)(input.exit, options),
           {
             onSuccess: (exit) => new Complete({ exit }),
             onFailure: (issue) =>
-              new SchemaIssue.Composite(ast, Option.some(input), [
+              new SchemaIssue.Composite(ast, [
                 new SchemaIssue.Pointer(["exit"], issue)
               ])
           }

--- a/packages/effect/test/Brand.test.ts
+++ b/packages/effect/test/Brand.test.ts
@@ -29,7 +29,7 @@ describe("Brand", () => {
     const Int = Brand.check<Int>(Schema.isInt())
     const result = Int.result(1.1)
     assertTrue(Result.isFailure(result))
-    strictEqual(String(result.failure), "BrandError(Expected an integer, got 1.1)")
+    strictEqual(String(result.failure), "BrandError(Expected an integer)")
   })
 
   it("creates nominal brands without runtime validation", () => {
@@ -94,7 +94,7 @@ describe("Brand", () => {
       assertSome(Int.option(-1), -1 as Int)
 
       assertSuccess(Int, 1)
-      assertFailure(Int, 1.1, "Expected an integer, got 1.1")
+      assertFailure(Int, 1.1, "Expected an integer")
       assertSuccess(Int, -1)
     })
 
@@ -103,13 +103,13 @@ describe("Brand", () => {
       const PositiveInt = Brand.check<PositiveInt>(Schema.isInt(), Schema.isGreaterThan(0))
 
       assertSuccess(PositiveInt, 1)
-      assertFailure(PositiveInt, 1.1, "Expected an integer, got 1.1")
-      assertFailure(PositiveInt, -1, "Expected a value greater than 0, got -1")
+      assertFailure(PositiveInt, 1.1, "Expected an integer")
+      assertFailure(PositiveInt, -1, "Expected a value greater than 0")
       assertFailure(
         PositiveInt,
         -1.1,
-        `Expected an integer, got -1.1
-Expected a value greater than 0, got -1.1`
+        `Expected an integer
+Expected a value greater than 0`
       )
     })
 
@@ -121,9 +121,9 @@ Expected a value greater than 0, got -1.1`
       )
 
       assertSuccess(PositiveInt, 1)
-      assertFailure(PositiveInt, 1.1, "Expected an integer, got 1.1")
-      assertFailure(PositiveInt, -1, "Expected a value greater than 0, got -1")
-      assertFailure(PositiveInt, -1.1, `Expected an integer, got -1.1`)
+      assertFailure(PositiveInt, 1.1, "Expected an integer")
+      assertFailure(PositiveInt, -1, "Expected a value greater than 0")
+      assertFailure(PositiveInt, -1.1, `Expected an integer`)
     })
   })
 
@@ -149,12 +149,12 @@ Expected a value greater than 0, got -1.1`
     assertNone(PositiveInt.option(-1))
 
     assertSuccess(PositiveInt, 1)
-    assertFailure(PositiveInt, 1.1, "Expected an integer, got 1.1")
+    assertFailure(PositiveInt, 1.1, "Expected an integer")
     assertFailure(
       PositiveInt,
       -1.1,
-      `Expected an integer, got -1.1
-Expected a value greater than 0, got -1.1`
+      `Expected an integer
+Expected a value greater than 0`
     )
   })
 })

--- a/packages/effect/test/Config.test.ts
+++ b/packages/effect/test/Config.test.ts
@@ -46,7 +46,7 @@ describe("Config", () => {
     it("fail creates an always-failing config", async () => {
       await assertFailure(
         Config.fail(
-          new Schema.SchemaError(new SchemaIssue.Forbidden(Option.none(), { message: "failure message" }))
+          new Schema.SchemaError(new SchemaIssue.Forbidden({ message: "failure message" }))
         ),
         ConfigProvider.fromUnknown({}),
         `failure message`
@@ -64,7 +64,7 @@ describe("Config", () => {
       await assertFailure(
         Config.string("b"),
         provider,
-        `Expected string, got undefined
+        `Expected string
   at ["b"]`
       )
     })
@@ -75,7 +75,7 @@ describe("Config", () => {
       await assertFailure(
         Config.nonEmptyString("b"),
         provider,
-        `Expected a value with a length of at least 1, got ""
+        `Expected a value with a length of at least 1
   at ["b"]`
       )
     })
@@ -87,7 +87,7 @@ describe("Config", () => {
       await assertFailure(
         Config.number("b"),
         provider,
-        `Expected string | "Infinity" | "-Infinity" | "NaN", got undefined
+        `Expected string | "Infinity" | "-Infinity" | "NaN"
   at ["b"]`
       )
     })
@@ -98,13 +98,13 @@ describe("Config", () => {
       await assertFailure(
         Config.finite("b"),
         provider,
-        `Expected a string representing a finite number, got "a"
+        `Expected a string representing a finite number
   at ["b"]`
       )
       await assertFailure(
         Config.finite("c"),
         provider,
-        `Expected a string representing a finite number, got "Infinity"
+        `Expected a string representing a finite number
   at ["c"]`
       )
     })
@@ -115,7 +115,7 @@ describe("Config", () => {
       await assertFailure(
         Config.int("b"),
         provider,
-        `Expected an integer, got 1.2
+        `Expected an integer
   at ["b"]`
       )
     })
@@ -126,7 +126,7 @@ describe("Config", () => {
       await assertFailure(
         Config.literal("-", "a"),
         provider,
-        `Expected "-", got "L"
+        `Expected "-"
   at ["a"]`
       )
     })
@@ -137,7 +137,7 @@ describe("Config", () => {
       await assertFailure(
         Config.literals(["development", "production"], "b"),
         provider,
-        `Expected "development" | "production", got "staging"
+        `Expected "development" | "production"
   at ["b"]`
       )
     })
@@ -148,7 +148,7 @@ describe("Config", () => {
       await assertFailure(
         Config.literals([1, 2], "b"),
         provider,
-        `Expected "1" | "2", got "3"
+        `Expected "1" | "2"
   at ["b"]`
       )
     })
@@ -159,12 +159,12 @@ describe("Config", () => {
       await assertFailure(
         Config.date("b"),
         provider,
-        `Expected a valid Date, got Invalid Date
+        `Expected a valid Date
   at ["b"]`
       )
     })
 
-    it("redacted hides values in validation errors", async () => {
+    it("redacted creates redacted values and reports missing input", async () => {
       const provider = ConfigProvider.fromUnknown({
         a: "value"
       })
@@ -173,7 +173,7 @@ describe("Config", () => {
       await assertFailure(
         Config.redacted("failure"),
         provider,
-        `Invalid data <redacted>
+        `Expected string
   at ["failure"]`
       )
     })
@@ -187,7 +187,7 @@ describe("Config", () => {
       await assertFailure(
         Config.url("failure"),
         provider,
-        `Expected string, got undefined
+        `Expected string
   at ["failure"]`
       )
     })
@@ -215,7 +215,7 @@ describe("Config", () => {
         s === ""
           ? Effect.fail(
             new Config.ConfigError(
-              new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.some(s), { message: "empty" }))
+              new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "empty" }))
             )
           )
           : Effect.succeed(s.toUpperCase())
@@ -266,7 +266,7 @@ describe("Config", () => {
           })
         ).parse(provider)
         const recovered = Config.fail(
-          new Schema.SchemaError(new SchemaIssue.Forbidden(Option.none(), { message: "failure" }))
+          new Schema.SchemaError(new SchemaIssue.Forbidden({ message: "failure" }))
         ).pipe(
           Config.orElse(() => {
             orElseCalls++
@@ -295,13 +295,13 @@ describe("Config", () => {
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "", b: "1" }, { preserveEmptyStrings: true }),
-          `Expected a value with a length of at least 1, got ""
+          `Expected a value with a length of at least 1
   at ["a"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "a", b: "b" }),
-          `Expected a string representing a finite number, got "b"
+          `Expected a string representing a finite number
   at ["b"]`
         )
       })
@@ -313,13 +313,13 @@ describe("Config", () => {
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "", b: "1" }, { preserveEmptyStrings: true }),
-          `Expected a value with a length of at least 1, got ""
+          `Expected a value with a length of at least 1
   at ["a"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "a", b: "b" }),
-          `Expected a string representing a finite number, got "b"
+          `Expected a string representing a finite number
   at ["b"]`
         )
       })
@@ -331,13 +331,13 @@ describe("Config", () => {
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "", d: "1" }, { preserveEmptyStrings: true }),
-          `Expected a value with a length of at least 1, got ""
+          `Expected a value with a length of at least 1
   at ["b"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "b", d: "b" }),
-          `Expected a string representing a finite number, got "b"
+          `Expected a string representing a finite number
   at ["d"]`
         )
       })
@@ -353,7 +353,7 @@ describe("Config", () => {
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "value" }),
-          `Expected a string representing a finite number, got "value"
+          `Expected a string representing a finite number
   at ["a"]`
         )
       })
@@ -384,9 +384,9 @@ describe("Config", () => {
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: { a: "" }, preserveEmptyStrings: true }),
-          `Expected a string representing a finite number, got ""
+          `Expected a string representing a finite number
   at ["a"]
-Expected "Infinity" | "-Infinity" | "NaN", got ""
+Expected "Infinity" | "-Infinity" | "NaN"
   at ["a"]`
         )
       })
@@ -402,20 +402,20 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "b" }),
-          `Expected string, got undefined
+          `Expected string
   at ["d"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ d: "1" }),
-          `Expected string, got undefined
+          `Expected string
   at ["b"]`
         )
 
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "", d: "1" }, { preserveEmptyStrings: true }),
-          `Expected a value with a length of at least 1, got ""
+          `Expected a value with a length of at least 1
   at ["b"]`
         )
       })
@@ -427,16 +427,14 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ LOG_LEVEL: "debug" }),
-          `Expected "All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace" | "None", got "debug"
+          `Expected "All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace" | "None"
   at ["LOG_LEVEL"]`
         )
       })
 
       it("does not recover from schema refinement failures", async () => {
         const schema = Schema.String.check(
-          Schema.makeFilter((s) =>
-            s === "a" ? undefined : new SchemaIssue.InvalidValue(Option.none(), { message: `must be "a"` })
-          )
+          Schema.makeFilter((s) => s === "a" ? undefined : new SchemaIssue.InvalidValue({ message: `must be "a"` }))
         )
         const config = Config.schema(schema, "a").pipe(Config.withDefault("fallback"))
 
@@ -559,7 +557,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "value" }),
-          `Expected a string representing a finite number, got "value"
+          `Expected a string representing a finite number
   at ["a"]`
         )
       })
@@ -574,26 +572,26 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "b" }),
-          `Expected string, got undefined
+          `Expected string
   at ["d"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ d: "1" }),
-          `Expected string, got undefined
+          `Expected string
   at ["b"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "", d: "1" }),
-          `Expected string, got undefined
+          `Expected string
   at ["b"]`
         )
 
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ b: "", d: "1" }, { preserveEmptyStrings: true }),
-          `Expected a value with a length of at least 1, got ""
+          `Expected a value with a length of at least 1
   at ["b"]`
         )
       })
@@ -662,7 +660,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             allConfig.pipe(Config.withDefault(fallback)),
             provider,
-            `Expected string, got undefined
+            `Expected string
   at ["database"]["port"]`
           )
         })
@@ -746,7 +744,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           ).pipe(Effect.flip)
           assert.strictEqual(
             error.cause.message,
-            `Expected string, got undefined
+            `Expected string
   at ["required"]`
           )
         }))
@@ -763,7 +761,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
 
           assert.strictEqual(
             error.cause.message,
-            `Expected string, got undefined
+            `Expected string
   at ["required"]`
           )
         }))
@@ -794,7 +792,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
 
           assert.strictEqual(
             error.cause.message,
-            `Expected string, got undefined
+            `Expected string
   at ["fallback"]`
           )
         }))
@@ -802,7 +800,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
       it.effect("preserves provider input evidence through mapOrFail and orElse", () =>
         Effect.gen(function*() {
           const validationError = new Config.ConfigError(
-            new Schema.SchemaError(new SchemaIssue.Forbidden(Option.none(), { message: "invalid value" }))
+            new Schema.SchemaError(new SchemaIssue.Forbidden({ message: "invalid value" }))
           )
           const config = Config.all({
             recovered: Config.string("recovered").pipe(
@@ -817,7 +815,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
 
           assert.strictEqual(
             error.cause.message,
-            `Expected string, got undefined
+            `Expected string
   at ["required"]`
           )
         }))
@@ -843,7 +841,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
 
           assert.strictEqual(
             error.cause.message,
-            `Expected string, got undefined
+            `Expected string
   at ["required"]`
           )
         }))
@@ -953,7 +951,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({}),
-            `Expected string, got undefined
+            `Expected string
   at ["a"]`
           )
         })
@@ -969,7 +967,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({}),
-            `Expected string, got undefined
+            `Expected string
   at ["b"]["a"]`
           )
         })
@@ -985,7 +983,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({ c: { b: {} } }),
-            `Expected string, got undefined
+            `Expected string
   at ["c"]["b"]["a"]`
           )
         })
@@ -1004,7 +1002,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({}),
-            `Expected string, got undefined
+            `Expected string
   at ["database"]["host"]`
           )
         })
@@ -1022,7 +1020,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: {} }),
-            `Expected string, got undefined
+            `Expected string
   at ["a"]`
           )
         })
@@ -1038,7 +1036,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: {} }),
-            `Expected string, got undefined
+            `Expected string
   at ["b"]["a"]`
           )
         })
@@ -1054,7 +1052,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { "c_b": "value" } }),
-            `Expected string, got undefined
+            `Expected string
   at ["c"]["b"]["a"]`
           )
         })
@@ -1073,7 +1071,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: {} }),
-            `Expected string, got undefined
+            `Expected string
   at ["database"]["host"]`
           )
         })
@@ -1088,7 +1086,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: {} }).pipe(ConfigProvider.nested("app")),
-            `Expected string, got undefined
+            `Expected string
   at ["database"]["host"]`
           )
         })
@@ -1102,9 +1100,9 @@ Expected "Infinity" | "-Infinity" | "NaN", got ""
           await assertFailure(
             Config.number("port"),
             provider,
-            `Expected a string representing a finite number, got "abc"
+            `Expected a string representing a finite number
   at ["port"]
-Expected "Infinity" | "-Infinity" | "NaN", got "abc"
+Expected "Infinity" | "-Infinity" | "NaN"
   at ["port"]`
           )
         })
@@ -1137,11 +1135,11 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
   })
 
   describe("schema", () => {
-    it("does not expose redacted input in errors", async () => {
+    it("reports missing redacted input", async () => {
       await assertFailure(
         Config.schema(Schema.Redacted(Schema.Literal("secret")), "a"),
         ConfigProvider.fromUnknown({}),
-        `Invalid data <redacted>
+        `Expected "secret"
   at ["a"]`
       )
     })
@@ -1175,7 +1173,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           Config.boolean("failure"),
           provider,
-          `Expected "true" | "yes" | "on" | "1" | "y" | "false" | "no" | "off" | "0" | "n", got "value"
+          `Expected "true" | "yes" | "on" | "1" | "y" | "false" | "no" | "off" | "0" | "n"
   at ["failure"]`
         )
       })
@@ -1196,7 +1194,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           Config.duration("failure"),
           provider,
-          `Invalid Duration string: value
+          `Expected a valid Duration string
   at ["failure"]`
         )
       })
@@ -1211,7 +1209,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           Config.port("failure"),
           provider,
-          `Expected a value between 1 and 65535, got -1
+          `Expected a value between 1 and 65535
   at ["failure"]`
         )
       })
@@ -1227,13 +1225,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           Config.logLevel("failure_1"),
           provider,
-          `Expected "All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace" | "None", got "info"
+          `Expected "All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace" | "None"
   at ["failure_1"]`
         )
         await assertFailure(
           Config.logLevel("failure_2"),
           provider,
-          `Expected "All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace" | "None", got "value"
+          `Expected "All" | "Fatal" | "Error" | "Warn" | "Info" | "Debug" | "Trace" | "None"
   at ["failure_2"]`
         )
       })
@@ -1612,7 +1610,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             provider,
-            `Expected exactly one member to match the input <configuration>
+            `Expected exactly one member to match
   at ["database"]["value"]`
           )
         })
@@ -1643,7 +1641,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
             const error = yield* config.parse(provider).pipe(Effect.flip)
             assert.strictEqual(
               error.cause.message,
-              `Expected string, got undefined
+              `Expected string
   at ["required"]`
             )
           }))
@@ -1656,7 +1654,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
             ]).check(
               Schema.makeFilter((value) =>
                 typeof value === "string"
-                  ? new SchemaIssue.InvalidValue(Option.none(), { message: "union check failed" })
+                  ? new SchemaIssue.InvalidValue({ message: "union check failed" })
                   : undefined
               )
             )
@@ -1751,7 +1749,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Expected "null", got undefined
+          `Expected "null"
   at ["a"]`
         )
       })
@@ -1764,7 +1762,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Expected string, got undefined
+          `Expected string
   at ["a"]`
         )
       })
@@ -1777,7 +1775,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Expected string | "Infinity" | "-Infinity" | "NaN", got undefined
+          `Expected string | "Infinity" | "-Infinity" | "NaN"
   at ["a"]`
         )
       })
@@ -1790,7 +1788,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Expected string, got undefined
+          `Expected string
   at ["a"]`
         )
       })
@@ -1803,7 +1801,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Expected string, got undefined
+          `Expected string
   at ["a"]`
         )
       })
@@ -1817,7 +1815,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Expected "true" | "false", got undefined
+          `Expected "true" | "false"
   at ["a"]`
         )
       })
@@ -1862,13 +1860,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a: "" }, preserveEmptyStrings: true }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a: "1" } }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
           await assertSuccess(config, ConfigProvider.fromEnv({ env: { a_0: "1" } }), { a: [1] })
@@ -1877,7 +1875,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: {} }),
-            `Expected object, got undefined`
+            `Expected object`
           )
         })
       })
@@ -1891,7 +1889,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: { a: "1", b: "value" } }),
-          `Expected a string representing a finite number, got "value"
+          `Expected a string representing a finite number
   at ["b"]`
         )
       })
@@ -1904,7 +1902,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a: "" }, preserveEmptyStrings: true }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
         })
@@ -1916,7 +1914,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a: "1" } }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
         })
@@ -1929,13 +1927,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a: "a" } }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a_0: "a", a_1: "value" } }),
-            `Expected a string representing a finite number, got "value"
+            `Expected a string representing a finite number
   at ["a"][1]`
           )
         })
@@ -1948,7 +1946,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: { a: "1,2,3" } }),
-          `Expected array, got undefined
+          `Expected array
   at ["a"]`
         )
         await assertSuccess(config, ConfigProvider.fromEnv({ env: { a_0: "1", a_1: "2" } }), { a: [1, 2] })
@@ -1956,13 +1954,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: { a_0: "1", a_2: "2" } }),
-          `Expected string, got undefined
+          `Expected string
   at ["a"][1]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: { a_0: "1", a_1: "value" } }),
-          `Expected a string representing a finite number, got "value"
+          `Expected a string representing a finite number
   at ["a"][1]`
         )
       })
@@ -2000,7 +1998,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
           await assertFailure(
             config,
             ConfigProvider.fromEnv({ env: { a: "a", b: "1" } }),
-            `Expected exactly one member to match the input <configuration>`
+            "Expected exactly one member to match"
           )
         })
 
@@ -2021,7 +2019,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         })
       })
 
-      it("redacts Int validation errors", async () => {
+      it("reports Int validation errors", async () => {
         const schema = Schema.Redacted(Schema.Int)
         const config = Config.schema(schema, "a")
 
@@ -2029,13 +2027,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: {} }),
-          `Invalid data <redacted>
+          `Expected string
   at ["a"]`
         )
         await assertFailure(
           config,
           ConfigProvider.fromEnv({ env: { a: "1.1" } }),
-          `Invalid data <redacted>
+          `Expected an integer
   at ["a"]`
         )
       })
@@ -2065,7 +2063,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         const config = Config.schema(schema)
 
         await assertSuccess(config, ConfigProvider.fromUnknown(undefined), undefined)
-        await assertFailure(config, ConfigProvider.fromUnknown("a"), `Expected undefined, got "a"`)
+        await assertFailure(config, ConfigProvider.fromUnknown("a"), `Expected undefined`)
       })
 
       it("decodes Null", async () => {
@@ -2073,7 +2071,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         const config = Config.schema(schema)
 
         await assertSuccess(config, ConfigProvider.fromUnknown("null"), null)
-        await assertFailure(config, ConfigProvider.fromUnknown("a"), `Expected "null", got "a"`)
+        await assertFailure(config, ConfigProvider.fromUnknown("a"), `Expected "null"`)
       })
 
       it("decodes String and rejects object input", async () => {
@@ -2081,7 +2079,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         const config = Config.schema(schema)
 
         await assertSuccess(config, ConfigProvider.fromUnknown("value"), "value")
-        await assertFailure(config, ConfigProvider.fromUnknown({}), `Expected string, got undefined`)
+        await assertFailure(config, ConfigProvider.fromUnknown({}), `Expected string`)
       })
 
       it("decodes Number and rejects invalid input", async () => {
@@ -2092,8 +2090,8 @@ Expected "Infinity" | "-Infinity" | "NaN", got "abc"
         await assertFailure(
           config,
           ConfigProvider.fromUnknown("a"),
-          `Expected a string representing a finite number, got "a"
-Expected "Infinity" | "-Infinity" | "NaN", got "a"`
+          `Expected a string representing a finite number
+Expected "Infinity" | "-Infinity" | "NaN"`
         )
       })
 
@@ -2105,7 +2103,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await assertFailure(
           config,
           ConfigProvider.fromUnknown("a"),
-          `Expected a string representing a finite number, got "a"`
+          `Expected a string representing a finite number`
         )
       })
 
@@ -2117,7 +2115,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await assertFailure(
           config,
           ConfigProvider.fromUnknown("a"),
-          `Expected a string representing a finite number, got "a"`
+          `Expected a string representing a finite number`
         )
       })
 
@@ -2127,7 +2125,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
 
         await assertSuccess(config, ConfigProvider.fromUnknown("true"), true)
         await assertSuccess(config, ConfigProvider.fromUnknown("false"), false)
-        await assertFailure(config, ConfigProvider.fromUnknown("a"), `Expected "true" | "false", got "a"`)
+        await assertFailure(config, ConfigProvider.fromUnknown("a"), `Expected "true" | "false"`)
       })
 
       describe("Struct", () => {
@@ -2145,7 +2143,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({ a: "value" }),
-            `Expected a string representing a finite number, got "value"
+            `Expected a string representing a finite number
   at ["a"]`
           )
         })
@@ -2188,13 +2186,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({ a: "" }, { preserveEmptyStrings: true }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({ a: "1" }),
-            `Expected array, got undefined
+            `Expected array
   at ["a"]`
           )
         })
@@ -2209,7 +2207,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "1", b: "value" }),
-          `Expected a string representing a finite number, got "value"
+          `Expected a string representing a finite number
   at ["b"]`
         )
       })
@@ -2220,7 +2218,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
           const config = Config.schema(schema)
 
           await assertSuccess(config, ConfigProvider.fromUnknown(["1"]), [1])
-          await assertFailure(config, ConfigProvider.fromUnknown("1"), `Expected array, got undefined`)
+          await assertFailure(config, ConfigProvider.fromUnknown("1"), `Expected array`)
         })
 
         it("requires and validates every tuple element", async () => {
@@ -2237,7 +2235,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
           await assertFailure(
             config,
             ConfigProvider.fromUnknown(["a", "value"]),
-            `Expected a string representing a finite number, got "value"
+            `Expected a string representing a finite number
   at [1]`
           )
         })
@@ -2248,12 +2246,12 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         const config = Config.schema(schema)
 
         await assertSuccess(config, ConfigProvider.fromUnknown(["1"]), [1])
-        await assertFailure(config, ConfigProvider.fromUnknown("1"), `Expected array, got undefined`)
+        await assertFailure(config, ConfigProvider.fromUnknown("1"), `Expected array`)
         await assertSuccess(config, ConfigProvider.fromUnknown(["1", "2"]), [1, 2])
         await assertFailure(
           config,
           ConfigProvider.fromUnknown(["1", "value"]),
-          `Expected a string representing a finite number, got "value"
+          `Expected a string representing a finite number
   at [1]`
         )
       })
@@ -2291,7 +2289,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
           await assertFailure(
             config,
             ConfigProvider.fromUnknown({ a: "a", b: "1" }),
-            `Expected exactly one member to match the input <configuration>`
+            "Expected exactly one member to match"
           )
         })
 
@@ -2330,7 +2328,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         })
       })
 
-      it("redacts nested Int validation errors", async () => {
+      it("reports nested Int validation errors", async () => {
         const schema = Schema.Struct({ a: Schema.Redacted(Schema.Int) })
         const config = Config.schema(schema)
 
@@ -2344,7 +2342,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await assertFailure(
           config,
           ConfigProvider.fromUnknown({ a: "1.1" }),
-          `Invalid data <redacted>
+          `Expected an integer
   at ["a"]`
         )
       })

--- a/packages/effect/test/Optic.test.ts
+++ b/packages/effect/test/Optic.test.ts
@@ -319,7 +319,7 @@ describe("Optic", () => {
       type S = number
       const optic = Optic.id<S>().check(Schema.isGreaterThan(0))
       assertSuccess(optic.getResult(1), 1)
-      assertFailure(optic.getResult(0), `Expected a value greater than 0, got 0`)
+      assertFailure(optic.getResult(0), `Expected a value greater than 0`)
       strictEqual(optic.set(1), 1)
       strictEqual(optic.set(0), 0)
       deepStrictEqual(optic.modify(addOne)(1), 2)
@@ -330,12 +330,12 @@ describe("Optic", () => {
       type S = number
       const optic = Optic.id<S>().check(Schema.isInt(), Schema.isGreaterThan(0))
       assertSuccess(optic.getResult(1), 1)
-      assertFailure(optic.getResult(0), `Expected a value greater than 0, got 0`)
-      assertFailure(optic.getResult(1.1), `Expected an integer, got 1.1`)
+      assertFailure(optic.getResult(0), `Expected a value greater than 0`)
+      assertFailure(optic.getResult(1.1), `Expected an integer`)
       assertFailure(
         optic.getResult(-1.1),
-        `Expected an integer, got -1.1
-Expected a value greater than 0, got -1.1`
+        `Expected an integer
+Expected a value greater than 0`
       )
       deepStrictEqual(optic.modify(addOne)(1), 2)
       deepStrictEqual(optic.modify(addOne)(0), 0)
@@ -350,8 +350,8 @@ Expected a value greater than 0, got -1.1`
 
       assertFailure(
         optic.getResult(-1.1),
-        `Expected an integer, got -1.1
-Expected a value greater than 0, got -1.1`
+        `Expected an integer
+Expected a value greater than 0`
       )
     })
   })
@@ -365,7 +365,7 @@ Expected a value greater than 0, got -1.1`
     ).key("b")
 
     assertSuccess(optic.getResult({ _tag: "b", b: 1 }), 1)
-    assertFailure(optic.getResult({ _tag: "a", a: "value" }), `Expected "b" tag, got {"_tag":"a","a":"value"}`)
+    assertFailure(optic.getResult({ _tag: "a", a: "value" }), `Expected "b" tag`)
     deepStrictEqual(optic.modify(addOne)({ _tag: "a", a: "value" }), { _tag: "a", a: "value" })
     deepStrictEqual(optic.modify(addOne)({ _tag: "b", b: 1 }), { _tag: "b", b: 2 })
   })
@@ -410,9 +410,9 @@ Expected a value greater than 0, got -1.1`
     type S = { readonly a: number }
     const optic = Optic.id<S>().key("a").check(Schema.isGreaterThan(0))
     assertSuccess(optic.getResult({ a: 1 }), 1)
-    assertFailure(optic.getResult({ a: 0 }), `Expected a value greater than 0, got 0`)
+    assertFailure(optic.getResult({ a: 0 }), `Expected a value greater than 0`)
     assertSuccess(optic.replaceResult(2, { a: 1 }), { a: 2 })
-    assertFailure(optic.replaceResult(2, { a: 0 }), `Expected a value greater than 0, got 0`)
+    assertFailure(optic.replaceResult(2, { a: 0 }), `Expected a value greater than 0`)
     deepStrictEqual(optic.replace(2, { a: 1 }), { a: 2 })
     deepStrictEqual(optic.replace(2, { a: 0 }), { a: 0 })
   })
@@ -530,7 +530,7 @@ Expected a value greater than 0, got -1.1`
   it("notUndefined", () => {
     const optic = Optic.id<number | undefined>().notUndefined()
     assertSuccess(optic.getResult(1), 1)
-    assertFailure(optic.getResult(undefined), "Expected a value other than `undefined`, got undefined")
+    assertFailure(optic.getResult(undefined), "Expected a value other than `undefined`")
 
     deepStrictEqual(optic.replace(2, undefined), 2)
     deepStrictEqual(optic.replace(2, 1), 2)
@@ -591,22 +591,22 @@ Expected a value greater than 0, got -1.1`
   it("fromChecks", () => {
     const optic = Optic.id<number>().compose(Optic.fromChecks(Schema.isGreaterThan(0), Schema.isInt()))
     assertSuccess(optic.getResult(1), 1)
-    assertFailure(optic.getResult(0), `Expected a value greater than 0, got 0`)
-    assertFailure(optic.getResult(1.1), `Expected an integer, got 1.1`)
+    assertFailure(optic.getResult(0), `Expected a value greater than 0`)
+    assertFailure(optic.getResult(1.1), `Expected an integer`)
   })
 
   describe("Option", () => {
     it("some", () => {
       const optic = Optic.id<Option.Option<number>>().compose(Optic.some())
       assertSuccess(optic.getResult(Option.some(1)), 1)
-      assertFailure(optic.getResult(Option.none()), `Expected a Some value, got none()`)
+      assertFailure(optic.getResult(Option.none()), `Expected a Some value`)
       deepStrictEqual(optic.set(2), Option.some(2))
     })
 
     it("none", () => {
       const optic = Optic.id<Option.Option<number>>().compose(Optic.none())
       assertSuccess(optic.getResult(Option.none()), undefined)
-      assertFailure(optic.getResult(Option.some(1)), `Expected a None value, got some(1)`)
+      assertFailure(optic.getResult(Option.some(1)), `Expected a None value`)
       deepStrictEqual(optic.set(undefined), Option.none())
     })
   })
@@ -615,14 +615,14 @@ Expected a value greater than 0, got -1.1`
     it("success", () => {
       const optic = Optic.id<Result.Result<number, string>>().compose(Optic.success())
       assertSuccess(optic.getResult(Result.succeed(1)), 1)
-      assertFailure(optic.getResult(Result.fail("error")), `Expected a Result.Success value, got failure("error")`)
+      assertFailure(optic.getResult(Result.fail("error")), `Expected a Result.Success value`)
       deepStrictEqual(optic.set(2), Result.succeed(2))
     })
 
     it("failure", () => {
       const optic = Optic.id<Result.Result<number, string>>().compose(Optic.failure())
       assertSuccess(optic.getResult(Result.fail("error")), "error")
-      assertFailure(optic.getResult(Result.succeed(1)), `Expected a Result.Failure value, got success(1)`)
+      assertFailure(optic.getResult(Result.succeed(1)), `Expected a Result.Failure value`)
       deepStrictEqual(optic.set("new error"), Result.fail("new error"))
     })
   })

--- a/packages/effect/test/cluster/ShardingConfig.test.ts
+++ b/packages/effect/test/cluster/ShardingConfig.test.ts
@@ -21,7 +21,7 @@ describe("ShardingConfig", () => {
       ).pipe(Effect.flip)
       assert.strictEqual(
         missingHost.cause.message,
-        `Expected string, got undefined
+        `Expected string
   at ["listenHost"]`
       )
 
@@ -30,7 +30,7 @@ describe("ShardingConfig", () => {
       ).pipe(Effect.flip)
       assert.strictEqual(
         invalidPort.cause.message,
-        `Expected a string representing a finite number, got "invalid"
+        `Expected a string representing a finite number
   at ["listenPort"]`
       )
     }))

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -62,7 +62,7 @@ describe("Schema", () => {
     const schema = Schema.String
     const result = Schema.decodeUnknownExit(schema)(null)
     assertTrue(Exit.isFailure(result))
-    strictEqual(String(result.cause.reasons[0]), "Fail(SchemaError(Expected string, got null))")
+    strictEqual(String(result.cause.reasons[0]), "Fail(SchemaError(Expected string))")
   })
 
   describe("SchemaError", () => {
@@ -77,8 +77,8 @@ describe("Schema", () => {
       strictEqual(error._tag, "SchemaError")
       strictEqual(error.name, "SchemaError")
       strictEqual(error.issue, result.failure)
-      strictEqual(error.message, "Expected string, got null")
-      strictEqual(String(error), "SchemaError(Expected string, got null)")
+      strictEqual(error.message, "Expected string")
+      strictEqual(String(error), "SchemaError(Expected string)")
     })
   })
 
@@ -92,8 +92,8 @@ describe("Schema", () => {
       const decoding = asserts.decoding()
       await decoding.fail(
         -1.2,
-        `Expected a value greater than 0, got -1.2
-Expected an integer, got -1.2`
+        `Expected a value greater than 0
+Expected an integer`
       )
     })
 
@@ -171,6 +171,25 @@ Missing key
     })
   })
 
+  describe("issue actual field", () => {
+    it("does not add actual to parser-created issues", () => {
+      const result = SchemaParser.decodeUnknownResult(Schema.String)({ secret: "value" })
+
+      assertTrue(Result.isFailure(result))
+      assertTrue(result.failure._tag === "InvalidType")
+      assertFalse("actual" in result.failure)
+      strictEqual(String(result.failure), "Expected string")
+    })
+
+    it("preserves user-provided messages", () => {
+      const schema = Schema.String.annotate({ message: "user supplied message" })
+      const result = SchemaParser.decodeUnknownResult(schema)(null)
+
+      assertTrue(Result.isFailure(result))
+      strictEqual(String(result.failure), "user supplied message")
+    })
+  })
+
   describe("Literal", () => {
     it("should throw an error if the literal is not a finite number", () => {
       throws(
@@ -199,15 +218,15 @@ Missing key
 
       const make = asserts.make()
       await make.succeed("a")
-      await make.fail(null, `Expected "a", got null`)
+      await make.fail(null, `Expected "a"`)
 
       const decoding = asserts.decoding()
       await decoding.succeed("a")
-      await decoding.fail(1, `Expected "a", got 1`)
+      await decoding.fail(1, `Expected "a"`)
 
       const encoding = asserts.encoding()
       await encoding.succeed("a")
-      await encoding.fail(1, `Expected "a", got 1`)
+      await encoding.fail(1, `Expected "a"`)
     })
 
     it(`1`, async () => {
@@ -216,15 +235,15 @@ Missing key
 
       const make = asserts.make()
       await make.succeed(1)
-      await make.fail(null, `Expected 1, got null`)
+      await make.fail(null, `Expected 1`)
 
       const decoding = asserts.decoding()
       await decoding.succeed(1)
-      await decoding.fail("1", `Expected 1, got "1"`)
+      await decoding.fail("1", `Expected 1`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(1)
-      await encoding.fail("1", `Expected 1, got "1"`)
+      await encoding.fail("1", `Expected 1`)
     })
 
     it("transform", async () => {
@@ -233,11 +252,11 @@ Missing key
 
       const decoding = asserts.decoding()
       await decoding.succeed(0, "a")
-      await decoding.fail(1, `Expected 0, got 1`)
+      await decoding.fail(1, `Expected 0`)
 
       const encoding = asserts.encoding()
       await encoding.succeed("a", 0)
-      await encoding.fail("b", `Expected "a", got "b"`)
+      await encoding.fail("b", `Expected "a"`)
     })
   })
 
@@ -252,7 +271,7 @@ Missing key
       await make.succeed("red")
       await make.succeed("green")
       await make.succeed("blue")
-      await make.fail("yellow", `Expected "red" | "green" | "blue", got "yellow"`)
+      await make.fail("yellow", `Expected "red" | "green" | "blue"`)
     })
 
     it("transform", async () => {
@@ -262,12 +281,12 @@ Missing key
       const decoding = asserts.decoding()
       await decoding.succeed(0, "a")
       await decoding.succeed(1, "b")
-      await decoding.fail(2, `Expected 0 | 1, got 2`)
+      await decoding.fail(2, `Expected 0 | 1`)
 
       const encoding = asserts.encoding()
       await encoding.succeed("a", 0)
       await encoding.succeed("b", 1)
-      await encoding.fail("c", `Expected "a" | "b", got "c"`)
+      await encoding.fail("c", `Expected "a" | "b"`)
     })
 
     it("pick", () => {
@@ -282,13 +301,13 @@ Missing key
     const asserts = new TestSchema.Asserts(schema)
 
     const make = asserts.make()
-    await make.fail(null as never, `Expected never, got null`)
+    await make.fail(null as never, `Expected never`)
 
     const decoding = asserts.decoding()
-    await decoding.fail("a", `Expected never, got "a"`)
+    await decoding.fail("a", `Expected never`)
 
     const encoding = asserts.encoding()
-    await encoding.fail("a", `Expected never, got "a"`)
+    await encoding.fail("a", `Expected never`)
   })
 
   it("Any", async () => {
@@ -319,7 +338,7 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(null)
-    await make.fail(undefined, `Expected null, got undefined`)
+    await make.fail(undefined, `Expected null`)
   })
 
   it("Undefined", async () => {
@@ -328,7 +347,7 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(undefined)
-    await make.fail(null, `Expected undefined, got null`)
+    await make.fail(null, `Expected undefined`)
   })
 
   it("String", async () => {
@@ -337,15 +356,15 @@ Missing key
 
     const make = asserts.make()
     await make.succeed("a")
-    await make.fail(null, `Expected string, got null`)
+    await make.fail(null, `Expected string`)
 
     const decoding = asserts.decoding()
     await decoding.succeed("a")
-    await decoding.fail(1, `Expected string, got 1`)
+    await decoding.fail(1, `Expected string`)
 
     const encoding = asserts.encoding()
     await encoding.succeed("a")
-    await encoding.fail(1, `Expected string, got 1`)
+    await encoding.fail(1, `Expected string`)
   })
 
   it("Number", async () => {
@@ -354,15 +373,15 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(1)
-    await make.fail(null, `Expected number, got null`)
+    await make.fail(null, `Expected number`)
 
     const decoding = asserts.decoding()
     await decoding.succeed(1)
-    await decoding.fail("a", `Expected number, got "a"`)
+    await decoding.fail("a", `Expected number`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(1)
-    await encoding.fail("a", `Expected number, got "a"`)
+    await encoding.fail("a", `Expected number`)
   })
 
   it("Boolean", async () => {
@@ -372,17 +391,17 @@ Missing key
     const make = asserts.make()
     await make.succeed(true)
     await make.succeed(false)
-    await make.fail(null, `Expected boolean, got null`)
+    await make.fail(null, `Expected boolean`)
 
     const decoding = asserts.decoding()
     await decoding.succeed(true)
     await decoding.succeed(false)
-    await decoding.fail("a", `Expected boolean, got "a"`)
+    await decoding.fail("a", `Expected boolean`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(true)
     await encoding.succeed(false)
-    await encoding.fail("a", `Expected boolean, got "a"`)
+    await encoding.fail("a", `Expected boolean`)
   })
 
   it("Symbol", async () => {
@@ -391,15 +410,15 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(Symbol("a"))
-    await make.fail(null, `Expected symbol, got null`)
+    await make.fail(null, `Expected symbol`)
 
     const decoding = asserts.decoding()
     await decoding.succeed(Symbol("a"))
-    await decoding.fail("a", `Expected symbol, got "a"`)
+    await decoding.fail("a", `Expected symbol`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(Symbol("a"))
-    await encoding.fail("a", `Expected symbol, got "a"`)
+    await encoding.fail("a", `Expected symbol`)
   })
 
   it("UniqueSymbol", async () => {
@@ -409,11 +428,11 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(a)
-    await make.fail(Symbol("b"), `Expected Symbol(a), got Symbol(b)`)
+    await make.fail(Symbol("b"), `Expected Symbol(a)`)
 
     const decoding = asserts.decoding()
     await decoding.succeed(a)
-    await decoding.fail(Symbol("b"), `Expected Symbol(a), got Symbol(b)`)
+    await decoding.fail(Symbol("b"), `Expected Symbol(a)`)
   })
 
   it("BigInt", async () => {
@@ -422,15 +441,15 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(1n)
-    await make.fail(null, `Expected bigint, got null`)
+    await make.fail(null, `Expected bigint`)
 
     const decoding = asserts.decoding()
     await decoding.succeed(1n)
-    await decoding.fail("1", `Expected bigint, got "1"`)
+    await decoding.fail("1", `Expected bigint`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(1n)
-    await encoding.fail("1", `Expected bigint, got "1"`)
+    await encoding.fail("1", `Expected bigint`)
   })
 
   it("Void", async () => {
@@ -468,17 +487,17 @@ Missing key
     const make = asserts.make()
     await make.succeed({})
     await make.succeed([])
-    await make.fail(null, `Expected object | array | function, got null`)
+    await make.fail(null, `Expected object | array | function`)
 
     const decoding = asserts.decoding()
     await decoding.succeed({})
     await decoding.succeed([])
-    await decoding.fail("1", `Expected object | array | function, got "1"`)
+    await decoding.fail("1", `Expected object | array | function`)
 
     const encoding = asserts.encoding()
     await encoding.succeed({})
     await encoding.succeed([])
-    await encoding.fail("1", `Expected object | array | function, got "1"`)
+    await encoding.fail("1", `Expected object | array | function`)
   })
 
   it("optionalKey", () => {
@@ -573,22 +592,22 @@ Missing key
         const decoding = asserts.decoding({ parseOptions: { onExcessProperty: "error" } })
         await decoding.fail(
           { a: "a", b: "b" },
-          `Unexpected key with value "b"
+          `Expected no excess property
   at ["b"]`
         )
         const sym = Symbol("sym")
         await decoding.fail(
           { a: "a", [sym]: "sym" },
-          `Unexpected key with value "sym"
+          `Expected no excess property
   at [Symbol(sym)]`
         )
 
         const decodingAll = asserts.decoding({ parseOptions: { onExcessProperty: "error", errors: "all" } })
         await decodingAll.fail(
           { a: "a", b: "b", c: "c" },
-          `Unexpected key with value "b"
+          `Expected no excess property
   at ["b"]
-Unexpected key with value "c"
+Expected no excess property
   at ["c"]`
         )
       })
@@ -633,7 +652,7 @@ Unexpected key with value "c"
 
       const make = asserts.make()
       await make.succeed({ a: "a" })
-      await make.fail(null, `Expected object, got null`)
+      await make.fail(null, `Expected object`)
 
       const decoding = asserts.decoding()
       await decoding.succeed({ a: "a" })
@@ -644,7 +663,7 @@ Unexpected key with value "c"
       )
       await decoding.fail(
         { a: 1 },
-        `Expected string, got 1
+        `Expected string
   at ["a"]`
       )
 
@@ -657,7 +676,7 @@ Unexpected key with value "c"
       )
       await encoding.fail(
         { a: 1 },
-        `Expected string, got 1
+        `Expected string
   at ["a"]`
       )
     })
@@ -672,7 +691,7 @@ Unexpected key with value "c"
       await decoding.succeed({ a: "1" }, { a: 1 })
       await decoding.fail(
         { a: "a" },
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["a"]`
       )
 
@@ -680,7 +699,7 @@ Unexpected key with value "c"
       await encoding.succeed({ a: 1 }, { a: "1" })
       await encoding.fail(
         { a: "a" },
-        `Expected number, got "a"
+        `Expected number
   at ["a"]`
       )
     })
@@ -692,7 +711,7 @@ Unexpected key with value "c"
       const asserts = new TestSchema.Asserts(schema)
 
       const decoding = asserts.decoding()
-      await decoding.fail(null, `Expected ID, got null`)
+      await decoding.fail(null, `Expected ID`)
     })
 
     it(`Schema.optionalKey: { readonly "a"?: string }`, async () => {
@@ -710,7 +729,7 @@ Unexpected key with value "c"
       await decoding.succeed({})
       await decoding.fail(
         { a: 1 },
-        `Expected string, got 1
+        `Expected string
   at ["a"]`
       )
 
@@ -719,7 +738,7 @@ Unexpected key with value "c"
       await encoding.succeed({})
       await encoding.fail(
         { a: 1 },
-        `Expected string, got 1
+        `Expected string
   at ["a"]`
       )
     })
@@ -741,7 +760,7 @@ Unexpected key with value "c"
       await decoding.succeed({})
       await decoding.fail(
         { a: 1 },
-        `Expected string | undefined, got 1
+        `Expected string | undefined
   at ["a"]`
       )
 
@@ -751,7 +770,7 @@ Unexpected key with value "c"
       await encoding.succeed({})
       await encoding.fail(
         { a: 1 },
-        `Expected string | undefined, got 1
+        `Expected string | undefined
   at ["a"]`
       )
     })
@@ -767,7 +786,7 @@ Unexpected key with value "c"
       await decoding.succeed({})
       await decoding.fail(
         { a: undefined },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]`
       )
 
@@ -847,7 +866,7 @@ Missing key
         await decoding.succeed({ a: "a", b: 1, c: 2 })
         await decoding.fail(
           { a: "a", b: "b" },
-          `Expected number, got "b"
+          `Expected number
   at ["b"]`
         )
       })
@@ -866,7 +885,7 @@ Missing key
         await decoding.succeed({ a: "a", b: "a", c: "c" })
         await decoding.fail(
           { a: "", b: "b", c: "c" },
-          `Expected a === b, got {"a":"","b":"b","c":"c"}`
+          `Expected a === b`
         )
       })
     })
@@ -917,15 +936,15 @@ Missing key
       const decoding = asserts.decoding()
       await decoding.fail(
         ["a", "b"],
-        `Unexpected key with value "b"
+        `Expected no excess property
   at [1]`
       )
       const decodingAll = asserts.decoding({ parseOptions: { errors: "all" } })
       await decodingAll.fail(
         ["a", "b", "c"],
-        `Unexpected key with value "b"
+        `Expected no excess property
   at [1]
-Unexpected key with value "c"
+Expected no excess property
   at [2]`
       )
     })
@@ -941,13 +960,13 @@ Unexpected key with value "c"
       await make.succeed(["a"])
       await make.fail(
         [""],
-        `Expected a value with a length of at least 1, got ""
+        `Expected a value with a length of at least 1
   at [0]`
       )
 
       const decoding = asserts.decoding()
       await decoding.succeed(["a"])
-      await decoding.fail(null, `Expected array, got null`)
+      await decoding.fail(null, `Expected array`)
       await decoding.fail(
         [],
         `Missing key
@@ -955,7 +974,7 @@ Unexpected key with value "c"
       )
       await decoding.fail(
         [1],
-        `Expected string, got 1
+        `Expected string
   at [0]`
       )
 
@@ -968,7 +987,7 @@ Unexpected key with value "c"
       )
       await encoding.fail(
         [1],
-        `Expected string, got 1
+        `Expected string
   at [0]`
       )
     })
@@ -1009,7 +1028,7 @@ Unexpected key with value "c"
       await decoding.succeed(["a", "b"])
       await decoding.fail(
         ["a", 1],
-        `Expected string, got 1
+        `Expected string
   at [1]`
       )
 
@@ -1017,7 +1036,7 @@ Unexpected key with value "c"
       await encoding.succeed(["a", "b"])
       await encoding.fail(
         ["a", 1],
-        `Expected string, got 1
+        `Expected string
   at [1]`
       )
     })
@@ -1031,11 +1050,11 @@ Unexpected key with value "c"
     await decoding.succeed("1", [1])
     await decoding.succeed(["1", "2"], [1, 2])
     await decoding.succeed([], [])
-    await decoding.fail(null, `Expected string | array, got null`)
-    await decoding.fail("a", `Expected a finite number, got NaN`)
+    await decoding.fail(null, `Expected string | array`)
+    await decoding.fail("a", `Expected a finite number`)
     await decoding.fail(
       ["a"],
-      `Expected a finite number, got NaN
+      `Expected a finite number
   at [0]`
     )
 
@@ -1069,7 +1088,7 @@ Unexpected key with value "c"
       )
       await decoding.fail(
         ["a", 1],
-        `Expected string, got 1
+        `Expected string
   at [1]`
       )
 
@@ -1083,7 +1102,7 @@ Unexpected key with value "c"
       )
       await encoding.fail(
         ["a", 1],
-        `Expected string, got 1
+        `Expected string
   at [1]`
       )
     })
@@ -1101,7 +1120,7 @@ Unexpected key with value "c"
     await decoding.succeed("a")
     await decoding.fail(
       " a ",
-      `Expected a string with no leading or trailing whitespace, got " a "`
+      `Expected a string with no leading or trailing whitespace`
     )
   })
 
@@ -1115,7 +1134,7 @@ Unexpected key with value "c"
         await decoding.succeed("abc")
         await decoding.fail(
           "ab",
-          `Expected a value with a length of at least 3, got "ab"`
+          `Expected a value with a length of at least 3`
         )
       })
 
@@ -1130,13 +1149,13 @@ Unexpected key with value "c"
         await decoding.succeed("abc")
         await decoding.fail(
           "ab",
-          `Expected a value with a length of at least 3, got "ab"`
+          `Expected a value with a length of at least 3`
         )
         const decodingAll = asserts.decoding({ parseOptions: { errors: "all" } })
         await decodingAll.fail(
           "ab",
-          `Expected a value with a length of at least 3, got "ab"
-Expected a string including "c", got "ab"`
+          `Expected a value with a length of at least 3
+Expected a string including "c"`
         )
       })
 
@@ -1150,7 +1169,7 @@ Expected a string including "c", got "ab"`
         const decoding = asserts.decoding()
         await decoding.fail(
           "a",
-          `Expected a value with a length of at least 2, got "a"`
+          `Expected a value with a length of at least 2`
         )
       })
 
@@ -1177,7 +1196,7 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("abc")
         await decoding.fail(
           "",
-          `Expected a value with a length of at least 3, got ""`
+          `Expected a value with a length of at least 3`
         )
       })
 
@@ -1219,11 +1238,11 @@ Expected a string including "c", got "ab"`
       await decoding.succeed(Option.some("a"))
       await decoding.fail(
         Option.some(""),
-        `Expected length > 0, got some("")`
+        `Expected length > 0`
       )
       await decoding.fail(
         Option.none(),
-        `Expected isSome, got none()`
+        `Expected isSome`
       )
     })
 
@@ -1236,14 +1255,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("a")
         await decoding.fail(
           "b",
-          `Expected a string matching the RegExp ^a, got "b"`
+          `Expected a string matching the RegExp ^a`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("a")
         await encoding.fail(
           "b",
-          `Expected a string matching the RegExp ^a, got "b"`
+          `Expected a string matching the RegExp ^a`
         )
       })
 
@@ -1266,14 +1285,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("a")
         await decoding.fail(
           "b",
-          `Expected a string starting with "a", got "b"`
+          `Expected a string starting with "a"`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("a")
         await encoding.fail(
           "b",
-          `Expected a string starting with "a", got "b"`
+          `Expected a string starting with "a"`
         )
       })
 
@@ -1285,14 +1304,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("a")
         await decoding.fail(
           "b",
-          `Expected a string ending with "a", got "b"`
+          `Expected a string ending with "a"`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("a")
         await encoding.fail(
           "b",
-          `Expected a string ending with "a", got "b"`
+          `Expected a string ending with "a"`
         )
       })
 
@@ -1304,14 +1323,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("a")
         await decoding.fail(
           "A",
-          `Expected a string with all characters in lowercase, got "A"`
+          `Expected a string with all characters in lowercase`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("a")
         await encoding.fail(
           "A",
-          `Expected a string with all characters in lowercase, got "A"`
+          `Expected a string with all characters in lowercase`
         )
       })
 
@@ -1323,14 +1342,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("A")
         await decoding.fail(
           "a",
-          `Expected a string with all characters in uppercase, got "a"`
+          `Expected a string with all characters in uppercase`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("A")
         await encoding.fail(
           "a",
-          `Expected a string with all characters in uppercase, got "a"`
+          `Expected a string with all characters in uppercase`
         )
       })
 
@@ -1342,14 +1361,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("Abc")
         await decoding.fail(
           "abc",
-          `Expected a string with the first character in uppercase, got "abc"`
+          `Expected a string with the first character in uppercase`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("Abc")
         await encoding.fail(
           "abc",
-          `Expected a string with the first character in uppercase, got "abc"`
+          `Expected a string with the first character in uppercase`
         )
       })
 
@@ -1361,14 +1380,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("aBC")
         await decoding.fail(
           "ABC",
-          `Expected a string with the first character in lowercase, got "ABC"`
+          `Expected a string with the first character in lowercase`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("aBC")
         await encoding.fail(
           "ABC",
-          `Expected a string with the first character in lowercase, got "ABC"`
+          `Expected a string with the first character in lowercase`
         )
       })
 
@@ -1380,14 +1399,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed("a")
         await decoding.fail(
           "",
-          `Expected a value with a length of at least 1, got ""`
+          `Expected a value with a length of at least 1`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed("a")
         await encoding.fail(
           "",
-          `Expected a value with a length of at least 1, got ""`
+          `Expected a value with a length of at least 1`
         )
       })
     })
@@ -1401,14 +1420,14 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(2)
         await decoding.fail(
           1,
-          `Expected a value greater than 1, got 1`
+          `Expected a value greater than 1`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed(2)
         await encoding.fail(
           1,
-          `Expected a value greater than 1, got 1`
+          `Expected a value greater than 1`
         )
       })
 
@@ -1420,7 +1439,7 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(1)
         await decoding.fail(
           0,
-          `Expected a value greater than or equal to 1, got 0`
+          `Expected a value greater than or equal to 1`
         )
       })
 
@@ -1432,7 +1451,7 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(0)
         await decoding.fail(
           1,
-          `Expected a value less than 1, got 1`
+          `Expected a value less than 1`
         )
       })
 
@@ -1444,7 +1463,7 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(1)
         await decoding.fail(
           2,
-          `Expected a value less than or equal to 1, got 2`
+          `Expected a value less than or equal to 1`
         )
       })
 
@@ -1456,7 +1475,7 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(4)
         await decoding.fail(
           3,
-          `Expected a value that is a multiple of 2, got 3`
+          `Expected a value that is a multiple of 2`
         )
       })
 
@@ -1476,11 +1495,11 @@ Expected a string including "c", got "ab"`
           await decoding.succeed(3)
           await decoding.fail(
             0,
-            `Expected a value between 1 and 3, got 0`
+            `Expected a value between 1 and 3`
           )
           await decoding.fail(
             4,
-            `Expected a value between 1 and 3, got 4`
+            `Expected a value between 1 and 3`
           )
 
           const encoding = asserts.encoding()
@@ -1488,7 +1507,7 @@ Expected a string including "c", got "ab"`
           await encoding.succeed(3)
           await encoding.fail(
             0,
-            `Expected a value between 1 and 3, got 0`
+            `Expected a value between 1 and 3`
           )
         })
 
@@ -1498,22 +1517,22 @@ Expected a string including "c", got "ab"`
 
           const decoding = asserts.decoding()
           await decoding.succeed(1)
-          await decoding.fail(3, `Expected a value between 1 and 3 (excluded), got 3`)
+          await decoding.fail(3, `Expected a value between 1 and 3 (excluded)`)
           await decoding.fail(
             0,
-            `Expected a value between 1 and 3 (excluded), got 0`
+            `Expected a value between 1 and 3 (excluded)`
           )
           await decoding.fail(
             4,
-            `Expected a value between 1 and 3 (excluded), got 4`
+            `Expected a value between 1 and 3 (excluded)`
           )
 
           const encoding = asserts.encoding()
           await encoding.succeed(1)
-          await encoding.fail(3, `Expected a value between 1 and 3 (excluded), got 3`)
+          await encoding.fail(3, `Expected a value between 1 and 3 (excluded)`)
           await encoding.fail(
             0,
-            `Expected a value between 1 and 3 (excluded), got 0`
+            `Expected a value between 1 and 3 (excluded)`
           )
         })
 
@@ -1522,23 +1541,23 @@ Expected a string including "c", got "ab"`
           const asserts = new TestSchema.Asserts(schema)
 
           const decoding = asserts.decoding()
-          await decoding.fail(1, `Expected a value between 1 (excluded) and 3, got 1`)
+          await decoding.fail(1, `Expected a value between 1 (excluded) and 3`)
           await decoding.succeed(3)
           await decoding.fail(
             0,
-            `Expected a value between 1 (excluded) and 3, got 0`
+            `Expected a value between 1 (excluded) and 3`
           )
           await decoding.fail(
             4,
-            `Expected a value between 1 (excluded) and 3, got 4`
+            `Expected a value between 1 (excluded) and 3`
           )
 
           const encoding = asserts.encoding()
-          await encoding.fail(1, `Expected a value between 1 (excluded) and 3, got 1`)
+          await encoding.fail(1, `Expected a value between 1 (excluded) and 3`)
           await encoding.succeed(3)
           await encoding.fail(
             0,
-            `Expected a value between 1 (excluded) and 3, got 0`
+            `Expected a value between 1 (excluded) and 3`
           )
         })
 
@@ -1550,24 +1569,24 @@ Expected a string including "c", got "ab"`
 
           const decoding = asserts.decoding()
           await decoding.succeed(2)
-          await decoding.fail(1, `Expected a value between 1 (excluded) and 3 (excluded), got 1`)
-          await decoding.fail(3, `Expected a value between 1 (excluded) and 3 (excluded), got 3`)
+          await decoding.fail(1, `Expected a value between 1 (excluded) and 3 (excluded)`)
+          await decoding.fail(3, `Expected a value between 1 (excluded) and 3 (excluded)`)
           await decoding.fail(
             0,
-            `Expected a value between 1 (excluded) and 3 (excluded), got 0`
+            `Expected a value between 1 (excluded) and 3 (excluded)`
           )
           await decoding.fail(
             4,
-            `Expected a value between 1 (excluded) and 3 (excluded), got 4`
+            `Expected a value between 1 (excluded) and 3 (excluded)`
           )
 
           const encoding = asserts.encoding()
           await encoding.succeed(2)
-          await encoding.fail(1, `Expected a value between 1 (excluded) and 3 (excluded), got 1`)
-          await encoding.fail(3, `Expected a value between 1 (excluded) and 3 (excluded), got 3`)
+          await encoding.fail(1, `Expected a value between 1 (excluded) and 3 (excluded)`)
+          await encoding.fail(3, `Expected a value between 1 (excluded) and 3 (excluded)`)
           await encoding.fail(
             0,
-            `Expected a value between 1 (excluded) and 3 (excluded), got 0`
+            `Expected a value between 1 (excluded) and 3 (excluded)`
           )
         })
       })
@@ -1580,26 +1599,26 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(1)
         await decoding.fail(
           1.1,
-          `Expected an integer, got 1.1`
+          `Expected an integer`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed(1)
         await encoding.fail(
           1.1,
-          `Expected an integer, got 1.1`
+          `Expected an integer`
         )
         await decoding.fail(
           NaN,
-          `Expected an integer, got NaN`
+          `Expected an integer`
         )
         await decoding.fail(
           Infinity,
-          `Expected an integer, got Infinity`
+          `Expected an integer`
         )
         await decoding.fail(
           -Infinity,
-          `Expected an integer, got -Infinity`
+          `Expected an integer`
         )
       })
 
@@ -1611,36 +1630,36 @@ Expected a string including "c", got "ab"`
         await decoding.succeed(1)
         await decoding.fail(
           1.1,
-          `Expected an integer, got 1.1`
+          `Expected an integer`
         )
         await decoding.fail(
           Number.MAX_SAFE_INTEGER + 1,
-          `Expected an integer, got 9007199254740992`
+          `Expected an integer`
         )
         await decoding.fail(
           1.1,
-          `Expected an integer, got 1.1`
+          `Expected an integer`
         )
         await decoding.fail(
           Number.MIN_SAFE_INTEGER - 1,
-          `Expected an integer, got -9007199254740992`
+          `Expected an integer`
         )
         const decodingAll = asserts.decoding({ parseOptions: { errors: "all" } })
         await decodingAll.fail(
           Number.MAX_SAFE_INTEGER + 1,
-          `Expected an integer, got 9007199254740992
-Expected a value between -2147483648 and 2147483647, got 9007199254740992`
+          `Expected an integer
+Expected a value between -2147483648 and 2147483647`
         )
 
         const encoding = asserts.encoding()
         await encoding.succeed(1)
         await encoding.fail(
           1.1,
-          `Expected an integer, got 1.1`
+          `Expected an integer`
         )
         await encoding.fail(
           Number.MAX_SAFE_INTEGER + 1,
-          `Expected an integer, got 9007199254740992`
+          `Expected an integer`
         )
       })
     })
@@ -1664,7 +1683,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed(10n)
         await decoding.fail(
           4n,
-          `Expected a value between 5n and 10n, got 4n`
+          `Expected a value between 5n and 10n`
         )
       })
 
@@ -1676,7 +1695,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed(6n)
         await decoding.fail(
           5n,
-          `Expected a value greater than 5n, got 5n`
+          `Expected a value greater than 5n`
         )
       })
 
@@ -1689,7 +1708,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed(6n)
         await decoding.fail(
           4n,
-          `Expected a value greater than or equal to 5n, got 4n`
+          `Expected a value greater than or equal to 5n`
         )
       })
 
@@ -1701,7 +1720,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed(4n)
         await decoding.fail(
           5n,
-          `Expected a value less than 5n, got 5n`
+          `Expected a value less than 5n`
         )
       })
 
@@ -1714,7 +1733,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed(4n)
         await decoding.fail(
           6n,
-          `Expected a value less than or equal to 5n, got 6n`
+          `Expected a value less than or equal to 5n`
         )
       })
     })
@@ -1728,7 +1747,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ a: 1, b: 2 })
         await decoding.fail(
           {},
-          `Expected a value with at least 1 entry, got {}`
+          `Expected a value with at least 1 entry`
         )
       })
 
@@ -1740,11 +1759,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ a: 1, b: 2 })
         await decoding.fail(
           { a: 1, b: 2, c: 3 },
-          `Expected a value with at most 2 entries, got {"a":1,"b":2,"c":3}`
+          `Expected a value with at most 2 entries`
         )
         await decoding.fail(
           { a: 1, b: 2, c: 3 },
-          `Expected a value with at most 2 entries, got {"a":1,"b":2,"c":3}`
+          `Expected a value with at most 2 entries`
         )
       })
 
@@ -1759,7 +1778,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ a: 1, [sym]: 2 })
         await decoding.fail(
           { [sym]: 1 },
-          `Expected a value with at least 2 entries, got {Symbol(test):1}`
+          `Expected a value with at least 2 entries`
         )
       })
 
@@ -1776,7 +1795,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ [sym1]: 1, [sym2]: 2 })
         await decoding.fail(
           { [sym1]: 1, [sym2]: 2, [sym3]: 3 },
-          `Expected a value with at most 2 entries, got {Symbol(test1):1,Symbol(test2):2,Symbol(test3):3}`
+          `Expected a value with at most 2 entries`
         )
       })
 
@@ -1789,11 +1808,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ ["__proto__"]: 0, "": 0 })
         await decoding.fail(
           { a: 1 },
-          `Expected a value with exactly 2 entries, got {"a":1}`
+          `Expected a value with exactly 2 entries`
         )
         await decoding.fail(
           { a: 1, b: 2, c: 3 },
-          `Expected a value with exactly 2 entries, got {"a":1,"b":2,"c":3}`
+          `Expected a value with exactly 2 entries`
         )
       })
 
@@ -1810,11 +1829,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ a: 1, [sym1]: 2 })
         await decoding.fail(
           { [sym1]: 1 },
-          `Expected a value with exactly 2 entries, got {Symbol(test1):1}`
+          `Expected a value with exactly 2 entries`
         )
         await decoding.fail(
           { [sym1]: 1, [sym2]: 2, a: 3 },
-          `Expected a value with exactly 2 entries, got {"a":3,Symbol(test1):1,Symbol(test2):2}`
+          `Expected a value with exactly 2 entries`
         )
       })
 
@@ -1828,7 +1847,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({ Ab: 1 })
         await decoding.fail(
           { ab: 1 },
-          `Expected a string matching the RegExp ^[A-Z], got "ab"
+          `Expected a string matching the RegExp ^[A-Z]
   at ["ab"]`
         )
       })
@@ -1841,7 +1860,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed({})
         await decoding.fail(
           { a: 1 },
-          `Expected never, got "a"
+          `Expected never
   at ["a"]`
         )
       })
@@ -1859,7 +1878,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await decoding.succeed([{ a: "a", b: "b" }, { a: "c", b: "d" }])
         await decoding.fail(
           [{ a: "a", b: "b" }, { a: "a", b: "b" }],
-          `Expected an array with unique items, got [{"a":"a","b":"b"},{"a":"a","b":"b"}]`
+          `Expected an array with unique items`
         )
       })
     })
@@ -1896,7 +1915,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(-Infinity, "-Infinity")
       await encoding.fail(
         "a",
-        `Expected number, got "a"`
+        `Expected number`
       )
     })
 
@@ -1909,11 +1928,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed("2021-01-01T00:00:00.000Z", new Date("2021-01-01T00:00:00.000Z"))
-      await decoding.fail("invalid", `Expected a valid Date, got Invalid Date`)
+      await decoding.fail("invalid", `Expected a valid Date`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(new Date("2021-01-01T00:00:00.000Z"), "2021-01-01T00:00:00.000Z")
-      await encoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
+      await encoding.fail(new Date(NaN), `Expected a valid Date`)
     })
 
     it("DateFromMillis", async () => {
@@ -1925,18 +1944,18 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed(0, new Date(0))
-      await decoding.fail(NaN, `Expected an integer, got NaN`)
-      await decoding.fail(Infinity, `Expected an integer, got Infinity`)
-      await decoding.fail(-Infinity, `Expected an integer, got -Infinity`)
-      await decoding.fail(null, `Expected number, got null`)
-      await decoding.fail(8640000000000001, `Expected a valid Date, got Invalid Date`)
+      await decoding.fail(NaN, `Expected an integer`)
+      await decoding.fail(Infinity, `Expected an integer`)
+      await decoding.fail(-Infinity, `Expected an integer`)
+      await decoding.fail(null, `Expected number`)
+      await decoding.fail(8640000000000001, `Expected a valid Date`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(new Date(0), 0)
-      await encoding.fail(new Date("invalid"), `Expected a valid Date, got Invalid Date`)
-      await encoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
-      await encoding.fail(new Date(Infinity), `Expected a valid Date, got Invalid Date`)
-      await encoding.fail(new Date(-Infinity), `Expected a valid Date, got Invalid Date`)
+      await encoding.fail(new Date("invalid"), `Expected a valid Date`)
+      await encoding.fail(new Date(NaN), `Expected a valid Date`)
+      await encoding.fail(new Date(Infinity), `Expected a valid Date`)
+      await encoding.fail(new Date(-Infinity), `Expected a valid Date`)
     })
 
     it("FiniteFromString", async () => {
@@ -1951,30 +1970,30 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("1", 1)
       await decoding.fail(
         "a",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
       await decoding.fail(
         "NaN",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
       await decoding.fail(
         "Infintiy",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
       await decoding.fail(
         "+Infintiy",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
       await decoding.fail(
         "-Infintiy",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed(1, "1")
       await encoding.fail(
         "a",
-        `Expected number, got "a"`
+        `Expected number`
       )
     })
 
@@ -1989,7 +2008,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("0", 0n)
       await decoding.fail(
         "a",
-        `Expected a string representing a bigint, got "a"`
+        `Expected a string representing a bigint`
       )
 
       const encoding = asserts.encoding()
@@ -2013,7 +2032,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(BigDecimal.make(123456n, 3), "123.456")
       await encoding.fail(
         "a",
-        `Expected BigDecimal, got "a"`
+        `Expected BigDecimal`
       )
     })
 
@@ -2032,7 +2051,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(DateTime.zoneMakeNamedUnsafe("Europe/London"), "Europe/London")
       await encoding.fail(
         "a",
-        `Expected DateTime.TimeZone.Named, got "a"`
+        `Expected DateTime.TimeZone.Named`
       )
     })
 
@@ -2053,7 +2072,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(DateTime.zoneMakeOffset(3 * 60 * 60 * 1000), "+03:00")
       await encoding.fail(
         "a",
-        `Expected DateTime.TimeZone, got "a"`
+        `Expected DateTime.TimeZone`
       )
     })
 
@@ -2068,13 +2087,13 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const zoned = DateTime.makeZonedUnsafe("2021-01-01T00:00:00.000Z", { timeZone: "Europe/London" })
 
       const decoding = asserts.decoding()
-      await decoding.fail("invalid", `Invalid Zoned DateTime string: invalid`)
+      await decoding.fail("invalid", "Expected a valid Zoned DateTime string")
 
       const encoding = asserts.encoding()
       await encoding.succeed(zoned, DateTime.formatIsoZoned(zoned))
       await encoding.fail(
         "a",
-        `Expected DateTime.Zoned, got "a"`
+        `Expected DateTime.Zoned`
       )
     })
 
@@ -2086,14 +2105,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("3", 3)
       await decoding.fail(
         "1",
-        `Expected a value greater than 2, got 1`
+        `Expected a value greater than 2`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed(3, "3")
       await encoding.fail(
         1,
-        `Expected a value greater than 2, got 1`
+        `Expected a value greater than 2`
       )
     })
   })
@@ -2194,7 +2213,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(" 2 ", 2)
       await decoding.fail(
         " a2 ",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
 
       const encoding = asserts.encoding()
@@ -2220,7 +2239,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: "aaa" })
       await decoding.fail(
         { a: "aa" },
-        `Expected a value with a length of at least 3, got "aa"
+        `Expected a value with a length of at least 3
   at ["a"]`
       )
 
@@ -2228,7 +2247,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed({ a: "aaa" })
       await encoding.fail(
         { a: "aa" },
-        `Expected a value with a length of at least 3, got "aa"
+        `Expected a value with a length of at least 3
   at ["a"]`
       )
     })
@@ -2372,7 +2391,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(" 2 ", 2)
       await decoding.fail(
         " a2 ",
-        `Expected a finite number, got NaN`
+        `Expected a finite number`
       )
 
       const encoding = asserts.encoding()
@@ -2398,7 +2417,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: "aaa" })
       await decoding.fail(
         { a: "aa" },
-        `Expected a value with a length of at least 3, got "aa"
+        `Expected a value with a length of at least 3
   at ["a"]`
       )
 
@@ -2406,7 +2425,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed({ a: "aaa" })
       await encoding.fail(
         { a: "aa" },
-        `Expected a value with a length of at least 3, got "aa"
+        `Expected a value with a length of at least 3
   at ["a"]`
       )
     })
@@ -2451,11 +2470,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         2,
-        `Expected a value greater than 2, got 2`
+        `Expected a value greater than 2`
       )
       await decoding.fail(
         3,
-        `Expected a value with a length of at least 3, got "3"`
+        `Expected a value with a length of at least 3`
       )
 
       const encoding = asserts.encoding()
@@ -2476,14 +2495,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         { a: "a" },
-        `Expected a length > 1, got {"a":"a"}`
+        `Expected a length > 1`
       )
       await decoding.succeed({ a: "aa" })
 
       const encoding = asserts.encoding()
       await encoding.fail(
         { a: "a" },
-        `Expected a length > 1, got {"a":"a"}`
+        `Expected a length > 1`
       )
       await encoding.succeed({ a: "aa" })
     })
@@ -2502,14 +2521,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         ["a"],
-        `Expected head length > 1, got ["a"]`
+        `Expected head length > 1`
       )
       await decoding.succeed(["aa"])
 
       const encoding = asserts.encoding()
       await encoding.fail(
         ["a"],
-        `Expected head length > 1, got ["a"]`
+        `Expected head length > 1`
       )
       await encoding.succeed(["aa"])
     })
@@ -2528,14 +2547,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         "a",
-        `Expected "aa", got "a"`
+        `Expected "aa"`
       )
       await decoding.succeed("aa")
 
       const encoding = asserts.encoding()
       await encoding.fail(
         "a",
-        `Expected "aa", got "a"`
+        `Expected "aa"`
       )
       await encoding.succeed("aa")
     })
@@ -2557,14 +2576,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         "a",
-        `Expected a length > 1, got "a"`
+        `Expected a length > 1`
       )
       await decoding.succeed("aa")
 
       const encoding = asserts.encoding()
       await encoding.fail(
         "a",
-        `Expected a length > 1, got "a"`
+        `Expected a length > 1`
       )
       await encoding.succeed("aa")
     })
@@ -2591,14 +2610,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         { b: "a" },
-        `Expected a length > 1, got {"a":"a"}`
+        `Expected a length > 1`
       )
       await decoding.succeed({ b: "aa" }, { a: "aa" })
 
       const encoding = asserts.encoding()
       await encoding.fail(
         { a: "a" },
-        `Expected a length > 1, got {"a":"a"}`
+        `Expected a length > 1`
       )
       await encoding.succeed({ a: "aa" }, { b: "aa" })
     })
@@ -2637,7 +2656,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new File([], "a.txt"))
-    await decoding.fail("a", `Expected File, got "a"`)
+    await decoding.fail("a", `Expected File`)
   })
 
   describe("Redacted", () => {
@@ -2645,6 +2664,17 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const schema = Schema.Redacted(Schema.String)
       strictEqual(schema.value, Schema.String)
       strictEqual(schema.annotate({}).value, Schema.String)
+    })
+
+    it("does not expose unwrapped inputs", async () => {
+      const schema = Schema.Redacted(Schema.String)
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding()
+      await decoding.fail("secret", `Expected Redacted`)
+
+      const encoding = asserts.encoding()
+      await encoding.fail("secret", `Expected Redacted`)
     })
 
     it("Redacted(Finite)", async () => {
@@ -2657,29 +2687,29 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed(Redacted.make(123))
-      await decoding.fail(null, `Expected Redacted, got null`)
+      await decoding.fail(null, `Expected Redacted`)
       await decoding.fail(
         Redacted.make("a"),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
       await decoding.fail(
         Redacted.make(1.2),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed(Redacted.make(123))
-      await encoding.fail(null, `Expected Redacted, got null`)
+      await encoding.fail(null, `Expected Redacted`)
       await encoding.fail(
         Redacted.make("a"),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
       await encoding.fail(
         Redacted.make(1.2),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
     })
@@ -2694,39 +2724,39 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed(Redacted.make("123"), Redacted.make(123))
-      await decoding.fail(null, `Expected Redacted, got null`)
+      await decoding.fail(null, `Expected Redacted`)
       await decoding.fail(
         Redacted.make(null),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
       await decoding.fail(
         Redacted.make("a"),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
       await decoding.fail(
         Redacted.make("1.2"),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed(Redacted.make(123), Redacted.make("123"))
-      await encoding.fail(null, `Expected Redacted, got null`)
+      await encoding.fail(null, `Expected Redacted`)
       await encoding.fail(
         Redacted.make(null),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
       await encoding.fail(
         Redacted.make("a"),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
       await encoding.fail(
         Redacted.make(1.2),
-        `Invalid data <redacted>
+        `Expected a valid value
   at ["value"]`
       )
     })
@@ -2739,17 +2769,17 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(Redacted.make("a", { label: "password" }))
       await decoding.fail(
         Redacted.make("a", { label: "API key" }),
-        `Expected "password", got "API key"
+        `Expected "password"
   at ["label"]`
       )
       await decoding.fail(
         Redacted.make(1, { label: "API key" }),
-        `Expected "password", got "API key"
+        `Expected "password"
   at ["label"]`
       )
       await decoding.fail(
         Redacted.make(1, { label: "password" }),
-        `Invalid data <redacted:password>
+        `Expected a valid value
   at ["value"]`
       )
 
@@ -2757,34 +2787,40 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(Redacted.make("a", { label: "password" }))
       await encoding.fail(
         Redacted.make("a", { label: "API key" }),
-        `Expected "password", got "API key"
+        `Expected "password"
   at ["label"]`
       )
       await encoding.fail(
         Redacted.make("", { label: "password" }),
-        `Invalid data <redacted:password>
+        `Expected a valid value
   at ["value"]`
       )
     })
   })
 
   describe("RedactedFromValue", () => {
-    it("should not leak any information about the value", async () => {
-      const schema = Schema.RedactedFromValue(Schema.Literal("secret"))
-      const asserts = new TestSchema.Asserts(schema)
-
-      const decoding = asserts.decoding()
-      await decoding.fail(null, `Invalid data <redacted>`)
-    })
-
     it("should decode a value", async () => {
       const schema = Schema.RedactedFromValue(Schema.FiniteFromString.check(Schema.isInt()))
       const asserts = new TestSchema.Asserts(schema)
 
       const decoding = asserts.decoding()
       await decoding.succeed("123", Redacted.make(123))
-      await decoding.fail(null, `Invalid data <redacted>`)
-      await decoding.fail("1.2", `Invalid data <redacted>`)
+      await decoding.fail(null, `Expected string`)
+      await decoding.fail("1.2", `Expected an integer`)
+
+      const encoding = asserts.encoding()
+      await encoding.succeed(Redacted.make(123), "123")
+      await encoding.fail("schema-secret", `Expected Redacted`)
+      await encoding.fail(
+        Redacted.make("schema-secret"),
+        `Expected a valid value
+  at ["value"]`
+      )
+      await encoding.fail(
+        Redacted.make(1.2),
+        `Expected a valid value
+  at ["value"]`
+      )
     })
   })
 
@@ -2806,20 +2842,20 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.succeed(Option.none())
       await decoding.succeed(Option.some("123"), Option.some(123))
-      await decoding.fail(null, `Expected Option, got null`)
+      await decoding.fail(null, `Expected Option`)
       await decoding.fail(
         Option.some(null),
-        `Expected string, got null
+        `Expected string
   at ["value"]`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed(Option.none())
       await encoding.succeed(Option.some(123), Option.some("123"))
-      await encoding.fail(null, `Expected Option, got null`)
+      await encoding.fail(null, `Expected Option`)
       await encoding.fail(
         Option.some(null),
-        `Expected number, got null
+        `Expected number
   at ["value"]`
       )
     })
@@ -2836,7 +2872,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     const decoding = asserts.decoding()
     await decoding.succeed(null, Option.none())
     await decoding.succeed("1", Option.some(1))
-    await decoding.fail("a", `Expected a finite number, got NaN`)
+    await decoding.fail("a", `Expected a finite number`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(Option.none(), null)
@@ -2854,7 +2890,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     const decoding = asserts.decoding()
     await decoding.succeed(undefined, Option.none())
     await decoding.succeed("1", Option.some(1))
-    await decoding.fail("a", `Expected a finite number, got NaN`)
+    await decoding.fail("a", `Expected a finite number`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(Option.none(), undefined)
@@ -2874,7 +2910,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(null, Option.none())
       await decoding.succeed(undefined, Option.none())
       await decoding.succeed("1", Option.some(1))
-      await decoding.fail("a", `Expected a finite number, got NaN`)
+      await decoding.fail("a", `Expected a finite number`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(Option.none(), null)
@@ -2893,7 +2929,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(null, Option.none())
       await decoding.succeed(undefined, Option.none())
       await decoding.succeed("1", Option.some(1))
-      await decoding.fail("a", `Expected a finite number, got NaN`)
+      await decoding.fail("a", `Expected a finite number`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(Option.none(), undefined)
@@ -2916,12 +2952,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed({ a: "1" }, { a: Option.some(1) })
     await decoding.fail(
       { a: undefined },
-      `Expected string, got undefined
+      `Expected string
   at ["a"]`
     )
     await decoding.fail(
       { a: "a" },
-      `Expected a finite number, got NaN
+      `Expected a finite number
   at ["a"]`
     )
 
@@ -2946,7 +2982,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed({ a: "1" }, { a: Option.some(1) })
     await decoding.fail(
       { a: "a" },
-      `Expected a finite number, got NaN
+      `Expected a finite number
   at ["a"]`
     )
 
@@ -2973,7 +3009,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: "1" }, { a: Option.some(1) })
       await decoding.fail(
         { a: "a" },
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["a"]`
       )
 
@@ -2982,7 +3018,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed({ a: Option.some(1) }, { a: "1" })
       await encoding.fail(
         { a: null },
-        `Expected Option, got null
+        `Expected Option
   at ["a"]`
       )
     })
@@ -3042,15 +3078,15 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.succeed(Result.succeed("1"), Result.succeed(1))
       await decoding.succeed(Result.fail("2"), Result.fail(2))
-      await decoding.fail(null, `Expected Result, got null`)
+      await decoding.fail(null, `Expected Result`)
       await decoding.fail(
         Result.succeed("a"),
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["success"]`
       )
       await decoding.fail(
         Result.fail("b"),
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["failure"]`
       )
 
@@ -3174,12 +3210,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         Cause.fail("a"),
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["failures"][0]["error"]`
       )
       await decoding.fail(
         Cause.die("a"),
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["failures"][0]["defect"]`
       )
 
@@ -3190,12 +3226,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await encoding.fail(
         Cause.fail("a"),
-        `Expected number, got "a"
+        `Expected number
   at ["failures"][0]["error"]`
       )
       await encoding.fail(
         Cause.die("a"),
-        `Expected number, got "a"
+        `Expected number
   at ["failures"][0]["defect"]`
       )
     })
@@ -3219,11 +3255,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed(customError)
     await decoding.fail(
       { message: "a" },
-      `Expected Error, got {"message":"a"}`
+      `Expected Error`
     )
     await decoding.fail(
       "a",
-      `Expected Error, got "a"`
+      `Expected Error`
     )
 
     const encoding = asserts.encoding()
@@ -3231,11 +3267,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await encoding.succeed(customError)
     await encoding.fail(
       { message: "a" },
-      `Expected Error, got {"message":"a"}`
+      `Expected Error`
     )
     await encoding.fail(
       "a",
-      `Expected Error, got "a"`
+      `Expected Error`
     )
   })
 
@@ -3263,16 +3299,16 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(Exit.fail("boom"))
       await decoding.fail(
         null,
-        `Expected Exit, got null`
+        `Expected Exit`
       )
       await decoding.fail(
         Exit.succeed(123),
-        `Expected string, got 123
+        `Expected string
   at ["value"]`
       )
       await decoding.fail(
         Exit.fail(null),
-        `Expected string, got null
+        `Expected string
   at ["cause"]["failures"][0]["error"]`
       )
     })
@@ -3321,7 +3357,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
           a: "1",
           categories: [{ a: "a", categories: [] }]
         },
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["categories"][0]["a"]`
       )
 
@@ -3333,7 +3369,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       })
       await encoding.fail(
         { a: 1, categories: [{ a: -1, categories: [] }] },
-        `Expected a value greater than 0, got -1
+        `Expected a value greater than 0
   at ["categories"][0]["a"]`
       )
     })
@@ -3368,7 +3404,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     it("should throw an error when the cause contains both a schema issue and a defect", () => {
       const cause = Cause.combine(
-        Cause.fail(new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" }))),
+        Cause.fail(new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "schema issue" }))),
         Cause.die(new Error("defect"))
       )
       const schema = Schema.Struct({
@@ -3442,7 +3478,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       Effect.gen(function*() {
         const cause = Cause.combine(
           Cause.fail(
-            new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" }))
+            new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "schema issue" }))
           ),
           Cause.die(new Error("defect"))
         )
@@ -3570,7 +3606,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         const schema = Schema.Struct({
           a: Schema.FiniteFromString.pipe(Schema.withConstructorDefault(
             Effect.fail(
-              new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.none(), { message: "ctor default failed" }))
+              new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "ctor default failed" }))
             )
           ))
         })
@@ -3600,7 +3636,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         await make.succeed({ a: 1 })
         await make.fail(
           {},
-          `Expected a value greater than 0, got -1
+          `Expected a value greater than 0
   at ["a"]["n"]`
         )
       })
@@ -3703,14 +3739,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const make = asserts.make()
       await make.succeed({ a: 1 })
-      await make.fail(null, `Expected object, got null`)
+      await make.fail(null, `Expected object`)
 
       const decoding = asserts.decoding()
       await decoding.succeed({ a: 1 })
-      await decoding.fail(null, "Expected object, got null")
+      await decoding.fail(null, "Expected object")
       await decoding.fail(
         { a: "b" },
-        `Expected number, got "b"
+        `Expected number
   at ["a"]`
       )
 
@@ -3718,10 +3754,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed({ a: 1 })
       await encoding.fail(
         { a: "b" },
-        `Expected number, got "b"
+        `Expected number
   at ["a"]`
       )
-      await encoding.fail(null, "Expected object, got null")
+      await encoding.fail(null, "Expected object")
     })
 
     it("recursive values stay lazy", async () => {
@@ -3772,7 +3808,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const make = asserts.make()
       await make.succeed({ a: 1 })
       await make.succeed({ a: undefined })
-      await make.fail(null, `Expected object, got null`)
+      await make.fail(null, `Expected object`)
 
       const decoding = asserts.decoding()
       await decoding.succeed({ a: 1 })
@@ -3791,7 +3827,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: 1, ab: 2, b: "ignored" }, { a: 1, ab: 2 })
       await decoding.fail(
         { a: "bad", b: 1 },
-        `Expected number, got "bad"
+        `Expected number
   at ["a"]`
       )
     })
@@ -3802,14 +3838,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const make = asserts.make()
       await make.succeed({ [Symbol.for("a")]: 1 })
-      await make.fail(null, `Expected object, got null`)
+      await make.fail(null, `Expected object`)
 
       const decoding = asserts.decoding()
       await decoding.succeed({ [Symbol.for("a")]: 1 })
-      await decoding.fail(null, "Expected object, got null")
+      await decoding.fail(null, "Expected object")
       await decoding.fail(
         { [Symbol.for("a")]: "b" },
-        `Expected number, got "b"
+        `Expected number
   at [Symbol(a)]`
       )
 
@@ -3817,10 +3853,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed({ [Symbol.for("a")]: 1 })
       await encoding.fail(
         { [Symbol.for("a")]: "b" },
-        `Expected number, got "b"
+        `Expected number
   at [Symbol(a)]`
       )
-      await encoding.fail(null, "Expected object, got null")
+      await encoding.fail(null, "Expected object")
     })
 
     it("Record(Symbol.check, Number) should use the key checks to select keys", async () => {
@@ -3836,7 +3872,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ [a]: 1, [b]: "ignored" }, { [a]: 1 })
       await decoding.fail(
         { [a]: "bad", [b]: 1 },
-        `Expected number, got "bad"
+        `Expected number
   at [Symbol(a)]`
       )
     })
@@ -3865,7 +3901,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ [a]: 1 })
       await decoding.fail(
         { [a]: "b" },
-        `Expected number, got "b"
+        `Expected number
   at [Symbol(a)]`
       )
     })
@@ -3937,12 +3973,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       })
       await decoding.fail(
         { 1: null },
-        `Expected string, got null
+        `Expected string
   at ["1"]`
       )
       await decoding.fail(
         { 1: "a" },
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["1"]`
       )
     })
@@ -3956,12 +3992,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ 1: "1", "1.1": "ignored", Infinity: "ignored", NaN: "ignored" }, { "1": 1 })
       await decoding.fail(
         { 1: null },
-        `Expected string, got null
+        `Expected string
   at ["1"]`
       )
       await decoding.fail(
         { 1: "a" },
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["1"]`
       )
     })
@@ -3974,7 +4010,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: "ignored", ab: 1 }, { ab: 1 })
       await decoding.fail(
         { a: 1, ab: "bad" },
-        `Expected number, got "bad"
+        `Expected number
   at ["ab"]`
       )
     })
@@ -4004,7 +4040,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const asserts = new TestSchema.Asserts(schema)
 
       const decoding = asserts.decoding()
-      await decoding.fail(null, `Expected never, got null`)
+      await decoding.fail(null, `Expected never`)
     })
 
     it(`String`, async () => {
@@ -4013,7 +4049,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed("a")
-      await decoding.fail(null, `Expected string, got null`)
+      await decoding.fail(null, `Expected string`)
     })
 
     it(`Void`, async () => {
@@ -4048,7 +4084,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(1)
       await decoding.fail(
         null,
-        `Expected string | number, got null`
+        `Expected string | number`
       )
     })
 
@@ -4058,7 +4094,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed("a")
-      await decoding.fail(null, `Expected string | never, got null`)
+      await decoding.fail(null, `Expected string | never`)
     })
 
     it(`String & isMinLength(1) | number & isGreaterThan(0)`, async () => {
@@ -4073,11 +4109,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(1)
       await decoding.fail(
         "",
-        `Expected a value with a length of at least 1, got ""`
+        `Expected a value with a length of at least 1`
       )
       await decoding.fail(
         -1,
-        `Expected a value greater than 0, got -1`
+        `Expected a value greater than 0`
       )
     })
 
@@ -4093,7 +4129,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ b: 1 })
       await decoding.fail(
         { a: "a", b: 1 },
-        `Expected exactly one member to match the input {"a":"a","b":1}`
+        "Expected exactly one member to match"
       )
     })
 
@@ -4107,7 +4143,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         { kind: "a", status: "ready", value: "value" },
-        `Expected exactly one member to match the input {"kind":"a","status":"ready","value":"value"}`
+        "Expected exactly one member to match"
       )
     })
 
@@ -4119,7 +4155,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         { kind: "a" },
-        `Expected exactly one member to match the input {"kind":"a"}`
+        "Expected exactly one member to match"
       )
     })
 
@@ -4131,7 +4167,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         "a",
-        `Expected exactly one member to match the input "a"`
+        "Expected exactly one member to match"
       )
     })
 
@@ -4191,7 +4227,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decodingOneOf = new TestSchema.Asserts(
         Schema.Union([decodingFallback, Schema.Null], { mode: "oneOf" })
       ).decoding()
-      await decodingOneOf.fail(null, `Expected exactly one member to match the input null`)
+      await decodingOneOf.fail(null, "Expected exactly one member to match")
 
       const encoding = new TestSchema.Asserts(Schema.Union([encodingFallback, Schema.Null])).encoding()
       await encoding.succeed(null, "fallback")
@@ -4199,7 +4235,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const encodingOneOf = new TestSchema.Asserts(
         Schema.Union([encodingFallback, Schema.Null], { mode: "oneOf" })
       ).encoding()
-      await encodingOneOf.fail(null, `Expected exactly one member to match the input null`)
+      await encodingOneOf.fail(null, "Expected exactly one member to match")
     })
 
     it("preserves recovering members during sentinel dispatch", async () => {
@@ -4226,7 +4262,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decodingOneOf = new TestSchema.Asserts(
         Schema.Union([decodingFirst, second], { mode: "oneOf" })
       ).decoding()
-      await decodingOneOf.fail(input, `Expected exactly one member to match the input {"kind":"b"}`)
+      await decodingOneOf.fail(input, "Expected exactly one member to match")
 
       const encoding = new TestSchema.Asserts(Schema.Union([encodingFirst, second])).encoding()
       await encoding.succeed(input, { kind: "a" })
@@ -4234,7 +4270,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const encodingOneOf = new TestSchema.Asserts(
         Schema.Union([encodingFirst, second], { mode: "oneOf" })
       ).encoding()
-      await encodingOneOf.fail(input, `Expected exactly one member to match the input {"kind":"b"}`)
+      await encodingOneOf.fail(input, "Expected exactly one member to match")
     })
 
     it("keeps suspended members lazy during candidate selection", async () => {
@@ -4274,7 +4310,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         Schema.Union([Schema.Literal("a"), oneOfSuspended], { mode: "oneOf" })
       ).decoding()
 
-      await oneOf.fail("a", `Expected exactly one member to match the input "a"`)
+      await oneOf.fail("a", "Expected exactly one member to match")
       strictEqual(oneOfEvaluations, 1)
     })
 
@@ -4326,9 +4362,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         const secondCompleted = yield* Deferred.make<void>()
         const first = Schema.String.pipe(
           Schema.decode({
-            decode: SchemaGetter.transformOrFail((value) =>
+            decode: SchemaGetter.transformOrFail(() =>
               Deferred.await(firstLatch).pipe(
-                Effect.andThen(Effect.fail(new SchemaIssue.Forbidden(Option.some(value), { message: "first failed" })))
+                Effect.andThen(Effect.fail(new SchemaIssue.Forbidden({ message: "first failed" })))
               )
             ),
             encode: SchemaGetter.passthrough()
@@ -4439,7 +4475,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const asserts = new TestSchema.Asserts(schema)
 
       const decoding = asserts.decoding()
-      await decoding.fail("a", `Expected exactly one member to match the input "a"`)
+      await decoding.fail("a", "Expected exactly one member to match")
     })
 
     it("Struct({}) preserves its semantics in a union", async () => {
@@ -4461,7 +4497,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({})
       await decoding.succeed([])
       await decoding.succeed(null)
-      await decoding.fail(undefined, `Expected object | array | null, got undefined`)
+      await decoding.fail(undefined, `Expected object | array | null`)
     })
 
     describe("should exclude members based on failed sentinels", () => {
@@ -4475,7 +4511,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         const decoding = asserts.decoding()
         await decoding.fail(
           {},
-          `Expected string | { readonly "_tag": "a", ... }, got {}`
+          `Expected string | { readonly "_tag": "a", ... }`
         )
       })
 
@@ -4489,7 +4525,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         const decoding = asserts.decoding()
         await decoding.fail(
           [],
-          `Expected string | readonly [ "a", ... ], got []`
+          `Expected string | readonly [ "a", ... ]`
         )
       })
 
@@ -4513,7 +4549,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         )
         await decoding.fail(
           { _tag: "c" },
-          `Expected { readonly "_tag": "a", ... } | { readonly "_tag": "b", ... }, got {"_tag":"c"}`
+          `Expected { readonly "_tag": "a", ... } | { readonly "_tag": "b", ... }`
         )
       })
 
@@ -4537,7 +4573,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         )
         await decoding.fail(
           ["c"],
-          `Expected readonly [ "a", ... ] | readonly [ "b", ... ], got ["c"]`
+          `Expected readonly [ "a", ... ] | readonly [ "b", ... ]`
         )
       })
     })
@@ -4600,17 +4636,17 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       )
       await decoding.fail(
         ["1", "a", true],
-        `Expected string, got true
+        `Expected string
   at [2]`
       )
       await decoding.fail(
         ["1", "a", "b", "c"],
-        `Expected boolean, got "b"
+        `Expected boolean
   at [2]`
       )
       await decoding.fail(
         ["1", "a", true, "b", "c"],
-        `Expected boolean, got "b"
+        `Expected boolean
   at [3]`
       )
 
@@ -4642,7 +4678,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       )
       await decoding.fail(
         ["1", "a", "b", "c"],
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at [3]`
       )
 
@@ -4661,7 +4697,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         ["a", true, "b", "1", "x"],
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at [4]`
       )
       await decoding.succeed(["a", true, "b", "1", "2"], ["a", true, "b", 1, 2])
@@ -4692,7 +4728,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: 1, b: 2 })
       await decoding.fail(
         { a: 1, b: "" },
-        `Expected number, got ""
+        `Expected number
   at ["b"]`
       )
     })
@@ -4709,7 +4745,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: 1, [Symbol.for("b")]: 2 })
       await decoding.fail(
         { a: 1, [Symbol.for("b")]: "c" },
-        `Expected number, got "c"
+        `Expected number
   at [Symbol(b)]`
       )
     })
@@ -4726,12 +4762,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: 1, "ab": 2 })
       await decoding.fail(
         { a: NaN, "ab": 2 },
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at ["a"]`
       )
       await decoding.fail(
         { a: 1, "ab": "c" },
-        `Expected number, got "c"
+        `Expected number
   at ["ab"]`
       )
     })
@@ -4754,11 +4790,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: 1, b: 2 })
       await decoding.fail(
         { a: 0 },
-        `Expected agt(0), got {"a":0}`
+        `Expected agt(0)`
       )
       await decoding.fail(
         { a: 1, b: 1 },
-        `Expected bgt(1), got {"a":1,"b":1}`
+        `Expected bgt(1)`
       )
     })
 
@@ -4798,10 +4834,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.succeed("a")
       await decoding.succeed(null)
-      await decoding.fail(undefined, `Expected string | null, got undefined`)
+      await decoding.fail(undefined, `Expected string | null`)
       await decoding.fail(
         "",
-        `Expected a value with a length of at least 1, got ""`
+        `Expected a value with a length of at least 1`
       )
     })
   })
@@ -4814,10 +4850,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.succeed("a")
       await decoding.succeed(undefined)
-      await decoding.fail(null, `Expected string | undefined, got null`)
+      await decoding.fail(null, `Expected string | undefined`)
       await decoding.fail(
         "",
-        `Expected a value with a length of at least 1, got ""`
+        `Expected a value with a length of at least 1`
       )
     })
   })
@@ -4833,7 +4869,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(undefined)
       await decoding.fail(
         "",
-        `Expected a value with a length of at least 1, got ""`
+        `Expected a value with a length of at least 1`
       )
     })
   })
@@ -4873,9 +4909,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed("Zm9vYmFy", encoder.encode("foobar"))
-    await decoding.fail("Zm9vY", "Length must be a multiple of 4, but is 5")
-    await decoding.fail("Zm9vYmF-", "Invalid character -")
-    await decoding.fail("=Zm9vYmF", "Found a '=' character, but it is not at the end")
+    await decoding.fail("Zm9vY", "Expected a valid Base64 string")
+    await decoding.fail("Zm9vYmF-", "Expected a valid Base64 string")
+    await decoding.fail("=Zm9vYmF", "Expected a valid Base64 string")
 
     const encoding = asserts.encoding()
     await encoding.succeed(encoder.encode("foobar"), "Zm9vYmFy")
@@ -4887,9 +4923,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed("Zm9vYmFy", "foobar")
-    await decoding.fail("Zm9vY", "Length must be a multiple of 4, but is 5")
-    await decoding.fail("Zm9vYmF-", "Invalid character -")
-    await decoding.fail("=Zm9vYmF", "Found a '=' character, but it is not at the end")
+    await decoding.fail("Zm9vY", "Expected a valid Base64 string")
+    await decoding.fail("Zm9vYmF-", "Expected a valid Base64 string")
+    await decoding.fail("=Zm9vYmF", "Expected a valid Base64 string")
 
     const encoding = asserts.encoding()
     await encoding.succeed("foobar", "Zm9vYmFy")
@@ -4901,9 +4937,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed("Zm9vYmFy", "foobar")
-    await decoding.fail("Zm9vY", "Length should be a multiple of 4, but is 5")
+    await decoding.fail("Zm9vY", "Expected a valid Base64Url string")
     await decoding.succeed("Pj8-ZD_Dnw", ">?>d?\u00DF")
-    await decoding.fail("Pj8/ZD+Dnw", "Invalid input")
+    await decoding.fail("Pj8/ZD+Dnw", "Expected a valid Base64Url string")
 
     const encoding = asserts.encoding()
     await encoding.succeed("foobar", "Zm9vYmFy")
@@ -4916,9 +4952,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed("67", "g")
-    await decoding.fail("0", "Length must be a multiple of 2, but is 1")
-    await decoding.fail("zd4aa", "Length must be a multiple of 2, but is 5")
-    await decoding.fail("0\x01", "Invalid input")
+    await decoding.fail("0", "Expected a valid hexadecimal string")
+    await decoding.fail("zd4aa", "Expected a valid hexadecimal string")
+    await decoding.fail("0\x01", "Expected a valid hexadecimal string")
 
     const encoding = asserts.encoding()
     await encoding.succeed("g", "67")
@@ -4933,7 +4969,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed("%D1%88%D0%B5%D0%BB%D0%BB%D1%8B", "шеллы")
     await decoding.succeed("hello%20world", "hello world")
     await decoding.succeed("hello", "hello")
-    await decoding.fail("%ZZ", `URI malformed`)
+    await decoding.fail("%ZZ", "Expected a valid URI component")
 
     const encoding = asserts.encoding()
     await encoding.succeed("{\"a\":1}", "%7B%22a%22%3A1%7D")
@@ -4951,9 +4987,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed("Zm9vYmFy", encoder.encode("foobar"))
-    await decoding.fail("Zm9vY", "Length should be a multiple of 4, but is 5")
+    await decoding.fail("Zm9vY", "Expected a valid Base64Url string")
     await decoding.succeed("Pj8-ZD_Dnw", encoder.encode(">?>d?ß"))
-    await decoding.fail("Pj8/ZD+Dnw", "Invalid input")
+    await decoding.fail("Pj8/ZD+Dnw", "Expected a valid Base64Url string")
 
     const encoding = asserts.encoding()
     await encoding.succeed(encoder.encode("foobar"), "Zm9vYmFy")
@@ -4979,9 +5015,9 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       Uint8Array.from([0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7])
     )
     await decoding.succeed("67", encoder.encode("g"))
-    await decoding.fail("0", "Length must be a multiple of 2, but is 1")
-    await decoding.fail("2d4aa", "Length must be a multiple of 2, but is 5")
-    await decoding.fail("0\x01", "Invalid input")
+    await decoding.fail("0", "Expected a valid hexadecimal string")
+    await decoding.fail("2d4aa", "Expected a valid hexadecimal string")
+    await decoding.fail("0\x01", "Expected a valid hexadecimal string")
 
     const encoding = asserts.encoding()
     await encoding.succeed(Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7]), "0001020304050607")
@@ -4997,13 +5033,13 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new Date("2021-01-01"))
-    await decoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
-    await decoding.fail(null, `Expected a valid Date, got null`)
-    await decoding.fail(0, `Expected a valid Date, got 0`)
+    await decoding.fail(new Date(NaN), `Expected a valid Date`)
+    await decoding.fail(null, `Expected a valid Date`)
+    await decoding.fail(0, `Expected a valid Date`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(new Date("2021-01-01"))
-    await encoding.fail(new Date(NaN), `Expected a valid Date, got Invalid Date`)
+    await encoding.fail(new Date(NaN), `Expected a valid Date`)
   })
 
   it("DateTimeUtc", async () => {
@@ -5031,7 +5067,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new Date("2021-01-01T00:00:00.000Z"), DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"))
-    await decoding.fail(new Date("invalid date"), `Expected a valid Date, got Invalid Date`)
+    await decoding.fail(new Date("invalid date"), `Expected a valid Date`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"), new Date("2021-01-01T00:00:00.000Z"))
@@ -5047,8 +5083,8 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed("2021-01-01T00:00:00.000Z", DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"))
-    await decoding.fail("invalid", `Invalid UTC DateTime string: invalid`)
-    await decoding.fail(null, `Expected string, got null`)
+    await decoding.fail("invalid", "Expected a valid UTC DateTime string")
+    await decoding.fail(null, `Expected string`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"), "2021-01-01T00:00:00.000Z")
@@ -5064,7 +5100,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(1609459200000, DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"))
-    await decoding.fail(null, `Expected number, got null`)
+    await decoding.fail(null, `Expected number`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(DateTime.makeUnsafe("2021-01-01T00:00:00.000Z"), 1609459200000)
@@ -5145,10 +5181,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new Set(["1", "2", "3"]), new Set([1, 2, 3]))
-    await decoding.fail(null, `Expected ReadonlySet, got null`)
+    await decoding.fail(null, `Expected ReadonlySet`)
     await decoding.fail(
       new Set(["1", "2", null]),
-      `Expected string, got null
+      `Expected string
   at ["values"][2]`
     )
   })
@@ -5166,10 +5202,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(HashSet.make("1", "2", "3"), HashSet.make(1, 2, 3))
-    await decoding.fail(null, `Expected HashSet, got null`)
+    await decoding.fail(null, `Expected HashSet`)
     await decoding.fail(
       HashSet.make(null),
-      `Expected string, got null
+      `Expected string
   at ["values"][0]`
     )
 
@@ -5190,10 +5226,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(Chunk.make("1", "2", "3"), Chunk.make(1, 2, 3))
-    await decoding.fail(null, `Expected Chunk, got null`)
+    await decoding.fail(null, `Expected Chunk`)
     await decoding.fail(
       Chunk.make(null),
-      `Expected string, got null
+      `Expected string
   at ["values"][0]`
     )
 
@@ -5216,10 +5252,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(new Map([["a", "1"]]), new Map([["a", 1]]))
-    await decoding.fail(null, `Expected ReadonlyMap, got null`)
+    await decoding.fail(null, `Expected ReadonlyMap`)
     await decoding.fail(
       new Map([["a", null]]),
-      `Expected string, got null
+      `Expected string
   at ["entries"][0][1]`
     )
 
@@ -5242,10 +5278,10 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(HashMap.make(["a", "1"]), HashMap.make(["a", 1]))
-    await decoding.fail(null, `Expected HashMap, got null`)
+    await decoding.fail(null, `Expected HashMap`)
     await decoding.fail(
       HashMap.make(["a", null]),
-      `Expected string, got null
+      `Expected string
   at ["entries"][0][1]`
     )
 
@@ -5316,11 +5352,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed(new MyError("a"))
-      await decoding.fail(null, `Expected MyError, got null`)
+      await decoding.fail(null, `Expected MyError`)
 
       const encoding = asserts.encoding()
       await encoding.succeed(new MyError("a"))
-      await encoding.fail(null, `Expected MyError, got null`)
+      await encoding.fail(null, `Expected MyError`)
     })
   })
 
@@ -5342,7 +5378,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed("1 second", Duration.seconds(1))
     await decoding.succeed("Infinity", Duration.infinity)
     await decoding.succeed("-Infinity", Duration.negativeInfinity)
-    await decoding.fail("value", "Invalid Duration string: value")
+    await decoding.fail("value", "Expected a valid Duration string")
 
     const encoding = asserts.encoding()
     await encoding.succeed(Duration.zero, "0 millis")
@@ -5369,8 +5405,8 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await encoding.succeed(Duration.millis(5), 5_000_000n)
     await encoding.succeed(Duration.nanos(5000n), 5000n)
     await encoding.succeed(Duration.nanos(-5000n), -5000n)
-    await encoding.fail(Duration.infinity, "Unable to encode Infinity into a bigint")
-    await encoding.fail(Duration.negativeInfinity, "Unable to encode -Infinity into a bigint")
+    await encoding.fail(Duration.infinity, "Expected a Duration representable as a bigint")
+    await encoding.fail(Duration.negativeInfinity, "Expected a Duration representable as a bigint")
   })
 
   it("DurationFromMillis", async () => {
@@ -5412,7 +5448,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     const decoding = asserts.decoding()
     await decoding.succeed(BigDecimal.fromStringUnsafe("123.45"))
-    await decoding.fail(null, `Expected BigDecimal, got null`)
+    await decoding.fail(null, `Expected BigDecimal`)
 
     const encoding = asserts.encoding()
     await encoding.succeed(BigDecimal.fromStringUnsafe("123.45"))
@@ -5427,7 +5463,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(BigDecimal.fromStringUnsafe("2"))
       await decoding.fail(
         BigDecimal.fromStringUnsafe("1"),
-        `Expected a value greater than 1, got BigDecimal(1)`
+        `Expected a value greater than 1`
       )
     })
 
@@ -5441,7 +5477,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(BigDecimal.fromStringUnsafe("1"))
       await decoding.fail(
         BigDecimal.fromStringUnsafe("0"),
-        `Expected a value greater than or equal to 1, got BigDecimal(0)`
+        `Expected a value greater than or equal to 1`
       )
     })
 
@@ -5453,7 +5489,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(BigDecimal.fromStringUnsafe("0"))
       await decoding.fail(
         BigDecimal.fromStringUnsafe("1"),
-        `Expected a value less than 1, got BigDecimal(1)`
+        `Expected a value less than 1`
       )
     })
 
@@ -5465,7 +5501,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(BigDecimal.fromStringUnsafe("1"))
       await decoding.fail(
         BigDecimal.fromStringUnsafe("2"),
-        `Expected a value less than or equal to 1, got BigDecimal(2)`
+        `Expected a value less than or equal to 1`
       )
     })
 
@@ -5480,7 +5516,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(BigDecimal.fromStringUnsafe("3"))
       await decoding.fail(
         BigDecimal.fromStringUnsafe("0"),
-        `Expected a value between 1 and 5, got BigDecimal(0)`
+        `Expected a value between 1 and 5`
       )
     })
   })
@@ -5561,7 +5597,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await make.succeed({ a: 1 }, { _tag: "a", a: 1 })
     await make.fail(
       { _tag: "c", a: 1 },
-      `Expected "a", got "c"
+      `Expected "a"
   at ["_tag"]`
     )
 
@@ -5570,7 +5606,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed({ a: "1" }, { _tag: "a", a: 1 })
     await decoding.fail(
       { _tag: "c", a: 1 },
-      `Expected "a", got "c"
+      `Expected "a"
   at ["_tag"]`
     )
 
@@ -5607,7 +5643,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed("https://effect.website", new URL("https://effect.website"))
     await decoding.fail(
       "123",
-      `Invalid URL string: 123`
+      "Expected a valid URL string"
     )
 
     const encoding = asserts.encoding()
@@ -5627,7 +5663,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(`{"a":1}`, { a: 1 })
       await decoding.fail(
         `{"a"`,
-        "SyntaxError: Expected ':' after property name in JSON at position 4 (line 1 column 5)"
+        "Expected a valid JSON string"
       )
 
       const encoding = asserts.encoding()
@@ -5735,7 +5771,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       formData.append("a", "")
       await decoding.fail(
         formData,
-        `Expected a value with a length of at least 1, got ""
+        `Expected a value with a length of at least 1
   at ["a"]`
       )
     }
@@ -5770,7 +5806,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const urlSearchParams = new URLSearchParams("a=")
       await decoding.fail(
         urlSearchParams,
-        `Expected a value with a length of at least 1, got ""
+        `Expected a value with a length of at least 1
   at ["a"]`
       )
     }
@@ -5795,7 +5831,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await encoding.succeed("a")
     await encoding.fail(
       "a ",
-      `Expected a string with no leading or trailing whitespace, got "a "`
+      `Expected a string with no leading or trailing whitespace`
     )
   })
 
@@ -5806,11 +5842,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         SchemaTransformation.transformOrFail({
           decode: (s) =>
             s === "a"
-              ? Effect.fail(new SchemaIssue.Forbidden(Option.some(s), { message: `input should not be "a"` }))
+              ? Effect.fail(new SchemaIssue.Forbidden({ message: `input should not be "a"` }))
               : Effect.succeed(s),
           encode: (s) =>
             s === "b"
-              ? Effect.fail(new SchemaIssue.Forbidden(Option.some(s), { message: `input should not be "b"` }))
+              ? Effect.fail(new SchemaIssue.Forbidden({ message: `input should not be "b"` }))
               : Effect.succeed(s)
         })
       )
@@ -5870,14 +5906,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const decoding = asserts.decoding()
       await decoding.succeed("a")
-      await decoding.fail(null, "Expected string, got null")
+      await decoding.fail(null, "Expected string")
       await decoding.fail(
         "ab",
-        `Expected a string matching template literal parts, got "ab"`
+        "Expected a string matching template literal parts"
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -5890,7 +5926,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         "a  b",
-        `Expected a string matching template literal parts, got "a  b"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -5903,7 +5939,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -5917,11 +5953,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -5950,15 +5986,15 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "aa",
-        `Expected a string matching template literal parts, got "aa"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -5973,23 +6009,23 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "aa",
-        `Expected a string matching template literal parts, got "aa"`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "a1.2",
-        `Expected a string matching template literal parts, got "a1.2"`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "a+1",
-        `Expected a string matching template literal parts, got "a+1"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6016,7 +6052,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("\na")
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6039,15 +6075,15 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("abb")
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "b",
-        `Expected a string matching template literal parts, got "b"`
+        `Expected a string matching template literal parts`
       )
 
       const encoding = asserts.encoding()
@@ -6064,11 +6100,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("acbd")
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "b",
-        `Expected a string matching template literal parts, got "b"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6086,7 +6122,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         "_id",
-        `Expected a string matching template literal parts, got "_id"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6098,7 +6134,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("a0")
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6110,7 +6146,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("a1")
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6123,7 +6159,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("aa")
       await decoding.fail(
         "b",
-        `Expected a string matching template literal parts, got "b"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6140,7 +6176,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("10.1")
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6157,7 +6193,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("ca  bd")
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6170,7 +6206,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("<h2>")
       await decoding.fail(
         "<h3>",
-        `Expected a string matching template literal parts, got "<h3>"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6182,15 +6218,15 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("ab")
       await decoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "a",
-        `Expected a string matching template literal parts, got "a"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6204,15 +6240,15 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "ab",
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at [1]`
       )
     })
@@ -6262,15 +6298,15 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("a", ["a"])
       await decoding.fail(
         "ab",
-        `Expected a string matching template literal parts, got "ab"`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         "",
-        `Expected a string matching template literal parts, got ""`
+        `Expected a string matching template literal parts`
       )
       await decoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
     })
 
@@ -6283,7 +6319,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         "a  b",
-        `Expected a string matching template literal parts, got "a  b"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6295,14 +6331,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("1a", [1, "a"])
       await decoding.fail(
         "1.1a",
-        `Expected a string matching template literal parts, got "1.1a"`
+        `Expected a string matching template literal parts`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed([1, "a"], "1a")
       await encoding.fail(
         [1.1, "a"],
-        `Expected an integer, got 1.1
+        `Expected an integer
   at [0]`
       )
     })
@@ -6324,7 +6360,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("100ab23a", [100, "a", "b23a"])
       await decoding.fail(
         "-ab",
-        `Expected a finite number, got NaN
+        `Expected a finite number
   at [0]`
       )
 
@@ -6332,7 +6368,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed([100, "a", "b"], "100ab")
       await encoding.fail(
         [100, "a", ""],
-        `Expected a value with a length of at least 1, got ""
+        `Expected a value with a length of at least 1
   at [2]`
       )
     })
@@ -6358,12 +6394,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("ced", ["c", "e", "d"])
       await decoding.fail(
         "cabd",
-        `Expected a string matching template literal parts, got "ab"
+        `Expected a string matching template literal parts
   at [1]`
       )
       await decoding.fail(
         "ed",
-        `Expected a string matching template literal parts, got "ed"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6383,12 +6419,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("ca1bd", ["c", ["a", 1, "b"], "d"])
       await decoding.fail(
         "ca1.1bd",
-        `Expected a string matching template literal parts, got "a1.1b"
+        `Expected a string matching template literal parts
   at [1]`
       )
       await decoding.fail(
         "ca-bd",
-        `Expected a string matching template literal parts, got "a-b"
+        `Expected a string matching template literal parts
   at [1]`
       )
     })
@@ -6402,7 +6438,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("<h2>", ["<", "h2", ">"])
       await decoding.fail(
         "<h3>",
-        `Expected a string matching template literal parts, got "<h3>"`
+        `Expected a string matching template literal parts`
       )
     })
 
@@ -6419,7 +6455,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed("<h2>", ["<", ["h", 2], ">"])
       await decoding.fail(
         "<h3>",
-        `Expected a string matching template literal parts, got "h3"
+        `Expected a string matching template literal parts
   at [1]`
       )
     })
@@ -6607,11 +6643,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: "a" }, new A({ a: "a" }))
       await decoding.fail(
         null,
-        `Expected object, got null`
+        `Expected object`
       )
       await decoding.fail(
         { a: 1 },
-        `Expected string, got 1
+        `Expected string
   at ["a"]`
       )
 
@@ -6619,11 +6655,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(new A({ a: "a" }), { a: "a" })
       await encoding.fail(
         null,
-        "Expected A, got null"
+        "Expected A"
       )
       await encoding.fail(
         { a: "a" },
-        `Expected A, got {"a":"a"}`
+        `Expected A`
       )
     })
 
@@ -6667,7 +6703,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed({ a: "a" }, new A({ a: "a" }))
       await decoding.fail(
         { a: 1 },
-        `Expected string, got 1
+        `Expected string
   at ["a"]`
       )
 
@@ -6675,11 +6711,11 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(new A({ a: "a" }), { a: "a" })
       await encoding.fail(
         null,
-        "Expected A, got null"
+        "Expected A"
       )
       await encoding.fail(
         { a: "a" },
-        `Expected A, got {"a":"a"}`
+        `Expected A`
       )
     })
 
@@ -6864,8 +6900,8 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
         const make = asserts.make()
         await make.succeed({ a: 1, b: 1 }, new B({ a: 1, b: 1 }))
-        await make.fail({ a: 0, b: 1 }, `Expected positive a, got {"a":0,"b":1}`)
-        await make.fail({ a: 1, b: 0 }, `Expected positive b, got {"a":1,"b":0}`)
+        await make.fail({ a: 0, b: 1 }, `Expected positive a`)
+        await make.fail({ a: 1, b: 0 }, `Expected positive b`)
       })
 
       it("static members", async () => {
@@ -6947,7 +6983,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       const make = asserts.make()
       await make.succeed({ a: "a" }, new A({ a: "a" }))
-      await make.fail({ a: "" }, `Expected "a" being longer than 0, got {"_tag":"A","a":""}`)
+      await make.fail({ a: "" }, `Expected "a" being longer than 0`)
 
       const decoding = asserts.decoding()
       await decoding.succeed({ _tag: "A", a: "a" }, new A({ a: "a" }))
@@ -6956,7 +6992,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         `Missing key
   at ["_tag"]`
       )
-      await decoding.fail({ _tag: "A", a: "" }, `Expected "a" being longer than 0, got {"_tag":"A","a":""}`)
+      await decoding.fail({ _tag: "A", a: "" }, `Expected "a" being longer than 0`)
     })
 
     it("extended constructor does not treat subclass fields as excess properties", () => {
@@ -7317,7 +7353,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         3,
-        `Expected 0 | 1, got 3`
+        `Expected 0 | 1`
       )
 
       const encoding = asserts.encoding()
@@ -7344,7 +7380,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         "Cantaloupe",
-        `Expected "apple" | "banana" | 0, got "Cantaloupe"`
+        `Expected "apple" | "banana" | 0`
       )
 
       const encoding = asserts.encoding()
@@ -7369,7 +7405,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       await decoding.fail(
         "Cantaloupe",
-        `Expected "apple" | "banana" | 3, got "Cantaloupe"`
+        `Expected "apple" | "banana" | 3`
       )
 
       const encoding = asserts.encoding()
@@ -7390,14 +7426,14 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(null, "b")
       await decoding.fail(
         "",
-        `Expected a value with a length of at least 1, got ""`
+        `Expected a value with a length of at least 1`
       )
 
       const encoding = asserts.encoding()
       await encoding.succeed("a")
       await encoding.fail(
         null,
-        "Expected string, got null"
+        "Expected string"
       )
     })
 
@@ -7452,14 +7488,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.succeed("1", 1)
       await decoding.succeed("a", 0)
-      await decoding.fail(null, "Expected string, got null")
+      await decoding.fail(null, "Expected string")
     })
 
     it("forced failure", async () => {
       const schema = Schema.String.pipe(
-        Schema.middlewareDecoding(() =>
-          Effect.fail(new SchemaIssue.Forbidden(Option.none(), { message: "my message" }))
-        )
+        Schema.middlewareDecoding(() => Effect.fail(new SchemaIssue.Forbidden({ message: "my message" })))
       )
       const asserts = new TestSchema.Asserts(schema)
 
@@ -7481,7 +7515,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await decoding.succeed(1)
       await decoding.fail(
         1.2,
-        `Expected an integer, got 1.2`
+        `Expected an integer`
       )
 
       const encoding = asserts.encoding()
@@ -7489,7 +7523,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(null, 0)
       await encoding.fail(
         1.2,
-        `Expected an integer, got 1.2`
+        `Expected an integer`
       )
     })
 
@@ -7503,7 +7537,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       await encoding.succeed(null, 0)
       await encoding.fail(
         1.2,
-        `Expected an integer, got 1.2`
+        `Expected an integer`
       )
     })
   })
@@ -7530,7 +7564,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await encoding.succeed(null, 0)
     await encoding.fail(
       1.2,
-      `Expected an integer, got 1.2`
+      `Expected an integer`
     )
   })
 
@@ -7555,14 +7589,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const encoding = asserts.encoding()
       await encoding.succeed(1, "1")
       await encoding.succeed(NaN, "b")
-      await encoding.fail(null, "Expected number, got null")
+      await encoding.fail(null, "Expected number")
     })
 
     it("forced failure", async () => {
       const schema = Schema.String.pipe(
-        Schema.middlewareEncoding(() =>
-          Effect.fail(new SchemaIssue.Forbidden(Option.none(), { message: "my message" }))
-        )
+        Schema.middlewareEncoding(() => Effect.fail(new SchemaIssue.Forbidden({ message: "my message" })))
       )
       const asserts = new TestSchema.Asserts(schema)
 
@@ -7752,12 +7784,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await encoding.succeed({ a: 1, b: 2 }, { a: "1", b: "2" })
     await encoding.fail(
       { a: 1, b: NaN },
-      `Expected a finite number, got NaN
+      `Expected a finite number
   at ["b"]`
     )
     await encoding.fail(
       { a: 1, b: undefined },
-      `Expected number, got undefined
+      `Expected number
   at ["b"]`
     )
   })
@@ -7780,7 +7812,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await decoding.succeed({ a: "1", b: "2" }, { a: 1, b: 2 })
     await decoding.fail(
       { a: "1", b: null },
-      `Expected string, got null
+      `Expected string
   at ["b"]`
     )
 
@@ -7788,12 +7820,12 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     await encoding.succeed({ a: 1, b: 2 }, { a: "1", b: "2" })
     await encoding.fail(
       { a: 1, b: NaN },
-      `Expected a finite number, got NaN
+      `Expected a finite number
   at ["b"]`
     )
     await encoding.fail(
       { a: 1, b: undefined },
-      `Expected number, got undefined
+      `Expected number
   at ["b"]`
     )
   })
@@ -7805,7 +7837,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
           decode: SchemaGetter.checkEffect((s) =>
             Effect.gen(function*() {
               if (s.length === 0) {
-                return new SchemaIssue.InvalidValue(Option.some(s), { message: "input should not be empty string" })
+                return new SchemaIssue.InvalidValue({ message: "input should not be empty string" })
               }
             }).pipe(Effect.delay(100))
           ),
@@ -7831,7 +7863,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
             Effect.gen(function*() {
               yield* Service
               if (s.length === 0) {
-                return new SchemaIssue.InvalidValue(Option.some(s), { message: "input should not be empty string" })
+                return new SchemaIssue.InvalidValue({ message: "input should not be empty string" })
               }
             })
           ),
@@ -7874,7 +7906,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
         fail("Expected asserts to throw an error")
       } catch (e) {
         ok(e instanceof Error)
-        strictEqual(e.message, `Expected number, got "a"`)
+        strictEqual(e.message, `Expected number`)
       }
     })
   })
@@ -7893,7 +7925,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const r2 = await decodeUnknownPromise(null).then(Result.succeed, Result.fail)
       assertTrue(Result.isFailure(r2))
       assertTrue(Schema.isSchemaError(r2.failure))
-      strictEqual(r2.failure.message, "Expected string, got null")
+      strictEqual(r2.failure.message, "Expected string")
 
       const r3 = await encodeUnknownPromise(1).then(Result.succeed, Result.fail)
       deepStrictEqual(r3, Result.succeed("1"))
@@ -7901,22 +7933,22 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const r4 = await encodeUnknownPromise(null).then(Result.succeed, Result.fail)
       assertTrue(Result.isFailure(r4))
       assertTrue(Schema.isSchemaError(r4.failure))
-      strictEqual(r4.failure.message, "Expected number, got null")
+      strictEqual(r4.failure.message, "Expected number")
 
       const r5 = await decodeUnknownPromiseIssue(null).then(Result.succeed, Result.fail)
       assertTrue(Result.isFailure(r5))
       assertTrue(r5.failure instanceof Error)
-      strictEqual(r5.failure.message, "Expected string, got null")
+      strictEqual(r5.failure.message, "Expected string")
 
       const r6 = await encodeUnknownPromiseIssue(null).then(Result.succeed, Result.fail)
       assertTrue(Result.isFailure(r6))
       assertTrue(r6.failure instanceof Error)
-      strictEqual(r6.failure.message, "Expected number, got null")
+      strictEqual(r6.failure.message, "Expected number")
     })
 
     it("should reject with an error when the cause contains both a schema issue and a defect", async () => {
       const cause = Cause.combine(
-        Cause.fail(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" })),
+        Cause.fail(new SchemaIssue.InvalidValue({ message: "schema issue" })),
         Cause.die(new Error("defect"))
       )
       const decodeSchema = Schema.String.pipe(Schema.decode({
@@ -7985,7 +8017,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
     it("should throw an error when the cause contains both a schema issue and a defect", () => {
       const cause = Cause.combine(
-        Cause.fail(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" })),
+        Cause.fail(new SchemaIssue.InvalidValue({ message: "schema issue" })),
         Cause.die(new Error("defect"))
       )
       const decodeSchema = Schema.String.pipe(Schema.decode({
@@ -8023,7 +8055,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const r2 = decodeUnknownResult(null)
       assertTrue(Result.isFailure(r2))
       assertTrue(Schema.isSchemaError(r2.failure))
-      strictEqual(r2.failure.message, "Expected string, got null")
+      strictEqual(r2.failure.message, "Expected string")
 
       const r3 = encodeUnknownResult(1)
       assertTrue(Result.isSuccess(r3))
@@ -8032,22 +8064,22 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const r4 = encodeUnknownResult(null)
       assertTrue(Result.isFailure(r4))
       assertTrue(Schema.isSchemaError(r4.failure))
-      strictEqual(r4.failure.message, "Expected number, got null")
+      strictEqual(r4.failure.message, "Expected number")
 
       const r5 = SchemaParser.decodeUnknownResult(schema)(null)
       assertTrue(Result.isFailure(r5))
       assertTrue(SchemaIssue.isIssue(r5.failure))
-      strictEqual(r5.failure.toString(), "Expected string, got null")
+      strictEqual(r5.failure.toString(), "Expected string")
 
       const r6 = SchemaParser.encodeUnknownResult(schema)(null)
       assertTrue(Result.isFailure(r6))
       assertTrue(SchemaIssue.isIssue(r6.failure))
-      strictEqual(r6.failure.toString(), "Expected number, got null")
+      strictEqual(r6.failure.toString(), "Expected number")
     })
 
     it("should throw an error when the cause contains both a schema issue and a defect", () => {
       const cause = Cause.combine(
-        Cause.fail(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" })),
+        Cause.fail(new SchemaIssue.InvalidValue({ message: "schema issue" })),
         Cause.die(new Error("defect"))
       )
       const decodeSchema = Schema.String.pipe(Schema.decode({
@@ -8081,30 +8113,30 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
 
       throws(() => Schema.decodeUnknownSync(schema)(null), (e) => {
         assertTrue(Schema.isSchemaError(e))
-        strictEqual(e.message, "Expected string, got null")
+        strictEqual(e.message, "Expected string")
       })
 
       throws(() => Schema.encodeUnknownSync(schema)(null), (e) => {
         assertTrue(Schema.isSchemaError(e))
-        strictEqual(e.message, "Expected number, got null")
+        strictEqual(e.message, "Expected number")
       })
 
       throws(() => SchemaParser.decodeUnknownSync(schema)(null), (e) => {
         assertTrue(e instanceof Error)
         assertTrue(SchemaIssue.isIssue(e.cause))
-        strictEqual(e.cause.toString(), "Expected string, got null")
+        strictEqual(e.cause.toString(), "Expected string")
       })
 
       throws(() => SchemaParser.encodeUnknownSync(schema)(null), (e) => {
         assertTrue(e instanceof Error)
         assertTrue(SchemaIssue.isIssue(e.cause))
-        strictEqual(e.cause.toString(), "Expected number, got null")
+        strictEqual(e.cause.toString(), "Expected number")
       })
     })
 
     it("should throw an error when the cause contains both a schema issue and a defect", () => {
       const cause = Cause.combine(
-        Cause.fail(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" })),
+        Cause.fail(new SchemaIssue.InvalidValue({ message: "schema issue" })),
         Cause.die(new Error("defect"))
       )
       const decodeSchema = Schema.String.pipe(Schema.decode({
@@ -8199,7 +8231,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
   describe("decodeUnknownExit / encodeUnknownExit", () => {
     it("should preserve mixed schema issue and defect causes", () => {
       const cause = Cause.combine(
-        Cause.fail(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" })),
+        Cause.fail(new SchemaIssue.InvalidValue({ message: "schema issue" })),
         Cause.die(new Error("defect"))
       )
       const decodeSchema = Schema.String.pipe(Schema.decode({
@@ -8691,7 +8723,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
       const decoding = asserts.decoding()
       await decoding.fail(
         "a",
-        `Expected <filter>, got "a"`
+        `Expected <filter>`
       )
     })
 
@@ -8708,7 +8740,7 @@ Expected a value between -2147483648 and 2147483647, got 9007199254740992`
     describe("returns issue", () => {
       it("abort: false", async () => {
         const schema = Schema.String.check(
-          Schema.makeFilter((s) => new SchemaIssue.InvalidValue(Option.some(s), { message: "error message 1" }), {
+          Schema.makeFilter(() => new SchemaIssue.InvalidValue({ message: "error message 1" }), {
             title: "filter title 1"
           }),
           Schema.makeFilter(() => false, { title: "filter title 2", message: "error message 2" })
@@ -8725,7 +8757,7 @@ error message 2`
 
       it("abort: true", async () => {
         const schema = Schema.String.check(
-          Schema.makeFilter((s) => new SchemaIssue.InvalidValue(Option.some(s), { message: "error message 1" }), {
+          Schema.makeFilter(() => new SchemaIssue.InvalidValue({ message: "error message 1" }), {
             title: "filter title 1"
           }, true),
           Schema.makeFilter(() => false, { title: "filter title 2", message: "error message 2" })
@@ -8778,7 +8810,7 @@ error message 2`
       it("issue: Issue", async () => {
         const schema = Schema.String.check(
           Schema.makeFilter(
-            (s) => ({ path: ["a"], issue: new SchemaIssue.InvalidValue(Option.some(s), { message: "custom issue" }) }),
+            () => ({ path: ["a"], issue: new SchemaIssue.InvalidValue({ message: "custom issue" }) }),
             { title: "filter title" }
           )
         )
@@ -8834,9 +8866,9 @@ error message 2
 
       it("array mixing string, Issue, and { path, issue }", async () => {
         const schema = Schema.String.check(
-          Schema.makeFilter((s) => [
+          Schema.makeFilter(() => [
             "top-level message",
-            new SchemaIssue.InvalidValue(Option.some(s), { message: "direct issue" }),
+            new SchemaIssue.InvalidValue({ message: "direct issue" }),
             { path: ["a"], issue: "pointed message" }
           ], { title: "filter title" })
         )
@@ -9122,7 +9154,7 @@ pointed message
       await decoding.succeed({ a: "2" }, { a: 2 })
       await decoding.fail(
         { a: undefined },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]`
       )
     })
@@ -9163,7 +9195,7 @@ pointed message
       await decoding.succeed({ a: { b: "2" } }, { a: { b: 2 } })
       await decoding.fail(
         { a: { b: undefined } },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]["b"]`
       )
     })
@@ -9172,7 +9204,7 @@ pointed message
       const schema = Schema.Struct({
         a: Schema.FiniteFromString.pipe(Schema.withDecodingDefaultKey(
           Effect.fail(
-            new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.none(), { message: "decoding default failed" }))
+            new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "decoding default failed" }))
           )
         ))
       })
@@ -9190,7 +9222,7 @@ pointed message
     it("Effect failing with SchemaError and a defect preserves the mixed cause", () => {
       const cause = Cause.combine(
         Cause.fail(
-          new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.none(), { message: "decoding default failed" }))
+          new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "decoding default failed" }))
         ),
         Cause.die(new Error("defect"))
       )
@@ -9291,7 +9323,7 @@ pointed message
     it("Effect failing with SchemaError and a defect preserves the mixed cause", () => {
       const cause = Cause.combine(
         Cause.fail(
-          new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.none(), { message: "decoding default failed" }))
+          new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "decoding default failed" }))
         ),
         Cause.die(new Error("defect"))
       )
@@ -9344,7 +9376,7 @@ pointed message
       await decoding.succeed({ a: "2" }, { a: 2 })
       await decoding.fail(
         { a: undefined },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]`
       )
     })
@@ -9385,7 +9417,7 @@ pointed message
       await decoding.succeed({ a: { b: "2" } }, { a: { b: 2 } })
       await decoding.fail(
         { a: { b: undefined } },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]["b"]`
       )
     })
@@ -9394,7 +9426,7 @@ pointed message
       const schema = Schema.Struct({
         a: Schema.FiniteFromString.pipe(Schema.withDecodingDefaultTypeKey(
           Effect.fail(
-            new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.none(), { message: "decoding default failed" }))
+            new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "decoding default failed" }))
           )
         ))
       })
@@ -9492,7 +9524,7 @@ pointed message
       const schema = Schema.Struct({
         a: Schema.FiniteFromString.pipe(Schema.withDecodingDefaultType(
           Effect.fail(
-            new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.none(), { message: "decoding default failed" }))
+            new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "decoding default failed" }))
           )
         ))
       })
@@ -9535,14 +9567,14 @@ pointed message
     await decoding.succeed("a")
     await decoding.fail(
       "",
-      `Expected a value with a length of at least 1, got ""`
+      `Expected a value with a length of at least 1`
     )
 
     const encoding = asserts.encoding()
     await encoding.succeed("a")
     await encoding.fail(
       "",
-      `Expected a value with a length of at least 1, got ""`
+      `Expected a value with a length of at least 1`
     )
   })
 
@@ -9558,14 +9590,14 @@ pointed message
     await decoding.succeed("a")
     await decoding.fail(
       "ab",
-      `Expected a value with a length of 1, got "ab"`
+      `Expected a value with a length of 1`
     )
 
     const encoding = asserts.encoding()
     await encoding.succeed("a")
     await encoding.fail(
       "ab",
-      `Expected a value with a length of 1, got "ab"`
+      `Expected a value with a length of 1`
     )
   })
 
@@ -9581,26 +9613,26 @@ pointed message
     await decoding.succeed(1)
     await decoding.fail(
       1.1,
-      `Expected an integer, got 1.1`
+      `Expected an integer`
     )
     await decoding.fail(
       NaN,
-      `Expected an integer, got NaN`
+      `Expected an integer`
     )
     await decoding.fail(
       Infinity,
-      `Expected an integer, got Infinity`
+      `Expected an integer`
     )
     await decoding.fail(
       -Infinity,
-      `Expected an integer, got -Infinity`
+      `Expected an integer`
     )
 
     const encoding = asserts.encoding()
     await encoding.succeed(1)
     await encoding.fail(
       1.1,
-      `Expected an integer, got 1.1`
+      `Expected an integer`
     )
   })
 
@@ -9617,18 +9649,18 @@ pointed message
     await decoding.succeed(1)
     await decoding.fail(
       -1,
-      `Expected a value greater than or equal to 0, got -1`
+      `Expected a value greater than or equal to 0`
     )
     await decoding.fail(
       1.1,
-      `Expected an integer, got 1.1`
+      `Expected an integer`
     )
 
     const encoding = asserts.encoding()
     await encoding.succeed(0)
     await encoding.fail(
       -1,
-      `Expected a value greater than or equal to 0, got -1`
+      `Expected a value greater than or equal to 0`
     )
   })
 
@@ -9652,7 +9684,7 @@ pointed message
     await encoding.succeed("Abc")
     await encoding.fail(
       "abc",
-      `Expected a string with the first character in uppercase, got "abc"`
+      `Expected a string with the first character in uppercase`
     )
   })
 
@@ -9676,7 +9708,7 @@ pointed message
     await encoding.succeed("abc")
     await encoding.fail(
       "Abc",
-      `Expected a string with the first character in lowercase, got "Abc"`
+      `Expected a string with the first character in lowercase`
     )
   })
 
@@ -9700,7 +9732,7 @@ pointed message
     await encoding.succeed("abc")
     await encoding.fail(
       "ABC",
-      `Expected a string with all characters in lowercase, got "ABC"`
+      `Expected a string with all characters in lowercase`
     )
   })
 
@@ -9724,7 +9756,7 @@ pointed message
     await encoding.succeed("ABC")
     await encoding.fail(
       "abc",
-      `Expected a string with all characters in uppercase, got "abc"`
+      `Expected a string with all characters in uppercase`
     )
   })
 })
@@ -9739,11 +9771,11 @@ describe("Getter", () => {
 
     const decoding = asserts.decoding()
     await decoding.succeed(0, "a")
-    await decoding.fail(1, `Expected 0, got 1`)
+    await decoding.fail(1, `Expected 0`)
 
     const encoding = asserts.encoding()
     await encoding.succeed("a", 0)
-    await encoding.fail("b", `Expected "a", got "b"`)
+    await encoding.fail("b", `Expected "a"`)
   })
 })
 
@@ -9795,7 +9827,7 @@ describe("Check", () => {
     await decoding.succeed("00000000-0000-4000-8000-000000000001")
     await decoding.fail(
       "00000000-0000-0000-0000-000000000001",
-      `Expected a UUID, got "00000000-0000-0000-0000-000000000001"`
+      `Expected a UUID`
     )
   })
 
@@ -9807,11 +9839,11 @@ describe("Check", () => {
     await decoding.succeed("00000000-0000-4000-8000-000000000001")
     await decoding.fail(
       "00000000-0000-0000-0000-000000000000",
-      `Expected a UUID v4, got "00000000-0000-0000-0000-000000000000"`
+      `Expected a UUID v4`
     )
     await decoding.fail(
       "ffffffff-ffff-ffff-ffff-ffffffffffff",
-      `Expected a UUID v4, got "ffffffff-ffff-ffff-ffff-ffffffffffff"`
+      `Expected a UUID v4`
     )
   })
 
@@ -9833,7 +9865,7 @@ describe("Check", () => {
     await decoding.succeed("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")
     await decoding.fail(
       "not-a-guid",
-      `Expected a GUID, got "not-a-guid"`
+      `Expected a GUID`
     )
   })
 
@@ -9854,7 +9886,7 @@ describe("Check", () => {
     await decoding.succeed("01H4PGGGJVN2DKP2K1H7EH996V")
     await decoding.fail(
       "",
-      `Expected a string matching the RegExp ^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$, got ""`
+      `Expected a string matching the RegExp ^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$`
     )
   })
 
@@ -9900,7 +9932,7 @@ describe("Check", () => {
 
       const decoding = asserts.decoding()
       await decoding.succeed("a")
-      await decoding.fail(1, `Expected string, got 1`)
+      await decoding.fail(1, `Expected string`)
 
       deepStrictEqual(schema.ast.annotations?.brands, ["a"])
     })
@@ -9914,8 +9946,8 @@ describe("Check", () => {
 
       const decoding = asserts.decoding()
       await decoding.succeed(1)
-      await decoding.fail("a", `Expected number, got "a"`)
-      await decoding.fail(1.2, `Expected an integer, got 1.2`)
+      await decoding.fail("a", `Expected number`)
+      await decoding.fail(1.2, `Expected an integer`)
 
       deepStrictEqual(schema.ast.checks?.at(-1)?.annotations?.brands, ["Int"])
     })
@@ -9934,9 +9966,9 @@ describe("Check", () => {
 
       const decoding = asserts.decoding()
       await decoding.succeed(1)
-      await decoding.fail("a", `Expected number, got "a"`)
-      await decoding.fail(1.2, `Expected an integer, got 1.2`)
-      await decoding.fail(-1, `Expected a value greater than 0, got -1`)
+      await decoding.fail("a", `Expected number`)
+      await decoding.fail(1.2, `Expected an integer`)
+      await decoding.fail(-1, `Expected a value greater than 0`)
 
       deepStrictEqual(schema.ast.checks?.at(-1)?.annotations?.brands, ["PositiveInt"])
     })
@@ -9959,7 +9991,7 @@ describe("Check", () => {
       )
       await decoding.fail(
         { a: "a", b: undefined },
-        `Expected number, got undefined
+        `Expected number
   at ["b"]`
       )
       await decoding.fail(
@@ -10011,7 +10043,7 @@ describe("Check", () => {
       )
       await decoding.fail(
         { a: "a", b: undefined },
-        `Expected number, got undefined
+        `Expected number
   at ["b"]`
       )
       await decoding.fail(
@@ -10021,7 +10053,7 @@ describe("Check", () => {
       )
       await decoding.fail(
         { a: undefined, b: 1 },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]`
       )
     })

--- a/packages/effect/test/schema/SchemaIssue.test.ts
+++ b/packages/effect/test/schema/SchemaIssue.test.ts
@@ -1,10 +1,88 @@
-import { SchemaIssue } from "effect"
-import { describe, it } from "vitest"
+import { assert, describe, it } from "@effect/vitest"
+import { Result, Schema, SchemaIssue } from "effect"
 import { assertFalse, assertTrue } from "../utils/assert.ts"
 
 describe("SchemaIssue", () => {
   it("isIssue", () => {
     assertTrue(SchemaIssue.isIssue(new SchemaIssue.MissingKey(undefined)))
     assertFalse(SchemaIssue.isIssue({ "~effect/SchemaIssue/Issue": false }))
+  })
+
+  it("does not expose an actual field", () => {
+    const union = Schema.Union([Schema.String, Schema.Number]).ast
+    const invalidValue = new SchemaIssue.InvalidValue()
+    const issues: ReadonlyArray<SchemaIssue.Issue> = [
+      new SchemaIssue.InvalidType(Schema.String.ast),
+      invalidValue,
+      new SchemaIssue.MissingKey(undefined),
+      new SchemaIssue.UnexpectedKey(Schema.String.ast),
+      new SchemaIssue.Forbidden(undefined),
+      new SchemaIssue.OneOf(union, [Schema.String.ast]),
+      new SchemaIssue.Filter(Schema.isMinLength(1), invalidValue),
+      new SchemaIssue.Encoding(Schema.String.ast, invalidValue),
+      new SchemaIssue.Pointer(["value"], invalidValue),
+      new SchemaIssue.Composite(Schema.String.ast, [invalidValue]),
+      new SchemaIssue.AnyOf(union, [invalidValue])
+    ]
+
+    for (const issue of issues) {
+      assertFalse("actual" in issue)
+    }
+  })
+
+  it("preserves structural metadata", () => {
+    const annotations = { message: "custom message" }
+    const invalidType = new SchemaIssue.InvalidType(Schema.String.ast)
+    const invalidValue = new SchemaIssue.InvalidValue(annotations)
+    const unexpectedKey = new SchemaIssue.UnexpectedKey(Schema.Number.ast)
+    const union = Schema.Union([Schema.String, Schema.Number]).ast
+    const successes = [Schema.String.ast]
+    const oneOf = new SchemaIssue.OneOf(union, successes)
+
+    assert.strictEqual(invalidType.ast, Schema.String.ast)
+    assert.strictEqual(invalidValue.annotations, annotations)
+    assert.strictEqual(unexpectedKey.ast, Schema.Number.ast)
+    assert.strictEqual(oneOf.ast, union)
+    assert.strictEqual(oneOf.successes, successes)
+  })
+
+  it("formats leaf issues with static built-in messages", () => {
+    const union = Schema.Union([Schema.String, Schema.Number]).ast
+    const cases: ReadonlyArray<readonly [SchemaIssue.Leaf, string]> = [
+      [new SchemaIssue.InvalidType(Schema.String.ast), "Expected string"],
+      [new SchemaIssue.InvalidValue(), "Expected a valid value"],
+      [new SchemaIssue.MissingKey(undefined), "Missing key"],
+      [new SchemaIssue.UnexpectedKey(Schema.String.ast), "Expected no excess property"],
+      [new SchemaIssue.Forbidden(undefined), "Forbidden operation"],
+      [new SchemaIssue.OneOf(union, [Schema.String.ast]), "Expected exactly one member to match"]
+    ]
+
+    for (const [issue, expected] of cases) {
+      assert.strictEqual(String(issue), expected)
+    }
+  })
+
+  it("formats filters from their expected constraint", () => {
+    const issue = new SchemaIssue.Filter(
+      Schema.isMinLength(1),
+      new SchemaIssue.InvalidValue()
+    )
+
+    assert.strictEqual(String(issue), "Expected a value with a length of at least 1")
+  })
+
+  it("preserves user-provided messages", () => {
+    const issue = new SchemaIssue.InvalidValue({ message: "must not be empty" })
+
+    assert.strictEqual(String(issue), "must not be empty")
+  })
+
+  it("uses an empty AnyOf when no union candidates apply", () => {
+    const result = Schema.decodeUnknownResult(Schema.Union([Schema.String, Schema.Number]))(null)
+
+    assertTrue(Result.isFailure(result))
+    assertTrue(result.failure.issue._tag === "AnyOf")
+    assert.deepStrictEqual(result.failure.issue.issues, [])
+    assert.strictEqual(String(result.failure.issue), "Expected string | number")
   })
 })

--- a/packages/effect/test/schema/SchemaParser.test.ts
+++ b/packages/effect/test/schema/SchemaParser.test.ts
@@ -5,12 +5,12 @@ import { assertTrue, strictEqual, throws } from "../utils/assert.ts"
 describe("SchemaParser", () => {
   const makeMixedCause = () =>
     Cause.combine(
-      Cause.fail(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" })),
+      Cause.fail(new SchemaIssue.InvalidValue({ message: "schema issue" })),
       Cause.die(new Error("defect"))
     )
   const makeMixedSchemaErrorCause = () =>
     Cause.combine(
-      Cause.fail(new Schema.SchemaError(new SchemaIssue.InvalidValue(Option.some("a"), { message: "schema issue" }))),
+      Cause.fail(new Schema.SchemaError(new SchemaIssue.InvalidValue({ message: "schema issue" }))),
       Cause.die(new Error("defect"))
     )
 
@@ -20,7 +20,7 @@ describe("SchemaParser", () => {
       throws(() => SchemaParser.make(schema)(null as any), (e) => {
         assertTrue(e instanceof Error)
         assertTrue(SchemaIssue.isIssue(e.cause))
-        strictEqual(e.message, "Expected string, got null")
+        strictEqual(e.message, "Expected string")
       })
     })
 
@@ -69,12 +69,12 @@ describe("SchemaParser", () => {
       throws(() => SchemaParser.decodeUnknownSync(schema)(null), (e) => {
         assertTrue(e instanceof Error)
         assertTrue(SchemaIssue.isIssue(e.cause))
-        strictEqual(e.message, "Expected string, got null")
+        strictEqual(e.message, "Expected string")
       })
       throws(() => SchemaParser.encodeUnknownSync(schema)(null), (e) => {
         assertTrue(e instanceof Error)
         assertTrue(SchemaIssue.isIssue(e.cause))
-        strictEqual(e.message, "Expected string, got null")
+        strictEqual(e.message, "Expected string")
       })
     })
 
@@ -108,12 +108,12 @@ describe("SchemaParser", () => {
       assertTrue(Result.isFailure(r1))
       assertTrue(r1.failure instanceof Error)
       assertTrue(SchemaIssue.isIssue(r1.failure.cause))
-      strictEqual(r1.failure.message, "Expected string, got null")
+      strictEqual(r1.failure.message, "Expected string")
       const r2 = await SchemaParser.encodeUnknownPromise(schema)(null).then(Result.succeed, Result.fail)
       assertTrue(Result.isFailure(r2))
       assertTrue(r2.failure instanceof Error)
       assertTrue(SchemaIssue.isIssue(r2.failure.cause))
-      strictEqual(r2.failure.message, "Expected string, got null")
+      strictEqual(r2.failure.message, "Expected string")
     })
 
     it("should reject with an error when the cause contains both an Issue and a defect", async () => {
@@ -387,7 +387,7 @@ describe("SchemaParser", () => {
 
       let rejectedReads = 0
       const rejectedKey = Schema.String.pipe(Schema.decode({
-        decode: new SchemaGetter.Getter((input) => Effect.fail(new SchemaIssue.InvalidValue(input))),
+        decode: new SchemaGetter.Getter(() => Effect.fail(new SchemaIssue.InvalidValue())),
         encode: SchemaGetter.passthrough()
       }))
       const rejectedInput = {
@@ -483,9 +483,9 @@ describe("SchemaParser", () => {
     it.effect("wraps an asynchronous failure from a uniquely selected union member", () =>
       Effect.gen(function*() {
         const failing = Schema.String.pipe(Schema.decode({
-          decode: new SchemaGetter.Getter((input) =>
+          decode: new SchemaGetter.Getter(() =>
             Effect.yieldNow.pipe(
-              Effect.andThen(Effect.fail(new SchemaIssue.InvalidValue(input)))
+              Effect.andThen(Effect.fail(new SchemaIssue.InvalidValue()))
             )
           ),
           encode: SchemaGetter.passthrough()
@@ -507,9 +507,9 @@ describe("SchemaParser", () => {
     it.effect("resolves an unchanged concurrent union candidate", () =>
       Effect.gen(function*() {
         const delayedFailure = Schema.String.pipe(Schema.decode({
-          decode: new SchemaGetter.Getter((input) =>
+          decode: new SchemaGetter.Getter(() =>
             Effect.yieldNow.pipe(
-              Effect.andThen(Effect.fail(new SchemaIssue.InvalidValue(input)))
+              Effect.andThen(Effect.fail(new SchemaIssue.InvalidValue()))
             )
           ),
           encode: SchemaGetter.passthrough()

--- a/packages/effect/test/schema/representation/fromJson.test.ts
+++ b/packages/effect/test/schema/representation/fromJson.test.ts
@@ -386,7 +386,7 @@ describe("SchemaRepresentation.fromJson", () => {
           representation: { _tag: "Reference", $ref: "" },
           references: {}
         }),
-      `Expected a value with a length of at least 1, got ""\n  at ["representation"]["$ref"]`
+      `Expected a value with a length of at least 1\n  at ["representation"]["$ref"]`
     )
   })
 
@@ -401,7 +401,7 @@ describe("SchemaRepresentation.fromJson", () => {
           },
           references: {}
         } as never),
-      `Expected JSON value, got 1n\n  at ["representation"]["annotations"]["invalid"]`
+      `Expected JSON value\n  at ["representation"]["annotations"]["invalid"]`
     )
   })
 
@@ -409,7 +409,7 @@ describe("SchemaRepresentation.fromJson", () => {
     const input = () => undefined
     throws(
       () => SchemaRepresentation.fromJson(input as never),
-      `Expected object, got () => undefined`
+      `Expected object`
     )
   })
 

--- a/packages/effect/test/schema/representation/toJson.test.ts
+++ b/packages/effect/test/schema/representation/toJson.test.ts
@@ -39,7 +39,7 @@ describe("SchemaRepresentation.toJson", () => {
           representation: { _tag: "Reference", $ref: "" },
           references: {}
         }),
-      `Expected a value with a length of at least 1, got ""\n  at ["representation"]["$ref"]`
+      `Expected a value with a length of at least 1\n  at ["representation"]["$ref"]`
     )
   })
 
@@ -54,7 +54,7 @@ describe("SchemaRepresentation.toJson", () => {
           } as never,
           references: {}
         }),
-      `Unexpected key with value null\n  at ["representation"]["checks"][0]`
+      `Expected no excess property\n  at ["representation"]["checks"][0]`
     )
   })
 

--- a/packages/effect/test/schema/toArbitrary.test.ts
+++ b/packages/effect/test/schema/toArbitrary.test.ts
@@ -1,4 +1,4 @@
-import { BigDecimal, Chunk, DateTime, Effect, HashMap, HashSet, Option, Order, Schema, SchemaIssue } from "effect"
+import { BigDecimal, Chunk, DateTime, Effect, HashMap, HashSet, Order, Schema, SchemaIssue } from "effect"
 import { FastCheck, TestSchema } from "effect/testing"
 import { describe, it } from "vitest"
 import { assertInclude, assertInstanceOf, deepStrictEqual, strictEqual, throws } from "../utils/assert.ts"
@@ -55,7 +55,7 @@ function CustomArray<A extends Schema.Constraint>(
     () => (input, ast) =>
       globalThis.Array.isArray(input)
         ? Effect.succeed(input as ReadonlyArray<A["Type"]>)
-        : Effect.fail(new SchemaIssue.InvalidType(ast, Option.some(input))),
+        : Effect.fail(new SchemaIssue.InvalidType(ast)),
     { toArbitrary }
   )
 }

--- a/packages/effect/test/schema/toCodec.test.ts
+++ b/packages/effect/test/schema/toCodec.test.ts
@@ -77,9 +77,9 @@ describe("Serializers", () => {
 
           await asserts.encoding().fail(
             new URL("https://example.com"),
-            "Expected JSON value, got https://example.com/"
+            "Expected JSON value"
           )
-          await asserts.decoding().fail({}, "Expected <Declaration>, got {}")
+          await asserts.decoding().fail({}, "Expected <Declaration>")
         })
 
         describe("instanceOf with annotation", () => {
@@ -222,7 +222,7 @@ describe("Serializers", () => {
         const asserts = new TestSchema.Asserts(Schema.toCodecJson(schema))
 
         const encoding = asserts.encoding()
-        await encoding.fail({}, "Expected never, got {}")
+        await encoding.fail({}, "Expected never")
       })
 
       it("Any", async () => {
@@ -247,7 +247,7 @@ describe("Serializers", () => {
         await encoding.succeed(null)
         await encoding.succeed({ a: "a", b: 1, c: true })
         await encoding.succeed(["a", 1, true])
-        await encoding.fail({ a: 1n }, `Expected JSON value, got {"a":1n}`)
+        await encoding.fail({ a: 1n }, `Expected JSON value`)
 
         const decoding = asserts.decoding()
         await decoding.succeed("a")
@@ -256,7 +256,7 @@ describe("Serializers", () => {
         await decoding.succeed(null)
         await decoding.succeed({ a: "a", b: 1, c: true })
         await decoding.succeed(["a", 1, true])
-        await decoding.fail({ a: 1n }, `Expected JSON value, got {"a":1n}`)
+        await decoding.fail({ a: 1n }, `Expected JSON value`)
       })
 
       it("ObjectKeyword", async () => {
@@ -266,14 +266,14 @@ describe("Serializers", () => {
         const encoding = asserts.encoding()
         await encoding.succeed({ a: "a", b: 1, c: true })
         await encoding.succeed(["a", 1, true])
-        await encoding.fail("a", `Expected object | array | function, got "a"`)
-        await encoding.fail({ a: 1n }, `Expected JSON value, got 1n\n  at ["a"]`)
+        await encoding.fail("a", `Expected object | array | function`)
+        await encoding.fail({ a: 1n }, `Expected JSON value\n  at ["a"]`)
 
         const decoding = asserts.decoding()
         await decoding.succeed({ a: "a", b: 1, c: true })
         await decoding.succeed(["a", 1, true])
-        await decoding.fail("a", `Expected array | object, got "a"`)
-        await decoding.fail({ a: 1n }, `Expected JSON value, got 1n\n  at ["a"]`)
+        await decoding.fail("a", `Expected array | object`)
+        await decoding.fail({ a: 1n }, `Expected JSON value\n  at ["a"]`)
       })
 
       it("Undefined", async () => {
@@ -362,11 +362,11 @@ describe("Serializers", () => {
           await decoding.succeed("Infinity", Infinity)
           await decoding.succeed("-Infinity", -Infinity)
           await decoding.succeed("NaN", NaN)
-          await decoding.fail(Infinity, "Expected a finite number, got Infinity")
-          await decoding.fail(-Infinity, "Expected a finite number, got -Infinity")
-          await decoding.fail(NaN, "Expected a finite number, got NaN")
-          await decoding.fail(null, `Expected number | "Infinity" | "-Infinity" | "NaN", got null`)
-          await decoding.fail("a", `Expected "Infinity" | "-Infinity" | "NaN", got "a"`)
+          await decoding.fail(Infinity, "Expected a finite number")
+          await decoding.fail(-Infinity, "Expected a finite number")
+          await decoding.fail(NaN, "Expected a finite number")
+          await decoding.fail(null, `Expected number | "Infinity" | "-Infinity" | "NaN"`)
+          await decoding.fail("a", `Expected "Infinity" | "-Infinity" | "NaN"`)
         })
 
         describe("checks", () => {
@@ -378,22 +378,22 @@ describe("Serializers", () => {
             await encoding.succeed(1)
             await encoding.succeed(-1)
             await encoding.succeed(1.2)
-            await encoding.fail(Infinity, "Expected a finite number, got Infinity")
-            await encoding.fail(-Infinity, "Expected a finite number, got -Infinity")
-            await encoding.fail(NaN, "Expected a finite number, got NaN")
+            await encoding.fail(Infinity, "Expected a finite number")
+            await encoding.fail(-Infinity, "Expected a finite number")
+            await encoding.fail(NaN, "Expected a finite number")
 
             const decoding = asserts.decoding()
             await decoding.succeed(1)
             await decoding.succeed(-1)
             await decoding.succeed(1.2)
-            await decoding.fail("Infinity", `Expected number, got "Infinity"`)
-            await decoding.fail("-Infinity", `Expected number, got "-Infinity"`)
-            await decoding.fail("NaN", `Expected number, got "NaN"`)
-            await decoding.fail(Infinity, `Expected a finite number, got Infinity`)
-            await decoding.fail(-Infinity, `Expected a finite number, got -Infinity`)
-            await decoding.fail(NaN, `Expected a finite number, got NaN`)
-            await decoding.fail(null, `Expected number, got null`)
-            await decoding.fail("a", `Expected number, got "a"`)
+            await decoding.fail("Infinity", `Expected number`)
+            await decoding.fail("-Infinity", `Expected number`)
+            await decoding.fail("NaN", `Expected number`)
+            await decoding.fail(Infinity, `Expected a finite number`)
+            await decoding.fail(-Infinity, `Expected a finite number`)
+            await decoding.fail(NaN, `Expected a finite number`)
+            await decoding.fail(null, `Expected number`)
+            await decoding.fail("a", `Expected number`)
           })
 
           it("Int", async () => {
@@ -403,23 +403,23 @@ describe("Serializers", () => {
             const encoding = asserts.encoding()
             await encoding.succeed(1)
             await encoding.succeed(-1)
-            await encoding.fail(1.2, `Expected an integer, got 1.2`)
-            await encoding.fail(Infinity, "Expected an integer, got Infinity")
-            await encoding.fail(-Infinity, "Expected an integer, got -Infinity")
-            await encoding.fail(NaN, "Expected an integer, got NaN")
+            await encoding.fail(1.2, `Expected an integer`)
+            await encoding.fail(Infinity, "Expected an integer")
+            await encoding.fail(-Infinity, "Expected an integer")
+            await encoding.fail(NaN, "Expected an integer")
 
             const decoding = asserts.decoding()
             await decoding.succeed(1)
             await decoding.succeed(-1)
-            await decoding.fail(1.2, `Expected an integer, got 1.2`)
-            await decoding.fail("Infinity", `Expected number, got "Infinity"`)
-            await decoding.fail("-Infinity", `Expected number, got "-Infinity"`)
-            await decoding.fail("NaN", `Expected number, got "NaN"`)
-            await decoding.fail(Infinity, `Expected an integer, got Infinity`)
-            await decoding.fail(-Infinity, `Expected an integer, got -Infinity`)
-            await decoding.fail(NaN, `Expected an integer, got NaN`)
-            await decoding.fail(null, `Expected number, got null`)
-            await decoding.fail("a", `Expected number, got "a"`)
+            await decoding.fail(1.2, `Expected an integer`)
+            await decoding.fail("Infinity", `Expected number`)
+            await decoding.fail("-Infinity", `Expected number`)
+            await decoding.fail("NaN", `Expected number`)
+            await decoding.fail(Infinity, `Expected an integer`)
+            await decoding.fail(-Infinity, `Expected an integer`)
+            await decoding.fail(NaN, `Expected an integer`)
+            await decoding.fail(null, `Expected number`)
+            await decoding.fail("a", `Expected number`)
           })
 
           it("isGreaterThanOrEqualTo", async () => {
@@ -428,24 +428,24 @@ describe("Serializers", () => {
 
             const encoding = asserts.encoding()
             await encoding.succeed(1)
-            await encoding.fail(-1, `Expected a value greater than or equal to 1, got -1`)
+            await encoding.fail(-1, `Expected a value greater than or equal to 1`)
             await encoding.succeed(1.2)
             await encoding.succeed(Infinity, "Infinity")
-            await encoding.fail(-Infinity, "Expected a value greater than or equal to 1, got -Infinity")
-            await encoding.fail(NaN, "Expected a value greater than or equal to 1, got NaN")
+            await encoding.fail(-Infinity, "Expected a value greater than or equal to 1")
+            await encoding.fail(NaN, "Expected a value greater than or equal to 1")
 
             const decoding = asserts.decoding()
             await decoding.succeed(1)
-            await encoding.fail(-1, `Expected a value greater than or equal to 1, got -1`)
+            await encoding.fail(-1, `Expected a value greater than or equal to 1`)
             await decoding.succeed(1.2)
             await decoding.succeed("Infinity", Infinity)
-            await decoding.fail("-Infinity", `Expected a value greater than or equal to 1, got -Infinity`)
-            await decoding.fail("NaN", `Expected a value greater than or equal to 1, got NaN`)
-            await decoding.fail(Infinity, "Expected a finite number, got Infinity")
-            await decoding.fail(-Infinity, "Expected a finite number, got -Infinity")
-            await decoding.fail(NaN, "Expected a finite number, got NaN")
-            await decoding.fail(null, `Expected number | "Infinity" | "-Infinity" | "NaN", got null`)
-            await decoding.fail("a", `Expected "Infinity" | "-Infinity" | "NaN", got "a"`)
+            await decoding.fail("-Infinity", `Expected a value greater than or equal to 1`)
+            await decoding.fail("NaN", `Expected a value greater than or equal to 1`)
+            await decoding.fail(Infinity, "Expected a finite number")
+            await decoding.fail(-Infinity, "Expected a finite number")
+            await decoding.fail(NaN, "Expected a finite number")
+            await decoding.fail(null, `Expected number | "Infinity" | "-Infinity" | "NaN"`)
+            await decoding.fail("a", `Expected "Infinity" | "-Infinity" | "NaN"`)
           })
         })
       })
@@ -570,7 +570,7 @@ describe("Serializers", () => {
         const decoding = asserts.decoding()
         await decoding.fail(
           "-",
-          `Expected "a" | 1 | "2" | true, got "-"`
+          `Expected "a" | 1 | "2" | true`
         )
       })
 
@@ -1093,7 +1093,7 @@ describe("Serializers", () => {
         )
         await decoding.fail(
           "not a url",
-          `Invalid URL string: not a url`
+          "Expected a valid URL string"
         )
       })
 
@@ -1173,11 +1173,11 @@ describe("Serializers", () => {
         await decoding.succeed({ source: "a", flags: "i" }, new RegExp("a", "i"))
         await decoding.fail(
           { source: "(", flags: "" },
-          `SyntaxError: Invalid regular expression: /(/: Unterminated group`
+          "Expected valid RegExp source and flags"
         )
         await decoding.fail(
           { source: "a", flags: "x" },
-          `SyntaxError: Invalid flags supplied to RegExp constructor 'x'`
+          "Expected valid RegExp source and flags"
         )
       })
 
@@ -1192,7 +1192,7 @@ describe("Serializers", () => {
         await decoding.succeed("AQID", new Uint8Array([1, 2, 3]))
         await decoding.fail(
           "not a base64 string",
-          "Length must be a multiple of 4, but is 19"
+          "Expected a valid Base64 string"
         )
       })
 
@@ -1307,7 +1307,7 @@ describe("Serializers", () => {
           const encoding = asserts.encoding()
           await encoding.fail(
             Redacted.make("a", { label: "API key" }),
-            `Expected "password", got "API key"
+            `Expected "password"
   at ["label"]`
           )
         })
@@ -1604,7 +1604,7 @@ describe("Serializers", () => {
       const encoding = asserts.encoding()
       await encoding.succeed(failureResult, {
         issues: [
-          { path: ["a"], message: `Expected a value with a length of at least 1, got ""` },
+          { path: ["a"], message: `Expected a value with a length of at least 1` },
           { path: ["c", 0], message: "Missing key" },
           { path: ["Symbol(b)"], message: "Missing key" }
         ]
@@ -1613,7 +1613,7 @@ describe("Serializers", () => {
       const decoding = asserts.decoding()
       await decoding.succeed({
         issues: [
-          { path: ["a"], message: `Expected a value with a length of at least 1, got ""` },
+          { path: ["a"], message: `Expected a value with a length of at least 1` },
           { path: ["c", 0], message: "Missing key" },
           { path: ["Symbol(b)"], message: "Missing key" }
         ]
@@ -1756,16 +1756,16 @@ describe("Serializers", () => {
         await encoding.succeed("a")
         await encoding.succeed(["a"])
         await encoding.succeed({ a: "a" })
-        await encoding.fail(1, `Expected StringTree, got 1`)
-        await encoding.fail(true, `Expected StringTree, got true`)
-        await encoding.fail(null, `Expected StringTree, got null`)
-        await encoding.fail({ a: 1 }, `Expected StringTree, got {"a":1}`)
+        await encoding.fail(1, `Expected StringTree`)
+        await encoding.fail(true, `Expected StringTree`)
+        await encoding.fail(null, `Expected StringTree`)
+        await encoding.fail({ a: 1 }, `Expected StringTree`)
 
         const decoding = asserts.decoding()
         await decoding.succeed("a")
         await decoding.succeed(["a"])
         await decoding.succeed({ a: "a" })
-        await decoding.fail(undefined, `Expected JSON value, got undefined`)
+        await decoding.fail(undefined, `Expected JSON value`)
       })
 
       it("Unknown", async () => {
@@ -1774,17 +1774,17 @@ describe("Serializers", () => {
 
         const encoding = asserts.encoding()
         await encoding.succeed("a")
-        await encoding.fail(1, `Expected StringTree, got 1`)
+        await encoding.fail(1, `Expected StringTree`)
         await encoding.succeed({ a: "a" })
         await encoding.succeed(["a"])
-        await encoding.fail({ a: 1 }, `Expected StringTree, got {"a":1}`)
+        await encoding.fail({ a: 1 }, `Expected StringTree`)
 
         const decoding = asserts.decoding()
         await decoding.succeed("a")
-        await decoding.fail(1, `Expected StringTree, got 1`)
+        await decoding.fail(1, `Expected StringTree`)
         await decoding.succeed({ a: "a" })
         await decoding.succeed(["a"])
-        await decoding.fail({ a: 1 }, `Expected StringTree, got {"a":1}`)
+        await decoding.fail({ a: 1 }, `Expected StringTree`)
       })
 
       it("ObjectKeyword", async () => {
@@ -1792,18 +1792,18 @@ describe("Serializers", () => {
         const asserts = new TestSchema.Asserts(Schema.toCodecStringTree(schema))
 
         const encoding = asserts.encoding()
-        await encoding.fail("a", `Expected object | array | function, got "a"`)
-        await encoding.fail(1, `Expected object | array | function, got 1`)
+        await encoding.fail("a", `Expected object | array | function`)
+        await encoding.fail(1, `Expected object | array | function`)
         await encoding.succeed({ a: "a" })
         await encoding.succeed(["a"])
-        await encoding.fail({ a: 1 }, `Expected StringTree, got {"a":1}`)
+        await encoding.fail({ a: 1 }, `Expected StringTree`)
 
         const decoding = asserts.decoding()
-        await decoding.fail("a", `Expected object | array | function, got "a"`)
-        await decoding.fail(1, `Expected StringTree, got 1`)
+        await decoding.fail("a", `Expected object | array | function`)
+        await decoding.fail(1, `Expected StringTree`)
         await decoding.succeed({ a: "a" })
         await decoding.succeed(["a"])
-        await decoding.fail({ a: 1 }, `Expected StringTree, got {"a":1}`)
+        await decoding.fail({ a: 1 }, `Expected StringTree`)
       })
 
       it("Never", async () => {
@@ -1811,7 +1811,7 @@ describe("Serializers", () => {
         const asserts = new TestSchema.Asserts(Schema.toCodecStringTree(schema))
 
         const encoding = asserts.encoding()
-        await encoding.fail({}, "Expected never, got {}")
+        await encoding.fail({}, "Expected never")
       })
 
       it("Any should be an escape hatch", async () => {
@@ -1889,14 +1889,14 @@ describe("Serializers", () => {
           await decoding.succeed("Infinity", Infinity)
           await decoding.succeed("-Infinity", -Infinity)
           await decoding.succeed("NaN", NaN)
-          await decoding.fail(Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN", got Infinity`)
-          await decoding.fail(-Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN", got -Infinity`)
-          await decoding.fail(NaN, `Expected string | "Infinity" | "-Infinity" | "NaN", got NaN`)
-          await decoding.fail(null, `Expected string | "Infinity" | "-Infinity" | "NaN", got null`)
+          await decoding.fail(Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
+          await decoding.fail(-Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
+          await decoding.fail(NaN, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
+          await decoding.fail(null, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
           await decoding.fail(
             "a",
-            `Expected a string representing a finite number, got "a"
-Expected "Infinity" | "-Infinity" | "NaN", got "a"`
+            `Expected a string representing a finite number
+Expected "Infinity" | "-Infinity" | "NaN"`
           )
         })
 
@@ -1909,22 +1909,22 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
             await encoding.succeed(1, "1")
             await encoding.succeed(-1, "-1")
             await encoding.succeed(1.2, "1.2")
-            await encoding.fail(Infinity, "Expected a finite number, got Infinity")
-            await encoding.fail(-Infinity, "Expected a finite number, got -Infinity")
-            await encoding.fail(NaN, "Expected a finite number, got NaN")
+            await encoding.fail(Infinity, "Expected a finite number")
+            await encoding.fail(-Infinity, "Expected a finite number")
+            await encoding.fail(NaN, "Expected a finite number")
 
             const decoding = asserts.decoding()
             await decoding.succeed("1", 1)
             await decoding.succeed("-1", -1)
             await decoding.succeed("1.2", 1.2)
-            await decoding.fail("Infinity", `Expected a string representing a finite number, got "Infinity"`)
-            await decoding.fail("-Infinity", `Expected a string representing a finite number, got "-Infinity"`)
-            await decoding.fail("NaN", `Expected a string representing a finite number, got "NaN"`)
-            await decoding.fail(Infinity, `Expected string, got Infinity`)
-            await decoding.fail(-Infinity, `Expected string, got -Infinity`)
-            await decoding.fail(NaN, `Expected string, got NaN`)
-            await decoding.fail(null, `Expected string, got null`)
-            await decoding.fail("a", `Expected a string representing a finite number, got "a"`)
+            await decoding.fail("Infinity", `Expected a string representing a finite number`)
+            await decoding.fail("-Infinity", `Expected a string representing a finite number`)
+            await decoding.fail("NaN", `Expected a string representing a finite number`)
+            await decoding.fail(Infinity, `Expected string`)
+            await decoding.fail(-Infinity, `Expected string`)
+            await decoding.fail(NaN, `Expected string`)
+            await decoding.fail(null, `Expected string`)
+            await decoding.fail("a", `Expected a string representing a finite number`)
           })
 
           it("Int", async () => {
@@ -1934,23 +1934,23 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
             const encoding = asserts.encoding()
             await encoding.succeed(1, "1")
             await encoding.succeed(-1, "-1")
-            await encoding.fail(1.2, `Expected an integer, got 1.2`)
-            await encoding.fail(Infinity, `Expected an integer, got Infinity`)
-            await encoding.fail(-Infinity, `Expected an integer, got -Infinity`)
-            await encoding.fail(NaN, `Expected an integer, got NaN`)
+            await encoding.fail(1.2, `Expected an integer`)
+            await encoding.fail(Infinity, `Expected an integer`)
+            await encoding.fail(-Infinity, `Expected an integer`)
+            await encoding.fail(NaN, `Expected an integer`)
 
             const decoding = asserts.decoding()
             await decoding.succeed("1", 1)
             await decoding.succeed("-1", -1)
-            await decoding.fail("1.2", `Expected an integer, got 1.2`)
-            await decoding.fail("Infinity", `Expected a string representing a finite number, got "Infinity"`)
-            await decoding.fail("-Infinity", `Expected a string representing a finite number, got "-Infinity"`)
-            await decoding.fail("NaN", `Expected a string representing a finite number, got "NaN"`)
-            await decoding.fail(Infinity, `Expected string, got Infinity`)
-            await decoding.fail(-Infinity, `Expected string, got -Infinity`)
-            await decoding.fail(NaN, `Expected string, got NaN`)
-            await decoding.fail(null, `Expected string, got null`)
-            await decoding.fail("a", `Expected a string representing a finite number, got "a"`)
+            await decoding.fail("1.2", `Expected an integer`)
+            await decoding.fail("Infinity", `Expected a string representing a finite number`)
+            await decoding.fail("-Infinity", `Expected a string representing a finite number`)
+            await decoding.fail("NaN", `Expected a string representing a finite number`)
+            await decoding.fail(Infinity, `Expected string`)
+            await decoding.fail(-Infinity, `Expected string`)
+            await decoding.fail(NaN, `Expected string`)
+            await decoding.fail(null, `Expected string`)
+            await decoding.fail("a", `Expected a string representing a finite number`)
           })
 
           it("isGreaterThanOrEqualTo", async () => {
@@ -1959,27 +1959,27 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
 
             const encoding = asserts.encoding()
             await encoding.succeed(1, "1")
-            await encoding.fail(-1, `Expected a value greater than or equal to 1, got -1`)
+            await encoding.fail(-1, `Expected a value greater than or equal to 1`)
             await encoding.succeed(1.2, "1.2")
             await encoding.succeed(Infinity, "Infinity")
-            await encoding.fail(-Infinity, "Expected a value greater than or equal to 1, got -Infinity")
-            await encoding.fail(NaN, "Expected a value greater than or equal to 1, got NaN")
+            await encoding.fail(-Infinity, "Expected a value greater than or equal to 1")
+            await encoding.fail(NaN, "Expected a value greater than or equal to 1")
 
             const decoding = asserts.decoding()
             await decoding.succeed("1", 1)
-            await decoding.fail("-1", `Expected a value greater than or equal to 1, got -1`)
+            await decoding.fail("-1", `Expected a value greater than or equal to 1`)
             await decoding.succeed("1.2", 1.2)
             await decoding.succeed("Infinity", Infinity)
-            await decoding.fail("-Infinity", `Expected a value greater than or equal to 1, got -Infinity`)
-            await decoding.fail("NaN", `Expected a value greater than or equal to 1, got NaN`)
-            await decoding.fail(Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN", got Infinity`)
-            await decoding.fail(-Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN", got -Infinity`)
-            await decoding.fail(NaN, `Expected string | "Infinity" | "-Infinity" | "NaN", got NaN`)
-            await decoding.fail(null, `Expected string | "Infinity" | "-Infinity" | "NaN", got null`)
+            await decoding.fail("-Infinity", `Expected a value greater than or equal to 1`)
+            await decoding.fail("NaN", `Expected a value greater than or equal to 1`)
+            await decoding.fail(Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
+            await decoding.fail(-Infinity, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
+            await decoding.fail(NaN, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
+            await decoding.fail(null, `Expected string | "Infinity" | "-Infinity" | "NaN"`)
             await decoding.fail(
               "a",
-              `Expected a string representing a finite number, got "a"
-Expected "Infinity" | "-Infinity" | "NaN", got "a"`
+              `Expected a string representing a finite number
+Expected "Infinity" | "-Infinity" | "NaN"`
             )
           })
         })
@@ -2015,7 +2015,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
 
         const decoding = asserts.decoding()
         await decoding.succeed("Symbol(a)", Symbol.for("a"))
-        await decoding.fail("a", `Expected a string representing a symbol, got "a"`)
+        await decoding.fail("a", `Expected a string representing a symbol`)
       })
 
       it("UniqueSymbol", async () => {
@@ -2027,7 +2027,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
 
         const decoding = asserts.decoding()
         await decoding.succeed("Symbol(a)", Symbol.for("a"))
-        await decoding.fail("a", `Expected a string representing a symbol, got "a"`)
+        await decoding.fail("a", `Expected a string representing a symbol`)
       })
 
       it("BigInt", async () => {
@@ -2039,7 +2039,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
 
         const decoding = asserts.decoding()
         await decoding.succeed("1", 1n)
-        await decoding.fail("a", `Expected a string representing a bigint, got "a"`)
+        await decoding.fail("a", `Expected a string representing a bigint`)
       })
 
       it("PropertyKey", async () => {
@@ -2110,7 +2110,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         const decoding = asserts.decoding()
         await decoding.fail(
           "-",
-          `Expected "a" | "1" | "2" | "true", got "-"`
+          `Expected "a" | "1" | "2" | "true"`
         )
       })
 
@@ -2391,7 +2391,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await encoding.succeed([1, 2], ["1", "2"])
 
         const decoding = asserts.decoding()
-        await decoding.fail("1,2", `Expected array, got "1,2"`)
+        await decoding.fail("1,2", `Expected array`)
         await decoding.succeed(["1", "2"], [1, 2])
       })
 
@@ -2578,7 +2578,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         )
         await decoding.fail(
           "not a url",
-          `Invalid URL string: not a url`
+          "Expected a valid URL string"
         )
       })
 
@@ -2595,7 +2595,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         await decoding.succeed({ source: "a", flags: "i" }, new RegExp("a", "i"))
         await decoding.fail(
           { source: "a", flags: "x" },
-          `SyntaxError: Invalid flags supplied to RegExp constructor 'x'`
+          "Expected valid RegExp source and flags"
         )
       })
 
@@ -2731,7 +2731,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
       const decoding = asserts.decoding()
       await decoding.succeed({})
       await decoding.succeed({ a: ["a"] })
-      await decoding.fail({ a: "a" }, `Expected array, got "a"\n  at ["a"]`)
+      await decoding.fail({ a: "a" }, `Expected array\n  at ["a"]`)
     })
   })
 
@@ -2744,11 +2744,11 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
 
       const encoding = asserts.encoding()
       await encoding.succeed([1, 2], ["1", "2"])
-      await encoding.fail(1 as any, "Expected array, got 1")
+      await encoding.fail(1 as any, "Expected array")
 
       const decoding = asserts.decoding()
       await decoding.succeed("1", [1])
-      await decoding.fail("1,2", `Expected a string representing a finite number, got "1,2"\n  at [0]`)
+      await decoding.fail("1,2", `Expected a string representing a finite number\n  at [0]`)
       await decoding.succeed(["1", "2"], [1, 2])
     })
 
@@ -2862,7 +2862,7 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
     })
 
     it("Never", async () => {
-      await assertXmlFailure(Schema.Never, "test", `Expected never, got "test"`)
+      await assertXmlFailure(Schema.Never, "test", `Expected never`)
     })
 
     it("Any", async () => {

--- a/packages/effect/test/schema/toDifferJsonPatch.test.ts
+++ b/packages/effect/test/schema/toDifferJsonPatch.test.ts
@@ -102,7 +102,7 @@ describe("Schema.toDifferJsonPatch", () => {
 
       throws(
         () => differ.diff(new Date("1970-01-01T00:00:00.000Z"), new Date(NaN)),
-        "Expected a valid Date, got Invalid Date"
+        "Expected a valid Date"
       )
     })
 

--- a/packages/effect/test/schema/toIso.test.ts
+++ b/packages/effect/test/schema/toIso.test.ts
@@ -67,7 +67,7 @@ describe("Optic generation", () => {
         const modify = optic.modify((n) => schema.make(n - 1))
 
         strictEqual(modify(schema.make(2)), 1)
-        throws(() => modify(schema.make(1)), "Expected a value greater than 0, got 0")
+        throws(() => modify(schema.make(1)), "Expected a value greater than 0")
       })
     })
 

--- a/packages/effect/test/schema/toStandardSchemaV1.test.ts
+++ b/packages/effect/test/schema/toStandardSchemaV1.test.ts
@@ -120,13 +120,13 @@ describe("toStandardSchemaV1", () => {
     expectSyncSuccess(standardSchema, "a", "a")
     expectSyncFailure(standardSchema, null, [
       {
-        message: "Expected string, got null",
+        message: "Expected string",
         path: []
       }
     ])
     expectSyncFailure(standardSchema, "", [
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: []
       }
     ])
@@ -138,13 +138,13 @@ describe("toStandardSchemaV1", () => {
     await expectAsyncSuccess(standardSchema, "a", "a")
     expectSyncFailure(standardSchema, null, [
       {
-        message: "Expected string, got null",
+        message: "Expected string",
         path: []
       }
     ])
     await expectAsyncFailure(standardSchema, "", [
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: []
       }
     ])
@@ -204,29 +204,29 @@ describe("toStandardSchemaV1", () => {
     expectSyncSuccess(standardSchema, { a: "a", b: "b" }, { a: "a", b: "b" })
     expectSyncFailure(standardSchema, null, [
       {
-        message: "Expected object, got null",
+        message: "Expected object",
         path: []
       }
     ])
     expectSyncFailure(standardSchema, { a: "a", b: "" }, [
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: ["b"]
       }
     ])
     expectSyncFailure(standardSchema, { a: "", b: "b" }, [
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: ["a"]
       }
     ])
     expectSyncFailure(standardSchema, { a: "", b: "" }, [
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: ["a"]
       },
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: ["b"]
       }
     ])
@@ -240,7 +240,7 @@ describe("toStandardSchemaV1", () => {
     const standardSchema = Schema.toStandardSchemaV1(schema, { parseOptions: { errors: "first" } })
     expectSyncFailure(standardSchema, { a: "", b: "" }, [
       {
-        message: `Expected a value with a length of at least 1, got ""`,
+        message: `Expected a value with a length of at least 1`,
         path: ["a"]
       }
     ])
@@ -275,7 +275,7 @@ describe("toStandardSchemaV1", () => {
         const standardSchema = Schema.toStandardSchemaV1(schema)
         expectSyncFailure(standardSchema, null, [
           {
-            message: "Expected string, got null",
+            message: "Expected string",
             path: []
           }
         ])
@@ -292,7 +292,7 @@ describe("toStandardSchemaV1", () => {
         const standardSchema = Schema.toStandardSchemaV1(schema)
         expectSyncFailure(standardSchema, null, [
           {
-            message: "Expected string, got null",
+            message: "Expected string",
             path: []
           }
         ])
@@ -456,7 +456,7 @@ describe("toStandardSchemaV1", () => {
       })
       expectSyncFailure(standardSchema, null, [
         {
-          message: "Expected string, got null",
+          message: "Expected string",
           path: []
         }
       ])
@@ -469,7 +469,7 @@ describe("toStandardSchemaV1", () => {
       })
       expectSyncFailure(standardSchema, "", [
         {
-          message: `Expected a value with a length of at least 1, got ""`,
+          message: `Expected a value with a length of at least 1`,
           path: []
         }
       ])

--- a/packages/effect/test/schema/v3-v4.test.ts
+++ b/packages/effect/test/schema/v3-v4.test.ts
@@ -38,7 +38,7 @@ describe("v3 -> v4 migration tests", () => {
       )
       await encoding.fail(
         { a: undefined },
-        `Expected number, got undefined
+        `Expected number
   at ["a"]`
       )
     })
@@ -68,7 +68,7 @@ describe("v3 -> v4 migration tests", () => {
       await decoding.succeed({}, { a: -1 })
       await decoding.fail(
         { a: undefined },
-        `Expected string, got undefined
+        `Expected string
   at ["a"]`
       )
 
@@ -81,7 +81,7 @@ describe("v3 -> v4 migration tests", () => {
       )
       await encoding.fail(
         { a: undefined },
-        `Expected number, got undefined
+        `Expected number
   at ["a"]`
       )
     })
@@ -118,7 +118,7 @@ describe("v3 -> v4 migration tests", () => {
       await encoding.succeed({})
       await encoding.fail(
         { a: null },
-        `Expected number | undefined, got null
+        `Expected number | undefined
   at ["a"]`
       )
     })
@@ -149,7 +149,7 @@ describe("v3 -> v4 migration tests", () => {
       await decoding.succeed({ a: null }, {})
       await decoding.fail(
         { a: undefined },
-        `Expected string | null, got undefined
+        `Expected string | null
   at ["a"]`
       )
 
@@ -158,7 +158,7 @@ describe("v3 -> v4 migration tests", () => {
       await encoding.succeed({})
       await encoding.fail(
         { a: undefined },
-        `Expected number, got undefined
+        `Expected number
   at ["a"]`
       )
     })
@@ -229,7 +229,7 @@ describe("v3 -> v4 migration tests", () => {
       await decoding.succeed({ a: null }, { a: -1 })
       await decoding.fail(
         { a: undefined },
-        `Expected string | null, got undefined
+        `Expected string | null
   at ["a"]`
       )
 
@@ -237,7 +237,7 @@ describe("v3 -> v4 migration tests", () => {
       await encoding.succeed({ a: 1 }, { a: "1" })
       await encoding.fail(
         { a: undefined },
-        `Expected number, got undefined
+        `Expected number
   at ["a"]`
       )
       await encoding.fail(

--- a/packages/effect/test/testing/TestSchema.test.ts
+++ b/packages/effect/test/testing/TestSchema.test.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Option, Schema, SchemaGetter, SchemaIssue } from "effect"
+import { Context, Effect, Schema, SchemaGetter, SchemaIssue } from "effect"
 import { TestSchema } from "effect/testing"
 import { describe, it } from "vitest"
 
@@ -8,8 +8,8 @@ describe("TestSchema", () => {
     const assert = new TestSchema.Asserts(schema)
     const decoding = assert.decoding()
     await decoding.succeed("1", 1)
-    await decoding.fail("-1", `Expected a value greater than 0, got -1`)
-    await decoding.fail("a", `Expected a finite number, got NaN`)
+    await decoding.fail("-1", `Expected a value greater than 0`)
+    await decoding.fail("a", `Expected a finite number`)
   })
 
   it("decoding.provide", async () => {
@@ -21,7 +21,7 @@ describe("TestSchema", () => {
           Effect.gen(function*() {
             yield* Service
             if (s.length === 0) {
-              return new SchemaIssue.InvalidValue(Option.some(s), {
+              return new SchemaIssue.InvalidValue({
                 message: "input should not be empty string"
               })
             }
@@ -42,7 +42,7 @@ describe("TestSchema", () => {
     const assert = new TestSchema.Asserts(schema)
     const encoding = assert.encoding()
     await encoding.succeed(1, "1")
-    await encoding.fail(-1, `Expected a value greater than 0, got -1`)
+    await encoding.fail(-1, `Expected a value greater than 0`)
   })
 
   it("encoding.provide", async () => {
@@ -55,7 +55,7 @@ describe("TestSchema", () => {
           Effect.gen(function*() {
             yield* Service
             if (s.length === 0) {
-              return new SchemaIssue.InvalidValue(Option.some(s), {
+              return new SchemaIssue.InvalidValue({
                 message: "input should not be empty string"
               })
             }

--- a/packages/effect/test/unstable/ai/AnthropicStructuredOutput.test.ts
+++ b/packages/effect/test/unstable/ai/AnthropicStructuredOutput.test.ts
@@ -624,7 +624,7 @@ describe("toCodecAnthropic", () => {
       })
       await new TestSchema.Asserts(result.codec).decoding().fail(
         [{ 0: "a", 1: 1 }, { 0: "a", 1: 2 }],
-        `Expected a value with at least 2 entries, got {"a":2}`
+        `Expected a value with at least 2 entries`
       )
     })
 

--- a/packages/effect/test/unstable/ai/AnthropicStructuredOutputRepresentation.test.ts
+++ b/packages/effect/test/unstable/ai/AnthropicStructuredOutputRepresentation.test.ts
@@ -42,7 +42,7 @@ describe("AnthropicStructuredOutput representation v2", () => {
     })
     await new TestSchema.Asserts(result.codec).decoding().fail(
       "a",
-      `Expected <filter>, got "a"`
+      `Expected <filter>`
     )
   })
 

--- a/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer/McpServer.test.ts
@@ -253,7 +253,7 @@ describe("McpServer", () => {
         assert.isFalse(handlerInvoked)
         assert.instanceOf(error, McpSchema.InvalidParams)
         assert.match(error.message, /Invalid parameters for tool 'OptionalStringTool'/)
-        assert.match(error.message, /Expected string \| undefined, got null/)
+        assert.match(error.message, /Expected string \| undefined/)
         assert.match(error.message, /at \["signature"\]/)
       }))
 

--- a/packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
+++ b/packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
@@ -799,7 +799,7 @@ describe("toCodecOpenAI", () => {
       const result = toCodecOpenAI(Schema.Struct({ value: schema }))
       await new TestSchema.Asserts(result.codec).decoding().fail(
         { value: [{ 0: "a", 1: 1 }, { 0: "a", 1: 2 }] },
-        `Expected a value with at least 2 entries, got {"a":2}
+        `Expected a value with at least 2 entries
   at ["value"]`
       )
     })

--- a/packages/effect/test/unstable/ai/OpenAiStructuredOutputRepresentation.test.ts
+++ b/packages/effect/test/unstable/ai/OpenAiStructuredOutputRepresentation.test.ts
@@ -50,7 +50,7 @@ describe("OpenAiStructuredOutput representation v2", () => {
     })
     await new TestSchema.Asserts(result.codec).decoding().fail(
       { value: "a" },
-      `Expected <filter>, got "a"
+      `Expected <filter>
   at ["value"]`
     )
   })

--- a/packages/effect/test/unstable/cli/Arguments.test.ts
+++ b/packages/effect/test/unstable/cli/Arguments.test.ts
@@ -156,7 +156,7 @@ describe("Command arguments", () => {
       expect(errorText).toMatchInlineSnapshot(`
         "
         ERROR
-          Invalid value for argument <count>: "not-a-number". Expected a string representing a finite number, got "not-a-number""
+          Invalid value for argument <count>: "not-a-number". Expected a string representing a finite number"
       `)
     }).pipe(Effect.provide(TestLayer)))
 

--- a/packages/effect/test/unstable/cli/Primitive.test.ts
+++ b/packages/effect/test/unstable/cli/Primitive.test.ts
@@ -85,7 +85,7 @@ describe("Primitive", () => {
         expectInvalidValues(
           Primitive.boolean,
           ["invalid"],
-          [`Expected "true" | "yes" | "on" | "1" | "y" | "false" | "no" | "off" | "0" | "n", got "invalid"`]
+          [`Expected "true" | "yes" | "on" | "1" | "y" | "false" | "no" | "off" | "0" | "n"`]
         ))
 
       it("should have correct _tag", () => {
@@ -107,7 +107,7 @@ describe("Primitive", () => {
 
       it.effect("should fail for invalid values", () =>
         expectInvalidValues(Primitive.float, ["not-a-number"], [
-          `Expected a string representing a finite number, got "not-a-number"`
+          `Expected a string representing a finite number`
         ]))
 
       it("should have correct _tag", () => {
@@ -145,7 +145,7 @@ describe("Primitive", () => {
         ]))
 
       it.effect("should fail for invalid values", () =>
-        expectInvalidValues(Primitive.date, ["not-a-date"], [`Expected a valid Date, got Invalid Date`]))
+        expectInvalidValues(Primitive.date, ["not-a-date"], [`Expected a valid Date`]))
 
       it("should have correct _tag", () => {
         assert.strictEqual(Primitive.date._tag, "Date")
@@ -168,7 +168,7 @@ describe("Primitive", () => {
         expectInvalidValues(
           Primitive.integer,
           ["3.14", "not-a-number"],
-          [`Expected an integer, got 3.14`, `Expected a string representing a finite number, got "not-a-number"`]
+          [`Expected an integer`, `Expected a string representing a finite number`]
         ))
 
       it("should have correct _tag", () => {

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -1,4 +1,3 @@
-import type { SchemaAST } from "effect"
 import {
   Brand,
   Context,
@@ -7,6 +6,7 @@ import {
   Option,
   Predicate,
   Schema,
+  type SchemaAST,
   SchemaGetter,
   SchemaTransformation,
   Struct,
@@ -26,6 +26,12 @@ const revealClass = <Self, S extends Schema.Struct<Schema.Struct.Fields>, Inheri
 ): Schema.Class<Self, S, Inherited> => klass
 
 describe("Schema", () => {
+  it("RedactedFromValue", () => {
+    const schema = Schema.RedactedFromValue(Schema.String)
+    expect(schema).type.toBe<Schema.RedactedFromValue<Schema.String>>()
+    expect(schema.from).type.toBe<Schema.String>()
+  })
+
   describe("variance", () => {
     it("Type", () => {
       const f1 = hole<

--- a/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts
+++ b/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts
@@ -8,7 +8,6 @@ import {
   Effect,
   Fiber,
   Layer,
-  Option,
   Schema,
   SchemaGetter,
   SchemaIssue,
@@ -69,7 +68,7 @@ const VerifyId = Schema.String.pipe(
         const { maxLength } = yield* VerifyContext
         if (s.length > maxLength) {
           return yield* Effect.fail(
-            new SchemaIssue.InvalidValue(Option.some(s), {
+            new SchemaIssue.InvalidValue({
               message: "Max length exceeded"
             })
           )


### PR DESCRIPTION
| Scenario                 | Effect (ns/op) | Valibot (ns/op) | Zod (ns/op) | HEAD vs main | Classification |
| ------------------------ | -------------: | --------------: | ----------: | -----------: | -------------- |
| `initialization-schema`  |      108191.30 |    **30549.81** |   212715.66 |       -0.92% | inconclusive   |
| `initialization-decoder` |  **109796.34** |               — |           — |       +1.98% | inconclusive   |
| `validation-valid`       |        5221.80 |     **5070.81** |           — |       +2.06% | inconclusive   |
| `validation-invalid`     |        1279.77 |      **234.92** |           — |       +0.59% | inconclusive   |
| `parsing-all-valid`      |    **5144.58** |         5192.19 |     7176.19 |       -3.79% | inconclusive   |
| `parsing-all-invalid`    |    **7594.49** |        15236.82 |    37780.35 |       -5.94% | improvement    |
| `parsing-first-valid`    |        5188.33 |     **5135.75** |           — |       -1.49% | inconclusive   |
| `parsing-first-invalid`  |        1330.82 |      **243.64** |           — |       +1.01% | inconclusive   |
| `standard-all-valid`     |        5722.01 |         5200.05 | **3801.26** |       -1.78% | inconclusive   |
| `standard-all-invalid`   |   **12024.65** |        15528.50 |    30982.17 |       -7.78% | improvement    |
| `standard-first-valid`   |    **5655.33** |               — |           — |       +3.84% | inconclusive   |
| `standard-first-invalid` |    **2001.69** |               — |           — |       -4.56% | inconclusive   |
| `codec-typed-encode`     |         342.59 |               — |   **39.29** |       -7.62% | inconclusive   |
| `codec-typed-decode`     |         418.78 |               — |   **50.14** |      -10.89% | improvement    |
| `codec-unknown-encode`   |     **328.38** |               — |           — |       -5.55% | inconclusive   |
| `codec-unknown-decode`   |     **347.35** |               — |           — |       -5.25% | inconclusive   |
